### PR TITLE
fix(drizzle adapter): count returning undefined

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -331,7 +331,7 @@ export const drizzleAdapter =
 					.select({ count: count() })
 					.from(schemaModel)
 					.where(...clause);
-				return res.count;
+				return res[0].count;
 			},
 			async update(data) {
 				const { model, where, update: values } = data;


### PR DESCRIPTION
During the creation of a custom plugin that I am working on, I found out that the Drizzle adapter count function would return undefined. This is due to the count function in Drizzle returning with `[{ count: 1 }]` instead of `{ count: 1 }`. This pull request changes `res.count` to `res[0].count` which fixes this issue.

Example issue repository (uses `internalAdapter.countTotalUsers()`): https://github.com/Creaous/better-auth-drizzle-count-issue