### PR TITLE
Adding possible config path /auth

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -47,6 +47,7 @@ Create a file named `auth.ts` in one of these locations:
    - Project root
    - `lib/` folder
    - `utils/` folder
+   - `auth/` folder
 
 You can also nest any of these folders under `src/`, `app/` or `server/` folder. (e.g. `src/lib/auth.ts`, `app/lib/auth.ts`).
 

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -18,6 +18,7 @@ possiblePaths = [
 	...possiblePaths.map((it) => `server/${it}`),
 	...possiblePaths.map((it) => `lib/${it}`),
 	...possiblePaths.map((it) => `utils/${it}`),
+	...possiblePaths.map((it) => `auth/${it}`),
 ];
 possiblePaths = [
 	...possiblePaths,


### PR DESCRIPTION
I'm currently working on a project that will need to extend better-auth a bit, so I would like to have everything related to auth under `src/auth`, and having the instance exported from `src/auth/auth.ts`.

I'm currently doing that, but exporting better-auth instance from /src/auth.ts. 

Unsure if there are any implications to consider with this.