### PR TITLE
fix(docs): rate-limit schema has two primary keys

### DIFF
--- a/docs/content/docs/concepts/rate-limit.mdx
+++ b/docs/content/docs/concepts/rate-limit.mdx
@@ -211,7 +211,6 @@ Table Name: `rateLimit`
         name: "key", 
         type: "string", 
         description: "Unique identifier for each rate limit key",
-        isPrimaryKey: true
         },
         { 
         name: "count", 


### PR DESCRIPTION
The field `key` shouldn't be the primary key, only `id`.