### PR TITLE
Added the Key ID in the token header

### DIFF
--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -174,6 +174,7 @@ export const jwt = (options?: JwtOptions) => {
 					})
 						.setProtectedHeader({
 							alg: options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
+							kid: key.id,
 						})
 						.setIssuedAt()
 						.setIssuer(options?.jwt?.issuer ?? ctx.context.options.baseURL!)


### PR DESCRIPTION
I noticed that I forgot to add the ID of the key that got used to sign the token in the header. 