### PR TITLE
chore: typo in expo docs change plugins expo to expo() 

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -48,7 +48,7 @@ Expo is a popular framework for building cross-platform apps with React Native. 
 
         export const auth = betterAuth({
             plugins: [
-                expo
+                expo()
             ]
         });
         ```


### PR DESCRIPTION
changes 
  plugins: [
    expo
]
to 
  plugins: [
    expo()
]