### PR TITLE
feat: file-storage plugin (WIP)

### DIFF
--- a/packages/file-storage/build.config.ts
+++ b/packages/file-storage/build.config.ts
@@ -1,0 +1,18 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+	declaration: true,
+	rollup: {
+		emitCJS: true,
+	},
+	outDir: "dist",
+	clean: false,
+	failOnWarn: false,
+	externals: [
+		"better-auth",
+		"better-call",
+		"@better-fetch/fetch",
+		"uploadthing",
+		"@uploadthing/shared",
+	],
+});

--- a/packages/file-storage/package.json
+++ b/packages/file-storage/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@better-auth/file-storage",
+  "author": "Zach Grimaldi",
+  "version": "0.0.1",
+  "main": "dist/index.cjs",
+  "license": "MIT",
+  "keywords": [
+    "file-storage",
+    "auth",
+    "providers",
+    "images",
+    "documents"
+  ],
+  "module": "dist/index.mjs",
+  "description": "File Storage plugin for Better Auth",
+  "scripts": {
+    "test": "vitest",
+    "build": "unbuild",
+    "typecheck": "tsc --noEmit",
+    "dev": "unbuild --watch"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.mjs",
+      "require": "./dist/client.cjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/index.d.ts"
+      ],
+      "client": [
+        "./dist/client.d.ts"
+      ]
+    }
+  },
+  "dependencies": {
+    "better-auth": "workspace:^",
+    "zod": "^3.24.1",
+    "uploadthing": "^6.13.3",
+    "@uploadthing/shared": "^6.7.9"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "better-call": "catalog:",
+    "better-sqlite3": "^11.6.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/file-storage/src/client.ts
+++ b/packages/file-storage/src/client.ts
@@ -1,0 +1,9 @@
+import type { BetterAuthClientPlugin } from "better-auth";
+import type { fileStorage } from ".";
+
+export const fileStorageClient = () => {
+	return {
+		id: "file-storage",
+		$InferServerPlugin: {} as ReturnType<typeof fileStorage>,
+	} satisfies BetterAuthClientPlugin;
+};

--- a/packages/file-storage/src/index.ts
+++ b/packages/file-storage/src/index.ts
@@ -1,0 +1,273 @@
+import type { BetterAuthPlugin, ZodRawShape, ZodTypeAny } from "better-auth";
+import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
+import {
+	mergeSchema,
+	type FieldAttribute,
+	type InferFieldsInput,
+} from "better-auth/db";
+import { z } from "zod";
+import { schema, type FileStorageEntry } from "./schema";
+import type { FileStorageOptions } from "./types";
+
+export * from "./client";
+export * from "./storage-providers/uploadthing";
+export * from "./types";
+export * from "./utils";
+
+export const ERROR_CODES = {
+	FILE_TOO_LARGE: "File is too large",
+	INVALID_FILE_TYPE: "Invalid file type",
+	USER_NOT_LOGGED_IN: "User must be logged in to upload a file",
+	USER_NOT_FOUND: "User not found",
+	USER_NOT_ALLOWED: "You are not allowed to upload a file",
+	MISSING_OR_INVALID_FILE: "Missing or invalid file",
+	FILE_NOT_FOUND: "File not found",
+	MISSING_REQUEST_BODY:
+		"Missing request body. This is likely caused by the endpoint being called from auth.api.",
+	USER_DOES_NOT_OWN_FILE: "You are not allowed to delete this file",
+	FAILED_TO_UPLOAD_FILE: "Failed to upload file",
+} as const;
+
+export const fileStorage = (options: FileStorageOptions) => {
+	const opts = {
+		storageProvider: options?.storageProvider,
+		maxSize: options?.maxSize ?? 5 * 1024 * 1024, // 5MB default
+		allowedTypes: options?.allowedTypes,
+		requireAuth: options?.requireAuth ?? true,
+		canUploadFile: options?.canUploadFile,
+		onFileUploaded: options?.onFileUploaded,
+		schema: options?.schema,
+		additionalFields: options?.additionalFields ?? {},
+	} satisfies FileStorageOptions;
+
+	// Start with a deep copy of the schema
+	// Use manual deep copy to handle functions that structuredClone can't handle
+	const baseSchema = {
+		files: {
+			...schema.files,
+			fields: {
+				...schema.files.fields,
+			},
+		},
+	};
+
+	// If authentication is not required, mark the userId field as not required
+	if (!opts.requireAuth && baseSchema.files.fields.userId) {
+		baseSchema.files.fields.userId = {
+			...baseSchema.files.fields.userId,
+			required: false,
+		};
+	}
+
+	// Now merge with user-provided schema
+	const merged_schema = mergeSchema(baseSchema, opts.schema);
+	merged_schema.files.fields = {
+		...merged_schema.files.fields,
+		...opts.additionalFields,
+	};
+
+	type FileStorageEntryModified = FileStorageEntry &
+		InferFieldsInput<typeof opts.additionalFields>;
+
+	const modelName = Object.keys(merged_schema)[0]!;
+
+	return {
+		id: "file-storage",
+		schema: merged_schema,
+		$ERROR_CODES: ERROR_CODES,
+		endpoints: {
+			uploadFile: createAuthEndpoint(
+				"/files/upload",
+				{
+					method: "POST",
+					body: z.object({
+						file: convertAdditionalFieldsToZodSchema({
+							...opts.additionalFields,
+							name: { type: "string", required: true },
+							type: { type: "string", required: true },
+							base64: { type: "string", required: true },
+						}) as never as z.ZodType<
+							Omit<FileStorageEntryModified, "id" | "createdAt" | "userId">
+						>,
+					}),
+					use: [sessionMiddleware],
+				},
+				async (ctx) => {
+					const { name, type, base64, ...everythingElse } = ctx.body.file as {
+						name: string;
+						type: string;
+						base64: string;
+					} & Record<string, any>;
+
+					const user = ctx.context.session.user;
+
+					// Check if user is allowed to upload a file
+					if (opts.canUploadFile) {
+						const isAllowed = await Promise.resolve(
+							opts.canUploadFile(ctx.context.session),
+						);
+						if (!isAllowed) {
+							throw ctx.error("FORBIDDEN", {
+								message: ERROR_CODES.USER_NOT_ALLOWED,
+							});
+						}
+					}
+
+					// Decode base64 string to file
+					const fileBuffer = Buffer.from(base64, "base64");
+					const file = new File([fileBuffer], name, {
+						type,
+					});
+					if (!file || !(file instanceof File)) {
+						throw ctx.error("BAD_REQUEST", {
+							message: ERROR_CODES.MISSING_OR_INVALID_FILE,
+						});
+					}
+
+					// Validate file size
+					if (file.size > opts.maxSize) {
+						throw ctx.error("BAD_REQUEST", {
+							message: ERROR_CODES.FILE_TOO_LARGE,
+						});
+					}
+
+					const allowedTypes =
+						typeof opts.allowedTypes === "function"
+							? await opts.allowedTypes(ctx.context.session)
+							: opts.allowedTypes;
+
+					// Validate file type
+					if (allowedTypes && !allowedTypes.includes(file.type)) {
+						throw ctx.error("BAD_REQUEST", {
+							message: ERROR_CODES.INVALID_FILE_TYPE,
+						});
+					}
+
+					const userId = user.id;
+
+					// Upload file using storage provider
+					let url: string;
+					let key: string;
+					try {
+						const res = await opts.storageProvider.uploadFile(
+							{
+								file,
+								userId,
+								metadata: everythingElse,
+							},
+							ctx.context.logger,
+						);
+						url = res.url;
+						key = res.key;
+					} catch (error) {
+						ctx.context.logger.error(
+							`[BETTER-AUTH: file-storage]: User "${userId}" failed to upload file with Storage Provider:`,
+							error,
+						);
+						throw ctx.error("INTERNAL_SERVER_ERROR", {
+							message: ERROR_CODES.FAILED_TO_UPLOAD_FILE,
+						});
+					}
+
+					// Store record of the file in the database
+					await ctx.context.adapter.create({
+						model: modelName,
+						data: {
+							userId,
+							name: file.name,
+							type: file.type,
+							size: file.size,
+							url,
+							...everythingElse,
+						},
+					});
+
+					// Call onFileUploaded handler if provided
+					if (opts.onFileUploaded && user) {
+						await Promise.resolve(
+							opts.onFileUploaded({
+								file: {
+									url,
+									key,
+								},
+								user,
+							}),
+						);
+					}
+
+					return ctx.json({
+						success: true,
+						file: {
+							url,
+							key,
+						},
+					});
+				},
+			),
+
+			deleteFile: createAuthEndpoint(
+				"/files/delete",
+				{
+					method: "POST",
+					body: z.object({
+						fileKey: z.string(),
+					}),
+					use: [sessionMiddleware],
+				},
+				async (ctx) => {
+					const user = ctx.context.session.user;
+
+					// Ensure this user owns the file
+					if (user.file !== ctx.body.fileKey) {
+						throw ctx.error("FORBIDDEN", {
+							message: ERROR_CODES.USER_DOES_NOT_OWN_FILE,
+						});
+					}
+
+					// Delete from storage provider if possible
+					if (opts.storageProvider.deleteFile) {
+						await opts.storageProvider.deleteFile(
+							{
+								fileURL: user.file,
+								userId: user.id,
+							},
+							ctx.context.logger,
+						);
+					}
+
+					return ctx.json({ success: true });
+				},
+			),
+		},
+	} satisfies BetterAuthPlugin;
+};
+
+function convertAdditionalFieldsToZodSchema(
+	additionalFields: Record<string, FieldAttribute>,
+) {
+	const additionalFieldsZodSchema: ZodRawShape = {};
+	for (const [key, value] of Object.entries(additionalFields)) {
+		let res: ZodTypeAny;
+
+		if (value.type === "string") {
+			res = z.string();
+		} else if (value.type === "number") {
+			res = z.number();
+		} else if (value.type === "boolean") {
+			res = z.boolean();
+		} else if (value.type === "date") {
+			res = z.date();
+		} else if (value.type === "string[]") {
+			res = z.array(z.string());
+		} else {
+			res = z.array(z.number());
+		}
+
+		if (!value.required) {
+			res = res.optional();
+		}
+
+		additionalFieldsZodSchema[key] = res;
+	}
+	return z.object(additionalFieldsZodSchema);
+}

--- a/packages/file-storage/src/schema.ts
+++ b/packages/file-storage/src/schema.ts
@@ -1,0 +1,49 @@
+import type { AuthPluginSchema } from "better-auth";
+
+export const schema = {
+	files: {
+		fields: {
+			userId: {
+				type: "string",
+				required: true as boolean,
+				input: true,
+			},
+			name: {
+				type: "string",
+				required: true,
+				input: true,
+			},
+			type: {
+				type: "string",
+				required: true,
+				input: true,
+			},
+			size: {
+				type: "number",
+				required: true,
+				input: true,
+			},
+			url: {
+				type: "string",
+				required: true,
+				input: true,
+			},
+			createdAt: {
+				type: "date",
+				required: true,
+				input: true,
+				defaultValue: () => new Date(),
+			},
+		},
+	},
+} satisfies AuthPluginSchema;
+
+export type FileStorageEntry = {
+	id: string;
+	userId: string;
+	name: string;
+	type: string;
+	size: number;
+	url: string;
+	createdAt: Date;
+};

--- a/packages/file-storage/src/storage-providers/uploadthing.ts
+++ b/packages/file-storage/src/storage-providers/uploadthing.ts
@@ -1,0 +1,64 @@
+import type { UTApi } from "uploadthing/server";
+import type { StorageLogger, StorageProvider } from "../types";
+
+export class UploadThingProvider implements StorageProvider {
+	utapi: UTApi;
+	constructor(UTAPI: UTApi) {
+		this.utapi = UTAPI;
+	}
+
+	async uploadFile(
+		params: { file: File; userId: string; metadata?: Record<string, string> },
+		logger: StorageLogger,
+	): Promise<{
+		url: string;
+		key: string;
+		size: number;
+	}> {
+		const { file, userId, metadata } = params;
+		try {
+			const ext = file.name.split(".").pop();
+			const newFile = new File([file], `${userId}.${ext}`, {
+				type: file.type,
+			});
+			logger.info(`[BETTER-AUTH file-storage]: Uploading file:`, newFile.name);
+
+			// Upload the file using UploadThing
+			const response = await this.utapi.uploadFiles([newFile], {
+				metadata: { userId, ...metadata },
+			});
+
+			const fileData = response[0];
+			if (!fileData || fileData.error) {
+				throw new Error("Failed to upload file");
+			}
+
+			return {
+				url: fileData.data.url,
+				key: fileData.data.key,
+				size: fileData.data.size,
+			};
+		} catch (error) {
+			logger.error("Error uploading file:", error);
+			throw new Error("Failed to upload file");
+		}
+	}
+
+	async deleteFile(
+		params: {
+			fileURL: string;
+			userId: string;
+		},
+		logger: StorageLogger,
+	): Promise<void> {
+		const { fileURL } = params;
+
+		try {
+			// Delete the file using UploadThing
+			await this.utapi.deleteFiles([fileURL]);
+		} catch (error) {
+			logger.error("Error deleting file:", error);
+			throw new Error("Failed to delete file");
+		}
+	}
+}

--- a/packages/file-storage/src/types.ts
+++ b/packages/file-storage/src/types.ts
@@ -1,0 +1,101 @@
+import type { LogLevel, Session, User } from "better-auth";
+import type { FieldAttribute } from "better-auth/db";
+
+export type StorageLogger = Record<
+	LogLevel,
+	(message: string, ...args: any[]) => void
+>;
+
+/**
+ * Storage provider interface for file uploads, allowing you
+ * to use any storage provider you want.
+ */
+export interface StorageProvider {
+	/**
+	 * Upload a file
+	 */
+	uploadFile: (
+		params: {
+			file: File;
+			userId: string;
+			metadata?: Record<string, string>;
+		},
+		logger: StorageLogger,
+	) => Promise<{ url: string; key: string }>;
+
+	/**
+	 * Delete a file from storage
+	 */
+	deleteFile?: (
+		params: {
+			fileURL: string;
+			userId: string;
+		},
+		logger: StorageLogger,
+	) => Promise<void>;
+}
+
+export interface FileStorageOptions {
+	/**
+	 * Storage provider to use for file uploads
+	 */
+	storageProvider: StorageProvider;
+
+	/**
+	 * Maximum file size in bytes
+	 * @default 5242880 (5MB)
+	 */
+	maxSize?: number;
+
+	/**
+	 * Allowed file types (image, pdf, etc.) to restrict file uploads
+	 * @default ["image/jpeg", "image/png", "image/webp", "application/pdf"]
+	 */
+	allowedTypes?:
+		| string[]
+		| ((session: { user: User; session: Session }) =>
+				| string[]
+				| Promise<string[]>);
+
+	/**
+	 * Whether authentication is required to upload a file.
+	 * @default true (only authenticated users can upload a file)
+	 */
+	requireAuth?: boolean;
+
+	/**
+	 * Function to authorize file uploads. If provided, this function will be called
+	 * before each file upload to verify the user has permission.
+	 * @default undefined (all users are always allowed to upload a file)
+	 */
+	canUploadFile?: (session: { user: User; session: Session }) =>
+		| boolean
+		| Promise<boolean>;
+
+	/**
+	 * Callback function that gets executed server-side when a file is uploaded
+	 * @param params Object containing file entry and user
+	 */
+	onFileUploaded?: (params: {
+		file: {
+			url: string;
+			key: string;
+		};
+		user: User;
+	}) => void | Promise<void>;
+
+	/**
+	 * Custom schema configuration
+	 */
+	schema?: {
+		files?: {
+			modelName?: string;
+			fields?: Record<string, string>;
+		};
+	};
+
+	/**
+	 * Additional fields to add to the files schema
+	 */
+	additionalFields?: Record<string, FieldAttribute>;
+}

--- a/packages/file-storage/src/utils.ts
+++ b/packages/file-storage/src/utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Convert a file to a base64 string.
+ */
+export function fileToBase64(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result?.toString().split(",")[1];
+			if (!result) throw new Error("Failed to read file");
+			resolve(result);
+		};
+		reader.onerror = reject;
+		reader.readAsDataURL(file);
+	});
+}

