### PR TITLE
fix(kysley-adapter): Unknown DB types should default to safer supported field types

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -32,12 +32,15 @@ export const kyselyAdapter = (db: Kysely<any>, config?: KyselyAdapterConfig) =>
 			supportsBooleans:
 				config?.type === "sqlite" || config?.type === "mssql" || !config?.type
 					? false
-					: true,
+					: config?.type === "postgres"
+						? true
+						: false,
 			supportsDates:
 				config?.type === "sqlite" || config?.type === "mssql" || !config?.type
 					? false
-					: true,
-			supportsJSON: false,
+					: config?.type === "postgres"
+						? true
+						: false,			supportsJSON: false,
 		},
 		adapter: ({ getFieldName, schema }) => {
 			const withReturning = async (

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -40,7 +40,8 @@ export const kyselyAdapter = (db: Kysely<any>, config?: KyselyAdapterConfig) =>
 					? false
 					: config?.type === "postgres"
 						? true
-						: false,			supportsJSON: false,
+						: false,
+			supportsJSON: false,
 		},
 		adapter: ({ getFieldName, schema }) => {
 			const withReturning = async (


### PR DESCRIPTION
A user had issues using Cloudflare D1 with Kysely adapter and how Date fields work.

I suspect this is the cause. (View this PR code change)
I'm honestly not sure if Cloudflare D1 supports dates or not, but regardless this PR should make any unrecognised DB types to have `Date`s and `Boolean`s to not be supported - just to be on the safer side.