### PR TITLE
fix: access of undefined in runtime that does have great support of instanceof

### DIFF
--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -250,7 +250,7 @@ export const getSessionCookie = (
 			config.cookiePrefix = `${config.cookiePrefix}.`;
 		}
 	}
-	const headers = request instanceof Headers ? request : request.headers;
+	const headers = 'headers' in request ? request.headers : request;
 	const req = request instanceof Request ? request : undefined;
 	const url = getBaseURL(req?.url, config?.path, req);
 	const cookies = headers.get("cookie");

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -250,7 +250,7 @@ export const getSessionCookie = (
 			config.cookiePrefix = `${config.cookiePrefix}.`;
 		}
 	}
-	const headers = 'headers' in request ? request.headers : request;
+	const headers = "headers" in request ? request.headers : request;
 	const req = request instanceof Request ? request : undefined;
 	const url = getBaseURL(req?.url, config?.path, req);
 	const cookies = headers.get("cookie");

--- a/packages/better-auth/src/utils/get-request-ip.ts
+++ b/packages/better-auth/src/utils/get-request-ip.ts
@@ -24,7 +24,7 @@ export function getIp(
 		"forwarded-for",
 		"forwarded",
 	];
-	const headers = req instanceof Request ? req.headers : req;
+	const headers = 'headers' in req ? req.headers : req;
 	for (const key of keys) {
 		const value = headers.get(key);
 		if (typeof value === "string") {

--- a/packages/better-auth/src/utils/get-request-ip.ts
+++ b/packages/better-auth/src/utils/get-request-ip.ts
@@ -24,7 +24,7 @@ export function getIp(
 		"forwarded-for",
 		"forwarded",
 	];
-	const headers = 'headers' in req ? req.headers : req;
+	const headers = "headers" in req ? req.headers : req;
 	for (const key of keys) {
 		const value = headers.get(key);
 		if (typeof value === "string") {


### PR DESCRIPTION
## Issue this solves

[Discord thread](https://discord.com/channels/1288403910284935179/1349503864260530209)

This fixes the issue `The \"payload\" argument must be of type object. Received null` where when debugged closer we got an error like this:
![image](https://github.com/user-attachments/assets/6a36b331-ba93-4b1a-a502-64592727c6dd)

It wasn't easy to track down, I had to get better-auth setup in my own codebase and add a bunch of logs at certain areas to determine where this obfuscated `i.get` was coming from. 

## Summary of change

Replaces `instanceof Request` check with a more robust `'headers' in req` property check. This change improves reliability by:

1. Avoiding cross-realm issues where `instanceof` can fail when objects are passed between different JavaScript contexts
2. Supporting scenarios with multiple versions of the Request class in the application
3. Following "duck typing" principles - focusing on an object's capabilities rather than its constructor

The property check is more resilient in complex environments like server/client boundaries, iframes, or when working with polyfills, ensuring proper header extraction regardless of how the Request object was constructed.

## Further details

I think it could be worth considering using alternatives to `instanceof`  such as the [`in` operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) if possible to reduce the risk of these hard to track down type issues