### PR TITLE
fix: import setCookie from tanstack start core package

### DIFF
--- a/packages/better-auth/src/integrations/react-start.ts
+++ b/packages/better-auth/src/integrations/react-start.ts
@@ -20,9 +20,7 @@ export const reactStartCookies = () => {
 							const setCookies = returned?.get("set-cookie");
 							if (!setCookies) return;
 							const parsed = parseSetCookieHeader(setCookies);
-							const { setCookie } = await import(
-								"@tanstack/react-start/server"
-							);
+							const { setCookie } = await import("@tanstack/start-server-core");
 							parsed.forEach((value, key) => {
 								if (!key) return;
 								const opts = {


### PR DESCRIPTION
This PR enables to use the Tanstack Start integration with both the React and the Solid flavor of Tanstack Start.

Previously, the `setCookie` method was imported from `@tanstack/react-start` which is typically not installed in projects using the Solid flavor.
By importing `setCookie` from the core package `@tanstack/start-server-core`, this integration works regardless of whether `@tanstack/react-start` or `@tanstack/solid-start` is used.
The framework-specific packages re-export the`setCookie` method from the core package ([here](https://github.com/TanStack/router/blob/b01a349583d92c9a8e21024bc9dcceb71ab08244/packages/react-start-server/src/index.tsx#L4)) without modification.