### PR TITLE
feat: add sendVerificationOnSignIn to prevent automatic resending of verification email on login with requireEmailVerification

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -134,26 +134,55 @@ export const auth = betterAuth({
 });
 ```
 
-If a user tries to sign in without verifying their email, you can handle the error and show a message to the user.
+If you prefer to control when verification emails are sent, you can disable automatic sending:
 
-```ts title="auth-client.ts"
-await authClient.signIn.email(
-  {
-    email: "email@example.com",
-    password: "password",
+```ts title="auth.ts"
+export const auth = betterAuth({
+  emailAndPassword: {
+    requireEmailVerification: true,
+    sendVerificationOnSignIn: false, // Email verification still required, but emails won't be sent automatically
   },
-  {
-    onError: (ctx) => {
-      // Handle the error
-      if (ctx.error.status === 403) {
-        alert("Please verify your email address");
-      }
-      //you can also show the original error message
-      alert(ctx.error.message);
-    },
-  }
-);
+});
 ```
+
+With this option, email verification is still required, but you'll need to manually trigger verification emails using the `sendVerificationEmail` function.
+
+Here's an example of how to manually trigger verification emails when sign-in fails due to unverified email:
+
+```ts title="SignInForm.tsx"
+import { authClient } from "./auth-client";
+
+async function handleSignIn(email: string, password: string) {
+  const result = await authClient.signIn.email({
+    email,
+    password,
+  }, {
+    onError: async (ctx) => {
+      // Check if the error is due to email not being verified
+      if (ctx.error.status === 403 && ctx.error.message === "EMAIL_NOT_VERIFIED") {
+        // Manually send verification email
+        await authClient.sendVerificationEmail({
+          email,
+          callbackURL: "/dashboard"
+        });
+        
+        // Show message to user
+        alert("We've sent you a verification email. Please check your inbox.");
+      } else {
+        // Handle other errors
+        alert(ctx.error.message);
+      }
+    }
+  });
+  
+  if (result.data) {
+    // Redirect to dashboard or other protected page
+    window.location.href = "/dashboard";
+  }
+}
+```
+
+This approach gives you more control over when verification emails are sent and allows you to implement custom UX flows for the verification process.
 
 #### Triggering manually Email Verification
 
@@ -277,6 +306,16 @@ export const auth = betterAuth({
       description: "Disable email and password sign up.",
       type: "boolean",
       default: "false"
+    },
+    requireEmailVerification: {
+      description: "Require email verification before a user can log in.",
+      type: "boolean",
+      default: "false"
+    },
+    sendVerificationOnSignIn: {
+      description: "Whether to automatically send verification emails during sign-in attempts when requireEmailVerification is true.",
+      type: "boolean",
+      default: "true"
     },
     minPasswordLength: {
       description: "The minimum length of a password.",

--- a/docs/content/docs/concepts/email.mdx
+++ b/docs/content/docs/concepts/email.mdx
@@ -78,6 +78,29 @@ export const auth = betterAuth({
 })
 ```
 
+##### Controlling verification email sending
+
+By default, when `requireEmailVerification` is true, verification emails are automatically sent during sign-in attempts if the user's email isn't verified. This might not be the desired behavior for all applications.
+
+If you want more control over when verification emails are sent, you can disable automatic sending:
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+    emailAndPassword: {
+        requireEmailVerification: true,
+        sendVerificationOnSignIn: false // Email verification still required, but emails won't be sent automatically
+    }
+})
+```
+
+With this configuration:
+- Email verification is still required to sign in
+- Users with unverified emails will still receive a 403 error when trying to sign in
+- However, verification emails won't be automatically sent during sign-in attempts
+- You'll need to explicitly trigger verification emails using the `sendVerificationEmail` function
+
+This gives you more control over your authentication flow, similar to how OTP verification works.
+
 if a user tries to sign in without verifying their email, you can handle the error and show a message to the user.
 
 ```ts title="auth-client.ts"

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -135,6 +135,7 @@ export const auth = betterAuth({
 		enabled: true,
 		disableSignUp: false,
 		requireEmailVerification: true,
+		sendVerificationOnSignIn: true,
 		minPasswordLength: 8,
 		maxPasswordLength: 128,
 		autoSignIn: true,
@@ -159,6 +160,7 @@ export const auth = betterAuth({
 - `enabled`: Enable email and password authentication (default: `false`)
 - `disableSignUp`: Disable email and password sign up (default: `false`)
 - `requireEmailVerification`: Require email verification before a session can be created
+- `sendVerificationOnSignIn`: Whether to automatically send verification emails during sign-in attempts when requireEmailVerification is true (default: `true`)
 - `minPasswordLength`: Minimum password length (default: `8`)
 - `maxPasswordLength`: Maximum password length (default: `128`)
 - `autoSignIn`: Automatically sign in the user after sign up

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -501,23 +501,28 @@ export const signInEmail = createAuthEndpoint(
 					message: BASE_ERROR_CODES.EMAIL_NOT_VERIFIED,
 				});
 			}
-			const token = await createEmailVerificationToken(
-				ctx.context.secret,
-				user.user.email,
-				undefined,
-				ctx.context.options.emailVerification?.expiresIn,
-			);
-			const url = `${
-				ctx.context.baseURL
-			}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;
-			await ctx.context.options.emailVerification.sendVerificationEmail(
-				{
-					user: user.user,
-					url,
-					token,
-				},
-				ctx.request,
-			);
+			
+			// Check if sending verification email on sign-in is enabled (default is true)
+			if (ctx.context.options.emailAndPassword.sendVerificationOnSignIn !== false) {
+				const token = await createEmailVerificationToken(
+					ctx.context.secret,
+					user.user.email,
+					undefined,
+					ctx.context.options.emailVerification?.expiresIn,
+				);
+				const url = `${
+					ctx.context.baseURL
+				}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;
+				await ctx.context.options.emailVerification.sendVerificationEmail(
+					{
+						user: user.user,
+						url,
+						token,
+					},
+					ctx.request,
+				);
+			}
+			
 			throw new APIError("FORBIDDEN", {
 				message: BASE_ERROR_CODES.EMAIL_NOT_VERIFIED,
 			});

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -150,7 +150,10 @@ export const username = (options?: UsernameOptions) => {
 						!user.emailVerified &&
 						ctx.context.options.emailAndPassword?.requireEmailVerification
 					) {
-						await sendVerificationEmailFn(ctx, user);
+						// Check if sending verification email on sign-in is enabled (default is true)
+						if (ctx.context.options.emailAndPassword.sendVerificationOnSignIn !== false) {
+							await sendVerificationEmailFn(ctx, user);
+						}
 						throw new APIError("FORBIDDEN", {
 							message: ERROR_CODES.EMAIL_NOT_VERIFIED,
 						});

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -189,6 +189,15 @@ export type BetterAuthOptions = {
 		 */
 		requireEmailVerification?: boolean;
 		/**
+		 * Controls whether verification emails are sent during sign-in 
+		 * attempts when requireEmailVerification is true.
+		 * When set to false, verification emails won't be sent automatically
+		 * during sign-in, giving developers more control over the flow.
+		 * 
+		 * @default true
+		 */
+		sendVerificationOnSignIn?: boolean;
+		/**
 		 * The maximum length of the password.
 		 *
 		 * @default 128


### PR DESCRIPTION
This pull request introduces a new configuration option, `sendVerificationOnSignIn`, to provide more control over email verification during the sign-in process. The changes span documentation updates, backend logic, and test cases to support this feature. Key updates include the ability to disable automatic verification emails and manually trigger them, alongside enhanced flexibility for developers in customizing the user authentication flow.

### Documentation Updates:
* Added explanations and examples for the new `sendVerificationOnSignIn` option in the authentication documentation (`docs/content/docs/authentication/email-password.mdx`, `docs/content/docs/concepts/email.mdx`, `docs/content/docs/reference/options.mdx`). [[1]](diffhunk://#diff-dae429fa3662f75a0374f14e5c0564fd7b3e14aedbce267b4f5537cd97db5e78L137-R186) [[2]](diffhunk://#diff-dae429fa3662f75a0374f14e5c0564fd7b3e14aedbce267b4f5537cd97db5e78R310-R319) [[3]](diffhunk://#diff-100613a5a97d8e43008d0d33731d4bfdf97f74435e5b3478f773a5d17eaa5c05R81-R103) [[4]](diffhunk://#diff-31827aa0dc7160b3102b6a05cd14641760cd34bf5ff499a40d16862b36345819R138) [[5]](diffhunk://#diff-31827aa0dc7160b3102b6a05cd14641760cd34bf5ff499a40d16862b36345819R163)

### Backend Logic Enhancements:
* Updated the `sign-in` endpoint to respect the `sendVerificationOnSignIn` option, skipping automatic email verification when set to `false` (`packages/better-auth/src/api/routes/sign-in.ts`). [[1]](diffhunk://#diff-d23d71b9544f44d17b8e26b0a1ed49fc5fc804aaa290db92dbfb5665c7df4797R504-R506) [[2]](diffhunk://#diff-d23d71b9544f44d17b8e26b0a1ed49fc5fc804aaa290db92dbfb5665c7df4797R524-R525)
* Added similar logic to the `username` plugin to conditionally send verification emails based on the new option (`packages/better-auth/src/plugins/username/index.ts`).

### Type Definitions:
* Introduced the `sendVerificationOnSignIn` property in the `BetterAuthOptions` type, with a default value of `true` (`packages/better-auth/src/types/options.ts`).

### Test Coverage:
* Added a test case to ensure no verification email is sent when `sendVerificationOnSignIn` is set to `false` (`packages/better-auth/src/api/routes/email-verification.test.ts`).