### PR TITLE
fix(docs): Add reference to `ctx` object for database hooks

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -519,7 +519,7 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        before: async (user) => {
+        before: async (user, ctx) => {
           // Modify the user object before it is created
           return {
             data: {
@@ -550,7 +550,7 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        before: async (user) => {
+        before: async (user, ctx) => {
           if (user.isAgreedToTerms === false) {
             // Your special condition.
             // Send the API error.
@@ -567,6 +567,9 @@ export const auth = betterAuth({
   },
 });
 ```
+#### Ctx
+
+Much like standard hooks, database hooks also provide a `ctx` object that offer a variety of useful properties. Learn more in the [Hooks Documentation](/docs/concepts/hooks#ctx).
 
 ## Plugins Schema
 

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -567,7 +567,6 @@ export const auth = betterAuth({
   },
 });
 ```
-#### Ctx
 
 Much like standard hooks, database hooks also provide a `ctx` object that offers a variety of useful properties. Learn more in the [Hooks Documentation](/docs/concepts/hooks#ctx).
 

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -569,7 +569,7 @@ export const auth = betterAuth({
 ```
 #### Ctx
 
-Much like standard hooks, database hooks also provide a `ctx` object that offer a variety of useful properties. Learn more in the [Hooks Documentation](/docs/concepts/hooks#ctx).
+Much like standard hooks, database hooks also provide a `ctx` object that offers a variety of useful properties. Learn more in the [Hooks Documentation](/docs/concepts/hooks#ctx).
 
 ## Plugins Schema
 


### PR DESCRIPTION
Just a small doc tweak that would have saved me time when learning how the database hooks operate.  Ctx object is available and very useful in these hooks, but not explicitly mentioned in the database hooks docs