### PR TITLE
docs: consistent indents with space instead of tabs

### DIFF
--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -70,8 +70,8 @@ export const auth = betterAuth({
         defaultCookieAttributes: {
             secure: true,
             httpOnly: true,
-            sameSite: "none", // Allows CORS-based cookie sharing across subdomains
-            partitioned: true // New browser standards will mandate this for foreign cookies
+            sameSite: "none",  // Allows CORS-based cookie sharing across subdomains
+            partitioned: true, // New browser standards will mandate this for foreign cookies
         },
     },
     trustedOrigins: [

--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -128,7 +128,7 @@ export const auth = createAuth({
     defaultCookieAttributes: {
       sameSite: "none",
       secure: true,
-			partitioned: true // New browser standards will mandate this for foreign cookies
+      partitioned: true // New browser standards will mandate this for foreign cookies
     }
   }
 })
@@ -143,7 +143,7 @@ export const auth = createAuth({
       sessionToken: {
         sameSite: "none",
         secure: true,
-				partitioned: true // New browser standards will mandate this for foreign cookies
+        partitioned: true // New browser standards will mandate this for foreign cookies
       }
     }
   }


### PR DESCRIPTION
Fixes a previous PR where tabs were used instead of spaces for `partitioned: true`