### PR TITLE
fix(cli): add bigint type to generators

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -18,8 +18,14 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	const timestampAndBoolean =
 		databaseType !== "sqlite" ? "timestamp, boolean" : "";
 	const int = databaseType === "mysql" ? "int" : "integer";
+	const hasBigint = Object.values(tables).some((table) =>
+		Object.values(table.fields).some((field) => field.bigint),
+	);
+	const bigint = databaseType !== "sqlite" ? "bigint" : "";
 	const text = databaseType === "mysql" ? "varchar, text" : "text";
-	let code = `import { ${databaseType}Table, ${text}, ${int}, ${timestampAndBoolean} } from "drizzle-orm/${databaseType}-core";
+	let code = `import { ${databaseType}Table, ${text}, ${int}${hasBigint ? 
+		`, ${bigint}` : ""
+	}, ${timestampAndBoolean} } from "drizzle-orm/${databaseType}-core";
 			`;
 
 	const fileExist = existsSync(filePath);
@@ -49,8 +55,8 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				},
 				number: {
 					sqlite: `integer('${name}')`,
-					pg: `integer('${name}')`,
-					mysql: `int('${name}')`,
+					pg: field.bigint ? `bigint('${name}', { mode: 'number' })` : `integer('${name}')`,
+					mysql: field.bigint ? `bigint('${name}', { mode: 'number' })` : `int('${name}')`,
 				},
 				date: {
 					sqlite: `integer('${name}', { mode: 'timestamp' })`,

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -51,9 +51,12 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 			const originalTable = tables[table]?.modelName;
 			const modelName = capitalizeFirstLetter(originalTable || "");
 
-			function getType(type: FieldType, isOptional: boolean) {
+			function getType(type: FieldType, isOptional: boolean, isBigint: boolean) {
 				if (type === "string") {
 					return isOptional ? "String?" : "String";
+				}
+				if (type === "number" && isBigint) {
+					return isOptional ? "BigInt?" : "BigInt";
 				}
 				if (type === "number") {
 					return isOptional ? "Int?" : "Int";
@@ -103,7 +106,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 
 				builder
 					.model(modelName)
-					.field(field, getType(attr.type, !attr?.required));
+					.field(field, getType(attr.type, !attr?.required, attr?.bigint || false));
 				if (attr.unique) {
 					builder.model(modelName).blockAttribute(`unique([${field}])`);
 				}


### PR DESCRIPTION
This pull request adds logic to the schema generators for both Drizzle and Prisma to handle `bigint` fields appropriately.

Closes #1216

Updates to Drizzle schema generation:

* [`packages/cli/src/generators/drizzle.ts`](diffhunk://#diff-08d92411458f1a542439c00e1269f9c43f2e69d6cdbaeb9d5d205c6c092bf9e6R21-R28): Added logic to check for `bigint` fields and update the import statements to include `bigint` if necessary.
* [`packages/cli/src/generators/drizzle.ts`](diffhunk://#diff-08d92411458f1a542439c00e1269f9c43f2e69d6cdbaeb9d5d205c6c092bf9e6L52-R59): Modified the schema generation logic to use `bigint` for PostgreSQL and MySQL when a field is marked as `bigint`.

Updates to Prisma schema generation:

* [`packages/cli/src/generators/prisma.ts`](diffhunk://#diff-b32e8aeb98c8b8239920a352c8ca1f870e295b5b4ed323b4e823d8befbf0003fL54-R60): Updated the `getType` function to return `BigInt` for fields marked as `bigint`.
* [`packages/cli/src/generators/prisma.ts`](diffhunk://#diff-b32e8aeb98c8b8239920a352c8ca1f870e295b5b4ed323b4e823d8befbf0003fL106-R109): Modified the schema generation logic to pass the `bigint` attribute to the `getType` function.