### PR TITLE
fix(docs): remove a line that broke Forget Password section in mdx wh…

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -104,7 +104,6 @@ on the client side you can use `sendVerificationEmail` function to send verifica
 
 Once the user clicks on the link in the email, if the token is valid, the user will be redirected to the URL provided in the `callbackURL` parameter. If the token is invalid, the user will be redirected to the URL provided in the `callbackURL` parameter with an error message in the query string `?error=invalid_token`.
 
-```ts title="client.ts"
 
 ### Forget Password
 


### PR DESCRIPTION
Hello,

i notice that a line broke the markdown for Forget Password section in [authentication/email password page ](https://www.better-auth.com/docs/authentication/email-password)

So here a some pr for that :)