### PR TITLE
fix(stripe): inconsistency preventing subscription upgrades

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -200,7 +200,18 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				const subscriptionToUpdate = ctx.body.subscriptionId
 					? await ctx.context.adapter.findOne<Subscription>({
 							model: "subscription",
-							where: [{ field: "id", value: ctx.body.subscriptionId }],
+							where: [
+								{
+									field: "id",
+									value: ctx.body.subscriptionId,
+									connector: "OR",
+								},
+								{
+									field: "stripeSubscriptionId",
+									value: ctx.body.subscriptionId,
+									connector: "OR",
+								},
+							],
 						})
 					: null;
 


### PR DESCRIPTION
fixes #2860. 

an alternative way of doing this that doesnt depend on the `connector: "OR"` pattern that I haven't seen anywhere else in the repo would be updating this line 
https://github.com/better-auth/better-auth/blob/96634ceefd4605761eb183ae8ed3529b9eb1db3e/packages/stripe/src/index.ts#L260
to this: `(subscription) => subscription.id === subscriptionToUpdate?.stripeSubscriptionId,`
