### PR TITLE
fix(docs): remove references to multiSession.revokeAll() endpoint

### DIFF
--- a/docs/content/docs/plugins/multi-session.mdx
+++ b/docs/content/docs/plugins/multi-session.mdx
@@ -79,17 +79,9 @@ await authClient.multiSession.revoke({
 })
 ```
 
-### Revoke all sessions
+### Signout and Revoke all sessions
 
-To revoke all sessions, you can call the `revokeAll` method.
-
-```ts
-await authClient.multiSession.revokeAll();
-```
-
-### Signout Behaviour
-
-When a user logs out, the plugin will revoke all active sessions for the user.
+When a user logs out, the plugin will revoke all active sessions for the user. You can do this by calling the existing `signOut` method, which handles revoking all sessions automatically.
 
 ### Max Sessions
 


### PR DESCRIPTION
The multiSession.revokeAll() endpoint has been removed and is no longer part of the API.
This fix removes mentions and usage examples from the docs.