### PR TITLE
Add support for ZenStack Prisma when generating migration.

### DIFF
--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -13,8 +13,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 }) => {
 	const provider = adapter.options?.provider || "postgresql";
 	const tables = getAuthTables(options);
-	// Add schema.zmodel, to update that first if ZenStack is being used on top of Prisma
-	const filePath = file || "./schema.zmodel" || "./prisma/schema.prisma";
+	const filePath = file || (existsSync(path.join(process.cwd(), "./schema.zmodel")) ? "./schema.zmodel" : "./prisma/schema.prisma");
 	const schemaPrismaExist = existsSync(path.join(process.cwd(), filePath));
 	let schemaPrisma = "";
 	if (schemaPrismaExist) {

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -13,7 +13,8 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 }) => {
 	const provider = adapter.options?.provider || "postgresql";
 	const tables = getAuthTables(options);
-	const filePath = file || "./prisma/schema.prisma";
+	// Add schema.zmodel, to update that first if ZenStack is being used on top of Prisma
+	const filePath = file || "./schema.zmodel" || "./prisma/schema.prisma";
 	const schemaPrismaExist = existsSync(path.join(process.cwd(), filePath));
 	let schemaPrisma = "";
 	if (schemaPrismaExist) {


### PR DESCRIPTION
Just a quick fix to check if schema.zmodel existing before jumping straight to schema.prisma, as when using ZenStack, the prisma schema is automatically generated from the zmodel, and is not supposed to be modified manually.