### PR TITLE
fix(api-key): pass real rateLimitvalue from ctx.body

### DIFF
--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -146,6 +146,40 @@ describe("api-key", async () => {
 		expect(apiKey.rateLimitEnabled).toBe(true);
 	});
 
+	it("should respect rateLimit configuration from plugin options", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance(
+			{
+				plugins: [
+					apiKey({
+						rateLimit: {
+							enabled: false,
+							timeWindow: 1000,
+							maxRequests: 10,
+						},
+						enableMetadata: true,
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [apiKeyClient()],
+				},
+			},
+		);
+
+		const { user } = await signInWithTestUser();
+		const apiKeyResult = await auth.api.createApiKey({
+			body: {
+				userId: user.id,
+			},
+		});
+
+		expect(apiKeyResult).not.toBeNull();
+		expect(apiKeyResult.rateLimitEnabled).toBe(false);
+		expect(apiKeyResult.rateLimitTimeWindow).toBe(1000);
+		expect(apiKeyResult.rateLimitMax).toBe(10);
+	});
+
 	it("should create the API key with the given name", async () => {
 		const apiKey = await auth.api.createApiKey({
 			body: {

--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -115,6 +115,10 @@ describe("api-key", async () => {
 		expect(apiKey.lastRefillAt).toBeNull();
 		expect(apiKey.enabled).toEqual(true);
 		expect(apiKey.rateLimitTimeWindow).toEqual(86400000);
+		expect(apiKey.rateLimitMax).toEqual(10);
+		expect(apiKey.requestCount).toEqual(0);
+		expect(apiKey.remaining).toBeNull();
+		expect(apiKey.lastRequest).toBeNull();
 		expect(apiKey.rateLimitEnabled).toBe(true);
 	});
 

--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -115,10 +115,31 @@ describe("api-key", async () => {
 		expect(apiKey.lastRefillAt).toBeNull();
 		expect(apiKey.enabled).toEqual(true);
 		expect(apiKey.rateLimitTimeWindow).toEqual(86400000);
-		expect(apiKey.rateLimitMax).toEqual(10);
-		expect(apiKey.requestCount).toEqual(0);
-		expect(apiKey.remaining).toBeNull();
-		expect(apiKey.lastRequest).toBeNull();
+		expect(apiKey.rateLimitEnabled).toBe(true);
+	});
+
+	it("should have the real value from rateLimitEnabled", async () => {
+		const apiKey = await auth.api.createApiKey({
+			body: {
+				userId: user.id,
+				rateLimitEnabled: false,
+			},
+		});
+
+		expect(apiKey).not.toBeNull();
+		expect(apiKey.rateLimitEnabled).toBe(false);
+	});
+
+	it("should have true if the rate limit is undefined", async () => {
+		const apiKey = await auth.api.createApiKey({
+			body: {
+				userId: user.id,
+				rateLimitEnabled: undefined,
+			},
+		});
+
+		expect(apiKey).not.toBeNull();
+		expect(apiKey.rateLimitEnabled).toBe(true);
 	});
 
 	it("should create the API key with the given name", async () => {

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -407,7 +407,7 @@ export function createApiKey({
 				refillInterval: refillInterval ?? null,
 				rateLimitEnabled:
 					rateLimitEnabled === undefined
-						? opts.rateLimit.enabled || true
+						? opts.rateLimit.enabled ?? true
 						: rateLimitEnabled,
 				requestCount: 0,
 				//@ts-ignore - we intentionally save the permissions as string on DB.

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -406,9 +406,9 @@ export function createApiKey({
 				refillAmount: refillAmount ?? null,
 				refillInterval: refillInterval ?? null,
 				rateLimitEnabled:
-					rateLimitEnabled ?? opts.rateLimit.enabled === undefined
-						? true
-						: opts.rateLimit.enabled,
+					rateLimitEnabled === undefined
+						? opts.rateLimit.enabled || true
+						: rateLimitEnabled,
 				requestCount: 0,
 				//@ts-ignore - we intentionally save the permissions as string on DB.
 				permissions: permissionsToApply,


### PR DESCRIPTION
Ensures the `rateLimitEnabled` property in the ApiKey schema accurately reflects the provided input value, prioritizing it over defaults.

I noticed the value in the database was always true, linked issue to dokploy https://github.com/Dokploy/dokploy/issues/1757