### PR TITLE
fix(vue): baseURL not working

### DIFF
--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -17,6 +17,7 @@ import type {
 	BetterFetchResponse,
 } from "@better-fetch/fetch";
 import type { BASE_ERROR_CODES } from "../../error/codes";
+import { getBaseURL } from "../../utils/url";
 
 function getAtomKey(str: string) {
 	return `use${capitalizeFirstLetter(str)}`;
@@ -93,10 +94,8 @@ export function createAuthClient<Option extends ClientOptions>(
 	) {
 		if (useFetch) {
 			const ref = useStore(pluginsAtoms.$sessionSignal);
-			const baseURL = options?.fetchOptions?.baseURL || options?.baseURL;
-			let authPath = baseURL ? new URL(baseURL).pathname : "/api/auth";
-			authPath = authPath === "/" ? "/api/auth" : authPath; //fix for root path
-			authPath = authPath.endsWith("/") ? authPath.slice(0, -1) : authPath; //fix for trailing slash
+			const authPath = getBaseURL(options?.fetchOptions?.baseURL || options?.baseURL);
+
 			return useFetch(`${authPath}/get-session`, {
 				ref,
 			}).then((res: any) => {


### PR DESCRIPTION
~/utils/auth.ts

```ts
import { createAuthClient } from 'better-auth/vue'

const { useSession, signIn, signUp } = createAuthClient({
  baseURL: 'http://localhost:8000',
})

export default {
  useSession,
  signIn,
  signUp,
}
```

page.vue

```ts
const { data: session } = await auth.useSession(useFetch)
```

The baseURL is not merged into the actual url for the API call.

<img width="960" alt="image" src="https://github.com/user-attachments/assets/94cc4d2b-4897-4539-926f-54bede0d940c" />