### PR TITLE
feat: custom origin checker and remove `currentURL` usage

### DIFF
--- a/packages/better-auth/src/api/middlewares/origin-check.test.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.test.ts
@@ -105,28 +105,6 @@ describe("Origin Check", async (it) => {
 		expect(res.data?.user).toBeDefined();
 	});
 
-	it("shouldn't allow untrusted currentURL", async (ctx) => {
-		const client = createAuthClient({
-			baseURL: "http://localhost:3000",
-			fetchOptions: {
-				customFetchImpl,
-			},
-		});
-
-		const res2 = await client.signIn.email({
-			email: testUser.email,
-			password: testUser.password,
-			fetchOptions: {
-				// @ts-expect-error - query is not defined in the type
-				query: {
-					currentURL: "http://malicious.com",
-				},
-			},
-		});
-		expect(res2.error?.status).toBe(403);
-		expect(res2.error?.message).toBe("Invalid currentURL");
-	});
-
 	it("shouldn't allow untrusted redirectTo", async (ctx) => {
 		const client = createAuthClient({
 			baseURL: "http://localhost:3000",
@@ -157,18 +135,6 @@ describe("Origin Check", async (it) => {
 			redirectTo: "http://localhost:5000/reset-password",
 		});
 		expect(res.data?.status).toBeTruthy();
-
-		const res2 = await client.signIn.email({
-			email: testUser.email,
-			password: testUser.password,
-			fetchOptions: {
-				// @ts-expect-error - query is not defined in the type
-				query: {
-					currentURL: "http://localhost:5000",
-				},
-			},
-		});
-		expect(res2.data?.user).toBeDefined();
 	});
 
 	it("should work with wildcard trusted origins", async (ctx) => {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -61,15 +61,6 @@ export const linkSocialAccount = createAuthEndpoint(
 	{
 		method: "POST",
 		requireHeaders: true,
-		query: z
-			.object({
-				/**
-				 * Redirect to the current URL after the
-				 * user has signed in.
-				 */
-				currentURL: z.string().optional(),
-			})
-			.optional(),
 		body: z.object({
 			/**
 			 * Callback URL to redirect to after the user has signed in.

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -52,7 +52,7 @@ export async function sendVerificationEmailFn(
 		user.email,
 	);
 	const url = `${ctx.context.baseURL}/verify-email?token=${token}&callbackURL=${
-		ctx.body.callbackURL || ctx.query?.currentURL || "/"
+		ctx.body.callbackURL || "/"
 	}`;
 	await ctx.context.options.emailVerification.sendVerificationEmail(
 		{
@@ -68,15 +68,6 @@ export const sendVerificationEmail = createAuthEndpoint(
 	"/send-verification-email",
 	{
 		method: "POST",
-		query: z
-			.object({
-				currentURL: z
-					.string({
-						description: "The URL to use for email verification callback",
-					})
-					.optional(),
-			})
-			.optional(),
 		body: z.object({
 			email: z
 				.string({

--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -196,7 +196,6 @@ export const resetPassword = createAuthEndpoint(
 		query: z.optional(
 			z.object({
 				token: z.string().optional(),
-				currentURL: z.string().optional(),
 			}),
 		),
 		method: "POST",
@@ -234,12 +233,7 @@ export const resetPassword = createAuthEndpoint(
 		},
 	},
 	async (ctx) => {
-		const token =
-			ctx.body.token ||
-			ctx.query?.token ||
-			(ctx.query?.currentURL
-				? new URL(ctx.query.currentURL).searchParams.get("token")
-				: "");
+		const token = ctx.body.token || ctx.query?.token;
 		if (!token) {
 			throw new APIError("BAD_REQUEST", {
 				message: BASE_ERROR_CODES.INVALID_TOKEN,

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -12,15 +12,6 @@ export const signInSocial = createAuthEndpoint(
 	"/sign-in/social",
 	{
 		method: "POST",
-		query: z
-			.object({
-				/**
-				 * Redirect to the current URL after the
-				 * user has signed in.
-				 */
-				currentURL: z.string().optional(),
-			})
-			.optional(),
 		body: z.object({
 			/**
 			 * Callback URL to redirect to after the user

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -17,11 +17,6 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 		"/sign-up/email",
 		{
 			method: "POST",
-			query: z
-				.object({
-					currentURL: z.string().optional(),
-				})
-				.optional(),
 			body: z.record(z.string(), z.any()) as unknown as ZodObject<{
 				name: ZodString;
 				email: ZodString;
@@ -189,9 +184,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				);
 				const url = `${
 					ctx.context.baseURL
-				}/verify-email?token=${token}&callbackURL=${
-					body.callbackURL || ctx.query?.currentURL || "/"
-				}`;
+				}/verify-email?token=${token}&callbackURL=${body.callbackURL || "/"}`;
 				await ctx.context.options.emailVerification?.sendVerificationEmail?.(
 					{
 						user: createdUser,

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -449,11 +449,6 @@ export const changeEmail = createAuthEndpoint(
 	"/change-email",
 	{
 		method: "POST",
-		query: z
-			.object({
-				currentURL: z.string().optional(),
-			})
-			.optional(),
 		body: z.object({
 			newEmail: z
 				.string({
@@ -548,9 +543,7 @@ export const changeEmail = createAuthEndpoint(
 		);
 		const url = `${
 			ctx.context.baseURL
-		}/verify-email?token=${token}&callbackURL=${
-			ctx.body.callbackURL || ctx.query?.currentURL || "/"
-		}`;
+		}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;
 		await ctx.context.options.user.changeEmail.sendChangeEmailVerification(
 			{
 				user: ctx.context.session.user,

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -2,7 +2,7 @@ import { createFetch } from "@better-fetch/fetch";
 import { getBaseURL } from "../utils/url";
 import { type WritableAtom } from "nanostores";
 import type { AtomListener, ClientOptions } from "./types";
-import { addCurrentURL, redirectPlugin } from "./fetch-plugins";
+import { redirectPlugin } from "./fetch-plugins";
 import { getSessionAtom } from "./session-atom";
 import { parseJSON } from "./parser";
 
@@ -28,7 +28,6 @@ export const getClientConfig = <O extends ClientOptions>(options?: O) => {
 			? [...(options?.fetchOptions?.plugins || []), ...pluginsFetchPlugins]
 			: [
 					redirectPlugin,
-					addCurrentURL,
 					...(options?.fetchOptions?.plugins || []),
 					...pluginsFetchPlugins,
 				],

--- a/packages/better-auth/src/client/fetch-plugins.ts
+++ b/packages/better-auth/src/client/fetch-plugins.ts
@@ -17,22 +17,3 @@ export const redirectPlugin = {
 		},
 	},
 } satisfies BetterFetchPlugin;
-
-export const addCurrentURL = {
-	id: "add-current-url",
-	name: "Add current URL",
-	hooks: {
-		onRequest(context) {
-			if (typeof window !== "undefined" && window.location) {
-				if (window.location) {
-					try {
-						const url = new URL(context.url);
-						url.searchParams.set("currentURL", window.location.href);
-						context.url = url;
-					} catch {}
-				}
-			}
-			return context;
-		},
-	},
-} satisfies BetterFetchPlugin;

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -252,9 +252,7 @@ function getTrustedOrigins(options: BetterAuthOptions) {
 	}
 	const trustedOrigins = [new URL(baseURL).origin];
 	if (options.trustedOrigins) {
-		if (typeof options.trustedOrigins !== "function") {
-			trustedOrigins.push(...options.trustedOrigins);
-		}
+		trustedOrigins.push(...options.trustedOrigins);
 	}
 	const envTrustedOrigins = env.BETTER_AUTH_TRUSTED_ORIGINS;
 	if (envTrustedOrigins) {

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -252,7 +252,9 @@ function getTrustedOrigins(options: BetterAuthOptions) {
 	}
 	const trustedOrigins = [new URL(baseURL).origin];
 	if (options.trustedOrigins) {
-		trustedOrigins.push(...options.trustedOrigins);
+		if (typeof options.trustedOrigins !== "function") {
+			trustedOrigins.push(...options.trustedOrigins);
+		}
 	}
 	const envTrustedOrigins = env.BETTER_AUTH_TRUSTED_ORIGINS;
 	if (envTrustedOrigins) {

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -14,10 +14,7 @@ export async function generateState(
 		userId: string;
 	},
 ) {
-	const callbackURL =
-		c.body?.callbackURL ||
-		(c.query?.currentURL ? getOrigin(c.query?.currentURL) : "") ||
-		c.context.options.baseURL;
+	const callbackURL = c.body?.callbackURL || "/";
 	if (!callbackURL) {
 		throw new APIError("BAD_REQUEST", {
 			message: "callbackURL is required",
@@ -28,7 +25,7 @@ export async function generateState(
 	const data = JSON.stringify({
 		callbackURL,
 		codeVerifier,
-		errorURL: c.body?.errorCallbackURL || c.query?.currentURL,
+		errorURL: c.body?.errorCallbackURL,
 		link,
 		/**
 		 * This is the actual expiry time of the state

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -258,19 +258,6 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 				"/sign-in/oauth2",
 				{
 					method: "POST",
-					query: z
-						.object({
-							/**
-							 * Redirect to the current URL after the
-							 * user has signed in.
-							 */
-							currentURL: z
-								.string({
-									description: "Redirect to the current URL after sign in",
-								})
-								.optional(),
-						})
-						.optional(),
 					body: z.object({
 						providerId: z.string({
 							description: "The provider ID for the OAuth provider",

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -403,7 +403,7 @@ export interface BetterAuthOptions {
 	/**
 	 * List of trusted origins.
 	 */
-	trustedOrigins?: string[];
+	trustedOrigins?: string[] | ((request: Request) => Promise<boolean>);
 	/**
 	 * Rate limiting configuration
 	 */
@@ -519,6 +519,24 @@ export interface BetterAuthOptions {
 		 * ⚠︎ This is a security risk and it may expose your application to CSRF attacks
 		 */
 		disableCSRFCheck?: boolean;
+		/**
+		 * Custom origin checker. This will completely override check for `trustedOrigins`.
+		 *
+		 * ⚠︎ This could easily expose you to open redirect and csrf attacks. Only use this
+		 * if you know what you're doing!
+		 *
+		 * @param url -  the url to check. it could be a path (e.g, `/dashboard`)
+		 * @param label - the label of the parameter the url between "origin" | "callbackURL"
+		 * @param request - the request object
+		 * @returns - boolean or promise that resolves boolean
+		 */
+		customOriginChecker?: (
+			input: {
+				url: string;
+				label: "callbackURL" | "origin";
+			},
+			request: Request,
+		) => boolean | Promise<boolean>;
 		/**
 		 * Configure cookies to be cross subdomains
 		 */

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -403,7 +403,7 @@ export interface BetterAuthOptions {
 	/**
 	 * List of trusted origins.
 	 */
-	trustedOrigins?: string[] | ((request: Request) => Promise<boolean>);
+	trustedOrigins?: string[];
 	/**
 	 * Rate limiting configuration
 	 */


### PR DESCRIPTION
This PR introduces `customOriginChecker`, which overrides the default trusted origin checking and remove `currentURL` usage.