### PR TITLE
fix: pass token in reset-password

### DIFF
--- a/demo/nextjs/app/(auth)/reset-password/page.tsx
+++ b/demo/nextjs/app/(auth)/reset-password/page.tsx
@@ -29,6 +29,7 @@ export default function ResetPassword() {
 		setError("");
 		const res = await client.resetPassword({
 			newPassword: password,
+			token: new URLSearchParams(window.location.search).get("token")!,
 		});
 		if (res.error) {
 			toast.error(res.error.message);

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -213,8 +213,13 @@ When a user clicks on the link in the email, they will be redirected to the rese
 - `newPassword`: The new password of the user.
 
 ```ts title="auth-client.ts"
+const token = new URLSearchParams(window.location.search).get("token");
+if (!token) {
+  // Handle the error
+}
 const { data, error } = await authClient.resetPassword({
   newPassword: "password1234",
+  token,
 });
 ```
 

--- a/packages/better-auth/src/api/routes/forget-password.test.ts
+++ b/packages/better-auth/src/api/routes/forget-password.test.ts
@@ -31,6 +31,7 @@ describe("forget password", async (it) => {
 		const res = await client.resetPassword(
 			{
 				newPassword: "short",
+				token,
 			},
 			{
 				query: {
@@ -46,6 +47,7 @@ describe("forget password", async (it) => {
 		const res = await client.resetPassword(
 			{
 				newPassword,
+				token,
 			},
 			{
 				query: {
@@ -76,6 +78,7 @@ describe("forget password", async (it) => {
 		const res = await client.resetPassword(
 			{
 				newPassword,
+				token,
 			},
 			{
 				query: {

--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -205,11 +205,9 @@ export const resetPassword = createAuthEndpoint(
 			newPassword: z.string({
 				description: "The new password to set",
 			}),
-			token: z
-				.string({
-					description: "The token to reset the password",
-				})
-				.optional(),
+			token: z.string({
+				description: "The token to reset the password",
+			}),
 		}),
 		metadata: {
 			openapi: {


### PR DESCRIPTION
Because we no longer read the token from `currentURL`.

I've also made it a required parameter, feel free to remove it if you don't want it.
