### PR TITLE
docs: add Nuxt server API route getSession example

### DIFF
--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -68,6 +68,27 @@ const session = authClient.useSession()
 </template>
 ```
 
+### Server Usage
+
+The `api` object exported from the auth instance contains all the actions that you can perform on the server. Every endpoint made inside Better Auth is a invocable as a function. Including plugins endpoints.
+
+**Example: Getting Session on a server API route**
+
+```tsx title="server/api/example.ts"
+import { auth } from "~/lib/auth";
+
+export default defineEventHandler((event) => {
+    const session = await auth.api.getSession({
+      headers: event.headers
+    });
+
+   if(session) {
+     // access the session.session && session.user
+   }
+});
+```
+
+
 ### SSR Usage
 
 If you are using Nuxt with SSR, you can use the `useSession` function in the `setup` function of your page component and pass `useFetch` to make it work with SSR.


### PR DESCRIPTION
Added an example to get the session on a server route. When implementing this I looked at the other integrations to see how it worked.