### PR TITLE
docs: Fix typo in 'trustedOrigins' heading

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -235,7 +235,7 @@ const auth = betterAuth({
     }}
 />
 
-### `trustedOrignins`
+### `trustedOrigins`
 
 list of trusted origins. This is very important to prevent CSRF attacks and open redirects.
 


### PR DESCRIPTION
This fixes a small typo in the `options` docs