### PR TITLE
feat(drizzle-adapter): add customIdGenerator config

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -17,7 +17,11 @@ import {
 } from "drizzle-orm";
 import { BetterAuthError } from "../../error";
 import type { Where } from "../../types";
-import { createAdapter, type AdapterDebugLogs } from "../create-adapter";
+import {
+	createAdapter,
+	type AdapterConfig,
+	type AdapterDebugLogs,
+} from "../create-adapter";
 
 export interface DB {
 	[key: string]: any;
@@ -44,6 +48,10 @@ export interface DrizzleAdapterConfig {
 	 * @default false
 	 */
 	debugLogs?: AdapterDebugLogs;
+	/**
+	 * Custom ID generator function.
+	 */
+	customIdGenerator?: AdapterConfig["customIdGenerator"];
 }
 
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) =>
@@ -53,6 +61,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) =>
 			adapterName: "Drizzle Adapter",
 			usePlural: config.usePlural ?? false,
 			debugLogs: config.debugLogs ?? false,
+			customIdGenerator: config.customIdGenerator ?? undefined,
 		},
 		adapter: ({ getFieldName, debugLog }) => {
 			function getSchema(model: string) {


### PR DESCRIPTION
Seems to me like build-in custom adapters should take in more options than these, but in any case... starting here.