### PR TITLE
fix(cli): add on delete cascade constraint to Drizzle references

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -89,7 +89,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 											usePlural
 												? `${attr.references.model}s`
 												: attr.references.model
-										}.${attr.references.field})`
+										}.${attr.references.field}, { onDelete: 'cascade' })`
 									: ""
 							}`;
 						})

--- a/packages/cli/test/__snapshots__/auth-schema.txt
+++ b/packages/cli/test/__snapshots__/auth-schema.txt
@@ -20,14 +20,14 @@ export const session = pgTable("session", {
  updatedAt: timestamp('updated_at').notNull(),
  ipAddress: text('ip_address'),
  userAgent: text('user_agent'),
- userId: text('user_id').notNull().references(()=> user.id)
+ userId: text('user_id').notNull().references(()=> user.id, { onDelete: 'cascade' })
 				});
 
 export const account = pgTable("account", {
 					id: text("id").primaryKey(),
 					accountId: text('account_id').notNull(),
  providerId: text('provider_id').notNull(),
- userId: text('user_id').notNull().references(()=> user.id),
+ userId: text('user_id').notNull().references(()=> user.id, { onDelete: 'cascade' }),
  accessToken: text('access_token'),
  refreshToken: text('refresh_token'),
  idToken: text('id_token'),
@@ -52,5 +52,5 @@ export const twoFactor = pgTable("two_factor", {
 					id: text("id").primaryKey(),
 					secret: text('secret').notNull(),
  backupCodes: text('backup_codes').notNull(),
- userId: text('user_id').notNull().references(()=> user.id)
+ userId: text('user_id').notNull().references(()=> user.id, { onDelete: 'cascade' })
 				});


### PR DESCRIPTION
Adds `{ onDelete: "cascade" }` to all foreign key references in the Drizzle schema generator, matching the behavior of the Prisma schema generator