### PR TITLE
fix: update admin plugin UserWithRole type to reflect db schema

### DIFF
--- a/packages/better-auth/src/plugins/admin/index.ts
+++ b/packages/better-auth/src/plugins/admin/index.ts
@@ -22,7 +22,7 @@ export interface UserWithRole extends User {
 	role?: string | null;
 	banned?: boolean | null;
 	banReason?: string | null;
-	banExpires?: number | null;
+	banExpires?: Date | null;
 }
 
 interface SessionWithImpersonatedBy extends Session {


### PR DESCRIPTION
Updates `banExpires` field type in `UserWithRole` to `Date` to reflect the database type