### PR TITLE
chore: remove duplicate passkey export

### DIFF
--- a/packages/better-auth/src/client/plugins/index.ts
+++ b/packages/better-auth/src/client/plugins/index.ts
@@ -2,7 +2,6 @@ export * from "../../plugins/organization/client";
 export * from "../../plugins/username/client";
 export * from "../../plugins/passkey/client";
 export * from "../../plugins/two-factor/client";
-export * from "../../plugins/passkey/client";
 export * from "../../plugins/magic-link/client";
 export * from "../../plugins/phone-number/client";
 export * from "../../plugins/anonymous/client";


### PR DESCRIPTION
Simple fix to remove duplicate line
`export * from "../../plugins/passkey/client";`