### PR TITLE
docs(fix): add `inviterId` field to invitation schema

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -833,6 +833,12 @@ Table Name: `invitation`
       description: "The email address of the user" 
     },
     { 
+      name: "inviterId", 
+      type: "string", 
+      description: "The id of the inviter",
+      isForeignKey: true
+    },
+    { 
       name: "organizationId", 
       type: "string", 
       description: "The id of the organization",


### PR DESCRIPTION
Adds a missing required field to the invitation schema on docs.

Before:
![image](https://github.com/user-attachments/assets/10f47228-8c84-4f8b-8c6d-0d8c4663f903)

After:
![image](https://github.com/user-attachments/assets/59ba6b51-21a9-444a-be60-12a160d9e339)
