### PR TITLE
fix: only delete reset token after db query success

### DIFF
--- a/docs/content/docs/plugins/have-i-been-pwned.mdx
+++ b/docs/content/docs/plugins/have-i-been-pwned.mdx
@@ -1,0 +1,52 @@
+# Have I Been Pwned Password Check
+
+## Overview
+
+The Have I Been Pwned plugin helps protect user accounts by preventing the use of passwords that have been exposed in known data breaches.
+
+## Installation
+
+```ts
+import { betterAuth } from "better-auth"
+import { haveIBeenPwnd } from "./have-i-been-pwnd"
+
+export const auth = betterAuth({
+    plugins: [
+        haveIBeenPwnd()
+    ]
+})
+```
+
+## Features
+
+- Checks passwords against the Have I Been Pwned database
+- Prevents account creation with compromised passwords
+- Blocks password updates using exposed passwords
+- Protects user privacy by only sending partial password hash
+
+## Customization
+
+You can customize the error message:
+
+```ts
+haveIBeenPwnd({
+    customPasswordCompromisedMessage: "Please choose a more secure password."
+})
+```
+
+## User Experience
+
+When a user attempts to create an account or update their password with a compromised password, they'll receive an error:
+
+```json
+{
+  "error": "BAD_REQUEST",
+  "message": "For your security, please choose a different password."
+}
+```
+
+## Security Notes
+
+- Only the first 5 characters of the password hash are sent to the API
+- The full password is never transmitted
+- Provides an additional layer of account security

--- a/docs/content/docs/plugins/have-i-been-pwned.mdx
+++ b/docs/content/docs/plugins/have-i-been-pwned.mdx
@@ -8,11 +8,11 @@ The Have I Been Pwned plugin helps protect user accounts by preventing the use o
 
 ```ts
 import { betterAuth } from "better-auth"
-import { haveIBeenPwnd } from "./have-i-been-pwnd"
+import { haveIBeenPwned } from "better-auth/plugins" // [!code highlight]
 
 export const auth = betterAuth({
     plugins: [
-        haveIBeenPwnd()
+        haveIBeenPwned()
     ]
 })
 ```

--- a/docs/content/docs/plugins/have-i-been-pwned.mdx
+++ b/docs/content/docs/plugins/have-i-been-pwned.mdx
@@ -29,19 +29,19 @@ export const auth = betterAuth({
 You can customize the error message:
 
 ```ts
-haveIBeenPwnd({
+haveIBeenPwned({
     customPasswordCompromisedMessage: "Please choose a more secure password."
 })
 ```
 
 ## User Experience
 
-When a user attempts to create an account or update their password with a compromised password, they'll receive an error:
+When a user attempts to create an account or update their password with a compromised password, they'll receive the following default error:
 
 ```json
 {
   "error": "BAD_REQUEST",
-  "message": "For your security, please choose a different password."
+  "message": "The password you entered has been compromised. Please choose a different password."
 }
 ```
 

--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -271,12 +271,14 @@ export const resetPassword = createAuthEndpoint(
 				},
 				ctx,
 			);
-			await ctx.context.internalAdapter.deleteVerificationValue(verification.id);
+			await ctx.context.internalAdapter.deleteVerificationValue(
+				verification.id,
+			);
 			return ctx.json({
 				status: true,
 			});
 		}
-	 	await ctx.context.internalAdapter.updatePassword(
+		await ctx.context.internalAdapter.updatePassword(
 			userId,
 			hashedPassword,
 			ctx,

--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -257,7 +257,6 @@ export const resetPassword = createAuthEndpoint(
 				message: BASE_ERROR_CODES.INVALID_TOKEN,
 			});
 		}
-		await ctx.context.internalAdapter.deleteVerificationValue(verification.id);
 		const userId = verification.value;
 		const hashedPassword = await ctx.context.password.hash(newPassword);
 		const accounts = await ctx.context.internalAdapter.findAccounts(userId);
