### PR TITLE
feat: add SoundCloud social provider

### DIFF
--- a/docs/content/docs/authentication/soundcloud.mdx
+++ b/docs/content/docs/authentication/soundcloud.mdx
@@ -1,0 +1,63 @@
+---
+title: SoundCloud
+description: SoundCloud provider setup and usage.
+---
+
+<Steps>
+    <Step>
+        ### Get your SoundCloud credentials
+        To use SoundCloud sign-in, you need a **Client ID** and a **Client Secret**.   
+        SoundCloud currently does not give self-service access to their API. You need to contact them via their [SoundCloud Support - ChatBot](https://help.soundcloud.com/hc/en-us/requests/new).
+
+        After support has created the app for you, copy the following values from the app's [dashboard](https://soundcloud.com/you/apps):
+        - **Client ID** → `clientId`
+        - **Client Secret** → `clientSecret`
+
+         When making the original support request, make sure to also ask them to set/change the **Redirect URI** of the app to:
+        `http://localhost:3000/api/auth/callback/soundcloud` for local development.  
+        In production, it should be `https://<your-domain>/api/auth/callback/soundcloud` (or similar if you changed the base auth path).
+    </Step>
+
+    <Step>
+        ### Configure the provider
+        Import the provider and pass it into the `socialProviders` option of your auth instance.
+
+        ```ts title="auth.ts"
+        import { betterAuth } from "better-auth"
+
+        export const auth = betterAuth({
+          socialProviders: {
+            soundcloud: { // [!code highlight]
+              clientId: process.env.SOUNDCLOUD_CLIENT_ID as string, // [!code highlight]
+              clientSecret: process.env.SOUNDCLOUD_CLIENT_SECRET as string, // [!code highlight]
+            }, // [!code highlight]
+          },
+        })
+        ```
+
+        <Callout type="info">
+            - The SoundCloud API does not provide email addresses. As a workaround, this implementation uses the user's `username@soundcloud` value for the `email` field and we also check if their primary email is confirmed on SoundCloud.
+        </Callout>
+    </Step>
+
+    <Step>
+        ### Sign In with SoundCloud
+        Use the `signIn.social` helper from the client:
+
+        ```ts title="auth-client.ts"
+        import { createAuthClient } from "better-auth/client"
+        const authClient = createAuthClient()
+
+        const signIn = async () => {
+          const { data, error } = await authClient.signIn.social({
+            provider: "soundcloud",
+          })
+        }
+        ```
+    </Step>
+</Steps>
+
+<Callout type="info">
+    SoundCloud does **not** provide granular scopes – once the user authorises your application you receive a token that is allowed to perform all actions permitted for third-party apps (upload, like, follow, etc.).  
+    Therefore the `scope` option in the provider configuration is ignored.
+</Callout>

--- a/packages/better-auth/src/social-providers/index.ts
+++ b/packages/better-auth/src/social-providers/index.ts
@@ -7,6 +7,7 @@ import { google } from "./google";
 import { huggingface } from "./huggingface";
 import { microsoft } from "./microsoft-entra-id";
 import { spotify } from "./spotify";
+import { soundcloud } from "./soundcloud";
 import { twitch } from "./twitch";
 import { twitter } from "./twitter";
 import { dropbox } from "./dropbox";
@@ -28,6 +29,7 @@ export const socialProviders = {
 	google,
 	huggingface,
 	spotify,
+	soundcloud,
 	twitch,
 	twitter,
 	dropbox,
@@ -66,6 +68,7 @@ export * from "./apple";
 export * from "./microsoft-entra-id";
 export * from "./discord";
 export * from "./spotify";
+export * from "./soundcloud";
 export * from "./twitch";
 export * from "./facebook";
 export * from "./twitter";

--- a/packages/better-auth/src/social-providers/soundcloud.ts
+++ b/packages/better-auth/src/social-providers/soundcloud.ts
@@ -1,0 +1,98 @@
+import { betterFetch } from "@better-fetch/fetch";
+import type { OAuthProvider, ProviderOptions } from "../oauth2";
+import {
+	createAuthorizationURL,
+	refreshAccessToken,
+	validateAuthorizationCode,
+} from "../oauth2";
+
+export interface SoundCloudProfile {
+	/** The user id */
+	id: number | string;
+	/** The username */
+	username: string;
+	/** The full display name */
+	full_name: string;
+	/** Avatar image */
+	avatar_url: string;
+	/** Email is not available for SoundCloud */
+	email?: string;
+	/** Whether the email is verified on SoundCloud */
+	primary_email_confirmed: boolean;
+}
+
+export interface SoundCloudOptions extends ProviderOptions<SoundCloudProfile> {}
+
+export const soundcloud = (options: SoundCloudOptions) => {
+	const authorizationEndpoint = "https://secure.soundcloud.com/authorize";
+	const tokenEndpoint = "https://secure.soundcloud.com/oauth/token";
+	return {
+		id: "soundcloud",
+		name: "SoundCloud",
+		async createAuthorizationURL({ state, codeVerifier, redirectURI }) {
+			// SoundCloud does not implement granular scopes; the token returned is always full-access.
+			return await createAuthorizationURL({
+				id: "soundcloud",
+				options,
+				authorizationEndpoint,
+				scopes: [], // scope param will be empty
+				state,
+				redirectURI,
+				codeVerifier,
+			});
+		},
+		async validateAuthorizationCode({ code, codeVerifier, redirectURI }) {
+			return await validateAuthorizationCode({
+				code,
+				codeVerifier,
+				redirectURI,
+				options,
+				tokenEndpoint,
+			});
+		},
+		refreshAccessToken: options.refreshAccessToken
+			? options.refreshAccessToken
+			: async (refreshToken) =>
+					refreshAccessToken({
+						refreshToken,
+						options: {
+							clientId: options.clientId,
+							clientKey: options.clientKey,
+							clientSecret: options.clientSecret,
+						},
+						tokenEndpoint,
+					}),
+		async getUserInfo(token) {
+			if (options.getUserInfo) {
+				return options.getUserInfo(token);
+			}
+			const { data: profile, error } = await betterFetch<SoundCloudProfile>(
+				"https://api.soundcloud.com/me",
+				{
+					headers: {
+						Authorization: `Bearer ${token.accessToken}`,
+					},
+				},
+			);
+
+			if (error) {
+				return null;
+			}
+
+			const userMap = await options.mapProfileToUser?.(profile);
+			return {
+				user: {
+					id: profile.id.toString(),
+					name: profile.full_name || profile.username,
+					/** @note SoundCloud does not provide email addresses, so we use the username as a fallback. */
+					email: profile.email || profile.username + "@soundcloud",
+					image: profile.avatar_url,
+					emailVerified: profile.primary_email_confirmed,
+					...userMap,
+				},
+				data: profile,
+			};
+		},
+		options,
+	} satisfies OAuthProvider<SoundCloudProfile>;
+};


### PR DESCRIPTION
This adds SoundCloud as a social login provider. 

The provider gives full-scope access, as it's not fine-tunable on SC side, but in return the site can support liking tracks/playlists etc via the signed in user's account. 

Note: SC does not return an email address, so a workaround is used for that as `username@soundcloud`

Would appreciate some help on where Better-Auth gets the sidebar logos, as I've omitted them for now. 

https://developers.soundcloud.com/docs/api/guide#authentication
