### PR TITLE
[FIX]: update Discord link to use the correct invite URL in blogs section

### DIFF
--- a/docs/app/blog/[[...slug]]/page.tsx
+++ b/docs/app/blog/[[...slug]]/page.tsx
@@ -103,7 +103,7 @@ export default async function Page({
 							GitHub
 						</IconLink>
 						<IconLink
-							href="https://discord.com/better-auth"
+							href="https://discord.gg/better-auth"
 							icon={DiscordLogoIcon}
 							className="flex-none text-gray-600 dark:text-gray-300"
 						>

--- a/docs/app/blog/_components/blog-list.tsx
+++ b/docs/app/blog/_components/blog-list.tsx
@@ -40,7 +40,7 @@ export async function BlogPage() {
 							GitHub
 						</IconLink>
 						<IconLink
-							href="https://discord.com/better-auth"
+							href="https://discord.gg/better-auth"
 							icon={DiscordLogoIcon}
 							className="flex-none text-gray-600 dark:text-gray-300"
 						>

--- a/docs/app/blog/_components/changelog-layout.tsx
+++ b/docs/app/blog/_components/changelog-layout.tsx
@@ -69,7 +69,7 @@ export function Intro() {
 					GitHub
 				</IconLink>
 				<IconLink
-					href="https://discord.com/better-auth"
+					href="https://discord.gg/better-auth"
 					icon={DiscordLogoIcon}
 					className="flex-none text-gray-600 dark:text-gray-300"
 				>

--- a/docs/app/blog/_components/default-changelog.tsx
+++ b/docs/app/blog/_components/default-changelog.tsx
@@ -97,7 +97,7 @@ const ChangelogPage = async () => {
 							GitHub
 						</IconLink>
 						<IconLink
-							href="https://discord.com/better-auth"
+							href="https://discord.gg/better-auth"
 							icon={DiscordLogoIcon}
 							className="flex-none text-gray-600 dark:text-gray-300"
 						>


### PR DESCRIPTION
This pull request updates the Discord link across multiple components in the blog section of the documentation. The link has been changed from `https://discord.com/better-auth` to `https://discord.gg/better-auth` to reflect the correct URL.

Updated Discord links:

* `docs/app/blog/[[...slug]]/page.tsx`: Modified the `href` attribute of the `IconLink` component to use the updated Discord URL. ([docs/app/blog/[[...slug]]/page.tsxL106-R106](diffhunk://#diff-cfbda0f576cacf8abe7216deb1c6233c42072fe514cccaa94d8ed3d58d5fab74L106-R106))
* [`docs/app/blog/_components/blog-list.tsx`](diffhunk://#diff-615d3062cf1af946cc9d255d74a6e7de95b93c0f7b07c40d02355bda07ff65f7L43-R43): Updated the `href` attribute of the `IconLink` component to point to the new Discord URL.
* [`docs/app/blog/_components/changelog-layout.tsx`](diffhunk://#diff-17e45543b192146da92a156fc347830a1eb144e82f43f3eec2a607a01eef09faL72-R72): Adjusted the `href` attribute of the `IconLink` component to reflect the correct Discord URL.
* [`docs/app/blog/_components/default-changelog.tsx`](diffhunk://#diff-8e5eba58aa325e42a4f0b58f7a61e6f3036a1f262d09826bc93b5357e1d57ee9L100-R100): Changed the `href` attribute of the `IconLink` component to use the updated Discord link.


https://github.com/user-attachments/assets/aa2c5d4f-1c1d-4787-9da6-e89bfb801c84


https://github.com/user-attachments/assets/714a513e-5005-496d-9d4b-0a3db8ec875b