### PR TITLE
docs(drizzle): Clarify option for plural tables

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -60,7 +60,15 @@ export const auth = betterAuth({
       ...schema,
       user: schema.users,
     },
-    //if all of them are just using plural form, you can just pass the option below
+  }),
+});
+```
+
+If all your tables are using plural form, you can just pass the `usePlural` option:
+```ts
+export const auth = betterAuth({
+  database: drizzleAdapter(db, {
+    ...
     usePlural: true,
   }),
 });


### PR DESCRIPTION
This is supposed to clarify the usage of `usePlural` for the Drizzle ORM adapter.
Looking at the docs I was confused, as the example was using both: a `user` field and the `usePlural` option. But together, they don't make sense in a real config.
This change splits these two up.