### PR TITLE
docs: wrong pattern in hono integration code

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -17,7 +17,7 @@ import { cors } from "hono/cors";
 
 const app = new Hono();
 
-app.on(["POST", "GET"], "/api/auth/**", (c) => {
+app.on(["POST", "GET"], "/api/auth/*", (c) => {
 	return auth.handler(c.req.raw);
 });
 


### PR DESCRIPTION
Caused by c26285b238b84215665729f47257b0d6dc9b6aec

The pattern should be `*` instead of `**` since it's not a supported syntax

It is causing strange issue then in the Hono server handlers

**Working version**
```ts
const app = new Hono()

const userRoute = new Hono()
  // .get("/top", (c) => {
  //   return c.json({ message: "Top" }, 200)
  // })
  .get(
    "/:id",
    zValidator(
      "param",
      z.object({
        id: z.string(),
      })
    ),
    (c) => {
      return c.json({ message: `Hello ${c.req.param("id")}` }, 200)
    }
  )

const routes = app.route("/user", userRoute)

app.on(["POST", "GET"], "/api/auth/**", (c) => {
  return c.json({ message: "Hello" }, 200)
})

export default app

// curl http://localhost:3000/api/auth/ok 
// {"message":"Hello"}

```

**Non working version**
```tsx
const userRoute = new Hono()
  .get("/top", (c) => {
    return c.json({ message: "Top" }, 200)
  }) // I've added this 😅😅😅😅
  .get(
    "/:id",
    zValidator(
      "param",
      z.object({
        id: z.string(),
      })
    ),
    (c) => {
      return c.json({ message: `Hello ${c.req.param("id")}` }, 200)
    }
  )

const routes = app.route("/user", userRoute)

app.on(["POST", "GET"], "/api/auth/**", (c) => {
  return c.json({ message: "Hello" }, 200)
})

export default app
// curl http://localhost:3000/api/auth/ok 
// 404 Not Found

```