### PR TITLE
feat(oidc-provider): Add a token introspection endpoint

### DIFF
--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -124,6 +124,25 @@ The UserInfo endpoint returns different claims based on the scopes that were gra
 
 The `getAdditionalUserInfoClaim` function receives the user object and the requested scopes array, allowing you to conditionally include claims based on the scopes granted during authorization. These additional claims will be included in both the UserInfo endpoint response and the ID token.
 
+### Introspection Endpoint
+
+The OIDC provider contains an [RFC7662](https://datatracker.ietf.org/doc/html/rfc7662) compliant endpoint to introspect a token. It can be used to determine if a token is active or not. Both access and refresh token can be intropsected.
+
+<Endpoint path="/oauth2/introspection" method="POST" />
+```ts title="api-app.ts"
+// Example of how an API call would use the introspection endpoint
+const response = await fetch('https://your-domain.com/api/auth/oauth2/introspection', {
+  headers: {
+    'Authorization': 'Basic BASE64_CLIENT_ID_CLIENT_SECRET'
+  }
+});
+
+const introspection = await response.json();
+const active = introspection.active
+```
+
+If the token is inactive, only the `active` properties is returned. The other ones such as, `scope`, `client_id`, etc. are ommited.
+
 ### Consent Screen
 
 When a user is redirected to the OIDC provider for authentication, they may be prompted to authorize the application to access their data. This is known as the consent screen. By default, Better Auth will display a sample consent screen. You can customize the consent screen by providing a `consentPage` option during initialization.

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -22,6 +22,7 @@ import { authorize } from "./authorize";
 import { parseSetCookieHeader } from "../../cookies";
 import { createHash } from "@better-auth/utils/hash";
 import { base64 } from "@better-auth/utils/base64";
+import { introspection } from "./introspection";
 
 const getMetadata = (
 	ctx: GenericEndpointContext,
@@ -807,6 +808,62 @@ export const oidcProvider = (options: OIDCOptions) => {
 						...userClaims,
 					});
 				},
