### PR TITLE
feat: Add API key regeneration functionality

### DIFF
--- a/docs/content/docs/plugins/api-key.mdx
+++ b/docs/content/docs/plugins/api-key.mdx
@@ -276,6 +276,41 @@ Otherwise, you'll receive the API Key details, except for the `key` value itself
 
 ---
 
+### Regenerate an API key
+
+<Endpoint method="POST" path="/api-key/regenerate"/>
+
+<Tabs items={['Client', 'Server']}>
+    <Tab value="Client">
+      ```ts
+      const { data: apiKey, error } = await authClient.apiKey.regenerate({
+        keyId: "your_api_key_id_here",
+      });
+      ```
+    </Tab>
+    <Tab value="Server">
+      ```ts
+      const apiKey = await auth.api.regenerateApiKey({
+        body: {
+          keyId: "your_api_key_id_here",
+        },
+      });
+      ```
+    </Tab>
+</Tabs>
+
+#### Properties
+
+- `keyId`: The API Key id to delete.
+
+#### Result
+
+If fails, throws `APIError`.
+Otherwise, you'll receive the API Key details.
+
+---
+
+
 ### Delete an API Key
 
 <Endpoint method="POST" path="/api-key/delete" />

--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -1430,6 +1430,69 @@ describe("api-key", async () => {
 	});
 
 	// =========================================================================
+	// REGENERATE API KEY
+	// =========================================================================
+
+	it("should fail to regenerate API key without headers or userId", async () => {
+		const apiKey = await client.apiKey.regenerate({
+			keyId: firstApiKey.id,
+		});
+		expect(apiKey.data).toBeNull();
+		expect(apiKey.error).toBeDefined();
+		expect(apiKey.error?.status).toEqual(401);
+		expect(apiKey.error?.statusText).toEqual("UNAUTHORIZED");
+	});
+
+	it("should regenerate API key with headers on client", async () => {
+		const apiKey = await client.apiKey.regenerate(
+			{
+				keyId: firstApiKey.id,
+			},
+			{ headers },
+		);
+		expect(apiKey.data).toBeDefined();
+		expect(apiKey.data?.key).not.toEqual(firstApiKey.key);
+		expect(apiKey.error).toBeNull();
+	});
+
+	it("should fail to regenerate an API key by ID that doesn't exist", async () => {
+		const apiKey = await client.apiKey.regenerate(
+			{
+				keyId: "invalid",
+			},
+			{ headers },
+		);
+		expect(apiKey.data).toBeNull();
+		expect(apiKey.error).toBeDefined();
+		expect(apiKey.error?.status).toEqual(404);
+		expect(apiKey.error?.statusText).toEqual("NOT_FOUND");
+		expect(apiKey.error?.message).toEqual(ERROR_CODES.KEY_NOT_FOUND);
+	});
+
+	it("should regenerate API key with headers on server", async () => {
+		let result: { data: Partial<ApiKey> | null; error: Err | null } = {
+			data: null,
+			error: null,
+		};
+
+		try {
+			const apiKey = await auth.api.regenerateApiKey({
+				body: {
+					keyId: firstApiKey.id,
+				},
+				headers,
+			});
+			result.data = apiKey;
+		} catch (error: any) {
+			result.error = error;
+		}
+
+		expect(result.data).toBeDefined();
+		expect(result.data?.key).not.toEqual(firstApiKey.key);
+		expect(result.error).toBeNull();
+	});
+
+	// =========================================================================
 	// DELETE API KEY
 	// =========================================================================
 

