### PR TITLE
cli(fix): Correct typo in auth-config for DrizzleAdapter

### DIFF
--- a/packages/cli/src/generators/auth-config.ts
+++ b/packages/cli/src/generators/auth-config.ts
@@ -365,7 +365,7 @@ export async function generateAuthConfig({
 				opts.database === "drizzle:pg"
 			) {
 				await add_db({
-					db_code: `new DrizzleAdapter(db, {\nprovider: "${opts.database.replace(
+					db_code: `new drizzleAdapter(db, {\nprovider: "${opts.database.replace(
 						"drizzle:",
 						"",
 					)}",\n})`,
@@ -376,7 +376,7 @@ export async function generateAuthConfig({
 							path: "better-auth/adapters/drizzle",
 							variables: [
 								{
-									name: "DrizzleAdapter",
+									name: "drizzleAdapter",
 								},
 							],
 						},

--- a/packages/cli/src/generators/auth-config.ts
+++ b/packages/cli/src/generators/auth-config.ts
@@ -365,7 +365,7 @@ export async function generateAuthConfig({
 				opts.database === "drizzle:pg"
 			) {
 				await add_db({
-					db_code: `new drizzleAdapter(db, {\nprovider: "${opts.database.replace(
+					db_code: `drizzleAdapter(db, {\nprovider: "${opts.database.replace(
 						"drizzle:",
 						"",
 					)}",\n})`,


### PR DESCRIPTION
This fixes the typo for the use `DrizzleAdapter` to `drizzleAdapter` causing errors after running the new init command.
![image](https://github.com/user-attachments/assets/c6987753-ae60-44c0-8765-58ec81391156)