### PR TITLE
fix(oidc): await for getAdditionalUserInfoClaim

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -623,7 +623,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					};
 
 					const additionalUserClaims = options.getAdditionalUserInfoClaim
-						? options.getAdditionalUserInfoClaim(user, requestedScopes)
+						? await options.getAdditionalUserInfoClaim(user, requestedScopes)
 						: {};
 
 					const idToken = await new SignJWT({
@@ -800,7 +800,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 							: undefined,
 					};
 					const userClaims = options.getAdditionalUserInfoClaim
-						? options.getAdditionalUserInfoClaim(user, requestedScopes)
+						? await options.getAdditionalUserInfoClaim(user, requestedScopes)
 						: baseUserClaims;
 					return ctx.json({
 						...baseUserClaims,


### PR DESCRIPTION
The signature of the function is either a sync function or an async function. Without this change, if you use an async function (that in theory should be correct), the response gets returned without the promise being finished.

With this change, if:
  - is an async function, will wait for the promise to finish before returning
  - is a sync function, will create a promise, run the function, and wait for the promise to finish