### PR TITLE
feat: [plugins/have-i-been-pwned] add support for disabling password compromise checks on specific paths

### DIFF
--- a/docs/content/docs/plugins/have-i-been-pwned.mdx
+++ b/docs/content/docs/plugins/have-i-been-pwned.mdx
@@ -38,6 +38,14 @@ haveIBeenPwned({
     customPasswordCompromisedMessage: "Please choose a more secure password."
 })
 ```
+
+You can also disable the plugin for specific paths:
+
+```ts
+haveIBeenPwned({
+    disabledPaths: ["/sign-in/email"]
+})
+```
 ## Security Notes
 
 - Only the first 5 characters of the password hash are sent to the API


### PR DESCRIPTION
added a new feature to the haveIBeenPwned plugin, allowing devs to specify paths where password compromise checks should be disabled. this is particularly useful for scenarios where certain endpoints, such as login pages, should not trigger password compromise checks.

key changes:
- `HaveIBeenPwnedOptions` Interface: added a new optional property `disabledPaths`, which accepts an array of strings representing paths where the password compromise check should be bypassed.
- path matcher logic: implemented logic in the `before` hook to skip password checks for requests matching any of the specified `disabledPaths`.
- backward compatibility: the feature is optional and does not affect existing functionality unless `disabledPaths` is explicitly defined.
