### PR TITLE
fix(get-session): missing `null` type on /get-session

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
@@ -1,1 +1,1 @@
-RUNNING
+IDLE

--- a/packages/better-auth/src/adapters/prisma-adapter/test/state.txt
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/state.txt
@@ -1,1 +1,1 @@
-RUNNING
+IDLE

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -55,7 +55,7 @@ describe("updateUser", async () => {
 			},
 		});
 		expect(updated.data?.status).toBe(true);
-		expect(session.user.name).toBe("newName");
+		expect(session?.user.name).toBe("newName");
 	});
 
 	it("should unset image", async () => {
@@ -71,7 +71,7 @@ describe("updateUser", async () => {
 				throw: true,
 			},
 		});
-		expect(session.user.image).toBeNull();
+		expect(session?.user.image).toBeNull();
 	});
 
 	it("should update user email", async () => {
@@ -88,8 +88,8 @@ describe("updateUser", async () => {
 				throw: true,
 			},
 		});
-		expect(session.user.email).toBe(newEmail);
-		expect(session.user.emailVerified).toBe(false);
+		expect(session?.user.email).toBe(newEmail);
+		expect(session?.user.emailVerified).toBe(false);
 	});
 
 	it("should verify email", async () => {
@@ -107,7 +107,7 @@ describe("updateUser", async () => {
 				throw: true,
 			},
 		});
-		expect(session.user.emailVerified).toBe(true);
+		expect(session?.user.emailVerified).toBe(true);
 	});
 
 	it("should send email verification before update", async () => {
@@ -298,7 +298,7 @@ describe("updateUser", async () => {
 				throw: true,
 			},
 		});
-		expect(secondSession.user.name).toBe("updatedName");
+		expect(secondSession?.user.name).toBe("updatedName");
 
 		const firstSession = await authClient.getSession({
 			fetchOptions: {
@@ -307,7 +307,7 @@ describe("updateUser", async () => {
 			},
 		});
 
-		expect(firstSession.user.name).toBe("updatedName");
+		expect(firstSession?.user.name).toBe("updatedName");
 	});
 });
 

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -128,7 +128,7 @@ export type InferRoute<API, COpts extends ClientOptions> = API extends Record<
 												? {
 														user: InferUserFromClient<COpts>;
 														session: InferSessionFromClient<COpts>;
-													}
+													} | null
 												: NonNullable<Awaited<R>>,
 										{
 											code?: string;

--- a/packages/better-auth/src/db/db.test.ts
+++ b/packages/better-auth/src/db/db.test.ts
@@ -69,7 +69,7 @@ describe("db", async () => {
 				throw: true,
 			},
 		});
-		expect(session.user?.image).toBe("test-image");
+		expect(session?.user?.image).toBe("test-image");
 		expect(callback).toBe(true);
 	});
 
@@ -94,6 +94,6 @@ describe("db", async () => {
 				throw: true,
 			},
 		});
-		expect(session.user.email).toBe("test@email.com");
+		expect(session?.user.email).toBe("test@email.com");
 	});
 });

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -156,9 +156,9 @@ describe("phone auth flow", async () => {
 				throw: true,
 			},
 		});
-		expect(session.user.phoneNumberVerified).toBe(true);
-		expect(session.user.email).toBe("temp-+251911121314");
-		expect(session.session.token).toBeDefined();
+		expect(session?.user.phoneNumberVerified).toBe(true);
+		expect(session?.user.email).toBe("temp-+251911121314");
+		expect(session?.session.token).toBeDefined();
 	});
 
 	let headers = new Headers();


### PR DESCRIPTION
When there isn't an active session, `null` is returned on the `/get-session` endpoint. This was missing in types.