### PR TITLE
docs: fix scopes array for mcp plugin oidc

### DIFF
--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -214,7 +214,7 @@ The plugin supports additional OIDC configuration options through the `oidcConfi
     scopes: {
         description: "Additional scopes to support",
         type: "string[]",
-        default: ["openid", "profile", "email", "offline_access"]
+        default: '["openid", "profile", "email", "offline_access"]'
     }
   }}
 />


### PR DESCRIPTION
before:
<img width="780" alt="image" src="https://github.com/user-attachments/assets/07720fcc-43a5-4faf-b961-e95ab90ce841" />
after:
<img width="786" alt="image" src="https://github.com/user-attachments/assets/8319926f-2c68-458f-a420-c08fea60e878" />
