### PR TITLE
fix: only delete verification token after succesful db query

### DIFF
--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -257,7 +257,6 @@ export const resetPassword = createAuthEndpoint(
 				message: BASE_ERROR_CODES.INVALID_TOKEN,
 			});
 		}
-		await ctx.context.internalAdapter.deleteVerificationValue(verification.id);
 		const userId = verification.value;
 		const hashedPassword = await ctx.context.password.hash(newPassword);
 		const accounts = await ctx.context.internalAdapter.findAccounts(userId);
@@ -272,6 +271,10 @@ export const resetPassword = createAuthEndpoint(
 				},
 				ctx,
 			);
+			await ctx.context.internalAdapter.deleteVerificationValue(
+				verification.id,
+			);
+
 			return ctx.json({
 				status: true,
 			});
@@ -281,6 +284,8 @@ export const resetPassword = createAuthEndpoint(
 			hashedPassword,
 			ctx,
 		);
+		await ctx.context.internalAdapter.deleteVerificationValue(verification.id);
+
 		return ctx.json({
 			status: true,
 		});


### PR DESCRIPTION
Hey,

This PR will help for dbhooks, since right now if a dbhook returns an error (for example a validation error), the verification token will be already removed.

Thanks for great lib 😄 