### PR TITLE
feat: Add existing account check for Social Provider sign-up

### DIFF
--- a/docs/content/docs/contribute/testing.mdx
+++ b/docs/content/docs/contribute/testing.mdx
@@ -26,6 +26,10 @@ Our approach to testing emphasizes:
 
 ## Getting Started
 
+<Callout type="warn">
+  If you face MongoDB connection issues, download <Link href="https://www.mongodb.com/try/download/community">MongoDB</Link>
+</Callout>
+
 ### Setup
 
 ```bash

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -114,6 +114,16 @@ export const callbackOAuth = createAuthEndpoint(
 				`${c.context.baseURL}/error?error=please_restart_the_process`,
 			);
 		}
+
+		/** Check if there's already an account with this accountId */
+		const existingAccount = await c.context.internalAdapter.findAccount(
+			userInfo.id,
+		);
+		if (existingAccount) {
+			c.context.logger.info("An account with this accountId already exists");
+			return redirectOnError("account_already_linked");
+		}
+		
 		if (link) {
 			if (
 				c.context.options.account?.accountLinking?.allowDifferentEmails !==

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -123,7 +123,7 @@ export const callbackOAuth = createAuthEndpoint(
 			c.context.logger.info("An account with this accountId already exists");
 			return redirectOnError("account_already_linked");
 		}
-		
+
 		if (link) {
 			if (
 				c.context.options.account?.accountLinking?.allowDifferentEmails !==

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -1,4 +1,4 @@
-import { z, ZodObject, ZodString } from "zod";
+import { z } from "zod";
 import { createAuthEndpoint } from "../call";
 import { createEmailVerificationToken } from "./email-verification";
 import { setSessionCookie } from "../../cookies";

--- a/packages/better-auth/src/social-providers/social.test.ts
+++ b/packages/better-auth/src/social-providers/social.test.ts
@@ -80,7 +80,7 @@ describe("Social Providers", async () => {
 			disableTestUser: true,
 		},
 	);
-	
+
 	let state = "";
 	const headers = new Headers();
 
@@ -144,50 +144,53 @@ describe("Social Providers", async () => {
 					const cookies = parseSetCookieHeader(
 						context.response.headers.get("set-cookie") || "",
 					);
-					expect(cookies.get("better-auth.session_token")?.value).toBeUndefined();
+					expect(
+						cookies.get("better-auth.session_token")?.value,
+					).toBeUndefined();
 				},
 			});
 		});
 	});
 
-	const { client: mapProfileClient, cookieSetter: mapProfileCookieSetter } = await getTestInstance(
-		{
-			user: {
-				additionalFields: {
-					firstName: {
-						type: "string",
+	const { client: mapProfileClient, cookieSetter: mapProfileCookieSetter } =
+		await getTestInstance(
+			{
+				user: {
+					additionalFields: {
+						firstName: {
+							type: "string",
+						},
+						lastName: {
+							type: "string",
+						},
+						isOAuth: {
+							type: "boolean",
+						},
 					},
-					lastName: {
-						type: "string",
+				},
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+						enabled: true,
+						mapProfileToUser(profile) {
+							return {
+								firstName: profile.given_name,
+								lastName: profile.family_name,
+								isOAuth: true,
+							};
+						},
 					},
-					isOAuth: {
-						type: "boolean",
+					apple: {
+						clientId: "test",
+						clientSecret: "test",
 					},
 				},
 			},
-			socialProviders: {
-				google: {
-					clientId: "test",
-					clientSecret: "test",
-					enabled: true,
-					mapProfileToUser(profile) {
-						return {
-							firstName: profile.given_name,
-							lastName: profile.family_name,
-							isOAuth: true,
-						};
-					},
-				},
-				apple: {
-					clientId: "test",
-					clientSecret: "test",
-				},
+			{
+				disableTestUser: true,
 			},
-		},
-		{
-			disableTestUser: true,
-		},
-	);
+		);
 
 	it("should be able to map profile to user", async () => {
 		const signInRes = await mapProfileClient.signIn.social({

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -164,7 +164,7 @@ export async function getTestInstance<
 			await fs.unlink(dbName);
 		} catch (error) {
 			// If file is still busy, wait a bit and try again
-			await new Promise(resolve => setTimeout(resolve, 100));
+			await new Promise((resolve) => setTimeout(resolve, 100));
 			await fs.unlink(dbName);
 		}
 	});

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -156,7 +156,17 @@ export async function getTestInstance<
 			return;
 		}
 
-		await fs.unlink(dbName);
+		// For SQLite, close the connection before deleting
+		if (opts.database instanceof Database) {
+			opts.database.close();
+		}
+		try {
+			await fs.unlink(dbName);
+		} catch (error) {
+			// If file is still busy, wait a bit and try again
+			await new Promise(resolve => setTimeout(resolve, 100));
+			await fs.unlink(dbName);
+		}
 	});
 
 	async function signInWithTestUser() {


### PR DESCRIPTION
For anyone who does not have a composite unique constraint on their ``accountId`` & ``providerId`` fields in their Account model, signing up via any Social Provider will just keep creating accounts with no check for existing ones.

This PR adds a check for an existing account with a lookup of ``accountId`` before completing the callback request.

Extra: I also included a Callout in the contributing docs for installing MongoDB, I found out that not having MongoDB installed would just keep giving me "MongoError: connect ECONNREFUSED 127.0.0.1:27017" errors when running ``test``. I also edited the test instance so it attempts an unlink twice & closes the SQLite database before unlinking it as I kept running into errors like "EBUSY: resource busy or locked".