@@ -272,15 +271,18 @@ export const resetPassword = createAuthEndpoint(
 				},
 				ctx,
 			);
+			await ctx.context.internalAdapter.deleteVerificationValue(verification.id);
 			return ctx.json({
 				status: true,
 			});
 		}
-		await ctx.context.internalAdapter.updatePassword(
+	 	await ctx.context.internalAdapter.updatePassword(
 			userId,
 			hashedPassword,
 			ctx,
 		);
+		await ctx.context.internalAdapter.deleteVerificationValue(verification.id);
+
 		return ctx.json({
 			status: true,
 		});

--- a/packages/better-auth/src/plugins/have-i-been-pwned/have-i-been-pwned.test.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/have-i-been-pwned.test.ts
@@ -2,74 +2,70 @@ import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { haveIBeenPwned } from "./index";
 
-describe("have-i-been-pwned", async () => { 
-const {
-  client
-} = await getTestInstance({
-    plugins: [haveIBeenPwned()],
-  }
-)
+describe("have-i-been-pwned", async () => {
+	const { client } = await getTestInstance({
+		plugins: [haveIBeenPwned()],
+	});
 
-it("should prevent account creation with compromised password", async () => {
-    const uniqueEmail = `test-${Date.now()}@example.com`;
-    const compromisedPassword = "123456789";
+	it("should prevent account creation with compromised password", async () => {
+		const uniqueEmail = `test-${Date.now()}@example.com`;
+		const compromisedPassword = "123456789";
 
-    const result = await client.signUp.email({
-      email: uniqueEmail,
-      password: compromisedPassword,
-      name: "Test User",
-    });
-    
-    expect(result.error).toBeDefined();
-    expect(result.error?.status).toBe('BAD_REQUEST');
+		const result = await client.signUp.email({
+			email: uniqueEmail,
+			password: compromisedPassword,
+			name: "Test User",
+		});
 
-  });
+		expect(result.error).toBeDefined();
+		expect(result.error?.status).toBe("BAD_REQUEST");
+	});
 
-    it("should allow account creation with strong, uncompromised password", async () => {
-        const uniqueEmail = `test-${Date.now()}@example.com`;
-        const strongPassword = `Str0ng!P@ssw0rd-${Date.now()}`;
-    
-        const result = await client.signUp.email({
-        email: uniqueEmail,
-        password: strongPassword,
-        name: "Test User",
-        });
-        expect(result.data?.user).toBeDefined();
-    });
+	it("should allow account creation with strong, uncompromised password", async () => {
+		const uniqueEmail = `test-${Date.now()}@example.com`;
+		const strongPassword = `Str0ng!P@ssw0rd-${Date.now()}`;
 
-    it("should prevent password update to compromised password", async () => {
-        const uniqueEmail = `test-${Date.now()}@example.com`;
-        const initialPassword = "123456789";
+		const result = await client.signUp.email({
+			email: uniqueEmail,
+			password: strongPassword,
+			name: "Test User",
+		});
+		expect(result.data?.user).toBeDefined();
+	});
 
-         await client.signUp.email({
-            email: uniqueEmail,
-            password: initialPassword,
-            name: "Test User",
-        });
+	it("should prevent password update to compromised password", async () => {
+		const uniqueEmail = `test-${Date.now()}@example.com`;
+		const initialPassword = "123456789";
 
-        const result = await client.changePassword({
-            currentPassword: initialPassword,
-            newPassword: "123456789",
-        });
-        expect(result.error).toBeDefined();
-        expect(result.error?.status).toBe('BAD_REQUEST');
-    });
+		await client.signUp.email({
+			email: uniqueEmail,
+			password: initialPassword,
+			name: "Test User",
+		});
 
-    it("should allow password update to strong, uncompromised password", async () => {
-        const uniqueEmail = `test-${Date.now()}@example.com`;
-        const initialPassword = "123456789";
-        const strongPassword = `Str0ng!P@ssw0rd-${Date.now()}`;
+		const result = await client.changePassword({
+			currentPassword: initialPassword,
+			newPassword: "123456789",
+		});
+		expect(result.error).toBeDefined();
+		expect(result.error?.status).toBe("BAD_REQUEST");
+	});
 
-        await client.signUp.email({
-            email: uniqueEmail,
-            password: initialPassword,
-            name: "Test User",
-        });
-        
-        const result = await client.changePassword({
-            currentPassword: initialPassword,
-            newPassword: strongPassword,
-        });
-        expect(result.data?.user).toBeDefined();
-    });
-})
+	it("should allow password update to strong, uncompromised password", async () => {
+		const uniqueEmail = `test-${Date.now()}@example.com`;
+		const initialPassword = "123456789";
+		const strongPassword = `Str0ng!P@ssw0rd-${Date.now()}`;
+
+		await client.signUp.email({
+			email: uniqueEmail,
+			password: initialPassword,
+			name: "Test User",
+		});
+
+		const result = await client.changePassword({
+			currentPassword: initialPassword,
+			newPassword: strongPassword,
+		});
+		expect(result.data?.user).toBeDefined();
+	});
+});

--- a/packages/better-auth/src/plugins/have-i-been-pwned/have-i-been-pwned.test.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/have-i-been-pwned.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { haveIBeenPwned } from "./index";
+
+describe("have-i-been-pwned", async () => { 
+const {
+  client
+} = await getTestInstance({
+    plugins: [haveIBeenPwned()],
+  }
+)
+
+it("should prevent account creation with compromised password", async () => {
+    const uniqueEmail = `test-${Date.now()}@example.com`;
+    const compromisedPassword = "123456789";
+
+    const result = await client.signUp.email({
+      email: uniqueEmail,
+      password: compromisedPassword,
+      name: "Test User",
+    });
+    
+    expect(result.error).toBeDefined();
+    expect(result.error?.status).toBe('BAD_REQUEST');
+
+  });
+
+    it("should allow account creation with strong, uncompromised password", async () => {
+        const uniqueEmail = `test-${Date.now()}@example.com`;
+        const strongPassword = `Str0ng!P@ssw0rd-${Date.now()}`;
+    
+        const result = await client.signUp.email({
+        email: uniqueEmail,
+        password: strongPassword,
+        name: "Test User",
+        });
+        expect(result.data?.user).toBeDefined();
+    });
+
+    it("should prevent password update to compromised password", async () => {
+        const uniqueEmail = `test-${Date.now()}@example.com`;
+        const initialPassword = "123456789";
+
+         await client.signUp.email({
+            email: uniqueEmail,
+            password: initialPassword,
+            name: "Test User",
+        });
+
+        const result = await client.changePassword({
+            currentPassword: initialPassword,
+            newPassword: "123456789",
+        });
+        expect(result.error).toBeDefined();
+        expect(result.error?.status).toBe('BAD_REQUEST');
+    });
+
+    it("should allow password update to strong, uncompromised password", async () => {
+        const uniqueEmail = `test-${Date.now()}@example.com`;
+        const initialPassword = "123456789";
+        const strongPassword = `Str0ng!P@ssw0rd-${Date.now()}`;
+
+        await client.signUp.email({
+            email: uniqueEmail,
+            password: initialPassword,
+            name: "Test User",
+        });
+        
+        const result = await client.changePassword({
+            currentPassword: initialPassword,
+            newPassword: strongPassword,
+        });
+        expect(result.data?.user).toBeDefined();
+    });
+})

--- a/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
@@ -1,14 +1,14 @@
 import type { BetterAuthPlugin } from "better-auth";
-import { APIError } from "better-auth/api";
+import { APIError } from "../../api";
 import { createHash } from "@better-auth/utils/hash"
 import { betterFetch } from '@better-fetch/fetch';
 
 async function checkPasswordCompromise(password: string, customMessage?: string) {
     if (!password) return
+
     const sha1Hash = (await createHash('SHA-1', 'hex').digest(password)).toUpperCase()
     const prefix = sha1Hash.substring(0, 5)
     const suffix = sha1Hash.substring(5)
-  
     try {
         const {data, error} = await betterFetch<string>(`https://api.pwnedpasswords.com/range/${prefix}`, {
             headers: {
@@ -16,7 +16,7 @@ async function checkPasswordCompromise(password: string, customMessage?: string)
                 'User-Agent': 'BetterAuth Password Checker' 
             }
         })
-   
+
         if (error) {
             throw new APIError('INTERNAL_SERVER_ERROR', { 
                 message: `Failed to check password. Status: ${error.status}` 
@@ -40,6 +40,7 @@ async function checkPasswordCompromise(password: string, customMessage?: string)
         })
     }
 }
+
 export interface HaveIBeenPwnedOptions {
     customPasswordCompromisedMessage?: string
 }
@@ -54,7 +55,7 @@ export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions) =>
                 async before(user, ctx) {
                     if(ctx && ctx.body){
                         const password = ctx.body.newPassword || ctx.body.password
-                        await checkPasswordCompromise(password, options.customPasswordCompromisedMessage)
+                        await checkPasswordCompromise(password, options?.customPasswordCompromisedMessage)
                     }
                 }
               },
