### PR TITLE
remove(docs): static route indicator by next

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -42,4 +42,7 @@ export default withMDX({
 			},
 		],
 	},
+	devIndicators: {
+		appIsrStatus: false
+	}
 });


### PR DESCRIPTION
Removed this indicator because it's useless for a fumadocs docs site: (also it's super annoying IMO)

<img width="247" alt="image" src="https://github.com/user-attachments/assets/9b9753bf-c999-410b-a8e5-0c2cd57d3948" />
