### PR TITLE
docs: fix typo issue

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -90,7 +90,7 @@ The Prisma adapter expects a prisma client instance and a provider key that spec
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
-import { PrismaAdapter } from "better-auth/adapters/prisma";
+import { prismaAdapter } from "better-auth/adapters/prisma";
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();


### PR DESCRIPTION
Fixed the library name typo issue that confused users, ensuring that any other imports in the documentation are clear for them to understand.