### PR TITLE
feat: allow disabling email and password signup

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -255,6 +255,11 @@ export const auth = betterAuth({
       type: "boolean",
       default: "false",
     },
+    disableSignUp: {
+      description: "Disable email and password sign up.",
+      type: "boolean",
+      default: "false"
+    },
     minPasswordLength: {
       description: "The minimum length of a password.",
       type: "number",

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -95,7 +95,10 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 			},
 		},
 		async (ctx) => {
-			if (!ctx.context.options.emailAndPassword?.enabled) {
+			if (
+				!ctx.context.options.emailAndPassword?.enabled ||
+				ctx.context.options.emailAndPassword?.disableSignUp
+			) {
 				throw new APIError("BAD_REQUEST", {
 					message: "Email and password sign up is not enabled",
 				});

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -165,6 +165,12 @@ export type BetterAuthOptions = {
 		 */
 		enabled: boolean;
 		/**
+		 * Disable email and password sign up
+		 *
+		 * @default false
+		 */
+		disableSignUp?: boolean;
+		/**
 		 * Require email verification before a session
 		 * can be created for the user.
 		 *


### PR DESCRIPTION
This PR brings a new option to the email and password authentication. `disableSignUp` allows disabling the `/sign-up/email` endpoint.

## Docs

![image](https://github.com/user-attachments/assets/ec330c1a-2cb0-4928-90cb-306274e1833b)

closes https://github.com/better-auth/better-auth/issues/1142