### PR TITLE
docs: redis value change

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -250,8 +250,8 @@ export const auth = betterAuth({
 	secondaryStorage: {
 		get: async (key) => await redis.get(key),
 		set: async (key, value, ttl) => {
-			if (ttl) await redis.set(key, value, { EX: ttl });
-			else await redis.set(key, value);
+			if (ttl) await redis.set(key, JSON.stringify(value), { EX: ttl });
+			else await redis.set(key, JSON.stringify(value));
 		},
 		delete: async (key) => await redis.del(key),
 	}


### PR DESCRIPTION
This pull request includes a change to the `secondaryStorage` configuration in the `database.mdx` file to ensure that values are stored as JSON strings in Redis.

```
const sessionStringified = await secondaryStorage.get(sessionId);
        if (sessionStringified) {
          const s = JSON.parse(sessionStringified);
```

* [`docs/content/docs/concepts/database.mdx`](diffhunk://#diff-3fb82b9771e62eb4c129ceb5109e4500f630d5fd40b289d06ff38f69d4c52dc3L253-R254): Modified the `set` method in `secondaryStorage` to store values as JSON strings in Redis.