### PR TITLE
fix(username): add `callbackURL` option to `signInUsername`

### DIFF
--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -56,6 +56,11 @@ export const username = (options?: UsernameOptions) => {
 								description: "Remember the user session",
 							})
 							.optional(),
+						callbackURL: z
+							.string({
+								description: "The URL to redirect to after the user signs in",
+							})
+							.optional(),
 					}),
 					metadata: {
 						openapi: {


### PR DESCRIPTION
Added `callbackURL` to body validator.

Handling of this option is already present here:

https://github.com/better-auth/better-auth/blob/c749ccf86934a276f4de732a7ada0b71b2f4c782/packages/better-auth/src/plugins/username/index.ts#L160

https://github.com/better-auth/better-auth/blob/b766b22865895f5cdd7dc575b0cc2e023e795740/packages/better-auth/src/api/routes/email-verification.ts#L55