--- a/packages/file-storage/tsconfig.json
+++ b/packages/file-storage/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"target": "es2022",
+		"allowJs": true,
+		"resolveJsonModule": true,
+		"module": "ESNext",
+		"noEmit": true,
+		"moduleResolution": "Bundler",
+		"moduleDetection": "force",
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"exclude": ["node_modules", "dist"],
+	"include": ["src"]
+}

--- a/packages/file-storage/vitest.config.ts
+++ b/packages/file-storage/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	root: ".",
+	test: {
+		clearMocks: true,
+		globals: true,
+		setupFiles: ["dotenv/config"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,7 +358,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.2.13
+        version: 1.2.14
 
   dev/cloudflare:
     dependencies:
@@ -367,7 +367,7 @@ importers:
         version: link:../../packages/better-auth
       drizzle-orm:
         specifier: ^0.39.3
-        version: 0.39.3(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2))
+        version: 0.39.3(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2))
       hono:
         specifier: ^4.7.2
         version: 4.7.4
@@ -476,7 +476,7 @@ importers:
         version: 0.5.15(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1))(react@19.0.0)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(@remix-run/react@2.16.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2))(@sveltejs/kit@2.19.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1))(react@19.0.0)(svelte@5.22.6)(vue-router@4.5.1(vue@3.5.14(typescript@5.8.2)))(vue@3.5.14(typescript@5.8.2))
+        version: 1.5.0(@remix-run/react@2.16.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2))(@sveltejs/kit@2.19.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1))(react@19.0.0)(svelte@5.22.6)(vue-router@4.5.1(vue@3.5.15(typescript@5.8.2)))(vue@3.5.15(typescript@5.8.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -731,7 +731,7 @@ importers:
     devDependencies:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.1.1
-        version: 4.1.1(@vue/compiler-sfc@3.5.14)(prettier@3.2.4)
+        version: 4.1.1(@vue/compiler-sfc@3.5.15)(prettier@3.2.4)
       '@types/chrome':
         specifier: 0.0.258
         version: 0.0.258
@@ -940,7 +940,7 @@ importers:
     dependencies:
       '@radix-icons/vue':
         specifier: ^1.0.0
-        version: 1.0.0(vue@3.5.14(typescript@5.8.2))
+        version: 1.0.0(vue@3.5.15(typescript@5.8.2))
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.12
@@ -949,13 +949,13 @@ importers:
         version: 1.4.3-beta.0
       '@unovis/vue':
         specifier: 1.4.3-beta.0
-        version: 1.4.3-beta.0(@unovis/ts@1.4.3-beta.0)(vue@3.5.14(typescript@5.8.2))
+        version: 1.4.3-beta.0(@unovis/ts@1.4.3-beta.0)(vue@3.5.15(typescript@5.8.2))
       '@vee-validate/zod':
         specifier: ^4.14.7
-        version: 4.15.0(vue@3.5.14(typescript@5.8.2))(zod@3.24.2)
+        version: 4.15.0(vue@3.5.15(typescript@5.8.2))(zod@3.24.2)
       '@vueuse/core':
         specifier: ^11.3.0
-        version: 11.3.0(vue@3.5.14(typescript@5.8.2))
+        version: 11.3.0(vue@3.5.15(typescript@5.8.2))
       better-auth:
         specifier: workspace:*
         version: link:../../packages/better-auth
@@ -970,13 +970,13 @@ importers:
         version: 2.1.1
       embla-carousel-vue:
         specifier: ^8.5.1
-        version: 8.5.2(vue@3.5.14(typescript@5.8.2))
+        version: 8.5.2(vue@3.5.15(typescript@5.8.2))
       nuxt:
         specifier: ^3.14.1592
-        version: 3.16.0(kygbndsg3u7xffwrewwioaaldy)
+        version: 3.16.0(6hzfuplutu4lpsxqlj5qyvz2li)
       radix-vue:
         specifier: ^1.9.11
-        version: 1.9.17(vue@3.5.14(typescript@5.8.2))
+        version: 1.9.17(vue@3.5.15(typescript@5.8.2))
       shadcn-nuxt:
         specifier: ^0.10.4
         version: 0.10.4(magicast@0.3.5)
@@ -988,19 +988,19 @@ importers:
         version: 1.0.7(tailwindcss@3.4.17)
       v-calendar:
         specifier: ^3.1.2
-        version: 3.1.2(@popperjs/core@2.11.8)(vue@3.5.14(typescript@5.8.2))
+        version: 3.1.2(@popperjs/core@2.11.8)(vue@3.5.15(typescript@5.8.2))
       vaul-vue:
         specifier: ^0.2.0
-        version: 0.2.1(radix-vue@1.9.17(vue@3.5.14(typescript@5.8.2)))(vue@3.5.14(typescript@5.8.2))
+        version: 0.2.1(radix-vue@1.9.17(vue@3.5.15(typescript@5.8.2)))(vue@3.5.15(typescript@5.8.2))
       vee-validate:
         specifier: ^4.14.7
-        version: 4.15.0(vue@3.5.14(typescript@5.8.2))
+        version: 4.15.0(vue@3.5.15(typescript@5.8.2))
       vue:
         specifier: latest
-        version: 3.5.14(typescript@5.8.2)
+        version: 3.5.15(typescript@5.8.2)
       vue-router:
         specifier: latest
-        version: 4.5.1(vue@3.5.14(typescript@5.8.2))
+        version: 4.5.1(vue@3.5.15(typescript@5.8.2))
       vue-sonner:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1360,7 +1360,7 @@ importers:
         version: 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/start':
         specifier: ^1.86.1
-        version: 1.113.0(umfczj6grv5xwnnilehiba4mti)
+        version: 1.113.0(byszfgl2x46wwa7wxh3rgelbcu)
       '@types/ua-parser-js':
         specifier: ^0.7.39
         version: 0.7.39
@@ -1408,7 +1408,7 @@ importers:
         version: 0.7.40
       vinxi:
         specifier: ^0.4.3
-        version: 0.4.3(xigip3pwxsynk4cmajsowrm4re)
+        version: 0.4.3(ygzqaoi4rwas5cwvf5qrrt2zjy)
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
@@ -1418,7 +1418,7 @@ importers:
         version: 7.6.12
       '@types/bun':
         specifier: latest
-        version: 1.2.13
+        version: 1.2.14
       '@types/node':
         specifier: ^22.10.1
         version: 22.13.10
@@ -1488,13 +1488,13 @@ importers:
         version: 5.22.0(prisma@5.22.0)
       '@tanstack/react-start':
         specifier: ^1.114.34
-        version: 1.114.34(xdtxozacaptx2f2yoax7hh4is4)
+        version: 1.114.34(hknldnrpkejl4v5ig7dqtwm36i)
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.12
       '@types/bun':
         specifier: latest
-        version: 1.2.13
+        version: 1.2.14
       '@types/pg':
         specifier: ^8.11.10
         version: 8.11.11
@@ -1512,7 +1512,7 @@ importers:
         version: 9.1.2
       drizzle-orm:
         specifier: ^0.38.2
-        version: 0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0)
+        version: 0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0)
       happy-dom:
         specifier: ^15.11.7
         version: 15.11.7
