### PR TITLE
Fix docs default maxPasswordLength

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -258,7 +258,7 @@ export const auth = betterAuth({
     maxPasswordLength: {
       description: "The maximum length of a password.",
       type: "number",
-      default: 32,
+      default: 128,
     },
     sendResetPassword: {
       description:


### PR DESCRIPTION
The docs show the default maxPasswordLength to be 32, when it is 128.