### PR TITLE
fix: pass context into createVerificationValue

### DIFF
--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -108,11 +108,14 @@ export const forgetPassword = createAuthEndpoint(
 			"sec",
 		);
 		const verificationToken = generateId(24);
-		await ctx.context.internalAdapter.createVerificationValue({
-			value: user.user.id,
-			identifier: `reset-password:${verificationToken}`,
-			expiresAt,
-		});
+		await ctx.context.internalAdapter.createVerificationValue(
+			{
+				value: user.user.id,
+				identifier: `reset-password:${verificationToken}`,
+				expiresAt,
+			},
+			ctx,
+		);
 		const url = `${ctx.context.baseURL}/reset-password/${verificationToken}?callbackURL=${redirectTo}`;
 		await ctx.context.options.emailAndPassword.sendResetPassword(
 			{

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -472,16 +472,19 @@ export const deleteUser = createAuthEndpoint(
 
 		if (ctx.context.options.user.deleteUser?.sendDeleteAccountVerification) {
 			const token = generateRandomString(32, "0-9", "a-z");
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: session.user.id,
-				identifier: `delete-account-${token}`,
-				expiresAt: new Date(
-					Date.now() +
-						(ctx.context.options.user.deleteUser?.deleteTokenExpiresIn ||
-							60 * 60 * 24) *
-							1000,
-				),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: session.user.id,
+					identifier: `delete-account-${token}`,
+					expiresAt: new Date(
+						Date.now() +
+							(ctx.context.options.user.deleteUser?.deleteTokenExpiresIn ||
+								60 * 60 * 24) *
+								1000,
+					),
+				},
+				ctx,
+			);
 			const url = `${
 				ctx.context.baseURL
 			}/delete-user/callback?token=${token}&callbackURL=${

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -33,11 +33,14 @@ export async function generateState(
 	});
 	const expiresAt = new Date();
 	expiresAt.setMinutes(expiresAt.getMinutes() + 10);
-	const verification = await c.context.internalAdapter.createVerificationValue({
-		value: data,
-		identifier: state,
-		expiresAt,
-	});
+	const verification = await c.context.internalAdapter.createVerificationValue(
+		{
+			value: data,
+			identifier: state,
+			expiresAt,
+		},
+		c,
+	);
 	if (!verification) {
 		c.context.logger.error(
 			"Unable to create verification. Make sure the database adapter is properly working and there is a verification table in the database",

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -144,22 +144,28 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						ctx.request,
 					);
 					await ctx.context.internalAdapter
-						.createVerificationValue({
-							value: `${otp}:0`,
-							identifier: `${ctx.body.type}-otp-${email}`,
-							expiresAt: getDate(opts.expiresIn, "sec"),
-						})
+						.createVerificationValue(
+							{
+								value: `${otp}:0`,
+								identifier: `${ctx.body.type}-otp-${email}`,
+								expiresAt: getDate(opts.expiresIn, "sec"),
+							},
+							ctx,
+						)
 						.catch(async (error) => {
 							// might be duplicate key error
 							await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 								`${ctx.body.type}-otp-${email}`,
 							);
 							//try again
-							await ctx.context.internalAdapter.createVerificationValue({
-								value: `${otp}:0`,
-								identifier: `${ctx.body.type}-otp-${email}`,
-								expiresAt: getDate(opts.expiresIn, "sec"),
-							});
+							await ctx.context.internalAdapter.createVerificationValue(
+								{
+									value: `${otp}:0`,
+									identifier: `${ctx.body.type}-otp-${email}`,
+									expiresAt: getDate(opts.expiresIn, "sec"),
+								},
+								ctx,
+							);
 						});
 					await options.sendVerificationOTP(
 						{
@@ -211,11 +217,14 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						{ email, type: ctx.body.type },
 						ctx.request,
 					);
-					await ctx.context.internalAdapter.createVerificationValue({
-						value: `${otp}:0`,
-						identifier: `${ctx.body.type}-otp-${email}`,
-						expiresAt: getDate(opts.expiresIn, "sec"),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							value: `${otp}:0`,
+							identifier: `${ctx.body.type}-otp-${email}`,
+							expiresAt: getDate(opts.expiresIn, "sec"),
+						},
+						ctx,
+					);
 					return otp;
 				},
 			),
@@ -621,11 +630,14 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						{ email, type: "forget-password" },
 						ctx.request,
 					);
-					await ctx.context.internalAdapter.createVerificationValue({
-						value: `${otp}:0`,
-						identifier: `forget-password-otp-${email}`,
-						expiresAt: getDate(opts.expiresIn, "sec"),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							value: `${otp}:0`,
+							identifier: `forget-password-otp-${email}`,
+							expiresAt: getDate(opts.expiresIn, "sec"),
+						},
+						ctx,
+					);
 					await options.sendVerificationOTP(
 						{
 							email,
@@ -780,11 +792,14 @@ export const emailOTP = (options: EmailOTPOptions) => {
 								{ email, type: ctx.body.type },
 								ctx.request,
 							);
-							await ctx.context.internalAdapter.createVerificationValue({
-								value: `${otp}:0`,
-								identifier: `email-verification-otp-${email}`,
-								expiresAt: getDate(opts.expiresIn, "sec"),
-							});
+							await ctx.context.internalAdapter.createVerificationValue(
+								{
+									value: `${otp}:0`,
+									identifier: `email-verification-otp-${email}`,
+									expiresAt: getDate(opts.expiresIn, "sec"),
+								},
+								ctx,
+							);
 							await options.sendVerificationOTP(
 								{
 									email,

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -115,13 +115,16 @@ export const magicLink = (options: MagicLinkOptions) => {
 					const verificationToken = options?.generateToken
 						? await options.generateToken(email)
 						: generateRandomString(32, "a-z", "A-Z");
-					await ctx.context.internalAdapter.createVerificationValue({
-						identifier: verificationToken,
-						value: JSON.stringify({ email, name: ctx.body.name }),
-						expiresAt: new Date(
-							Date.now() + (options.expiresIn || 60 * 5) * 1000,
-						),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							identifier: verificationToken,
+							value: JSON.stringify({ email, name: ctx.body.name }),
+							expiresAt: new Date(
+								Date.now() + (options.expiresIn || 60 * 5) * 1000,
+							),
+						},
+						ctx,
+					);
 					const url = `${
 						ctx.context.baseURL
 					}/magic-link/verify?token=${verificationToken}&callbackURL=${

--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -169,34 +169,37 @@ export async function authorize(
 		/**
 		 * Save the code in the database
 		 */
-		await ctx.context.internalAdapter.createVerificationValue({
-			value: JSON.stringify({
-				clientId: client.clientId,
-				redirectURI: query.redirect_uri,
-				scope: requestScope,
-				userId: session.user.id,
-				authTime: session.session.createdAt.getTime(),
-				/**
-				 * If the prompt is set to `consent`, then we need
-				 * to require the user to consent to the scopes.
-				 *
-				 * This means the code now needs to be treated as a
-				 * consent request.
-				 *
-				 * once the user consents, teh code will be updated
-				 * with the actual code. This is to prevent the
-				 * client from using the code before the user
-				 * consents.
-				 */
-				requireConsent: query.prompt === "consent",
-				state: query.prompt === "consent" ? query.state : null,
-				codeChallenge: query.code_challenge,
-				codeChallengeMethod: query.code_challenge_method,
-				nonce: query.nonce,
-			}),
-			identifier: code,
-			expiresAt,
-		});
+		await ctx.context.internalAdapter.createVerificationValue(
+			{
+				value: JSON.stringify({
+					clientId: client.clientId,
+					redirectURI: query.redirect_uri,
+					scope: requestScope,
+					userId: session.user.id,
+					authTime: session.session.createdAt.getTime(),
+					/**
+					 * If the prompt is set to `consent`, then we need
+					 * to require the user to consent to the scopes.
+					 *
+					 * This means the code now needs to be treated as a
+					 * consent request.
+					 *
+					 * once the user consents, teh code will be updated
+					 * with the actual code. This is to prevent the
+					 * client from using the code before the user
+					 * consents.
+					 */
+					requireConsent: query.prompt === "consent",
+					state: query.prompt === "consent" ? query.state : null,
+					codeChallenge: query.code_challenge,
+					codeChallengeMethod: query.code_challenge_method,
+					nonce: query.nonce,
+				}),
+				identifier: code,
+				expiresAt,
+			},
+			ctx,
+		);
 	} catch (e) {
 		throw ctx.redirect(
 			redirectErrorURL(

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -303,16 +303,19 @@ export const passkey = (options?: PasskeyOptions) => {
 							maxAge: maxAgeInSeconds,
 						},
 					);
-					await ctx.context.internalAdapter.createVerificationValue({
-						identifier: id,
-						value: JSON.stringify({
-							expectedChallenge: options.challenge,
-							userData: {
-								id: session.user.id,
-							},
-						}),
-						expiresAt: expirationTime,
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							identifier: id,
+							value: JSON.stringify({
+								expectedChallenge: options.challenge,
+								userData: {
+									id: session.user.id,
+								},
+							}),
+							expiresAt: expirationTime,
+						},
+						ctx,
+					);
 					return ctx.json(options, {
 						status: 200,
 					});
@@ -469,11 +472,14 @@ export const passkey = (options?: PasskeyOptions) => {
 							maxAge: maxAgeInSeconds,
 						},
 					);
-					await ctx.context.internalAdapter.createVerificationValue({
-						identifier: id,
-						value: JSON.stringify(data),
-						expiresAt: expirationTime,
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							identifier: id,
+							value: JSON.stringify(data),
+							expiresAt: expirationTime,
+						},
+						ctx,
+					);
 					return ctx.json(options, {
 						status: 200,
 					});

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -210,15 +210,21 @@ export const phoneNumber = (options?: PhoneNumberOptions) => {
 					if (opts.requireVerification) {
 						if (!user.phoneNumberVerified) {
 							const otp = generateOTP(opts.otpLength);
-							await ctx.context.internalAdapter.createVerificationValue({
-								value: otp,
-								identifier: phoneNumber,
-								expiresAt: getDate(opts.expiresIn, "sec"),
-							});
-							await opts.sendOTP?.({
-								phoneNumber,
-								code: otp,
-							});
+							await ctx.context.internalAdapter.createVerificationValue(
+								{
+									value: otp,
+									identifier: phoneNumber,
+									expiresAt: getDate(opts.expiresIn, "sec"),
+								},
+								ctx,
+							);
+							await opts.sendOTP?.(
+								{
+									phoneNumber,
+									code: otp,
+								},
+								ctx.request,
+							);
 							throw new APIError("UNAUTHORIZED", {
 								message: ERROR_CODES.PHONE_NUMBER_NOT_VERIFIED,
 							});
@@ -343,11 +349,14 @@ export const phoneNumber = (options?: PhoneNumberOptions) => {
 					}
 
 					const code = generateOTP(opts.otpLength);
-					await ctx.context.internalAdapter.createVerificationValue({
-						value: `${code}:0`,
-						identifier: ctx.body.phoneNumber,
-						expiresAt: getDate(opts.expiresIn, "sec"),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							value: `${code}:0`,
+							identifier: ctx.body.phoneNumber,
+							expiresAt: getDate(opts.expiresIn, "sec"),
+						},
+						ctx,
+					);
 					await options.sendOTP(
 						{
 							phoneNumber: ctx.body.phoneNumber,
@@ -734,11 +743,14 @@ export const phoneNumber = (options?: PhoneNumberOptions) => {
 						});
 					}
 					const code = generateOTP(opts.otpLength);
-					await ctx.context.internalAdapter.createVerificationValue({
-						value: `${code}:0`,
-						identifier: `${ctx.body.phoneNumber}-forget-password`,
-						expiresAt: getDate(opts.expiresIn, "sec"),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							value: `${code}:0`,
+							identifier: `${ctx.body.phoneNumber}-forget-password`,
+							expiresAt: getDate(opts.expiresIn, "sec"),
+						},
+						ctx,
+					);
 					await options?.sendForgetPasswordOTP?.(
 						{
 							phoneNumber: ctx.body.phoneNumber,

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -304,11 +304,14 @@ export const twoFactor = (options?: TwoFactorOptions) => {
 							},
 						);
 						const identifier = `2fa-${generateRandomString(20)}`;
-						await ctx.context.internalAdapter.createVerificationValue({
-							value: data.user.id,
-							identifier,
-							expiresAt: new Date(Date.now() + maxAge * 1000),
-						});
+						await ctx.context.internalAdapter.createVerificationValue(
+							{
+								value: data.user.id,
+								identifier,
+								expiresAt: new Date(Date.now() + maxAge * 1000),
+							},
+							ctx,
+						);
 						await ctx.setSignedCookie(
 							twoFactorCookie.name,
 							identifier,

--- a/packages/better-auth/src/plugins/two-factor/otp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/otp/index.ts
@@ -134,11 +134,14 @@ export const otp2fa = (options?: OTPOptions) => {
 				});
 			}
 			const code = generateRandomString(opts.digits, "0-9");
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${code}!0`,
-				identifier: `2fa-otp-${key}`,
-				expiresAt: new Date(Date.now() + opts.period),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: `${code}!0`,
+					identifier: `2fa-otp-${key}`,
+					expiresAt: new Date(Date.now() + opts.period),
+				},
+				ctx,
+			);
 			await options.sendOTP(
 				{ user: session.user as UserWithTwoFactor, otp: code },
 				ctx.request,


### PR DESCRIPTION
ctx wasn’t passed down before, so in `config.databaseHooks.verification.create.before = async (verification, ctx) => {}` the `ctx` argument was `undefined` in some cases. Now we forward ctx so the hook can receive it as expected.