### PR TITLE
fix: Make plugin options type exports consistent

### DIFF
--- a/packages/better-auth/src/plugins/admin/index.ts
+++ b/packages/better-auth/src/plugins/admin/index.ts
@@ -29,7 +29,7 @@ export interface SessionWithImpersonatedBy extends Session {
 	impersonatedBy?: string;
 }
 
-interface AdminOptions {
+export interface AdminOptions {
 	/**
 	 * The default role for a user created by the admin
 	 *

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -5,7 +5,7 @@ import { generateRandomString } from "../../crypto";
 import { getDate } from "../../utils/date";
 import { setSessionCookie } from "../../cookies";
 
-interface EmailOTPOptions {
+export interface EmailOTPOptions {
 	/**
 	 * Function to send email verification
 	 */

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -23,7 +23,7 @@ function generateOTP(size: number) {
 	return generateRandomString(size, "0-9");
 }
 
-export const phoneNumber = (options?: {
+export interface PhoneNumberOptions = {
 	/**
 	 * Length of the OTP code
 	 * @default 6
@@ -93,7 +93,9 @@ export const phoneNumber = (options?: {
 	 * Custom schema for the admin plugin
 	 */
 	schema?: InferOptionSchema<typeof schema>;
-}) => {
+}
+
+export const phoneNumber = (options?: PhoneNumberOptions) => {
 	const opts = {
 		expiresIn: options?.expiresIn || 300,
 		otpLength: options?.otpLength || 6,


### PR DESCRIPTION
Plugins are currently inconsistently exporting their options. Most are... but a few don't. I'm using this in my code.

This PR adds exports for:
- PhoneNumberOptions
- AdminOptions
- EmailOTPOptions