### PR TITLE
fix: sign In with Apple With ID Token not work

### DIFF
--- a/docs/content/docs/authentication/apple.mdx
+++ b/docs/content/docs/authentication/apple.mdx
@@ -25,10 +25,14 @@ description: Apple provider setup and usage.
                 apple: { // [!code highlight]
                     clientId: process.env.APPLE_CLIENT_ID as string, // [!code highlight]
                     clientSecret: process.env.APPLE_CLIENT_SECRET as string, // [!code highlight]
+                    // Optional
+                    appBundleIdentifier: process.env.APPLE_APP_BUNDLE_IDENTIFIER as string, // [!code highlight]
                 }, // [!code highlight]
             },
         })
         ```
+
+        On native iOS, it doesn't use the service id but the app id (bundle id) as client id, so if using the service id as clientId in signIn.social() with idToken, it throws an error: JWTClaimValidationFailed: unexpected "aud" claim value. So you need to provide the appBundleIdentifier when you want to sign in with Apple using the ID Token.
     </Step>
 </Steps>
 

--- a/packages/better-auth/src/social-providers/apple.ts
+++ b/packages/better-auth/src/social-providers/apple.ts
@@ -127,7 +127,7 @@ export const apple = (options: AppleOptions) => {
 			if (!token.idToken) {
 				return null;
 			}
-			const profile = decodeJwt(token.idToken) as AppleProfile | null;
+			const profile = decodeJwt<AppleProfile>(token.idToken);
 			if (!profile) {
 				return null;
 			}

--- a/packages/better-auth/src/social-providers/apple.ts
+++ b/packages/better-auth/src/social-providers/apple.ts
@@ -127,7 +127,7 @@ export const apple = (options: AppleOptions) => {
 			if (!token.idToken) {
 				return null;
 			}
-			const profile = decodeJwt(token.idToken)?.payload as AppleProfile | null;
+			const profile = decodeJwt(token.idToken) as AppleProfile | null;
 			if (!profile) {
 				return null;
 			}

--- a/packages/better-auth/src/social-providers/apple.ts
+++ b/packages/better-auth/src/social-providers/apple.ts
@@ -64,7 +64,9 @@ export interface AppleNonConformUser {
 	email: string;
 }
 
-export interface AppleOptions extends ProviderOptions<AppleProfile> {}
+export interface AppleOptions extends ProviderOptions<AppleProfile> {
+	appBundleIdentifier?: string;
+}
 
 export const apple = (options: AppleOptions) => {
 	const tokenEndpoint = "https://appleid.apple.com/auth/token";
@@ -105,7 +107,7 @@ export const apple = (options: AppleOptions) => {
 			const { payload: jwtClaims } = await jwtVerify(token, publicKey, {
 				algorithms: [jwtAlg],
 				issuer: "https://appleid.apple.com",
-				audience: options.clientId,
+				audience: options.appBundleIdentifier || options.clientId,
 				maxTokenAge: "1h",
 			});
 			["email_verified", "is_private_email"].forEach((field) => {


### PR DESCRIPTION
> The main thing that tripped me up, is that better-auth requires clientId and clientSecret on socialProviders.apple in config -> this is where you're place the service id and jwt secret generated from p8-file for "Sign-in with Apple" on web.
However on native iOS, it doesn't use the service id but the app id (bundle id) as client id, so if using the service id as clientId in signIn.social() with idToken, it throws an error: JWTClaimValidationFailed: unexpected "aud" claim value.

> For iOS native "SignIn with Apple" with idToken, it expects the app/bundle id as clientId and doesn't require the clientSecret.

https://github.com/better-auth/better-auth/issues/421#issuecomment-2466911181

The return value of the `decodeJwt` function is already the payload