### PR TITLE
feat: restore the user data in the response

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -267,6 +267,15 @@ export const verifyEmail = createAuthEndpoint(
 			}
 			return ctx.json({
 				status: true,
+				user: {
+					id: updatedUser.id,
+					email: updatedUser.email,
+					name: updatedUser.name,
+					image: updatedUser.image,
+					emailVerified: updatedUser.emailVerified,
+					createdAt: updatedUser.createdAt,
+					updatedAt: updatedUser.updatedAt,
+				},
 			});
 		}
 		await ctx.context.internalAdapter.updateUserByEmail(parsed.email, {
@@ -293,6 +302,7 @@ export const verifyEmail = createAuthEndpoint(
 		}
 		return ctx.json({
 			status: true,
+			user: null,
 		});
 	},
 );

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -236,9 +236,18 @@ export const signInSocial = createAuthEndpoint(
 			}
 			await setSessionCookie(c, data.data!);
 			return c.json({
+				redirect: false,
 				token: data.data!.session.token,
 				url: undefined,
-				redirect: false,
+				user: {
+					id: data.data!.user.id,
+					email: data.data!.user.email,
+					name: data.data!.user.name,
+					image: data.data!.user.image,
+					emailVerified: data.data!.user.emailVerified,
+					createdAt: data.data!.user.createdAt,
+					updatedAt: data.data!.user.updatedAt,
+				},
 			});
 		}
 
@@ -431,6 +440,9 @@ export const signInEmail = createAuthEndpoint(
 			ctx.body.rememberMe === false,
 		);
 		return ctx.json({
+			redirect: !!ctx.body.callbackURL,
+			token: session.token,
+			url: ctx.body.callbackURL,
 			user: {
 				id: user.user.id,
 				email: user.user.email,
@@ -440,9 +452,6 @@ export const signInEmail = createAuthEndpoint(
 				createdAt: user.user.createdAt,
 				updatedAt: user.user.updatedAt,
 			},
-			token: session.token,
-			redirect: !!ctx.body.callbackURL,
-			url: ctx.body.callbackURL,
 		});
 	},
 );

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -214,6 +214,15 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 			) {
 				return ctx.json({
 					token: null,
+					user: {
+						id: createdUser.id,
+						email: createdUser.email,
+						name: createdUser.name,
+						image: createdUser.image,
+						emailVerified: createdUser.emailVerified,
+						createdAt: createdUser.createdAt,
+						updatedAt: createdUser.updatedAt,
+					},
 				});
 			}
 
@@ -231,6 +240,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				user: createdUser,
 			});
 			return ctx.json({
+				token: session.token,
 				user: {
 					id: createdUser.id,
 					email: createdUser.email,
@@ -240,7 +250,6 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					createdAt: createdUser.createdAt,
 					updatedAt: createdUser.updatedAt,
 				},
-				token: session.token,
 			});
 		},
 	);

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -231,6 +231,15 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				user: createdUser,
 			});
 			return ctx.json({
+				user: {
+					id: createdUser.id,
+					email: createdUser.email,
+					name: createdUser.name,
+					image: createdUser.image,
+					emailVerified: createdUser.emailVerified,
+					createdAt: createdUser.createdAt,
+					updatedAt: createdUser.updatedAt,
+				},
 				token: session.token,
 			});
 		},

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -237,6 +237,15 @@ export const changePassword = createAuthEndpoint(
 
 		return ctx.json({
 			token,
+			user: {
+				id: session.user.id,
+				email: session.user.email,
+				name: session.user.name,
+				image: session.user.image,
+				emailVerified: session.user.emailVerified,
+				createdAt: session.user.createdAt,
+				updatedAt: session.user.updatedAt,
+			},
 		});
 	},
 );

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -141,6 +141,14 @@ export const anonymous = (options?: AnonymousOptions) => {
 					});
 					return ctx.json({
 						token: session.token,
+						user: {
+							id: newUser.id,
+							email: newUser.email,
+							emailVerified: newUser.emailVerified,
+							name: newUser.name,
+							createdAt: newUser.createdAt,
+							updatedAt: newUser.updatedAt,
+						},
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -341,14 +341,32 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							user: updatedUser,
 						});
 						return ctx.json({
-							token: session.token,
 							status: true,
+							token: session.token,
+							user: {
+								id: updatedUser.id,
+								email: updatedUser.email,
+								emailVerified: updatedUser.emailVerified,
+								name: updatedUser.name,
+								image: updatedUser.image,
+								createdAt: updatedUser.createdAt,
+								updatedAt: updatedUser.updatedAt,
+							},
 						});
 					}
 
 					return ctx.json({
 						status: true,
 						token: null,
+						user: {
+							id: updatedUser.id,
+							email: updatedUser.email,
+							emailVerified: updatedUser.emailVerified,
+							name: updatedUser.name,
+							image: updatedUser.image,
+							createdAt: updatedUser.createdAt,
+							updatedAt: updatedUser.updatedAt,
+						},
 					});
 				},
 			),
