### PR TITLE
Remove repeated word in docs

### DIFF
--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -498,6 +498,6 @@ const verifyTOTP = async() => {
 </Step>
 
 <Step>
-Next step: See the <Link href="/docs/plugins/2fa">the two factor plugin documentation</Link>.
+Next step: See the <Link href="/docs/plugins/2fa">two factor plugin documentation</Link>.
 </Step>
 </Steps>


### PR DESCRIPTION
The basic usage docs say

> Next step: See the [the two factor plugin documentation](https://www.better-auth.com/docs/plugins/2fa).

This PR just removes the repeated `the`. 