### PR TITLE
fix: impersonatedBy not appearing in client (type fix)

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -592,9 +592,8 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 						});
 					}
 
-					const sessions = await ctx.context.internalAdapter.listSessions(
-						ctx.body.userId,
-					);
+					const sessions: SessionWithImpersonatedBy[] =
+						await ctx.context.internalAdapter.listSessions(ctx.body.userId);
 					return {
 						sessions: sessions,
 					};


### PR DESCRIPTION
This PR fixes the admin plugin, where when the user sessions are listed on the client, `impersonatedBy` field is not suggested by the code editor but the `impersonatedBy` field is clearly available when using `console.log()`.