### PR TITLE
feat(username): support additional signup paths

### DIFF
--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -30,6 +30,13 @@ export type UsernameOptions = {
 	 * By default, the username should only contain alphanumeric characters and underscores
 	 */
 	usernameValidator?: (username: string) => boolean | Promise<boolean>;
+	/**
+	 * Additional paths which allows user signup with username
+	 *
+	 * @example
+	 * ["/some-path"]
+	 */
+	additionalSignUpPaths?: string[];
 };
 
 function defaultUsernameValidator(username: string) {
@@ -232,7 +239,8 @@ export const username = (options?: UsernameOptions) => {
 					matcher(context) {
 						return (
 							context.path === "/sign-up/email" ||
-							context.path === "/update-user"
+							context.path === "/update-user" ||
+							!!options?.additionalSignUpPaths?.includes(context.path)
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {


### PR DESCRIPTION
The invite-app plugin allows the user to sign up upon accepting the invitation. If a dev is also using the username plugin, they expect to be able to pass username during signup process too.