### PR TITLE
Fix rate-limiter test timers

### DIFF
--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
+
+afterEach(() => {
+    vi.useRealTimers();
+});
 
 describe(
 	"rate-limiter",


### PR DESCRIPTION
## Summary
- reset vitest timers after each rate limiter test

## Testing
- `pnpm test` *(fails: Test run cancelled. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6855b3eddf30832ba8f6125f690b9abe