### PR TITLE
fix: ignore invalid provider

### DIFF
--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -65,7 +65,10 @@ export const init = async (options: BetterAuthOptions) => {
 	const tables = getAuthTables(options);
 	const providers = Object.keys(options.socialProviders || {})
 		.map((key) => {
-			const value = options.socialProviders?.[key as "github"]!;
+			const value = options.socialProviders?.[key as "github"];
+			if (!value) {
+				return null;
+			}
 			if (value.enabled === false) {
 				return null;
 			}


### PR DESCRIPTION
When I'm developing, I might fill in an invalid `clientId`, which will cause the project to fail to run.

```
TypeError: Cannot read properties of undefined (reading 'enabled')
    at file:///Users/hyoban/i/follow-server/node_modules/.pnpm/better-auth@1.0.9/node_modules/better-auth/dist/index.js:83:30962
    at Array.map (<anonymous>)
    at Xt (file:///Users/hyoban/i/follow-server/node_modules/.pnpm/better-auth@1.0.9/node_modules/better-auth/dist/index.js:83:30916)
```

We might be able to ignore invalid socialProvider, or throw an error, WDYT?
