### PR TITLE
Issue #2384 solved : Added the createdAt field in the subscription

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 	"biome.enabled": true,
 	"editor.defaultFormatter": "biomejs.biome",
 	"[typescript]": {
-		"editor.defaultFormatter": "biomejs.biome"
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
 	"[jsonc]": {
 		"editor.defaultFormatter": "biomejs.biome"

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -3,73 +3,78 @@ import type { StripeOptions } from "./types";
 import { mergeSchema } from "better-auth/db";
 
 export const subscriptions = {
-	subscription: {
-		fields: {
-			plan: {
-				type: "string",
-				required: true,
-			},
-			referenceId: {
-				type: "string",
-				required: true,
-			},
-			stripeCustomerId: {
-				type: "string",
-				required: false,
-			},
-			stripeSubscriptionId: {
-				type: "string",
-				required: false,
-			},
-			status: {
-				type: "string",
-				defaultValue: "incomplete",
-			},
-			periodStart: {
-				type: "date",
-				required: false,
-			},
-			periodEnd: {
-				type: "date",
-				required: false,
-			},
-			cancelAtPeriodEnd: {
-				type: "boolean",
-				required: false,
-				defaultValue: false,
-			},
-			seats: {
-				type: "number",
-				required: false,
-			},
-		},
-	},
+  subscription: {
+    fields: {
+      plan: {
+        type: "string",
+        required: true,
+      },
+      referenceId: {
+        type: "string",
+        required: true,
+      },
+      stripeCustomerId: {
+        type: "string",
+        required: false,
+      },
+      stripeSubscriptionId: {
+        type: "string",
+        required: false,
+      },
+      status: {
+        type: "string",
+        defaultValue: "incomplete",
+      },
+      periodStart: {
+        type: "date",
+        required: false,
+      },
+      periodEnd: {
+        type: "date",
+        required: false,
+      },
+      cancelAtPeriodEnd: {
+        type: "boolean",
+        required: false,
+        defaultValue: false,
+      },
+      seats: {
+        type: "number",
+        required: false,
+      },
+      createdAt: {
+        type: "date",
+        required: true,
+        defaultValue: Date.now,
+      },
+    },
+  },
 } satisfies AuthPluginSchema;
 
 export const user = {
-	user: {
-		fields: {
-			stripeCustomerId: {
-				type: "string",
-				required: false,
-			},
-		},
-	},
+  user: {
+    fields: {
+      stripeCustomerId: {
+        type: "string",
+        required: false,
+      },
+    },
+  },
 } satisfies AuthPluginSchema;
 
 export const getSchema = (options: StripeOptions) => {
-	if (
-		options.schema &&
-		!options.subscription?.enabled &&
-		"subscription" in options.schema
-	) {
-		options.schema.subscription = undefined;
-	}
-	return mergeSchema(
-		{
-			...(options.subscription?.enabled ? subscriptions : {}),
-			...user,
-		},
-		options.schema,
-	);
+  if (
+    options.schema &&
+    !options.subscription?.enabled &&
+    "subscription" in options.schema
+  ) {
+    options.schema.subscription = undefined;
+  }
+  return mergeSchema(
+    {
+      ...(options.subscription?.enabled ? subscriptions : {}),
+      ...user,
+    },
+    options.schema
+  );
 };

--- a/packages/stripe/src/stripe.test.ts
+++ b/packages/stripe/src/stripe.test.ts
@@ -175,6 +175,7 @@ describe("stripe", async () => {
 			status: "incomplete",
 			periodStart: undefined,
 			cancelAtPeriodEnd: undefined,
+			createdAt: expect.any(Date),
 		});
 	});
 


### PR DESCRIPTION
<h1 align="left" id="title">Issue #2384 solved </h1>
 Added the createdAt field in the subscription

<h1 align="left" id="title">Description </h1>
This PR contains the modified Stripe code with the field createdAt and also been added this field in stripe.test.ts file for checking of the presence of the createdAt value.
By default createdAt value takes the default time of the payment.

<h1 align="left" id="title">Code Snippets (Screenshots) </h1>


![new12](https://github.com/user-attachments/assets/3eb368ba-09c6-40cc-a76d-0f68ca3f6795)


![image1](https://github.com/user-attachments/assets/1669e15e-7195-48a3-b564-f0c8f4ecef88)

<h1 align="left" id="title">Considerations</h1>

[✅] I have performed a self-review of my code
[✅] I have read and followed the Contribution Guidelines.
[✅] I have tested the changes thoroughly before submitting this pull request.
[✅] I have provided relevant issue numbers, screenshots, and videos after making the changes.
[✅] I have commented my code, particularly in hard-to-understand areas.