### PR TITLE
fix: ensure activeOrganizationId is stored as a ObjectId

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -583,6 +583,10 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 						type: "string",
 						required: false,
 						fieldName: options?.schema?.session?.fields?.activeOrganizationId,
+						references: {
+							model: "organization",
+							field: "id",
+						}
 					},
 				},
 			},


### PR DESCRIPTION
Added the reference field for MongoDB adapter to store the activeOrganizationId as ObjectId instead of string