### PR TITLE
docs: update nuxt catch-all route to match example

### DIFF
--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -7,9 +7,9 @@ Before you start, make sure you have a Better Auth instance configured. If you h
 
 ### Create API Route
 
-We need to mount the handler to an API route. Create a file inside `/server/api` called `[...auth].ts` and add the following code:
+We need to mount the handler to an API route. Create a file inside `/server/api/auth` called `[...all].ts` and add the following code:
 
-```ts title="server/api/[...auth].ts"
+```ts title="server/api/auth/[...all].ts"
 import { auth } from "~/lib/auth"; // import your auth config
 
 export default defineEventHandler((event) => {
@@ -17,7 +17,7 @@ export default defineEventHandler((event) => {
 });
 ```
 <Callout type="info">
- You can change the path on your better-auth configuration but it's recommended to keep it as `/api/[...auth]`
+ You can change the path on your better-auth configuration but it's recommended to keep it as `/api/auth/[...all]`
 </Callout>
 
 ### Migrate the database


### PR DESCRIPTION
The docs refer to `server/api/[...auth].ts` as the path to place the server route handler. This is incorrect as it matches all routes under `/api`. The [nuxt example correctly uses `server/api/auth/[...all].ts`](https://github.com/better-auth/better-auth/blob/dd122da3e5ea8e20e6d3bebad8ec7490d656b95d/examples/nuxt-example/server/api/auth/%5B...all%5D.ts) which only matches routes under `/api/auth`.

This PR updates the docs to match the proper usage in the example