### PR TITLE
feat: add total users table/collection count to admin plugin list-users endpoint

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -12,7 +12,6 @@ import {
 	Mailbox,
 	NotebookPen,
 	Phone,
-	Plug,
 	ScanFace,
 	ShieldCheck,
 	UserCircle,

--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -126,6 +126,45 @@ const users = await authClient.admin.listUsers({
 });
 ```
 
+#### Pagination
+The `listUsers` function supports pagination by returning metadata alongside the user list. The response includes the following fields:  
+
+```ts
+{
+  users: User[],   // Array of returned users
+  total: number,   // Total number of users after filters and search queries
+  limit: number | undefined,   // The limit provided in the query
+  offset: number | undefined   // The offset provided in the query
+}
+
+##### How to Implement Pagination  
+
+To paginate results, use the `total`, `limit`, and `offset` values to calculate:  
+
+- **Total pages:** `Math.ceil(total / limit)`  
+- **Current page:** `(offset / limit) + 1`  
+- **Next page offset:** `Math.min(offset + limit, (total - 1))` – The value to use as `offset` for the next page, ensuring it does not exceed the total number of pages.
+- **Previous page offset:** `Math.max(0, offset - limit)` – The value to use as `offset` for the previous page (ensuring it doesn’t go below zero).
+
+##### Example Usage  
+
+Fetching the second page with 10 users per page:  
+
+```ts title="admin.ts"
+const pageSize = 10;
+const currentPage = 2;
+
+const users = await authClient.admin.listUsers({
+    query: {
+        limit: pageSize,
+        offset: (currentPage - 1) * pageSize
+    }
+});
+
+const totalUsers = users.total;
+const totalPages = Math.ceil(totalUsers / limit)
+```
+
 ### Set User Role
 
 Changes the role of a user.

--- a/packages/better-auth/src/__snapshots__/init.test.ts.snap
+++ b/packages/better-auth/src/__snapshots__/init.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`init > should match config 1`] = `
 {
   "adapter": {
+    "count": [Function],
     "create": [Function],
     "delete": [Function],
     "deleteMany": [Function],
@@ -51,6 +52,7 @@ exports[`init > should match config 1`] = `
   "createAuthCookie": [Function],
   "generateId": [Function],
   "internalAdapter": {
+    "countTotalUsers": [Function],
     "createAccount": [Function],
     "createOAuthUser": [Function],
     "createSession": [Function],

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, like, or, SQL } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, like, or, SQL } from "drizzle-orm";
 import { getAuthTables } from "../../db";
 import { BetterAuthError } from "../../error";
 import type { Adapter, BetterAuthOptions, Where } from "../../types";
@@ -290,10 +290,10 @@ export const drizzleAdapter =
 				const schemaModel = getSchema(model);
 				const clause = where ? convertWhereClause(where, model) : [];
 				const res = await db
-					.select()
+					.select({ count: count() })
 					.from(schemaModel)
 					.where(...clause);
-				return res.length;
+				return res.count;
 			},
 			async update(data) {
 				const { model, where, update: values } = data;

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -285,6 +285,16 @@ export const drizzleAdapter =
 				const res = (await builder.where(...clause)) as any[];
 				return res.map((r) => transformOutput(r, model));
 			},
