### PR TITLE
fix: fix issues with openapi types and references

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -174,6 +174,7 @@ export const verifyEmail = createAuthEndpoint(
 									properties: {
 										user: {
 											type: "object",
+											ref: "#/components/schemas/User",
 										},
 										status: {
 											type: "boolean",

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -66,17 +66,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 										properties: {
 											session: {
 												type: "object",
-												properties: {
-													token: {
-														type: "string",
-													},
-													userId: {
-														type: "string",
-													},
-													expiresAt: {
-														type: "string",
-													},
-												},
+												$ref: "#/components/schemas/Session",
 											},
 											user: {
 												type: "object",

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -144,11 +144,12 @@ export const signInSocial = createAuthEndpoint(
 								schema: {
 									type: "object",
 									properties: {
-										session: {
+										token: {
 											type: "string",
 										},
 										user: {
 											type: "object",
+											ref: "#/components/schemas/User",
 										},
 										url: {
 											type: "string",
@@ -157,7 +158,7 @@ export const signInSocial = createAuthEndpoint(
 											type: "boolean",
 										},
 									},
-									required: ["session", "user", "url", "redirect"],
+									required: ["redirect"],
 								},
 							},
 						},
@@ -329,8 +330,12 @@ export const signInEmail = createAuthEndpoint(
 								schema: {
 									type: "object",
 									properties: {
+										token: {
+											type: "string",
+										},
 										user: {
 											type: "object",
+											ref: "#/components/schemas/User",
 										},
 										url: {
 											type: "string",
@@ -339,7 +344,7 @@ export const signInEmail = createAuthEndpoint(
 											type: "boolean",
 										},
 									},
-									required: ["session", "user", "url", "redirect"],
+									required: ["token", "user", "redirect"],
 								},
 							},
 						},

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -61,6 +61,7 @@ export const updateUser = <O extends BetterAuthOptions>() =>
 										properties: {
 											user: {
 												type: "object",
+												ref: "#/components/schemas/User",
 											},
 										},
 									},
@@ -547,6 +548,7 @@ export const changeEmail = createAuthEndpoint(
 									properties: {
 										user: {
 											type: "object",
+											ref: "#/components/schemas/User",
 										},
 										status: {
 											type: "boolean",


### PR DESCRIPTION
I noticed a bunch of issues when generating a http client using the openapi spec - either wrong return types, required fields or didn't reference the defined models.