### PR TITLE
fix: on change email request for unverified emails should use the new Email on verification token payload

### DIFF
--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -89,6 +89,25 @@ describe("updateUser", async () => {
 			},
 		});
 		expect(session.user.email).toBe(newEmail);
+		expect(session.user.emailVerified).toBe(false);
+	});
+
+	it("should verify email", async () => {
+		await client.verifyEmail({
+			query: {
+				token: emailVerificationToken,
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+				throw: true,
+			},
+		});
+		expect(session.user.emailVerified).toBe(true);
 	});
 
 	it("should send email verification before update", async () => {

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -612,8 +612,8 @@ export const changeEmail = createAuthEndpoint(
 			if (ctx.context.options.emailVerification?.sendVerificationEmail) {
 				const token = await createEmailVerificationToken(
 					ctx.context.secret,
-					ctx.context.session.user.email,
 					newEmail,
+					undefined,
 					ctx.context.options.emailVerification?.expiresIn,
 				);
 				const url = `${


### PR DESCRIPTION
closes #1799 