### PR TITLE
Remix documentation: Change file name from ``auth.client.ts`` to ``auth-client.ts``

### DIFF
--- a/docs/content/docs/integrations/remix.mdx
+++ b/docs/content/docs/integrations/remix.mdx
@@ -59,9 +59,9 @@ export async function action({ request }: ActionFunctionArgs) {
 
 ## Create a client
 
-Create a client instance. Here we are creating `auth.client.ts` file inside the `lib/` directory.
+Create a client instance. Here we are creating `auth-client.ts` file inside the `lib/` directory.
 
-```ts title="app/lib/auth.client.ts"
+```ts title="app/lib/auth-client.ts"
 import { createAuthClient } from "better-auth/react" // make sure to import from better-auth/react
 
 export const authClient = createAuthClient({


### PR DESCRIPTION

``auth.client.ts`` will trigger code splitting. While this would be fine for the server component (``auth.server.ts``, which needs to stay hidden to end users), putting the authClient in a client only component will force the authClient out of the server bundle. This causes authClient to be undefined during SSR. This makes the integration guide non functional.

Please note that the example you have about Remix is already correctly *not* using ``.client.ts``. 
https://github.com/better-auth/better-auth/blob/main/examples/remix-example/app/lib/auth-client.ts

Read: https://reactrouter.com/explanation/special-files#client-modules