### PR TITLE
chore: added comments to schema unit test code

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/test/schema.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/test/schema.ts
@@ -1,3 +1,14 @@
+/*
+
+This file is used explicitly for testing purposes.
+
+It's not used in the production code.
+
+For information on how to use the drizzle-adapter, please refer to the documentation.
+
+https://www.better-auth.com/docs/concepts/database#drizzle-adapter
+
+*/
 import { boolean, text, timestamp } from "drizzle-orm/pg-core";
 import { pgTable } from "drizzle-orm/pg-core";
 


### PR DESCRIPTION
I noticed a user in the BetterAuth Discord server who was reading this file as a reference to creating their schema. This schema file has inaccurate values, but was specifically designed for unit-testing. I added comments at the top to state this.