### PR TITLE
fix(docs): page navigation buttons don't work if the next/prev category's index[0] is a group

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -201,6 +201,9 @@ function getPageLinks(path: string) {
 		if (!next_category) next_category = contents[0];
 
 		next_page = next_category.list[0];
+		if(next_page.group){ 
+			next_page = next_category.list[1];
+		}
 	}
 	// the prev page in the array.
 	let prev_page = current_category.list.filter((x) => !x.group)[
@@ -215,6 +218,9 @@ function getPageLinks(path: string) {
 		// if doesn't exist, return to last cat.
 		if (!prev_category) prev_category = contents[contents.length - 1];
 		prev_page = prev_category.list[prev_category.list.length - 1];
+		if(prev_page.group){ 
+			prev_page = prev_category.list[prev_category.list.length - 2];
+		}
 	}
 
 	const pages = source.getPages();


### PR DESCRIPTION
# Before

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/d9d8dab5-bb36-414b-8821-3cbec09cebd8" />

# After

<img width="908" alt="image" src="https://github.com/user-attachments/assets/b3ecc0ff-a2d3-4e8a-9520-f984ae973e68" />
