### PR TITLE
fix: add userDisplayName to the generateRegistrationOptions call

### DIFF
--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -271,6 +271,7 @@ export const passkey = (options?: PasskeyOptions) => {
 						rpID: getRpID(opts, ctx.context.options.baseURL),
 						userID,
 						userName: session.user.email || session.user.id,
+						userDisplayName: session.user.email || session.user.id,
 						attestationType: "none",
 						excludeCredentials: userPasskeys.map((passkey) => ({
 							id: passkey.credentialID,


### PR DESCRIPTION
Hi! 

This change fixes the YubiKey USB passkey registration flow on mobile devices.

For some reason, registration fails when the `displayName` field is empty. To reproduce the issue, I’ve prepared a demo project with a basic anonymous + passkey setup:

- GitHub repo: [yubikey-better-auth](https://github.com/EugeneDraitsev/yubikey-better-auth)
- Live demo: [yubikey-better-auth.vercel.app](https://yubikey-better-auth.vercel.app/)

Here’s a screen recording showing the issue:

https://github.com/user-attachments/assets/4e2d2798-6a8f-41ee-ab09-737e656fe35a

To work around the problem, I added the following logic to `auth.ts`:
```typescript
  hooks: {
    after: createAuthMiddleware(async (ctx) => {
      if (ctx.path === '/passkey/generate-register-options') {
        const result = ctx.context.returned as {
          user: { id: string; displayName: string; name?: string };
        };

        const modified = {
          ...result,
          user: {
            ...result?.user,
            displayName: result?.user?.displayName || result?.user?.name
          }
        };

        return ctx.json(modified);
      }
    })
  },
```

Here’s a live version with the fix applied:
[yubikey-better-auth-git-display-name-fix-drais-projects.vercel.app](https://yubikey-better-auth-git-display-name-fix-drais-projects.vercel.app/)

And a screen recording of it working as expected:

https://github.com/user-attachments/assets/cde03c05-739e-472d-b26d-b2c307d78712

It would be great to get this fix into `better-auth`, so that YubiKey USB registration works out of the box without needing custom middleware.

