### PR TITLE
fix: remove userInfoUrl check to allow using custom function without url

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -299,9 +299,6 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 					},
 
 					async getUserInfo(tokens) {
-						if (!finalUserInfoUrl) {
-							return null;
-						}
 						const userInfo = c.getUserInfo
 							? await c.getUserInfo(tokens)
 							: await getUserInfo(tokens, finalUserInfoUrl);


### PR DESCRIPTION
As of now if I try to create a generic oauth provider by providing a custom `getUserInfo` function, it fails if I also dont provide a url for `userInfoUrl`.

This should not be the case, if the `getUserInfo` is provided it should be called regardless of the url which is unused either way, so It removes the check for the URL and calls the function if available rightaway