### PR TITLE
fix: Update admin plugin documentation with code examples and comments

### DIFF
--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -319,21 +319,21 @@ The plugin provides an easy way to define your own set of permissions for each r
     ```ts title="permissions.ts"
     import { createAccessControl } from "better-auth/plugins/access";
 
-    const statement = {
-        project: ["create", "share", "update", "delete"],
+    export const statement = {
+        project: ["create", "share", "update", "delete"], // <-- Permissions available for created roles
     } as const;
 
     const ac = createAccessControl(statement);
 
-    const user = ac.newRole({ // [!code highlight]
+    export const user = ac.newRole({ // [!code highlight]
         project: ["create"], // [!code highlight]
     }); // [!code highlight]
 
-    const admin = ac.newRole({ // [!code highlight]
+   export const admin = ac.newRole({ // [!code highlight]
         project: ["create", "update"], // [!code highlight]
     }); // [!code highlight]
 
-    const myCustomRole = ac.newRole({ // [!code highlight]
+    export const myCustomRole = ac.newRole({ // [!code highlight]
         project: ["create", "update", "delete"], // [!code highlight]
         user: ["ban"], // [!code highlight]
     }); // [!code highlight]


### PR DESCRIPTION
# Documentation improvement for role exports and permissions array

## Description
This PR adds important clarification to the documentation regarding the need to explicitly export created roles along with their permissions. It also specifies that the array created contains the available permissions for the roles.

## Motivation
While using the library, I noticed the current documentation didn't clearly explain that:
1. Created roles must be explicitly exported
2. The permissions array serves as the foundation for the roles

These details weren't evident for new users like myself, and this clarification will help prevent common confusion during implementation.

## Changes made
- Added text indicating that roles must be explicitly exported
- Clarified that the created array contains the available permissions for roles