### PR TITLE
Use redirect URI from options rather than manually overriding

### DIFF
--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -27,7 +27,7 @@ export async function validateAuthorizationCode({
 	body.set("grant_type", "authorization_code");
 	body.set("code", code);
 	codeVerifier && body.set("code_verifier", codeVerifier);
-	body.set("redirect_uri", redirectURI);
+	body.set("redirect_uri", options.redirectURI || redirectURI);
 	if (authentication === "basic") {
 		const encodedCredentials = btoa(
 			`${options.clientId}:${options.clientSecret}`,

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -221,6 +221,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							options: {
 								clientId: c.clientId,
 								clientSecret: c.clientSecret,
+								redirectURI: c.redirectURI,
 							},
 							tokenEndpoint: finalTokenUrl,
 						});
@@ -497,6 +498,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							options: {
 								clientId: provider.clientId,
 								clientSecret: provider.clientSecret,
+								redirectURI: provider.redirectURI,
 							},
 							tokenEndpoint: finalTokenUrl,
 						});

--- a/packages/better-auth/src/social-providers/apple.ts
+++ b/packages/better-auth/src/social-providers/apple.ts
@@ -88,7 +88,7 @@ export const apple = (options: AppleOptions) => {
 			return validateAuthorizationCode({
 				code,
 				codeVerifier,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint,
 			});

--- a/packages/better-auth/src/social-providers/discord.ts
+++ b/packages/better-auth/src/social-providers/discord.ts
@@ -98,7 +98,7 @@ export const discord = (options: DiscordOptions) => {
 		validateAuthorizationCode: async ({ code, redirectURI }) => {
 			return validateAuthorizationCode({
 				code,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint: "https://discord.com/api/oauth2/token",
 			});

--- a/packages/better-auth/src/social-providers/dropbox.ts
+++ b/packages/better-auth/src/social-providers/dropbox.ts
@@ -46,7 +46,7 @@ export const dropbox = (options: DropboxOptions) => {
 			return await validateAuthorizationCode({
 				code,
 				codeVerifier,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint,
 			});

--- a/packages/better-auth/src/social-providers/facebook.ts
+++ b/packages/better-auth/src/social-providers/facebook.ts
@@ -46,7 +46,7 @@ export const facebook = (options: FacebookOptions) => {
 		validateAuthorizationCode: async ({ code, redirectURI }) => {
 			return validateAuthorizationCode({
 				code,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint: "https://graph.facebook.com/oauth/access_token",
 			});

--- a/packages/better-auth/src/social-providers/github.ts
+++ b/packages/better-auth/src/social-providers/github.ts
@@ -70,7 +70,7 @@ export const github = (options: GithubOptions) => {
 		validateAuthorizationCode: async ({ code, redirectURI }) => {
 			return validateAuthorizationCode({
 				code,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint,
 			});

--- a/packages/better-auth/src/social-providers/gitlab.ts
+++ b/packages/better-auth/src/social-providers/gitlab.ts
@@ -96,7 +96,7 @@ export const gitlab = (options: GitlabOptions) => {
 		validateAuthorizationCode: async ({ code, redirectURI, codeVerifier }) => {
 			return validateAuthorizationCode({
 				code,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				codeVerifier,
 				tokenEndpoint,

--- a/packages/better-auth/src/social-providers/google.ts
+++ b/packages/better-auth/src/social-providers/google.ts
@@ -78,7 +78,7 @@ export const google = (options: GoogleOptions) => {
 			return validateAuthorizationCode({
 				code,
 				codeVerifier,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint: "https://oauth2.googleapis.com/token",
 			});

--- a/packages/better-auth/src/social-providers/linkedin.ts
+++ b/packages/better-auth/src/social-providers/linkedin.ts
@@ -41,7 +41,7 @@ export const linkedin = (options: LinkedInOptions) => {
 		validateAuthorizationCode: async ({ code, redirectURI }) => {
 			return await validateAuthorizationCode({
 				code,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint,
 			});

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -62,7 +62,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 			return validateAuthorizationCode({
 				code,
 				codeVerifier,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint,
 			});

--- a/packages/better-auth/src/social-providers/spotify.ts
+++ b/packages/better-auth/src/social-providers/spotify.ts
@@ -34,7 +34,7 @@ export const spotify = (options: SpotifyOptions) => {
 			return validateAuthorizationCode({
 				code,
 				codeVerifier,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint: "https://accounts.spotify.com/api/token",
 			});

--- a/packages/better-auth/src/social-providers/twitch.ts
+++ b/packages/better-auth/src/social-providers/twitch.ts
@@ -50,7 +50,7 @@ export const twitch = (options: TwitchOptions) => {
 		validateAuthorizationCode: async ({ code, redirectURI }) => {
 			return validateAuthorizationCode({
 				code,
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint: "https://id.twitch.tv/oauth2/token",
 			});

--- a/packages/better-auth/src/social-providers/twitter.ts
+++ b/packages/better-auth/src/social-providers/twitter.ts
@@ -119,7 +119,7 @@ export const twitter = (options: TwitterOption) => {
 				code,
 				codeVerifier,
 				authentication: "basic",
-				redirectURI: options.redirectURI || redirectURI,
+				redirectURI,
 				options,
 				tokenEndpoint: "https://api.x.com/2/oauth2/token",
 			});


### PR DESCRIPTION
In some places in the codebase we allow the user to override the redirect URI. Sometimes this is respected and sometimes it is not. This change ensures that we handle it consistently, and that it is respected in the generic oauth plugin.

My concrete use case was setting up oauth proxy (the plugin didn't quite fit my use-case) and my generic oauth provider was not behaving.