### PR TITLE
fix(reset-password): remove status: true & throw not user found error

### DIFF
--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -97,9 +97,9 @@ export const forgetPassword = createAuthEndpoint(
 		});
 		if (!user) {
 			ctx.context.logger.error("Reset Password: User not found", { email });
-			return ctx.json({
-				status: true,
-			});
+			throw new APIError('INVALID_EMAIL', {
+				message: "User not found",
+			})
 		}
 		const defaultExpiresIn = 60 * 60 * 1;
 		const expiresAt = getDate(


### PR DESCRIPTION
I added throw new APIError for user not found.

And remove `status: true` I think it's not intended