### PR TITLE
refactor: standardize how session and user data is returend in endpoints

### DIFF
--- a/packages/better-auth/src/api/call.test.ts
+++ b/packages/better-auth/src/api/call.test.ts
@@ -10,6 +10,7 @@ import { init } from "../init";
 import type { BetterAuthOptions, BetterAuthPlugin } from "../types";
 import { z } from "zod";
 import { createAuthClient } from "../client";
+import { bearer } from "src/plugins";
 
 describe("call", async () => {
 	const q = z.optional(
@@ -177,7 +178,7 @@ describe("call", async () => {
 	} satisfies BetterAuthPlugin;
 	const options = {
 		baseURL: "http://localhost:3000",
-		plugins: [testPlugin, testPlugin2],
+		plugins: [testPlugin, testPlugin2, bearer()],
 		emailAndPassword: {
 			enabled: true,
 		},
@@ -396,7 +397,13 @@ describe("call", async () => {
 				name: "test",
 			},
 		});
-		expect(response.email).toBe("changed@email.com");
+
+		const session = await api.getSession({
+			headers: new Headers({
+				Authorization: `Bearer ${response?.token}`,
+			}),
+		});
+		expect(session?.user.email).toBe("changed@email.com");
 	});
 
 	it("should fetch using a client", async () => {

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -266,7 +266,6 @@ export const verifyEmail = createAuthEndpoint(
 				throw ctx.redirect(ctx.query.callbackURL);
 			}
 			return ctx.json({
-				user: updatedUser,
 				status: true,
 			});
 		}
@@ -294,7 +293,6 @@ export const verifyEmail = createAuthEndpoint(
 			throw ctx.redirect(ctx.query.callbackURL);
 		}
 		return ctx.json({
-			user: null,
 			status: true,
 		});
 	},

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -236,8 +236,7 @@ export const signInSocial = createAuthEndpoint(
 			}
 			await setSessionCookie(c, data.data!);
 			return c.json({
-				session: data.data!.session,
-				user: data.data!.user,
+				token: data.data!.session.token,
 				url: undefined,
 				redirect: false,
 			});

--- a/packages/better-auth/src/api/routes/sign-up.test.ts
+++ b/packages/better-auth/src/api/routes/sign-up.test.ts
@@ -35,7 +35,6 @@ describe("sign-up with custom fields", async (it) => {
 			disableTestUser: true,
 		},
 	);
-	let user: User | null = null;
 	it("should work with custom fields on account table", async () => {
 		const res = await auth.api.signUpEmail({
 			body: {
@@ -44,8 +43,7 @@ describe("sign-up with custom fields", async (it) => {
 				name: "Test Name",
 			},
 		});
-		user = res as User;
-		expect(user).toBeDefined();
+		expect(res.token).toBeDefined();
 		const accounts = await db.findMany({
 			model: "account",
 		});

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -210,11 +210,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				ctx.context.options.emailAndPassword.requireEmailVerification
 			) {
 				return ctx.json({
-					id: createdUser.id,
-					email: createdUser.email,
-					name: createdUser.name,
-					image: createdUser.image,
-					emailVerified: createdUser.emailVerified,
+					token: null,
 				});
 			}
 
@@ -232,13 +228,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				user: createdUser,
 			});
 			return ctx.json({
-				id: createdUser.id,
-				email: createdUser.email,
-				name: createdUser.name,
-				image: createdUser.image,
-				emailVerified: createdUser.emailVerified,
-				createdAt: createdUser.createdAt,
-				updatedAt: createdUser.updatedAt,
+				token: session.token,
 			});
 		},
 	);

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -48,7 +48,14 @@ describe("updateUser", async () => {
 				headers,
 			},
 		});
