### PR TITLE
docs: fix astro pages path

### DIFF
--- a/docs/content/docs/integrations/astro.mdx
+++ b/docs/content/docs/integrations/astro.mdx
@@ -9,9 +9,9 @@ Before you start, make sure you have a Better Auth instance configured. If you h
 
 ### Mount the handler
 
-To enable Better Auth to handle requests, we need to mount the handler to a catch all API route. Create a file inside `/page/api/auth` called `[...all].ts` and add the following code:
+To enable Better Auth to handle requests, we need to mount the handler to a catch all API route. Create a file inside `/pages/api/auth` called `[...all].ts` and add the following code:
 
-```ts title="page/api/auth/[...all].ts"
+```ts title="pages/api/auth/[...all].ts"
 import { auth } from "~/auth";
 import type { APIRoute } from "astro";
 


### PR DESCRIPTION
**Title**: Fix Typo in Astro Integration Documentation Path

**Description**:  
This pull request addresses a typo in the Astro integration documentation. The current path mentioned as `page/api/auth/[...all].ts` has been corrected to `pages/api/auth/[...all].ts` to align with the standard directory structure.

This change ensures that users following the documentation will have accurate instructions, preventing potential confusion during setup.

**Linked Issue**:  
Closes #488 