### PR TITLE
fix(haveIBeenPwned): Meaningful error code

### DIFF
--- a/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
@@ -22,9 +22,7 @@ describe("have-i-been-pwned", async () => {
 		});
 		expect(result.error).not.toBeNull();
 		expect(result.error?.status).toBe(400);
-		expect(result.error?.code).toBe(
-			"THE_PASSWORD_YOU_ENTERED_HAS_BEEN_COMPROMISED_PLEASE_CHOOSE_A_DIFFERENT_PASSWORD",
-		);
+		expect(result.error?.code).toBe("PASSWORD_COMPROMISED");
 	});
 
 	it("should allow account creation with strong, uncompromised password", async () => {

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -5,7 +5,8 @@ import type { BetterAuthPlugin } from "../../types";
 import { createAuthMiddleware } from "../../api";
 
 const ERROR_CODES = {
-	PASSWORD_COMPROMISED: "Password compromised",
+	PASSWORD_COMPROMISED:
+		"The password you entered has been compromised. Please choose a different password.",
 } as const;
 
 async function checkPasswordCompromise(
@@ -42,10 +43,8 @@ async function checkPasswordCompromise(
 
 		if (found) {
 			throw new APIError("BAD_REQUEST", {
-				message:
-					customMessage ||
-					"The password you entered has been compromised. Please choose a different password.",
-				code: ERROR_CODES.PASSWORD_COMPROMISED,
+				message: customMessage || ERROR_CODES.PASSWORD_COMPROMISED,
+				code: "PASSWORD_COMPROMISED",
 			});
 		}
 	} catch (error) {

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -5,7 +5,7 @@ import type { BetterAuthPlugin } from "../../types";
 import { createAuthMiddleware } from "../../api";
 
 const ERROR_CODES = {
-	PASSWORD_COMPROMISED: "PASSWORD_COMPROMISED"
+	PASSWORD_COMPROMISED: "Password compromised",
 } as const;
 
 async function checkPasswordCompromise(

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -5,8 +5,7 @@ import type { BetterAuthPlugin } from "../../types";
 import { createAuthMiddleware } from "../../api";
 
 const ERROR_CODES = {
-	PASSWORD_COMPROMISED:
-		"THE_PASSWORD_YOU_ENTERED_HAS_BEEN_COMPROMISED_PLEASE_CHOOSE_A_DIFFERENT_PASSWORD",
+	PASSWORD_COMPROMISED: "PASSWORD_COMPROMISED"
 } as const;
 
 async function checkPasswordCompromise(


### PR DESCRIPTION
In my humble opinion, `THE_PASSWORD_YOU_ENTERED_HAS_BEEN_COMPROMISED_PLEASE_CHOOSE_A_DIFFERENT_PASSWORD` is **not** a valid error code.

Error codes should be short and are not required the be understand by an end user.

This MR changes the error code to `PASSWORD_COMPROMISED`.