### PR TITLE
feat: allow pass trusted origin as function

### DIFF
--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -351,9 +351,9 @@ export interface BetterAuthOptions {
 		fields?: Partial<Record<keyof OmitId<Verification>, string>>;
 	};
 	/**
-	 * List of trusted origins.
+	 * List of trusted origins, or a function that returns a trusted origin
 	 */
-	trustedOrigins?: string[];
+	trustedOrigins?: string[] | ((origin: string) => string | null);
 	/**
 	 * Rate limiting configuration
 	 */

--- a/packages/better-auth/src/utils/callback-url.ts
+++ b/packages/better-auth/src/utils/callback-url.ts
@@ -11,7 +11,7 @@ export const checkCallbackURL = (
 ) => {
 	const trustedOrigins = ctx.context.trustedOrigins;
 	const callbackOrigin = callbackURL ? new URL(callbackURL).origin : null;
-	if (callbackOrigin && !trustedOrigins.includes(callbackOrigin)) {
+	if (callbackOrigin && !trustedOrigins(callbackOrigin)) {
 		throw new APIError("FORBIDDEN", {
 			message: "Invalid callback URL",
 		});


### PR DESCRIPTION
This would be helpful if I have like vecel deployment and there're many subdomain, otherwise the social provider callback url will not working as expected