### PR TITLE
fix(oidc-plugin): sub is required /userinfo response

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -639,6 +639,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					}
 					const requestedScopes = accessToken.scopes.split(" ");
 					const userClaims = {
+						sub: user.id,
 						email: requestedScopes.includes("email") ? user.email : undefined,
 						name: requestedScopes.includes("profile") ? user.name : undefined,
 						picture: requestedScopes.includes("profile")


### PR DESCRIPTION
The `sub` property is missing from the /userinfo response.

`The sub (subject) Claim MUST always be returned in the UserInfo Response.`
Reference: https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse