### PR TITLE
Docs: Delete nonsense word `helo_` from navigation bar

### DIFF
--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -108,10 +108,6 @@ export const Navbar = () => {
 
 export const navMenu = [
 	{
-		name: "helo_",
-		path: "/",
-	},
-	{
 		name: "docs",
 		path: "/docs",
 	},

--- a/docs/components/nav-mobile.tsx
+++ b/docs/components/nav-mobile.tsx
@@ -201,11 +201,6 @@ export const navMenu: {
 	}[];
 }[] = [
 	{
-		name: "_helo",
-		path: "/",
-	},
-
-	{
 		name: "docs",
 		path: "/docs",
 	},


### PR DESCRIPTION
Currently the website uses the nonsense word `helo_` (or `_helo` on mobile) to navigate to the root page. This is redundant, since clicking on the Better Auth logo also navigates to the root page. It also doesn't make sense to use a nonsense word for this.