### PR TITLE
enhance alias path resolution

### DIFF
--- a/packages/cli/test/getConfig.test.ts
+++ b/packages/cli/test/getConfig.test.ts
@@ -1,0 +1,313 @@
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+
+import {test} from "vitest";
+import os from "node:os";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {getConfig} from "../src/utils/get-config";
+
+interface TmpDirFixture {
+	tmpdir: string;
+}
+
+async function createTempDir() {
+	const tmpdir = path.join(process.cwd(), 'test', "getConfig_test-");
+	return await fs.mkdtemp(tmpdir);
+}
+
+export const tmpdirTest = test.extend<TmpDirFixture>({
+	tmpdir: async ({}, use) => {
+		const directory = await createTempDir();
+
+		await use(directory);
+
+		await fs.rm(directory, {recursive: true});
+	},
+});
+
+let tmpDir = '.';
+
+describe("getConfig", async () => {
+	beforeEach(async () => {
+		const tmp = path.join(process.cwd(), "getConfig_test-");
+		tmpDir = await fs.mkdtemp(tmp);
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, {recursive: true});
+	})
+
+	it("should resolve resolver type alias", async () => {
+		const authPath = path.join(tmpDir, 'server', 'auth');
+		const dbPath = path.join(tmpDir, 'server', 'db');
+		await fs.mkdir(authPath, {recursive: true});
+		await fs.mkdir(dbPath, {recursive: true});
+
+		//create dummy tsconfig.json
+		await fs.writeFile(path.join(tmpDir, "tsconfig.json"),
+			`{
+              "compilerOptions": {
+                /* Path Aliases */
+                "baseUrl": ".",
+                "paths": {
+                  "@server/*": ["./server/*"]
+                }
+              }
+					}`);
+
+		//create dummy auth.ts
+		await fs.writeFile(path.join(authPath, "auth.ts"),
+			`import {betterAuth} from "better-auth";
+			 import {prismaAdapter} from "better-auth/adapters/prisma";			
+			 import {db} from "@server/db/db";
+
+			 export const auth = betterAuth({
+					database: prismaAdapter(db, {
+							provider: 'sqlite'
+					}),
+					emailAndPassword: {
+						enabled: true,
+					}
+			 })`);
+
+		//create dummy db.ts
+		await fs.writeFile(path.join(dbPath, "db.ts"),
+			`class PrismaClient {
+				constructor() {}
+			}
+			
+			export const db = new PrismaClient()`);
+
+		const config = await getConfig({cwd: tmpDir, configPath: 'server/auth/auth.ts'})
+
+		expect(config).not.toBe(null);
+	});
+
+	it("should resolve direct alias", async () => {
+		const authPath = path.join(tmpDir, 'server', 'auth');
+		const dbPath = path.join(tmpDir, 'server', 'db');
+		await fs.mkdir(authPath, {recursive: true});
+		await fs.mkdir(dbPath, {recursive: true});
+
+		//create dummy tsconfig.json
+		await fs.writeFile(path.join(tmpDir, "tsconfig.json"),
+			`{
+              "compilerOptions": {
+                /* Path Aliases */
+                "baseUrl": ".",
+                "paths": {
+                  "prismaDbClient": ["./server/db/db"]
+                }
+              }
+					}`);
+
+		//create dummy auth.ts
+		await fs.writeFile(path.join(authPath, "auth.ts"),
+			`import {betterAuth} from "better-auth";
+			 import {prismaAdapter} from "better-auth/adapters/prisma";			
+			 import {db} from "prismaDbClient";
+
+			 export const auth = betterAuth({
+					database: prismaAdapter(db, {
+							provider: 'sqlite'
+					}),
+					emailAndPassword: {
+						enabled: true,
+					}
+			 })`);
+
+		//create dummy db.ts
+		await fs.writeFile(path.join(dbPath, "db.ts"),
+			`class PrismaClient {
+				constructor() {}
+			}
+			
+			export const db = new PrismaClient()`);
+
+		const config = await getConfig({cwd: tmpDir, configPath: 'server/auth/auth.ts'})
+
+		expect(config).not.toBe(null);
+	});
+
+	it("should resolve resolver type alias with relative path", async () => {
+		const authPath = path.join(tmpDir, 'test','server', 'auth');
+		const dbPath = path.join(tmpDir, 'test','server', 'db');
+		await fs.mkdir(authPath, {recursive: true});
+		await fs.mkdir(dbPath, {recursive: true});
+
+		//create dummy tsconfig.json
+		await fs.writeFile(path.join(tmpDir, "tsconfig.json"),
+			`{
+              "compilerOptions": {
+                /* Path Aliases */
+                "baseUrl": "./test",
+                "paths": {
+                  "@server/*": ["./server/*"]
+                }
+              }
+					}`);
+
+		//create dummy auth.ts
+		await fs.writeFile(path.join(authPath, "auth.ts"),
+			`import {betterAuth} from "better-auth";
+			 import {prismaAdapter} from "better-auth/adapters/prisma";			
+			 import {db} from "@server/db/db";
+
+			 export const auth = betterAuth({
+					database: prismaAdapter(db, {
+							provider: 'sqlite'
+					}),
+					emailAndPassword: {
+						enabled: true,
+					}
+			 })`);
+
+		//create dummy db.ts
+		await fs.writeFile(path.join(dbPath, "db.ts"),
+			`class PrismaClient {
+				constructor() {}
+			}
+			
+			export const db = new PrismaClient()`);
+
+		const config = await getConfig({cwd: tmpDir, configPath: 'test/server/auth/auth.ts'})
+
+		expect(config).not.toBe(null);
+	});
+
+	it("should resolve direct alias with relative path", async () => {
+		const authPath = path.join(tmpDir, 'test','server', 'auth');
+		const dbPath = path.join(tmpDir, 'test','server', 'db');
+		await fs.mkdir(authPath, {recursive: true});
+		await fs.mkdir(dbPath, {recursive: true});
+
+		//create dummy tsconfig.json
+		await fs.writeFile(path.join(tmpDir, "tsconfig.json"),
+			`{
+              "compilerOptions": {
+                /* Path Aliases */
+                "baseUrl": "./test",
+                "paths": {
+                  "prismaDbClient": ["./server/db/db"]
+                }
+              }
+					}`);
+
+		//create dummy auth.ts
+		await fs.writeFile(path.join(authPath, "auth.ts"),
+			`import {betterAuth} from "better-auth";
+			 import {prismaAdapter} from "better-auth/adapters/prisma";			
+			 import {db} from "prismaDbClient";
+
+			 export const auth = betterAuth({
+					database: prismaAdapter(db, {
+							provider: 'sqlite'
+					}),
+					emailAndPassword: {
+						enabled: true,
+					}
+			 })`);
+
+		//create dummy db.ts
+		await fs.writeFile(path.join(dbPath, "db.ts"),
+			`class PrismaClient {
+				constructor() {}
+			}
+			
+			export const db = new PrismaClient()`);
+
+		const config = await getConfig({cwd: tmpDir, configPath: 'test/server/auth/auth.ts'})
+
+		expect(config).not.toBe(null);
+	});
+
+	it("should resolve with relative import", async () => {
+		const authPath = path.join(tmpDir, 'test','server', 'auth');
+		const dbPath = path.join(tmpDir, 'test','server', 'db');
+		await fs.mkdir(authPath, {recursive: true});
+		await fs.mkdir(dbPath, {recursive: true});
+
+		//create dummy tsconfig.json
+		await fs.writeFile(path.join(tmpDir, "tsconfig.json"),
+			`{
+              "compilerOptions": {
+                /* Path Aliases */
+                "baseUrl": "./test",
+                "paths": {
+                  "prismaDbClient": ["./server/db/db"]
+                }
+              }
+					}`);
+
+		//create dummy auth.ts
+		await fs.writeFile(path.join(authPath, "auth.ts"),
+			`import {betterAuth} from "better-auth";
+			 import {prismaAdapter} from "better-auth/adapters/prisma";			
+			 import {db} from "../db/db";
+
+			 export const auth = betterAuth({
+					database: prismaAdapter(db, {
+							provider: 'sqlite'
+					}),
+					emailAndPassword: {
+						enabled: true,
+					}
+			 })`);
+
+		//create dummy db.ts
+		await fs.writeFile(path.join(dbPath, "db.ts"),
+			`class PrismaClient {
+				constructor() {}
+			}
+			
+			export const db = new PrismaClient()`);
+
+		const config = await getConfig({cwd: tmpDir, configPath: 'test/server/auth/auth.ts'})
+
+		expect(config).not.toBe(null);
+	});
+
+	it("should error with invalid alias", async () => {
+		const authPath = path.join(tmpDir, 'server', 'auth');
+		const dbPath = path.join(tmpDir, 'server', 'db');
+		await fs.mkdir(authPath, {recursive: true});
+		await fs.mkdir(dbPath, {recursive: true});
+
+		//create dummy tsconfig.json
+		await fs.writeFile(path.join(tmpDir, "tsconfig.json"),
+			`{
+              "compilerOptions": {
+                /* Path Aliases */
+                "baseUrl": ".",
+                "paths": {
+                  "@server/*": ["./PathIsInvalid/*"]
+                }
+              }
+					}`);
+
+		//create dummy auth.ts
+		await fs.writeFile(path.join(authPath, "auth.ts"),
+			`import {betterAuth} from "better-auth";
+			 import {prismaAdapter} from "better-auth/adapters/prisma";			
+			 import {db} from "@server/db/db";
+
+			 export const auth = betterAuth({
+					database: prismaAdapter(db, {
+							provider: 'sqlite'
+					}),
+					emailAndPassword: {
+						enabled: true,
+					}
+			 })`);
+
+		//create dummy db.ts
+		await fs.writeFile(path.join(dbPath, "db.ts"),
+			`class PrismaClient {
+				constructor() {}
+			}
+			
+			export const db = new PrismaClient()`);
+
+		await expect(() => getConfig({cwd: tmpDir, configPath: 'server/auth/auth.ts'})).rejects.toThrowError();
+	});
+})


### PR DESCRIPTION
this pull request resolves #343 through:
 
1) calculating the resolved base url by extracting it from tsconfig and joining to the cwd that is at the root of the tsconfig file. the baseUrl is relative to the tsconfig file.
2) checking if the alias and/or alias path is of a resolver type or a direct alias to a file
3) since the alias paths is relative to the base url the resulting path is the path join of the resolvedBaseUrl and the alias path
4) ensure the full alias is used.