### PR TITLE
fix(rate-limiter): convert bigint lastRequest to number

### DIFF
--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -44,6 +44,11 @@ function createDBStorage(ctx: AuthContext, modelName?: string) {
 				where: [{ field: "key", value: key }],
 			});
 			const data = res[0];
+			
+			if (typeof data?.lastRequest === "bigint") {
+				data.lastRequest = Number(data.lastRequest);
+			}
+
 			return data;
 		},
 		set: async (key: string, value: RateLimit, _update?: boolean) => {


### PR DESCRIPTION
This pull request includes a change to the `createDBStorage` function in the `packages/better-auth/src/api/rate-limiter/index.ts` file. The change ensures that the `lastRequest` field returned from db is converted from a `bigint` to a `number` before use in TypeScript.

Closes #1231

* [`packages/better-auth/src/api/rate-limiter/index.ts`](diffhunk://#diff-266a45270a21e4b11dcd53ed439c47158c823a5305a589055fa2307f5a543d44R47-R51): Added a check to convert `lastRequest` from `bigint` to `number` if necessary.