### PR TITLE
chore: add repo info to `package.json`

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -3,6 +3,11 @@
     "version": "0.4.7-beta.2",
     "description": "The most comprehensive authentication library for TypeScript.",
     "type": "module",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/better-auth/better-auth",
+		"directory": "packages/better-auth"
+	},
     "scripts": {
         "build": "NODE_OPTIONS='--max-old-space-size=4000' tsup --clean --dts",
         "dev": "NODE_OPTIONS='--max-old-space-size=4000' tsup --watch --sourcemap",


### PR DESCRIPTION
https://www.npmjs.com/package/better-auth doesn't link to the repo since the field is missing