### PR TITLE
docs: Remove the double space in the Vanilla create client instance on the installation page

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -397,7 +397,7 @@ If you're using a different base path other than `/api/auth` make sure to pass t
   "vanilla"]} defaultValue="react">
     <Tab value="vanilla">
             ```ts  title="lib/auth-client.ts"
-            import { createAuthClient } from  "better-auth/client"
+            import { createAuthClient } from "better-auth/client"
             export const authClient = createAuthClient({
                 baseURL: "http://localhost:3000" // the base url of your auth server // [!code highlight]
             })


### PR DESCRIPTION
This commit removes a double space in the Vanilla create client instance section of the installation page.