### PR TITLE
feat: support overwriting auth-url params in the generic-oauth plugin

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -101,6 +101,11 @@ interface GenericOAuthConfig {
 				emailVerified?: boolean;
 				[key: string]: any;
 		  }>;
+	/**
+	 * Additional search-params to add to the authorizationUrl.
+	 * Warning: Search-params added here overwrite any default params.
+	 */
+	authorizationUrlParams?: Record<string, string>
 }
 
 interface GenericOAuthOptions {
@@ -336,6 +341,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						pkce,
 						prompt,
 						accessType,
+						authorizationUrlParams
 					} = config;
 					let finalAuthUrl = authorizationUrl;
 					let finalTokenUrl = tokenUrl;
@@ -360,6 +366,14 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							message: ERROR_CODES.INVALID_OAUTH_CONFIGURATION,
 						});
 					}
+					if (authorizationUrlParams){
+						const withAdditionalParams = new URL(finalAuthUrl);
+							for (const [paramName, paramValue] of Object.entries(authorizationUrlParams)) {
+								withAdditionalParams.searchParams.set(paramName, paramValue)
+							}
+							finalAuthUrl = withAdditionalParams.toString();
+					}
+
 					const { state, codeVerifier } = await generateState(ctx);
 					const authUrl = await createAuthorizationURL({
 						id: providerId,


### PR DESCRIPTION
Various oauth providers support custom parameters as part of their `authorization_endpoint` url. This allows users of the `genericOAuth` plugin to provide those custom parameters.

closes #1064