### PR TITLE
docs: fix typo

### DIFF
--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -39,7 +39,7 @@ export const Navbar = () => {
 
 export const navMenu = [
 	{
-		name: "helo_",
+		name: "_hello",
 		path: "/",
 	},
 	{

--- a/docs/components/nav-mobile.tsx
+++ b/docs/components/nav-mobile.tsx
@@ -216,7 +216,7 @@ export const navMenu: {
 	}[];
 }[] = [
 	{
-		name: "_helo",
+		name: "_hello",
 		path: "/",
 	},
 


### PR DESCRIPTION
This assumes the navMenu item name for the root path was meant to be "hello" instead of "helo"

The navMenu item name for the root path contains incorrect spelling and inconsistent position of the underscore