### PR TITLE
fix(organization): limit creator role invites to users with same role

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -163,67 +163,89 @@ describe("organization", async (it) => {
 		expect(org?.members.length).toBe(1);
 	});
 
-	const newUser = {
-		email: "test2@test.com",
-		password: "test123456",
-		name: "test2",
-	};
-
-	it("invites user to organization", async () => {
-		const { headers } = await signInWithTestUser();
-		const invite = await client.organization.inviteMember({
-			organizationId: organizationId,
-			email: newUser.email,
+	it.each([
+		{
+			role: "owner",
+			newUser: {
+				email: "test2@test.com",
+				password: "test123456",
+				name: "test2",
+			},
+		},
+		{
+			role: "admin",
+			newUser: {
+				email: "test3@test.com",
+				password: "test123456",
+				name: "test3",
+			},
+		},
+		{
 			role: "member",
-			fetchOptions: {
-				headers,
+			newUser: {
+				email: "test4@test.com",
+				password: "test123456",
+				name: "test4",
 			},
-		});
-		if (!invite.data) throw new Error("Invitation not created");
-		expect(invite.data.email).toBe("test2@test.com");
-		expect(invite.data.role).toBe("member");
-		await client.signUp.email({
-			email: newUser.email,
-			password: newUser.password,
-			name: newUser.name,
-		});
-		const { headers: headers2 } = await signInWithUser(
-			newUser.email,
-			newUser.password,
-		);
+		},
+	])(
+		"invites user to organization with $role role",
+		async ({ role, newUser }) => {
+			const { headers } = await signInWithTestUser();
+			const invite = await client.organization.inviteMember({
+				organizationId: organizationId,
+				email: newUser.email,
+				role: role,
+				fetchOptions: {
+					headers,
+				},
+			});
+			if (!invite.data) throw new Error("Invitation not created");
+			expect(invite.data.email).toBe(newUser.email);
+			expect(invite.data.role).toBe(role);
+			await client.signUp.email({
+				email: newUser.email,
+				password: newUser.password,
+				name: newUser.name,
+			});
+			const { headers: headers2 } = await signInWithUser(
+				newUser.email,
+				newUser.password,
+			);
 
-		const wrongInvitation = await client.organization.acceptInvitation({
-			invitationId: "123",
-			fetchOptions: {
-				headers: headers2,
-			},
-		});
-		expect(wrongInvitation.error?.status).toBe(400);
+			const wrongInvitation = await client.organization.acceptInvitation({
+				invitationId: "123",
+				fetchOptions: {
+					headers: headers2,
+				},
+			});
+			expect(wrongInvitation.error?.status).toBe(400);
 
-		const wrongPerson = await client.organization.acceptInvitation({
-			invitationId: invite.data.id,
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(wrongPerson.error?.status).toBe(403);
+			const wrongPerson = await client.organization.acceptInvitation({
+				invitationId: invite.data.id,
+				fetchOptions: {
+					headers,
+				},
+			});
+			expect(wrongPerson.error?.status).toBe(403);
 
-		const invitation = await client.organization.acceptInvitation({
-			invitationId: invite.data.id,
-			fetchOptions: {
-				headers: headers2,
-			},
-		});
-		expect(invitation.data?.invitation.status).toBe("accepted");
-		const invitedUserSession = await client.getSession({
-			fetchOptions: {
-				headers: headers2,
-			},
-		});
-		expect((invitedUserSession.data?.session as any).activeOrganizationId).toBe(
-			organizationId,
-		);
-	});
+			const invitation = await client.organization.acceptInvitation({
+				invitationId: invite.data.id,
+				fetchOptions: {
+					headers: headers2,
+				},
+			});
+			expect(invitation.data?.invitation.status).toBe("accepted");
+			const invitedUserSession = await client.getSession({
+				fetchOptions: {
+					headers: headers2,
+				},
+			});
+			expect(
+				(invitedUserSession.data?.session as any).activeOrganizationId,
+			).toBe(organizationId);
+		},
+	);
 
 	it("should allow getting a member", async () => {
 		const { headers } = await signInWithTestUser();
@@ -254,10 +276,10 @@ describe("organization", async (it) => {
 			},
 		});
 		if (!org.data) throw new Error("Organization not found");
-		expect(org.data?.members[1].role).toBe("member");
+		expect(org.data?.members[3].role).toBe("member");
 		const member = await client.organization.updateMemberRole({
 			organizationId: org.data.id,
-			memberId: org.data.members[1].id,
+			memberId: org.data.members[3].id,
 			role: "admin",
 			fetchOptions: {
 				headers,
@@ -266,11 +288,20 @@ describe("organization", async (it) => {
 		expect(member.data?.role).toBe("admin");
 	});
 
+	const adminUser = {
+		email: "test3@test.com",
+		password: "test123456",
+		name: "test3",
+	};
+
 	it("should not allow inviting member with a creator role unless they are creator", async () => {
-		const { headers } = await signInWithUser(newUser.email, newUser.password);
+		const { headers } = await signInWithUser(
+			adminUser.email,
+			adminUser.password,
+		);
 		const invite = await client.organization.inviteMember({
 			organizationId: organizationId,
-			email: newUser.email,
+			email: adminUser.email,
 			role: "owner",
 			fetchOptions: {
 				headers,
@@ -292,7 +323,7 @@ describe("organization", async (it) => {
 			},
 		});
 
-		expect(orgBefore.data?.members.length).toBe(2);
+		expect(orgBefore.data?.members.length).toBe(4);
 		await client.organization.removeMember({
 			organizationId: organizationId,
 			memberIdOrEmail: "test2@test.com",
@@ -309,7 +340,7 @@ describe("organization", async (it) => {
 				headers,
 			},
 		});
-		expect(org.data?.members.length).toBe(1);
+		expect(org.data?.members.length).toBe(3);
 	});
 
 	it("shouldn't allow removing owner from organization", async () => {

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -131,7 +131,7 @@ export const createInvitation = <O extends OrganizationOptions | undefined>(
 
 			const creatorRole = ctx.context.orgOptions.creatorRole || "owner";
 
-			if (member.role !== creatorRole || ctx.body.role === creatorRole) {
+			if (member.role !== creatorRole && ctx.body.role === creatorRole) {
 				throw new APIError("FORBIDDEN", {
 					message:
 						ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USER_WITH_THIS_ROLE,


### PR DESCRIPTION
Via the commit https://github.com/better-auth/better-auth/commit/6ab16893 a new check was introduced, with the goal to limit the assignment of the "creator" role during the sending of an invitation, so that only other users holding the "creator" role can invite new users and assign them the "creator role" as part of this invitation.

There are two conditions involved in this check:

1. Does the user sending the invite have the "creator" role, and
1. is the role, that is to be assigned to the new user, the "creator" role

These however are combined with an OR operator, instead of an AND.
This introduced two issues:

1. Invites can only be sent by users holding the creator role, other roles can no longer send any invites, even when they have the correct permissions, and
1. the "creator" role itself cannot be used as the role to be assigned to the invitee, even when the user sending the invite themselves has the "creator" role

### Changes

This PR changes the operator of the check to an AND to fix both of these issues.

This PR also extends the existing "invites user to organization" test to test inviting a user with each of the three default roles ("owner", "admin", "member"). 
This would catch the issue where invites with the "creator" role are not possible, even when the inviting user has the "creator" role.