### PR TITLE
feat: add get error codes action for the client

### DIFF
--- a/docs/content/docs/concepts/client.mdx
+++ b/docs/content/docs/concepts/client.mdx
@@ -301,40 +301,29 @@ if (error) {
 The client instance contains $ERROR_CODES object that contains all the error codes returned by the server. You can use this to handle error translations or custom error messages.
 
 ```ts title="auth-client.ts"
-const authClient = createAuthClient();
-
-type ErrorTypes = Partial<
-	Record<
-		keyof typeof client.$ERROR_CODES,
-		{
-			en: string;
-			es: string;
-		}
-	>
->;
+const ERROR_CODES = authClient.getErrorCodes();
 
 const errorCodes = {
-	USER_ALREADY_EXISTS: {
+	[ERROR_CODES.USER_ALREADY_EXISTS]: {
 		en: "user already registered",
 		es: "usuario ya registrada",
 	},
-} satisfies ErrorTypes;
-
-const getErrorMessage = (code: string, lang: "en" | "es") => {
-	if (code in errorCodes) {
-		return errorCodes[code as keyof typeof errorCodes][lang];
+} as Record<
+	string,
+	{
+		en: string;
+		es: string;
 	}
-	return "";
-};
-
+>;
 
 const { error } = await authClient.signUp.email({
 	email: "user@email.com",
 	password: "password",
 	name: "User",
 });
-if(error?.code){
-    alert(getErrorMessage(error.code), "en");
+
+if (error?.message) {
+	alert(errorCodes[error.message]);
 }
 ```
 

--- a/packages/better-auth/src/client/client.test.ts
+++ b/packages/better-auth/src/client/client.test.ts
@@ -13,6 +13,8 @@ import type { Session } from "../types";
 import { BetterFetchError } from "@better-fetch/fetch";
 import { twoFactorClient } from "../plugins";
 import { organizationClient, passkeyClient } from "./plugins";
+import { BASE_ERROR_CODES } from "../error/codes";
+import { ORGANIZATION_ERROR_CODES } from "../plugins/organization/error-codes";
 
 describe("run time proxy", async () => {
 	it("proxy api should be called", async () => {
@@ -112,6 +114,20 @@ describe("run time proxy", async () => {
 			},
 		);
 		expect(called).toBe(true);
+	});
+
+	it("should return error codes", async () => {
+		const client = createSolidClient({
+			plugins: [twoFactorClient(), organizationClient()],
+		});
+		const ErrorCodes = client.getErrorCodes();
+		const c = client.$ERROR_CODES;
+		expect(ErrorCodes.ACCOUNT_NOT_FOUND).toBe(
+			BASE_ERROR_CODES.ACCOUNT_NOT_FOUND,
+		);
+		expect(ErrorCodes.ORGANIZATION_ALREADY_EXISTS).toBe(
+			ORGANIZATION_ERROR_CODES.ORGANIZATION_ALREADY_EXISTS,
+		);
 	});
 });
 

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -5,6 +5,7 @@ import type { AtomListener, ClientOptions } from "./types";
 import { redirectPlugin } from "./fetch-plugins";
 import { getSessionAtom } from "./session-atom";
 import { parseJSON } from "./parser";
+import { BASE_ERROR_CODES } from "../error/codes";
 
 export const getClientConfig = (options?: ClientOptions) => {
 	/* check if the credentials property is supported. Useful for cf workers */
@@ -92,17 +93,22 @@ export const getClientConfig = (options?: ClientOptions) => {
 		},
 		atoms: pluginsAtoms,
 	};
-
+	let $ERROR_CODES = BASE_ERROR_CODES;
 	for (const plugin of plugins) {
 		if (plugin.getActions) {
 			Object.assign(pluginsActions, plugin.getActions?.($fetch, $store));
 		}
+		if (plugin.$ERROR_CODES) {
+			Object.assign($ERROR_CODES, plugin.$ERROR_CODES);
+		}
 	}
+
 	return {
 		pluginsActions,
 		pluginsAtoms,
 		pluginPathMethods,
 		atomListeners,
+		$ERROR_CODES,
 		$fetch,
 		$store,
 	};

--- a/packages/better-auth/src/client/react/index.ts
+++ b/packages/better-auth/src/client/react/index.ts
@@ -52,6 +52,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		$fetch,
 		$store,
 		atomListeners,
+		$ERROR_CODES,
 	} = getClientConfig(options);
 	let resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
