### PR TITLE
nit(docs): add callback URL property to sign up method

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -40,6 +40,7 @@ To sign a user up, you can use the `signUp.email` function provided by the clien
 - `password`: The password of the user. It should be at least 8 characters long and max 128 by default.
 - `name`: The name of the user.
 - `image`: The image of the user. (optional)
+- `callbackURL`: The URL to redirect to after the user signs in. (optional)
 
 ```ts title="auth-client.ts"
 const { data, error } = await authClient.signUp.email({

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -40,7 +40,7 @@ To sign a user up, you can use the `signUp.email` function provided by the clien
 - `password`: The password of the user. It should be at least 8 characters long and max 128 by default.
 - `name`: The name of the user.
 - `image`: The image of the user. (optional)
-- `callbackURL`: The URL to redirect to after the user signs in. (optional)
+- `callbackURL`: The URL to redirect to after the user signs up. (optional)
 
 ```ts title="auth-client.ts"
 const { data, error } = await authClient.signUp.email({

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -40,7 +40,7 @@ To sign a user up, you can use the `signUp.email` function provided by the clien
 - `password`: The password of the user. It should be at least 8 characters long and max 128 by default.
 - `name`: The name of the user.
 - `image`: The image of the user. (optional)
-- `callbackURL`: The URL to redirect to after the user signs up. (optional)
+- `callbackURL`: The URL to redirect to after the user verifies their email. (optional)
 
 ```ts title="auth-client.ts"
 const { data, error } = await authClient.signUp.email({


### PR DESCRIPTION
I was a bit worried that I had to create logic to handle the callback URL, but it turns out that the `authClient.signUp.email()` method supports it.