### PR TITLE
fix: oauth failing when using drizzle adapter

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -802,7 +802,7 @@ export const createInternalAdapter = (
 					where: [
 						{
 							field: "expiresAt",
-							value: new Date().toISOString(),
+							value: new Date(),
 							operator: "lt",
 						},
 					],


### PR DESCRIPTION
This PR addresses an issue with the Drizzle adapter where OAuth providers were failing due to incorrect date format handling. The fix removes the .toISOString() call on the Date object when doing verifications cleanup.

Drizzle expects date to be passed as a Date object rather than string.

Error:
```
ERROR [Better Auth]: TypeError: value.toISOString is not a function
```

See more people having this issue on #1035

**Edit -** 
Forgot to add that this bug is only present on v1.2 beta