@@ -61,8 +62,10 @@ export function createAuthClient<Option extends ClientOptions>(
 	const routes = {
 		...pluginsActions,
 		...resolvedHooks,
+		$ERROR_CODES,
 		$fetch,
 		$store,
+		getErrorCodes: () => $ERROR_CODES,
 	};
 	const proxy = createDynamicPathProxy(
 		routes,
@@ -94,6 +97,9 @@ export function createAuthClient<Option extends ClientOptions>(
 			$fetch: typeof $fetch;
 			$store: typeof $store;
 			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+			getErrorCodes: () => PrettifyDeep<
 				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
 			>;
 		};

--- a/packages/better-auth/src/client/solid/index.ts
+++ b/packages/better-auth/src/client/solid/index.ts
@@ -49,6 +49,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		pluginsAtoms,
 		$fetch,
 		atomListeners,
+		$ERROR_CODES,
 	} = getClientConfig(options);
 	let resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
@@ -57,6 +58,7 @@ export function createAuthClient<Option extends ClientOptions>(
 	const routes = {
 		...pluginsActions,
 		...resolvedHooks,
+		getErrorCodes: () => $ERROR_CODES,
 	};
 	const proxy = createDynamicPathProxy(
 		routes,
@@ -89,6 +91,9 @@ export function createAuthClient<Option extends ClientOptions>(
 			};
 			$fetch: typeof $fetch;
 			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+			getErrorCodes: () => PrettifyDeep<
 				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
 			>;
 		};

--- a/packages/better-auth/src/client/svelte/index.ts
+++ b/packages/better-auth/src/client/svelte/index.ts
@@ -45,6 +45,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		$fetch,
 		atomListeners,
 		$store,
+		$ERROR_CODES,
 	} = getClientConfig(options);
 	let resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
@@ -55,6 +56,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		...resolvedHooks,
 		$fetch,
 		$store,
+		getErrorCodes: () => $ERROR_CODES,
 	};
 	const proxy = createDynamicPathProxy(
 		routes,
@@ -88,6 +90,9 @@ export function createAuthClient<Option extends ClientOptions>(
 				Session: NonNullable<Session>;
 			};
 			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+			getErrorCodes: () => PrettifyDeep<
 				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
 			>;
 		};

--- a/packages/better-auth/src/client/types.ts
+++ b/packages/better-auth/src/client/types.ts
@@ -57,6 +57,10 @@ export interface BetterAuthClientPlugin {
 	 * plugin or any plugin the user might have added.
 	 */
 	atomListeners?: AtomListener[];
+	/**
+	 * The error codes returned by the plugin
+	 */
+	$ERROR_CODES?: Record<string, string>;
 }
 
 export interface ClientOptions {
@@ -102,8 +106,8 @@ export type InferErrorCodes<O extends ClientOptions> =
 	O["plugins"] extends Array<infer Plugin>
 		? UnionToIntersection<
 				Plugin extends BetterAuthClientPlugin
-					? Plugin["$InferServerPlugin"] extends BetterAuthPlugin
-						? Plugin["$InferServerPlugin"]["$ERROR_CODES"]
+					? Plugin["$ERROR_CODES"] extends Record<string, any>
+						? Plugin["$ERROR_CODES"]
 						: {}
 					: {}
 			>

--- a/packages/better-auth/src/client/vanilla.ts
+++ b/packages/better-auth/src/client/vanilla.ts
@@ -44,6 +44,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		pluginsAtoms,
 		$fetch,
 		atomListeners,
+		$ERROR_CODES,
 		$store,
 	} = getClientConfig(options);
 	let resolvedHooks: Record<string, any> = {};
@@ -55,6 +56,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		...resolvedHooks,
 		$fetch,
 		$store,
+		getErrorCodes: () => $ERROR_CODES,
 	};
 	const proxy = createDynamicPathProxy(
 		routes,
@@ -87,6 +89,9 @@ export function createAuthClient<Option extends ClientOptions>(
 				Session: NonNullable<Session>;
 			};
 			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+			getErrorCodes: () => PrettifyDeep<
 				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
 			>;
 		};

--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -52,6 +52,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		$fetch,
 		$store,
 		atomListeners,
+		$ERROR_CODES,
 	} = getClientConfig(options);
 	let resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
@@ -116,6 +117,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		useSession,
 		$fetch,
 		$store,
