### PR TITLE
fix consent not able to be accepted if state is empty oidcProvider

### DIFF
--- a/dev/bun/auth.ts
+++ b/dev/bun/auth.ts
@@ -1,5 +1,4 @@
 import { betterAuth } from "better-auth";
-import { prismaAdapter } from "better-auth/adapters/prisma";
 import { twoFactor } from "better-auth/plugins";
 import Database from "bun:sqlite";
 

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -287,7 +287,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					});
 					const redirectURI = new URL(value.redirectURI);
 					redirectURI.searchParams.set("code", code);
-					if(value.state) redirectURI.searchParams.set("state", value.state);
+					if (value.state) redirectURI.searchParams.set("state", value.state);
 					return ctx.json({
 						redirectURI: redirectURI.toString(),
 					});

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -245,7 +245,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 						});
 					}
 					const value = JSON.parse(verification.value) as CodeVerificationValue;
-					if (!value.requireConsent || !value.state) {
+					if (!value.requireConsent) {
 						throw new APIError("UNAUTHORIZED", {
 							error_description: "Consent not required",
 							error: "invalid_request",
@@ -287,7 +287,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					});
 					const redirectURI = new URL(value.redirectURI);
 					redirectURI.searchParams.set("code", code);
-					redirectURI.searchParams.set("state", value.state);
+					if(value.state) redirectURI.searchParams.set("state", value.state);
 					return ctx.json({
 						redirectURI: redirectURI.toString(),
 					});


### PR DESCRIPTION
When using the oidc provider. 

if i do not set a consent page, i get an error.

So I added one:

```
consentPage: "/api/auth/consent",
```

Since i didn't really need one, i just did this in the route:

```
  app.get("/api/auth/consent", async (req, res) => {
    try {
      const data = await auth.api.oAuthConsent({
        body: { accept: true },
        query: req.query,
        headers: req.headers,
      });
      res.redirect(data.redirectURI);
    } catch (e) {
      console.error(e);
    }
  });

```


This doesnt even work, because there is a line checking if the verification has a state param, which should be optional. just removing this one check, allows oauthConsent to be accepted. Doesn't make sense to throw an error when consent is required but state is empty?
