### PR TITLE
fix: support numeric user IDs

### DIFF
--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -126,7 +126,7 @@ export const callbackOAuth = createAuthEndpoint(
 			);
 
 			if (existingAccount) {
-				if (existingAccount.userId !== link.userId) {
+				if (existingAccount.userId.toString() !== link.userId.toString()) {
 					return redirectOnError("account_already_linked_to_different_user");
 				}
 			}

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -9,7 +9,7 @@ export const accountSchema = z.object({
 	id: z.string(),
 	providerId: z.string(),
 	accountId: z.string(),
-	userId: z.string(),
+	userId: z.coerce.string(),
 	accessToken: z.string().nullish(),
 	refreshToken: z.string().nullish(),
 	idToken: z.string().nullish(),
@@ -45,7 +45,7 @@ export const userSchema = z.object({
 
 export const sessionSchema = z.object({
 	id: z.string(),
-	userId: z.string(),
+	userId: z.coerce.string(),
 	expiresAt: z.date(),
 	createdAt: z.date().default(() => new Date()),
 	updatedAt: z.date().default(() => new Date()),

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -73,7 +73,7 @@ export async function parseState(c: GenericEndpointContext) {
 			link: z
 				.object({
 					email: z.string(),
-					userId: z.string(),
+					userId: z.coerce.string(),
 				})
 				.optional(),
 			requestSignUp: z.boolean().optional(),

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -202,7 +202,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 				{
 					method: "POST",
 					body: z.object({
-						userId: z.string({
+						userId: z.coerce.string({
 							description: "The user id",
 						}),
 						role: z.string({
@@ -543,7 +543,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					method: "POST",
 					use: [adminMiddleware],
 					body: z.object({
-						userId: z.string({
+						userId: z.coerce.string({
 							description: "The user id",
 						}),
 					}),
@@ -605,7 +605,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 				{
 					method: "POST",
 					body: z.object({
-						userId: z.string({
+						userId: z.coerce.string({
 							description: "The user id",
 						}),
 					}),
@@ -669,7 +669,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 				{
 					method: "POST",
 					body: z.object({
-						userId: z.string({
+						userId: z.coerce.string({
 							description: "The user id",
 						}),
 						/**
@@ -762,7 +762,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 				{
 					method: "POST",
 					body: z.object({
-						userId: z.string({
+						userId: z.coerce.string({
 							description: "The user id",
 						}),
 					}),
@@ -974,7 +974,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 				{
 					method: "POST",
 					body: z.object({
-						userId: z.string({
+						userId: z.coerce.string({
 							description: "The user id",
 						}),
 					}),
@@ -1032,7 +1032,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 				{
 					method: "POST",
 					body: z.object({
-						userId: z.string({
+						userId: z.coerce.string({
 							description: "The user id",
 						}),
 					}),
@@ -1092,7 +1092,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 						newPassword: z.string({
 							description: "The new password",
 						}),
-						userId: z.string({
+						userId: z.coerce.string({
 							description: "The user id",
 						}),
 					}),
@@ -1155,7 +1155,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					method: "POST",
 					body: z.object({
 						permission: z.record(z.string(), z.array(z.string())),
-						userId: z.string().optional(),
+						userId: z.coerce.string().optional(),
 						role: z.string().optional(),
 					}),
 					metadata: {

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -42,7 +42,7 @@ export function createApiKey({
 					.nullable()
 					.default(null),
 
-				userId: z
+				userId: z.coerce
 					.string({
 						description:
 							"User Id of the user that the Api Key belongs to. Useful for server-side only.",

--- a/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
@@ -27,7 +27,7 @@ export function updateApiKey({
 				keyId: z.string({
 					description: "The id of the Api Key",
 				}),
-				userId: z.string().optional(),
+				userId: z.coerce.string().optional(),
 				name: z
 					.string({
 						description: "The name of the key",

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -17,7 +17,7 @@ export const addMember = <O extends OrganizationOptions>() =>
 		{
 			method: "POST",
 			body: z.object({
-				userId: z.string(),
+				userId: z.coerce.string(),
 				role: z.union([z.string(), z.array(z.string())]),
 				organizationId: z.string().optional(),
 			}),

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -28,7 +28,7 @@ export const createOrganization = createAuthEndpoint(
 			slug: z.string({
 				description: "The slug of the organization",
 			}),
-			userId: z
+			userId: z.coerce
 				.string({
 					description:
 						"The user id of the organization creator. If not provided, the current user will be used. Should only be used by admins or when called by the server.",

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -23,7 +23,7 @@ export const organizationSchema = z.object({
 export const memberSchema = z.object({
 	id: z.string().default(generateId),
 	organizationId: z.string(),
-	userId: z.string(),
+	userId: z.coerce.string(),
 	role,
 	createdAt: z.date().default(() => new Date()),
 	teamId: z.string().optional(),

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -224,7 +224,7 @@ export const backupCode2fa = (options?: BackupCodeOptions) => {
 				{
 					method: "GET",
 					body: z.object({
-						userId: z.string(),
+						userId: z.coerce.string(),
 					}),
 					metadata: {
 						SERVER_ONLY: true,


### PR DESCRIPTION
Currently if you have a numeric user ID in your database, Better Auth mostly works, but it fails when encountering Zod schema validation. For example, when linking a social account, Zod is expecting a string for the existing user ID instead of a potential number.

To fix this I've made the Zod schema coerce ids to a string, so if they are represented as numbers in the database, they will always be transformed to strings internally.

Should close #998
