### PR TITLE
Fix TOTP get-totp-uri 

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -154,7 +154,7 @@ export const totp2fa = (options?: TOTPOptions) => {
 					},
 				],
 			});
-			if (!twoFactor || !user.twoFactorEnabled) {
+			if (!twoFactor) {
 				throw new APIError("BAD_REQUEST", {
 					message: TWO_FACTOR_ERROR_CODES.TOTP_NOT_ENABLED,
 				});


### PR DESCRIPTION
The twoFactorEnabled boolean isn't enabled when enabling 2FA and you have to verify a code before confirming but you are unable to do this if twoFactorEnabled isn't set to true.