### PR TITLE
respect drizzle config while generating schema

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "biomejs.biome"
+    ]
+}

--- a/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
@@ -1,1 +1,1 @@
-IDLE
+RUNNING

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "dotenv": "^16.4.7",
+    "drizzle-kit": "^0.30.4",
     "drizzle-orm": "^0.33.0",
     "fs-extra": "^11.3.0",
     "get-tsconfig": "^4.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1612,6 +1612,9 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.5.0
+      drizzle-kit:
+        specifier: ^0.30.4
+        version: 0.30.6
       drizzle-orm:
         specifier: ^0.33.0
         version: 0.33.0(@cloudflare/workers-types@4.20250531.0)(@libsql/client@0.12.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/react@19.1.6)(better-sqlite3@11.10.0)(bun-types@1.2.17)(kysely@0.28.2)(mysql2@3.14.1)(pg@8.16.0)(prisma@5.22.0)(react@19.1.0)


### PR DESCRIPTION
## Changes in this PR
- This PR adds the ability in the cli to read the `drizzle.config.{js,ts,mjs}` and emit the schema in its `config.schema` or `config.schema[0]` location.
- This PR also adds a `extensions.json` which gives the contributors a popup to install recommended extensions(biome in this case) 