### PR TITLE
update: `getActions` from client plugins to include `clientOptions` in get user client config

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -100,7 +100,7 @@ export const getClientConfig = (options?: ClientOptions) => {
 
 	for (const plugin of plugins) {
 		if (plugin.getActions) {
-			Object.assign(pluginsActions, plugin.getActions?.($fetch, $store));
+			Object.assign(pluginsActions, plugin.getActions?.($fetch, $store, options));
 		}
 	}
 	return {

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -100,7 +100,10 @@ export const getClientConfig = (options?: ClientOptions) => {
 
 	for (const plugin of plugins) {
 		if (plugin.getActions) {
-			Object.assign(pluginsActions, plugin.getActions?.($fetch, $store, options));
+			Object.assign(
+				pluginsActions,
+				plugin.getActions?.($fetch, $store, options),
+			);
 		}
 	}
 	return {

--- a/packages/better-auth/src/client/types.ts
+++ b/packages/better-auth/src/client/types.ts
@@ -42,7 +42,7 @@ export interface BetterAuthClientPlugin {
 		/**
 		 * better-auth client options
 		 */
-		clientOptions: ClientOptions | undefined,
+		options: ClientOptions | undefined,
 	) => Record<string, any>;
 	/**
 	 * State atoms that'll be resolved by each framework

--- a/packages/better-auth/src/client/types.ts
+++ b/packages/better-auth/src/client/types.ts
@@ -36,7 +36,14 @@ export interface BetterAuthClientPlugin {
 	/**
 	 * Custom actions
 	 */
-	getActions?: ($fetch: BetterFetch, $store: Store) => Record<string, any>;
+	getActions?: (
+		$fetch: BetterFetch,
+		$store: Store,
+		/**
+		 * better-auth client options
+		 */
+		clientOptions: ClientOptions | undefined,
+	) => Record<string, any>;
 	/**
 	 * State atoms that'll be resolved by each framework
 	 * auth store.


### PR DESCRIPTION
Helpful for situations like this where you need to get the basePath to fetch internal auth API within `getActions` of a client plugin:
![image](https://github.com/user-attachments/assets/d40a786a-a923-4570-8f88-19d378e6d95d)