+			),
+			introspection: createAuthEndpoint(
+				"/oauth2/introspection",
+				{
+					method: "POST",
+					body: z.object({
+						token: z.string(),
+						token_type_hint: z.enum(["access_token", "refresh_token"]).optional(),
+					}),
+					metadata: {
+						openapi: {
+							description: "The token introspection endpoint",
+							responses: {
+								"200": {
+									description: "The token introspection result",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													active: {
+														type: "boolean",
+														description: "Whether or not the token is active"
+													},
+													scope: {
+														type: "string",
+														description: "The token scopes"
+													},
+													client_id: {
+														type: "string",
+														description: "The token client ID"
+													},
+													username: {
+														type: "string",
+														description: "Human friendly user identifier"
+													},
+													token_type: {
+														type: "string",
+														description: "The type of token"
+													},
+													exp: {
+														type: "string",
+														description: "Token expiry timestamp, measured in the number of seconds"
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				async (ctx) => {
+					return introspection(ctx)
+				}
 			),
 			registerOAuthApplication: createAuthEndpoint(
 				"/oauth2/register",

--- a/packages/better-auth/src/plugins/oidc-provider/introspection.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/introspection.ts
@@ -118,12 +118,16 @@ export async function introspection(
         });
     }
 
+    const expiry = token === accessToken.accessToken
+        ? accessToken.accessTokenExpiresAt
+        : accessToken.refreshTokenExpiresAt
+
     return ctx.json({
         active: true,
         scope: accessToken.scopes,
         client_id: accessToken.clientId,
         username: user.name,
         token_type: "Bearer",
-        exp: Math.floor(accessToken.accessTokenExpiresAt.getTime() / 1000),
+        exp: Math.floor(expiry.getTime() / 1000),
     })
 }

--- a/packages/better-auth/src/plugins/oidc-provider/introspection.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/introspection.ts
@@ -1,0 +1,129 @@
+import { base64 } from "@better-auth/utils/base64";
+import { APIError } from "../../api";
+import type { GenericEndpointContext, Where } from "../../types";
+import type { OAuthAccessToken } from "./types";
+
+export async function introspection(
+    ctx: GenericEndpointContext,
+) { 
+    if (!ctx.request) {
+        throw new APIError("UNAUTHORIZED", {
+            error_description: "request not found",
+            error: "invalid_request",
+        });
+    }
+    const authorization = ctx.request.headers.get("authorization");
+    
+    if (
+        !authorization || 
+        !authorization.startsWith("Basic ")
+    ) {
+        throw new APIError("UNAUTHORIZED", {
+            error_description: "invalid or missing authorization header",
+            error: "invalid_request",
+        });
+    }
+
+    let authorizationValue: string | null = null
+    try {
+        const encoded = authorization.replace("Basic ", "");
+        authorizationValue = new TextDecoder().decode(base64.decode(encoded));
+    } catch (e) {
+        throw new APIError("UNAUTHORIZED", {
+            error_description: "invalid authorization header format",
+            error: "invalid_request",
+        });
+    }
+
+    if (!authorizationValue || !authorizationValue.includes(":")) {
+        throw new APIError("UNAUTHORIZED", {
+            error_description: "invalid authorization header format",
+            error: "invalid_request",
+        });
+    }
+    
+    const [id, secret] = authorizationValue.split(":");
+    if (!id || !secret) {
+        throw new APIError("UNAUTHORIZED", {
+            error_description: "invalid authorization header format",
+            error: "invalid_request",
+        });
+    }
+    
+    const client = await ctx.context.adapter
+        .findOne<Record<string, any>>({
+            model: "oauthApplication",
+            where: [{ field: "clientId", value: id.toString() }],
+        })
+    if (!client) {
+        throw new APIError("UNAUTHORIZED", {
+            error_description: "invalid client id",
+            error: "invalid_client",
+        });
+    }
+    if (client.disabled) {
+        throw new APIError("UNAUTHORIZED", {
+            error_description: "client is disabled",
+            error: "invalid_client",
+        });
+    }
+    if (client.clientSecret !== secret.toString()) {
+        throw new APIError("UNAUTHORIZED", {
+            error_description: "invalid client secret",
+            error: "invalid_client",
+        });
+    }
+
+    const { body } = ctx
+    if (!body) {
+        throw new APIError("BAD_REQUEST", {
+            error_description: "request body not found",
+            error: "invalid_request",
+        });
+    }
+    
+    const { token_type_hint, token } = body
+    if (!token) {
+        throw new APIError("BAD_REQUEST", {
+            error_description: "request token not found",
+            error: "invalid_request",
+        });
+    }
+
+    const tokenTypeHintWhere: Where[] = []
+
+    if (token_type_hint === "access_token" || !token_type_hint) {
+        tokenTypeHintWhere.push({ field: "accessToken", value: token, connector: "OR" })
+    }
+    
+    if (token_type_hint === "refresh_token" || !token_type_hint) {
+        tokenTypeHintWhere.push({ field: "refreshToken", value: token, connector: "OR" })
+    }
+                        
+    const accessToken = await ctx.context.adapter.findOne<OAuthAccessToken>({
+        model: "oauthAccessToken",
+        where: tokenTypeHintWhere,
+    });
+
+    if (!accessToken || accessToken.accessTokenExpiresAt < new Date()) {
+        return ctx.json({ active: false })
+    }
+
+    const user = await ctx.context.internalAdapter.findUserById(accessToken.userId)
+
+    if (!user) {
+        throw new APIError("BAD_REQUEST", {
+            error_description: "user not found",
+            error: "invalid_token",
+        });
+    }
+
+    return ctx.json({
+        active: true,
+        scope: accessToken.scopes,
+        client_id: accessToken.clientId,
+        username: user.name,
+        token_type: "Bearer",
+        exp: Math.floor(accessToken.accessTokenExpiresAt.getTime() / 1000),
+    })
+}


### PR DESCRIPTION
Added an (hopefully) [rfc7662](https://datatracker.ietf.org/doc/html/rfc7662) compliant introspection endpoint to the OIDC provider plugin.

It is protected using Basic auth using client ID and client secret and supports the optional `token_type_hint` parameter to help locate the token to introspect. Both access and refresh tokens can be introspected.

Note that the client ID used in the authorization header is not "checked" against the token, meaning that, for example, client ID A (The one in the authorization header) can introspect token from client ID B.

Docs & openAPI are also updated.