### PR TITLE
Fix/3138 stripe updatedAt

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -256,6 +256,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							model: "user",
 							update: {
 								stripeCustomerId: stripeCustomer.id,
+								updatedAt: new Date(),
 							},
 							where: [
 								{
@@ -516,6 +517,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								update: {
 									status: currentSubscription?.status,
 									cancelAtPeriodEnd: true,
+									updatedAt: new Date(),
 								},
 								where: [
 									{
@@ -649,6 +651,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 									model: "subscription",
 									update: {
 										cancelAtPeriodEnd: true,
+										updatedAt: new Date(),
 									},
 									where: [
 										{
@@ -1017,6 +1020,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 												model: "user",
 												update: {
 													stripeCustomerId: stripeCustomer.id,
+													updatedAt: new Date(),
 												},
 												where: [
 													{

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -42,6 +42,16 @@ export const subscriptions = {
 				type: "number",
 				required: false,
 			},
+			createdAt: {
+				type: "date",
+				required: false,
+				defaultValue: () => new Date(),
+			},
+			updatedAt: {
+				type: "date",
+				required: false,
+				defaultValue: () => new Date(),
+			},
 		},
 	},
 } satisfies AuthPluginSchema;

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -157,6 +157,14 @@ export interface Subscription {
 	 * Number of seats for the subscription (useful for team plans)
 	 */
 	seats?: number;
+	/**
+	 * Created at timestamp
+	 */
+	createdAt?: Date;
+	/**
+	 * Updated at timestamp
+	 */
+	updatedAt?: Date;
 }
 
 export interface StripeOptions {


### PR DESCRIPTION
What & Why
Fixes missing timestamp columns that caused `updatedAt` write errors in the Stripe plugin and ensures the field is kept in-sync on every mutation.

Changes
schema.ts – added `createdAt` & `updatedAt` fields to `subscription` model (default `new Date()`).
types.ts – added optional `createdAt` / `updatedAt` props to `Subscription` interface.
index.ts – stamped `updatedAt: new Date()` in the few `adapter.update` paths that previously omitted it (customer creation, cancel-at-period-end, manual cancel fallback, restore).

closes: https://github.com/better-auth/better-auth/issues/3138