### PR TITLE
fix(admin): throw an error if user id in `/remove-user` is invalid

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1184,7 +1184,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					const user = await ctx.context.internalAdapter.findUserById(
 						ctx.body.userId,
 					);
-					
+
 					if (!user) {
 						throw new APIError("NOT_FOUND", {
 							message: "User not found",

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1181,6 +1181,16 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 							message: ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_DELETE_USERS,
 						});
 					}
+					const user = await ctx.context.internalAdapter.findUserById(
+						ctx.body.userId,
+					);
+					
+					if (!user) {
+						throw new APIError("NOT_FOUND", {
+							message: "User not found",
+						});
+					}
+
 					await ctx.context.internalAdapter.deleteUser(ctx.body.userId);
 					return ctx.json({
 						success: true,


### PR DESCRIPTION
Right now if the user id is faked it still returns `success: true`. This shouldn't be the case, we should return an error if the user id is invalid.