### PR TITLE
Fix incorrect call to `getModelName`

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -186,7 +186,7 @@ const createTransform = (
 				return c[0];
 			}
 			await builder;
-			const schemaModel = getSchema(getModelName(model));
+			const schemaModel = getSchema(model);
 			const res = await db
 				.select()
 				.from(schemaModel)


### PR DESCRIPTION
`getSchema` already calls `getModelName`. When custom tables are used, this results in a bug where better-auth can't find the table name:

```
TypeError: undefined is not an object
```

This PR fixes the incorrect call to `getModelName`.