### PR TITLE
re-add concurrently dev dependency

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -660,6 +660,7 @@
     "@types/prompts": "^2.4.9",
     "@types/react": "^18.3.14",
     "better-sqlite3": "^11.6.0",
+    "concurrently": "^9.1.2",
     "drizzle-orm": "^0.38.2",
     "happy-dom": "^15.11.7",
     "hono": "^4.6.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1458,6 +1458,9 @@ importers:
       better-sqlite3:
         specifier: ^11.6.0
         version: 11.8.1
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
       drizzle-orm:
         specifier: ^0.38.2
         version: 0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.9)(kysely@0.27.6)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0)
@@ -11158,6 +11161,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.1.2:
+    resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -35597,6 +35605,16 @@ snapshots:
   compute-scroll-into-view@3.1.0: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@9.1.2:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.2
+      shell-quote: 1.8.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   confbox@0.1.8: {}
 


### PR DESCRIPTION
This was fixed [here](https://github.com/better-auth/better-auth/commit/f6cad2b6dbf137fa5fa6cb887780adebcb5be5a0) and regressed [here](https://github.com/better-auth/better-auth/commit/f91270260181f6c0fa226d3cf4b37dbd3f79713b).

Keeping the dependency in the one place it's used (better-auth package) might help avoid accidental removal.

Related to https://github.com/better-auth/better-auth/issues/2024