@@ -1611,7 +1611,7 @@ importers:
         version: 16.4.7
       drizzle-orm:
         specifier: ^0.33.0
-        version: 0.33.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@19.0.10)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0)
+        version: 0.33.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@19.0.10)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0)
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
@@ -1651,7 +1651,7 @@ importers:
         version: 5.8.2
       unbuild:
         specifier: 'catalog:'
-        version: 3.5.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.14(typescript@5.8.2))
+        version: 3.5.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.15(typescript@5.8.2))
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@22.15.3)(happy-dom@17.4.1)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)
@@ -1691,7 +1691,35 @@ importers:
         version: 14.0.2(expo@52.0.37(@babel/core@7.27.1)(@babel/preset-env@7.26.9(@babel/core@7.27.1))(@expo/metro-runtime@4.0.1(react-native@0.78.0(@babel/core@7.27.1)(@babel/preset-env@7.26.9(@babel/core@7.27.1))(@react-native-community/cli-server-api@13.6.9(encoding@0.1.13))(@types/react@19.0.10)(react@19.0.0)))(encoding@0.1.13)(graphql@15.10.1)(react-native@0.78.0(@babel/core@7.27.1)(@babel/preset-env@7.26.9(@babel/core@7.27.1))(@react-native-community/cli-server-api@13.6.9(encoding@0.1.13))(@types/react@19.0.10)(react@19.0.0))(react@19.0.0))(react-native@0.78.0(@babel/core@7.27.1)(@babel/preset-env@7.26.9(@babel/core@7.27.1))(@react-native-community/cli-server-api@13.6.9(encoding@0.1.13))(@types/react@19.0.10)(react@19.0.0))
       unbuild:
         specifier: ^3.5.0
-        version: 3.5.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.14(typescript@5.8.2))
+        version: 3.5.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.15(typescript@5.8.2))
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@22.15.3)(happy-dom@17.4.1)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)
+
+  packages/file-storage:
+    dependencies:
+      '@uploadthing/shared':
+        specifier: ^6.7.9
+        version: 6.7.9
+      better-auth:
+        specifier: workspace:^
+        version: link:../better-auth
+      uploadthing:
+        specifier: ^6.13.3
+        version: 6.13.3(express@5.1.0)(h3@1.15.1)(next@15.3.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1))(tailwindcss@4.0.12)
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.4
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.12
+      better-call:
+        specifier: 'catalog:'
+        version: 1.0.8
+      better-sqlite3:
+        specifier: ^11.6.0
+        version: 11.8.1
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@22.15.3)(happy-dom@17.4.1)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)
@@ -3396,6 +3424,12 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@effect/schema@0.68.18':
+    resolution: {integrity: sha512-+knLs36muKsyqIvQTB0itGp5Lwy+5jgEC0G5P8wSsrB6EWGFirS87QjbaFYGbg32l/P51RM+9cPMiAEyICwN6g==}
+    deprecated: this package has been merged into the main effect package
+    peerDependencies:
+      effect: ^3.4.8
 
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
@@ -9661,8 +9695,8 @@ packages:
   '@types/braces@3.0.4':
     resolution: {integrity: sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==}
 
-  '@types/bun@1.2.13':
-    resolution: {integrity: sha512-u6vXep/i9VBxoJl3GjZsl/BFIsvML8DfVDO0RYLEwtSZSp981kEO1V5NwRcO1CPJ7AmvpbnDCiMKo3JvbDEjAg==}
+  '@types/bun@1.2.14':
+    resolution: {integrity: sha512-VsFZKs8oKHzI7zwvECiAJ5oSorWndIWEVhfbYqZd4HI/45kzW7PN2Rr5biAzvGvRuNmYLSANY+H59ubHq8xw7Q==}
 
   '@types/canvas-confetti@1.9.0':
     resolution: {integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==}
@@ -10142,6 +10176,12 @@ packages:
       '@unovis/ts': 1.4.3-beta.0
       vue: ^3
 
+  '@uploadthing/mime-types@0.2.10':
+    resolution: {integrity: sha512-kz3F0oEgAyts25NAGXlUBCWh3mXonbSOQJFGFMawHuIgbUbnzXbe4w5WI+0XdneCbjNmikfWrdWrs8m/7HATfQ==}
+
+  '@uploadthing/shared@6.7.9':
+    resolution: {integrity: sha512-EsHkD31HLBHYB59ZbUVQg1pADtMNf+qjlKwniq+gxXsOOe5heD/zunJStjYWLhwB+C8+SaCPXvM7LiDmv5s/Vw==}
+
   '@urql/core@5.1.1':
     resolution: {integrity: sha512-aGh024z5v2oINGD/In6rAtVKTm4VmQ2TxKQBAtk2ZSME5dunZFcjltw4p5ENQg+5CBhZ3FHMzl0Oa+rwqiWqlg==}
 
@@ -10351,6 +10391,9 @@ packages:
   '@vue/compiler-core@3.5.14':
     resolution: {integrity: sha512-k7qMHMbKvoCXIxPhquKQVw3Twid3Kg4s7+oYURxLGRd56LiuHJVrvFKI4fm2AM3c8apqODPfVJGoh8nePbXMRA==}
 
+  '@vue/compiler-core@3.5.15':
+    resolution: {integrity: sha512-nGRc6YJg/kxNqbv/7Tg4juirPnjHvuVdhcmDvQWVZXlLHjouq7VsKmV1hIxM/8yKM0VUfwT/Uzc0lO510ltZqw==}
+
   '@vue/compiler-dom@3.3.4':
     resolution: {integrity: sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==}
 
@@ -10359,6 +10402,9 @@ packages:
 
   '@vue/compiler-dom@3.5.14':
     resolution: {integrity: sha512-1aOCSqxGOea5I80U2hQJvXYpPm/aXo95xL/m/mMhgyPUsKe9jhjwWpziNAw7tYRnbz1I61rd9Mld4W9KmmRoug==}
+
+  '@vue/compiler-dom@3.5.15':
+    resolution: {integrity: sha512-ZelQd9n+O/UCBdL00rlwCrsArSak+YLZpBVuNDio1hN3+wrCshYZEDUO3khSLAzPbF1oQS2duEoMDUHScUlYjA==}
 
   '@vue/compiler-sfc@3.3.4':
     resolution: {integrity: sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==}
@@ -10369,6 +10415,9 @@ packages:
   '@vue/compiler-sfc@3.5.14':
     resolution: {integrity: sha512-9T6m/9mMr81Lj58JpzsiSIjBgv2LiVoWjIVa7kuXHICUi8LiDSIotMpPRXYJsXKqyARrzjT24NAwttrMnMaCXA==}
 
+  '@vue/compiler-sfc@3.5.15':
+    resolution: {integrity: sha512-3zndKbxMsOU6afQWer75Zot/aydjtxNj0T2KLg033rAFaQUn2PGuE32ZRe4iMhflbTcAxL0yEYsRWFxtPro8RQ==}
+
   '@vue/compiler-ssr@3.3.4':
     resolution: {integrity: sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==}
 
@@ -10377,6 +10426,9 @@ packages:
 
   '@vue/compiler-ssr@3.5.14':
     resolution: {integrity: sha512-Y0G7PcBxr1yllnHuS/NxNCSPWnRGH4Ogrp0tsLA5QemDZuJLs99YjAKQ7KqkHE0vCg4QTKlQzXLKCMF7WPSl7Q==}
