### PR TITLE
feat(anonymous): Allow async functions for generating names when using the anonymous auth plugin

### DIFF
--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -58,7 +58,7 @@ export interface AnonymousOptions {
 			},
 			AuthContext
 		>,
-	) => string;
+	) => Promise<string> | string;
 	/**
 	 * Custom schema for the anonymous plugin
 	 */
@@ -121,7 +121,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 						options || {};
 					const id = ctx.context.generateId({ model: "user" });
 					const email = `temp-${id}@${emailDomainName}`;
-					const name = options?.generateName?.(ctx) || "Anonymous";
+					const name = (await options?.generateName?.(ctx)) || "Anonymous";
 					const newUser = await ctx.context.internalAdapter.createUser(
 						{
 							email,


### PR DESCRIPTION
Allows the use of async functions with the generateName callback for the anonymous authentication plugin.

Changes:
- Changed generateName type on AnonymousOptions to support returning a promise
- Added await to the options.generateName call in the auth endpoint