### PR TITLE
Support multiple valid email OTPs

### DIFF
--- a/packages/better-auth/src/__snapshots__/init.test.ts.snap
+++ b/packages/better-auth/src/__snapshots__/init.test.ts.snap
@@ -87,6 +87,7 @@ exports[`init > should match config 1`] = `
     "findUserByEmail": [Function],
     "findUserById": [Function],
     "findVerificationValue": [Function],
+    "findVerificationValues": [Function],
     "linkAccount": [Function],
     "listSessions": [Function],
     "listUsers": [Function],

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -881,6 +881,34 @@ export const createInternalAdapter = (
 			const lastVerification = verification[0];
 			return lastVerification as Verification | null;
 		},
+		findVerificationValues: async (identifier: string) => {
+			const verifications = await adapter.findMany<Verification>({
+				model: "verification",
+				where: [
+					{
+						field: "identifier",
+						value: identifier,
+					},
+				],
+				sortBy: {
+					field: "createdAt",
+					direction: "desc",
+				},
+			});
+			if (!options.verification?.disableCleanup) {
+				await adapter.deleteMany({
+					model: "verification",
+					where: [
+						{
+							field: "expiresAt",
+							value: new Date(),
+							operator: "lt",
+						},
+					],
+				});
+			}
+			return verifications as Verification[];
+		},
 		deleteVerificationValue: async (id: string) => {
 			await adapter.delete<Verification>({
 				model: "verification",


### PR DESCRIPTION
## Summary
- add `findVerificationValues` to internal adapter
- add `allowMultipleOTPs` option
- handle multiple OTPs when verifying email OTPs
- test verifying old OTPs when multiple OTPs are allowed

## Testing
- `pnpm test` *(fails: 7 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_6855b1985f44832b9975c784f3e0346d