### PR TITLE
docs:fix: Fix error on type Session

### DIFF
--- a/docs/content/docs/concepts/typescript.mdx
+++ b/docs/content/docs/concepts/typescript.mdx
@@ -40,6 +40,8 @@ type Session = typeof auth.$Infer.Session
 Better Auth allows you to add additional fields to the user and session objects. All additional fields are properly inferred and available on the server and client side.
 
 ```ts twoslash
+// @noErrors
+
 import { betterAuth } from "better-auth"
 import Database from "better-sqlite3"
 
@@ -55,7 +57,7 @@ export const auth = betterAuth({
    
 })
 
-// type Session = typeof auth.$Infer.Session
+type Session = typeof auth.$Infer.Session
 ```
 
 In the example above, we added a `role` field to the user object. This field is now available on the `Session` type.

--- a/docs/content/docs/concepts/typescript.mdx
+++ b/docs/content/docs/concepts/typescript.mdx
@@ -9,8 +9,7 @@ Better Auth is designed to be type-safe. Both the client and server are built wi
 
 Both the client SDK and the server offer types that can be inferred using the `$Infer` property. Plugins can extend base types like `User` and `Session`, and you can use `$Infer` to infer these types. Additionally, plugins can provide extra types that can also be inferred through `$Infer`.
 
-```ts title="client.ts" twoslash
-// @noErrors
+```ts title="client.ts"
 import { createAuthClient } from "better-auth/client"
 
 const client = createAuthClient()
@@ -22,8 +21,7 @@ The `Session` type includes both `session` and `user` properties. The user prope
 
 You can also infer types on the server side.
 
-```ts title="auth.ts" twoslash
-// @noErrors
+```ts title="auth.ts"
 import { betterAuth } from "better-auth"
 import Database from "better-sqlite3"
 
@@ -39,8 +37,7 @@ type Session = typeof auth.$Infer.Session
 
 Better Auth allows you to add additional fields to the user and session objects. All additional fields are properly inferred and available on the server and client side.
 
-```ts twoslash
-// @noErrors
+```ts
 
 import { betterAuth } from "better-auth"
 import Database from "better-sqlite3"

--- a/docs/content/docs/concepts/typescript.mdx
+++ b/docs/content/docs/concepts/typescript.mdx
@@ -10,6 +10,7 @@ Better Auth is designed to be type-safe. Both the client and server are built wi
 Both the client SDK and the server offer types that can be inferred using the `$Infer` property. Plugins can extend base types like `User` and `Session`, and you can use `$Infer` to infer these types. Additionally, plugins can provide extra types that can also be inferred through `$Infer`.
 
 ```ts title="client.ts" twoslash
+// @noErrors
 import { createAuthClient } from "better-auth/client"
 
 const client = createAuthClient()
@@ -22,6 +23,7 @@ The `Session` type includes both `session` and `user` properties. The user prope
 You can also infer types on the server side.
 
 ```ts title="auth.ts" twoslash
+// @noErrors
 import { betterAuth } from "better-auth"
 import Database from "better-sqlite3"
 
@@ -53,7 +55,7 @@ export const auth = betterAuth({
    
 })
 
-type Session = typeof auth.$Infer.Session
+// type Session = typeof auth.$Infer.Session
 ```
 
 In the example above, we added a `role` field to the user object. This field is now available on the `Session` type.


### PR DESCRIPTION
since `createAuthClient()` and `betterAuth()`  do not have the required props, $Infer is breaking in the example. 

PS. I am not super-familiar with twoslash or fumadocs so forgive me if this is not the best approach to solve the issue.