### PR TITLE
fix(email-otp): doesn't call onEmailVerification

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -392,6 +392,10 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						},
 						ctx,
 					);
+					await ctx.context.options.emailVerification?.onEmailVerification?.(
+						updatedUser,
+						ctx.request,
+					);
 
 					if (
 						ctx.context.options.emailVerification?.autoSignInAfterVerification


### PR DESCRIPTION
Not too long ago we made email-otp set `emailVerified` to true, however we forgot to add implementation to call the `onEmailVerification` fn which could be possibly defined in the users auth config.

WIth this change, upon email-otp verification, the user will be `emailVerified` and the `onEmailVerification` fn will be called.
