### PR TITLE
fix: missing export type for admin plugin

### DIFF
--- a/packages/better-auth/src/plugins/admin/index.ts
+++ b/packages/better-auth/src/plugins/admin/index.ts
@@ -25,7 +25,7 @@ export interface UserWithRole extends User {
 	banExpires?: Date | null;
 }
 
-interface SessionWithImpersonatedBy extends Session {
+export interface SessionWithImpersonatedBy extends Session {
 	impersonatedBy?: string;
 }
 


### PR DESCRIPTION
closes #682 