### PR TITLE
fix: Allow empty name in updateUser

### DIFF
--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -88,7 +88,11 @@ export const updateUser = <O extends BetterAuthOptions>() =>
 			}
 			const { name, image, ...rest } = body;
 			const session = ctx.context.session;
-			if (image === undefined && name === undefined && Object.keys(rest).length === 0) {
+			if (
+				image === undefined &&
+				name === undefined &&
+				Object.keys(rest).length === 0
+			) {
 				return ctx.json({
 					id: session.user.id,
 					email: session.user.email,

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -88,7 +88,7 @@ export const updateUser = <O extends BetterAuthOptions>() =>
 			}
 			const { name, image, ...rest } = body;
 			const session = ctx.context.session;
-			if (image === undefined && !name && Object.keys(rest).length === 0) {
+			if (image === undefined && name === undefined && Object.keys(rest).length === 0) {
 				return ctx.json({
 					id: session.user.id,
 					email: session.user.email,


### PR DESCRIPTION
Due to a `!name`, the following code wouldn't work:

```ts
await auth.api.updateUser({
    body: {
        name: ''
    },
    headers: await headers()
});
```