### PR TITLE
fix(stripe): allow the user to upgrade a plan with an amount of seats

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -293,7 +293,8 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				if (
 					existingSubscription &&
 					existingSubscription.status === "active" &&
-					existingSubscription.plan === ctx.body.plan
+					existingSubscription.plan === ctx.body.plan &&
+					existingSubscription.seats === ctx.body.seats
 				) {
 					throw new APIError("BAD_REQUEST", {
 						message: STRIPE_ERROR_CODES.ALREADY_SUBSCRIBED_PLAN,
@@ -312,7 +313,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 									items: [
 										{
 											id: activeSubscription.items.data[0]?.id as string,
-											quantity: 1,
+											quantity: ctx.body.seats || 1,
 											price: ctx.body.annual
 												? plan.annualDiscountPriceId
 												: plan.priceId,


### PR DESCRIPTION
Closes: #2890

When trying to upgrade an existing subscription, use the quantity from the request instead of using the default 1 value.

I've also added a check to verify that the seats are not the same, since it tries to change the subscription and I wouldn't be useful to update with the same amount of seats.