+			async count(data) {
+				const { model, where } = data;
+				const schemaModel = getSchema(model);
+				const clause = where ? convertWhereClause(where, model) : [];
+				const res = await db
+					.select()
+					.from(schemaModel)
+					.where(...clause);
+				return res.length;
+			},
 			async update(data) {
 				const { model, where, update: values } = data;
 				const schemaModel = getSchema(model);

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -6,360 +6,360 @@ import type { KyselyDatabaseType } from "./types";
 import type { InsertQueryBuilder, Kysely, UpdateQueryBuilder } from "kysely";
 
 interface KyselyAdapterConfig {
-  /**
-   * Database type.
-   */
-  type?: KyselyDatabaseType;
+	/**
+	 * Database type.
+	 */
+	type?: KyselyDatabaseType;
 }
 
 const createTransform = (
-  db: Kysely<any>,
-  options: BetterAuthOptions,
-  config?: KyselyAdapterConfig,
+	db: Kysely<any>,
+	options: BetterAuthOptions,
+	config?: KyselyAdapterConfig,
 ) => {
-  const schema = getAuthTables(options);
+	const schema = getAuthTables(options);
 
-  function getField(model: string, field: string) {
-    if (field === "id") {
-      return field;
-    }
-    const f = schema[model].fields[field];
-    if (!f) {
-      console.log("Field not found", model, field);
-    }
-    return f.fieldName || field;
-  }
+	function getField(model: string, field: string) {
+		if (field === "id") {
+			return field;
+		}
+		const f = schema[model].fields[field];
+		if (!f) {
+			console.log("Field not found", model, field);
+		}
+		return f.fieldName || field;
+	}
 
-  function transformValueToDB(value: any, model: string, field: string) {
-    const { type = "sqlite" } = config || {};
-    const f = schema[model].fields[field];
-    if (
-      f.type === "boolean" &&
-      type === "sqlite" &&
-      value !== null &&
-      value !== undefined
-    ) {
-      return value ? 1 : 0;
-    }
-    if (f.type === "date" && value && value instanceof Date) {
-      return type === "sqlite" ? value.toISOString() : value;
-    }
-    return value;
-  }
+	function transformValueToDB(value: any, model: string, field: string) {
+		const { type = "sqlite" } = config || {};
+		const f = schema[model].fields[field];
+		if (
+			f.type === "boolean" &&
+			type === "sqlite" &&
+			value !== null &&
+			value !== undefined
+		) {
+			return value ? 1 : 0;
+		}
+		if (f.type === "date" && value && value instanceof Date) {
+			return type === "sqlite" ? value.toISOString() : value;
+		}
+		return value;
+	}
 
-  function transformValueFromDB(value: any, model: string, field: string) {
-    const { type = "sqlite" } = config || {};
+	function transformValueFromDB(value: any, model: string, field: string) {
+		const { type = "sqlite" } = config || {};
 
-    const f = schema[model].fields[field];
-    if (f.type === "boolean" && type === "sqlite" && value !== null) {
-      return value === 1;
-    }
-    if (f.type === "date" && value) {
-      return new Date(value);
-    }
-    return value;
-  }
+		const f = schema[model].fields[field];
+		if (f.type === "boolean" && type === "sqlite" && value !== null) {
+			return value === 1;
+		}
+		if (f.type === "date" && value) {
+			return new Date(value);
+		}
+		return value;
+	}
 
-  function getModelName(model: string) {
-    return schema[model].modelName;
-  }
+	function getModelName(model: string) {
+		return schema[model].modelName;
+	}
 
-  const useDatabaseGeneratedId = options?.advanced?.generateId === false;
-  return {
-    transformInput(
-      data: Record<string, any>,
-      model: string,
-      action: "create" | "update",
-    ) {
-      const transformedData: Record<string, any> =
-        useDatabaseGeneratedId || action === "update"
-          ? {}
-          : {
-              id: options.advanced?.generateId
-                ? options.advanced.generateId({
-                    model,
-                  })
-                : data.id || generateId(),
-            };
-      const fields = schema[model].fields;
-      for (const field in fields) {
-        const value = data[field];
-        transformedData[fields[field].fieldName || field] = withApplyDefault(
-          transformValueToDB(value, model, field),
-          fields[field],
-          action,
-        );
-      }
-      return transformedData;
-    },
-    transformOutput(
-      data: Record<string, any>,
-      model: string,
-      select: string[] = [],
-    ) {
-      if (!data) return null;
-      const transformedData: Record<string, any> = data.id
-        ? select.length === 0 || select.includes("id")
-          ? {
-              id: data.id,
-            }
-          : {}
-        : {};
-      const tableSchema = schema[model].fields;
-      for (const key in tableSchema) {
-        if (select.length && !select.includes(key)) {
-          continue;
-        }
-        const field = tableSchema[key];
-        if (field) {
-          transformedData[key] = transformValueFromDB(
-            data[field.fieldName || key],
-            model,
-            key,
-          );
-        }
-      }
-      return transformedData as any;
-    },
-    convertWhereClause(model: string, w?: Where[]) {
-      if (!w)
-        return {
-          and: null,
-          or: null,
-        };
+	const useDatabaseGeneratedId = options?.advanced?.generateId === false;
+	return {
+		transformInput(
+			data: Record<string, any>,
+			model: string,
+			action: "create" | "update",
+		) {
+			const transformedData: Record<string, any> =
+				useDatabaseGeneratedId || action === "update"
+					? {}
+					: {
+							id: options.advanced?.generateId
+								? options.advanced.generateId({
+										model,
+									})
+								: data.id || generateId(),
+						};
+			const fields = schema[model].fields;
+			for (const field in fields) {
+				const value = data[field];
+				transformedData[fields[field].fieldName || field] = withApplyDefault(
+					transformValueToDB(value, model, field),
+					fields[field],
+					action,
+				);
+			}
+			return transformedData;
+		},
+		transformOutput(
+			data: Record<string, any>,
+			model: string,
+			select: string[] = [],
+		) {
+			if (!data) return null;
+			const transformedData: Record<string, any> = data.id
+				? select.length === 0 || select.includes("id")
+					? {
+							id: data.id,
+						}
+					: {}
+				: {};
+			const tableSchema = schema[model].fields;
+			for (const key in tableSchema) {
+				if (select.length && !select.includes(key)) {
+					continue;
+				}
+				const field = tableSchema[key];
+				if (field) {
+					transformedData[key] = transformValueFromDB(
+						data[field.fieldName || key],
+						model,
+						key,
+					);
+				}
+			}
+			return transformedData as any;
+		},
+		convertWhereClause(model: string, w?: Where[]) {
+			if (!w)
+				return {
+					and: null,
+					or: null,
+				};
 
-      const conditions = {
-        and: [] as any[],
-        or: [] as any[],
-      };
+			const conditions = {
+				and: [] as any[],
+				or: [] as any[],
+			};
 
-      w.forEach((condition) => {
-        const {
-          field: _field,
-          value,
-          operator = "=",
-          connector = "AND",
-        } = condition;
-        const field = getField(model, _field);
-        const expr = (eb: any) => {
-          if (operator.toLowerCase() === "in") {
-            return eb(field, "in", Array.isArray(value) ? value : [value]);
-          }
+			w.forEach((condition) => {
+				const {
+					field: _field,
+					value,
+					operator = "=",
+					connector = "AND",
+				} = condition;
+				const field = getField(model, _field);
+				const expr = (eb: any) => {
+					if (operator.toLowerCase() === "in") {
+						return eb(field, "in", Array.isArray(value) ? value : [value]);
+					}
 
-          if (operator === "contains") {
-            return eb(field, "like", `%${value}%`);
-          }
+					if (operator === "contains") {
+						return eb(field, "like", `%${value}%`);
+					}
 
-          if (operator === "starts_with") {
-            return eb(field, "like", `${value}%`);
-          }
+					if (operator === "starts_with") {
+						return eb(field, "like", `${value}%`);
+					}
 
-          if (operator === "ends_with") {
-            return eb(field, "like", `%${value}`);
-          }
+					if (operator === "ends_with") {
+						return eb(field, "like", `%${value}`);
+					}
 
-          if (operator === "eq") {
-            return eb(field, "=", value);
-          }
+					if (operator === "eq") {
+						return eb(field, "=", value);
+					}
 
-          if (operator === "ne") {
-            return eb(field, "<>", value);
-          }
+					if (operator === "ne") {
+						return eb(field, "<>", value);
+					}
 
-          if (operator === "gt") {
-            return eb(field, ">", value);
-          }
+					if (operator === "gt") {
+						return eb(field, ">", value);
+					}
 
-          if (operator === "gte") {
-            return eb(field, ">=", value);
-          }
+					if (operator === "gte") {
+						return eb(field, ">=", value);
+					}
 
-          if (operator === "lt") {
-            return eb(field, "<", value);
-          }
+					if (operator === "lt") {
+						return eb(field, "<", value);
+					}
 
-          if (operator === "lte") {
-            return eb(field, "<=", value);
-          }
+					if (operator === "lte") {
+						return eb(field, "<=", value);
+					}
 
-          return eb(field, operator, value);
-        };
+					return eb(field, operator, value);
+				};
 
-        if (connector === "OR") {
-          conditions.or.push(expr);
-        } else {
-          conditions.and.push(expr);
-        }
-      });
+				if (connector === "OR") {
+					conditions.or.push(expr);
+				} else {
+					conditions.and.push(expr);
+				}
+			});
 
-      return {
-        and: conditions.and.length ? conditions.and : null,
-        or: conditions.or.length ? conditions.or : null,
-      };
-    },
-    async withReturning(
-      values: Record<string, any>,
-      builder:
-        | InsertQueryBuilder<any, any, any>
-        | UpdateQueryBuilder<any, string, string, any>,
-      model: string,
-      where: Where[],
-    ) {
-      let res: any;
-      if (config?.type !== "mysql") {
-        res = await builder.returningAll().executeTakeFirst();
-      } else {
-        //this isn't good, but kysely doesn't support returning in mysql and it doesn't return the inserted id. Change this if there is a better way.
-        await builder.execute();
-        const field = values.id ? "id" : where[0].field ? where[0].field : "id";
-        const value = values[field] || where[0].value;
-        res = await db
-          .selectFrom(getModelName(model))
-          .selectAll()
-          .where(getField(model, field), "=", value)
-          .executeTakeFirst();
-      }
-      return res;
-    },
-    getModelName,
-    getField,
-  };
+			return {
+				and: conditions.and.length ? conditions.and : null,
+				or: conditions.or.length ? conditions.or : null,
+			};
+		},
+		async withReturning(
+			values: Record<string, any>,
+			builder:
+				| InsertQueryBuilder<any, any, any>
+				| UpdateQueryBuilder<any, string, string, any>,
+			model: string,
+			where: Where[],
+		) {
+			let res: any;
+			if (config?.type !== "mysql") {
+				res = await builder.returningAll().executeTakeFirst();
+			} else {
+				//this isn't good, but kysely doesn't support returning in mysql and it doesn't return the inserted id. Change this if there is a better way.
+				await builder.execute();
+				const field = values.id ? "id" : where[0].field ? where[0].field : "id";
+				const value = values[field] || where[0].value;
+				res = await db
+					.selectFrom(getModelName(model))
+					.selectAll()
+					.where(getField(model, field), "=", value)
+					.executeTakeFirst();
+			}
+			return res;
+		},
+		getModelName,
+		getField,
+	};
 };
 
 export const kyselyAdapter =
-  (db: Kysely<any>, config?: KyselyAdapterConfig) =>
-  (opts: BetterAuthOptions) => {
-    const {
-      transformInput,
-      withReturning,
-      transformOutput,
-      convertWhereClause,
-      getModelName,
-      getField,
-    } = createTransform(db, opts, config);
-    return {
-      id: "kysely",
-      async create(data) {
-        const { model, data: values, select } = data;
-        const transformed = transformInput(values, model, "create");
-        const builder = db.insertInto(getModelName(model)).values(transformed);
-        return transformOutput(
-          await withReturning(transformed, builder, model, []),
-          model,
-          select,
-        );
-      },
-      async findOne(data) {
-        const { model, where, select } = data;
-        const { and, or } = convertWhereClause(model, where);
-        let query = db.selectFrom(getModelName(model)).selectAll();
-        if (and) {
-          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-        }
-        if (or) {
-          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-        }
-        const res = await query.executeTakeFirst();
-        if (!res) return null;
-        return transformOutput(res, model, select);
-      },
-      async findMany(data) {
-        const { model, where, limit, offset, sortBy } = data;
-        const { and, or } = convertWhereClause(model, where);
-        let query = db.selectFrom(getModelName(model));
-        if (and) {
-          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-        }
-        if (or) {
-          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-        }
-        query = query.limit(limit || 100);
-        if (offset) {
-          query = query.offset(offset);
-        }
-        if (sortBy) {
-          query = query.orderBy(
-            getField(model, sortBy.field),
-            sortBy.direction,
-          );
-        }
-        const res = await query.selectAll().execute();
-        if (!res) return [];
-        return res.map((r) => transformOutput(r, model));
-      },
-      async update(data) {
-        const { model, where, update: values } = data;
-        const { and, or } = convertWhereClause(model, where);
-        const transformedData = transformInput(values, model, "update");
+	(db: Kysely<any>, config?: KyselyAdapterConfig) =>
+	(opts: BetterAuthOptions) => {
+		const {
+			transformInput,
+			withReturning,
+			transformOutput,
+			convertWhereClause,
+			getModelName,
+			getField,
+		} = createTransform(db, opts, config);
+		return {
+			id: "kysely",
+			async create(data) {
+				const { model, data: values, select } = data;
+				const transformed = transformInput(values, model, "create");
+				const builder = db.insertInto(getModelName(model)).values(transformed);
+				return transformOutput(
+					await withReturning(transformed, builder, model, []),
+					model,
+					select,
+				);
+			},
+			async findOne(data) {
+				const { model, where, select } = data;
+				const { and, or } = convertWhereClause(model, where);
+				let query = db.selectFrom(getModelName(model)).selectAll();
+				if (and) {
+					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+				}
+				if (or) {
+					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+				}
+				const res = await query.executeTakeFirst();
+				if (!res) return null;
+				return transformOutput(res, model, select);
+			},
+			async findMany(data) {
+				const { model, where, limit, offset, sortBy } = data;
+				const { and, or } = convertWhereClause(model, where);
+				let query = db.selectFrom(getModelName(model));
+				if (and) {
+					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+				}
+				if (or) {
+					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+				}
+				query = query.limit(limit || 100);
+				if (offset) {
+					query = query.offset(offset);
+				}
+				if (sortBy) {
+					query = query.orderBy(
+						getField(model, sortBy.field),
+						sortBy.direction,
+					);
+				}
+				const res = await query.selectAll().execute();
+				if (!res) return [];
+				return res.map((r) => transformOutput(r, model));
+			},
+			async update(data) {
+				const { model, where, update: values } = data;
+				const { and, or } = convertWhereClause(model, where);
+				const transformedData = transformInput(values, model, "update");
 
-        let query = db.updateTable(getModelName(model)).set(transformedData);
-        if (and) {
-          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-        }
-        if (or) {
-          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-        }
-        const res = await transformOutput(
-          await withReturning(transformedData, query, model, where),
-          model,
-        );
-        return res;
-      },
-      async updateMany(data) {
-        const { model, where, update: values } = data;
-        const { and, or } = convertWhereClause(model, where);
-        const transformedData = transformInput(values, model, "update");
-        let query = db.updateTable(getModelName(model)).set(transformedData);
-        if (and) {
-          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-        }
-        if (or) {
-          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-        }
-        const res = await query.execute();
-        return res.length;
-      },
-      async count(data) {
-        const { model, where } = data;
-        const { and, or } = convertWhereClause(model, where);
-        let query = db
-          .selectFrom(getModelName(model))
-          // a temporal solution for counting other than "*" - see more - https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted
-          .select(db.fn.count("id").as("count"));
-        if (and) {
-          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-        }
-        if (or) {
-          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-        }
-        const res = await query.execute();
-        return res[0].count as number;
-      },
-      async delete(data) {
-        const { model, where } = data;
-        const { and, or } = convertWhereClause(model, where);
-        let query = db.deleteFrom(getModelName(model));
-        if (and) {
-          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-        }
+				let query = db.updateTable(getModelName(model)).set(transformedData);
+				if (and) {
+					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+				}
+				if (or) {
+					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+				}
+				const res = await transformOutput(
+					await withReturning(transformedData, query, model, where),
+					model,
+				);
+				return res;
+			},
+			async updateMany(data) {
+				const { model, where, update: values } = data;
+				const { and, or } = convertWhereClause(model, where);
+				const transformedData = transformInput(values, model, "update");
+				let query = db.updateTable(getModelName(model)).set(transformedData);
+				if (and) {
+					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+				}
+				if (or) {
+					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+				}
+				const res = await query.execute();
+				return res.length;
+			},
+			async count(data) {
+				const { model, where } = data;
+				const { and, or } = convertWhereClause(model, where);
+				let query = db
+					.selectFrom(getModelName(model))
+					// a temporal solution for counting other than "*" - see more - https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted
+					.select(db.fn.count("id").as("count"));
+				if (and) {
+					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+				}
+				if (or) {
+					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+				}
+				const res = await query.execute();
+				return res[0].count as number;
+			},
+			async delete(data) {
+				const { model, where } = data;
+				const { and, or } = convertWhereClause(model, where);
+				let query = db.deleteFrom(getModelName(model));
+				if (and) {
+					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+				}
 
-        if (or) {
-          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-        }
-        await query.execute();
-      },
-      async deleteMany(data) {
-        const { model, where } = data;
-        const { and, or } = convertWhereClause(model, where);
-        let query = db.deleteFrom(getModelName(model));
-        if (and) {
-          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-        }
-        if (or) {
-          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-        }
-        return (await query.execute()).length;
-      },
-      options: config,
-    } satisfies Adapter;
-  };
+				if (or) {
+					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+				}
+				await query.execute();
+			},
+			async deleteMany(data) {
+				const { model, where } = data;
+				const { and, or } = convertWhereClause(model, where);
+				let query = db.deleteFrom(getModelName(model));
+				if (and) {
+					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+				}
+				if (or) {
+					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+				}
+				return (await query.execute()).length;
+			},
+			options: config,
+		} satisfies Adapter;
+	};

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -6,359 +6,360 @@ import type { KyselyDatabaseType } from "./types";
 import type { InsertQueryBuilder, Kysely, UpdateQueryBuilder } from "kysely";
 
 interface KyselyAdapterConfig {
-	/**
-	 * Database type.
-	 */
-	type?: KyselyDatabaseType;
+  /**
+   * Database type.
+   */
+  type?: KyselyDatabaseType;
 }
 
 const createTransform = (
-	db: Kysely<any>,
-	options: BetterAuthOptions,
-	config?: KyselyAdapterConfig,
+  db: Kysely<any>,
+  options: BetterAuthOptions,
+  config?: KyselyAdapterConfig,
 ) => {
-	const schema = getAuthTables(options);
+  const schema = getAuthTables(options);
 
-	function getField(model: string, field: string) {
-		if (field === "id") {
-			return field;
-		}
-		const f = schema[model].fields[field];
-		if (!f) {
-			console.log("Field not found", model, field);
-		}
-		return f.fieldName || field;
-	}
+  function getField(model: string, field: string) {
+    if (field === "id") {
+      return field;
+    }
+    const f = schema[model].fields[field];
+    if (!f) {
+      console.log("Field not found", model, field);
+    }
+    return f.fieldName || field;
+  }
 
-	function transformValueToDB(value: any, model: string, field: string) {
-		const { type = "sqlite" } = config || {};
-		const f = schema[model].fields[field];
-		if (
-			f.type === "boolean" &&
-			type === "sqlite" &&
-			value !== null &&
-			value !== undefined
-		) {
-			return value ? 1 : 0;
-		}
-		if (f.type === "date" && value && value instanceof Date) {
-			return type === "sqlite" ? value.toISOString() : value;
-		}
-		return value;
-	}
+  function transformValueToDB(value: any, model: string, field: string) {
+    const { type = "sqlite" } = config || {};
+    const f = schema[model].fields[field];
+    if (
+      f.type === "boolean" &&
+      type === "sqlite" &&
+      value !== null &&
+      value !== undefined
+    ) {
+      return value ? 1 : 0;
+    }
+    if (f.type === "date" && value && value instanceof Date) {
+      return type === "sqlite" ? value.toISOString() : value;
+    }
+    return value;
+  }
 
-	function transformValueFromDB(value: any, model: string, field: string) {
-		const { type = "sqlite" } = config || {};
+  function transformValueFromDB(value: any, model: string, field: string) {
+    const { type = "sqlite" } = config || {};
 
-		const f = schema[model].fields[field];
-		if (f.type === "boolean" && type === "sqlite" && value !== null) {
-			return value === 1;
-		}
-		if (f.type === "date" && value) {
-			return new Date(value);
-		}
-		return value;
-	}
+    const f = schema[model].fields[field];
+    if (f.type === "boolean" && type === "sqlite" && value !== null) {
+      return value === 1;
+    }
+    if (f.type === "date" && value) {
+      return new Date(value);
+    }
+    return value;
+  }
 
-	function getModelName(model: string) {
-		return schema[model].modelName;
-	}
+  function getModelName(model: string) {
+    return schema[model].modelName;
+  }
 
-	const useDatabaseGeneratedId = options?.advanced?.generateId === false;
-	return {
-		transformInput(
-			data: Record<string, any>,
-			model: string,
-			action: "create" | "update",
-		) {
-			const transformedData: Record<string, any> =
-				useDatabaseGeneratedId || action === "update"
-					? {}
-					: {
-							id: options.advanced?.generateId
-								? options.advanced.generateId({
-										model,
-									})
-								: data.id || generateId(),
-						};
-			const fields = schema[model].fields;
-			for (const field in fields) {
-				const value = data[field];
-				transformedData[fields[field].fieldName || field] = withApplyDefault(
-					transformValueToDB(value, model, field),
-					fields[field],
-					action,
-				);
-			}
-			return transformedData;
-		},
-		transformOutput(
-			data: Record<string, any>,
-			model: string,
-			select: string[] = [],
-		) {
-			if (!data) return null;
-			const transformedData: Record<string, any> = data.id
-				? select.length === 0 || select.includes("id")
-					? {
-							id: data.id,
-						}
-					: {}
-				: {};
-			const tableSchema = schema[model].fields;
-			for (const key in tableSchema) {
-				if (select.length && !select.includes(key)) {
-					continue;
-				}
-				const field = tableSchema[key];
-				if (field) {
-					transformedData[key] = transformValueFromDB(
-						data[field.fieldName || key],
-						model,
-						key,
-					);
-				}
-			}
-			return transformedData as any;
-		},
-		convertWhereClause(model: string, w?: Where[]) {
-			if (!w)
-				return {
-					and: null,
-					or: null,
-				};
+  const useDatabaseGeneratedId = options?.advanced?.generateId === false;
+  return {
+    transformInput(
+      data: Record<string, any>,
+      model: string,
+      action: "create" | "update",
+    ) {
+      const transformedData: Record<string, any> =
+        useDatabaseGeneratedId || action === "update"
+          ? {}
+          : {
+              id: options.advanced?.generateId
+                ? options.advanced.generateId({
+                    model,
+                  })
+                : data.id || generateId(),
+            };
+      const fields = schema[model].fields;
+      for (const field in fields) {
+        const value = data[field];
+        transformedData[fields[field].fieldName || field] = withApplyDefault(
+          transformValueToDB(value, model, field),
+          fields[field],
+          action,
+        );
+      }
+      return transformedData;
+    },
+    transformOutput(
+      data: Record<string, any>,
+      model: string,
+      select: string[] = [],
+    ) {
+      if (!data) return null;
+      const transformedData: Record<string, any> = data.id
+        ? select.length === 0 || select.includes("id")
+          ? {
+              id: data.id,
+            }
+          : {}
+        : {};
+      const tableSchema = schema[model].fields;
+      for (const key in tableSchema) {
+        if (select.length && !select.includes(key)) {
+          continue;
+        }
+        const field = tableSchema[key];
+        if (field) {
+          transformedData[key] = transformValueFromDB(
+            data[field.fieldName || key],
+            model,
+            key,
+          );
+        }
+      }
+      return transformedData as any;
+    },
+    convertWhereClause(model: string, w?: Where[]) {
+      if (!w)
+        return {
+          and: null,
+          or: null,
+        };
 
-			const conditions = {
-				and: [] as any[],
-				or: [] as any[],
-			};
+      const conditions = {
+        and: [] as any[],
+        or: [] as any[],
+      };
 
-			w.forEach((condition) => {
-				const {
-					field: _field,
-					value,
-					operator = "=",
-					connector = "AND",
-				} = condition;
-				const field = getField(model, _field);
-				const expr = (eb: any) => {
-					if (operator.toLowerCase() === "in") {
-						return eb(field, "in", Array.isArray(value) ? value : [value]);
-					}
+      w.forEach((condition) => {
+        const {
+          field: _field,
+          value,
+          operator = "=",
+          connector = "AND",
+        } = condition;
+        const field = getField(model, _field);
+        const expr = (eb: any) => {
+          if (operator.toLowerCase() === "in") {
+            return eb(field, "in", Array.isArray(value) ? value : [value]);
+          }
 
-					if (operator === "contains") {
-						return eb(field, "like", `%${value}%`);
-					}
+          if (operator === "contains") {
+            return eb(field, "like", `%${value}%`);
+          }
 
-					if (operator === "starts_with") {
-						return eb(field, "like", `${value}%`);
-					}
+          if (operator === "starts_with") {
+            return eb(field, "like", `${value}%`);
+          }
 
-					if (operator === "ends_with") {
-						return eb(field, "like", `%${value}`);
-					}
+          if (operator === "ends_with") {
+            return eb(field, "like", `%${value}`);
+          }
 
-					if (operator === "eq") {
-						return eb(field, "=", value);
-					}
+          if (operator === "eq") {
+            return eb(field, "=", value);
+          }
 
-					if (operator === "ne") {
-						return eb(field, "<>", value);
-					}
+          if (operator === "ne") {
+            return eb(field, "<>", value);
+          }
 
-					if (operator === "gt") {
-						return eb(field, ">", value);
-					}
+          if (operator === "gt") {
+            return eb(field, ">", value);
+          }
 
-					if (operator === "gte") {
-						return eb(field, ">=", value);
-					}
+          if (operator === "gte") {
+            return eb(field, ">=", value);
+          }
 
-					if (operator === "lt") {
-						return eb(field, "<", value);
-					}
+          if (operator === "lt") {
+            return eb(field, "<", value);
+          }
 
-					if (operator === "lte") {
-						return eb(field, "<=", value);
-					}
+          if (operator === "lte") {
+            return eb(field, "<=", value);
+          }
 
-					return eb(field, operator, value);
-				};
+          return eb(field, operator, value);
+        };
 
-				if (connector === "OR") {
-					conditions.or.push(expr);
-				} else {
-					conditions.and.push(expr);
-				}
-			});
+        if (connector === "OR") {
+          conditions.or.push(expr);
+        } else {
+          conditions.and.push(expr);
+        }
+      });
 
-			return {
-				and: conditions.and.length ? conditions.and : null,
-				or: conditions.or.length ? conditions.or : null,
-			};
-		},
-		async withReturning(
-			values: Record<string, any>,
-			builder:
-				| InsertQueryBuilder<any, any, any>
-				| UpdateQueryBuilder<any, string, string, any>,
-			model: string,
-			where: Where[],
-		) {
-			let res: any;
-			if (config?.type !== "mysql") {
-				res = await builder.returningAll().executeTakeFirst();
-			} else {
-				//this isn't good, but kysely doesn't support returning in mysql and it doesn't return the inserted id. Change this if there is a better way.
-				await builder.execute();
-				const field = values.id ? "id" : where[0].field ? where[0].field : "id";
-				const value = values[field] || where[0].value;
-				res = await db
-					.selectFrom(getModelName(model))
-					.selectAll()
-					.where(getField(model, field), "=", value)
-					.executeTakeFirst();
-			}
-			return res;
-		},
-		getModelName,
-		getField,
-	};
+      return {
+        and: conditions.and.length ? conditions.and : null,
+        or: conditions.or.length ? conditions.or : null,
+      };
+    },
+    async withReturning(
+      values: Record<string, any>,
+      builder:
+        | InsertQueryBuilder<any, any, any>
+        | UpdateQueryBuilder<any, string, string, any>,
+      model: string,
+      where: Where[],
+    ) {
+      let res: any;
+      if (config?.type !== "mysql") {
+        res = await builder.returningAll().executeTakeFirst();
+      } else {
+        //this isn't good, but kysely doesn't support returning in mysql and it doesn't return the inserted id. Change this if there is a better way.
+        await builder.execute();
+        const field = values.id ? "id" : where[0].field ? where[0].field : "id";
+        const value = values[field] || where[0].value;
+        res = await db
+          .selectFrom(getModelName(model))
+          .selectAll()
+          .where(getField(model, field), "=", value)
+          .executeTakeFirst();
+      }
+      return res;
+    },
+    getModelName,
+    getField,
+  };
 };
 
 export const kyselyAdapter =
-	(db: Kysely<any>, config?: KyselyAdapterConfig) =>
-	(opts: BetterAuthOptions) => {
-		const {
-			transformInput,
-			withReturning,
-			transformOutput,
-			convertWhereClause,
-			getModelName,
-			getField,
-		} = createTransform(db, opts, config);
-		return {
-			id: "kysely",
-			async create(data) {
-				const { model, data: values, select } = data;
-				const transformed = transformInput(values, model, "create");
-				const builder = db.insertInto(getModelName(model)).values(transformed);
-				return transformOutput(
-					await withReturning(transformed, builder, model, []),
-					model,
-					select,
-				);
-			},
-			async findOne(data) {
-				const { model, where, select } = data;
-				const { and, or } = convertWhereClause(model, where);
-				let query = db.selectFrom(getModelName(model)).selectAll();
-				if (and) {
-					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-				}
-				if (or) {
-					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-				}
-				const res = await query.executeTakeFirst();
-				if (!res) return null;
-				return transformOutput(res, model, select);
-			},
-			async findMany(data) {
-				const { model, where, limit, offset, sortBy } = data;
-				const { and, or } = convertWhereClause(model, where);
-				let query = db.selectFrom(getModelName(model));
-				if (and) {
-					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-				}
-				if (or) {
-					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-				}
-				query = query.limit(limit || 100);
-				if (offset) {
-					query = query.offset(offset);
-				}
-				if (sortBy) {
-					query = query.orderBy(
-						getField(model, sortBy.field),
-						sortBy.direction,
-					);
-				}
-				const res = await query.selectAll().execute();
-				if (!res) return [];
-				return res.map((r) => transformOutput(r, model));
-			},
-			async update(data) {
-				const { model, where, update: values } = data;
-				const { and, or } = convertWhereClause(model, where);
-				const transformedData = transformInput(values, model, "update");
+  (db: Kysely<any>, config?: KyselyAdapterConfig) =>
+  (opts: BetterAuthOptions) => {
+    const {
+      transformInput,
+      withReturning,
+      transformOutput,
+      convertWhereClause,
+      getModelName,
+      getField,
+    } = createTransform(db, opts, config);
+    return {
+      id: "kysely",
+      async create(data) {
+        const { model, data: values, select } = data;
+        const transformed = transformInput(values, model, "create");
+        const builder = db.insertInto(getModelName(model)).values(transformed);
+        return transformOutput(
+          await withReturning(transformed, builder, model, []),
+          model,
+          select,
+        );
+      },
+      async findOne(data) {
+        const { model, where, select } = data;
+        const { and, or } = convertWhereClause(model, where);
+        let query = db.selectFrom(getModelName(model)).selectAll();
+        if (and) {
+          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+        }
+        if (or) {
+          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+        }
+        const res = await query.executeTakeFirst();
+        if (!res) return null;
+        return transformOutput(res, model, select);
+      },
+      async findMany(data) {
+        const { model, where, limit, offset, sortBy } = data;
+        const { and, or } = convertWhereClause(model, where);
+        let query = db.selectFrom(getModelName(model));
+        if (and) {
+          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+        }
+        if (or) {
+          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+        }
+        query = query.limit(limit || 100);
+        if (offset) {
+          query = query.offset(offset);
+        }
+        if (sortBy) {
+          query = query.orderBy(
+            getField(model, sortBy.field),
+            sortBy.direction,
+          );
+        }
+        const res = await query.selectAll().execute();
+        if (!res) return [];
+        return res.map((r) => transformOutput(r, model));
+      },
+      async update(data) {
+        const { model, where, update: values } = data;
+        const { and, or } = convertWhereClause(model, where);
+        const transformedData = transformInput(values, model, "update");
 
-				let query = db.updateTable(getModelName(model)).set(transformedData);
-				if (and) {
-					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-				}
-				if (or) {
-					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-				}
-				const res = await transformOutput(
-					await withReturning(transformedData, query, model, where),
-					model,
-				);
-				return res;
-			},
-			async updateMany(data) {
-				const { model, where, update: values } = data;
-				const { and, or } = convertWhereClause(model, where);
-				const transformedData = transformInput(values, model, "update");
-				let query = db.updateTable(getModelName(model)).set(transformedData);
-				if (and) {
-					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-				}
-				if (or) {
-					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-				}
-				const res = await query.execute();
-				return res.length;
-			},
-			async count(data) {
-				const { model, where } = data;
-				const { and, or } = convertWhereClause(model, where);
-				let query = db
-					.selectFrom(getModelName(model))
-					.select(db.fn.count("*").as("count"));
-				if (and) {
-					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-				}
-				if (or) {
-					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-				}
-				const res = await query.execute();
-				return res[0].count as number;
-			},
-			async delete(data) {
-				const { model, where } = data;
-				const { and, or } = convertWhereClause(model, where);
-				let query = db.deleteFrom(getModelName(model));
-				if (and) {
-					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-				}
+        let query = db.updateTable(getModelName(model)).set(transformedData);
+        if (and) {
+          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+        }
+        if (or) {
+          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+        }
+        const res = await transformOutput(
+          await withReturning(transformedData, query, model, where),
+          model,
+        );
+        return res;
+      },
+      async updateMany(data) {
+        const { model, where, update: values } = data;
+        const { and, or } = convertWhereClause(model, where);
+        const transformedData = transformInput(values, model, "update");
+        let query = db.updateTable(getModelName(model)).set(transformedData);
+        if (and) {
+          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+        }
+        if (or) {
+          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+        }
+        const res = await query.execute();
+        return res.length;
+      },
+      async count(data) {
+        const { model, where } = data;
+        const { and, or } = convertWhereClause(model, where);
+        let query = db
+          .selectFrom(getModelName(model))
+          // a temporal solution for counting other than "*" - see more - https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted
+          .select(db.fn.count("id").as("count"));
+        if (and) {
+          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+        }
+        if (or) {
+          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+        }
+        const res = await query.execute();
+        return res[0].count as number;
+      },
+      async delete(data) {
+        const { model, where } = data;
+        const { and, or } = convertWhereClause(model, where);
+        let query = db.deleteFrom(getModelName(model));
+        if (and) {
+          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+        }
 
-				if (or) {
-					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-				}
-				await query.execute();
-			},
-			async deleteMany(data) {
-				const { model, where } = data;
-				const { and, or } = convertWhereClause(model, where);
-				let query = db.deleteFrom(getModelName(model));
-				if (and) {
-					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
-				}
-				if (or) {
-					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
-				}
-				return (await query.execute()).length;
-			},
-			options: config,
-		} satisfies Adapter;
-	};
+        if (or) {
+          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+        }
+        await query.execute();
+      },
+      async deleteMany(data) {
+        const { model, where } = data;
+        const { and, or } = convertWhereClause(model, where);
+        let query = db.deleteFrom(getModelName(model));
+        if (and) {
+          query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+        }
+        if (or) {
+          query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+        }
+        return (await query.execute()).length;
+      },
+      options: config,
+    } satisfies Adapter;
+  };

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -319,6 +319,19 @@ export const kyselyAdapter =
 				const res = await query.execute();
 				return res.length;
 			},
