### PR TITLE
docs: Add productionURL to OAuth Proxy options

### DIFF
--- a/docs/content/docs/plugins/oauth-proxy.mdx
+++ b/docs/content/docs/plugins/oauth-proxy.mdx
@@ -64,3 +64,5 @@ To share cookies between the proxy server and your main server it uses url query
 ## Options
 
 **currentURL**: The application's current URL is automatically determined by the plugin. It first it check for the request URL if invoked by a client, then it checks the base URL from popular hosting providers, and finally falls back to the `baseURL` in your auth config. If the URL isn’t inferred correctly, you can specify it manually here.
+
+**productionURL**: If a request originates from the production URL, it will not be proxied. If not explicitly set, this option will default to the `BETTER_AUTH_URL` environment variable.

--- a/docs/content/docs/plugins/oauth-proxy.mdx
+++ b/docs/content/docs/plugins/oauth-proxy.mdx
@@ -65,4 +65,4 @@ To share cookies between the proxy server and your main server it uses url query
 
 **currentURL**: The application's current URL is automatically determined by the plugin. It first it check for the request URL if invoked by a client, then it checks the base URL from popular hosting providers, and finally falls back to the `baseURL` in your auth config. If the URL isn’t inferred correctly, you can specify it manually here.
 
-**productionURL**: If a request originates from the production URL, it will not be proxied. If not explicitly set, this option will default to the `BETTER_AUTH_URL` environment variable.
+**productionURL**: If the auth config's `baseURL` matches the production URL, requests will not be proxied. If not explicitly set, this option will default to the `BETTER_AUTH_URL` environment variable.

--- a/docs/content/docs/plugins/oauth-proxy.mdx
+++ b/docs/content/docs/plugins/oauth-proxy.mdx
@@ -65,4 +65,4 @@ To share cookies between the proxy server and your main server it uses url query
 
 **currentURL**: The application's current URL is automatically determined by the plugin. It first it check for the request URL if invoked by a client, then it checks the base URL from popular hosting providers, and finally falls back to the `baseURL` in your auth config. If the URL isn’t inferred correctly, you can specify it manually here.
 
-**productionURL**: If the auth config's `baseURL` matches the production URL, requests will not be proxied. If not explicitly set, this option will default to the `BETTER_AUTH_URL` environment variable.
+**productionURL**: If this value matches the `baseURL` in your auth config, requests will not be proxied. Defaults to the `BETTER_AUTH_URL` environment variable.


### PR DESCRIPTION
This option is currently missing from the docs. For reference, here's [the relevant code](https://github.com/better-auth/better-auth/blob/fb312ce10b42165d219c2b63673a80dc6ed0d383/packages/better-auth/src/plugins/oauth-proxy/index.ts#L164). 