### PR TITLE
fix(username): ensure `APIError` code matches `USERNAME_ERROR_CODES`

### DIFF
--- a/packages/better-auth/src/plugins/username/error-codes.ts
+++ b/packages/better-auth/src/plugins/username/error-codes.ts
@@ -2,8 +2,8 @@ export const USERNAME_ERROR_CODES = {
 	INVALID_USERNAME_OR_PASSWORD: "invalid username or password",
 	EMAIL_NOT_VERIFIED: "email not verified",
 	UNEXPECTED_ERROR: "unexpected error",
-	USERNAME_IS_ALREADY_TAKEN: "username is already taken. please try another.",
+	USERNAME_IS_ALREADY_TAKEN: "username is already taken",
 	USERNAME_TOO_SHORT: "username is too short",
 	USERNAME_TOO_LONG: "username is too long",
-	INVALID_USERNAME: "username is invalid",
+	INVALID_USERNAME: "invalid username",
 };


### PR DESCRIPTION
The `throw new APIError` statements in the Username plugin do not specify the `code` option, so it's [generated by `better-call`](https://github.com/Bekacru/better-call/blob/b6f1948a1ab08833aef717fd0fac1c3871fda0f3/src/error.ts#L136-L144) from the `message` option. To ensure that [client-side error handling](https://www.better-auth.com/docs/concepts/client#error-codes) can function properly, the values of `USERNAME_ERROR_CODES` must use the same words/spelling as its keys.