### PR TITLE
[docs] Update `basic-usage.mdx`

### DIFF
--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -82,6 +82,20 @@ export default function SignUp() {
 }
 ```
 
+By default, the user is automatically logged in after signing up. This behaviour can be changed by configuring your `auth-config`
+
+```js
+import { betterAuth } from "better-auth"
+
+export const auth = betterAuth({
+    //...rest of the options
+    emailAndPassword: {
+    	enabled: true,
+    	autoSignIn: false //defaults to true // [!code highlight]
+  },
+})
+```
+
 ### Signin
 
 To signin a user, you can use the `signIn.email` function provided by the client. The `signIn` function takes an object with the following properties:

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -51,6 +51,11 @@ List of all the available options for configuring Better Auth.
       type: 'boolean',
       default: false,
     },
+    autoSignIn: {
+      description: "Automatically login after successfull signup",
+      type: 'boolean',
+      default: true,
+    },
     minPasswordLength: {
       description: "Minimum length of the password.",
         type: 'number',


### PR DESCRIPTION
By default, `email.signUp` will automatically log the user in upon a successful signup. Make this known in the docs and show them that this behaviour can be changed