### PR TITLE
feat: allow extra data when registering with OAuth

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -97,7 +97,7 @@ export function getEndpoints<
 			.flat() || [];
 
 	const baseEndpoints = {
-		signInSocial,
+		signInSocial: signInSocial<Option>(),
 		callbackOAuth,
 		getSession: getSession<Option>(),
 		signOut,

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -67,7 +67,7 @@ export const callbackOAuth = createAuthEndpoint(
 				`${c.context.baseURL}/error?error=oauth_provider_not_found`,
 			);
 		}
-		const { codeVerifier, callbackURL, link, errorURL, newUserURL } =
+		const { codeVerifier, callbackURL, link, errorURL, newUserURL, additionalData } =
 			await parseState(c);
 
 		let tokens: OAuth2Tokens;
@@ -84,7 +84,7 @@ export const callbackOAuth = createAuthEndpoint(
 			);
 		}
 		const userInfo = await provider
-			.getUserInfo(tokens)
+			.getUserInfo(tokens, additionalData)
 			.then((res) => res?.user);
 
 		function redirectOnError(error: string) {

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -45,6 +45,13 @@ export const signInSocial = createAuthEndpoint(
 			 */
 			provider: SocialProviderListEnum,
 			/**
+			 * Additional data to be passed to createOauthUser
+			 * 
+			 * useful if you want to pass additional data when creating an OAuth user
+			 * such as a user role for instance
+			 */
+			additionalData: z.record(z.string()).optional(),
+			/**
 			 * Disable automatic redirection to the provider
 			 *
 			 * This is useful if you want to handle the redirection

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -28,7 +28,7 @@ export const createInternalAdapter = (
 
 	return {
 		createOAuthUser: async (
-			user: Omit<User, "id" | "createdAt" | "updatedAt"> & Partial<User>,
+			user: Omit<User, "id" | "createdAt" | "updatedAt"> & Partial<User> & Record<string, any> ,
 			account: Omit<Account, "userId" | "id" | "createdAt" | "updatedAt"> &
 				Partial<Account>,
 		) => {

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -23,12 +23,14 @@ export async function generateState(
 		codeVerifier,
 		errorURL: c.body?.errorCallbackURL,
 		newUserURL: c.body?.newUserCallbackURL,
+		additionalData: c.body?.additionalData,
 		link,
 		/**
 		 * This is the actual expiry time of the state
 		 */
 		expiresAt: Date.now() + 10 * 60 * 1000,
 	});