+			async count(data) {
+				const { model, where } = data;
+				const { and, or } = convertWhereClause(model, where);
+				let query = db.selectFrom(getModelName(model)).selectAll();
+				if (and) {
+					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
+				}
+				if (or) {
+					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
+				}
+				const res = await query.execute();
+				return res.length;
+			},
 			async delete(data) {
 				const { model, where } = data;
 				const { and, or } = convertWhereClause(model, where);

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -322,7 +322,7 @@ export const kyselyAdapter =
 			async count(data) {
 				const { model, where } = data;
 				const { and, or } = convertWhereClause(model, where);
-				let query = db.selectFrom(getModelName(model)).selectAll();
+				let query = db.selectFrom(getModelName(model)).select(db.fn.count('*').as('count'));
 				if (and) {
 					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
 				}
@@ -330,7 +330,7 @@ export const kyselyAdapter =
 					query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
 				}
 				const res = await query.execute();
-				return res.length;
+				return res[0].count as number;
 			},
 			async delete(data) {
 				const { model, where } = data;

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -322,7 +322,9 @@ export const kyselyAdapter =
 			async count(data) {
 				const { model, where } = data;
 				const { and, or } = convertWhereClause(model, where);
-				let query = db.selectFrom(getModelName(model)).select(db.fn.count('*').as('count'));
+				let query = db
+					.selectFrom(getModelName(model))
+					.select(db.fn.count("*").as("count"));
 				if (and) {
 					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));
 				}

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -141,6 +141,9 @@ export const memoryAdapter = (db: MemoryDB) => (options: BetterAuthOptions) => {
 			}
 			return table.map((record) => transformOutput(record, model));
 		},
