### PR TITLE
fixes cookie MaxAge not being updated when calling getSession

### DIFF
--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -107,21 +107,21 @@ export async function setSessionCookie(
 		? undefined
 		: ctx.context.sessionConfig.expiresIn;
 
-	const hasAlreadySession = await getSessionFromCtx(ctx).catch(() => {
-		// this could throw error when headers isn't found. but we don't want to throw error
-		return null;
-	});
-	if (hasAlreadySession) {
-		if (
-			hasAlreadySession.session.userId === session.session.userId &&
-			hasAlreadySession.session.token !== session.session.token
-		) {
-			// If the user already has a session, delete the old session
-			await ctx.context.internalAdapter.deleteSession(
-				hasAlreadySession.session.token,
-			);
-		}
-	}
+	// const hasAlreadySession = await getSessionFromCtx(ctx).catch(() => {
+	// 	// this could throw error when headers isn't found. but we don't want to throw error
+	// 	return null;
+	// });
+	// if (hasAlreadySession) {
+	// 	if (
+	// 		hasAlreadySession.session.userId === session.session.userId &&
+	// 		hasAlreadySession.session.token !== session.session.token
+	// 	) {
+	// 		// If the user already has a session, delete the old session
+	// 		await ctx.context.internalAdapter.deleteSession(
+	// 			hasAlreadySession.session.token,
+	// 		);
+	// 	}
+	// }
 
 	await ctx.setSignedCookie(
 		ctx.context.authCookies.sessionToken.name,


### PR DESCRIPTION
Not fetching session inside `setSessionCookie` seems to work. Please verify it doesn't break other things. 

Closes issue #722 