### PR TITLE
Fix typo

### DIFF
--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -113,7 +113,7 @@ export async function handleOAuthUserInfo(
 				...restUserInfo,
 				email: userInfo.email.toLowerCase(),
 				emailVerified:
-					userInfo.email.toLocaleLowerCase() === dbUser.user.email
+					userInfo.email.toLowerCase() === dbUser.user.email
 						? dbUser.user.emailVerified || userInfo.emailVerified
 						: userInfo.emailVerified,
 			});


### PR DESCRIPTION
Convert email to lower case using `toLowerCase` instead of `toLocaleLowerCase`