### PR TITLE
docs: change code example comment wording

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -678,7 +678,7 @@ export const auth = betterAuth({
                   }
               },
               after: async (user) => {
-                  //perform additional actions, like creating a stripe customer
+                  //perform additional actions, like adding additional fields to other tables
               },
           },
       },


### PR DESCRIPTION
Removed this considering if they want to use Stripe, they can use the (soon to come) plugin instead.