### PR TITLE
feat: custom authorization request headers

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -1,8 +1,10 @@
 import { betterFetch } from "@better-fetch/fetch";
 import { APIError } from "better-call";
+import { decodeJwt } from "jose";
 import { z } from "zod";
 import { createAuthEndpoint, sessionMiddleware } from "../../api";
 import { setSessionCookie } from "../../cookies";
+import { BASE_ERROR_CODES } from "../../error/codes";
 import {
 	createAuthorizationURL,
 	validateAuthorizationCode,
@@ -10,11 +12,9 @@ import {
 	type OAuthProvider,
 } from "../../oauth2";
 import { handleOAuthUserInfo } from "../../oauth2/link-account";
+import { refreshAccessToken } from "../../oauth2/refresh-access-token";
 import { generateState, parseState } from "../../oauth2/state";
 import type { BetterAuthPlugin, User } from "../../types";
-import { decodeJwt } from "jose";
-import { BASE_ERROR_CODES } from "../../error/codes";
-import { refreshAccessToken } from "../../oauth2/refresh-access-token";
 
 /**
  * Configuration interface for generic OAuth providers.
@@ -133,6 +133,11 @@ export interface GenericOAuthConfig {
 	 */
 	discoveryHeaders?: Record<string, string>;
 	/**
+	 * Custom headers to include in the authorization request.
+	 * Useful for providers like Qonto that require specific headers (e.g., X-Qonto-Staging-Token for local development).
+	 */
+	authorizationHeaders?: Record<string, string>;
+	/**
 	 * Override user info with the provider info.
 	 *
 	 * This will update the user info with the provider info,
@@ -250,6 +255,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							});
 						}
 						return validateAuthorizationCode({
+							headers: c.authorizationHeaders,
 							code: data.code,
 							codeVerifier: data.codeVerifier,
 							redirectURI: data.redirectURI,
@@ -590,6 +596,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							});
 						}
 						tokens = await validateAuthorizationCode({
+							headers: provider.authorizationHeaders,
 							code,
 							codeVerifier: provider.pkce ? codeVerifier : undefined,
 							redirectURI: `${ctx.context.baseURL}/oauth2/callback/${provider.providerId}`,


### PR DESCRIPTION
Some OAuth2 provider asks headers to be passed on the authorization request.
In my case, I'm using Qonto and I need to pass a specific header for local development when calling any API endpoints (i.e. https://qonto.notion.site/08c9087f738340fc95a3cd61884f7700?v=15c985c4a8ff4d14b3806a6a42d00ecc&p=108734c9484b4e5cb190157e3093c149&pm=s)

API documentation: https://api-doc.qonto.com/docs/business-api/d6e8790ba0d51-token-endpoint