### PR TITLE
fix: use `global_name` for discord

### DIFF
--- a/packages/better-auth/src/social-providers/discord.ts
+++ b/packages/better-auth/src/social-providers/discord.ts
@@ -134,7 +134,7 @@ export const discord = (options: DiscordOptions) => {
 			return {
 				user: {
 					id: profile.id,
-					name: profile.display_name || profile.username || "",
+					name: profile.global_name || profile.username || "",
 					email: profile.email,
 					emailVerified: profile.verified,
 					image: profile.image_url,


### PR DESCRIPTION
`display_name` seems to not be present anymore, keeping it in the type just incase im just not seeing it on my own personal discord account

this matches the way next auth handles discord names [here](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/discord.ts)