### PR TITLE
refactor(mongoAdapter): Migrate to createAdapter

### DIFF
--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -1,326 +1,274 @@
 import { ObjectId, type Db } from "mongodb";
-import { getAuthTables } from "../../db";
-import type { Adapter, BetterAuthOptions, Where } from "../../types";
-import { withApplyDefault } from "../utils";
+import type { Where } from "../../types";
+import { createAdapter, type AdapterDebugLogs } from "../create-adapter";
 
-const createTransform = (options: BetterAuthOptions) => {
-	const schema = getAuthTables(options);
+export interface MongoDBAdapterConfig {
 	/**
-	 * if custom id gen is provided we don't want to override with object id
+	 * Enable debug logs for the adapter
+	 *
+	 * @default false
 	 */
-	const customIdGen =
-		options.advanced?.database?.generateId || options.advanced?.generateId;
+	debugLogs?: AdapterDebugLogs;
+	/**
+	 * Use plural table names
+	 *
+	 * @default false
+	 */
+	usePlural?: boolean;
+}
 
-	function serializeID(field: string, value: any, model: string) {
-		if (customIdGen) {
-			return value;
-		}
-		if (
-			field === "id" ||
-			field === "_id" ||
-			schema[model].fields[field].references?.field === "id"
-		) {
-			if (typeof value !== "string") {
-				if (value instanceof ObjectId) {
+export const mongodbAdapter = (db: Db, config?: MongoDBAdapterConfig) =>
+	createAdapter({
+		config: {
+			adapterId: "mongodb-adapter",
+			adapterName: "MongoDB Adapter",
+			usePlural: config?.usePlural ?? false,
+			debugLogs: config?.debugLogs ?? false,
+			mapKeysTransformInput: {
+				id: "_id",
+			},
+			mapKeysTransformOutput: {
+				_id: "id",
+			},
+			supportsNumericIds: false,
+			customTransformInput({
+				action,
+				data,
+				field,
+				fieldAttributes,
+				schema,
+				model,
+			}) {
+				// Given the key transformation, we know that `id` is already mapped to `_id`
+				if (field === "_id" || fieldAttributes.references?.field === "id") {
+					if (action === "update") {
+						return data;
+					}
+					if (Array.isArray(data)) {
+						return data.map((v) => new ObjectId());
+					}
+					if (typeof data === "string") {
+						try {
+							return new ObjectId(data);
+						} catch (error) {
+							return new ObjectId();
+						}
+					}
+					return new ObjectId();
+				}
+				return data;
+			},
+			customTransformOutput({ data, field, fieldAttributes }) {
+				if (field === "id" || fieldAttributes.references?.field === "id") {
+					if (data instanceof ObjectId) {
+						return data.toHexString();
+					}
+					if (Array.isArray(data)) {
+						return data.map((v) => {
+							if (v instanceof ObjectId) {
+								return v.toHexString();
+							}
+							return v;
+						});
+					}
+					return data;
+				}
+				return data;
+			},
+		},
+		adapter: ({ options, getFieldName, schema, getDefaultModelName }) => {
+			/**
+			 * if custom id gen is provided we don't want to override with object id
+			 */
+			const customIdGen = options.advanced?.database?.generateId;
+
+			function serializeID({
+				field,
+				value,
+				model,
+			}: { field: string; value: any; model: string }) {
+				if (customIdGen) {
 					return value;
 				}
-				if (Array.isArray(value)) {
-					return value.map((v) => {
-						if (typeof v === "string") {
-							try {
-								return new ObjectId(v);
-							} catch (e) {
-								return v;
-							}
+				model = getDefaultModelName(model);
+				if (
+					field === "id" ||
+					field === "_id" ||
+					schema[model].fields[field]?.references?.field === "id"
+				) {
+					if (typeof value !== "string") {
+						if (value instanceof ObjectId) {
+							return value;
 						}
-						if (v instanceof ObjectId) {
-							return v;
+						if (Array.isArray(value)) {
+							return value.map((v) => {
+								if (typeof v === "string") {
+									try {
+										return new ObjectId(v);
+									} catch (e) {
+										return v;
+									}
+								}
+								if (v instanceof ObjectId) {
+									return v;
+								}
+								throw new Error("Invalid id value");
+							});
 						}
 						throw new Error("Invalid id value");
-					});
+					}
+					try {
+						return new ObjectId(value);
+					} catch (e) {
+						return value;
+					}
 				}
-				throw new Error("Invalid id value");
-			}
-			try {
-				return new ObjectId(value);
-			} catch (e) {
 				return value;
 			}
-		}
-		return value;
-	}
 
-	function deserializeID(field: string, value: any, model: string) {
-		if (customIdGen) {
-			return value;
-		}
-		if (
-			field === "id" ||
-			schema[model].fields[field].references?.field === "id"
-		) {
-			if (value instanceof ObjectId) {
-				return value.toHexString();
-			}
-			if (Array.isArray(value)) {
-				return value.map((v) => {
-					if (v instanceof ObjectId) {
-						return v.toHexString();
-					}
-					return v;
-				});
-			}
-			return value;
-		}
-		return value;
-	}
-
-	function getField(field: string, model: string) {
-		if (field === "id") {
-			if (customIdGen) {
-				return "id";
-			}
-			return "_id";
-		}
-		const f = schema[model].fields[field];
-		return f.fieldName || field;
-	}
-
-	return {
-		transformInput(
-			data: Record<string, any>,
-			model: string,
-			action: "create" | "update",
-		) {
-			const transformedData: Record<string, any> =
-				action === "update"
-					? {}
-					: customIdGen
-						? {
-								id: customIdGen({ model }),
-							}
-						: {
-								_id: new ObjectId(),
+			function convertWhereClause({
+				where,
+				model,
+			}: { where: Where[]; model: string }) {
+				if (!where.length) return {};
+				const conditions = where.map((w) => {
+					const {
+						field: field_,
+						value,
+						operator = "eq",
+						connector = "AND",
+					} = w;
+					let condition: any;
+					let field = getFieldName({ model, field: field_ });
+					if (field === "id") field = "_id";
+					switch (operator.toLowerCase()) {
+						case "eq":
+							condition = {
+								[field]: serializeID({
+									field,
+									value,
+									model,
+								}),
 							};
-			const fields = schema[model].fields;
-			for (const field in fields) {
-				const value = data[field];
-				if (
-					value === undefined &&
-					(!fields[field].defaultValue || action === "update")
-				) {
-					continue;
-				}
-				transformedData[fields[field].fieldName || field] = withApplyDefault(
-					serializeID(field, value, model),
-					fields[field],
-					action,
-				);
-			}
-			return transformedData;
-		},
-		transformOutput(
-			data: Record<string, any>,
-			model: string,
-			select: string[] = [],
-		) {
-			const transformedData: Record<string, any> =
-				data.id || data._id
-					? select.length === 0 || select.includes("id")
-						? {
-								id: data.id ? data.id.toString() : data._id.toString(),
-							}
-						: {}
-					: {};
+							break;
+						case "in":
+							condition = {
+								[field]: {
+									$in: Array.isArray(value)
+										? value.map((v) => serializeID({ field, value: v, model }))
+										: [serializeID({ field, value, model })],
+								},
+							};
+							break;
+						case "gt":
+							condition = { [field]: { $gt: value } };
+							break;
+						case "gte":
+							condition = { [field]: { $gte: value } };
+							break;
+						case "lt":
+							condition = { [field]: { $lt: value } };
+							break;
+						case "lte":
+							condition = { [field]: { $lte: value } };
+							break;
+						case "ne":
+							condition = { [field]: { $ne: value } };
+							break;
 
-			const tableSchema = schema[model].fields;
-			for (const key in tableSchema) {
-				if (select.length && !select.includes(key)) {
-					continue;
+						case "contains":
+							condition = { [field]: { $regex: `.*${value}.*` } };
+							break;
+						case "starts_with":
+							condition = { [field]: { $regex: `${value}.*` } };
+							break;
+						case "ends_with":
+							condition = { [field]: { $regex: `.*${value}` } };
+							break;
+						default:
+							throw new Error(`Unsupported operator: ${operator}`);
+					}
+					return { condition, connector };
+				});
+				if (conditions.length === 1) {
+					return conditions[0].condition;
 				}
-				const field = tableSchema[key];
-				if (field) {
-					transformedData[key] = deserializeID(
-						key,
-						data[field.fieldName || key],
-						model,
+				const andConditions = conditions
+					.filter((c) => c.connector === "AND")
+					.map((c) => c.condition);
+				const orConditions = conditions
+					.filter((c) => c.connector === "OR")
+					.map((c) => c.condition);
+
+				let clause = {};
+				if (andConditions.length) {
+					clause = { ...clause, $and: andConditions };
+				}
+				if (orConditions.length) {
+					clause = { ...clause, $or: orConditions };
+				}
+				return clause;
+			}
+
+			return {
+				async create({ model, data: values }) {
+					const res = await db.collection(model).insertOne(values);
+					const insertedData = { _id: res.insertedId.toString(), ...values };
+					return insertedData as any;
+				},
+				async findOne({ model, where, select }) {
+					const clause = convertWhereClause({ where, model });
+					const res = await db.collection(model).findOne(clause);
+					if (!res) return null;
+					return res as any;
+				},
+				async findMany({ model, where, limit, offset, sortBy }) {
+					const clause = where ? convertWhereClause({ where, model }) : {};
+					const cursor = db.collection(model).find(clause);
+					if (limit) cursor.limit(limit);
+					if (offset) cursor.skip(offset);
+					if (sortBy)
+						cursor.sort(
+							getFieldName({ field: sortBy.field, model }),
+							sortBy.direction === "desc" ? -1 : 1,
+						);
+					const res = await cursor.toArray();
+					return res as any;
+				},
+				async count({ model }) {
+					const res = await db.collection(model).countDocuments();
+					return res;
+				},
+				async update({ model, where, update: values }) {
+					const clause = convertWhereClause({ where, model });
+
+					const res = await db.collection(model).findOneAndUpdate(
+						clause,
+						{ $set: values as any },
+						{
+							returnDocument: "after",
+						},
 					);
-				}
-			}
-			return transformedData as any;
-		},
-		convertWhereClause(where: Where[], model: string) {
-			if (!where.length) return {};
-			const conditions = where.map((w) => {
-				const { field: _field, value, operator = "eq", connector = "AND" } = w;
-				let condition: any;
-				const field = getField(_field, model);
-				switch (operator.toLowerCase()) {
-					case "eq":
-						condition = {
-							[field]: serializeID(_field, value, model),
-						};
-						break;
-					case "in":
-						condition = {
-							[field]: {
-								$in: Array.isArray(value)
-									? serializeID(_field, value, model)
-									: [serializeID(_field, value, model)],
-							},
-						};
-						break;
-					case "gt":
-						condition = { [field]: { $gt: value } };
-						break;
-					case "gte":
-						condition = { [field]: { $gte: value } };
-						break;
-					case "lt":
-						condition = { [field]: { $lt: value } };
-						break;
-					case "lte":
-						condition = { [field]: { $lte: value } };
-						break;
-					case "ne":
-						condition = { [field]: { $ne: value } };
-						break;
+					if (!res) return null;
+					return res as any;
+				},
+				async updateMany({ model, where, update: values }) {
+					const clause = convertWhereClause({ where, model });
 
-					case "contains":
-						condition = { [field]: { $regex: `.*${value}.*` } };
-						break;
-					case "starts_with":
-						condition = { [field]: { $regex: `${value}.*` } };
-						break;
-					case "ends_with":
-						condition = { [field]: { $regex: `.*${value}` } };
-						break;
-					default:
-						throw new Error(`Unsupported operator: ${operator}`);
-				}
-				return { condition, connector };
-			});
-			if (conditions.length === 1) {
-				return conditions[0].condition;
-			}
-			const andConditions = conditions
-				.filter((c) => c.connector === "AND")
-				.map((c) => c.condition);
-			const orConditions = conditions
-				.filter((c) => c.connector === "OR")
-				.map((c) => c.condition);
-
-			let clause = {};
-			if (andConditions.length) {
-				clause = { ...clause, $and: andConditions };
-			}
-			if (orConditions.length) {
-				clause = { ...clause, $or: orConditions };
-			}
-			return clause;
+					const res = await db.collection(model).updateMany(clause, {
+						$set: values as any,
+					});
+					return res.modifiedCount;
+				},
+				async delete({ model, where }) {
+					const clause = convertWhereClause({ where, model });
+					await db.collection(model).deleteOne(clause);
+				},
+				async deleteMany({ model, where }) {
+					const clause = convertWhereClause({ where, model });
+					const res = await db.collection(model).deleteMany(clause);
+					return res.deletedCount;
+				},
+			};
 		},
-		getModelName: (model: string) => {
-			return schema[model].modelName;
-		},
-		getField,
-	};
-};
-
-export const mongodbAdapter = (db: Db) => (options: BetterAuthOptions) => {
-	const transform = createTransform(options);
-	const hasCustomId = options.advanced?.generateId;
-	return {
-		id: "mongodb-adapter",
-		async create(data) {
-			const { model, data: values, select } = data;
-			const transformedData = transform.transformInput(values, model, "create");
-			if (transformedData.id && !hasCustomId) {
-				// biome-ignore lint/performance/noDelete: setting id to undefined will cause the id to be null in the database which is not what we want
-				delete transformedData.id;
-			}
-			const res = await db
-				.collection(transform.getModelName(model))
-				.insertOne(transformedData);
-			const id = res.insertedId;
-			const insertedData = { id: id.toString(), ...transformedData };
-			const t = transform.transformOutput(insertedData, model, select);
-			return t;
-		},
-		async findOne(data) {
-			const { model, where, select } = data;
-			const clause = transform.convertWhereClause(where, model);
-			const res = await db
-				.collection(transform.getModelName(model))
-				.findOne(clause);
-			if (!res) return null;
-			const transformedData = transform.transformOutput(res, model, select);
-			return transformedData;
-		},
-		async findMany(data) {
-			const { model, where, limit, offset, sortBy } = data;
-			const clause = where ? transform.convertWhereClause(where, model) : {};
-			const cursor = db.collection(transform.getModelName(model)).find(clause);
-			if (limit) cursor.limit(limit);
-			if (offset) cursor.skip(offset);
-			if (sortBy)
-				cursor.sort(
-					transform.getField(sortBy.field, model),
-					sortBy.direction === "desc" ? -1 : 1,
-				);
-			const res = await cursor.toArray();
-			return res.map((r) => transform.transformOutput(r, model));
-		},
-		async count(data) {
-			const { model } = data;
-			const res = await db
-				.collection(transform.getModelName(model))
-				.countDocuments();
-			return res;
-		},
-		async update(data) {
-			const { model, where, update: values } = data;
-			const clause = transform.convertWhereClause(where, model);
-
-			const transformedData = transform.transformInput(values, model, "update");
-
-			const res = await db
-				.collection(transform.getModelName(model))
-				.findOneAndUpdate(
-					clause,
-					{ $set: transformedData },
-					{
-						returnDocument: "after",
-					},
-				);
-			const output = res?.value ?? res;
-			if (!output) return null;
-			return transform.transformOutput(output, model);
-		},
-		async updateMany(data) {
-			const { model, where, update: values } = data;
-			const clause = transform.convertWhereClause(where, model);
-			const transformedData = transform.transformInput(values, model, "update");
-			const res = await db
-				.collection(transform.getModelName(model))
-				.updateMany(clause, { $set: transformedData });
-			return res.modifiedCount;
-		},
-		async delete(data) {
-			const { model, where } = data;
-			const clause = transform.convertWhereClause(where, model);
-			const res = await db
-				.collection(transform.getModelName(model))
-				.findOneAndDelete(clause);
-			const output = res?.value ?? res;
-			if (!output) return null;
-			return transform.transformOutput(output, model);
-		},
-		async deleteMany(data) {
-			const { model, where } = data;
-			const clause = transform.convertWhereClause(where, model);
-			const res = await db
-				.collection(transform.getModelName(model))
-				.deleteMany(clause);
-			return res.deletedCount;
-		},
-	} satisfies Adapter;
-};
+	});


### PR DESCRIPTION
In the past we didn't have mongoDb adapter move over to createAdapter since we've seen users running into issues.

However some time ago I've merged a PR which I believe fixed the issue, and after testing the org plugin with the mongo adapter that uses `createAdapter` I don't see any issues.