### PR TITLE
corrected, updated cross subdomain cookies docs

### DIFF
--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -54,7 +54,9 @@ export const auth = betterAuth({
 
 Sometimes you may need to share cookies across subdomains. For example, if you have `app.example.com` and `example.com`, and if you authenticate on `example.com`, you may want to access the same session on `app.example.com`.
 
-By default, cookies are not shared between subdomains. However, if you need to access the same session across different subdomains, you can enable cross-subdomain cookies. To enable them, configure `crossSubDomainCookies` in the `advanced` object of the auth options.
+By default, cookies are not shared between subdomains. However, if you need to access the same session across different subdomains, you can enable cross-subdomain cookies by configuring `crossSubDomainCookies` and `defaultCookieAttributes` in the `advanced` object of the auth options.
+
+<Callout>The leading period of the `domain` attribute broadens the cookie's scope beyond your main domain, making it accessible across all subdomains.</Callout>
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"
@@ -63,11 +65,23 @@ export const auth = betterAuth({
     advanced: {
         crossSubDomainCookies: {
             enabled: true,
-            domain: "example.com" // Optional. Defaults to the base url domain
-        }
-    }
+            domain: ".example.com", // Domain with a leading period
+        },
+        defaultCookieAttributes: {
+            secure: true,
+            httpOnly: true,
+            sameSite: "none", // Allows CORS-based cookie sharing across subdomains
+        },
+    },
+    trustedOrigins: [
+        'https://example.com',
+        'https://app1.example.com',
+        'https://app2.example.com',
+    ],
 })
 ```
+
+<Callout type="warn">Setting your `sameSite` cookie attribute to `none` makes you vulnerable to CSRF attacks. To mitigate risks, configure `trustedOrigins` with an array of authorized origins to allow.</Callout>
 
 ### Secure Cookies
 

--- a/docs/content/docs/reference/security.mdx
+++ b/docs/content/docs/reference/security.mdx
@@ -32,9 +32,9 @@ To secure OAuth flows, Better Auth stores the OAuth state and PKCE (Proof Key fo
 
 ## Cookies
 
-Better Auth assigns secure cookies by default when the base URL uses `https`. These secure cookies are encrypted and only sent over secure connections, adding an extra layer of protection. They are also set with the `SameSite` attribute to `LAX` by default to prevent cross-site request forgery attacks. And the `HttpOnly` attribute is enabled to prevent client-side JavaScript from accessing the cookie. 
+Better Auth assigns secure cookies by default when the base URL uses `https`. These secure cookies are encrypted and only sent over secure connections, adding an extra layer of protection. They are also set with the `sameSite` attribute to `lax` by default to prevent cross-site request forgery attacks. And the `httpOnly` attribute is enabled to prevent client-side JavaScript from accessing the cookie. 
 
-For Cross Sub Domain cookies, you can set the `crossSubDomain` option in the configuration. This option allows cookies to be shared across subdomains, enabling seamless authentication across multiple subdomains.
+For Cross-Subdomain Cookies, you can set the `crossSubDomainCookies` option in the configuration. This option allows cookies to be shared across subdomains, enabling seamless authentication across multiple subdomains.
 
 ### Customizing Cookies
 


### PR DESCRIPTION
docs/concepts/cookies:
- updated the `Cross Subdomain Cookies` section  with missing details and additional information to make subdomain cookies work

docs/reference/security:
- updated the `Cookies` section with corrected attribute and option names