### PR TITLE
Fix Incorrect JSON Handling in secondaryStorage.get Documentation

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -82,7 +82,7 @@ export const auth = betterAuth({
 	secondaryStorage: {
 		get: async (key) => {
 			const value = await redis.get(key);
-			return value ? JSON.stringify(value) : null;
+			return value ? JSON.parse(value) : null;
 		},
 		set: async (key, value, ttl) => {
 			if (ttl) await redis.set(key, value, { EX: ttl });

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -82,7 +82,7 @@ export const auth = betterAuth({
 	secondaryStorage: {
 		get: async (key) => {
 			const value = await redis.get(key);
-			return value ? JSON.parse(value) : null;
+			return value ? value : null;
 		},
 		set: async (key, value, ttl) => {
 			if (ttl) await redis.set(key, value, { EX: ttl });


### PR DESCRIPTION
This PR updates the `database.mdx` documentation file to fix an issue caused by incorrect handling of JSON data in `secondaryStorage.get`.  

#### **Issue**  
The current documentation suggests using:  
```js
return value ? JSON.stringify(value) : null;
```  
This results in the stored JSON string being re-stringified, causing an issue when parsing it later. Specifically, when `safeJSONParse` is used, it returns a string instead of an array, leading to:  
```
TypeError: list.filter is not a function.
```

#### **Fix**  
The correct approach is to return the value directly instead of wrapping it in `JSON.stringify(value)`. The updated code should be:  
```js
return value ? value : null;
```

#### **Changes**  
- Updated `database.mdx` to reflect the correct implementation.  
- Added a note explaining that `JSON.stringify` should not be used in `get`, as Redis stores values as strings by default.  

#### **Impact**  
This fix ensures that retrieved JSON data remains correctly formatted and prevents runtime errors related to `.filter` being called on a string instead of an array.  