### PR TITLE
fix: Drizzle schema generate reference mode doesnt use custom name

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -30,6 +30,13 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 
 	const fileExist = existsSync(filePath);
 
+	function getReferenceName({ model }: { model: string }) {
+		if (tables[model] && tables[model].modelName) {
+			return tables[model].modelName;
+		}
+		return usePlural ? `${model}s` : model;
+	}
+
 	for (const table in tables) {
 		const modelName = usePlural
 			? `${tables[table].modelName}s`
@@ -85,11 +92,9 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 								attr.required ? ".notNull()" : ""
 							}${attr.unique ? ".unique()" : ""}${
 								attr.references
-									? `.references(()=> ${
-											usePlural
-												? `${attr.references.model}s`
-												: attr.references.model
-										}.${attr.references.field}, { onDelete: 'cascade' })`
+									? `.references(()=> ${getReferenceName({
+											model: attr.references.model,
+										})}.${attr.references.field}, { onDelete: 'cascade' })`
 									: ""
 							}`;
 						})


### PR DESCRIPTION
When generating a schema in drizzle, any reference fields to other models don't take into account if the given model name had been customized by the user's BA config. This PR fixes this.