+		count: async ({ model }) => {
+			return db[model].length;
+		},
 		update: async ({ model, where, update }) => {
 			const table = db[model];
 			const res = convertWhereClause(where, table, model);

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -247,6 +247,13 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 			const res = await cursor.toArray();
 			return res.map((r) => transform.transformOutput(r, model));
 		},
+		async count(data) {
+			const { model } = data;
+			const res = await db
+				.collection(transform.getModelName(model))
+				.countDocuments();
+			return res;
+		},
 		async update(data) {
 			const { model, where, update: values } = data;
 			const clause = transform.convertWhereClause(where, model);

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -245,13 +245,10 @@ export const prismaAdapter =
 						`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
 					);
 				}
-				const result = await db[getModelName(model)].findMany({
+				const result = await db[getModelName(model)].count({
 					where: whereClause,
-					select: {
-						id: true,
-					},
 				});
-				return result.length;
+				return result;
 			},
 			async update(data) {
 				const { model, where, update } = data;

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -237,6 +237,22 @@ export const prismaAdapter =
 				})) as any[];
 				return result.map((r) => transformOutput(r, model));
 			},
+			async count(data) {
+				const { model, where } = data;
+				const whereClause = convertWhereClause(model, where);
+				if (!db[getModelName(model)]) {
+					throw new BetterAuthError(
+						`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
+					);
+				}
+				const result = await db[getModelName(model)].findMany({
+					where: whereClause,
+					select: {
+						id: true,
+					},
+				});
+				return result.length;
+			},
 			async update(data) {
 				const { model, where, update } = data;
 				if (!db[getModelName(model)]) {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -143,6 +143,12 @@ export const createInternalAdapter = (
 			});
 			return users;
 		},
