### PR TITLE
Allow filtering users from using 'contains' operator

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -518,7 +518,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 							.or(z.boolean())
 							.optional(),
 						filterOperator: z
-							.enum(["eq", "ne", "lt", "lte", "gt", "gte"], {
+							.enum(["eq", "ne", "lt", "lte", "gt", "gte", "contains"], {
 								description: "The operator to use for the filter",
 							})
 							.optional(),


### PR DESCRIPTION
Motivation to allow 'contains' was so that i could filter by role when calling authClient.admin.listUsers().
Currently 'eq' (equals) is the only valid operator for filtering by role but it only works if role is the unique role set on user.
A user with roles 'admin' and 'user' can not be filtered using 'admin' nor 'user' as filter value

Closes #2588 