### PR TITLE
fix(disabledPaths): Disable paths on api calls

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -35,6 +35,14 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 	for (const [key, endpoint] of Object.entries(endpoints)) {
 		api[key] = async (context) => {
 			const authContext = await ctx;
+			if (authContext.options.disabledPaths?.includes(endpoint.path)) {
+				return {
+					response: new APIError("NOT_FOUND", {
+						message: BASE_ERROR_CODES.NOT_FOUND 
+					}),
+					headers: null
+				};
+			}
 			let internalContext: InternalContext = {
 				...context,
 				context: {


### PR DESCRIPTION
This may need some more thought, but if a path is disabled, it is currently only disabled on HTTP requests.  When using the `auth.api.` the routes still execute like normal.  I feel like for consistency it would make sense to also return a 404 in these cases