### PR TITLE
feat: add customRole support to access and organization plugins

### DIFF
--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -16,6 +16,7 @@ export function role<TStatements extends Statements>(statements: TStatements) {
 							connector: "OR" | "AND";
 					  };
 			},
+			customRole: string,
 			connector: "OR" | "AND" = "AND",
 		): AuthortizeResponse {
 			let success = false;

--- a/packages/better-auth/src/plugins/access/types.ts
+++ b/packages/better-auth/src/plugins/access/types.ts
@@ -22,6 +22,6 @@ export type AccessControl<TStatements extends Statements = Statements> =
 	ReturnType<typeof createAccessControl<TStatements>>;
 
 export type Role<TStatements extends Statements = Record<string, any>> = {
-	authorize: (request: any, connector?: "OR" | "AND") => AuthortizeResponse;
+	authorize: (request: any, customRole?: string, connector?: "OR" | "AND") => AuthortizeResponse;
 	statements: TStatements;
 };

--- a/packages/better-auth/src/plugins/access/types.ts
+++ b/packages/better-auth/src/plugins/access/types.ts
@@ -22,6 +22,6 @@ export type AccessControl<TStatements extends Statements = Statements> =
 	ReturnType<typeof createAccessControl<TStatements>>;
 
 export type Role<TStatements extends Statements = Record<string, any>> = {
-	authorize: (request: any, customRole?: string, connector?: "OR" | "AND") => AuthortizeResponse;
+	authorize: (request: any, customRole: string, connector?: "OR" | "AND") => AuthortizeResponse;
 	statements: TStatements;
 };

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -264,6 +264,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canSetRole = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: ctx.context.session.user.role,
+						customRole: ctx.context.session.user.customRole,
 						options: opts,
 						permission: {
 							user: ["set-role"],
@@ -361,7 +362,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					},
 				},
 				async (ctx) => {
-					const session = await getSessionFromCtx<{ role: string }>(ctx);
+					const session = await getSessionFromCtx<{ role: string, customRole: string }>(ctx);
 					if (!session && (ctx.request || ctx.headers)) {
 						throw ctx.error("UNAUTHORIZED");
 					}
@@ -369,6 +370,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 						const canCreateUser = hasPermission({
 							userId: session.user.id,
 							role: session.user.role,
+							customRole: session.user.customRole,
 							options: opts,
 							permission: {
 								user: ["create"],
@@ -527,6 +529,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canListUsers = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
+						customRole: session.user.customRole,
 						options: opts,
 						permission: {
 							user: ["list"],
@@ -628,6 +631,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canListSessions = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
+						customRole: session.user.customRole,
 						options: opts,
 						permission: {
 							session: ["list"],
@@ -688,6 +692,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canBanUser = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
+						customRole: session.user.customRole,
 						options: opts,
 						permission: {
 							user: ["ban"],
@@ -768,6 +773,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canBanUser = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
+						customRole: session.user.customRole,
 						options: opts,
 						permission: {
 							user: ["ban"],
@@ -847,6 +853,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canImpersonateUser = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: ctx.context.session.user.role,
+						customRole: ctx.context.session.user.customRole,
 						options: opts,
 						permission: {
 							user: ["impersonate"],
@@ -997,6 +1004,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canRevokeSession = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
+						customRole: session.user.customRole,
 						options: opts,
 						permission: {
 							session: ["revoke"],
@@ -1057,6 +1065,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canRevokeSession = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
+						customRole: session.user.customRole,
 						options: opts,
 						permission: {
 							session: ["revoke"],
@@ -1116,6 +1125,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canDeleteUser = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: session.user.role,
+						customRole: session.user.customRole,
 						options: opts,
 						permission: {
 							user: ["delete"],
@@ -1174,6 +1184,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const canSetUserPassword = hasPermission({
 						userId: ctx.context.session.user.id,
 						role: ctx.context.session.user.role,
+						customRole: ctx.context.session.user.customRole,
 						options: opts,
 						permission: {
 							user: ["set-password"],
@@ -1283,7 +1294,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 						session?.user ||
 						((await ctx.context.internalAdapter.findUserById(
 							ctx.body.userId as string,
-						)) as { role?: string; id: string }) ||
+						)) as { role?: string; id: string, customRole?: string }) ||
 						(ctx.body.role ? { id: "", role: ctx.body.role } : null);
 					if (!user) {
 						throw new APIError("BAD_REQUEST", {
@@ -1295,6 +1306,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 						role: user.role,
 						options: options as AdminOptions,
 						permission: ctx.body.permission as any,
+						customRole: user.customRole,
 					});
 					return ctx.json({
 						error: null,

--- a/packages/better-auth/src/plugins/admin/client.ts
+++ b/packages/better-auth/src/plugins/admin/client.ts
@@ -46,6 +46,7 @@ export const adminClient = <O extends AdminClientOptions>(options?: O) => {
 						: "admin" | "user",
 				>(data: {
 					role: R;
+					customRole?: string;
 					permission: {
 						//@ts-expect-error fix this later
 						[key in keyof Statements]?: Statements[key][number][];
@@ -58,6 +59,7 @@ export const adminClient = <O extends AdminClientOptions>(options?: O) => {
 					}
 					const isAuthorized = hasPermission({
 						role: data.role as string,
+						customRole: data.role as string,
 						options: {
 							ac: options?.ac,
 							roles: roles,

--- a/packages/better-auth/src/plugins/admin/client.ts
+++ b/packages/better-auth/src/plugins/admin/client.ts
@@ -59,7 +59,7 @@ export const adminClient = <O extends AdminClientOptions>(options?: O) => {
 					}
 					const isAuthorized = hasPermission({
 						role: data.role as string,
-						customRole: data.role as string,
+						customRole: data.customRole as string,
 						options: {
 							ac: options?.ac,
 							roles: roles,

--- a/packages/better-auth/src/plugins/admin/has-permission.ts
+++ b/packages/better-auth/src/plugins/admin/has-permission.ts
@@ -5,6 +5,7 @@ export const hasPermission = (input: {
 	userId?: string;
 	role?: string;
 	options?: AdminOptions;
+	customRole?: string;
 	permission: {
 		[key: string]: string[];
 	};
@@ -16,7 +17,7 @@ export const hasPermission = (input: {
 	const acRoles = input.options?.roles || defaultRoles;
 	for (const role of roles) {
 		const _role = acRoles[role as keyof typeof acRoles];
-		const result = _role?.authorize(input.permission);
+		const result = _role?.authorize(input.permission, input.customRole || "");
 		if (result?.success) {
 			return true;
 		}

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -88,6 +88,7 @@ export const organizationClient = <O extends OrganizationClientOptions>(
 						: "admin" | "member" | "owner",
 				>(data: {
 					role: R;
+					customRole?: string;
 					permission: {
 						//@ts-expect-error fix this later
 						[key in keyof Statements]?: Statements[key][number][];
@@ -100,6 +101,7 @@ export const organizationClient = <O extends OrganizationClientOptions>(
 					}
 					const isAuthorized = hasPermission({
 						role: data.role as string,
+						customRole: data.role as string,
 						options: {
 							ac: options?.ac,
 							roles: roles,

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -101,7 +101,7 @@ export const organizationClient = <O extends OrganizationClientOptions>(
 					}
 					const isAuthorized = hasPermission({
 						role: data.role as string,
-						customRole: data.role as string,
+						customRole: data.customRole as string,
 						options: {
 							ac: options?.ac,
 							roles: roles,

--- a/packages/better-auth/src/plugins/organization/has-permission.ts
+++ b/packages/better-auth/src/plugins/organization/has-permission.ts
@@ -3,6 +3,7 @@ import type { OrganizationOptions } from "./organization";
 
 export const hasPermission = (input: {
 	role: string;
+	customRole?: string;
 	options: OrganizationOptions;
 	permission: {
 		[key: string]: string[];
@@ -12,7 +13,7 @@ export const hasPermission = (input: {
 	const acRoles = input.options.roles || defaultRoles;
 	for (const role of roles) {
 		const _role = acRoles[role as keyof typeof acRoles];
-		const result = _role?.authorize(input.permission);
+		const result = _role?.authorize(input.permission, input.customRole || '');
 		if (result?.success) {
 			return true;
 		}

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -527,6 +527,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 					}
 					const result = hasPermission({
 						role: member.role,
+						customRole: member.customRole,
 						options: options as OrganizationOptions,
 						permission: ctx.body.permission as any,
 					});

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -152,6 +152,7 @@ export const createInvitation = <O extends OrganizationOptions | undefined>(
 			}
 			const canInvite = hasPermission({
 				role: member.role,
+				customRole: member.customRole,
 				options: ctx.context.orgOptions,
 				permission: {
 					invitation: ["create"],
@@ -488,6 +489,7 @@ export const cancelInvitation = createAuthEndpoint(
 		}
 		const canCancel = hasPermission({
 			role: member.role,
+			customRole: member.customRole,
 			options: ctx.context.orgOptions,
 			permission: {
 				invitation: ["cancel"],

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -243,7 +243,7 @@ export const removeMember = createAuthEndpoint(
 		}
 		const canDeleteMember = hasPermission({
 			role: member.role,
-			customRole: member.role,
+			customRole: member.customRole,
 			options: ctx.context.orgOptions,
 			permission: {
 				member: ["delete"],
@@ -399,7 +399,7 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 
 			const canUpdateMember = hasPermission({
 				role: member.role,
-				customRole: member.role,
+				customRole: member.customRole,
 				options: ctx.context.orgOptions,
 				permission: {
 					member: ["update"],

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -243,6 +243,7 @@ export const removeMember = createAuthEndpoint(
 		}
 		const canDeleteMember = hasPermission({
 			role: member.role,
+			customRole: member.role,
 			options: ctx.context.orgOptions,
 			permission: {
 				member: ["delete"],
@@ -398,6 +399,7 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 
 			const canUpdateMember = hasPermission({
 				role: member.role,
+				customRole: member.role,
 				options: ctx.context.orgOptions,
 				permission: {
 					member: ["update"],

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -325,7 +325,7 @@ export const updateOrganization = createAuthEndpoint(
 				organization: ["update"],
 			},
 			role: member.role,
-			customRole: member.role,
+			customRole: member.customRole,
 			options: ctx.context.orgOptions,
 		});
 		if (!canUpdateOrg) {
@@ -404,7 +404,7 @@ export const deleteOrganization = createAuthEndpoint(
 		}
 		const canDeleteOrg = hasPermission({
 			role: member.role,
-			customRole: member.role,
+			customRole: member.customRole,
 			permission: {
 				organization: ["delete"],
 			},

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -325,6 +325,7 @@ export const updateOrganization = createAuthEndpoint(
 				organization: ["update"],
 			},
 			role: member.role,
+			customRole: member.role,
 			options: ctx.context.orgOptions,
 		});
 		if (!canUpdateOrg) {
@@ -403,6 +404,7 @@ export const deleteOrganization = createAuthEndpoint(
 		}
 		const canDeleteOrg = hasPermission({
 			role: member.role,
+			customRole: member.role,
 			permission: {
 				organization: ["delete"],
 			},

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -98,6 +98,7 @@ export const createTeam = <O extends OrganizationOptions | undefined>(
 				}
 				const canCreate = hasPermission({
 					role: member.role,
+					customRole: member.customRole,
 					options: ctx.context.orgOptions,
 					permission: {
 						team: ["create"],
@@ -207,6 +208,7 @@ export const removeTeam = createAuthEndpoint(
 
 			const canRemove = hasPermission({
 				role: member.role,
+				customRole: member.customRole,
 				options: ctx.context.orgOptions,
 				permission: {
 					team: ["delete"],
@@ -328,6 +330,7 @@ export const updateTeam = createAuthEndpoint(
 
 		const canUpdate = hasPermission({
 			role: member.role,
+			customRole: member.customRole,
 			options: ctx.context.orgOptions,
 			permission: {
 				team: ["update"],

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -3,6 +3,7 @@ import { generateId } from "../../utils";
 import type { OrganizationOptions } from "./organization";
 
 export const role = z.string();
+export const customRole = z.string().optional();
 export const invitationStatus = z
 	.enum(["pending", "accepted", "rejected", "canceled"])
 	.default("pending");
@@ -25,6 +26,7 @@ export const memberSchema = z.object({
 	organizationId: z.string(),
 	userId: z.coerce.string(),
 	role,
+	customRole,
 	createdAt: z.date().default(() => new Date()),
 	teamId: z.string().optional(),
 });
@@ -34,6 +36,7 @@ export const invitationSchema = z.object({
 	organizationId: z.string(),
 	email: z.string(),
 	role,
+	customRole,
 	status: invitationStatus,
 	teamId: z.string().optional(),
 	inviterId: z.string(),


### PR DESCRIPTION
I'm trying to come up with a custom role structure. I think this will work. With the existing better auth role we need to check within our own role structure authorize.


This structure did not work properly. Please help me ! 