+
+  '@vue/compiler-ssr@3.5.15':
+    resolution: {integrity: sha512-gShn8zRREZbrXqTtmLSCffgZXDWv8nHc/GhsW+mbwBfNZL5pI96e7IWcIq8XGQe1TLtVbu7EV9gFIVSmfyarPg==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -10410,8 +10462,8 @@ packages:
   '@vue/reactivity@3.5.13':
     resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
 
-  '@vue/reactivity@3.5.14':
-    resolution: {integrity: sha512-7cK1Hp343Fu/SUCCO52vCabjvsYu7ZkOqyYu7bXV9P2yyfjUMUXHZafEbq244sP7gf+EZEz+77QixBTuEqkQQw==}
+  '@vue/reactivity@3.5.15':
+    resolution: {integrity: sha512-GaA5VUm30YWobCwpvcs9nvFKf27EdSLKDo2jA0IXzGS344oNpFNbEQ9z+Pp5ESDaxyS8FcH0vFN/XSe95BZtHQ==}
 
   '@vue/runtime-core@3.3.4':
     resolution: {integrity: sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==}
@@ -10419,8 +10471,8 @@ packages:
   '@vue/runtime-core@3.5.13':
     resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
 
-  '@vue/runtime-core@3.5.14':
-    resolution: {integrity: sha512-w9JWEANwHXNgieAhxPpEpJa+0V5G0hz3NmjAZwlOebtfKyp2hKxKF0+qSh0Xs6/PhfGihuSdqMprMVcQU/E6ag==}
+  '@vue/runtime-core@3.5.15':
+    resolution: {integrity: sha512-CZAlIOQ93nj0OPpWWOx4+QDLCMzBNY85IQR4Voe6vIID149yF8g9WQaWnw042f/6JfvLttK7dnyWlC1EVCRK8Q==}
 
   '@vue/runtime-dom@3.3.4':
     resolution: {integrity: sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==}
@@ -10428,8 +10480,8 @@ packages:
   '@vue/runtime-dom@3.5.13':
     resolution: {integrity: sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==}
 
-  '@vue/runtime-dom@3.5.14':
-    resolution: {integrity: sha512-lCfR++IakeI35TVR80QgOelsUIdcKjd65rWAMfdSlCYnaEY5t3hYwru7vvcWaqmrK+LpI7ZDDYiGU5V3xjMacw==}
+  '@vue/runtime-dom@3.5.15':
+    resolution: {integrity: sha512-wFplHKzKO/v998up2iCW3RN9TNUeDMhdBcNYZgs5LOokHntrB48dyuZHspcahKZczKKh3v6i164gapMPxBTKNw==}
 
   '@vue/server-renderer@3.3.4':
     resolution: {integrity: sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==}
@@ -10441,10 +10493,10 @@ packages:
     peerDependencies:
       vue: 3.5.13
 
-  '@vue/server-renderer@3.5.14':
-    resolution: {integrity: sha512-Rf/ISLqokIvcySIYnv3tNWq40PLpNLDLSJwwVWzG6MNtyIhfbcrAxo5ZL9nARJhqjZyWWa40oRb2IDuejeuv6w==}
+  '@vue/server-renderer@3.5.15':
+    resolution: {integrity: sha512-Gehc693kVTYkLt6QSYEjGvqvdK2zZ/gf/D5zkgmvBdeB30dNnVZS8yY7+IlBmHRd1rR/zwaqeu06Ij04ZxBscg==}
     peerDependencies:
-      vue: 3.5.14
+      vue: 3.5.15
 
   '@vue/shared@3.3.4':
     resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
@@ -10454,6 +10506,9 @@ packages:
 
   '@vue/shared@3.5.14':
     resolution: {integrity: sha512-oXTwNxVfc9EtP1zzXAlSlgARLXNC84frFYkS0HHz0h3E4WZSP9sywqjqzGCP9Y34M8ipNmd380pVgmMuwELDyQ==}
+
+  '@vue/shared@3.5.15':
+    resolution: {integrity: sha512-bKvgFJJL1ZX9KxMCTQY6xD9Dhe3nusd1OhyOb1cJYGqvAr0Vg8FIjHPMOEVbJ9GDT9HG+Bjdn4oS8ohKP8EvoA==}
 
   '@vueuse/core@10.11.1':
     resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
@@ -11336,8 +11391,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  bun-types@1.2.13:
-    resolution: {integrity: sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q==}
+  bun-types@1.2.14:
+    resolution: {integrity: sha512-Kuh4Ub28ucMRWeiUUWMHsT9Wcbr4H3kLIO72RZZElSDxSu7vpetRvxIUDUaW6QtaIeixIpm7OXtNnZPf82EzwA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -12915,6 +12970,9 @@ packages:
 
   effect@3.13.7:
     resolution: {integrity: sha512-yjDuWX5M34kB38Pwilv8QU956nA2m1a6ws0i+04VQkQJEBPI4GfVhUhtNNFRaqKIOlkqdqzJHCDOwARmaf2XzA==}
+
+  effect@3.4.8:
+    resolution: {integrity: sha512-qOQNrSSN3ITuAtARtN2Ldq6E5f42splY9VV18LqpKOXMwQCCEWkXdns4by3D2CJnDXQD2KCE0iGcRR2KowiQIA==}
 
   electron-to-chromium@1.5.113:
     resolution: {integrity: sha512-wjT2O4hX+wdWPJ76gWSkMhcHAV2PTMX+QetUCPYEdCIe+cxmgzzSSiGRCKW8nuh4mwKZlpv0xvoW7OF2X+wmHg==}
@@ -20337,6 +20395,30 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  uploadthing@6.13.3:
+    resolution: {integrity: sha512-MkwKeuo0cVSJ9XHZgEW67qzCmk8QF1mDNf3cDnDC4v0g7o7mnCWgATyYsKSFURQPLnRvysddDxmsaekDOomXvw==}
+    engines: {node: '>=18.13.0'}
+    peerDependencies:
+      '@effect/platform': '*'
+      express: '*'
+      fastify: '*'
+      h3: '*'
+      next: '*'
+      tailwindcss: '*'
+    peerDependenciesMeta:
+      '@effect/platform':
+        optional: true
+      express:
+        optional: true
+      fastify:
+        optional: true
+      h3:
+        optional: true
+      next:
+        optional: true
+      tailwindcss:
+        optional: true
+
   uqr@0.1.2:
     resolution: {integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==}
 
@@ -21026,8 +21108,8 @@ packages:
       typescript:
         optional: true
 
-  vue@3.5.14:
-    resolution: {integrity: sha512-LbOm50/vZFG6Mhy6KscQYXZMQ0LMCC/y40HDJPPvGFQ+i/lUH+PJHR6C3assgOQiXdl6tAfsXHbXYVBZZu65ew==}
+  vue@3.5.15:
+    resolution: {integrity: sha512-aD9zK4rB43JAMK/5BmS4LdPiEp8Fdh8P1Ve/XNuMF5YRf78fCyPE6FUbQwcaWQ5oZ1R2CD9NKE0FFOVpMR7gEQ==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -21886,7 +21968,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.0
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.10)
       '@babel/helpers': 7.27.0
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/template': 7.27.1
       '@babel/traverse': 7.27.0
       '@babel/types': 7.27.1
@@ -21926,7 +22008,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.1
       '@babel/helper-module-transforms': 7.27.1(@babel/core@7.27.1)
       '@babel/helpers': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/template': 7.27.1
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
@@ -21956,7 +22038,7 @@ snapshots:
 
   '@babel/generator@7.27.1':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/types': 7.27.1
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
@@ -24603,13 +24685,13 @@ snapshots:
   '@babel/template@7.27.0':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/types': 7.27.1
 
   '@babel/template@7.27.1':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/types': 7.27.1
 
   '@babel/traverse@7.26.5':
@@ -24640,7 +24722,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/template': 7.27.1
       '@babel/types': 7.27.1
       debug: 4.4.0(supports-color@9.4.0)
@@ -24652,7 +24734,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/template': 7.27.1
       '@babel/types': 7.27.1
       debug: 4.4.0(supports-color@9.4.0)
@@ -24887,6 +24969,11 @@ snapshots:
       which: 4.0.0
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@effect/schema@0.68.18(effect@3.4.8)':
+    dependencies:
+      effect: 3.4.8
+      fast-check: 3.23.2
 
   '@egjs/hammerjs@2.0.17':
     dependencies:
@@ -26100,11 +26187,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@floating-ui/vue@1.1.5(vue@3.5.14(typescript@5.8.2))':
+  '@floating-ui/vue@1.1.5(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       '@floating-ui/dom': 1.6.12
       '@floating-ui/utils': 0.2.8
-      vue-demi: 0.14.10(vue@3.5.14(typescript@5.8.2))
+      vue-demi: 0.14.10(vue@3.5.15(typescript@5.8.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -26161,7 +26248,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
-  '@ianvs/prettier-plugin-sort-imports@4.1.1(@vue/compiler-sfc@3.5.14)(prettier@3.2.4)':
+  '@ianvs/prettier-plugin-sort-imports@4.1.1(@vue/compiler-sfc@3.5.15)(prettier@3.2.4)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/generator': 7.26.9
@@ -26171,7 +26258,7 @@ snapshots:
       prettier: 3.2.4
       semver: 7.7.1
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.14
+      '@vue/compiler-sfc': 3.5.15
     transitivePeerDependencies:
       - supports-color
 
@@ -27072,12 +27159,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.1
 
-  '@nuxt/devtools@2.2.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2))':
+  '@nuxt/devtools@2.2.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       '@nuxt/devtools-kit': 2.2.1(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@nuxt/devtools-wizard': 2.2.1
       '@nuxt/kit': 3.16.0(magicast@0.3.5)
-      '@vue/devtools-core': 7.7.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2))
+      '@vue/devtools-core': 7.7.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2))
       '@vue/devtools-kit': 7.7.2
       birpc: 2.2.0
       consola: 3.4.0
@@ -27104,7 +27191,7 @@ snapshots:
       tinyglobby: 0.2.12
       vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       vite-plugin-inspect: 11.0.0(@nuxt/kit@3.16.0(magicast@0.3.5))(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
-      vite-plugin-vue-tracer: 0.1.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2))
+      vite-plugin-vue-tracer: 0.1.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2))
       which: 5.0.0
       ws: 8.18.1
     transitivePeerDependencies:
@@ -27191,12 +27278,12 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@3.16.0(@biomejs/biome@1.9.4)(@types/node@22.15.3)(eslint@9.22.0(jiti@2.4.2))(less@4.2.2)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.38.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(vue@3.5.14(typescript@5.8.2))(yaml@2.7.0)':
+  '@nuxt/vite-builder@3.16.0(@biomejs/biome@1.9.4)(@types/node@22.15.3)(eslint@9.22.0(jiti@2.4.2))(less@4.2.2)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.38.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(vue@3.5.15(typescript@5.8.2))(yaml@2.7.0)':
     dependencies:
       '@nuxt/kit': 3.16.0(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.38.0)
-      '@vitejs/plugin-vue': 5.2.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2))
-      '@vitejs/plugin-vue-jsx': 4.1.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2))
+      '@vitejs/plugin-vue': 5.2.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2))
+      '@vitejs/plugin-vue-jsx': 4.1.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2))
       autoprefixer: 10.4.20(postcss@8.5.3)
       consola: 3.4.0
       cssnano: 7.0.6(postcss@8.5.3)
@@ -27224,7 +27311,7 @@ snapshots:
       vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       vite-node: 3.0.8(@types/node@22.15.3)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)
       vite-plugin-checker: 0.9.0(@biomejs/biome@1.9.4)(eslint@9.22.0(jiti@2.4.2))(optionator@0.9.4)(typescript@5.8.2)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
       vue-bundle-renderer: 2.1.1
     transitivePeerDependencies:
       - '@biomejs/biome'
@@ -28613,9 +28700,9 @@ snapshots:
       '@prisma/debug': 6.4.1
     optional: true
 
-  '@radix-icons/vue@1.0.0(vue@3.5.14(typescript@5.8.2))':
+  '@radix-icons/vue@1.0.0(vue@3.5.15(typescript@5.8.2))':
     dependencies:
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   '@radix-ui/number@1.1.0': {}
 
@@ -30970,7 +31057,7 @@ snapshots:
 
   '@react-native/codegen@0.78.0(@babel/preset-env@7.26.9(@babel/core@7.26.9))':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/preset-env': 7.26.9(@babel/core@7.26.9)
       glob: 7.2.3
       hermes-parser: 0.25.1
@@ -30984,7 +31071,7 @@ snapshots:
 
   '@react-native/codegen@0.78.0(@babel/preset-env@7.26.9(@babel/core@7.27.1))':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/preset-env': 7.26.9(@babel/core@7.27.1)
       glob: 7.2.3
       hermes-parser: 0.25.1
@@ -32053,7 +32140,7 @@ snapshots:
     dependencies:
       '@scalar/openapi-types': 0.1.9
       '@unhead/schema': 1.11.20
-      zod: 3.24.2
+      zod: 3.24.4
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -32733,11 +32820,11 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-api-routes@1.112.18(do3hc3md4wd7it5bigaqcra2vq)':
+  '@tanstack/react-start-api-routes@1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)':
     dependencies:
-      '@tanstack/react-start-server': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
+      '@tanstack/react-start-server': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
       '@tanstack/router-core': 1.112.18
-      vinxi: 0.5.3(qmycrikecd3inn5enqnqcdtkym)
+      vinxi: 0.5.3(u6rzw6lpze2euny7wyp5bo3kgm)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -32783,7 +32870,7 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-client@1.112.18(do3hc3md4wd7it5bigaqcra2vq)':
+  '@tanstack/react-start-client@1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)':
     dependencies:
       '@tanstack/react-router': 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/router-core': 1.112.18
@@ -32793,7 +32880,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
-      vinxi: 0.5.3(qmycrikecd3inn5enqnqcdtkym)
+      vinxi: 0.5.3(u6rzw6lpze2euny7wyp5bo3kgm)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -32837,7 +32924,7 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-client@1.114.34(2plvxtj6a7vw55mtbqwukj7brm)':
+  '@tanstack/react-start-client@1.114.34(k3h642e4vkmjbtiifejnl2nvpe)':
     dependencies:
       '@tanstack/react-router': 1.114.34(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/router-core': 1.114.33
@@ -32848,7 +32935,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
-      vinxi: 0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+      vinxi: 0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -32892,7 +32979,7 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-client@1.114.34(do3hc3md4wd7it5bigaqcra2vq)':
+  '@tanstack/react-start-client@1.114.34(rd5gcwrhvc4hvphtyxcplbtrvm)':
     dependencies:
       '@tanstack/react-router': 1.114.34(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/router-core': 1.114.33
@@ -32903,7 +32990,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
-      vinxi: 0.5.3(qmycrikecd3inn5enqnqcdtkym)
+      vinxi: 0.5.3(u6rzw6lpze2euny7wyp5bo3kgm)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -32947,7 +33034,7 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-config@1.114.34(xdtxozacaptx2f2yoax7hh4is4)':
+  '@tanstack/react-start-config@1.114.34(hknldnrpkejl4v5ig7dqtwm36i)':
     dependencies:
       '@tanstack/react-start-plugin': 1.114.32(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       '@tanstack/router-core': 1.114.33
@@ -32957,13 +33044,13 @@ snapshots:
       '@tanstack/start-server-functions-handler': 1.114.33
       '@vitejs/plugin-react': 4.3.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       import-meta-resolve: 4.1.0
-      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
+      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
       ofetch: 1.4.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      vinxi: 0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+      vinxi: 0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
       vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
-      zod: 3.24.2
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -33066,11 +33153,11 @@ snapshots:
       - tsx
       - yaml
 
-  '@tanstack/react-start-router-manifest@1.112.18(qmycrikecd3inn5enqnqcdtkym)':
+  '@tanstack/react-start-router-manifest@1.112.18(u6rzw6lpze2euny7wyp5bo3kgm)':
     dependencies:
       '@tanstack/router-core': 1.112.18
       tiny-invariant: 1.3.3
-      vinxi: 0.5.3(qmycrikecd3inn5enqnqcdtkym)
+      vinxi: 0.5.3(u6rzw6lpze2euny7wyp5bo3kgm)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -33114,11 +33201,11 @@ snapshots:
       - xml2js
       - yaml
 
-  ? '@tanstack/react-start-router-manifest@1.114.33(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)'
+  ? '@tanstack/react-start-router-manifest@1.114.33(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)'
   : dependencies:
       '@tanstack/router-core': 1.114.33
       tiny-invariant: 1.3.3
-      vinxi: 0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+      vinxi: 0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -33162,9 +33249,9 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-server-functions-client@1.112.18(rikohmhqegmq4stnnvkdxooyim)':
+  '@tanstack/react-start-server-functions-client@1.112.18(totbgintwwiblii3amyq7w43vy)':
     dependencies:
-      '@tanstack/react-start-server-functions-fetcher': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
+      '@tanstack/react-start-server-functions-fetcher': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
       '@tanstack/server-functions-plugin': 1.112.18(@types/node@22.13.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -33212,10 +33299,10 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-server-functions-fetcher@1.112.18(do3hc3md4wd7it5bigaqcra2vq)':
+  '@tanstack/react-start-server-functions-fetcher@1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)':
     dependencies:
       '@tanstack/react-router': 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tanstack/react-start-client': 1.114.34(do3hc3md4wd7it5bigaqcra2vq)
+      '@tanstack/react-start-client': 1.114.34(rd5gcwrhvc4hvphtyxcplbtrvm)
       '@tanstack/router-core': 1.112.18
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -33262,11 +33349,11 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-server-functions-handler@1.112.18(do3hc3md4wd7it5bigaqcra2vq)':
+  '@tanstack/react-start-server-functions-handler@1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)':
     dependencies:
       '@tanstack/react-router': 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tanstack/react-start-client': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
-      '@tanstack/react-start-server': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
+      '@tanstack/react-start-client': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
+      '@tanstack/react-start-server': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tiny-invariant: 1.3.3
@@ -33313,11 +33400,11 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-server-functions-ssr@1.112.18(rikohmhqegmq4stnnvkdxooyim)':
+  '@tanstack/react-start-server-functions-ssr@1.112.18(totbgintwwiblii3amyq7w43vy)':
     dependencies:
-      '@tanstack/react-start-client': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
-      '@tanstack/react-start-server': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
-      '@tanstack/react-start-server-functions-fetcher': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
+      '@tanstack/react-start-client': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
+      '@tanstack/react-start-server': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
+      '@tanstack/react-start-server-functions-fetcher': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
       '@tanstack/server-functions-plugin': 1.112.18(@types/node@22.13.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
@@ -33366,11 +33453,11 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-server@1.112.18(do3hc3md4wd7it5bigaqcra2vq)':
+  '@tanstack/react-start-server@1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)':
     dependencies:
       '@tanstack/history': 1.112.18
       '@tanstack/react-router': 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tanstack/react-start-client': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
+      '@tanstack/react-start-client': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
       '@tanstack/router-core': 1.112.18
       h3: 1.13.0
       isbot: 5.1.23
@@ -33437,13 +33524,13 @@ snapshots:
       tiny-warning: 1.0.3
       unctx: 2.4.1
 
-  '@tanstack/react-start@1.114.34(xdtxozacaptx2f2yoax7hh4is4)':
+  '@tanstack/react-start@1.114.34(hknldnrpkejl4v5ig7dqtwm36i)':
     dependencies:
-      '@tanstack/react-start-client': 1.114.34(2plvxtj6a7vw55mtbqwukj7brm)
-      '@tanstack/react-start-config': 1.114.34(xdtxozacaptx2f2yoax7hh4is4)
-      '@tanstack/react-start-router-manifest': 1.114.33(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+      '@tanstack/react-start-client': 1.114.34(k3h642e4vkmjbtiifejnl2nvpe)
+      '@tanstack/react-start-config': 1.114.34(hknldnrpkejl4v5ig7dqtwm36i)
+      '@tanstack/react-start-router-manifest': 1.114.33(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
       '@tanstack/react-start-server': 1.114.34(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@tanstack/start-api-routes': 1.114.33(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+      '@tanstack/start-api-routes': 1.114.33(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
       '@tanstack/start-server-functions-client': 1.114.33(@types/node@22.15.3)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       '@tanstack/start-server-functions-handler': 1.114.33
       '@tanstack/start-server-functions-server': 1.114.32(@types/node@22.15.3)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -33529,7 +33616,7 @@ snapshots:
       '@tanstack/virtual-file-routes': 1.99.0
       prettier: 3.5.3
       tsx: 4.19.3
-      zod: 3.24.2
+      zod: 3.24.4
     optionalDependencies:
       '@tanstack/react-router': 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
@@ -33538,7 +33625,7 @@ snapshots:
       '@tanstack/virtual-file-routes': 1.114.29
       prettier: 3.5.3
       tsx: 4.19.3
-      zod: 3.24.2
+      zod: 3.24.4
     optionalDependencies:
       '@tanstack/react-router': 1.114.34(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
@@ -33560,7 +33647,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.9
       chokidar: 3.6.0
       unplugin: 2.2.0
-      zod: 3.24.2
+      zod: 3.24.4
     optionalDependencies:
       '@tanstack/react-router': 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite: 6.3.4(@types/node@22.13.10)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -33586,7 +33673,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.10
       chokidar: 3.6.0
       unplugin: 2.2.0
-      zod: 3.24.2
+      zod: 3.24.4
     optionalDependencies:
       '@tanstack/react-router': 1.114.34(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -33597,14 +33684,14 @@ snapshots:
   '@tanstack/router-utils@1.112.18':
     dependencies:
       '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       ansis: 3.17.0
       diff: 7.0.0
 
   '@tanstack/router-utils@1.114.29':
     dependencies:
       '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       ansis: 3.17.0
       diff: 7.0.0
 
@@ -33664,11 +33751,11 @@ snapshots:
       - tsx
       - yaml
 
-  '@tanstack/start-api-routes@1.114.33(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)':
+  '@tanstack/start-api-routes@1.114.33(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)':
     dependencies:
       '@tanstack/router-core': 1.114.33
       '@tanstack/start-server-core': 1.114.33
-      vinxi: 0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+      vinxi: 0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -33719,23 +33806,23 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/start-config@1.113.0(umfczj6grv5xwnnilehiba4mti)':
+  '@tanstack/start-config@1.113.0(byszfgl2x46wwa7wxh3rgelbcu)':
     dependencies:
       '@tanstack/react-router': 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-start-plugin': 1.112.18(@types/node@22.13.10)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
-      '@tanstack/react-start-server-functions-handler': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
+      '@tanstack/react-start-server-functions-handler': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
       '@tanstack/router-generator': 1.113.0(@tanstack/react-router@1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tanstack/router-plugin': 1.113.0(@tanstack/react-router@1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite-plugin-solid@2.11.6(solid-js@1.9.5)(vite@6.3.4(@types/node@22.13.10)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(vite@6.3.4(@types/node@22.13.10)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@tanstack/server-functions-plugin': 1.112.18(@types/node@22.13.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       '@vitejs/plugin-react': 4.3.4(vite@6.3.4(@types/node@22.13.10)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       import-meta-resolve: 4.1.0
-      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
+      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
       ofetch: 1.4.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      vinxi: 0.5.3(qmycrikecd3inn5enqnqcdtkym)
+      vinxi: 0.5.3(u6rzw6lpze2euny7wyp5bo3kgm)
       vite: 6.3.4(@types/node@22.13.10)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
-      zod: 3.24.2
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -33885,16 +33972,16 @@ snapshots:
       - tsx
       - yaml
 
-  '@tanstack/start@1.113.0(umfczj6grv5xwnnilehiba4mti)':
+  '@tanstack/start@1.113.0(byszfgl2x46wwa7wxh3rgelbcu)':
     dependencies:
-      '@tanstack/react-start-api-routes': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
-      '@tanstack/react-start-client': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
-      '@tanstack/react-start-router-manifest': 1.112.18(qmycrikecd3inn5enqnqcdtkym)
-      '@tanstack/react-start-server': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
-      '@tanstack/react-start-server-functions-client': 1.112.18(rikohmhqegmq4stnnvkdxooyim)
-      '@tanstack/react-start-server-functions-handler': 1.112.18(do3hc3md4wd7it5bigaqcra2vq)
-      '@tanstack/react-start-server-functions-ssr': 1.112.18(rikohmhqegmq4stnnvkdxooyim)
-      '@tanstack/start-config': 1.113.0(umfczj6grv5xwnnilehiba4mti)
+      '@tanstack/react-start-api-routes': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
+      '@tanstack/react-start-client': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
+      '@tanstack/react-start-router-manifest': 1.112.18(u6rzw6lpze2euny7wyp5bo3kgm)
+      '@tanstack/react-start-server': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
+      '@tanstack/react-start-server-functions-client': 1.112.18(totbgintwwiblii3amyq7w43vy)
+      '@tanstack/react-start-server-functions-handler': 1.112.18(rd5gcwrhvc4hvphtyxcplbtrvm)
+      '@tanstack/react-start-server-functions-ssr': 1.112.18(totbgintwwiblii3amyq7w43vy)
+      '@tanstack/start-config': 1.113.0(byszfgl2x46wwa7wxh3rgelbcu)
       '@tanstack/start-server-functions-server': 1.112.18(@types/node@22.13.10)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -33954,10 +34041,10 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.99.0': {}
 
-  '@tanstack/vue-virtual@3.10.8(vue@3.5.14(typescript@5.8.2))':
+  '@tanstack/vue-virtual@3.10.8(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       '@tanstack/virtual-core': 3.10.8
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   '@trysound/sax@0.2.0': {}
 
@@ -34005,9 +34092,9 @@ snapshots:
 
   '@types/braces@3.0.4': {}
 
-  '@types/bun@1.2.13':
+  '@types/bun@1.2.14':
     dependencies:
-      bun-types: 1.2.13
+      bun-types: 1.2.14
 
   '@types/canvas-confetti@1.9.0': {}
 
@@ -34611,11 +34698,11 @@ snapshots:
       hookable: 5.5.3
       zhead: 2.2.4
 
-  '@unhead/vue@2.0.0-rc.9(vue@3.5.14(typescript@5.8.2))':
+  '@unhead/vue@2.0.0-rc.9(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       hookable: 5.5.3
       unhead: 2.0.0-rc.9
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   '@unovis/dagre-layout@0.8.8-2':
     dependencies:
@@ -34663,10 +34750,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@unovis/vue@1.4.3-beta.0(@unovis/ts@1.4.3-beta.0)(vue@3.5.14(typescript@5.8.2))':
+  '@unovis/vue@1.4.3-beta.0(@unovis/ts@1.4.3-beta.0)(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       '@unovis/ts': 1.4.3-beta.0
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
+
+  '@uploadthing/mime-types@0.2.10': {}
+
+  '@uploadthing/shared@6.7.9':
+    dependencies:
+      '@uploadthing/mime-types': 0.2.10
+      effect: 3.4.8
+      std-env: 3.8.1
 
   '@urql/core@5.1.1(graphql@15.10.1)':
     dependencies:
@@ -34732,23 +34827,23 @@ snapshots:
 
   '@vanilla-extract/private@1.0.6': {}
 
-  '@vee-validate/zod@4.15.0(vue@3.5.14(typescript@5.8.2))(zod@3.24.2)':
+  '@vee-validate/zod@4.15.0(vue@3.5.15(typescript@5.8.2))(zod@3.24.2)':
     dependencies:
       type-fest: 4.26.1
-      vee-validate: 4.15.0(vue@3.5.14(typescript@5.8.2))
+      vee-validate: 4.15.0(vue@3.5.15(typescript@5.8.2))
       zod: 3.24.2
     transitivePeerDependencies:
       - vue
 
-  '@vercel/analytics@1.5.0(@remix-run/react@2.16.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2))(@sveltejs/kit@2.19.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1))(react@19.0.0)(svelte@5.22.6)(vue-router@4.5.1(vue@3.5.14(typescript@5.8.2)))(vue@3.5.14(typescript@5.8.2))':
+  '@vercel/analytics@1.5.0(@remix-run/react@2.16.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2))(@sveltejs/kit@2.19.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1))(react@19.0.0)(svelte@5.22.6)(vue-router@4.5.1(vue@3.5.15(typescript@5.8.2)))(vue@3.5.15(typescript@5.8.2))':
     optionalDependencies:
       '@remix-run/react': 2.16.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)
       '@sveltejs/kit': 2.19.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(svelte@5.22.6)(vite@6.3.4(@types/node@22.13.8)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       next: 15.2.3(@babel/core@7.26.9)(babel-plugin-macros@3.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1)
       react: 19.0.0
       svelte: 5.22.6
-      vue: 3.5.14(typescript@5.8.2)
-      vue-router: 4.5.1(vue@3.5.14(typescript@5.8.2))
+      vue: 3.5.15(typescript@5.8.2)
+      vue-router: 4.5.1(vue@3.5.15(typescript@5.8.2))
 
   '@vercel/mcp-adapter@0.4.1(next@15.3.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1))':
     dependencies:
@@ -34834,20 +34929,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.1.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2))':
+  '@vitejs/plugin-vue-jsx@4.1.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-transform-typescript': 7.26.8(@babel/core@7.26.9)
       '@vue/babel-plugin-jsx': 1.3.0(@babel/core@7.26.9)
       vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2))':
+  '@vitejs/plugin-vue@5.2.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -34989,16 +35084,16 @@ snapshots:
 
   '@vscode/l10n@0.0.18': {}
 
-  '@vue-macros/common@1.16.1(vue@3.5.14(typescript@5.8.2))':
+  '@vue-macros/common@1.16.1(vue@3.5.15(typescript@5.8.2))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.13
+      '@vue/compiler-sfc': 3.5.14
       ast-kit: 1.4.2
       local-pkg: 1.1.1
       magic-string-ast: 0.7.1
       pathe: 2.0.3
       picomatch: 4.0.2
     optionalDependencies:
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   '@vue/babel-helper-vue-transform-on@1.3.0': {}
 
@@ -35012,7 +35107,7 @@ snapshots:
       '@babel/types': 7.27.1
       '@vue/babel-helper-vue-transform-on': 1.3.0
       '@vue/babel-plugin-resolve-type': 1.3.0(@babel/core@7.26.9)
-      '@vue/shared': 3.5.13
+      '@vue/shared': 3.5.14
     optionalDependencies:
       '@babel/core': 7.26.9
     transitivePeerDependencies:
@@ -35024,21 +35119,21 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/parser': 7.27.1
-      '@vue/compiler-sfc': 3.5.13
+      '@babel/parser': 7.27.2
+      '@vue/compiler-sfc': 3.5.14
     transitivePeerDependencies:
       - supports-color
 
   '@vue/compiler-core@3.3.4':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -35048,6 +35143,14 @@ snapshots:
     dependencies:
       '@babel/parser': 7.27.2
       '@vue/shared': 3.5.14
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-core@3.5.15':
+    dependencies:
+      '@babel/parser': 7.27.2
+      '@vue/shared': 3.5.15
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -35067,9 +35170,14 @@ snapshots:
       '@vue/compiler-core': 3.5.14
       '@vue/shared': 3.5.14
 
+  '@vue/compiler-dom@3.5.15':
+    dependencies:
+      '@vue/compiler-core': 3.5.15
+      '@vue/shared': 3.5.15
+
   '@vue/compiler-sfc@3.3.4':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@vue/compiler-core': 3.3.4
       '@vue/compiler-dom': 3.3.4
       '@vue/compiler-ssr': 3.3.4
@@ -35104,6 +35212,18 @@ snapshots:
       postcss: 8.5.3
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.15':
+    dependencies:
+      '@babel/parser': 7.27.2
+      '@vue/compiler-core': 3.5.15
+      '@vue/compiler-dom': 3.5.15
+      '@vue/compiler-ssr': 3.5.15
+      '@vue/shared': 3.5.15
+      estree-walker: 2.0.2
+      magic-string: 0.30.17
+      postcss: 8.5.3
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.3.4':
     dependencies:
       '@vue/compiler-dom': 3.3.4
@@ -35119,13 +35239,18 @@ snapshots:
       '@vue/compiler-dom': 3.5.14
       '@vue/shared': 3.5.14
 
+  '@vue/compiler-ssr@3.5.15':
+    dependencies:
+      '@vue/compiler-dom': 3.5.15
+      '@vue/shared': 3.5.15
+
   '@vue/devtools-api@6.6.4': {}
 
   '@vue/devtools-api@7.6.2':
     dependencies:
       '@vue/devtools-kit': 7.6.2
 
-  '@vue/devtools-core@7.7.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2))':
+  '@vue/devtools-core@7.7.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       '@vue/devtools-kit': 7.7.2
       '@vue/devtools-shared': 7.7.2
@@ -35133,7 +35258,7 @@ snapshots:
       nanoid: 5.1.5
       pathe: 2.0.3
       vite-hot-client: 0.2.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
     transitivePeerDependencies:
       - vite
 
@@ -35167,7 +35292,7 @@ snapshots:
 
   '@vue/reactivity-transform@3.3.4':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
@@ -35181,9 +35306,9 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.13
 
-  '@vue/reactivity@3.5.14':
+  '@vue/reactivity@3.5.15':
     dependencies:
-      '@vue/shared': 3.5.14
+      '@vue/shared': 3.5.15
 
   '@vue/runtime-core@3.3.4':
     dependencies:
@@ -35195,10 +35320,10 @@ snapshots:
       '@vue/reactivity': 3.5.13
       '@vue/shared': 3.5.13
 
-  '@vue/runtime-core@3.5.14':
+  '@vue/runtime-core@3.5.15':
     dependencies:
-      '@vue/reactivity': 3.5.14
-      '@vue/shared': 3.5.14
+      '@vue/reactivity': 3.5.15
+      '@vue/shared': 3.5.15
 
   '@vue/runtime-dom@3.3.4':
     dependencies:
@@ -35213,11 +35338,11 @@ snapshots:
       '@vue/shared': 3.5.13
       csstype: 3.1.3
 
-  '@vue/runtime-dom@3.5.14':
+  '@vue/runtime-dom@3.5.15':
     dependencies:
-      '@vue/reactivity': 3.5.14
-      '@vue/runtime-core': 3.5.14
-      '@vue/shared': 3.5.14
+      '@vue/reactivity': 3.5.15
+      '@vue/runtime-core': 3.5.15
+      '@vue/shared': 3.5.15
       csstype: 3.1.3
 
   '@vue/server-renderer@3.3.4(vue@3.3.4)':
@@ -35232,11 +35357,11 @@ snapshots:
       '@vue/shared': 3.5.13
       vue: 3.5.13(typescript@5.8.2)
 
-  '@vue/server-renderer@3.5.14(vue@3.5.14(typescript@5.8.2))':
+  '@vue/server-renderer@3.5.15(vue@3.5.15(typescript@5.8.2))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.14
-      '@vue/shared': 3.5.14
-      vue: 3.5.14(typescript@5.8.2)
+      '@vue/compiler-ssr': 3.5.15
+      '@vue/shared': 3.5.15
+      vue: 3.5.15(typescript@5.8.2)
 
   '@vue/shared@3.3.4': {}
 
@@ -35244,22 +35369,24 @@ snapshots:
 
   '@vue/shared@3.5.14': {}
 
-  '@vueuse/core@10.11.1(vue@3.5.14(typescript@5.8.2))':
+  '@vue/shared@3.5.15': {}
+
+  '@vueuse/core@10.11.1(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.14(typescript@5.8.2))
-      vue-demi: 0.14.10(vue@3.5.14(typescript@5.8.2))
+      '@vueuse/shared': 10.11.1(vue@3.5.15(typescript@5.8.2))
+      vue-demi: 0.14.10(vue@3.5.15(typescript@5.8.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@11.3.0(vue@3.5.14(typescript@5.8.2))':
+  '@vueuse/core@11.3.0(vue@3.5.15(typescript@5.8.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 11.3.0
-      '@vueuse/shared': 11.3.0(vue@3.5.14(typescript@5.8.2))
-      vue-demi: 0.14.10(vue@3.5.14(typescript@5.8.2))
+      '@vueuse/shared': 11.3.0(vue@3.5.15(typescript@5.8.2))
+      vue-demi: 0.14.10(vue@3.5.15(typescript@5.8.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -35268,16 +35395,16 @@ snapshots:
 
   '@vueuse/metadata@11.3.0': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.14(typescript@5.8.2))':
+  '@vueuse/shared@10.11.1(vue@3.5.15(typescript@5.8.2))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.14(typescript@5.8.2))
+      vue-demi: 0.14.10(vue@3.5.15(typescript@5.8.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@11.3.0(vue@3.5.14(typescript@5.8.2))':
+  '@vueuse/shared@11.3.0(vue@3.5.15(typescript@5.8.2))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.14(typescript@5.8.2))
+      vue-demi: 0.14.10(vue@3.5.15(typescript@5.8.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -36077,7 +36204,7 @@ snapshots:
 
   ast-kit@1.4.2:
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       pathe: 2.0.3
 
   ast-types-flow@0.0.8: {}
@@ -36229,7 +36356,7 @@ snapshots:
   babel-dead-code-elimination@1.0.10:
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/traverse': 7.27.0
       '@babel/types': 7.27.1
     transitivePeerDependencies:
@@ -36238,7 +36365,7 @@ snapshots:
   babel-dead-code-elimination@1.0.9:
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/traverse': 7.26.9
       '@babel/types': 7.27.1
     transitivePeerDependencies:
@@ -36801,7 +36928,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  bun-types@1.2.13:
+  bun-types@1.2.14:
     dependencies:
       '@types/node': 20.17.24
 
@@ -37867,18 +37994,18 @@ snapshots:
 
   dayjs@1.11.13: {}
 
-  db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0):
+  db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0):
     optionalDependencies:
       '@libsql/client': 0.14.0
       better-sqlite3: 11.8.1
-      drizzle-orm: 0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0)
+      drizzle-orm: 0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0)
       mysql2: 3.13.0
 
-  db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0):
+  db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0):
     optionalDependencies:
       '@libsql/client': 0.14.0
       better-sqlite3: 11.8.1
-      drizzle-orm: 0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2))
+      drizzle-orm: 0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2))
       mysql2: 3.13.0
 
   debug@2.6.9:
@@ -38114,7 +38241,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.33.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@19.0.10)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0):
+  drizzle-orm@0.33.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@19.0.10)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250303.0
       '@libsql/client': 0.14.0
@@ -38123,14 +38250,14 @@ snapshots:
       '@types/pg': 8.11.11
       '@types/react': 19.0.10
       better-sqlite3: 11.8.1
-      bun-types: 1.2.13
+      bun-types: 1.2.14
       kysely: 0.28.1
       mysql2: 3.13.0
       pg: 8.13.3
       prisma: 5.22.0
       react: 19.0.0
 
-  drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0):
+  drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250303.0
       '@libsql/client': 0.14.0
@@ -38140,14 +38267,14 @@ snapshots:
       '@types/pg': 8.11.11
       '@types/react': 18.3.18
       better-sqlite3: 11.8.1
-      bun-types: 1.2.13
+      bun-types: 1.2.14
       kysely: 0.28.1
       mysql2: 3.13.0
       pg: 8.13.3
       prisma: 5.22.0
       react: 19.0.0
 
-  drizzle-orm@0.39.3(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)):
+  drizzle-orm@0.39.3(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250303.0
       '@libsql/client': 0.14.0
@@ -38156,13 +38283,13 @@ snapshots:
       '@types/better-sqlite3': 7.6.12
       '@types/pg': 8.11.11
       better-sqlite3: 11.8.1
-      bun-types: 1.2.13
+      bun-types: 1.2.14
       kysely: 0.28.1
       mysql2: 3.13.0
       pg: 8.13.3
       prisma: 6.4.1(typescript@5.8.2)
 
-  drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)):
+  drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250303.0
       '@libsql/client': 0.14.0
