### PR TITLE
docs: add NuxSaaS link as example integration with Nuxt

### DIFF
--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -129,3 +129,4 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 - [Nuxt and Nuxt Hub example](https://github.com/atinux/nuxthub-better-auth) on GitHub.
 - [NuxtZzle is Nuxt,Drizzle ORM example](https://github.com/leamsigc/nuxt-better-auth-drizzle) on GitHub [preview](https://nuxt-better-auth.giessen.dev/)
 - [Nuxt example](https://stackblitz.com/github/better-auth/better-auth/tree/main/examples/nuxt-example) on StackBlitz.
+- [NuxSaaS (Github)](https://github.com/NuxSaaS/NuxSaaS) is a full-stack SaaS Starter Kit that leverages Better Auth for secure and efficient user authentication. [Demo](https://nuxsaas.com/)


### PR DESCRIPTION
Documentation:
* Add Nuxt integration example

NuxSaaS is a Nuxt.js full-stack SaaS starter kit:
- Nuxt + Vue 3 + TypeScript
- Nuxt UI
- Auth: Better Auth
- PostgreSQL + DrizzleORM
- Payment: Stripe
- Email: Resend
- Built-in Admin Dashboard
- I18n Support
- SEO Ready
- Deploy to Cloudflare Workers or a self-hosted VPS
 