### PR TITLE
fix(admin): Fix total in listUsers not using where clause

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -160,9 +160,10 @@ export const createInternalAdapter = (
 			});
 			return users;
 		},
-		countTotalUsers: async () => {
+		countTotalUsers: async (where?: Where[]) => {
 			const total = await adapter.count({
 				model: "user",
+				where,
 			});
 			return total;
 		},

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -129,6 +129,20 @@ describe("Admin plugin", async () => {
 		expect(res.data?.users.length).toBe(2);
 	});
 
+	it("should list users with search query", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				filterField: "role",
+				filterOperator: "eq",
+				filterValue: "admin",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data?.total).toBe(1);
+	});
+
 	it("should not allow non-admin to list users", async () => {
 		const res = await client.admin.listUsers({
 			query: {

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -567,7 +567,9 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 								: undefined,
 							where.length ? where : undefined,
 						);
-						const total = await ctx.context.internalAdapter.countTotalUsers();
+						const total = await ctx.context.internalAdapter.countTotalUsers(
+							where.length ? where : undefined,
+						);
 						return ctx.json({
 							users: users as UserWithRole[],
 							total: total,


### PR DESCRIPTION
- Fixed the total in admin.listUsers to return the correct total after using the where clause
- Changed internalAdapter.countTotalUsers function to accept an optional where clause
- Added test

closes #2108