### PR TITLE
Update database.mdx

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -431,6 +431,11 @@ Table Name: `verification`
       type: "Date",
       description: "The time when the verification request expires"
     }
+    {
+      name: "createdAt",
+      type: "Date",
+      description: "Timestamp of when the user account was created"
+    }
   ]}
 />
 


### PR DESCRIPTION
createdAt is required for the verifications table, needed for those creating tables manually instead of the CLI.

Caused this issue: `ERROR   Cannot read properties of undefined (reading 'create')`