### PR TITLE
fix(api-key): update rateLimitEnabled default to consider options

### DIFF
--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -53,7 +53,10 @@ export const apiKey = (options?: ApiKeyOptions) => {
 		minimumNameLength: options?.minimumNameLength ?? 1,
 		enableMetadata: options?.enableMetadata ?? false,
 		rateLimit: {
-			enabled: options?.rateLimit?.enabled ?? true,
+			enabled:
+				options?.rateLimit?.enabled === undefined
+					? true
+					: options?.rateLimit?.enabled,
 			timeWindow: options?.rateLimit?.timeWindow ?? 1000 * 60 * 60 * 24,
 			maxRequests: options?.rateLimit?.maxRequests ?? 10,
 		},

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -268,7 +268,10 @@ export function createApiKey({
 				remaining: remaining || refillAmount || null,
 				refillAmount: refillAmount ?? null,
 				refillInterval: refillInterval ?? null,
-				rateLimitEnabled: rateLimitEnabled ?? opts.rateLimit.enabled ?? true,
+				rateLimitEnabled:
+					rateLimitEnabled ?? opts.rateLimit.enabled === undefined
+						? true
+						: opts.rateLimit.enabled,
 				requestCount: 0,
 				permissions: permissionsToApply,
 			};

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -268,7 +268,7 @@ export function createApiKey({
 				remaining: remaining || refillAmount || null,
 				refillAmount: refillAmount ?? null,
 				refillInterval: refillInterval ?? null,
-				rateLimitEnabled: rateLimitEnabled ?? true,
+				rateLimitEnabled: rateLimitEnabled ?? opts.rateLimit.enabled ?? true,
 				requestCount: 0,
 				permissions: permissionsToApply,
 			};


### PR DESCRIPTION
added check for options in create-api-key.ts. 
option rateLimit.enabled was not used.

closes #1886 