### PR TITLE
fix(oauth2): encode clientId and clientSecret in authorization header

### DIFF
--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -1,6 +1,7 @@
 import { betterFetch } from "@better-fetch/fetch";
 import type { OAuth2Tokens } from "./types";
 import type { ProviderOptions } from "./types";
+import { encodeOAuthParameter } from "./utils";
 
 export async function refreshAccessToken({
 	refreshToken,
@@ -27,7 +28,7 @@ export async function refreshAccessToken({
 	body.set("refresh_token", refreshToken);
 	if (authentication === "basic") {
 		const encodedCredentials = btoa(
-			`${options.clientId}:${options.clientSecret}`,
+			`${encodeOAuthParameter(options.clientId)}:${encodeOAuthParameter(options.clientSecret)}`,
 		);
 		headers["authorization"] = `Basic ${encodedCredentials}`;
 	} else {

--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -28,7 +28,9 @@ export async function refreshAccessToken({
 	body.set("refresh_token", refreshToken);
 	if (authentication === "basic") {
 		const encodedCredentials = btoa(
-			`${encodeOAuthParameter(options.clientId)}:${encodeOAuthParameter(options.clientSecret)}`,
+			`${encodeOAuthParameter(options.clientId)}:${encodeOAuthParameter(
+				options.clientSecret,
+			)}`,
 		);
 		headers["authorization"] = `Basic ${encodedCredentials}`;
 	} else {

--- a/packages/better-auth/src/oauth2/utils.ts
+++ b/packages/better-auth/src/oauth2/utils.ts
@@ -27,4 +27,5 @@ export function getOAuth2Tokens(data: Record<string, any>): OAuth2Tokens {
 	};
 }
 
-export const encodeOAuthParameter = (value: string) => encodeURIComponent(value).replace(/%20/g, '+');
+export const encodeOAuthParameter = (value: string) =>
+	encodeURIComponent(value).replace(/%20/g, "+");

--- a/packages/better-auth/src/oauth2/utils.ts
+++ b/packages/better-auth/src/oauth2/utils.ts
@@ -26,3 +26,5 @@ export function getOAuth2Tokens(data: Record<string, any>): OAuth2Tokens {
 		idToken: data.id_token,
 	};
 }
+
+export const encodeOAuthParameter = (value: string) => encodeURIComponent(value).replace(/%20/g, '+');

--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -35,7 +35,9 @@ export async function validateAuthorizationCode({
 	body.set("redirect_uri", options.redirectURI || redirectURI);
 	if (authentication === "basic") {
 		const encodedCredentials = btoa(
-			`${encodeOAuthParameter(options.clientId)}:${encodeOAuthParameter(options.clientSecret)}`,
+			`${encodeOAuthParameter(options.clientId)}:${encodeOAuthParameter(
+				options.clientSecret,
+			)}`,
 		);
 		headers["authorization"] = `Basic ${encodedCredentials}`;
 	} else {

--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -3,6 +3,8 @@ import type { ProviderOptions } from "./types";
 import { getOAuth2Tokens } from "./utils";
 import { jwtVerify } from "jose";
 
+const formUrlEncode = (value: string) => encodeURIComponent(value).replace(/%20/g, '+');
+
 export async function validateAuthorizationCode({
 	code,
 	codeVerifier,
@@ -34,7 +36,7 @@ export async function validateAuthorizationCode({
 	body.set("redirect_uri", options.redirectURI || redirectURI);
 	if (authentication === "basic") {
 		const encodedCredentials = btoa(
-			`${options.clientId}:${options.clientSecret}`,
+			`${formUrlEncode(options.clientId)}:${formUrlEncode(options.clientSecret)}`,
 		);
 		headers["authorization"] = `Basic ${encodedCredentials}`;
 	} else {

--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -2,8 +2,7 @@ import { betterFetch } from "@better-fetch/fetch";
 import type { ProviderOptions } from "./types";
 import { getOAuth2Tokens } from "./utils";
 import { jwtVerify } from "jose";
-
-const formUrlEncode = (value: string) => encodeURIComponent(value).replace(/%20/g, '+');
+import { encodeOAuthParameter } from "./utils";
 
 export async function validateAuthorizationCode({
 	code,
@@ -36,7 +35,7 @@ export async function validateAuthorizationCode({
 	body.set("redirect_uri", options.redirectURI || redirectURI);
 	if (authentication === "basic") {
 		const encodedCredentials = btoa(
-			`${formUrlEncode(options.clientId)}:${formUrlEncode(options.clientSecret)}`,
+			`${encodeOAuthParameter(options.clientId)}:${encodeOAuthParameter(options.clientSecret)}`,
 		);
 		headers["authorization"] = `Basic ${encodedCredentials}`;
 	} else {


### PR DESCRIPTION
Hi, I found that I always encounter errors when using genericOAuth:
```
 {
  error: 'invalid_client',
  error_description: 'Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method).',
  status: 401,
  statusText: 'Unauthorized'
}
```
My client_secret contained characters like '+' '=' which didn't seem to be escaped correctly, so I created this PR to fix the issue