### PR TITLE
feat: add Discord bot permissions parameter support

### DIFF
--- a/docs/content/docs/authentication/discord.mdx
+++ b/docs/content/docs/authentication/discord.mdx
@@ -28,20 +28,46 @@ description: Discord provider setup and usage.
         })
         ```
     </Step>
-       <Step>
-        ### Sign In with Discord 
-        To sign in with Discord, you can use the `signIn.social` function provided by the client. The `signIn` function takes an object with the following properties:
-        - `provider`: The provider to use. It should be set to `discord`.
-
-        ```ts title="auth-client.ts"
-        import { createAuthClient } from "better-auth/client"
-        const authClient =  createAuthClient()
-        
-        const signIn = async () => {
-            const data = await authClient.signIn.social({
-                provider: "discord"
-            })
-        }
-        ```
-    </Step>
 </Steps>
+
+## Usage
+
+### Sign In with Discord 
+
+To sign in with Discord, you can use the `signIn.social` function provided by the client. The `signIn` function takes an object with the following properties:
+- `provider`: The provider to use. It should be set to `discord`.
+
+```ts title="auth-client.ts"
+import { createAuthClient } from "better-auth/client"
+const authClient =  createAuthClient()
+
+const signIn = async () => {
+    const data = await authClient.signIn.social({
+        provider: "discord"
+    })
+}
+```
+
+## Options
+
+For full list of options support by all social provider, check the [Provider Options](/docs/concepts/oauth#provider-options).
+
+### Bot Permissions (Optional)
+
+If you're using the `bot` scope with Discord OAuth, you can specify bot permissions using the `permissions` option. It can either be a bitwise value (e.g `2048 | 4096` for Send Messages and Embed Links) or a specific permission value (e.g `4096` for Embed Links).
+
+```ts title="auth.ts" 
+import { betterAuth } from "better-auth"
+
+export const auth = betterAuth({ 
+    socialProviders: {
+        discord: {
+            clientId: process.env.DISCORD_CLIENT_ID as string,
+            clientSecret: process.env.DISCORD_CLIENT_SECRET as string,
+            permissions: 2048 | 4096, // Send Messages + Embed Links // [!code highlight]
+        }, 
+    },
+})
+```
+
+**Note:** The `permissions` parameter only works when the `bot` scope is included in your OAuth2 scopes. Read more about [Discord bot permissions](https://discord.com/developers/docs/topics/permissions).

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -132,27 +132,64 @@ const requestAdditionalScopes = async () => {
 Make sure you're running Better Auth version 1.2.7 or later. Earlier versions (like 1.2.2) may show a "Social account already linked" error when trying to link with an existing provider for additional scopes.
 </Callout>
 
-### Other Provider Configurations
+## Provider Options
 
-**scope** The scope of the access request. For example, `email` or `profile`.
+### scope
 
-**redirectURI** Custom redirect URI for the provider. By default, it uses `/api/auth/callback/${providerName}`.
+The scope of the access request. For example, `email` or `profile`.
 
-**disableImplicitSignUp:** Disables implicit sign-up. In order to sign up a user, `requestSignUp` needs to be set to `true` when signing in.
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
 
-**disableSignUp:** Disables sign-up for new users.
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    google: {
+      clientId: "YOUR_GOOGLE_CLIENT_ID",
+      clientSecret: "YOUR_GOOGLE_CLIENT_SECRET",
+      scope: ["email", "profile"],
+    },
+  },
+});
+```
 
-**disableIdTokenSignIn:** Disables the use of the ID token for sign-in. By default, it's enabled for some providers like Google and Apple.
+### redirectURI
 
-**verifyIdToken** A custom function to verify the ID token.
+Custom redirect URI for the provider. By default, it uses `/api/auth/callback/${providerName}`
 
-**getUserInfo** A custom function to fetch user information from the provider. Given the tokens returned from the provider, this function should return the user's information.
+```ts title="auth.ts"
 
-**overrideUserInfoOnSignIn**: A boolean value that determines whether to override the user information in the database when signing in. By default, it is set to `false`, meaning that the user information will not be overridden during sign-in. If you want to update the user information every time they sign in, set this to `true`.
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    google: {
+      clientId: "YOUR_GOOGLE_CLIENT_ID",
+      clientSecret: "YOUR_GOOGLE_CLIENT_SECRET",
+      redirectURI: "https://your-app.com/auth/callback",
+    },
+  },
+});
+```
 
-**refreshAccessToken**: A custom function to refresh the token. This feature is only supported for built-in social providers (Google, Facebook, GitHub, etc.) and is not currently supported for custom OAuth providers configured through the Generic OAuth Plugin. For built-in providers, you can provide a custom function to refresh the token if needed.
+### disableSignUp
 
-**mapProfileToUser** A custom function to map the user profile returned from the provider to the user object in your database.
+Disables sign-up for new users.
+
+### disableIdTokenSignIn
+
+Disables the use of the ID token for sign-in. By default, it's enabled for some providers like Google and Apple.
+
+### verifyIdToken
+
+A custom function to verify the ID token.
+
+### overrideUserInfoOnSignIn
+
+A boolean value that determines whether to override the user information in the database when signing in. By default, it is set to `false`, meaning that the user information will not be overridden during sign-in. If you want to update the user information every time they sign in, set this to `true`.
+
+### mapProfileToUser
+
+A custom function to map the user profile returned from the provider to the user object in your database.
 
 Useful, if you have additional fields in your user object you want to populate from the provider's profile. Or if you want to change how by default the user object is mapped.
 
@@ -176,28 +213,162 @@ export const auth = betterAuth({
 });
 ```
 
-## How OAuth Works in Better Auth
+### refreshAccessToken
 
-Here's what happens when a user selects a provider to authenticate with:
+A custom function to refresh the token. This feature is only supported for built-in social providers (Google, Facebook, GitHub, etc.) and is not currently supported for custom OAuth providers configured through the Generic OAuth Plugin. For built-in providers, you can provide a custom function to refresh the token if needed.
 
-1. **Configuration Check:** Ensure the necessary provider details (e.g., client ID, secret) are configured.
-2. **State Generation:** Generate and save a state token in your database for CSRF protection.
-3. **PKCE Support:** If applicable, create a PKCE code challenge and verifier for secure exchanges.
-4. **Authorization URL Construction:** Build the provider's authorization URL with parameters like client ID, redirect URI, state, etc. The callback URL usually follows the pattern `/api/auth/callback/${providerName}`.
-5. **User Redirection:**
-   - If redirection is enabled, users are redirected to the provider's login page.
-   - If redirection is disabled, the authorization URL is returned for the client to handle the redirection.
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
 
-### Post-Login Flow
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    google: {
+      clientId: "YOUR_GOOGLE_CLIENT_ID",
+      clientSecret: "YOUR_GOOGLE_CLIENT_SECRET",
+      refreshAccessToken: async (token) => {
+        return {
+          accessToken: "new-access-token",
+          refreshToken: "new-refresh-token",
+        };
+      },
+    },
+  },
+});
+```
 
-After the user completes the login process, the provider redirects them back to the callback URL with a code and state. Better Auth handles the rest:
+### clientKey
 
-1. **Token Exchange:** The code is exchanged for an access token and user information.
-2. **User Handling:**
-   - If the user doesn't exist, a new account is created.
-   - If the user exists, they are logged in.
-   - If the user has multiple accounts across providers, Better Auth links them based on your configuration. Learn more about [account linking](/docs/concepts/users-accounts#account-linking).
-3. **Session Creation:** A new session is created for the user.
-4. **Redirect:** Users are redirected to the specified URL provided during the initial request or `/`.
+The client key of your application. This is used by TikTok Social Provider instead of `clientId`.
 
-If any error occurs during the process, Better Auth handles it and redirects the user to the error URL (if provided) or the callbackURL. And it includes the error message in the query string `?error=...`.
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    tiktok: {
+      clientKey: "YOUR_TIKTOK_CLIENT_KEY",
+      clientSecret: "YOUR_TIKTOK_CLIENT_SECRET",
+    },
+  },
+});
+```
+
+### getUserInfo
+
+A custom function to get user info from the provider. This allows you to override the default user info retrieval process.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    google: {
+      clientId: "YOUR_GOOGLE_CLIENT_ID",
+      clientSecret: "YOUR_GOOGLE_CLIENT_SECRET",
+      getUserInfo: async (token) => {
+        // Custom implementation to get user info
+        const response = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
+          headers: {
+            Authorization: `Bearer ${token.accessToken}`,
+          },
+        });
+        const profile = await response.json();
+        return {
+          user: {
+            id: profile.id,
+            name: profile.name,
+            email: profile.email,
+            image: profile.picture,
+            emailVerified: profile.verified_email,
+          },
+          data: profile,
+        };
+      },
+    },
+  },
+});
+```
+
+### disableImplicitSignUp
+
+Disables implicit sign up for new users. When set to true for the provider, sign-in needs to be called with `requestSignUp` as true to create new users.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    google: {
+      clientId: "YOUR_GOOGLE_CLIENT_ID",
+      clientSecret: "YOUR_GOOGLE_CLIENT_SECRET",
+      disableImplicitSignUp: true,
+    },
+  },
+});
+```
+
+### prompt
+
+The prompt to use for the authorization code request. This controls the authentication flow behavior.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    google: {
+      clientId: "YOUR_GOOGLE_CLIENT_ID",
+      clientSecret: "YOUR_GOOGLE_CLIENT_SECRET",
+      prompt: "select_account", // or "consent", "login", "none", "select_account+consent"
+    },
+  },
+});
+```
+
+### responseMode
+
+The response mode to use for the authorization code request. This determines how the authorization response is returned.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    google: {
+      clientId: "YOUR_GOOGLE_CLIENT_ID",
+      clientSecret: "YOUR_GOOGLE_CLIENT_SECRET",
+      responseMode: "query", // or "form_post"
+    },
+  },
+});
+```
+
+### disableDefaultScope
+
+Removes the default scopes of the provider. By default, providers include certain scopes like `email` and `profile`. Set this to `true` to remove these default scopes and use only the scopes you specify.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    google: {
+      clientId: "YOUR_GOOGLE_CLIENT_ID",
+      clientSecret: "YOUR_GOOGLE_CLIENT_SECRET",
+      disableDefaultScope: true,
+      scope: ["https://www.googleapis.com/auth/userinfo.email"], // Only this scope will be used
+    },
+  },
+});
+```
+
+### Other Provider Configurations
+
+Each provider may have additional options, check the specific provider documentation for more details.

