### PR TITLE
fix(organization): Fix multiple role array not referenced properly

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -597,7 +597,7 @@ auth.api.addMember({
   body: {
       userId: "user-id",
       organizationId: "organization-id",
-      role: "admin"
+      role: "admin" // this can also be an array for multiple roles (e.g. ["admin", "sale"])
   }
 })
 ```

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -250,6 +250,18 @@ describe("organization", async (it) => {
 		},
 	);
 
+	it("should create invitation with multiple roles", async () => {
+		const invite = await client.organization.inviteMember({
+			organizationId: organizationId,
+			email: "test5@test.com",
+			role: ["admin", "member"],
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(invite.data?.role).toBe("admin,member");
+	});
+
 	it("should allow getting a member", async () => {
 		const { headers } = await signInWithTestUser();
 		await client.organization.setActive({
@@ -517,6 +529,36 @@ describe("organization", async (it) => {
 			},
 		});
 		expect(member?.role).toBe("admin");
+	});
+
+	it("should add member on the server with multiple roles", async () => {
+		const newUser = await auth.api.signUpEmail({
+			body: {
+				email: "new-member-mr@email.com",
+				password: "password",
+				name: "new member mr",
+			},
+		});
+		const session = await auth.api.getSession({
+			headers: new Headers({
+				Authorization: `Bearer ${newUser?.token}`,
+			}),
+		});
+		const org = await auth.api.createOrganization({
+			body: {
+				name: "test2",
+				slug: "test4",
+			},
+			headers,
+		});
+		const member = await auth.api.addMember({
+			body: {
+				organizationId: org?.id,
+				userId: session?.user.id!,
+				role: ["admin", "member"],
+			},
+		});
+		expect(member?.role).toBe("admin,member");
 	});
 
 	it("should respect membershipLimit when adding members to organization", async () => {

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -44,6 +44,10 @@ import { ORGANIZATION_ERROR_CODES } from "./error-codes";
 import { defaultRoles, defaultStatements } from "./access";
 import { hasPermission } from "./has-permission";
 
+export function parseRoles(roles: string | string[]): string {
+	return Array.isArray(roles) ? roles.join(",") : roles;
+}
+
 export interface OrganizationOptions {
 	/**
 	 * Configure whether new users are able to create new organizations.

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -5,7 +5,7 @@ import { orgMiddleware, orgSessionMiddleware } from "../call";
 import type { InferRolesFromOption, Member } from "../schema";
 import { APIError } from "better-call";
 import { generateId } from "../../../utils";
-import type { OrganizationOptions } from "../organization";
+import { parseRoles, type OrganizationOptions } from "../organization";
 import { getSessionFromCtx, sessionMiddleware } from "../../../api";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { BASE_ERROR_CODES } from "../../../error/codes";
@@ -16,14 +16,18 @@ export const addMember = <O extends OrganizationOptions>() =>
 		"/organization/add-member",
 		{
 			method: "POST",
-			body: z.record(z.string()),
+			body: z.object({
+				userId: z.string(),
+				role: z.union([z.string(), z.array(z.string())]),
+				organizationId: z.string().optional(),
+			}),
 			use: [orgMiddleware],
 			metadata: {
 				SERVER_ONLY: true,
 				$Infer: {
 					body: {} as {
 						userId: string;
-						role: InferRolesFromOption<O>;
+						role: InferRolesFromOption<O> | InferRolesFromOption<O>[];
 						organizationId?: string;
 					},
 				},
@@ -86,7 +90,7 @@ export const addMember = <O extends OrganizationOptions>() =>
 				id: generateId(),
 				organizationId: orgId,
 				userId: user.id,
-				role: ctx.body.role as string,
+				role: parseRoles(ctx.body.role as string | string[]),
 				createdAt: new Date(),
 			});
 
@@ -257,7 +261,11 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 		"/organization/update-member-role",
 		{
 			method: "POST",
-			body: z.record(z.any()),
+			body: z.object({
+				role: z.union([z.string(), z.array(z.string())]),
+				memberId: z.string(),
+				organizationId: z.string().optional(),
+			}),
 			use: [orgMiddleware, orgSessionMiddleware],
 			metadata: {
 				$Infer: {
@@ -380,9 +388,7 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 
 			const updatedMember = await adapter.updateMember(
 				ctx.body.memberId,
-				Array.isArray(ctx.body.role)
-					? ctx.body.role?.join(",")
-					: (ctx.body.role as string),
+				parseRoles(ctx.body.role as string | string[]),
 			);
 			if (!updatedMember) {
 				throw new APIError("BAD_REQUEST", {


### PR DESCRIPTION
- Added ability to pass multiple roles as array to addMember in addition to string roles
- Changed role type to `InferRolesFromOption<O> | InferRolesFromOption<O>[]` to stop typescript errors when using array with role.
- Add tests to check multiple roles with `addMember` and `inviteMember`
![image](https://github.com/user-attachments/assets/a57d3930-d192-4245-bb19-e563023db15e)
![image](https://github.com/user-attachments/assets/732e3c98-cb25-44f8-b2ab-304755eb0c0a)
![image](https://github.com/user-attachments/assets/5a6de112-3863-4a9c-a395-fe5a82147e02)
- Updated docs

Breaking Changes: None
