### PR TITLE
Fix (bearer): 'set-auth-token' header not exposed with CORS (#917)

### DIFF
--- a/packages/better-auth/src/plugins/bearer/index.ts
+++ b/packages/better-auth/src/plugins/bearer/index.ts
@@ -105,6 +105,7 @@ export const bearer = (options?: BearerOptions) => {
 						}
 						const token = sessionCookie.value;
 						ctx.responseHeader.set("set-auth-token", token);
+						ctx.responseHeader.set("Access-Control-Expose-Headers", "set-auth-token" );
 						return {
 							responseHeader: ctx.responseHeader,
 						};


### PR DESCRIPTION
closes #917 