### PR TITLE
fix(get-request-ip): improve header value retrieval for IP address extraction

### DIFF
--- a/packages/better-auth/src/utils/get-request-ip.ts
+++ b/packages/better-auth/src/utils/get-request-ip.ts
@@ -26,7 +26,7 @@ export function getIp(
 	];
 	const headers = "headers" in req ? req.headers : req;
 	for (const key of keys) {
-		const value = headers.get(key);
+		const value = "get" in headers ? headers.get(key): headers[key];
 		if (typeof value === "string") {
 			const ip = value.split(",")[0].trim();
 			if (ip) return ip;


### PR DESCRIPTION
This pull request includes a small but important change to the `getIp` function in the `packages/better-auth/src/utils/get-request-ip.ts` file. The change ensures compatibility with different types of request objects by checking if the `headers` object has a `get` method before attempting to call it.

* [`packages/better-auth/src/utils/get-request-ip.ts`](diffhunk://#diff-b386c725fba47b675a264ee1c46a6a31cf037534f1aae2f758cb7fbf1a18300bL29-R29): Modified the `getIp` function to use `headers.get(key)` if the `headers` object has a `get` method, otherwise it falls back to `headers[key]`.