### PR TITLE
fix: always prefer custom generateId function

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -60,13 +60,11 @@ const createTransform = (
 				useDatabaseGeneratedId || action === "update"
 					? {}
 					: {
-							id:
-								data.id ||
-								(options.advanced?.generateId
-									? options.advanced.generateId({
-											model,
-										})
-									: generateId()),
+							id: options.advanced?.generateId
+								? options.advanced.generateId({
+										model,
+									})
+								: data.id || generateId(),
 						};
 			for (const key in data) {
 				const field = schema[model].fields[key];

--- a/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.test.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.test.ts
@@ -50,7 +50,9 @@ describe("Drizzle Adapter Tests", async () => {
 	const adapter = drizzleAdapter(db, { provider: "pg", schema });
 
 	await runAdapterTest({
-		adapter: adapter(opts),
+		getAdapter: async (customOptions = {}) => {
+			return adapter({ ...opts, ...customOptions });
+		},
 	});
 });
 

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -69,13 +69,11 @@ const createTransform = (
 				useDatabaseGeneratedId || action === "update"
 					? {}
 					: {
-							id:
-								data.id ||
-								(options.advanced?.generateId
-									? options.advanced.generateId({
-											model,
-										})
-									: generateId()),
+							id: options.advanced?.generateId
+								? options.advanced.generateId({
+										model,
+									})
+								: data.id || generateId(),
 						};
 			for (const key in data) {
 				const field = schema[model].fields[key];

--- a/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysley.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysley.test.ts
@@ -57,15 +57,19 @@ describe("adapter test", async () => {
 
 	const mysqlAdapter = kyselyAdapter(mysqlKy, {
 		type: "mysql",
-	})(mysqlOptions);
+	});
 	await runAdapterTest({
-		adapter: mysqlAdapter,
+		getAdapter: async (customOptions = {}) => {
+			return mysqlAdapter({ ...mysqlOptions, ...customOptions });
+		},
 	});
 
 	const sqliteAdapter = kyselyAdapter(sqliteKy, {
 		type: "sqlite",
-	})(sqliteOptions);
+	});
 	await runAdapterTest({
-		adapter: sqliteAdapter,
+		getAdapter: async (customOptions = {}) => {
+			return sqliteAdapter({ ...sqliteOptions, ...customOptions });
+		},
 	});
 });

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -26,13 +26,11 @@ const createTransform = (options: BetterAuthOptions) => {
 				action === "update"
 					? {}
 					: {
-							id:
-								data.id ||
-								(options.advanced?.generateId
-									? options.advanced.generateId({
-											model,
-										})
-									: generateId()),
+							id: options.advanced?.generateId
+								? options.advanced.generateId({
+										model,
+									})
+								: data.id || generateId(),
 						};
 			for (const key in data) {
 				const field = schema[model].fields[key];

--- a/packages/better-auth/src/adapters/memory-adapter/memory.test.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory.test.ts
@@ -11,12 +11,15 @@ describe("adapter test", async () => {
 	};
 	const adapter = memoryAdapter(db);
 	await runAdapterTest({
-		adapter: adapter({
-			user: {
-				fields: {
-					email: "email_address",
+		getAdapter: async (customOptions = {}) => {
+			return adapter({
+				user: {
+					fields: {
+						email: "email_address",
+					},
 				},
-			},
-		} as BetterAuthOptions),
+				...customOptions,
+			});
+		},
 	});
 });

--- a/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
@@ -39,6 +39,7 @@ describe("adapter test", async () => {
 				...customOptions,
 			});
 		},
+		skipGenerateIdTest: true,
 	});
 });
 

--- a/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
@@ -4,7 +4,6 @@ import { MongoClient } from "mongodb";
 import { runAdapterTest } from "../test";
 import { mongodbAdapter } from ".";
 import { getTestInstance } from "../../test-utils/test-instance";
