### PR TITLE
Fix docs typo in Other Social Providers example

### DIFF
--- a/docs/content/docs/authentication/other-social-providers.mdx
+++ b/docs/content/docs/authentication/other-social-providers.mdx
@@ -83,7 +83,7 @@ export const auth = betterAuth({
           clientSecret: process.env.SLACK_CLIENT_SECRET as string,
           authorizationUrl: "https://slack.com/oauth/v2/authorize",
           tokenUrl: "https://slack.com/api/oauth.v2.access",
-          scope: ["users:read", "users:read.email"], // and more...
+          scopes: ["users:read", "users:read.email"], // and more...
         },
       ],
     }),
@@ -115,7 +115,7 @@ export const auth = betterAuth({
           clientSecret: process.env.INSTAGRAM_CLIENT_SECRET as string,
           authorizationUrl: "https://api.instagram.com/oauth/authorize",
           tokenUrl: "https://api.instagram.com/oauth/access_token",
-          scope: ["user_profile", "user_media"],
+          scopes: ["user_profile", "user_media"],
         },
       ],
     }),
@@ -147,7 +147,7 @@ export const auth = betterAuth({
           clientSecret: process.env.COINBASE_CLIENT_SECRET as string,
           authorizationUrl: "https://www.coinbase.com/oauth/authorize",
           tokenUrl: "https://api.coinbase.com/oauth/token",
-          scope: ["wallet:user:read"], // and more...
+          scopes: ["wallet:user:read"], // and more...
         },
       ],
     }),


### PR DESCRIPTION
The genericOAuth plugin uses ``scopes``, but the docs says ``scope``.