### PR TITLE
feat: support use number id

### DIFF
--- a/packages/better-auth/src/adapters/utils.ts
+++ b/packages/better-auth/src/adapters/utils.ts
@@ -4,7 +4,13 @@ export function withApplyDefault(
 	value: any,
 	field: FieldAttribute,
 	action: "create" | "update",
+	useNumberId: boolean,
 ) {
+	if (field.references && field.references.field === "id") {
+		if (useNumberId && value) {
+			return Number(value);
+		}
+	}
 	if (action === "update") {
 		return value;
 	}

--- a/packages/better-auth/src/adapters/utils.ts
+++ b/packages/better-auth/src/adapters/utils.ts
@@ -6,11 +6,6 @@ export function withApplyDefault(
 	action: "create" | "update",
 	useNumberId: boolean = false,
 ) {
-	if (field.references && field.references.field === "id") {
-		if (useNumberId && value) {
-			return Number(value);
-		}
-	}
 	if (action === "update") {
 		return value;
 	}

--- a/packages/better-auth/src/adapters/utils.ts
+++ b/packages/better-auth/src/adapters/utils.ts
@@ -4,7 +4,7 @@ export function withApplyDefault(
 	value: any,
 	field: FieldAttribute,
 	action: "create" | "update",
-	useNumberId: boolean,
+	useNumberId: boolean = false,
 ) {
 	if (field.references && field.references.field === "id") {
 		if (useNumberId && value) {

--- a/packages/better-auth/src/adapters/utils.ts
+++ b/packages/better-auth/src/adapters/utils.ts
@@ -6,6 +6,9 @@ export function withApplyDefault(
 	action: "create" | "update",
 	useNumberId: boolean = false,
 ) {
+	if (useNumberId && field.references && field.references.field === "id") {
+		return Number(value);
+	}
 	if (action === "update") {
 		return value;
 	}
@@ -17,5 +20,9 @@ export function withApplyDefault(
 			return field.defaultValue;
 		}
 	}
-	return value;
+	return field.type === "string"
+		? String(value)
+		: field.type === "number"
+			? Number(value)
+			: value;
 }

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -652,6 +652,15 @@ export type BetterAuthOptions = {
 					size?: number;
 			  }) => string)
 			| false;
+		/**
+		 * Use number id instead of string id
+		 *
+		 * This would be useful if you are using a
+		 * database that auto generates number ids.
+		 *
+		 * @default false
+		 */
+		useNumberId?: boolean;
 	};
 	logger?: Logger;
 	/**


### PR DESCRIPTION
Add the` useNumberId` option under `advanced` to convert id fields referenced in where clauses and similar cases into numbers.

- [x] prisma support
- [ ] drizzle support
- [ ] kysley support
- [ ] mongodb support
- [ ] documentation