### PR TITLE
fix: genericOAuth default redirectURI for account linking

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -766,7 +766,8 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							clientId,
 							clientSecret,
 							redirectURI:
-								redirectURI || `${c.context.baseURL}/oauth2/callback/${providerId}`,
+								redirectURI ||
+								`${c.context.baseURL}/oauth2/callback/${providerId}`,
 						},
 						authorizationEndpoint: finalAuthUrl,
 						state: state.state,

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -766,7 +766,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							clientId,
 							clientSecret,
 							redirectURI:
-								redirectURI || `${c.context.baseURL}/oauth2/callback`,
+								redirectURI || `${c.context.baseURL}/oauth2/callback/${providerId}`,
 						},
 						authorizationEndpoint: finalAuthUrl,
 						state: state.state,


### PR DESCRIPTION
I noticed that oauth flow for `oauth2.link` is defaulting to the wrong redirect uri. 

## Expected

Given the base url is ` https://www.example.com` and a generic oauth plugin config like:
```
{
    providerId: "slack",
    clientId: env.SLACK_CLIENT_ID,
    clientSecret: env.SLACK_CLIENT_SECRET,
    discoveryUrl: "https://slack.com/.well-known/openid-configuration",
    scopes: ["openid", "email", "profile"]
}
```

I would expect that `oauth2.link` redirects to `https://www.example.com/api/auth/oauth2/callback/slack`. 

## Current State

I'm seeing an incorrect redirect to `https://www.example.com/api/auth/oauth2/callback`. Looking at the code this is becuase we've hardcoded that as the default.

NOTE: This is only an issue for generic oauth linking. `signIn.oauth2` correctly includes the provider id at the end of the redirect URI.