### PR TITLE
fix: biome format stack overflow due to `build` outputs

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -30,6 +30,7 @@
 	"files": {
 		"ignore": [
 			"dist",
+			"build",
 			".next",
 			".svelte-kit",
 			"package.json",


### PR DESCRIPTION
- In particular, the browser-extensions example's build folder.