### PR TITLE
Fix typo: "retunr" to "return" in customSession

### DIFF
--- a/docs/content/docs/concepts/session-management.mdx
+++ b/docs/content/docs/concepts/session-management.mdx
@@ -214,7 +214,7 @@ export const auth = betterAuth({
         ...options.plugins,
         customSession(async ({ user, session }) => {
             // now both user and session will infer the fields added by plugins and your custom fields
-            retunr {
+            return {
                 user,
                 session
             }


### PR DESCRIPTION
Corrected "retunr" to "return" in the customSession function to fix the typo