### PR TITLE
Add tenantId optional to Microsoft Social Provider example

### DIFF
--- a/docs/content/docs/authentication/microsoft.mdx
+++ b/docs/content/docs/authentication/microsoft.mdx
@@ -28,6 +28,7 @@ Enabling OAuth with Microsoft Azure Entra ID (formerly Active Directory) allows 
                 clientId: process.env.MICROSOFT_CLIENT_ID as string, // [!code highlight]
                 clientSecret: process.env.MICROSOFT_CLIENT_SECRET as string, // [!code highlight]
                 // Optional
+                tenantId: 'common', // [!code highlight]
                 requireSelectAccount: true // [!code highlight]
             }, // [!code highlight]
         },


### PR DESCRIPTION
add a simple line to show that a tenant id can be passed optionally