### PR TITLE
add support for business login using config ids

### DIFF
--- a/docs/content/docs/authentication/facebook.mdx
+++ b/docs/content/docs/authentication/facebook.mdx
@@ -34,9 +34,14 @@ description: Facebook provider setup and usage.
             },
         })
         ```
+
+        <Callout>
+        BetterAuth also supports Facebook Login for Business, all you need
+        to do is provide the `configId` as listed in **Facebook Login For Business > Configurations** alongside your `clientId` and `clientSecret`. Note that the app must be a Business app and, since BetterAuth expects to have an email address and account id, the configuration must be of the "User access token" type. "System-user access token" is not supported.
+        </Callout>
     </Step>
        <Step>
-        ### Sign In with Facebook 
+        ### Sign In with Facebook
         To sign in with Facebook, you can use the `signIn.social` function provided by the client. The `signIn` function takes an object with the following properties:
         - `provider`: The provider to use. It should be set to `facebook`.
 

--- a/packages/better-auth/src/social-providers/facebook.ts
+++ b/packages/better-auth/src/social-providers/facebook.ts
@@ -25,6 +25,11 @@ export interface FacebookOptions extends ProviderOptions<FacebookProfile> {
 	 * @default ["id", "name", "email", "picture"]
 	 */
 	fields?: string[];
+
+	/**
+	 * The config id to use when undergoing oauth
+	 */
+	configId?: string;
 }
 
 export const facebook = (options: FacebookOptions) => {
@@ -45,6 +50,11 @@ export const facebook = (options: FacebookOptions) => {
 				state,
 				redirectURI,
 				loginHint,
+				additionalParams: options.configId
+					? {
+							config_id: options.configId,
+						}
+					: {},
 			});
 		},
 		validateAuthorizationCode: async ({ code, redirectURI }) => {


### PR DESCRIPTION
Facebook login for business requires an additional parameter 'config_id` which points to a specific login strategy since the same business app can have different logins for different purposes (personal login, business system user, etc)

I have threaded that param through and added some docs

![image](https://github.com/user-attachments/assets/62d33ca2-557a-487c-8fe4-473a26fc410c)

![image](https://github.com/user-attachments/assets/93205aaf-ce21-495d-9ffd-eaf77fef826b)

