### PR TITLE
docs: update reset password documentation for missing props

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -293,6 +293,12 @@ export const auth = betterAuth({
         "Sends a password reset email. It takes a function that takes two parameters: token and user.",
       type: "function",
     },
+    resetPasswordTokenExpiresIn: {
+      description:
+        "Number of seconds the reset password token is valid for."
+      type: "number",
+      default: 3600
+    }
     password: {
       description: "Password configuration.",
       type: "object",


### PR DESCRIPTION
- added `resetPasswordTokenExpiresIn` in props table