### PR TITLE
chore: fix haveibeenpwned typescript issue and added inline docs

### DIFF
--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -1,7 +1,7 @@
 import { APIError } from "../../api";
 import { createHash } from "@better-auth/utils/hash";
 import { betterFetch } from "@better-fetch/fetch";
-import type { BetterAuthPlugin } from "../../types";
+import type { BetterAuthPlugin } from "../../types/plugins";
 
 const ERROR_CODES = {
 	PASSWORD_COMPROMISED:
@@ -55,6 +55,10 @@ async function checkPasswordCompromise(
 }
 
 export interface HaveIBeenPwnedOptions {
+	/**
+	 * Custom message to be shown when the password is compromised.
+	 * @default "The password you entered has been compromised. Please choose a different password."
+	 */
 	customPasswordCompromisedMessage?: string;
 }
 


### PR DESCRIPTION
## Fixed the issue where when a user has the haveIBeenPwned plugin it throws a typescript compilation error:
```bash
 error TS2742: The inferred type of 'auth' cannot be named without a reference to '../../node_modules/better-auth/dist/shared/better-auth.qzSbzJNO'. This is likely not portable. A type annotation is necessary.
````
```ts
export const auth = betterAuth(
                ~~~~~~~~~~~~~~~~
 ```
 
I fixed it by changing
### From
```ts
import type { BetterAuthPlugin } from "../../types";
```
### To
```ts
import type { BetterAuthPlugin } from "../../types/plugins";
```
 More information about the issue: #2413 