### PR TITLE
Fixed: MongoDB Adapter Docs

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -153,8 +153,10 @@ import { mongodbAdapter } from "better-auth/adapters/mongodb";
 
 const client = new MongoClient("mongodb://localhost:27017");
 
+const db = client.db()
+
 export const auth = betterAuth({
-    database: mongodbAdapter(client)
+    database: mongodbAdapter(db)
 })
 ```
 


### PR DESCRIPTION
In the example given in docs the the mongo client is passed directly passed to the mongodbAdapter, which is not working it should be db from mongo client 

Reading the whole code now, willing to contribute to code as well

This got me into reading the source code to get working,