### PR TITLE
fix: Internal adapter `findVerificationValue()` returns undefined at runtime

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -878,6 +878,9 @@ export const createInternalAdapter = (
 					],
 				});
 			}
+
+			if (!verification.length) return;
+
 			const lastVerification = verification[0];
 			return lastVerification as Verification | null;
 		},


### PR DESCRIPTION
https://github.com/better-auth/better-auth/pull/389 introduces potential for an error which only is caught in runtime where the return type of findVerificationValue() conflicts with the actual return type of `undefined | null | Verification`. Previously it looks like this function had used the `findOne()` db-adapater helper, but moved to `findMany()`. The `findOne()` function has logic for handling the undefined case with:

`if (!results.length) return null; // length 0 is falsey`

This PR adapts findVerificationValue() to utilize this same check as `adapter.findOne()` to ensure at runtime the return type matches that of typescripts type of `Verification | null`