### PR TITLE
fix: update babel config on expo docs

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -136,10 +136,10 @@ Expo is a popular framework for building cross-platform apps with React Native. 
                         "module-resolver",
                         {
                             alias: {
-                                "better-auth/react": "path/to/node_modules/better-auth/dist/react.js"
-                                "@better-auth/expo/client": "path/to/node_modules/@better-auth/expo/dist/client.js",
+                                "better-auth/react": "path/to/node_modules/better-auth/dist/client/react/index.cjs"
+                                "@better-auth/expo/client": "path/to/node_modules/@better-auth/expo/dist/client.cjs",
                             },
-                            extensions: [".js", ".jsx", ".ts", ".tsx"],
+                            extensions: [".cjs", ".js", ".jsx", ".ts", ".tsx"],
                         },
                     ],
                 ],


### PR DESCRIPTION
I installed a new version of better auth for expo and realized the imports are broken. After digging in the code saw that you no longer build `.js` files, and the `dist` directory structure has changed. But your docs don't reflect these changes.