### PR TITLE
fix: type error

### DIFF
--- a/packages/better-auth/src/index.ts
+++ b/packages/better-auth/src/index.ts
@@ -6,3 +6,5 @@ export type * from "better-call";
 export type * from "zod";
 //@ts-expect-error: we need to export helper types even when they conflict with better-call types to avoid "The inferred type of 'auth' cannot be named without a reference to..."
 export type * from "./types/helper";
+// export this as we are referencing OAuth2Tokens in the `refresh-token` api as return type
+export type * from "./oauth2/types";


### PR DESCRIPTION
close #2018

I got this when I built the type from the server code

![CleanShot 2025-03-28 at 00 28 14@2x](https://github.com/user-attachments/assets/c08b7049-2512-4947-8ee0-192c2674088a)

It indeed uses OAuth2Tokens as the return type.

![CleanShot 2025-03-28 at 00 29 32@2x](https://github.com/user-attachments/assets/9075e27a-a2ae-4fcd-aa4e-4662bd90e91d)

So I use the same method to fix it.