### PR TITLE
closes: #26

### DIFF
--- a/packages/better-auth/src/cli/utils/get-migration.ts
+++ b/packages/better-auth/src/cli/utils/get-migration.ts
@@ -1,7 +1,4 @@
-import type {
-	AlterTableColumnAlteringBuilder,
-	CreateTableBuilder,
-} from "kysely";
+import type { AlterTableColumnAlteringBuilder, CreateTableBuilder } from "kysely";
 import type { FieldAttribute, FieldType } from "../../db";
 import { logger } from "../../utils/logger";
 import type { BetterAuthOptions } from "../../types";
@@ -9,186 +6,159 @@ import { getSchema } from "./get-schema";
 import { createKyselyAdapter, getDatabaseType } from "../../db/kysely";
 
 const postgresMap = {
-	string: ["character varying", "text"],
-	number: [
-		"int4",
-		"integer",
-		"bigint",
-		"smallint",
-		"numeric",
-		"real",
-		"double precision",
-	],
-	boolean: ["bool", "boolean"],
-	date: ["timestamp", "date"],
+  string: ["character varying", "text"],
+  number: ["int4", "integer", "bigint", "smallint", "numeric", "real", "double precision"],
+  boolean: ["bool", "boolean"],
+  date: ["timestamp", "date"],
 };
 const mysqlMap = {
-	string: ["varchar", "text"],
-	number: [
-		"integer",
-		"int",
-		"bigint",
-		"smallint",
-		"decimal",
-		"float",
-		"double",
-	],
-	boolean: ["boolean"],
-	date: ["date", "datetime"],
+  string: ["varchar", "text"],
+  number: ["integer", "int", "bigint", "smallint", "decimal", "float", "double"],
+  boolean: ["boolean"],
+  date: ["date", "datetime"],
 };
 
 const sqliteMap = {
-	string: ["TEXT"],
-	number: ["INTEGER", "REAL"],
-	boolean: ["INTEGER", "BOOLEAN"], // 0 or 1
-	date: ["DATE", "INTEGER"],
+  string: ["TEXT"],
+  number: ["INTEGER", "REAL"],
+  boolean: ["INTEGER", "BOOLEAN"], // 0 or 1
+  date: ["DATE", "INTEGER"],
 };
 
 const map = {
-	postgres: postgresMap,
-	mysql: mysqlMap,
-	sqlite: sqliteMap,
+  postgres: postgresMap,
+  mysql: mysqlMap,
+  sqlite: sqliteMap,
 };
 
 export function matchType(
-	columnDataType: string,
-	fieldType: FieldType,
-	dbType: "postgres" | "sqlite" | "mysql",
+  columnDataType: string,
+  fieldType: FieldType,
+  dbType: "postgres" | "sqlite" | "mysql"
 ) {
-	const types = map[dbType];
-	const type = types[fieldType].map((t) => t.toLowerCase());
-	const matches = type.includes(columnDataType.toLowerCase());
-	return matches;
+  const types = map[dbType];
+  const type = types[fieldType].map((t) => t.toLowerCase());
+  const matches = type.includes(columnDataType.toLowerCase());
+  return matches;
 }
 
 export async function getMigrations(config: BetterAuthOptions) {
-	const betterAuthSchema = getSchema(config);
-	const dbType = getDatabaseType(config);
-	const db = createKyselyAdapter(config);
-	if (!db) {
-		logger.error("Invalid database configuration.");
-		process.exit(1);
-	}
-	const tableMetadata = await db.introspection.getTables();
-	const toBeCreated: {
-		table: string;
-		fields: Record<string, FieldAttribute>;
-		order: number;
-	}[] = [];
-	const toBeAdded: {
-		table: string;
-		fields: Record<string, FieldAttribute>;
-		order: number;
-	}[] = [];
+  const betterAuthSchema = getSchema(config);
+  const dbType = getDatabaseType(config);
+  const db = createKyselyAdapter(config);
+  if (!db) {
+    logger.error("Invalid database configuration.");
+    process.exit(1);
+  }
+  const tableMetadata = await db.introspection.getTables();
+  const toBeCreated: {
+    table: string;
+    fields: Record<string, FieldAttribute>;
+    order: number;
+  }[] = [];
+  const toBeAdded: {
+    table: string;
+    fields: Record<string, FieldAttribute>;
+    order: number;
+  }[] = [];
 
-	for (const [key, value] of Object.entries(betterAuthSchema)) {
-		const table = tableMetadata.find((t) => t.name === key);
-		if (!table) {
-			const tIndex = toBeCreated.findIndex((t) => t.table === key);
-			const tableData = {
-				table: key,
-				fields: value.fields,
-				order: value.order || Infinity,
-			};
+  for (const [key, value] of Object.entries(betterAuthSchema)) {
+    const table = tableMetadata.find((t) => t.name === key);
+    if (!table) {
+      const tIndex = toBeCreated.findIndex((t) => t.table === key);
+      const tableData = {
+        table: key,
+        fields: value.fields,
+        order: value.order || Infinity,
+      };
 
-			const insertIndex = toBeCreated.findIndex(
-				(t) => (t.order || Infinity) > tableData.order,
-			);
+      const insertIndex = toBeCreated.findIndex((t) => (t.order || Infinity) > tableData.order);
 
-			if (insertIndex === -1) {
-				if (tIndex === -1) {
-					toBeCreated.push(tableData);
-				} else {
-					toBeCreated[tIndex].fields = {
-						...toBeCreated[tIndex].fields,
-						...value.fields,
-					};
-				}
-			} else {
-				toBeCreated.splice(insertIndex, 0, tableData);
-			}
-			continue;
-		}
-		let toBeAddedFields: Record<string, FieldAttribute> = {};
-		for (const [fieldName, field] of Object.entries(value.fields)) {
-			const column = table.columns.find((c) => c.name === fieldName);
-			if (!column) {
-				toBeAddedFields[fieldName] = field;
-				continue;
-			}
+      if (insertIndex === -1) {
+        if (tIndex === -1) {
+          toBeCreated.push(tableData);
+        } else {
+          toBeCreated[tIndex].fields = {
+            ...toBeCreated[tIndex].fields,
+            ...value.fields,
+          };
+        }
+      } else {
+        toBeCreated.splice(insertIndex, 0, tableData);
+      }
+      continue;
+    }
+    let toBeAddedFields: Record<string, FieldAttribute> = {};
+    for (const [fieldName, field] of Object.entries(value.fields)) {
+      const column = table.columns.find((c) => c.name === fieldName);
+      if (!column) {
+        toBeAddedFields[fieldName] = field;
+        continue;
+      }
 
-			if (matchType(column.dataType, field.type, dbType)) {
-				continue;
-			} else {
-				logger.warn(
-					`Field ${fieldName} in table ${key} has a different type in the database. Expected ${field.type} but got ${column.dataType}.`,
-				);
-			}
-		}
-		if (Object.keys(toBeAddedFields).length > 0) {
-			toBeAdded.push({
-				table: key,
-				fields: toBeAddedFields,
-				order: value.order || Infinity,
-			});
-		}
-	}
+      if (matchType(column.dataType, field.type, dbType)) {
+        continue;
+      } else {
+        logger.warn(
+          `Field ${fieldName} in table ${key} has a different type in the database. Expected ${field.type} but got ${column.dataType}.`
+        );
+      }
+    }
+    if (Object.keys(toBeAddedFields).length > 0) {
+      toBeAdded.push({
+        table: key,
+        fields: toBeAddedFields,
+        order: value.order || Infinity,
+      });
+    }
+  }
 
-	const typeMap = {
-		string: "text",
-		boolean: "boolean",
-		number: "integer",
-		date: "date",
-	} as const;
-	const migrations: (
-		| AlterTableColumnAlteringBuilder
-		| CreateTableBuilder<string, string>
-	)[] = [];
+  const typeMap = {
+    string: "text",
+    boolean: "boolean",
+    number: "integer",
+    date: "date",
+  } as const;
+  const migrations: (AlterTableColumnAlteringBuilder | CreateTableBuilder<string, string>)[] = [];
 
-	if (toBeAdded.length) {
-		for (const table of toBeAdded) {
-			for (const [fieldName, field] of Object.entries(table.fields)) {
-				const type = typeMap[field.type];
-				const exec = db.schema
-					.alterTable(table.table)
-					.addColumn(fieldName, type, (col) => {
-						col = field.required !== false ? col.notNull() : col;
-						if (field.references) {
-							col = col.references(
-								`${field.references.model}.${field.references.field}`,
-							);
-						}
-						return col;
-					});
-				migrations.push(exec);
-			}
-		}
-	}
+  if (toBeAdded.length) {
+    for (const table of toBeAdded) {
+      for (const [fieldName, field] of Object.entries(table.fields)) {
+        const type = typeMap[field.type];
+        const exec = db.schema.alterTable(table.table).addColumn(fieldName, type, (col) => {
+          col = field.required !== false ? col.notNull() : col;
+          if (field.references) {
+            col = col.references(`${field.references.model}.${field.references.field}`);
+          }
+          return col;
+        });
+        migrations.push(exec);
+      }
+    }
+  }
 
-	if (toBeCreated.length) {
-		for (const table of toBeCreated) {
-			let dbT = db.schema
-				.createTable(table.table)
-				.addColumn("id", "text", (col) => col.primaryKey());
-			for (const [fieldName, field] of Object.entries(table.fields)) {
-				const type = typeMap[field.type];
-				dbT = dbT.addColumn(fieldName, type, (col) => {
-					col = field.required !== false ? col.notNull() : col;
-					if (field.references) {
-						col = col.references(
-							`${field.references.model}.${field.references.field}`,
-						);
-					}
-					return col;
-				});
-			}
-			migrations.push(dbT);
-		}
-	}
-	async function runMigrations() {
-		for (const migration of migrations) {
-			await migration.execute();
-		}
-	}
-	return { toBeCreated, toBeAdded, runMigrations };
+  if (toBeCreated.length) {
+    for (const table of toBeCreated) {
+      let dbT = db.schema
+        .createTable(table.table)
+        .addColumn("id", dbType === "mysql" ? "varchar(255)" : "text", (col) => col.primaryKey());
+      for (const [fieldName, field] of Object.entries(table.fields)) {
+        const type = typeMap[field.type];
+        dbT = dbT.addColumn(fieldName, type, (col) => {
+          col = field.required !== false ? col.notNull() : col;
+          if (field.references) {
+            col = col.references(`${field.references.model}.${field.references.field}`);
+          }
+          return col;
+        });
+      }
+      migrations.push(dbT);
+    }
+  }
+  async function runMigrations() {
+    for (const migration of migrations) {
+      await migration.execute();
+    }
+  }
+  return { toBeCreated, toBeAdded, runMigrations };
 }


### PR DESCRIPTION
## Changes
According to the requirements the following error occurred because MySQL can index only the first _N_ chars of a `BLOB` or `TEXT` column. So The error mainly happens when there is a field/column type of `TEXT` or `BLOB` or those belong to `TEXT` or `BLOB` types such as `TINYBLOB`, `MEDIUMBLOB`, `LONGBLOB`, `TINYTEXT`, `MEDIUMTEXT`, and `LONGTEXT` that you try to make a primary key or index. With full `BLOB` or `TEXT` without the length value, MySQL is unable to guarantee the uniqueness of the column as it’s of variable and dynamic size. So, when using `BLOB` or `TEXT` types as an index, the value of N must be supplied so that MySQL can determine the key length. However, MySQL doesn’t support a key length limit on `TEXT` or `BLOB`. `TEXT(88)` simply won’t work.

A workaround, was conditionally rendering type in the schema generated. When the `dbType` is mysql then we set the type to `VARCHAR(255)` otherwise `TEXT`.

> `VARCHAR` can accepts upto 256 characters.