@@ -62,7 +63,7 @@ export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions) =>
                 async before(user, ctx) {
                     if(ctx && ctx.body){
                     const password = ctx.body.newPassword || ctx.body.password
-                    await checkPasswordCompromise(password, options.customPasswordCompromisedMessage)
+                    await checkPasswordCompromise(password, options?.customPasswordCompromisedMessage)
                 }
                 }
               }

--- a/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
@@ -1,73 +1,89 @@
 import type { BetterAuthPlugin } from "better-auth";
 import { APIError } from "../../api";
-import { createHash } from "@better-auth/utils/hash"
-import { betterFetch } from '@better-fetch/fetch';
+import { createHash } from "@better-auth/utils/hash";
+import { betterFetch } from "@better-fetch/fetch";
 
-async function checkPasswordCompromise(password: string, customMessage?: string) {
-    if (!password) return
+async function checkPasswordCompromise(
+	password: string,
+	customMessage?: string,
+) {
+	if (!password) return;
 
-    const sha1Hash = (await createHash('SHA-1', 'hex').digest(password)).toUpperCase()
-    const prefix = sha1Hash.substring(0, 5)
-    const suffix = sha1Hash.substring(5)
-    try {
-        const {data, error} = await betterFetch<string>(`https://api.pwnedpasswords.com/range/${prefix}`, {
-            headers: {
-                'Add-Padding': 'true', 
-                'User-Agent': 'BetterAuth Password Checker' 
-            }
-        })
+	const sha1Hash = (
+		await createHash("SHA-1", "hex").digest(password)
+	).toUpperCase();
+	const prefix = sha1Hash.substring(0, 5);
+	const suffix = sha1Hash.substring(5);
+	try {
+		const { data, error } = await betterFetch<string>(
+			`https://api.pwnedpasswords.com/range/${prefix}`,
+			{
+				headers: {
+					"Add-Padding": "true",
+					"User-Agent": "BetterAuth Password Checker",
+				},
+			},
+		);
 
-        if (error) {
-            throw new APIError('INTERNAL_SERVER_ERROR', { 
-                message: `Failed to check password. Status: ${error.status}` 
-            })
-        }
-    
-        const lines = data.split('\n')        
-        const found = lines.some(line => 
-            line.split(':')[0].toUpperCase() === suffix.toUpperCase()
-        )
-    
-        if (found) {
-            throw new APIError('BAD_REQUEST', { 
-                message: customMessage || 'The password you entered has been compromised. Please choose a different password.'
-            })
-        }
-    } catch (error) {
-        if (error instanceof APIError) throw error
-        throw new APIError('INTERNAL_SERVER_ERROR', { 
-            message: 'Failed to check password. Please try again later.'
-        })
-    }
+		if (error) {
+			throw new APIError("INTERNAL_SERVER_ERROR", {
+				message: `Failed to check password. Status: ${error.status}`,
+			});
+		}
+
+		const lines = data.split("\n");
+		const found = lines.some(
+			(line) => line.split(":")[0].toUpperCase() === suffix.toUpperCase(),
+		);
+
+		if (found) {
+			throw new APIError("BAD_REQUEST", {
+				message:
+					customMessage ||
+					"The password you entered has been compromised. Please choose a different password.",
+			});
+		}
+	} catch (error) {
+		if (error instanceof APIError) throw error;
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			message: "Failed to check password. Please try again later.",
+		});
+	}
 }
 
 export interface HaveIBeenPwnedOptions {
-    customPasswordCompromisedMessage?: string
+	customPasswordCompromisedMessage?: string;
 }
 
 export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions) =>
