### PR TITLE
Fixed redis and ioredis implementation 

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -78,23 +78,31 @@ const redis = createClient();
 await redis.connect();
 
 export const auth = betterAuth({
-	// ... other options
-	secondaryStorage: {
-		get: async (key) => {
-			const value = await redis.get(key);
-			return value ? JSON.stringify(value) : null;
-		},
-		set: async (key, value, ttl) => {
-			if (ttl) await redis.set(key, value, { EX: ttl });
-			// or for ioredis:
-			// if (ttl) await redis.set(key, value, 'EX', ttl)
-			else await redis.set(key, value);
-		},
-		delete: async (key) => {
-			await redis.del(key);
-		}
-	}
+  // ... existing code ...
+  secondaryStorage: {
+    get: async (key) => {
+      const value = await redis.get(key);
+      return value ? value : null; 
+    },
+    set: async (key, value, ttl) => {
+      const stringValue = typeof value === 'string' ? value : JSON.stringify(value); 
+
+      // For ioredis:
+      if (ttl) {
+        await redis.set(key, stringValue, "EX", ttl); // ioredis uses 'EX' for TTL
+      }
+      // For non-ioredis:
+      else {
+        await redis.set(key, stringValue); // Default Redis client
+      }
+    },
+    delete: async (key) => {
+      await redis.del(key);
+    },
+  },
+  // ... existing code ...
 });
+
 ```
 
 This implementation allows Better Auth to use Redis for storing session data and rate limiting counters. You can also add prefixes to the keys names.

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -78,7 +78,7 @@ const redis = createClient();
 await redis.connect();
 
 export const auth = betterAuth({
-  // ... existing code ...
+  // ... other options
   secondaryStorage: {
     get: async (key) => {
       const value = await redis.get(key);
@@ -100,7 +100,6 @@ export const auth = betterAuth({
       await redis.del(key);
     },
   },
-  // ... existing code ...
 });
 
 ```


### PR DESCRIPTION
Fixed redis and ioredis implementation 
Error without these changes : ERROR [Better Auth]: INTERNAL_SERVER_ERROR [TypeError: Cannot read properties of undefined (reading 'expiresAt')] 
This line is required to fix this error :
const stringValue = typeof value === 'string' ? value : JSON.stringify(value); 