@@ -38171,7 +38298,7 @@ snapshots:
       '@types/better-sqlite3': 7.6.12
       '@types/pg': 8.11.11
       better-sqlite3: 11.8.1
-      bun-types: 1.2.13
+      bun-types: 1.2.14
       gel: 2.0.1
       kysely: 0.28.1
       mysql2: 3.13.0
@@ -38219,6 +38346,8 @@ snapshots:
       fast-check: 3.23.2
     optional: true
 
+  effect@3.4.8: {}
+
   electron-to-chromium@1.5.113: {}
 
   electron-to-chromium@1.5.50: {}
@@ -38253,11 +38382,11 @@ snapshots:
       embla-carousel-reactive-utils: 8.5.2(embla-carousel@8.5.2)
       svelte: 4.2.19
 
-  embla-carousel-vue@8.5.2(vue@3.5.14(typescript@5.8.2)):
+  embla-carousel-vue@8.5.2(vue@3.5.15(typescript@5.8.2)):
     dependencies:
       embla-carousel: 8.5.2
       embla-carousel-reactive-utils: 8.5.2(embla-carousel@8.5.2)
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   embla-carousel@8.5.2: {}
 
@@ -39690,7 +39819,6 @@ snapshots:
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
-    optional: true
 
   fast-deep-equal@2.0.1: {}
 
