### PR TITLE
feat(docs): move search documentation box to main navbar

### DIFF
--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -26,14 +26,14 @@ export const Navbar = () => {
 				</Link>
 				<div className="md:col-span-10 flex items-center justify-end relative">
 					<div
-						className="flex items-center gap-2 py-3.5 md:py-4 h-full px-4 bg-gradient-to-br dark:from-stone-900 dark:to-stone-950/80"
+						className="flex items-center gap-2 py-3.5 md:py-4 h-full px-4 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-stone-900 dark:to-stone-950/80"
 						onClick={() => {
 							setOpenSearch(true);
 							loglib.track("navbar-search-open");
 						}}
 					>
 						<Search className="w-4 h-4" />
-						<p className="text-sm text-transparent bg-gradient-to-tr from-gray-500 to-stone-400 bg-clip-text">
+						<p className="text-sm text-transparent bg-gradient-to-tr from-gray-700 to-gray-800 dark:from-gray-500 dark:to-stone-400 bg-clip-text">
 							Search <span className="lg:hidden">...</span> <span className="hidden lg:inline">documentation...</span>
 						</p>
 					</div>

--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -34,7 +34,7 @@ export const Navbar = () => {
 					>
 						<Search className="w-4 h-4" />
 						<p className="text-sm text-transparent bg-gradient-to-tr from-gray-700 to-gray-800 dark:from-gray-500 dark:to-stone-400 bg-clip-text">
-							Search <span className="lg:hidden">...</span> <span className="hidden lg:inline">documentation...</span>
+							 <span className="lg:hidden">Search...</span> <span className="hidden lg:inline">Search documentation...</span>
 						</p>
 					</div>
 					<ul className="md:flex items-center divide-x w-max hidden shrink-0">

--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -1,10 +1,15 @@
+"use client";
 import Link from "next/link";
 import { ThemeToggle } from "@/components/theme-toggler";
 import { NavbarMobile, NavbarMobileBtn } from "./nav-mobile";
 import { NavLink } from "./nav-link";
+import { useSearchContext } from "fumadocs-ui/provider";
+import { loglib } from "@loglib/tracker";
+import { Search } from "lucide-react";
 import { Logo } from "./logo";
 
 export const Navbar = () => {
+	const { setOpenSearch } = useSearchContext();
 	return (
 		<div className="flex flex-col sticky top-0 bg-background backdrop-blur-md z-30">
 			<nav className="md:grid grid-cols-12 md:border-b top-0 flex items-center justify-between ">
@@ -20,6 +25,18 @@ export const Navbar = () => {
 					</div>
 				</Link>
 				<div className="md:col-span-10 flex items-center justify-end relative">
+					<div
+						className="flex items-center gap-2 py-3.5 md:py-4 h-full px-4 bg-gradient-to-br dark:from-stone-900 dark:to-stone-950/80"
+						onClick={() => {
+							setOpenSearch(true);
+							loglib.track("navbar-search-open");
+						}}
+					>
+						<Search className="w-4 h-4" />
+						<p className="text-sm text-transparent bg-gradient-to-tr from-gray-500 to-stone-400 bg-clip-text">
+							Search <span className="lg:hidden">...</span> <span className="hidden lg:inline">documentation...</span>
+						</p>
+					</div>
 					<ul className="md:flex items-center divide-x w-max hidden shrink-0">
 						{navMenu.map((menu, i) => (
 							<NavLink key={menu.name} href={menu.path}>

--- a/docs/components/nav-link.tsx
+++ b/docs/components/nav-link.tsx
@@ -20,7 +20,7 @@ export const NavLink = ({ href, children, className, external }: Props) => {
 			<Link
 				href={href}
 				className={cn(
-					"w-full h-full block py-4 px-5 transition-colors",
+					"w-full h-full block py-4 md:px-3 lg:px-5 transition-colors",
 					"group-hover:text-foreground",
 					isActive ? "text-foreground" : "text-muted-foreground",
 				)}

--- a/docs/components/side-bar.tsx
+++ b/docs/components/side-bar.tsx
@@ -4,10 +4,9 @@ import { AnimatePresence, motion, MotionConfig } from "framer-motion";
 
 import { AsideLink } from "@/components/ui/aside-link";
 import { Suspense, useEffect, useState } from "react";
-import { useSearchContext } from "fumadocs-ui/provider";
 import { usePathname, useRouter } from "next/navigation";
 import { contents, examples } from "./sidebar-content";
-import { ChevronDownIcon, Search } from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
 import {
 	Select,
 	SelectContent,
@@ -21,7 +20,6 @@ import { cn } from "@/lib/utils";
 export default function ArticleLayout() {
 	const [currentOpen, setCurrentOpen] = useState<number>(0);
 
-	const { setOpenSearch } = useSearchContext();
 	const pathname = usePathname();
 
 	function getDefaultValue() {
@@ -120,19 +118,6 @@ export default function ArticleLayout() {
 							</SelectItem>
 						</SelectContent>
 					</Select>
-					<div
-						className="flex items-center gap-2 p-2 px-4 border-b bg-gradient-to-br dark:from-stone-900 dark:to-stone-950/80"
-						onClick={() => {
-							setOpenSearch(true);
-							loglib.track("sidebar-search-open");
-						}}
-					>
-						<Search className="w-4 h-4" />
-						<p className="text-sm text-transparent bg-gradient-to-tr from-gray-500 to-stone-400 bg-clip-text">
-							Search documentation...
-						</p>
-					</div>
-
 					<MotionConfig
 						transition={{ duration: 0.4, type: "spring", bounce: 0 }}
 					>


### PR DESCRIPTION
As a developer who checks better-auth docs a lot, I want to find the searchbox when I go to the home page so I can navigate and search the docs as fast as possible. The problem with the previous look is that it had to go to https://www.better-auth.com/docs first to search the docs. But now, It's as simple as searching the docs in shadcn.
This is how it will look:
![image](https://github.com/user-attachments/assets/41d4d085-9f49-4f23-a7d5-d261f20a6c57)
