### PR TITLE
fix: should use deleteMany instead of delete on session table using token field

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -430,7 +430,7 @@ export const createInternalAdapter = (
 			if (secondaryStorage) {
 				await secondaryStorage.delete(token);
 				if (options.session?.storeSessionInDatabase) {
-					await adapter.delete<Session>({
+					await adapter.deleteMany({
 						model: "session",
 						where: [
 							{
@@ -442,7 +442,7 @@ export const createInternalAdapter = (
 				}
 				return;
 			}
-			await adapter.delete<Session>({
+			await adapter.deleteMany({
 				model: "session",
 				where: [
 					{


### PR DESCRIPTION
In Prisma (probably others) when deleting `session` on user logout, we use `delete` with field `token`. Since this field is not `id` or `unique field` we should use `deleteMany` otherwise there is an error: 

````
prisma:error 
Invalid `db[getModelName(model)].delete()` invocation in
better-auth/src/adapters/prisma-adapter/prisma-adapter.ts:237:41

  234 const { model, where } = data;
  235 const whereClause = convertWhereClause(model, where);
  236 try {
→ 237   await db[getModelName(model)].delete({
          where: {
            token: "YGx--5eI4P6trC6g3EQT27GjFmzPosMde",
        ?   id?: String,
        ?   AND?: SessionWhereInput | SessionWhereInput[],
        ?   OR?: SessionWhereInput[],
        ?   NOT?: SessionWhereInput | SessionWhereInput[],
        ?   expiresAt?: DateTimeFilter | DateTime,
        ?   ipAddress?: StringNullableFilter | String | Null,
        ?   userAgent?: StringNullableFilter | String | Null,
        ?   userId?: StringFilter | String,
        ?   createdAt?: DateTimeFilter | DateTime,
        ?   updatedAt?: DateTimeFilter | DateTime,
        ?   user?: UserRelationFilter | UserWhereInput
          }
        })

Argument `where` of type SessionWhereUniqueInput needs at least one of `id` arguments. Available options are marked with ?.
````