### PR TITLE
docs: fix path of nextJS app router route handler in next.mdx

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -9,9 +9,9 @@ Before you start, make sure you have a Better Auth instance configured. If you h
 
 ### Create API Route
 
-We need to mount the handler to an API route. Create a route file inside `/api/auth/[...all]` directory. And add the following code:
+We need to mount the handler to an API route. Create a route file inside `app/api/auth/[...all]` directory. And add the following code:
 
-```ts title="api/auth/[...all]/route.ts"
+```ts title="app/api/auth/[...all]/route.ts"
 import { auth } from "@/lib/auth";
 import { toNextJsHandler } from "better-auth/next-js";
 

--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -19,7 +19,7 @@ export const { GET, POST } = toNextJsHandler(auth.handler);
 ```
 
 <Callout type="info">
- You can change the path on your better-auth configuration but it's recommended to keep it as `/api/auth/[...all]`
+ You can change the path on your better-auth configuration but it's recommended to keep it as `app/api/auth/[...all]`
 </Callout>
 
 


### PR DESCRIPTION
Default path of route handler for app router is /app/api

https://nextjs.org/docs/app/building-your-application/routing/route-handlers