### PR TITLE
chore: enable CI for all pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on: 
     pull_request:  
-        branches: main
+        types: 
+          - opened
+          - synchronize
     push: 
         branches: main
     merge_group: {}

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -37,6 +37,7 @@ describe("Admin plugin", async () => {
 			customFetchImpl,
 		},
 		plugins: [adminClient()],
+		baseURL: "http://localhost:3000",
 	});
 
 	const { headers: adminHeaders } = await signInWithTestUser();


### PR DESCRIPTION
The CI jobs doesn't run all Pull requests, thus the Pull's to v1.2 goes without CI.

I ran the tests locally and few of them were failing, I managed to fix the admin ones, but the organization ones are still broken and needs to be investigated