### PR TITLE
Correct Svelte Kit to SvelteKit

### DIFF
--- a/docs/components/builder/index.tsx
+++ b/docs/components/builder/index.tsx
@@ -69,7 +69,7 @@ const frameworks = [
 		),
 	},
 	{
-		title: "Svelte Kit",
+		title: "SvelteKit",
 		description: "Web development for the rest of us",
 		Icon: () => (
 			<svg

--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1065,7 +1065,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				href: "/docs/integrations/nuxt",
 			},
 			{
-				title: "Svelte Kit",
+				title: "SvelteKit",
 				icon: Icons.svelteKit,
 				href: "/docs/integrations/svelte-kit",
 			},
@@ -1821,7 +1821,7 @@ export const examples: Content[] = [
 				icon: Icons.nuxt,
 			},
 			{
-				title: "Svelte Kit",
+				title: "SvelteKit",
 				href: "/docs/examples/svelte-kit",
 				icon: Icons.svelteKit,
 			},

--- a/docs/components/techstack-icons.tsx
+++ b/docs/components/techstack-icons.tsx
@@ -15,7 +15,7 @@ export const techStackIcons: TechStackIconType = {
 		icon: <Icons.nuxt className="w-10 h-10" />,
 	},
 	svelteKit: {
-		name: "Svelte Kit",
+		name: "SvelteKit",
 		icon: <Icons.svelteKit className="w-10 h-10" />,
 	},
 	solidStart: {

--- a/docs/content/docs/examples/svelte-kit.mdx
+++ b/docs/content/docs/examples/svelte-kit.mdx
@@ -18,7 +18,7 @@ Email & Password . <u>Social Sign-in with Google</u> . Passkeys . Email Verifica
       borderRadius: "4px",
       overflow: "hidden"
    }}
-   title="Better Auth Svlete Kit Example"
+   title="Better Auth SvelteKit Example"
    allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
    sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    >

--- a/examples/svelte-kit-example/README.md
+++ b/examples/svelte-kit-example/README.md
@@ -1,7 +1,7 @@
-# Svelte Kit Better Auth Example
+# SvelteKit Better Auth Example
 
 
-This is an example of how to use Better Auth with Svelte Kit.
+This is an example of how to use Better Auth with SvelteKit.
 
 **Implements the following features:**
 Email & Password . <u>Social Sign-in with Google</u> . Passkeys . Email Verification . Password Reset . Two Factor Authentication . Profile Update . Session Management


### PR DESCRIPTION
Corrected all instances of “Svelte Kit” to “SvelteKit” in documentation for consistency with official branding.
Did not rename svelte-kit to sveltekit in code as it could introduce breaking changes.