### PR TITLE
fix(oidc-provider): Update advertised ID token signing alg to HS256

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -45,7 +45,7 @@ const getMetadata = (
 			"urn:mace:incommon:iap:bronze",
 		],
 		subject_types_supported: ["public"],
-		id_token_signing_alg_values_supported: ["RS256", "none"],
+		id_token_signing_alg_values_supported: ["HS256", "none"],
 		token_endpoint_auth_methods_supported: [
 			"client_secret_basic",
 			"client_secret_post",

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -488,12 +488,12 @@ export interface OIDCMetadata {
 	/**
 	 * Supported ID token signing algorithms.
 	 *
-	 * only `RS256` and `none` are supported.
+	 * only `HS256` and `none` are supported.
 	 *
 	 * @default
-	 * ["RS256", "none"]
+	 * ["HS256", "none"]
 	 */
-	id_token_signing_alg_values_supported: ("RS256" | "none")[];
+	id_token_signing_alg_values_supported: ("HS256" | "none")[];
 	/**
 	 * Supported token endpoint authentication methods.
 	 *


### PR DESCRIPTION
The current generated key used to sign the ID token, is using `HS256` algorithm while the openid-configuration endpoint is advertising `RS256` as the only signing algorithm.

Line 598:
```
let secretKey = {
        alg: "HS256",
        key: await subtle.generateKey(
	        {
		        name: "HMAC",
		        hash: "SHA-256",
	        },
	        true,
	        ["sign", "verify"],
        ),
};
```

While it doesn't address the fact that the key used is not one of the keys advertised in the JWKS endpoint (probably due to the fact that they are not from the same plugin?)-At least, now, the `alg` property of the ID token header is matching the openid-configuration.