### PR TITLE
Update hero.tsx - Fix typo in hero section - "npm add better-auth" -> "npm install better-auth"

### DIFF
--- a/docs/components/landing/hero.tsx
+++ b/docs/components/landing/hero.tsx
@@ -98,7 +98,7 @@ export default function Hero() {
 											<span className="italic text-amber-600"> x</span>
 										</p>
 										<p className=" relative inline tracking-tight opacity-90 md:text-sm text-xs dark:text-white font-mono text-black">
-											npm add{" "}
+											npm install{" "}
 											<span className="relative dark:text-fuchsia-100 text-fuchsia-950">
 												better-auth
 												<span className="absolute h-2 bg-gradient-to-tr from-white via-stone-200 to-stone-300 blur-3xl w-full top-0 left-2"></span>


### PR DESCRIPTION
I know that `npm add` is an alias for `npm install` but a lot of beginners would get confused when trying out the package.