### PR TITLE
fix: Set emailVerified to false when changing email

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -242,6 +242,7 @@ export const verifyEmail = createAuthEndpoint(
 				parsed.email,
 				{
 					email: parsed.updateTo,
+					emailVerified: false
 				},
 			);
 

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -242,7 +242,7 @@ export const verifyEmail = createAuthEndpoint(
 				parsed.email,
 				{
 					email: parsed.updateTo,
-					emailVerified: false
+					emailVerified: false,
 				},
 			);
 


### PR DESCRIPTION
When changing an email, `emailVerified` is not updated to false when the new email is set.