### PR TITLE
fix: apple redirect uri

### DIFF
--- a/packages/better-auth/src/social-providers/apple.ts
+++ b/packages/better-auth/src/social-providers/apple.ts
@@ -79,7 +79,7 @@ export const apple = (options: AppleOptions) => {
 				`https://appleid.apple.com/auth/authorize?client_id=${
 					options.clientId
 				}&response_type=code&redirect_uri=${
-					redirectURI || options.redirectURI
+					options.redirectURI || redirectURI
 				}&scope=${_scope.join(" ")}&state=${state}&response_mode=form_post`,
 			);
 		},


### PR DESCRIPTION
The `options.redirectURI` should be prioritized, only the Apple provider has this bug.