### PR TITLE
docs(fix): provided updated link for next js example

### DIFF
--- a/docs/content/docs/examples/next-js.mdx
+++ b/docs/content/docs/examples/next-js.mdx
@@ -10,7 +10,7 @@ Email & Password . Social Sign-in . Passkeys . Email Verification . Password Res
 
 See [Demo](https://demo.better-auth.com)
 
-<ForkButton url="better-auth/better-auth/tree/main/examples/nextjs-example"  />
+<ForkButton url="better-auth/better-auth/tree/main/demo/nextjs"  />
 
 <iframe src="https://stackblitz.com/github/better-auth/better-auth/tree/main/demo/nextjs?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
    style={{


### PR DESCRIPTION
The link for the next js example in the docs was incorrect. Added the updated link.