### PR TITLE
(stripe/hono fix): webhook patches for the stripe plugin in hono js

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -692,7 +692,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								message: "Stripe webhook secret not found",
 							});
 						}
-						event = client.webhooks.constructEvent(buf, sig, webhookSecret);
+						event = await client.webhooks.constructEventAsync(buf, sig, webhookSecret);
 					} catch (err: any) {
 						ctx.context.logger.error(`${err.message}`);
 						throw new APIError("BAD_REQUEST", {


### PR DESCRIPTION
Fixed an issue where SubtleCryptoProvider cannot be used in a synchronous context in hono by making it async. The issue broke the stripe plugin completely