### PR TITLE
fix(stripe): update priceId on subscription upgrade and webhook sync

### DIFF
--- a/packages/stripe/src/hooks.ts
+++ b/packages/stripe/src/hooks.ts
@@ -40,6 +40,7 @@ export async function onCheckoutSessionCompleted(
 						update: {
 							plan: plan.name.toLowerCase(),
 							status: subscription.status,
+							priceId,
 							updatedAt: new Date(),
 							periodStart: new Date(
 								subscription.items.data[0].current_period_start * 1000,
@@ -141,6 +142,7 @@ export async function onSubscriptionUpdated(
 							limits: plan.limits,
 						}
 					: {}),
+				priceId,
 				updatedAt: new Date(),
 				status: subscriptionUpdated.status,
 				periodStart: new Date(

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -812,7 +812,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						return {
 							...sub,
 							limits: plan?.limits,
-							priceId: plan?.priceId,
+							priceId: sub.priceId ?? plan?.priceId,
 						};
 					})
 					.filter((sub) => {

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -21,6 +21,10 @@ export const subscriptions = {
 				type: "string",
 				required: false,
 			},
+			priceId: {
+				type: "string",
+				required: false,
+			},
 			status: {
 				type: "string",
 				defaultValue: "incomplete",


### PR DESCRIPTION
related issue: https://github.com/better-auth/better-auth/issues/3235



### 1. File: `packages/stripe/src/hooks.ts`
- **On Checkout Session Completion and Subscription Update:**  
  - The `priceId` is now included when updating the subscription object in the database.  
  - This ensures the correct Stripe price ID is stored whenever a subscription is completed or updated, supporting better synchronization.

### 2. File: `packages/stripe/src/index.ts`
- **Subscription Object Construction:**  
  - When constructing the subscription object, `priceId` is now set to `sub.priceId` if it exists, otherwise it falls back to `plan?.priceId`.
  - Previously, it always took `plan?.priceId`. This makes the assignment more robust by preferring the subscription's own price ID, which is important after upgrades or webhook syncs.

### 3. File: `packages/stripe/src/schema.ts`
- **Subscription Schema Update:**  
  - The `subscriptions` schema now includes `priceId` as a (non-required) string field.
  - This update allows the `priceId` to be stored in the database alongside other subscription details, supporting the changes above.

