### PR TITLE
feat: add swarm management plugin with CRUD operations for swarms, members, and invitations

### DIFF
--- a/packages/better-auth/src/plugins/swarm/access/access.ts
+++ b/packages/better-auth/src/plugins/swarm/access/access.ts
@@ -1,0 +1,73 @@
+import type { StatementsPrimitive as Statements, Subset } from "./types";
+
+type Connector = "OR" | "AND";
+
+type AuthorizeResponse =
+	| { success: false; error: string }
+	| { success: true; error?: undefined };
+
+function parsingError(message: string, path: string): Error {
+	const error = new Error(message);
+	(error as any).path = path;
+	return error;
+}
+
+export function createAccessControl<
+	TStatements extends Statements = Statements,
+>(s: TStatements) {
+	const statements = s;
+	return {
+		newRole<K extends keyof TStatements>(statements: Subset<K, TStatements>) {
+			return role<Subset<K, TStatements>>(statements);
+		},
+	};
+}
+
+export function role<TStatements extends Statements>(statements: TStatements) {
+	return {
+		statements,
+		authorize<K extends keyof TStatements>(
+			request: Subset<K, TStatements>,
+			connector?: Connector,
+		): AuthorizeResponse {
+			for (const [requestedResource, requestedActions] of Object.entries(
+				request,
+			)) {
+				const allowedActions = statements[requestedResource];
+				if (!allowedActions) {
+					return {
+						success: false,
+						error: `You are not allowed to access resource: ${requestedResource}`,
+					};
+				}
+				const success =
+					connector === "OR"
+						? (requestedActions as string[]).some((requestedAction) =>
+								allowedActions.includes(requestedAction),
+							)
+						: (requestedActions as string[]).every((requestedAction) =>
+								allowedActions.includes(requestedAction),
+							);
+				if (success) {
+					return { success: true };
+				}
+				return {
+					success: false,
+					error: `Unauthorized to access resource "${requestedResource}"`,
+				};
+			}
+			return {
+				success: false,
+				error: "Not authorized",
+			};
+		},
+	};
+}
+
+export type AccessControl<TStatements extends Statements = Statements> =
+	ReturnType<typeof createAccessControl<TStatements>>;
+
+export type Role<TStatements extends Statements = Record<string, any>> = {
+	authorize: (request: any, connector?: Connector) => AuthorizeResponse;
+	statements: TStatements;
+};

--- a/packages/better-auth/src/plugins/swarm/access/index.ts
+++ b/packages/better-auth/src/plugins/swarm/access/index.ts
@@ -1,0 +1,3 @@
+export * from "./access";
+export * from "./types";
+export * from "./statement";

--- a/packages/better-auth/src/plugins/swarm/access/statement.ts
+++ b/packages/better-auth/src/plugins/swarm/access/statement.ts
@@ -1,0 +1,33 @@
+import { createAccessControl } from "./access";
+
+export const defaultStatements = {
+	swarm: ["update", "delete"],
+	member: ["create", "update", "delete"],
+	invitation: ["create", "cancel"],
+} as const;
+
+export const defaultAc = createAccessControl(defaultStatements);
+
+export const adminAc = defaultAc.newRole({
+	swarm: ["update"],
+	invitation: ["create", "cancel"],
+	member: ["create", "update", "delete"],
+});
+
+export const ownerAc = defaultAc.newRole({
+	swarm: ["update", "delete"],
+	member: ["create", "update", "delete"],
+	invitation: ["create", "cancel"],
+});
+
+export const memberAc = defaultAc.newRole({
+	swarm: [],
+	member: [],
+	invitation: [],
+});
+
+export const defaultRoles = {
+	admin: adminAc,
+	owner: ownerAc,
+	member: memberAc,
+};

--- a/packages/better-auth/src/plugins/swarm/access/types.ts
+++ b/packages/better-auth/src/plugins/swarm/access/types.ts
@@ -1,0 +1,18 @@
+import type { LiteralString } from "../../../types/helper";
+
+export type SubArray<T extends unknown[] | readonly unknown[] | any[]> =
+	T[number][];
+
+export type Subset<
+	K extends keyof R,
+	R extends Record<
+		string | LiteralString,
+		readonly string[] | readonly LiteralString[]
+	>,
+> = {
+	[P in K]: SubArray<R[P]>;
+};
+
+export type StatementsPrimitive = {
+	readonly [resource: string]: readonly LiteralString[];
+};

--- a/packages/better-auth/src/plugins/swarm/adapter.ts
+++ b/packages/better-auth/src/plugins/swarm/adapter.ts
@@ -1,0 +1,488 @@
+import type { Session, User } from "../../types";
+import { getDate } from "../../utils/date";
+import type { SwarmOptions } from "./swarm";
+import type {
+	Invitation,
+	InvitationInput,
+	Member,
+	MemberInput,
+	Swarm,
+	SwarmInput,
+} from "./schema";
+import { BetterAuthError } from "../../error";
+import type { AuthContext } from "../../types";
+import parseJSON from "../../client/parser";
+
+export const getSwmAdapter = (
+	context: AuthContext,
+	options?: SwarmOptions,
+) => {
+	const adapter = context.adapter;
+	return {
+		findSwarmBySlug: async (slug: string) => {
+			const swarm = await adapter.findOne<Swarm>({
+				model: "swarm",
+				where: [
+					{
+						field: "slug",
+						value: slug,
+					},
+				],
+			});
+			return swarm;
+		},
+		createSwarm: async (data: {
+			swarm: SwarmInput;
+			user: User;
+		}) => {
+			const swarm = await adapter.create<
+				SwarmInput,
+				Swarm
+			>({
+				model: "swarm",
+				data: {
+					...data.swarm,
+					metadata: data.swarm.metadata
+						? JSON.stringify(data.swarm.metadata)
+						: undefined,
+				},
+			});
+			const member = await adapter.create<MemberInput>({
+				model: "member",
+				data: {
+					swarmId: swarm.id,
+					userId: data.user.id,
+					createdAt: new Date(),
+					role: options?.creatorRole || "owner",
+				},
+			});
+			return {
+				...swarm,
+				metadata: swarm.metadata
+					? JSON.parse(swarm.metadata)
+					: undefined,
+				members: [
+					{
+						...member,
+						user: {
+							id: data.user.id,
+							name: data.user.name,
+							email: data.user.email,
+							image: data.user.image,
+						},
+					},
+				],
+			};
+		},
+		findMemberByEmail: async (data: {
+			email: string;
+			swarmId: string;
+		}) => {
+			const user = await adapter.findOne<User>({
+				model: "user",
+				where: [
+					{
+						field: "email",
+						value: data.email,
+					},
+				],
+			});
+			if (!user) {
+				return null;
+			}
+			const member = await adapter.findOne<Member>({
+				model: "member",
+				where: [
+					{
+						field: "swarmId",
+						value: data.swarmId,
+					},
+					{
+						field: "userId",
+						value: user.id,
+					},
+				],
+			});
+			if (!member) {
+				return null;
+			}
+			return {
+				...member,
+				user: {
+					id: user.id,
+					name: user.name,
+					email: user.email,
+					image: user.image,
+				},
+			};
+		},
+		findMemberBySwmId: async (data: {
+			userId: string;
+			swarmId: string;
+		}) => {
+			const [member, user] = await Promise.all([
+				await adapter.findOne<Member>({
+					model: "member",
+					where: [
+						{
+							field: "userId",
+							value: data.userId,
+						},
+						{
+							field: "swarmId",
+							value: data.swarmId,
+						},
+					],
+				}),
+				await adapter.findOne<User>({
+					model: "user",
+					where: [
+						{
+							field: "id",
+							value: data.userId,
+						},
+					],
+				}),
+			]);
+			if (!user || !member) {
+				return null;
+			}
+			return {
+				...member,
+				user: {
+					id: user.id,
+					name: user.name,
+					email: user.email,
+					image: user.image,
+				},
+			};
+		},
+		findMemberById: async (memberId: string) => {
+			const member = await adapter.findOne<Member>({
+				model: "member",
+				where: [
+					{
+						field: "id",
+						value: memberId,
+					},
+				],
+			});
+			if (!member) {
+				return null;
+			}
+			const user = await adapter.findOne<User>({
+				model: "user",
+				where: [
+					{
+						field: "id",
+						value: member.userId,
+					},
+				],
+			});
+			if (!user) {
+				return null;
+			}
+			return {
+				...member,
+				user: {
+					id: user.id,
+					name: user.name,
+					email: user.email,
+					image: user.image,
+				},
+			};
+		},
+		createMember: async (data: MemberInput) => {
+			const member = await adapter.create<MemberInput>({
+				model: "member",
+				data: data,
+			});
+			return member;
+		},
+		updateMember: async (memberId: string, role: string) => {
+			const member = await adapter.update<Member>({
+				model: "member",
+				where: [
+					{
+						field: "id",
+						value: memberId,
+					},
+				],
+				update: {
+					role,
+				},
+			});
+			return member;
+		},
+		deleteMember: async (memberId: string) => {
+			const member = await adapter.delete<Member>({
+				model: "member",
+				where: [
+					{
+						field: "id",
+						value: memberId,
+					},
+				],
+			});
+			return member;
+		},
+		updateSwarm: async (
+			swarmId: string,
+			data: Partial<Swarm>,
+		) => {
+			const swarm = await adapter.update<Swarm>({
+				model: "swarm",
+				where: [
+					{
+						field: "id",
+						value: swarmId,
+					},
+				],
+				update: {
+					...data,
+					metadata:
+						typeof data.metadata === "object"
+							? JSON.stringify(data.metadata)
+							: data.metadata,
+				},
+			});
+			if (!swarm) {
+				return null;
+			}
+			return {
+				...swarm,
+				metadata: swarm.metadata
+					? parseJSON<Record<string, any>>(swarm.metadata)
+					: undefined,
+			};
+		},
+		deleteSwarm: async (swarmId: string) => {
+			await adapter.delete({
+				model: "member",
+				where: [
+					{
+						field: "swarmId",
+						value: swarmId,
+					},
+				],
+			});
+			await adapter.delete({
+				model: "invitation",
+				where: [
+					{
+						field: "swarmId",
+						value: swarmId,
+					},
+				],
+			});
+			await adapter.delete<Swarm>({
+				model: "swarm",
+				where: [
+					{
+						field: "id",
+						value: swarmId,
+					},
+				],
+			});
+			return swarmId;
+		},
+		setActiveSwarm: async (
+			sessionToken: string,
+			swarmId: string | null,
+		) => {
+			const session = await context.internalAdapter.updateSession(
+				sessionToken,
+				{
+					activeSwarmId: swarmId,
+				},
+			);
+			return session as Session;
+		},
+		findSwarmById: async (swarmId: string) => {
+			const swarm = await adapter.findOne<Swarm>({
+				model: "swarm",
+				where: [
+					{
+						field: "id",
+						value: swarmId,
+					},
+				],
+			});
+			return swarm;
+		},
+		/**
+		 * @requires db
+		 */
+		findFullSwarm: async ({
+			swarmId,
+			isSlug,
+		}: {
+			swarmId: string;
+			isSlug?: boolean;
+		}) => {
+			const swm = await adapter.findOne<Swarm>({
+				model: "swarm",
+				where: [{ field: isSlug ? "slug" : "id", value: swarmId }],
+			});
+			if (!swm) {
+				return null;
+			}
+			const [invitations, members] = await Promise.all([
+				adapter.findMany<Invitation>({
+					model: "invitation",
+					where: [{ field: "swarmId", value: swm.id }],
+				}),
+				adapter.findMany<Member>({
+					model: "member",
+					where: [{ field: "swarmId", value: swm.id }],
+				}),
+			]);
+
+			if (!swm) return null;
+
+			const userIds = members.map((member) => member.userId);
+			const users = await adapter.findMany<User>({
+				model: "user",
+				where: [{ field: "id", value: userIds, operator: "in" }],
+			});
+
+			const userMap = new Map(users.map((user) => [user.id, user]));
+			const membersWithUsers = members.map((member) => {
+				const user = userMap.get(member.userId);
+				if (!user) {
+					throw new BetterAuthError(
+						"Unexpected error: User not found for member",
+					);
+				}
+				return {
+					...member,
+					user: {
+						id: user.id,
+						name: user.name,
+						email: user.email,
+						image: user.image,
+					},
+				};
+			});
+
+			return {
+				...swm,
+				invitations,
+				members: membersWithUsers,
+			};
+		},
+		listSwarms: async (userId: string) => {
+			const members = await adapter.findMany<Member>({
+				model: "member",
+				where: [
+					{
+						field: "userId",
+						value: userId,
+					},
+				],
+			});
+
+			if (!members || members.length === 0) {
+				return [];
+			}
+
+			const swarmIds = members.map((member) => member.swarmId);
+
+			const swarms = await adapter.findMany<Swarm>({
+				model: "swarm",
+				where: [
+					{
+						field: "id",
+						value: swarmIds,
+						operator: "in",
+					},
+				],
+			});
+			return swarms;
+		},
+		createInvitation: async ({
+			invitation,
+			user,
+		}: {
+			invitation: {
+				email: string;
+				role: string;
+				swarmId: string;
+			};
+			user: User;
+		}) => {
+			const defaultExpiration = 1000 * 60 * 60 * 48;
+			const expiresAt = getDate(
+				options?.invitationExpiresIn || defaultExpiration,
+			);
+			const invite = await adapter.create<InvitationInput, Invitation>({
+				model: "invitation",
+				data: {
+					email: invitation.email,
+					role: invitation.role,
+					swarmId: invitation.swarmId,
+					status: "pending",
+					expiresAt,
+					inviterId: user.id,
+				},
+			});
+
+			return invite;
+		},
+		findInvitationById: async (id: string) => {
+			const invitation = await adapter.findOne<Invitation>({
+				model: "invitation",
+				where: [
+					{
+						field: "id",
+						value: id,
+					},
+				],
+			});
+			return invitation;
+		},
+		findPendingInvitation: async (data: {
+			email: string;
+			swarmId: string;
+		}) => {
+			const invitation = await adapter.findMany<Invitation>({
+				model: "invitation",
+				where: [
+					{
+						field: "email",
+						value: data.email,
+					},
+					{
+						field: "swarmId",
+						value: data.swarmId,
+					},
+					{
+						field: "status",
+						value: "pending",
+					},
+				],
+			});
+			return invitation.filter(
+				(invite) => new Date(invite.expiresAt) > new Date(),
+			);
+		},
+		updateInvitation: async (data: {
+			invitationId: string;
+			status: "accepted" | "canceled" | "rejected";
+		}) => {
+			const invitation = await adapter.update<Invitation>({
+				model: "invitation",
+				where: [
+					{
+						field: "id",
+						value: data.invitationId,
+					},
+				],
+				update: {
+					status: data.status,
+				},
+			});
+			return invitation;
+		},
+	};
+};

