### PR TITLE
fix: sidebar placement issue with header

### DIFF
--- a/docs/components/side-bar.tsx
+++ b/docs/components/side-bar.tsx
@@ -39,7 +39,7 @@ export default function ArticleLayout() {
 			<aside
 				className={cn(
 					"md:transition-all",
-					"border-r border-lines top-[43px] md:flex hidden md:w-[268px] lg:w-[286px] overflow-y-auto absolute h-[calc(92dvh-7px)] flex-col justify-between w-[var(--fd-sidebar-width)]",
+					"border-r border-lines top-[56px] md:flex hidden md:w-[268px] lg:w-[286px] overflow-y-auto absolute h-[calc(100dvh-56px)] flex-col justify-between w-[var(--fd-sidebar-width)]",
 				)}
 			>
 				<div>


### PR DESCRIPTION
Before: Top dropdown gets cut off by the header and the sidebar border does not stretch fully to the bottom of the screen

![image](https://github.com/user-attachments/assets/41c43186-0c68-4cf3-91b4-b1a4091a728c)

After: Top dropdown is not cut off by header as the top value of it is now set to the header height explicitly. The sidebar border now stretches to the bottom of the screen by setting the height to `calc(100dvh - 56px)`, 56px is the current header height.

![image](https://github.com/user-attachments/assets/b3c0d832-0241-406c-bf87-f6370d7a99cc)

Getting the header height via Javascript and then setting the value via CSS custom properties would have been a more future proof solution. But at the moment, this is a simple fix without tweaking much.
