### PR TITLE
feat(cli): account for usePlural option in drizzle schema generation

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -10,6 +10,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	const tables = getAuthTables(options);
 	const filePath = file || "./auth-schema.ts";
 	const databaseType = adapter.options?.provider;
+	const usePlural = adapter.options?.usePlural;
 	const timestampAndBoolean =
 		databaseType !== "sqlite" ? "timestamp, boolean" : "";
 	const int = databaseType === "mysql" ? "int" : "integer";
@@ -19,7 +20,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	const fileExist = existsSync(filePath);
 
 	for (const table in tables) {
-		const modelName = tables[table].modelName;
+		const modelName = usePlural ? `${tables[table].modelName}s` : tables[table].modelName;
 		const fields = tables[table].fields;
 		function getType(name: string, type: FieldType) {
 			if (type === "string") {
@@ -54,7 +55,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 								attr.required ? ".notNull()" : ""
 							}${attr.unique ? ".unique()" : ""}${
 								attr.references
-									? `.references(()=> ${attr.references.model}.${attr.references.field})`
+									? `.references(()=> ${usePlural ? `${attr.references.model}s` : attr.references.model}.${attr.references.field})`
 									: ""
 							}`;
 						})


### PR DESCRIPTION
Using the `usePlural` option in the Drizzle adapter options does not affect the behaviour of the `generate` CLI command.
This PR addresses this and makes the CLI command pluralize the generated model names when the `usePlural` option is `true`.