### PR TITLE
fix(apple): correctly map email verification status from profile

### DIFF
--- a/packages/better-auth/src/social-providers/apple.ts
+++ b/packages/better-auth/src/social-providers/apple.ts
@@ -155,12 +155,16 @@ export const apple = (options: AppleOptions) => {
 			const name = token.user
 				? `${token.user.name?.firstName} ${token.user.name?.lastName}`
 				: profile.name || profile.email;
+			const emailVerified =
+				typeof profile.email_verified === "boolean"
+					? profile.email_verified
+					: profile.email_verified === "true";
 			const userMap = await options.mapProfileToUser?.(profile);
 			return {
 				user: {
 					id: profile.sub,
 					name: name,
-					emailVerified: false,
+					emailVerified: emailVerified,
 					email: profile.email,
 					...userMap,
 				},


### PR DESCRIPTION
> After logging in with apple, the`emailVerified` is always false. It should be read from the profile like Google.


https://github.com/better-auth/better-auth/blob/87b2ffa5620fc1ca534e8d3d2f3859b629b365ce/packages/better-auth/src/social-providers/google.ts#L156