### PR TITLE
docs: Fix minor typo

### DIFF
--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -119,7 +119,7 @@ In addition to signing in a user using send-verify flow, you can also use phone 
 await authClient.signIn.phoneNumber({
     phoneNumber: "+123456789",
     password: "password",
-    remeberMe: true //optional defaults to true
+    rememberMe: true //optional defaults to true
 })
 ```
 


### PR DESCRIPTION
Just fixed a small typo from the docs: "remeberMe" -> "rememberMe"

PS: Thanks for Better Auth btw, it's so good! Keep up the great work 🙌