### PR TITLE
feat(passkey): AAGUID support

### DIFF
--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -258,6 +258,12 @@ Table Name: `passkey`
             type: "Date", 
             description: "The time when the passkey was created",
         },
+        {
+                name: "aaguid",
+                type: "string",
+                description: "Authenticator's Attestation GUID indicating the type of the authenticator",
+                isOptional: true
+            },
     ]}
     />
 

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -92,6 +92,7 @@ export type Passkey = {
 	backedUp: boolean;
 	transports?: string;
 	createdAt: Date;
+	aaguid?: string;
 };
 
 export const passkey = (options?: PasskeyOptions) => {
@@ -569,6 +570,7 @@ export const passkey = (options?: PasskeyOptions) => {
 							});
 						}
 						const {
+							aaguid,
 							// credentialID,
 							// credentialPublicKey,
 							// counter,
@@ -589,6 +591,7 @@ export const passkey = (options?: PasskeyOptions) => {
 							transports: resp.response.transports.join(","),
 							backedUp: credentialBackedUp,
 							createdAt: new Date(),
+							aaguid: aaguid,
 						};
 						const newPasskeyRes = await ctx.context.adapter.create<Passkey>({
 							model: "passkey",
@@ -909,6 +912,10 @@ const schema = {
 			},
 			createdAt: {
 				type: "date",
+				required: false,
+			},
+			aaguid: {
+				type: "string",
 				required: false,
 			},
 		},

--- a/packages/better-auth/src/plugins/passkey/passkey.test.ts
+++ b/packages/better-auth/src/plugins/passkey/passkey.test.ts
@@ -69,6 +69,7 @@ describe("passkey", async () => {
 				createdAt: new Date(),
 				backedUp: false,
 				transports: "mockTransports",
+				aaguid: "mockAAGUID",
 			} satisfies Passkey,
 		});
 
@@ -81,6 +82,7 @@ describe("passkey", async () => {
 		expect(passkeys[0]).toHaveProperty("userId");
 		expect(passkeys[0]).toHaveProperty("publicKey");
 		expect(passkeys[0]).toHaveProperty("credentialID");
+		expect(passkeys[0]).toHaveProperty("aaguid");
 	});
 
 	it("should update a passkey", async () => {


### PR DESCRIPTION
Expose AAGUID in the passkey plugin to enable passkey provider identification.