### PR TITLE
fix: expo plugin accessing wrong key for response headers

### DIFF
--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -49,7 +49,7 @@ export const expo = (options?: ExpoOptions) => {
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {
-						const headers = ctx.context.responseHeader;
+						const headers = ctx.context.responseHeaders;
 
 						const location = headers.get("location");
 						if (!location) {


### PR DESCRIPTION
The expo handler is trying to pull the location header from the responseHeader key however this key is actually `responseHeaders` plural. This causes a cannot find property on undefined error when trying to use social logins with the expo plugin.

I think this issue is in reference to this:
https://github.com/better-auth/better-auth/issues/1612