### PR TITLE
fix: nuxt internal fetch url

### DIFF
--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -41,7 +41,7 @@ export const authClient = createAuthClient({
 ```
 
 Once you have created the client, you can use it to sign up, sign in, and perform other actions.
-Some of the actinos are reactive.
+Some of the actions are reactive.
 
 ### Example usage
 
@@ -72,9 +72,11 @@ const session = authClient.useSession()
 
 If you are using Nuxt with SSR, you can use the `useSession` function in the `setup` function of your page component and pass `useFetch` to make it work with SSR.
 
+Note that you cannot pass a `baseURL` or `fetchOptions.baseURL` to the client while using the same nuxt app as a backend since it will throw a 401 on request using the complete url.
+
 ```vue title="index.vue"
 <script setup lang="ts">
-import { authClient } from "~/lib/auth-clietn";
+import { authClient } from "~/lib/auth-client";
 
 const { data: session } = authClient.useSession(useFetch);
 </script>

--- a/examples/nuxt-example/lib/auth-client.ts
+++ b/examples/nuxt-example/lib/auth-client.ts
@@ -1,8 +1,6 @@
 import { createAuthClient } from "better-auth/vue";
 
-export const authClient = createAuthClient({
-	baseURL: "http://localhost:3000",
-});
+export const authClient = createAuthClient();
 
 export const {
 	signIn,

--- a/packages/better-auth/src/client/vue.ts
+++ b/packages/better-auth/src/client/vue.ts
@@ -12,7 +12,6 @@ import type {
 import { createDynamicPathProxy } from "./proxy";
 import { getSessionAtom } from "./session-atom";
 import type { UnionToIntersection } from "../types/helper";
-import { getBaseURL } from "../utils/base-url";
 
 function getAtomKey(str: string) {
 	return `use${capitalizeFirstLetter(str)}`;
@@ -77,10 +76,12 @@ export function createAuthClient<Option extends ClientOptions>(
 	) {
 		if (useFetch) {
 			const ref = useStore(_sessionSignal);
-			const baseUrl =
-				getBaseURL(options?.fetchOptions?.baseURL || options?.baseURL) ??
-				"/api/auth";
-			return useFetch(`${baseUrl}/session`, {
+			const baseURL = options?.fetchOptions?.baseURL || options?.baseURL;
+			const calculatedURL =
+				baseURL && baseURL.endsWith("/")
+					? baseURL.slice(0, baseURL.length - 1)
+					: (baseURL ?? "") + "/auth/api";
+			return useFetch(`${calculatedURL}/session`, {
 				ref,
 			}).then((res: any) => {
 				return {


### PR DESCRIPTION
nuxt doesn't allow to fetch internal api using the complete url when rendering on the server.

This pr allows to still have a decoupled backend or a fullstack nuxt app.