### PR TITLE
fix(oauth): Google prompt doesn't allow `+`

### DIFF
--- a/packages/better-auth/src/social-providers/google.ts
+++ b/packages/better-auth/src/social-providers/google.ts
@@ -74,8 +74,8 @@ export const google = (options: GoogleOptions) => {
 				: ["email", "profile", "openid"];
 			options.scope && _scopes.push(...options.scope);
 			scopes && _scopes.push(...scopes);
-			//@ts-expect-error - Google expects there to be a space not `+` in the prompt
 			if (options.prompt === "select_account+consent")
+				//@ts-expect-error - Google expects there to be a space not `+` in the prompt
 				options.prompt = "select_account consent";
 			const url = await createAuthorizationURL({
 				id: "google",

--- a/packages/better-auth/src/social-providers/google.ts
+++ b/packages/better-auth/src/social-providers/google.ts
@@ -74,6 +74,8 @@ export const google = (options: GoogleOptions) => {
 				: ["email", "profile", "openid"];
 			options.scope && _scopes.push(...options.scope);
 			scopes && _scopes.push(...scopes);
+			//@ts-expect-error - Google expects there to be a space not `+` in the prompt
+			if(options.prompt === "select_account+consent") options.prompt = "select_account consent";
 			const url = await createAuthorizationURL({
 				id: "google",
 				options,

--- a/packages/better-auth/src/social-providers/google.ts
+++ b/packages/better-auth/src/social-providers/google.ts
@@ -75,7 +75,8 @@ export const google = (options: GoogleOptions) => {
 			options.scope && _scopes.push(...options.scope);
 			scopes && _scopes.push(...scopes);
 			//@ts-expect-error - Google expects there to be a space not `+` in the prompt
-			if(options.prompt === "select_account+consent") options.prompt = "select_account consent";
+			if (options.prompt === "select_account+consent")
+				options.prompt = "select_account consent";
 			const url = await createAuthorizationURL({
 				id: "google",
 				options,


### PR DESCRIPTION
Regarding Google social provider: In order to get `consent` and `select_account` prompt, we need to pass it like "select_account consent". However BA's type definitions only allow for "select_account+consent" - likely because it's the standard?

Anyway this PR will take that `select_account+consent` defined by the user and convert it to the spaced version (`select_account consent`).