### PR TITLE
feat: all core tables now have createdAt and updatedAt fields and session id is now stored in a token field

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -549,7 +549,7 @@ res.user.lang // > "fr"
 
 ### ID Generation
 
-Better Auth uses `nanoId` by default to generate unique IDs for users, sessions, and other entities. If you want to customize how IDs are generated, you can pass your own function through the adapter or database configuration.
+Better Auth uses `nanoId` by default to generate unique IDs for users, sessions, and other entities. If you want to customize how IDs are generated, you can configure this in the `advanced` section of the <Link href="/docs/reference/options">options</Link>.
 
 **Guidelines:**
 
@@ -557,14 +557,16 @@ Better Auth uses `nanoId` by default to generate unique IDs for users, sessions,
 - The ID should be unique for each entity type (like users, sessions, etc.).
 - Since the session ID acts as the token, it should be both unique and sufficiently long for security.
 
-**Example: Built In Kysley Adapter**
+**Example: Custom ID Generation**
 ```ts title="auth.ts" 
 import { betterAuth } from "better-auth";
 import { db } from "./db";
 
 export const auth = betterAuth({
    database: {
-      db: db,
+      db: db
+   },
+   advanced: {
       generateId: () => {
          // custom id generation logic
       }
@@ -572,21 +574,22 @@ export const auth = betterAuth({
 })
 ```
 
-**Example: Prisma Adapter**
-```ts title="auth.ts"
+You can also disable ID generation by setting the `generateId` option to `false`. This will assume your database will generate the ID automatically.
+
+**Example: Automatic Database IDs**
+```ts title="auth.ts" 
 import { betterAuth } from "better-auth";
+import { db } from "./db";
 
 export const auth = betterAuth({
-   database: prismaAdapter(prisma, {
-      provider: "sqlite",
-      generateId: () => {
-         // custom id generation logic
-      }
-   })
+   database: {
+      db: db
+   },
+   advanced: {
+      generateId: false,
+   },
 })
 ```
-
-You can also disable ID generation by setting the `generateId` option to `false` in your adapter configuration. This will assume your database will generate the ID automatically.
 
 ### Database Hooks
 

--- a/packages/better-auth/src/__snapshots__/init.test.ts.snap
+++ b/packages/better-auth/src/__snapshots__/init.test.ts.snap
@@ -139,6 +139,11 @@ exports[`init > should match config 1`] = `
           "required": true,
           "type": "string",
         },
