### PR TITLE
feat: allow manually linking account with different email address than user

### DIFF
--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -324,6 +324,17 @@ Users already signed in can manually link their account to additional social pro
   });
   ```
 
+  If you want your users to be able to link a social account with a different email address than the user, or if you want to use a provider that does not return email addresses, you will need to disable email matching in the account linking settings. 
+  ```ts title="auth.ts"
+  const auth = new BetterAuth({
+      account: {
+          accountLinking: {
+              requireEmailMatch: false
+          }
+      },
+  });
+  ```
+
 - **Linking Credential-Based Accounts:** To link a credential-based account (e.g., email and password), users can initiate a "forgot password" flow, or you can call the `setPassword` method on the server. 
 
   ```ts

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -115,7 +115,7 @@ export const callbackOAuth = createAuthEndpoint(
 			);
 		}
 		if (link) {
-			if (link.email !== userInfo.email.toLowerCase()) {
+			if (c.context.options.account?.accountLinking?.requireEmailMatch !== false && link.email !== userInfo.email.toLowerCase()) {
 				return redirectOnError("email_doesn't_match");
 			}
 			const newAccount = await c.context.internalAdapter.createAccount({

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -412,6 +412,12 @@ export type BetterAuthOptions = {
 			trustedProviders?: Array<
 				LiteralUnion<SocialProviderList[number] | "email-password", string>
 			>;
+			/**
+			 * If disabled (false), this will allow users to manually linking accounts with different email addresses than the main user.
+			 * 
+			 * @default true
+			 */
+			requireEmailMatch?: boolean;
 		};
 	};
 	/**


### PR DESCRIPTION
closes #918 

This PR includes both the fix, a settings option to disable the email check, as well as an edit to the users-accounts documentation to display the settings option.

This is my first time ever creating a PR so please feel free to let me know if I need to improve or change something.