### PR TITLE
fix: table width for plugin names are now larger to fit the names pro…

### DIFF
--- a/docs/content/docs/plugins/community-plugins.mdx
+++ b/docs/content/docs/plugins/community-plugins.mdx
@@ -9,7 +9,7 @@ We encourage you to create custom plugins and maybe get added to the list!
 
 To create your own custom plugin, get started by reading our [plugins documentation](https://www.better-auth.com/docs/concepts/plugins). And if you want to share your plugin with the community, please open a pull request to add it to this list.
 
-| Plugin                                                                              | Description                                                                                          |
+| <div className="w-[200px]">Plugin</div>                                                                              | Description                                                                                          |
 | ------------------------------------------------------------------------------------| ---------------------------------------------------------------------------------------------------- |
 | [better-auth-harmony](https://github.com/gekorm/better-auth-harmony/)               | Email & phone normalization and additional validation, blocking over 55,000 temporary email domains. |
 | [validation-better-auth](https://github.com/Daanish2003/validation-better-auth)     | Validate API request using any validation library (e.g., Zod, Yup)                                   |


### PR DESCRIPTION
This was really annoying me, I had to send a PR...

Before:

<img width="906" alt="image" src="https://github.com/user-attachments/assets/72e0166a-d11c-41a5-9341-1417afd560a3" />


After: 

<img width="991" alt="image" src="https://github.com/user-attachments/assets/8f8a3221-e7fc-40e4-a1c7-56669737e442" />
