### PR TITLE
Bugfix: Expo client with cookieCache enabled.

### DIFF
--- a/packages/expo/src/expo.test.ts
+++ b/packages/expo/src/expo.test.ts
@@ -1,6 +1,6 @@
 import { createAuthClient } from "better-auth/client";
 import Database from "better-sqlite3";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
 import { expo } from ".";
 import { expoClient } from "./client";
 import { betterAuth } from "better-auth";
@@ -44,7 +44,7 @@ vi.mock("expo-linking", async () => {
 
 const fn = vi.fn();
 
-describe("expo", async () => {
+function testUtils(extraOpts?: Parameters<typeof betterAuth>[0]) {
 	const storage = new Map<string, string>();
 
 	const auth = betterAuth({
@@ -61,6 +61,7 @@ describe("expo", async () => {
 		},
 		plugins: [expo()],
 		trustedOrigins: ["better-auth://"],
+		...extraOpts,
 	});
 
 	const client = createAuthClient({
@@ -80,9 +81,20 @@ describe("expo", async () => {
 			}),
 		],
 	});
+
+	return { storage, auth, client };
+}
+
+describe("expo", async () => {
+	const { auth, client, storage } = testUtils();
+
 	beforeAll(async () => {
 		const { runMigrations } = await getMigrations(auth.options);
 		await runMigrations();
+		vi.useFakeTimers();
+	});
+	afterAll(() => {
+		vi.useRealTimers();
 	});
 
 	it("should store cookie with expires date", async () => {
@@ -96,7 +108,7 @@ describe("expo", async () => {
 		expect(storedCookie).toBeDefined();
 		const parsedCookie = JSON.parse(storedCookie || "");
 		expect(parsedCookie["better-auth.session_token"]).toMatchObject({
-			value: expect.any(String),
+			value: expect.stringMatching(/.+/),
 			expires: expect.any(String),
 		});
 	});
@@ -126,5 +138,81 @@ describe("expo", async () => {
 	it("should get cookies", async () => {
 		const c = client.getCookie();
 		expect(c).includes("better-auth.session_token");
+	});
+});
+
+describe("expo with cookieCache", async () => {
+	const { auth, client, storage } = testUtils({
+		session: {
+			expiresIn: 5,
+			cookieCache: {
+				enabled: true,
+				maxAge: 1,
+			},
+		},
+	});
+	beforeAll(async () => {
+		const { runMigrations } = await getMigrations(auth.options);
+		await runMigrations();
+		vi.useFakeTimers();
+	});
+	afterAll(() => {
+		vi.useRealTimers();
+	});
+
+	it("should store cookie with expires date", async () => {
+		const testUser = {
+			email: "test@test.com",
+			password: "password",
+			name: "Test User",
+		};
+		await client.signUp.email(testUser);
+		const storedCookie = storage.get("better-auth_cookie");
+		expect(storedCookie).toBeDefined();
+		const parsedCookie = JSON.parse(storedCookie || "");
+		expect(parsedCookie["better-auth.session_token"]).toMatchObject({
+			value: expect.stringMatching(/.+/),
+			expires: expect.any(String),
+		});
+		expect(parsedCookie["better-auth.session_data"]).toMatchObject({
+			value: expect.stringMatching(/.+/),
+			expires: expect.any(String),
+		});
+	});
+	it("should refresh session_data when it expired without erasing session_token", async () => {
+		vi.advanceTimersByTime(1000);
+		const { data } = await client.getSession();
+		expect(data).toMatchObject({
+			session: expect.any(Object),
+			user: expect.any(Object),
+		});
+		const storedCookie = storage.get("better-auth_cookie");
+		expect(storedCookie).toBeDefined();
+		const parsedCookie = JSON.parse(storedCookie || "");
+		expect(parsedCookie["better-auth.session_token"]).toMatchObject({
+			value: expect.stringMatching(/.+/),
+			expires: expect.any(String),
+		});
+		expect(parsedCookie["better-auth.session_data"]).toMatchObject({
+			value: expect.stringMatching(/.+/),
+			expires: expect.any(String),
+		});
+	});
+
+	it("should erase both session_data and session_token when token expired", async () => {
+		vi.advanceTimersByTime(5000);
+		const { data } = await client.getSession();
+		expect(data).toBeNull();
+		const storedCookie = storage.get("better-auth_cookie");
+		expect(storedCookie).toBeDefined();
+		const parsedCookie = JSON.parse(storedCookie || "");
+		expect(parsedCookie["better-auth.session_token"]).toMatchObject({
+			value: expect.stringMatching(/^$/),
+			expires: expect.any(String),
+		});
+		expect(parsedCookie["better-auth.session_data"]).toMatchObject({
+			value: expect.stringMatching(/^$/),
+			expires: expect.any(String),
+		});
 	});
 });


### PR DESCRIPTION
In cases where the session_data cookie is expired, but session_token is not, the server returns only a newly signed session_data. 
The current implementation causes the existing session_token to be erased, causing a log-out. 
This commit fixes it, along with test cases to verify.