### PR TITLE
docs: update config guide for expo

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -142,13 +142,25 @@ Expo is a popular framework for building cross-platform apps with React Native. 
         module.exports = config;
         ```
 
-        If you can't enable `unstable_enablePackageExports` option, you can use the following workaround when importing Better Auth.
+        If you can't enable `unstable_enablePackageExports` option, you can use [babel-plugin-module-resolver](https://github.com/tleunen/babel-plugin-module-resolver) to manually resolve the paths.
 
-        ```ts title="src/auth-client.ts"
-        const { expoClient } =
-          require("@better-auth/expo/dist/client.js") as typeof import("@better-auth/expo/client")
-        const { createAuthClient } =
-          require("better-auth/dist/react.js") as typeof import("better-auth/react")
+        ```ts title="babel.config.js"
+        module.exports = function (api) {
+            return {
+                plugins: [
+                    [
+                        "module-resolver",
+                        {
+                            alias: {
+                                "better-auth/react": "path/to/node_modules/better-auth/dist/react.js"
+                                "@better-auth/expo/client": "path/to/node_modules/@better-auth/expo/dist/client.js",
+                            },
+                            extensions: [".js", ".jsx", ".ts", ".tsx"],
+                        },
+                    ],
+                ],
+            }
+        }
         ```
 
     </Step>

--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -163,6 +163,12 @@ Expo is a popular framework for building cross-platform apps with React Native. 
         }
         ```
 
+        Don't forget to clear the cache after making changes.
+
+        ```bash
+        npx expo start --clear
+        ```
+
     </Step>
 </Steps>
 


### PR DESCRIPTION
In https://github.com/better-auth/better-auth/pull/1020/files#diff-a95fa03eaa3ede5409efe90244f6f137c4f09e3354e652b4a4d20500f23c4f40, `@better-auth/expo` is importing `better-auth/react`. So the old workaround no longer works properly.