@@ -41327,7 +41455,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -41557,7 +41685,7 @@ snapshots:
   jscodeshift@17.3.0(@babel/preset-env@7.26.9(@babel/core@7.26.9)):
     dependencies:
       '@babel/core': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.27.1)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.27.1)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.27.1)
@@ -41583,7 +41711,7 @@ snapshots:
   jscodeshift@17.3.0(@babel/preset-env@7.26.9(@babel/core@7.27.1)):
     dependencies:
       '@babel/core': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.27.1)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.27.1)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.27.1)
@@ -42914,7 +43042,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.9
       '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/types': 7.27.1
       flow-enums-runtime: 0.0.6
       metro: 0.80.12
@@ -42934,7 +43062,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.9
       '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/types': 7.27.1
       flow-enums-runtime: 0.0.6
       metro: 0.81.3
@@ -42954,7 +43082,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.1
       '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/types': 7.27.1
       flow-enums-runtime: 0.0.6
       metro: 0.81.4
@@ -42975,7 +43103,7 @@ snapshots:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.26.9
       '@babel/generator': 7.26.9
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/template': 7.26.9
       '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
@@ -43071,7 +43199,7 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.27.1
       '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@babel/template': 7.27.1
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
@@ -43678,7 +43806,7 @@ snapshots:
       typescript: 5.8.2
       vue: 3.5.13(typescript@5.8.2)
 
-  mkdist@2.2.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.14(typescript@5.8.2)):
+  mkdist@2.2.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.15(typescript@5.8.2)):
     dependencies:
       autoprefixer: 10.4.20(postcss@8.5.3)
       citty: 0.1.6
@@ -43696,7 +43824,7 @@ snapshots:
     optionalDependencies:
       sass: 1.85.1
       typescript: 5.8.2
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   mlly@1.7.3:
     dependencies:
@@ -43970,7 +44098,7 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  nitropack@2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2):
+  nitropack@2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@netlify/functions': 3.0.0
@@ -43993,7 +44121,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.0.0
       crossws: 0.3.4
-      db0: 0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0)
+      db0: 0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0)
       defu: 6.1.4
       destr: 2.0.3
       dot-prop: 9.0.0
@@ -44041,7 +44169,7 @@ snapshots:
       unenv: 2.0.0-rc.12
       unimport: 4.1.2
       unplugin-utils: 0.2.4
-      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(ioredis@5.6.0)
+      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(ioredis@5.6.0)
       untyped: 2.0.0
       unwasm: 0.3.9
       youch: 4.1.0-beta.6
@@ -44074,7 +44202,7 @@ snapshots:
       - typescript
       - uploadthing
 
-  nitropack@2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2):
+  nitropack@2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@netlify/functions': 3.0.0
@@ -44097,7 +44225,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.0.0
       crossws: 0.3.4
-      db0: 0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0)
+      db0: 0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0)
       defu: 6.1.4
       destr: 2.0.3
       dot-prop: 9.0.0
@@ -44145,7 +44273,7 @@ snapshots:
       unenv: 2.0.0-rc.12
       unimport: 4.1.2
       unplugin-utils: 0.2.4
-      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0)
+      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0)
       untyped: 2.0.0
       unwasm: 0.3.9
       youch: 4.1.0-beta.6
@@ -44318,17 +44446,17 @@ snapshots:
     dependencies:
       esm-env: 1.2.1
 
-  nuxt@3.16.0(kygbndsg3u7xffwrewwioaaldy):
+  nuxt@3.16.0(6hzfuplutu4lpsxqlj5qyvz2li):
     dependencies:
       '@nuxt/cli': 3.22.5(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.2.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2))
+      '@nuxt/devtools': 2.2.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2))
       '@nuxt/kit': 3.16.0(magicast@0.3.5)
       '@nuxt/schema': 3.16.0
       '@nuxt/telemetry': 2.6.5(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.16.0(@biomejs/biome@1.9.4)(@types/node@22.15.3)(eslint@9.22.0(jiti@2.4.2))(less@4.2.2)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.38.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(vue@3.5.14(typescript@5.8.2))(yaml@2.7.0)
+      '@nuxt/vite-builder': 3.16.0(@biomejs/biome@1.9.4)(@types/node@22.15.3)(eslint@9.22.0(jiti@2.4.2))(less@4.2.2)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.38.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(vue@3.5.15(typescript@5.8.2))(yaml@2.7.0)
       '@oxc-parser/wasm': 0.56.5
-      '@unhead/vue': 2.0.0-rc.9(vue@3.5.14(typescript@5.8.2))
+      '@unhead/vue': 2.0.0-rc.9(vue@3.5.15(typescript@5.8.2))
       '@vue/shared': 3.5.13
       c12: 3.0.2(magicast@0.3.5)
       chokidar: 4.0.3
@@ -44354,7 +44482,7 @@ snapshots:
       magic-string: 0.30.17
       mlly: 1.7.4
       nanotar: 0.2.0
-      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
+      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
       nypm: 0.6.0
       ofetch: 1.4.1
       ohash: 2.0.11
@@ -44376,13 +44504,13 @@ snapshots:
       unenv: 2.0.0-rc.12
       unimport: 4.1.2
       unplugin: 2.2.0
-      unplugin-vue-router: 0.12.0(vue-router@4.5.1(vue@3.5.14(typescript@5.8.2)))(vue@3.5.14(typescript@5.8.2))
-      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0)
+      unplugin-vue-router: 0.12.0(vue-router@4.5.1(vue@3.5.15(typescript@5.8.2)))(vue@3.5.15(typescript@5.8.2))
+      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0)
       untyped: 2.0.0
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
       vue-bundle-renderer: 2.1.1
       vue-devtools-stub: 0.1.0
-      vue-router: 4.5.1(vue@3.5.14(typescript@5.8.2))
+      vue-router: 4.5.1(vue@3.5.15(typescript@5.8.2))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
       '@types/node': 22.15.3
@@ -45783,8 +45911,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  pure-rand@6.1.0:
-    optional: true
+  pure-rand@6.1.0: {}
 
   pvtsutils@1.3.5:
     dependencies:
@@ -45825,20 +45952,20 @@ snapshots:
 
   quickselect@2.0.0: {}
 
-  radix-vue@1.9.17(vue@3.5.14(typescript@5.8.2)):
+  radix-vue@1.9.17(vue@3.5.15(typescript@5.8.2)):
     dependencies:
       '@floating-ui/dom': 1.6.12
-      '@floating-ui/vue': 1.1.5(vue@3.5.14(typescript@5.8.2))
+      '@floating-ui/vue': 1.1.5(vue@3.5.15(typescript@5.8.2))
       '@internationalized/date': 3.6.0
       '@internationalized/number': 3.5.4
-      '@tanstack/vue-virtual': 3.10.8(vue@3.5.14(typescript@5.8.2))
-      '@vueuse/core': 10.11.1(vue@3.5.14(typescript@5.8.2))
-      '@vueuse/shared': 10.11.1(vue@3.5.14(typescript@5.8.2))
+      '@tanstack/vue-virtual': 3.10.8(vue@3.5.15(typescript@5.8.2))
+      '@vueuse/core': 10.11.1(vue@3.5.15(typescript@5.8.2))
+      '@vueuse/shared': 10.11.1(vue@3.5.15(typescript@5.8.2))
       aria-hidden: 1.2.4
       defu: 6.1.4
       fast-deep-equal: 3.1.3
       nanoid: 5.0.9
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -48086,8 +48213,8 @@ snapshots:
       superstruct: 2.0.2
       valibot: 1.0.0-beta.11(typescript@5.8.2)
       yup: 1.6.1
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.3(zod@3.24.2)
+      zod: 3.24.4
+      zod-to-json-schema: 3.24.3(zod@3.24.4)
     transitivePeerDependencies:
       - '@types/json-schema'
       - typescript
