### PR TITLE
docs: Minor grammar and spelling fixes

### DIFF
--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -101,9 +101,9 @@ export const auth = betterAuth({
                 getTempEmail: (phoneNumber) => {
                     return `${phoneNumber}@my-site.com`
                 },
-                //optionally you can alos pass `getTempName` function to generate a temporary name for the user
+                //optionally, you can also pass `getTempName` function to generate a temporary name for the user
                 getTempName: (phoneNumber) => {
-                    return phoneNumber //by default it will use the phone number as the name
+                    return phoneNumber //by default, it will use the phone number as the name
                 }
             }
         })

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -88,7 +88,7 @@ When the phone number is verified, the `phoneNumberVerified` field in the user t
 
 ### Allow Sign-Up with Phone Number
 
-to allow users to sign up using their phone number, you can pass `signUpOnVerification` option to the your plugin configuration. It requires you to pass `getTempEmail` function to generate a temporary email for the user.
+to allow users to sign up using their phone number, you can pass `signUpOnVerification` option to your plugin configuration. It requires you to pass `getTempEmail` function to generate a temporary email for the user.
 
 ```ts title="auth.ts"
 export const auth = betterAuth({

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -88,7 +88,7 @@ When the phone number is verified, the `phoneNumberVerified` field in the user t
 
 ### Allow Sign-Up with Phone Number
 
-to allow users to sign up using their phone number, you can pass `signUpOnVerification` option to the your plugin configuration. It reqiures you to pass `getTempEmail` function to generate a temporary email for the user. 
+to allow users to sign up using their phone number, you can pass `signUpOnVerification` option to the your plugin configuration. It requires you to pass `getTempEmail` function to generate a temporary email for the user.
 
 ```ts title="auth.ts"
 export const auth = betterAuth({

--- a/docs/content/docs/reference/faq.mdx
+++ b/docs/content/docs/reference/faq.mdx
@@ -15,7 +15,7 @@ If you're using the auth client on react front-end, you'll need to import it fro
 import { createAuthClient } from "better-auth/react";
 ```
 
-Where as if you're using the auth client in Next.js middelware, server-actions, server-components or anything server-related, you'll likely need to import it from `/client`:
+Where as if you're using the auth client in Next.js middleware, server-actions, server-components or anything server-related, you'll likely need to import it from `/client`:
 
 ```ts title="server.ts"
 import { createAuthClient } from "better-auth/client";


### PR DESCRIPTION
Bello! I was reading through the docs and just noticed some small typos or grammar errors here or there, and took it upon myself to fix everything up! All changes are listed below!

- "middelware" → "middleware" (`docs/content/docs/reference/faq.mdx`)
- "reqiures" → "requires" (`docs/content/docs/plugins/phone-number.mdx`)
- "//optionally you can alos pass `getTempName` function to generate a temporary name for the user" → "//optionally, you can also pass `getTempName` function to generate a temporary name for the user" (`docs/content/docs/plugins/phone-number.mdx`)
- "//by default it will use the phone number as the name" → "//by default, it will use the phone number as the name" (`docs/content/docs/plugins/phone-number.mdx`)