### PR TITLE
fix(docs): add missing comma in listUsers query parameters

### DIFF
--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -120,7 +120,7 @@ const users = await authClient.admin.listUsers({
         limit: 10,
         offset: 0,
         sortBy: "createdAt",
-        sortDirection: "desc"
+        sortDirection: "desc",
         filterField: "role",
         filterOperator: "eq",
         filterValue: "admin"


### PR DESCRIPTION
I discovered what appears to be a missing comma in a snippet in the `/plugins/admin` of the documentation, so I will fix it.

Thank you.

https://www.better-auth.com/docs/plugins/admin

```diff
const users = await authClient.admin.listUsers({
    query: {
        searchField: "email",
        searchOperator: "contains",
        searchValue: "@example.com",
        limit: 10,
        offset: 0,
        sortBy: "createdAt",
-       sortDirection: "desc"
+       sortDirection: "desc",
        filterField: "role",
        filterOperator: "eq",
        filterValue: "admin"
    }
});
```