--- a/packages/better-auth/src/plugins/swarm/call.ts
+++ b/packages/better-auth/src/plugins/swarm/call.ts
@@ -1,0 +1,38 @@
+import { type Context } from "better-call";
+import type { Session, User } from "../../types";
+import { createAuthMiddleware } from "../../api/call";
+import { sessionMiddleware } from "../../api";
+import type { Role, defaultRoles } from "./access";
+import type { SwarmOptions } from "./swarm";
+
+export const swmMiddleware = createAuthMiddleware(async (ctx) => {
+	return {} as {
+		swmOptions: SwarmOptions;
+		roles: typeof defaultRoles & {
+			[key: string]: Role<{}>;
+		};
+		getSession: (context: Context<any, any>) => Promise<{
+			session: Session & {
+				activeSwarmId?: string;
+			};
+			user: User;
+		}>;
+	};
+});
+
+export const swmSessionMiddleware = createAuthMiddleware(
+	{
+		use: [sessionMiddleware],
+	},
+	async (ctx) => {
+		const session = ctx.context.session as {
+			session: Session & {
+				activeSwarmId?: string;
+			};
+			user: User;
+		};
+		return {
+			session,
+		};
+	},
+);

--- a/packages/better-auth/src/plugins/swarm/client.ts
+++ b/packages/better-auth/src/plugins/swarm/client.ts
@@ -1,0 +1,188 @@
+import { atom } from "nanostores";
+import type {
+	Invitation,
+	Member,
+	Swarm,
+} from "../swarm/schema";
+import type { Prettify } from "../../types/helper";
+import {
+	adminAc,
+	defaultStatements,
+	memberAc,
+	ownerAc,
+	type AccessControl,
+	type Role,
+} from "./access";
+import type { BetterAuthClientPlugin } from "../../client/types";
+import type { swarm } from "./swarm";
+import { useAuthQuery } from "../../client";
+import { BetterAuthError } from "../../error";
+
+interface SwarmClientOptions {
+	ac: AccessControl;
+	roles: {
+		[key in string]: Role;
+	};
+}
+
+export const swarmClient = <O extends SwarmClientOptions>(
+	options?: O,
+) => {
+	const $listSwm = atom<boolean>(false);
+	const $activeSwmSignal = atom<boolean>(false);
+	const $activeMemberSignal = atom<boolean>(false);
+
+	type DefaultStatements = typeof defaultStatements;
+	type Statements = O["ac"] extends AccessControl<infer S>
+		? S extends Record<string, Array<any>>
+			? S & DefaultStatements
+			: DefaultStatements
+		: DefaultStatements;
+	const roles = {
+		admin: adminAc,
+		member: memberAc,
+		owner: ownerAc,
+		...options?.roles,
+	};
+	return {
+		id: "swarm",
+		$InferServerPlugin: {} as ReturnType<
+			typeof swarm<{
+				ac: O["ac"] extends AccessControl
+					? O["ac"]
+					: AccessControl<DefaultStatements>;
+				roles: O["roles"] extends Record<string, Role>
+					? O["roles"]
+					: {
+							admin: Role;
+							member: Role;
+							owner: Role;
+						};
+			}>
+		>,
+		getActions: ($fetch) => ({
+			$Infer: {
+				ActiveSwarm: {} as Prettify<
+					Swarm & {
+						members: Prettify<
+							Member & {
+								user: {
+									id: string;
+									name: string;
+									email: string;
+									image?: string | null;
+								};
+							}
+						>[];
+						invitations: Invitation[];
+					}
+				>,
+				Swarm: {} as Swarm,
+				Invitation: {} as Invitation,
+				Member: {} as Member,
+			},
+			swarm: {
+				checkRolePermission: <
+					R extends O extends { roles: any }
+						? keyof O["roles"]
+						: "admin" | "member" | "owner",
+				>(data: {
+					role: R;
+					permission: {
+						//@ts-expect-error fix this later
+						[key in keyof Statements]?: Statements[key][number][];
+					};
+				}) => {
+					if (Object.keys(data.permission).length > 1) {
+						throw new BetterAuthError(
+							"you can only check one resource permission at a time.",
+						);
+					}
+					const role = roles[data.role as unknown as "admin"];
+					if (!role) {
+						return false;
+					}
+					const isAuthorized = role?.authorize(data.permission as any);
+					return isAuthorized.success;
+				},
+			},
+		}),
+		getAtoms: ($fetch) => {
+			const listSwarms = useAuthQuery<Swarm[]>(
+				$listSwm,
+				"/swarm/list",
+				$fetch,
+				{
+					method: "GET",
+				},
+			);
+			const activeSwarm = useAuthQuery<
+				Prettify<
+					Swarm & {
+						members: (Member & {
+							user: {
+								id: string;
+								name: string;
+								email: string;
+								image: string | undefined;
+							};
+						})[];
+						invitations: Invitation[];
+					}
+				>
+			>(
+				[$activeSwmSignal],
+				"/swarm/get-full-swarm",
+				$fetch,
+				() => ({
+					method: "GET",
+				}),
+			);
+
+			const activeMember = useAuthQuery<Member>(
+				[$activeMemberSignal],
+				"/swarm/get-active-member",
+				$fetch,
+				{
+					method: "GET",
+				},
+			);
+
+			return {
+				$listSwm,
+				$activeSwmSignal,
+				$activeMemberSignal,
+				activeSwarm,
+				listSwarms,
+				activeMember,
+			};
+		},
+		pathMethods: {
+			"/swarm/get-full-swarm": "GET",
+		},
+		atomListeners: [
+			{
+				matcher(path) {
+					return (
+						path === "/swarm/create" ||
+						path === "/swarm/delete" ||
+						path === "/swarm/update"
+					);
+				},
+				signal: "$listSwm",
+			},
+			{
+				matcher(path) {
+					return path.startsWith("/swarm");
+				},
+				signal: "$activeSwmSignal",
+			},
+			{
+				matcher(path) {
+					return path.includes("/swarm/update-member-role");
+				},
+				signal: "$activeMemberSignal",
+			},
+		],
+	} satisfies BetterAuthClientPlugin;
+};

