### PR TITLE
Fix scope issues for Google and Microsoft

### DIFF
--- a/packages/better-auth/src/social-providers/google.ts
+++ b/packages/better-auth/src/social-providers/google.ts
@@ -87,6 +87,9 @@ export const google = (options: GoogleOptions) => {
 				display: display || options.display,
 				loginHint,
 				hd: options.hd,
+				additionalParams: {
+					include_granted_scopes: "true",
+				},
 			});
 			return url;
 		},

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -47,7 +47,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 				? []
 				: ["openid", "profile", "email", "User.Read", "offline_access"];
 			options.scope && scopes.push(...options.scope);
-			data.scopes && scopes.push(...scopes);
+			data.scopes && scopes.push(...data.scopes);
 			return createAuthorizationURL({
 				id: "microsoft",
 				options,


### PR DESCRIPTION
For Microsoft: Allows incremental scope expansion
For Google: Return all granted scopes to current key, so that signIn does not overwrite previously granted scopes in db