### PR TITLE
fix(two-factor): Pass options to default backup code generate function

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -43,7 +43,7 @@ export async function generateBackupCodes(
 	const key = secret;
 	const backupCodes = options?.customBackupCodesGenerate
 		? options.customBackupCodesGenerate()
-		: generateBackupCodesFn();
+		: generateBackupCodesFn(options);
 	const encCodes = await symmetricEncrypt({
 		data: JSON.stringify(backupCodes),
 		key: key,


### PR DESCRIPTION
I noticed that the options parameter was not being passed into the default backup code generation function, which would mean the `length` and `amount` options would never be used. This PR simply fixes that behavior.