### PR TITLE
Fix for #2250 : Checking if User is intended recipient of Invite is casesensetive

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -239,7 +239,7 @@ export const createInvitation = <O extends OrganizationOptions | undefined>(
 			const invitation = await adapter.createInvitation({
 				invitation: {
 					role: roles,
-					email: ctx.body.email,
+					email: ctx.body.email.toLowerCase(),
 					organizationId: organizationId,
 					...("teamId" in ctx.body
 						? {
@@ -420,7 +420,7 @@ export const rejectInvitation = createAuthEndpoint(
 				message: "Invitation not found!",
 			});
 		}
-		if (invitation.email !== session.user.email) {
+		if (invitation.email.toLowerCase() !== session.user.email.toLowerCase()) {
 			throw new APIError("FORBIDDEN", {
 				message:
 					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION,
@@ -598,7 +598,7 @@ export const getInvitation = createAuthEndpoint(
 				message: "Invitation not found!",
 			});
 		}
-		if (invitation.email !== session.user.email) {
+		if (invitation.email.toLowerCase() !== session.user.email.toLowerCase()) {
 			throw new APIError("FORBIDDEN", {
 				message:
 					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION,

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -317,7 +317,7 @@ export const acceptInvitation = createAuthEndpoint(
 				message: ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
 			});
 		}
-		if (invitation.email !== session.user.email) {
+		if (invitation.email.toLowerCase() !== session.user.email.toLowerCase()) {
 			throw new APIError("FORBIDDEN", {
 				message:
 					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION,


### PR DESCRIPTION
This resolves a bug where, while you can use 
Email@example.com to log into the account email@example.com. Inviting Email@example.com would mean they can not accept the invite. 

This is done by using .tolowercase on both emails before comparing them 