### PR TITLE
Fix: Aggregate permissions from all user roles in hasPermission

### DIFF
--- a/packages/better-auth/src/plugins/organization/has-permission.ts
+++ b/packages/better-auth/src/plugins/organization/has-permission.ts
@@ -2,35 +2,49 @@ import { defaultRoles } from "./access";
 import type { OrganizationOptions } from "./organization";
 
 type PermissionExclusive =
-	| {
-			/**
-			 * @deprecated Use `permissions` instead
-			 */
-			permission: { [key: string]: string[] };
-			permissions?: never;
-	  }
-	| {
-			permissions: { [key: string]: string[] };
-			permission?: never;
-	  };
+  | {
+      /**
+       * @deprecated Use `permissions` instead
+       */
+      permission: { [key: string]: string[] };
+      permissions?: never;
+    }
+  | {
+      permissions: { [key: string]: string[] };
+      permission?: never;
+    };
 
 export const hasPermission = (
-	input: {
-		role: string;
-		options: OrganizationOptions;
-	} & PermissionExclusive,
+  input: {
+    role: string;
+    options: OrganizationOptions;
+  } & PermissionExclusive,
 ) => {
-	if (!input.permissions && !input.permission) {
-		return false;
-	}
-	const roles = input.role.split(",");
-	const acRoles = input.options.roles || defaultRoles;
-	for (const role of roles) {
-		const _role = acRoles[role as keyof typeof acRoles];
-		const result = _role?.authorize(input.permissions ?? input.permission);
-		if (result?.success) {
-			return true;
-		}
-	}
-	return false;
+  if (!input.permissions && !input.permission) {
+    return false;
+  }
+  const roles = input.role.split(",");
+  const acRoles = input.options.roles || defaultRoles;
+
+  // Collect all permissions from all roles
+  const userPermissions = new Set<string>();
+  for (const role of roles) {
+    const _role = acRoles[role as keyof typeof acRoles];
+    if (_role?.permissions && Array.isArray(_role.permissions)) {
+      _role.permissions.forEach((perm: string) => userPermissions.add(perm));
+    }
+    // For backward compatibility, also check for permission property
+    if (_role?.permission && Array.isArray(_role.permission)) {
+      _role.permission.forEach((perm: string) => userPermissions.add(perm));
+    }
+  }
+
+  // Determine requested permissions
+  const requested = input.permissions
+    ? Object.values(input.permissions).flat()
+    : Object.values(input.permission ?? {}).flat();
+
+  // Check if user has all requested permissions
+  const hasAll = requested.every((perm) => userPermissions.has(perm));
+  return hasAll;
 };


### PR DESCRIPTION
# hasPermission fails when called with multiple permissions if those permissions are granted by different roles

This PR updates the hasPermission function to aggregate permissions from all roles assigned to a user, rather than requiring a single role to grant all requested permissions. Previously, hasPermission would only return true if one role contained all requested permissions. Now, it returns true if the union of all assigned roles grants all requested permissions.

Summary of changes:

Collects permissions from all roles assigned to the user.
Checks if the user, via the union of their roles, has all requested permissions.
Maintains backward compatibility for both permissions and deprecated permission properties.
Why:
This change aligns permission checks with expected behavior: a user with multiple roles should be granted access if their combined roles provide all required permissions.

Closes:
#3011 
(Or: "Addresses issue where users with multiple roles could not access features requiring permissions spread across those roles.")