### PR TITLE
fix: support `allowDifferentEmails` on Generic OAuth Plugin

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -538,7 +538,10 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						: null;
 
 					if (link) {
-						if (link.email !== userInfo.email.toLowerCase()) {
+						if (
+							ctx.context.options.account?.accountLinking?.allowDifferentEmails !== true &&
+							link.email !== userInfo.email.toLowerCase()
+						) {
 							return redirectOnError("email_doesn't_match");
 						}
 						const newAccount = await ctx.context.internalAdapter.createAccount({


### PR DESCRIPTION
This PR adds support to `account.accountLinking.allowDifferentEmails` to the Generic OAuth Plugin, so providers that doesn't provide the email can be added and also accounts with different emails can be linked as well, similar to the built-in social providers.

Closes #1479.