+		countTotalUsers: async () => {
+			const total = await adapter.count({
+				model: "user",
+			});
+			return total;
+		},
 		deleteUser: async (userId: string) => {
 			await adapter.deleteMany({
 				model: "session",

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -4,374 +4,374 @@ import { admin, type UserWithRole } from ".";
 import { adminClient } from "./client";
 
 describe("Admin plugin", async () => {
-  const { client, signInWithTestUser, signInWithUser, cookieSetter } =
-    await getTestInstance(
-      {
-        plugins: [admin()],
-        databaseHooks: {
-          user: {
-            create: {
-              before: async (user) => {
-                if (user.name === "Admin") {
-                  return {
-                    data: {
-                      ...user,
-                      role: "admin",
-                    },
-                  };
-                }
-              },
-            },
-          },
-        },
-      },
-      {
-        testUser: {
-          name: "Admin",
-        },
-        clientOptions: {
-          plugins: [adminClient()],
-        },
-      },
-    );
-  const { headers: adminHeaders } = await signInWithTestUser();
-  let newUser: UserWithRole | undefined;
+	const { client, signInWithTestUser, signInWithUser, cookieSetter } =
+		await getTestInstance(
+			{
+				plugins: [admin()],
+				databaseHooks: {
+					user: {
+						create: {
+							before: async (user) => {
+								if (user.name === "Admin") {
+									return {
+										data: {
+											...user,
+											role: "admin",
+										},
+									};
+								}
+							},
+						},
+					},
+				},
+			},
+			{
+				testUser: {
+					name: "Admin",
+				},
+				clientOptions: {
+					plugins: [adminClient()],
+				},
+			},
+		);
+	const { headers: adminHeaders } = await signInWithTestUser();
+	let newUser: UserWithRole | undefined;
 
-  it("should allow admin to create users", async () => {
-    const res = await client.admin.createUser(
-      {
-        name: "Test User",
-        email: "test2@test.com",
-        password: "test",
-        role: "user",
-      },
-      {
-        headers: adminHeaders,
-      },
-    );
-    newUser = res.data?.user;
+	it("should allow admin to create users", async () => {
+		const res = await client.admin.createUser(
+			{
+				name: "Test User",
+				email: "test2@test.com",
+				password: "test",
+				role: "user",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		newUser = res.data?.user;
 
-    expect(newUser?.role).toBe("user");
-  });
+		expect(newUser?.role).toBe("user");
+	});
 
-  it("should allow admin to list users", async () => {
-    const res = await client.admin.listUsers({
-      query: {
-        limit: 2,
-      },
-      fetchOptions: {
-        headers: adminHeaders,
-      },
-    });
-    expect(res.data?.users.length).toBe(2);
-  });
+	it("should allow admin to list users", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				limit: 2,
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data?.users.length).toBe(2);
+	});
 
-  it("should allow admin to count users", async () => {
-    const res = await client.admin.listUsers({
-      query: {
-        limit: 2,
-      },
-      fetchOptions: {
-        headers: adminHeaders,
-      },
-    });
-    expect(res.data?.total).toBe(2);
-  });
+	it("should allow admin to count users", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				limit: 2,
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data?.total).toBe(2);
+	});
 
-  it("should allow to sort users by name", async () => {
-    const res = await client.admin.listUsers({
-      query: {
-        sortBy: "name",
-        sortDirection: "desc",
-      },
-      fetchOptions: {
-        headers: adminHeaders,
-      },
-    });
+	it("should allow to sort users by name", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				sortBy: "name",
+				sortDirection: "desc",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
 
-    expect(res.data?.users[0].name).toBe("Test User");
+		expect(res.data?.users[0].name).toBe("Test User");
 
-    const res2 = await client.admin.listUsers({
-      query: {
-        sortBy: "name",
-        sortDirection: "asc",
-      },
-      fetchOptions: {
-        headers: adminHeaders,
-      },
-    });
-    expect(res2.data?.users[0].name).toBe("Admin");
-  });
+		const res2 = await client.admin.listUsers({
+			query: {
+				sortBy: "name",
+				sortDirection: "asc",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res2.data?.users[0].name).toBe("Admin");
+	});
 
-  it("should allow offset and limit", async () => {
-    const res = await client.admin.listUsers({
-      query: {
-        limit: 1,
-        offset: 1,
-      },
-      fetchOptions: {
-        headers: adminHeaders,
-      },
-    });
-    expect(res.data?.users.length).toBe(1);
-    expect(res.data?.users[0].name).toBe("Test User");
-  });
+	it("should allow offset and limit", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				limit: 1,
+				offset: 1,
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data?.users.length).toBe(1);
+		expect(res.data?.users[0].name).toBe("Test User");
+	});
 
-  it("should allow to search users by name", async () => {
-    const res = await client.admin.listUsers({
-      query: {
-        searchValue: "Admin",
-        searchField: "name",
-        searchOperator: "contains",
-      },
-      fetchOptions: {
-        headers: adminHeaders,
-      },
-    });
-    expect(res.data?.users.length).toBe(1);
-  });
+	it("should allow to search users by name", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				searchValue: "Admin",
+				searchField: "name",
+				searchOperator: "contains",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data?.users.length).toBe(1);
+	});
 
-  it("should allow to filter users by role", async () => {
-    const res = await client.admin.listUsers({
-      query: {
-        filterValue: "admin",
-        filterField: "role",
-        filterOperator: "eq",
-      },
-      fetchOptions: {
-        headers: adminHeaders,
-      },
-    });
-    expect(res.data?.users.length).toBe(1);
-  });
+	it("should allow to filter users by role", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				filterValue: "admin",
+				filterField: "role",
+				filterOperator: "eq",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data?.users.length).toBe(1);
+	});
 
