### PR TITLE
fix: typo in api call

### DIFF
--- a/packages/better-auth/src/client/vue.ts
+++ b/packages/better-auth/src/client/vue.ts
@@ -80,7 +80,7 @@ export function createAuthClient<Option extends ClientOptions>(
 			const calculatedURL =
 				baseURL && baseURL.endsWith("/")
 					? baseURL.slice(0, baseURL.length - 1)
-					: (baseURL ?? "") + "/auth/api";
+					: (baseURL ?? "") + "/api/auth";
 			return useFetch(`${calculatedURL}/session`, {
 				ref,
 			}).then((res: any) => {


### PR DESCRIPTION
fix wrong order in fetch url

/auth/api -> /api/auth