### PR TITLE
fix(docs): make it clear that we use an outdated stripe version

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -41,7 +41,7 @@ This plugin is currently in beta. We're actively collecting feedback and explori
         Next, install the Stripe SDK on your server:
 
         ```package-install
-        stripe
+        stripe@17.7.0
         ```
     </Step>
     <Step>
@@ -52,7 +52,9 @@ This plugin is currently in beta. We're actively collecting feedback and explori
         import { stripe } from "@better-auth/stripe"
         import Stripe from "stripe"
 
-        const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
+        const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+            apiVersion: "2025-02-24.acacia",
+        })
 
         export const auth = betterAuth({
             // ... your existing config


### PR DESCRIPTION
This should resolve confusion with errors related to breaking changes that were introduced in the basil api version of stripe.

> [!CAUTION]
> **This PR should not be merged or reverted, if #2316 gets merged!**

If the next (beta) release will take a while to be put out it might make sense to merge this PR in order to have the docs reflect the current state until the next version. Then in #2316 the changes made via this PR needs to be removed.