### PR TITLE
docs: fix typos in basic-usage.mdx

### DIFF
--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -413,7 +413,7 @@ The server provides a `session` object that you can use to access the session da
 
 ## Using Plugins
 
-One of the unique features of Better Auth is a plugins ecosystem. It allows you to add complex auth realted functionilty with small lines of code.
+One of the unique features of Better Auth is a plugins ecosystem. It allows you to add complex auth related functionilty with small lines of code.
 
 Below is an example of how to add two factor authentication using two factor plugin.
 

--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -413,7 +413,7 @@ The server provides a `session` object that you can use to access the session da
 
 ## Using Plugins
 
-One of the unique features of Better Auth is a plugins ecosystem. It allows you to add complex auth related functionilty with small lines of code.
+One of the unique features of Better Auth is a plugins ecosystem. It allows you to add complex auth related functionality with small lines of code.
 
 Below is an example of how to add two factor authentication using two factor plugin.
 


### PR DESCRIPTION
Fix typos "realted" to "related" and "functionilty" to "functionality" in basic-usage.mdx.