### PR TITLE
docs(microsoft): correct how to require account selection

### DIFF
--- a/docs/content/docs/authentication/microsoft.mdx
+++ b/docs/content/docs/authentication/microsoft.mdx
@@ -28,8 +28,8 @@ Enabling OAuth with Microsoft Azure Entra ID (formerly Active Directory) allows 
                 clientId: process.env.MICROSOFT_CLIENT_ID as string, // [!code highlight]
                 clientSecret: process.env.MICROSOFT_CLIENT_SECRET as string, // [!code highlight]
                 // Optional
-                tenantId: 'common', // [!code highlight]
-                requireSelectAccount: true // [!code highlight]
+                tenantId: 'common', // [!code highlight]                
+                prompt: "select_account", // Forces account selection // [!code highlight]
             }, // [!code highlight]
         },
     })


### PR DESCRIPTION
Hi.

Thanks for building better-auth.

This request is a small documentation fix for Microsoft on how to correctly require user account selection. The original requireSelectAccount is only mentioned in docs in the whole codebase, and consequently does nothing. The setting prompt: "select_account" is from OAuth 2.0, and tested to work.