### PR TITLE
fix: userId should be unique on 2fa plugin

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/schema.ts
+++ b/packages/better-auth/src/plugins/two-factor/schema.ts
@@ -26,6 +26,7 @@ export const schema = {
 			userId: {
 				type: "string",
 				required: true,
+				unique: true,
 				returned: false,
 				references: {
 					model: "user",


### PR DESCRIPTION
When using the Prisma DB adaptor (haven't tested others) when trying to generate new backup codes (when 2fa is enabled) it fails. This is because when running `update` (instead of `updateMany`) a unique field is required in the `where`.

This works for me, but do let me know if any issues come of this as I would of suspected someone would of already reported this / fixed it before me as it is a pretty core functionality of the 2fa plugin.