### PR TITLE
fix(stripe): Allow customizing subscription schema

### DIFF
--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -1,62 +1,75 @@
 import type { AuthPluginSchema } from "better-auth";
 import type { StripeOptions } from "./types";
+import { mergeSchema } from "better-auth/db";
+
+export const subscriptions = {
+	subscription: {
+		fields: {
+			plan: {
+				type: "string",
+				required: true,
+			},
+			referenceId: {
+				type: "string",
+				required: true,
+			},
+			stripeCustomerId: {
+				type: "string",
+				required: false,
+			},
+			stripeSubscriptionId: {
+				type: "string",
+				required: false,
+			},
+			status: {
+				type: "string",
+				defaultValue: "incomplete",
+			},
+			periodStart: {
+				type: "date",
+				required: false,
+			},
+			periodEnd: {
+				type: "date",
+				required: false,
+			},
+			cancelAtPeriodEnd: {
+				type: "boolean",
+				required: false,
+				defaultValue: false,
+			},
+			seats: {
+				type: "number",
+				required: false,
+			},
+		},
+	},
+} satisfies AuthPluginSchema;
+
+export const user = {
+	user: {
+		fields: {
+			stripeCustomerId: {
+				type: "string",
+				required: false,
+			},
+		},
+	},
+} satisfies AuthPluginSchema;
 
 export const getSchema = (options: StripeOptions) => {
-	const subscriptions = {
-		subscription: {
-			fields: {
-				plan: {
-					type: "string",
-					required: true,
-				},
-				referenceId: {
-					type: "string",
-					required: true,
-				},
-				stripeCustomerId: {
-					type: "string",
-					required: false,
-				},
-				stripeSubscriptionId: {
-					type: "string",
-					required: false,
-				},
-				status: {
-					type: "string",
-					defaultValue: "incomplete",
-				},
-				periodStart: {
-					type: "date",
-					required: false,
-				},
-				periodEnd: {
-					type: "date",
-					required: false,
-				},
-				cancelAtPeriodEnd: {
-					type: "boolean",
-					required: false,
-					defaultValue: false,
-				},
-				seats: {
-					type: "number",
-					required: false,
-				},
-			},
+	if (
+		options.schema &&
+		!options.subscription?.enabled &&
+		"subscription" in options.schema
+	) {
+		options.schema.subscription = undefined;
+	}
+	return mergeSchema(
+		{
+			...(options.subscription?.enabled ? subscriptions : {}),
+			...user,
 		},
-	} satisfies AuthPluginSchema;
-	const user = {
-		user: {
-			fields: {
-				stripeCustomerId: {
-					type: "string",
-					required: false,
-				},
-			},
-		},
-	} satisfies AuthPluginSchema;
-	return {
-		...(options.subscription?.enabled ? subscriptions : {}),
-		...user,
-	} as typeof user & typeof subscriptions;
+		options.schema,
+	);
 };

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -1,5 +1,6 @@
-import type { Session, User } from "better-auth";
+import type { InferOptionSchema, Session, User } from "better-auth";
 import type Stripe from "stripe";
+import type { subscriptions, user } from "./schema";
 
 export type StripePlan = {
 	/**
@@ -312,6 +313,10 @@ export interface StripeOptions {
 		};
 	};
 	onEvent?: (event: Stripe.Event) => Promise<void>;
+	/**
+	 * Schema for the stripe plugin
+	 */
+	schema?: InferOptionSchema<typeof subscriptions & typeof user>;
 }
 
 export interface Customer {


### PR DESCRIPTION
This was documented in docs at https://www.better-auth.com/docs/plugins/stripe#customizing-the-schema but wasn't implemented. This is now fixed.