### PR TITLE
feat: add mapProfileToUser in vk

### DIFF
--- a/packages/better-auth/src/social-providers/vk.ts
+++ b/packages/better-auth/src/social-providers/vk.ts
@@ -94,6 +94,9 @@ export const vk = (options: VkOption) => {
 			if (!profile.user.email) {
 				return null;
 			}
+
+			const userMap = await options.mapProfileToUser?.(profile);
+
 			return {
 				user: {
 					id: profile.user.user_id,
@@ -105,6 +108,7 @@ export const vk = (options: VkOption) => {
 					emailVerified: !!profile.user.email,
 					birthday: profile.user.birthday,
 					sex: profile.user.sex,
+					...userMap,
 				},
 				data: profile,
 			};


### PR DESCRIPTION
### Why?
It will allow to map profile in VK social-network provider like it already implemented in [kick](https://github.com/better-auth/better-auth/blob/94d2d0544a9e86998444911bef88abca196069a5/packages/better-auth/src/social-providers/kick.ts#L78)

Example:
```typescript
export const auth = betterAuth({
  socialProviders: {
    vk: {
      clientId: process.env.VK_CLIENT_ID!, 
      clientSecret: process.env.VK_CLIENT_SECRET!, 

      mapProfileToUser: (profile) => {
        return {
          id: profile.user.user_id,
          firstName: profile.user.first_name,
          lastName: profile.user.last_name,
          middleName: profile.user.middle_name,

          email: profile.user.email,
          emailVerified: !!profile.user.email,

          image: profile.user.avatar,

          birthday: profile.user.birthday,
	  sex: profile.user.sex,
        };
      },
    },
  },
});
```