### PR TITLE
fix: typo in AuthorizeResponse type ✅

### DIFF
--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -1,7 +1,7 @@
 import { BetterAuthError } from "../../error";
 import type { Statements, Subset } from "./types";
 
-export type AuthortizeResponse =
+export type AuthorizeResponse =
 	| { success: false; error: string }
 	| { success: true; error?: never };
 
@@ -17,7 +17,7 @@ export function role<TStatements extends Statements>(statements: TStatements) {
 					  };
 			},
 			connector: "OR" | "AND" = "AND",
-		): AuthortizeResponse {
+		): AuthorizeResponse {
 			let success = false;
 			for (const [requestedResource, requestedActions] of Object.entries(
 				request,

--- a/packages/better-auth/src/plugins/access/types.ts
+++ b/packages/better-auth/src/plugins/access/types.ts
@@ -1,5 +1,5 @@
 import type { LiteralString } from "../../types/helper";
-import type { AuthortizeResponse, createAccessControl } from "./access";
+import type { AuthorizeResponse, createAccessControl } from "./access";
 
 export type SubArray<T extends unknown[] | readonly unknown[] | any[]> =
 	T[number][];
@@ -22,6 +22,6 @@ export type AccessControl<TStatements extends Statements = Statements> =
 	ReturnType<typeof createAccessControl<TStatements>>;
 
 export type Role<TStatements extends Statements = Record<string, any>> = {
-	authorize: (request: any, connector?: "OR" | "AND") => AuthortizeResponse;
+	authorize: (request: any, connector?: "OR" | "AND") => AuthorizeResponse;
 	statements: TStatements;
 };


### PR DESCRIPTION
Fixes the typo in codebase:

```diff
- AuthortizeResponse
+ AuthorizeResponse
```