### PR TITLE
refactor: Adapter types to support schema creation better

### DIFF
--- a/packages/better-auth/src/types/adapter.ts
+++ b/packages/better-auth/src/types/adapter.ts
@@ -80,6 +80,7 @@ export type AdapterSchemaCreation = {
 	code: string;
 	/**
 	 * Path to the file, including the file name and extension.
+	 * Relative paths are supported.
 	 */
 	path: string;
 	/**

--- a/packages/better-auth/src/types/adapter.ts
+++ b/packages/better-auth/src/types/adapter.ts
@@ -65,18 +65,32 @@ export type Adapter = {
 	 *
 	 * @param options
 	 * @param file - file path if provided by the user
-	 * @returns
 	 */
 	createSchema?: (
 		options: BetterAuthOptions,
 		file?: string,
-	) => Promise<{
-		code: string;
-		fileName: string;
-		append?: boolean;
-		overwrite?: boolean;
-	}>;
+	) => Promise<AdapterSchemaCreation[]>;
 	options?: Record<string, any>;
+};
+
+export type AdapterSchemaCreation = {
+	/**
+	 * Code to be inserted into the file
+	 */
+	code: string;
+	/**
+	 * Path to the file, including the file name and extension.
+	 */
+	path: string;
+	/**
+	 * Append the file if it already exists.
+	 * Note: This will not apply if `overwrite` is set to true.
+	 */
+	append?: boolean;
+	/**
+	 * Overwrite the file if it already exists
+	 */
+	overwrite?: boolean;
 };
 
 export interface AdapterInstance {


### PR DESCRIPTION
* Added JSDoc for each property
* Made the `createSchema` fn have an array return value, since the Convex Database expects multiple files per schema, this may be true for other database schemas that could be encountered in the future as well.