### PR TITLE
Fix session param typo in MCP demo

### DIFF
--- a/examples/nextjs-mcp/README.md
+++ b/examples/nextjs-mcp/README.md
@@ -54,7 +54,7 @@ import { createMcpHandler } from "@vercel/mcp-adapter";
 import { withMcpAuth } from "better-auth/plugins";
 import { z } from "zod";
 
-const handler = withMcpAuth(auth, (req, sesssion) => {
+const handler = withMcpAuth(auth, (req, session) => {
     //session => This isn’t a typical Better Auth session - instead, it returns the access token record along with the scopes and user ID.
 	return createMcpHandler(
 		(server) => {


### PR DESCRIPTION
## Summary
- fix a typo in `examples/nextjs-mcp/README.md`

## Testing
- `pnpm lint`
- `pnpm --filter "better-auth" test -- --run`
- `pnpm --filter "cli" test -- --run`
- `pnpm --filter "expo" test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6855b3e3d7f4832bb3c8021a5bac25c4