### PR TITLE
fix: add missing `id` field in generated OpenAPI for each schema (Mod…

### DIFF
--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -290,7 +290,7 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 					};
 					return acc;
 				},
-				{} as Record<string, any>,
+				{ id: { type: "string" } } as Record<string, any>,
 			),
 		};
 		return acc;

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -11,4 +11,15 @@ describe("open-api", async (it) => {
 		const schema = await auth.api.generateOpenAPISchema();
 		expect(schema).toBeDefined();
 	});
+
+	it("should have an id field in the User schema", async () => {
+		const schema = await auth.api.generateOpenAPISchema();
+		const schemas = schema.components.schemas as Record<
+			string,
+			Record<string, any>
+		>;
+		expect(schemas["User"].properties.id).toEqual({
+			type: "string",
+		});
+	});
 });


### PR DESCRIPTION
…els)

closes https://github.com/better-auth/better-auth/issues/1490