### PR TITLE
feat(signin): make verification sending in sign in route explicit

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -121,6 +121,7 @@ export const auth = betterAuth({
 
 - `sendVerificationEmail`: Function to send verification email
 - `sendOnSignUp`: Send verification email automatically after sign up (default: `false`)
+- `sendOnSignIn`: Send verification email automatically on sign in when the user's email is not verified (default: `false`)
 - `autoSignInAfterVerification`: Auto sign in the user after they verify their email
 - `expiresIn`: Number of seconds the verification token is valid for (default: `3600` seconds)
 

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -499,23 +499,27 @@ export const signInEmail = createAuthEndpoint(
 					message: BASE_ERROR_CODES.EMAIL_NOT_VERIFIED,
 				});
 			}
-			const token = await createEmailVerificationToken(
-				ctx.context.secret,
-				user.user.email,
-				undefined,
-				ctx.context.options.emailVerification?.expiresIn,
-			);
-			const url = `${
-				ctx.context.baseURL
-			}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;
-			await ctx.context.options.emailVerification.sendVerificationEmail(
-				{
-					user: user.user,
-					url,
-					token,
-				},
-				ctx.request,
-			);
+
+			if (ctx.context.options?.emailVerification?.sendOnSignIn) {
+				const token = await createEmailVerificationToken(
+					ctx.context.secret,
+					user.user.email,
+					undefined,
+					ctx.context.options.emailVerification?.expiresIn,
+				);
+				const url = `${
+					ctx.context.baseURL
+				}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;
+				await ctx.context.options.emailVerification.sendVerificationEmail(
+					{
+						user: user.user,
+						url,
+						token,
+					},
+					ctx.request,
+				);
+			}
+
 			throw new APIError("FORBIDDEN", {
 				message: BASE_ERROR_CODES.EMAIL_NOT_VERIFIED,
 			});

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -509,7 +509,9 @@ export const signInEmail = createAuthEndpoint(
 				);
 				const url = `${
 					ctx.context.baseURL
-				}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;
+				}/verify-email?token=${token}&callbackURL=${
+					ctx.body.callbackURL || "/"
+				}`;
 				await ctx.context.options.emailVerification.sendVerificationEmail(
 					{
 						user: user.user,

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -147,6 +147,13 @@ export type BetterAuthOptions = {
 		 */
 		sendOnSignUp?: boolean;
 		/**
+		 * Send a verification email automatically
+		 * on sign in when the user's email is not verified
+		 *
+		 * @default false
+		 */
+		sendOnSignIn?: boolean;
+		/**
 		 * Auto signin the user after they verify their email
 		 */
 		autoSignInAfterVerification?: boolean;


### PR DESCRIPTION
Made the email sending inside the sign in route explicit, similar to the sign up route.