### PR TITLE
docs: fix typo in cookies.mdx

### DIFF
--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -9,7 +9,7 @@ Core Better Auth cookies like `session` and `csrf` will follow `betterauth.${coo
 
 All cookies are `httpOnly` and `secure` if the server is running in production mode.
 
-### Cross Subdomain Cookies (🧪 Expiremental)
+### Cross Subdomain Cookies (🧪 Experimental)
 
 Sometimes you may need to share cookies across subdomains. For example, if you have `app.example.com` and `example.com`, and if you authenticate on `example.com`, you may want to access the same session on `app.example.com`.
 


### PR DESCRIPTION
fix typo in cookies.mdx which said ¨expiremental¨ instead of ¨experimental¨

<img width="907" alt="image" src="https://github.com/user-attachments/assets/fda84c7c-e23e-4d5e-a585-779d12ae07cf">
