### PR TITLE
fix: make getAccessToken available to client

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -271,7 +271,6 @@ export const getAccessToken = createAuthEndpoint(
 				.optional(),
 		}),
 		metadata: {
-			SERVER_ONLY: true,
 			openapi: {
 				description: "Get a valid access token, doing a refresh if needed",
 				responses: {


### PR DESCRIPTION
ref https://github.com/better-auth/better-auth/pull/2557#issuecomment-2883594724

removed `SERVER_ONLY` on `getAccessToken` endpoint so that the method is available to client as stated in the docs