+		getErrorCodes: () => $ERROR_CODES,
 	};
 
 	const proxy = createDynamicPathProxy(
@@ -136,6 +138,9 @@ export function createAuthClient<Option extends ClientOptions>(
 			$fetch: typeof $fetch;
 			$store: typeof $store;
 			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+			getErrorCodes: () => PrettifyDeep<
 				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
 			>;
 		};

--- a/packages/better-auth/src/plugins/admin/client.ts
+++ b/packages/better-auth/src/plugins/admin/client.ts
@@ -1,4 +1,4 @@
-import type { admin } from ".";
+import { ADMIN_ERROR_CODES, type admin } from ".";
 import type { BetterAuthClientPlugin } from "../../types";
 
 export const adminClient = () => {
@@ -9,5 +9,6 @@ export const adminClient = () => {
 			"/admin/list-users": "GET",
 			"/admin/stop-impersonating": "POST",
 		},
+		$ERROR_CODES: ADMIN_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/admin/index.ts
+++ b/packages/better-auth/src/plugins/admin/index.ts
@@ -68,20 +68,20 @@ interface AdminOptions {
 	schema?: InferOptionSchema<typeof schema>;
 }
 
+export const ADMIN_ERROR_CODES = {
+	FAILED_TO_CREATE_USER: "Failed to create user",
+	USER_ALREADY_EXISTS: "User already exists",
+	USER_NOT_FOUND: "User not found",
+	YOU_CANNOT_BAN_YOURSELF: "You cannot ban yourself",
+	ONLY_ADMINS_CAN_ACCESS_THIS_ENDPOINT: "Only admins can access this endpoint",
+} as const;
+
 export const admin = <O extends AdminOptions>(options?: O) => {
 	const opts = {
 		defaultRole: "user",
 		adminRole: "admin",
 		...options,
 	};
-	const ERROR_CODES = {
-		FAILED_TO_CREATE_USER: "Failed to create user",
-		USER_ALREADY_EXISTS: "User already exists",
-		USER_NOT_FOUND: "User not found",
-		YOU_CANNOT_BAN_YOURSELF: "You cannot ban yourself",
-		ONLY_ADMINS_CAN_ACCESS_THIS_ENDPOINT:
-			"Only admins can access this endpoint",
-	} as const;
 	const adminMiddleware = createAuthMiddleware(async (ctx) => {
 		const session = await getSessionFromCtx(ctx);
 		if (!session?.session) {
@@ -286,7 +286,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					);
 					if (existUser) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.USER_ALREADY_EXISTS,
+							message: ADMIN_ERROR_CODES.USER_ALREADY_EXISTS,
 						});
 					}
 					const user =
@@ -299,7 +299,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 
 					if (!user) {
 						throw new APIError("INTERNAL_SERVER_ERROR", {
-							message: ERROR_CODES.FAILED_TO_CREATE_USER,
+							message: ADMIN_ERROR_CODES.FAILED_TO_CREATE_USER,
 						});
 					}
 					const hashedPassword = await ctx.context.password.hash(
@@ -596,7 +596,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 				async (ctx) => {
 					if (ctx.body.userId === ctx.context.session.user.id) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.YOU_CANNOT_BAN_YOURSELF,
+							message: ADMIN_ERROR_CODES.YOU_CANNOT_BAN_YOURSELF,
 						});
 					}
 					const user = await ctx.context.internalAdapter.updateUser(
@@ -681,7 +681,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					);
 					if (!session) {
 						throw new APIError("INTERNAL_SERVER_ERROR", {
-							message: ERROR_CODES.FAILED_TO_CREATE_USER,
+							message: ADMIN_ERROR_CODES.FAILED_TO_CREATE_USER,
 						});
 					}
 					const authCookies = ctx.context.authCookies;
@@ -884,7 +884,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 				},
 			),
 		},
-		$ERROR_CODES: ERROR_CODES,
+		$ERROR_CODES: ADMIN_ERROR_CODES,
 		schema: mergeSchema(schema, opts.schema),
 	} satisfies BetterAuthPlugin;
 };

