### PR TITLE
docs: added "partitioned: true" for cross-domain (foreign) cookies

### DIFF
--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -71,6 +71,7 @@ export const auth = betterAuth({
             secure: true,
             httpOnly: true,
             sameSite: "none", // Allows CORS-based cookie sharing across subdomains
+            partitioned: true // New browser standards will mandate this for foreign cookies
         },
     },
     trustedOrigins: [

--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -127,7 +127,8 @@ export const auth = createAuth({
   advanced: {
     defaultCookieAttributes: {
       sameSite: "none",
-      secure: true
+      secure: true,
+			partitioned: true // New browser standards will mandate this for foreign cookies
     }
   }
 })
@@ -141,7 +142,8 @@ export const auth = createAuth({
     cookies: {
       sessionToken: {
         sameSite: "none",
-        secure: true
+        secure: true,
+				partitioned: true // New browser standards will mandate this for foreign cookies
       }
     }
   }


### PR DESCRIPTION
Removes the warning below by using partitioned cookies:

![foreign-cookies-warning](https://github.com/user-attachments/assets/043afcd2-5185-46ee-8675-667b24bc53de)

<details close>

<summary>raw warnings</summary>

```
Cookie warnings

Cookie "better-auth.session_token" will soon be rejected because it is foreign and does not have the "Partitioned" attribute.

Cookie "better-auth.session_data" will soon be rejected because it is foreign and does not have the "Partitioned" attribute.
```

</details>

I stumbled upon this issue while deploying my frontend web application and backend server to two different domains - repository below:
- https://github.com/nktnet1/rt-stack

1. Deploy apps/web to one domain
2. Deploy apps/server to a different domain using the settings
    ```ts
    advanced: {
      defaultCookieAttributes: {
        sameSite: "none",
        secure: true,
        // partitioned: true                 // comment out to produce warnings
      }
    }
    ```
3. Open the browser and register an account - the warnings above can be observed.

Further reading:
- https://developers.google.com/privacy-sandbox/cookies/chips-transition
- https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies
- https://github.com/ory/hydra/issues/3703