### PR TITLE
Add expiresIn for email verification

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -15,6 +15,10 @@ export async function createEmailVerificationToken(
 	 * The email to update from
 	 */
 	updateTo?: string,
+	/**
+	 * The time in seconds for the token to expire
+	 */
+	expiresIn: number = 3600,
 ) {
 	const token = await signJWT(
 		{
@@ -22,6 +26,7 @@ export async function createEmailVerificationToken(
 			updateTo,
 		},
 		secret,
+		expiresIn,
 	);
 	return token;
 }
@@ -42,6 +47,8 @@ export async function sendVerificationEmailFn(
 	const token = await createEmailVerificationToken(
 		ctx.context.secret,
 		user.email,
+		undefined,
+		ctx.context.options.emailVerification?.expiresIn,
 	);
 	const url = `${ctx.context.baseURL}/verify-email?token=${token}&callbackURL=${
 		ctx.body.callbackURL || ctx.query?.currentURL || "/"

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -392,6 +392,8 @@ export const signInEmail = createAuthEndpoint(
 			const token = await createEmailVerificationToken(
 				ctx.context.secret,
 				user.user.email,
+				undefined,
+				ctx.context.options.emailVerification?.expiresIn,
 			);
 			const url = `${
 				ctx.context.baseURL

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -192,6 +192,8 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				const token = await createEmailVerificationToken(
 					ctx.context.secret,
 					createdUser.email,
+					undefined,
+					ctx.context.options.emailVerification?.expiresIn,
 				);
 				const url = `${
 					ctx.context.baseURL

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -605,6 +605,7 @@ export const changeEmail = createAuthEndpoint(
 			ctx.context.secret,
 			ctx.context.session.user.email,
 			ctx.body.newEmail,
+			ctx.context.options.emailVerification?.expiresIn,
 		);
 		const url = `${
 			ctx.context.baseURL

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -124,6 +124,8 @@ export async function handleOAuthUserInfo(
 				const token = await createEmailVerificationToken(
 					c.context.secret,
 					user.email,
+					undefined,
+					c.context.options.emailVerification?.expiresIn,
 				);
 				const url = `${c.context.baseURL}/verify-email?token=${token}&callbackURL=${callbackURL}`;
 				await c.context.options.emailVerification?.sendVerificationEmail?.(

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -146,6 +146,13 @@ export type BetterAuthOptions = {
 		 * Auto signin the user after they verify their email
 		 */
 		autoSignInAfterVerification?: boolean;
+
+		/**
+		 * Number of seconds the verification token is
+		 * valid for.
+		 * @default 3600 seconds (1 hour)
+		 */
+		expiresIn?: number;
 	};
 	/**
 	 * Email and password authentication


### PR DESCRIPTION
This adds the possibility to set an expiration time (in seconds) for the verification mail.
I left it a 3600s as default, but you can add any time.

Example:
```typescript
emailVerification: {
        expiresIn: 7200, // 2 hours
        sendVerificationEmail: async ({ user, url, token }, request) => {
            // Send the email verification email
        },
    }
```