### PR TITLE
🐛 Fix Google IdToken Auth

### DIFF
--- a/packages/better-auth/src/social-providers/google.ts
+++ b/packages/better-auth/src/social-providers/google.ts
@@ -105,7 +105,8 @@ export const google = (options: GoogleOptions) => {
 			}
 			const isValid =
 				tokenInfo.aud === options.clientId &&
-				tokenInfo.iss === "https://accounts.google.com";
+				(tokenInfo.iss === "https://accounts.google.com" ||
+					tokenInfo.iss === "accounts.google.com");
 			return isValid;
 		},
 		async getUserInfo(token) {


### PR DESCRIPTION
"The value of iss in the ID token is equal to accounts.google.com or https://accounts.google.com."

Source: https://developers.google.com/identity/gsi/web/guides/verify-google-id-token

I ran into this when trying to auth via idToken obtained from auth within a Chrome Extension. According to the Google doc above the iss can also be "accounts.google.com", which was the case for the idToken I got.