### PR TITLE
Use custom errorURL when available

### DIFF
--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -31,9 +31,9 @@ export async function handleOAuthUserInfo(
 				"Better auth was unable to query your database.\nError: ",
 				e,
 			);
-			throw c.redirect(
-				`${c.context.baseURL}/error?error=internal_server_error`,
-			);
+			const errorURL =
+				c.context.options.onAPIError?.errorURL || `${c.context.baseURL}/error`;
+			throw c.redirect(`${errorURL}?error=internal_server_error`);
 		});
 	let user = dbUser?.user;
 	let isRegister = !user;

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -62,9 +62,8 @@ export async function parseState(c: GenericEndpointContext) {
 		c.context.logger.error("State Mismatch. Verification not found", {
 			state,
 		});
-		throw c.redirect(
-			`${c.context.baseURL}/error?error=please_restart_the_process`,
-		);
+		const errorURL = c.context.options.onAPIError?.errorURL || `${c.context.baseURL}/error`;
+		throw c.redirect(`${errorURL}?error=please_restart_the_process`);
 	}
 	const parsedData = z
 		.object({
@@ -88,9 +87,9 @@ export async function parseState(c: GenericEndpointContext) {
 	}
 	if (parsedData.expiresAt < Date.now()) {
 		await c.context.internalAdapter.deleteVerificationValue(data.id);
-		throw c.redirect(
-			`${c.context.baseURL}/error?error=please_restart_the_process`,
-		);
+		const errorURL =
+				c.context.options.onAPIError?.errorURL || `${c.context.baseURL}/error`;
+		throw c.redirect(`${errorURL}?error=please_restart_the_process`);
 	}
 	await c.context.internalAdapter.deleteVerificationValue(data.id);
 	return parsedData;

--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -10,6 +10,10 @@ function redirectErrorURL(url: string, error: string, description: string) {
 	}error=${error}&error_description=${description}`;
 }
 
+function getDefaultOrCustomErrorURL(ctx: GenericEndpointContext) {
+	return ctx.context.options.onAPIError?.errorURL || `${ctx.context.baseURL}/error`;
+}
+
 export async function authorize(
 	ctx: GenericEndpointContext,
 	options: OIDCOptions,
@@ -54,10 +58,12 @@ export async function authorize(
 
 	const query = ctx.query as AuthorizationQuery;
 	if (!query.client_id) {
-		throw ctx.redirect(`${ctx.context.baseURL}/error?error=invalid_client`);
+		const errorURL = getDefaultOrCustomErrorURL(ctx);
+		throw ctx.redirect(`${errorURL}?error=invalid_client`);
 	}
 
 	if (!query.response_type) {
+		const errorURL = getDefaultOrCustomErrorURL(ctx);
 		throw ctx.redirect(
 			redirectErrorURL(
 				`${ctx.context.baseURL}/error`,
@@ -88,7 +94,8 @@ export async function authorize(
 			} as Client;
 		});
 	if (!client) {
-		throw ctx.redirect(`${ctx.context.baseURL}/error?error=invalid_client`);
+		const errorURL = getDefaultOrCustomErrorURL(ctx);
+		throw ctx.redirect(`${errorURL}?error=invalid_client`);
 	}
 	const redirectURI = client.redirectURLs.find(
 		(url) => url === ctx.query.redirect_uri,
@@ -103,12 +110,14 @@ export async function authorize(
 		});
 	}
 	if (client.disabled) {
-		throw ctx.redirect(`${ctx.context.baseURL}/error?error=client_disabled`);
+		const errorURL = getDefaultOrCustomErrorURL(ctx);
+		throw ctx.redirect(`${errorURL}?error=client_disabled`);
 	}
 
 	if (query.response_type !== "code") {
+		const errorURL = getDefaultOrCustomErrorURL(ctx);
 		throw ctx.redirect(
-			`${ctx.context.baseURL}/error?error=unsupported_response_type`,
+			`${errorURL}?error=unsupported_response_type`,
 		);
 	}
 

--- a/packages/better-auth/src/plugins/sso/index.ts
+++ b/packages/better-auth/src/plugins/sso/index.ts
@@ -645,9 +645,10 @@ export const sso = (options?: SSOOptions) => {
 					const { code, state, error, error_description } = ctx.query;
 					const stateData = await parseState(ctx);
 					if (!stateData) {
-						throw ctx.redirect(
-							`${ctx.context.baseURL}/error?error=invalid_state`,
-						);
+						const errorURL =
+							ctx.context.options.onAPIError?.errorURL ||
+							`${ctx.context.baseURL}/error`;
+						throw ctx.redirect(`${errorURL}?error=invalid_state`);
 					}
 					const { callbackURL, errorURL, newUserURL, requestSignUp } =
 						stateData;


### PR DESCRIPTION
This PR resolves: https://github.com/better-auth/better-auth/issues/2519

### Summary
There are a few places in the code where the custom errorURL is not checked/used, resulting in the default Better Auth error page.  This PR copies the way this is done elsewhere to check for the custom errorURL in context before deciding which URL to use. 


### Notes
Future improvement opportunities:  centralize the logic so it isn't duplicated throughout the codebase as it is today.  Or potentially have a higher level error function that handles throwing the redirect with the error URL.  I kept it simple for this bug fix though.