### PR TITLE
feat: base64 conversion without Buffer

### DIFF
--- a/packages/better-auth/src/crypto/hash.ts
+++ b/packages/better-auth/src/crypto/hash.ts
@@ -1,11 +1,12 @@
 import { constantTimeEqual } from "./buffer";
 import { createHash } from "@better-auth/utils/hash";
+import { base64 } from "@better-auth/utils/base64";
 
 export async function hashToBase64(
 	data: string | ArrayBuffer,
 ): Promise<string> {
 	const buffer = await createHash("SHA-256").digest(data);
-	return Buffer.from(buffer).toString("base64");
+	return base64.encode(buffer);
 }
 
 export async function compareHash(
@@ -15,6 +16,6 @@ export async function compareHash(
 	const buffer = await createHash("SHA-256").digest(
 		typeof data === "string" ? new TextEncoder().encode(data) : data,
 	);
-	const hashBuffer = Buffer.from(hash, "base64");
+	const hashBuffer = base64.decode(hash);
 	return constantTimeEqual(buffer, hashBuffer);
 }

--- a/packages/better-auth/src/crypto/password.ts
+++ b/packages/better-auth/src/crypto/password.ts
@@ -2,6 +2,7 @@ import { constantTimeEqual } from "./buffer";
 import { scryptAsync } from "@noble/hashes/scrypt";
 import { getRandomValues } from "@better-auth/utils";
 import { hex } from "@better-auth/utils/hex";
+import { hexToBytes } from "@noble/hashes/utils";
 
 const config = {
 	N: 16384,
@@ -32,5 +33,5 @@ export const verifyPassword = async ({
 }: { hash: string; password: string }) => {
 	const [salt, key] = hash.split(":");
 	const targetKey = await generateKey(password, salt!);
-	return constantTimeEqual(targetKey, new Uint8Array(Buffer.from(key, "hex")));
+	return constantTimeEqual(targetKey, hexToBytes(key));
 };

--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -1,4 +1,5 @@
 import { subtle, getRandomValues } from "@better-auth/utils";
+import { base64 } from "@better-auth/utils/base64";
 
 async function deriveKey(secretKey: string): Promise<CryptoKey> {
 	const enc = new TextEncoder();
@@ -41,10 +42,8 @@ export async function encryptPrivateKey(
 		enc.encode(privateKey),
 	);
 
-	const encryptedPrivateKey = Buffer.from(new Uint8Array(ciphertext)).toString(
-		"base64",
-	);
-	const ivBase64 = Buffer.from(iv).toString("base64");
+	const encryptedPrivateKey = base64.encode(ciphertext);
+	const ivBase64 = base64.encode(iv);
 
 	return {
 		encryptedPrivateKey,
@@ -64,10 +63,8 @@ export async function decryptPrivateKey(
 	const key = await deriveKey(secretKey);
 	const { encryptedPrivateKey, iv } = encryptedPrivate;
 
-	const ivBuffer = Uint8Array.from(Buffer.from(iv, "base64"));
-	const ciphertext = Uint8Array.from(
-		Buffer.from(encryptedPrivateKey, "base64"),
-	);
+	const ivBuffer = base64.decode(iv);
+	const ciphertext = base64.decode(encryptedPrivateKey);
 
 	const decrypted = await subtle.decrypt(
 		{

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -343,6 +343,40 @@ describe("organization", async (it) => {
 		});
 	});
 
+	it("shouldn't allow removing owner from organization", async () => {
+		const { headers } = await signInWithTestUser();
+		const res = await client.organization.removeMember({
+			organizationId: organizationId,
+			memberIdOrEmail: "test2@test.com",
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(res.error?.status).toBe(400);
+	});
+
+	it("shouldn't allow updating owner role", async () => {
+		const { headers } = await signInWithTestUser();
+		const { members } = await client.organization.getFullOrganization({
+			query: {
+				organizationId,
+			},
+			fetchOptions: {
+				headers,
+				throw: true,
+			},
+		});
+		const res = await client.organization.updateMemberRole({
+			organizationId: organizationId,
+			role: "admin",
+			memberId: members.find((m) => m.role === "owner")?.id!,
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(res.error?.status).toBe(400);
+	});
+
 	it("should allow removing member from organization", async () => {
 		const { headers } = await signInWithTestUser();
 		const orgBefore = await client.organization.getFullOrganization({
@@ -357,7 +391,7 @@ describe("organization", async (it) => {
 		expect(orgBefore.data?.members.length).toBe(4);
 		await client.organization.removeMember({
 			organizationId: organizationId,
-			memberIdOrEmail: "test2@test.com",
+			memberIdOrEmail: adminUser.email,
 			fetchOptions: {
 				headers,
 			},

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -24,6 +24,7 @@ import type {
 import { setSessionCookie } from "../../cookies";
 import { generateId } from "../../utils";
 import { mergeSchema } from "../../db/schema";
+import { base64 } from "@better-auth/utils/base64";
 
 interface WebAuthnChallengeValue {
 	expectedChallenge: string;
@@ -237,8 +238,8 @@ export const passkey = (options?: PasskeyOptions) => {
 							},
 						],
 					});
-					const userID = new Uint8Array(
-						Buffer.from(generateRandomString(32, "a-z", "0-9")),
+					const userID = new TextEncoder().encode(
+						generateRandomString(32, "a-z", "0-9"),
 					);
 					let options: PublicKeyCredentialCreationOptionsJSON;
 					options = await generateRegistrationOptions({
@@ -547,7 +548,7 @@ export const passkey = (options?: PasskeyOptions) => {
 							credential,
 							credentialType,
 						} = registrationInfo;
-						const pubKey = Buffer.from(credential.publicKey).toString("base64");
+						const pubKey = base64.encode(credential.publicKey);
 						const newPasskey: Passkey = {
 							name: ctx.body.name,
 							userId: userData.id,
@@ -668,9 +669,7 @@ export const passkey = (options?: PasskeyOptions) => {
 							expectedRPID: getRpID(opts, ctx.context.options.baseURL),
 							credential: {
 								id: passkey.credentialID,
-								publicKey: new Uint8Array(
-									Buffer.from(passkey.publicKey, "base64"),
-								),
+								publicKey: base64.decode(passkey.publicKey),
 								counter: passkey.counter,
 								transports: passkey.transports?.split(
 									",",

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -75,9 +75,11 @@ export async function verifyBackupCode(
 }
 
 export async function getBackupCodes(backupCodes: string, key: string) {
-	const secret = Buffer.from(
-		await symmetricDecrypt({ key, data: backupCodes }),
-	).toString("utf-8");
+	const secret = new TextDecoder("utf-8").decode(
+		new TextEncoder().encode(
+			await symmetricDecrypt({ key, data: backupCodes }),
+		),
+	);
 	const data = JSON.parse(secret);
 	const result = z.array(z.string()).safeParse(data);
 	if (result.success) {

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -4,6 +4,7 @@ import type { OAuthProvider } from "../oauth2";
 import { betterFetch } from "@better-fetch/fetch";
 import { logger } from "../utils/logger";
 import { decodeJwt } from "jose";
+import { base64 } from "@better-auth/utils/base64";
 
 export interface MicrosoftEntraIDProfile extends Record<string, any> {
 	sub: string;
@@ -89,8 +90,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 						try {
 							const response = context.response.clone();
 							const pictureBuffer = await response.arrayBuffer();
-							const pictureBase64 =
-								Buffer.from(pictureBuffer).toString("base64");
+							const pictureBase64 = base64.encode(pictureBuffer);
 							user.picture = `data:image/jpeg;base64, ${pictureBase64}`;
 						} catch (e) {
 							logger.error(

--- a/packages/better-auth/src/social-providers/reddit.ts
+++ b/packages/better-auth/src/social-providers/reddit.ts
@@ -1,6 +1,7 @@
 import { betterFetch } from "@better-fetch/fetch";
 import type { OAuthProvider, ProviderOptions } from "../oauth2";
 import { createAuthorizationURL, getOAuth2Tokens } from "../oauth2";
+import { base64 } from "@better-auth/utils/base64";
 
 export interface RedditProfile {
 	id: string;
@@ -43,9 +44,9 @@ export const reddit = (options: RedditOptions) => {
 				"content-type": "application/x-www-form-urlencoded",
 				accept: "text/plain",
 				"user-agent": "better-auth",
-				Authorization: `Basic ${Buffer.from(
+				Authorization: `Basic ${base64.encode(
 					`${options.clientId}:${options.clientSecret}`,
-				).toString("base64")}`,
+				)}`,
 			};
 
 			const { data, error } = await betterFetch<object>(


### PR DESCRIPTION
BetterAuth doesn't work on cloudflare workers without `nodejs_compact` flags due to usage of `Buffer` to do base64 encoding/decoding.
This PR replaces all `Buffer` usage with `base64` from `@better-auth/utils/base64` and `TextEncoder`/`TextDecoder`.

~~There will be a follow up PR to add a cloudflare worker example and test suite to make sure workerd compatibly doesn't break in future.~~
Follow up #1524

fixes #1375