### PR TITLE
fix: Next JS demo confirm password validation

### DIFF
--- a/demo/nextjs/components/sign-up.tsx
+++ b/demo/nextjs/components/sign-up.tsx
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PasswordInput } from "@/components/ui/password-input";
 import { DiscordLogoIcon, GitHubLogoIcon } from "@radix-ui/react-icons";
-import { useState } from "react";
+import { JSXElementConstructor, ReactElement, ReactNode, ReactPortal, useState } from "react";
 import { signIn, signUp } from "@/lib/auth-client";
 import Image from "next/image";
 import { Loader2, X } from "lucide-react";
@@ -150,6 +150,10 @@ export function SignUp() {
 						className="w-full"
 						disabled={loading}
 						onClick={async () => {
+							if (password !== passwordConfirmation){
+								toast.error("Please ensure your password and confirm password match.");
+								return;
+							}
 							await signUp.email({
 								email,
 								password,

--- a/demo/nextjs/components/sign-up.tsx
+++ b/demo/nextjs/components/sign-up.tsx
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PasswordInput } from "@/components/ui/password-input";
 import { DiscordLogoIcon, GitHubLogoIcon } from "@radix-ui/react-icons";
-import { JSXElementConstructor, ReactElement, ReactNode, ReactPortal, useState } from "react";
+import { useState } from "react";
 import { signIn, signUp } from "@/lib/auth-client";
 import Image from "next/image";
 import { Loader2, X } from "lucide-react";


### PR DESCRIPTION
This PR aims to fix the bug on the sign-up page of the Next JS demo. Previously the form on the sign-up page asks the user to enter their password with which they want to sign up and then re-enter the password. The issue is that the sign-up process goes through even if the user enters a different password in the 'Confirm Password' field. 

After the changes in this PR. The user will be notified with a toast which should guide them to match the passwords entered in the 'Password' and 'Confirm Password' field.

Closes #1450 