-import type { BetterAuthOptions } from "../../types";
 
 describe("adapter test", async () => {
 	const dbClient = async (connectionString: string, dbName: string) => {
@@ -27,16 +26,19 @@ describe("adapter test", async () => {
 
 	const adapter = mongodbAdapter(db);
 	await runAdapterTest({
-		adapter: adapter({
-			user: {
-				fields: {
-					email: "email_address",
+		getAdapter: async (customOptions = {}) => {
+			return adapter({
+				user: {
+					fields: {
+						email: "email_address",
+					},
 				},
-			},
-			session: {
-				modelName: "sessions",
-			},
-		} as BetterAuthOptions),
+				session: {
+					modelName: "sessions",
+				},
+				...customOptions,
+			});
+		},
 	});
 });
 

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -65,13 +65,11 @@ const createTransform = (config: PrismaConfig, options: BetterAuthOptions) => {
 				useDatabaseGeneratedId || action === "update"
 					? {}
 					: {
-							id:
-								data.id ||
-								(options.advanced?.generateId
-									? options.advanced.generateId({
-											model,
-										})
-									: generateId()),
+							id: options.advanced?.generateId
+								? options.advanced.generateId({
+										model,
+									})
+								: data.id || generateId(),
 						};
 			for (const key in data) {
 				const field = schema[model].fields[key];

--- a/packages/better-auth/src/adapters/prisma-adapter/test/adapter.prisma.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/adapter.prisma.test.ts
@@ -14,16 +14,19 @@ describe("adapter test", async () => {
 	});
 
 	await runAdapterTest({
-		adapter: adapter({
-			user: {
-				fields: {
-					email: "email_address",
+		getAdapter: async (customOptions = {}) => {
+			return adapter({
+				user: {
+					fields: {
+						email: "email_address",
+					},
 				},
-			},
-			session: {
-				modelName: "sessions",
-			},
-		} as BetterAuthOptions),
+				session: {
+					modelName: "sessions",
+				},
+				...customOptions,
+			});
+		},
 	});
 });
 

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -1,14 +1,15 @@
 import { expect, test } from "vitest";
-import type { Adapter, User } from "../types";
-import { nanoid } from "nanoid";
+import type { Adapter, BetterAuthOptions, User } from "../types";
 import { generateId } from "../utils";
 
 interface AdapterTestOptions {
-	adapter: Adapter;
+	getAdapter: (
+		customOptions?: Pick<BetterAuthOptions, "advanced">,
+	) => Promise<Adapter>;
 }
 
 export async function runAdapterTest(opts: AdapterTestOptions) {
-	const { adapter } = opts;
+	const adapter = await opts.getAdapter();
 	const user = {
 		id: "1",
 		name: "user",
@@ -410,5 +411,27 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 			],
 		});
 		expect(res.length).toBe(1);
+	});
+
+	test("should prefer generateId if provided", async () => {
+		const customAdapter = await opts.getAdapter({
+			advanced: {
+				generateId: () => "mocked-id",
+			},
+		});
+
+		const res = await customAdapter.create({
+			model: "user",
+			data: {
+				id: "1",
+				name: "user4",
+				email: "user4@email.com",
+				emailVerified: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+
+		expect(res.id).toBe("mocked-id");
 	});
 }

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -4,8 +4,9 @@ import { generateId } from "../utils";
 
 interface AdapterTestOptions {
 	getAdapter: (
-		customOptions?: Pick<BetterAuthOptions, "advanced">,
+		customOptions?: Omit<BetterAuthOptions, "database">,
 	) => Promise<Adapter>;
+	skipGenerateIdTest?: boolean;
 }
 
 export async function runAdapterTest(opts: AdapterTestOptions) {
@@ -413,25 +414,27 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		expect(res.length).toBe(1);
 	});
 
-	test("should prefer generateId if provided", async () => {
-		const customAdapter = await opts.getAdapter({
-			advanced: {
-				generateId: () => "mocked-id",
-			},
-		});
+	if (!opts.skipGenerateIdTest) {
+		test("should prefer generateId if provided", async () => {
+			const customAdapter = await opts.getAdapter({
+				advanced: {
+					generateId: () => "mocked-id",
+				},
+			});
 
-		const res = await customAdapter.create({
-			model: "user",
-			data: {
-				id: "1",
-				name: "user4",
-				email: "user4@email.com",
-				emailVerified: true,
-				createdAt: new Date(),
-				updatedAt: new Date(),
-			},
-		});
+			const res = await customAdapter.create({
+				model: "user",
+				data: {
+					id: "1",
+					name: "user4",
+					email: "user4@email.com",
+					emailVerified: true,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
 
-		expect(res.id).toBe("mocked-id");
-	});
+			expect(res.id).toBe("mocked-id");
+		});
+	}
 }


### PR DESCRIPTION
This PR resolves an issue where the `generateId` function was not called consistently, specifically when a model `id` was already provided to the adapter. You can reproduce the issue using the `/organization/create` API endpoint.