### PR TITLE
docs: fix syntax error

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -243,7 +243,7 @@ export const auth = betterAuth({
 			else await redis.set(key, value);
 		},
 		delete: async (key) => {
-			await redis.del(key),
+			await redis.del(key);
 		}
 	}
 });


### PR DESCRIPTION
This pull request includes a minor change to the `docs/content/docs/concepts/database.mdx` file. The change corrects a syntax error by replacing a comma with a semicolon in the `delete` method of the `betterAuth` configuration.

* [`docs/content/docs/concepts/database.mdx`](diffhunk://#diff-3fb82b9771e62eb4c129ceb5109e4500f630d5fd40b289d06ff38f69d4c52dc3L246-R246): Corrected a syntax error in the `delete` method by replacing a comma with a semicolon.