### PR TITLE
fix: use correct refresh token endpoint for github

### DIFF
--- a/packages/better-auth/src/social-providers/github.ts
+++ b/packages/better-auth/src/social-providers/github.ts
@@ -94,7 +94,7 @@ export const github = (options: GithubOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: "https://github.com/login/oauth/token",
+						tokenEndpoint: "https://github.com/login/oauth/access_token",
 					});
 				},
 		async getUserInfo(token) {


### PR DESCRIPTION
closes #3094 