### PR TITLE
Support matcher functions for captcha validation endpoints

### DIFF
--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -79,7 +79,9 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 
 - **`provider` (required)**: your captcha provider.
 - **`secretKey` (required)**: your provider's secret key used for the server-side validation.
-- `endpoints` (optional): overrides the default array of paths where captcha validation is enforced. Default is: `["/sign-up/email", "/sign-in/email", "/forget-password",]`.
+- `endpoints` (optional): overrides the default array of paths where captcha validation is enforced.\
+   Default is: `["/sign-up/email", "/sign-in/email", "/forget-password"]`.\
+   Supports both strings and matcher functions: `["/sign-up", (url) => new URL(url).pathname === "/api/auth/sign-in/magic-link"]`.
 - `minScore` (optional - only *Google ReCAPTCHA v3*): minimum score threshold. Default is `0.5`.
 - `siteKey` (optional - only *hCaptcha*): prevents tokens issued on one sitekey from being redeemed elsewhere.
 - `siteVerifyURLOverride` (optional): overrides endpoint URL for the captcha verification request.

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -14,8 +14,16 @@ export const captcha = (options: CaptchaOptions) =>
 					? options.endpoints
 					: defaultEndpoints;
 
-				if (!endpoints.some((endpoint) => request.url.includes(endpoint)))
+				if (
+					!endpoints.some((endpoint) => {
+						if (typeof endpoint === "function") {
+							return endpoint(request.url);
+						}
+						return request.url.includes(endpoint);
+					})
+				) {
 					return undefined;
+				}
 
 				if (!options.secretKey) {
 					throw new Error(INTERNAL_ERROR_CODES.MISSING_SECRET_KEY);

--- a/packages/better-auth/src/plugins/captcha/types.ts
+++ b/packages/better-auth/src/plugins/captcha/types.ts
@@ -2,9 +2,11 @@ import type { Providers } from "./constants";
 
 export type Provider = (typeof Providers)[keyof typeof Providers];
 
+export type EndpointMatcherFn = (url: string) => boolean;
+
 export interface BaseCaptchaOptions {
 	secretKey: string;
-	endpoints?: string[];
+	endpoints?: Array<string | EndpointMatcherFn>;
 	siteVerifyURLOverride?: string;
 }
 


### PR DESCRIPTION
## What’s the problem?

Right now, the captcha plugin checks each request by seeing if the URL string includes any entry in the `endpoints` array. For example:

```ts
endpoints: ["/magic-link"]
```

Because the plugin does a simple substring check, a request to `/magic-link/verify` also matches. This means CAPTCHA is added to the verify route even when it shouldn’t be.

## Why is this bad?

- **Over‑protection**: Users must solve CAPTCHA on verify routes that don’t need it.
- **Confusion**: Developers expect `/magic-link` to protect only that exact path, not its sub‑paths.
- **Potential breakage**: Integrations for `/magic-link/verify` may fail unexpectedly.

## What does this PR do?

 What does this PR do?

This PR changes the `endpoints` option so it can accept both plain strings and custom matcher functions (`EndpointMatcherFn`).

- **String matchers**: default prefix-match on the path.
- **Custom matcher functions**: any function that takes the full URL and returns `true` when the route should be protected.

Example usage:
```ts
captcha({
  secretKey: process.env.TURNSTILE_SECRET_KEY!,
  endpoints: [
    "/sign-up/email",  // prefix matches /sign-up/email and subpaths
    (url) => new URL(url).pathname === "/api/auth/sign-in/magic-link" // exact match only
  ],
});
```

Let me know if you’d like additional tests or examples added to the docs!