### PR TITLE
fix(docs): navigation buttons not showing due to groups

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -189,8 +189,8 @@ function getPageLinks(path: string) {
 
 	// the next page in the array.
 	let next_page =
-		current_category.list[
-			current_category.list.findIndex((x) => x.href === current_page.href) + 1
+		current_category.list.filter(x => !x.group)[
+			current_category.list.filter(x => !x.group).findIndex((x) => x.href === current_page.href) + 1
 		];
 	//if there isn't a next page, then go to next cat's page.
 	if (!next_page) {
@@ -203,8 +203,8 @@ function getPageLinks(path: string) {
 	}
 	// the prev page in the array.
 	let prev_page =
-		current_category.list[
-			current_category.list.findIndex((x) => x.href === current_page.href) - 1
+		current_category.list.filter(x => !x.group)[
+			current_category.list.filter(x => !x.group).findIndex((x) => x.href === current_page.href) - 1
 		];
 	// if there isn't a prev page, then go to prev cat's page.
 	if (!prev_page) {


### PR DESCRIPTION
It breaks because the next/prev page is a group, not a usual page.

# Before
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/26d9d0aa-ca6a-43e5-950b-93799df31ac1" />

# After
<img width="1310" alt="image" src="https://github.com/user-attachments/assets/2d2feee2-8609-4c3a-a894-8eed880938f0" />