--- a/packages/better-auth/src/plugins/api-key/client.ts
+++ b/packages/better-auth/src/plugins/api-key/client.ts
@@ -7,6 +7,7 @@ export const apiKeyClient = () => {
 		$InferServerPlugin: {} as ReturnType<typeof apiKey>,
 		pathMethods: {
 			"/api-key/create": "POST",
+			"/api-key/regenerate": "POST",
 			"/api-key/delete": "POST",
 			"/api-key/delete-all-expired-api-keys": "POST",
 		},

--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -222,6 +222,7 @@ export const apiKey = (options?: ApiKeyOptions) => {
 		},
 		endpoints: {
 			createApiKey: routes.createApiKey,
+			regenerateApiKey: routes.regenerateApiKey,
 			verifyApiKey: routes.verifyApiKey,
 			getApiKey: routes.getApiKey,
 			updateApiKey: routes.updateApiKey,

--- a/packages/better-auth/src/plugins/api-key/routes/index.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/index.ts
@@ -8,6 +8,7 @@ import { updateApiKey } from "./update-api-key";
 import { verifyApiKey } from "./verify-api-key";
 import { listApiKeys } from "./list-api-keys";
 import { deleteAllExpiredApiKeysEndpoint } from "./delete-all-expired-api-keys";
+import { regenerateApiKey } from "./regenerate-api-key";
 import { API_KEY_TABLE_NAME } from "..";
 
 export type PredefinedApiKeyOptions = ApiKeyOptions &
@@ -76,6 +77,12 @@ export function createApiKeyRoutes({
 
 	return {
 		createApiKey: createApiKey({
+			keyGenerator,
+			opts,
+			schema,
+			deleteAllExpiredApiKeys,
+		}),
+		regenerateApiKey: regenerateApiKey({
 			keyGenerator,
 			opts,
 			schema,

--- a/packages/better-auth/src/plugins/api-key/routes/regenerate-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/regenerate-api-key.ts
@@ -1,0 +1,296 @@
+import { z } from "zod";
+import { APIError, createAuthEndpoint, sessionMiddleware } from "../../../api";
+import { API_KEY_TABLE_NAME, ERROR_CODES } from "..";
+import { apiKeySchema } from "../schema";
+import type { ApiKey } from "../types";
+import type { AuthContext } from "../../../types";
+import { createHash } from "@better-auth/utils/hash";
+import { base64Url } from "@better-auth/utils/base64";
+import type { PredefinedApiKeyOptions } from ".";
+import { safeJSONParse } from "../../../utils/json";
+
+export function regenerateApiKey({
+	keyGenerator,
+	opts,
+	schema,
+	deleteAllExpiredApiKeys,
+}: {
+	keyGenerator: (options: { length: number; prefix: string | undefined }) =>
+		| Promise<string>
+		| string;
+	opts: PredefinedApiKeyOptions;
+	schema: ReturnType<typeof apiKeySchema>;
+	deleteAllExpiredApiKeys(
+		ctx: AuthContext,
+		byPassLastCheckTime?: boolean,
+	): Promise<number> | undefined;
+}) {
+	return createAuthEndpoint(
+		"/api-key/regenerate",
+		{
+			method: "POST",
+			body: z.object({
+				keyId: z.string({
+					description: "The id of the Api Key to regenerate",
+				}),
+			}),
+			use: [sessionMiddleware],
+			metadata: {
+				openapi: {
+					description: "Regenerate an existing API key",
+					requestBody: {
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										keyId: {
+											type: "string",
+											description: "The id of the API key to regenerate",
+										},
+									},
+									required: ["keyId"],
+								},
+							},
+						},
+					},
+					responses: {
+						"200": {
+							description: "API key regenerated successfully",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											id: {
+												type: "string",
+												description: "Unique identifier of the API key",
+											},
+											createdAt: {
+												type: "string",
+												format: "date-time",
+												description: "Creation timestamp",
+											},
+											updatedAt: {
+												type: "string",
+												format: "date-time",
+												description: "Last update timestamp",
+											},
+											name: {
+												type: "string",
+												nullable: true,
+												description: "Name of the API key",
+											},
+											prefix: {
+												type: "string",
+												nullable: true,
+												description: "Prefix of the API key",
+											},
+											start: {
+												type: "string",
+												nullable: true,
+												description:
+													"Starting characters of the key (if configured)",
+											},
+											key: {
+												type: "string",
+												description:
+													"The full API key (only returned on creation/regeneration)",
+											},
+											enabled: {
+												type: "boolean",
+												description: "Whether the key is enabled",
+											},
+											expiresAt: {
+												type: "string",
+												format: "date-time",
+												nullable: true,
+												description: "Expiration timestamp",
+											},
+											userId: {
+												type: "string",
+												description: "ID of the user owning the key",
+											},
+											lastRefillAt: {
+												type: "string",
+												format: "date-time",
+												nullable: true,
+												description: "Last refill timestamp",
+											},
+											lastRequest: {
+												type: "string",
+												format: "date-time",
+												nullable: true,
+												description: "Last request timestamp",
+											},
+											metadata: {
+												type: "object",
+												nullable: true,
+												additionalProperties: true,
+												description: "Metadata associated with the key",
+											},
+											rateLimitMax: {
+												type: "number",
+												nullable: true,
+												description: "Maximum requests in time window",
+											},
+											rateLimitTimeWindow: {
+												type: "number",
+												nullable: true,
+												description: "Rate limit time window in milliseconds",
+											},
+											remaining: {
+												type: "number",
+												nullable: true,
+												description: "Remaining requests",
+											},
+											refillAmount: {
+												type: "number",
+												nullable: true,
+												description: "Amount to refill",
+											},
+											refillInterval: {
+												type: "number",
+												nullable: true,
+												description: "Refill interval in milliseconds",
+											},
+											rateLimitEnabled: {
+												type: "boolean",
+												description: "Whether rate limiting is enabled",
+											},
+											requestCount: {
+												type: "number",
+												description: "Current request count in window",
+											},
+											permissions: {
+												type: "object",
+												nullable: true,
+												additionalProperties: {
+													type: "array",
+													items: { type: "string" },
+												},
+												description: "Permissions associated with the key",
+											},
+										},
+										required: [
+											"id",
+											"createdAt",
+											"updatedAt",
+											"key",
+											"enabled",
+											"userId",
+											"rateLimitEnabled",
+											"requestCount",
+										],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const { keyId } = ctx.body;
+			const session = ctx.context.session;
+
+			if (session.user.banned === true) {
+				throw new APIError("UNAUTHORIZED", {
+					message: ERROR_CODES.USER_BANNED,
+				});
+			}
+
+			const apiKey = await ctx.context.adapter.findOne<ApiKey>({
+				model: API_KEY_TABLE_NAME,
+				where: [
+					{
+						field: "id",
+						value: keyId,
+					},
+				],
+			});
+
+			if (!apiKey || apiKey.userId !== session.user.id) {
+				throw new APIError("NOT_FOUND", {
+					message: ERROR_CODES.KEY_NOT_FOUND,
+				});
+			}
+
+			const key = await keyGenerator({
+				length: opts.defaultKeyLength,
+				prefix: apiKey.prefix ?? opts.defaultPrefix, // Use existing prefix or default
+			});
+
+			const hash = await createHash("SHA-256").digest(key);
+			const hashed = base64Url.encode(hash, {
+				padding: false,
+			});
+
+			let start: string | null = null;
+
+			if (opts.startingCharactersConfig.shouldStore) {
+				start = key.substring(
+					0,
+					opts.startingCharactersConfig.charactersLength,
+				);
+			}
+
+			let updatedApiKey: ApiKey;
+			try {
+				const result = await ctx.context.adapter.update<ApiKey>({
+					model: API_KEY_TABLE_NAME,
+					where: [
+						{
+							field: "id",
+							value: apiKey.id,
+						},
+						{
+							field: "userId",
+							value: session.user.id,
+						},
+					],
+					update: {
+						key: hashed,
+						start: start,
+						updatedAt: new Date(),
+					},
+				});
+
+				if (!result) {
+					throw new APIError("INTERNAL_SERVER_ERROR", {
+						message:
+							"Failed to update API key: Record not found for the given user or update was unsuccessful.",
+					});
+				}
+				updatedApiKey = result;
+			} catch (error: any) {
+				if (error instanceof APIError) {
+					throw error;
+				}
+				throw new APIError("INTERNAL_SERVER_ERROR", {
+					message:
+						error?.message ??
+						"An unexpected error occurred while regenerating the API key.",
+				});
+			}
+
+			deleteAllExpiredApiKeys(ctx.context);
+
+			return ctx.json({
+				...updatedApiKey,
+				metadata: updatedApiKey.metadata
+					? safeJSONParse(
+							//@ts-ignore - from DB, this value is always a string
+							updatedApiKey.metadata,
+						)
+					: null,
+				permissions: updatedApiKey.permissions
+					? safeJSONParse(
+							//@ts-ignore - from DB, this value is always a string
+							updatedApiKey.permissions,
+						)
+					: null,
+			});
+		},
+	);
+}


### PR DESCRIPTION
This PR introduces the ability to regenerate existing API keys. This enhancement allows users to generate a new key while maintaining the same associated permissions, configurations and id.

If you want me to change anything just let me know.