-  ({
-    id: "haveIBeenPwned",
-    options: {
-        databaseHooks: {
-            account: {
-              create: {
-                async before(user, ctx) {
-                    if(ctx && ctx.body){
-                        const password = ctx.body.newPassword || ctx.body.password
-                        await checkPasswordCompromise(password, options?.customPasswordCompromisedMessage)
-                    }
-                }
-              },
-              update: {
-                async before(user, ctx) {
-                    if(ctx && ctx.body){
-                    const password = ctx.body.newPassword || ctx.body.password
-                    await checkPasswordCompromise(password, options?.customPasswordCompromisedMessage)
-                }
-                }
-              }
-            }
-          },
-        },
-  } satisfies BetterAuthPlugin);
+	({
+		id: "haveIBeenPwned",
+		options: {
+			databaseHooks: {
+				account: {
+					create: {
+						async before(user, ctx) {
+							if (ctx && ctx.body) {
+								const password = ctx.body.newPassword || ctx.body.password;
+								await checkPasswordCompromise(
+									password,
+									options?.customPasswordCompromisedMessage,
+								);
+							}
+						},
+					},
+					update: {
+						async before(user, ctx) {
+							if (ctx && ctx.body) {
+								const password = ctx.body.newPassword || ctx.body.password;
+								await checkPasswordCompromise(
+									password,
+									options?.customPasswordCompromisedMessage,
+								);
+							}
+						},
+					},
+				},
+			},
+		},
+	}) satisfies BetterAuthPlugin;

