### PR TITLE
fix: Docs typo

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -25,7 +25,7 @@ export const auth = betterAuth({
 });
 ```
 
-## Schema generaton & migration
+## Schema generation & migration
 
 The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate
 your database schema based on your Better Auth configuration and plugins.

--- a/docs/content/docs/adapters/mongo.mdx
+++ b/docs/content/docs/adapters/mongo.mdx
@@ -24,7 +24,7 @@ export const auth = betterAuth({
 });
 ```
 
-## Schema generaton & migration
+## Schema generation & migration
 
 The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate
 your database schema based on your Better Auth configuration and plugins.

--- a/docs/content/docs/adapters/mysql.mdx
+++ b/docs/content/docs/adapters/mysql.mdx
@@ -30,7 +30,7 @@ export const auth = betterAuth({
   [MySQLDialect](https://kysely-org.github.io/kysely-apidoc/classes/MysqlDialect.html).
 </Callout>
 
-## Schema generaton & migration
+## Schema generation & migration
 
 The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate
 your database schema based on your Better Auth configuration and plugins.

--- a/docs/content/docs/adapters/postgresql.mdx
+++ b/docs/content/docs/adapters/postgresql.mdx
@@ -27,7 +27,7 @@ export const auth = betterAuth({
   [PostgresDialect](https://kysely-org.github.io/kysely-apidoc/classes/PostgresDialect.html).
 </Callout>
 
-## Schema generaton & migration
+## Schema generation & migration
 
 The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate
 your database schema based on your Better Auth configuration and plugins.

--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -25,7 +25,7 @@ export const auth = betterAuth({
 });
 ```
 
-## Schema generaton & migration
+## Schema generation & migration
 
 The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate
 your database schema based on your Better Auth configuration and plugins.

--- a/docs/content/docs/adapters/sqlite.mdx
+++ b/docs/content/docs/adapters/sqlite.mdx
@@ -25,7 +25,7 @@ export const auth = betterAuth({
   [SqliteDialect](https://kysely-org.github.io/kysely-apidoc/classes/SqliteDialect.html).
 </Callout>
 
-## Schema generaton & migration
+## Schema generation & migration
 
 The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate
 your database schema based on your Better Auth configuration and plugins.


### PR DESCRIPTION
`generaton` should be `generation`. For example, see here: https://www.better-auth.com/docs/adapters/postgresql#schema-generaton--migration

![image](https://github.com/user-attachments/assets/003c7eea-d408-46d6-92d8-a8c2446f85f0)
