### PR TITLE
fix(api-key): Results of `verify` endpoint's metadata isn't parsed

### DIFF
--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -1520,6 +1520,34 @@ describe("api-key", async () => {
 		});
 	});
 
+	it("should have valid metadata from key verification results", async () => {
+		const metadata = {
+			test: "hello-world-123",
+		};
+		const apiKey = await auth.api.createApiKey({
+			body: {
+				userId: user.id,
+				metadata: metadata,
+			},
+			headers,
+		});
+
+		expect(apiKey).not.toBeNull();
+		if (apiKey) {
+			const result = await auth.api.verifyApiKey({
+				body: {
+					key: apiKey.key,
+					metadata: metadata,
+				},
+				headers,
+			});
+
+			expect(result.valid).toBe(true);
+			expect(result.error).toBeNull();
+			expect(result.key?.metadata).toEqual(metadata);
+		}
+	});
+
 	it("should verify an API key with matching permissions", async () => {
 		const permissions = {
 			files: ["read", "write"],

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -268,6 +268,12 @@ export function verifyApiKey({
 			deleteAllExpiredApiKeys(ctx.context);
 
 			const { key: _, ...returningApiKey } = newApiKey ?? { key: 1 };
+			if ("metadata" in returningApiKey) {
+				returningApiKey.metadata =
+					schema.apikey.fields.metadata.transform.output(
+						returningApiKey.metadata as never as string,
+					);
+			}
 
 			return ctx.json({
 				valid: true,


### PR DESCRIPTION
Calling verify endpoint returns the stringified version of the metadata. This is fixed now.