### PR TITLE
docs: fix typo issue

### DIFF
--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -229,7 +229,7 @@ It has the following properties:
             ```svelte title="user.svelte"
             <script lang="ts">
             import { client } from "$lib/client";
-            const session = client.useSsession();
+            const session = client.useSession();
             </script>
 
             <div


### PR DESCRIPTION
Fixed a typo in the documentation where client.useSsession() was incorrectly referenced instead of client.useSession().