### PR TITLE
docs: add warn for node `express.json()` before install

### DIFF
--- a/docs/content/docs/integrations/node.mdx
+++ b/docs/content/docs/integrations/node.mdx
@@ -15,6 +15,10 @@ Note that CommonJS (cjs) isn't supported. Use ECMAScript Modules (ESM) by settin
 
 To enable Better Auth to handle requests, we need to mount the handler to an API route. Create a catch-all route to manage all requests to `/api/auth/*` (or any other path specified in your Better Auth options).
 
+<Callout type="warn">
+Don’t use `express.json()` before the Better Auth handler. Use it only for other routes, or the client API will get stuck on "pending".
+</Callout>
+
 ```ts title="server.ts"
 import express from "express";
 import { toNodeHandler } from "better-auth/node";


### PR DESCRIPTION
A few people on the team fell for this trick, I added an extra Warn before installing it. 

thx https://github.com/better-auth/better-auth/issues/320