### PR TITLE
fix(docs): Polar icon breaking on mobile devices

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1424,7 +1424,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 						viewBox="0 0 280 350"
 						fill="none"
 						xmlns="http://www.w3.org/2000/svg"
-						className="mx-auto"
+						className="size-4"
 					>
 						<g transform="translate(30, 20)">
 							<path


### PR DESCRIPTION
# Before
![image](https://github.com/user-attachments/assets/24ccbf3e-653a-4dc4-a5fc-5086bb95b571)

# After
<img width="425" alt="image" src="https://github.com/user-attachments/assets/a22cd4cb-3754-4262-a874-304727f83714" />
