### PR TITLE
fix: baseUrl in vue client

### DIFF
--- a/packages/better-auth/src/client/vue.ts
+++ b/packages/better-auth/src/client/vue.ts
@@ -1,12 +1,18 @@
-import {useStore} from "@nanostores/vue";
-import type {DeepReadonly, Ref} from "vue";
-import {getClientConfig} from "./config";
-import {capitalizeFirstLetter} from "../utils/misc";
-import type {BetterAuthClientPlugin, ClientOptions, InferActions, InferClientAPI, IsSignal,} from "./types";
-import {createDynamicPathProxy} from "./proxy";
-import {getSessionAtom} from "./session-atom";
-import type {UnionToIntersection} from "../types/helper";
-import {getBaseURL} from "../utils/base-url";
+import { useStore } from "@nanostores/vue";
+import type { DeepReadonly, Ref } from "vue";
+import { getClientConfig } from "./config";
+import { capitalizeFirstLetter } from "../utils/misc";
+import type {
+	BetterAuthClientPlugin,
+	ClientOptions,
+	InferActions,
+	InferClientAPI,
+	IsSignal
+} from "./types";
+import { createDynamicPathProxy } from "./proxy";
+import { getSessionAtom } from "./session-atom";
+import type { UnionToIntersection } from "../types/helper";
+import { getBaseURL } from "../utils/base-url";
 
 function getAtomKey(str: string) {
 	return `use${capitalizeFirstLetter(str)}`;

--- a/packages/better-auth/src/client/vue.ts
+++ b/packages/better-auth/src/client/vue.ts
@@ -7,7 +7,7 @@ import type {
 	ClientOptions,
 	InferActions,
 	InferClientAPI,
-	IsSignal
+	IsSignal,
 } from "./types";
 import { createDynamicPathProxy } from "./proxy";
 import { getSessionAtom } from "./session-atom";
@@ -77,7 +77,9 @@ export function createAuthClient<Option extends ClientOptions>(
 	) {
 		if (useFetch) {
 			const ref = useStore(_sessionSignal);
-			const baseUrl = getBaseURL(options?.fetchOptions?.baseURL || options?.baseURL) ?? "/api/auth";
+			const baseUrl =
+				getBaseURL(options?.fetchOptions?.baseURL || options?.baseURL) ??
+				"/api/auth";
 			return useFetch(`${baseUrl}/session`, {
 				ref,
 			}).then((res: any) => {

--- a/packages/better-auth/src/client/vue.ts
+++ b/packages/better-auth/src/client/vue.ts
@@ -1,17 +1,12 @@
-import { useStore } from "@nanostores/vue";
-import type { DeepReadonly, Ref } from "vue";
-import { getClientConfig } from "./config";
-import { capitalizeFirstLetter } from "../utils/misc";
-import type {
-	BetterAuthClientPlugin,
-	ClientOptions,
-	InferActions,
-	InferClientAPI,
-	IsSignal,
-} from "./types";
-import { createDynamicPathProxy } from "./proxy";
-import { getSessionAtom } from "./session-atom";
-import type { UnionToIntersection } from "../types/helper";
+import {useStore} from "@nanostores/vue";
+import type {DeepReadonly, Ref} from "vue";
+import {getClientConfig} from "./config";
+import {capitalizeFirstLetter} from "../utils/misc";
+import type {BetterAuthClientPlugin, ClientOptions, InferActions, InferClientAPI, IsSignal,} from "./types";
+import {createDynamicPathProxy} from "./proxy";
+import {getSessionAtom} from "./session-atom";
+import type {UnionToIntersection} from "../types/helper";
+import {getBaseURL} from "../utils/base-url";
 
 function getAtomKey(str: string) {
 	return `use${capitalizeFirstLetter(str)}`;
@@ -76,10 +71,8 @@ export function createAuthClient<Option extends ClientOptions>(
 	) {
 		if (useFetch) {
 			const ref = useStore(_sessionSignal);
-			const basePath = options?.baseURL
-				? new URL(options.baseURL).pathname
-				: "/api/auth";
-			const session = useFetch(`${basePath}/session`, {
+			const baseUrl = getBaseURL(options?.fetchOptions?.baseURL || options?.baseURL) ?? "/api/auth";
+			return useFetch(`${baseUrl}/session`, {
 				ref,
 			}).then((res: any) => {
 				return {
@@ -88,7 +81,6 @@ export function createAuthClient<Option extends ClientOptions>(
 					error: res.error,
 				};
 			});
-			return session;
 		}
 		return useStoreSession();
 	}


### PR DESCRIPTION
When an explicit baseUrl is defined in the client like shown in the docs. The website will throw following error since it currently tries to call //session.

Error thrown:
`[nuxt] [useFetch] the request URL must not start with "//".`

This pr uses the already implemented `getBaseURL` function which is used in other api calls as well, though it will still fallback to /api/auth in edge cases. 