### PR TITLE
docs(expo): Fix module-resolver alias configuration

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -136,8 +136,8 @@ Expo is a popular framework for building cross-platform apps with React Native. 
                         "module-resolver",
                         {
                             alias: {
-                                "better-auth/react": "path/to/node_modules/better-auth/dist/client/react/index.cjs"
-                                "@better-auth/expo/client": "path/to/node_modules/@better-auth/expo/dist/client.cjs",
+                                "better-auth/react": "path/to/node_modules/better-auth/dist/client/react/index.cjs",
+                                "@better-auth/expo/client": "path/to/node_modules/@better-auth/expo/dist/client.cjs"
                             },
                             extensions: [".cjs", ".js", ".jsx", ".ts", ".tsx"],
                         },


### PR DESCRIPTION
# Pull Request: Fix Syntax Error in Metro Configuration for Expo Integration

## Description
This PR addresses a syntax error in the Metro Configuration Section (6) of the Expo integration documentation. The issue was caused by an incorrect file path alias in the `babel.config.js` file, where a missing comma led to invalid JSON syntax. The fix corrects the alias formatting to ensure proper module resolution for the "better-auth" library.

## Changes
- Updated the `alias` object in `babel.config.js` to include proper comma separation between entries.
- Ensured consistency in the file path aliases for `"better-auth/react"` and `"@better-auth/expo/client"`.

### Old Code
```javascript
alias: {
    "better-auth/react": "path/to/node_modules/better-auth/dist/client/react/index.cjs"
    "@better-auth/expo/client": "path/to/node_modules/@better-auth/expo/dist/client.cjs",
}