### PR TITLE
feat: support Microsoft Entra ID select_account prompt

### DIFF
--- a/docs/content/docs/authentication/microsoft.mdx
+++ b/docs/content/docs/authentication/microsoft.mdx
@@ -5,7 +5,6 @@ description: Microsoft provider setup and usage.
 
 Enabling OAuth with Microsoft Azure Entra ID (formerly Active Directory) allows your users to sign in and sign up to your application with their Microsoft account.
 
-
 <Steps>
     <Step> 
         ### Get your Microsoft credentials
@@ -18,21 +17,23 @@ Enabling OAuth with Microsoft Azure Entra ID (formerly Active Directory) allows 
     ### Configure the provider
     To configure the provider, you need to pass the `clientId` and `clientSecret` to `socialProviders.microsoft` in your auth configuration.
 
-    ```ts title="auth.ts"   
+    ```ts title="auth.ts"
     import { betterAuth } from "better-auth"
-    
+
     export const auth = betterAuth({
         socialProviders: {
             microsoft: { // [!code highlight]
                 clientId: process.env.MICROSOFT_CLIENT_ID as string, // [!code highlight]
                 clientSecret: process.env.MICROSOFT_CLIENT_SECRET as string, // [!code highlight]
+                // Optional
+                requireSelectAccount: true // [!code highlight]
             }, // [!code highlight]
-        }, 
+        },
     })
     ```
     </Step>
-</Steps>
 
+</Steps>
 
 ## Sign In with Microsoft
 
@@ -41,14 +42,14 @@ To sign in with Microsoft, you can use the `signIn.social` function provided by 
 - `provider`: The provider to use. It should be set to `microsoft`.
 
 ```ts title="auth-client.ts"  /
-import { createAuthClient } from "better-auth/client"
+import { createAuthClient } from "better-auth/client";
 
-const authClient =  createAuthClient()
+const authClient = createAuthClient();
 
 const signIn = async () => {
-    const data = await authClient.signIn.social({
-        provider: "microsoft",
-        callbackURL: "/dashboard" //the url to redirect to after the sign in
-    })
-}
+  const data = await authClient.signIn.social({
+    provider: "microsoft",
+    callbackURL: "/dashboard", //the url to redirect to after the sign in
+  });
+};
 ```

--- a/packages/better-auth/src/oauth2/create-authorization-url.ts
+++ b/packages/better-auth/src/oauth2/create-authorization-url.ts
@@ -11,6 +11,7 @@ export async function createAuthorizationURL({
 	claims,
 	redirectURI,
 	duration,
+	prompt,
 }: {
 	id: string;
 	options: ProviderOptions;
@@ -21,6 +22,7 @@ export async function createAuthorizationURL({
 	scopes: string[];
 	claims?: string[];
 	duration?: string;
+	prompt?: boolean;
 }) {
 	const url = new URL(authorizationEndpoint);
 	url.searchParams.set("response_type", "code");
@@ -51,6 +53,9 @@ export async function createAuthorizationURL({
 	}
 	if (duration) {
 		url.searchParams.set("duration", duration);
+	}
+	if (prompt) {
+		url.searchParams.set("prompt", "select_account");
 	}
 
 	return url;

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -28,6 +28,12 @@ export interface MicrosoftOptions
 	 * Disable profile photo
 	 */
 	disableProfilePhoto?: boolean;
+
+	/**
+	 * Require user to select their account even if only one account is logged in
+	 * @default false
+	 */
+	requireSelectAccount?: boolean;
 }
 
 export const microsoft = (options: MicrosoftOptions) => {
@@ -49,6 +55,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 				codeVerifier: data.codeVerifier,
 				scopes,
 				redirectURI: data.redirectURI,
+				prompt: options.requireSelectAccount || false,
 			});
 		},
 		validateAuthorizationCode({ code, codeVerifier, redirectURI }) {


### PR DESCRIPTION
Adds a `requireSelectAccount` option to Microsoft Entra ID so that when `true` even if the user is logged in with only one Microsoft account they have to choose their account. Defaults to `false`.

Closes #1209 