### PR TITLE
fix(oidc-provider): remove need for client secret in `authorization_code` flows

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -463,7 +463,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					await ctx.context.internalAdapter.deleteVerificationValue(
 						verificationValue.id,
 					);
-					if (!client_id || !client_secret) {
+					if (!client_id) {
 						throw new APIError("UNAUTHORIZED", {
 							error_description: "client_id and client_secret are required",
 							error: "invalid_client",
@@ -513,14 +513,6 @@ export const oidcProvider = (options: OIDCOptions) => {
 					if (client.disabled) {
 						throw new APIError("UNAUTHORIZED", {
 							error_description: "client is disabled",
-							error: "invalid_client",
-						});
-					}
-					const isValidSecret =
-						client.clientSecret === client_secret.toString();
-					if (!isValidSecret) {
-						throw new APIError("UNAUTHORIZED", {
-							error_description: "invalid client_secret",
 							error: "invalid_client",
 						});
 					}


### PR DESCRIPTION
Fixes #2655 

In `authorization_code` flows the `client_secret` should not be required because it wouldn't be a secret anyways. This PR removes the need for a `client_secret` when calling the `/token` endpoint in oidc flows.