### PR TITLE
fix(deps): migrate from createAPIFileRoute to createServerFileRoute (TanStack Start)

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -374,15 +374,15 @@ Better Auth supports any backend framework with standard Request and Response ob
     <Tab value="tanstack-start">
     ```ts title="src/routes/api/auth/$.ts"
     import { auth } from '~/lib/server/auth'
-    import { createAPIFileRoute } from '@tanstack/react-start/api'
+    import { createServerFileRoute } from '@tanstack/react-start/server'
 
-    export const APIRoute = createAPIFileRoute('/api/auth/$')({
-        GET: ({ request }) => {
-            return auth.handler(request)
-        },
-        POST: ({ request }) => {
-            return auth.handler(request)
-        },
+    export const ServerRoute = createServerFileRoute('/api/auth/$').methods({
+    GET: ({ request }) => {
+        return auth.handler(request)
+    },
+    POST: ({ request }) => {
+        return auth.handler(request)
+    },
     });
     ```
     </Tab>


### PR DESCRIPTION
The `createAPIFileRoute` method is no longer available in the latest version of TanStack Start. This commit updates the codebase to use the new `createServerFileRoute` method for handling API routes, ensuring compatibility with the latest library version.

See https://tanstack.com/start/latest/docs/framework/react/server-routes