### PR TITLE
docs: minor typo fix 

### DIFF
--- a/docs/content/docs/examples/svelte-kit.mdx
+++ b/docs/content/docs/examples/svelte-kit.mdx
@@ -10,7 +10,7 @@ Email & Password . <u>Social Sign-in with Google</u> . Passkeys . Email Verifica
 
 <ForkButton url="better-auth/better-auth/tree/main/examples/svelte-kit-example"  />
 
-<iframe src="https://stackblitz.com/github/better-auth/better-auth/tree/main/examples/svlte-kit-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
+<iframe src="https://stackblitz.com/github/better-auth/better-auth/tree/main/examples/svelte-kit-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
    style={{
       width: "100%",
       height: "500px",


### PR DESCRIPTION
Minor typo fix on the svelte-kit docs example
![image](https://github.com/user-attachments/assets/feaaf39b-f16f-47f3-9edd-b84febe4297e)