-		expect(updated.data?.name).toBe("newName");
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+				throw: true,
+			},
+		});
+		expect(updated.data?.status).toBe(true);
+		expect(session.user.name).toBe("newName");
 	});
 
 	it("should unset image", async () => {
@@ -58,7 +65,13 @@ describe("updateUser", async () => {
 				headers,
 			},
 		});
-		expect(updated.data?.image).toBeNull();
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+				throw: true,
+			},
+		});
+		expect(session.user.image).toBeNull();
 	});
 
 	it("should update user email", async () => {
@@ -69,7 +82,13 @@ describe("updateUser", async () => {
 				headers: headers,
 			},
 		});
-		expect(res.data?.user.email).toBe(newEmail);
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+				throw: true,
+			},
+		});
+		expect(session.user.email).toBe(newEmail);
 	});
 
 	it("should send email verification before update", async () => {

--- a/packages/better-auth/src/db/db.test.ts
+++ b/packages/better-auth/src/db/db.test.ts
@@ -61,12 +61,20 @@ describe("db", async () => {
 			name: "test",
 			password: "password",
 		});
-		expect(res.data?.image).toBe("test-image");
+		const session = await client.getSession({
+			fetchOptions: {
+				headers: {
+					Authorization: `Bearer ${res.data?.token}`,
+				},
+				throw: true,
+			},
+		});
+		expect(session.user?.image).toBe("test-image");
 		expect(callback).toBe(true);
 	});
 
 	it("should work with custom field names", async () => {
-		const { client, signInWithTestUser } = await getTestInstance({
+		const { client } = await getTestInstance({
 			user: {
 				fields: {
 					email: "email_address",
@@ -78,16 +86,14 @@ describe("db", async () => {
 			password: "password",
 			name: "Test User",
 		});
-		expect(res.data?.email).toBe("test@email.com");
-		const { headers } = await signInWithTestUser();
-		const res2 = await client.updateUser(
-			{
-				name: "New Name",
+		const session = await client.getSession({
+			fetchOptions: {
+				headers: {
+					Authorization: `Bearer ${res.data?.token}`,
+				},
+				throw: true,
 			},
-			{
-				headers,
-			},
-		);
-		expect(res2.data?.name).toBe("New Name");
+		});
+		expect(session.user.email).toBe("test@email.com");
 	});
 });

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -224,9 +224,16 @@ describe("Admin plugin", async () => {
 	const impersonateHeaders = new Headers();
 	it("should allow admins to impersonate user", async () => {
 		const userToImpersonate = await client.signUp.email(data);
+		const session = await client.getSession({
+			fetchOptions: {
+				headers: new Headers({
+					Authorization: `Bearer ${userToImpersonate.data?.token}`,
+				}),
+			},
+		});
 		const res = await client.admin.impersonateUser(
 			{
-				userId: userToImpersonate.data?.id || "",
+				userId: session.data?.user.id || "",
 			},
 			{
 				headers: adminHeaders,
@@ -236,7 +243,7 @@ describe("Admin plugin", async () => {
 			},
 		);
 		expect(res.data?.session).toBeDefined();
-		expect(res.data?.user?.id).toBe(userToImpersonate.data?.id);
+		expect(res.data?.user?.id).toBe(session.data?.user.id);
 	});
 
 	it("should filter impersonated sessions", async () => {

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -140,12 +140,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 						user: newUser,
 					});
 					return ctx.json({
-						id: newUser.id,
-						email: newUser.email,
-						emailVerified: newUser.emailVerified,
-						name: newUser.name,
-						createdAt: newUser.createdAt,
-						updatedAt: newUser.updatedAt,
+						token: session.token,
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -328,25 +328,15 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							user: updatedUser,
 						});
 						return ctx.json({
-							id: updatedUser.id,
-							email: updatedUser.email,
-							emailVerified: updatedUser.emailVerified,
-							name: updatedUser.name,
-							image: updatedUser.image,
-							createdAt: updatedUser.createdAt,
-							updatedAt: updatedUser.updatedAt,
+							token: session.token,
+							status: true,
 						});
 					}
 
 					return ctx.json({
-						id: updatedUser.id,
-						email: updatedUser.email,
-						emailVerified: updatedUser.emailVerified,
-						name: updatedUser.name,
-						image: updatedUser.image,
-						createdAt: updatedUser.createdAt,
-						updatedAt: updatedUser.updatedAt,
-					} as User);
+						status: true,
+						token: null,
+					});
 				},
 			),
 			signInEmailOTP: createAuthEndpoint(
@@ -436,8 +426,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							user: newUser,
 						});
 						return ctx.json({
-							user: newUser,
-							session,
+							token: session.token,
 						});
 					}
 
@@ -456,8 +445,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						user: user.user,
 					});
 					return ctx.json({
-						session,
-						user,
+						token: session.token,
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -226,8 +226,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					});
 					if (!callbackURL) {
 						return ctx.json({
-							session,
-							user: user?.user!,
+							token: session.token,
 						});
 					}
 					throw ctx.redirect(callbackURL);

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -55,7 +55,7 @@ describe("magic link", async () => {
 				onSuccess: sessionSetter(headers),
 			},
 		});
-		expect(response.data?.session).toBeDefined();
+		expect(response.data?.token).toBeDefined();
 		const betterAuthCookie = headers.get("set-cookie");
 		expect(betterAuthCookie).toBeDefined();
 	});
@@ -148,7 +148,7 @@ describe("magic link verify", async () => {
 				onSuccess: sessionSetter(headers),
 			},
 		});
-		expect(response.data?.session).toBeDefined();
+		expect(response.data?.token).toBeDefined();
 		const betterAuthCookie = headers.get("set-cookie");
 		expect(betterAuthCookie).toBeDefined();
 	});

--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -153,7 +153,7 @@ export const multiSession = (options?: MultiSessionConfig) => {
 											schema: {
 												type: "object",
 												properties: {
-													success: {
+													status: {
 														type: "boolean",
 													},
 												},
@@ -184,7 +184,7 @@ export const multiSession = (options?: MultiSessionConfig) => {
 						maxAge: 0,
 					});
 					const isActive = ctx.context.session?.session.token === sessionToken;
-					if (!isActive) return ctx.json({ success: true });
+					if (!isActive) return ctx.json({ status: true });
 
 					const cookieHeader = ctx.headers?.get("cookie");
 					if (cookieHeader) {
@@ -222,7 +222,7 @@ export const multiSession = (options?: MultiSessionConfig) => {
 						deleteSessionCookie(ctx);
 					}
 					return ctx.json({
-						success: true,
+						status: true,
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -122,8 +122,7 @@ export const oneTap = (options?: OneTapOptions) =>
 						session,
 					});
 					return c.json({
-						session,
-						user,
+						token: session.token,
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -365,6 +365,11 @@ describe("organization", async (it) => {
 				name: "new member",
 			},
 		});
+		const session = await auth.api.getSession({
+			headers: new Headers({
+				Authorization: `Bearer ${newUser?.token}`,
+			}),
+		});
 		const org = await auth.api.createOrganization({
 			body: {
 				name: "test",
@@ -375,7 +380,7 @@ describe("organization", async (it) => {
 		const member = await auth.api.addMember({
 			body: {
 				organizationId: org?.id,
-				userId: newUser.id,
+				userId: session?.user.id!,
 				role: "admin",
 			},
 		});

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -238,8 +238,7 @@ export const phoneNumber = (options?: {
 						ctx.body.rememberMe === false,
 					);
 					return ctx.json({
-						user: user,
-						session,
+						token: session.token,
 					});
 				},
 			),
@@ -417,16 +416,13 @@ export const phoneNumber = (options?: {
 								message: BASE_ERROR_CODES.USER_NOT_FOUND,
 							});
 						}
-						const user = await ctx.context.internalAdapter.updateUser(
-							session.user.id,
-							{
-								[opts.phoneNumber]: ctx.body.phoneNumber,
-								[opts.phoneNumberVerified]: true,
-							},
-						);
+						await ctx.context.internalAdapter.updateUser(session.user.id, {
+							[opts.phoneNumber]: ctx.body.phoneNumber,
+							[opts.phoneNumberVerified]: true,
+						});
 						return ctx.json({
-							user: user as UserWithPhoneNumber,
-							session: session.session,
+							token: session.session.token,
+							status: true,
 						});
 					}
 
@@ -495,14 +491,14 @@ export const phoneNumber = (options?: {
 							user,
 						});
 						return ctx.json({
-							user,
-							session,
+							token: session.token,
+							status: true,
 						});
 					}
 
 					return ctx.json({
-						user,
-						session: null,
+						token: null,
+						status: true,
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -3,6 +3,7 @@ import { getTestInstance } from "../../test-utils/test-instance";
 import { phoneNumber } from ".";
 import { createAuthClient } from "../../client";
 import { phoneNumberClient } from "./client";
+import { bearer } from "../bearer";
 
 describe("phone-number", async (it) => {
 	let otp = "";
@@ -52,7 +53,7 @@ describe("phone-number", async (it) => {
 			},
 		);
 		expect(res.error).toBe(null);
-		expect(res.data?.user.phoneNumberVerified).toBe(true);
+		expect(res.data?.status).toBe(true);
 	});
 
 	it("shouldn't verify again with the same code", async () => {
@@ -117,6 +118,7 @@ describe("phone auth flow", async () => {
 					},
 				},
 			}),
+			bearer(),
 		],
 		user: {
 			changeEmail: {
@@ -146,9 +148,17 @@ describe("phone auth flow", async () => {
 			phoneNumber: "+251911121314",
 			code: otp,
 		});
-		expect(res.data?.user.phoneNumberVerified).toBe(true);
-		expect(res.data?.user.email).toBe("temp-+251911121314");
-		expect(res.data?.session).toBeDefined();
+		const session = await client.getSession({
+			fetchOptions: {
+				headers: {
+					Authorization: `Bearer ${res.data?.token}`,
+				},
+				throw: true,
+			},
+		});
+		expect(session.user.phoneNumberVerified).toBe(true);
+		expect(session.user.email).toBe("temp-+251911121314");
+		expect(session.session.token).toBeDefined();
 	});
 
 	let headers = new Headers();
@@ -165,7 +175,7 @@ describe("phone auth flow", async () => {
 				onSuccess: sessionSetter(headers),
 			},
 		);
-		expect(res.data?.session).toBeDefined();
+		expect(res.data?.status).toBe(true);
 	});
 
 	const newEmail = "new-email@email.com";
@@ -183,7 +193,7 @@ describe("phone auth flow", async () => {
 			},
 		});
 		expect(changedEmailRes.error).toBe(null);
-		expect(changedEmailRes.data?.user.email).toBe(newEmail);
+		expect(changedEmailRes.data?.status).toBe(true);
 	});
 
 	it("should sign in with phone number and password", async () => {
@@ -191,7 +201,7 @@ describe("phone auth flow", async () => {
 			phoneNumber: "+251911121314",
 			password: "password",
 		});
-		expect(res.data?.session).toBeDefined();
+		expect(res.data?.token).toBeDefined();
 	});
 
 	it("should sign in with new email", async () => {
@@ -256,6 +266,6 @@ describe("verify phone-number", async (it) => {
 			},
 		);
 		expect(res.error).toBe(null);
-		expect(res.data?.user.phoneNumberVerified).toBe(true);
+		expect(res.data?.status).toBe(true);
 	});
 });

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -105,7 +105,7 @@ describe("two factor", async () => {
 				onSuccess: sessionSetter(headers),
 			},
 		});
