### PR TITLE
fix: csrf token verification

### DIFF
--- a/packages/better-auth/src/api/middlewares/csrf.ts
+++ b/packages/better-auth/src/api/middlewares/csrf.ts
@@ -44,7 +44,7 @@ export const csrfMiddleware = createAuthMiddleware(
 			!csrfCookie ||
 			!token ||
 			!hash ||
-			csrfCookie !== csrfToken
+			token !== csrfToken
 		) {
 			ctx.setCookie(ctx.context.authCookies.csrfToken.name, "", {
 				maxAge: 0,

--- a/packages/better-auth/src/api/routes/csrf.ts
+++ b/packages/better-auth/src/api/routes/csrf.ts
@@ -16,7 +16,7 @@ export const getCSRFToken = createAuthEndpoint(
 		);
 
 		if (csrfCookie) {
-			const [token, _] = csrfCookie?.split("!") || [null, null];
+			const [token, _] = csrfCookie.split("!") || [null, null];
 			return {
 				csrfToken: token,
 			};

--- a/packages/better-auth/src/api/routes/csrf.ts
+++ b/packages/better-auth/src/api/routes/csrf.ts
@@ -10,14 +10,15 @@ export const getCSRFToken = createAuthEndpoint(
 		metadata: HIDE_METADATA,
 	},
 	async (ctx) => {
-		const csrfToken = await ctx.getSignedCookie(
+		const csrfCookie = await ctx.getSignedCookie(
 			ctx.context.authCookies.csrfToken.name,
 			ctx.context.secret,
 		);
 
-		if (csrfToken) {
+		if (csrfCookie) {
+			const [token, _] = csrfCookie?.split("!") || [null, null];
 			return {
-				csrfToken,
+				csrfToken: token,
 			};
 		}
 


### PR DESCRIPTION
Current endpoint returns a token or a token with hash (current cookie). This leads to different csrf tokens being set on the client. Also the current middleware compares the current cookie (token + hash) with only the token (or token + hash if /csrf is called separately).

This pr aims to return the correct token on every `/csrf` call and to compare the correct tokens in the middleware