### PR TITLE
Fix Entra token refresh

### DIFF
--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -120,8 +120,8 @@ export const microsoft = (options: MicrosoftOptions) => {
 			? options.refreshAccessToken
 			: async (refreshToken) => {
 					const scopes = options.disableDefaultScope
-					? []
-					: ["openid", "profile", "email", "User.Read", "offline_access"];
+						? []
+						: ["openid", "profile", "email", "User.Read", "offline_access"];
 					options.scope && scopes.push(...options.scope);
 
 					return refreshAccessToken({
@@ -131,7 +131,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 							clientSecret: options.clientSecret,
 						},
 						extraParams: {
-							scope: scopes.join(' ') //Include the scopes in request to microsoft
+							scope: scopes.join(" "), // Include the scopes in request to microsoft
 						},
 						tokenEndpoint,
 					});

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -119,12 +119,20 @@ export const microsoft = (options: MicrosoftOptions) => {
 		refreshAccessToken: options.refreshAccessToken
 			? options.refreshAccessToken
 			: async (refreshToken) => {
+					const scopes = options.disableDefaultScope
+					? []
+					: ["openid", "profile", "email", "User.Read", "offline_access"];
+					options.scope && scopes.push(...options.scope);
+
 					return refreshAccessToken({
 						refreshToken,
 						options: {
 							clientId: options.clientId,
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
+						},
+						extraParams: {
+							scope: scopes.join(' ') //Include the scopes in request to microsoft
 						},
 						tokenEndpoint,
 					});

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -45,7 +45,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 		createAuthorizationURL(data) {
 			const scopes = options.disableDefaultScope
 				? []
-				: ["openid", "profile", "email", "User.Read"];
+				: ["openid", "profile", "email", "User.Read", "offline_access"];
 			options.scope && scopes.push(...options.scope);
 			data.scopes && scopes.push(...scopes);
 			return createAuthorizationURL({

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -128,7 +128,6 @@ export const microsoft = (options: MicrosoftOptions) => {
 						refreshToken,
 						options: {
 							clientId: options.clientId,
-							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
 						extraParams: {


### PR DESCRIPTION
This closes #2769 by fixing the token refresh mechanism for Entra ID.

From Microsoft's documentation [here](https://learn.microsoft.com/en-us/graph/auth-v2-user?tabs=http#step-4-use-the-refresh-token-to-renew-an-expired-access-token) we need to include the "scope" parameter when refreshing the access token.

We also need to include the `offline_access` scope when requesting token, which is documented [here](https://learn.microsoft.com/en-us/graph/auth-v2-user?tabs=http#response-body-properties) so I have added that to the default scopes. 
