### PR TITLE
Expose CLI command as `better-auth` instead of `cli`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,9 @@
     ]
   },
   "exports": "./dist/index.mjs",
-  "bin": "./dist/index.mjs",
+  "bin": {
+    "better-auth": "dist/index.mjs"
+  },
   "devDependencies": {
     "@types/diff": "^7.0.1",
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
Currently, in my project if I want to use the CLI, I have 2 options :
1. As docs suggest, run `npx @better-auth/cli generate` (but not ideal if developing locally on a plane)
2. Create a script in package.json with this as a command : `cli generate`

Option 2. should be `better-auth generate`.

This PR is offering to map better-auth's CLI to better-auth.

⚠️ This is breaking backwards compatibility use of `cli` in package.json scripts. Even though not documented, some users may do it already.

⚠️ I did not try to build the package and use it in another project.