### PR TITLE
docs: fix number of triggers

### DIFF
--- a/docs/content/docs/concepts/email.mdx
+++ b/docs/content/docs/concepts/email.mdx
@@ -40,7 +40,7 @@ export const auth = betterAuth({
 
 ### Triggering Email Verification
 
-You can initiate email verification in two ways:
+You can initiate email verification in several ways:
 
 #### 1. During Sign-up
 


### PR DESCRIPTION
The docs mention that there are two ways to initiate email verification, but three ways are listed. I changed the word "two" to "several".