### PR TITLE
docs: update getSessionCookie description

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -140,11 +140,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSessionCookie } from "better-auth/cookies";
 
 export async function middleware(request: NextRequest) {
-	const sessionCookie = getSessionCookie(request, {
-        // Optionally pass config if cookie name or prefix is customized in auth config.
-		cookieName: "session_token",
-		cookiePrefix: "better-auth"
-    });
+	const sessionCookie = getSessionCookie(request);
 
 	if (!sessionCookie) {
 		return NextResponse.redirect(new URL("/", request.url));
@@ -157,6 +153,27 @@ export const config = {
 	matcher: ["/dashboard"], // Specify the routes the middleware applies to
 };
 ```
+
+**getSessionCookie options**
+
+Optionally pass a `config` object as the second parameter to override the default cookie name or prefix, only if they were customized in your auth config's `advanced` options.
+
+<TypeTable
+  type={{
+    cookiePrefix: {
+        description: "Overrides default cookie prefix (configured in auth config's `advanced` options).",
+        type: "string",
+        default: "better-auth",
+    },
+    cookieName: {
+        description: "Overrides default session_token cookie name (configured in auth config's `advanced` options).",
+        type: "string",
+        default: "session_token",
+    }
+  }}
+/>
+
+Read more about [cookies](/docs/concepts/cookies)
 
 ### For Next.js release `15.1.7` and below
 

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -9,7 +9,6 @@ import { base64Url } from "@better-auth/utils/base64";
 import { createTime } from "../utils/time";
 import { createHMAC } from "@better-auth/utils/hmac";
 import { safeJSONParse } from "../utils/json";
-import { getBaseURL } from "../utils/url";
 
 export function createCookieGetter(options: BetterAuthOptions) {
 	const secure =
@@ -239,7 +238,6 @@ export const getSessionCookie = (
 	config?: {
 		cookiePrefix?: string;
 		cookieName?: string;
-		path?: string;
 	},
 ) => {
 	if (config?.cookiePrefix) {
@@ -250,8 +248,6 @@ export const getSessionCookie = (
 		}
 	}
 	const headers = "headers" in request ? request.headers : request;
-	const req = request instanceof Request ? request : undefined;
-	const url = getBaseURL(req?.url, config?.path, req);
 	const cookies = headers.get("cookie");
 	if (!cookies) {
 		return null;


### PR DESCRIPTION
Adds an options table to the getSessionCookie docs. To point it more out that the config object is optional and only needed when auth config cookies are customized https://github.com/better-auth/better-auth/issues/2233


Also removed unused stuff inside getSessionCookie fn