### PR TITLE
docs: fix invalid typescript in magic-link docs

### DIFF
--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -19,11 +19,7 @@ Magic link or email link is a way to authenticate users without a password. When
     export const auth = betterAuth({
         plugins: [
             magicLink({
-                sendMagicLink: async ({
-                    email: string,
-                    token: string,
-                    url: string
-                }, request) => {
+                sendMagicLink: async ({ email, token, url }, request) => {
                     // send email to user
                 }
             })


### PR DESCRIPTION
Fixed invalid typescript annotation in demo code for magic link plugin.