### PR TITLE
feat(generateId): support async id generator

### DIFF
--- a/packages/better-auth/src/adapters/create-adapter/index.ts
+++ b/packages/better-auth/src/adapters/create-adapter/index.ts
@@ -248,7 +248,7 @@ export const createAdapter =
 				required: shouldGenerateId ? true : false,
 				...(shouldGenerateId
 					? {
-							defaultValue() {
+							defaultValue: async () => {
 								if (config.disableIdGeneration) return undefined;
 								const useNumberId = options.advanced?.database?.useNumberId;
 								let generateId = options.advanced?.database?.generateId;
@@ -260,7 +260,7 @@ export const createAdapter =
 								}
 								if (generateId === false || useNumberId) return undefined;
 								if (generateId) {
-									return generateId({
+									return await generateId({
 										model,
 									});
 								}
@@ -329,7 +329,7 @@ export const createAdapter =
 					continue;
 				}
 				// If the value is undefined, but the fieldAttr provides a `defaultValue`, then we'll use that.
-				let newValue = withApplyDefault(value, fieldAttributes, action);
+				let newValue = await withApplyDefault(value, fieldAttributes, action);
 
 				// If the field attr provides a custom transform input, then we'll let it handle the value transformation.
 				// Afterwards, we'll continue to apply the default transformations just to make sure it saves in the correct format.

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -86,7 +86,7 @@ const createTransform = (options: BetterAuthOptions) => {
 	}
 
 	return {
-		transformInput(
+		async transformInput(
 			data: Record<string, any>,
 			model: string,
 			action: "create" | "update",
@@ -110,11 +110,12 @@ const createTransform = (options: BetterAuthOptions) => {
 				) {
 					continue;
 				}
-				transformedData[fields[field].fieldName || field] = withApplyDefault(
-					serializeID(field, value, model),
-					fields[field],
-					action,
-				);
+				transformedData[fields[field].fieldName || field] =
+					await withApplyDefault(
+						serializeID(field, value, model),
+						fields[field],
+						action,
+					);
 			}
 			return transformedData;
 		},
@@ -232,7 +233,11 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 		id: "mongodb-adapter",
 		async create(data) {
 			const { model, data: values, select } = data;
-			const transformedData = transform.transformInput(values, model, "create");
+			const transformedData = await transform.transformInput(
+				values,
+				model,
+				"create",
+			);
 			if (transformedData.id && !hasCustomId) {
 				// biome-ignore lint/performance/noDelete: setting id to undefined will cause the id to be null in the database which is not what we want
 				delete transformedData.id;

--- a/packages/better-auth/src/adapters/utils.ts
+++ b/packages/better-auth/src/adapters/utils.ts
@@ -1,6 +1,6 @@
 import type { FieldAttribute } from "../db";
 
-export function withApplyDefault(
+export async function withApplyDefault(
 	value: any,
 	field: FieldAttribute,
 	action: "create" | "update",
@@ -11,7 +11,7 @@ export function withApplyDefault(
 	if (value === undefined || value === null) {
 		if (field.defaultValue) {
 			if (typeof field.defaultValue === "function") {
-				return field.defaultValue();
+				return await field.defaultValue();
 			}
 			return field.defaultValue;
 		}

--- a/packages/better-auth/src/db/field.ts
+++ b/packages/better-auth/src/db/field.ts
@@ -42,7 +42,7 @@ export type FieldAttributeConfig<T extends FieldType = FieldType> = {
 	 * Note: This will not create a default value on the database level. It will only
 	 * be used when creating a new record.
 	 */
-	defaultValue?: Primitive | (() => Primitive);
+	defaultValue?: Primitive | (() => Primitive | Promise<Primitive>);
 	/**
 	 * transform the value before storing it.
 	 */

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -81,12 +81,12 @@ export const init = async (options: BetterAuthOptions) => {
 		})
 		.filter((x) => x !== null);
 
-	const generateIdFunc: AuthContext["generateId"] = ({ model, size }) => {
+	const generateIdFunc: AuthContext["generateId"] = async ({ model, size }) => {
 		if (typeof options.advanced?.generateId === "function") {
 			return options.advanced.generateId({ model, size });
 		}
 		if (typeof options?.advanced?.database?.generateId === "function") {
-			return options.advanced.database.generateId({ model, size });
+			return await options.advanced.database.generateId({ model, size });
 		}
 		return generateId(size);
 	};
@@ -205,7 +205,7 @@ export type AuthContext = {
 	generateId: (options: {
 		model: LiteralUnion<Models, string>;
 		size?: number;
-	}) => string;
+	}) => Promise<string> | string;
 	secondaryStorage: SecondaryStorage | undefined;
 	password: {
 		hash: (password: string) => Promise<string>;

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -699,7 +699,7 @@ export type BetterAuthOptions = {
 				| ((options: {
 						model: LiteralUnion<Models, string>;
 						size?: number;
-				  }) => string)
+				  }) => string | Promise<string>)
 				| false;
 		};
 		/**


### PR DESCRIPTION
Adds support for `async` on `generateId`.
![image](https://github.com/user-attachments/assets/4571de01-c391-4a6c-aef2-021a8fa1931e)
