### PR TITLE
chore(docs): fix callbackURL description of `signInUsername` endpoint

### DIFF
--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -58,7 +58,7 @@ export const username = (options?: UsernameOptions) => {
 							.optional(),
 						callbackURL: z
 							.string({
-								description: "The URL to redirect to after the user signs in",
+								description: "The URL to redirect to after email verification",
 							})
 							.optional(),
 					}),


### PR DESCRIPTION
When passing `callbackURL` to `signInUsername`, it's used as the redirect URL after email verification. The current description does not say that.