### PR TITLE
fix(docs): code highlight typo

### DIFF
--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -399,7 +399,7 @@ const myPlugin = ()=>{
         endpoints: {
             getHelloWorld: createAuthEndpoint("/my-plugin/hello-world", {
                 method: "GET",
-                use: [sessionMiddleware], //[!code highlight]
+                use: [sessionMiddleware], // [!code highlight]
             }, async(ctx) => {
                 const session = ctx.context.session;
                 return ctx.json({


### PR DESCRIPTION
Fixed this:

<img width="882" alt="image" src="https://github.com/user-attachments/assets/3c118f71-e061-469b-9cf6-767d8e3e1e55" />
