### PR TITLE
Fix code blocks in "Passkey"

### DIFF
--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -72,16 +72,16 @@ The passkey plugin implementation is powered by [simple-web-authn](https://simpl
     <Step>
         ### Add the client plugin
 
-         ```ts title="auth-client.ts"
-            import { createAuthClient } from "better-auth/client"
-            import { passkeyClient } from "better-auth/client/plugins"
+        ```ts title="auth-client.ts"
+        import { createAuthClient } from "better-auth/client"
+        import { passkeyClient } from "better-auth/client/plugins"
 
-            const authClient =  createAuthClient({
-                plugins: [ // [!code highlight]
-                    passkeyClient() // [!code highlight]
-                ] // [!code highlight]
-            })
-            ```
+        const authClient =  createAuthClient({
+            plugins: [ // [!code highlight]
+                passkeyClient() // [!code highlight]
+            ] // [!code highlight]
+        })
+        ```
     </Step>
 
 </Steps>
@@ -93,16 +93,6 @@ The passkey plugin implementation is powered by [simple-web-authn](https://simpl
 To add or register a passkey make sure a user is authenticated and then call the `passkey.addPasskey` function provided by the client.
 
 ```ts title="auth-client.ts"
-import { createAuthClient } from "better-auth/client";
-import { passkeyClient } from "better-auth/client/plugins";
-
-const authClient = createAuthClient({
-  plugins: [
-    // [!code highlight]
-    passkeyClient(), // [!code highlight]
-  ], // [!code highlight]
-});
-
 // Default behavior allows both platform and cross-platform passkeys
 const { data, error } = await authClient.passkey.addPasskey();
 ```
@@ -130,15 +120,6 @@ Signin method accepts:
 `callbackURL`: The URL to redirect to after the user has signed in. (optional)
 
 ```ts title="auth-client.ts"
-import { createAuthClient } from "better-auth/client";
-import { passkeyClient } from "better-auth/client/plugins";
-
-const authClient = createAuthClient({
-  plugins: [
-    // [!code highlight]
-    passkeyClient(), // [!code highlight]
-  ], // [!code highlight]
-});
 const data = await authClient.signIn.passkey();
 ```
 

--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -92,7 +92,7 @@ The passkey plugin implementation is powered by [simple-web-authn](https://simpl
 
 To add or register a passkey make sure a user is authenticated and then call the `passkey.addPasskey` function provided by the client.
 
-```ts title="auth-client.ts"
+```ts
 // Default behavior allows both platform and cross-platform passkeys
 const { data, error } = await authClient.passkey.addPasskey();
 ```
@@ -101,7 +101,7 @@ This will prompt the user to register a passkey. And it'll add the passkey to th
 
 You can also specify the type of authenticator you want to register. The authenticatorAttachment can be either `platform` or `cross-platform`.
 
-```ts title="auth-client.ts"
+```ts
 // Register a cross-platform passkey showing only a QR code
 // for the user to scan as well as the option to plug in a security key
 const { data, error } = await authClient.passkey.addPasskey({
@@ -119,7 +119,7 @@ Signin method accepts:
 
 `callbackURL`: The URL to redirect to after the user has signed in. (optional)
 
-```ts title="auth-client.ts"
+```ts
 const data = await authClient.signIn.passkey();
 ```
 


### PR DESCRIPTION
I fixed the indentation in the first code block and removed duplicated code in the last two.

However, the docs don't provide enough info on how and where `addPasskey` and `signIn.passkey` should be used. Currently these code blocks include the title `auth-client.ts`, but I believe this is incorrect.