### PR TITLE
remove unused github import line

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -206,7 +206,6 @@ Configure the authentication methods you want to use. Better Auth comes with bui
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"
-import { github } from "better-auth/social-providers"
 
 export const auth = betterAuth({
     //...other options


### PR DESCRIPTION
removed 
import { github } from "better-auth/social-providers"

from the example because its unused