@@ -48747,7 +48874,7 @@ snapshots:
       - vue
       - vue-tsc
 
-  unbuild@3.5.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.14(typescript@5.8.2)):
+  unbuild@3.5.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.15(typescript@5.8.2)):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.34.8)
       '@rollup/plugin-commonjs': 28.0.2(rollup@4.34.8)
@@ -48763,7 +48890,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.4.2
       magic-string: 0.30.17
-      mkdist: 2.2.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.14(typescript@5.8.2))
+      mkdist: 2.2.0(sass@1.85.1)(typescript@5.8.2)(vue@3.5.15(typescript@5.8.2))
       mlly: 1.7.4
       pathe: 2.0.3
       pkg-types: 2.0.0
@@ -48991,10 +49118,10 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.2
 
-  unplugin-vue-router@0.12.0(vue-router@4.5.1(vue@3.5.14(typescript@5.8.2)))(vue@3.5.14(typescript@5.8.2)):
+  unplugin-vue-router@0.12.0(vue-router@4.5.1(vue@3.5.15(typescript@5.8.2)))(vue@3.5.15(typescript@5.8.2)):
     dependencies:
       '@babel/types': 7.26.9
-      '@vue-macros/common': 1.16.1(vue@3.5.14(typescript@5.8.2))
+      '@vue-macros/common': 1.16.1(vue@3.5.15(typescript@5.8.2))
       ast-walker-scope: 0.6.2
       chokidar: 4.0.3
       fast-glob: 3.3.3
@@ -49009,7 +49136,7 @@ snapshots:
       unplugin-utils: 0.2.4
       yaml: 2.7.0
     optionalDependencies:
-      vue-router: 4.5.1(vue@3.5.14(typescript@5.8.2))
+      vue-router: 4.5.1(vue@3.5.15(typescript@5.8.2))
     transitivePeerDependencies:
       - vue
 
@@ -49023,7 +49150,7 @@ snapshots:
       acorn: 8.14.1
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(ioredis@5.6.0):
+  unstorage@1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(ioredis@5.6.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -49035,10 +49162,10 @@ snapshots:
       ufo: 1.5.4
     optionalDependencies:
       '@azure/identity': 4.6.0
-      db0: 0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0)
+      db0: 0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0)
       ioredis: 5.6.0
 
-  unstorage@1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0):
+  unstorage@1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -49050,7 +49177,7 @@ snapshots:
       ufo: 1.5.4
     optionalDependencies:
       '@azure/identity': 4.6.0
-      db0: 0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0)
+      db0: 0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0)
       ioredis: 5.6.0
 
   untun@0.1.3:
@@ -49106,6 +49233,20 @@ snapshots:
       browserslist: 4.24.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uploadthing@6.13.3(express@5.1.0)(h3@1.15.1)(next@15.3.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1))(tailwindcss@4.0.12):
+    dependencies:
+      '@effect/schema': 0.68.18(effect@3.4.8)
+      '@uploadthing/mime-types': 0.2.10
+      '@uploadthing/shared': 6.7.9
+      consola: 3.4.0
+      effect: 3.4.8
+      std-env: 3.8.1
+    optionalDependencies:
+      express: 5.1.0
+      h3: 1.15.1
+      next: 15.3.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.85.1)
+      tailwindcss: 4.0.12
 
   uqr@0.1.2: {}
 
@@ -49188,7 +49329,7 @@ snapshots:
       kleur: 4.1.5
       sade: 1.8.1
 
-  v-calendar@3.1.2(@popperjs/core@2.11.8)(vue@3.5.14(typescript@5.8.2)):
+  v-calendar@3.1.2(@popperjs/core@2.11.8)(vue@3.5.15(typescript@5.8.2)):
     dependencies:
       '@popperjs/core': 2.11.8
       '@types/lodash': 4.17.13
@@ -49196,8 +49337,8 @@ snapshots:
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       lodash: 4.17.21
-      vue: 3.5.14(typescript@5.8.2)
-      vue-screen-utils: 1.0.0-beta.13(vue@3.5.14(typescript@5.8.2))
+      vue: 3.5.15(typescript@5.8.2)
+      vue-screen-utils: 1.0.0-beta.13(vue@3.5.15(typescript@5.8.2))
 
   valibot@0.31.1:
     optional: true
@@ -49230,11 +49371,11 @@ snapshots:
       bits-ui: 0.21.16(svelte@4.2.19)
       svelte: 4.2.19
 
-  vaul-vue@0.2.1(radix-vue@1.9.17(vue@3.5.14(typescript@5.8.2)))(vue@3.5.14(typescript@5.8.2)):
+  vaul-vue@0.2.1(radix-vue@1.9.17(vue@3.5.15(typescript@5.8.2)))(vue@3.5.15(typescript@5.8.2)):
     dependencies:
-      '@vueuse/core': 10.11.1(vue@3.5.14(typescript@5.8.2))
-      radix-vue: 1.9.17(vue@3.5.14(typescript@5.8.2))
-      vue: 3.5.14(typescript@5.8.2)
+      '@vueuse/core': 10.11.1(vue@3.5.15(typescript@5.8.2))
+      radix-vue: 1.9.17(vue@3.5.15(typescript@5.8.2))
+      vue: 3.5.15(typescript@5.8.2)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -49265,11 +49406,11 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  vee-validate@4.15.0(vue@3.5.14(typescript@5.8.2)):
+  vee-validate@4.15.0(vue@3.5.15(typescript@5.8.2)):
     dependencies:
       '@vue/devtools-api': 7.6.2
       type-fest: 4.26.1
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   vfile-location@5.0.3:
     dependencies:
@@ -49315,7 +49456,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vinxi@0.4.3(xigip3pwxsynk4cmajsowrm4re):
+  vinxi@0.4.3(ygzqaoi4rwas5cwvf5qrrt2zjy):
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
@@ -49337,7 +49478,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
+      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
       node-fetch-native: 1.6.6
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -49348,7 +49489,7 @@ snapshots:
       ufo: 1.5.4
       unctx: 2.4.1
       unenv: 1.10.0
-      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0)
+      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0)
       vite: 5.4.19(@types/node@22.13.10)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)
       zod: 3.24.2
     transitivePeerDependencies:
@@ -49392,7 +49533,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  vinxi@0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0):
+  vinxi@0.5.3(@azure/identity@4.6.0)(@libsql/client@0.14.0)(@types/node@22.15.3)(better-sqlite3@11.8.1)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(mysql2@3.13.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0):
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
@@ -49414,7 +49555,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
+      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
       node-fetch-native: 1.6.6
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -49425,9 +49566,9 @@ snapshots:
       ufo: 1.5.4
       unctx: 2.4.1
       unenv: 1.10.0
-      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.13)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(ioredis@5.6.0)
+      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(@types/react@18.3.18)(better-sqlite3@11.8.1)(bun-types@1.2.14)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@5.22.0)(react@19.0.0))(mysql2@3.13.0))(ioredis@5.6.0)
       vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
-      zod: 3.24.2
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -49471,7 +49612,7 @@ snapshots:
       - xml2js
       - yaml
 
-  vinxi@0.5.3(qmycrikecd3inn5enqnqcdtkym):
+  vinxi@0.5.3(u6rzw6lpze2euny7wyp5bo3kgm):
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
@@ -49493,7 +49634,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
+      nitropack: 2.11.5(@azure/identity@4.6.0)(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(encoding@0.1.13)(mysql2@3.13.0)(typescript@5.8.2)
       node-fetch-native: 1.6.6
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -49504,9 +49645,9 @@ snapshots:
       ufo: 1.5.4
       unctx: 2.4.1
       unenv: 1.10.0
-      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.13)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0)
+      unstorage: 1.15.0(@azure/identity@4.6.0)(db0@0.3.1(@libsql/client@0.14.0)(better-sqlite3@11.8.1)(drizzle-orm@0.40.0(@cloudflare/workers-types@4.20250303.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@prisma/client@6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2))(@types/better-sqlite3@7.6.12)(@types/pg@8.11.11)(better-sqlite3@11.8.1)(bun-types@1.2.14)(gel@2.0.1)(kysely@0.28.1)(mysql2@3.13.0)(pg@8.13.3)(prisma@6.4.1(typescript@5.8.2)))(mysql2@3.13.0))(ioredis@5.6.0)
       vite: 6.3.4(@types/node@22.13.10)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
-      zod: 3.24.2
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -49712,14 +49853,14 @@ snapshots:
       - supports-color
     optional: true
 
-  vite-plugin-vue-tracer@0.1.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.14(typescript@5.8.2)):
+  vite-plugin-vue-tracer@0.1.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.15(typescript@5.8.2)):
     dependencies:
       estree-walker: 3.0.3
       magic-string: 0.30.17
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   vite-tsconfig-paths@4.3.2(typescript@5.8.2)(vite@5.4.19(@types/node@22.15.3)(less@4.2.2)(lightningcss@1.29.2)(sass@1.85.1)(terser@5.39.0)):
     dependencies:
@@ -50127,20 +50268,20 @@ snapshots:
     dependencies:
       ufo: 1.5.4
 
-  vue-demi@0.14.10(vue@3.5.14(typescript@5.8.2)):
+  vue-demi@0.14.10(vue@3.5.15(typescript@5.8.2)):
     dependencies:
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   vue-devtools-stub@0.1.0: {}
 
-  vue-router@4.5.1(vue@3.5.14(typescript@5.8.2)):
+  vue-router@4.5.1(vue@3.5.15(typescript@5.8.2)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
-  vue-screen-utils@1.0.0-beta.13(vue@3.5.14(typescript@5.8.2)):
+  vue-screen-utils@1.0.0-beta.13(vue@3.5.15(typescript@5.8.2)):
     dependencies:
-      vue: 3.5.14(typescript@5.8.2)
+      vue: 3.5.15(typescript@5.8.2)
 
   vue-sonner@1.3.0: {}
 
@@ -50162,13 +50303,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.2
 
-  vue@3.5.14(typescript@5.8.2):
+  vue@3.5.15(typescript@5.8.2):
     dependencies:
-      '@vue/compiler-dom': 3.5.14
-      '@vue/compiler-sfc': 3.5.14
-      '@vue/runtime-dom': 3.5.14
-      '@vue/server-renderer': 3.5.14(vue@3.5.14(typescript@5.8.2))
-      '@vue/shared': 3.5.14
+      '@vue/compiler-dom': 3.5.15
+      '@vue/compiler-sfc': 3.5.15
+      '@vue/runtime-dom': 3.5.15
+      '@vue/server-renderer': 3.5.15(vue@3.5.15(typescript@5.8.2))
+      '@vue/shared': 3.5.15
     optionalDependencies:
       typescript: 5.8.2
 


### PR DESCRIPTION
Adding a file-storage plugin to tie file uploads to users that upload them. This should be usable for profile images, file sharing, organization logos, and other use cases in your application.

Includes:
-  `StorageProvider` interface so that we can easily add more providers or users can bring their own.
-  `schema` options and ability to add `additionalFields` to the database table
- `canUploadFile` for your custom pre-upload checks of whether the user can upload a file
- `onFileUploaded` callback for your handling of file uploads completed