### PR TITLE
fix: correct way detect facebook limited token jwt

### DIFF
--- a/packages/better-auth/src/social-providers/facebook.ts
+++ b/packages/better-auth/src/social-providers/facebook.ts
@@ -76,7 +76,7 @@ export const facebook = (options: FacebookOptions) => {
 
 			/* limited login */
 			// check is limited token
-			if (token.split(".").length) {
+			if (token.split(".")[1]) {
 				try {
 					const { payload: jwtClaims } = await jwtVerify(
 						token,
@@ -122,7 +122,7 @@ export const facebook = (options: FacebookOptions) => {
 				return options.getUserInfo(token);
 			}
 
-			if (token.idToken) {
+			if (token.idToken && token.idToken.split(".")[1]) {
 				const profile = decodeJwt(token.idToken) as {
 					sub: string;
 					email: string;


### PR DESCRIPTION
I found an issue with how I was detecting the JWT—it was incorrect. I’ve fixed it now.