### PR TITLE
feat(stripe): Reuse existing subscription instead of creating one every time

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -286,14 +286,13 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							],
 						});
 
-				const existingSubscription = subscriptions.find(
+				const existingActiveSubscription = subscriptions.find(
 					(sub) => sub.status === "active" || sub.status === "trialing",
 				);
 
 				if (
-					existingSubscription &&
-					existingSubscription.status === "active" &&
-					existingSubscription.plan === ctx.body.plan
+					existingActiveSubscription &&
+					existingActiveSubscription.plan === ctx.body.plan
 				) {
 					throw new APIError("BAD_REQUEST", {
 						message: STRIPE_ERROR_CODES.ALREADY_SUBSCRIBED_PLAN,
@@ -333,7 +332,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 					});
 				}
 
-				let subscription = existingSubscription;
+				let subscription = existingActiveSubscription ?? subscriptions[0];
 				if (!subscription) {
 					const newSubscription = await ctx.context.adapter.create<
 						InputSubscription,


### PR DESCRIPTION
I don't know if it's intentional but every time a user proceed to checkout and then cancel, an "incomplete" subscription is created on the db and never used again. So I updated the plugin to use only one subscription by user. Obviously a user can only have one unique subscription now, but I think it can be nice if in the future a config option is implemented to allow a user to have multiple subscriptions.