### PR TITLE
feat: refactor database adapters

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -345,7 +345,7 @@ export const drizzleAdapter =
 					.select({ count: count() })
 					.from(schemaModel)
 					.where(...clause);
-				return res.count;
+				return res[0].count;
 			},
 			async update(data) {
 				const { model, where, update: values } = data;

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -115,7 +115,7 @@ const createTransform = (
 					condition = like(schemaModel[field], `%${value}`);
 					break;
 				default:
-					// will throw an error if unknown operator is provided not if operator is undefined
+					// throw an error if unknown operator is provided
 					throw new BetterAuthError(
 						`[# Drizzle Adapter]: Unsupported operator: ${operator}`,
 					);

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, inArray, like, or, SQL } from "drizzle-orm";
+import { and, asc, count, desc, eq, gt, gte, inArray, like, lt, lte, ne, or, SQL } from "drizzle-orm";
 import { getAuthTables } from "../../db";
 import { BetterAuthError } from "../../error";
 import type { Adapter, BetterAuthOptions, Where } from "../../types";
@@ -50,70 +50,75 @@ const createTransform = (
 	};
 
 	function convertWhereClause(where: Where[], model: string) {
-		const schemaModel = getSchema(model);
 		if (!where) return [];
-		if (where.length === 1) {
-			const w = where[0];
-			if (!w) {
-				return [];
-			}
+		const schemaModel = getSchema(model);
+		const conditions = where.map((w) => {
 			const field = getField(model, w.field);
 			if (!schemaModel[field]) {
 				throw new BetterAuthError(
 					`The field "${w.field}" does not exist in the schema for the model "${model}". Please update your schema.`,
 				);
 			}
-			if (w.operator === "in") {
-				if (!Array.isArray(w.value)) {
-					throw new BetterAuthError(
-						`The value for the field "${w.field}" must be an array when using the "in" operator.`,
-					);
-				}
-				return [inArray(schemaModel[field], w.value)];
-			}
-
-			if (w.operator === "contains") {
-				return [like(schemaModel[field], `%${w.value}%`)];
-			}
-
-			if (w.operator === "starts_with") {
-				return [like(schemaModel[field], `${w.value}%`)];
-			}
-
-			if (w.operator === "ends_with") {
-				return [like(schemaModel[field], `%${w.value}`)];
-			}
-
-			return [eq(schemaModel[field], w.value)];
-		}
-		const andGroup = where.filter((w) => w.connector === "AND" || !w.connector);
-		const orGroup = where.filter((w) => w.connector === "OR");
-
-		const andClause = and(
-			...andGroup.map((w) => {
-				const field = getField(model, w.field);
-				if (w.operator === "in") {
-					if (!Array.isArray(w.value)) {
+			const { value, operator, connector } = w;
+			let condition;
+			switch (operator) {
+				case "in":
+					if (!Array.isArray(value)) {
 						throw new BetterAuthError(
 							`The value for the field "${w.field}" must be an array when using the "in" operator.`,
 						);
 					}
-					return inArray(schemaModel[field], w.value);
-				}
-				return eq(schemaModel[field], w.value);
-			}),
-		);
-		const orClause = or(
-			...orGroup.map((w) => {
-				const field = getField(model, w.field);
-				return eq(schemaModel[field], w.value);
-			}),
-		);
+					condition = inArray(schemaModel[field], value);
+					break;
+				case "contains":
+					condition = like(schemaModel[field], `%${value}%`);
+					break;
+				case "starts_with":
+					condition = like(schemaModel[field], `${value}%`);
+					break;
+				case "ends_with":
+					condition = like(schemaModel[field], `%${value}`);
+					break;
+				case "eq":
+					condition = eq(schemaModel[field], value);
+					break;
+				case "ne":
+					condition = ne(schemaModel[field], value);
+					break;
+				case "lt":
+					condition = lt(schemaModel[field], value);
+					break;
+				case "lte":
+					condition = lte(schemaModel[field], value);
+					break;
+				case "gt":
+					condition = gt(schemaModel[field], value);
+					break;
+				case "gte":
+					condition = gte(schemaModel[field], value);
+					break;
+				default:
+					throw new BetterAuthError(`Unsupported operator: ${operator}`);
+			}
+			return { condition, connector };
+		});
+		if (conditions.length === 1) {
+			return [conditions[0].condition];
+		}
+		const andConditions = conditions
+			.filter((c) => c.connector === "AND" || !c.connector)
+			.map((c) => c.condition);
+		const orConditions = conditions
+			.filter((c) => c.connector === "OR")
+			.map((c) => c.condition);
 
 		const clause: SQL<unknown>[] = [];
-
-		if (andGroup.length) clause.push(andClause!);
-		if (orGroup.length) clause.push(orClause!);
+		if (andConditions.length) {
+			clause.push(and(...andConditions)!);
+		}
+		if (orConditions.length) {
+			clause.push(or(...orConditions)!);
+		}
 		return clause;
 	}
 

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -124,7 +124,7 @@ const createTransform = (
 		if (conditions.length === 1) {
 			return [conditions[0].condition];
 		}
-		// Filter out conditions with a connector of "AND" and "OR"
+		// Separate the conditions into "AND" and "OR" connector conditions
 		const andConditions = conditions
 			.filter((c) => c.connector === "AND" || !c.connector)
 			.map((c) => c.condition);

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -75,26 +75,10 @@ const createTransform = (
 					`[# Drizzle Adapter]: The field "${w.field}" does not exist in the schema for the model "${model}". Please update your schema.`,
 				);
 			}
-			const { value, operator, connector } = w;
+			// if no operator is provided, set it to "eq"
+			const { value, operator = "eq", connector } = w;
 			let condition: SQL;
 			switch (operator) {
-				case "in":
-					if (!Array.isArray(value)) {
-						throw new BetterAuthError(
-							`[# Drizzle Adapter]: The value for the field "${w.field}" must be an array when using the "in" operator.`,
-						);
-					}
-					condition = inArray(schemaModel[field], value);
-					break;
-				case "contains":
-					condition = like(schemaModel[field], `%${value}%`);
-					break;
-				case "starts_with":
-					condition = like(schemaModel[field], `${value}%`);
-					break;
-				case "ends_with":
-					condition = like(schemaModel[field], `%${value}`);
-					break;
 				case "eq":
 					condition = eq(schemaModel[field], value);
 					break;
@@ -113,7 +97,25 @@ const createTransform = (
 				case "gte":
 					condition = gte(schemaModel[field], value);
 					break;
+				case "in":
+					if (!Array.isArray(value)) {
+						throw new BetterAuthError(
+							`[# Drizzle Adapter]: The value for the field "${w.field}" must be an array when using the "in" operator.`,
+						);
+					}
+					condition = inArray(schemaModel[field], value);
+					break;
+				case "contains":
+					condition = like(schemaModel[field], `%${value}%`);
+					break;
+				case "starts_with":
+					condition = like(schemaModel[field], `${value}%`);
+					break;
+				case "ends_with":
+					condition = like(schemaModel[field], `%${value}`);
+					break;
 				default:
+					// will throw an error if unknown operator is provided not if operator is undefined
 					throw new BetterAuthError(
 						`[# Drizzle Adapter]: Unsupported operator: ${operator}`,
 					);

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -75,7 +75,7 @@ const createTransform = (
 					`[# Drizzle Adapter]: The field "${w.field}" does not exist in the schema for the model "${model}". Please update your schema.`,
 				);
 			}
-			// if no operator is provided, set it to "eq"
+			// if no operator is provided, set it to "eq" by default
 			const { value, operator = "eq", connector } = w;
 			let condition: SQL;
 			switch (operator) {

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -64,7 +64,7 @@ const createTransform = (
 				: model;
 	};
 
-	function convertWhereClause(where: Where[], model: string): SQL[] {
+	function convertWhereClause(model: string, where: Where[]): SQL[] {
 		if (!where || !where.length) return [];
 		const schemaModel = getSchema(model);
 		// Map each where condition to a drizzle query condition
@@ -222,7 +222,7 @@ const createTransform = (
 			const schemaModel = getSchema(model);
 			const builderVal = builder.config?.values;
 			if (where?.length) {
-				const clause = convertWhereClause(where, model);
+				const clause = convertWhereClause(model, where);
 				const res = await db
 					.select()
 					.from(schemaModel)
@@ -309,7 +309,7 @@ export const drizzleAdapter =
 			async findOne(data) {
 				const { model, where, select } = data;
 				const schemaModel = getSchema(model);
-				const clause = convertWhereClause(where, model);
+				const clause = convertWhereClause(model, where);
 				const res = await db
 					.select()
 					.from(schemaModel)
@@ -321,7 +321,7 @@ export const drizzleAdapter =
 			async findMany(data) {
 				const { model, where, sortBy, limit, offset } = data;
 				const schemaModel = getSchema(model);
-				const clause = where ? convertWhereClause(where, model) : [];
+				const clause = where ? convertWhereClause(model, where) : [];
 
 				const sortFn = sortBy?.direction === "desc" ? desc : asc;
 				const builder = db
@@ -338,7 +338,7 @@ export const drizzleAdapter =
 			async count(data) {
 				const { model, where } = data;
 				const schemaModel = getSchema(model);
-				const clause = where ? convertWhereClause(where, model) : [];
+				const clause = where ? convertWhereClause(model, where) : [];
 				const res = await db
 					.select({ count: count() })
 					.from(schemaModel)
@@ -348,7 +348,7 @@ export const drizzleAdapter =
 			async update(data) {
 				const { model, where, update: values } = data;
 				const schemaModel = getSchema(model);
-				const clause = convertWhereClause(where, model);
+				const clause = convertWhereClause(model, where);
 				const transformed = transformInput(values, model, "update");
 				const builder = db
 					.update(schemaModel)
@@ -365,7 +365,7 @@ export const drizzleAdapter =
 			async updateMany(data) {
 				const { model, where, update: values } = data;
 				const schemaModel = getSchema(model);
-				const clause = convertWhereClause(where, model);
+				const clause = convertWhereClause(model, where);
 				const transformed = transformInput(values, model, "update");
 				const builder = db
 					.update(schemaModel)
@@ -377,14 +377,14 @@ export const drizzleAdapter =
 			async delete(data) {
 				const { model, where } = data;
 				const schemaModel = getSchema(model);
-				const clause = convertWhereClause(where, model);
+				const clause = convertWhereClause(model, where);
 				const builder = db.delete(schemaModel).where(...clause);
 				await builder;
 			},
 			async deleteMany(data) {
 				const { model, where } = data;
 				const schemaModel = getSchema(model);
-				const clause = convertWhereClause(where, model); //con
+				const clause = convertWhereClause(model, where);
 				const builder = db.delete(schemaModel).where(...clause);
 				const res = await builder;
 				return res ? res.length : 0;

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -28,7 +28,7 @@ const createTransform = (
 		const schema = config.schema || db._.fullSchema;
 		if (!schema) {
 			throw new BetterAuthError(
-				"Drizzle adapter failed to initialize. Schema not found. Please provide a schema object in the adapter options object.",
+				"[# Drizzle Adapter]: Drizzle adapter failed to initialize. Schema not found. Please provide a schema object in the adapter options object.",
 			);
 		}
 		const model = getModelName(modelName);
@@ -56,7 +56,7 @@ const createTransform = (
 			const field = getField(model, w.field);
 			if (!schemaModel[field]) {
 				throw new BetterAuthError(
-					`The field "${w.field}" does not exist in the schema for the model "${model}". Please update your schema.`,
+					`[# Drizzle Adapter]: The field "${w.field}" does not exist in the schema for the model "${model}". Please update your schema.`,
 				);
 			}
 			const { value, operator, connector } = w;
@@ -65,7 +65,7 @@ const createTransform = (
 				case "in":
 					if (!Array.isArray(value)) {
 						throw new BetterAuthError(
-							`The value for the field "${w.field}" must be an array when using the "in" operator.`,
+							`[# Drizzle Adapter]: The value for the field "${w.field}" must be an array when using the "in" operator.`,
 						);
 					}
 					condition = inArray(schemaModel[field], value);
@@ -98,7 +98,7 @@ const createTransform = (
 					condition = gte(schemaModel[field], value);
 					break;
 				default:
-					throw new BetterAuthError(`Unsupported operator: ${operator}`);
+					throw new BetterAuthError(`[# Drizzle Adapter]: Unsupported operator: ${operator}`);
 			}
 			return { condition, connector };
 		});
@@ -245,13 +245,13 @@ function checkMissingFields(
 ) {
 	if (!schema) {
 		throw new BetterAuthError(
-			"Drizzle adapter failed to initialize. Schema not found. Please provide a schema object in the adapter options object.",
+			"[# Drizzle Adapter]: Drizzle adapter failed to initialize. Schema not found. Please provide a schema object in the adapter options object.",
 		);
 	}
 	for (const key in values) {
 		if (!schema[key]) {
 			throw new BetterAuthError(
-				`The field "${key}" does not exist in the "${model}" schema. Please update your drizzle schema or re-generate using "npx @better-auth/cli generate".`,
+				`[# Drizzle Adapter]: The field "${key}" does not exist in the "${model}" schema. Please update your drizzle schema or re-generate using "npx @better-auth/cli generate".`,
 			);
 		}
 	}

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -85,7 +85,8 @@ const createTransform = (options: BetterAuthOptions) => {
 		}) {
 			return table.filter((record) => {
 				return where.every((clause) => {
-					const { field: _field, value, operator } = clause;
+					// if no operator is provided, set it to "eq" by default
+					const { field: _field, value, operator = "eq" } = clause;
 					const field = getField(model, _field);
 					switch (operator) {
 						case "eq":
@@ -118,10 +119,6 @@ const createTransform = (options: BetterAuthOptions) => {
 						case "ends_with":
 							return record[field].endsWith(value);
 						default:
-							// if no operator is provided, default to equals
-							if (operator === undefined) {
-								return record[field] === value;
-							}
 							// throw an error if unknown operator is provided
 							throw new Error(
 								`[# Memory Adapter]: Unsupported operator: ${operator}`,

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -171,8 +171,10 @@ export const memoryAdapter = (db: MemoryDB) => (options: BetterAuthOptions) => {
 			}
 			return table.map((record) => transformOutput(record, model));
 		},
-		count: async ({ model }) => {
-			return db[model].length;
+		count: async ({ model, where }) => {
+			const table = db[model];
+			const res = where ? convertWhereClause({ model, table, where }) : table;
+			return res.length;
 		},
 		update: async ({ model, where, update }) => {
 			const table = db[model];

--- a/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
@@ -16,7 +16,7 @@ describe("adapter test", async () => {
 	const db = await dbClient("mongodb://127.0.0.1:27017", "better-auth");
 	async function clearDb() {
 		await db.collection(user).deleteMany({});
-		await db.collection("session").deleteMany({});
+		await db.collection("sessions").deleteMany({});
 	}
 
 	beforeAll(async () => {

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -147,7 +147,7 @@ const createTransform = (options: BetterAuthOptions) => {
 			}
 			return transformedData as any;
 		},
-		convertWhereClause(where: Where[], model: string) {
+		convertWhereClause(model: string, where: Where[]) {
 			if (!where.length) return {};
 			const conditions = where.map((w) => {
 				const { field: _field, value, operator = "eq", connector = "AND" } = w;
@@ -246,7 +246,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 		},
 		async findOne(data) {
 			const { model, where, select } = data;
-			const clause = transform.convertWhereClause(where, model);
+			const clause = transform.convertWhereClause(model, where);
 			const res = await db
 				.collection(transform.getModelName(model))
 				.findOne(clause);
@@ -256,7 +256,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 		},
 		async findMany(data) {
 			const { model, where, limit, offset, sortBy } = data;
-			const clause = where ? transform.convertWhereClause(where, model) : {};
+			const clause = where ? transform.convertWhereClause(model, where) : {};
 			const cursor = db.collection(transform.getModelName(model)).find(clause);
 			if (limit) cursor.limit(limit);
 			if (offset) cursor.skip(offset);
@@ -277,7 +277,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 		},
 		async update(data) {
 			const { model, where, update: values } = data;
-			const clause = transform.convertWhereClause(where, model);
+			const clause = transform.convertWhereClause(model, where);
 
 			const transformedData = transform.transformInput(values, model, "update");
 
@@ -295,7 +295,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 		},
 		async updateMany(data) {
 			const { model, where, update: values } = data;
-			const clause = transform.convertWhereClause(where, model);
+			const clause = transform.convertWhereClause(model, where);
 			const transformedData = transform.transformInput(values, model, "update");
 			const res = await db
 				.collection(transform.getModelName(model))
@@ -304,7 +304,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 		},
 		async delete(data) {
 			const { model, where } = data;
-			const clause = transform.convertWhereClause(where, model);
+			const clause = transform.convertWhereClause(model, where);
 			const res = await db
 				.collection(transform.getModelName(model))
 				.findOneAndDelete(clause);
@@ -313,7 +313,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 		},
 		async deleteMany(data) {
 			const { model, where } = data;
-			const clause = transform.convertWhereClause(where, model);
+			const clause = transform.convertWhereClause(model, where);
 			const res = await db
 				.collection(transform.getModelName(model))
 				.deleteMany(clause);

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -304,10 +304,11 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 			return res.map((r) => transform.transformOutput(r, model));
 		},
 		async count(data) {
-			const { model } = data;
+			const { model, where } = data;
+			const clause = where ? transform.convertWhereClause(model, where) : {};
 			const res = await db
 				.collection(transform.getModelName(model))
-				.countDocuments();
+				.countDocuments(clause);
 			return res;
 		},
 		async update(data) {

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -165,6 +165,11 @@ const createTransform = (options: BetterAuthOptions) => {
 					};
 				};
 				const field = getField(_field, model);
+
+				function escapeRegex(value: string) {
+					return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+				}
+
 				switch (operator.toLowerCase()) {
 					case "eq":
 						condition = {
@@ -197,13 +202,28 @@ const createTransform = (options: BetterAuthOptions) => {
 						break;
 
 					case "contains":
-						condition = { [field]: { $regex: `.*${value}.*` } };
+						if (typeof value !== "string") {
+							throw new BetterAuthError(
+								`[# Mongodb Adapter]: contains operator requires a string but was provided ${typeof value}`,
+							);
+						}
+						condition = { [field]: { $regex: escapeRegex(value) } };
 						break;
 					case "starts_with":
-						condition = { [field]: { $regex: `${value}.*` } };
+						if (typeof value !== "string") {
+							throw new BetterAuthError(
+								`[# Mongodb Adapter]: starts_with operator requires a string but was provided ${typeof value}`,
+							);
+						}
+						condition = { [field]: { $regex: `^${escapeRegex(value)}` } };
 						break;
 					case "ends_with":
-						condition = { [field]: { $regex: `.*${value}` } };
+						if (typeof value !== "string") {
+							throw new BetterAuthError(
+								`[# Mongodb Adapter]: ends_with operator requires a string but was provided ${typeof value}`,
+							);
+						}
+						condition = { [field]: { $regex: `${escapeRegex(value)}$` } };
 						break;
 					default:
 						// throw an error if unknown operator is provided

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -41,20 +41,32 @@ const createTransform = (config: PrismaConfig, options: BetterAuthOptions) => {
 		return f.fieldName || field;
 	}
 
-	function operatorToPrismaOperator(operator: Where["operator"]): string {
+	function operatorToPrismaOperator(
+		// if no operator is provided, set it to "eq" by default
+		operator: Where["operator"] = "eq",
+	): string {
 		switch (operator) {
 			case "eq":
 				return "equals";
 			case "ne":
 				return "not";
+			// lt, lte, gt, gte, in, contains operators have same name
+			case "lt":
+			case "lte":
+			case "gt":
+			case "gte":
+			case "in":
+			case "contains":
+				return operator;
 			case "starts_with":
 				return "startsWith";
 			case "ends_with":
 				return "endsWith";
 			default:
-				// lt, lte, gt, gte, in, contains operators have same name
-				// if no operator is provided, default to equals
-				return operator ?? "equals";
+				// throw an error if unknown operator is provided
+				throw new BetterAuthError(
+					`[# Prisma Adapter]: Unsupported operator: ${operator}`,
+				);
 		}
 	}
 

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -180,16 +180,19 @@ export const prismaAdapter =
 			getModelName,
 			getField,
 		} = createTransform(config, options);
+		function checkModelExistsOrThrow(model: string): void {
+			if (!db[getModelName(model)]) {
+				throw new BetterAuthError(
+					`[# Prisma Adapter]: Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
+				);
+			}
+		}
 		return {
 			id: "prisma",
 			async create(data) {
 				const { model, data: values, select } = data;
 				const transformed = transformInput(values, model, "create");
-				if (!db[getModelName(model)]) {
-					throw new BetterAuthError(
-						`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
-					);
-				}
+				checkModelExistsOrThrow(model);
 				const result = await db[getModelName(model)].create({
 					data: transformed,
 					select: convertSelect(select, model),
@@ -199,11 +202,7 @@ export const prismaAdapter =
 			async findOne(data) {
 				const { model, where, select } = data;
 				const whereClause = convertWhereClause(model, where);
-				if (!db[getModelName(model)]) {
-					throw new BetterAuthError(
-						`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
-					);
-				}
+				checkModelExistsOrThrow(model);
 				const result = await db[getModelName(model)].findFirst({
 					where: whereClause,
 					select: convertSelect(select, model),
@@ -213,11 +212,7 @@ export const prismaAdapter =
 			async findMany(data) {
 				const { model, where, limit, offset, sortBy } = data;
 				const whereClause = convertWhereClause(model, where);
-				if (!db[getModelName(model)]) {
-					throw new BetterAuthError(
-						`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
-					);
-				}
+				checkModelExistsOrThrow(model);
 
 				const result = (await db[getModelName(model)].findMany({
 					where: whereClause,
@@ -237,11 +232,7 @@ export const prismaAdapter =
 			async count(data) {
 				const { model, where } = data;
 				const whereClause = convertWhereClause(model, where);
-				if (!db[getModelName(model)]) {
-					throw new BetterAuthError(
-						`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
-					);
-				}
+				checkModelExistsOrThrow(model);
 				const result = await db[getModelName(model)].count({
 					where: whereClause,
 				});
@@ -249,11 +240,7 @@ export const prismaAdapter =
 			},
 			async update(data) {
 				const { model, where, update } = data;
-				if (!db[getModelName(model)]) {
-					throw new BetterAuthError(
-						`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
-					);
-				}
+				checkModelExistsOrThrow(model);
 				const whereClause = convertWhereClause(model, where);
 				const transformed = transformInput(update, model, "update");
 				const result = await db[getModelName(model)].update({
@@ -264,6 +251,7 @@ export const prismaAdapter =
 			},
 			async updateMany(data) {
 				const { model, where, update } = data;
+				checkModelExistsOrThrow(model);
 				const whereClause = convertWhereClause(model, where);
 				const transformed = transformInput(update, model, "update");
 				const result = await db[getModelName(model)].updateMany({
@@ -274,6 +262,7 @@ export const prismaAdapter =
 			},
 			async delete(data) {
 				const { model, where } = data;
+				checkModelExistsOrThrow(model);
 				const whereClause = convertWhereClause(model, where);
 				try {
 					await db[getModelName(model)].delete({
@@ -285,6 +274,7 @@ export const prismaAdapter =
 			},
 			async deleteMany(data) {
 				const { model, where } = data;
+				checkModelExistsOrThrow(model);
 				const whereClause = convertWhereClause(model, where);
 				const result = await db[getModelName(model)].deleteMany({
 					where: whereClause,

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -295,6 +295,26 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		});
 	});
 
+	test("should count records", async () => {
+		const res = await adapter.count({
+			model: "user",
+		});
+		expect(res).toBe(5);
+	});
+
+	test("should count records with where", async () => {
+		const res = await adapter.count({
+			model: "user",
+			where: [
+				{
+					field: "id",
+					value: user.id,
+				},
+			],
+		});
+		expect(res).toBe(1);
+	});
+
 	test("delete model", async () => {
 		await adapter.delete({
 			model: "user",

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -185,7 +185,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 				createdAt: new Date(),
 				updatedAt: new Date(),
 				userId: user.id,
-				expiresAt: new Date(),
+				expiresAt: new Date(Date.now() + 1000 * 60 * 20),
 			},
 		});
 		token = session.token;
@@ -385,6 +385,128 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 			],
 		});
 		expect(res).toBeNull();
+	});
+
+	test("should not find user with ne operator", async () => {
+		const user = await adapter.create<User>({
+			model: "user",
+			data: {
+				id: "6",
+				name: "testuserop",
+				email: "test-userop@email.com",
+				emailVerified: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		const res = await adapter.findMany({
+			model: "user",
+			where: [
+				{
+					field: "email",
+					operator: "ne",
+					value: "test-userop@email.com",
+				},
+			],
+		});
+		expect(res).not.toContainEqual(user);
+	});
+
+	test("should find user with eq operator", async () => {
+		const res = await adapter.findOne<User>({
+			model: "user",
+			where: [
+				{
+					field: "email",
+					operator: "eq",
+					value: "test-userop@email.com",
+				},
+			],
+		});
+		expect(res?.email).toBe("test-userop@email.com");
+	});
+
+	test("should find user with no(undefined) operator", async () => {
+		const res = await adapter.findOne<User>({
+			model: "user",
+			where: [
+				{
+					field: "email",
+					value: "test-userop@email.com",
+				},
+			],
+		});
+		expect(res?.email).toBe("test-userop@email.com");
+	});
+
+	test("should find session with lt operator", async () => {
+		const res = await adapter.findMany({
+			model: "session",
+			where: [
+				{
+					field: "createdAt",
+					operator: "lt",
+					value: new Date(),
+				},
+			],
+		});
+		expect(res.length).toBe(1);
+	});
+
+	test("should find session with lte operator", async () => {
+		const res = await adapter.findMany({
+			model: "session",
+			where: [
+				{
+					field: "createdAt",
+					operator: "lte",
+					value: new Date(),
+				},
+			],
+		});
+		expect(res.length).toBe(1);
+	});
+
+	test("should find session with gt operator", async () => {
+		const res = await adapter.findMany({
+			model: "session",
+			where: [
+				{
+					field: "expiresAt",
+					operator: "gt",
+					value: new Date(),
+				},
+			],
+		});
+		expect(res.length).toBe(1);
+	});
+
+	test("should find session with gte operator", async () => {
+		const res = await adapter.findMany({
+			model: "session",
+			where: [
+				{
+					field: "expiresAt",
+					operator: "gte",
+					value: new Date(),
+				},
+			],
+		});
+		expect(res.length).toBe(1);
+	});
+
+	test("should find user with in operator", async () => {
+		const res = await adapter.findMany({
+			model: "user",
+			where: [
+				{
+					field: "email",
+					operator: "in",
+					value: ["test-userop@email.com", "test@email.com"],
+				},
+			],
+		});
+		expect(res.length).toBe(2);
 	});
 
 	test("should find many with contains operator", async () => {


### PR DESCRIPTION
1. **Drizzle Adapter:**
   - Refactored the `convertWhereClause` function to handle all operator conversions.
   - Changed the order of parameters `convertWhereClause(model: string, where?: Where[])` to make them consistent with other adapters.
   - Add `[# Drizzle Adapter]` prefix to error messages.
   - Fixed count method to return count `res[0].count` as drizzle returns an array with the count.

2. **Memory Adapter:**
   - Refactored the `convertWhereClause` function to handle all operator conversions.
   - Add `[# Memory Adapter]` prefix to error messages.
   - Fixed count method to use where clause.

3. **MongoDB Adapter:**
   - Updated `serializeID` and `deserializeID` to add proper typescript types.
   - Changed the order of parameters `convertWhereClause(model: string, where?: Where[])` to make them consistent with other adapters.
   - Changed the Error type to `BetterAuthError` instead of `Error`.
   - Added `escapeRegex` function to escape regex input to prevent regex injection.
   - Fixed regex in `contains`, `starts_with`, and `ends_with` operators.
   - Add `[# MongoDB Adapter]` prefix to error messages.
   - Fixed count method to use where clause.

   **MongoDB Tests:**
   - Fixed the `clearDB` function to delete `sessions` collection instead of `session` collection.
   - Added a test to verify proper regex input sanitization.

4. **Prisma Adapter:**
   - Extracted the check if model exists logic to `checkModelExistsOrThrow` function.
   - Refactored the `convertWhereClause` function.
   - Updated the `operatorToPrismaOperator` function to handle all operators.
   - Add `[# Prisma Adapter]` prefix to error messages.

5. **Tests:**
   - Added test for `adapter.count()` method with and without where clause.
   - Added tests for the operators `ne`, `eq`, `lt`, `lte`, `gt`, `gte`, `in` and undefined operator option.
![image](https://github.com/user-attachments/assets/b1954e1d-1602-4546-8182-3d07867cfeb8)
![image](https://github.com/user-attachments/assets/766da057-8af7-4b35-b34f-b22eb0802d28)
![image](https://github.com/user-attachments/assets/a6dccfbe-b555-4869-a02d-5331ee2b7f25)
![image](https://github.com/user-attachments/assets/f62fc196-410d-4da5-b67e-2f73eceb7a7d)
![image](https://github.com/user-attachments/assets/dcbd5ec9-bfeb-44d1-a4e6-8fa20f77be4e)
![image](https://github.com/user-attachments/assets/fe22e3d3-5eac-4d45-a717-5d9847c7da03)