--- a/packages/better-auth/src/plugins/swarm/error-codes.ts
+++ b/packages/better-auth/src/plugins/swarm/error-codes.ts
@@ -1,0 +1,36 @@
+export const SWARM_ERROR_CODES = {
+	YOU_ARE_NOT_ALLOWED_TO_CREATE_A_NEW_SWARM:
+		"You are not allowed to create a new swarm",
+	YOU_HAVE_REACHED_THE_MAXIMUM_NUMBER_OF_SWARMS:
+		"You have reached the maximum number of swarms",
+	SWARM_ALREADY_EXISTS: "Swarm already exists",
+	SWARM_NOT_FOUND: "Swarm not found",
+	USER_IS_NOT_A_MEMBER_OF_THE_SWARM:
+		"User is not a member of the swarm",
+	YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_SWARM:
+		"You are not allowed to update this swarm",
+	YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_SWARM:
+		"You are not allowed to delete this swarm",
+	NO_ACTIVE_SWARM: "No active swarm",
+	USER_IS_ALREADY_A_MEMBER_OF_THIS_SWARM:
+		"User is already a member of this swarm",
+	MEMBER_NOT_FOUND: "Member not found",
+	ROLE_NOT_FOUND: "Role not found",
+	YOU_CANNOT_LEAVE_THE_SWARM_AS_THE_ONLY_OWNER:
+		"You cannot leave the swarm as the only owner",
+	YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_MEMBER:
+		"You are not allowed to delete this member",
+	YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_SWARM:
+		"You are not allowed to invite users to this swarm",
+	USER_IS_ALREADY_INVITED_TO_THIS_SWARM:
+		"User is already invited to this swarm",
+	INVITATION_NOT_FOUND: "Invitation not found",
+	YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION:
+		"You are not the recipient of the invitation",
+	YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_INVITATION:
+		"You are not allowed to cancel this invitation",
+	INVITER_IS_NO_LONGER_A_MEMBER_OF_THE_SWARM:
+		"Inviter is no longer a member of the swarm",
+	YOU_ARE_NOT_ALLOWED_TO_INVITE_USER_WITH_THIS_ROLE:
+		"you are not allowed to invite user with this role",
+} as const;

--- a/packages/better-auth/src/plugins/swarm/index.ts
+++ b/packages/better-auth/src/plugins/swarm/index.ts
@@ -1,0 +1,1 @@
+export * from "./swarm";