--- a/packages/better-auth/src/plugins/anonymous/client.ts
+++ b/packages/better-auth/src/plugins/anonymous/client.ts
@@ -1,4 +1,4 @@
-import type { anonymous } from ".";
+import { ANONYMOUS_ERROR_CODES, type anonymous } from ".";
 import type { BetterAuthClientPlugin } from "../../client/types";
 
 export const anonymousClient = () => {
@@ -8,5 +8,6 @@ export const anonymousClient = () => {
 		pathMethods: {
 			"/sign-in/anonymous": "POST",
 		},
+		$ERROR_CODES: ANONYMOUS_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -60,13 +60,14 @@ const schema = {
 	},
 } satisfies AuthPluginSchema;
 
+export const ANONYMOUS_ERROR_CODES = {
+	FAILED_TO_CREATE_USER: "Failed to create user",
+	COULD_NOT_CREATE_SESSION: "Could not create session",
+	ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY:
+		"Anonymous users cannot sign in again anonymously",
+} as const;
+
 export const anonymous = (options?: AnonymousOptions) => {
-	const ERROR_CODES = {
-		FAILED_TO_CREATE_USER: "Failed to create user",
-		COULD_NOT_CREATE_SESSION: "Could not create session",
-		ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY:
-			"Anonymous users cannot sign in again anonymously",
-	} as const;
 	return {
 		id: "anonymous",
 		endpoints: {
@@ -118,7 +119,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 						return ctx.json(null, {
 							status: 500,
 							body: {
-								message: ERROR_CODES.FAILED_TO_CREATE_USER,
+								message: ANONYMOUS_ERROR_CODES.FAILED_TO_CREATE_USER,
 								status: 500,
 							},
 						});
@@ -131,7 +132,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 						return ctx.json(null, {
 							status: 400,
 							body: {
-								message: ERROR_CODES.COULD_NOT_CREATE_SESSION,
+								message: ANONYMOUS_ERROR_CODES.COULD_NOT_CREATE_SESSION,
 							},
 						});
 					}
@@ -205,7 +206,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 						if (ctx.path === "/sign-in/anonymous") {
 							throw new APIError("BAD_REQUEST", {
 								message:
-									ERROR_CODES.ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY,
+									ANONYMOUS_ERROR_CODES.ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY,
 							});
 						}
 						const newSession = ctx.context.newSession;
@@ -226,6 +227,6 @@ export const anonymous = (options?: AnonymousOptions) => {
 			],
 		},
 		schema: mergeSchema(schema, options?.schema),
-		$ERROR_CODES: ERROR_CODES,
+		$ERROR_CODES: ANONYMOUS_ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };

--- a/packages/better-auth/src/plugins/email-otp/client.ts
+++ b/packages/better-auth/src/plugins/email-otp/client.ts
@@ -1,9 +1,10 @@
-import type { emailOTP } from ".";
+import { EMAIL_OTP_ERROR_CODES, type emailOTP } from ".";
 import type { BetterAuthClientPlugin } from "../../client/types";
 
 export const emailOTPClient = () => {
 	return {
 		id: "email-otp",
 		$InferServerPlugin: {} as ReturnType<typeof emailOTP>,
+		$ERROR_CODES: EMAIL_OTP_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -46,18 +46,20 @@ interface EmailOTPOptions {
 
 const types = ["email-verification", "sign-in", "forget-password"] as const;
 
+export const EMAIL_OTP_ERROR_CODES = {
+	OTP_EXPIRED: "otp expired",
+	INVALID_OTP: "invalid otp",
+	INVALID_EMAIL: "invalid email",
+	USER_NOT_FOUND: "user not found",
+} as const;
+
 export const emailOTP = (options: EmailOTPOptions) => {
 	const opts = {
 		expiresIn: 5 * 60,
 		otpLength: 6,
 		...options,
 	};
-	const ERROR_CODES = {
-		OTP_EXPIRED: "otp expired",
-		INVALID_OTP: "invalid otp",
-		INVALID_EMAIL: "invalid email",
-		USER_NOT_FOUND: "user not found",
-	} as const;
+
 	return {
 		id: "email-otp",
 		endpoints: {
@@ -109,7 +111,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 					if (!emailRegex.test(email)) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.INVALID_EMAIL,
+							message: EMAIL_OTP_ERROR_CODES.INVALID_EMAIL,
 						});
 					}
 					if (ctx.body.type === "forget-password" || opts.disableSignUp) {
@@ -285,7 +287,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 					if (!emailRegex.test(email)) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.INVALID_EMAIL,
+							message: EMAIL_OTP_ERROR_CODES.INVALID_EMAIL,
 						});
 					}
 					const verificationValue =
@@ -295,7 +297,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 
 					if (!verificationValue) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.INVALID_OTP,
+							message: EMAIL_OTP_ERROR_CODES.INVALID_OTP,
 						});
 					}
 					if (verificationValue.expiresAt < new Date()) {
@@ -303,13 +305,13 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							verificationValue.id,
 						);
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.OTP_EXPIRED,
+							message: EMAIL_OTP_ERROR_CODES.OTP_EXPIRED,
 						});
 					}
 					const otp = ctx.body.otp;
 					if (verificationValue.value !== otp) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.INVALID_OTP,
