### PR TITLE
docs: improve expo doc by including Expo client plugin setup

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -59,11 +59,25 @@ Expo is a popular framework for building cross-platform apps with React Native. 
         
         To initialize Better Auth in your Expo app, you need to call `createAuthClient` with the base url of your Better Auth backend. Make sure to import the client from `/react`.
 
+        You need to also import client plugin from `@better-auth/expo/client` and pass it to the `plugins` array when initializing the auth client.
+
+        This is important because:
+
+        - **Social Authentication Support:** enables social auth flows by handling authorization URLs and callbacks within the Expo web browser.
+        - **Secure Cookie Management:** stores cookies securely and automatically adds them to the headers of your auth requests.
+
         ```ts title="src/auth-client.ts"
         import { createAuthClient } from 'better-auth/react';
+        import { expoClient } from '@better-auth/expo/client';
 
         const authClient = createAuthClient({
             baseURL: 'http://localhost:8081', /* base url of your Better Auth backend. */
+            plugins: [
+                expoClient({
+                    scheme: 'myapp',
+                    storagePrefix: "myapp"
+                })
+            ]
         });
         ```
         <Callout>


### PR DESCRIPTION
This PR updates the Expo integration documentation to include important instructions for enabling social authentication using Better Auth. Specifically, it adds details on importing the client plugin from `@better-auth/expo/client` and passing it to the plugins array when initializing the auth client.

### Changes Made:

In the _"Initialize Better Auth Client"_ step:

- I added instructions to import the client plugin from `@better-auth/expo/client`.

- I included a code snippet demonstrating how to pass the plugin to the plugins array.
- I provided a concise list explaining the importance of the client plugin:
     - **Social Authentication Support:** enables social auth flows by handling authorization URLs and callbacks within the Expo web browser.
     - **Secure Cookie Management:** Stores cookies securely and automatically adds them to request headers.
  
### Reason for Changes:

The client plugin is essential for social authentication to function properly in Expo apps.
Some developers ( like myself ) may encounter issues with social auth and cookie management if they are unaware of the need to include the client plugin.