--- a/packages/better-auth/src/social-providers/discord.ts
+++ b/packages/better-auth/src/social-providers/discord.ts
@@ -75,6 +75,7 @@ export interface DiscordProfile extends Record<string, any> {
 
 export interface DiscordOptions extends ProviderOptions<DiscordProfile> {
 	prompt?: "none" | "consent";
+	permissions?: number;
 }
 
 export const discord = (options: DiscordOptions) => {
@@ -85,6 +86,10 @@ export const discord = (options: DiscordOptions) => {
 			const _scopes = options.disableDefaultScope ? [] : ["identify", "email"];
 			scopes && _scopes.push(...scopes);
 			options.scope && _scopes.push(...options.scope);
+			const hasBotScope = _scopes.includes("bot");
+			const permissionsParam = hasBotScope && options.permissions
+				? `&permissions=${options.permissions}`
+				: "";
 			return new URL(
 				`https://discord.com/api/oauth2/authorize?scope=${_scopes.join(
 					"+",
@@ -92,7 +97,7 @@ export const discord = (options: DiscordOptions) => {
 					options.clientId
 				}&redirect_uri=${encodeURIComponent(
 					options.redirectURI || redirectURI,
-				)}&state=${state}&prompt=${options.prompt || "none"}`,
+				)}&state=${state}&prompt=${options.prompt || "none"}${permissionsParam}`,
 			);
 		},
 		validateAuthorizationCode: async ({ code, redirectURI }) => {

--- a/packages/better-auth/src/social-providers/discord.ts
+++ b/packages/better-auth/src/social-providers/discord.ts
@@ -1,6 +1,6 @@
 import { betterFetch } from "@better-fetch/fetch";
 import type { OAuthProvider, ProviderOptions } from "../oauth2";
-import { validateAuthorizationCode, refreshAccessToken } from "../oauth2";
+import { refreshAccessToken, validateAuthorizationCode } from "../oauth2";
 export interface DiscordProfile extends Record<string, any> {
 	/** the user's id (i.e. the numerical snowflake) */
 	id: string;
@@ -87,9 +87,10 @@ export const discord = (options: DiscordOptions) => {
 			scopes && _scopes.push(...scopes);
 			options.scope && _scopes.push(...options.scope);
 			const hasBotScope = _scopes.includes("bot");
-			const permissionsParam = hasBotScope && options.permissions
-				? `&permissions=${options.permissions}`
-				: "";
+			const permissionsParam =
+				hasBotScope && options.permissions
+					? `&permissions=${options.permissions}`
+					: "";
 			return new URL(
 				`https://discord.com/api/oauth2/authorize?scope=${_scopes.join(
 					"+",
@@ -97,7 +98,9 @@ export const discord = (options: DiscordOptions) => {
 					options.clientId
 				}&redirect_uri=${encodeURIComponent(
 					options.redirectURI || redirectURI,
-				)}&state=${state}&prompt=${options.prompt || "none"}${permissionsParam}`,
+				)}&state=${state}&prompt=${
+					options.prompt || "none"
+				}${permissionsParam}`,
 			);
 		},
 		validateAuthorizationCode: async ({ code, redirectURI }) => {


### PR DESCRIPTION
When using the Discord social plugin, you can set the `bot` scope, and this scope can have an additional `permissions` scope, referring to the permissions of the Discord Bot once authorized. 
This pull request introduces enhancements to the `discord` social provider in the `packages/better-auth` module. The changes add support for specifying Discord bot permissions during OAuth authorization, improving flexibility for integrations that require bot capabilities.

### Enhancements to Discord social provider:

* [`packages/better-auth/src/social-providers/discord.ts`](diffhunk://#diff-1a21b72f6948f413fefe8849f8fca8de99aa80f652eecaa356a8d34372010d7eR78): Added a new optional `permissions` property to the `DiscordOptions` interface, allowing developers to specify bot permissions during OAuth authorization.
* [`packages/better-auth/src/social-providers/discord.ts`](diffhunk://#diff-1a21b72f6948f413fefe8849f8fca8de99aa80f652eecaa356a8d34372010d7eR89-R100): Updated the `discord` function to append a `permissions` parameter to the authorization URL when the `bot` scope is included and `permissions` is defined. This ensures bot permissions are correctly passed during the OAuth flow.