### PR TITLE
docs(fix): Correct typo in drizzle-adapter

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -13,11 +13,11 @@ Then, you can use the Drizzle adapter to connect to your database.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
-import { DrizzleAdapter } from "better-auth/adapters/drizzle";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "./database.ts";
 
 export const auth = betterAuth({
-  database: new DrizzleAdapter(db, {
+  database: drizzleAdapter(db, {
     // [!code highlight]
     provider: "sqlite", // or "pg" or "mysql" // [!code highlight]
   }), // [!code highlight]


### PR DESCRIPTION
This fixes the notation in docs.
I think the correct notation is "drizzleAdapter" instead of "DrizzleAdapter."
https://www.better-auth.com/docs/adapters/drizzle
<img width="895" alt="スクリーンショット 2025-03-03 17 50 20" src="https://github.com/user-attachments/assets/56519439-d1e8-42bf-ad93-1df8887ae7ae" />
