### PR TITLE
chore: cache turbo output to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ jobs:
               with:
                     fetch-depth: 0
 
+            - name: Cache turbo build setup
+              uses: actions/cache@v4
+              with:
+                path: .turbo
+                key: ${{ runner.os }}-turbo-${{ github.sha }}
+                restore-keys: |
+                  ${{ runner.os }}-turbo-
+
             - uses: pnpm/action-setup@v4
 
             - uses: actions/setup-node@v4


### PR DESCRIPTION
Cache turbo outputs to massively improve CI times

<img width="336" alt="image" src="https://github.com/user-attachments/assets/ceb05ab2-041b-4080-af51-a2411873bb50" />
