### PR TITLE
fix: use same expires at date for cookie session data payload and signature

### DIFF
--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -118,21 +118,19 @@ export async function setCookieCache(
 			{} as Record<string, any>,
 		);
 		const sessionData = { session: filteredSession, user: session.user };
+		const expiresAtDate =  getDate(
+		  ctx.context.authCookies.sessionData.options.maxAge || 60,
+		  "sec",
+		).getTime();
 		const data = base64Url.encode(
 			JSON.stringify({
 				session: sessionData,
-				expiresAt: getDate(
-					ctx.context.authCookies.sessionData.options.maxAge || 60,
-					"sec",
-				).getTime(),
+				expiresAt: expiresAtDate,
 				signature: await createHMAC("SHA-256", "base64urlnopad").sign(
 					ctx.context.secret,
 					JSON.stringify({
 						...sessionData,
-						expiresAt: getDate(
-							ctx.context.authCookies.sessionData.options.maxAge || 60,
-							"sec",
-						).getTime(),
+						expiresAt: expiresAtDate,
 					}),
 				),
 			}),

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -118,9 +118,9 @@ export async function setCookieCache(
 			{} as Record<string, any>,
 		);
 		const sessionData = { session: filteredSession, user: session.user };
-		const expiresAtDate =  getDate(
-		  ctx.context.authCookies.sessionData.options.maxAge || 60,
-		  "sec",
+		const expiresAtDate = getDate(
+			ctx.context.authCookies.sessionData.options.maxAge || 60,
+			"sec",
 		).getTime();
 		const data = base64Url.encode(
 			JSON.stringify({


### PR DESCRIPTION
With cookie cache enabled, getSession was sporadically returning null and clearing the session data cookie. The problem is [setCookeCache](https://github.com/better-auth/better-auth/blob/2de1cd27f6177de7e18e57391eb1a0c5dc1cdda3/packages/better-auth/src/cookies/index.ts#L124) generates two expiresAt times, once for the session data and another when signing the payload of the cookie, instead of using the same value. When testing, the values were sometimes identical, and other times 1 tick off, which resulted in [getSession](https://github.com/better-auth/better-auth/blob/b98d17720e6fa642090a88bd8c6a0997647a9275/packages/better-auth/src/api/routes/session.ts#L109) sometimes returning null and clearing the cookies. The fix was to generate one expiresAt time so the signature is signing the same data as the session data.
