### PR TITLE
fix: support "ne" (not equal) filter in Prisma adapter

### DIFF
--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -68,6 +68,8 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) =>
 						return "startsWith";
 					case "ends_with":
 						return "endsWith";
+					case "ne":
+						return "not";
 					default:
 						return operator;
 				}


### PR DESCRIPTION
Add support for "ne" (not equal) filter in Prisma Adapter by mapping it to "not".
Fix https://github.com/better-auth/better-auth/issues/2468