### PR TITLE
feat: add 'where' clause support to add filters in the list users, admin plugin

### DIFF
--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -99,6 +99,7 @@ By default, 100 users are returned. You can adjust the limit and offset using th
 - `offset`: The number of users to skip.
 - `sortBy`: The field to sort the users by.
 - `sortDirection`: The direction to sort the users by. Defaults to `asc`.
+- `filter`: The filter to apply to the users. It can be an array of objects.
 
 ```ts title="admin.ts"
 const users = await authClient.admin.listUsers({
@@ -107,6 +108,13 @@ const users = await authClient.admin.listUsers({
         offset: 0,
         sortBy: "createdAt",
         sortDirection: "desc"
+        filter: [
+          {
+            field: "name",
+            operator: "eq",
+            value: "John",
+          }
+        ]
     }
 });
 ```

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthOptions } from "../types";
-import type { Adapter } from "../types/adapter";
+import type { Adapter, Where } from "../types/adapter";
 import { getDate } from "../utils/date";
 import { getAuthTables } from "./get-tables";
 import type { Account, Session, User, Verification } from "./schema";
@@ -84,12 +84,14 @@ export const createInternalAdapter = (
 				field: string;
 				direction: "asc" | "desc";
 			},
+			where?: Where[],
 		) => {
 			const users = await adapter.findMany<User>({
 				model: tables.user.tableName,
 				limit,
 				offset,
 				sortBy,
+				where,
 			});
 			return users;
 		},

--- a/packages/better-auth/src/plugins/admin/index.ts
+++ b/packages/better-auth/src/plugins/admin/index.ts
@@ -225,10 +225,10 @@ export const admin = (options?: AdminOptions) => {
 						offset: z.string().or(z.number()).optional(),
 						sortBy: z.string().optional(),
 						sortDirection: z.enum(["asc", "desc"]).optional(),
-						where: z.array(z.object({
+						filter: z.array(z.object({
 							field: z.string(),
 							value: z.string().or(z.number()).or(z.boolean()),
-							operator: z.enum(["eq", "ne", "gt", "lt", "gte", "lte"]),
+							operator: z.enum(["eq", "ne", "lt", "lte", "gt", "gte"]),
 							connector: z.enum(["AND", "OR"]).optional()
 						})).optional()
 					}),
@@ -243,7 +243,7 @@ export const admin = (options?: AdminOptions) => {
 									direction: ctx.query.sortDirection || "asc",
 								}
 							: undefined,
-						ctx.query?.where
+						ctx.query?.filter
 						
 					);
 					return ctx.json({

--- a/packages/better-auth/src/plugins/admin/index.ts
+++ b/packages/better-auth/src/plugins/admin/index.ts
@@ -225,6 +225,12 @@ export const admin = (options?: AdminOptions) => {
 						offset: z.string().or(z.number()).optional(),
 						sortBy: z.string().optional(),
 						sortDirection: z.enum(["asc", "desc"]).optional(),
+						where: z.array(z.object({
+							field: z.string(),
+							value: z.string().or(z.number()).or(z.boolean()),
+							operator: z.enum(["eq", "ne", "gt", "lt", "gte", "lte"]),
+							connector: z.enum(["AND", "OR"]).optional()
+						})).optional()
 					}),
 				},
 				async (ctx) => {
@@ -237,6 +243,8 @@ export const admin = (options?: AdminOptions) => {
 									direction: ctx.query.sortDirection || "asc",
 								}
 							: undefined,
+						ctx.query?.where
+						
 					);
 					return ctx.json({
 						users: users as UserWithRole[],


### PR DESCRIPTION
This PR is to add the option to filter the users in the function listUsers for the admin plugin.