@@ -440,6 +458,15 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						});
 						return ctx.json({
 							token: session.token,
+							user: {
+								id: newUser.id,
+								email: newUser.email,
+								emailVerified: newUser.emailVerified,
+								name: newUser.name,
+								image: newUser.image,
+								createdAt: newUser.createdAt,
+								updatedAt: newUser.updatedAt,
+							},
 						});
 					}
 
@@ -459,6 +486,15 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					});
 					return ctx.json({
 						token: session.token,
+						user: {
+							id: user.user.id,
+							email: user.user.email,
+							emailVerified: user.user.emailVerified,
+							name: user.user.name,
+							image: user.user.image,
+							createdAt: user.user.createdAt,
+							updatedAt: user.user.updatedAt,
+						},
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -237,6 +237,15 @@ export const magicLink = (options: MagicLinkOptions) => {
 					if (!callbackURL) {
 						return ctx.json({
 							token: session.token,
+							user: {
+								id: user.id,
+								email: user.email,
+								emailVerified: user.emailVerified,
+								name: user.name,
+								image: user.image,
+								createdAt: user.createdAt,
+								updatedAt: user.updatedAt,
+							},
 						});
 					}
 					throw ctx.redirect(callbackURL);

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -59,8 +59,8 @@ export const oneTap = (options?: OneTapOptions) =>
 						},
 					},
 				},
