### PR TITLE
Correct method name in MCP docs (getMCPSession → getMcpSession)

### DIFF
--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -113,7 +113,7 @@ const handler = withMcpAuth(auth, (req, session) => {
 export { handler as GET, handler as POST, handler as DELETE };
 ```
 
-You can also use `auth.api.getMCPSession` to get the session using the access token sent from the MCP client:
+You can also use `auth.api.getMcpSession` to get the session using the access token sent from the MCP client:
 
 ```ts title="api/[transport]/route.ts"
 import { auth } from "@/lib/auth";
@@ -122,7 +122,7 @@ import { z } from "zod";
 
 const handler = async (req: Request) => {
      // session contains the access token record with scopes and user ID
-    const session = await auth.api.getMCPSession({
+    const session = await auth.api.getMcpSession({
         headers: req.headers
     })
     if(!session){

--- a/examples/nextjs-mcp/README.md
+++ b/examples/nextjs-mcp/README.md
@@ -46,7 +46,7 @@ import { toNextJsHandler } from "better-auth/next-js";
 export const { GET, POST } = toNextJsHandler(auth);
 ```
 
-Use `auth.api.getMCPSession` to get the session using the access token sent from the MCP client
+Use `auth.api.getMcpSession` to get the session using the access token sent from the MCP client
 
 ```ts
 import { auth } from "@/lib/auth";


### PR DESCRIPTION
### Fix typo in documentation for MCP plugin
This PR fixes a small typo in the documentation for the MCP plugin, where auth.api.getMCPSession was incorrectly capitalized.

### Changes
- Corrected method name to auth.api.getMcpSession in the docs.

### Related Issue
Closes #2977