### PR TITLE
feat(captcha): add "code" key to error responses for standardized error handling

### DIFF
--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -27,6 +27,7 @@ export const captcha = (options: CaptchaOptions) =>
 
 				if (!captchaResponse) {
 					return middlewareResponse({
+						code: "MISSING_RESPONSE" as const,
 						message: EXTERNAL_ERROR_CODES.MISSING_RESPONSE,
 						status: 400,
 					});
@@ -69,6 +70,7 @@ export const captcha = (options: CaptchaOptions) =>
 				});
 
 				return middlewareResponse({
+					code: "UNKNOWN_ERROR" as const,
 					message: EXTERNAL_ERROR_CODES.UNKNOWN_ERROR,
 					status: 500,
 				});

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/cloudflare-turnstile.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/cloudflare-turnstile.ts
@@ -44,6 +44,7 @@ export const cloudflareTurnstile = async ({
 
 	if (!response.data.success) {
 		return middlewareResponse({
+			code: "VERIFICATION_FAILED" as const,
 			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED,
 			status: 403,
 		});

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/google-recaptcha.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/google-recaptcha.ts
@@ -66,6 +66,7 @@ export const googleRecaptcha = async ({
 		(isV3(response.data) && response.data.score < minScore)
 	) {
 		return middlewareResponse({
+			code: "VERIFICATION_FAILED" as const,
 			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED,
 			status: 403,
 		});

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/h-captcha.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/h-captcha.ts
@@ -59,6 +59,7 @@ export const hCaptcha = async ({
 
 	if (!response.data.success) {
 		return middlewareResponse({
+			code: "VERIFICATION_FAILED" as const,
 			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED,
 			status: 403,
 		});


### PR DESCRIPTION
Captcha plugin only returned "message" in response errors. This PR add "code" key that already are present in other endpoints.