### PR TITLE
fix: use dynamic list of social providers to allow generic oauth

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -1,9 +1,5 @@
 import { z } from "zod";
 import { createAuthEndpoint } from "../call";
-import {
-	socialProviderList,
-	type SocialProvider,
-} from "../../social-providers";
 import { APIError } from "better-call";
 import { generateState, type OAuth2Tokens } from "../../oauth2";
 import {
@@ -12,6 +8,7 @@ import {
 	sessionMiddleware,
 } from "./session";
 import { BASE_ERROR_CODES } from "../../error/codes";
+import { SocialProviderListEnum } from "../../social-providers";
 
 export const listUserAccounts = createAuthEndpoint(
 	"/list-accounts",
@@ -106,9 +103,7 @@ export const linkSocialAccount = createAuthEndpoint(
 			/**
 			 * OAuth2 provider to use
 			 */
-			provider: z.enum(socialProviderList, {
-				description: "The OAuth2 provider to use",
-			}),
+			provider: SocialProviderListEnum,
 			/**
 			 * Additional scopes to request when linking the account.
 			 * This is useful for requesting additional permissions when
@@ -326,7 +321,7 @@ export const getAccessToken = createAuthEndpoint(
 				message: `Either userId or session is required`,
 			});
 		}
-		if (!socialProviderList.includes(providerId as SocialProvider)) {
+		if (!ctx.context.socialProviders.find((p) => p.id === providerId)) {
 			throw new APIError("BAD_REQUEST", {
 				message: `Provider ${providerId} is not supported.`,
 			});
@@ -469,7 +464,7 @@ export const refreshToken = createAuthEndpoint(
 				message: `Either userId or session is required`,
 			});
 		}
-		if (!socialProviderList.includes(providerId as SocialProvider)) {
+		if (!ctx.context.socialProviders.find((p) => p.id === providerId)) {
 			throw new APIError("BAD_REQUEST", {
 				message: `Provider ${providerId} is not supported.`,
 			});

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -2,11 +2,11 @@ import { APIError } from "better-call";
 import { z } from "zod";
 import { createAuthEndpoint } from "../call";
 import { setSessionCookie } from "../../cookies";
-import { SocialProviderListEnum } from "../../social-providers";
 import { createEmailVerificationToken } from "./email-verification";
 import { generateState } from "../../utils";
 import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import { BASE_ERROR_CODES } from "../../error/codes";
+import { SocialProviderListEnum } from "../../social-providers";
 
 export const signInSocial = createAuthEndpoint(
 	"/sign-in/social",

--- a/packages/better-auth/src/social-providers/index.ts
+++ b/packages/better-auth/src/social-providers/index.ts
@@ -44,9 +44,9 @@ export const socialProviderList = Object.keys(socialProviders) as [
 	...(keyof typeof socialProviders)[],
 ];
 
-export const SocialProviderListEnum = z.enum(socialProviderList, {
-	description: "OAuth2 provider to use",
-});
+export const SocialProviderListEnum = z
+	.enum(socialProviderList)
+	.or(z.string()) as z.ZodType<SocialProviderList[number] | (string & {})>;
 
 export type SocialProvider = z.infer<typeof SocialProviderListEnum>;
 


### PR DESCRIPTION
fixes #2610
ref https://github.com/better-auth/better-auth/pull/2557#issuecomment-2876979264

the endpoints now use the soclal provider list in context so that generic oauth plugin providers are also allowed in token endpoints