### PR TITLE
fix: make image optional in organization plugin

### DIFF
--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -95,7 +95,7 @@ export const organizationClient = <O extends OrganizationClientOptions>(
 								id: string;
 								name: string;
 								email: string;
-								image: string;
+								image: string | undefined;
 							};
 						})[];
 						invitations: Invitation[];

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -368,7 +368,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 								id: string;
 								name: string;
 								email: string;
-								image: string;
+								image: string | undefined;
 							};
 						}
 					>[];


### PR DESCRIPTION
When using `auth.api.getFullOrganization` or `authClient.organization.getFull`, the type doesn't align with `typeof auth.$Infer.ActiveOrganization`

This PR changes the type of `image` from `string` to `string | undefined`