### PR TITLE
Support literal/enum type for drizzle schema generator

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -111,6 +111,16 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 					mysql: `text('${name}').array()`,
 				},
 			} as const;
+			if (Array.isArray(field.type)) {
+				const enumValues = field.type.map(t => `'${t}'`).join(', ');
+				if (databaseType === 'pg') {
+				  return `text('${name}', { enum: [${enumValues}] })`;
+				} else if (databaseType === 'mysql') {
+				  return `mysqlEnum('${name}', [${enumValues}])`;
+				} else {
+				  return `text('${name}', { enum: [${enumValues}] })`;
+				}
+			  }
 			return typeMap[type][databaseType];
 		}
 
@@ -181,6 +191,7 @@ function generateImport({
 	imports.push(hasBigint ? (databaseType !== "sqlite" ? "bigint" : "") : "");
 	imports.push(databaseType !== "sqlite" ? "timestamp, boolean" : "");
 	imports.push(databaseType === "mysql" ? "int" : "integer");
+	imports.push(databaseType === "mysql" ? "mysqlEnum" : "");
 
 	return `import { ${imports
 		.map((x) => x.trim())

--- a/packages/cli/test/__snapshots__/auth-schema.txt
+++ b/packages/cli/test/__snapshots__/auth-schema.txt
@@ -10,7 +10,8 @@ export const user = pgTable("user", {
  updatedAt: timestamp('updated_at').notNull(),
  twoFactorEnabled: boolean('two_factor_enabled'),
  username: text('username').unique(),
- displayUsername: text('display_username')
+ displayUsername: text('display_username'),
+ role: text('role', { enum: ['admin', 'user'] }).notNull()
 				});
 
 export const session = pgTable("session", {

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -126,6 +126,15 @@ describe("generate", async () => {
 						schema: {},
 					},
 				),
+				user: {
+					additionalFields: {
+						role: {
+							type: ['admin', 'user'],
+							required: true,
+							fieldName: 'role'
+						}
+					}
+				},
 				plugins: [twoFactor(), username()],
 			},
 		});


### PR DESCRIPTION
currently the literal type for additional fields doesn't work for the drizzle schema generator and just throws an error
this PR add support for it