### PR TITLE
fix: lowercase email in change email process, find as it is

### DIFF
--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -568,14 +568,16 @@ export const changeEmail = createAuthEndpoint(
 			});
 		}
 
-		if (ctx.body.newEmail === ctx.context.session.user.email) {
+		const newEmail = ctx.body.newEmail.toLowerCase();
+
+		if (newEmail === ctx.context.session.user.email) {
 			ctx.context.logger.error("Email is the same");
 			throw new APIError("BAD_REQUEST", {
 				message: "Email is the same",
 			});
 		}
 		const existingUser = await ctx.context.internalAdapter.findUserByEmail(
-			ctx.body.newEmail,
+			newEmail,
 		);
 		if (existingUser) {
 			ctx.context.logger.error("Email already exists");
@@ -588,7 +590,7 @@ export const changeEmail = createAuthEndpoint(
 		 */
 		if (ctx.context.session.user.emailVerified !== true) {
 			const existing = await ctx.context.internalAdapter.findUserByEmail(
-				ctx.body.newEmail,
+				newEmail,
 			);
 			if (existing) {
 				throw new APIError("UNPROCESSABLE_ENTITY", {
@@ -598,7 +600,7 @@ export const changeEmail = createAuthEndpoint(
 			await ctx.context.internalAdapter.updateUserByEmail(
 				ctx.context.session.user.email,
 				{
-					email: ctx.body.newEmail,
+					email: newEmail,
 				},
 				ctx,
 			);
@@ -606,14 +608,14 @@ export const changeEmail = createAuthEndpoint(
 				session: ctx.context.session.session,
 				user: {
 					...ctx.context.session.user,
-					email: ctx.body.newEmail,
+					email: newEmail,
 				},
 			});
 			if (ctx.context.options.emailVerification?.sendVerificationEmail) {
 				const token = await createEmailVerificationToken(
 					ctx.context.secret,
 					ctx.context.session.user.email,
-					ctx.body.newEmail,
+					newEmail,
 					ctx.context.options.emailVerification?.expiresIn,
 				);
 				const url = `${
@@ -625,7 +627,7 @@ export const changeEmail = createAuthEndpoint(
 					{
 						user: {
 							...ctx.context.session.user,
-							email: ctx.body.newEmail,
+							email: newEmail,
 						},
 						url,
 						token,
@@ -652,7 +654,7 @@ export const changeEmail = createAuthEndpoint(
 		const token = await createEmailVerificationToken(
 			ctx.context.secret,
 			ctx.context.session.user.email,
-			ctx.body.newEmail,
+			newEmail,
 			ctx.context.options.emailVerification?.expiresIn,
 		);
 		const url = `${
@@ -661,7 +663,7 @@ export const changeEmail = createAuthEndpoint(
 		await ctx.context.options.user.changeEmail.sendChangeEmailVerification(
 			{
 				user: ctx.context.session.user,
-				newEmail: ctx.body.newEmail,
+				newEmail: newEmail,
 				url,
 				token,
 			},

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -576,9 +576,8 @@ export const changeEmail = createAuthEndpoint(
 				message: "Email is the same",
 			});
 		}
-		const existingUser = await ctx.context.internalAdapter.findUserByEmail(
-			newEmail,
-		);
+		const existingUser =
+			await ctx.context.internalAdapter.findUserByEmail(newEmail);
 		if (existingUser) {
 			ctx.context.logger.error("Email already exists");
 			throw new APIError("BAD_REQUEST", {
@@ -589,9 +588,8 @@ export const changeEmail = createAuthEndpoint(
 		 * If the email is not verified, we can update the email
 		 */
 		if (ctx.context.session.user.emailVerified !== true) {
-			const existing = await ctx.context.internalAdapter.findUserByEmail(
-				newEmail,
-			);
+			const existing =
+				await ctx.context.internalAdapter.findUserByEmail(newEmail);
 			if (existing) {
 				throw new APIError("UNPROCESSABLE_ENTITY", {
 					message: BASE_ERROR_CODES.USER_ALREADY_EXISTS,

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -597,7 +597,7 @@ export const createInternalAdapter = (
 				model: "user",
 				where: [
 					{
-						value: email.toLowerCase(),
+						value: email,
 						field: "email",
 					},
 				],


### PR DESCRIPTION
Currently, if a user changes his email address to include uppercase letters, he will not be able to verify his email address or reset his password.

Related: https://github.com/RSSNext/Follow/issues/2950