### PR TITLE
docs(hono): add client-side auth (hono RPC) configuration guide

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -149,3 +149,33 @@ export const auth = createAuth({
   }
 })
 ```
+
+### Client-Side Configuration
+
+When using the Hono client (`@hono/client`) to make requests to your Better Auth-protected endpoints, you need to configure it to send credentials (cookies) with cross-origin requests.
+
+```ts title="api.ts"
+import { hc } from "@hono/client";
+import type { AppType } from "./server"; // Your Hono app type
+
+const client = hc<AppType>("http://localhost:8787/", {
+  fetch: ((input, init) => {
+    return fetch(input, { 
+      ...init, 
+      credentials: "include" // Required for sending cookies cross-origin
+    });
+  }) satisfies typeof fetch,
+});
+
+// Now your client requests will include credentials
+const response = await client.someProtectedEndpoint.$get();
+```
+
+This configuration is necessary when:
+- Your client and server are on different domains/ports during development
+- You're making cross-origin requests in production
+- You need to send authentication cookies with your requests
+
+The `credentials: "include"` option tells the fetch client to send cookies even for cross-origin requests. This works in conjunction with the CORS configuration on your server that has `credentials: true`.
+
+> **Note:** Make sure your CORS configuration on the server matches your client's domain, and that `credentials: true` is set in both the server's CORS config and the client's fetch config.


### PR DESCRIPTION
<!-- MRGE_STACK_DESCRIPTION_START -->
This PR is part of a [stack](https://docs.mrge.io/overview), managed by [mrge](https://mrge.io):

* `main` (default branch)
* [#1538: feat(organization): Add dynamic role authorization](https://github.com/better-auth/better-auth/pull/1538)
* **[#2209: docs(hono): add client-side auth (hono RPC) configuration guide](https://github.com/better-auth/better-auth/pull/2209)** ⬅️ Current PR ([View on mrge](https://mrge.io/pr/better-auth/better-auth/pull/2209))

---
<!-- MRGE_STACK_DESCRIPTION_END -->

## Description

Added documentation for configuring the Hono client to properly handle cross-origin authentication requests. This is a common pain point for developers when setting up Better Auth with Hono, especially during local development when the client and server are on different ports.

### Changes

- Added new "Client-Side Configuration" section to the Hono Integration docs
- Provided TypeScript example for configuring the Hono client
- Added notes about cross-origin authentication requirements
- Connected the client-side setup with existing CORS documentation

### Context

While implementing Better Auth with Hono in our own application, I encountered issues with cross-origin cookie transmission. The solution wasn't immediately obvious from the existing documentation, so this PR adds clear guidance for other developers who might face the same challenge.