### PR TITLE
fix(oidc-plugin): user info endpoint casing to match OIDC spec

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -31,7 +31,7 @@ const getMetadata = (
 		issuer,
 		authorization_endpoint: `${baseURL}/oauth2/authorize`,
 		token_endpoint: `${baseURL}/oauth2/token`,
-		userInfo_endpoint: `${baseURL}/oauth2/userinfo`,
+		userinfo_endpoint: `${baseURL}/oauth2/userinfo`,
 		jwks_uri: `${baseURL}/jwks`,
 		registration_endpoint: `${baseURL}/oauth2/register`,
 		scopes_supported: ["openid", "profile", "email", "offline_access"],

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -393,7 +393,7 @@ export interface OIDCMetadata {
 	 *
 	 * @default `/oauth2/userinfo`
 	 */
-	userInfo_endpoint: string;
+	userinfo_endpoint: string;
 	/**
 	 * The URL of the jwks_uri endpoint.
 	 *


### PR DESCRIPTION
The `userinfo_endpoint` key in an oidc discovery endpoint should be lowercase snake_case.

When using better-auth with the DotNET OIDC library it was throwing an error when it was unable to find the user info endpoint: https://learn.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.protocols.openidconnect.openidconnectconfiguration.userinfoendpoint?view=msal-web-dotnet-latest#microsoft-identitymodel-protocols-openidconnect-openidconnectconfiguration-userinfoendpoint

Reference: https://swagger.io/docs/specification/v3_0/authentication/openid-connect-discovery/

