### PR TITLE
fix(docs): use `APIRoute` instead of `Route` for tanstack start api routes

### DIFF
--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -401,7 +401,7 @@ The server provides a `session` object that you can use to access the session da
     import { auth } from "./auth";
     import { createAPIFileRoute } from "@tanstack/start/api";
 
-    export const Route = createAPIFileRoute("/api/$")({
+    export const APIRoute = createAPIFileRoute("/api/$")({
         GET: async ({ request }) => {
             const session = await auth.api.getSession({
                 headers: request.headers

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -363,7 +363,7 @@ Better Auth supports any backend framework with standard Request and Response ob
     import { auth } from '~/lib/server/auth'
     import { createAPIFileRoute } from '@tanstack/start/api'
 
-    export const Route = createAPIFileRoute('/api/auth/$')({
+    export const APIRoute = createAPIFileRoute('/api/auth/$')({
         GET: ({ request }) => {
             return auth.handler(request)
         },

--- a/docs/content/docs/integrations/tanstack.mdx
+++ b/docs/content/docs/integrations/tanstack.mdx
@@ -16,7 +16,7 @@ Create a new file: `/app/routes/api/auth/$.ts`
 import { auth } from '@/lib/auth'
 import { createAPIFileRoute } from '@tanstack/start/api'
 
-export const Route = createAPIFileRoute('/api/auth/$')({
+export const APIRoute = createAPIFileRoute('/api/auth/$')({
   GET: ({ request }) => {
     return auth.handler(request)
   },

--- a/examples/tanstack-example/app/routes/api/auth/$.ts
+++ b/examples/tanstack-example/app/routes/api/auth/$.ts
@@ -1,7 +1,7 @@
 import { createAPIFileRoute } from "@tanstack/start/api";
 import { auth } from "~/lib/auth";
 
-export const Route = createAPIFileRoute("/api/auth/$")({
+export const APIRoute = createAPIFileRoute("/api/auth/$")({
 	GET: ({ request }) => {
 		return auth.handler(request);
 	},

--- a/packages/cli/test/__snapshots__/auth-schema.txt
+++ b/packages/cli/test/__snapshots__/auth-schema.txt
@@ -1,4 +1,4 @@
-import { pgTable, text, integer, timestamp, boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean } from "drizzle-orm/pg-core";
 			
 export const user = pgTable("user", {
 					id: text("id").primaryKey(),


### PR DESCRIPTION
Unsure when exactly this was changed, but it was changed at some point and also updated in the tanstack docs over here three weeks ago: https://github.com/TanStack/router/commit/2cf38ac6fe3e74784f9b8289b9fd3202a3011a75