-  it("should allow to set user role", async () => {
-    const res = await client.admin.setRole(
-      {
-        userId: newUser?.id || "",
-        role: "admin",
-      },
-      {
-        headers: adminHeaders,
-      },
-    );
-    expect(res.data?.user?.role).toBe("admin");
-  });
+	it("should allow to set user role", async () => {
+		const res = await client.admin.setRole(
+			{
+				userId: newUser?.id || "",
+				role: "admin",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.user?.role).toBe("admin");
+	});
 
-  it("should allow to ban user", async () => {
-    const res = await client.admin.banUser(
-      {
-        userId: newUser?.id || "",
-      },
-      {
-        headers: adminHeaders,
-      },
-    );
-    expect(res.data?.user?.banned).toBe(true);
-  });
+	it("should allow to ban user", async () => {
+		const res = await client.admin.banUser(
+			{
+				userId: newUser?.id || "",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.user?.banned).toBe(true);
+	});
 
-  it("should allow to ban user with reason and expiration", async () => {
-    const res = await client.admin.banUser(
-      {
-        userId: newUser?.id || "",
-        banReason: "Test reason",
-        banExpiresIn: 60 * 60 * 24,
-      },
-      {
-        headers: adminHeaders,
-      },
-    );
-    expect(res.data?.user?.banned).toBe(true);
-    expect(res.data?.user?.banReason).toBe("Test reason");
-    expect(res.data?.user?.banExpires).toBeDefined();
-  });
+	it("should allow to ban user with reason and expiration", async () => {
+		const res = await client.admin.banUser(
+			{
+				userId: newUser?.id || "",
+				banReason: "Test reason",
+				banExpiresIn: 60 * 60 * 24,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.user?.banned).toBe(true);
+		expect(res.data?.user?.banReason).toBe("Test reason");
+		expect(res.data?.user?.banExpires).toBeDefined();
+	});
 
-  it("should not allow banned user to sign in", async () => {
-    const res = await client.signIn.email({
-      email: newUser?.email || "",
-      password: "test",
-    });
-    expect(res.error?.status).toBe(401);
-  });
+	it("should not allow banned user to sign in", async () => {
+		const res = await client.signIn.email({
+			email: newUser?.email || "",
+			password: "test",
+		});
+		expect(res.error?.status).toBe(401);
+	});
 
-  it("should allow banned user to sign in if ban expired", async () => {
-    vi.useFakeTimers();
-    await vi.advanceTimersByTimeAsync(60 * 60 * 24 * 1000);
-    const res = await client.signIn.email({
-      email: newUser?.email || "",
-      password: "test",
-    });
-    expect(res.data?.user).toBeDefined();
-  });
+	it("should allow banned user to sign in if ban expired", async () => {
+		vi.useFakeTimers();
+		await vi.advanceTimersByTimeAsync(60 * 60 * 24 * 1000);
+		const res = await client.signIn.email({
+			email: newUser?.email || "",
+			password: "test",
+		});
+		expect(res.data?.user).toBeDefined();
+	});
 
-  it("should allow to unban user", async () => {
-    const res = await client.admin.unbanUser(
-      {
-        userId: newUser?.id || "",
-      },
-      {
-        headers: adminHeaders,
-      },
-    );
-    expect(res.data?.user?.banned).toBe(false);
-  });
+	it("should allow to unban user", async () => {
+		const res = await client.admin.unbanUser(
+			{
+				userId: newUser?.id || "",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.user?.banned).toBe(false);
+	});
 
-  it("should allow admin to list user sessions", async () => {
-    const res = await client.admin.listUserSessions(
-      {
-        userId: newUser?.id || "",
-      },
-      {
-        headers: adminHeaders,
-      },
-    );
-    expect(res.data?.sessions.length).toBe(1);
-  });
+	it("should allow admin to list user sessions", async () => {
+		const res = await client.admin.listUserSessions(
+			{
+				userId: newUser?.id || "",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.sessions.length).toBe(1);
+	});
 
-  const data = {
-    email: "impersonate@mail.com",
-    password: "password",
-    name: "Impersonate User",
-  };
+	const data = {
+		email: "impersonate@mail.com",
+		password: "password",
+		name: "Impersonate User",
+	};
 
-  const impersonateHeaders = new Headers();
-  it("should allow admins to impersonate user", async () => {
-    const userToImpersonate = await client.signUp.email(data);
-    const session = await client.getSession({
-      fetchOptions: {
-        headers: new Headers({
-          Authorization: `Bearer ${userToImpersonate.data?.token}`,
-        }),
-      },
-    });
-    const res = await client.admin.impersonateUser(
-      {
-        userId: session.data?.user.id || "",
-      },
-      {
-        headers: adminHeaders,
-        onSuccess: (ctx) => {
-          cookieSetter(impersonateHeaders)(ctx);
-        },
-      },
-    );
-    expect(res.data?.session).toBeDefined();
-    expect(res.data?.user?.id).toBe(session.data?.user.id);
-  });
+	const impersonateHeaders = new Headers();
+	it("should allow admins to impersonate user", async () => {
+		const userToImpersonate = await client.signUp.email(data);
+		const session = await client.getSession({
+			fetchOptions: {
+				headers: new Headers({
+					Authorization: `Bearer ${userToImpersonate.data?.token}`,
+				}),
+			},
+		});
+		const res = await client.admin.impersonateUser(
+			{
+				userId: session.data?.user.id || "",
+			},
+			{
+				headers: adminHeaders,
+				onSuccess: (ctx) => {
+					cookieSetter(impersonateHeaders)(ctx);
+				},
+			},
+		);
+		expect(res.data?.session).toBeDefined();
+		expect(res.data?.user?.id).toBe(session.data?.user.id);
+	});
 
-  it("should filter impersonated sessions", async () => {
-    const { headers } = await signInWithUser(data.email, data.password);
-    const res = await client.listSessions({
-      fetchOptions: {
-        headers,
-      },
-    });
-    expect(res.data?.length).toBe(2);
-  });
+	it("should filter impersonated sessions", async () => {
+		const { headers } = await signInWithUser(data.email, data.password);
+		const res = await client.listSessions({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(res.data?.length).toBe(2);
+	});
 
-  it("should allow admin to stop impersonating", async () => {
-    const impersonatedUserRes = await client.admin.listUsers({
-      fetchOptions: {
-        headers: impersonateHeaders,
-      },
-      query: {
-        filterField: "role",
-        filterOperator: "eq",
-        filterValue: "admin",
-      },
-    });
-    //should reject cause the user is not admin
-    expect(impersonatedUserRes.error?.status).toBe(403);
-    const res = await client.admin.stopImpersonating(
-      {},
-      {
-        headers: impersonateHeaders,
-        onSuccess: (ctx) => {
-          cookieSetter(impersonateHeaders)(ctx);
-        },
-      },
-    );
-    expect(res.data?.session).toBeDefined();
+	it("should allow admin to stop impersonating", async () => {
+		const impersonatedUserRes = await client.admin.listUsers({
+			fetchOptions: {
+				headers: impersonateHeaders,
+			},
+			query: {
+				filterField: "role",
+				filterOperator: "eq",
+				filterValue: "admin",
+			},
+		});
+		//should reject cause the user is not admin
+		expect(impersonatedUserRes.error?.status).toBe(403);
+		const res = await client.admin.stopImpersonating(
+			{},
+			{
+				headers: impersonateHeaders,
+				onSuccess: (ctx) => {
+					cookieSetter(impersonateHeaders)(ctx);
+				},
+			},
+		);
+		expect(res.data?.session).toBeDefined();
 
-    const afterStopImpersonationRes = await client.admin.listUsers({
-      fetchOptions: {
-        headers: impersonateHeaders,
-      },
-      query: {
-        filterField: "role",
-        filterOperator: "eq",
-        filterValue: "admin",
-      },
-    });
-    expect(afterStopImpersonationRes.data?.users.length).toBeGreaterThan(1);
-  });
+		const afterStopImpersonationRes = await client.admin.listUsers({
+			fetchOptions: {
+				headers: impersonateHeaders,
+			},
+			query: {
+				filterField: "role",
+				filterOperator: "eq",
+				filterValue: "admin",
+			},
+		});
+		expect(afterStopImpersonationRes.data?.users.length).toBeGreaterThan(1);
+	});
 
-  it("should allow admin to revoke user session", async () => {
-    const {
-      res: { user },
-    } = await signInWithUser(data.email, data.password);
-    const sessions = await client.admin.listUserSessions(
-      {
-        userId: user.id,
-      },
-      {
-        headers: adminHeaders,
-      },
-    );
-    expect(sessions.data?.sessions.length).toBe(4);
-    const res = await client.admin.revokeUserSession(
-      { sessionToken: sessions.data?.sessions[0].token || "" },
-      { headers: adminHeaders },
-    );
-    expect(res.data?.success).toBe(true);
-    const sessions2 = await client.admin.listUserSessions(
-      { userId: user?.id || "" },
-      { headers: adminHeaders },
-    );
-    expect(sessions2.data?.sessions.length).toBe(3);
-  });
+	it("should allow admin to revoke user session", async () => {
+		const {
+			res: { user },
+		} = await signInWithUser(data.email, data.password);
+		const sessions = await client.admin.listUserSessions(
+			{
+				userId: user.id,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(sessions.data?.sessions.length).toBe(4);
+		const res = await client.admin.revokeUserSession(
+			{ sessionToken: sessions.data?.sessions[0].token || "" },
+			{ headers: adminHeaders },
+		);
+		expect(res.data?.success).toBe(true);
+		const sessions2 = await client.admin.listUserSessions(
+			{ userId: user?.id || "" },
+			{ headers: adminHeaders },
+		);
+		expect(sessions2.data?.sessions.length).toBe(3);
+	});
 
-  it("should allow admin to revoke user sessions", async () => {
-    const res = await client.admin.revokeUserSessions(
-      { userId: newUser?.id || "" },
-      { headers: adminHeaders },
-    );
-    expect(res.data?.success).toBe(true);
-    const sessions2 = await client.admin.listUserSessions(
-      { userId: newUser?.id || "" },
-      { headers: adminHeaders },
-    );
-    expect(sessions2.data?.sessions.length).toBe(0);
-  });
+	it("should allow admin to revoke user sessions", async () => {
+		const res = await client.admin.revokeUserSessions(
+			{ userId: newUser?.id || "" },
+			{ headers: adminHeaders },
+		);
+		expect(res.data?.success).toBe(true);
+		const sessions2 = await client.admin.listUserSessions(
+			{ userId: newUser?.id || "" },
+			{ headers: adminHeaders },
+		);
+		expect(sessions2.data?.sessions.length).toBe(0);
+	});
 
-  it("should list with me", async () => {
-    const response = await client.admin.listUsers({
-      query: {
-        sortBy: "createdAt",
-        sortDirection: "desc",
-        filterField: "role",
-        filterOperator: "ne",
-        filterValue: "user",
-      },
-      fetchOptions: {
-        headers: adminHeaders,
-      },
-    });
-    expect(response.data?.users.length).toBe(2);
-    const roles = response.data?.users.map((d) => d.role);
-    expect(roles).not.toContain("user");
-  });
+	it("should list with me", async () => {
+		const response = await client.admin.listUsers({
+			query: {
+				sortBy: "createdAt",
+				sortDirection: "desc",
+				filterField: "role",
+				filterOperator: "ne",
+				filterValue: "user",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(response.data?.users.length).toBe(2);
+		const roles = response.data?.users.map((d) => d.role);
+		expect(roles).not.toContain("user");
+	});
 
-  it("should allow admin to delete user", async () => {
-    const res = await client.admin.removeUser(
-      {
-        userId: newUser?.id || "",
-      },
-      {
-        headers: adminHeaders,
-      },
-    );
+	it("should allow admin to delete user", async () => {
+		const res = await client.admin.removeUser(
+			{
+				userId: newUser?.id || "",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
 
-    expect(res.data?.success).toBe(true);
-  });
+		expect(res.data?.success).toBe(true);
+	});
 });

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -4,361 +4,374 @@ import { admin, type UserWithRole } from ".";
 import { adminClient } from "./client";
 
 describe("Admin plugin", async () => {
-	const { client, signInWithTestUser, signInWithUser, cookieSetter } =
-		await getTestInstance(
-			{
-				plugins: [admin()],
-				databaseHooks: {
-					user: {
-						create: {
-							before: async (user) => {
-								if (user.name === "Admin") {
-									return {
-										data: {
-											...user,
-											role: "admin",
-										},
-									};
-								}
-							},
-						},
-					},
-				},
-			},
-			{
-				testUser: {
-					name: "Admin",
-				},
-				clientOptions: {
-					plugins: [adminClient()],
-				},
-			},
-		);
-	const { headers: adminHeaders } = await signInWithTestUser();
-	let newUser: UserWithRole | undefined;
+  const { client, signInWithTestUser, signInWithUser, cookieSetter } =
+    await getTestInstance(
+      {
+        plugins: [admin()],
+        databaseHooks: {
+          user: {
+            create: {
+              before: async (user) => {
+                if (user.name === "Admin") {
+                  return {
+                    data: {
+                      ...user,
+                      role: "admin",
+                    },
+                  };
+                }
+              },
+            },
+          },
+        },
+      },
+      {
+        testUser: {
+          name: "Admin",
+        },
+        clientOptions: {
+          plugins: [adminClient()],
+        },
+      },
+    );
+  const { headers: adminHeaders } = await signInWithTestUser();
+  let newUser: UserWithRole | undefined;
 
-	it("should allow admin to create users", async () => {
-		const res = await client.admin.createUser(
-			{
-				name: "Test User",
-				email: "test2@test.com",
-				password: "test",
-				role: "user",
-			},
-			{
-				headers: adminHeaders,
-			},
-		);
-		newUser = res.data?.user;
+  it("should allow admin to create users", async () => {
+    const res = await client.admin.createUser(
+      {
+        name: "Test User",
+        email: "test2@test.com",
+        password: "test",
+        role: "user",
+      },
+      {
+        headers: adminHeaders,
+      },
+    );
+    newUser = res.data?.user;
 
-		expect(newUser?.role).toBe("user");
-	});
+    expect(newUser?.role).toBe("user");
+  });
 
-	it("should allow admin to list users", async () => {
-		const res = await client.admin.listUsers({
-			query: {
-				limit: 2,
-			},
-			fetchOptions: {
-				headers: adminHeaders,
-			},
-		});
-		expect(res.data?.users.length).toBe(2);
-	});
+  it("should allow admin to list users", async () => {
+    const res = await client.admin.listUsers({
+      query: {
+        limit: 2,
+      },
+      fetchOptions: {
+        headers: adminHeaders,
+      },
+    });
+    expect(res.data?.users.length).toBe(2);
+  });
 
-	it("should allow to sort users by name", async () => {
-		const res = await client.admin.listUsers({
-			query: {
-				sortBy: "name",
-				sortDirection: "desc",
-			},
-			fetchOptions: {
-				headers: adminHeaders,
-			},
-		});
-		expect(res.data?.users[0].name).toBe("Test User");
+  it("should allow admin to count users", async () => {
+    const res = await client.admin.listUsers({
+      query: {
+        limit: 2,
+      },
+      fetchOptions: {
+        headers: adminHeaders,
+      },
+    });
+    expect(res.data?.total).toBe(2);
+  });
 
-		const res2 = await client.admin.listUsers({
-			query: {
-				sortBy: "name",
-				sortDirection: "asc",
-			},
-			fetchOptions: {
-				headers: adminHeaders,
-			},
-		});
-		expect(res2.data?.users[0].name).toBe("Admin");
-	});
+  it("should allow to sort users by name", async () => {
+    const res = await client.admin.listUsers({
+      query: {
+        sortBy: "name",
+        sortDirection: "desc",
+      },
+      fetchOptions: {
+        headers: adminHeaders,
+      },
+    });
 
-	it("should allow offset and limit", async () => {
-		const res = await client.admin.listUsers({
-			query: {
-				limit: 1,
-				offset: 1,
-			},
-			fetchOptions: {
-				headers: adminHeaders,
-			},
-		});
-		expect(res.data?.users.length).toBe(1);
-		expect(res.data?.users[0].name).toBe("Test User");
-	});
+    expect(res.data?.users[0].name).toBe("Test User");
 
-	it("should allow to search users by name", async () => {
-		const res = await client.admin.listUsers({
-			query: {
-				searchValue: "Admin",
-				searchField: "name",
-				searchOperator: "contains",
-			},
-			fetchOptions: {
-				headers: adminHeaders,
-			},
-		});
-		expect(res.data?.users.length).toBe(1);
-	});
+    const res2 = await client.admin.listUsers({
+      query: {
+        sortBy: "name",
+        sortDirection: "asc",
+      },
+      fetchOptions: {
+        headers: adminHeaders,
+      },
+    });
+    expect(res2.data?.users[0].name).toBe("Admin");
+  });
 
-	it("should allow to filter users by role", async () => {
-		const res = await client.admin.listUsers({
-			query: {
-				filterValue: "admin",
-				filterField: "role",
-				filterOperator: "eq",
-			},
-			fetchOptions: {
-				headers: adminHeaders,
-			},
-		});
-		expect(res.data?.users.length).toBe(1);
-	});
+  it("should allow offset and limit", async () => {
+    const res = await client.admin.listUsers({
+      query: {
+        limit: 1,
+        offset: 1,
+      },
+      fetchOptions: {
+        headers: adminHeaders,
+      },
+    });
+    expect(res.data?.users.length).toBe(1);
+    expect(res.data?.users[0].name).toBe("Test User");
+  });
 
-	it("should allow to set user role", async () => {
-		const res = await client.admin.setRole(
-			{
-				userId: newUser?.id || "",
-				role: "admin",
-			},
-			{
-				headers: adminHeaders,
-			},
-		);
-		expect(res.data?.user?.role).toBe("admin");
-	});
+  it("should allow to search users by name", async () => {
+    const res = await client.admin.listUsers({
+      query: {
+        searchValue: "Admin",
+        searchField: "name",
+        searchOperator: "contains",
+      },
+      fetchOptions: {
+        headers: adminHeaders,
+      },
+    });
+    expect(res.data?.users.length).toBe(1);
+  });
 
-	it("should allow to ban user", async () => {
-		const res = await client.admin.banUser(
-			{
-				userId: newUser?.id || "",
-			},
-			{
-				headers: adminHeaders,
-			},
-		);
-		expect(res.data?.user?.banned).toBe(true);
-	});
+  it("should allow to filter users by role", async () => {
+    const res = await client.admin.listUsers({
+      query: {
+        filterValue: "admin",
+        filterField: "role",
+        filterOperator: "eq",
+      },
+      fetchOptions: {
+        headers: adminHeaders,
+      },
+    });
+    expect(res.data?.users.length).toBe(1);
+  });
 
-	it("should allow to ban user with reason and expiration", async () => {
-		const res = await client.admin.banUser(
-			{
-				userId: newUser?.id || "",
-				banReason: "Test reason",
-				banExpiresIn: 60 * 60 * 24,
-			},
-			{
-				headers: adminHeaders,
-			},
-		);
-		expect(res.data?.user?.banned).toBe(true);
-		expect(res.data?.user?.banReason).toBe("Test reason");
-		expect(res.data?.user?.banExpires).toBeDefined();
-	});
+  it("should allow to set user role", async () => {
+    const res = await client.admin.setRole(
+      {
+        userId: newUser?.id || "",
+        role: "admin",
+      },
+      {
+        headers: adminHeaders,
+      },
+    );
+    expect(res.data?.user?.role).toBe("admin");
+  });
 
-	it("should not allow banned user to sign in", async () => {
-		const res = await client.signIn.email({
-			email: newUser?.email || "",
-			password: "test",
-		});
-		expect(res.error?.status).toBe(401);
-	});
+  it("should allow to ban user", async () => {
+    const res = await client.admin.banUser(
+      {
+        userId: newUser?.id || "",
+      },
+      {
+        headers: adminHeaders,
+      },
+    );
+    expect(res.data?.user?.banned).toBe(true);
+  });
 
-	it("should allow banned user to sign in if ban expired", async () => {
-		vi.useFakeTimers();
-		await vi.advanceTimersByTimeAsync(60 * 60 * 24 * 1000);
-		const res = await client.signIn.email({
-			email: newUser?.email || "",
-			password: "test",
-		});
-		expect(res.data?.user).toBeDefined();
-	});
+  it("should allow to ban user with reason and expiration", async () => {
+    const res = await client.admin.banUser(
+      {
+        userId: newUser?.id || "",
+        banReason: "Test reason",
+        banExpiresIn: 60 * 60 * 24,
+      },
+      {
+        headers: adminHeaders,
+      },
+    );
+    expect(res.data?.user?.banned).toBe(true);
+    expect(res.data?.user?.banReason).toBe("Test reason");
+    expect(res.data?.user?.banExpires).toBeDefined();
+  });
 
-	it("should allow to unban user", async () => {
-		const res = await client.admin.unbanUser(
-			{
-				userId: newUser?.id || "",
-			},
-			{
-				headers: adminHeaders,
-			},
-		);
-		expect(res.data?.user?.banned).toBe(false);
-	});
+  it("should not allow banned user to sign in", async () => {
+    const res = await client.signIn.email({
+      email: newUser?.email || "",
+      password: "test",
+    });
+    expect(res.error?.status).toBe(401);
+  });
 
-	it("should allow admin to list user sessions", async () => {
-		const res = await client.admin.listUserSessions(
-			{
-				userId: newUser?.id || "",
-			},
-			{
-				headers: adminHeaders,
-			},
-		);
-		expect(res.data?.sessions.length).toBe(1);
-	});
+  it("should allow banned user to sign in if ban expired", async () => {
+    vi.useFakeTimers();
+    await vi.advanceTimersByTimeAsync(60 * 60 * 24 * 1000);
+    const res = await client.signIn.email({
+      email: newUser?.email || "",
+      password: "test",
+    });
+    expect(res.data?.user).toBeDefined();
+  });
 
-	const data = {
-		email: "impersonate@mail.com",
-		password: "password",
-		name: "Impersonate User",
-	};
+  it("should allow to unban user", async () => {
+    const res = await client.admin.unbanUser(
+      {
+        userId: newUser?.id || "",
+      },
+      {
+        headers: adminHeaders,
+      },
+    );
+    expect(res.data?.user?.banned).toBe(false);
+  });
 
-	const impersonateHeaders = new Headers();
-	it("should allow admins to impersonate user", async () => {
-		const userToImpersonate = await client.signUp.email(data);
-		const session = await client.getSession({
-			fetchOptions: {
-				headers: new Headers({
-					Authorization: `Bearer ${userToImpersonate.data?.token}`,
-				}),
-			},
-		});
-		const res = await client.admin.impersonateUser(
-			{
-				userId: session.data?.user.id || "",
-			},
-			{
-				headers: adminHeaders,
-				onSuccess: (ctx) => {
-					cookieSetter(impersonateHeaders)(ctx);
-				},
-			},
-		);
-		expect(res.data?.session).toBeDefined();
-		expect(res.data?.user?.id).toBe(session.data?.user.id);
-	});
+  it("should allow admin to list user sessions", async () => {
+    const res = await client.admin.listUserSessions(
+      {
+        userId: newUser?.id || "",
+      },
+      {
+        headers: adminHeaders,
+      },
+    );
+    expect(res.data?.sessions.length).toBe(1);
+  });
 
-	it("should filter impersonated sessions", async () => {
-		const { headers } = await signInWithUser(data.email, data.password);
-		const res = await client.listSessions({
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(res.data?.length).toBe(2);
-	});
+  const data = {
+    email: "impersonate@mail.com",
+    password: "password",
+    name: "Impersonate User",
+  };
 
-	it("should allow admin to stop impersonating", async () => {
-		const impersonatedUserRes = await client.admin.listUsers({
-			fetchOptions: {
-				headers: impersonateHeaders,
-			},
-			query: {
-				filterField: "role",
-				filterOperator: "eq",
-				filterValue: "admin",
-			},
-		});
-		//should reject cause the user is not admin
-		expect(impersonatedUserRes.error?.status).toBe(403);
-		const res = await client.admin.stopImpersonating(
-			{},
-			{
-				headers: impersonateHeaders,
-				onSuccess: (ctx) => {
-					cookieSetter(impersonateHeaders)(ctx);
-				},
-			},
-		);
-		expect(res.data?.session).toBeDefined();
+  const impersonateHeaders = new Headers();
+  it("should allow admins to impersonate user", async () => {
+    const userToImpersonate = await client.signUp.email(data);
+    const session = await client.getSession({
+      fetchOptions: {
+        headers: new Headers({
+          Authorization: `Bearer ${userToImpersonate.data?.token}`,
+        }),
+      },
+    });
+    const res = await client.admin.impersonateUser(
+      {
+        userId: session.data?.user.id || "",
+      },
+      {
+        headers: adminHeaders,
+        onSuccess: (ctx) => {
+          cookieSetter(impersonateHeaders)(ctx);
+        },
+      },
+    );
+    expect(res.data?.session).toBeDefined();
+    expect(res.data?.user?.id).toBe(session.data?.user.id);
+  });
 
-		const afterStopImpersonationRes = await client.admin.listUsers({
-			fetchOptions: {
-				headers: impersonateHeaders,
-			},
-			query: {
-				filterField: "role",
-				filterOperator: "eq",
-				filterValue: "admin",
-			},
-		});
-		expect(afterStopImpersonationRes.data?.users.length).toBeGreaterThan(1);
-	});
+  it("should filter impersonated sessions", async () => {
+    const { headers } = await signInWithUser(data.email, data.password);
+    const res = await client.listSessions({
+      fetchOptions: {
+        headers,
+      },
+    });
+    expect(res.data?.length).toBe(2);
+  });
 
-	it("should allow admin to revoke user session", async () => {
-		const {
-			res: { user },
-		} = await signInWithUser(data.email, data.password);
-		const sessions = await client.admin.listUserSessions(
-			{
-				userId: user.id,
-			},
-			{
-				headers: adminHeaders,
-			},
-		);
-		expect(sessions.data?.sessions.length).toBe(4);
-		const res = await client.admin.revokeUserSession(
-			{ sessionToken: sessions.data?.sessions[0].token || "" },
-			{ headers: adminHeaders },
-		);
-		expect(res.data?.success).toBe(true);
-		const sessions2 = await client.admin.listUserSessions(
-			{ userId: user?.id || "" },
-			{ headers: adminHeaders },
-		);
-		expect(sessions2.data?.sessions.length).toBe(3);
-	});
+  it("should allow admin to stop impersonating", async () => {
+    const impersonatedUserRes = await client.admin.listUsers({
+      fetchOptions: {
+        headers: impersonateHeaders,
+      },
+      query: {
+        filterField: "role",
+        filterOperator: "eq",
+        filterValue: "admin",
+      },
+    });
+    //should reject cause the user is not admin
+    expect(impersonatedUserRes.error?.status).toBe(403);
+    const res = await client.admin.stopImpersonating(
+      {},
+      {
+        headers: impersonateHeaders,
+        onSuccess: (ctx) => {
+          cookieSetter(impersonateHeaders)(ctx);
+        },
+      },
+    );
+    expect(res.data?.session).toBeDefined();
 
-	it("should allow admin to revoke user sessions", async () => {
-		const res = await client.admin.revokeUserSessions(
-			{ userId: newUser?.id || "" },
-			{ headers: adminHeaders },
-		);
-		expect(res.data?.success).toBe(true);
-		const sessions2 = await client.admin.listUserSessions(
-			{ userId: newUser?.id || "" },
-			{ headers: adminHeaders },
-		);
-		expect(sessions2.data?.sessions.length).toBe(0);
-	});
+    const afterStopImpersonationRes = await client.admin.listUsers({
+      fetchOptions: {
+        headers: impersonateHeaders,
+      },
+      query: {
+        filterField: "role",
+        filterOperator: "eq",
+        filterValue: "admin",
+      },
+    });
+    expect(afterStopImpersonationRes.data?.users.length).toBeGreaterThan(1);
+  });
 
-	it("should list with ne", async () => {
-		const response = await client.admin.listUsers({
-			query: {
-				sortBy: "createdAt",
-				sortDirection: "desc",
-				filterField: "role",
-				filterOperator: "ne",
-				filterValue: "user",
-			},
-			fetchOptions: {
-				headers: adminHeaders,
-			},
-		});
-		expect(response.data?.users.length).toBe(2);
-		const roles = response.data?.users.map((d) => d.role);
-		expect(roles).not.toContain("user");
-	});
+  it("should allow admin to revoke user session", async () => {
+    const {
+      res: { user },
+    } = await signInWithUser(data.email, data.password);
+    const sessions = await client.admin.listUserSessions(
+      {
+        userId: user.id,
+      },
+      {
+        headers: adminHeaders,
+      },
+    );
+    expect(sessions.data?.sessions.length).toBe(4);
+    const res = await client.admin.revokeUserSession(
+      { sessionToken: sessions.data?.sessions[0].token || "" },
+      { headers: adminHeaders },
+    );
+    expect(res.data?.success).toBe(true);
+    const sessions2 = await client.admin.listUserSessions(
+      { userId: user?.id || "" },
+      { headers: adminHeaders },
+    );
+    expect(sessions2.data?.sessions.length).toBe(3);
+  });
 
-	it("should allow admin to delete user", async () => {
-		const res = await client.admin.removeUser(
-			{
-				userId: newUser?.id || "",
-			},
-			{
-				headers: adminHeaders,
-			},
-		);
+  it("should allow admin to revoke user sessions", async () => {
+    const res = await client.admin.revokeUserSessions(
+      { userId: newUser?.id || "" },
+      { headers: adminHeaders },
+    );
+    expect(res.data?.success).toBe(true);
+    const sessions2 = await client.admin.listUserSessions(
+      { userId: newUser?.id || "" },
+      { headers: adminHeaders },
+    );
+    expect(sessions2.data?.sessions.length).toBe(0);
+  });
 
-		expect(res.data?.success).toBe(true);
-	});
+  it("should list with me", async () => {
+    const response = await client.admin.listUsers({
+      query: {
+        sortBy: "createdAt",
+        sortDirection: "desc",
+        filterField: "role",
+        filterOperator: "ne",
+        filterValue: "user",
+      },
+      fetchOptions: {
+        headers: adminHeaders,
+      },
+    });
+    expect(response.data?.users.length).toBe(2);
+    const roles = response.data?.users.map((d) => d.role);
+    expect(roles).not.toContain("user");
+  });
+
+  it("should allow admin to delete user", async () => {
+    const res = await client.admin.removeUser(
+      {
+        userId: newUser?.id || "",
+      },
+      {
+        headers: adminHeaders,
+      },
+    );
+
+    expect(res.data?.success).toBe(true);
+  });
 });

--- a/packages/better-auth/src/plugins/admin/index.ts
+++ b/packages/better-auth/src/plugins/admin/index.ts
@@ -398,6 +398,15 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 															$ref: "#/components/schemas/User",
 														},
 													},
+													total: {
+														type: "number",
+													},
+													limit: {
+														type: ["number", "undefined"],
+													},
+													offset: {
+														type: ["number", "undefined"],
+													},
 												},
 											},
 										},
@@ -438,12 +447,17 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 								: undefined,
 							where.length ? where : undefined,
 						);
+						const total = await ctx.context.internalAdapter.countTotalUsers();
 						return ctx.json({
 							users: users as UserWithRole[],
+							total: total,
+							limit: Number(ctx.query?.limit) || undefined,
+							offset: Number(ctx.query?.offset) || undefined,
 						});
 					} catch (e) {
 						return ctx.json({
 							users: [],
+							total: 0,
 						});
 					}
 				},

--- a/packages/better-auth/src/types/adapter.ts
+++ b/packages/better-auth/src/types/adapter.ts
@@ -45,6 +45,10 @@ export type Adapter = {
 		};
 		offset?: number;
 	}) => Promise<T[]>;
+	count: (data: {
+		model: string;
+		where?: Where[];
+	}) => Promise<number>;
 	/**
 	 * ⚠︎ Update may not return the updated data
 	 * if multiple where clauses are provided


### PR DESCRIPTION
closes #1222 and various feature requests in the discord.

This feature will return the total amount of users as well as the limit and offset that were used for the list-users search. This will allow you to do proper pagination without requiring additional API calls.

Types:
```
{
  users: [User],
  total: number,
  limit: number | undefined
  offset: number | undefined
}
```
I purposefully made `limit` and `offset` be undefined when they aren't queried. This way you can easily check if a limit or offset were used or not. If making them undefined is undesirable I can always change them to, for example, -1.

Example response:
```json
{
  "users": [
    {
      "id": "678faf201d309d6892b774c0",
      "name": "d3vision",
      "email": "info@d3vision.dev",
      "emailVerified": true,
      "image": "https://cdn.discordapp.com/embed/avatars/3.png",
      "createdAt": "2025-01-21T14:28:48.355Z",
      "updatedAt": "2025-01-21T14:28:48.355Z",
      "role": "user"
    }
  ],
  "total": 2,
  "limit": 1,
  "offset": 1
}
```
_This is for a users collection with 2 users._

If the query errors, it will return:
```json
{
  "users": [],
  "total": 0,
}
```

Lastly, I updated the `init.test.ts.snap` file to reflect my adding of the count function in the adapter and the countTotalUsers function in the internalAdapter.

**As usual, please let me know if I need to make any changes or if there are things I should add!**