### PR TITLE
fix(organization): organization with no members error

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -350,12 +350,15 @@ export const getOrgAdapter = (
 			if (!org) return null;
 
 			const userIds = members.map((member) => member.userId);
-			const users = userIds.length > 0 ?  await adapter.findMany<User>({
-				model: "user",
-				where: [{ field: "id", value: userIds, operator: "in" }],
-				limit: options?.membershipLimit || 100,
-			}): [];
-			
+			const users =
+				userIds.length > 0
+					? await adapter.findMany<User>({
+							model: "user",
+							where: [{ field: "id", value: userIds, operator: "in" }],
+							limit: options?.membershipLimit || 100,
+						})
+					: [];
+
 			const userMap = new Map(users.map((user) => [user.id, user]));
 			const membersWithUsers = members.map((member) => {
 				const user = userMap.get(member.userId);


### PR DESCRIPTION
This pull request includes a small but important improvement to the `getOrgAdapter` function in `packages/better-auth/src/plugins/organization/adapter.ts`. The change ensures that the `findMany` query is only executed if there are user IDs to query, avoiding unnecessary database calls when the `userIds` array is empty. There are also errors when no users belong to an organization.



