### PR TITLE
feat(organization): maximumMembersPerTeam support

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -972,7 +972,14 @@ The teams feature supports several configuration options:
       // Dynamic limit based on organization plan
       const plan = await getPlan(organizationId)
       return plan === 'pro' ? 20 : 5
-    }
+    },
+    maximumMembersPerTeam: 10 // Fixed number
+    // OR
+    maximumMembersPerTeam: async ({ teamId, session, organizationId }, request) => {
+      // Dynamic limit based on team plan
+      const plan = await getPlan(organizationId, teamId)
+      return plan === 'pro' ? 50 : 10
+    },
   }
   ```
 

--- a/packages/better-auth/src/plugins/organization/error-codes.ts
+++ b/packages/better-auth/src/plugins/organization/error-codes.ts
@@ -52,4 +52,5 @@ export const ORGANIZATION_ERROR_CODES = {
 	YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_TEAM:
 		"You are not allowed to update this team",
 	INVITATION_LIMIT_REACHED: "Invitation limit reached",
+	TEAM_MEMBER_LIMIT_REACHED: "Team member limit reached",
 } as const;

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -151,6 +151,22 @@ export interface OrganizationOptions {
 					request?: Request,
 			  ) => number | Promise<number>)
 			| number;
+
+		/**
+		 * The maximum number of members per team.
+		 *
+		 * if `undefined`, there is no limit.
+		 *
+		 * @default undefined
+		 */
+		maximumMembersPerTeam?:
+			| number
+			| ((data: {
+					teamId: string;
+					session: { user: User; session: Session };
+					organizationId: string;
+			  }) => Promise<number> | number)
+			| undefined;
 		/**
 		 * By default, if an organization does only have one team, they'll not be able to remove it.
 		 *

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -213,4 +213,104 @@ describe("team", async (it) => {
 			expect(error).toBeDefined();
 		}
 	});
+
+	it("should not be allowed to invite a member to a team that's reached maximum members", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			user: {
+				modelName: "users",
+			},
+			plugins: [
+				organization({
+					async sendInvitationEmail(data, request) {},
+					teams: {
+						enabled: true,
+						maximumMembersPerTeam: 1,
+					},
+				}),
+			],
+			logger: {
+				level: "error",
+			},
+		});
+
+		const { headers } = await signInWithTestUser();
+		const client = createAuthClient({
+			plugins: [
+				organizationClient({
+					teams: {
+						enabled: true,
+					},
+				}),
+			],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					return auth.handler(new Request(url, init));
+				},
+			},
+		});
+		const createOrganizationResponse = await client.organization.create({
+			name: "Test Organization",
+			slug: "test-org",
+			metadata: {
+				test: "organization-metadata",
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(createOrganizationResponse.data?.id).toBeDefined();
+
+		const createTeamResponse = await client.organization.createTeam(
+			{
+				name: "Development Team",
+				organizationId: createOrganizationResponse.data?.id,
+			},
+			{
+				headers,
+			},
+		);
+		expect(createTeamResponse.data?.id).toBeDefined();
+
+		const res = await client.organization.inviteMember(
+			{
+				teamId: createTeamResponse.data?.id,
+				email: invitedUser.email,
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+		expect(res.data).toBeDefined();
+		const newHeaders = new Headers();
+		const signUpRes = await client.signUp.email(invitedUser, {
+			onSuccess: cookieSetter(newHeaders),
+		});
+
+		expect(signUpRes.data?.user).toBeDefined();
+
+		const acceptInvitationResponse = await client.organization.acceptInvitation(
+			{
+				invitationId: res.data?.id as string,
+			},
+			{
+				headers: newHeaders,
+			},
+		);
+		expect(acceptInvitationResponse.data).toBeDefined();
+
+		const res2 = await client.organization.inviteMember(
+			{
+				teamId: createTeamResponse.data?.id,
+				email: "test2@test.com",
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+		expect(res2.data).toBeNull();
+		expect(res2.error?.code).toEqual("TEAM_MEMBER_LIMIT_REACHED");
+	});
 });


### PR DESCRIPTION
Allow configuration of maximum number of members allowed in a team.

- [x] docs
- [x] tests

Demo:
<img width="379" alt="image" src="https://github.com/user-attachments/assets/28dad5cc-36a7-4159-8f59-c2d73e0d8f2a" />


Further context:
https://discord.com/channels/1288403910284935179/1305306590848614423/1363442367759384696 