### PR TITLE
fix: return local IP in development mode

### DIFF
--- a/packages/better-auth/src/utils/get-request-ip.ts
+++ b/packages/better-auth/src/utils/get-request-ip.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthOptions } from "../types";
-import { isTest } from "../utils/env";
+import { isTest, isDevelopment } from "../utils/env";
 
 export function getIp(
 	req: Request | Headers,
@@ -11,6 +11,9 @@ export function getIp(
 	const testIP = "127.0.0.1";
 	if (isTest) {
 		return testIP;
+	}
+	if (isDevelopment) {
+		return testIP
 	}
 
 	const headers = "headers" in req ? req.headers : req;


### PR DESCRIPTION
In the getIp function, added a condition to return the loopback IP address (127.0.0.1) when running in development mode. This ensures that Better Auth's rate limiting functions correctly during local development by providing a consistent IP address. This change addresses issues where the client's IP address isn't available in local development environments because it is set to ::1 or another value, leading to the rate limiter not functioning as intended as it will not pass the isValidIp check.