### PR TITLE
feat: allow customizable captcha header keys in BaseCaptchaOptions

### DIFF
--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -21,9 +21,11 @@ export const captcha = (options: CaptchaOptions) =>
 					throw new Error(INTERNAL_ERROR_CODES.MISSING_SECRET_KEY);
 				}
 
-				const captchaResponse = request.headers.get("x-captcha-response");
-				const remoteUserIP =
-					request.headers.get("x-captcha-user-remote-ip") ?? undefined;
+				const captchaResponseHeader = options.captchaResponseHeader ?? "x-captcha-response";
+				const remoteUserIPHeader = options.remoteUserIPHeader ?? "x-captcha-user-remote-ip";
+
+				const captchaResponse = request.headers.get(captchaResponseHeader);
+				const remoteUserIP = request.headers.get(remoteUserIPHeader) ?? undefined;
 
 				if (!captchaResponse) {
 					return middlewareResponse({

--- a/packages/better-auth/src/plugins/captcha/types.ts
+++ b/packages/better-auth/src/plugins/captcha/types.ts
@@ -6,6 +6,8 @@ export interface BaseCaptchaOptions {
 	secretKey: string;
 	endpoints?: string[];
 	siteVerifyURLOverride?: string;
+	captchaResponseHeader?: string;
+	remoteUserIPHeader?: string;
 }
 
 export interface GoogleRecaptchaOptions extends BaseCaptchaOptions {


### PR DESCRIPTION
feat: allow customizable captcha header keys in BaseCaptchaOptions

- Added optional properties `captchaResponseHeader` and `remoteUserIPHeader` to `BaseCaptchaOptions` to specify custom header keys.
- Fallback to default headers (`x-captcha-response`, `x-captcha-user-remote-ip`) if not specified.
