### PR TITLE
fix: ensure correct status code for unverified email in sign-in

### DIFF
--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -385,7 +385,7 @@ export const signInEmail = createAuthEndpoint(
 			!user.user.emailVerified
 		) {
 			if (!ctx.context.options?.emailVerification?.sendVerificationEmail) {
-				throw new APIError("UNAUTHORIZED", {
+				throw new APIError("FORBIDDEN", {
 					message: BASE_ERROR_CODES.EMAIL_NOT_VERIFIED,
 				});
 			}


### PR DESCRIPTION
closes #1130 