### PR TITLE
feat: add support for configurable digits length

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -213,7 +213,7 @@ const verifyTotp = async (code: string) => {
 
 ### OTP
 
-OTP (One-Time Password) is similar to TOTP but the code is sent directly to the user, and the code is valid for 3 mins by default.
+OTP (One-Time Password) is similar to TOTP but a random code is generated and sent to the user's email or phone.
 
 Before using OTP to verify the second factor, you need to configure `sendOTP` in your Better Auth instance. This function is responsible for sending the OTP to the user's email, phone, or any other method supported by your application.
 

--- a/packages/better-auth/src/plugins/two-factor/otp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/otp/index.ts
@@ -1,5 +1,4 @@
 import { APIError } from "better-call";
-import { TOTPController } from "oslo/otp";
 import { z } from "zod";
 import { createAuthEndpoint } from "../../../api/call";
 import { verifyTwoFactorMiddleware } from "../verify-middleware";
@@ -9,6 +8,7 @@ import type {
 	UserWithTwoFactor,
 } from "../types";
 import { TimeSpan } from "oslo";
+import { alphabet, generateRandomString } from "../../../crypto";
 
 export interface OTPOptions {
 	/**
@@ -18,14 +18,12 @@ export interface OTPOptions {
 	 * @default "3 mins"
 	 */
 	period?: number;
-
 	/**
 	 * Number of digits for the OTP code
 	 *
 	 * @default 6
 	 */
-	digits?: 6 | 8;
-
+	digits?: number;
 	/**
 	 * Send the otp to the user
 	 *
@@ -60,10 +58,6 @@ export const otp2fa = (options: OTPOptions, twoFactorTable: string) => {
 		digits: options?.digits || 6,
 		period: new TimeSpan(options?.period || 3, "m"),
 	};
-	const totp = new TOTPController({
-		digits: opts.digits,
-		period: opts.period,
-	});
 	/**
 	 * Generate OTP and send it to the user.
 	 */
@@ -120,7 +114,12 @@ export const otp2fa = (options: OTPOptions, twoFactorTable: string) => {
 					message: "OTP isn't enabled",
 				});
 			}
-			const code = await totp.generate(Buffer.from(twoFactor.secret));
+			const code = generateRandomString(opts.digits, alphabet("0-9"));
+			await ctx.context.internalAdapter.createVerificationValue({
+				value: code,
+				identifier: `2fa-otp-${user.id}`,
+				expiresAt: new Date(Date.now() + opts.period.milliseconds()),
+			});
 			await options.sendOTP({ user, otp: code }, ctx.request);
 			return ctx.json({ status: true });
 		},
@@ -181,8 +180,16 @@ export const otp2fa = (options: OTPOptions, twoFactorTable: string) => {
 					message: "OTP isn't enabled",
 				});
 			}
-			const toCheckOtp = await totp.generate(Buffer.from(twoFactor.secret));
-			if (toCheckOtp === ctx.body.code) {
+			const toCheckOtp =
+				await ctx.context.internalAdapter.findVerificationValue(
+					`2fa-otp-${user.id}`,
+				);
+			if (!toCheckOtp || toCheckOtp.expiresAt < new Date()) {
+				throw new APIError("BAD_REQUEST", {
+					message: "OTP has expired",
+				});
+			}
+			if (toCheckOtp.value === ctx.body.code) {
 				return ctx.context.valid();
 			} else {
 				return ctx.context.invalid();

--- a/packages/better-auth/src/plugins/two-factor/otp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/otp/index.ts
@@ -18,6 +18,14 @@ export interface OTPOptions {
 	 * @default "3 mins"
 	 */
 	period?: number;
+
+	/**
+	 * Number of digits for the OTP code
+	 *
+	 * @default 6
+	 */
+	digits?: 6 | 8;
+
 	/**
 	 * Send the otp to the user
 	 *
@@ -49,10 +57,11 @@ export interface OTPOptions {
 export const otp2fa = (options: OTPOptions, twoFactorTable: string) => {
 	const opts = {
 		...options,
+		digits: options?.digits || 6,
 		period: new TimeSpan(options?.period || 3, "m"),
 	};
 	const totp = new TOTPController({
-		digits: 6,
+		digits: opts.digits,
 		period: opts.period,
 	});
 	/**

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -39,7 +39,7 @@ export type TOTPOptions = {
 export const totp2fa = (options: TOTPOptions, twoFactorTable: string) => {
 	const opts = {
 		...options,
-		digits: 6,
+		digits: options?.digits || 6,
 		period: new TimeSpan(options?.period || 30, "s"),
 	};
 


### PR DESCRIPTION
This pull request closes #653 . It adds the option, to make the digit length of otp configurable. 