### PR TITLE
fix: protocol-specific wildcard trusted origins does not work

### DIFF
--- a/packages/better-auth/src/api/middlewares/origin-check.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.ts
@@ -32,6 +32,11 @@ export const originCheckMiddleware = createAuthMiddleware(async (ctx) => {
 			return false;
 		}
 		if (pattern.includes("*")) {
+			// For protocol-specific wildcards, match the full origin
+			if (pattern.includes("://")) {
+				return wildcardMatch(pattern)(getOrigin(url) || url);
+			}
+			// For host-only wildcards, match just the host
 			return wildcardMatch(pattern)(getHost(url));
 		}
 
@@ -92,6 +97,11 @@ export const originCheck = (
 				return false;
 			}
 			if (pattern.includes("*")) {
+				// For protocol-specific wildcards, match the full origin
+				if (pattern.includes("://")) {
+					return wildcardMatch(pattern)(getOrigin(url) || url);
+				}
+				// For host-only wildcards, match just the host
 				return wildcardMatch(pattern)(getHost(url));
 			}
 			return url.startsWith(pattern);


### PR DESCRIPTION
fix https://github.com/better-auth/better-auth/issues/3154

## Summary

The changes fix a bug where protocol-specific wildcard patterns like `https://*.example.com` do not work. This happen because there is a missing logic, if protocol is defined in wildcard trusted origins, we should consider entire url, not only the host to be matched.

## Changes made:
1. Fixed wildcard matching logic.
2. Added test coverage - New test case validates both positive and negative scenarios for protocol-specific wildcards.
3. Applied fix to both middleware functions - Both originCheckMiddleware and originCheck now handle protocol-specific wildcards correctly.