### PR TITLE
fix: onRequest callback not interrupting requests

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -245,8 +245,8 @@ export const router = <C extends AuthContext, Option extends BetterAuthOptions>(
 			for (const plugin of ctx.options.plugins || []) {
 				if (plugin.onRequest) {
 					const response = await plugin.onRequest(req, ctx);
-					if (response) {
-						return response;
+					if (response && 'response' in response) {
+						return response.response
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #395 

The response type coming back from `plugin.onRequest(req, ctx)` is 
```ts
const response: void | {
    response: Response;
} | {
    request: Request;
}
```

I suspect that because of that union type, we were returning `response` although it is not an actual Fetch Response. For this reason, the request was actually not interrupted.

This fix is a pretty simple solution, I also considered using a type guard, let me know what you think :) 
```ts
function hasResponseInterruptor(response: void | { response: Response } | { request: Request }): response is { response: Response } {
	return response !== undefined && typeof response === 'object' && 'response' in response;
}
```