### PR TITLE
Support postgres array types

### DIFF
--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -64,8 +64,38 @@ export function matchType(
 	fieldType: FieldType,
 	dbType: KyselyDatabaseType,
 ) {
+	const lowerColumnDataType = columnDataType.toLowerCase();
+
+	if (dbType === "postgres") {
+		if (fieldType === "string[]") {
+			if (
+				lowerColumnDataType === "_text" ||
+				lowerColumnDataType === "text[]" ||
+				lowerColumnDataType === "_varchar" ||
+				lowerColumnDataType === "varchar[]" ||
+				lowerColumnDataType === "_char" ||
+				lowerColumnDataType === "char[]" ||
+				lowerColumnDataType === "_bpchar" ||
+				lowerColumnDataType === "bpchar[]"
+			) {
+				return true;
+			}
+		} else if (fieldType === "number[]") {
+			if (
+				lowerColumnDataType === "_int4" || lowerColumnDataType === "integer[]" ||
+				lowerColumnDataType === "_int8" || lowerColumnDataType === "bigint[]" ||
+				lowerColumnDataType === "_int2" || lowerColumnDataType === "smallint[]" ||
+				lowerColumnDataType === "_float4" || lowerColumnDataType === "real[]" ||
+				lowerColumnDataType === "_float8" || lowerColumnDataType === "double precision[]" ||
+				lowerColumnDataType === "_numeric" || lowerColumnDataType === "numeric[]"
+			) {
+				return true;
+			}
+		}
+	}
+
 	if (fieldType === "string[]" || fieldType === "number[]") {
-		return columnDataType.toLowerCase().includes("json");
+		return lowerColumnDataType.includes("json");
 	}
 	const types = map[dbType];
 	const type = Array.isArray(fieldType)


### PR DESCRIPTION
I have a custom plugin with a string[] type and that resulted in a warning despite me using a postgres array type.
```
2025-05-13 10:26:10.237 WARN  servercode/src/lib/auth/auth.ts:107 Field roles in table user has a different type in the database. Expected string[] but got _text.
```

Looking at the code it only allowed json previously, this is a small patch that adds various array types into the check.