### PR TITLE
fix(docs): improve the hooks section

### DIFF
--- a/docs/content/docs/concepts/hooks.mdx
+++ b/docs/content/docs/concepts/hooks.mdx
@@ -37,8 +37,9 @@ export const auth = betterAuth({
 
 To adjust the request context before proceeding:
 
-```ts
+```ts title="auth.ts"
 import { betterAuth } from "better-auth";
+import { createAuthMiddleware } from "better-auth/api";
 
 export const auth = betterAuth({
     hooks: {
@@ -65,8 +66,9 @@ export const auth = betterAuth({
 
 This hook adds a custom header to the response:
 
-```ts
+```ts title="auth.ts"
 import { betterAuth } from "better-auth";
+import { createAuthMiddleware } from "better-auth/api";
 
 export const auth = betterAuth({
     hooks: {

--- a/docs/content/docs/concepts/hooks.mdx
+++ b/docs/content/docs/concepts/hooks.mdx
@@ -73,7 +73,7 @@ import { createAuthMiddleware } from "better-auth/api";
 export const auth = betterAuth({
     hooks: {
         after: createAuthMiddleware(async (ctx) => {
-            ctx.response.headers.set("X-Custom-Header", "Hello World");
+            ctx.responseHeader.set("X-Custom-Header", "Hello World");
             return {
                 responseHeader: ctx.responseHeader // return the updated response headers
             }


### PR DESCRIPTION
- add the import `createAuthMiddleware` where the entire auth.ts is shown as example
- change `ctx.response.headers.set` to `ctx.responseHeader.set`, as former is not correct