### PR TITLE
fix(cli): simplify and correct comma insertion logic in plugin array

### DIFF
--- a/packages/cli/src/generators/auth-config.ts
+++ b/packages/cli/src/generators/auth-config.ts
@@ -132,26 +132,16 @@ export async function generateAuthConfig({
 					insert_content: `${opts.pluginFunctionName}(${opts.pluginContents}),`,
 				});
 			} else {
-				let has_found_comma = false;
-				const str = opts.config
+				const pluginArrayContent = opts.config
 					.slice(start_of_plugins.index, end_of_plugins.index)
-					.split("")
-					.reverse();
-				for (let index = 0; index < str.length; index++) {
-					const char = str[index];
-					if (char === ",") {
-						has_found_comma = true;
-					}
-					if (char === ")") {
-						break;
-					}
-				}
+					.trim();
+				const isPluginArrayEmpty = pluginArrayContent === "";
 
 				new_content = insertContent({
 					line: end_of_plugins.line,
 					character: end_of_plugins.character,
 					content: opts.config,
-					insert_content: `${!has_found_comma ? "," : ""}${
+					insert_content: `${isPluginArrayEmpty ? "" : ","}${
 						opts.pluginFunctionName
 					}(${opts.pluginContents})`,
 				});


### PR DESCRIPTION
---

This PR fixes an edge case bug by simplifying and cleaning up the plugin insertion logic.

---

For example:

```
◇  Would you like to set up plugins?
│  Yes
│
◇  Select your new plugins
│  none
│
◇  It looks like you're using NextJS. Do you want to add the next-cookies plugin? (Recommended)
│  Yes
```

Result:

```ts
import { nextCookies } from "better-auth/next-js";
import { betterAuth } from "better-auth";

export const auth = betterAuth({
    appName: "testing",
    plugins: [, nextCookies()],
});

```