### PR TITLE
fix(api-key): improve error statuses

### DIFF
--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -1651,7 +1651,7 @@ describe("api-key", async () => {
 			result.error = error;
 		}
 
-		expect(result.error?.status).toEqual("UNAUTHORIZED");
+		expect(result.error?.status).toEqual("TOO_MANY_REQUESTS");
 		expect(result.error?.body?.message).toEqual(ERROR_CODES.USAGE_EXCEEDED);
 		expect(result.error?.body?.code).toEqual("USAGE_EXCEEDED");
 	});

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -116,7 +116,7 @@ export async function validateApiKey({
 			ctx.context.logger.error(`Failed to delete expired API keys:`, error);
 		}
 
-		throw new APIError("UNAUTHORIZED", {
+		throw new APIError("TOO_MANY_REQUESTS", {
 			message: ERROR_CODES.USAGE_EXCEEDED,
 			code: "USAGE_EXCEEDED" as const,
 		});
@@ -138,8 +138,7 @@ export async function validateApiKey({
 
 		if (remaining === 0) {
 			// if there are no more remaining requests, than the key is invalid
-
-			throw new APIError("UNAUTHORIZED", {
+			throw new APIError("BAD_REQUEST", {
 				message: ERROR_CODES.USAGE_EXCEEDED,
 				code: "USAGE_EXCEEDED" as const,
 			});


### PR DESCRIPTION
When an API key is rate-limited, the status should be `TOO_MANY_REQUESTS` not `UNAUTHORIZED`