### PR TITLE
docs(plugin): update schema key to optional for username plugin

### DIFF
--- a/docs/content/docs/plugins/username.mdx
+++ b/docs/content/docs/plugins/username.mdx
@@ -106,13 +106,15 @@ The plugin requires 1 field to be added to the user table:
             name: "username", 
             type: "string", 
             description: "The username of the user",
-            isUnique: true
+            isUnique: true,
+            isOptional: true
         },
         { 
             name: "displayUsername", 
             type: "string", 
             description: "Non normalized username of the user",
-            isUnique: true
+            isUnique: true,
+            isOptional: true
         },
     ]}
 />


### PR DESCRIPTION
Updated the `username` plugin docs to reflect the current behavior, where username is not required during registration. Also, `session.user.username` can be `string | null | undefined`, so the schema fields should be optional.