### PR TITLE
fix(types): add missing 'nullable' property to FieldAttributeConfig

### DIFF
--- a/packages/better-auth/src/db/field.ts
+++ b/packages/better-auth/src/db/field.ts
@@ -73,7 +73,14 @@ export type FieldAttributeConfig<T extends FieldType = FieldType> = {
 			| "set null"
 			| "set default";
 	};
+	/**
+	 * If the value must be unique.
+	 */
 	unique?: boolean;
+	/**
+	 * If the value can be null.
+	 */
+	nullable?: boolean;
 	/**
 	 * If the field should be a bigint on the database instead of integer.
 	 */


### PR DESCRIPTION
![code](https://github.com/user-attachments/assets/68e0e972-818d-40a9-9887-db263f9fce64)
![code](https://github.com/user-attachments/assets/24a96e58-8fe3-4e6e-b354-05b804f2d067)

While developing, I extracted BetterAuthOptions into a separate file to make it reusable across different environments (e.g., Better Auth CLI and Cloudflare Wrangler). After doing so, I encountered a type error specifically related to the `nullable` property — other properties were working as expected.

Upon investigation, I found that the `nullable` field was missing from the type definition.
This PR fixes the issue by adding the missing `nullable` property back to the relevant type.
