### PR TITLE
Expose User and Session in `userHasPermission` Response

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1308,8 +1308,14 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 													success: {
 														type: "boolean",
 													},
+													user: {	
+														$ref: "#/components/schemas/User",
+													},
+													session: {	
+														$ref: "#/components/schemas/Session",
+													},
 												},
-												required: ["success"],
+												required: ["success", "user", "session"],
 											},
 										},
 									},
@@ -1361,6 +1367,8 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					return ctx.json({
 						error: null,
 						success: result,
+						user,
+						session: session.session,
 					});
 				},
 			),


### PR DESCRIPTION
Currently, userHasPermission internally fetches the active user to evaluate permissions but doesn't expose the user or session in the response. As a result, consumers of this function (like API endpoints) are forced to make an additional DB call to retrieve the same user for downstream logic (e.g., using user.id as a foreign key).

This PR updates userHasPermission to return the user and session objects alongside success and error to avoid redundant lookups and improve efficiency.