### PR TITLE
fix: encode/decode magic link callbackURL

### DIFF
--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -127,9 +127,9 @@ export const magicLink = (options: MagicLinkOptions) => {
 					);
 					const url = `${
 						ctx.context.baseURL
-					}/magic-link/verify?token=${verificationToken}&callbackURL=${
+					}/magic-link/verify?token=${verificationToken}&callbackURL=${encodeURIComponent(
 						ctx.body.callbackURL || "/"
-					}`;
+					)}`;
 					await options.sendMagicLink(
 						{
 							email,
@@ -158,7 +158,9 @@ export const magicLink = (options: MagicLinkOptions) => {
 							})
 							.optional(),
 					}),
-					use: [originCheck((ctx) => ctx.query.callbackURL)],
+					use: [
+						originCheck((ctx) => decodeURIComponent(ctx.query.callbackURL))
+					],
 					requireHeaders: true,
 					metadata: {
 						openapi: {
@@ -187,7 +189,15 @@ export const magicLink = (options: MagicLinkOptions) => {
 					},
 				},
 				async (ctx) => {
-					const { token, callbackURL } = ctx.query;
+					const token = ctx.query.token;
+					const encodedCallbackURL = ctx.query.callbackURL;
+					let callbackURL: string;
+					try {
+						callbackURL = encodedCallbackURL ? decodeURIComponent(encodedCallbackURL) : "/";
+					} catch (e) {
+						callbackURL = '/';
+					}
+					
 					const toRedirectTo = callbackURL?.startsWith("http")
 						? callbackURL
 						: callbackURL


### PR DESCRIPTION
Fixes an issue preventing **magic link** authentication from correctly redirecting to **callbackURL**s with **query parameters**. This is crucial for restoring post-login redirection to specific states.

Closes #2592 