### PR TITLE
fix: exclude current user from username update checks

### DIFF
--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -270,7 +270,10 @@ export const username = (options?: UsernameOptions) => {
 									},
 								],
 							});
-							if (user) {
+
+							const blockChangeSignUp = ctx.path === "/sign-up/email" && user;
+							const blockChangeUpdateUser = ctx.path === "/update-user" && user && user.id !== ctx.context.session?.session.userId;
+							if (blockChangeSignUp || blockChangeUpdateUser) {
 								throw new APIError("UNPROCESSABLE_ENTITY", {
 									message: ERROR_CODES.USERNAME_IS_ALREADY_TAKEN,
 								});

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -275,7 +275,8 @@ export const username = (options?: UsernameOptions) => {
 							const blockChangeUpdateUser =
 								ctx.path === "/update-user" &&
 								user &&
-								user.id !== ctx.context.session?.session.userId;
+								ctx.context.session &&
+								user.id !== ctx.context.session.session.userId;
 							if (blockChangeSignUp || blockChangeUpdateUser) {
 								throw new APIError("UNPROCESSABLE_ENTITY", {
 									message: ERROR_CODES.USERNAME_IS_ALREADY_TAKEN,

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -272,7 +272,10 @@ export const username = (options?: UsernameOptions) => {
 							});
 
 							const blockChangeSignUp = ctx.path === "/sign-up/email" && user;
-							const blockChangeUpdateUser = ctx.path === "/update-user" && user && user.id !== ctx.context.session?.session.userId;
+							const blockChangeUpdateUser =
+								ctx.path === "/update-user" &&
+								user &&
+								user.id !== ctx.context.session?.session.userId;
 							if (blockChangeSignUp || blockChangeUpdateUser) {
 								throw new APIError("UNPROCESSABLE_ENTITY", {
 									message: ERROR_CODES.USERNAME_IS_ALREADY_TAKEN,

--- a/packages/better-auth/src/plugins/username/username.test.ts
+++ b/packages/better-auth/src/plugins/username/username.test.ts
@@ -70,7 +70,7 @@ describe("username", async (it) => {
 		expect(session?.user.username).toBe("new_username_2.1");
 	});
 
-	it("should fail on duplicate username", async () => {
+	it("should fail on duplicate username in sign-up", async () => {
 		const res = await client.signUp.email({
 			email: "new-email-2@gamil.com",
 			username: "New_username_2.1",
@@ -78,6 +78,43 @@ describe("username", async (it) => {
 			name: "new-name",
 		});
 		expect(res.error?.status).toBe(422);
+	});
+
+	it("should fail on duplicate username in update-user if user is different", async () => {
+		await client.signUp.email({
+			email: "new-email-2@gamil.com",
+			username: "new_username1",
+			password: "new_password",
+			name: "new-name",
+			fetchOptions: {
+				headers: new Headers(),
+			}
+		});
+
+		const res = await client.updateUser({
+			username: "new_username1",
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(res.error?.status).toBe(422);
+	});
+
+	it("should succeed on duplicate username in update-user if user is the same", async () => {
+		const res = await client.updateUser({
+			username: "new_username",
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+				throw: true,
+			},
+		});
+		expect(session?.user.username).toBe("new_username");
 	});
 
 	it("should fail on invalid username", async () => {

--- a/packages/better-auth/src/plugins/username/username.test.ts
+++ b/packages/better-auth/src/plugins/username/username.test.ts
@@ -4,7 +4,7 @@ import { username } from ".";
 import { usernameClient } from "./client";
 
 describe("username", async (it) => {
-	const { client, sessionSetter } = await getTestInstance(
+	const { client, sessionSetter, signInWithTestUser } = await getTestInstance(
 		{
 			plugins: [
 				username({
@@ -81,28 +81,30 @@ describe("username", async (it) => {
 	});
 
 	it("should fail on duplicate username in update-user if user is different", async () => {
+		const newHeaders = new Headers();
 		await client.signUp.email({
 			email: "new-email-2@gamil.com",
-			username: "new_username1",
+			username: "duplicate-username",
 			password: "new_password",
 			name: "new-name",
 			fetchOptions: {
-				headers: new Headers(),
+				headers: newHeaders,
 			},
 		});
 
+		const { headers: testUserHeaders } = await signInWithTestUser();
 		const res = await client.updateUser({
-			username: "new_username1",
+			username: "duplicate-username",
 			fetchOptions: {
-				headers,
+				headers: testUserHeaders,
 			},
 		});
 		expect(res.error?.status).toBe(422);
 	});
 
 	it("should succeed on duplicate username in update-user if user is the same", async () => {
-		const res = await client.updateUser({
-			username: "new_username",
+		await client.updateUser({
+			username: "New_username_2.1",
 			fetchOptions: {
 				headers,
 			},
@@ -114,7 +116,7 @@ describe("username", async (it) => {
 				throw: true,
 			},
 		});
-		expect(session?.user.username).toBe("new_username");
+		expect(session?.user.username).toBe("new_username_2.1");
 	});
 
 	it("should fail on invalid username", async () => {

--- a/packages/better-auth/src/plugins/username/username.test.ts
+++ b/packages/better-auth/src/plugins/username/username.test.ts
@@ -88,7 +88,7 @@ describe("username", async (it) => {
 			name: "new-name",
 			fetchOptions: {
 				headers: new Headers(),
-			}
+			},
 		});
 
 		const res = await client.updateUser({


### PR DESCRIPTION
since the username plugin hooks into the `updateUser` endpoint, it's perfectly reasonable for devs to add this field onto a general user/profile/settings update form with other fields. the plugin currently doesn't discriminate between:

1. user sign up
2. user update conflicting with another user
3. user update conflicting with itself

right now if you wanted to keep the username field within your general `updateUser` form, you would need to conditionally remove the `username` property before submission. this pr allows 3 but still blocks 1 and 2