### PR TITLE
feat: allow header auth for token ednpoint

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -272,14 +272,18 @@ export const oidcProvider = (options: OIDCOptions) => {
 						});
 					}
 					let { client_id, client_secret } = body;
-					const authorization = ctx.request?.headers.get("authorization") || null
+					const authorization =
+						ctx.request?.headers.get("authorization") || null;
 					if (authorization && !client_id && !client_secret) {
-							const encoded = authorization.replace("Basic ", "");
-							client_id = new TextDecoder().decode(base64.decode(encoded)).split(":")[0]
-							client_secret = new TextDecoder().decode(base64.decode(encoded)).split(":")[1]
+						const encoded = authorization.replace("Basic ", "");
+						client_id = new TextDecoder()
+							.decode(base64.decode(encoded))
+							.split(":")[0];
+						client_secret = new TextDecoder()
+							.decode(base64.decode(encoded))
+							.split(":")[1];
 					}
 					const {
-						
 						grant_type,
 						code,
 						redirect_uri,

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -273,7 +273,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					}
 					let { client_id, client_secret } = body;
 					const authorization = ctx.request?.headers.get("authorization") || null
-					if (authorization) {
+					if (authorization && !client_id && !client_secret) {
 							const encoded = authorization.replace("Basic ", "");
 							client_id = new TextDecoder().decode(base64.decode(encoded)).split(":")[0]
 							client_secret = new TextDecoder().decode(base64.decode(encoded)).split(":")[1]

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -280,22 +280,29 @@ export const oidcProvider = (options: OIDCOptions) => {
 						!client_secret &&
 						authorization.startsWith("Basic ")
 					) {
-						const encoded = authorization.replace("Basic ", "");
-						const decoded = new TextDecoder().decode(base64.decode(encoded));
-						if (!decoded.includes(":"))
-							throw new APIError("UNAUTHORIZED", {
-								error_description: "invalid authorization header format",
-								error: "invalid_client",
-							});
-						const [id, secret] = decoded.split(":");
-						if (!id || !secret) {
+						try {
+							const encoded = authorization.replace("Basic ", "");
+							const decoded = new TextDecoder().decode(base64.decode(encoded));
+							if (!decoded.includes(":"))
+								throw new APIError("UNAUTHORIZED", {
+									error_description: "invalid authorization header format",
+									error: "invalid_client",
+								});
+							const [id, secret] = decoded.split(":");
+							if (!id || !secret) {
+								throw new APIError("UNAUTHORIZED", {
+									error_description: "invalid authorization header format",
+									error: "invalid_client",
+								});
+							}
+							client_id = id;
+							client_secret = secret;
+						} catch (error) {
 							throw new APIError("UNAUTHORIZED", {
 								error_description: "invalid authorization header format",
 								error: "invalid_client",
 							});
 						}
-						client_id = id;
-						client_secret = secret;
 					}
 					const {
 						grant_type,

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -20,6 +20,7 @@ import type {
 import { authorize } from "./authorize";
 import { parseSetCookieHeader } from "../../cookies";
 import { createHash } from "@better-auth/utils/hash";
+import { base64 } from "@better-auth/utils/base64";
 
 const getMetadata = (
 	ctx: GenericEndpointContext,
@@ -270,9 +271,15 @@ export const oidcProvider = (options: OIDCOptions) => {
 							error: "invalid_request",
 						});
 					}
+					let { client_id, client_secret } = body;
+					const authorization = ctx.request?.headers.get("authorization") || null
+					if (authorization) {
+							const encoded = authorization.replace("Basic ", "");
+							client_id = new TextDecoder().decode(base64.decode(encoded)).split(":")[0]
+							client_secret = new TextDecoder().decode(base64.decode(encoded)).split(":")[1]
+					}
 					const {
-						client_id,
-						client_secret,
+						
 						grant_type,
 						code,
 						redirect_uri,

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -283,11 +283,12 @@ export const oidcProvider = (options: OIDCOptions) => {
 						try {
 							const encoded = authorization.replace("Basic ", "");
 							const decoded = new TextDecoder().decode(base64.decode(encoded));
-							if (!decoded.includes(":"))
+							if (!decoded.includes(":")) {
 								throw new APIError("UNAUTHORIZED", {
 									error_description: "invalid authorization header format",
 									error: "invalid_client",
 								});
+							}
 							const [id, secret] = decoded.split(":");
 							if (!id || !secret) {
 								throw new APIError("UNAUTHORIZED", {


### PR DESCRIPTION
should be a small change to allow the header `authorization` to be used if body does not contain the client id/secret

refer to https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication