### PR TITLE
feat: add package previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,4 +36,4 @@ jobs:
           TURBO_REMOTE_ONLY: true
         run: pnpm build
           
-      - run: pnpm dlx pkg-pr-new publish ./packages/better-auth
+      - run: pnpm dlx pkg-pr-new publish

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,6 +2,8 @@ name: Publish Approved Pull Requests
 on:
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [opened]
 
 jobs:
   check:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,31 +1,10 @@
-name: Publish Approved Pull Requests
-on:
-  pull_request_review:
-    types: [submitted]
-  pull_request:
-    types: [opened]
+name: Publish Any Commit
+on: [push, pull_request]
 
 jobs:
-  check:
-    # First, trigger a permissions check on the user approving the pull request.
-    if: github.event.review.state == 'approved'
+  build:
     runs-on: ubuntu-latest
-    outputs:
-      has-permissions: ${{ steps.checkPermissions.outputs.require-result }}
-    steps:
-      - name: Check permissions
-        id: checkPermissions
-        uses: actions-cool/check-user-permission@v2
-        with:
-          # In this example, the approver must have the write access
-          # to the repository to trigger the package preview.
-          require: "write"
 
-  publish:
-    needs: check
-    # Publish the preview package only if the permissions check passed.
-    if: needs.check.outputs.has-permissions == 'true'
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,5 +17,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Build
+        run: pnpm build
 
       - run: pnpm dlx pkg-pr-new publish ./packages/better-auth

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,4 +36,4 @@ jobs:
           TURBO_REMOTE_ONLY: true
         run: pnpm build
           
-      - run: pnpm dlx pkg-pr-new --pnpm publish
+      - run: pnpm dlx pkg-pr-new --pnpm publish ./packages/better-auth

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,4 +36,4 @@ jobs:
           TURBO_REMOTE_ONLY: true
         run: pnpm build
           
-      - run: pnpm dlx pkg-pr-new publish
+      - run: pnpm dlx pkg-pr-new --pnpm publish

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,24 +1,39 @@
 name: Publish Any Commit
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - run: corepack enable
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: "pnpm"
-
-      - name: Install dependencies
+          node-version: 20.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+      
+      - name: Install
         run: pnpm install
 
       - name: Build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+          TURBO_REMOTE_ONLY: true
         run: pnpm build
-
+          
       - run: pnpm dlx pkg-pr-new publish ./packages/better-auth

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,4 +36,4 @@ jobs:
           TURBO_REMOTE_ONLY: true
         run: pnpm build
           
-      - run: pnpm dlx pkg-pr-new publish --pnpm ./packages/better-auth
+      - run: pnpm dlx pkg-pr-new publish --pnpm ./packages/*

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,4 +36,4 @@ jobs:
           TURBO_REMOTE_ONLY: true
         run: pnpm build
           
-      - run: pnpm dlx pkg-pr-new publish --pnpm --compact ./packages/*
+      - run: pnpm dlx pkg-pr-new publish --pnpm ./packages/*

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,4 +36,4 @@ jobs:
           TURBO_REMOTE_ONLY: true
         run: pnpm build
           
-      - run: pnpm dlx pkg-pr-new --pnpm publish ./packages/better-auth
+      - run: pnpm dlx pkg-pr-new publish --pnpm ./packages/better-auth

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,4 +36,4 @@ jobs:
           TURBO_REMOTE_ONLY: true
         run: pnpm build
           
-      - run: pnpm dlx pkg-pr-new publish --pnpm ./packages/*
+      - run: pnpm dlx pkg-pr-new publish --pnpm --compact ./packages/*

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,40 @@
+name: Publish Approved Pull Requests
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  check:
+    # First, trigger a permissions check on the user approving the pull request.
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    outputs:
+      has-permissions: ${{ steps.checkPermissions.outputs.require-result }}
+    steps:
+      - name: Check permissions
+        id: checkPermissions
+        uses: actions-cool/check-user-permission@v2
+        with:
+          # In this example, the approver must have the write access
+          # to the repository to trigger the package preview.
+          require: "write"
+
+  publish:
+    needs: check
+    # Publish the preview package only if the permissions check passed.
+    if: needs.check.outputs.has-permissions == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - run: pnpm dlx pkg-pr-new publish ./packages/better-auth

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "type": "module",
     "version": "0.0.2-beta.8",
-    "packageManager": "pnpm@10.5.2",
+    "packageManager": "pnpm@9.15.0",
     "scripts": {
         "build": "turbo --filter \"./packages/*\" build",
         "build:docs": "turbo --filter \"./docs\" build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "type": "module",
     "version": "0.0.2-beta.8",
-    "packageManager": "pnpm@9.15.0",
+    "packageManager": "pnpm@10.5.2",
     "scripts": {
         "build": "turbo --filter \"./packages/*\" build",
         "build:docs": "turbo --filter \"./docs\" build",


### PR DESCRIPTION
There's no easy way to test changes made on pull requests by contributors. This PR implements pkg.pr.new, which will publish a preview for every better-auth package on each new commit, providing an easy way to test locally.

See it in action in here:
https://github.com/ThallesP/better-auth/pull/1