### PR TITLE
Fix MCP authorize comment typo

### DIFF
--- a/packages/better-auth/src/plugins/mcp/authorize.ts
+++ b/packages/better-auth/src/plugins/mcp/authorize.ts
@@ -194,7 +194,7 @@ export async function authorizeMCPOAuth(
 					 * This means the code now needs to be treated as a
 					 * consent request.
 					 *
-					 * once the user consents, teh code will be updated
+					 * once the user consents, the code will be updated
 					 * with the actual code. This is to prevent the
 					 * client from using the code before the user
 					 * consents.


### PR DESCRIPTION
## Summary
- fix a typo in `authorize.ts` comment

## Testing
- `pnpm lint`
- `pnpm -r -F "./packages/**" exec vitest run` *(fails: Could not connect to localhost:1433)*

------
https://chatgpt.com/codex/tasks/task_e_6855b3b432d4832b82c1c0af158c7453