### PR TITLE
OIDC Fixes

### DIFF
--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -61,6 +61,7 @@ export const verificationSchema = z.object({
 	updatedAt: z.date().default(() => new Date()),
 	expiresAt: z.date(),
 	identifier: z.string(),
+	nonce: z.string().nullish(),
 });
 
 export function parseOutputData<T extends Record<string, any>>(

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -156,8 +156,9 @@ export const jwt = (options?: JwtOptions) => {
 					const keySets = await adapter.getAllKeys();
 
 					if (keySets.length === 0) {
+						const alg = options?.jwks?.keyPairConfig?.alg ?? "EdDSA";
 						const { publicKey, privateKey } = await generateKeyPair(
-							options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
+							alg,
 							options?.jwks?.keyPairConfig ?? {
 								crv: "Ed25519",
 								extractable: true,
@@ -173,7 +174,7 @@ export const jwt = (options?: JwtOptions) => {
 							id: ctx.context.generateId({
 								model: "jwks",
 							}),
-							publicKey: JSON.stringify(publicWebKey),
+							publicKey: JSON.stringify({ alg, ...publicWebKey }),
 							privateKey: privateKeyEncryptionEnabled
 								? JSON.stringify(
 										await symmetricEncrypt({
@@ -191,6 +192,7 @@ export const jwt = (options?: JwtOptions) => {
 							keys: [
 								{
 									...publicWebKey,
+									alg,
 									kid: jwk.id,
 								},
 							],

--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -186,6 +186,7 @@ export async function authorize(
 				state: query.prompt === "consent" ? query.state : null,
 				codeChallenge: query.code_challenge,
 				codeChallengeMethod: query.code_challenge_method,
+				nonce: query.nonce,
 			}),
 			identifier: code,
 			expiresAt,

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -484,7 +484,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 
 					const requestedScopes = value.scope;
 					await ctx.context.internalAdapter.deleteVerificationValue(
-						code.toString(),
+						verificationValue.id,
 					);
 					const accessToken = generateRandomString(32, "a-z", "A-Z");
 					const refreshToken = generateRandomString(32, "A-Z", "a-z");

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -549,7 +549,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 						aud: client_id.toString(),
 						iat: Date.now(),
 						auth_time: ctx.context.session?.session.createdAt.getTime(),
-						nonce: body.nonce,
+						nonce: value.nonce,
 						acr: "urn:mace:incommon:iap:silver", // default to silver - ⚠︎ this should be configurable and should be validated against the client's metadata
 						...userClaims,
 					})

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -206,6 +206,15 @@ export interface AuthorizationQuery {
 	 * Code challenge method used
 	 */
 	code_challenge_method?: "plain" | "s256";
+	/**
+	 * String value used to associate a Client session with an ID Token, and to mitigate replay
+	 * attacks. The value is passed through unmodified from the Authentication Request to the ID Token.
+	 * If present in the ID Token, Clients MUST verify that the nonce Claim Value is equal to the
+	 * value of the nonce parameter sent in the Authentication Request. If present in the
+	 * Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token
+	 * with the Claim Value being the nonce value sent in the Authentication Request.
+	 */
+	nonce?: string;
 }
 
 export interface Client {
@@ -335,6 +344,10 @@ export interface CodeVerificationValue {
 	 * Code Challenge Method
 	 */
 	codeChallengeMethod?: "sha256" | "plain";
+	/**
+	 * Nonce
+	 */
+	nonce?: string;
 }
 
 export interface OAuthAccessToken {


### PR DESCRIPTION
- `deleteVerificationValue` was incorrectly using `code.toString()` instead of `verificationValue.id` as parameter
- Added `nonce` value to `verifications` schema to store and handle correctly as part of OIDC flow. Previously the nonce used in the `SignJWT` method was set to `body.nonce` which was undefined.
- Added `alg` property to output of `/jwks` endpoint. See #1277. 