### PR TITLE
docs: link npm downloads to npm.chart.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
     <a href="https://github.com/better-auth/better-auth/issues">Issues</a>
   </p>
 
-[![npm](https://img.shields.io/npm/dm/better-auth)](https://www.npmjs.com/package/better-auth)
+[![npm](https://img.shields.io/npm/dm/better-auth)](https://npm.chart.dev/better-auth?primary=neutral&gray=neutral&theme=dark)
 [![npm version](https://img.shields.io/npm/v/better-auth.svg)](https://www.npmjs.com/package/better-auth)
 [![GitHub stars](https://img.shields.io/github/stars/better-auth/better-auth)](https://github.com/better-auth/better-auth/stargazers)
 </p>


### PR DESCRIPTION
Looks better for download badge: https://npm.chart.dev/better-auth?primary=neutral&gray=neutral&theme=dark