### PR TITLE
fix: remove trailing slashes from base url

### DIFF
--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -18,7 +18,7 @@ function withPath(url: string, path = "/api/auth") {
 		return url;
 	}
 	path = path.startsWith("/") ? path : `/${path}`;
-	return `${url}${path}`;
+	return `${url.replace(/\/+$/, "")}${path}`;
 }
 
 export function getBaseURL(url?: string, path?: string) {


### PR DESCRIPTION
This pull request includes an important change to the `withPath` function in the `packages/better-auth/src/utils/url.ts` file. The change ensures that the URL does not end with multiple slashes before appending the path.

* [`packages/better-auth/src/utils/url.ts`](diffhunk://#diff-ee268e99ecf5bb4eff434ec4334aa0e0fa636ab90853abf1cb584f48a74c3776L21-R21): Modified the `withPath` function to remove trailing slashes from the URL before appending the path.
* I updated the `packages/better-auth/src/init.test.ts` file by adding test cases for baseUrl with trailing slashes and ran the tests to ensure the changes work as expected.

<img width="798" alt="image" src="https://github.com/user-attachments/assets/d8e9d4dc-9559-4be4-8b80-69f798a6c96f" />

Closes #1156
