### PR TITLE
fix(mongo-adapter): fix incorrect transformation of findOneAndX outputs

### DIFF
--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -291,7 +291,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 						returnDocument: "after",
 					},
 				);
-			const output = res?.value ?? res
+			const output = res?.value ?? res;
 			if (!output) return null;
 			return transform.transformOutput(output, model);
 		},
@@ -310,7 +310,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 			const res = await db
 				.collection(transform.getModelName(model))
 				.findOneAndDelete(clause);
-			const output = res?.value ?? res
+			const output = res?.value ?? res;
 			if (!output) return null;
 			return transform.transformOutput(output, model);
 		},

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -292,7 +292,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 					},
 				);
 			if (!res) return null;
-			return transform.transformOutput(res.value, model);
+			return transform.transformOutput(res.value || res, model);
 		},
 		async updateMany(data) {
 			const { model, where, update: values } = data;
@@ -310,7 +310,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 				.collection(transform.getModelName(model))
 				.findOneAndDelete(clause);
 			if (!res) return null;
-			return transform.transformOutput(res.value, model);
+			return transform.transformOutput(res.value || res, model);
 		},
 		async deleteMany(data) {
 			const { model, where } = data;

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -292,7 +292,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 					},
 				);
 			if (!res) return null;
-			return transform.transformOutput(res, model);
+			return transform.transformOutput(res.value, model);
 		},
 		async updateMany(data) {
 			const { model, where, update: values } = data;
@@ -310,7 +310,7 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 				.collection(transform.getModelName(model))
 				.findOneAndDelete(clause);
 			if (!res) return null;
-			return transform.transformOutput(res, model);
+			return transform.transformOutput(res.value, model);
 		},
 		async deleteMany(data) {
 			const { model, where } = data;

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -291,8 +291,9 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 						returnDocument: "after",
 					},
 				);
-			if (!res) return null;
-			return transform.transformOutput(res.value || res, model);
+			const output = res?.value ?? res
+			if (!output) return null;
+			return transform.transformOutput(output, model);
 		},
 		async updateMany(data) {
 			const { model, where, update: values } = data;
@@ -309,8 +310,9 @@ export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
 			const res = await db
 				.collection(transform.getModelName(model))
 				.findOneAndDelete(clause);
-			if (!res) return null;
-			return transform.transformOutput(res.value || res, model);
+			const output = res?.value ?? res
+			if (!output) return null;
+			return transform.transformOutput(output, model);
 		},
 		async deleteMany(data) {
 			const { model, where } = data;


### PR DESCRIPTION
The MongoDB adapter was using the `res` from the `findOneAndX` operations instead of using `res.value`. This was causing all properties to have `undefined` as their value. This causes a `APIError: Failed to get session` to be thrown when a session is being refreshed once past `updateAge`.

The return value from `findOneAndX` is `Promise<WithId<TSchema> | ModifyResult<TSchema> | null>`.

MongoDB type definitions:
https://github.com/mongodb/node-mongodb-native/blob/main/src/collection.ts#L100
https://github.com/mongodb/node-mongodb-native/blob/main/src/collection.ts#L982