### PR TITLE
refactor: better error handling for server side calls

### DIFF
--- a/dev/bun/_auth.ts
+++ b/dev/bun/_auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
+import { APIError } from "better-auth/api";
 import { twoFactor } from "better-auth/plugins";
 
 export const auth = betterAuth({
@@ -11,3 +12,10 @@ export const auth = betterAuth({
 	),
 	plugins: [twoFactor()],
 });
+
+try {
+	await auth.api.signOut();
+} catch (e) {
+	if (e instanceof APIError) {
+	}
+}

--- a/docs/content/docs/concepts/api.mdx
+++ b/docs/content/docs/concepts/api.mdx
@@ -42,3 +42,24 @@ await auth.api.getSession({
 
 Unlike the client, the server needs the values to be passed as an object with the key `body` for the body, `headers` for the headers, and `query` for the query.
 
+
+## Error Handling
+
+When you call an API endpoint in the server, it will throw an error if the request fails. You can catch the error and handle it as you see fit. The error instance is an instance of `APIError`.
+ 
+```ts title="server.ts"
+import { APIError } from "better-auth/api";
+
+try {
+    await auth.api.signInEmail({
+        body: {
+            email: "",
+            password: ""
+        }
+    })
+} catch (error) {
+    if (error instanceof APIError) {
+        console.log(error.message, error.status)
+    }
+}
+```

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -254,3 +254,4 @@ export const router = <C extends AuthContext, Option extends BetterAuthOptions>(
 export * from "./routes";
 export * from "./middlewares";
 export * from "./call";
+export { APIError } from "better-call";

--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -3,6 +3,7 @@ import { createJWT, parseJWT, type JWT } from "oslo/jwt";
 import { validateJWT } from "oslo/jwt";
 import { z } from "zod";
 import { createAuthEndpoint } from "../call";
+import { APIError } from "better-call";
 
 export const forgetPassword = createAuthEndpoint(
 	"/forget-password",
@@ -27,12 +28,8 @@ export const forgetPassword = createAuthEndpoint(
 			ctx.context.logger.error(
 				"Reset password isn't enabled.Please pass an emailAndPassword.sendResetPasswordToken function to your auth config!",
 			);
-			return ctx.json(null, {
-				status: 400,
-				statusText: "RESET_PASSWORD_EMAIL_NOT_SENT",
-				body: {
-					message: "Reset password isn't enabled",
-				},
+			throw new APIError("BAD_REQUEST", {
+				message: "Reset password isn't enabled",
 			});
 		}
 		const { email } = ctx.body;
@@ -129,19 +126,9 @@ export const resetPassword = createAuthEndpoint(
 	async (ctx) => {
 		const token = ctx.query?.currentURL.split("?token=")[1];
 		if (!token) {
-			return ctx.json(
-				{
-					error: "Invalid token",
-					data: null,
-				},
-				{
-					status: 400,
-					statusText: "INVALID_TOKEN",
-					body: {
-						message: "Invalid token",
-					},
-				},
-			);
+			throw new APIError("BAD_REQUEST", {
+				message: "Token not found",
+			});
 		}
 		const { newPassword } = ctx.body;
 		try {
@@ -175,19 +162,9 @@ export const resetPassword = createAuthEndpoint(
 				newPassword.length >
 					(ctx.context.options.emailAndPassword?.maxPasswordLength || 32)
 			) {
-				return ctx.json(
-					{
-						data: null,
-						error: "password is too short or too long",
-					},
-					{
-						status: 400,
-						statusText: "INVALID_PASSWORD_LENGTH",
-						body: {
-							message: "password is too short or too long",
-						},
-					},
-				);
+				throw new APIError("BAD_REQUEST", {
+					message: "Password is too short or too long",
+				});
 			}
 			const hashedPassword = await ctx.context.password.hash(newPassword);
 			const updatedUser = await ctx.context.internalAdapter.updatePassword(
@@ -195,12 +172,8 @@ export const resetPassword = createAuthEndpoint(
 				hashedPassword,
 			);
 			if (!updatedUser) {
-				return ctx.json(null, {
-					status: 400,
-					statusText: "USER_NOT_FOUND",
-					body: {
-						message: "User doesn't have a credential account",
-					},
+				throw new APIError("BAD_REQUEST", {
+					message: "Failed to update password",
 				});
 			}
 			return ctx.json(
@@ -221,20 +194,10 @@ export const resetPassword = createAuthEndpoint(
 				},
 			);
 		} catch (e) {
-			console.log(e);
-			return ctx.json(
-				{
-					error: "Invalid token",
-					data: null,
-				},
-				{
-					status: 400,
-					statusText: "INVALID_TOKEN",
-					body: {
-						message: "Invalid token",
-					},
-				},
-			);
+			ctx.context.logger.error("Failed to reset password", e);
+			throw new APIError("BAD_REQUEST", {
+				message: "Failed to reset password",
+			});
 		}
 	},
 );

--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -35,6 +35,7 @@ export const forgetPassword = createAuthEndpoint(
 		const { email } = ctx.body;
 		const user = await ctx.context.internalAdapter.findUserByEmail(email);
 		if (!user) {
+			ctx.context.logger.error("Reset Password: User not found", { email });
 			//only on the server status is false for the client it's always true
 			//to avoid leaking information
 			return ctx.json(

--- a/packages/better-auth/src/api/routes/verify-email.ts
+++ b/packages/better-auth/src/api/routes/verify-email.ts
@@ -2,6 +2,7 @@ import { TimeSpan } from "oslo";
 import { createJWT, validateJWT, type JWT } from "oslo/jwt";
 import { z } from "zod";
 import { createAuthEndpoint } from "../call";
+import { APIError } from "better-call";
 
 export async function createEmailVerificationToken(
 	secret: string,
@@ -43,12 +44,8 @@ export const sendVerificationEmail = createAuthEndpoint(
 			ctx.context.logger.error(
 				"Verification email isn't enabled. Pass `sendVerificationEmail` in `emailAndPassword` options to enable it.",
 			);
-			return ctx.json(null, {
-				status: 400,
-				statusText: "VERIFICATION_EMAIL_NOT_SENT",
-				body: {
-					message: "Verification email isn't enabled",
-				},
+			throw new APIError("BAD_REQUEST", {
+				message: "Verification email isn't enabled",
 			});
 		}
 		const { email } = ctx.body;

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -95,12 +95,8 @@ export const magicLink = (options: MagicLinkOptions) => {
 						if (callbackURL) {
 							throw ctx.redirect(`${callbackURL}?error=INVALID_TOKEN`);
 						}
-						return ctx.json(null, {
-							status: 400,
-							statusText: "INVALID_TOKEN",
-							body: {
-								message: "Invalid token",
-							},
+						throw new APIError("BAD_REQUEST", {
+							message: "Invalid token",
 						});
 					}
 					const schema = z.object({
@@ -114,12 +110,8 @@ export const magicLink = (options: MagicLinkOptions) => {
 						if (callbackURL) {
 							throw ctx.redirect(`${callbackURL}?error=USER_NOT_FOUND`);
 						}
-						return ctx.json(null, {
-							status: 400,
-							statusText: "USER_NOT_FOUND",
-							body: {
-								message: "User not found",
-							},
+						throw new APIError("BAD_REQUEST", {
+							message: "User not found",
 						});
 					}
 					const session = await ctx.context.internalAdapter.createSession(
@@ -130,12 +122,8 @@ export const magicLink = (options: MagicLinkOptions) => {
 						if (callbackURL) {
 							throw ctx.redirect(`${callbackURL}?error=SESSION_NOT_CREATED`);
 						}
-						return ctx.json(null, {
-							status: 400,
-							statusText: "SESSION NOT CREATED",
-							body: {
-								message: "Failed to create session",
-							},
+						throw new APIError("INTERNAL_SERVER_ERROR", {
+							message: "Unable to create session",
 						});
 					}
 					await setSessionCookie(ctx, session.id);

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -128,7 +128,7 @@ describe("organization", async (it) => {
 				headers,
 			},
 		});
-		expect(wrongPerson.error?.status).toBe(400);
+		expect(wrongPerson.error?.status).toBe(403);
 
 		const invitation = await client.organization.acceptInvitation({
 			invitationId: invite.data.id,

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -264,12 +264,8 @@ export const passkey = (options?: PasskeyOptions) => {
 						ctx.context.secret,
 					);
 					if (!challengeId) {
-						return ctx.json(null, {
-							status: 400,
-							statusText: "No challenge found",
-							body: {
-								message: "No challenge found",
-							},
+						throw new APIError("BAD_REQUEST", {
+							message: "Challenge not found",
 						});
 					}
 
@@ -335,11 +331,8 @@ export const passkey = (options?: PasskeyOptions) => {
 						});
 					} catch (e) {
 						console.log(e);
-						return ctx.json(null, {
-							status: 400,
-							body: {
-								message: "Registration failed",
-							},
+						throw new APIError("INTERNAL_SERVER_ERROR", {
+							message: "Failed to verify registration",
 						});
 					}
 				},
@@ -355,8 +348,8 @@ export const passkey = (options?: PasskeyOptions) => {
 				async (ctx) => {
 					const origin = options?.origin || ctx.headers?.get("origin") || "";
 					if (!origin) {
-						return ctx.json(null, {
-							status: 400,
+						throw new APIError("BAD_REQUEST", {
+							message: "origin missing",
 						});
 					}
 					const resp = ctx.body.response;
@@ -365,8 +358,8 @@ export const passkey = (options?: PasskeyOptions) => {
 						ctx.context.secret,
 					);
 					if (!challengeId) {
-						return ctx.json(null, {
-							status: 400,
+						throw new APIError("BAD_REQUEST", {
+							message: "Challenge not found",
 						});
 					}
 
@@ -375,8 +368,8 @@ export const passkey = (options?: PasskeyOptions) => {
 							challengeId,
 						);
 					if (!data) {
-						return ctx.json(null, {
-							status: 400,
+						throw new APIError("BAD_REQUEST", {
+							message: "Challenge not found",
 						});
 					}
 					const { expectedChallenge, callbackURL } = JSON.parse(
@@ -392,11 +385,8 @@ export const passkey = (options?: PasskeyOptions) => {
 						],
 					});
 					if (!passkey) {
-						return ctx.json(null, {
-							status: 401,
-							body: {
-								message: "Passkey not found",
-							},
+						throw new APIError("UNAUTHORIZED", {
+							message: "Passkey not found",
 						});
 					}
 					try {
@@ -418,11 +408,8 @@ export const passkey = (options?: PasskeyOptions) => {
 						});
 						const { verified } = verification;
 						if (!verified)
-							return ctx.json(null, {
-								status: 401,
-								body: {
-									message: "verification failed",
-								},
+							throw new APIError("UNAUTHORIZED", {
+								message: "Authentication failed",
 							});
 
 						await ctx.context.adapter.update<Passkey>({
@@ -442,11 +429,8 @@ export const passkey = (options?: PasskeyOptions) => {
 							ctx.request,
 						);
 						if (!s) {
-							return ctx.json(null, {
-								status: 500,
-								body: {
-									message: "Failed to create session",
-								},
+							throw new APIError("INTERNAL_SERVER_ERROR", {
+								message: "Unable to create session",
 							});
 						}
 						await setSessionCookie(ctx, s.id);
@@ -467,11 +451,8 @@ export const passkey = (options?: PasskeyOptions) => {
 						);
 					} catch (e) {
 						ctx.context.logger.error(e);
-						return ctx.json(null, {
-							status: 400,
-							body: {
-								message: "Authentication failed",
-							},
+						throw new APIError("BAD_REQUEST", {
+							message: "Failed to verify authentication",
 						});
 					}
 				},

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -337,7 +337,7 @@ export const phoneNumber = (options?: {
 								message: "OTP expired",
 							});
 						}
-						throw new APIError("NOT_FOUND", {
+						throw new APIError("BAD_REQUEST", {
 							message: "OTP not found",
 						});
 					}

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -220,71 +220,66 @@ export const phoneNumber = (options?: {
 							},
 						);
 					}
-					const res = await signUpEmail({
-						...ctx,
-						//@ts-expect-error
-						options: {
-							...ctx.context.options,
-						},
-						_flag: undefined,
-					});
-					if (res.error) {
-						return ctx.json(
-							{
-								user: null,
-								session: null,
+					try {
+						const res = await signUpEmail({
+							...ctx,
+							//@ts-expect-error
+							options: {
+								...ctx.context.options,
 							},
-							{
-								status: 400,
-								body: {
-									message: res.error.message,
-									status: 400,
-								},
-							},
-						);
-					}
-					if (options?.otp?.sendOTPonSignUp) {
-						if (!options.otp.sendOTP) {
-							logger.warn("sendOTP not implemented");
-							throw new APIError("NOT_IMPLEMENTED", {
-								message: "sendOTP not implemented",
-							});
-						}
-						const code = generateOTP(options?.otp?.otpLength || 6);
-						await ctx.context.internalAdapter.createVerificationValue({
-							value: code,
-							identifier: ctx.body.phoneNumber,
-							expiresAt: getDate(opts.otp.expiresIn, "sec"),
+							_flag: undefined,
 						});
-						await options.otp.sendOTP(ctx.body.phoneNumber, code);
-					}
 
-					const updated = await ctx.context.internalAdapter.updateUserByEmail(
-						res.user.email,
-						{
-							[opts.phoneNumber]: ctx.body.phoneNumber,
-						},
-					);
+						if (options?.otp?.sendOTPonSignUp) {
+							if (!options.otp.sendOTP) {
+								logger.warn("sendOTP not implemented");
+								throw new APIError("NOT_IMPLEMENTED", {
+									message: "sendOTP not implemented",
+								});
+							}
+							const code = generateOTP(options?.otp?.otpLength || 6);
+							await ctx.context.internalAdapter.createVerificationValue({
+								value: code,
+								identifier: ctx.body.phoneNumber,
+								expiresAt: getDate(opts.otp.expiresIn, "sec"),
+							});
+							await options.otp.sendOTP(ctx.body.phoneNumber, code);
+						}
 
-					if (ctx.body.callbackURL) {
-						return ctx.json(
+						const updated = await ctx.context.internalAdapter.updateUserByEmail(
+							res.user.email,
 							{
-								user: updated,
-								session: res.session,
-							},
-							{
-								body: {
-									url: ctx.body.callbackURL,
-									redirect: true,
-									...res,
-								},
+								[opts.phoneNumber]: ctx.body.phoneNumber,
 							},
 						);
+
+						if (ctx.body.callbackURL) {
+							return ctx.json(
+								{
+									user: updated,
+									session: res.session,
+								},
+								{
+									body: {
+										url: ctx.body.callbackURL,
+										redirect: true,
+										...res,
+									},
+								},
+							);
+						}
+						return ctx.json({
+							user: updated,
+							session: res.session,
+						});
+					} catch (e) {
+						if (e instanceof APIError) {
+							throw e;
+						}
+						throw new APIError("INTERNAL_SERVER_ERROR", {
+							message: "Failed to create user",
+						});
 					}
-					return ctx.json({
-						user: updated,
-						session: res.session,
-					});
 				},
 			),
 			sendVerificationCode: createAuthEndpoint(
@@ -338,31 +333,18 @@ export const phoneNumber = (options?: {
 					if (!otp || otp.expiresAt < new Date()) {
 						if (otp && otp.expiresAt < new Date()) {
 							await ctx.context.internalAdapter.deleteVerificationValue(otp.id);
+							throw new APIError("BAD_REQUEST", {
+								message: "OTP expired",
+							});
 						}
-						return ctx.json(
-							{
-								status: false,
-							},
-							{
-								body: {
-									message: "Invalid code",
-								},
-								status: 400,
-							},
-						);
+						throw new APIError("NOT_FOUND", {
+							message: "OTP not found",
+						});
 					}
 					if (otp.value !== ctx.body.code) {
-						return ctx.json(
-							{
-								status: false,
-							},
-							{
-								body: {
-									message: "Invalid code",
-								},
-								status: 400,
-							},
-						);
+						throw new APIError("BAD_REQUEST", {
+							message: "Invalid OTP",
+						});
 					}
 					await ctx.context.internalAdapter.deleteVerificationValue(otp.id);
 					const user = await ctx.context.adapter.findOne<User>({

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -5,6 +5,7 @@ import { sessionMiddleware } from "../../../api";
 import { symmetricDecrypt, symmetricEncrypt } from "../../../crypto";
 import { verifyTwoFactorMiddleware } from "../verify-middleware";
 import type { TwoFactorProvider, UserWithTwoFactor } from "../types";
+import { APIError } from "better-call";
 
 export interface BackupCodeOptions {
 	/**
@@ -98,12 +99,9 @@ export const backupCode2fa = (options?: BackupCodeOptions) => {
 						ctx.context.secret,
 					);
 					if (!validate) {
-						return ctx.json(
-							{ status: false },
-							{
-								status: 401,
-							},
-						);
+						throw new APIError("BAD_REQUEST", {
+							message: "Invalid backup code",
+						});
 					}
 					return ctx.json({ status: true });
 				},

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -11,6 +11,7 @@ import type { TwoFactorOptions, UserWithTwoFactor } from "./types";
 import type { Session } from "../../db/schema";
 import { TWO_FACTOR_COOKIE_NAME, TRUST_DEVICE_COOKIE_NAME } from "./constant";
 import { validatePassword } from "../../utils/password";
+import { APIError } from "better-call";
 
 export const twoFactor = (options?: TwoFactorOptions) => {
 	const totp = totp2fa({
@@ -42,15 +43,9 @@ export const twoFactor = (options?: TwoFactorOptions) => {
 						userId: user.id,
 					});
 					if (!isPasswordValid) {
-						return ctx.json(
-							{ status: false },
-							{
-								status: 400,
-								body: {
-									message: "Invalid password",
-								},
-							},
-						);
+						throw new APIError("BAD_REQUEST", {
+							message: "Invalid password",
+						});
 					}
 					const secret = generateRandomString(16, alphabet("a-z", "0-9", "-"));
 					const encryptedSecret = symmetricEncrypt({
@@ -95,15 +90,9 @@ export const twoFactor = (options?: TwoFactorOptions) => {
 						userId: user.id,
 					});
 					if (!isPasswordValid) {
-						return ctx.json(
-							{ status: false },
-							{
-								status: 400,
-								body: {
-									message: "Invalid password",
-								},
-							},
-						);
+						throw new APIError("BAD_REQUEST", {
+							message: "Invalid password",
+						});
 					}
 					await ctx.context.adapter.update({
 						model: "user",

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -112,7 +112,7 @@ export const totp2fa = (options: TOTPOptions) => {
 			}
 			const totp = new TOTPController(opts);
 			const secret = Buffer.from(
-				await symmetricDecrypt({
+				symmetricDecrypt({
 					key: ctx.context.secret,
 					data: ctx.context.session.user.twoFactorSecret,
 				}),

--- a/packages/better-auth/src/plugins/two-factor/verify-middleware.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-middleware.ts
@@ -111,15 +111,9 @@ export const verifyTwoFactorMiddleware = createAuthMiddleware(
 						return ctx.json({ status: true });
 					},
 					invalid: async () => {
-						return ctx.json(
-							{ status: false },
-							{
-								status: 401,
-								body: {
-									message: "Invalid code",
-								},
-							},
-						);
+						throw new APIError("UNAUTHORIZED", {
+							message: "invalid two factor authentication",
+						});
 					},
 					session: {
 						id: session.id,

--- a/studio/next-env.d.ts
+++ b/studio/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
This PR refactors all error-handling logic to throw an `APIError` instead of returning null and handling errors with status codes on the client side. If `APIError` is thrown on the client, it will be transformed into a proper error response. On the server, it will actually throw the error. 

closes #73 