### PR TITLE
fix: id is not a property in idToken payload when accountLinked is enabled

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -103,7 +103,12 @@ async function getUserInfo(
 	if (type === "oidc" && tokens.idToken) {
 		const decoded = parseJWT(tokens.idToken);
 		if (decoded?.payload) {
-			return decoded.payload;
+			return {
+				id: decoded.payload.sub,
+				emailVerified: decoded.payload.email_verified,
+				email: decoded.payload.email,
+				...decoded.payload,
+			};
 		}
 	}
 


### PR DESCRIPTION
It is possible that the idToken does not contain the required id or data, so it is better to unify and destructure the information; this resolves the error when accountLinking is enabled