### PR TITLE
Fix delete user fresh age check

### DIFF
--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -512,7 +512,7 @@ export const deleteUser = createAuthEndpoint(
 			const currentAge = session.session.createdAt.getTime();
 			const freshAge = ctx.context.options.session.freshAge;
 			const now = Date.now();
-			if (now - currentAge > freshAge) {
+			if (now - currentAge > freshAge * 1000) {
 				throw new APIError("BAD_REQUEST", {
 					message: BASE_ERROR_CODES.SESSION_EXPIRED,
 				});


### PR DESCRIPTION
The `deleteUser` api route checks if a session is fresh before allowing the delete, but the `freshAge` config value was never converted from seconds to milliseconds.

With the default `freshAge` of 1 day, this means that the delete call session currently expires after 86 seconds.

This bug appears to have been around for a long time. Given how often time checks need to be made against config times, it would probably be better to create a utility function for doing time comparisons instead and refactor all existing time checks to use it.