### PR TITLE
[docs] Change email verification must be sent to the current user email 

### DIFF
--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -53,9 +53,9 @@ export const auth = betterAuth({
             enabled: true,
             sendChangeEmailVerification: async ({ user, newEmail, url, token }, request) => {
                 await sendEmail({
-                    to: newEmail,
-                    subject: 'Verify your email change',
-                    text: `Click the link to verify: ${url}`
+                    to: user.email, // verification email must be sent to the current user email to approve the change
+                    subject: 'Approve email change',
+                    text: `Click the link to approve the change: ${url}`
                 })
             }
         }


### PR DESCRIPTION
I made a small fix in the docs to emphasize that the change verification email must be sent to the current user email address, not to the new email. 
 
P.S. Thanks for the beautiful and useful auth library. I am integrating it on a real production project and soon will write a post about it. I migrated from NextAuth.js (v4). 
