### PR TITLE
oidcProvider authorize post-auth flow fix

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -14,6 +14,28 @@ export async function authorize(
 	ctx: GenericEndpointContext,
 	options: OIDCOptions,
 ) {
+	const fromFetch = ctx.request?.headers.get("sec-fetch-mode") === "cors"
+
+	// Helper function to handle redirects vs JSON responses based on request type
+	const handleRedirect = (url: string) => {
+
+		ctx.context.logger.info("handleRedirect", {
+			fromFetch,
+			url,
+		});
+
+		if (fromFetch) {
+			// Return JSON response for API calls (like authClient.signIn.email)
+			return ctx.json({
+				redirect: true,
+				url,
+			});
+		} else {
+			// Use regular redirect for browser navigation
+			throw ctx.redirect(url);
+		}
+	};
+
 	const opts = {
 		codeExpiresIn: 600,
 		defaultScope: "openid",
@@ -49,16 +71,16 @@ export async function authorize(
 			},
 		);
 		const queryFromURL = ctx.request.url?.split("?")[1];
-		throw ctx.redirect(`${options.loginPage}?${queryFromURL}`);
+		return handleRedirect(`${options.loginPage}?${queryFromURL}`);
 	}
 
 	const query = ctx.query as AuthorizationQuery;
 	if (!query.client_id) {
-		throw ctx.redirect(`${ctx.context.baseURL}/error?error=invalid_client`);
+		return handleRedirect(`${ctx.context.baseURL}/error?error=invalid_client`);
 	}
 
 	if (!query.response_type) {
-		throw ctx.redirect(
+		return handleRedirect(
 			redirectErrorURL(
 				`${ctx.context.baseURL}/error`,
 				"invalid_request",
@@ -88,7 +110,7 @@ export async function authorize(
 			} as Client;
 		});
 	if (!client) {
-		throw ctx.redirect(`${ctx.context.baseURL}/error?error=invalid_client`);
+		return handleRedirect(`${ctx.context.baseURL}/error?error=invalid_client`);
 	}
 	const redirectURI = client.redirectURLs.find(
 		(url) => url === ctx.query.redirect_uri,
@@ -103,11 +125,11 @@ export async function authorize(
 		});
 	}
 	if (client.disabled) {
-		throw ctx.redirect(`${ctx.context.baseURL}/error?error=client_disabled`);
+		return handleRedirect(`${ctx.context.baseURL}/error?error=client_disabled`);
 	}
 
 	if (query.response_type !== "code") {
-		throw ctx.redirect(
+		return handleRedirect(
 			`${ctx.context.baseURL}/error?error=unsupported_response_type`,
 		);
 	}
@@ -121,7 +143,7 @@ export async function authorize(
 		return isInvalid;
 	});
 	if (invalidScopes.length) {
-		throw ctx.redirect(
+		return handleRedirect(
 			redirectErrorURL(
 				query.redirect_uri,
 				"invalid_scope",
@@ -134,7 +156,7 @@ export async function authorize(
 		(!query.code_challenge || !query.code_challenge_method) &&
 		options.requirePKCE
 	) {
-		throw ctx.redirect(
+		return handleRedirect(
 			redirectErrorURL(
 				query.redirect_uri,
 				"invalid_request",
@@ -153,7 +175,7 @@ export async function authorize(
 			options.allowPlainCodeChallengeMethod ? "plain" : "s256",
 		].includes(query.code_challenge_method?.toLowerCase() || "")
 	) {
-		throw ctx.redirect(
+		return handleRedirect(
 			redirectErrorURL(
 				query.redirect_uri,
 				"invalid_request",
@@ -201,7 +223,7 @@ export async function authorize(
 			ctx,
 		);
 	} catch (e) {
-		throw ctx.redirect(
+		return handleRedirect(
 			redirectErrorURL(
 				query.redirect_uri,
 				"server_error",
@@ -215,7 +237,7 @@ export async function authorize(
 	redirectURIWithCode.searchParams.set("state", ctx.query.state);
 
 	if (query.prompt !== "consent") {
-		throw ctx.redirect(redirectURIWithCode.toString());
+        return handleRedirect(redirectURIWithCode.toString());	
 	}
 
 	const hasAlreadyConsented = await ctx.context.adapter
@@ -237,7 +259,7 @@ export async function authorize(
 		.then((res) => !!res?.consentGiven);
 
 	if (hasAlreadyConsented) {
-		throw ctx.redirect(redirectURIWithCode.toString());
+		return handleRedirect(redirectURIWithCode.toString());
 	}
 
 	if (options?.consentPage) {
@@ -246,10 +268,11 @@ export async function authorize(
 			path: "/",
 			sameSite: "lax",
 		});
-		const conceptURI = `${options.consentPage}?client_id=${
+		const consentURI = `${options.consentPage}?client_id=${
 			client.clientId
 		}&scope=${requestScope.join(" ")}`;
-		throw ctx.redirect(conceptURI);
+		
+		return handleRedirect(consentURI);
 	}
 	const htmlFn = options?.getConsentHTML;
 


### PR DESCRIPTION
Issue:

Recommended way to handle login for OIDC Provider flow is to call authClient.signIn -- However, many of the callbacks in authorize.ts endpoint directly throw their redirects, in many of these cases this is not desired as it will redirect the fetch request when the intent is to redirect the browser instead.

Fix:

If the call is coming from a cors (non-browser navigate) fetch call when doing the consent page redirect or the final authorization callback redirect, redirect using a hint in json payload to authClient rather than attempting to redirect the CORS call.

This resolves issues both with CORS (that people were seeing) as well as well as removing the need for the work around hack provided in #2461

Tested: Locally, using updated code, oidcProvider and a genericOauth client. Verified happy paths for login with / without scope, there are some other issues with consent flow in general, but I'll address those in a different PR.