### PR TITLE
fix: get scheme from expo config

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -95,8 +95,12 @@ export const expoClient = (opts?: ExpoClientOptions) => {
 	const cookieName = `${opts?.storagePrefix || "better-auth"}_cookie`;
 	const localCacheName = `${opts?.storagePrefix || "better-auth"}_session_data`;
 	const storage = opts?.storage || SecureStore;
-	const scheme = opts?.scheme || Constants.platform?.scheme;
 	const isWeb = Platform.OS === "web";
+
+	const rawScheme =
+		opts?.scheme || Constants.expoConfig?.scheme || Constants.platform?.scheme;
+	const scheme = Array.isArray(rawScheme) ? rawScheme[0] : rawScheme;
+
 	if (!scheme && !isWeb) {
 		throw new Error(
 			"Scheme not found in app.json. Please provide a scheme in the options.",


### PR DESCRIPTION

- **`Constants.platform?.scheme`** when working with platform-specific functionality or debugging native builds.
- **`Constants.expoConfig?.scheme`** for a simpler, cross-platform approach during development or managed workflows.

If the app has not been ejected, `Constants.expoConfig?.scheme` will generally be sufficient.