### PR TITLE
refactor: Adapter createSchema return type

### DIFF
--- a/packages/better-auth/src/types/adapter.ts
+++ b/packages/better-auth/src/types/adapter.ts
@@ -65,18 +65,33 @@ export type Adapter = {
 	 *
 	 * @param options
 	 * @param file - file path if provided by the user
-	 * @returns
 	 */
 	createSchema?: (
 		options: BetterAuthOptions,
 		file?: string,
-	) => Promise<{
-		code: string;
-		fileName: string;
-		append?: boolean;
-		overwrite?: boolean;
-	}>;
+	) => Promise<AdapterSchemaCreation>;
 	options?: Record<string, any>;
+};
+
+export type AdapterSchemaCreation = {
+	/**
+	 * Code to be inserted into the file
+	 */
+	code: string;
+	/**
+	 * Path to the file, including the file name and extension.
+	 * Relative paths are supported, with the current working directory devs as the base.
+	 */
+	path: string;
+	/**
+	 * Append the file if it already exists.
+	 * Note: This will not apply if `overwrite` is set to true.
+	 */
+	append?: boolean;
+	/**
+	 * Overwrite the file if it already exists
+	 */
+	overwrite?: boolean;
 };
 
 export interface AdapterInstance {


### PR DESCRIPTION
* Extracted the types out so that devs who are creating adapters can infer the type
* renamed `filename` to path as some database libraries require the file to be in a specific location.
  * For example with the Convex DB, the schema MUST be in the `/convex/schema.ts` file.
  * By using `path`, and setting the dev's project directory as a base, devs can pass relative pathnames including the file name & extension to explicitly define the schema file creation location
* added JSDoc to each property