### PR TITLE
fix(api-key): creating API keys metadata always returns null

### DIFF
--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -489,6 +489,18 @@ describe("api-key", async () => {
 
 		expect(apiKey).not.toBeNull();
 		expect(apiKey.metadata).toEqual(metadata);
+
+		const res = await auth.api.getApiKey({
+			query: {
+				id: apiKey.id,
+			},
+			headers,
+		});
+
+		expect(res).not.toBeNull();
+		if (res) {
+			expect(res.metadata).toEqual(metadata);
+		}
 	});
 
 	it("create API key's returned metadata should be an object", async () => {

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -275,14 +275,8 @@ export function createApiKey({
 			};
 
 			if (metadata) {
-				const parseMetadata = parseInputData(
-					data,
-					apiKeySchema({
-						rateLimitMax: opts.rateLimit.maxRequests!,
-						timeWindow: opts.rateLimit.timeWindow!,
-					}).apikey,
-				);
-				data.metadata = parseMetadata.metadata ?? null;
+				//@ts-expect-error - we intentionally save the metadata as string on DB.
+				data.metadata = schema.apikey.fields.metadata.transform.input(metadata);
 			}
 
 			const apiKey = await ctx.context.adapter.create<ApiKey>({


### PR DESCRIPTION
- also updated the tests to actually check if the metadata is valid.

read more here: https://discord.com/channels/1288403910284935179/1346739320588992589/1346739320588992589