### PR TITLE
fix(create-adapter): doesn't work with mongoAdapter

### DIFF
--- a/packages/better-auth/src/adapters/create-adapter/index.ts
+++ b/packages/better-auth/src/adapters/create-adapter/index.ts
@@ -92,8 +92,8 @@ export const createAdapter =
 			// Plugin `schema`s can't define their own `id`. Better-auth auto provides `id` to every schema model.
 			// Given this, we can't just check if the `field` (that being `id`) is within the schema's fields, since it is never defined.
 			// So we check if the `field` is `id` and if so, we return `id` itself. Otherwise, we return the `field` from the schema.
-			if (field === "id") {
-				return field;
+			if (field === "id" || field === "_id") {
+				return "id"
 			}
 			const model = getDefaultModelName(unsafe_model); // Just to make sure the model name is correct.
 
@@ -517,6 +517,8 @@ export const createAdapter =
 					field: defaultFieldName,
 					model: defaultModelName,
 				});
+
+				console.log(defaultFieldName)
 
 				if (defaultFieldName === "id" || fieldAttr.references?.field === "id") {
 					if (options.advanced?.database?.useNumberId) {

--- a/packages/better-auth/src/adapters/create-adapter/index.ts
+++ b/packages/better-auth/src/adapters/create-adapter/index.ts
@@ -93,7 +93,7 @@ export const createAdapter =
 			// Given this, we can't just check if the `field` (that being `id`) is within the schema's fields, since it is never defined.
 			// So we check if the `field` is `id` and if so, we return `id` itself. Otherwise, we return the `field` from the schema.
 			if (field === "id" || field === "_id") {
-				return "id"
+				return "id";
 			}
 			const model = getDefaultModelName(unsafe_model); // Just to make sure the model name is correct.
 
@@ -518,7 +518,7 @@ export const createAdapter =
 					model: defaultModelName,
 				});
 
-				console.log(defaultFieldName)
+				console.log(defaultFieldName);
 
 				if (defaultFieldName === "id" || fieldAttr.references?.field === "id") {
 					if (options.advanced?.database?.useNumberId) {

--- a/packages/better-auth/src/adapters/create-adapter/index.ts
+++ b/packages/better-auth/src/adapters/create-adapter/index.ts
@@ -518,8 +518,6 @@ export const createAdapter =
 					model: defaultModelName,
 				});
 
-				console.log(defaultFieldName);
-
 				if (defaultFieldName === "id" || fieldAttr.references?.field === "id") {
 					if (options.advanced?.database?.useNumberId) {
 						if (Array.isArray(value)) {


### PR DESCRIPTION
In Better-auth, we do not allow customising IDs, so nothing takes into account of "different ids". However MongoDB requires ids to be different.

The `getDefaultFieldName` fn in the create-adapter doesn't take into account that IDs from Mongo are not the same as the normal `id`. This is a patch fix until proper resolve is implemented.