### PR TITLE
feat: Add account parameter to custom password verifier

### DIFF
--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -372,6 +372,7 @@ export const signInEmail = createAuthEndpoint(
 		const validPassword = await ctx.context.password.verify({
 			hash: currentPassword,
 			password,
+			account: credentialAccount
 		});
 		if (!validPassword) {
 			ctx.context.logger.error("Invalid password");

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -206,6 +206,7 @@ export const changePassword = createAuthEndpoint(
 		const verify = await ctx.context.password.verify({
 			hash: account.password,
 			password: currentPassword,
+			account
 		});
 		if (!verify) {
 			throw new APIError("BAD_REQUEST", {
@@ -366,6 +367,7 @@ export const deleteUser = createAuthEndpoint(
 			const verify = await ctx.context.password.verify({
 				hash: account.password,
 				password: ctx.body.password,
+				account
 			});
 			if (!verify) {
 				throw new APIError("BAD_REQUEST", {

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -4,6 +4,7 @@ import { createInternalAdapter } from "./db";
 import { getAuthTables } from "./db/get-tables";
 import { getAdapter } from "./db/utils";
 import type {
+	Account,
 	Adapter,
 	BetterAuthOptions,
 	BetterAuthPlugin,
@@ -195,7 +196,7 @@ export type AuthContext = {
 	secondaryStorage: SecondaryStorage | undefined;
 	password: {
 		hash: (password: string) => Promise<string>;
-		verify: (data: { password: string; hash: string }) => Promise<boolean>;
+		verify: (data: { password: string; hash: string, account: Account }) => Promise<boolean>;
 		config: {
 			minPasswordLength: number;
 			maxPasswordLength: number;

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -211,6 +211,7 @@ export const phoneNumber = (options?: {
 					const validPassword = await ctx.context.password.verify({
 						hash: currentPassword,
 						password,
+						account: credentialAccount
 					});
 					if (!validPassword) {
 						ctx.context.logger.error("Invalid password");

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -118,6 +118,7 @@ export const username = () => {
 					const validPassword = await ctx.context.password.verify({
 						hash: currentPassword,
 						password: ctx.body.password,
+						account
 					});
 					if (!validPassword) {
 						ctx.context.logger.error("Invalid password");

--- a/packages/better-auth/src/utils/password.ts
+++ b/packages/better-auth/src/utils/password.ts
@@ -19,6 +19,7 @@ export async function validatePassword(
 	const compare = await ctx.context.password.verify({
 		hash: currentPassword,
 		password: data.password,
+		account: credentialAccount
 	});
 	return compare;
 }
@@ -37,6 +38,7 @@ export async function checkPassword(userId: string, c: GenericEndpointContext) {
 	const compare = await c.context.password.verify({
 		hash: currentPassword,
 		password: c.body.password,
+		account: credentialAccount
 	});
 	if (!compare) {
 		throw new APIError("BAD_REQUEST", {


### PR DESCRIPTION
Hi,

Following some discussion on discord (https://discord.com/channels/1288403910284935179/1288403910284935182/1320099161659674725) I figured I'd take a stab at adding an `account` parameter to the custom password verifier.
In short, this helps in implementing external authentication, similar to what is provided by authjs (https://next-auth.js.org/configuration/providers/credentials).
I'd say this is probably not something most people should use, but given that the API already exists, I think this PR makes it more useful without adding more risks.

Opened this as Draft to collect feedback and also because for some reason the build fails on my setup (but in my defense the main branch also fails so perhaps its a local issue)