### PR TITLE
fix: fixed number mapping for rate limit migration

### DIFF
--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -186,7 +186,7 @@ export async function onRequestRateLimit(req: Request, ctx: AuthContext) {
 				key,
 				{
 					...data,
-					count: data.count + 1,
+					count: Number(data.count) + 1,
 					lastRequest: now,
 				},
 				true,

--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -186,7 +186,7 @@ export async function onRequestRateLimit(req: Request, ctx: AuthContext) {
 				key,
 				{
 					...data,
-					count: Number(data.count) + 1,
+					count: data.count + 1,
 					lastRequest: now,
 				},
 				true,

--- a/packages/better-auth/src/db/field.ts
+++ b/packages/better-auth/src/db/field.ts
@@ -73,6 +73,9 @@ export type FieldAttributeConfig<T extends FieldType = FieldType> = {
 			| "set default";
 	};
 	unique?: boolean;
+  /**
+   * If the field should be a bigint on the database instead of integer.
+   */
   bigint?: boolean;
 	/**
 	 * A zod schema to validate the value.

--- a/packages/better-auth/src/db/field.ts
+++ b/packages/better-auth/src/db/field.ts
@@ -73,6 +73,7 @@ export type FieldAttributeConfig<T extends FieldType = FieldType> = {
 			| "set default";
 	};
 	unique?: boolean;
+  bigint?: boolean;
 	/**
 	 * A zod schema to validate the value.
 	 */

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -184,10 +184,10 @@ export async function getMigrations(config: BetterAuthOptions) {
 				mssql: "boolean",
 			},
 			number: {
-				sqlite: "bigint",
-				postgres: "bigint",
-				mysql: "bigint",
-				mssql: "bigint",
+				sqlite: field.bigint ? "bigint" : "integer",
+				postgres: field.bigint ? "bigint" : "integer",
+				mysql: field.bigint ? "bigint" : "integer",
+				mssql: field.bigint ? "bigint" : "integer",
 			},
 			date: {
 				sqlite: "date",

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -184,10 +184,10 @@ export async function getMigrations(config: BetterAuthOptions) {
 				mssql: "boolean",
 			},
 			number: {
-				sqlite: "integer",
-				postgres: "integer",
-				mysql: "integer",
-				mssql: "integer",
+				sqlite: "bigint",
+				postgres: "bigint",
+				mysql: "bigint",
+				mssql: "bigint",
 			},
 			date: {
 				sqlite: "date",

--- a/packages/better-auth/src/db/get-tables.ts
+++ b/packages/better-auth/src/db/get-tables.ts
@@ -63,6 +63,7 @@ export const getAuthTables = (
 				},
 				lastRequest: {
 					type: "number",
+          bigint: true,
 					fieldName: options.rateLimit?.fields?.lastRequest || "lastRequest",
 				},
 			},


### PR DESCRIPTION
closes #1190   closes #1154

lastRequest column on rate limit table was using int4 since we stored timestamp in ms it was way over int4 limit so we need to change it to int8. This is the only table in better auth package that has number in schema, so for now this fix should be okay but i can take a look and implement more customizable approach for database types so in future for example all fields that have type of number won't use int8 but instead specified by schema/options