### PR TITLE
feat(stripe): adds option `preventDuplicateCustomers`

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -215,7 +215,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 
 				if (!customerId) {
 					try {
-						let stripeCustomer;
+						let stripeCustomer: Stripe.Customer | null = null;
 						
 						// Check for existing customer if preventDuplicateCustomers is enabled
 						if (options.preventDuplicateCustomers) {
@@ -983,7 +983,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							create: {
 								async after(user, ctx) {
 									if (ctx && options.createCustomerOnSignUp) {
-										let stripeCustomer;
+										let stripeCustomer: Stripe.Customer | null = null;
 										
 										// Check for existing customer if preventDuplicateCustomers is enabled
 										if (options.preventDuplicateCustomers) {

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -219,13 +219,17 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						
 						// Check for existing customer if preventDuplicateCustomers is enabled
 						if (options.preventDuplicateCustomers) {
-							const existingCustomers = await client.customers.list({
-								email: user.email,
-								limit: 1,
-							});
-							
-							if (existingCustomers.data.length > 0) {
-								stripeCustomer = existingCustomers.data[0];
+							try {
+								const existingCustomers = await client.customers.list({
+									email: user.email,
+									limit: 1,
+								});
+								
+								if (existingCustomers.data.length > 0) {
+									stripeCustomer = existingCustomers.data[0];
+								}
+							} catch (error) {
+								logger.error("Error checking for existing Stripe customer", error);
 							}
 						}
 						
@@ -983,13 +987,17 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 										
 										// Check for existing customer if preventDuplicateCustomers is enabled
 										if (options.preventDuplicateCustomers) {
-											const existingCustomers = await client.customers.list({
-												email: user.email,
-												limit: 1,
-											});
-											
-											if (existingCustomers.data.length > 0) {
-												stripeCustomer = existingCustomers.data[0];
+											try {
+												const existingCustomers = await client.customers.list({
+													email: user.email,
+													limit: 1,
+												});
+												
+												if (existingCustomers.data.length > 0) {
+													stripeCustomer = existingCustomers.data[0];
+												}
+											} catch (error) {
+												logger.error("Error checking for existing Stripe customer", error);
 											}
 										}
 										

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -216,7 +216,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				if (!customerId) {
 					try {
 						let stripeCustomer: Stripe.Customer | null = null;
-						
+
 						// Check for existing customer if preventDuplicateCustomers is enabled
 						if (options.preventDuplicateCustomers) {
 							try {
@@ -224,15 +224,18 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 									email: user.email,
 									limit: 1,
 								});
-								
+
 								if (existingCustomers.data.length > 0) {
 									stripeCustomer = existingCustomers.data[0];
 								}
 							} catch (error) {
-								logger.error("Error checking for existing Stripe customer", error);
+								logger.error(
+									"Error checking for existing Stripe customer",
+									error,
+								);
 							}
 						}
-						
+
 						// Create new customer if not found
 						if (!stripeCustomer) {
 							stripeCustomer = await client.customers.create(
@@ -249,7 +252,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								},
 							);
 						}
-						
+
 						await ctx.context.adapter.update({
 							model: "user",
 							update: {
@@ -984,7 +987,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								async after(user, ctx) {
 									if (ctx && options.createCustomerOnSignUp) {
 										let stripeCustomer: Stripe.Customer | null = null;
-										
+
 										// Check for existing customer if preventDuplicateCustomers is enabled
 										if (options.preventDuplicateCustomers) {
 											try {
@@ -992,15 +995,18 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 													email: user.email,
 													limit: 1,
 												});
-												
+
 												if (existingCustomers.data.length > 0) {
 													stripeCustomer = existingCustomers.data[0];
 												}
 											} catch (error) {
-												logger.error("Error checking for existing Stripe customer", error);
+												logger.error(
+													"Error checking for existing Stripe customer",
+													error,
+												);
 											}
 										}
-										
+
 										// Create new customer if not found
 										if (!stripeCustomer) {
 											stripeCustomer = await client.customers.create({
@@ -1011,7 +1017,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 												},
 											});
 										}
-										
+
 										const customer = await ctx.context.adapter.update<Customer>(
 											{
 												model: "user",

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -244,7 +244,11 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 
 						// Check for existing customer if preventDuplicateCustomers is enabled
 						if (options.preventDuplicateCustomers) {
-							stripeCustomer = await findExistingCustomer(client, user.email, options);
+							stripeCustomer = await findExistingCustomer(
+								client,
+								user.email,
+								options,
+							);
 						}
 
 						// Create new customer if not found
@@ -1001,7 +1005,11 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 
 										// Check for existing customer if preventDuplicateCustomers is enabled
 										if (options.preventDuplicateCustomers) {
-											stripeCustomer = await findExistingCustomer(client, user.email, options);
+											stripeCustomer = await findExistingCustomer(
+												client,
+												user.email,
+												options,
+											);
 										}
 
 										// Create new customer if not found

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -41,15 +41,6 @@ const STRIPE_ERROR_CODES = {
 		"Subscription is not scheduled for cancellation",
 } as const;
 
-const getUrl = (ctx: GenericEndpointContext, url: string) => {
-	if (url.startsWith("http")) {
-		return url;
-	}
-	return `${ctx.context.options.baseURL}${
-		url.startsWith("/") ? url : `/${url}`
-	}`;
-};
-
 /**
  * Helper function to check for existing Stripe customer by email
  */
@@ -73,6 +64,15 @@ const findExistingCustomer = async (
 		logger.error("Error checking for existing Stripe customer", error);
 		return null;
 	}
+};
+
+const getUrl = (ctx: GenericEndpointContext, url: string) => {
+	if (url.startsWith("http")) {
+		return url;
+	}
+	return `${ctx.context.options.baseURL}${
+		url.startsWith("/") ? url : `/${url}`
+	}`;
 };
 
 export const stripe = <O extends StripeOptions>(options: O) => {

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -175,6 +175,12 @@ export interface StripeOptions {
 	 */
 	createCustomerOnSignUp?: boolean;
 	/**
+	 * Prevent duplicate customers with the same email address
+	 * If enabled, will check if a customer with the email already exists in Stripe
+	 * and use that instead of creating a new one
+	 */
+	preventDuplicateCustomers?: boolean;
+	/**
 	 * A callback to run after a customer has been created
 	 * @param customer - Customer Data
 	 * @param stripeCustomer - Stripe Customer Data


### PR DESCRIPTION
Closes #2495 

This adds an option to the stripe plugin called `preventDuplicateCustomers` which, if enabled, will verify that a customer with that email doesn't already exist before creating a new customer.