### PR TITLE
docs: fix example use of `useSession` to use synchronous instead

### DIFF
--- a/docs/content/docs/concepts/session-management.mdx
+++ b/docs/content/docs/concepts/session-management.mdx
@@ -54,7 +54,7 @@ The `useSession` action provides a reactive way to access the current session.
 ```ts client="client.ts"
 import { authClient } from "@/lib/client"
 
-const session = await authClient.useSession()
+const session = authClient.useSession()
 ```
 
 ### List Sessions

--- a/docs/content/docs/concepts/session-management.mdx
+++ b/docs/content/docs/concepts/session-management.mdx
@@ -44,7 +44,7 @@ The `getSession` function retrieves the current active session.
 ```ts client="client.ts"
 import { authClient } from "@/lib/client"
 
-const session = await authClient.getSession()
+const { data: session, error } = authClient.useSession();
 ```
 
 ### Use Session


### PR DESCRIPTION
`useSession` hook must be used as a sync function.

https://www.better-auth.com/docs/concepts/session-management#use-session