### PR TITLE
Add object type support for database field

### DIFF
--- a/packages/better-auth/src/db/field.ts
+++ b/packages/better-auth/src/db/field.ts
@@ -6,6 +6,7 @@ export type FieldType =
 	| "number"
 	| "boolean"
 	| "date"
+	| "object"
 	| `${"string" | "number"}[]`;
 
 export type FieldAttributeConfig<T extends FieldType = FieldType> = {
@@ -102,11 +103,13 @@ export type InferValueType<T extends FieldType> = T extends "string"
 		? number
 		: T extends "boolean"
 			? boolean
-			: T extends `${infer T}[]`
-				? T extends "string"
-					? string[]
-					: number[]
-				: never;
+			: T extends "object"
+				? Record<string, any>
+				: T extends `${infer T}[]`
+					? T extends "string"
+						? string[]
+						: number[]
+					: never;
 
 export type InferFieldsOutput<Field> = Field extends Record<
 	infer Key,

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -68,8 +68,15 @@ export function matchType(
 	fieldType: FieldType,
 	dbType: KyselyDatabaseType,
 ) {
-	if (fieldType === "string[]" || fieldType === "number[]" || fieldType === "object") {
-		return columnDataType.toLowerCase().includes("json") || columnDataType.toLowerCase() === "text";
+	if (
+		fieldType === "string[]" ||
+		fieldType === "number[]" ||
+		fieldType === "object"
+	) {
+		return (
+			columnDataType.toLowerCase().includes("json") ||
+			columnDataType.toLowerCase() === "text"
+		);
 	}
 	const types = map[dbType];
 	const type = types[fieldType].map((t) => t.toLowerCase());
@@ -176,7 +183,10 @@ export async function getMigrations(config: BetterAuthOptions) {
 		if (dbType === "mysql" && type === "string") {
 			return "varchar(255)";
 		}
-		if (dbType === "sqlite" && (type === "string[]" || type === "number[]" || type === "object")) {
+		if (
+			dbType === "sqlite" &&
+			(type === "string[]" || type === "number[]" || type === "object")
+		) {
 			return "text";
 		}
 		if (type === "string[]" || type === "number[]") {

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -22,6 +22,7 @@ const postgresMap = {
 	],
 	boolean: ["bool", "boolean"],
 	date: ["timestamp", "date"],
+	object: ["json", "jsonb"],
 };
 const mysqlMap = {
 	string: ["varchar", "text"],
@@ -36,6 +37,7 @@ const mysqlMap = {
 	],
 	boolean: ["boolean"],
 	date: ["datetime", "date"],
+	object: ["json"],
 };
 
 const sqliteMap = {
@@ -43,6 +45,7 @@ const sqliteMap = {
 	number: ["INTEGER", "REAL"],
 	boolean: ["INTEGER", "BOOLEAN"], // 0 or 1
 	date: ["DATE", "INTEGER"],
+	object: ["TEXT"],
 };
 
 const mssqlMap = {
@@ -50,6 +53,7 @@ const mssqlMap = {
 	number: ["int", "bigint", "smallint", "decimal", "float", "double"],
 	boolean: ["bit", "boolean"],
 	date: ["datetime", "date"],
+	object: ["nvarchar(max)", "json"],
 };
 
 const map = {
@@ -64,8 +68,8 @@ export function matchType(
 	fieldType: FieldType,
 	dbType: KyselyDatabaseType,
 ) {
-	if (fieldType === "string[]" || fieldType === "number[]") {
-		return columnDataType.toLowerCase().includes("json");
+	if (fieldType === "string[]" || fieldType === "number[]" || fieldType === "object") {
+		return columnDataType.toLowerCase().includes("json") || columnDataType.toLowerCase() === "text";
 	}
 	const types = map[dbType];
 	const type = types[fieldType].map((t) => t.toLowerCase());
@@ -167,11 +171,12 @@ export async function getMigrations(config: BetterAuthOptions) {
 			boolean: "boolean",
 			number: "integer",
 			date: "date",
+			object: "jsonb",
 		} as const;
 		if (dbType === "mysql" && type === "string") {
 			return "varchar(255)";
 		}
-		if (dbType === "sqlite" && (type === "string[]" || type === "number[]")) {
+		if (dbType === "sqlite" && (type === "string[]" || type === "number[]" || type === "object")) {
 			return "text";
 		}
 		if (type === "string[]" || type === "number[]") {

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -14,9 +14,10 @@ export function toZodSchema(fields: Record<string, FieldAttribute>) {
 					[key]: z.array(field.type === "string[]" ? z.string() : z.number()),
 				};
 			}
-			let schema: ZodSchema = field.type === "object" 
-				? z.record(z.string(), z.any())
-				: z[field.type]();
+			let schema: ZodSchema =
+				field.type === "object"
+					? z.record(z.string(), z.any())
+					: z[field.type]();
 			if (field?.required === false) {
 				schema = schema.optional();
 			}

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -14,7 +14,9 @@ export function toZodSchema(fields: Record<string, FieldAttribute>) {
 					[key]: z.array(field.type === "string[]" ? z.string() : z.number()),
 				};
 			}
-			let schema: ZodSchema = z[field.type]();
+			let schema: ZodSchema = field.type === "object" 
+				? z.record(z.string(), z.any())
+				: z[field.type]();
 			if (field?.required === false) {
 				schema = schema.optional();
 			}


### PR DESCRIPTION
## Overview
This PR adds support for storing object type fields in the database across different database engines. It is useful for [extending core schema](https://www.better-auth.com/docs/concepts/database#extending-core-schema) to add a JSON object or even gives the opportunity to add a relationship between the user and other table while still using the user [inferring types](https://www.better-auth.com/docs/concepts/typescript#infering-types).


## Example Usage

```typescript
import { betterAuth } from "better-auth";
 
export const auth = betterAuth({
   user: {
      additionalFields: { 
          role: {
             type: "object",
             required: false,
             defaultValue: "{}",
             input: false // don't allow user to set role
          },
      }
   }
})
```
