### PR TITLE
Small typo in example syntax fix

### DIFF
--- a/docs/content/docs/plugins/oauth-proxy.mdx
+++ b/docs/content/docs/plugins/oauth-proxy.mdx
@@ -35,7 +35,7 @@ A proxy plugin, that allows you to proxy OAuth requests. Useful for development 
             github: {
                 clientId: "your-client-id",
                 clientSecret: "your-client-secret",
-                redirectURI: "https://my-main-app.com/api/auth/callback/github". // [!code highlight]
+                redirectURI: "https://my-main-app.com/api/auth/callback/github" // [!code highlight]
             }
        }
     })


### PR DESCRIPTION
Noticed a rouge period at the end there. 