### PR TITLE
chore: update getSessionCookie import in demo and docs

### DIFF
--- a/demo/nextjs/middleware.ts
+++ b/demo/nextjs/middleware.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSessionCookie } from "better-auth";
+import { getSessionCookie } from "better-auth/cookies";
 
 export async function middleware(request: NextRequest) {
 	const cookies = getSessionCookie(request);

--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -133,7 +133,7 @@ You can use the `getSessionCookie` helper from Better Auth for this purpose:
 
 ```ts
 import { NextRequest, NextResponse } from "next/server";
-import { getSessionCookie } from "better-auth";
+import { getSessionCookie } from "better-auth/cookies";
 
 export async function middleware(request: NextRequest) {
 	const sessionCookie = getSessionCookie(request); // Optionally pass config as the second argument if cookie name or prefix is customized.


### PR DESCRIPTION
in #1528, cookie helper exports were removed from `better-auth` root import and were made only available at `better-auth/cookies`, this PR fixes the imports for the demo and docs

This is somewhat a breaking change for who rely on this export from root and should be mentioned in changelog