### PR TITLE
fix: omit id in custom column names

### DIFF
--- a/packages/better-auth/src/types/helper.ts
+++ b/packages/better-auth/src/types/helper.ts
@@ -2,6 +2,8 @@ import type { Primitive } from "zod";
 
 export type LiteralString = "" | (string & Record<never, never>);
 
+export type OmitId<T extends { id: unknown }> = Omit<T, "id">;
+
 export type Prettify<T> = Omit<T, never>;
 export type LiteralUnion<LiteralType, BaseType extends Primitive> =
 	| LiteralType

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -6,7 +6,7 @@ import type { Adapter, AdapterInstance, SecondaryStorage } from "./adapter";
 import type { KyselyDatabaseType } from "../adapters/kysely-adapter/types";
 import type { FieldAttribute } from "../db";
 import type { RateLimit } from "./models";
-import type { AuthContext } from ".";
+import type { AuthContext, OmitId } from ".";
 import type { CookieOptions } from "better-call";
 import type { Database } from "better-sqlite3";
 
@@ -234,7 +234,7 @@ export interface BetterAuthOptions {
 		 * The model name for the user. Defaults to "user".
 		 */
 		modelName?: string;
-		fields?: Partial<Record<keyof User, string>>;
+		fields?: Partial<Record<keyof OmitId<User>, string>>;
 		/**
 		 * Additional fields for the session
 		 */
@@ -282,7 +282,7 @@ export interface BetterAuthOptions {
 		 *  userId: "user_id"
 		 * }
 		 */
-		fields?: Partial<Record<keyof Session, string>>;
+		fields?: Partial<Record<keyof OmitId<Session>, string>>;
 		/**
 		 * Expiration time for the session token. The value
 		 * should be in seconds.
@@ -332,7 +332,7 @@ export interface BetterAuthOptions {
 	};
 	account?: {
 		modelName?: string;
-		fields?: Partial<Record<keyof Account, string>>;
+		fields?: Partial<Record<keyof OmitId<Account>, string>>;
 		accountLinking?: {
 			/**
 			 * Enable account linking
@@ -351,7 +351,7 @@ export interface BetterAuthOptions {
 	 */
 	verification?: {
 		modelName?: string;
-		fields?: Partial<Record<keyof Verification, string>>;
+		fields?: Partial<Record<keyof OmitId<Verification>, string>>;
 	};
 	/**
 	 * List of trusted origins.


### PR DESCRIPTION
Adapters currently do not support custom id column name