### PR TITLE
Fix Next headers import

### DIFF
--- a/docs/content/docs/concepts/api.mdx
+++ b/docs/content/docs/concepts/api.mdx
@@ -13,7 +13,7 @@ To call an API endpoint on the server, import your `auth` instance and call the 
 
 ```ts title="server.ts"
 import { betterAuth } from "better-auth";
-import { headers } from "next/server";
+import { headers } from "next/headers";
 
 export const auth = betterAuth({
     //...


### PR DESCRIPTION
The `headers` in the Next.js comes from `next/headers` instead of `next/server`. Here's the [doc](https://nextjs.org/docs/app/api-reference/functions/headers#headers) as a reference