### PR TITLE
fix: Drizzle schema generation custom model name

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -45,7 +45,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				return `timestamp('${name}')`;
 			}
 		}
-		const schema = `export const ${table} = ${databaseType}Table("${modelName}", {
+		const schema = `export const ${modelName} = ${databaseType}Table("${modelName}", {
 					id: text("id").primaryKey(),
 					${Object.keys(fields)
 						.map((field) => {


### PR DESCRIPTION
Providing a custom model name results in errors as the `references` uses the custom model name, but the actual model definition does not. The drizzle adapter also looks up the custom model name when forming queries, which would also currently not find the model correctly. 