### PR TITLE
fix(admin): pass correct options to hasPermission

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -202,7 +202,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canSetRole = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: ctx.context.session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							user: ["set-role"],
 						},
@@ -284,7 +284,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canCreateUser = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							user: ["create"],
 						},
@@ -437,7 +437,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canListUsers = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							user: ["list"],
 						},
@@ -536,7 +536,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canListSessions = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							session: ["list"],
 						},
@@ -596,7 +596,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canBanUser = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							user: ["ban"],
 						},
@@ -676,7 +676,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canBanUser = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							user: ["ban"],
 						},
@@ -755,7 +755,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canImpersonateUser = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: ctx.context.session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							user: ["impersonate"],
 						},
@@ -905,7 +905,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canRevokeSession = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							session: ["revoke"],
 						},
@@ -965,7 +965,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canRevokeSession = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							session: ["revoke"],
 						},
@@ -1024,7 +1024,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canDeleteUser = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							user: ["delete"],
 						},
@@ -1082,7 +1082,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canSetUserPassword = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: ctx.context.session.user.role,
-						options: ctx.context.adminOptions,
+						options: opts,
 						permission: {
 							user: ["set-password"],
 						},

--- a/packages/better-auth/src/plugins/admin/call.ts
+++ b/packages/better-auth/src/plugins/admin/call.ts
@@ -1,8 +1,6 @@
-import { type AdminOptions, type UserWithRole } from "./admin";
+import { type UserWithRole } from "./admin";
 import { APIError, createAuthMiddleware, getSessionFromCtx } from "../../api";
 import { type Session } from "../../types";
-import { type Role } from "../access";
-import { type defaultRoles } from "./access/statement";
 
 export const adminMiddleware = createAuthMiddleware(async (ctx) => {
 	const session = await getSessionFromCtx(ctx);
@@ -12,13 +10,9 @@ export const adminMiddleware = createAuthMiddleware(async (ctx) => {
 	return {
 		session,
 	} as {
-		adminOptions: AdminOptions;
 		session: {
 			user: UserWithRole;
 			session: Session;
-		};
-		roles: typeof defaultRoles & {
-			[key: string]: Role;
 		};
 	};
 });


### PR DESCRIPTION
`ctx.context.adminOptions` is not available because the context is no longer shimmed. The commited changes use `opts` instead.

Also removed unnecessary typings in `adminMiddleware`.