### PR TITLE
fix(docs) session seconday storage value redis example

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -234,7 +234,7 @@ export const auth = betterAuth({
 	secondaryStorage: {
 		get: async (key) => {
 			const value = await redis.get(key);
-			return value ? value : null;
+			return value ? JSON.stringify(value) : null;
 		},
 		set: async (key, value, ttl) => {
 			if (ttl) await redis.set(key, value, { EX: ttl });


### PR DESCRIPTION
When using secondary storage, in this case redis the expected session value should be should be proper json but this example doesnt cover that hence getting this error whenever session is used.

>ERROR [Better Auth]: INTERNAL_SERVER_ERROR SyntaxError: "[object Object]" is not valid JSON
