### PR TITLE
fixes #2908 - cli missing dependency @babel/core

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.26.0",
     "@clack/prompts": "^0.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1570,6 +1570,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@babel/core':
+        specifier: ^7.0.0
+        version: 7.27.4
       '@babel/preset-react':
         specifier: ^7.26.3
         version: 7.27.1(@babel/core@7.27.4)


### PR DESCRIPTION
Closes #2908 

Adds @babel/core@^7.0.0 as a dependency of @better-auth/cli