### PR TITLE
feat: added functionality to link a stripe customer to an organization as it's own entity

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -281,7 +281,7 @@ This will reactivate a subscription that was previously set to cancel at the end
 
 ### Reference System
 
-By default, subscriptions are associated with the user ID. However, you can use a custom reference ID to associate subscriptions with other entities, such as organizations:
+By default, subscriptions are associated with the user ID or the active organization ID. However, you can use a custom reference ID to associate subscriptions with other entities, such as organizations:
 
 ```ts title="client.ts"
 // Create a subscription for an organization
@@ -437,6 +437,22 @@ Table Name: `user`
   ]}
 />
 
+
+### Organization (if enabled)
+
+Table Name: `organization
+
+<DatabaseTable
+  fields={[
+    { 
+      name: "stripeCustomerId", 
+      type: "string", 
+      description: "The Stripe customer ID",
+      isOptional: true
+    },
+  ]}
+/>
+
 ### Subscription
 
 Table Name: `subscription`
@@ -546,6 +562,8 @@ stripe({
 
 **createCustomerOnSignUp**: `boolean` - Whether to automatically create a Stripe customer when a user signs up. Default: `false`.
 
+**createOrganizationCustomer**: `boolean` - Whether to automatically create a Stripe customer when a new organization is created. Default: `false`.
+
 **onCustomerCreate**: `(data: { customer: Customer, stripeCustomer: Stripe.Customer, user: User }, request?: Request) => Promise<void>` - A function called after a customer is created.
 
 **getCustomerCreateParams**: `(data: { user: User, session: Session }, request?: Request) => Promise<{}>` - A function to customize the Stripe customer creation parameters.
@@ -589,21 +607,34 @@ Each plan can have the following properties:
 ## Advanced Usage
 
 ### Using with Organizations
+The Stripe plugin works well with the organization plugin. You can associate a Stripe customer to an organization instead of a user. This is useful for B2B applications where you want to manage subscriptions at the organization level.
 
-The Stripe plugin works well with the organization plugin. You can associate subscriptions with organizations instead of individual users:
+This is especially useful for apps, where:
+- Each organization needs its own billing entity.
+- One user might be the admin/payer for Org A, but a member (non-payer) in Org B.
+- Each organization wants its own invoices, card, and tax info (especially if orgs are legal entities).
+
+You can enable this by setting the `createOrganizationCustomer` option to `true` and/or implementing the `authorizeReference` function to check if the user has permission to manage subscriptions for the organization.
+
+
+```ts title="auth.ts"
+stripe({
+    // ... other options
+    createCustomerOnSignUp: false,
+    createOrganizationCustomer: true,
+})
+```
+
+You can then create subscriptions for organizations similarly to how you would for users. The `referenceId` is inferred from the active organization if not provided, or you can specify it explicitly.
 
 ```ts title="client.ts"
-// Get the active organization
-const { data: activeOrg } = client.useActiveOrganization();
-
-// Create a subscription for the organization
+// Create a subscription for an organization
 await client.subscription.upgrade({
-    plan: "team",
-    referenceId: activeOrg.id,
-    seats: 10,
-    annual: true, // upgrade to an annual plan (optional)
-    successUrl: "/org/billing/success",
-    cancelUrl: "/org/billing"
+    plan: "pro",
+    // referenceId: "org_123", Inferred from the active organization id
+    successUrl: "/dashboard",
+    cancelUrl: "/pricing",
+    seats: 10, // Number of seats for team plans
 });
 ```
 

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -197,7 +197,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				let organization: (Organization & { stripeCustomerId: string }) | null =
 					null;
 
-				if (activeOrganizationId) {
+				if (activeOrganizationId && options.createOrganizationCustomer) {
 					organization = await ctx.context.adapter.findOne<
 						Organization & { stripeCustomerId: string }
 					>({
@@ -248,7 +248,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 
 				if (!customerId) {
 					try {
-						if (organization) {
+						if (organization && options.createOrganizationCustomer) {
 							const stripeCustomer = await client.customers.create(
 								{
 									email: user.email,
@@ -466,7 +466,9 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								subscriptionId: subscription.id,
 								referenceId,
 								...params?.params?.metadata,
-								...(organization ? { organizationId: organization.id } : {}),
+								...(organization && options.createOrganizationCustomer
+									? { organizationId: organization.id }
+									: {}),
 							},
 						},
 						params?.options,
@@ -577,10 +579,12 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				],
 			},
 			async (ctx) => {
-				const referenceId =
-					ctx.body?.referenceId ||
-					ctx.context?.session?.session?.activeOrganizationId ||
-					ctx.context.session.user.id;
+				let referenceId = ctx.body?.referenceId || ctx.context.session.user.id;
+
+				if (options.createOrganizationCustomer) {
+					referenceId =
+						ctx.context.session.session.activeOrganizationId || referenceId;
+				}
 
 				const subscription = ctx.body.subscriptionId
 					? await ctx.context.adapter.findOne<Subscription>({
@@ -704,10 +708,12 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				use: [sessionMiddleware, referenceMiddleware("restore-subscription")],
 			},
 			async (ctx) => {
-				const referenceId =
-					ctx.body?.referenceId ||
-					ctx.context?.session?.session?.activeOrganizationId ||
-					ctx.context.session.user.id;
+				let referenceId = ctx.body?.referenceId || ctx.context.session.user.id;
+
+				if (options.createOrganizationCustomer) {
+					referenceId =
+						ctx.context.session.session.activeOrganizationId || referenceId;
+				}
 
 				const subscription = ctx.body.subscriptionId
 					? await ctx.context.adapter.findOne<Subscription>({
@@ -813,15 +819,19 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				use: [sessionMiddleware, referenceMiddleware("list-subscription")],
 			},
 			async (ctx) => {
+				let referenceId = ctx.query?.referenceId || ctx.context.session.user.id;
+
+				if (options.createOrganizationCustomer) {
+					referenceId =
+						ctx.context.session.session.activeOrganizationId || referenceId;
+				}
+
 				const subscriptions = await ctx.context.adapter.findMany<Subscription>({
 					model: "subscription",
 					where: [
 						{
 							field: "referenceId",
-							value:
-								ctx.query?.referenceId ||
-								ctx.context?.session?.session?.activeOrganizationId ||
-								ctx.context.session.user.id,
+							value: referenceId,
 						},
 					],
 				});
@@ -873,17 +883,22 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				const { user } = session;
 				const { callbackURL, subscriptionId } = ctx.query;
 
-				const organization = await ctx.context.adapter.findOne<
-					Organization & { stripeCustomerId: string }
-				>({
-					model: "organization",
-					where: [
-						{
-							field: "id",
-							value: activeOrganizationId ?? "",
-						},
-					],
-				});
+				let organization: (Organization & { stripeCustomerId: string }) | null =
+					null;
+
+				if (activeOrganizationId && options.createOrganizationCustomer) {
+					organization = await ctx.context.adapter.findOne<
+						Organization & { stripeCustomerId: string }
+					>({
+						model: "organization",
+						where: [
+							{
+								field: "id",
+								value: activeOrganizationId ?? "",
+							},
+						],
+					});
+				}
 
 				const subscription = await ctx.context.adapter.findOne<Subscription>({
 					model: "subscription",
@@ -1058,8 +1073,6 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								| null
 								| undefined;
 
-							console.log("✅ Organization created", organization);
-
 							if (!organization || organization instanceof APIError) {
 								return logger.error(
 									"#BETTER_AUTH: Organization create hook returned an error or null",
@@ -1142,7 +1155,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 												],
 											},
 										);
-										console.log("✅ Customer created", customer);
+
 										if (!customer) {
 											logger.error("#BETTER_AUTH: Failed to create  customer");
 										} else {

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -2,8 +2,14 @@ import {
 	type GenericEndpointContext,
 	type BetterAuthPlugin,
 	logger,
+	type User,
 } from "better-auth";
-import { createAuthEndpoint, createAuthMiddleware } from "better-auth/plugins";
+import {
+	createAuthEndpoint,
+	createAuthMiddleware,
+	type Member,
+	type Organization,
+} from "better-auth/plugins";
 import Stripe from "stripe";
 import { z } from "zod";
 import {
@@ -65,8 +71,12 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 			if (!session) {
 				throw new APIError("UNAUTHORIZED");
 			}
+			// TODO: Make the referenceId the activeOrganizationId if available or the user id
 			const referenceId =
-				ctx.body?.referenceId || ctx.query?.referenceId || session.user.id;
+				ctx.body?.referenceId ||
+				ctx.query?.referenceId ||
+				session?.session?.activeOrganizationId ||
+				session.user.id;
 
 			if (ctx.body?.referenceId && !options.subscription?.authorizeReference) {
 				logger.error(
@@ -182,6 +192,25 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 			},
 			async (ctx) => {
 				const { user, session } = ctx.context.session;
+				const activeOrganizationId = session.activeOrganizationId;
+
+				let organization: (Organization & { stripeCustomerId: string }) | null =
+					null;
+
+				if (activeOrganizationId) {
+					organization = await ctx.context.adapter.findOne<
+						Organization & { stripeCustomerId: string }
+					>({
+						model: "organization",
+						where: [
+							{
+								field: "id",
+								value: activeOrganizationId ?? "",
+							},
+						],
+					});
+				}
+
 				if (
 					!user.emailVerified &&
 					options.subscription?.requireEmailVerification
@@ -190,8 +219,10 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						message: STRIPE_ERROR_CODES.EMAIL_VERIFICATION_REQUIRED,
 					});
 				}
-				const referenceId = ctx.body.referenceId || user.id;
+				const referenceId = ctx.body.referenceId || organization?.id || user.id;
+
 				const plan = await getPlanByName(options, ctx.body.plan);
+
 				if (!plan) {
 					throw new APIError("BAD_REQUEST", {
 						message: STRIPE_ERROR_CODES.SUBSCRIPTION_PLAN_NOT_FOUND,
@@ -211,36 +242,67 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				}
 
 				let customerId =
-					subscriptionToUpdate?.stripeCustomerId || user.stripeCustomerId;
+					subscriptionToUpdate?.stripeCustomerId ||
+					organization?.stripeCustomerId ||
+					user.stripeCustomerId;
 
 				if (!customerId) {
 					try {
-						const stripeCustomer = await client.customers.create(
-							{
-								email: user.email,
-								name: user.name,
-								metadata: {
-									...ctx.body.metadata,
-									userId: user.id,
-								},
-							},
-							{
-								idempotencyKey: generateRandomString(32, "a-z", "0-9"),
-							},
-						);
-						await ctx.context.adapter.update({
-							model: "user",
-							update: {
-								stripeCustomerId: stripeCustomer.id,
-							},
-							where: [
+						if (organization) {
+							const stripeCustomer = await client.customers.create(
 								{
-									field: "id",
-									value: user.id,
+									email: user.email,
+									name: organization.name,
+									metadata: {
+										...ctx.body.metadata,
+										organizationId: organization.id,
+									},
 								},
-							],
-						});
-						customerId = stripeCustomer.id;
+								{
+									idempotencyKey: generateRandomString(32, "a-z", "0-9"),
+								},
+							);
+							await ctx.context.adapter.update({
+								model: "organization",
+								update: {
+									stripeCustomerId: stripeCustomer.id,
+								},
+								where: [
+									{
+										field: "id",
+										value: organization.id,
+									},
+								],
+							});
+							customerId = stripeCustomer.id;
+						} else {
+							const stripeCustomer = await client.customers.create(
+								{
+									email: user.email,
+									name: user.name,
+									metadata: {
+										...ctx.body.metadata,
+										userId: user.id,
+									},
+								},
+								{
+									idempotencyKey: generateRandomString(32, "a-z", "0-9"),
+								},
+							);
+							await ctx.context.adapter.update({
+								model: "user",
+								update: {
+									stripeCustomerId: stripeCustomer.id,
+								},
+								where: [
+									{
+										field: "id",
+										value: user.id,
+									},
+								],
+							});
+							customerId = stripeCustomer.id;
+						}
 					} catch (e: any) {
 						ctx.context.logger.error(e);
 						throw new APIError("BAD_REQUEST", {
@@ -270,7 +332,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							where: [
 								{
 									field: "referenceId",
-									value: ctx.body.referenceId || user.id,
+									value: ctx.body.referenceId || organization?.id || user.id,
 								},
 							],
 						});
@@ -351,6 +413,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						session,
 						plan,
 						subscription,
+						organization,
 					},
 					ctx.request,
 				);
@@ -403,6 +466,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								subscriptionId: subscription.id,
 								referenceId,
 								...params?.params?.metadata,
+								...(organization ? { organizationId: organization.id } : {}),
 							},
 						},
 						params?.options,
@@ -514,7 +578,10 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 			},
 			async (ctx) => {
 				const referenceId =
-					ctx.body?.referenceId || ctx.context.session.user.id;
+					ctx.body?.referenceId ||
+					ctx.context?.session?.session?.activeOrganizationId ||
+					ctx.context.session.user.id;
+
 				const subscription = ctx.body.subscriptionId
 					? await ctx.context.adapter.findOne<Subscription>({
 							model: "subscription",
@@ -638,7 +705,9 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 			},
 			async (ctx) => {
 				const referenceId =
-					ctx.body?.referenceId || ctx.context.session.user.id;
+					ctx.body?.referenceId ||
+					ctx.context?.session?.session?.activeOrganizationId ||
+					ctx.context.session.user.id;
 
 				const subscription = ctx.body.subscriptionId
 					? await ctx.context.adapter.findOne<Subscription>({
@@ -749,7 +818,10 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 					where: [
 						{
 							field: "referenceId",
-							value: ctx.query?.referenceId || ctx.context.session.user.id,
+							value:
+								ctx.query?.referenceId ||
+								ctx.context?.session?.session?.activeOrganizationId ||
+								ctx.context.session.user.id,
 						},
 					],
 				});
@@ -791,11 +863,27 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				const session = await getSessionFromCtx<{ stripeCustomerId: string }>(
 					ctx,
 				);
+
+				const activeOrganizationId = session?.session?.activeOrganizationId;
+
 				if (!session) {
 					throw ctx.redirect(getUrl(ctx, ctx.query?.callbackURL || "/"));
 				}
+
 				const { user } = session;
 				const { callbackURL, subscriptionId } = ctx.query;
+
+				const organization = await ctx.context.adapter.findOne<
+					Organization & { stripeCustomerId: string }
+				>({
+					model: "organization",
+					where: [
+						{
+							field: "id",
+							value: activeOrganizationId ?? "",
+						},
+					],
+				});
 
 				const subscription = await ctx.context.adapter.findOne<Subscription>({
 					model: "subscription",
@@ -814,7 +902,9 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 					return ctx.redirect(getUrl(ctx, callbackURL));
 				}
 				const customerId =
-					subscription?.stripeCustomerId || user.stripeCustomerId;
+					subscription?.stripeCustomerId ||
+					organization?.stripeCustomerId ||
+					user.stripeCustomerId;
 
 				if (customerId) {
 					try {
@@ -956,6 +1046,76 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 		init(ctx) {
 			return {
 				options: {
+					hooks: {
+						after: createAuthMiddleware(async (ctx) => {
+							if (ctx.path !== "/organization/create") {
+								return;
+							}
+
+							const organization = ctx.context.returned as
+								| (Organization & { members: Member[] })
+								| APIError
+								| null
+								| undefined;
+
+							console.log("✅ Organization created", organization);
+
+							if (!organization || organization instanceof APIError) {
+								return logger.error(
+									"#BETTER_AUTH: Organization create hook returned an error or null",
+								);
+							}
+
+							if (
+								options.createOrganizationCustomer &&
+								organization.members?.[0]?.userId
+							) {
+								const user = await ctx.context.adapter.findOne<User>({
+									model: "user",
+									where: [
+										{
+											field: "id",
+											value: organization.members?.[0]?.userId,
+										},
+									],
+								});
+
+								const stripeCustomer = await client.customers.create({
+									name: organization.name,
+									email: user?.email,
+									metadata: {
+										organizationId: organization.id,
+									},
+								});
+
+								const customer = await ctx.context.adapter.update<Customer>({
+									model: "organization",
+									update: {
+										stripeCustomerId: stripeCustomer.id,
+									},
+									where: [
+										{
+											field: "id",
+											value: organization.id,
+										},
+									],
+								});
+
+								if (!customer) {
+									logger.error(
+										"#BETTER_AUTH: Failed to create organization customer",
+									);
+								} else {
+									await options.onCustomerCreate?.({
+										customer,
+										stripeCustomer,
+										type: "organization",
+										organization,
+									});
+								}
+							}
+						}),
+					},
 					databaseHooks: {
 						user: {
 							create: {
@@ -982,12 +1142,14 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 												],
 											},
 										);
+										console.log("✅ Customer created", customer);
 										if (!customer) {
 											logger.error("#BETTER_AUTH: Failed to create  customer");
 										} else {
 											await options.onCustomerCreate?.({
 												customer,
 												stripeCustomer,
+												type: "user",
 												user,
 											});
 										}

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -57,6 +57,17 @@ export const user = {
 	},
 } satisfies AuthPluginSchema;
 
+export const organization = {
+	organization: {
+		fields: {
+			stripeCustomerId: {
+				type: "string",
+				required: false,
+			},
+		},
+	},
+} satisfies AuthPluginSchema;
+
 export const getSchema = (options: StripeOptions) => {
 	if (
 		options.schema &&
@@ -69,6 +80,7 @@ export const getSchema = (options: StripeOptions) => {
 		{
 			...(options.subscription?.enabled ? subscriptions : {}),
 			...user,
+			...organization
 		},
 		options.schema,
 	);

--- a/packages/stripe/src/stripe.test.ts
+++ b/packages/stripe/src/stripe.test.ts
@@ -2,7 +2,8 @@ import { betterAuth, type User } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { createAuthClient } from "better-auth/client";
 import { setCookieToHeader } from "better-auth/cookies";
-import { bearer } from "better-auth/plugins";
+import { bearer, organization, type Organization } from "better-auth/plugins";
+import { organizationClient } from "better-auth/client/plugins";
 import Stripe from "stripe";
 import { vi } from "vitest";
 import { stripe } from ".";
@@ -47,12 +48,16 @@ describe("stripe", async () => {
 		account: [],
 		customer: [],
 		subscription: [],
+		organization: [],
+		member: [],
+		invitation: [],
 	};
 	const memory = memoryAdapter(data);
 	const stripeOptions = {
 		stripeClient: _stripe,
 		stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
 		createCustomerOnSignUp: true,
+		createOrganizationCustomer: true,
 		subscription: {
 			enabled: true,
 			plans: [
@@ -74,13 +79,14 @@ describe("stripe", async () => {
 		emailAndPassword: {
 			enabled: true,
 		},
-		plugins: [stripe(stripeOptions)],
+		plugins: [organization(), stripe(stripeOptions)],
 	});
 	const ctx = await auth.$context;
 	const authClient = createAuthClient({
 		baseURL: "http://localhost:3000",
 		plugins: [
 			bearer(),
+			organizationClient(),
 			stripeClient({
 				subscription: true,
 			}),
@@ -699,5 +705,184 @@ describe("stripe", async () => {
 		await eventTestAuth.handler(deleteRequest);
 
 		expect(onSubscriptionDeleted).toHaveBeenCalled();
+	});
+
+	// Organization tests
+	it("should create a customer when organization is created", async () => {
+		const userRes = await authClient.signUp.email(
+			{
+				...testUser,
+				email: "list-test@email.com",
+			},
+			{
+				throw: true,
+			},
+		);
+
+		const headers = new Headers();
+		await authClient.signIn.email(
+			{
+				...testUser,
+				email: "list-test@email.com",
+			},
+			{
+				throw: true,
+				onSuccess: setCookieToHeader(headers),
+			},
+		);
+
+		const organization = await authClient.organization.create({
+			name: "My Organization",
+			slug: "my-org-001",
+			logo: "https://example.com/logo.png",
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(organization.data?.id).toBeDefined();
+
+		const res = await ctx.adapter.findOne<
+			Organization & { stripeCustomerId: string }
+		>({
+			model: "organization",
+			where: [
+				{
+					field: "id",
+					value: organization?.data?.id ?? "",
+				},
+			],
+		});
+
+		expect(res).toMatchObject({
+			id: expect.any(String),
+			stripeCustomerId: expect.any(String),
+		});
+	});
+
+	it("should create a subscription for organization customer", async () => {
+		const userRes = await authClient.signUp.email(
+			{
+				...testUser,
+				email: "list-test@email.com",
+			},
+			{
+				throw: true,
+			},
+		);
+
+		const headers = new Headers();
+		await authClient.signIn.email(
+			{
+				...testUser,
+				email: "list-test@email.com",
+			},
+			{
+				throw: true,
+				onSuccess: setCookieToHeader(headers),
+			},
+		);
+
+		const organization = await authClient.organization.create({
+			name: "My Organization",
+			slug: "my-org-002",
+			logo: "https://example.com/logo.png",
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(organization.data?.id).toBeDefined();
+
+		const res = await authClient.subscription.upgrade({
+			plan: "starter",
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(res.data?.url).toBeDefined();
+
+		const subscription = await ctx.adapter.findOne<Subscription>({
+			model: "subscription",
+			where: [
+				{
+					field: "referenceId",
+					value: organization?.data?.id ?? "",
+				},
+			],
+		});
+
+		expect(subscription).toMatchObject({
+			id: expect.any(String),
+			plan: "starter",
+			referenceId: organization?.data?.id ?? "",
+			stripeCustomerId: expect.any(String),
+			status: "incomplete",
+			periodStart: undefined,
+			cancelAtPeriodEnd: undefined,
+		});
+	});
+
+	it("should list active subscriptions for organization customer", async () => {
+		await authClient.signUp.email(testUser, {
+			throw: true,
+		});
+
+		const headers = new Headers();
+
+		await authClient.signIn.email(testUser, {
+			throw: true,
+			onSuccess: setCookieToHeader(headers),
+		});
+
+		const organization = await authClient.organization.create({
+			name: "My Organization",
+			slug: "my-org-003",
+			logo: "https://example.com/logo.png",
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const listRes = await authClient.subscription.list({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(Array.isArray(listRes.data)).toBe(true);
+
+		await authClient.subscription.upgrade({
+			plan: "starter",
+			fetchOptions: {
+				headers,
+			},
+		});
+		const listBeforeActive = await authClient.subscription.list({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(listBeforeActive.data?.length).toBe(0);
+		// Update the subscription status to active
+		await ctx.adapter.update({
+			model: "subscription",
+			update: {
+				status: "active",
+			},
+			where: [
+				{
+					field: "referenceId",
+					value: organization?.data?.id ?? "",
+				},
+			],
+		});
+		const listAfterRes = await authClient.subscription.list({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(listAfterRes.data?.length).toBeGreaterThan(0);
 	});
 });

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -1,6 +1,7 @@
 import type { InferOptionSchema, Session, User } from "better-auth";
 import type Stripe from "stripe";
 import type { subscriptions, user } from "./schema";
+import type { Organization } from "better-auth/plugins";
 
 export type StripePlan = {
 	/**
@@ -175,6 +176,12 @@ export interface StripeOptions {
 	 */
 	createCustomerOnSignUp?: boolean;
 	/**
+	 * Enable customer creation when a new organization is created
+	 * @description This will is especially useful for B2B platforms
+	 * where you want to create a customer for each organization/entity
+	 */
+	createOrganizationCustomer?: boolean;
+	/**
 	 * A callback to run after a customer has been created
 	 * @param customer - Customer Data
 	 * @param stripeCustomer - Stripe Customer Data
@@ -184,8 +191,10 @@ export interface StripeOptions {
 		data: {
 			customer: Customer;
 			stripeCustomer: Stripe.Customer;
-			user: User;
-		},
+		} & (
+			| { type: "user"; user: User }
+			| { type: "organization"; organization: Organization }
+		),
 		request?: Request,
 	) => Promise<void>;
 	/**
@@ -295,7 +304,8 @@ export interface StripeOptions {
 				session: Session & Record<string, any>;
 				plan: StripePlan;
 				subscription: Subscription;
-			},
+				organization: Organization & Record<string, any> | null;
+			} ,
 			request?: Request,
 		) =>
 			| Promise<{
@@ -323,9 +333,11 @@ export interface StripeOptions {
 export interface Customer {
 	id: string;
 	stripeCustomerId?: string;
-	userId: string;
+	// TODO: Make this exchangeable with user id
+	referenceId: string;
 	createdAt: Date;
 	updatedAt: Date;
+	// type: "user" | "organization";
 }
 
 export interface InputSubscription extends Omit<Subscription, "id"> {}


### PR DESCRIPTION
This enables associating a Stripe customer to an organization instead of a user. This is useful for B2B applications where you want to manage subscriptions at the organization level.

This is especially useful for apps, where:
- Each organization needs its own billing entity.
- One user might be the admin/payer for Org A, but a member (non-payer) in Org B.
- Each organization wants its own invoices, card, and tax info (especially if orgs are legal entities).

You can enable this by setting the `createOrganizationCustomer` option to `true` and/or implementing the `authorizeReference` function to check if the user has permission to manage subscriptions for the organization.


```ts title="auth.ts"
stripe({
    // ... other options
    createCustomerOnSignUp: false,
    createOrganizationCustomer: true,
})
```

This issue is mentioned here: https://github.com/better-auth/better-auth/issues/2079