--- a/packages/better-auth/src/plugins/swarm/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/swarm/routes/crud-invites.ts
@@ -1,0 +1,534 @@
+import { z } from "zod";
+import { createAuthEndpoint } from "../../../api/call";
+import { getSessionFromCtx } from "../../../api/routes";
+import { getSwmAdapter } from "../adapter";
+import { swmMiddleware, swmSessionMiddleware } from "../call";
+import { type InferRolesFromOption } from "../schema";
+import { APIError } from "better-call";
+import type { SwarmOptions } from "../swarm";
+import { SWARM_ERROR_CODES } from "../error-codes";
+
+export const createInvitation = <O extends SwarmOptions | undefined>(
+	option: O,
+) =>
+	createAuthEndpoint(
+		"/swarm/invite-member",
+		{
+			method: "POST",
+			use: [swmMiddleware, swmSessionMiddleware],
+			body: z.object({
+				email: z.string({
+					description: "The email address of the user to invite",
+				}),
+				role: z.string({
+					description: "The role to assign to the user",
+				}) as unknown as InferRolesFromOption<O>,
+				swarmId: z
+					.string({
+						description: "The swarm ID to invite the user to",
+					})
+					.optional(),
+				resend: z
+					.boolean({
+						description:
+							"Resend the invitation email, if the user is already invited",
+					})
+					.optional(),
+			}),
+			metadata: {
+				openapi: {
+					description: "Invite a user to an swarm",
+					responses: {
+						"200": {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											id: {
+												type: "string",
+											},
+											email: {
+												type: "string",
+											},
+											role: {
+												type: "string",
+											},
+											swarmId: {
+												type: "string",
+											},
+											inviterId: {
+												type: "string",
+											},
+											status: {
+												type: "string",
+											},
+											expiresAt: {
+												type: "string",
+											},
+										},
+										required: [
+											"id",
+											"email",
+											"role",
+											"swarmId",
+											"inviterId",
+											"status",
+											"expiresAt",
+										],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			if (!ctx.context.swmOptions.sendInvitationEmail) {
+				ctx.context.logger.warn(
+					"Invitation email is not enabled. Pass `sendInvitationEmail` to the plugin options to enable it.",
+				);
+				throw new APIError("BAD_REQUEST", {
+					message: "Invitation email is not enabled",
+				});
+			}
+
+			const session = ctx.context.session;
+			const swarmId =
+				ctx.body.swarmId || session.session.activeSwarmId;
+			if (!swarmId) {
+				throw new APIError("BAD_REQUEST", {
+					message: SWARM_ERROR_CODES.SWARM_NOT_FOUND,
+				});
+			}
+			const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+			const member = await adapter.findMemberBySwmId({
+				userId: session.user.id,
+				swarmId: swarmId,
+			});
+			if (!member) {
+				throw new APIError("BAD_REQUEST", {
+					message: SWARM_ERROR_CODES.MEMBER_NOT_FOUND,
+				});
+			}
+			const role = ctx.context.roles[member.role];
+			if (!role) {
+				throw new APIError("BAD_REQUEST", {
+					message: SWARM_ERROR_CODES.ROLE_NOT_FOUND,
+				});
+			}
+			const canInvite = role.authorize({
+				invitation: ["create"],
+			});
+			if (canInvite.error) {
+				throw new APIError("FORBIDDEN", {
+					message:
+						SWARM_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_SWARM,
+				});
+			}
+
+			const creatorRole = ctx.context.swmOptions.creatorRole || "owner";
+
+			if (member.role !== creatorRole && ctx.body.role === creatorRole) {
+				throw new APIError("FORBIDDEN", {
+					message:
+						SWARM_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USER_WITH_THIS_ROLE,
+				});
+			}
+
+			const alreadyMember = await adapter.findMemberByEmail({
+				email: ctx.body.email,
+				swarmId: swarmId,
+			});
+			if (alreadyMember) {
+				throw new APIError("BAD_REQUEST", {
+					message:
+						SWARM_ERROR_CODES.USER_IS_ALREADY_A_MEMBER_OF_THIS_SWARM,
+				});
+			}
+			const alreadyInvited = await adapter.findPendingInvitation({
+				email: ctx.body.email,
+				swarmId: swarmId,
+			});
+			if (alreadyInvited.length && !ctx.body.resend) {
+				throw new APIError("BAD_REQUEST", {
+					message:
+						SWARM_ERROR_CODES.USER_IS_ALREADY_INVITED_TO_THIS_SWARM,
+				});
+			}
+
+			const invitation = await adapter.createInvitation({
+				invitation: {
+					role: ctx.body.role as string,
+					email: ctx.body.email,
+					swarmId: swarmId,
+				},
+				user: session.user,
+			});
+
+			const swarm = await adapter.findSwarmById(swarmId);
+
+			if (!swarm) {
+				throw new APIError("BAD_REQUEST", {
+					message: SWARM_ERROR_CODES.SWARM_NOT_FOUND,
+				});
+			}
+
+			await ctx.context.swmOptions.sendInvitationEmail?.(
+				{
+					id: invitation.id,
+					role: invitation.role as string,
+					email: invitation.email,
+					swarm: swarm,
+					inviter: {
+						...member,
+						user: session.user,
+					},
+				},
+				ctx.request,
+			);
+			return ctx.json(invitation);
+		},
+	);
+
+export const acceptInvitation = createAuthEndpoint(
+	"/swarm/accept-invitation",
+	{
+		method: "POST",
+		body: z.object({
+			invitationId: z.string({
+				description: "The ID of the invitation to accept",
+			}),
+		}),
+		use: [swmMiddleware, swmSessionMiddleware],
+		metadata: {
+			openapi: {
+				description: "Accept an invitation to an swarm",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										invitation: {
+											type: "object",
+										},
+										member: {
+											type: "object",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = ctx.context.session;
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const invitation = await adapter.findInvitationById(ctx.body.invitationId);
+		if (
+			!invitation ||
+			invitation.expiresAt < new Date() ||
+			invitation.status !== "pending"
+		) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.INVITATION_NOT_FOUND,
+			});
+		}
+		if (invitation.email !== session.user.email) {
+			throw new APIError("FORBIDDEN", {
+				message:
+					SWARM_ERROR_CODES.YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION,
+			});
+		}
+		const acceptedI = await adapter.updateInvitation({
+			invitationId: ctx.body.invitationId,
+			status: "accepted",
+		});
+		const member = await adapter.createMember({
+			swarmId: invitation.swarmId,
+			userId: session.user.id,
+			role: invitation.role,
+			createdAt: new Date(),
+		});
+		await adapter.setActiveSwarm(
+			session.session.token,
+			invitation.swarmId,
+		);
+		if (!acceptedI) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message: SWARM_ERROR_CODES.INVITATION_NOT_FOUND,
+				},
+			});
+		}
+		return ctx.json({
+			invitation: acceptedI,
+			member,
+		});
+	},
+);
+export const rejectInvitation = createAuthEndpoint(
+	"/swarm/reject-invitation",
+	{
+		method: "POST",
+		body: z.object({
+			invitationId: z.string({
+				description: "The ID of the invitation to reject",
+			}),
+		}),
+		use: [swmMiddleware, swmSessionMiddleware],
+		metadata: {
+			openapi: {
+				description: "Reject an invitation to an swarm",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										invitation: {
+											type: "object",
+										},
+										member: {
+											type: "null",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = ctx.context.session;
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const invitation = await adapter.findInvitationById(ctx.body.invitationId);
+		if (
+			!invitation ||
+			invitation.expiresAt < new Date() ||
+			invitation.status !== "pending"
+		) {
+			throw new APIError("BAD_REQUEST", {
+				message: "Invitation not found!",
+			});
+		}
+		if (invitation.email !== session.user.email) {
+			throw new APIError("FORBIDDEN", {
+				message:
+					SWARM_ERROR_CODES.YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION,
+			});
+		}
+		const rejectedI = await adapter.updateInvitation({
+			invitationId: ctx.body.invitationId,
+			status: "rejected",
+		});
+		return ctx.json({
+			invitation: rejectedI,
+			member: null,
+		});
+	},
+);
+
+export const cancelInvitation = createAuthEndpoint(
+	"/swarm/cancel-invitation",
+	{
+		method: "POST",
+		body: z.object({
+			invitationId: z.string({
+				description: "The ID of the invitation to cancel",
+			}),
+		}),
+		use: [swmMiddleware, swmSessionMiddleware],
+		openapi: {
+			description: "Cancel an invitation to an swarm",
+			responses: {
+				"200": {
+					description: "Success",
+					content: {
+						"application/json": {
+							schema: {
+								type: "object",
+								properties: {
+									invitation: {
+										type: "object",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = ctx.context.session;
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const invitation = await adapter.findInvitationById(ctx.body.invitationId);
+		if (!invitation) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.INVITATION_NOT_FOUND,
+			});
+		}
+		const member = await adapter.findMemberBySwmId({
+			userId: session.user.id,
+			swarmId: invitation.swarmId,
+		});
+		if (!member) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.MEMBER_NOT_FOUND,
+			});
+		}
+		const canCancel = ctx.context.roles[member.role].authorize({
+			invitation: ["cancel"],
+		});
+		if (canCancel.error) {
+			throw new APIError("FORBIDDEN", {
+				message:
+					SWARM_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_INVITATION,
+			});
+		}
+		const canceledI = await adapter.updateInvitation({
+			invitationId: ctx.body.invitationId,
+			status: "canceled",
+		});
+		return ctx.json(canceledI);
+	},
+);
+
+export const getInvitation = createAuthEndpoint(
+	"/swarm/get-invitation",
+	{
+		method: "GET",
+		use: [swmMiddleware],
+		requireHeaders: true,
+		query: z.object({
+			id: z.string({
+				description: "The ID of the invitation to get",
+			}),
+		}),
+		metadata: {
+			openapi: {
+				description: "Get an invitation by ID",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										id: {
+											type: "string",
+										},
+										email: {
+											type: "string",
+										},
+										role: {
+											type: "string",
+										},
+										swarmId: {
+											type: "string",
+										},
+										inviterId: {
+											type: "string",
+										},
+										status: {
+											type: "string",
+										},
+										expiresAt: {
+											type: "string",
+										},
+										swarmName: {
+											type: "string",
+										},
+										swarmSlug: {
+											type: "string",
+										},
+										inviterEmail: {
+											type: "string",
+										},
+									},
+									required: [
+										"id",
+										"email",
+										"role",
+										"swarmId",
+										"inviterId",
+										"status",
+										"expiresAt",
+										"swarmName",
+										"swarmSlug",
+										"inviterEmail",
+									],
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = await getSessionFromCtx(ctx);
+		if (!session) {
+			throw new APIError("UNAUTHORIZED", {
+				message: "Not authenticated",
+			});
+		}
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const invitation = await adapter.findInvitationById(ctx.query.id);
+		if (
+			!invitation ||
+			invitation.status !== "pending" ||
+			invitation.expiresAt < new Date()
+		) {
+			throw new APIError("BAD_REQUEST", {
+				message: "Invitation not found!",
+			});
+		}
+		if (invitation.email !== session.user.email) {
+			throw new APIError("FORBIDDEN", {
+				message:
+					SWARM_ERROR_CODES.YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION,
+			});
+		}
+		const swarm = await adapter.findSwarmById(
+			invitation.swarmId,
+		);
+		if (!swarm) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.SWARM_NOT_FOUND,
+			});
+		}
+		const member = await adapter.findMemberBySwmId({
+			userId: invitation.inviterId,
+			swarmId: invitation.swarmId,
+		});
+		if (!member) {
+			throw new APIError("BAD_REQUEST", {
+				message:
+					SWARM_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THE_SWARM,
+			});
+		}
+
+		return ctx.json({
+			...invitation,
+			swarmName: swarm.name,
+			swarmSlug: swarm.slug,
+			inviterEmail: member.user.email,
+		});
+	},
+);

--- a/packages/better-auth/src/plugins/swarm/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/swarm/routes/crud-members.ts
@@ -1,0 +1,404 @@
+import { z } from "zod";
+import { createAuthEndpoint } from "../../../api/call";
+import { getSwmAdapter } from "../adapter";
+import { swmMiddleware, swmSessionMiddleware } from "../call";
+import type { InferRolesFromOption, Member } from "../schema";
+import { APIError } from "better-call";
+import { generateId } from "../../../utils";
+import type { SwarmOptions } from "../swarm";
+import { getSessionFromCtx } from "../../../api";
+import { SWARM_ERROR_CODES } from "../error-codes";
+import { BASE_ERROR_CODES } from "../../../error/codes";
+
+export const addMember = <O extends SwarmOptions>() =>
+	createAuthEndpoint(
+		"/swarm/add-member",
+		{
+			method: "POST",
+			body: z.object({
+				userId: z.string(),
+				role: z.string() as unknown as InferRolesFromOption<O>,
+				swarmId: z.string().optional(),
+			}),
+			use: [swmMiddleware],
+			metadata: {
+				SERVER_ONLY: true,
+			},
+		},
+		async (ctx) => {
+			const session = ctx.body.userId
+				? await getSessionFromCtx<{
+						session: {
+							activeSwarmId?: string;
+						};
+					}>(ctx).catch((e) => null)
+				: null;
+			const swmId =
+				ctx.body.swarmId || session?.session.activeSwarmId;
+			if (!swmId) {
+				return ctx.json(null, {
+					status: 400,
+					body: {
+						message: SWARM_ERROR_CODES.NO_ACTIVE_SWARM,
+					},
+				});
+			}
+
+			const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+
+			const user = await ctx.context.internalAdapter.findUserById(
+				ctx.body.userId,
+			);
+
+			if (!user) {
+				throw new APIError("BAD_REQUEST", {
+					message: BASE_ERROR_CODES.USER_NOT_FOUND,
+				});
+			}
+
+			const alreadyMember = await adapter.findMemberByEmail({
+				email: user.email,
+				swarmId: swmId,
+			});
+			if (alreadyMember) {
+				throw new APIError("BAD_REQUEST", {
+					message:
+						SWARM_ERROR_CODES.USER_IS_ALREADY_A_MEMBER_OF_THIS_SWARM,
+				});
+			}
+
+			const createdMember = await adapter.createMember({
+				id: generateId(),
+				swarmId: swmId,
+				userId: user.id,
+				role: ctx.body.role as string,
+				createdAt: new Date(),
+			});
+
+			return ctx.json(createdMember);
+		},
+	);
+
+export const removeMember = createAuthEndpoint(
+	"/swarm/remove-member",
+	{
+		method: "POST",
+		body: z.object({
+			memberIdOrEmail: z.string({
+				description: "The ID or email of the member to remove",
+			}),
+			/**
+			 * If not provided, the active swarm will be used
+			 */
+			swarmId: z
+				.string({
+					description:
+						"The ID of the swarm to remove the member from. If not provided, the active swarm will be used",
+				})
+				.optional(),
+		}),
+		use: [swmMiddleware, swmSessionMiddleware],
+		metadata: {
+			openapi: {
+				description: "Remove a member from an swarm",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										member: {
+											type: "object",
+											properties: {
+												id: {
+													type: "string",
+												},
+												userId: {
+													type: "string",
+												},
+												swarmId: {
+													type: "string",
+												},
+												role: {
+													type: "string",
+												},
+											},
+											required: ["id", "userId", "swarmId", "role"],
+										},
+									},
+									required: ["member"],
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = ctx.context.session;
+		const swarmId =
+			ctx.body.swarmId || session.session.activeSwarmId;
+		if (!swarmId) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message: SWARM_ERROR_CODES.NO_ACTIVE_SWARM,
+				},
+			});
+		}
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const member = await adapter.findMemberBySwmId({
+			userId: session.user.id,
+			swarmId: swarmId,
+		});
+		if (!member) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.MEMBER_NOT_FOUND,
+			});
+		}
+		const role = ctx.context.roles[member.role];
+		if (!role) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.ROLE_NOT_FOUND,
+			});
+		}
+		const isLeaving =
+			session.user.email === ctx.body.memberIdOrEmail ||
+			member.id === ctx.body.memberIdOrEmail;
+		const isOwnerLeaving =
+			isLeaving &&
+			member.role === (ctx.context.swmOptions?.creatorRole || "owner");
+		if (isOwnerLeaving) {
+			throw new APIError("BAD_REQUEST", {
+				message:
+					SWARM_ERROR_CODES.YOU_CANNOT_LEAVE_THE_SWARM_AS_THE_ONLY_OWNER,
+			});
+		}
+
+		const canDeleteMember =
+			isLeaving ||
+			role.authorize({
+				member: ["delete"],
+			}).success;
+		if (!canDeleteMember) {
+			throw new APIError("UNAUTHORIZED", {
+				message:
+					SWARM_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_MEMBER,
+			});
+		}
+		let existing: Member | null = null;
+		if (ctx.body.memberIdOrEmail.includes("@")) {
+			existing = await adapter.findMemberByEmail({
+				email: ctx.body.memberIdOrEmail,
+				swarmId: swarmId,
+			});
+		} else {
+			existing = await adapter.findMemberById(ctx.body.memberIdOrEmail);
+		}
+		if (existing?.swarmId !== swarmId) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.MEMBER_NOT_FOUND,
+			});
+		}
+		await adapter.deleteMember(existing.id);
+		if (
+			session.user.id === existing.userId &&
+			session.session.activeSwarmId === existing.swarmId
+		) {
+			await adapter.setActiveSwarm(session.session.token, null);
+		}
+		return ctx.json({
+			member: existing,
+		});
+	},
+);
+
+export const updateMemberRole = <O extends SwarmOptions>(option: O) =>
+	createAuthEndpoint(
+		"/swarm/update-member-role",
+		{
+			method: "POST",
+			body: z.object({
+				role: z.string() as unknown as InferRolesFromOption<O>,
+				memberId: z.string(),
+				/**
+				 * If not provided, the active swarm will be used
+				 */
+				swarmId: z.string().optional(),
+			}),
+			use: [swmMiddleware, swmSessionMiddleware],
+			metadata: {
+				openapi: {
+					description: "Update the role of a member in an swarm",
+					responses: {
+						"200": {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											member: {
+												type: "object",
+												properties: {
+													id: {
+														type: "string",
+													},
+													userId: {
+														type: "string",
+													},
+													swarmId: {
+														type: "string",
+													},
+													role: {
+														type: "string",
+													},
+												},
+												required: ["id", "userId", "swarmId", "role"],
+											},
+										},
+										required: ["member"],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const session = ctx.context.session;
+			const swarmId =
+				ctx.body.swarmId || session.session.activeSwarmId;
+			if (!swarmId) {
+				return ctx.json(null, {
+					status: 400,
+					body: {
+						message: SWARM_ERROR_CODES.NO_ACTIVE_SWARM,
+					},
+				});
+			}
+			const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+			const member = await adapter.findMemberBySwmId({
+				userId: session.user.id,
+				swarmId: swarmId,
+			});
+			if (!member) {
+				return ctx.json(null, {
+					status: 400,
+					body: {
+						message: SWARM_ERROR_CODES.MEMBER_NOT_FOUND,
+					},
+				});
+			}
+			const role = ctx.context.roles[member.role];
+			if (!role) {
+				return ctx.json(null, {
+					status: 400,
+					body: {
+						message: SWARM_ERROR_CODES.ROLE_NOT_FOUND,
+					},
+				});
+			}
+			/**
+			 * If the member is not an owner, they cannot update the role of another member
+			 * as an owner.
+			 */
+			const canUpdateMember =
+				role.authorize({
+					member: ["update"],
+				}).error ||
+				(ctx.body.role === "owner" && member.role !== "owner");
+			if (canUpdateMember) {
+				return ctx.json(null, {
+					body: {
+						message: "You are not allowed to update this member",
+					},
+					status: 403,
+				});
+			}
+
+			const updatedMember = await adapter.updateMember(
+				ctx.body.memberId,
+				ctx.body.role as string,
+			);
+			if (!updatedMember) {
+				return ctx.json(null, {
+					status: 400,
+					body: {
+						message: SWARM_ERROR_CODES.MEMBER_NOT_FOUND,
+					},
+				});
+			}
+			return ctx.json(updatedMember);
+		},
+	);
+
+export const getActiveMember = createAuthEndpoint(
+	"/swarm/get-active-member",
+	{
+		method: "GET",
+		use: [swmMiddleware, swmSessionMiddleware],
+		metadata: {
+			openapi: {
+				description: "Get the active member in the swarm",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										id: {
+											type: "string",
+										},
+										userId: {
+											type: "string",
+										},
+										swarmId: {
+											type: "string",
+										},
+										role: {
+											type: "string",
+										},
+									},
+									required: ["id", "userId", "swarmId", "role"],
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = ctx.context.session;
+		const swarmId = session.session.activeSwarmId;
+		if (!swarmId) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message: SWARM_ERROR_CODES.NO_ACTIVE_SWARM,
+				},
+			});
+		}
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const member = await adapter.findMemberBySwmId({
+			userId: session.user.id,
+			swarmId: swarmId,
+		});
+		if (!member) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message: SWARM_ERROR_CODES.MEMBER_NOT_FOUND,
+				},
+			});
+		}
+		return ctx.json(member);
+	},
+);

