### PR TITLE
fix:  pevent duplicate trusted origins after plugin init with expo

### DIFF
--- a/docs/components/builder/index.tsx
+++ b/docs/components/builder/index.tsx
@@ -28,7 +28,6 @@ import { useAtom } from "jotai";
 import { optionsAtom } from "./store";
 import { useTheme } from "next-themes";
 import { ScrollArea } from "../ui/scroll-area";
-import styles from "./builder.module.css";
 const frameworks = [
 	{
 		title: "Next.js",

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -249,7 +249,7 @@ function runPluginInit(ctx: AuthContext) {
 	if (options.trustedOrigins) {
 		options.trustedOrigins = [...new Set(options.trustedOrigins as string[])];
 	}
-	
+
 	// Add the global database hooks last
 	dbHooks.push(options.databaseHooks);
 	context.internalAdapter = createInternalAdapter(ctx.adapter, {

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -247,7 +247,9 @@ function runPluginInit(ctx: AuthContext) {
 	}
 
 	if (options.trustedOrigins) {
-		options.trustedOrigins = [...new Set(options.trustedOrigins as string[])];
+		options.trustedOrigins = Array.isArray(options.trustedOrigins)
+			? [...new Set(options.trustedOrigins)]
+			: options.trustedOrigins;
 	}
 
 	// Add the global database hooks last

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -245,6 +245,11 @@ function runPluginInit(ctx: AuthContext) {
 			}
 		}
 	}
+
+	if (options.trustedOrigins) {
+		options.trustedOrigins = [...new Set(options.trustedOrigins as string[])];
+	}
+	
 	// Add the global database hooks last
 	dbHooks.push(options.databaseHooks);
 	context.internalAdapter = createInternalAdapter(ctx.adapter, {

--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -13,9 +13,7 @@ export const expo = (options?: ExpoOptions) => {
 		id: "expo",
 		init: (ctx) => {
 			const trustedOrigins =
-				process.env.NODE_ENV === "development"
-					? [...(ctx.trustedOrigins || []), "exp://"]
-					: ctx.trustedOrigins;
+				process.env.NODE_ENV === "development" ? ["exp://"] : [];
 			return {
 				options: {
 					trustedOrigins,


### PR DESCRIPTION
closes #3027