-		expect(res.data?.session).toBeDefined();
+		expect(res.data?.token).toBeDefined();
 	});
 
 	it("should require two factor", async () => {
@@ -159,7 +159,7 @@ describe("two factor", async () => {
 				},
 			},
 		});
-		expect(verifyRes.data?.session).toBeDefined();
+		expect(verifyRes.data?.token).toBeDefined();
 	});
 
 	let backupCodes: string[] = [];

--- a/packages/better-auth/src/plugins/two-factor/verify-middleware.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-middleware.ts
@@ -79,8 +79,7 @@ export const verifyTwoFactorMiddleware = createAuthMiddleware(
 						);
 					}
 					return ctx.json({
-						session,
-						user,
+						token: session.token,
 					});
 				},
 				invalid: async () => {
@@ -97,8 +96,7 @@ export const verifyTwoFactorMiddleware = createAuthMiddleware(
 		return {
 			valid: async () => {
 				return ctx.json({
-					session,
-					user: session.user,
+					token: session.session.token,
 				});
 			},
 			invalid: async () => {

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -145,13 +145,7 @@ export const username = () => {
 						ctx.body.rememberMe === false,
 					);
 					return ctx.json({
-						id: user.id,
-						email: user.email,
-						name: user.name,
-						image: user.image,
-						emailVerified: user.emailVerified,
-						createdAt: user.createdAt,
-						updatedAt: user.updatedAt,
+						token: session.token,
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/username/username.test.ts
+++ b/packages/better-auth/src/plugins/username/username.test.ts
@@ -47,7 +47,7 @@ describe("username", async (it) => {
 				onSuccess: sessionSetter(headers),
 			},
 		);
-		expect(res.data?.id).toBeDefined();
+		expect(res.data?.token).toBeDefined();
 	});
 	it("should update username", async () => {
 		const res = await client.updateUser({

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -15,6 +15,7 @@ import { Pool } from "pg";
 import { MongoClient } from "mongodb";
 import { mongodbAdapter } from "../adapters";
 import { createPool } from "mysql2/promise";
+import { bearer } from "src/plugins";
 
 export async function getTestInstance<
 	O extends Partial<BetterAuthOptions>,
@@ -101,6 +102,7 @@ export async function getTestInstance<
 			disableCSRFCheck: true,
 			...options?.advanced,
 		},
+		plugins: [bearer(), ...(options?.plugins || [])],
 	} as O extends undefined ? typeof opts : O & typeof opts);
 
 	const testUser = {

--- a/packages/cli/test/migrate.test.ts
+++ b/packages/cli/test/migrate.test.ts
@@ -39,7 +39,7 @@ describe("migrate base auth instance", () => {
 				password: "password",
 			},
 		});
-		expect(signUpRes.id).toBeDefined();
+		expect(signUpRes.token).toBeDefined();
 	});
 });
 


### PR DESCRIPTION
This PR standardizes how endpoints return user and session-related data. All endpoints, except `/get-session`, now return a `token` if a new one is generated, and `status: true` for updates and related calls.