### PR TITLE
Allow creating new orgs without changing the current active org

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -35,6 +35,7 @@ export const createOrganization = createAuthEndpoint(
 					description: "The metadata of the organization",
 				})
 				.optional(),
+			keepCurrentActiveOrg: z.boolean().optional(),
 		}),
 		use: [orgMiddleware],
 		metadata: {
@@ -124,7 +125,7 @@ export const createOrganization = createAuthEndpoint(
 			},
 			user,
 		});
-		if (ctx.context.session) {
+		if (ctx.context.session && ctx.body.keepCurrentActiveOrg !== true) {
 			await adapter.setActiveOrganization(
 				ctx.context.session.session.token,
 				organization.id,


### PR DESCRIPTION
Does what it says on the tin. Adds a new flag—defaulted to `false`—which when set true will forgo changing the currently active org to the newly created org.

For an example of a use-case, I have a particular API that should be used when an organization creates another. This needs to be run from the parent org and switching the session back immediately after feels clunky.

EDIT: types all working. decided to not use `default` from zod