### PR TITLE
docs: add missing trustedOrigins option

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -42,6 +42,17 @@ export const auth = betterAuth({
 
 Default: `/api/auth`
 
+## `trustedOrigins`
+
+List of trusted origins.
+
+```ts
+import { betterAuth } from "better-auth";
+export const auth = betterAuth({
+	trustedOrigins: ["http://localhost:3000", "https://example.com"],
+})
+```
+
 ## `secret`
 
 The secret used for encryption, signing, and hashing.


### PR DESCRIPTION
This PR updates the options reference to include the `trustedOrigins` option, which was previously undocumented but necessary for usage.