### PR TITLE
Docs: Fix add import headers

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -205,6 +205,7 @@ Be careful when using the new runtime. It's an experimental feature and it may b
 
 ```ts
 import { NextRequest, NextResponse } from "next/server";
+import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
The import of headers was missing.