### PR TITLE
Docs: Fix typo in Basic usage documentation page

### DIFF
--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -89,7 +89,7 @@ To signin a user, you can use the `signIn.email` function provided by the client
 - **email**: the user's email address
 - **password**: the user's password
 
-**Example: Using Svlete**
+**Example: Using Svelte**
 
 ```svelte title="signin.svelte"
 <script lang="ts">


### PR DESCRIPTION
Found a typo in the Basic Usage documentation page: Changed "Svlete" to "Svelte"