### PR TITLE
doc update for client.oauth2.register. name -> client_name

### DIFF
--- a/demo/nextjs/app/apps/register/page.tsx
+++ b/demo/nextjs/app/apps/register/page.tsx
@@ -35,8 +35,7 @@ export default function RegisterOAuthClient() {
 			return;
 		}
 		const res = await client.oauth2.register({
-			// @ts-ignore
-			name,
+			client_name: name,
 			icon: await convertImageToBase64(logo),
 			redirectURLs: [redirectUri],
 		});

--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -89,7 +89,7 @@ To register a new OIDC client, use the `oauth2.register` method.
 
 ```ts title="client.ts"
 const application = await client.oauth2.register({
-    name: "My Client",
+    client_name: "My Client",
     redirect_uris: ["https://client.example.com/callback"],
 });
 ```


### PR DESCRIPTION
updates the docs to reflect the types

```
const application = await authClient.oauth2.register({
  client_name: "My Client",
  redirect_uris: ["https://client.example.com/callback"],
});
```