### PR TITLE
fix(docs): add note regarding cookie caching and RSC

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -91,6 +91,8 @@ export async function ServerComponent() {
 }
 ```
 
+<Callout type="warn">As RSCs cannot set cookies, the [cookie cache](/docs/concepts/session-management#cookie-cache) will not be refreshed until the server is interacted with from the client via Server Actions or Route Handlers.</Callout>
+
 ### Server Action Cookies
 
 When you call a function that needs to set cookies, like `signInEmail` or `signUpEmail` in a server action, cookies won’t be set. This is because server actions need to use the `cookies` helper from Next.js to set cookies.


### PR DESCRIPTION
spent an embarrassingly long time working to fix this problem until i remembered that RSCs cannot set cookies. should probably be noted in the docs which would then prevent issues like #2434 

noticed there's pr #2451 but that's an actual integration change instead of a docs note.