### PR TITLE
fix: prevent parseState from overriding custom error url

### DIFF
--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -83,9 +83,6 @@ export async function parseState(c: GenericEndpointContext) {
 		})
 		.parse(JSON.parse(data.value));
 
-	if (!parsedData.errorURL) {
-		parsedData.errorURL = `${c.context.baseURL}/error`;
-	}
 	if (parsedData.expiresAt < Date.now()) {
 		await c.context.internalAdapter.deleteVerificationValue(data.id);
 		throw c.redirect(


### PR DESCRIPTION
This PR addresses an issue where `parseState` unconditionally sets a default `errorURL` if it's not found in the state object.

This behavior causes redirection to the default error page instead of the one configured via `onAPIError.errorURL`.