### PR TITLE
update(stripe): Export `StripePlan` type

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -22,6 +22,7 @@ import type {
 	Customer,
 	InputSubscription,
 	StripeOptions,
+	StripePlan,
 	Subscription,
 } from "./types";
 import { getPlanByName, getPlanByPriceId, getPlans } from "./utils";
@@ -993,4 +994,4 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 	} satisfies BetterAuthPlugin;
 };
 
-export type { Subscription };
+export type { Subscription, StripePlan };


### PR DESCRIPTION
Useful for users who want to make a `plans` array containing stripe plans.

Closes:
https://github.com/better-auth/better-auth/issues/2358