### PR TITLE
fix: add `requireHeaders` to sign out api

### DIFF
--- a/packages/better-auth/src/api/routes/sign-out.ts
+++ b/packages/better-auth/src/api/routes/sign-out.ts
@@ -7,6 +7,7 @@ export const signOut = createAuthEndpoint(
 	"/sign-out",
 	{
 		method: "POST",
+		requireHeaders: true,
 	},
 	async (ctx) => {
 		const sessionCookieToken = await ctx.getSignedCookie(


### PR DESCRIPTION
Fix for #451

From what I can tell, this fixes the types on `signOut`

Before:
![image](https://github.com/user-attachments/assets/6249e379-e0b2-435a-83e8-8e4763d6c9cd)

After:
![image](https://github.com/user-attachments/assets/65ad1a30-d15f-4fbf-ab64-db211abede8e)

Let me know if there's anything else I can add 🙂 