### PR TITLE
feat(types): Add a type for shared options

### DIFF
--- a/packages/better-auth/src/client/types.ts
+++ b/packages/better-auth/src/client/types.ts
@@ -12,7 +12,7 @@ import type {
 } from "../types/helper";
 import type { Auth } from "../auth";
 import type { InferRoutes } from "./path-to-object";
-import type { Session, User } from "../types";
+import type { BetterAuthSharedOptions, Session, User } from "../types";
 import type { InferFieldsInputClient, InferFieldsOutput } from "../db";
 
 export type AtomListener = {
@@ -59,11 +59,9 @@ export interface BetterAuthClientPlugin {
 	atomListeners?: AtomListener[];
 }
 
-export interface ClientOptions {
+export interface ClientOptions extends BetterAuthSharedOptions {
 	fetchOptions?: BetterFetchOption;
 	plugins?: BetterAuthClientPlugin[];
-	baseURL?: string;
-	basePath?: string;
 	disableDefaultFetchPlugins?: boolean;
 }
 

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -19,15 +19,7 @@ import type { Logger } from "../utils";
 import type { AuthMiddleware } from "../plugins";
 import type { LiteralUnion, OmitId } from "./helper";
 
-export type BetterAuthOptions = {
-	/**
-	 * The name of the application
-	 *
-	 * process.env.APP_NAME
-	 *
-	 * @default "Better Auth"
-	 */
-	appName?: string;
+export type BetterAuthSharedOptions = {
 	/**
 	 * Base URL for the better auth. This is typically the
 	 * root URL where your application server is hosted.
@@ -47,6 +39,17 @@ export type BetterAuthOptions = {
 	 * @default "/api/auth"
 	 */
 	basePath?: string;
+};
+
+export type BetterAuthOptions = BetterAuthSharedOptions & {
+	/**
+	 * The name of the application
+	 *
+	 * process.env.APP_NAME
+	 *
+	 * @default "Better Auth"
+	 */
+	appName?: string;
 	/**
 	 * The secret to use for encryption,
 	 * signing and hashing.


### PR DESCRIPTION
This is a small quality of life change to provide a type that is exclusively for configuration options that are shared between better-auth and the better-auth client