### PR TITLE
feat(admin/organization): add ability to return missing perms

### DIFF
--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -428,6 +428,16 @@ const canCreateProjectAndCreateSale = await authClient.admin.hasPermission({
     sale: ["create"]
   },
 });
+
+// `hasPermission` can also return missing permissions
+const canCreateProjectAndCreateSaleWithMissingPerms = await authClient.admin.hasPermission({
+  permissions: {
+    project: ["create"],
+    sale: ["create"]
+  },
+  returnMissingPermissions: true
+});
+// ^ { success: boolean; missingPermissions: { [key: string]: string[] } | null }
 ```
 
 If you want to check a user's permissions server-side, you can use the `userHasPermission` action provided by the `api` to check the user's permissions.
@@ -446,7 +456,7 @@ auth.api.userHasPermission({
 // You can also just pass the role directly
 auth.api.userHasPermission({
   body: {
-   role: "admin",
+    role: "admin",
     permissions: {
       project: ["create"], // This must match the structure in your access control
     },
@@ -456,13 +466,26 @@ auth.api.userHasPermission({
 // You can also check multiple resource permissions at the same time
 auth.api.userHasPermission({
   body: {
-   role: "admin",
+    role: "admin",
     permissions: {
       project: ["create"], // This must match the structure in your access control
       sale: ["create"]
     },
   },
 });
+
+// `userHasPermission` can also return missing permissions
+auth.api.userHasPermission({
+  body: {
+    role: "admin",
+    permissions: {
+      project: ["create"], // This must match the structure in your access control
+      sale: ["create"]
+    },
+    returnMissingPermissions: true
+  },
+});
+// ^ { success: boolean; missingPermissions: { [key: string]: string[] } | null }
 ```
 
 
@@ -486,6 +509,17 @@ const canCreateProjectAndRevokeSession = client.admin.checkRolePermission({
   },
   role: "admin",
 });
+
+// `checkRolePermission` can also return missing permissions
+const canCreateProjectAndRevokeSessionWithMissingPerms = client.admin.checkRolePermission({
+  permissions: {
+    user: ["delete"],
+    session: ["revoke"]
+  },
+  returnMissingPermissions: true
+  role: "admin",
+});
+// ^ { success: boolean; missingPermissions: { [key: string]: string[] } | null }
 ```
 
 ## Schema

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -819,6 +819,19 @@ auth.api.hasPermission({
       }
     }
 });
+
+// `hasPermission` can also return missing permissions
+auth.api.hasPermission({
+  headers: await headers(),
+    body: {
+      permissions: {
+        project: ["create"], // This must match the structure in your access control
+        sale: ["create"]
+      },
+      returnMissingPermissions: true
+    }
+});
+// ^ { success: boolean; missingPermissions: { [key: string]: string[] } | null }
 ```
 
 If you want to check the permission of the user on the client from the server you can use the `hasPermission` function provided by the client.
@@ -837,6 +850,16 @@ const canCreateProjectAndCreateSale = await authClient.organization.hasPermissio
         sale: ["create"]
     }
 })
+
+// `hasPermission` can also return missing permissions
+const canCreateProjectAndCreateSaleWithMissingPerms = await authClient.organization.hasPermission({
+    permissions: {
+        project: ["create"],
+        sale: ["create"]
+    },
+    returnMissingPermissions: true
+})
+// ^ { success: boolean; missingPermissions: { [key: string]: string[] } | null }
 ```
 
 **Check Role Permission**:
@@ -859,6 +882,17 @@ const canCreateProjectAndCreateSale = client.organization.checkRolePermission({
 	},
 	role: "admin",
 });
+
+// `checkRolePermission` can also return missing permissions
+const canCreateProjectAndCreateSaleWithMissingPerms = client.organization.checkRolePermission({
+	permissions: {
+		organization: ["delete"],
+    member: ["delete"]
+	},
+	role: "admin",
+  returnMissingPermissions: true
+})
+// ^ { success: boolean; missingPermissions: { [key: string]: string[] } | null }
 ```
 
 ## Teams

--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -62,6 +62,24 @@ describe("access", () => {
 		expect(response.success).toBe(true);
 	});
 