--- a/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
@@ -1,0 +1,82 @@
+import type { BetterAuthPlugin } from "better-auth";
+import { APIError } from "better-auth/api";
+import { createHash } from "@better-auth/utils/hash"
+import { betterFetch } from '@better-fetch/fetch';
+
+async function checkPasswordCompromise(password: string) {
+    const sha1Hash = (await createHash('SHA-1', 'hex').digest(password)).toUpperCase()
+    const prefix = sha1Hash.substring(0, 5)
+    const suffix = sha1Hash.substring(5)
+  
+    try {
+        const {data, error} = await betterFetch<string>(`https://api.pwnedpasswords.com/range/${prefix}`, {
+            headers: {
+                'Add-Padding': 'true', 
+                'User-Agent': 'BetterAuth Password Checker' 
+            }
+        })
+   
+        if (error) {
+            throw new APIError('INTERNAL_SERVER_ERROR', { 
+                message: `Failed to check password. Status: ${error.status}` 
+            })
+        }
+    
+        const lines = data.split('\n')        
+        const found = lines.some(line => 
+            line.split(':')[0].toUpperCase() === suffix.toUpperCase()
+        )
+    
+        if (found) {
+            throw new APIError('BAD_REQUEST', { 
+                message: 'Password has been compromised. Choose another one.' 
+            })
+        }
+    } catch (error) {
+        if (error instanceof APIError) throw error
+        throw new APIError('INTERNAL_SERVER_ERROR', { 
+            message: 'Network error while checking password compromise'
+        })
+    }
+}
+
+export const haveIBeenPwnd = () =>
+  ({
+    id: "betterPassword",
+    options: {
+        databaseHooks: {
+            account: {
+              create: {
+                async before(user, ctx) {
+                  if (!ctx?.body) {
+                    throw new APIError('BAD_REQUEST', { message: 'No data provided' })
+                  }
+        
+                  const password = ctx.body.newPassword || ctx.body.password
+        
+                  if (!password) {
+                    throw new APIError('BAD_REQUEST', { message: 'Password is required' })
+                  }
+        
+                  await checkPasswordCompromise(password)
+                }
+              },
+              update: {
+                async before(user, ctx) {
+                  if (!ctx?.body) {
+                    throw new APIError('BAD_REQUEST', { message: 'No data provided' })
+                  }
+        
+                  const password = ctx.body.newPassword || ctx.body.password
+        
+                  if (!password) {
+                    throw new APIError('BAD_REQUEST', { message: 'Password is required' })
+                  }
+        
+                  await checkPasswordCompromise(password)
+                }
+              }
+            }
+          },
+        },
+  } satisfies BetterAuthPlugin);

