### PR TITLE
feat: Add Membership Validation to getFullOrganization Endpoint closes #1165

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -396,7 +396,6 @@ export const getFullOrganization = createAuthEndpoint(
 			(member) => member.userId === session.user.id,
 		);
 		if (!isMember) {
-			await adapter.setActiveOrganization(session.session.token, null);
 			throw new APIError("FORBIDDEN", {
 				message:
 					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -392,6 +392,16 @@ export const getFullOrganization = createAuthEndpoint(
 			organizationId,
 			isSlug: !!ctx.query?.organizationSlug,
 		});
+		const isMember = organization?.members.find(
+			(member) => member.userId === session.user.id,
+		);
+		if (!isMember) {
+			await adapter.setActiveOrganization(session.session.token, null);
+			throw new APIError("FORBIDDEN", {
+				message:
+					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
+			});
+		}
 		if (!organization) {
 			throw new APIError("BAD_REQUEST", {
 				message: ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,


### PR DESCRIPTION
This PR adds membership validation to the `getFullOrganization` endpoint by checking if the requesting user is a member of the specified organization. This change enhances security by ensuring that only authorized users can access the organization's details.

Reused isMember check from `setActiveOrganization`

closes #1165