+	it("should return missing permissions if success is false", () => {
+		const response = role1.authorize({
+			project: ["create", "delete"],
+			ui: ["view", "edit"],
+		});
+		expect(response.success).toBe(true);
+		expect(response.missingPermissions).toBeUndefined();
+
+		const failedResponse = role1.authorize({
+			project: ["create", "delete-many"],
+			ui: ["view", "edit"],
+		});
+		expect(failedResponse.success).toBe(false);
+		expect(failedResponse.missingPermissions).toEqual({
+			project: ["delete-many"],
+		});
+	});
+
 	it("should validate using or connector for a specific resource", () => {
 		const response = role1.authorize({
 			project: {

--- a/packages/better-auth/src/plugins/access/types.ts
+++ b/packages/better-auth/src/plugins/access/types.ts
@@ -1,5 +1,5 @@
 import type { LiteralString } from "../../types/helper";
-import type { AuthortizeResponse, createAccessControl } from "./access";
+import type { AuthorizeResponse, createAccessControl } from "./access";
 
 export type SubArray<T extends unknown[] | readonly unknown[] | any[]> =
 	T[number][];
@@ -21,7 +21,18 @@ export type Statements = {
 export type AccessControl<TStatements extends Statements = Statements> =
 	ReturnType<typeof createAccessControl<TStatements>>;
 
-export type Role<TStatements extends Statements = Record<string, any>> = {
-	authorize: (request: any, connector?: "OR" | "AND") => AuthortizeResponse;
+export type ResourceRequest<TActionType> =
+	| TActionType
+	| { actions: TActionType; connector: "OR" | "AND" };
+
+export type AuthorizeRequest<TStatements extends Statements> = {
+	[P in keyof TStatements]?: ResourceRequest<TStatements[P]>;
+};
+
+export type Role<TStatements extends Statements = Statements> = {
+	authorize: (
+		request: AuthorizeRequest<TStatements>,
+		connector?: "OR" | "AND",
+	) => AuthorizeResponse<typeof request>;
 	statements: TStatements;
 };

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -724,6 +724,20 @@ describe("access control", async (it) => {
 		});
 		expect(canCreateOrderAndReadUser).toBe(true);
 
+		const canCreateOrderAndReadUserWithMissingPerms =
+			client.admin.checkRolePermission({
+				role: "admin",
+				permissions: {
+					order: ["create"],
+					user: ["read"],
+				},
+				returnMissingPermissions: true,
+			});
+		expect(canCreateOrderAndReadUserWithMissingPerms.success).toBe(true);
+		expect(
+			canCreateOrderAndReadUserWithMissingPerms.missingPermissions,
+		).toBeNull();
+
 		const canCreateUser = client.admin.checkRolePermission({
 			role: "user",
 			permissions: {
@@ -740,6 +754,23 @@ describe("access control", async (it) => {
 			},
 		});
 		expect(canCreateOrderAndCreateUser).toBe(false);
+
+		const canCreateOrderAndCreateUserWithMissingPerms =
+			client.admin.checkRolePermission({
+				role: "user",
+				permissions: {
+					order: ["create"],
+					user: ["create"],
+				},
+				returnMissingPermissions: true,
+			});
+		expect(canCreateOrderAndCreateUserWithMissingPerms.success).toBe(false);
+		expect(
+			canCreateOrderAndCreateUserWithMissingPerms.missingPermissions,
+		).toEqual({
+			order: ["create"],
+			user: ["create"],
+		});
 	});
 
 	it("should validate using userId", async () => {
@@ -764,6 +795,22 @@ describe("access control", async (it) => {
 		});
 		expect(canCreateUserAndCreateOrder.success).toBe(true);
 
+		const canCreateUserAndCreateOrderWithMissingPerms =
+			await auth.api.userHasPermission({
+				body: {
+					userId: user.id,
+					permissions: {
+						user: ["create"],
+						order: ["create"],
+					},
+					returnMissingPermissions: true,
+				},
+			});
+		expect(canCreateUserAndCreateOrderWithMissingPerms.success).toBe(true);
+		expect(
+			canCreateUserAndCreateOrderWithMissingPerms.missingPermissions,
+		).toBeNull();
+
 		const canUpdateManyOrder = await auth.api.userHasPermission({
 			body: {
 				userId: user.id,
@@ -785,6 +832,27 @@ describe("access control", async (it) => {
 				},
 			});
 		expect(canUpdateManyOrderAndBulkDeleteUser.success).toBe(false);
+
+		const canUpdateManyOrderAndBulkDeleteUserWithMissingPerms =
+			await auth.api.userHasPermission({
+				body: {
+					userId: user.id,
+					permissions: {
+						user: ["bulk-delete"],
+						order: ["update-many"],
+					},
+					returnMissingPermissions: true,
+				},
+			});
+		expect(canUpdateManyOrderAndBulkDeleteUserWithMissingPerms.success).toBe(
+			false,
+		);
+		expect(
+			canUpdateManyOrderAndBulkDeleteUserWithMissingPerms.missingPermissions,
+		).toEqual({
+			user: ["bulk-delete"],
+			order: ["update-many"],
+		});
 	});
 
 	it("should validate using role", async () => {

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1290,7 +1290,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 														type: "boolean",
 													},
 													missingPermissions: {
-														type: "object",
+														type: ["object", "null"],
 													},
 												},
 												required: ["success"],

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1354,7 +1354,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 						missingPermissions: MissingPermissions<any> | null;
 					};
 					if (typeof result === "object")
-						ctxRes.missingPermissions = result.missingPermissions ?? null;
+						ctxRes.missingPermissions = result.missingPermissions;
 
 					return ctx.json(ctxRes);
 				},

--- a/packages/better-auth/src/plugins/admin/has-permission.ts
+++ b/packages/better-auth/src/plugins/admin/has-permission.ts
@@ -1,16 +1,18 @@
+import type { AuthorizeRequest, Statements } from "../access/types";
 import { defaultRoles } from "./access";
 import type { AdminOptions } from "./admin";
 
+type PermissionInput = AuthorizeRequest<Statements>;
 type PermissionExclusive =
 	| {
 			/**
 			 * @deprecated Use `permissions` instead
 			 */
-			permission: { [key: string]: string[] };
+			permission: PermissionInput;
 			permissions?: never;
 	  }
 	| {
-			permissions: { [key: string]: string[] };
+			permissions: PermissionInput;
 			permission?: never;
 	  };
 
@@ -19,22 +21,30 @@ export const hasPermission = (
 		userId?: string;
 		role?: string;
 		options?: AdminOptions;
+		returnMissingPermissions?: boolean;
 	} & PermissionExclusive,
 ) => {
 	if (input.userId && input.options?.adminUserIds?.includes(input.userId)) {
 		return true;
 	}
-	if (!input.permissions && !input.permission) {
+	const permissionsToAuthorize = input.permissions ?? input.permission;
+	if (!permissionsToAuthorize) {
 		return false;
 	}
 	const roles = (input.role || input.options?.defaultRole || "user").split(",");
 	const acRoles = input.options?.roles || defaultRoles;
 	for (const role of roles) {
 		const _role = acRoles[role as keyof typeof acRoles];
-		const result = _role?.authorize(input.permission ?? input.permissions);
-		if (result?.success) {
-			return true;
+		const result = _role?.authorize(permissionsToAuthorize);
+		if (input.returnMissingPermissions) {
+			return {
+				success: result?.success,
+				missingPermissions: result?.missingPermissions ?? null,
+			};
 		}
+
+		return result?.success ?? false;
 	}
+
 	return false;
 };

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -112,7 +112,7 @@ export const organizationClient = <O extends OrganizationClientOptions>(
 				checkRolePermission: <
 					R extends O extends { roles: any }
 						? keyof O["roles"]
-						: "admin" | "user",
+						: "admin" | "member" | "owner",
 					T extends boolean | undefined = false,
 				>(
 					data: PermissionExclusive & {

--- a/packages/better-auth/src/plugins/organization/has-permission.ts
+++ b/packages/better-auth/src/plugins/organization/has-permission.ts
@@ -18,6 +18,7 @@ export const hasPermission = (
 	input: {
 		role: string;
 		options: OrganizationOptions;
+		returnMissingPermissions?: boolean;
 	} & PermissionExclusive,
 ) => {
 	if (!input.permissions && !input.permission) {
@@ -28,9 +29,15 @@ export const hasPermission = (
 	for (const role of roles) {
 		const _role = acRoles[role as keyof typeof acRoles];
 		const result = _role?.authorize(input.permissions ?? input.permission);
-		if (result?.success) {
-			return true;
+		if (input.returnMissingPermissions) {
+			return {
+				success: result?.success,
+				missingPermissions: result?.missingPermissions ?? null,
+			};
 		}
+
+		return result?.success ?? false;
 	}
+
 	return false;
 };

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -518,6 +518,22 @@ describe("organization", async (it) => {
 			},
 		});
 		expect(hasMultiplePermissions.data?.success).toBe(true);
+
+		const hasMultiplePermissionsWithMissingPerms =
+			await client.organization.hasPermission({
+				permissions: {
+					member: ["update"],
+					invitation: ["create"],
+				},
+				returnMissingPermissions: true,
+				fetchOptions: {
+					headers,
+				},
+			});
+		expect(hasMultiplePermissionsWithMissingPerms.data?.success).toBe(true);
+		expect(
+			hasMultiplePermissionsWithMissingPerms.data?.missingPermissions,
+		).toBeNull();
 	});
 
 	it("should allow deleting organization", async () => {

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -545,7 +545,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 														type: "boolean",
 													},
 													missingPermissions: {
-														type: "object",
+														type: ["object", "null"],
 													},
 												},
 												required: ["success"],

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -592,7 +592,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 						missingPermissions: MissingPermissions<any> | null;
 					};
 					if (typeof result === "object")
-						ctxRes.missingPermissions = result.missingPermissions ?? null;
+						ctxRes.missingPermissions = result.missingPermissions;
 
 					return ctx.json(ctxRes);
 				},


### PR DESCRIPTION
need some opinion about it

that would be a great feature for developers that wanna return the missing permissions or just see in the code themselves

all tests (existing & new ones) **pass** after modifying `authorize` fn