### PR TITLE
Correct option name in the reset password error message

### DIFF
--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -84,7 +84,7 @@ export const forgetPassword = createAuthEndpoint(
 	async (ctx) => {
 		if (!ctx.context.options.emailAndPassword?.sendResetPassword) {
 			ctx.context.logger.error(
-				"Reset password isn't enabled.Please pass an emailAndPassword.sendResetPasswordToken function in your auth config!",
+				"Reset password isn't enabled.Please pass an emailAndPassword.sendResetPassword function in your auth config!",
 			);
 			throw new APIError("BAD_REQUEST", {
 				message: "Reset password isn't enabled",


### PR DESCRIPTION
Seems like `sendResetPasswordToken` isn't seen anywhere esle in the project and is supposed to be just `sendResetPassword`.