### PR TITLE
Fix React prop spreading warnings in CodeEditor component

### DIFF
--- a/docs/components/builder/code-tabs/code-editor.tsx
+++ b/docs/components/builder/code-tabs/code-editor.tsx
@@ -32,16 +32,20 @@ export function CodeEditor({ code, language }: CodeEditorProps) {
 						className={`${className} text-sm p-4 w-fit overflow-scroll  max-h-[400px] rounded-md`}
 						style={style}
 					>
-						{tokens.map((line, i) => (
-							<div key={i} {...getLineProps({ line, key: i })}>
+						{tokens.map((line, i) => {
+							const lineProps = getLineProps({ line, key: i });
+							return (<div key={i} className={lineProps.className}
+								style={lineProps.style}>
 								<span className="inline-block w-4 mr-3 text-gray-500 select-none">
 									{i + 1}
 								</span>
-								{line.map((token, key) => (
-									<span key={key} {...getTokenProps({ token, key })} />
-								))}
-							</div>
-						))}
+								{line.map((token, key) => {
+									const tokenProps = getTokenProps({token, key})
+									return <span key={key} className={tokenProps.className} style={tokenProps.style} >{tokenProps.children}</span>
+
+								})}
+							</div>)
+						})}
 					</pre>
 				)}
 			</Highlight>


### PR DESCRIPTION
Error shown in the image was occurred when codeEditor component was opened in dev mode :
![Screenshot 2025-01-31 193422](https://github.com/user-attachments/assets/714d74a3-0155-4cc8-80f7-4a4c495fdf7d)
![Screenshot 2025-01-31 193410](https://github.com/user-attachments/assets/5fedff53-fff0-48fb-adba-fdfad7c71fbb)

