### PR TITLE
fix: oauth proxy between http and https

### DIFF
--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -99,7 +99,18 @@ export const oAuthProxy = (opts?: OAuthProxyOptions) => {
 						key: ctx.context.secret,
 						data: cookies,
 					});
-					ctx.setHeader("set-cookie", decryptedCookies);
+
+					const isSecureContext = ctx.request
+            					? new URL(ctx.request.url).protocol === "https:"
+            					: true;
+
+          				const cookieToSet = isSecureContext
+            					? decryptedCookies
+            					: decryptedCookies
+                					.replace("Secure;", "")
+                					.replace("__Secure-better-auth", "better-auth");
+
+					ctx.setHeader("set-cookie", cookieToSet);
 					throw ctx.redirect(ctx.query.callbackURL);
 				},
 			),


### PR DESCRIPTION
Shows a POC of an issue with the oauth proxy. We're setting secure headers, even if the proxied url is a localhost without ssl.

This is hacky, probably a much nicer solution exists, as it won't cover custom cookie names etc. The `isSecureContext` check might also not be the best, but this is what I did to make it work. Happy to continue with guidance on proper helpers etc to use as well as adding tests