### PR TITLE
fix: SSR handling in useAuthQuery to prevent hydration issues

### DIFF
--- a/packages/better-auth/src/client/query.ts
+++ b/packages/better-auth/src/client/query.ts
@@ -94,29 +94,20 @@ export const useAuthQuery = <T>(
 		? initializedAtom
 		: [initializedAtom];
 	let isMounted = false;
-	let hasInitialFetch = false;
 
 	for (const initAtom of initializedAtom) {
 		initAtom.subscribe(() => {
+			if (isServer) {
+				// On server, don't trigger fetch
+				return;
+			}
 			if (isMounted) {
 				fn();
 			} else {
-				// SSR-safe mounting behavior
-				if (isServer) {
-					// On server, don't trigger fetch immediately
-					isMounted = true;
-					return;
-				}
-				
 				onMount(value, () => {
-					// Only fetch once on initial mount to prevent hydration issues
-					if (!hasInitialFetch) {
-						hasInitialFetch = true;
-						// Small delay to ensure hydration is complete
-						setTimeout(() => {
-							fn();
-						}, 0);
-					}
+					setTimeout(() => {
+						fn();
+					}, 0);
 					isMounted = true;
 					return () => {
 						value.off();


### PR DESCRIPTION
Fixes https://github.com/better-auth/better-auth/issues/2462

Fixes the `useAuthQuery` function in `packages/better-auth/src/client/query.ts` to be compatible with server-side rendering and prevent hydration issues. 

As a result, server always renders with `isPending: true` and keeps the client initialize with `isPending: true` as well. Session fetch only happens after nanostores is mounted on client browser. A small delay is added on browser to prevent immediate `isPending: false` in case session fetch immediately errors and what not. 

### Changes
- Skipping fetch on the server
- Safe initial fetch on client on nanostores mount