### PR TITLE
feat: allow passing userId and email for accepting invitation

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -113,6 +113,15 @@ export const getOrgAdapter = (
 			});
 			return members;
 		},
+		countMembers: async (data: {
+			organizationId: string;
+		}) => {
+			const count = await adapter.count({
+				model: "member",
+				where: [{ field: "organizationId", value: data.organizationId }],
+			});
+			return count;
+		},
 		findMemberByOrgId: async (data: {
 			userId: string;
 			organizationId: string;
@@ -505,7 +514,7 @@ export const getOrgAdapter = (
 		},
 
 		listTeams: async (organizationId: string) => {
-			const teams = await adapter.findMany<Team>({
+			const teams = await adapter.findMany({
 				model: "team",
 				where: [
 					{

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -163,7 +163,8 @@ export interface OrganizationOptions {
 			| number
 			| ((data: {
 					teamId: string;
-					session: { user: User; session: Session };
+					invitedUserEmail: string;
+					invitedUserId: string;
 					organizationId: string;
 			  }) => Promise<number> | number)
 			| undefined;
@@ -752,6 +753,5 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 			>,
 		},
 		$ERROR_CODES: ORGANIZATION_ERROR_CODES,
-		options: options as any,
 	} satisfies BetterAuthPlugin;
 };

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -357,7 +357,14 @@ export const acceptInvitation = createAuthEndpoint(
 				message: "Not authenticated",
 			});
 		}
-		const email = session?.user.email || ctx.body.email;
+		const email =
+			session?.user.email ||
+			ctx.body.email ||
+			(ctx.body.userId
+				? await ctx.context.internalAdapter
+						.findUserById(ctx.body.userId!)
+						.then((user) => user?.email)
+				: null);
 		if (!email) {
 			throw new APIError("BAD_REQUEST", {
 				message: "Email is required",


### PR DESCRIPTION
Allow passing `userId` and `email` to accept invitation without requiring a session