### PR TITLE
chore: Added export for passkey plugin for consistency of imports

### DIFF
--- a/packages/better-auth/src/plugins/index.ts
+++ b/packages/better-auth/src/plugins/index.ts
@@ -20,3 +20,4 @@ export * from "./open-api";
 export * from "./oidc-provider";
 export * from "./captcha";
 export * from "./api-key";
+export * from "./passkey";


### PR DESCRIPTION
Currently it requires 2 lines to import plugins with `passkey`
Example:
```ts
import { passkey } from 'better-auth/plugins/passkey'
import { anonymous, openAPI, oidcProvider } from 'better-auth/plugins'
```
This change aims to fix it and make possible to import passkey from plugins/index
```ts
import { passkey, anonymous, openAPI, oidcProvider } from 'better-auth/plugins'
```