### PR TITLE
fix: typo on JSDoc

### DIFF
--- a/packages/better-auth/src/types/adapter.ts
+++ b/packages/better-auth/src/types/adapter.ts
@@ -80,7 +80,7 @@ export type AdapterSchemaCreation = {
 	code: string;
 	/**
 	 * Path to the file, including the file name and extension.
-	 * Relative paths are supported, with the current working directory devs as the base.
+	 * Relative paths are supported, with the current working directory of the developer's project as the base.
 	 */
 	path: string;
 	/**


### PR DESCRIPTION
Changed:
"Relative paths are supported, with the current working directory devs as the base."
To:
"Relative paths are supported, with the current working directory of the developer's project as the base."

This also means the CLI which generates schemas must also identify the projects package.json and use that as a reference for the base directory.