### PR TITLE
fix(cli): wrong kysely schema filename

### DIFF
--- a/packages/cli/src/generators/kysely.ts
+++ b/packages/cli/src/generators/kysely.ts
@@ -1,13 +1,18 @@
 import { getMigrations } from "better-auth/db";
 import type { SchemaGenerator } from "./types";
 
-export const generateMigrations: SchemaGenerator = async ({ options }) => {
+export const generateMigrations: SchemaGenerator = async ({
+	options,
+	file,
+}) => {
 	const { compileMigrations } = await getMigrations(options);
 	const migrations = await compileMigrations();
 	return {
 		code: migrations,
-		fileName: `./better-auth_migrations/${new Date()
-			.toISOString()
-			.replace(/:/g, "-")}.sql`,
+		fileName:
+			file ||
+			`./better-auth_migrations/${new Date()
+				.toISOString()
+				.replace(/:/g, "-")}.sql`,
 	};
 };


### PR DESCRIPTION
Change kysely generate schema file name confirmation based on output option

Previously if we fill the `--output` option, we still got a confirmation message with the better auth default file name instead of the `--output` that we input before.

Closes #1268 