### PR TITLE
fix(auth): avoid refreshing tokens without expiration

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -346,17 +346,15 @@ export const getAccessToken = createAuthEndpoint(
 				message: `Provider ${providerId} not found.`,
 			});
 		}
-		if (!provider.refreshAccessToken) {
-			throw new APIError("BAD_REQUEST", {
-				message: `Provider ${providerId} does not support token refreshing.`,
-			});
-		}
+
 		try {
 			let newTokens: OAuth2Tokens | null = null;
 
 			if (
-				account.accessTokenExpiresAt &&
-				account.accessTokenExpiresAt.getTime() - Date.now() < 5_000 // 5 second buffer
+				account.refreshToken &&
+				(!account.accessTokenExpiresAt ||
+					account.accessTokenExpiresAt.getTime() - Date.now() < 5_000) &&
+				provider.refreshAccessToken
 			) {
 				newTokens = await provider.refreshAccessToken(
 					account.refreshToken as string,

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -355,7 +355,7 @@ export const getAccessToken = createAuthEndpoint(
 			let newTokens: OAuth2Tokens | null = null;
 
 			if (
-				!account.accessTokenExpiresAt ||
+				account.accessTokenExpiresAt &&
 				account.accessTokenExpiresAt.getTime() - Date.now() < 5_000 // 5 second buffer
 			) {
 				newTokens = await provider.refreshAccessToken(


### PR DESCRIPTION
## 📦 What does this PR do?

This PR fixes an issue where the token refresh logic incorrectly attempts to refresh access tokens that **do not have an expiration** (`accessTokenExpiresAt` is `null`).

---

## 🐛 The Problem

This bug is especially noticeable when using **GitHub social login**, as GitHub:
- Does **not** provide a `refreshToken`
- Does **not** return an `accessTokenExpiresAt`

As a result, the system incorrectly tries to refresh the token and throws: 
```
Failed to get a valid access token
```

---

## ✅ The Fix

The logic now checks if `accessTokenExpiresAt` exists **before** attempting a refresh, preventing unnecessary and invalid refresh attempts for providers like GitHub.

---

## 🔍 Affected Areas

- Token refresh behavior in `getAccessToken`
- Social login providers with long-lived tokens and no refresh support

closes: #2765

