### PR TITLE
feat: update hover style for light mode in community page

### DIFF
--- a/docs/app/community/_components/stats.tsx
+++ b/docs/app/community/_components/stats.tsx
@@ -38,7 +38,7 @@ export default function Stats({ npmDownloads }: { npmDownloads: number }) {
 								>
 									<Button
 										variant="outline"
-										className="group duration-500 cursor-pointer text-gray-400 flex items-center gap-2 text-md hover:bg-transparent border-l-input/50 border-r-input/50 md:border-r-0 md:border-l-0 border-t-[1px] border-t-input py-7 w-full hover:text-white"
+										className="group duration-500 cursor-pointer text-gray-400 flex items-center gap-2 text-md hover:bg-transparent border-l-input/50 border-r-input/50 md:border-r-0 md:border-l-0 border-t-[1px] border-t-input py-7 w-full hover:text-black dark:hover:text-white"
 									>
 										<span className="uppercase font-mono group-hover:text-black duration-300 dark:group-hover:text-white">
 											Join Our Discord
@@ -63,7 +63,7 @@ export default function Stats({ npmDownloads }: { npmDownloads: number }) {
 								>
 									<Button
 										variant="outline"
-										className="group duration-500 cursor-pointer text-gray-400 flex items-center gap-2 text-md hover:bg-transparent  border-l-input/50 border-r-input/50 md:border-r-0 md:border-l-0 border-t-[1px] border-t-input py-7 w-full hover:text-white"
+										className="group duration-500 cursor-pointer text-gray-400 flex items-center gap-2 text-md hover:bg-transparent  border-l-input/50 border-r-input/50 md:border-r-0 md:border-l-0 border-t-[1px] border-t-input py-7 w-full hover:text-black dark:hover:text-white"
 									>
 										<svg
 											xmlns="http://www.w3.org/2000/svg"
@@ -122,7 +122,7 @@ export default function Stats({ npmDownloads }: { npmDownloads: number }) {
 								>
 									<Button
 										variant="outline"
-										className="group duration-500 cursor-pointer text-gray-400 flex items-center gap-2 text-md hover:bg-transparent border-l-input/50 border-r-input/50 md:border-r-0 md:border-l-0  border-t-[1px] border-t-input py-7 w-full hover:text-white"
+										className="group duration-500 cursor-pointer text-gray-400 flex items-center gap-2 text-md hover:bg-transparent border-l-input/50 border-r-input/50 md:border-r-0 md:border-l-0  border-t-[1px] border-t-input py-7 w-full hover:text-black dark:hover:text-white"
 									>
 										<span className="uppercase font-mono group-hover:text-black duration-300 dark:group-hover:text-white">
 											Join Subreddit


### PR DESCRIPTION
## Fix button hover text color in light mode

This PR addresses an issue with the button hover states in the community stats component. Previously, in light mode, text would change to white on hover, making it difficult to read against the light background.

### Changes made:
- Modified the hover text color for all three buttons (Discord, Downloads, Reddit) to ensure proper contrast
- Added separate styling for dark mode using the `dark:` variant
- Maintained existing group hover effects and transitions

This change ensures text remains legible in both light and dark mode, improving overall accessibility and user experience.
### Before

[preview1.webm](https://github.com/user-attachments/assets/5fc226be-75de-4126-9219-c9132a37cb6c)


### After
[preview.webm](https://github.com/user-attachments/assets/bb335a10-35e2-4e02-999e-945aec535774)

