### PR TITLE
feat(anonymous): Custom anonymous names

### DIFF
--- a/docs/content/docs/plugins/anonymous.mdx
+++ b/docs/content/docs/plugins/anonymous.mdx
@@ -121,6 +121,7 @@ export const auth = betterAuth({
 
 - `disableDeleteAnonymousUser`: By default, the anonymous user is deleted when the account is linked to a new authentication method. Set this option to `true` to disable this behavior.
 
+- `generateName`: A callback function that is called to generate a name for the anonymous user. Useful if you want to have random names for anonymous users, or if `name` is unique in your database.
 
 ## Schema
 

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -128,4 +128,30 @@ describe("anonymous", async () => {
 		});
 		expect(linkAccountFn).toHaveBeenCalledWith(expect.any(Object));
 	});
+
+	it("should work with generateName", async () => {
+		const { customFetchImpl, auth, sessionSetter, testUser } =
+			await getTestInstance({
+				plugins: [
+					anonymous({
+						generateName() {
+							return "i-am-anonymous";
+						},
+					}),
+				],
+			});
+		const client = createAuthClient({
+			plugins: [anonymousClient()],
+			fetchOptions: {
+				customFetchImpl,
+			},
+			baseURL: "http://localhost:3000",
+		});
+		const res = await client.signIn.anonymous({
+			fetchOptions: {
+				onSuccess: sessionSetter(headers),
+			},
+		});
+		expect(res.data?.user.name).toBe("i-am-anonymous");
+	});
 });

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -130,16 +130,15 @@ describe("anonymous", async () => {
 	});
 
 	it("should work with generateName", async () => {
-		const { customFetchImpl, auth, sessionSetter, testUser } =
-			await getTestInstance({
-				plugins: [
-					anonymous({
-						generateName() {
-							return "i-am-anonymous";
-						},
-					}),
-				],
-			});
+		const { customFetchImpl, sessionSetter } = await getTestInstance({
+			plugins: [
+				anonymous({
+					generateName() {
+						return "i-am-anonymous";
+					},
+				}),
+			],
+		});
 		const client = createAuthClient({
 			plugins: [anonymousClient()],
 			fetchOptions: {

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -14,7 +14,6 @@ import type {
 import { parseSetCookieHeader, setSessionCookie } from "../../cookies";
 import { getOrigin } from "../../utils/url";
 import { mergeSchema } from "../../db/schema";
-import { z } from "zod";
 
 export interface UserWithAnonymous extends User {
 	isAnonymous: boolean;

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -10,10 +10,12 @@ import type {
 	AuthPluginSchema,
 	Session,
 	User,
+	AuthContext,
 } from "../../types";
 import { parseSetCookieHeader, setSessionCookie } from "../../cookies";
 import { getOrigin } from "../../utils/url";
 import { mergeSchema } from "../../db/schema";
+import type { EndpointContext } from "better-call";
 
 export interface UserWithAnonymous extends User {
 	isAnonymous: boolean;
@@ -48,7 +50,15 @@ export interface AnonymousOptions {
 	 * Useful if you want to have random names for anonymous users, or if `name` is unique in your database.
 	 * @returns The name for the anonymous user.
 	 */
-	generateName?: () => string;
+	generateName?: (
+		ctx: EndpointContext<
+			"/sign-in/anonymous",
+			{
+				method: "POST";
+			},
+			AuthContext
+		>,
+	) => string;
 	/**
 	 * Custom schema for the anonymous plugin
 	 */
@@ -111,7 +121,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 						options || {};
 					const id = ctx.context.generateId({ model: "user" });
 					const email = `temp-${id}@${emailDomainName}`;
-					const name = options?.generateName?.() || "Anonymous";
+					const name = options?.generateName?.(ctx) || "Anonymous";
 					const newUser = await ctx.context.internalAdapter.createUser(
 						{
 							email,


### PR DESCRIPTION
In some cases, `name` is unique in the DB, so this allows the dev to configure generating a random name via the plugin config.
If suitable, in the future we can consider customizing `name`  (and maybe `image` too)  straight from the client's `signIn` method- but it's up for debate.

<img width="543" alt="image" src="https://github.com/user-attachments/assets/91947313-0ee5-4b5f-a99d-f2fe987c9447" />

- [x] Docs
- [x] Tests

For further context:
https://discord.com/channels/1288403910284935179/1363063581784018974