### PR TITLE
docs(fix): correct typo in api-key documentation

### DIFF
--- a/docs/content/docs/plugins/api-key.mdx
+++ b/docs/content/docs/plugins/api-key.mdx
@@ -401,7 +401,7 @@ export const auth = betterAuth({
 
 ## Rate Limiting
 
-Every API key can have its own rate limit settings, however, the built-in rate-limiting only applies to the veriification process for a given API key.
+Every API key can have its own rate limit settings, however, the built-in rate-limiting only applies to the verification process for a given API key.
 For every other endpoint/method, you should utilize Better Auth's [built-in rate-limiting](/docs/concepts/rate-limit).
 
 You can refer to the rate-limit default configurations below in the API Key plugin options.


### PR DESCRIPTION
Closes: #1651 