### PR TITLE
fix: Update "Getting Session on a loader" example

### DIFF
--- a/docs/content/docs/integrations/svelte-kit.mdx
+++ b/docs/content/docs/integrations/svelte-kit.mdx
@@ -69,10 +69,11 @@ Some of the actions are reactive. The client use [nano-store](https://github.com
 
 ### Example: Getting Session on a loader
 
-```ts title="+page.ts"
+```ts title="+page.server.ts"
 import { auth } from "$lib/auth";
+import type { PageServerLoad } from "./$types";
 
-export async function load(request: Request) {
+export const load: PageServerLoad = async ({request}) => {
 	const session = await auth.api.getSession({
 		headers: request.headers,
 	});


### PR DESCRIPTION
In SvelteKit, load function in `+page.ts` (which runs on the client) doesn't have access to request object. The request object is only available in the load function inside `+page.server.ts` or `+layout.server.ts` (which run on the server)

I've also added appropriate `PageServerLoad` Type instead of generic `Request` Type.

:)