--- a/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
@@ -46,7 +46,7 @@ export interface HaveIBeenPwnedOptions {
 
 export const haveIBeenPwned = (options: HaveIBeenPwnedOptions) =>
   ({
-    id: "haveIBeenPwnd",
+    id: "haveIBeenPwned",
     options: {
         databaseHooks: {
             account: {

--- a/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
@@ -49,14 +49,18 @@ export const haveIBeenPwnd = () =>
             account: {
               create: {
                 async before(user, ctx) {
-                  const password = ctx.body.newPassword || ctx.body.password
-                  await checkPasswordCompromise(password)
+                    if(ctx && ctx.body){
+                        const password = ctx.body.newPassword || ctx.body.password
+                        await checkPasswordCompromise(password)
+                    }
                 }
               },
               update: {
                 async before(user, ctx) {
+                    if(ctx && ctx.body){
                     const password = ctx.body.newPassword || ctx.body.password
                     await checkPasswordCompromise(password)
+                }
                 }
               }
             }

--- a/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
@@ -40,11 +40,11 @@ async function checkPasswordCompromise(password: string, customMessage?: string)
         })
     }
 }
-export interface HaveIBeenPwndOptions {
+export interface HaveIBeenPwnedOptions {
     customPasswordCompromisedMessage?: string
 }
 
-export const haveIBeenPwnd = (options: HaveIBeenPwndOptions) =>
+export const haveIBeenPwned = (options: HaveIBeenPwnedOptions) =>
   ({
     id: "haveIBeenPwnd",
     options: {

--- a/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
@@ -36,7 +36,7 @@ async function checkPasswordCompromise(password: string, customMessage?: string)
     } catch (error) {
         if (error instanceof APIError) throw error
         throw new APIError('INTERNAL_SERVER_ERROR', { 
-            message: 'Network error while checking password compromise'
+            message: 'Failed to check password. Please try again later.'
         })
     }
 }
@@ -44,7 +44,7 @@ export interface HaveIBeenPwnedOptions {
     customPasswordCompromisedMessage?: string
 }
 
-export const haveIBeenPwned = (options: HaveIBeenPwnedOptions) =>
+export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions) =>
   ({
     id: "haveIBeenPwned",
     options: {

--- a/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
@@ -4,6 +4,7 @@ import { createHash } from "@better-auth/utils/hash"
 import { betterFetch } from '@better-fetch/fetch';
 
 async function checkPasswordCompromise(password: string) {
+    if (!password) return
     const sha1Hash = (await createHash('SHA-1', 'hex').digest(password)).toUpperCase()
     const prefix = sha1Hash.substring(0, 5)
     const suffix = sha1Hash.substring(5)
@@ -42,38 +43,20 @@ async function checkPasswordCompromise(password: string) {
 
 export const haveIBeenPwnd = () =>
   ({
-    id: "betterPassword",
+    id: "haveIBeenPwnd",
     options: {
         databaseHooks: {
             account: {
               create: {
                 async before(user, ctx) {
-                  if (!ctx?.body) {
-                    throw new APIError('BAD_REQUEST', { message: 'No data provided' })
-                  }
-        
                   const password = ctx.body.newPassword || ctx.body.password
-        
-                  if (!password) {
-                    throw new APIError('BAD_REQUEST', { message: 'Password is required' })
-                  }
-        
                   await checkPasswordCompromise(password)
                 }
               },
               update: {
                 async before(user, ctx) {
-                  if (!ctx?.body) {
-                    throw new APIError('BAD_REQUEST', { message: 'No data provided' })
-                  }
-        
-                  const password = ctx.body.newPassword || ctx.body.password
-        
-                  if (!password) {
-                    throw new APIError('BAD_REQUEST', { message: 'Password is required' })
-                  }
-        
-                  await checkPasswordCompromise(password)
+                    const password = ctx.body.newPassword || ctx.body.password
+                    await checkPasswordCompromise(password)
                 }
               }
             }

--- a/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
+++ b/packages/better-auth/src/plugins/have-i-been-pwned/index.ts
@@ -3,7 +3,7 @@ import { APIError } from "better-auth/api";
 import { createHash } from "@better-auth/utils/hash"
 import { betterFetch } from '@better-fetch/fetch';
 
-async function checkPasswordCompromise(password: string) {
+async function checkPasswordCompromise(password: string, customMessage?: string) {
     if (!password) return
     const sha1Hash = (await createHash('SHA-1', 'hex').digest(password)).toUpperCase()
     const prefix = sha1Hash.substring(0, 5)
@@ -30,7 +30,7 @@ async function checkPasswordCompromise(password: string) {
     
         if (found) {
             throw new APIError('BAD_REQUEST', { 
-                message: 'Password has been compromised. Choose another one.' 
+                message: customMessage || 'The password you entered has been compromised. Please choose a different password.'
             })
         }
     } catch (error) {
@@ -40,8 +40,11 @@ async function checkPasswordCompromise(password: string) {
         })
     }
 }
+export interface HaveIBeenPwndOptions {
+    customPasswordCompromisedMessage?: string
+}
 
-export const haveIBeenPwnd = () =>
+export const haveIBeenPwnd = (options: HaveIBeenPwndOptions) =>
   ({
     id: "haveIBeenPwnd",
     options: {
@@ -51,7 +54,7 @@ export const haveIBeenPwnd = () =>
                 async before(user, ctx) {
                     if(ctx && ctx.body){
                         const password = ctx.body.newPassword || ctx.body.password
-                        await checkPasswordCompromise(password)
+                        await checkPasswordCompromise(password, options.customPasswordCompromisedMessage)
                     }
                 }
               },
@@ -59,7 +62,7 @@ export const haveIBeenPwnd = () =>
                 async before(user, ctx) {
                     if(ctx && ctx.body){
                     const password = ctx.body.newPassword || ctx.body.password
-                    await checkPasswordCompromise(password)
+                    await checkPasswordCompromise(password, options.customPasswordCompromisedMessage)
                 }
                 }
               }


### PR DESCRIPTION
Hey,

This PR will help for dbhooks, since right now if a dbhook returns an error (for example a validation error), the verification token will be already removed.

Thanks for great lib 😄 