### PR TITLE
fix: remove callback url from endpoints that doesn't necessarily need it

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -58,6 +58,7 @@ To signin a user, you can use the `signIn.email` function provided by the client
 - `email`: The email address of the user.
 - `password`: The password of the user.
 - `dontRememberMe`: If true, the user will be signed out when the browser is closed. (optional)
+- `callbackURL`: The URL to redirect to after the user signs in. (optional)
 
 ```ts title="client.ts"
 const { data, error } = await authClient.signIn.email({

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -41,7 +41,6 @@ To signup a user, you can use the `signUp.email` function provided by the client
 - `password`: The password of the user. It should be at least 8 characters long and max 32 by default.
 - `name`: The name of the user.
 - `image`: The image of the user. (optional)
-- `callbackURL`: The url to redirect to after the user has signed up. (optional)
 
 ```ts title="client.ts"
 const { data, error } = await authClient.signUp.email({
@@ -49,7 +48,6 @@ const { data, error } = await authClient.signUp.email({
   password: "password1234",
   name: "test",
   image: "https://example.com/image.png",
-  callbackURL: "/",
 });
 ```
 
@@ -59,14 +57,12 @@ To signin a user, you can use the `signIn.email` function provided by the client
 
 - `email`: The email address of the user.
 - `password`: The password of the user.
-- `callbackURL`: The url to redirect to after the user has signed in. (optional)
 - `dontRememberMe`: If true, the user will be signed out when the browser is closed. (optional)
 
 ```ts title="client.ts"
 const { data, error } = await authClient.signIn.email({
   email: "test@example.com",
   password: "password1234",
-  callbackURL: "/",
 });
 ```
 
@@ -76,6 +72,18 @@ To signout a user, you can use the `signOut` function provided by the client.
 
 ```ts title="client.ts"
 await client.signOut();
+```
+
+you can pass `fetchOptions` to redirect onSuccess
+  
+```ts title="client.ts" 
+await client.signOut({
+  fetchOptions: {
+    onSuccess: () => {
+      router.push("/login"); // redirect to login page
+    },
+  },
+});
 ```
 
 ### Email Verification

--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -192,6 +192,26 @@ export default {
 </template>
 ```
 
+## Signout
+
+To signout a user, you can use the `signOut` function provided by the client.
+
+```ts title="user-card.tsx"
+await authClient.signOut();
+```
+
+you can pass `fetchOptions` to redirect onSuccess
+  
+```ts title="user-card.tsx" 
+await authClient.signOut({
+  fetchOptions: {
+    onSuccess: () => {
+      router.push("/login"); // redirect to login page
+    },
+  },
+});
+```
+
 ## Session Management
 
 Once a user is signed in, you'll want to access their session. Better Auth allows you easily to access the session data from the server and client side.

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -94,7 +94,6 @@ export const signInEmail = createAuthEndpoint(
 		body: z.object({
 			email: z.string(),
 			password: z.string(),
-			callbackURL: z.string().optional(),
 			/**
 			 * If this is true the session will only be valid for the current browser session
 			 * @default false
@@ -216,8 +215,6 @@ export const signInEmail = createAuthEndpoint(
 		return ctx.json({
 			user: user.user,
 			session,
-			redirect: !!ctx.body.callbackURL,
-			url: ctx.body.callbackURL,
 		});
 	},
 );

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -94,6 +94,7 @@ export const signInEmail = createAuthEndpoint(
 		body: z.object({
 			email: z.string(),
 			password: z.string(),
+			callbackURL: z.string().optional(),
 			/**
 			 * If this is true the session will only be valid for the current browser session
 			 * @default false
@@ -215,6 +216,8 @@ export const signInEmail = createAuthEndpoint(
 		return ctx.json({
 			user: user.user,
 			session,
+			redirect: !!ctx.body.callbackURL,
+			url: ctx.body.callbackURL,
 		});
 	},
 );

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -29,7 +29,6 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				name: ZodString;
 				email: ZodString;
 				password: ZodString;
-				callbackURL: ZodOptional<ZodString>;
 			}> &
 				toZod<AdditionalUserFieldsInput<O>>,
 		},
@@ -172,22 +171,9 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				session,
 				user: createdUser,
 			});
-			return ctx.json(
-				{
-					user: createdUser as InferUser<O>,
-					session: session as InferSession<O>,
-				},
-				{
-					body: body.callbackURL
-						? {
-								url: body.callbackURL,
-								redirect: true,
-							}
-						: {
-								user: createdUser,
-								session,
-							},
-				},
-			);
+			return ctx.json({
+				user: createdUser as InferUser<O>,
+				session: session as InferSession<O>,
+			});
 		},
 	);


### PR DESCRIPTION
redirection should be handled on the frontend by the user for endpoints that don't require a callback URL to function. This pr remove callback url from endpoints that doesn't need it