### PR TITLE
fix(docs): update parameter destructuring in JWT payload example

### DIFF
--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -213,7 +213,7 @@ By default the entire user object is added to the JWT payload. You can modify th
 ```ts title="auth.ts"
 jwt({
   jwt: {
-    definePayload: (user) => {
+    definePayload: ({user}) => {
       return {
         id: user.id,
         email: user.email,


### PR DESCRIPTION
This pull request includes a small change to the `docs/content/docs/plugins/jwt.mdx` file.

The change modifies the `definePayload` function to destructure the `user` object directly in the function parameter.