### PR TITLE
Issue #2384 solved : Added the createdAt field in the subscription

### DIFF
--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -42,6 +42,12 @@ export const subscriptions = {
 				type: "number",
 				required: false,
 			},
+			createdAt: {
+				type: "date",
+				required: true,
+				defaultValue: Date.now(),
+				
+			}
 		},
 	},
 } satisfies AuthPluginSchema;

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -45,7 +45,7 @@ export const subscriptions = {
 			createdAt: {
 				type: "date",
 				required: true,
-				defaultValue: Date.now(),
+				defaultValue: Date.now,
 				
 			}
 		},

--- a/packages/stripe/src/stripe.test.ts
+++ b/packages/stripe/src/stripe.test.ts
@@ -175,6 +175,7 @@ describe("stripe", async () => {
 			status: "incomplete",
 			periodStart: undefined,
 			cancelAtPeriodEnd: undefined,
+			createdAt: expect.any(Date),
 		});
 	});
 


### PR DESCRIPTION
<h1 align="left" id="title">Issue #2384 solved </h1>
 Added the createdAt field in the subscription

<h1 align="left" id="title">Description </h1>
This PR contains the modified Stripe code with the field createdAt and also been added this field in stripe.test.ts file for checking of the presence of the createdAt value.
By default createdAt value takes the default time of the payment.

<h1 align="left" id="title">Code Snippets (Screenshots) </h1>

![image](https://github.com/user-attachments/assets/b0d28a7c-8ea0-459f-b537-886addcc7e8c)

![image1](https://github.com/user-attachments/assets/1669e15e-7195-48a3-b564-f0c8f4ecef88)

<h1 align="left" id="title">Considerations</h1>

- [✅] I have performed a self-review of my code
- [✅] I have read and followed the Contribution Guidelines.
- [✅] I have tested the changes thoroughly before submitting this pull request.
- [✅] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [✅] I have commented my code, particularly in hard-to-understand areas.