### PR TITLE
fix: Improve the callbackURL parameter for social, oauth, SSO

### DIFF
--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -285,6 +285,7 @@ export const signInSocial = createAuthEndpoint(
 					accountId: userInfo.user.id,
 					accessToken: c.body.idToken.accessToken,
 				},
+				callbackURL: c.body.callbackURL,
 				disableSignUp:
 					(provider.disableImplicitSignUp && !c.body.requestSignUp) ||
 					provider.disableSignUp,

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -706,6 +706,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							...tokens,
 							scope: tokens.scopes?.join(","),
 						},
+						callbackURL: callbackURL,
 						disableSignUp:
 							(provider.disableImplicitSignUp && !requestSignUp) ||
 							provider.disableSignUp,

--- a/packages/better-auth/src/plugins/sso/index.ts
+++ b/packages/better-auth/src/plugins/sso/index.ts
@@ -863,6 +863,7 @@ export const sso = (options?: SSOOptions) => {
 							refreshTokenExpiresAt: tokenResponse.refreshTokenExpiresAt,
 							scope: tokenResponse.scopes?.join(","),
 						},
+						callbackURL,
 						disableSignUp: options?.disableImplicitSignUp && !requestSignUp,
 						overrideUserInfo: config.overrideUserInfo,
 					});


### PR DESCRIPTION
Fix the issue where the callbackURL parameter is missing when emailVerified is false using the idToken method for social login.

Fixed: #2729