### PR TITLE
Use explicit 'node:' prefix for crypto import

### DIFF
--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -3,7 +3,7 @@ import {
 	createDecipheriv,
 	createHash,
 	randomBytes,
-} from "crypto";
+} from "node:crypto";
 
 // Helper function to handle different key formats and lengths
 function deriveKey(secretKey: string) {


### PR DESCRIPTION
To make better-auth more compatible with serverless environments like e.g. Cloudflare Pages, the import of the native crypto module needs to be prefixed with `node:`.