### PR TITLE
docs: make middleware example copy&pasteable

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -90,9 +90,9 @@ We're using `better-fetch` to make the request to the API route. You can use any
 
 ```ts
 import { betterFetch } from "@better-fetch/fetch";
-import { NextRequest, NextResponse } from "next/server";
-import type { Session } from "./lib/auth-types";
-
+import type { Session } from "better-auth/types";
+import { NextResponse, type NextRequest } from "next/server";
+ 
 export default async function authMiddleware(request: NextRequest) {
 	const { data: session } = await betterFetch<Session>(
 		"/api/auth/get-session",
@@ -104,13 +104,13 @@ export default async function authMiddleware(request: NextRequest) {
 			},
 		},
 	);
-
+ 
 	if (!session) {
-		return NextResponse.redirect(new URL("/", request.url));
+		return NextResponse.redirect(new URL("/sign-in", request.url));
 	}
 	return NextResponse.next();
 }
-
+ 
 export const config = {
 	matcher: ["/dashboard"],
 };


### PR DESCRIPTION
replaced the custom file which is not present by default to make the middleware easier to set up