### PR TITLE
Update astro.mdx with rate limiting information

### DIFF
--- a/docs/content/docs/integrations/astro.mdx
+++ b/docs/content/docs/integrations/astro.mdx
@@ -16,6 +16,8 @@ import { auth } from "~/auth";
 import type { APIRoute } from "astro";
 
 export const ALL: APIRoute = async (ctx) => {
+	// If you want to use rate limiting, make sure to set the 'x-forwarded-for' header to the request headers from the context
+	// ctx.request.headers.set("x-forwarded-for", ctx.clientAddress);
 	return auth.handler(ctx.request);
 };
 ```


### PR DESCRIPTION
By just following the current docs on Astro integration and rate limiting, you would not get a working solution.
This is because Astros request when using node as adapter does not have the `x-forwarded-for` header.
According to the adapter docs https://docs.astro.build/en/reference/adapter-reference/#clientaddress this seems like it's supposed to be responsibility of the node adapter yet it does not do that by default.

Adding this information to the docs enables users to use rate limiting without issues.