### PR TITLE
fix: app name shouldn't be used to prefix cookies

### DIFF
--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -23,6 +23,7 @@ const libsql = new LibsqlDialect({
 });
 
 export const auth = betterAuth({
+	appName: "Better Auth Demo",
 	database: {
 		dialect: libsql,
 		type: "sqlite",

--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -7,7 +7,7 @@ Cookies are used to store data such as session tokens, OAuth state, and more. Al
 
 ### Cookie Prefix
 
-Better Auth cookies will follow `${prefix}.${cookie_name}` format by default. The prefix equals to the `appName` provided in the auth options by default. If not provided, the prefix will be "better-auth". You can change the prefix by setting `cookiePrefix` in the `advanced` object of the auth options.
+Better Auth cookies will follow `${prefix}.${cookie_name}` format by default. The prefix will be "better-auth" by default. You can change the prefix by setting `cookiePrefix` in the `advanced` object of the auth options.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -31,8 +31,7 @@ export function createCookieGetter(options: BetterAuthOptions) {
 		cookieName: string,
 		overrideAttributes: Partial<CookieOptions> = {},
 	) {
-		const prefix =
-			options.advanced?.cookiePrefix || options.appName || "better-auth";
+		const prefix = options.advanced?.cookiePrefix || "better-auth";
 		const name =
 			options.advanced?.cookies?.[cookieName as "session_token"]?.name ||
 			`${prefix}.${cookieName}`;


### PR DESCRIPTION
closes #433 