-				async (c) => {
-					const { idToken } = c.body;
+				async (ctx) => {
+					const { idToken } = ctx.body;
 					const { data, error } = await betterFetch<{
 						email: string;
 						email_verified: string;
@@ -69,11 +69,11 @@ export const oneTap = (options?: OneTapOptions) =>
 						sub: string;
 					}>("https://oauth2.googleapis.com/tokeninfo?id_token=" + idToken);
 					if (error) {
-						return c.json({
+						return ctx.json({
 							error: "Invalid token",
 						});
 					}
-					const user = await c.context.internalAdapter.findUserByEmail(
+					const user = await ctx.context.internalAdapter.findUserByEmail(
 						data.email,
 					);
 					if (!user) {
@@ -82,7 +82,7 @@ export const oneTap = (options?: OneTapOptions) =>
 								message: "User not found",
 							});
 						}
-						const user = await c.context.internalAdapter.createOAuthUser(
+						const user = await ctx.context.internalAdapter.createOAuthUser(
 							{
 								email: data.email,
 								emailVerified: toBoolean(data.email_verified),
@@ -99,30 +99,47 @@ export const oneTap = (options?: OneTapOptions) =>
 								message: "Could not create user",
 							});
 						}
-						const session = await c.context.internalAdapter.createSession(
+						const session = await ctx.context.internalAdapter.createSession(
 							user?.user.id,
-							c.request,
+							ctx.request,
 						);
-						await setSessionCookie(c, {
+						await setSessionCookie(ctx, {
 							user: user.user,
 							session,
 						});
-						return c.json({
-							session,
-							user,
+						return ctx.json({
+							token: session.token,
+							user: {
+								id: user.user.id,
+								email: user.user.email,
+								emailVerified: user.user.emailVerified,
+								name: user.user.name,
+								image: user.user.image,
+								createdAt: user.user.createdAt,
+								updatedAt: user.user.updatedAt,
+							},
 						});
 					}
-					const session = await c.context.internalAdapter.createSession(
+					const session = await ctx.context.internalAdapter.createSession(
 						user.user.id,
-						c.request,
+						ctx.request,
 					);
 
-					await setSessionCookie(c, {
+					await setSessionCookie(ctx, {
 						user: user.user,
 						session,
 					});
-					return c.json({
+					return ctx.json({
 						token: session.token,
+						user: {
+							id: user.user.id,
+							email: user.user.email,
+							emailVerified: user.user.emailVerified,
+							name: user.user.name,
+							image: user.user.image,
+							createdAt: user.user.createdAt,
+							updatedAt: user.user.updatedAt,
+						},
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -240,6 +240,17 @@ export const phoneNumber = (options?: {
 					);
 					return ctx.json({
 						token: session.token,
+						user: {
+							id: user.id,
+							email: user.email,
+							emailVerified: user.emailVerified,
+							name: user.name,
+							image: user.image,
+							phoneNumber: user.phoneNumber,
+							phoneNumberVerified: user.phoneNumberVerified,
+							createdAt: user.createdAt,
+							updatedAt: user.updatedAt,
+						} as UserWithPhoneNumber,
 					});
 				},
 			),
@@ -417,13 +428,27 @@ export const phoneNumber = (options?: {
 								message: BASE_ERROR_CODES.USER_NOT_FOUND,
 							});
 						}
-						await ctx.context.internalAdapter.updateUser(session.user.id, {
-							[opts.phoneNumber]: ctx.body.phoneNumber,
-							[opts.phoneNumberVerified]: true,
-						});
+						let user = await ctx.context.internalAdapter.updateUser(
+							session.user.id,
+							{
+								[opts.phoneNumber]: ctx.body.phoneNumber,
+								[opts.phoneNumberVerified]: true,
+							},
+						);
 						return ctx.json({
-							token: session.session.token,
 							status: true,
+							token: session.session.token,
+							user: {
+								id: user.id,
+								email: user.email,
+								emailVerified: user.emailVerified,
+								name: user.name,
+								image: user.image,
+								phoneNumber: user.phoneNumber,
+								phoneNumberVerified: user.phoneNumberVerified,
+								createdAt: user.createdAt,
+								updatedAt: user.updatedAt,
+							} as UserWithPhoneNumber,
 						});
 					}
 
@@ -492,14 +517,36 @@ export const phoneNumber = (options?: {
 							user,
 						});
 						return ctx.json({
-							token: session.token,
 							status: true,
+							token: session.token,
+							user: {
+								id: user.id,
+								email: user.email,
+								emailVerified: user.emailVerified,
+								name: user.name,
+								image: user.image,
+								phoneNumber: user.phoneNumber,
+								phoneNumberVerified: user.phoneNumberVerified,
+								createdAt: user.createdAt,
+								updatedAt: user.updatedAt,
+							} as UserWithPhoneNumber,
 						});
 					}
 
 					return ctx.json({
-						token: null,
 						status: true,
+						token: null,
+						user: {
+							id: user.id,
+							email: user.email,
+							emailVerified: user.emailVerified,
+							name: user.name,
+							image: user.image,
+							phoneNumber: user.phoneNumber,
+							phoneNumberVerified: user.phoneNumberVerified,
+							createdAt: user.createdAt,
+							updatedAt: user.updatedAt,
+						} as UserWithPhoneNumber,
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/two-factor/verify-middleware.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-middleware.ts
@@ -80,6 +80,15 @@ export const verifyTwoFactorMiddleware = createAuthMiddleware(
 					}
 					return ctx.json({
 						token: session.token,
+						user: {
+							id: user.id,
+							email: user.email,
+							emailVerified: user.emailVerified,
+							name: user.name,
+							image: user.image,
+							createdAt: user.createdAt,
+							updatedAt: user.updatedAt,
+						},
 					});
 				},
 				invalid: async () => {
@@ -97,6 +106,15 @@ export const verifyTwoFactorMiddleware = createAuthMiddleware(
 			valid: async () => {
 				return ctx.json({
 					token: session.session.token,
+					user: {
+						id: session.user.id,
+						email: session.user.email,
+						emailVerified: session.user.emailVerified,
+						name: session.user.name,
+						image: session.user.image,
+						createdAt: session.user.createdAt,
+						updatedAt: session.user.updatedAt,
+					},
 				});
 			},
 			invalid: async () => {

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -146,6 +146,15 @@ export const username = () => {
 					);
 					return ctx.json({
 						token: session.token,
+						user: {
+							id: user.id,
+							email: user.email,
+							emailVerified: user.emailVerified,
+							name: user.name,
+							image: user.image,
+							createdAt: user.createdAt,
+							updatedAt: user.updatedAt,
+						},
 					});
 				},
 			),


### PR DESCRIPTION
I propose restoring the user data in the response of api.signUpEmail to complete the registration flow in my Nest.js application. Without this change, I am restricted to using versions of better-auth prior to v1.0.23.

The issue I am facing is described in #1036. Importantly, this modification does not break any existing functionality. Notably, the api.signInEmail endpoint already includes the user data in its response (which seems to be an oversight).

I kindly request that this PR be merged as a temporary measure.