### PR TITLE
fix: user verification shouldn't be required when passkey registration

### DIFF
--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -533,6 +533,7 @@ export const passkey = (options?: PasskeyOptions) => {
 							expectedChallenge,
 							expectedOrigin: origin,
 							expectedRPID: options?.rpID,
+							requireUserVerification: false,
 						});
 						const { verified, registrationInfo } = verification;
 						if (!verified || !registrationInfo) {


### PR DESCRIPTION
similar to #332