### PR TITLE
fix(docs): replace error with status in elysia example

### DIFF
--- a/docs/content/docs/integrations/elysia.mdx
+++ b/docs/content/docs/integrations/elysia.mdx
@@ -62,12 +62,12 @@ const betterAuth = new Elysia({ name: "better-auth" })
   .mount(auth.handler)
   .macro({
     auth: {
-      async resolve({ error, request: { headers } }) {
+      async resolve({ session, request: { headers } }) {
         const session = await auth.api.getSession({
           headers,
         });
 
-        if (!session) return error(401);
+        if (!session) return status(401);
 
         return {
           user: session.user,

--- a/docs/content/docs/integrations/elysia.mdx
+++ b/docs/content/docs/integrations/elysia.mdx
@@ -62,7 +62,7 @@ const betterAuth = new Elysia({ name: "better-auth" })
   .mount(auth.handler)
   .macro({
     auth: {
-      async resolve({ session, request: { headers } }) {
+      async resolve({ status, request: { headers } }) {
         const session = await auth.api.getSession({
           headers,
         });


### PR DESCRIPTION
This PR updates the example code to reflect the deprecation of error in resolve and instead uses status. This aligns with the latest Elysia context structure as seen [here](https://github.com/elysiajs/elysia/blob/7d921a2c90b99a83240b20d01e8673e49e4327fd/src/context.ts#L190).