### PR TITLE
fix(stripe): Throw err if passed `referenceId` when no `subscription` authorizeReference` is defined

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -62,6 +62,13 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 			}
 			const referenceId =
 				ctx.body?.referenceId || ctx.query?.referenceId || session.user.id;
+
+			if (ctx.body?.referenceId && !options.subscription?.authorizeReference) {
+				logger.error(`Passing referenceId into a subscription action isn't allowed if subscription.authorizedReference isn't defined in your stripe plugin config.`)
+				throw new APIError("BAD_REQUEST", {
+					message: "Reference id is not allowed. Read server logs for more details.",
+				});
+			}
 			const isAuthorized = ctx.body?.referenceId
 				? await options.subscription?.authorizeReference?.({
 						user: session.user,

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -64,7 +64,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				ctx.body?.referenceId || ctx.query?.referenceId || session.user.id;
 
 			if (ctx.body?.referenceId && !options.subscription?.authorizeReference) {
-				logger.error(`Passing referenceId into a subscription action isn't allowed if subscription.authorizedReference isn't defined in your stripe plugin config.`)
+				logger.error(`Passing referenceId into a subscription action isn't allowed if subscription.authorizeReference isn't defined in your stripe plugin config.`)
 				throw new APIError("BAD_REQUEST", {
 					message: "Reference id is not allowed. Read server logs for more details.",
 				});


### PR DESCRIPTION
If a user uses something like `subscription.upgrade` and pass a `referenceId`, but they never defined a `options.subscription.authorizeReference` then it will throw an error saying unauthorized. (since no function defined, means  it will just return `false` in it's checks)
While this error is valid, it isn't very clear up-front to the developer that it was due to them passing `referenceId`. To them, they're logged in, so it makes no sense why they would get an unauthorized error.
This PR adds a check if they're missing that function, yet passed `referenceId` to throw a bad request, and provide more info in the server logs.