### PR TITLE
docs: fix discord invite links

### DIFF
--- a/docs/app/changelogs/[[...slug]]/page.tsx
+++ b/docs/app/changelogs/[[...slug]]/page.tsx
@@ -79,7 +79,7 @@ export default async function Page({
 							GitHub
 						</IconLink>
 						<IconLink
-							href="https://discord.com/better-auth"
+							href="https://discord.gg/better-auth"
 							icon={DiscordLogoIcon}
 							className="flex-none text-gray-600 dark:text-gray-300"
 						>

--- a/docs/app/changelogs/_components/changelog-layout.tsx
+++ b/docs/app/changelogs/_components/changelog-layout.tsx
@@ -69,7 +69,7 @@ export function Intro() {
 					GitHub
 				</IconLink>
 				<IconLink
-					href="https://discord.com/better-auth"
+					href="https://discord.gg/better-auth"
 					icon={DiscordLogoIcon}
 					className="flex-none text-gray-600 dark:text-gray-300"
 				>

--- a/docs/app/changelogs/_components/default-changelog.tsx
+++ b/docs/app/changelogs/_components/default-changelog.tsx
@@ -97,7 +97,7 @@ const ChangelogPage = async () => {
 							GitHub
 						</IconLink>
 						<IconLink
-							href="https://discord.com/better-auth"
+							href="https://discord.gg/better-auth"
 							icon={DiscordLogoIcon}
 							className="flex-none text-gray-600 dark:text-gray-300"
 						>

--- a/docs/app/community/_components/stats.tsx
+++ b/docs/app/community/_components/stats.tsx
@@ -33,7 +33,7 @@ export default function Stats({ npmDownloads }: { npmDownloads: number }) {
 							<div className="flex items-end  w-full gap-2 mt-4 text-gray-400">
 								<Link
 									className="w-full"
-									href="https://discord.gg/Mh3DaacaFs"
+									href="https://discord.gg/better-auth"
 									target="_blank"
 								>
 									<Button

--- a/docs/app/v1/page.tsx
+++ b/docs/app/v1/page.tsx
@@ -78,7 +78,7 @@ export default function V1Ship() {
 						If you were using Better Auth for production, we recommend updating
 						to V1 as soon as possible. There are some breaking changes, feel
 						free to join us on{" "}
-						<Link href="https://discord.com/better-auth">Discord</Link>, and
+						<Link href="https://discord.gg/better-auth">Discord</Link>, and
 						we'll gladly assist.
 					</p>
 				</div>
@@ -194,7 +194,7 @@ function ReleaseRelated() {
 								<ArrowRight className="w-4 h-4" />
 							</Button>
 						</Link>
-						<Link className="w-full" href="https://discord.gg/GYC3W7tZzb">
+						<Link className="w-full" href="https://discord.gg/better-auth">
 							<Button
 								variant="outline"
 								className="w-full justify-between border-t-0"

--- a/docs/content/docs/guides/browser-extension-guide.mdx
+++ b/docs/content/docs/guides/browser-extension-guide.mdx
@@ -200,4 +200,4 @@ We highly recommend you visit the <Link href="https://docs.plasmo.com/">Plasmo d
 
 If you would like to view a completed example, you can check out the <Link href="https://github.com/better-auth/better-auth/tree/main/examples/browser-extension-example">browser extension example</Link>.
 
-If you have any questions, feel free to open an issue on our <Link href="https://github.com/better-auth/better-auth/issues">GitHub repo</Link>, or join our <Link href="https://discord.gg/6jHcdYMzyq">Discord server</Link> for support.
+If you have any questions, feel free to open an issue on our <Link href="https://github.com/better-auth/better-auth/issues">GitHub repo</Link>, or join our <Link href="https://discord.gg/better-auth">Discord server</Link> for support.

--- a/docs/content/docs/guides/your-first-plugin.mdx
+++ b/docs/content/docs/guides/your-first-plugin.mdx
@@ -228,6 +228,6 @@ Congratulations! You’ve successfully created your first ever Better Auth plugi
 We highly recommend you visit our <Link href="/docs/concepts/plugins">plugins documentation</Link> to learn more information.
 
 If you have a plugin you’d like to share with the community, feel free to let us know through 
-our <Link href="https://discord.gg/6jHcdYMzyq">Discord server</Link>,
+our <Link href="https://discord.gg/better-auth">Discord server</Link>,
 or through a <Link href="https://github.com/better-auth/better-auth/pulls">pull-request</Link>
 and we may add it to the <Link href="/docs/plugins/community-plugins">community-plugins</Link> list!

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -6,7 +6,7 @@ description: Stripe plugin for Better Auth to manage subscriptions and payments.
 The Stripe plugin integrates Stripe's payment and subscription functionality with Better Auth. Since payment and authentication are often tightly coupled, this plugin simplifies the integration of stripe into your application, handling customer creation, subscription management, and webhook processing.
 
 <Callout type="warn">
-This plugin is currently in beta. We're actively collecting feedback and exploring additional features. If you have feature requests or suggestions, please join our [Discord community](https://discord.com/invite/Mh3DaacaFs) to discuss them.
+This plugin is currently in beta. We're actively collecting feedback and exploring additional features. If you have feature requests or suggestions, please join our [Discord community](https://discord.gg/better-auth) to discuss them.
 </Callout>
 
 ## Features

--- a/docs/content/docs/reference/contributing.mdx
+++ b/docs/content/docs/reference/contributing.mdx
@@ -10,7 +10,7 @@ Thank you for your interest in contributing to Better Auth! This guide is a conc
 Before diving in, here are a few important resources:
 
 - Take a look at our existing <Link href="https://github.com/better-auth/better-auth/issues">issues</Link> and <Link href="https://github.com/better-auth/better-auth/pulls">pull requests</Link>
-- Join our community discussions in <Link href="https://discord.gg/GYC3W7tZzb">Discord</Link>
+- Join our community discussions in <Link href="https://discord.gg/better-auth">Discord</Link>
 
 
 ## Development Setup
@@ -169,7 +169,7 @@ describe("Feature", () => {
 Don't hesitate to ask for help! You can:
 
 - Open an <Link href="https://github.com/better-auth/better-auth/issues">issue</Link> with questions
-- Join our <Link href="https://discord.gg/GYC3W7tZzb">community discussions</Link>
+- Join our <Link href="https://discord.gg/better-auth">community discussions</Link>
 - Reach out to project maintainers
 
 Thank you for contributing to Better Auth!

--- a/packages/better-auth/README.md
+++ b/packages/better-auth/README.md
@@ -14,7 +14,7 @@
     <a href="https://better-auth.com"><strong>Learn more »</strong></a>
     <br />
     <br />
-    <a href="https://discord.com/invite/GYC3W7tZzb">Discord</a>
+    <a href="https://discord.gg/better-auth">Discord</a>
     ·
     <a href="https://better-auth.com">Website</a>
     ·


### PR DESCRIPTION
noticed there were some invalid discord invites, `https://discord.com/better-auth`, so while fixing them changed all links to point to `https://discord.gg/better-auth`