### PR TITLE
chore(passkey): allow attestation type option

### DIFF
--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -22,6 +22,11 @@ The passkey plugin implementation is powered by [SimpleWebAuthn](https://simplew
 
         `origin`: The URL at which registrations and authentications should occur. `http://localhost` and `http://localhost:PORT` are also valid. Do **NOT** include any trailing /
 
+        `attestationType`: Specifies the attestation type. Helpful for identifying the make and model of the device.
+            - `direct`: Requests attestation data from the authenticator
+            - `none`: No attestation is requested (most private)
+            - Default: `none`
+
         `authenticatorSelection`: Allows customization of WebAuthn authenticator selection criteria. Leave unspecified for default settings.
             - `authenticatorAttachment`: Specifies the type of authenticator
                 - `platform`: Authenticator is attached to the platform (e.g., fingerprint reader)

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -64,6 +64,14 @@ export interface PasskeyOptions {
 	origin?: string | null;
 
 	/**
+	 * Allow customization of the attestationType options
+	 * during passkey registration.
+	 * 
+	 * @default "none"
+	 */
+	attestationType?: "direct" | "none";
+
+	/**
 	 * Allow customization of the authenticatorSelection options
 	 * during passkey registration.
 	 */
@@ -272,7 +280,7 @@ export const passkey = (options?: PasskeyOptions) => {
 						userID,
 						userName: session.user.email || session.user.id,
 						userDisplayName: session.user.email || session.user.id,
-						attestationType: "none",
+						attestationType: opts.attestationType || "none",
 						excludeCredentials: userPasskeys.map((passkey) => ({
 							id: passkey.credentialID,
 							transports: passkey.transports?.split(


### PR DESCRIPTION
This PR adds the ability for `attestationType` to be set in the passkey options. Defaults to `none` still but allows for optional `direct` request.