### PR TITLE
fix: used x.com domain for all twitter provider urls

### DIFF
--- a/packages/better-auth/src/social-providers/twitter.ts
+++ b/packages/better-auth/src/social-providers/twitter.ts
@@ -138,7 +138,7 @@ export const twitter = (options: TwitterOption) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: "https://api.twitter.com/2/oauth2/token",
+						tokenEndpoint: "https://api.x.com/2/oauth2/token",
 					});
 				},
 		async getUserInfo(token) {


### PR DESCRIPTION
a small change, making sure we use x.com instead of twitter.com for all oauth endpoints.

reference: https://docs.x.com/resources/fundamentals/authentication/oauth-2-0/authorization-code