### PR TITLE
docs(fix): typo on cli page

### DIFF
--- a/docs/content/docs/concepts/cli.mdx
+++ b/docs/content/docs/concepts/cli.mdx
@@ -26,7 +26,7 @@ npx @better-auth/cli@latest init admin, organization, two-factor
 - `--framework` - The framework your codebase is using. Currently, the only supported framework is `nextjs`.
 - `--plugins` - The plugins you want to use. You can specify multiple plugins by separating them with a comma.
 - `--database` - The database you want to use. Currently, the only supported database is `sqlite`.
-- `--pacakge-manager` - The package manager you want to use. Currently, the only supported package managers are `npm`, `pnpm`, `yarn`, `bun`. (Defaults to the manager you used to initialize the CLI.)
+- `--package-manager` - The package manager you want to use. Currently, the only supported package managers are `npm`, `pnpm`, `yarn`, `bun`. (Defaults to the manager you used to initialize the CLI.)
 
 ### How it works
 


### PR DESCRIPTION
Fixes typo `--pacakge-manager`  with `--package-manager` on the CLI documentation. 