### PR TITLE
Support genericOAuth for oAuthProxy

### DIFF
--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -108,7 +108,10 @@ export const oAuthProxy = (opts?: OAuthProxyOptions) => {
 			after: [
 				{
 					matcher(context) {
-						return context.path?.startsWith("/callback");
+						return (
+						  context.path?.startsWith("/callback") ||
+              context.path?.startsWith("/oauth2/callback")
+            );
 					},
 					handler: createAuthMiddleware(async (ctx) => {
 						const headers = ctx.context.responseHeaders;
@@ -152,7 +155,10 @@ export const oAuthProxy = (opts?: OAuthProxyOptions) => {
 			before: [
 				{
 					matcher(context) {
-						return context.path?.startsWith("/sign-in/social");
+            return (
+              context.path?.startsWith("/sign-in/social") ||
+              context.path?.startsWith("/sign-in/oauth2")
+            );
 					},
 					handler: createAuthMiddleware(async (ctx) => {
 						const url = new URL(


### PR DESCRIPTION
I was able to develop & test this locally using this patch:

```diff
diff --git a/dist/plugins/oauth-proxy/index.mjs b/dist/plugins/oauth-proxy/index.mjs
index 3f76e7d8e961302fe9630b520191ad98e88b26c5..4f94bd1f99733e16319b56bd52824762e3606704 100644
--- a/dist/plugins/oauth-proxy/index.mjs
+++ b/dist/plugins/oauth-proxy/index.mjs
@@ -108,7 +108,10 @@ const oAuthProxy = (opts) => {
       after: [
         {
           matcher(context) {
-            return context.path?.startsWith("/callback");
+            return (
+              context.path?.startsWith("/callback") ||
+              context.path?.startsWith("/oauth2/callback")
+            );
           },
           handler: createAuthMiddleware(async (ctx) => {
             const headers = ctx.context.responseHeaders;
@@ -146,7 +149,10 @@ const oAuthProxy = (opts) => {
       before: [
         {
           matcher(context) {
-            return context.path?.startsWith("/sign-in/social");
+            return (
+              context.path?.startsWith("/sign-in/social") ||
+              context.path?.startsWith("/sign-in/oauth2")
+            );
           },
           handler: createAuthMiddleware(async (ctx) => {
             const url = new URL(
```

I used a Cloudflare Tunnel as my public URL to confirm this worked end-to-end.

I can help write tests for this if it's agreeable to you.

### TODOS

- [x] Support `genericOAuth`
- [ ] Fix GitHub's lousy spacing
- [ ] Add tests