+							message: EMAIL_OTP_ERROR_CODES.INVALID_OTP,
 						});
 					}
 					await ctx.context.internalAdapter.deleteVerificationValue(
@@ -318,7 +320,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					const user = await ctx.context.internalAdapter.findUserByEmail(email);
 					if (!user) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.USER_NOT_FOUND,
+							message: EMAIL_OTP_ERROR_CODES.USER_NOT_FOUND,
 						});
 					}
 					const updatedUser = await ctx.context.internalAdapter.updateUser(
@@ -416,7 +418,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						);
 					if (!verificationValue) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.INVALID_OTP,
+							message: EMAIL_OTP_ERROR_CODES.INVALID_OTP,
 						});
 					}
 					if (verificationValue.expiresAt < new Date()) {
@@ -424,13 +426,13 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							verificationValue.id,
 						);
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.OTP_EXPIRED,
+							message: EMAIL_OTP_ERROR_CODES.OTP_EXPIRED,
 						});
 					}
 					const otp = ctx.body.otp;
 					if (verificationValue.value !== otp) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.INVALID_OTP,
+							message: EMAIL_OTP_ERROR_CODES.INVALID_OTP,
 						});
 					}
 					await ctx.context.internalAdapter.deleteVerificationValue(
@@ -440,7 +442,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					if (!user) {
 						if (opts.disableSignUp) {
 							throw new APIError("BAD_REQUEST", {
-								message: ERROR_CODES.USER_NOT_FOUND,
+								message: EMAIL_OTP_ERROR_CODES.USER_NOT_FOUND,
 							});
 						}
 						const newUser = await ctx.context.internalAdapter.createUser({
@@ -535,7 +537,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					const user = await ctx.context.internalAdapter.findUserByEmail(email);
 					if (!user) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.USER_NOT_FOUND,
+							message: EMAIL_OTP_ERROR_CODES.USER_NOT_FOUND,
 						});
 					}
 					const otp = generateRandomString(opts.otpLength, "0-9");
@@ -605,7 +607,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					);
 					if (!user) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.USER_NOT_FOUND,
+							message: EMAIL_OTP_ERROR_CODES.USER_NOT_FOUND,
 						});
 					}
 					const verificationValue =
@@ -614,7 +616,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						);
 					if (!verificationValue) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.INVALID_OTP,
+							message: EMAIL_OTP_ERROR_CODES.INVALID_OTP,
 						});
 					}
 					if (verificationValue.expiresAt < new Date()) {
@@ -622,13 +624,13 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							verificationValue.id,
 						);
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.OTP_EXPIRED,
+							message: EMAIL_OTP_ERROR_CODES.OTP_EXPIRED,
 						});
 					}
 					const otp = ctx.body.otp;
 					if (verificationValue.value !== otp) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.INVALID_OTP,
+							message: EMAIL_OTP_ERROR_CODES.INVALID_OTP,
 						});
 					}
 					await ctx.context.internalAdapter.deleteVerificationValue(
@@ -702,7 +704,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 				},
 			],
 		},