+        "createdAt": {
+          "fieldName": "createdAt",
+          "required": true,
+          "type": "date",
+        },
         "expiresAt": {
           "fieldName": "expiresAt",
           "required": false,
@@ -164,6 +169,11 @@ exports[`init > should match config 1`] = `
           "required": false,
           "type": "string",
         },
+        "updatedAt": {
+          "fieldName": "updatedAt",
+          "required": true,
+          "type": "date",
+        },
         "userId": {
           "fieldName": "userId",
           "references": {
@@ -180,6 +190,11 @@ exports[`init > should match config 1`] = `
     },
     "session": {
       "fields": {
+        "createdAt": {
+          "fieldName": "createdAt",
+          "required": true,
+          "type": "date",
+        },
         "expiresAt": {
           "fieldName": "expiresAt",
           "required": true,
@@ -189,6 +204,17 @@ exports[`init > should match config 1`] = `
           "fieldName": "ipAddress",
           "required": false,
           "type": "string",
+        },
+        "token": {
+          "fieldName": "token",
+          "required": true,
+          "type": "string",
+          "unique": true,
+        },
+        "updatedAt": {
+          "fieldName": "updatedAt",
+          "required": true,
+          "type": "date",
         },
         "userAgent": {
           "fieldName": "userAgent",
@@ -266,6 +292,12 @@ exports[`init > should match config 1`] = `
           "fieldName": "identifier",
           "required": true,
           "type": "string",
+        },
+        "updatedAt": {
+          "defaultValue": [Function],
+          "fieldName": "updatedAt",
+          "required": false,
+          "type": "date",
         },
         "value": {
           "fieldName": "value",

--- a/packages/better-auth/src/__snapshots__/init.test.ts.snap
+++ b/packages/better-auth/src/__snapshots__/init.test.ts.snap
@@ -10,7 +10,6 @@ exports[`init > should match config 1`] = `
     "findOne": [Function],
     "id": "kysely",
     "options": {
-      "generateId": undefined,
       "type": "sqlite",
     },
     "update": [Function],
@@ -50,6 +49,7 @@ exports[`init > should match config 1`] = `
   },
   "baseURL": "http://localhost:3000/api/auth",
   "createAuthCookie": [Function],
+  "generateId": [Function],
   "internalAdapter": {
     "createAccount": [Function],
     "createOAuthUser": [Function],
@@ -280,6 +280,5 @@ exports[`init > should match config 1`] = `
   "trustedOrigins": [
     "http://localhost:3000",
   ],
-  "uuid": [Function],
 }
 `;

--- a/packages/better-auth/src/adapters/drizzle-adapter/test/schema.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/test/schema.ts
@@ -16,6 +16,9 @@ export const sessions = pgTable("sessions", {
 	expiresAt: timestamp("expiresAt").notNull(),
 	ipAddress: text("ipAddress"),
 	userAgent: text("userAgent"),
+	token: text("token").notNull(),
+	createdAt: timestamp("createdAt").notNull(),
+	updatedAt: timestamp("updatedAt").notNull(),
 	userId: text("userId")
 		.notNull()
 		.references(() => user.id),
@@ -29,6 +32,8 @@ export const account = pgTable("account", {
 		.notNull()
 		.references(() => user.id),
 	accessToken: text("accessToken"),
+	createdAt: timestamp("createdAt").notNull(),
+	updatedAt: timestamp("updatedAt").notNull(),
 	refreshToken: text("refreshToken"),
 	idToken: text("idToken"),
 	expiresAt: timestamp("expiresAt"),
@@ -40,5 +45,6 @@ export const verification = pgTable("verification", {
 	identifier: text("identifier").notNull(),
 	value: text("value").notNull(),
 	expiresAt: timestamp("expiresAt").notNull(),
-	createdAt: timestamp("createdAt"),
+	createdAt: timestamp("createdAt").notNull(),
+	updatedAt: timestamp("updatedAt").notNull(),
 });

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -1,5 +1,6 @@
 import { getAuthTables } from "../../db";
 import type { Adapter, BetterAuthOptions, Where } from "../../types";
+import { generateId } from "../../utils";
 
 export interface MemoryDB {
 	[key: string]: any[];
@@ -16,12 +17,23 @@ const createTransform = (options: BetterAuthOptions) => {
 		return f.fieldName || field;
 	}
 	return {
-		transformInput(data: Record<string, any>, model: string) {
-			const transformedData: Record<string, any> = data.id
-				? {
-						id: data.id,
-					}
-				: {};
+		transformInput(
+			data: Record<string, any>,
+			model: string,
+			action: "update" | "create",
+		) {
+			const transformedData: Record<string, any> =
+				action === "update"
+					? {}
+					: {
+							id:
+								data.id ||
+								(options.advanced?.generateId
+									? options.advanced.generateId({
+											model,
+										})
+									: generateId()),
+						};
 			for (const key in data) {
 				const field = schema[model].fields[key];
 				if (field) {
@@ -90,7 +102,7 @@ export const memoryAdapter = (db: MemoryDB) => (options: BetterAuthOptions) => {
 	return {
 		id: "memory",
 		create: async ({ model, data }) => {
-			const transformed = transformInput(data, model);
+			const transformed = transformInput(data, model, "create");
 			db[model].push(transformed);
 			return transformOutput(transformed, model);
 		},
@@ -127,7 +139,7 @@ export const memoryAdapter = (db: MemoryDB) => (options: BetterAuthOptions) => {
 			const table = db[model];
 			const res = convertWhereClause(where, table, model);
 			res.forEach((record) => {
-				Object.assign(record, transformInput(update, model));
+				Object.assign(record, transformInput(update, model, "update"));
 			});
 			return transformOutput(res[0], model);
 		},

--- a/packages/better-auth/src/adapters/prisma-adapter/test/schema.prisma
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/schema.prisma
@@ -19,5 +19,8 @@ model User {
 model Sessions {
     id        String   @id @default(cuid())
     userId    String
+    token     String   @unique
     expiresAt DateTime
+    createdAt DateTime @default(now())
+    updatedAt DateTime @default(now()) @updatedAt
 }

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -161,7 +161,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 	});
 
 	test("should work with reference fields", async () => {
-		const user = await adapter.create<Record<string, any>>({
+		const user = await adapter.create<{ id: string } & Record<string, any>>({
 			model: "user",
 			data: {
 				id: "4",

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import type { Adapter, User } from "../types";
 import { nanoid } from "nanoid";
+import { generateId } from "../utils";
 
 interface AdapterTestOptions {
 	adapter: Adapter;
@@ -176,6 +177,9 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 			model: "session",
 			data: {
 				id: "1",
+				token: generateId(),
+				createdAt: new Date(),
+				updatedAt: new Date(),
 				userId: user.id,
 				expiresAt: new Date(),
 			},

--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -3,6 +3,7 @@ import { createAuthEndpoint } from "../call";
 import { APIError } from "better-call";
 import type { AuthContext } from "../../init";
 import { getDate } from "../../utils/date";
+import { generateId } from "../../utils";
 
 function redirectError(
 	ctx: AuthContext,
@@ -81,7 +82,7 @@ export const forgetPassword = createAuthEndpoint(
 				defaultExpiresIn,
 			"sec",
 		);
-		const verificationToken = ctx.context.uuid();
+		const verificationToken = generateId(24);
 		await ctx.context.internalAdapter.createVerificationValue({
 			value: user.user.id,
 			identifier: `reset-password:${verificationToken}`,
@@ -180,7 +181,7 @@ export const resetPassword = createAuthEndpoint(
 				userId,
 				providerId: "credential",
 				password: hashedPassword,
-				accountId: ctx.context.uuid(),
+				accountId: userId,
 			});
 			return ctx.json({
 				status: true,

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -232,7 +232,7 @@ describe("session", async () => {
 			fetchOptions: {
 				headers,
 			},
-			id: res.data?.session?.id || "",
+			token: res.data?.session?.token || "",
 		});
 		const session = await client.getSession({
 			fetchOptions: {
@@ -280,8 +280,8 @@ describe("session storage", async () => {
 		});
 		expect(session.data).toMatchObject({
 			session: {
-				id: expect.any(String),
 				userId: expect.any(String),
+				token: expect.any(String),
 				expiresAt: expect.any(String),
 				ipAddress: expect.any(String),
 				userAgent: expect.any(String),
@@ -320,7 +320,7 @@ describe("session storage", async () => {
 			fetchOptions: {
 				headers,
 			},
-			id: session.data?.session?.id || "",
+			token: session.data?.session?.token || "",
 		});
 		const revokedSession = await client.getSession({
 			fetchOptions: {

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -141,7 +141,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 				if (shouldBeUpdated) {
 					const updatedSession =
 						await ctx.context.internalAdapter.updateSession(
-							session.session.id,
+							session.session.token,
 							{
 								expiresAt: getDate(ctx.context.sessionConfig.expiresIn, "sec"),
 							},
@@ -257,14 +257,14 @@ export const revokeSession = createAuthEndpoint(
 	{
 		method: "POST",
 		body: z.object({
-			id: z.string(),
+			token: z.string(),
 		}),
 		use: [sessionMiddleware],
 		requireHeaders: true,
 	},
 	async (ctx) => {
-		const id = ctx.body.id;
-		const findSession = await ctx.context.internalAdapter.findSession(id);
+		const token = ctx.body.token;
+		const findSession = await ctx.context.internalAdapter.findSession(token);
 		if (!findSession) {
 			throw new APIError("BAD_REQUEST", {
 				message: "Session not found",
@@ -274,7 +274,7 @@ export const revokeSession = createAuthEndpoint(
 			throw new APIError("UNAUTHORIZED");
 		}
 		try {
-			await ctx.context.internalAdapter.deleteSession(id);
+			await ctx.context.internalAdapter.deleteSession(token);
 		} catch (error) {
 			ctx.context.logger.error(
 				error && typeof error === "object" && "name" in error

--- a/packages/better-auth/src/client/client.test.ts
+++ b/packages/better-auth/src/client/client.test.ts
@@ -230,8 +230,11 @@ describe("type", () => {
 				id: string;
 				userId: string;
 				expiresAt: Date;
+				token: string;
 				ipAddress?: string | undefined | null;
 				userAgent?: string | undefined | null;
+				createdAt: Date;
+				updatedAt: Date;
 			};
 			user: {
 				id: string;

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -107,7 +107,7 @@ export async function setSessionCookie(
 		: ctx.context.sessionConfig.expiresIn;
 	await ctx.setSignedCookie(
 		ctx.context.authCookies.sessionToken.name,
-		session.session.id,
+		session.session.token,
 		ctx.context.secret,
 		{
 			...options,
@@ -154,7 +154,7 @@ export async function setSessionCookie(
 	 */
 	if (ctx.context.options.secondaryStorage) {
 		await ctx.context.secondaryStorage?.set(
-			session.session.id,
+			session.session.token,
 			JSON.stringify({
 				user: session.user,
 				session: session.session,

--- a/packages/better-auth/src/db/get-schema.ts
+++ b/packages/better-auth/src/db/get-schema.ts
@@ -21,7 +21,6 @@ export function getSchema(config: BetterAuthOptions) {
 				if (refTable) {
 					actualFields[field.fieldName || key].references = {
 						model: refTable.modelName,
-
 						field: field.references.field,
 					};
 				}

--- a/packages/better-auth/src/db/get-tables.ts
+++ b/packages/better-auth/src/db/get-tables.ts
@@ -121,6 +121,22 @@ export const getAuthTables = (
 					required: true,
 					fieldName: options.session?.fields?.expiresAt || "expiresAt",
 				},
+				token: {
+					type: "string",
+					required: true,
+					fieldName: options.session?.fields?.token || "token",
+					unique: true,
+				},
+				createdAt: {
+					type: "date",
+					required: true,
+					fieldName: options.session?.fields?.createdAt || "createdAt",
+				},
+				updatedAt: {
+					type: "date",
+					required: true,
+					fieldName: options.session?.fields?.updatedAt || "updatedAt",
+				},
 				ipAddress: {
 					type: "string",
 					required: false,
@@ -194,6 +210,16 @@ export const getAuthTables = (
 					required: false,
 					fieldName: options.account?.fields?.password || "password",
 				},
+				createdAt: {
+					type: "date",
+					required: true,
+					fieldName: options.account?.fields?.createdAt || "createdAt",
+				},
+				updatedAt: {
+					type: "date",
+					required: true,
+					fieldName: options.account?.fields?.updatedAt || "updatedAt",
+				},
 				...account?.fields,
 			},
 			order: 3,
@@ -221,6 +247,12 @@ export const getAuthTables = (
 					required: false,
 					defaultValue: () => new Date(),
 					fieldName: options.verification?.fields?.createdAt || "createdAt",
+				},
+				updatedAt: {
+					type: "date",
+					required: false,
+					defaultValue: () => new Date(),
+					fieldName: options.verification?.fields?.updatedAt || "updatedAt",
 				},
 			},
 			order: 4,

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -16,14 +16,16 @@ describe("adapter test", async () => {
 		database: {
 			dialect: sqliteDialect,
 			type: "sqlite",
-			generateId() {
-				return (id++).toString();
-			},
 		},
 		user: {
 			fields: {
 				email: "email_address",
 				emailVerified: "email_verified",
+			},
+		},
+		advanced: {
+			generateId() {
+				return (id++).toString();
 			},
 		},
 	} satisfies BetterAuthOptions;
@@ -34,6 +36,9 @@ describe("adapter test", async () => {
 	const internalAdapter = createInternalAdapter(adapter, {
 		options: opts,
 		hooks: [],
+		generateId() {
+			return opts.advanced.generateId();
+		},
 	});
 	it("should create oauth user with custom generate id", async () => {
 		const user = await internalAdapter.createOAuthUser(

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -46,6 +46,8 @@ describe("adapter test", async () => {
 				providerId: "provider",
 				accountId: "account",
 				expiresAt: new Date(),
+				createdAt: new Date(),
+				updatedAt: new Date(),
 			},
 		);
 

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -652,11 +652,13 @@ export const createInternalAdapter = (
 			return account;
 		},
 		createVerificationValue: async (
-			data: Omit<Verification, "createdAt" | "id"> & Partial<Verification>,
+			data: Omit<Verification, "createdAt" | "id" | "updatedAt"> &
+				Partial<Verification>,
 		) => {
 			const verification = await createWithHooks(
 				{
 					createdAt: new Date(),
+					updatedAt: new Date(),
 					...data,
 				},
 				"verification",

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -30,7 +30,8 @@ export const createInternalAdapter = (
 	return {
 		createOAuthUser: async (
 			user: Omit<User, "id" | "createdAt" | "updatedAt"> & Partial<User>,
-			account: Omit<Account, "userId" | "id"> & Partial<Account>,
+			account: Omit<Account, "userId" | "id" | "createdAt" | "updatedAt"> &
+				Partial<Account>,
 		) => {
 			try {
 				const createdUser = await createWithHooks(
@@ -45,6 +46,8 @@ export const createInternalAdapter = (
 					{
 						...account,
 						userId: createdUser.id || user.id,
+						createdAt: new Date(),
+						updatedAt: new Date(),
 					},
 					"account",
 				);
@@ -203,7 +206,7 @@ export const createInternalAdapter = (
 				"session",
 				secondaryStorage
 					? {
-							fn: async (input) => {
+							fn: async () => {
 								const user = await adapter.findOne<User>({
 									model: "user",
 									where: [{ field: "id", value: userId }],
@@ -540,8 +543,18 @@ export const createInternalAdapter = (
 			});
 			return user;
 		},
-		linkAccount: async (account: Omit<Account, "id"> & Partial<Account>) => {
-			const _account = await createWithHooks(account, "account");
+		linkAccount: async (
+			account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
+				Partial<Account>,
+		) => {
+			const _account = await createWithHooks(
+				{
+					...account,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+				"account",
+			);
 			return _account;
 		},
 		updateUser: async (

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -18,6 +18,8 @@ export const accountSchema = z.object({
 	 * Password is only stored in the credential provider
 	 */
 	password: z.string().nullish(),
+	createdAt: z.date().default(() => new Date()),
+	updatedAt: z.date().default(() => new Date()),
 });
 
 export const userSchema = z.object({
@@ -26,14 +28,17 @@ export const userSchema = z.object({
 	emailVerified: z.boolean().default(false),
 	name: z.string(),
 	image: z.string().nullish(),
-	createdAt: z.date().default(new Date()),
-	updatedAt: z.date().default(new Date()),
+	createdAt: z.date().default(() => new Date()),
+	updatedAt: z.date().default(() => new Date()),
 });
 
 export const sessionSchema = z.object({
 	id: z.string(),
 	userId: z.string(),
 	expiresAt: z.date(),
+	createdAt: z.date().default(() => new Date()),
+	updatedAt: z.date().default(() => new Date()),
+	token: z.string(),
 	ipAddress: z.string().nullish(),
 	userAgent: z.string().nullish(),
 });
@@ -41,7 +46,8 @@ export const sessionSchema = z.object({
 export const verificationSchema = z.object({
 	id: z.string(),
 	value: z.string(),
-	createdAt: z.date(),
+	createdAt: z.date().default(() => new Date()),
+	updatedAt: z.date().default(() => new Date()),
 	expiresAt: z.date(),
 	identifier: z.string(),
 });

--- a/packages/better-auth/src/db/utils.ts
+++ b/packages/better-auth/src/db/utils.ts
@@ -2,7 +2,6 @@ import type { FieldAttribute } from ".";
 import { BetterAuthError } from "../error";
 import type { BetterAuthOptions } from "../types";
 import type { Adapter } from "../types/adapter";
-import { getAuthTables } from "./get-tables";
 import { createKyselyAdapter } from "../adapters/kysely-adapter/dialect";
 import { kyselyAdapter } from "../adapters/kysely-adapter";
 
@@ -20,10 +19,6 @@ export async function getAdapter(options: BetterAuthOptions): Promise<Adapter> {
 		throw new BetterAuthError("Failed to initialize database adapter");
 	}
 	return kyselyAdapter(kysely, {
-		generateId:
-			"generateId" in options.database
-				? options.database.generateId
-				: undefined,
 		type: databaseType || "sqlite",
 	})(options);
 }

--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -1,5 +1,5 @@
 import type { Adapter, Where } from "./../types/adapter";
-import type { BetterAuthOptions } from "../types";
+import type { BetterAuthOptions, Models } from "../types";
 
 export function getWithHooks(
 	adapter: Adapter,
@@ -9,10 +9,13 @@ export function getWithHooks(
 	},
 ) {
 	const hooks = ctx.hooks;
-	type Models = "user" | "account" | "session" | "verification";
+	type BaseModels = Extract<
+		Models,
+		"user" | "account" | "session" | "verification"
+	>;
 	async function createWithHooks<T extends Record<string, any>>(
 		data: T,
-		model: Models,
+		model: BaseModels,
 		customCreateFn?: {
 			fn: (data: Record<string, any>) => void | Promise<any>;
 			executeMainFn?: boolean;
@@ -57,7 +60,7 @@ export function getWithHooks(
 	async function updateWithHooks<T extends Record<string, any>>(
 		data: any,
 		where: Where[],
-		model: Models,
+		model: BaseModels,
 		customUpdateFn?: {
 			fn: (data: Record<string, any>) => void | Promise<any>;
 			executeMainFn?: boolean;
@@ -103,7 +106,7 @@ export function getWithHooks(
 	async function updateManyWithHooks<T extends Record<string, any>>(
 		data: any,
 		where: Where[],
-		model: Models,
+		model: BaseModels,
 		customUpdateFn?: {
 			fn: (data: Record<string, any>) => void | Promise<any>;
 			executeMainFn?: boolean;

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -59,7 +59,6 @@ export async function handleOAuthUserInfo(
 				await c.context.internalAdapter.linkAccount({
 					providerId: account.providerId,
 					accountId: userInfo.id.toString(),
-					id: c.context.uuid(),
 					userId: dbUser.user.id,
 					accessToken: account.accessToken,
 					idToken: account.idToken,
@@ -88,7 +87,8 @@ export async function handleOAuthUserInfo(
 				.createOAuthUser(
 					{
 						...userInfo,
-						id: c.context.uuid(),
+						// setting id to undefined to let the database generate it
+						id: undefined,
 						emailVerified,
 						email: userInfo.email.toLowerCase(),
 					},

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -12,7 +12,7 @@ export async function handleOAuthUserInfo(
 		callbackURL,
 	}: {
 		userInfo: Omit<User, "createdAt" | "updatedAt">;
-		account: Omit<Account, "id" | "userId">;
+		account: Omit<Account, "id" | "userId" | "createdAt" | "updatedAt">;
 		callbackURL?: string;
 	},
 ) {

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -258,7 +258,7 @@ describe("Admin plugin", async () => {
 		);
 		expect(sessions.data?.sessions.length).toBe(4);
 		const res = await client.admin.revokeUserSession(
-			{ sessionId: sessions.data?.sessions[0].id || "" },
+			{ sessionId: sessions.data?.sessions[0].token || "" },
 			{ headers: adminHeaders },
 		);
 		expect(res.data?.success).toBe(true);

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -8,7 +8,6 @@ import type {
 } from "../../types";
 import { parseSetCookieHeader, setSessionCookie } from "../../cookies";
 import { z } from "zod";
-import { generateId } from "../../utils/id";
 import { getOrigin } from "../../utils/url";
 import { mergeSchema } from "../../db/schema";
 
@@ -69,7 +68,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 				async (ctx) => {
 					const { emailDomainName = getOrigin(ctx.context.baseURL) } =
 						options || {};
-					const id = generateId();
+					const id = ctx.context.generateId({ model: "user" });
 					const email = `temp-${id}@${emailDomainName}`;
 					const newUser = await ctx.context.internalAdapter.createUser({
 						id,

--- a/packages/better-auth/src/plugins/bearer/bearer.test.ts
+++ b/packages/better-auth/src/plugins/bearer/bearer.test.ts
@@ -11,7 +11,7 @@ describe("bearer", async () => {
 	let encryptedToken: string | undefined;
 	it("should get session", async () => {
 		const { res, headers } = await signInWithTestUser();
-		token = res.data?.session.id || "";
+		token = res.data?.session.token || "";
 		const session = await client.getSession({
 			fetchOptions: {
 				headers: {
@@ -22,7 +22,7 @@ describe("bearer", async () => {
 		encryptedToken = headers
 			.get("cookie")
 			?.split("better-auth.session_token=")[1];
-		expect(session.data?.session.id).toBe(res.data?.session.id);
+		expect(session.data?.session.token).toBe(res.data?.session.token);
 	});
 
 	it("should list session", async () => {
@@ -38,13 +38,13 @@ describe("bearer", async () => {
 
 	it("should work on server actions", async () => {
 		const { res } = await signInWithTestUser();
-		token = res.data?.session.id || "";
+		token = res.data?.session.token || "";
 		const headers = new Headers();
 		headers.set("authorization", `Bearer ${token}`);
 		const session = await auth.api.getSession({
 			headers,
 		});
-		expect(session?.session.id).toBe(token);
+		expect(session?.session.token).toBe(token);
 	});
 
 	it("should work with encrypted token", async () => {

--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -135,7 +135,7 @@ export const multiSession = (options?: MultiSessionConfig) => {
 						...ctx.context.authCookies.sessionToken.options,
 						maxAge: 0,
 					});
-					const isActive = ctx.context.session?.session.id === sessionId;
+					const isActive = ctx.context.session?.session.token === sessionId;
 					if (!isActive) return ctx.json({ success: true });
 
 					const cookieHeader = ctx.headers?.get("cookie");

--- a/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
+++ b/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
@@ -108,7 +108,7 @@ describe("multi-session", async () => {
 			{
 				onSuccess(context) {
 					expect(context.response.headers.get("set-cookie")).toContain(
-						`better-auth.session_token`,
+						`better-auth.session_token=`,
 					);
 				},
 			},

--- a/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
+++ b/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
@@ -74,7 +74,8 @@ describe("multi-session", async () => {
 		});
 		if (res.data) {
 			sessionId =
-				res.data.find((s) => s.user.email === testUser.email)?.session.id || "";
+				res.data.find((s) => s.user.email === testUser.email)?.session.token ||
+				"";
 		}
 		expect(res.data).toHaveLength(2);
 	});
@@ -103,7 +104,7 @@ describe("multi-session", async () => {
 				fetchOptions: {
 					headers,
 				},
-				sessionId: signUpRes.data?.session.id || "",
+				sessionId: signUpRes.data?.session.token || "",
 			},
 			{
 				onSuccess(context) {

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1,8 +1,14 @@
 import type { Session, User } from "../../db/schema";
 import { getDate } from "../../utils/date";
-import { generateId } from "../../utils/id";
 import type { OrganizationOptions } from "./organization";
-import type { Invitation, Member, Organization } from "./schema";
+import type {
+	Invitation,
+	InvitationInput,
+	Member,
+	MemberInput,
+	Organization,
+	OrganizationInput,
+} from "./schema";
 import { BetterAuthError } from "../../error";
 import type { AuthContext } from "../../types";
 
@@ -25,10 +31,13 @@ export const getOrgAdapter = (
 			return organization;
 		},
 		createOrganization: async (data: {
-			organization: Organization;
+			organization: OrganizationInput;
 			user: User;
 		}) => {
-			const organization = await adapter.create<Organization>({
+			const organization = await adapter.create<
+				OrganizationInput,
+				Organization
+			>({
 				model: "organization",
 				data: {
 					...data.organization,
@@ -37,10 +46,9 @@ export const getOrgAdapter = (
 						: undefined,
 				},
 			});
-			const member = await adapter.create<Member>({
+			const member = await adapter.create<MemberInput>({
 				model: "member",
 				data: {
-					id: generateId(),
 					organizationId: organization.id,
 					userId: data.user.id,
 					createdAt: new Date(),
@@ -183,8 +191,8 @@ export const getOrgAdapter = (
 				},
 			};
 		},
-		createMember: async (data: Member) => {
-			const member = await adapter.create<Member>({
+		createMember: async (data: MemberInput) => {
+			const member = await adapter.create<MemberInput>({
 				model: "member",
 				data: data,
 			});
@@ -389,10 +397,9 @@ export const getOrgAdapter = (
 			const expiresAt = getDate(
 				options?.invitationExpiresIn || defaultExpiration,
 			);
-			const invite = await adapter.create<Invitation>({
+			const invite = await adapter.create<InvitationInput, Invitation>({
 				model: "invitation",
 				data: {
-					id: generateId(),
 					email: invitation.email,
 					role: invitation.role,
 					organizationId: invitation.organizationId,

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { createAuthEndpoint } from "../../../api/call";
 import { getSessionFromCtx } from "../../../api/routes";
-import { generateId } from "../../../utils/id";
 import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { type InferRolesFromOption } from "../schema";
@@ -149,7 +148,6 @@ export const acceptInvitation = createAuthEndpoint(
 			status: "accepted",
 		});
 		const member = await adapter.createMember({
-			id: generateId(),
 			organizationId: invitation.organizationId,
 			userId: session.user.id,
 			role: invitation.role,

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { createAuthEndpoint } from "../../../api/call";
-import { generateId } from "../../../utils/id";
 import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { APIError } from "better-call";
@@ -64,7 +63,6 @@ export const createOrganization = createAuthEndpoint(
 		}
 		const organization = await adapter.createOrganization({
 			organization: {
-				id: generateId(),
 				slug: ctx.body.slug,
 				name: ctx.body.name,
 				logo: ctx.body.logo,

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -1,4 +1,5 @@
 import { z, ZodLiteral } from "zod";
+import { generateId } from "../../utils";
 import type { OrganizationOptions } from "./organization";
 
 export const role = z.string();
@@ -7,7 +8,7 @@ export const invitationStatus = z
 	.default("pending");
 
 export const organizationSchema = z.object({
-	id: z.string(),
+	id: z.string().default(generateId),
 	name: z.string(),
 	slug: z.string(),
 	logo: z.string().nullish(),
@@ -19,7 +20,7 @@ export const organizationSchema = z.object({
 });
 
 export const memberSchema = z.object({
-	id: z.string(),
+	id: z.string().default(generateId),
 	organizationId: z.string(),
 	userId: z.string(),
 	role,
@@ -27,7 +28,7 @@ export const memberSchema = z.object({
 });
 
 export const invitationSchema = z.object({
-	id: z.string(),
+	id: z.string().default(generateId),
 	organizationId: z.string(),
 	email: z.string(),
 	role,
@@ -42,6 +43,9 @@ export const invitationSchema = z.object({
 export type Organization = z.infer<typeof organizationSchema>;
 export type Member = z.infer<typeof memberSchema>;
 export type Invitation = z.infer<typeof invitationSchema>;
+export type InvitationInput = z.input<typeof invitationSchema>;
+export type MemberInput = z.input<typeof memberSchema>;
+export type OrganizationInput = z.input<typeof organizationSchema>;
 
 export type InferRolesFromOption<O extends OrganizationOptions | undefined> =
 	ZodLiteral<

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -23,8 +23,8 @@ import type {
 } from "../../types/plugins";
 import { setSessionCookie } from "../../cookies";
 import { BetterAuthError } from "../../error";
-import { generateId } from "../../utils/id";
 import { env } from "../../utils/env";
+import { generateId } from "../../utils";
 import { mergeSchema } from "../../db/schema";
 
 interface WebAuthnChallengeValue {
@@ -153,7 +153,7 @@ export const passkey = (options?: PasskeyOptions) => {
 						},
 					});
 
-					const id = generateId();
+					const id = generateId(32);
 					await ctx.setSignedCookie(
 						opts.advanced.webAuthnChallengeCookie,
 						id,
@@ -224,7 +224,7 @@ export const passkey = (options?: PasskeyOptions) => {
 							id: session?.user.id || "",
 						},
 					};
-					const id = generateId();
+					const id = generateId(32);
 					await ctx.setSignedCookie(
 						opts.advanced.webAuthnChallengeCookie,
 						id,
@@ -314,11 +314,10 @@ export const passkey = (options?: PasskeyOptions) => {
 							credentialBackedUp,
 						} = registrationInfo;
 						const pubKey = Buffer.from(credentialPublicKey).toString("base64");
-						const userID = generateId();
 						const newPasskey: Passkey = {
 							name: ctx.body.name,
 							userId: userData.id,
-							webauthnUserID: userID,
+							webauthnUserID: ctx.context.generateId({ model: "passkey" }),
 							id: credentialID,
 							publicKey: pubKey,
 							counter,

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -156,7 +156,7 @@ export const backupCode2fa = (
 
 					if (!ctx.body.disableSession) {
 						await setSessionCookie(ctx, {
-							session: ctx.context.session,
+							session: ctx.context.session.session,
 							user,
 						});
 					}

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -113,7 +113,6 @@ export const twoFactor = (options?: TwoFactorOptions) => {
 					await ctx.context.adapter.create({
 						model: opts.twoFactorTable,
 						data: {
-							id: ctx.context.uuid(),
 							secret: encryptedSecret,
 							backupCodes: backupCodes.encryptedBackupCodes,
 							userId: user.id,

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -3,6 +3,7 @@ import { createAuthEndpoint } from "../../api/call";
 import type { BetterAuthPlugin } from "../../types/plugins";
 import { APIError } from "better-call";
 import type { Account, User } from "../../db/schema";
+import { setSessionCookie } from "../../cookies";
 
 export const username = () => {
 	return {
@@ -88,16 +89,10 @@ export const username = () => {
 							},
 						});
 					}
-					await ctx.setSignedCookie(
-						ctx.context.authCookies.sessionToken.name,
-						session.id,
-						ctx.context.secret,
-						ctx.body.rememberMe === false
-							? {
-									...ctx.context.authCookies.sessionToken.options,
-									maxAge: undefined,
-								}
-							: ctx.context.authCookies.sessionToken.options,
+					await setSessionCookie(
+						ctx,
+						{ session, user },
+						ctx.body.rememberMe === false,
 					);
 					return ctx.json({
 						user: user,

--- a/packages/better-auth/src/types/adapter.ts
+++ b/packages/better-auth/src/types/adapter.ts
@@ -25,7 +25,7 @@ export type Where = {
  */
 export interface Adapter {
 	id: string;
-	create: <T extends { id?: string } & Record<string, any>, R = T>(data: {
+	create: <T extends Record<string, any>, R = T>(data: {
 		model: string;
 		data: T;
 		select?: string[];

--- a/packages/better-auth/src/types/models.ts
+++ b/packages/better-auth/src/types/models.ts
@@ -5,6 +5,19 @@ import type { InferFieldsFromOptions, InferFieldsFromPlugins } from "../db";
 import type { StripEmptyObjects, UnionToIntersection } from "./helper";
 import type { BetterAuthPlugin } from "./plugins";
 
+export type Models =
+	| "user"
+	| "account"
+	| "session"
+	| "verification"
+	| "rate-limit"
+	| "organization"
+	| "member"
+	| "invitation"
+	| "jwks"
+	| "passkey"
+	| "two-factor";
+
 export type AdditionalUserFieldsInput<Options extends BetterAuthOptions> =
 	InferFieldsFromPlugins<Options, "user", "input"> &
 		InferFieldsFromOptions<Options, "user", "input">;

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -2,11 +2,11 @@ import type { Dialect, Kysely, MysqlPool, PostgresPool } from "kysely";
 import type { Account, Session, User, Verification } from "../db/schema";
 import type { BetterAuthPlugin } from "./plugins";
 import type { SocialProviderList, SocialProviders } from "../social-providers";
-import type { Adapter, AdapterInstance, SecondaryStorage } from "./adapter";
+import type { AdapterInstance, SecondaryStorage } from "./adapter";
 import type { KyselyDatabaseType } from "../adapters/kysely-adapter/types";
 import type { FieldAttribute } from "../db";
-import type { RateLimit } from "./models";
-import type { AuthContext, OmitId } from ".";
+import type { Models, RateLimit } from "./models";
+import type { AuthContext, LiteralUnion, OmitId } from ".";
 import type { CookieOptions } from "better-call";
 import type { Database } from "better-sqlite3";
 import type { Logger } from "../utils";
@@ -75,15 +75,6 @@ export interface BetterAuthOptions {
 		| {
 				dialect: Dialect;
 				type: KyselyDatabaseType;
-				/**
-				 * Custom generateId function.
-				 *
-				 * If not provided, nanoid will be used.
-				 * If set to false, the database's auto generated id will be used.
-				 *
-				 * @default nanoid
-				 */
-				generateId?: ((size?: number) => string) | false;
 		  }
 		| {
 				/**
@@ -94,15 +85,6 @@ export interface BetterAuthOptions {
 				 * Database type between postgres, mysql and sqlite
 				 */
 				type: KyselyDatabaseType;
-				/**
-				 * Custom generateId function.
-				 *
-				 * If not provided, nanoid will be used.
-				 * If set to false, the database's auto generated id will be used.
-				 *
-				 * @default nanoid
-				 */
-				generateId?: ((size?: number) => string) | false;
 		  };
 	/**
 	 * Secondary storage configuration
@@ -513,6 +495,20 @@ export interface BetterAuthOptions {
 		 * ```
 		 */
 		cookiePrefix?: string;
+		/**
+		 * Custom generateId function.
+		 *
+		 * If not provided, nanoid will be used.
+		 * If set to false, the database's auto generated id will be used.
+		 *
+		 * @default nanoid
+		 */
+		generateId?:
+			| ((options: {
+					model: LiteralUnion<Models, string>;
+					size?: number;
+			  }) => string)
+			| false;
 	};
 	logger?: Logger;
 	/**

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -9,6 +9,9 @@ describe("general types", async (it) => {
 			session: {
 				id: string;
 				userId: string;
+				token: string;
+				createdAt: Date;
+				updatedAt: Date;
 				expiresAt: Date;
 				ipAddress?: string | undefined | null;
 				userAgent?: string | undefined | null;
@@ -44,6 +47,9 @@ describe("general types", async (it) => {
 			id: string;
 			userId: string;
 			expiresAt: Date;
+			createdAt: Date;
+			updatedAt: Date;
+			token: string;
 			ipAddress?: string | undefined | null;
 			userAgent?: string | undefined | null;
 			activeOrganizationId?: string | undefined | null;


### PR DESCRIPTION
This change introduces two new required fields, `createdAt` and `updatedAt`, in the session, verification, and accounts tables. Additionally, a major update is made regarding session tokens. Previously, session tokens were stored in the `id` field because, until recently, Better Auth handled ID generation. This approach allowed us to securely generate IDs for the session table and use them as tokens, eliminating the need for an extra token field and maintaining consistency with other tables. 

However, since we now allow custom ID generators or even database-generated IDs, this poses a security risk. User-implemented ID generators could produce IDs that are predictable or weak. To address this, a new `token` field has been added to the session table for storing tokens. This change also enables support for incremental numeric IDs, as requested in issue #227, which was not feasible under the previous design.