### PR TITLE
fix(passkey): getRpID did not trim path when baseURL has no port

### DIFF
--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -34,9 +34,7 @@ interface WebAuthnChallengeValue {
 
 function getRpID(options: PasskeyOptions, baseURL?: string) {
 	return (
-		options.rpID ||
-		baseURL?.replace("http://", "").replace("https://", "").split(":")[0] ||
-		"localhost" // default rpID
+		options.rpID || (baseURL ? new URL(baseURL).hostname : "localhost") // default rpID
 	);
 }
 


### PR DESCRIPTION
Before: 
```js
getRpID({}, "http://example.com/api/auth")
// example.com/api/auth
getRpID({}, "http://example.com:8080/api/auth")
// example.com
```
which invalid in `@simplewebauthn/browser`

After:
```js
getRpID({}, "http://example.com/api/auth")
// example.com
getRpID({}, "http://example.com:8080/api/auth")
// example.com
```
