### PR TITLE
fix:changed the name of column webauthnUserID

### DIFF
--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -145,7 +145,7 @@ Table Name: `passkey`
             isForeignKey: true
         },
         {
-            name: "WebAuthnUserId",
+            name: "webauthnUserID",
             type: "string",
             description: "The user id for WebAuthn",
         },


### PR DESCRIPTION
Changed the name of the column at passkey plugin from WebAuthnUserId to webauthnUserID