### PR TITLE
fix: renamed fromTopToBottom to fromtoptobottom and prevented fromtoptobottom prop from being passed to DOM

### DIFF
--- a/docs/components/nav-mobile.tsx
+++ b/docs/components/nav-mobile.tsx
@@ -80,7 +80,7 @@ export const NavbarMobile = () => {
 			<AnimatePresence>
 				{isOpen && (
 					<FadeIn
-						fromTopToBottom
+						fromtoptobottom
 						className="p-5 overflow-y-auto bg-transparent divide-y"
 					>
 						{navMenu.map((menu, i) => (
@@ -166,7 +166,7 @@ export const DocsNavBarMobile = () => {
 		<AnimatePresence>
 			{isOpen && (
 				<FadeIn
-					fromTopToBottom
+					fromtoptobottom
 					className="absolute top-[100px] left-0 bg-background h-[calc(100%-57px-27px)] w-full z-[1000] p-5 divide-y overflow-y-auto"
 				>
 					{content.map((menu, i) => (

--- a/docs/components/ui/fade-in.tsx
+++ b/docs/components/ui/fade-in.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import {
-	AnimatePresence as PrimitiveAnimatePresence,
-	motion,
-	useReducedMotion,
+  AnimatePresence as PrimitiveAnimatePresence,
+  motion,
+  useReducedMotion,
 } from "framer-motion";
 import { createContext, useContext } from "react";
 
@@ -11,57 +11,59 @@ const FadeInStaggerContext = createContext(false);
 
 const viewport = { once: true, margin: "0px 0px -200px" };
 
-export const FadeIn = (
-	props: React.ComponentPropsWithoutRef<typeof motion.div> & {
-		fromTopToBottom?: boolean;
-	},
-) => {
-	const shouldReduceMotion = useReducedMotion();
-	const isInStaggerGroup = useContext(FadeInStaggerContext);
+export const FadeIn = ({
+  fromtoptobottom,
+  ...props // Destructure fromtoptobottom and collect remaining props
+}: React.ComponentPropsWithoutRef<typeof motion.div> & {
+  fromtoptobottom?: boolean;
+}) => {
+  const shouldReduceMotion = useReducedMotion();
+  const isInStaggerGroup = useContext(FadeInStaggerContext);
 
-	return (
-		<motion.div
-			variants={{
-				hidden: {
-					opacity: 0,
-					y: shouldReduceMotion ? 0 : props.fromTopToBottom ? -24 : 2,
-				},
-				visible: { opacity: 1, y: 0 },
-			}}
-			transition={{ duration: 0.3 }}
-			{...(isInStaggerGroup
-				? {}
-				: {
-						initial: "hidden",
-						whileInView: "visible",
-						viewport,
-					})}
-			{...props}
-		/>
-	);
+  return (
+    <motion.div
+      variants={{
+        hidden: {
+          opacity: 0,
+          y: shouldReduceMotion ? 0 : fromtoptobottom ? -24 : 2,
+        },
+        visible: { opacity: 1, y: 0 },
+      }}
+      transition={{ duration: 0.3 }}
+      {...(isInStaggerGroup
+        ? {}
+        : {
+            initial: "hidden",
+            whileInView: "visible",
+            viewport,
+          })}
+      {...props} // Spread the remaining props, excluding fromtoptobottom
+    />
+  );
 };
 
+// Rest of the code remains the same
 export const FadeInStagger = ({
-	faster = false,
-	...props
+  faster = false,
+  ...props
 }: React.ComponentPropsWithoutRef<typeof motion.div> & {
-	faster?: boolean;
+  faster?: boolean;
 }) => {
-	return (
-		<FadeInStaggerContext.Provider value={true}>
-			<motion.div
-				initial="hidden"
-				whileInView="visible"
-				viewport={viewport}
-				transition={{ staggerChildren: faster ? 0.08 : 0.2 }}
-				{...props}
-			/>
-		</FadeInStaggerContext.Provider>
-	);
+  return (
+    <FadeInStaggerContext.Provider value={true}>
+      <motion.div
+        initial="hidden"
+        whileInView="visible"
+        viewport={viewport}
+        transition={{ staggerChildren: faster ? 0.08 : 0.2 }}
+        {...props}
+      />
+    </FadeInStaggerContext.Provider>
+  );
 };
 
 export const AnimatePresence = (
-	props: React.ComponentPropsWithoutRef<typeof PrimitiveAnimatePresence>,
+  props: React.ComponentPropsWithoutRef<typeof PrimitiveAnimatePresence>,
 ) => {
-	return <PrimitiveAnimatePresence {...props} />;
+  return <PrimitiveAnimatePresence {...props} />;
 };

--- a/docs/components/ui/fade-in.tsx
+++ b/docs/components/ui/fade-in.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import {
-  AnimatePresence as PrimitiveAnimatePresence,
-  motion,
-  useReducedMotion,
+	AnimatePresence as PrimitiveAnimatePresence,
+	motion,
+	useReducedMotion,
 } from "framer-motion";
 import { createContext, useContext } from "react";
 
@@ -12,58 +12,58 @@ const FadeInStaggerContext = createContext(false);
 const viewport = { once: true, margin: "0px 0px -200px" };
 
 export const FadeIn = ({
-  fromtoptobottom,
-  ...props // Destructure fromtoptobottom and collect remaining props
+	fromtoptobottom,
+	...props // Destructure fromtoptobottom and collect remaining props
 }: React.ComponentPropsWithoutRef<typeof motion.div> & {
-  fromtoptobottom?: boolean;
+	fromtoptobottom?: boolean;
 }) => {
-  const shouldReduceMotion = useReducedMotion();
-  const isInStaggerGroup = useContext(FadeInStaggerContext);
+	const shouldReduceMotion = useReducedMotion();
+	const isInStaggerGroup = useContext(FadeInStaggerContext);
 
-  return (
-    <motion.div
-      variants={{
-        hidden: {
-          opacity: 0,
-          y: shouldReduceMotion ? 0 : fromtoptobottom ? -24 : 2,
-        },
-        visible: { opacity: 1, y: 0 },
-      }}
-      transition={{ duration: 0.3 }}
-      {...(isInStaggerGroup
-        ? {}
-        : {
-            initial: "hidden",
-            whileInView: "visible",
-            viewport,
-          })}
-      {...props} // Spread the remaining props, excluding fromtoptobottom
-    />
-  );
+	return (
+		<motion.div
+			variants={{
+				hidden: {
+					opacity: 0,
+					y: shouldReduceMotion ? 0 : fromtoptobottom ? -24 : 2,
+				},
+				visible: { opacity: 1, y: 0 },
+			}}
+			transition={{ duration: 0.3 }}
+			{...(isInStaggerGroup
+				? {}
+				: {
+						initial: "hidden",
+						whileInView: "visible",
+						viewport,
+					})}
+			{...props} // Spread the remaining props, excluding fromtoptobottom
+		/>
+	);
 };
 
 // Rest of the code remains the same
 export const FadeInStagger = ({
-  faster = false,
-  ...props
+	faster = false,
+	...props
 }: React.ComponentPropsWithoutRef<typeof motion.div> & {
-  faster?: boolean;
+	faster?: boolean;
 }) => {
-  return (
-    <FadeInStaggerContext.Provider value={true}>
-      <motion.div
-        initial="hidden"
-        whileInView="visible"
-        viewport={viewport}
-        transition={{ staggerChildren: faster ? 0.08 : 0.2 }}
-        {...props}
-      />
-    </FadeInStaggerContext.Provider>
-  );
+	return (
+		<FadeInStaggerContext.Provider value={true}>
+			<motion.div
+				initial="hidden"
+				whileInView="visible"
+				viewport={viewport}
+				transition={{ staggerChildren: faster ? 0.08 : 0.2 }}
+				{...props}
+			/>
+		</FadeInStaggerContext.Provider>
+	);
 };
 
 export const AnimatePresence = (
-  props: React.ComponentPropsWithoutRef<typeof PrimitiveAnimatePresence>,
+	props: React.ComponentPropsWithoutRef<typeof PrimitiveAnimatePresence>,
 ) => {
-  return <PrimitiveAnimatePresence {...props} />;
+	return <PrimitiveAnimatePresence {...props} />;
 };


### PR DESCRIPTION
- [x] Renamed fromTopToBottom to fromtoptobottom
- [x] Destructure fromtoptobottom prop in FadeIn component
- [x] Fix React DOM attribute warning by preventing prop spread
- [x] Maintain animation functionality while cleaning up prop handling


Before : 

https://github.com/user-attachments/assets/37e654ce-1835-480e-865d-e86c5d68ff6d

After :

https://github.com/user-attachments/assets/3ea1905a-c081-4ac4-a56b-b8409a0e6cac

