### PR TITLE
Fix "email not found" Error in Twitter OAuth

### DIFF
--- a/docs/content/docs/authentication/twitter.mdx
+++ b/docs/content/docs/authentication/twitter.mdx
@@ -9,6 +9,12 @@ description: Twitter provider setup and usage.
         Get your Twitter credentials from the [Twitter Developer Portal](https://developer.twitter.com/en/portal/dashboard).
 
         Make sure to set the redirect URL to `http://localhost:3000/api/auth/callback/twitter` for local development. For production, you should set it to the URL of your application. If you change the base path of the auth routes, you should update the redirect URL accordingly.
+        
+        {/*
+        <Callout type="warn">
+            If twitter doesn't return the email address, the authentication won't be successful. Make sure to ask for the email address when you create the Twitter app.
+        </Callout>
+        */}
         <Callout type="info">
             Twitter API v2 does not provide email addresses. As a workaround, the user's `email` field uses the `username` value instead.
         </Callout>
@@ -46,8 +52,5 @@ description: Twitter provider setup and usage.
             })
         }
         ```
-        <Callout type="warn">
-            If twitter doesn't return the email address, the authentication won't be successful. Make sure to ask for the email address when you create the Twitter app.
-        </Callout>
     </Step>
 </Steps>

--- a/docs/content/docs/authentication/twitter.mdx
+++ b/docs/content/docs/authentication/twitter.mdx
@@ -9,6 +9,9 @@ description: Twitter provider setup and usage.
         Get your Twitter credentials from the [Twitter Developer Portal](https://developer.twitter.com/en/portal/dashboard).
 
         Make sure to set the redirect URL to `http://localhost:3000/api/auth/callback/twitter` for local development. For production, you should set it to the URL of your application. If you change the base path of the auth routes, you should update the redirect URL accordingly.
+        <Callout type="info">
+            Twitter API v2 does not provide email addresses. As a workaround, the user's `email` field uses the `username` value instead.
+        </Callout>
     </Step>
 
   <Step>

--- a/packages/better-auth/src/social-providers/twitter.ts
+++ b/packages/better-auth/src/social-providers/twitter.ts
@@ -144,7 +144,7 @@ export const twitter = (options: TwitterOption) => {
 				user: {
 					id: profile.data.id,
 					name: profile.data.name,
-					email: profile.data.email || null,
+					email: profile.data.username || null,
 					image: profile.data.profile_image_url,
 					emailVerified: profile.data.verified || false,
 				},


### PR DESCRIPTION
## Why is this change needed?
- The Twitter v2 API does not return the `email` field.
- However, the `getUserInfo` function in `/social-providers/twitter` expects an `email` value.
- This causes a sign-in failure with the error: `email_not_found` when using Twitter OAuth.
## Changes Made
- Replaced the usage of the `email` field with the `username` value returned by the Twitter API.
- Adjusted the `getUserInfo` function to handle this change.
## Change Impact
- Twitter OAuth now functions correctly without triggering the `email_not_found` error.
## Related Issues
- Fixes #591