### PR TITLE
Export PrismaConfig Interface

### DIFF
--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -4,7 +4,7 @@ import type { Adapter, BetterAuthOptions, Where } from "../../types";
 import { generateId } from "../../utils";
 import { withApplyDefault } from "../utils";
 
-interface PrismaConfig {
+export interface PrismaConfig {
 	/**
 	 * Database provider.
 	 */


### PR DESCRIPTION
This change exports the PrismaConfig interface from the Prisma adapter to fix errors related to creating declarations with tsc.

fixes #899 