### PR TITLE
fix: home-page builder using `twitter` instead of `x`

### DIFF
--- a/docs/components/builder/social-provider.tsx
+++ b/docs/components/builder/social-provider.tsx
@@ -304,7 +304,7 @@ export const socialProviders = {
 				></path>
 			</svg>`,
 	},
-	x: {
+	twitter: {
 		Icon: (props?: SVGProps<any>) => (
 			<svg
 				xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Currently, BetterAuth's social provider supports `twitter` instead of `x`. The Better Auth home page code builder generates `x`, which is incorrect. This is fixed.

# Before
<img width="1580" alt="image" src="https://github.com/user-attachments/assets/37bb5963-6ee4-48e9-a108-9bc7c1ddfaae" />

# After
<img width="1600" alt="image" src="https://github.com/user-attachments/assets/ac777f91-ad60-4e41-a8e8-8b4fd5533837" />
