### PR TITLE
update(trustedOrigin): Warn if invalid value is passed

### DIFF
--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -277,5 +277,10 @@ function getTrustedOrigins(options: BetterAuthOptions) {
 	if (envTrustedOrigins) {
 		trustedOrigins.push(...envTrustedOrigins.split(","));
 	}
+	if (trustedOrigins.filter((x) => !x).length) {
+		throw new BetterAuthError(
+			"A provided trusted origin is invalid, make sure your trusted origins list is properly defined.",
+		);
+	}
 	return trustedOrigins;
 }


### PR DESCRIPTION
Right now, if an invalid trusted origin is passed, it becomes very hard to debug and find the cause of a given endpoint failing.

As far as I've seen, there error can be as undescriptive as:
> dev: # SERVER_ERROR:  TypeError: Cannot read properties of undefined (reading 'includes')
> dev:     at Array.some (<anonymous>)
> dev:  POST /api/auth/sign-up/email 500 in 915ms

This will throw an error stating that a valid trusted origins list is required.