### PR TITLE
feat(discord): add consent as an option

### DIFF
--- a/packages/better-auth/src/social-providers/discord.ts
+++ b/packages/better-auth/src/social-providers/discord.ts
@@ -74,7 +74,9 @@ export interface DiscordProfile extends Record<string, any> {
 	image_url: string;
 }
 
-export interface DiscordOptions extends ProviderOptions<DiscordProfile> {}
+export interface DiscordOptions extends ProviderOptions<DiscordProfile> {
+	prompt?: "none" | "consent";
+}
 
 export const discord = (options: DiscordOptions) => {
 	return {
@@ -90,7 +92,7 @@ export const discord = (options: DiscordOptions) => {
 					options.clientId
 				}&redirect_uri=${encodeURIComponent(
 					options.redirectURI || redirectURI,
-				)}&state=${state}`,
+				)}&state=${state}&prompt=${options.prompt || "none"}`,
 			);
 		},
 		validateAuthorizationCode: async ({ code, redirectURI }) => {


### PR DESCRIPTION
closes #739 

adds a consent option to Discord, defaulting to none as suggested in the linked issue.