### PR TITLE
Fix OWSAP typo

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -229,7 +229,7 @@ const { data, error } = await authClient.resetPassword({
 
 Better Auth stores passwords inside the `account` table with `providerId` set to `credential`.
 
-**Password Hashing**: Better Auth uses `scrypt` to hash passwords. The `scrypt` algorithm is designed to be slow and memory-intensive to make it difficult for attackers to brute force passwords. OWSAP recommends using `scrypt` if `argon2id` is not available. We decided to use `scrypt` because it's natively supported by Node.js.
+**Password Hashing**: Better Auth uses `scrypt` to hash passwords. The `scrypt` algorithm is designed to be slow and memory-intensive to make it difficult for attackers to brute force passwords. OWASP recommends using `scrypt` if `argon2id` is not available. We decided to use `scrypt` because it's natively supported by Node.js.
 
 You can pass custom password hashing algorithm by setting `passwordHasher` option in the `auth` configuration.
 


### PR DESCRIPTION
The docs said "OWSAP" instead of "OWASP"