### PR TITLE
add: tests for create-adapter to not include an id when generate id is disabled

### DIFF
--- a/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
+++ b/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
@@ -172,7 +172,6 @@ describe("Create Adapter Helper", async () => {
 			adapter(args_0) {
 				return {
 					async create(data) {
-						console.log(data);
 						expect(data.data.id).not.toBeDefined();
 						return data.data;
 					},
@@ -180,11 +179,11 @@ describe("Create Adapter Helper", async () => {
 			},
 		});
 
-		const r = await adapter.create({
+		const testResult = await adapter.create({
 			model: "user",
 			data: { name: "test-name" },
 		});
-		expect(r.id).not.toBeDefined();
+		expect(testResult.id).not.toBeDefined();
 	});
 
 	test("Should throw an error if the database doesn't support numeric ids and the user has enabled `useNumberId`", async () => {

--- a/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
+++ b/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
@@ -161,6 +161,32 @@ describe("Create Adapter Helper", async () => {
 		expect(res.id).toBe("HARD-CODED-ID");
 	});
 
+	test("Should not generate an id if `advanced.database.generateId` is not defined or false", async () => {
+		const adapter = await createTestAdapter({
+			config: {},
+			options: {
+				advanced: {
+					database: { generateId: false, useNumberId: false },
+				},
+			},
+			adapter(args_0) {
+				return {
+					async create(data) {
+						console.log(data);
+						expect(data.data.id).not.toBeDefined();
+						return data.data;
+					},
+				};
+			},
+		});
+
+		const r = await adapter.create({
+			model: "user",
+			data: { name: "test-name" },
+		});
+		expect(r.id).not.toBeDefined();
+	});
+
 	test("Should throw an error if the database doesn't support numeric ids and the user has enabled `useNumberId`", async () => {
 		let error: any | null = null;
 		try {


### PR DESCRIPTION
Nothing is broken as of now, just adding another test to prevent future bugs