### PR TITLE
fix(stripe): use the stripeSubscriptionId from the fetched subscription instead of the one from the request

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -268,7 +268,10 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							})
 							.then((res) =>
 								res.data.find(
-									(subscription) => subscription.id === ctx.body.subscriptionId,
+									(subscription) =>
+										subscription.id ===
+											subscriptionToUpdate?.stripeSubscriptionId ||
+										ctx.body.subscriptionId,
 								),
 							)
 							.catch((e) => null)


### PR DESCRIPTION
Closes: #2938