### PR TITLE
docs: add middleware and cors guides for hono

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -55,7 +55,7 @@ app.use(
 
 ### Middleware
 
-You can add a middleware to save the session and user in a context.
+You can add a middleware to save the `session` and `user` in a `context` and also add validations for every route.
 
 ```ts
 import { Hono } from "hono";
@@ -92,7 +92,7 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => {
 serve(app);
 ```
 
-This will allow you to access the user and session object in all of your routes.
+This will allow you to access the `user` and `session` object in all of your routes.
 
 ```ts
 app.get("/session", async (c) => {

--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -26,3 +26,81 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => {
 serve(app);
 ```
 
+### Cors
+
+To configure cors, you need to use the `cors` plugin from `hono/cors`.
+
+```ts
+import { Hono } from "hono";
+import { auth } from "./auth";
+import { serve } from "@hono/node-server";
+import { cors } from "hono/cors";
+ 
+const app = new Hono();
+
+app.use(
+	"/api/auth/**", // or replace with "*" to enable cors for all routes
+	cors({
+		origin: "http://localhost:3001", // replace with your origin
+		allowHeaders: ["Content-Type", "Authorization"],
+		allowMethods: ["POST", "GET", "OPTIONS"],
+		exposeHeaders: ["Content-Length"],
+		maxAge: 600,
+		credentials: true,
+	}),
+);
+
+```
+
+
+### Middleware
+
+You can add a middleware to save the session and user in a context.
+
+```ts
+import { Hono } from "hono";
+import { auth } from "./auth";
+import { serve } from "@hono/node-server";
+import { cors } from "hono/cors";
+ 
+const app = new Hono<{
+	Variables: {
+		user: auth.$Infer.Session.user | null;
+		session: auth.$Infer.Session.session | null
+	}
+}>();
+
+app.use("*", async (c, next) => {
+	const session = await auth.api.getSession({ headers: c.req.raw.headers });
+
+  	if (!session) {
+    	c.set("user", null);
+    	c.set("session", null);
+    	return next();
+  	}
+
+  	c.set("user", session.user);
+  	c.set("session", session.session);
+  	return next();
+});
+
+app.on(["POST", "GET"], "/api/auth/**", (c) => {
+	return auth.handler(c.req.raw);
+});
+
+
+serve(app);
+```
+
+This will allow you to access the user and session object in all of your routes.
+
+```ts
+app.get("/session", async (c) => {
+	const session = c.get("session")
+	const user = c.get("user")
+	
+	if(!user) return c.body(null, 401);
+
+  	return c.json(session, user);
+});
+```


### PR DESCRIPTION
- added guide for configuring a middleware to access `user` and `session` object in all routes to avoid using the `auth.api.getSession` everytime (this works with all type of validations also) in hono
- added guide on how to correctly configure CORS in Hono.