### PR TITLE
fix: get-config paths for sveltekit or similar

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -15,8 +15,8 @@ let possiblePaths = ["auth.ts", "auth.tsx"];
 
 possiblePaths = [
 	...possiblePaths,
-	...possiblePaths.map((it) => `lib/server${it}`),
-	...possiblePaths.map((it) => `server${it}`),
+	...possiblePaths.map((it) => `lib/server/${it}`),
+	...possiblePaths.map((it) => `server/${it}`),
 	...possiblePaths.map((it) => `lib/${it}`),
 	...possiblePaths.map((it) => `utils/${it}`),
 ];


### PR DESCRIPTION
I'm using sveltekit and I wanted to put my `auth.ts` file in `lib/server` to follow [sveltekit's project structure](https://svelte.dev/docs/kit/project-structure) and better auth did not know where the config was anymore.

Found out this is most likely a typo in the get config file, just missing slashes.