### PR TITLE
fix: export captcha plugin

### DIFF
--- a/packages/better-auth/src/plugins/index.ts
+++ b/packages/better-auth/src/plugins/index.ts
@@ -18,3 +18,4 @@ export * from "./oauth-proxy";
 export * from "./custom-session";
 export * from "./open-api";
 export * from "./oidc-provider";
+export * from "./captcha";

--- a/packages/better-auth/tsup.config.ts
+++ b/packages/better-auth/tsup.config.ts
@@ -32,6 +32,7 @@ export default defineConfig((env) => {
 			"plugins/admin": "./src/plugins/admin/index.ts",
 			"plugins/anonymous": "./src/plugins/anonymous/index.ts",
 			"plugins/bearer": "./src/plugins/bearer/index.ts",
+			"plugins/captcha": "./src/plugins/captcha/index.ts",
 			"plugins/custom-session": "./src/plugins/custom-session/index.ts",
 			"plugins/email-otp": "./src/plugins/email-otp/index.ts",
 			"plugins/generic-oauth": "./src/plugins/generic-oauth/index.ts",


### PR DESCRIPTION
The captcha plugin is mentioned in [beta](https://beta.better-auth.com/docs/plugins/captcha), but not exported.