### PR TITLE
docs(error-handling): added error message when next.js tries to set cookies in a RSC or other enviroments where cookies() is read-only.

### DIFF
--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -52,7 +52,7 @@ export const nextCookies = () => {
 									cookieHelper.set(key, decodeURIComponent(value.value), opts);
 								} catch (e) {
 									// this will fail if the cookie is being set on server component
-									ctx.context.logger.error(`Error sending the cookie to the browser. A possible cause is trying to set the cookie in a React Server Component as RSCs can only read cookies. User Server actions or Client components instead. More info at https://nextjs.org/docs/app/api-reference/functions/cookies; ${e}`)							
+									ctx.context.logger.error(`Error sending the cookie to the browser. A possible cause is trying to set the cookie in a React Server Component as RSCs can only read cookies. Use Server actions or Client components instead. More info at https://nextjs.org/docs/app/api-reference/functions/cookies; ${e}`)							
 								}
 							});
 							return;

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -52,7 +52,7 @@ export const nextCookies = () => {
 									cookieHelper.set(key, decodeURIComponent(value.value), opts);
 								} catch (e) {
 									// this will fail if the cookie is being set on server component
-									ctx.context.logger.error("Error sending the cookie to the browser. A possible cause is trying to set the cookie in a React Server Component as RSCs can only read cookies. User Server actions or Client components instead. More info at https://nextjs.org/docs/app/api-reference/functions/cookies")							
+									ctx.context.logger.error(`Error sending the cookie to the browser. A possible cause is trying to set the cookie in a React Server Component as RSCs can only read cookies. User Server actions or Client components instead. More info at https://nextjs.org/docs/app/api-reference/functions/cookies; ${e}`)							
 								}
 							});
 							return;

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -52,6 +52,7 @@ export const nextCookies = () => {
 									cookieHelper.set(key, decodeURIComponent(value.value), opts);
 								} catch (e) {
 									// this will fail if the cookie is being set on server component
+									ctx.context.logger.error("Error sending the cookie to the browser. A possible cause is trying to set the cookie in a React Server Component as RSCs can only read cookies. User Server actions or Client components instead. More info at https://nextjs.org/docs/app/api-reference/functions/cookies")							
 								}
 							});
 							return;


### PR DESCRIPTION
Currently, setting a cookie in a read-only cookie enviroment fails silently, which is horrible. The Client is out of sync of the database and you have no idea why.

I had this problem and wasted 6 days working on it. It would save me all this time if I just had this error handling.