### PR TITLE
Fix: Ensure password confirmation field has type='password'

### DIFF
--- a/docs/components/builder/sign-up.tsx
+++ b/docs/components/builder/sign-up.tsx
@@ -92,6 +92,7 @@ export function SignUp() {
 						<Label htmlFor="password">Password</Label>
 						<Input
 							id="password"
+							type="password"
 							value={password}
 							onChange={(e) => setPassword(e.target.value)}
 							autoComplete="new-password"
@@ -102,6 +103,7 @@ export function SignUp() {
 						<Label htmlFor="password">Confirm Password</Label>
 						<Input
 							id="password_confirmation"
+							type="password"
 							value={passwordConfirmation}
 							onChange={(e) => setPasswordConfirmation(e.target.value)}
 							autoComplete="new-password"


### PR DESCRIPTION
The password fields was missing type="password", so it showed plain text. This PR fixes that.