### PR TITLE
fix: type issues with prettify ts util

### DIFF
--- a/packages/better-auth/src/types/helper.ts
+++ b/packages/better-auth/src/types/helper.ts
@@ -5,10 +5,10 @@ export type LiteralNumber = 0 | (number & Record<never, never>);
 
 export type OmitId<T extends { id: unknown }> = Omit<T, "id">;
 
-export type Prettify<T> = Omit<T, never>;
 export type PreserveJSDoc<T> = {
 	[K in keyof T]: T[K];
 } & {};
+export type Prettify<T> = PreserveJSDoc<T>;
 export type PrettifyDeep<T> = {
 	[K in keyof T]: T[K] extends (...args: any[]) => any
 		? T[K]


### PR DESCRIPTION

## Description
This PR addresses type issues that appeared after upgrading to version 1.2.0. The issue was related to the Prettify<T> type utility which was causing type errors on the client side.

Fixes #1660 and #1637 

## Changes

- Removed the previous implementation of Prettify<T> that was using Omit<T, never>
- Added a new implementation that sets Prettify<T> = PreserveJSDoc<T>, maintaining type functionality while resolving the client-side type errors
- Note that the PreserveJSDoc utility already handles prettifying TypeScript types while also preserving JSDoc comments

## Testing
Verified that client-side types work correctly after this change while maintaining the same functionality.