### PR TITLE
fix: signup with `emailAndPassword` email is required #1303

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -141,7 +141,10 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 
 			const additionalData = parseUserInput(
 				ctx.context.options,
-				additionalFields as any,
+				{
+					email,
+					...additionalFields as any,
+				},
 			);
 			let createdUser: User;
 			try {


### PR DESCRIPTION
This pull request includes an important change to the `signUpEmail` function in the `sign-up.ts` file to ensure that the user's email is included in the additional data parsed from the user input.

* [`packages/better-auth/src/api/routes/sign-up.ts`](diffhunk://#diff-c09cb9d90924e06f627b1816c6b13a4992d71cb088478cfa46a09331a9ecb490L144-R147): Modified the `parseUserInput` call to include the `email` field along with `additionalFields` to ensure that the email is part of the additional data.

fixed: #1303