-		$ERROR_CODES: ERROR_CODES,
+		$ERROR_CODES: EMAIL_OTP_ERROR_CODES,
 		rateLimit: [
 			{
 				pathMatcher(path) {

--- a/packages/better-auth/src/plugins/generic-oauth/client.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/client.ts
@@ -5,5 +5,8 @@ export const genericOAuthClient = () => {
 	return {
 		id: "generic-oauth-client",
 		$InferServerPlugin: {} as ReturnType<typeof genericOAuth>,
+		$ERROR_CODES: {
+			INVALID_OAUTH_CONFIGURATION: "Invalid OAuth configuration",
+		} as const,
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/multi-session/client.ts
+++ b/packages/better-auth/src/plugins/multi-session/client.ts
@@ -13,5 +13,8 @@ export const multiSessionClient = () => {
 				signal: "$sessionSignal",
 			},
 		],
+		$ERROR_CODES: {
+			INVALID_SESSION_TOKEN: "Invalid session token",
+		} as const,
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -17,6 +17,7 @@ import type { BetterAuthClientPlugin } from "../../client/types";
 import type { organization } from "./organization";
 import { useAuthQuery } from "../../client";
 import { BetterAuthError } from "../../error";
+import { ORGANIZATION_ERROR_CODES } from "./error-codes";
 
 interface OrganizationClientOptions {
 	ac: AccessControl;
@@ -184,5 +185,6 @@ export const organizationClient = <O extends OrganizationClientOptions>(
 				signal: "$activeMemberSignal",
 			},
 		],
+		$ERROR_CODES: ORGANIZATION_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/passkey/client.ts
+++ b/packages/better-auth/src/plugins/passkey/client.ts
@@ -10,7 +10,11 @@ import type {
 } from "@simplewebauthn/browser";
 import type { Session } from "inspector";
 import type { User } from "../../types";
-import type { passkey as passkeyPl, Passkey } from ".";
+import {
+	type passkey as passkeyPl,
+	type Passkey,
+	PASSKEY_ERROR_CODES,
+} from ".";
 import type { BetterAuthClientPlugin } from "../../client/types";
 import { useAuthQuery } from "../../client";
 import { atom } from "nanostores";
@@ -223,5 +227,6 @@ export const passkeyClient = () => {
 				signal: "_listPasskeys",
 			},
 		],
+		$ERROR_CODES: PASSKEY_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -88,6 +88,17 @@ export type Passkey = {
 	createdAt: Date;
 };
 
+export const PASSKEY_ERROR_CODES = {
+	CHALLENGE_NOT_FOUND: "Challenge not found",
+	YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY:
+		"You are not allowed to register this passkey",
+	FAILED_TO_VERIFY_REGISTRATION: "Failed to verify registration",
+	PASSKEY_NOT_FOUND: "Passkey not found",
+	AUTHENTICATION_FAILED: "Authentication failed",
+	UNABLE_TO_CREATE_SESSION: "Unable to create session",
+	FAILED_TO_UPDATE_PASSKEY: "Failed to update passkey",
+} as const;
+
 export const passkey = (options?: PasskeyOptions) => {
 	const opts = {
 		origin: null,
@@ -103,16 +114,6 @@ export const passkey = (options?: PasskeyOptions) => {
 		(expirationTime.getTime() - currentTime.getTime()) / 1000,
 	);
 
-	const ERROR_CODES = {
-		CHALLENGE_NOT_FOUND: "Challenge not found",
-		YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY:
-			"You are not allowed to register this passkey",
-		FAILED_TO_VERIFY_REGISTRATION: "Failed to verify registration",
-		PASSKEY_NOT_FOUND: "Passkey not found",
-		AUTHENTICATION_FAILED: "Authentication failed",
-		UNABLE_TO_CREATE_SESSION: "Unable to create session",
-		FAILED_TO_UPDATE_PASSKEY: "Failed to update passkey",
-	} as const;
 	return {
 		id: "passkey",
 		endpoints: {
@@ -503,7 +504,7 @@ export const passkey = (options?: PasskeyOptions) => {
 					);
 					if (!challengeId) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.CHALLENGE_NOT_FOUND,
+							message: PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
 						});
 					}
 
@@ -522,7 +523,8 @@ export const passkey = (options?: PasskeyOptions) => {
 
 					if (userData.id !== ctx.context.session.user.id) {
 						throw new APIError("UNAUTHORIZED", {
-							message: ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY,
+							message:
+								PASSKEY_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY,
 						});
 					}
 
@@ -572,7 +574,7 @@ export const passkey = (options?: PasskeyOptions) => {
 					} catch (e) {
 						console.log(e);
 						throw new APIError("INTERNAL_SERVER_ERROR", {
-							message: ERROR_CODES.FAILED_TO_VERIFY_REGISTRATION,
+							message: PASSKEY_ERROR_CODES.FAILED_TO_VERIFY_REGISTRATION,
 						});
 					}
 				},
@@ -632,7 +634,7 @@ export const passkey = (options?: PasskeyOptions) => {
 					);
 					if (!challengeId) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.CHALLENGE_NOT_FOUND,
+							message: PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
 						});
 					}
 
@@ -642,7 +644,7 @@ export const passkey = (options?: PasskeyOptions) => {
 						);
 					if (!data) {
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.CHALLENGE_NOT_FOUND,
+							message: PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
 						});
 					}
 					const { expectedChallenge } = JSON.parse(
@@ -659,7 +661,7 @@ export const passkey = (options?: PasskeyOptions) => {
 					});
 					if (!passkey) {
 						throw new APIError("UNAUTHORIZED", {
-							message: ERROR_CODES.PASSKEY_NOT_FOUND,
+							message: PASSKEY_ERROR_CODES.PASSKEY_NOT_FOUND,
 						});
 					}
 					try {
@@ -683,7 +685,7 @@ export const passkey = (options?: PasskeyOptions) => {
 						const { verified } = verification;
 						if (!verified)
 							throw new APIError("UNAUTHORIZED", {
-								message: ERROR_CODES.AUTHENTICATION_FAILED,
+								message: PASSKEY_ERROR_CODES.AUTHENTICATION_FAILED,
 							});
 
 						await ctx.context.adapter.update<Passkey>({
@@ -704,7 +706,7 @@ export const passkey = (options?: PasskeyOptions) => {
 						);
 						if (!s) {
 							throw new APIError("INTERNAL_SERVER_ERROR", {
-								message: ERROR_CODES.UNABLE_TO_CREATE_SESSION,
+								message: PASSKEY_ERROR_CODES.UNABLE_TO_CREATE_SESSION,
 							});
 						}
 						const user = await ctx.context.internalAdapter.findUserById(
@@ -730,7 +732,7 @@ export const passkey = (options?: PasskeyOptions) => {
 					} catch (e) {
 						ctx.context.logger.error("Failed to verify authentication", e);
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.AUTHENTICATION_FAILED,
+							message: PASSKEY_ERROR_CODES.AUTHENTICATION_FAILED,
 						});
 					}
 				},
@@ -798,13 +800,14 @@ export const passkey = (options?: PasskeyOptions) => {
 
 					if (!passkey) {
 						throw new APIError("NOT_FOUND", {
-							message: ERROR_CODES.PASSKEY_NOT_FOUND,
+							message: PASSKEY_ERROR_CODES.PASSKEY_NOT_FOUND,
 						});
 					}
 
 					if (passkey.userId !== ctx.context.session.user.id) {
 						throw new APIError("UNAUTHORIZED", {
-							message: ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY,
+							message:
+								PASSKEY_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY,
 						});
 					}
 
@@ -823,7 +826,7 @@ export const passkey = (options?: PasskeyOptions) => {
 
 					if (!updatedPasskey) {
 						throw new APIError("INTERNAL_SERVER_ERROR", {
-							message: ERROR_CODES.FAILED_TO_UPDATE_PASSKEY,
+							message: PASSKEY_ERROR_CODES.FAILED_TO_UPDATE_PASSKEY,
 						});
 					}
 					return ctx.json(
@@ -838,7 +841,7 @@ export const passkey = (options?: PasskeyOptions) => {
 			),
 		},
 		schema: mergeSchema(schema, options?.schema),
-		$ERROR_CODES: ERROR_CODES,
+		$ERROR_CODES: PASSKEY_ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
 

--- a/packages/better-auth/src/plugins/phone-number/client.ts
+++ b/packages/better-auth/src/plugins/phone-number/client.ts
@@ -1,4 +1,4 @@
-import type { phoneNumber } from ".";
+import { PHONE_NUMBER_ERROR_CODES, type phoneNumber } from ".";
 import type { BetterAuthClientPlugin } from "../../client/types";
 
 export const phoneNumberClient = () => {
@@ -15,5 +15,6 @@ export const phoneNumberClient = () => {
 				signal: "$sessionSignal",
 			},
 		],
+		$ERROR_CODES: PHONE_NUMBER_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -22,6 +22,12 @@ export interface UserWithPhoneNumber extends User {
 function generateOTP(size: number) {
 	return generateRandomString(size, "0-9");
 }
+export const PHONE_NUMBER_ERROR_CODES = {
+	INVALID_PHONE_NUMBER: "Invalid phone number",
+	INVALID_PHONE_NUMBER_OR_PASSWORD: "Invalid phone number or password",
+	UNEXPECTED_ERROR: "Unexpected error",
+	OTP_NOT_FOUND: "OTP not found",
+} as const;
 
 export const phoneNumber = (options?: {
 	/**
@@ -104,12 +110,6 @@ export const phoneNumber = (options?: {
 		createdAt: "createdAt",
 	};
 
-	const ERROR_CODES = {
-		INVALID_PHONE_NUMBER: "Invalid phone number",
-		INVALID_PHONE_NUMBER_OR_PASSWORD: "Invalid phone number or password",
-		UNEXPECTED_ERROR: "Unexpected error",
-		OTP_NOT_FOUND: "OTP not found",
-	} as const;
 	return {
 		id: "phone-number",
 		endpoints: {
@@ -169,7 +169,7 @@ export const phoneNumber = (options?: {
 						);
 						if (!isValidNumber) {
 							throw new APIError("BAD_REQUEST", {
-								message: ERROR_CODES.INVALID_PHONE_NUMBER,
+								message: PHONE_NUMBER_ERROR_CODES.INVALID_PHONE_NUMBER,
 							});
 						}
 					}
@@ -185,7 +185,8 @@ export const phoneNumber = (options?: {
 					});
 					if (!user) {
 						throw new APIError("UNAUTHORIZED", {
-							message: ERROR_CODES.INVALID_PHONE_NUMBER_OR_PASSWORD,
+							message:
+								PHONE_NUMBER_ERROR_CODES.INVALID_PHONE_NUMBER_OR_PASSWORD,
 						});
 					}
 					const accounts =
@@ -198,14 +199,15 @@ export const phoneNumber = (options?: {
 							phoneNumber,
 						});
 						throw new APIError("UNAUTHORIZED", {
-							message: ERROR_CODES.INVALID_PHONE_NUMBER_OR_PASSWORD,
+							message:
+								PHONE_NUMBER_ERROR_CODES.INVALID_PHONE_NUMBER_OR_PASSWORD,
 						});
 					}
 					const currentPassword = credentialAccount?.password;
 					if (!currentPassword) {
 						ctx.context.logger.error("Password not found", { phoneNumber });
 						throw new APIError("UNAUTHORIZED", {
-							message: ERROR_CODES.UNEXPECTED_ERROR,
+							message: PHONE_NUMBER_ERROR_CODES.UNEXPECTED_ERROR,
 						});
 					}
 					const validPassword = await ctx.context.password.verify({
@@ -215,7 +217,8 @@ export const phoneNumber = (options?: {
 					if (!validPassword) {
 						ctx.context.logger.error("Invalid password");
 						throw new APIError("UNAUTHORIZED", {
-							message: ERROR_CODES.INVALID_PHONE_NUMBER_OR_PASSWORD,
+							message:
+								PHONE_NUMBER_ERROR_CODES.INVALID_PHONE_NUMBER_OR_PASSWORD,
 						});
 					}
 					const session = await ctx.context.internalAdapter.createSession(
@@ -301,7 +304,7 @@ export const phoneNumber = (options?: {
 						);
 						if (!isValidNumber) {
 							throw new APIError("BAD_REQUEST", {
-								message: ERROR_CODES.INVALID_PHONE_NUMBER,
+								message: PHONE_NUMBER_ERROR_CODES.INVALID_PHONE_NUMBER,
 							});
 						}
 					}
@@ -410,7 +413,7 @@ export const phoneNumber = (options?: {
 							});
 						}
 						throw new APIError("BAD_REQUEST", {
-							message: ERROR_CODES.OTP_NOT_FOUND,
+							message: PHONE_NUMBER_ERROR_CODES.OTP_NOT_FOUND,
 						});
 					}
 					if (otp.value !== ctx.body.code) {
@@ -552,7 +555,7 @@ export const phoneNumber = (options?: {
 			),
 		},
 		schema: mergeSchema(schema, options?.schema),
-		$ERROR_CODES: ERROR_CODES,
+		$ERROR_CODES: PHONE_NUMBER_ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
 

--- a/packages/better-auth/src/plugins/two-factor/client.ts
+++ b/packages/better-auth/src/plugins/two-factor/client.ts
@@ -1,5 +1,6 @@
 import type { BetterAuthClientPlugin } from "../../client/types";
 import type { twoFactor as twoFa } from "../../plugins/two-factor";
+import { TWO_FACTOR_ERROR_CODES } from "./error-code";
 
 export const twoFactorClient = (options?: {
 	/**
@@ -38,5 +39,6 @@ export const twoFactorClient = (options?: {
 				},
 			},
 		],
+		$ERROR_CODES: TWO_FACTOR_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/username/client.ts
+++ b/packages/better-auth/src/plugins/username/client.ts
@@ -1,9 +1,10 @@
-import type { username } from ".";
+import { USERNAME_ERROR_CODES, type username } from ".";
 import type { BetterAuthClientPlugin } from "../../client/types";
 
 export const usernameClient = () => {
 	return {
 		id: "username",
 		$InferServerPlugin: {} as ReturnType<typeof username>,
+		$ERROR_CODES: USERNAME_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };


### PR DESCRIPTION
closes #980 

this pr introduces `authClient.getErrorCodes` functionality. It'll return all error codes including ones added by plugins.