### PR TITLE
Fixed broken hyperlink to betterauth.com

### DIFF
--- a/docs/content/docs/guides/next-auth-migration-guide.mdx
+++ b/docs/content/docs/guides/next-auth-migration-guide.mdx
@@ -179,4 +179,4 @@ To protect routes with middleware, refer to the [Next.js middleware guide](/docs
 
 Congratulations! You’ve successfully migrated from NextAuth.js to Better Auth. For a complete implementation with multiple authentication methods, check out the [demo repository](https://github.com/Bekacru/t3-app-better-auth).
 
-Better Auth offers greater flexibility and more features—be sure to explore the [documentation](https://betterauth.dev) to unlock its full potential.
+Better Auth offers greater flexibility and more features—be sure to explore the [documentation](/docs) to unlock its full potential.


### PR DESCRIPTION
Documentation was pointing to the outdated url: betterauth.com