### PR TITLE
Use `await` in the `next/headers` to prevent errors

### DIFF
--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -285,7 +285,7 @@ The server provides a `session` object that you can use to access the session da
     import { headers } from "next/headers";
 
     const session = await auth.api.getSession({
-        headers: headers() // you need to pass the headers object.
+        headers: await headers() // you need to pass the headers object.
     })
     ```
     </Tab>


### PR DESCRIPTION
We need to use `await` on the `next/headers` since `headers()` returns a promise. Directly accessing it shows an error in the console.

```bash
Error: In route / a header property was accessed directly with `headers().get('cookie')`. `headers()` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
```