### PR TITLE
fix: return passkey data if valid

### DIFF
--- a/packages/better-auth/src/plugins/passkey/client.ts
+++ b/packages/better-auth/src/plugins/passkey/client.ts
@@ -1,19 +1,19 @@
 import type { BetterFetch, BetterFetchOption } from "@better-fetch/fetch";
+import type {
+	PublicKeyCredentialCreationOptionsJSON,
+	PublicKeyCredentialRequestOptionsJSON,
+} from "@simplewebauthn/browser";
 import {
 	WebAuthnError,
 	startAuthentication,
 	startRegistration,
 } from "@simplewebauthn/browser";
-import type {
-	PublicKeyCredentialCreationOptionsJSON,
-	PublicKeyCredentialRequestOptionsJSON,
-} from "@simplewebauthn/browser";
 import type { Session } from "inspector";
-import type { User } from "../../types";
-import type { passkey as passkeyPl, Passkey } from ".";
-import type { BetterAuthClientPlugin } from "../../client/types";
-import { useAuthQuery } from "../../client";
 import { atom } from "nanostores";
+import type { Passkey, passkey as passkeyPl } from ".";
+import { useAuthQuery } from "../../client";
+import type { BetterAuthClientPlugin } from "../../client/types";
+import type { User } from "../../types";
 
 export const getPasskeyActions = (
 	$fetch: BetterFetch,
@@ -59,7 +59,7 @@ export const getPasskeyActions = (
 				...options,
 				method: "POST",
 			});
-			if (!verified.data) {
+			if (verified.data) {
 				return verified;
 			}
 		} catch (e) {
@@ -116,7 +116,7 @@ export const getPasskeyActions = (
 				},
 				method: "POST",
 			});
-			if (!verified.data) {
+			if (verified.data) {
 				return verified;
 			}
 			$listPasskeys.set(Math.random());


### PR DESCRIPTION
This pull request modifies two conditional checks in the passkey client actions (signInPasskey and registerPasskey) so that the functions return the verified data when it exists instead of returning it only when there is no verified data. By switching from if (!verified.data) to if (verified.data), we ensure that a successful server response is propagated back to the caller.