### PR TITLE
docs: add spacing at the bottom of the document

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -46,7 +46,8 @@ export default async function Page({
 				header: <div className="w-10 h-4"></div>,
 			}}
 			footer={{
-				enabled: false,
+				enabled: true,
+				component: <div className="w-10 h-4"/>
 			}}
 		>
 			<DocsTitle>{page.data.title}</DocsTitle>


### PR DESCRIPTION
This pull request includes a small but important change to the `docs/app/docs/[[...slug]]/page.tsx` file. The change enables the footer and add some margin to the bottom to make it look nicer

Changes in `page.tsx`:

* Enabled the footer and added a component to it. ([docs/app/docs/[[...slug]]/page.tsxL49-R50](diffhunk://#diff-bd8138eb3a2a89f261dfd07ac6032ea5d5b9cacd694bf167a6577cf5135b7a8eL49-R50))

<img width="1917" alt="image" src="https://github.com/user-attachments/assets/158bbada-3600-43bf-aef0-c3d0ba05961c" />
