### PR TITLE
fix(docs): add missing `annualDiscountLookupKey` to plan configuration

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -569,7 +569,9 @@ Each plan can have the following properties:
 
 **lookupKey**: `string` - The Stripe price lookup key. Alternative to `priceId`.
 
-**annualDiscountPriceId**: `string` - A price ID for annual billing with a discount.
+**annualDiscountPriceId**: `string` - A price ID for annual billing.
+
+**annualDiscountLookupKey**: `string` . The Stripe price lookup key for annual billing. Alternative to `annualDiscountPriceId`.
 
 **limits**: `Record<string, number>` - Limits associated with the plan (e.g., `{ projects: 10, storage: 5 }`).
 

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -571,7 +571,7 @@ Each plan can have the following properties:
 
 **annualDiscountPriceId**: `string` - A price ID for annual billing.
 
-**annualDiscountLookupKey**: `string` . The Stripe price lookup key for annual billing. Alternative to `annualDiscountPriceId`.
+**annualDiscountLookupKey**: `string` - The Stripe price lookup key for annual billing. Alternative to `annualDiscountPriceId`.
 
 **limits**: `Record<string, number>` - Limits associated with the plan (e.g., `{ projects: 10, storage: 5 }`).
 


### PR DESCRIPTION
According to https://github.com/better-auth/better-auth/blob/main/packages/stripe/src/types.ts#L30, this key exists.

I also removed the discount wording from the description (without changing the actual key), since it doesn't have to be a discount, but rather a different price created for the yearly billing period. Although since it mostly is cheaper when taking a look at the effective monthly price, it's probably best to keep the key the same. 