### PR TITLE
feat: add uiMode and additionalCheckoutSessionParams

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -440,9 +440,12 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							code: e.code,
 						});
 					});
+				// we only care about disableRedirect for hosted mode
+				// because in custom and embedded mode, there isn't any redirect that should happen
+				const redirect = !ctx.body.disableRedirect && ctx.body.uiMode === "hosted";
 				return ctx.json({
 					...checkoutSession,
-					redirect: !ctx.body.disableRedirect,
+					redirect,
 				});
 			},
 		),


### PR DESCRIPTION
This PR will add support for `ui_mode` and `additionalCheckoutSessionParams` 

![image](https://github.com/user-attachments/assets/ede272bc-58f4-4fd8-8ec1-cf8f3b858f7d)

Several considerations were taken into account in this PR.

1. ui_mode support --- allow for custom/embedded ui modes (hosted as default)
2. additionalCheckoutSessionParams --- allow the user to use the full scope of checkout session creation
3. success_url/cancel_url/return_url --- changes were needed to support ui_mode, actions were taken to keep the current flow intact for `/subscription/success` handling database updates
4. disableRedirect --- this body parameter only makes sense when in `hosted` `ui_mode`