### PR TITLE
feat: allow generating ids asynchronously

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -140,7 +140,7 @@ const createTransform = (
 	const useDatabaseGeneratedId = options?.advanced?.generateId === false;
 	return {
 		getSchema,
-		transformInput(
+		async transformInput(
 			data: Record<string, any>,
 			model: string,
 			action: "create" | "update",
@@ -150,7 +150,7 @@ const createTransform = (
 					? {}
 					: {
 							id: options.advanced?.generateId
-								? options.advanced.generateId({
+								? await options.advanced.generateId({
 										model,
 									})
 								: data.id || generateId(),
@@ -287,7 +287,7 @@ export const drizzleAdapter =
 			id: "drizzle",
 			async create(data) {
 				const { model, data: values } = data;
-				const transformed = transformInput(values, model, "create");
+				const transformed = await transformInput(values, model, "create");
 				const schemaModel = getSchema(model);
 				checkMissingFields(schemaModel, getModelName(model), transformed);
 				const builder = db.insert(schemaModel).values(transformed);
@@ -337,7 +337,7 @@ export const drizzleAdapter =
 				const { model, where, update: values } = data;
 				const schemaModel = getSchema(model);
 				const clause = convertWhereClause(where, model);
-				const transformed = transformInput(values, model, "update");
+				const transformed = await transformInput(values, model, "update");
 				const builder = db
 					.update(schemaModel)
 					.set(transformed)
@@ -354,7 +354,7 @@ export const drizzleAdapter =
 				const { model, where, update: values } = data;
 				const schemaModel = getSchema(model);
 				const clause = convertWhereClause(where, model);
-				const transformed = transformInput(values, model, "update");
+				const transformed = await transformInput(values, model, "update");
 				const builder = db
 					.update(schemaModel)
 					.set(transformed)

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -73,7 +73,7 @@ const createTransform = (
 
 	const useDatabaseGeneratedId = options?.advanced?.generateId === false;
 	return {
-		transformInput(
+		async transformInput(
 			data: Record<string, any>,
 			model: string,
 			action: "create" | "update",
@@ -83,7 +83,7 @@ const createTransform = (
 					? {}
 					: {
 							id: options.advanced?.generateId
-								? options.advanced.generateId({
+								? await options.advanced.generateId({
 										model,
 									})
 								: data.id || generateId(),
@@ -253,7 +253,7 @@ export const kyselyAdapter =
 			id: "kysely",
 			async create(data) {
 				const { model, data: values, select } = data;
-				const transformed = transformInput(values, model, "create");
+				const transformed = await transformInput(values, model, "create");
 				const builder = db.insertInto(getModelName(model)).values(transformed);
 				return transformOutput(
 					await withReturning(transformed, builder, model, []),
@@ -316,7 +316,7 @@ export const kyselyAdapter =
 			async update(data) {
 				const { model, where, update: values } = data;
 				const { and, or } = convertWhereClause(model, where);
-				const transformedData = transformInput(values, model, "update");
+				const transformedData = await transformInput(values, model, "update");
 
 				let query = db.updateTable(getModelName(model)).set(transformedData);
 				if (and) {
@@ -334,7 +334,7 @@ export const kyselyAdapter =
 			async updateMany(data) {
 				const { model, where, update: values } = data;
 				const { and, or } = convertWhereClause(model, where);
-				const transformedData = transformInput(values, model, "update");
+				const transformedData = await transformInput(values, model, "update");
 				let query = db.updateTable(getModelName(model)).set(transformedData);
 				if (and) {
 					query = query.where((eb) => eb.and(and.map((expr) => expr(eb))));

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -18,7 +18,7 @@ const createTransform = (options: BetterAuthOptions) => {
 		return f.fieldName || field;
 	}
 	return {
-		transformInput(
+		async transformInput(
 			data: Record<string, any>,
 			model: string,
 			action: "update" | "create",
@@ -28,7 +28,7 @@ const createTransform = (options: BetterAuthOptions) => {
 					? {}
 					: {
 							id: options.advanced?.generateId
-								? options.advanced.generateId({
+								? await options.advanced.generateId({
 										model,
 									})
 								: data.id || generateId(),
@@ -108,7 +108,7 @@ export const memoryAdapter = (db: MemoryDB) => (options: BetterAuthOptions) => {
 	return {
 		id: "memory",
 		create: async ({ model, data }) => {
-			const transformed = transformInput(data, model, "create");
+			const transformed = await transformInput(data, model, "create");
 			db[model].push(transformed);
 			return transformOutput(transformed, model);
 		},
@@ -147,9 +147,9 @@ export const memoryAdapter = (db: MemoryDB) => (options: BetterAuthOptions) => {
 		update: async ({ model, where, update }) => {
 			const table = db[model];
 			const res = convertWhereClause(where, table, model);
-			res.forEach((record) => {
-				Object.assign(record, transformInput(update, model, "update"));
-			});
+			for (const record of res) {
+				Object.assign(record, await transformInput(update, model, "update"));
+			}
 			return transformOutput(res[0], model);
 		},
 		delete: async ({ model, where }) => {

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -85,7 +85,7 @@ const createTransform = (options: BetterAuthOptions) => {
 	}
 
 	return {
-		transformInput(
+		async transformInput(
 			data: Record<string, any>,
 			model: string,
 			action: "create" | "update",
@@ -95,7 +95,7 @@ const createTransform = (options: BetterAuthOptions) => {
 					? {}
 					: customIdGen
 						? {
-								id: customIdGen({ model }),
+								id: await customIdGen({ model }),
 							}
 						: {
 								_id: new ObjectId(),
@@ -231,7 +231,11 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 		id: "mongodb-adapter",
 		async create(data) {
 			const { model, data: values, select } = data;
-			const transformedData = transform.transformInput(values, model, "create");
+			const transformedData = await transform.transformInput(
+				values,
+				model,
+				"create",
+			);
 			if (transformedData.id && !hasCustomId) {
 				// biome-ignore lint/performance/noDelete: setting id to undefined will cause the id to be null in the database which is not what we want
 				delete transformedData.id;
@@ -279,7 +283,11 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 			const { model, where, update: values } = data;
 			const clause = transform.convertWhereClause(where, model);
 
-			const transformedData = transform.transformInput(values, model, "update");
+			const transformedData = await transform.transformInput(
+				values,
+				model,
+				"update",
+			);
 
 			const res = await db
 				.collection(transform.getModelName(model))
@@ -296,7 +304,11 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 		async updateMany(data) {
 			const { model, where, update: values } = data;
 			const clause = transform.convertWhereClause(where, model);
-			const transformedData = transform.transformInput(values, model, "update");
+			const transformedData = await transform.transformInput(
+				values,
+				model,
+				"update",
+			);
 			const res = await db
 				.collection(transform.getModelName(model))
 				.updateMany(clause, { $set: transformedData });

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -58,7 +58,7 @@ const createTransform = (config: PrismaConfig, options: BetterAuthOptions) => {
 
 	const useDatabaseGeneratedId = options?.advanced?.generateId === false;
 	return {
-		transformInput(
+		async transformInput(
 			data: Record<string, any>,
 			model: string,
 			action: "create" | "update",
@@ -68,7 +68,7 @@ const createTransform = (config: PrismaConfig, options: BetterAuthOptions) => {
 					? {}
 					: {
 							id: options.advanced?.generateId
-								? options.advanced.generateId({
+								? await options.advanced.generateId({
 										model,
 									})
 								: data.id || generateId(),
@@ -187,7 +187,7 @@ export const prismaAdapter =
 			id: "prisma",
 			async create(data) {
 				const { model, data: values, select } = data;
-				const transformed = transformInput(values, model, "create");
+				const transformed = await transformInput(values, model, "create");
 				if (!db[getModelName(model)]) {
 					throw new BetterAuthError(
 						`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
@@ -258,7 +258,7 @@ export const prismaAdapter =
 					);
 				}
 				const whereClause = convertWhereClause(model, where);
-				const transformed = transformInput(update, model, "update");
+				const transformed = await transformInput(update, model, "update");
 				const result = await db[getModelName(model)].update({
 					where: whereClause,
 					data: transformed,
@@ -268,7 +268,7 @@ export const prismaAdapter =
 			async updateMany(data) {
 				const { model, where, update } = data;
 				const whereClause = convertWhereClause(model, where);
-				const transformed = transformInput(update, model, "update");
+				const transformed = await transformInput(update, model, "update");
 				const result = await db[getModelName(model)].updateMany({
 					where: whereClause,
 					data: transformed,

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -81,9 +81,9 @@ export const init = async (options: BetterAuthOptions) => {
 		})
 		.filter((x) => x !== null);
 
-	const generateIdFunc: AuthContext["generateId"] = ({ model, size }) => {
+	const generateIdFunc: AuthContext["generateId"] = async ({ model, size }) => {
 		if (typeof options?.advanced?.generateId === "function") {
-			return options.advanced.generateId({ model, size });
+			return await options.advanced.generateId({ model, size });
 		}
 		return generateId(size);
 	};
@@ -203,7 +203,7 @@ export type AuthContext = {
 	generateId: (options: {
 		model: LiteralUnion<Models, string>;
 		size?: number;
-	}) => string;
+	}) => Promise<string> | string;
 	secondaryStorage: SecondaryStorage | undefined;
 	password: {
 		hash: (password: string) => Promise<string>;

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -103,7 +103,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 				async (ctx) => {
 					const { emailDomainName = getOrigin(ctx.context.baseURL) } =
 						options || {};
-					const id = ctx.context.generateId({ model: "user" });
+					const id = await ctx.context.generateId({ model: "user" });
 					const email = `temp-${id}@${emailDomainName}`;
 					const newUser = await ctx.context.internalAdapter.createUser(
 						{

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -126,7 +126,7 @@ export async function getJwtToken(
 		const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
 
 		let jwk: Partial<Jwk> = {
-			id: ctx.context.generateId({
+			id: await ctx.context.generateId({
 				model: "jwks",
 			}),
 			publicKey: JSON.stringify(publicWebKey),
@@ -252,7 +252,7 @@ export const jwt = (options?: JwtOptions) => {
 						const privateKeyEncryptionEnabled =
 							!options?.jwks?.disablePrivateKeyEncryption;
 						let jwk: Partial<Jwk> = {
-							id: ctx.context.generateId({
+							id: await ctx.context.generateId({
 								model: "jwks",
 							}),
 							publicKey: JSON.stringify({ alg, ...publicWebKey }),

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -581,7 +581,7 @@ export const passkey = (options?: PasskeyOptions) => {
 						const newPasskey: Passkey = {
 							name: ctx.body.name,
 							userId: userData.id,
-							id: ctx.context.generateId({ model: "passkey" }),
+							id: await ctx.context.generateId({ model: "passkey" }),
 							credentialID: credential.id,
 							publicKey: pubKey,
 							counter: credential.counter,

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -650,7 +650,7 @@ export type BetterAuthOptions = {
 			| ((options: {
 					model: LiteralUnion<Models, string>;
 					size?: number;
-			  }) => string)
+			  }) => Promise<string> | string)
 			| false;
 	};
 	logger?: Logger;


### PR DESCRIPTION
Many crypto APIs allow async access (for the purposes of gathering
entropy etc). This change allows optionally returning a Promise
instead meaning these async APIs are accessible.

For the particular use-case that motivated this change, nextjs + ppr + dynamicIO requires async crypto APIs to work correctly and since I am using KSUID for generating IDs, the sync API is no longer viable.