--- a/packages/better-auth/src/plugins/swarm/routes/crud-swm.ts
+++ b/packages/better-auth/src/plugins/swarm/routes/crud-swm.ts
@@ -1,0 +1,563 @@
+import { z } from "zod";
+import { createAuthEndpoint } from "../../../api/call";
+import { generateId } from "../../../utils/id";
+import { getSwmAdapter } from "../adapter";
+import { swmMiddleware, swmSessionMiddleware } from "../call";
+import { APIError } from "better-call";
+import { setSessionCookie } from "../../../cookies";
+import { SWARM_ERROR_CODES } from "../error-codes";
+import { getSessionFromCtx } from "../../../api";
+
+export const createSwarm = createAuthEndpoint(
+	"/swarm/create",
+	{
+		method: "POST",
+		body: z.object({
+			name: z.string({
+				description: "The name of the swarm",
+			}),
+			slug: z.string({
+				description: "The slug of the swarm",
+			}),
+			userId: z
+				.string({
+					description:
+						"The user id of the swarm creator. If not provided, the current user will be used. Should only be used by admins or when called by the server.",
+				})
+				.optional(),
+			logo: z
+				.string({
+					description: "The logo of the swarm",
+				})
+				.optional(),
+			metadata: z
+				.record(z.string(), z.any(), {
+					description: "The metadata of the swarm",
+				})
+				.optional(),
+		}),
+		use: [swmMiddleware],
+		metadata: {
+			openapi: {
+				description: "Create an swarm",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									description: "The swarm that was created",
+									$ref: "#/components/schemas/Swarm",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = await getSessionFromCtx(ctx);
+		if (!session && (ctx.request || ctx.headers)) {
+			throw new APIError("UNAUTHORIZED");
+		}
+		let user = session?.user || null;
+		if (!user) {
+			if (!ctx.body.userId) {
+				throw new APIError("UNAUTHORIZED");
+			}
+			user = await ctx.context.internalAdapter.findUserById(ctx.body.userId);
+		}
+		if (!user) {
+			return ctx.json(null, {
+				status: 401,
+			});
+		}
+		const options = ctx.context.swmOptions;
+		const canCreateSwm =
+			typeof options?.allowUserToCreateSwarm === "function"
+				? await options.allowUserToCreateSwarm(user)
+				: options?.allowUserToCreateSwarm === undefined
+					? true
+					: options.allowUserToCreateSwarm;
+
+		if (!canCreateSwm) {
+			throw new APIError("FORBIDDEN", {
+				message:
+					SWARM_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CREATE_A_NEW_SWARM,
+			});
+		}
+		const adapter = getSwmAdapter(ctx.context, options);
+
+		const userSwarms = await adapter.listSwarms(user.id);
+		const hasReachedSwmLimit =
+			typeof options.swarmLimit === "number"
+				? userSwarms.length >= options.swarmLimit
+				: typeof options.swarmLimit === "function"
+					? await options.swarmLimit(user)
+					: false;
+
+		if (hasReachedSwmLimit) {
+			throw new APIError("FORBIDDEN", {
+				message:
+					SWARM_ERROR_CODES.YOU_HAVE_REACHED_THE_MAXIMUM_NUMBER_OF_SWARMS,
+			});
+		}
+
+		const existingSwarm = await adapter.findSwarmBySlug(
+			ctx.body.slug,
+		);
+		if (existingSwarm) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.SWARM_ALREADY_EXISTS,
+			});
+		}
+		const swarm = await adapter.createSwarm({
+			swarm: {
+				id: generateId(),
+				slug: ctx.body.slug,
+				name: ctx.body.name,
+				logo: ctx.body.logo,
+				createdAt: new Date(),
+				metadata: ctx.body.metadata,
+			},
+			user,
+		});
+		if (ctx.context.session) {
+			await adapter.setActiveSwarm(
+				ctx.context.session.session.token,
+				swarm.id,
+			);
+		}
+		return ctx.json(swarm);
+	},
+);
+
+export const updateSwarm = createAuthEndpoint(
+	"/swarm/update",
+	{
+		method: "POST",
+		body: z.object({
+			data: z
+				.object({
+					name: z
+						.string({
+							description: "The name of the swarm",
+						})
+						.optional(),
+					slug: z
+						.string({
+							description: "The slug of the swarm",
+						})
+						.optional(),
+					logo: z
+						.string({
+							description: "The logo of the swarm",
+						})
+						.optional(),
+					metadata: z
+						.record(z.string(), z.any(), {
+							description: "The metadata of the swarm",
+						})
+						.optional(),
+				})
+				.partial(),
+			swarmId: z.string().optional(),
+		}),
+		requireHeaders: true,
+		use: [swmMiddleware],
+		metadata: {
+			openapi: {
+				description: "Update an swarm",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									description: "The updated swarm",
+									$ref: "#/components/schemas/Swarm",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = await ctx.context.getSession(ctx);
+		if (!session) {
+			throw new APIError("UNAUTHORIZED", {
+				message: "User not found",
+			});
+		}
+		const swarmId =
+			ctx.body.swarmId || session.session.activeSwarmId;
+		if (!swarmId) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message: SWARM_ERROR_CODES.SWARM_NOT_FOUND,
+				},
+			});
+		}
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const member = await adapter.findMemberBySwmId({
+			userId: session.user.id,
+			swarmId: swarmId,
+		});
+		if (!member) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message:
+						SWARM_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_SWARM,
+				},
+			});
+		}
+		const role = ctx.context.roles[member.role];
+		if (!role) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message: "Role not found!",
+				},
+			});
+		}
+		const canUpdateSwm = role.authorize({
+			swarm: ["update"],
+		});
+		if (canUpdateSwm.error) {
+			return ctx.json(null, {
+				body: {
+					message:
+						SWARM_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_SWARM,
+				},
+				status: 403,
+			});
+		}
+		const updatedSwm = await adapter.updateSwarm(
+			swarmId,
+			ctx.body.data,
+		);
+		return ctx.json(updatedSwm);
+	},
+);
+
+export const deleteSwarm = createAuthEndpoint(
+	"/swarm/delete",
+	{
+		method: "POST",
+		body: z.object({
+			swarmId: z.string({
+				description: "The swarm id to delete",
+			}),
+		}),
+		requireHeaders: true,
+		use: [swmMiddleware],
+		metadata: {
+			openapi: {
+				description: "Delete an swarm",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "string",
+									description: "The swarm id that was deleted",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = await ctx.context.getSession(ctx);
+		if (!session) {
+			return ctx.json(null, {
+				status: 401,
+			});
+		}
+		const swarmId = ctx.body.swarmId;
+		if (!swarmId) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message: SWARM_ERROR_CODES.SWARM_NOT_FOUND,
+				},
+			});
+		}
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const member = await adapter.findMemberBySwmId({
+			userId: session.user.id,
+			swarmId: swarmId,
+		});
+		if (!member) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message:
+						SWARM_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_SWARM,
+				},
+			});
+		}
+		const role = ctx.context.roles[member.role];
+		if (!role) {
+			return ctx.json(null, {
+				status: 400,
+				body: {
+					message: "Role not found!",
+				},
+			});
+		}
+		const canDeleteSwm = role.authorize({
+			swarm: ["delete"],
+		});
+		if (canDeleteSwm.error) {
+			throw new APIError("FORBIDDEN", {
+				message:
+					SWARM_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_SWARM,
+			});
+		}
+		if (swarmId === session.session.activeSwarmId) {
+			/**
+			 * If the swarm is deleted, we set the active swarm to null
+			 */
+			await adapter.setActiveSwarm(session.session.token, null);
+		}
+		const option = ctx.context.swmOptions.swarmDeletion;
+		if (option?.disabled) {
+			throw new APIError("FORBIDDEN");
+		}
+		const swm = await adapter.findSwarmById(swarmId);
+		if (!swm) {
+			throw new APIError("BAD_REQUEST");
+		}
+		if (option?.beforeDelete) {
+			await option.beforeDelete({
+				swarm: swm,
+				user: session.user,
+			});
+		}
+		await adapter.deleteSwarm(swarmId);
+		if (option?.afterDelete) {
+			await option.afterDelete({
+				swarm: swm,
+				user: session.user,
+			});
+		}
+		return ctx.json(swm);
+	},
+);
+
+export const getFullSwarm = createAuthEndpoint(
+	"/swarm/get-full-swarm",
+	{
+		method: "GET",
+		query: z.optional(
+			z.object({
+				swarmId: z
+					.string({
+						description: "The swarm id to get",
+					})
+					.optional(),
+				swarmSlug: z
+					.string({
+						description: "The swarm slug to get",
+					})
+					.optional(),
+			}),
+		),
+		requireHeaders: true,
+		use: [swmMiddleware, swmSessionMiddleware],
+		metadata: {
+			openapi: {
+				description: "Get the full swarm",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									description: "The swarm",
+									$ref: "#/components/schemas/Swarm",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const session = ctx.context.session;
+		const swarmId =
+			ctx.query?.swarmSlug ||
+			ctx.query?.swarmId ||
+			session.session.activeSwarmId;
+		if (!swarmId) {
+			return ctx.json(null, {
+				status: 200,
+			});
+		}
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const swarm = await adapter.findFullSwarm({
+			swarmId,
+			isSlug: !!ctx.query?.swarmSlug,
+		});
+		const isMember = swarm?.members.find(
+			(member) => member.userId === session.user.id,
+		);
+		if (!isMember) {
+			throw new APIError("FORBIDDEN", {
+				message:
+					SWARM_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_SWARM,
+			});
+		}
+		if (!swarm) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.SWARM_NOT_FOUND,
+			});
+		}
+		return ctx.json(swarm);
+	},
+);
+
+export const setActiveSwarm = createAuthEndpoint(
+	"/swarm/set-active",
+	{
+		method: "POST",
+		body: z.object({
+			swarmId: z
+				.string({
+					description:
+						"The swarm id to set as active. It can be null to unset the active swarm",
+				})
+				.nullable()
+				.optional(),
+			swarmSlug: z
+				.string({
+					description:
+						"The swarm slug to set as active. It can be null to unset the active swarm if swarmId is not provided",
+				})
+				.optional(),
+		}),
+		use: [swmSessionMiddleware, swmMiddleware],
+		metadata: {
+			openapi: {
+				description: "Set the active swarm",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									description: "The swarm",
+									$ref: "#/components/schemas/Swarm",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const session = ctx.context.session;
+		let swarmId = ctx.body.swarmSlug || ctx.body.swarmId;
+		if (swarmId === null) {
+			const sessionSwmId = session.session.activeSwarmId;
+			if (!sessionSwmId) {
+				return ctx.json(null);
+			}
+			const updatedSession = await adapter.setActiveSwarm(
+				session.session.token,
+				null,
+			);
+			await setSessionCookie(ctx, {
+				session: updatedSession,
+				user: session.user,
+			});
+			return ctx.json(null);
+		}
+		if (!swarmId) {
+			const sessionSwmId = session.session.activeSwarmId;
+			if (!sessionSwmId) {
+				return ctx.json(null);
+			}
+			swarmId = sessionSwmId;
+		}
+		const swarm = await adapter.findFullSwarm({
+			swarmId,
+			isSlug: !!ctx.body.swarmSlug,
+		});
+		const isMember = swarm?.members.find(
+			(member) => member.userId === session.user.id,
+		);
+		if (!isMember) {
+			await adapter.setActiveSwarm(session.session.token, null);
+			throw new APIError("FORBIDDEN", {
+				message:
+					SWARM_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_SWARM,
+			});
+		}
+		if (!swarm) {
+			throw new APIError("BAD_REQUEST", {
+				message: SWARM_ERROR_CODES.SWARM_NOT_FOUND,
+			});
+		}
+		const updatedSession = await adapter.setActiveSwarm(
+			session.session.token,
+			swarm.id,
+		);
+		await setSessionCookie(ctx, {
+			session: updatedSession,
+			user: session.user,
+		});
+		return ctx.json(swarm);
+	},
+);
+
+export const listSwarms = createAuthEndpoint(
+	"/swarm/list",
+	{
+		method: "GET",
+		use: [swmMiddleware, swmSessionMiddleware],
+		metadata: {
+			openapi: {
+				description: "List all swarms",
+				responses: {
+					"200": {
+						description: "Success",
+						content: {
+							"application/json": {
+								schema: {
+									type: "array",
+									items: {
+										$ref: "#/components/schemas/Swarm",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const adapter = getSwmAdapter(ctx.context, ctx.context.swmOptions);
+		const swarms = await adapter.listSwarms(
+			ctx.context.session.user.id,
+		);
+		return ctx.json(swarms);
+	},
+);

--- a/packages/better-auth/src/plugins/swarm/schema.ts
+++ b/packages/better-auth/src/plugins/swarm/schema.ts
@@ -1,0 +1,53 @@
+import { z, ZodLiteral } from "zod";
+import { generateId } from "../../utils";
+import type { SwarmOptions } from "./swarm";
+
+export const role = z.string();
+export const invitationStatus = z
+	.enum(["pending", "accepted", "rejected", "canceled"])
+	.default("pending");
+
+export const swarmSchema = z.object({
+	id: z.string().default(generateId),
+	name: z.string(),
+	slug: z.string(),
+	logo: z.string().nullish(),
+	metadata: z
+		.record(z.string())
+		.or(z.string().transform((v) => JSON.parse(v)))
+		.nullish(),
+	createdAt: z.date(),
+});
+
+export const memberSchema = z.object({
+	id: z.string().default(generateId),
+	swarmId: z.string(),
+	userId: z.string(),
+	role,
+	createdAt: z.date(),
+});
+
+export const invitationSchema = z.object({
+	id: z.string().default(generateId),
+	swarmId: z.string(),
+	email: z.string(),
+	role,
+	status: invitationStatus,
+	/**
+	 * The id of the user who invited the user.
+	 */
+	inviterId: z.string(),
+	expiresAt: z.date(),
+});
+
+export type Swarm = z.infer<typeof swarmSchema>;
+export type Member = z.infer<typeof memberSchema>;
+export type Invitation = z.infer<typeof invitationSchema>;
+export type InvitationInput = z.input<typeof invitationSchema>;
+export type MemberInput = z.input<typeof memberSchema>;
+export type SwarmInput = z.input<typeof swarmSchema>;
+
+export type InferRolesFromOption<O extends SwarmOptions | undefined> =
+	ZodLiteral<
+		O extends { roles: any } ? keyof O["roles"] : "admin" | "member" | "owner"
+	>;

--- a/packages/better-auth/src/plugins/swarm/swarm.test.ts
+++ b/packages/better-auth/src/plugins/swarm/swarm.test.ts
@@ -1,0 +1,552 @@
+import { describe, expect, expectTypeOf } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { swarm } from "./swarm";
+import { createAuthClient } from "../../client";
+import { swarmClient } from "./client";
+import { createAccessControl } from "./access";
+import { SWARM_ERROR_CODES } from "./error-codes";
+import { BetterAuthError } from "../../error";
+
+describe("swarm", async (it) => {
+	const { auth, signInWithTestUser, signInWithUser } = await getTestInstance({
+		user: {
+			modelName: "users",
+		},
+		plugins: [
+			swarm({
+				async sendInvitationEmail(data, request) {},
+				schema: {
+					swarm: {
+						modelName: "team",
+					},
+					member: {
+						modelName: "teamMembers",
+					},
+				},
+			}),
+		],
+		logger: {
+			level: "error",
+		},
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [swarmClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	let swarmId: string;
+	it("create swarm", async () => {
+		const swarm = await client.swarm.create({
+			name: "test",
+			slug: "test",
+			metadata: {
+				test: "test",
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		swarmId = swarm.data?.id as string;
+		expect(swarm.data?.name).toBeDefined();
+		expect(swarm.data?.metadata).toBeDefined();
+		expect(swarm.data?.members.length).toBe(1);
+		expect(swarm.data?.members[0].role).toBe("owner");
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect((session.data?.session as any).activeSwarmId).toBe(
+			swarmId,
+		);
+	});
+
+	it("should create swarm directly in the server without cookie", async () => {
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const swarm = await auth.api.createSwarm({
+			body: {
+				name: "test2",
+				slug: "test2",
+				userId: session.data?.session.userId,
+			},
+		});
+
+		expect(swarm?.name).toBe("test2");
+		expect(swarm?.members.length).toBe(1);
+		expect(swarm?.members[0].role).toBe("owner");
+	});
+
+	it("should allow listing swarms", async () => {
+		const swarms = await client.swarm.list({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(swarms.data?.length).toBe(2);
+	});
+
+	it("should allow updating swarm", async () => {
+		const { headers } = await signInWithTestUser();
+		const swarm = await client.swarm.update({
+			swarmId,
+			data: {
+				name: "test2",
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(swarm.data?.name).toBe("test2");
+	});
+
+	it("should allow updating swarm metadata", async () => {
+		const { headers } = await signInWithTestUser();
+		const swarm = await client.swarm.update({
+			swarmId,
+			data: {
+				metadata: {
+					test: "test2",
+				},
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(swarm.data?.metadata?.test).toBe("test2");
+	});
+
+	it("should allow activating swarm and set session", async () => {
+		const swarm = await client.swarm.setActive({
+			swarmId,
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(swarm.data?.id).toBe(swarmId);
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect((session.data?.session as any).activeSwarmId).toBe(
+			swarmId,
+		);
+	});
+
+	it("should allow getting full swm on server", async () => {
+		const swm = await auth.api.getFullSwarm({
+			headers,
+		});
+		expect(swm?.members.length).toBe(1);
+	});
+
+	it("should allow getting full swm on server using slug", async () => {
+		const swm = await auth.api.getFullSwarm({
+			headers,
+			query: {
+				swarmSlug: "test",
+			},
+		});
+		expect(swm?.members.length).toBe(1);
+	});
+
+	it.each([
+		{
+			role: "owner",
+			newUser: {
+				email: "test2@test.com",
+				password: "test123456",
+				name: "test2",
+			},
+		},
+		{
+			role: "admin",
+			newUser: {
+				email: "test3@test.com",
+				password: "test123456",
+				name: "test3",
+			},
+		},
+		{
+			role: "member",
+			newUser: {
+				email: "test4@test.com",
+				password: "test123456",
+				name: "test4",
+			},
+		},
+	])(
+		"invites user to swarm with $role role",
+		async ({ role, newUser }) => {
+			const { headers } = await signInWithTestUser();
+			const invite = await client.swarm.inviteMember({
+				swarmId: swarmId,
+				email: newUser.email,
+				role: role,
+				fetchOptions: {
+					headers,
+				},
+			});
+			if (!invite.data) throw new Error("Invitation not created");
+			expect(invite.data.email).toBe(newUser.email);
+			expect(invite.data.role).toBe(role);
+			await client.signUp.email({
+				email: newUser.email,
+				password: newUser.password,
+				name: newUser.name,
+			});
+			const { headers: headers2 } = await signInWithUser(
+				newUser.email,
+				newUser.password,
+			);
+
+			const wrongInvitation = await client.swarm.acceptInvitation({
+				invitationId: "123",
+				fetchOptions: {
+					headers: headers2,
+				},
+			});
+			expect(wrongInvitation.error?.status).toBe(400);
+
+			const wrongPerson = await client.swarm.acceptInvitation({
+				invitationId: invite.data.id,
+				fetchOptions: {
+					headers,
+				},
+			});
+			expect(wrongPerson.error?.status).toBe(403);
+
+			const invitation = await client.swarm.acceptInvitation({
+				invitationId: invite.data.id,
+				fetchOptions: {
+					headers: headers2,
+				},
+			});
+			expect(invitation.data?.invitation.status).toBe("accepted");
+			const invitedUserSession = await client.getSession({
+				fetchOptions: {
+					headers: headers2,
+				},
+			});
+			expect(
+				(invitedUserSession.data?.session as any).activeSwarmId,
+			).toBe(swarmId);
+		},
+	);
+
+	it("should allow getting a member", async () => {
+		const { headers } = await signInWithTestUser();
+		await client.swarm.setActive({
+			swarmId,
+			fetchOptions: {
+				headers,
+			},
+		});
+		const member = await client.swarm.getActiveMember({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(member.data).toMatchObject({
+			role: "owner",
+		});
+	});
+
+	it("should allow updating member", async () => {
+		const { headers } = await signInWithTestUser();
+		const swm = await client.swarm.getFullSwarm({
+			query: {
+				swarmId,
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		if (!swm.data) throw new Error("Swarm not found");
+		expect(swm.data?.members[3].role).toBe("member");
+		const member = await client.swarm.updateMemberRole({
+			swarmId: swm.data.id,
+			memberId: swm.data.members[3].id,
+			role: "admin",
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(member.data?.role).toBe("admin");
+	});
+
+	const adminUser = {
+		email: "test3@test.com",
+		password: "test123456",
+		name: "test3",
+	};
+
+	it("should not allow inviting member with a creator role unless they are creator", async () => {
+		const { headers } = await signInWithUser(
+			adminUser.email,
+			adminUser.password,
+		);
+		const invite = await client.swarm.inviteMember({
+			swarmId: swarmId,
+			email: adminUser.email,
+			role: "owner",
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(invite.error?.message).toBe(
+			SWARM_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USER_WITH_THIS_ROLE,
+		);
+	});
+
+	it("should allow removing member from swarm", async () => {
+		const { headers } = await signInWithTestUser();
+		const swmBefore = await client.swarm.getFullSwarm({
+			query: {
+				swarmId,
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(swmBefore.data?.members.length).toBe(4);
+		await client.swarm.removeMember({
+			swarmId: swarmId,
+			memberIdOrEmail: "test2@test.com",
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const swm = await client.swarm.getFullSwarm({
+			query: {
+				swarmId,
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(swm.data?.members.length).toBe(3);
+	});
+
+	it("shouldn't allow removing owner from swarm", async () => {
+		const { headers } = await signInWithTestUser();
+		const swm = await client.swarm.getFullSwarm({
+			query: {
+				swarmId,
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		if (!swm.data) throw new Error("Swarm not found");
+		expect(swm.data.members[0].role).toBe("owner");
+		const removedMember = await client.swarm.removeMember({
+			swarmId: swm.data.id,
+			memberIdOrEmail: swm.data.members[0].id,
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(removedMember.error?.status).toBe(400);
+	});
+
+	it("should validate permissions", async () => {
+		await client.swarm.setActive({
+			swarmId,
+			fetchOptions: {
+				headers,
+			},
+		});
+		const hasPermission = await client.swarm.hasPermission({
+			permission: {
+				member: ["update"],
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(hasPermission.data?.success).toBe(true);
+	});
+
+	it("should allow deleting swarm", async () => {
+		await client.swarm.delete({
+			swarmId,
+			fetchOptions: {
+				headers,
+			},
+		});
+		const swm = await client.swarm.getFullSwarm({
+			query: {
+				swarmId,
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(swm.error?.status).toBe(403);
+	});
+
+	it("should have server side methods", async () => {
+		expectTypeOf(auth.api.createSwarm).toBeFunction();
+		expectTypeOf(auth.api.getInvitation).toBeFunction();
+	});
+
+	it("should add member on the server directly", async () => {
+		const newUser = await auth.api.signUpEmail({
+			body: {
+				email: "new-member@email.com",
+				password: "password",
+				name: "new member",
+			},
+		});
+		const session = await auth.api.getSession({
+			headers: new Headers({
+				Authorization: `Bearer ${newUser?.token}`,
+			}),
+		});
+		const swm = await auth.api.createSwarm({
+			body: {
+				name: "test",
+				slug: "test",
+			},
+			headers,
+		});
+		const member = await auth.api.addMember({
+			body: {
+				swarmId: swm?.id,
+				userId: session?.user.id!,
+				role: "admin",
+			},
+		});
+		expect(member?.role).toBe("admin");
+	});
+});
+
+describe("access control", async (it) => {
+	const ac = createAccessControl({
+		project: ["create", "read", "update", "delete"],
+		sales: ["create", "read", "update", "delete"],
+	});
+	const owner = ac.newRole({
+		project: ["create", "delete", "update", "read"],
+		sales: ["create", "read", "update", "delete"],
+	});
+	const admin = ac.newRole({
+		project: ["create", "read"],
+		sales: ["create", "read"],
+	});
+	const member = ac.newRole({
+		project: ["read"],
+		sales: ["read"],
+	});
+	const { auth, customFetchImpl, sessionSetter, signInWithTestUser } =
+		await getTestInstance({
+			plugins: [
+				swarm({
+					ac,
+					roles: {
+						admin,
+						member,
+						owner,
+					},
+				}),
+			],
+		});
+
+	const {
+		swarm: { checkRolePermission, hasPermission, create },
+	} = createAuthClient({
+		baseURL: "http://localhost:3000",
+		plugins: [
+			swarmClient({
+				ac,
+				roles: {
+					admin,
+					member,
+					owner,
+				},
+			}),
+		],
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	const { headers } = await signInWithTestUser();
+
+	const swm = await create(
+		{
+			name: "test",
+			slug: "test",
+			metadata: {
+				test: "test",
+			},
+		},
+		{
+			onSuccess: sessionSetter(headers),
+			headers,
+		},
+	);
+
+	it("should return success", async () => {
+		const canCreateProject = checkRolePermission({
+			role: "admin",
+			permission: {
+				project: ["create"],
+			},
+		});
+		expect(canCreateProject).toBe(true);
+		const canCreateProjectServer = await hasPermission({
+			permission: {
+				project: ["create"],
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(canCreateProjectServer.data?.success).toBe(true);
+	});
+
+	it("should return not success", async () => {
+		const canCreateProject = checkRolePermission({
+			role: "admin",
+			permission: {
+				project: ["delete"],
+			},
+		});
+		expect(canCreateProject).toBe(false);
+	});
+
+	it("should return not success", async () => {
+		let error: BetterAuthError | null = null;
+		try {
+			checkRolePermission({
+				role: "admin",
+				permission: {
+					project: ["read"],
+					sales: ["delete"],
+				},
+			});
+		} catch (e) {
+			if (e instanceof BetterAuthError) {
+				error = e;
+			}
+		}
+		expect(error).toBeInstanceOf(BetterAuthError);
+	});
+});

--- a/packages/better-auth/src/plugins/swarm/swarm.ts
+++ b/packages/better-auth/src/plugins/swarm/swarm.ts
@@ -1,0 +1,533 @@
+import { APIError } from "better-call";
+import {
+	type ZodArray,
+	type ZodLiteral,
+	type ZodObject,
+	type ZodOptional,
+	ZodString,
+	z,
+} from "zod";
+import type { User } from "../../types";
+import { createAuthEndpoint } from "../../api/call";
+import { getSessionFromCtx } from "../../api/routes";
+import type { AuthContext } from "../../init";
+import type { BetterAuthPlugin } from "../../types/plugins";
+import { shimContext } from "../../utils/shim";
+import {
+	type AccessControl,
+	type Role,
+	defaultRoles,
+	type defaultStatements,
+} from "./access";
+import { getSwmAdapter } from "./adapter";
+import { swmSessionMiddleware } from "./call";
+import {
+	acceptInvitation,
+	cancelInvitation,
+	createInvitation,
+	getInvitation,
+	rejectInvitation,
+} from "./routes/crud-invites";
+import {
+	addMember,
+	getActiveMember,
+	removeMember,
+	updateMemberRole,
+} from "./routes/crud-members";
+import {
+	createSwarm,
+	deleteSwarm,
+	getFullSwarm,
+	listSwarms,
+	setActiveSwarm,
+	updateSwarm,
+} from "./routes/crud-swm";
+import type { Invitation, Member, Swarm } from "./schema";
+import type { Prettify } from "../../types/helper";
+import { SWARM_ERROR_CODES } from "./error-codes";
+
+export interface SwarmOptions {
+	/**
+	 * Configure whether new users are able to create new swarms.
+	 * You can also pass a function that returns a boolean.
+	 *
+	 * 	@example
+	 * ```ts
+	 * allowUserToCreateSwarm: async (user) => {
+	 * 		const plan = await getUserPlan(user);
+	 *      return plan.name === "pro";
+	 * }
+	 * ```
+	 * @default true
+	 */
+	allowUserToCreateSwarm?:
+		| boolean
+		| ((user: User) => Promise<boolean> | boolean);
+	/**
+	 * The maximum number of swarms a user can create.
+	 *
+	 * You can also pass a function that returns a boolean
+	 */
+	swarmLimit?: number | ((user: User) => Promise<boolean> | boolean);
+	/**
+	 * The role that is assigned to the creator of the
+	 * swarm.
+	 *
+	 * @default "owner"
+	 */
+	creatorRole?: string;
+	/**
+	 * The number of memberships a user can have in an swarm.
+	 *
+	 * @default "unlimited"
+	 */
+	membershipLimit?: number;
+	/**
+	 * Configure the roles and permissions for the
+	 * swarm plugin.
+	 */
+	ac?: AccessControl;
+	/**
+	 * Custom permissions for roles.
+	 */
+	roles?: {
+		[key in string]?: Role<any>;
+	};
+	/**
+	 * The expiration time for the invitation link.
+	 *
+	 * @default 48 hours
+	 */
+	invitationExpiresIn?: number;
+	/**
+	 * Send an email with the
+	 * invitation link to the user.
+	 *
+	 * Note: Better Auth doesn't
+	 * generate invitation URLs.
+	 * You'll need to construct the
+	 * URL using the invitation ID
+	 * and pass it to the
+	 * acceptInvitation endpoint for
+	 * the user to accept the
+	 * invitation.
+	 *
+	 * @example
+	 * ```ts
+	 * sendInvitationEmail: async (data) => {
+	 * 	const url = `https://yourapp.com/swarm/
+	 * accept-invitation?id=${data.id}`;
+	 * 	await sendEmail(data.email, "Invitation to join
+	 * swarm", `Click the link to join the
+	 * swarm: ${url}`);
+	 * }
+	 * ```
+	 */
+	sendInvitationEmail?: (
+		data: {
+			/**
+			 * the invitation id
+			 */
+			id: string;
+			/**
+			 * the role of the user
+			 */
+			role: string;
+			/**
+			 * the email of the user
+			 */
+			email: string;
+			/**
+			 * the swarm the user is invited to join
+			 */
+			swarm: Swarm;
+			/**
+			 * the member who is inviting the user
+			 */
+			inviter: Member & {
+				user: User;
+			};
+		},
+		/**
+		 * The request object
+		 */
+		request?: Request,
+	) => Promise<void>;
+	/**
+	 * The schema for the swarm plugin.
+	 */
+	schema?: {
+		session?: {
+			fields?: {
+				activeSwarmId?: string;
+			};
+		};
+		swarm?: {
+			modelName?: string;
+			fields?: {
+				[key in keyof Omit<Swarm, "id">]?: string;
+			};
+		};
+		member?: {
+			modelName?: string;
+			fields?: {
+				[key in keyof Omit<Member, "id">]?: string;
+			};
+		};
+		invitation?: {
+			modelName?: string;
+			fields?: {
+				[key in keyof Omit<Invitation, "id">]?: string;
+			};
+		};
+	};
+	/**
+	 * Configure how swarm deletion is handled
+	 */
+	swarmDeletion?: {
+		/**
+		 * disable deleting swarm
+		 */
+		disabled?: boolean;
+		/**
+		 * A callback that runs before the swarm is
+		 * deleted
+		 *
+		 * @param data - swarm and user object
+		 * @param request - the request object
+		 * @returns
+		 */
+		beforeDelete?: (
+			data: {
+				swarm: Swarm;
+				user: User;
+			},
+			request?: Request,
+		) => Promise<void>;
+		/**
+		 * A callback that runs after the swarm is
+		 * deleted
+		 *
+		 * @param data - swarm and user object
+		 * @param request - the request object
+		 * @returns
+		 */
+		afterDelete?: (
+			data: {
+				swarm: Swarm;
+				user: User;
+			},
+			request?: Request,
+		) => Promise<void>;
+	};
+}
+/**
+ * Swarm plugin for Better Auth. Swarm allows you to create teams, members,
+ * and manage access control for your users.
+ *
+ * @example
+ * ```ts
+ * const auth = createAuth({
+ * 	plugins: [
+ * 		swarm({
+ * 			allowUserToCreateSwarm: true,
+ * 		}),
+ * 	],
+ * });
+ * ```
+ */
+export const swarm = <O extends SwarmOptions>(options?: O) => {
+	const endpoints = {
+		createSwarm,
+		updateSwarm,
+		deleteSwarm,
+		setActiveSwarm,
+		getFullSwarm,
+		listSwarms,
+		createInvitation: createInvitation(options as O),
+		cancelInvitation,
+		acceptInvitation,
+		getInvitation,
+		rejectInvitation,
+		addMember: addMember<O>(),
+		removeMember,
+		updateMemberRole: updateMemberRole(options as O),
+		getActiveMember,
+	};
+
+	const roles = {
+		...defaultRoles,
+		...options?.roles,
+	};
+
+	const api = shimContext(endpoints, {
+		swmOptions: options || {},
+		roles,
+		getSession: async (context: AuthContext) => {
+			//@ts-expect-error
+			return await getSessionFromCtx(context);
+		},
+	});
+
+	type DefaultStatements = typeof defaultStatements;
+	type Statements = O["ac"] extends AccessControl<infer S>
+		? S extends Record<string, any>
+			? S & DefaultStatements
+			: DefaultStatements
+		: DefaultStatements;
+	return {
+		id: "swarm",
+		endpoints: {
+			...api,
+			hasPermission: createAuthEndpoint(
+				"/swarm/has-permission",
+				{
+					method: "POST",
+					requireHeaders: true,
+					body: z.object({
+						swarmId: z.string().optional(),
+						permission: z.record(z.string(), z.array(z.string())),
+					}) as unknown as ZodObject<{
+						permission: ZodObject<{
+							[key in keyof Statements]: ZodOptional<
+								//@ts-expect-error TODO: fix this
+								ZodArray<ZodLiteral<Statements[key][number]>>
+							>;
+						}>;
+						swarmId: ZodOptional<ZodString>;
+					}>,
+					use: [swmSessionMiddleware],
+					metadata: {
+						openapi: {
+							description: "Check if the user has permission",
+							requestBody: {
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												permission: {
+													type: "object",
+													description: "The permission to check",
+												},
+											},
+											required: ["permission"],
+										},
+									},
+								},
+							},
+							responses: {
+								"200": {
+									description: "Success",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													error: {
+														type: "string",
+													},
+													success: {
+														type: "boolean",
+													},
+												},
+												required: ["success"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					if (
+						!ctx.body.permission ||
+						Object.keys(ctx.body.permission).length > 1
+					) {
+						throw new APIError("BAD_REQUEST", {
+							message:
+								"invalid permission check. you can only check one resource permission at a time.",
+						});
+					}
+					const activeSwarmId =
+						ctx.body.swarmId ||
+						ctx.context.session.session.activeSwarmId;
+					if (!activeSwarmId) {
+						throw new APIError("BAD_REQUEST", {
+							message: SWARM_ERROR_CODES.NO_ACTIVE_SWARM,
+						});
+					}
+					const adapter = getSwmAdapter(ctx.context);
+					const member = await adapter.findMemberBySwmId({
+						userId: ctx.context.session.user.id,
+						swarmId: activeSwarmId,
+					});
+					if (!member) {
+						throw new APIError("UNAUTHORIZED", {
+							message:
+								SWARM_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_SWARM,
+						});
+					}
+					const role = roles[member.role as keyof typeof roles];
+					const result = role.authorize(ctx.body.permission as any);
+					if (result.error) {
+						return ctx.json(
+							{
+								error: result.error,
+								success: false,
+							},
+							{
+								status: 403,
+							},
+						);
+					}
+					return ctx.json({
+						error: null,
+						success: true,
+					});
+				},
+			),
+		},
+		schema: {
+			session: {
+				fields: {
+					activeSwarmId: {
+						type: "string",
+						required: false,
+						fieldName: options?.schema?.session?.fields?.activeSwarmId,
+					},
+				},
+			},
+			swarm: {
+				modelName: options?.schema?.swarm?.modelName,
+				fields: {
+					name: {
+						type: "string",
+						required: true,
+						fieldName: options?.schema?.swarm?.fields?.name,
+					},
+					slug: {
+						type: "string",
+						unique: true,
+						fieldName: options?.schema?.swarm?.fields?.slug,
+					},
+					logo: {
+						type: "string",
+						required: false,
+						fieldName: options?.schema?.swarm?.fields?.logo,
+					},
+					createdAt: {
+						type: "date",
+						required: true,
+						fieldName: options?.schema?.swarm?.fields?.createdAt,
+					},
+					metadata: {
+						type: "string",
+						required: false,
+						fieldName: options?.schema?.swarm?.fields?.metadata,
+					},
+				},
+			},
+			member: {
+				modelName: options?.schema?.member?.modelName,
+				fields: {
+					swarmId: {
+						type: "string",
+						required: true,
+						references: {
+							model: "swarm",
+							field: "id",
+						},
+						fieldName: options?.schema?.member?.fields?.swarmId,
+					},
+					userId: {
+						type: "string",
+						required: true,
+						fieldName: options?.schema?.member?.fields?.userId,
+						references: {
+							model: "user",
+							field: "id",
+						},
+					},
+					role: {
+						type: "string",
+						required: true,
+						defaultValue: "member",
+						fieldName: options?.schema?.member?.fields?.role,
+					},
+					createdAt: {
+						type: "date",
+						required: true,
+						fieldName: options?.schema?.member?.fields?.createdAt,
+					},
+				},
+			},
+			invitation: {
+				modelName: options?.schema?.invitation?.modelName,
+				fields: {
+					swarmId: {
+						type: "string",
+						required: true,
+						references: {
+							model: "swarm",
+							field: "id",
+						},
+						fieldName: options?.schema?.invitation?.fields?.swarmId,
+					},
+					email: {
+						type: "string",
+						required: true,
+						fieldName: options?.schema?.invitation?.fields?.email,
+					},
+					role: {
+						type: "string",
+						required: false,
+						fieldName: options?.schema?.invitation?.fields?.role,
+					},
+					status: {
+						type: "string",
+						required: true,
+						defaultValue: "pending",
+						fieldName: options?.schema?.invitation?.fields?.status,
+					},
+					expiresAt: {
+						type: "date",
+						required: true,
+						fieldName: options?.schema?.invitation?.fields?.expiresAt,
+					},
+					inviterId: {
+						type: "string",
+						references: {
+							model: "user",
+							field: "id",
+						},
+						fieldName: options?.schema?.invitation?.fields?.inviterId,
+						required: true,
+					},
+				},
+			},
+		},
+		$Infer: {
+			Swarm: {} as Swarm,
+			Invitation: {} as Invitation,
+			Member: {} as Member,
+			ActiveSwarm: {} as Prettify<
+				Swarm & {
+					members: Prettify<
+						Member & {
+							user: {
+								id: string;
+								name: string;
+								email: string;
+								image?: string | null;
+							};
+						}
+					>[];
+					invitations: Invitation[];
+				}
+			>,
+		},
+		$ERROR_CODES: SWARM_ERROR_CODES,
+	} satisfies BetterAuthPlugin;
+};


### PR DESCRIPTION
- Introduced a new plugin for swarm management, including functionalities to create, update, delete, and list swarms.
- Implemented member management features, allowing for adding, removing, and updating member roles within swarms.
- Added invitation handling capabilities, enabling users to invite others to join swarms and manage invitation statuses.
- Established access control mechanisms to ensure proper permissions for swarm operations.
- Included error handling with specific error codes for various swarm-related actions.
- Created a comprehensive test suite to validate the functionality of the swarm management features.