### PR TITLE
fix(docs): fix routes in hono integration example code

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -37,7 +37,7 @@ import { cors } from "hono/cors";
 const app = new Hono();
 
 app.use(
-	"/api/auth/**", // or replace with "*" to enable cors for all routes
+	"/api/auth/*", // or replace with "*" to enable cors for all routes
 	cors({
 		origin: "http://localhost:3001", // replace with your origin
 		allowHeaders: ["Content-Type", "Authorization"],
@@ -82,7 +82,7 @@ app.use("*", async (c, next) => {
   	return next();
 });
 
-app.on(["POST", "GET"], "/api/auth/**", (c) => {
+app.on(["POST", "GET"], "/api/auth/*", (c) => {
 	return auth.handler(c.req.raw);
 });
 


### PR DESCRIPTION
With Hono `/api/auth/*` will cover everything that comes below that path.
There is no `**` in Hono, `*` works just fine.
