### PR TITLE
Fix JWT private key import by explicitly specifying algorithm

### DIFF
--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -281,7 +281,10 @@ export const jwt = (options?: JwtOptions) => {
 							})
 						: key.privateKey;
 
-					const privateKey = await importJWK(JSON.parse(privateWebKey));
+					const privateKey = await importJWK(
+						JSON.parse(privateWebKey),
+						options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
+					);
 
 					const payload = !options?.jwt?.definePayload
 						? ctx.context.session.user


### PR DESCRIPTION
fix: add missing algorithm parameter in importJWK function

- Add explicit algorithm parameter when importing private key using importJWK
- Resolve "'alg' argument is required when 'jwk.alg' is not present" error in Bun environment
- Default to 'EdDSA' if no algorithm is specified in keyPairConfig

This change ensures compatibility with stricter JWT implementations and fixes
the token generation process in Bun runtime.