### PR TITLE
fix: magic links sent to unregistered emails when disabled sign up

### DIFF
--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -55,6 +55,17 @@ export const magicLink = (options: MagicLinkOptions) => {
 				},
 				async (ctx) => {
 					const { email } = ctx.body;
+
+					if (options.disableSignUp) {
+						const user = await ctx.context.internalAdapter.findUserByEmail(email)
+
+						if (!user) {
+							throw new APIError("USER_NOT_FOUND", {
+								message: "User not found"
+							});
+						}
+					}
+					
 					const verificationToken = generateRandomString(
 						32,
 						alphabet("a-z", "A-Z"),

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -57,7 +57,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					const { email } = ctx.body;
 
 					if (options.disableSignUp) {
-						const user = await ctx.context.internalAdapter.findUserByEmail(email)
+						const user = await ctx.context.internalAdapter.findUserByEmail(email);
 
 						if (!user) {
 							throw new APIError("USER_NOT_FOUND", {

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -60,7 +60,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 						const user = await ctx.context.internalAdapter.findUserByEmail(email);
 
 						if (!user) {
-							throw new APIError("USER_NOT_FOUND", {
+							throw new APIError("BAD_REQUEST", {
 								message: "User not found"
 							});
 						}


### PR DESCRIPTION
As of right right now, we have to do something like this:
```ts
export const auth = betterAuth({
	// ...database
	plugins: [
		magicLink({
			disableSignUp: true,
			sendMagicLink: async (data: {
				email: string
				token: string
				url: string
			}) => {
				const isSignedUp =
					(await db.user.count({
						where: {
							email: data.email
						}
					})) > 0

				if (!isSignedUp) {
					throw new Error('User not found')
				}

				// ...send magic link to email
			}
		})
	]
})
```
but it brings some flaws with it. We are not able to provide an accurate error message to the client, because an `INTERNAL_SERVER_ERROR` is thrown.

With the commited adjustments an `USER_NOT_FOUND` error is thrown when a user isn't registered and disableSignUp is set to true. This allows us to provide a more detailed error message to the client.