### PR TITLE
fix: missing quotes for drizzle default values

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -139,6 +139,8 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 							if (attr.defaultValue) {
 								if (typeof attr.defaultValue === "function") {
 									type += `.$defaultFn(${attr.defaultValue})`;
+								} else if (typeof attr.defaultValue === "string") {
+									type += `.default("${attr.defaultValue}")`;
 								} else {
 									type += `.default(${attr.defaultValue})`;
 								}


### PR DESCRIPTION
When using the drizzle generator it doesn't include quotes for string default types, causing it to generate code that doesn't compile. This regression was introduced with af402dba3a0a00570a80b6401d6dde134ada1262