### PR TITLE
fix issue with hardcoded baseURL in withMcpAuth

### DIFF
--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -886,8 +886,7 @@ export const withMcpAuth = <
 		const session = await auth.api.getMcpSession({
 			headers: req.headers,
 		});
-		const wwwAuthenticateValue =
-			`Bearer resource_metadata=${baseURL}/api/auth/.well-known/oauth-authorization-server`;
+		const wwwAuthenticateValue = `Bearer resource_metadata=${baseURL}/api/auth/.well-known/oauth-authorization-server`;
 		if (!session) {
 			return Response.json(
 				{

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -18,10 +18,13 @@ import { generateRandomString } from "../../crypto";
 import { createHash } from "@better-auth/utils/hash";
 import { subtle } from "@better-auth/utils";
 import { SignJWT } from "jose";
-import type { GenericEndpointContext } from "../../types";
+import type { BetterAuthOptions, GenericEndpointContext } from "../../types";
 import { parseSetCookieHeader } from "../../cookies";
 import { schema } from "../oidc-provider/schema";
 import { authorizeMCPOAuth } from "./authorize";
+import { getBaseURL } from "../../utils/url";
+import { isProduction } from "../../utils/env";
+import { logger } from "../../utils";
 
 interface MCPOptions {
 	loginPage: string;
@@ -866,6 +869,7 @@ export const withMcpAuth = <
 		api: {
 			getMcpSession: (...args: any) => Promise<OAuthAccessToken | null>;
 		};
+		options: BetterAuthOptions;
 	},
 >(
 	auth: Auth,
@@ -875,11 +879,15 @@ export const withMcpAuth = <
 	) => Response | Promise<Response>,
 ) => {
 	return async (req: Request) => {
+		const baseURL = getBaseURL(auth.options.baseURL, auth.options.basePath);
+		if (!baseURL && !isProduction) {
+			logger.warn("Unable to get the baseURL, please check your config!");
+		}
 		const session = await auth.api.getMcpSession({
 			headers: req.headers,
 		});
 		const wwwAuthenticateValue =
-			"Bearer resource_metadata=http://localhost:3000/api/auth/.well-known/oauth-authorization-server";
+			`Bearer resource_metadata=${baseURL}/api/auth/.well-known/oauth-authorization-server`;
 		if (!session) {
 			return Response.json(
 				{


### PR DESCRIPTION
hey,
I came across an issue while integrating the mcp plugin with hono using version 1.2.9. The resource_metadata hardcodes the localhost:3000 host, see the issue at https://github.com/better-auth/better-auth/issues/2703 .

This PR fixes it, although I had to extend the Auth interface with the `options` property with type of `BetterAuthOptions`, but I think that should work since, the documentation mentions passing the `auth` instance in which should have the options property on it. (see docs at https://www.better-auth.com/docs/plugins/mcp#mcp-session-handling)

Let me know if anything else is needed, I'd be happy to adjust! 🙏 