### PR TITLE
fix: Encode callbackURL for reset-password handler. Fixes (#2561)

### DIFF
--- a/packages/better-auth/src/api/routes/forget-password.test.ts
+++ b/packages/better-auth/src/api/routes/forget-password.test.ts
@@ -141,6 +141,32 @@ describe("forget password", async (it) => {
 		});
 		expect(res2.error?.status).toBe(400);
 	});
+
+	it("should allow callbackURL to have multiple query params", async () => {
+		let url = "";
+
+		const { client, testUser } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword(context) {
+					url = context.url;
+					await mockSendEmail();
+				},
+				resetPasswordTokenExpiresIn: 10,
+			},
+		});
+
+		const queryParams = "foo=bar&baz=qux";
+		const redirectTo = `http://localhost:3000?${queryParams}`;
+		const res = await client.forgetPassword({
+			email: testUser.email,
+			redirectTo,
+		});
+
+		expect(res.data?.status).toBe(true);
+		expect(url).not.toContain(queryParams);
+		expect(url).toContain(`callbackURL=${encodeURIComponent(redirectTo)}`);
+	});
 });
 
 describe("revoke sessions on password reset", async (it) => {
@@ -230,30 +256,5 @@ describe("revoke sessions on password reset", async (it) => {
 			},
 		});
 		expect(sessionAttempt.data?.user).toBeDefined();
-	});
-	it("should allow callbackURL to have multiple query params", async () => {
-		let url = "";
-
-		const { client, testUser } = await getTestInstance({
-			emailAndPassword: {
-				enabled: true,
-				async sendResetPassword(context) {
-					url = context.url;
-					await mockSendEmail();
-				},
-				resetPasswordTokenExpiresIn: 10,
-			},
-		});
-
-		const queryParams = "foo=bar&baz=qux";
-		const redirectTo = `http://localhost:3000?${queryParams}`;
-		const res = await client.forgetPassword({
-			email: testUser.email,
-			redirectTo,
-		});
-
-		expect(res.data?.status).toBe(true);
-		expect(url).not.toContain(queryParams);
-		expect(url).toContain(`callbackURL=${encodeURIComponent(redirectTo)}`);
 	});
 });

--- a/packages/better-auth/src/api/routes/forget-password.ts
+++ b/packages/better-auth/src/api/routes/forget-password.ts
@@ -113,7 +113,8 @@ export const forgetPassword = createAuthEndpoint(
 			identifier: `reset-password:${verificationToken}`,
 			expiresAt,
 		});
-		const url = `${ctx.context.baseURL}/reset-password/${verificationToken}?callbackURL=${redirectTo}`;
+		const callbackURL = redirectTo ? encodeURIComponent(redirectTo) : "";
+		const url = `${ctx.context.baseURL}/reset-password/${verificationToken}?callbackURL=${callbackURL}`;
 		await ctx.context.options.emailAndPassword.sendResetPassword(
 			{
 				user: user.user,


### PR DESCRIPTION
This is a fix for the issue I found today #2561 