### PR TITLE
feat(github): Add custom URL options to enhance flexibility

### DIFF
--- a/packages/better-auth/src/social-providers/github.ts
+++ b/packages/better-auth/src/social-providers/github.ts
@@ -53,9 +53,15 @@ export interface GithubProfile {
 	};
 }
 
-export interface GithubOptions extends ProviderOptions<GithubProfile> {}
+export interface GithubOptions extends ProviderOptions<GithubProfile> {
+	tokenEndpointUrl?: string
+	refreshTokenUrl?: string
+    userInfoUrl?: string
+}
 export const github = (options: GithubOptions) => {
-	const tokenEndpoint = "https://github.com/login/oauth/access_token";
+	const tokenEndpoint = options.tokenEndpointUrl ?? "https://github.com/login/oauth/access_token";
+    const userInfoUrl = options.userInfoUrl ?? "https://api.github.com/user";
+    const refreshTokenUrl = options.refreshTokenUrl ?? "https://github.com/login/oauth/token";
 	return {
 		id: "github",
 		name: "GitHub",
@@ -93,7 +99,7 @@ export const github = (options: GithubOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: "https://github.com/login/oauth/token",
+						tokenEndpoint: refreshTokenUrl,
 					});
 				},
 		async getUserInfo(token) {
@@ -101,7 +107,7 @@ export const github = (options: GithubOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<GithubProfile>(
-				"https://api.github.com/user",
+				userInfoUrl,
 				{
 					headers: {
 						"User-Agent": "better-auth",


### PR DESCRIPTION
Allow users to customize GitHub's token endpoint, user info endpoint, and refresh token endpoint to improve configuration flexibility and scalability.