### PR TITLE
fix(two-factor): correct expiration time for 2fa cookie

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -296,7 +296,7 @@ export const twoFactor = (options?: TwoFactorOptions) => {
 						 */
 						deleteSessionCookie(ctx, true);
 						await ctx.context.internalAdapter.deleteSession(data.session.token);
-						const maxAge = options?.otpOptions?.period || 60 * 5; // 5 minutes
+						const maxAge = options?.otpOptions?.period || 5; // 5 minutes
 						const twoFactorCookie = ctx.context.createAuthCookie(
 							TWO_FACTOR_COOKIE_NAME,
 							{
@@ -308,7 +308,7 @@ export const twoFactor = (options?: TwoFactorOptions) => {
 							{
 								value: data.user.id,
 								identifier,
-								expiresAt: new Date(Date.now() + maxAge * 1000),
+								expiresAt: new Date(Date.now() + maxAge * 60 * 1000),
 							},
 							ctx,
 						);


### PR DESCRIPTION
This PR updates the expiration time calculation for the 2fa cookie. The `expiresAt` value is now aligned with the `otpOptions.period`, which is specified in minutes.