### PR TITLE
fix: allow trusted providers to accept a string value for generic OAuth

### DIFF
--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -388,7 +388,9 @@ export interface BetterAuthOptions {
 			/**
 			 * List of trusted providers
 			 */
-			trustedProviders?: Array<SocialProviderList[number] | "email-password">;
+			trustedProviders?: Array<
+				LiteralUnion<SocialProviderList[number] | "email-password", string>
+			>;
 		};
 	};
 	/**


### PR DESCRIPTION
closes #559 