### PR TITLE
🔧 PR: Fix Incorrect Max Password Length in Docs

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -37,7 +37,7 @@ export const auth = betterAuth({
 To sign a user up, you can use the `signUp.email` function provided by the client. The `signUp` function takes an object with the following properties:
 
 - `email`: The email address of the user.
-- `password`: The password of the user. It should be at least 8 characters long and max 32 by default.
+- `password`: The password of the user. It should be at least 8 characters long and max 128 by default.
 - `name`: The name of the user.
 - `image`: The image of the user. (optional)
 


### PR DESCRIPTION
This PR fixes a documentation error in the "Email & Password → Usage → Sign Up" section.

Issue: #2572 

✅ What Changed
Updated the max password length mentioned in the password field description from 32 to 128 characters.

Reflects the actual validation constraint used by the system.

📌 Why This Matters
The previous limit (32 characters) was misleading and could cause unnecessary client-side restrictions.

This fix ensures users and developers have accurate information for implementing sign-up forms.