### PR TITLE
Reset password expiration failed and date converted to timestamp to add precision

### DIFF
--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -3,10 +3,10 @@ import type {
 	CreateTableBuilder,
 } from "kysely";
 import type { FieldAttribute, FieldType } from ".";
-import { logger } from "../utils/logger";
-import type { BetterAuthOptions } from "../types";
 import { createKyselyAdapter } from "../adapters/kysely-adapter/dialect";
 import type { KyselyDatabaseType } from "../adapters/kysely-adapter/types";
+import type { BetterAuthOptions } from "../types";
+import { logger } from "../utils/logger";
 import { getSchema } from "./get-schema";
 
 const postgresMap = {
@@ -176,6 +176,9 @@ export async function getMigrations(config: BetterAuthOptions) {
 		}
 		if (type === "string[]" || type === "number[]") {
 			return "jsonb";
+		}
+		if (type === "date") {
+			return "timestamp"
 		}
 		return typeMap[type];
 	}


### PR DESCRIPTION
Initially, I was investigating why the format of expiresAt is a date (format: `YYYY-MM-DD`). What seemed unusual was that while the expiration time is set to one hour later, the expiresAt field doesn't include any time information. To address this, I attempted to convert it to a timestamp (which I think, it's not the best approach, as it converts all dates to timestamps – feel free to contribute and improve this solution). However, I encountered another issue: when you call `new Date()`, it returns a date in your machine's local timezone rather than UTC. Therefore, I needed to convert it to UTC to ensure that both the timestamp and UTC time were in the same timezone.