### PR TITLE
docs: corrected github user email scope name

### DIFF
--- a/docs/content/docs/authentication/github.mdx
+++ b/docs/content/docs/authentication/github.mdx
@@ -10,7 +10,7 @@ description: GitHub provider setup and usage.
 
         Make sure to set the redirect URL to `http://localhost:3000/api/auth/callback/github` for local development. For production, you should set it to the URL of your application. If you change the base path of the auth routes, you should update the redirect URL accordingly.
 
-        Important: You MUST include the user:email scope in your Github app. See details below.
+        Important: You MUST include the user:email scope in your GitHub app. See details below.
     </Step>
 
   <Step>

--- a/docs/content/docs/authentication/github.mdx
+++ b/docs/content/docs/authentication/github.mdx
@@ -10,7 +10,7 @@ description: GitHub provider setup and usage.
 
         Make sure to set the redirect URL to `http://localhost:3000/api/auth/callback/github` for local development. For production, you should set it to the URL of your application. If you change the base path of the auth routes, you should update the redirect URL accordingly.
 
-        Important: You MUST include the user.email scope in your Github app. See details below.
+        Important: You MUST include the user:email scope in your Github app. See details below.
     </Step>
 
   <Step>


### PR DESCRIPTION
Fixed wrong user email scope name `user.email` and changed to correct one `user:email`. See available scopes here: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes