### PR TITLE
docs(stripe): document switching plans on a subscription

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -218,6 +218,10 @@ await client.subscription.upgrade({
 
 This will create a Checkout Session and redirect the user to the Stripe Checkout page.
 
+<Callout type="warn">
+If the user already has an active subscription, you *must* provide the `subscriptionId` parameter. Otherwise, the user will be subscribed to (and pay for) both plans.
+</Callout>
+
 > **Important:** The `successUrl` parameter will be internally modified to handle race conditions between checkout completion and webhook processing. The plugin creates an intermediate redirect that ensures subscription status is properly updated before redirecting to your success page.
 
 ```ts
@@ -235,6 +239,18 @@ if(error) {
 For each reference ID (user or organization), only one active or trialing subscription is supported at a time. The plugin doesn't currently support multiple concurrent active subscriptions for the same reference ID.
 </Callout>
 
+#### Switching Plans
+
+To switch a subscription to a different plan, use the `subscription.upgrade` method:
+```ts title="client.ts"
+await client.subscription.upgrade({
+    plan: "pro",
+    successUrl: "/dashboard",
+    cancelUrl: "/pricing",
+    subscriptionId: "sub_123", // the stripe subscription ID of the user's current plan
+});
+```
+This ensures that the user only pays for the new plan, and not both.
 
 #### Listing Active Subscriptions
 

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -247,7 +247,7 @@ await client.subscription.upgrade({
     plan: "pro",
     successUrl: "/dashboard",
     cancelUrl: "/pricing",
-    subscriptionId: "sub_123", // the stripe subscription ID of the user's current plan
+    subscriptionId: "sub_123", // the Stripe subscription ID of the user's current plan
 });
 ```
 This ensures that the user only pays for the new plan, and not both.


### PR DESCRIPTION
fwiw, I think that making the user pass the `subscriptionId` parameter to make sure that they don't double charge their users is a really bad footgun. imo, it makes a lot more sense to default to updating subscriptions when there is already an active subscription.

needs #2864 to be merged before it actually works