### PR TITLE
Change URL of get full organization endpoint

### DIFF
--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -103,7 +103,7 @@ export const organizationClient = <O extends OrganizationClientOptions>(
 				>
 			>(
 				[$activeOrgSignal],
-				"/organization/get-full-organization",
+				"/organization/get-full",
 				$fetch,
 				() => ({
 					method: "GET",


### PR DESCRIPTION
Changed the URL in the client to match the endpoint in `crud-org.ts`: https://github.com/better-auth/better-auth/blob/00d36eb42482771a834f27573a55afda2f17a602/packages/better-auth/src/plugins/organization/routes/crud-org.ts#L218-L219