### PR TITLE
feat: add Figma OAuth2 provider

### DIFF
--- a/packages/better-auth/src/social-providers/figma.ts
+++ b/packages/better-auth/src/social-providers/figma.ts
@@ -1,0 +1,96 @@
+import type { OAuthProvider, ProviderOptions } from "../oauth2";
+import {
+  createAuthorizationURL,
+  validateAuthorizationCode,
+  refreshAccessToken,
+} from "../oauth2";
+import { betterFetch } from "@better-fetch/fetch";
+
+export interface FigmaProfile {
+  id: string;
+  handle: string;
+  img_url: string;
+  email: string;
+}
+
+export interface FigmaOptions extends ProviderOptions<FigmaProfile> {}
+
+export const figma = (options: FigmaOptions) => {
+  const tokenEndpoint = "https://www.figma.com/api/oauth/token";
+
+  return {
+    id: "figma",
+    name: "Figma",
+
+    createAuthorizationURL({ state, scopes, redirectURI }) {
+      const _scopes = options.disableDefaultScope ? [] : ["file_read"];
+      options.scope && _scopes.push(...options.scope);
+      scopes && _scopes.push(...scopes);
+
+      return createAuthorizationURL({
+        id: "figma",
+        options,
+        authorizationEndpoint: "https://www.figma.com/oauth",
+        scopes: _scopes,
+        state,
+        redirectURI,
+      });
+    },
+
+    validateAuthorizationCode: async ({ code, redirectURI }) => {
+      return validateAuthorizationCode({
+        code,
+        redirectURI,
+        options,
+        tokenEndpoint,
+      });
+    },
+
+    refreshAccessToken: options.refreshAccessToken
+      ? options.refreshAccessToken
+      : async (refreshToken) => {
+          return refreshAccessToken({
+            refreshToken,
+            options: {
+              clientId: options.clientId,
+              clientSecret: options.clientSecret,
+            },
+            tokenEndpoint,
+          });
+        },
+
+    async getUserInfo(token) {
+      if (options.getUserInfo) {
+        return options.getUserInfo(token);
+      }
+
+      const { data: profile, error } = await betterFetch<{ user: FigmaProfile }>(
+        "https://api.figma.com/v1/me",
+        {
+          headers: {
+            Authorization: `Bearer ${token.accessToken}`,
+          },
+        }
+      );
+
+      if (error || !profile?.user) return null;
+
+      const user = profile.user;
+      const userMap = await options.mapProfileToUser?.(user);
+
+      return {
+        user: {
+          id: user.id,
+          name: user.handle,
+          email: user.email,
+          image: user.img_url,
+          emailVerified: true,
+          ...userMap,
+        },
+        data: user,
+      };
+    },
+
+    options,
+  } satisfies OAuthProvider<FigmaProfile>;
+};

--- a/packages/better-auth/src/social-providers/figma.ts
+++ b/packages/better-auth/src/social-providers/figma.ts
@@ -1,3 +1,4 @@
+import { betterFetch } from "@better-fetch/fetch";
 import type {
   OAuthProvider,
   ProviderOptions,
@@ -8,7 +9,6 @@ import {
   validateAuthorizationCode,
   refreshAccessToken,
 } from "../oauth2";
-import { betterFetch } from "@better-fetch/fetch";
 
 export interface FigmaProfile {
   id: string;
@@ -18,19 +18,15 @@ export interface FigmaProfile {
 }
 
 export interface FigmaOptions extends ProviderOptions<FigmaProfile> {}
-
 export const figma = (options: FigmaOptions) => {
   const tokenEndpoint = "https://www.figma.com/api/oauth/token";
-
   return {
     id: "figma",
     name: "Figma",
-
     createAuthorizationURL({ state, scopes, redirectURI }) {
       const _scopes = options.disableDefaultScope ? [] : ["file_read"];
       options.scope && _scopes.push(...options.scope);
       scopes && _scopes.push(...scopes);
-
       return createAuthorizationURL({
         id: "figma",
         options,
@@ -40,7 +36,6 @@ export const figma = (options: FigmaOptions) => {
         redirectURI,
       });
     },
-
     validateAuthorizationCode: async ({ code, redirectURI }) => {
       return validateAuthorizationCode({
         code,
@@ -49,7 +44,6 @@ export const figma = (options: FigmaOptions) => {
         tokenEndpoint,
       });
     },
-
     refreshAccessToken: options.refreshAccessToken
       ? options.refreshAccessToken
       : async (refreshToken) => {
@@ -62,12 +56,10 @@ export const figma = (options: FigmaOptions) => {
             tokenEndpoint,
           });
         },
-
     async getUserInfo(token: OAuth2Tokens) {
       if (options.getUserInfo) {
         return options.getUserInfo(token);
       }
-
       const { data: profile, error } = await betterFetch<{ user: FigmaProfile }>(
         "https://api.figma.com/v1/me",
         {
@@ -81,7 +73,6 @@ export const figma = (options: FigmaOptions) => {
 
       const user = profile.user;
       const userMap = await options.mapProfileToUser?.(user);
-
       return {
         user: {
           id: user.id,
@@ -94,7 +85,6 @@ export const figma = (options: FigmaOptions) => {
         data: user,
       };
     },
-
     options,
   } satisfies OAuthProvider<FigmaProfile>;
 };

--- a/packages/better-auth/src/social-providers/figma.ts
+++ b/packages/better-auth/src/social-providers/figma.ts
@@ -1,4 +1,8 @@
-import type { OAuthProvider, ProviderOptions } from "../oauth2";
+import type {
+  OAuthProvider,
+  ProviderOptions,
+  OAuth2Tokens
+} from "../oauth2";
 import {
   createAuthorizationURL,
   validateAuthorizationCode,
@@ -59,7 +63,7 @@ export const figma = (options: FigmaOptions) => {
           });
         },
 
-    async getUserInfo(token) {
+    async getUserInfo(token: OAuth2Tokens) {
       if (options.getUserInfo) {
         return options.getUserInfo(token);
       }

--- a/packages/better-auth/src/social-providers/index.ts
+++ b/packages/better-auth/src/social-providers/index.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { vk } from "./vk";
 import { kick } from "./kick";
 import { zoom } from "./zoom";
+import { figma } from "./figma";
 export const socialProviders = {
 	apple,
 	discord,
@@ -37,6 +38,7 @@ export const socialProviders = {
 	roblox,
 	vk,
 	zoom,
+	figma,
 };
 
 export const socialProviderList = Object.keys(socialProviders) as [
@@ -76,5 +78,6 @@ export * from "./roblox";
 export * from "./vk";
 export * from "./zoom";
 export * from "./kick";
+export * from "./figma";
 
 export type SocialProviderList = typeof socialProviderList;


### PR DESCRIPTION
### PR Description  
This pull request adds support for **Figma** as an OAuth2 provider within the `better-auth` library.

#### Key features:
- Implements standard OAuth2 flow: authorization code → access token → user profile.
- Retrieves user data from `https://api.figma.com/v1/me`.
- Returns `id`, `handle`, `email`, and `avatar` (img_url).
- Marks emails as verified (Figma ensures verified emails).
- Supports custom scopes and profile mapping via `options`.

Ready for integration and extensibility.