### PR TITLE
feat(auth): set tokens on oauth account created during link

### DIFF
--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -135,6 +135,8 @@ export const callbackOAuth = createAuthEndpoint(
 				userId: link.userId,
 				providerId: provider.id,
 				accountId: userInfo.id,
+				...tokens,
+				scope: tokens.scopes?.join(","),
 			});
 			if (!newAccount) {
 				return redirectOnError("unable_to_link_account");


### PR DESCRIPTION
Make sure accounts created via manual linking do have oauth tokens set same as when regular oauth login happens.


fixes #1461 