### PR TITLE
feat(stripe): add support for metered billing

### DIFF
--- a/packages/stripe/src/hooks.ts
+++ b/packages/stripe/src/hooks.ts
@@ -60,7 +60,7 @@ export async function onCheckoutSessionCompleted(
 								checkoutSession.subscription as string,
 							seats,
 							// Set metered billing properties if plan has metering
-							meteredId: plan.metered
+							metered: plan.metered
 								? plan.metered.meterId
 								: undefined,
 							meteredUsage: plan.metered ? 0 : undefined,
@@ -304,6 +304,15 @@ export async function onAlertTriggered(
                         });
 
                     if (subscription) {
+                        // Also clear the stored alert ID since it's now triggered and archived
+                        await ctx.context.adapter.update({
+                            model: "subscription",
+                            update: {
+                                meteredAlertId: null
+                            },
+                            where: [{ field: "id", value: subscription.id }],
+                        });
+                        
                         ctx.context.logger.info("Usage alert triggered", {
                             meterId,
                             customerId,

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -42,7 +42,7 @@ export const subscriptions = {
 				type: "number",
 				required: false,
 			},
-			meteredId: {
+			metered: {
 				type: "string",
 				required: false,
 			},
@@ -52,6 +52,10 @@ export const subscriptions = {
 			},
 			meteredAlertThreshold: {
 				type: "number",
+				required: false,
+			},
+			meteredAlertId: {
+				type: "string",
 				required: false,
 			},
 			trialStart: {

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -42,6 +42,34 @@ export const subscriptions = {
 				type: "number",
 				required: false,
 			},
+			meteredId: {
+				type: "string",
+				required: false,
+			},
+			meteredUsage: {
+				type: "number",
+				required: false,
+			},
+			meteredAlertThreshold: {
+				type: "number",
+				required: false,
+			},
+			trialStart: {
+				type: "date",
+				required: false,
+			},
+			trialEnd: {
+				type: "date", 
+				required: false,
+			},
+			priceId: {
+				type: "string",
+				required: false,
+			},
+			groupId: {
+				type: "string",
+				required: false,
+			},
 		},
 	},
 } satisfies AuthPluginSchema;

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -63,7 +63,7 @@ export const subscriptions = {
 				required: false,
 			},
 			trialEnd: {
-				type: "date", 
+				type: "date",
 				required: false,
 			},
 			priceId: {

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -83,6 +83,19 @@ export type StripePlan = {
 			request?: Request,
 		) => Promise<void>;
 	};
+	/**
+	 * Metered billing configuration for usage-based pricing
+	 */
+	metered?: {
+		/**
+		 * Stripe meter ID
+		 */
+		meterId: string;
+		/**
+		 * Event name for usage tracking
+		 */
+		eventName: string;
+	};
 };
 
 export interface Subscription {
@@ -157,6 +170,18 @@ export interface Subscription {
 	 * Number of seats for the subscription (useful for team plans)
 	 */
 	seats?: number;
+	/**
+	 * Metered usage configuration
+	 */
+	meteredId?: string;
+	/**
+	 * Current usage amount for metered billing
+	 */
+	meteredUsage?: number;
+	/**
+	 * Alert threshold for metered billing (single threshold per subscription)
+	 */
+	meteredAlertThreshold?: number;
 }
 
 export interface StripeOptions {
@@ -277,12 +302,23 @@ export interface StripeOptions {
 		/**
 		 * A callback to run after a user has deleted their subscription
 		 * @returns
-		 */
+		*/
 		onSubscriptionDeleted?: (data: {
 			event: Stripe.Event;
 			stripeSubscription: Stripe.Subscription;
 			subscription: Subscription;
 		}) => Promise<void>;
+        /**
+         * A callback to run when a usage alert is triggered
+         * @param data - data containing event, subscription, user and alert details
+         * @returns
+         */
+        onAlertTriggered?: (data: {
+            event: Stripe.Event;
+            subscription: Subscription;
+            user: User;
+            alertData: Stripe.Billing.Alert;
+        }) => Promise<void>;
 		/**
 		 * parameters for session create params
 		 *

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -173,7 +173,7 @@ export interface Subscription {
 	/**
 	 * Metered usage configuration
 	 */
-	meteredId?: string;
+	metered?: string;
 	/**
 	 * Current usage amount for metered billing
 	 */
@@ -182,6 +182,10 @@ export interface Subscription {
 	 * Alert threshold for metered billing (single threshold per subscription)
 	 */
 	meteredAlertThreshold?: number;
+    /**
+     * Alert id for metered billing (only allow a single alert per subscription)
+     */
+	meteredAlertId?: string;
 }
 
 export interface StripeOptions {

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -182,9 +182,9 @@ export interface Subscription {
 	 * Alert threshold for metered billing (single threshold per subscription)
 	 */
 	meteredAlertThreshold?: number;
-    /**
-     * Alert id for metered billing (only allow a single alert per subscription)
-     */
+	/**
+	 * Alert id for metered billing (only allow a single alert per subscription)
+	 */
 	meteredAlertId?: string;
 }
 
@@ -306,23 +306,23 @@ export interface StripeOptions {
 		/**
 		 * A callback to run after a user has deleted their subscription
 		 * @returns
-		*/
+		 */
 		onSubscriptionDeleted?: (data: {
 			event: Stripe.Event;
 			stripeSubscription: Stripe.Subscription;
 			subscription: Subscription;
 		}) => Promise<void>;
-        /**
-         * A callback to run when a usage alert is triggered
-         * @param data - data containing event, subscription, user and alert details
-         * @returns
-         */
-        onAlertTriggered?: (data: {
-            event: Stripe.Event;
-            subscription: Subscription;
-            user: User;
-            alertData: Stripe.Billing.Alert;
-        }) => Promise<void>;
+		/**
+		 * A callback to run when a usage alert is triggered
+		 * @param data - data containing event, subscription, user and alert details
+		 * @returns
+		 */
+		onAlertTriggered?: (data: {
+			event: Stripe.Event;
+			subscription: Subscription;
+			user: User;
+			alertData: Stripe.Billing.Alert;
+		}) => Promise<void>;
 		/**
 		 * parameters for session create params
 		 *


### PR DESCRIPTION
Hi,

I've developed a feature enabling Stripe's metered billing (usage-based billing) within the Better Auth platform. This feature allows for the creation of usage alerts, such as sending an email when a user reaches their predefined limit (one alert per customer per meter), and supports adding usage data via Stripe. It supports all aggregation formulas. 

For reference, please see the relevant Stripe documentation:
- [Stripe Metered Billing API](https://docs.stripe.com/api/billing/meter)
- [Stripe Usage-Based Subscriptions](https://docs.stripe.com/billing/subscriptions/usage-based)

**How to Use:**

1. **Recording New Usage:**
   ```javascript
   const { data } = await authClient.subscription.usage({
     value: 20,
     referenceId: $activeOrganization?.data?.id,
   });
   ```

2. **Creating an Alert:**
   (Note: Limited to one alert per customer per meter)
   ```javascript
   const { data } = await authClient.subscription.alert({
     title: "Test Alert",
     threshold: 20,
     referenceId: $activeOrganization?.data?.id,
   });
   ```

3. **Configuration:**
   ```javascript
   stripe({
     subscription: {
       plans: [
         {
           name: "basic",
           priceId: "price_1RJJ82IxHNmbAzfl7fVDuY7a",
           metered: { // Add this
             meterId: "mtr_test_61SSh4j4EGb7KaQzb41IxHNmbAzflTMW",
             eventName: "api_calls",
           },
         },
       ],
       onAlertTriggered: async ({ event, subscription, user, alertData }) => {
         // Send an email or notification
         // Interesting values: currentUsage: subscription.meteredUsage, alertThreshold: subscription.meteredAlertThreshold
       },
     },
   });
   ```

This is my first contribution to Better Auth, so if anything is wrong or missing,  feel free to tell me and i'll change it :) Thanks