### PR TITLE
Don’t save email address as user name

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -446,6 +446,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						const newUser = await ctx.context.internalAdapter.createUser({
 							email,
 							emailVerified: true,
+							name: '',
 						});
 						const session = await ctx.context.internalAdapter.createSession(
 							newUser.id,

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -446,7 +446,6 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						const newUser = await ctx.context.internalAdapter.createUser({
 							email,
 							emailVerified: true,
-							name: email,
 						});
 						const session = await ctx.context.internalAdapter.createSession(
 							newUser.id,


### PR DESCRIPTION
Currently the email OTP plugin saves the user's email address as their "name". This is undesirable as it leads to duplicate data, and also the email address should reasonably be assumed to be private, where as the name can be public.