### PR TITLE
fix(docs): supabase-migration-guide.mdx types

### DIFF
--- a/docs/content/docs/guides/supabase-migration-guide.mdx
+++ b/docs/content/docs/guides/supabase-migration-guide.mdx
@@ -96,8 +96,8 @@ export const auth = betterAuth({
     },
     socialProviders: {
         github: {
-            clientId: process.env.GITHUB_CLIENT_ID,
-            clientSecret: process.env.GITHUB_CLIENT_SECRET,
+            clientId: process.env.GITHUB_CLIENT_ID!,
+            clientSecret: process.env.GITHUB_CLIENT_SECRET!,
         }
     },
     plugins: [admin(), anonymous()], // [!code highlight]


### PR DESCRIPTION
Node defaults types for environment variables to`string | undefined`. Adding the non-null assertion operator.