### PR TITLE
add dependency on root format task in turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,10 @@
 			]
 		},
 		"clean": {},
-		"format": {},
+		"format": {
+			"dependsOn": ["//#format"]
+		},
+		"//#format": {},
 		"lint": {},
 		"knip": {
 			"cache": true


### PR DESCRIPTION
Currently the format task only exists in the root. This adds that root task to the turbo.json file and places a dependency on it for the format task 