### PR TITLE
chore: add instructions to install required expo packages for login with social to docs

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -24,16 +24,30 @@ Expo is a popular framework for building cross-platform apps with React Native. 
         ```
     </Step>
     <Step>
-        ## Install Better Auth and Expo Plugin
+        ## Install Server Dependencies
 
-        Install both the expo plugin in your server and both the Better Auth package and the Expo plugin in your Expo app.
+        Install both the Better Auth package and expo plugin into your server application.
 
         ```package-install
-        @better-auth/expo
+        @better-auth/expo better-auth
         ```
 
+    </Step>
+
+    <Step>
+        ## Install Client Dependencies
+
+        You also need to install both of the Better Auth package and Expo plugin into your Expo application.
+
         ```package-install
-        better-auth
+        @better-auth/expo better-auth
+        ```
+
+        If you plan on using our social integrations (Google, Apple etc.) then there are a few more dependencies that are required in your Expo app. In the default Expo template these are already installed so you may be able to skip this step if you have these dependencies already.
+
+        ```package-install
+        expo-linking expo-web-browser expo-constants
+        
         ```
     </Step>
     

--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -37,10 +37,10 @@ Expo is a popular framework for building cross-platform apps with React Native. 
     <Step>
         ## Install Client Dependencies
 
-        You also need to install both of the Better Auth package and Expo plugin into your Expo application.
+        You also need to install both the Better Auth package and Expo plugin into your Expo application.
 
         ```package-install
-        @better-auth/expo better-auth
+        better-auth @better-auth/expo 
         ```
 
         If you plan on using our social integrations (Google, Apple etc.) then there are a few more dependencies that are required in your Expo app. In the default Expo template these are already installed so you may be able to skip this step if you have these dependencies already.

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -48,10 +48,7 @@
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "better-auth": "workspace:*",
-    "expo-linking": "*",
-    "expo-secure-store": "*",
-    "expo-web-browser": "*"
+    "better-auth": "workspace:*"
   },
   "dependencies": {
     "better-call": "catalog:",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -48,7 +48,10 @@
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "better-auth": "workspace:*"
+    "better-auth": "workspace:*",
+    "expo-linking": "*",
+    "expo-secure-store": "*",
+    "expo-web-browser": "*"
   },
   "dependencies": {
     "better-call": "catalog:",


### PR DESCRIPTION
`expo-linking`, `expo-web-browser` and `expo-constants` are required to use the social integrations the expo plugins provide. I imagine it's not been picked up as these are included in the default Expo template and in the example app but other templates do not include these.

I originally added these as peerDependencies however they are not strictly necessary if you are just going to use email password verification so removed them again.