### PR TITLE
fix(docs): prop names and react key warnings

### DIFF
--- a/docs/components/blocks/features.tsx
+++ b/docs/components/blocks/features.tsx
@@ -118,10 +118,10 @@ export function GridPattern({ width, height, x, y, squares, ...props }: any) {
 			/>
 			{squares && (
 				<svg x={x} y={y} className="overflow-visible">
-					{squares.map(([x, y]: any) => (
+					{squares.map(([x, y]: any, idx: number) => (
 						<rect
 							strokeWidth="0"
-							key={`${x}-${y}`}
+							key={`${x}-${y}-${idx}`}
 							width={width + 1}
 							height={height + 1}
 							x={x * width}

--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1068,9 +1068,9 @@ export const contents: Content[] = [
 						viewBox="0 0 24 24"
 						fill="none"
 						stroke="currentColor"
-						stroke-width="2"
+						strokeWidth="2"
 						stroke-linecap="round"
-						stroke-linejoin="round"
+						strokeLinejoin="round"
 						className="lucide lucide-users"
 					>
 						<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
@@ -1164,8 +1164,8 @@ export const contents: Content[] = [
 							fill="none"
 							stroke="currentColor"
 							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="32"
+							strokeLinejoin="round"
+							strokeWidth="32"
 							d="M413.66 246.1H386a2 2 0 0 1-2-2v-77.24A38.86 38.86 0 0 0 345.14 128H267.9a2 2 0 0 1-2-2V98.34c0-27.14-21.5-49.86-48.64-50.33a49.53 49.53 0 0 0-50.4 49.51V126a2 2 0 0 1-2 2H87.62A39.74 39.74 0 0 0 48 167.62V238a2 2 0 0 0 2 2h26.91c29.37 0 53.68 25.48 54.09 54.85c.42 29.87-23.51 57.15-53.29 57.15H50a2 2 0 0 0-2 2v70.38A39.74 39.74 0 0 0 87.62 464H158a2 2 0 0 0 2-2v-20.93c0-30.28 24.75-56.35 55-57.06c30.1-.7 57 20.31 57 50.28V462a2 2 0 0 0 2 2h71.14A38.86 38.86 0 0 0 384 425.14v-78a2 2 0 0 1 2-2h28.48c27.63 0 49.52-22.67 49.52-50.4s-23.2-48.64-50.34-48.64"
 						></path>
 					</svg>

--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1069,7 +1069,7 @@ export const contents: Content[] = [
 						fill="none"
 						stroke="currentColor"
 						strokeWidth="2"
-						stroke-linecap="round"
+						strokeLinecap="round"
 						strokeLinejoin="round"
 						className="lucide lucide-users"
 					>
@@ -1163,7 +1163,7 @@ export const contents: Content[] = [
 						<path
 							fill="none"
 							stroke="currentColor"
-							stroke-linecap="round"
+							strokeLinecap="round"
 							strokeLinejoin="round"
 							strokeWidth="32"
 							d="M413.66 246.1H386a2 2 0 0 1-2-2v-77.24A38.86 38.86 0 0 0 345.14 128H267.9a2 2 0 0 1-2-2V98.34c0-27.14-21.5-49.86-48.64-50.33a49.53 49.53 0 0 0-50.4 49.51V126a2 2 0 0 1-2 2H87.62A39.74 39.74 0 0 0 48 167.62V238a2 2 0 0 0 2 2h26.91c29.37 0 53.68 25.48 54.09 54.85c.42 29.87-23.51 57.15-53.29 57.15H50a2 2 0 0 0-2 2v70.38A39.74 39.74 0 0 0 87.62 464H158a2 2 0 0 0 2-2v-20.93c0-30.28 24.75-56.35 55-57.06c30.1-.7 57 20.31 57 50.28V462a2 2 0 0 0 2 2h71.14A38.86 38.86 0 0 0 384 425.14v-78a2 2 0 0 1 2-2h28.48c27.63 0 49.52-22.67 49.52-50.4s-23.2-48.64-50.34-48.64"


### PR DESCRIPTION
Minor fixes svg props name & key warnings in local documentation.

<img width="1055" alt="image" src="https://github.com/user-attachments/assets/496ff870-b2ef-4393-a6c3-14a7cee295d2" />

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/8457674c-e225-46b1-bfa4-f0b8ca1313e0" />

