### PR TITLE
feat: improve type hinting for social providers

### DIFF
--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -106,4 +106,5 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 ### Resources & Examples
 
 - [Nuxt and Nuxt Hub example](https://github.com/atinux/nuxthub-better-auth) on GitHub.
+- [NuxtZzle is Nuxt,Drizzle ORM example](https://github.com/leamsigc/nuxt-better-auth-drizzle) on github [preview](https://nuxt-better-auth.giessen.dev/)
 - [Nuxt example](https://stackblitz.com/github/better-auth/better-auth/tree/main/examples/nuxt-example) on StackBlitz.

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -561,12 +561,17 @@ You can use the `hasPermission` action provided by the `api` to check the permis
 ```ts title="api.ts"
 import { auth } from "@/auth";
 
-auth.api.hasPermission({
-    role: "admin",
-    permission: {
-        project: ["create"]
-    }
-})
+    auth.api.hasPermission({
+        headers: await headers(),
+        body: {
+            role: {
+                in: ['admin']
+            },
+            permission: {
+                project: ["create"] // This must match the structure in your access control
+            }
+        }
+    });
 ```
 
 If you want to check the permission of the user on the client from the server you can use the `hasPermission` function provided by the client. 

--- a/packages/better-auth/src/social-providers/index.ts
+++ b/packages/better-auth/src/social-providers/index.ts
@@ -32,13 +32,13 @@ export const socialProviderList = Object.keys(socialProviders) as [
 	...(keyof typeof socialProviders)[],
 ];
 
-export type SocialProviders = typeof socialProviders extends {
-	[key in infer K]: infer V;
+export type SocialProviderList = typeof socialProviderList;
+
+export type SocialProviders = {
+	[K in SocialProviderList[number]]?: Prettify<Parameters<typeof socialProviders[K]>[0] & {
+		enabled?: boolean;
+	}>;
 }
-	? V extends (options: infer V) => any
-		? Partial<Record<K, Prettify<V & { enabled?: boolean }>>>
-		: never
-	: never;
 
 export * from "./github";
 export * from "./google";
@@ -52,5 +52,3 @@ export * from "./twitter";
 export * from "./dropbox";
 export * from "./linkedin";
 export * from "./gitlab";
-
-export type SocialProviderList = typeof socialProviderList;

--- a/packages/better-auth/src/social-providers/index.ts
+++ b/packages/better-auth/src/social-providers/index.ts
@@ -35,10 +35,12 @@ export const socialProviderList = Object.keys(socialProviders) as [
 export type SocialProviderList = typeof socialProviderList;
 
 export type SocialProviders = {
-	[K in SocialProviderList[number]]?: Prettify<Parameters<typeof socialProviders[K]>[0] & {
-		enabled?: boolean;
-	}>;
-}
+	[K in SocialProviderList[number]]?: Prettify<
+		Parameters<(typeof socialProviders)[K]>[0] & {
+			enabled?: boolean;
+		}
+	>;
+};
 
 export * from "./github";
 export * from "./google";


### PR DESCRIPTION
I have bad DX on webstorm with old behavior. I think it's too much infer here that delays ts server

old behavior:
<img width="739" alt="image" src="https://github.com/user-attachments/assets/5171df34-7607-4834-ab3e-57a288b47cd6">

<img width="763" alt="image" src="https://github.com/user-attachments/assets/385e5e0e-b9e9-41d4-8e45-072cacaaacfe">


new behavior: 
<img width="762" alt="image" src="https://github.com/user-attachments/assets/95d12916-6883-4353-ad13-093fa27911f0">

<img width="710" alt="image" src="https://github.com/user-attachments/assets/bfd9ab11-e3b4-4a88-bb12-5123ecd45aac">
