### PR TITLE
docs: add info about defaultKeyLength

### DIFF
--- a/docs/content/docs/plugins/api-key.mdx
+++ b/docs/content/docs/plugins/api-key.mdx
@@ -490,6 +490,23 @@ export const auth = betterAuth({
 });
 ```
 
+<Callout>
+If you're **not** using the `length` property provided by `customKeyGenerator`, you **must** set the `defaultKeyLength` property to how long generated keys will be.
+
+```ts
+export const auth = betterAuth({
+  plugins: [
+    apiKey({
+      customKeyGenerator: () => {
+        return crypto.randomUUID();
+      },
+      defaultKeyLength: 36 // Or whatever the length is
+    })
+  ]
+});
+```
+</Callout>
+
 If an API key is validated from your `customAPIKeyValidator`, we still must match that against the database's key.
 However, by providing this custom function, you can improve the performance of the API key verification process,
 as all failed keys can be invalidated without having to query your database.


### PR DESCRIPTION
Better Auth errors with a `KEY_NOT_FOUND` message not just if the key isn't there, but also _if it's shorter than the length set_ (64 by default)

This PR adds a callout to point this out!

(see https://discord.com/channels/1288403910284935179/1366163971270508585)