### PR TITLE
feat(magic-link): add customizable error and new user callbacks

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
@@ -1,1 +1,1 @@
-IDLE
+RUNNING

--- a/packages/better-auth/src/plugins/magic-link/utils.ts
+++ b/packages/better-auth/src/plugins/magic-link/utils.ts
@@ -1,0 +1,3 @@
+export function redirectErrorURL(url: string, error: string) {
+	return `${url}${url.includes("?") ? "&" : "?"}error=${error}`;
+}


### PR DESCRIPTION
This pull request adds support for two new optional parameters to the magic link authentication flow: `errorCallbackURL` for redirecting users to a custom URL when an error occurs during verification, and `newUserCallbackURL` for redirecting new users after successful sign-up. 