### PR TITLE
Allow getUserInfo return null

### DIFF
--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -128,7 +128,7 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 			[key: string]: any;
 		};
 		data: any;
-	}>;
+	} | null>;
 	/**
 	 * Custom function to refresh a token
 	 */


### PR DESCRIPTION
Main `ProviderOptions.getUserInfo` do not allow to return `null` as value. But each oauth2 does.
VSCode complains about it:
<img width="563" alt="image" src="https://github.com/user-attachments/assets/9699ad21-0a6f-4b5d-96df-202321f14064" />

I've added `null` as a possible value for `ProviderOptions.getUserInfo` to `types.ts`