+
 	const expiresAt = new Date();
 	expiresAt.setMinutes(expiresAt.getMinutes() + 10);
 	const verification = await c.context.internalAdapter.createVerificationValue({
@@ -67,6 +69,7 @@ export async function parseState(c: GenericEndpointContext) {
 			codeVerifier: z.string(),
 			errorURL: z.string().optional(),
 			newUserURL: z.string().optional(),
+			additionalData: z.record(z.string()).optional(),
 			expiresAt: z.number(),
 			link: z
 				.object({

--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -26,7 +26,7 @@ export interface OAuthProvider<
 		redirectURI: string;
 		codeVerifier?: string;
 	}) => Promise<OAuth2Tokens>;
-	getUserInfo: (token: OAuth2Tokens) => Promise<{
+	getUserInfo: (token: OAuth2Tokens, additionalData?: Record<string, unknown>) => Promise<{
 		user: {
 			id: string;
 			name?: string;
@@ -73,7 +73,7 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 	/**
 	 * Custom function to get user info from the provider
 	 */
-	getUserInfo?: (token: OAuth2Tokens) => Promise<{
+	getUserInfo?: (token: OAuth2Tokens, additionalData?: Record<string, unknown>) => Promise<{
 		user: {
 			id: string;
 			name?: string;
@@ -88,7 +88,7 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 	 * Custom function to map the provider profile to a
 	 * user.
 	 */
-	mapProfileToUser?: (profile: Profile) =>
+	mapProfileToUser?: (profile: Profile, additionalData?: Record<string, unknown>) =>
 		| {
 				id?: string;
 				name?: string;

--- a/packages/better-auth/src/social-providers/apple.ts
+++ b/packages/better-auth/src/social-providers/apple.ts
@@ -120,9 +120,9 @@ export const apple = (options: AppleOptions) => {
 			}
 			return !!jwtClaims;
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			if (!token.idToken) {
 				return null;
@@ -134,7 +134,7 @@ export const apple = (options: AppleOptions) => {
 			const name = profile.user
 				? `${profile.user.name.firstName} ${profile.user.name.lastName}`
 				: profile.email;
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.sub,

--- a/packages/better-auth/src/social-providers/discord.ts
+++ b/packages/better-auth/src/social-providers/discord.ts
@@ -103,9 +103,9 @@ export const discord = (options: DiscordOptions) => {
 				tokenEndpoint: "https://discord.com/api/oauth2/token",
 			});
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			const { data: profile, error } = await betterFetch<DiscordProfile>(
 				"https://discord.com/api/users/@me",
@@ -129,7 +129,7 @@ export const discord = (options: DiscordOptions) => {
 				const format = profile.avatar.startsWith("a_") ? "gif" : "png";
 				profile.image_url = `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.${format}`;
 			}
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.id,

--- a/packages/better-auth/src/social-providers/dropbox.ts
+++ b/packages/better-auth/src/social-providers/dropbox.ts
@@ -51,9 +51,9 @@ export const dropbox = (options: DropboxOptions) => {
 				tokenEndpoint,
 			});
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			const { data: profile, error } = await betterFetch<DropboxProfile>(
 				"https://api.dropboxapi.com/2/users/get_current_account",
@@ -68,7 +68,7 @@ export const dropbox = (options: DropboxOptions) => {
 			if (error) {
 				return null;
 			}
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.account_id,

--- a/packages/better-auth/src/social-providers/facebook.ts
+++ b/packages/better-auth/src/social-providers/facebook.ts
@@ -90,9 +90,9 @@ export const facebook = (options: FacebookOptions) => {
 			return true;
 		},
 
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 
 			if (token.idToken) {
@@ -121,7 +121,7 @@ export const facebook = (options: FacebookOptions) => {
 				const userMap = await options.mapProfileToUser?.({
 					...user,
 					email_verified: true,
-				});
+				}, additionalData);
 
 				return {
 					user: {
@@ -152,7 +152,7 @@ export const facebook = (options: FacebookOptions) => {
 			if (error) {
 				return null;
 			}
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.id,

--- a/packages/better-auth/src/social-providers/github.ts
+++ b/packages/better-auth/src/social-providers/github.ts
@@ -75,9 +75,9 @@ export const github = (options: GithubOptions) => {
 				tokenEndpoint,
 			});
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			const { data: profile, error } = await betterFetch<GithubProfile>(
 				"https://api.github.com/user",
@@ -111,7 +111,7 @@ export const github = (options: GithubOptions) => {
 				emailVerified =
 					data.find((e) => e.email === profile.email)?.verified ?? false;
 			}
-			const userMap = await options.mapProfileToUser?.(profile, extraData);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.id.toString(),

--- a/packages/better-auth/src/social-providers/github.ts
+++ b/packages/better-auth/src/social-providers/github.ts
@@ -111,7 +111,7 @@ export const github = (options: GithubOptions) => {
 				emailVerified =
 					data.find((e) => e.email === profile.email)?.verified ?? false;
 			}
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, extraData);
 			return {
 				user: {
 					id: profile.id.toString(),

--- a/packages/better-auth/src/social-providers/gitlab.ts
+++ b/packages/better-auth/src/social-providers/gitlab.ts
@@ -102,9 +102,9 @@ export const gitlab = (options: GitlabOptions) => {
 				tokenEndpoint,
 			});
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			const { data: profile, error } = await betterFetch<GitlabProfile>(
 				userinfoEndpoint,
@@ -113,7 +113,7 @@ export const gitlab = (options: GitlabOptions) => {
 			if (error || profile.state !== "active" || profile.locked) {
 				return null;
 			}
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.id.toString(),

--- a/packages/better-auth/src/social-providers/google.ts
+++ b/packages/better-auth/src/social-providers/google.ts
@@ -109,15 +109,15 @@ export const google = (options: GoogleOptions) => {
 					tokenInfo.iss === "accounts.google.com");
 			return isValid;
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			if (!token.idToken) {
 				return null;
 			}
 			const user = decodeJwt(token.idToken) as GoogleProfile;
-			const userMap = await options.mapProfileToUser?.(user);
+			const userMap = await options.mapProfileToUser?.(user, additionalData);
 			return {
 				user: {
 					id: user.sub,

--- a/packages/better-auth/src/social-providers/linkedin.ts
+++ b/packages/better-auth/src/social-providers/linkedin.ts
@@ -46,7 +46,7 @@ export const linkedin = (options: LinkedInOptions) => {
 				tokenEndpoint,
 			});
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			const { data: profile, error } = await betterFetch<LinkedInProfile>(
 				"https://api.linkedin.com/v2/userinfo",
 				{
@@ -61,7 +61,7 @@ export const linkedin = (options: LinkedInOptions) => {
 				return null;
 			}
 
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.sub,

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -67,9 +67,9 @@ export const microsoft = (options: MicrosoftOptions) => {
 				tokenEndpoint,
 			});
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			if (!token.idToken) {
 				return null;
@@ -103,7 +103,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 					},
 				},
 			);
-			const userMap = await options.mapProfileToUser?.(user);
+			const userMap = await options.mapProfileToUser?.(user, additionalData);
 			return {
 				user: {
 					id: user.sub,

--- a/packages/better-auth/src/social-providers/reddit.ts
+++ b/packages/better-auth/src/social-providers/reddit.ts
@@ -63,9 +63,9 @@ export const reddit = (options: RedditOptions) => {
 
 			return getOAuth2Tokens(data);
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 
 			const { data: profile, error } = await betterFetch<RedditProfile>(
@@ -82,7 +82,7 @@ export const reddit = (options: RedditOptions) => {
 				return null;
 			}
 
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 
 			return {
 				user: {

--- a/packages/better-auth/src/social-providers/spotify.ts
+++ b/packages/better-auth/src/social-providers/spotify.ts
@@ -39,9 +39,9 @@ export const spotify = (options: SpotifyOptions) => {
 				tokenEndpoint: "https://accounts.spotify.com/api/token",
 			});
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			const { data: profile, error } = await betterFetch<SpotifyProfile>(
 				"https://api.spotify.com/v1/me",
@@ -55,7 +55,7 @@ export const spotify = (options: SpotifyOptions) => {
 			if (error) {
 				return null;
 			}
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.id,

--- a/packages/better-auth/src/social-providers/twitch.ts
+++ b/packages/better-auth/src/social-providers/twitch.ts
@@ -55,9 +55,9 @@ export const twitch = (options: TwitchOptions) => {
 				tokenEndpoint: "https://id.twitch.tv/oauth2/token",
 			});
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			const idToken = token.idToken;
 			if (!idToken) {
@@ -65,7 +65,7 @@ export const twitch = (options: TwitchOptions) => {
 				return null;
 			}
 			const profile = decodeJwt(idToken) as TwitchProfile;
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.sub,

--- a/packages/better-auth/src/social-providers/twitter.ts
+++ b/packages/better-auth/src/social-providers/twitter.ts
@@ -124,9 +124,9 @@ export const twitter = (options: TwitterOption) => {
 				tokenEndpoint: "https://api.x.com/2/oauth2/token",
 			});
 		},
-		async getUserInfo(token) {
+		async getUserInfo(token, additionalData) {
 			if (options.getUserInfo) {
-				return options.getUserInfo(token);
+				return options.getUserInfo(token, additionalData);
 			}
 			const { data: profile, error } = await betterFetch<TwitterProfile>(
 				"https://api.x.com/2/users/me?user.fields=profile_image_url",
@@ -140,7 +140,7 @@ export const twitter = (options: TwitterOption) => {
 			if (error) {
 				return null;
 			}
-			const userMap = await options.mapProfileToUser?.(profile);
+			const userMap = await options.mapProfileToUser?.(profile, additionalData);
 			return {
 				user: {
 					id: profile.data.id,


### PR DESCRIPTION
Provides a solution for #778.

# Use case
When registering a new user, one might wants to initialize a specific field - a good example would be providing different sign up forms for different user types. 
When using "authClient.signUp.email(...)", you could easily provide additional fields to be populated inside the user entity doing so: 
```js
authClient.signUp.email({
    email: "test@example.com",
    password: "password1234",
    name: "test",
    image: "https://example.com/image.png",
    type: 'USER_TYPE_1', // Here goes the extra field
})
```
 
However, if the system allows users to register with OAuth providers, one would needs the kind of additional data handling but the "authClient.signIn.social(...)" API does not allow to pass extra field when registering the user : 
```js
const data = await authClient.signIn.social({
    provider: "google",
    type: 'USER_TYPE_1', // <-- This won't work 
})
```

# Proposal
This PR proposal is to create an additionalData API on signIn.social so that we could also pass additional data when registering with OAuth:
```js
const data = await authClient.signIn.social({
    provider: "google",
	additionalData:  {
	    type: 'USER_TYPE_1',
	}
})
``` 
Then the data would become available inside `getUserInfo` hooks in order to pass it to the internal adapter creation function.
In the end the end-developer would just need to update Better Auth config file by using the additional field inside of getUserInfo : 

```js
export const auth = betterAuth({
// ... Rest of the config
socialProviders: {
    google: {
      clientId: <google_client_id>,
      clientSecret: <google_client_secret>,
      mapProfileToUser: (profile: GoogleProfile, additionalData: Record<string, unknown> = {}) => ({
        email: profile.email,
        name: `${profile.given_name} ${profile.family_name}`,
        emailVerified: profile.email_verified === true,
        image: profile.picture,
        ...additionalData, // <-- Here you can use additionalData as you want
      }),
    },
   // ... Repeat for every social provider you want to handle
  },
```

