### PR TITLE
fix: email OTP during signup fails to send when email verification is required

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -97,7 +97,7 @@ describe("email-otp", async () => {
 
 	it("should send verification otp on sign-up", async () => {
 		const testUser2 = {
-			email: "test@email.com",
+			email: "test8@email.com",
 			password: "password",
 			name: "test",
 		};


### PR DESCRIPTION
closes #954 