### PR TITLE
fix(drizzle-adapter): correct count retrieval in the update function

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -269,7 +269,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) =>
 						.select({ count: count() })
 						.from(schemaModel)
 						.where(...clause);
-					return res.count;
+					return res[0].count;
 				},
 				async update({ model, where, update: values }) {
 					const schemaModel = getSchema(model);


### PR DESCRIPTION
fix drizzle adapter count `undefined`

reference: #1737

close: #1993