### PR TITLE
fix(oidc): use JWT plugin if enabled to sign keys with tests

### DIFF
--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -7,15 +7,15 @@ import type {
 } from "../../types";
 import { type Jwk, schema } from "./schema";
 import { getJwksAdapter } from "./adapter";
-import { exportJWK, generateKeyPair, importJWK, SignJWT } from "jose";
+import { getJwtToken as genericGetJwtToken } from "./sign";
+import { exportJWK, generateKeyPair } from "jose";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 	sessionMiddleware,
 } from "../../api";
-import { symmetricDecrypt, symmetricEncrypt } from "../../crypto";
+import { symmetricEncrypt } from "../../crypto";
 import { mergeSchema } from "../../db/schema";
-import { BetterAuthError } from "../../error";
 
 type JWKOptions =
 	| {
@@ -124,77 +124,25 @@ export async function getJwtToken(
 	ctx: GenericEndpointContext,
 	options?: JwtOptions,
 ) {
-	const adapter = getJwksAdapter(ctx.context.adapter);
-
-	let key = await adapter.getLatestKey();
-	const privateKeyEncryptionEnabled =
-		!options?.jwks?.disablePrivateKeyEncryption;
-
-	if (key === undefined) {
-		const { publicKey, privateKey } = await generateKeyPair(
-			options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
-			options?.jwks?.keyPairConfig ?? {
-				crv: "Ed25519",
-				extractable: true,
-			},
-		);
-
-		const publicWebKey = await exportJWK(publicKey);
-		const privateWebKey = await exportJWK(privateKey);
-		const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
-
-		let jwk: Partial<Jwk> = {
-			publicKey: JSON.stringify(publicWebKey),
-			privateKey: privateKeyEncryptionEnabled
-				? JSON.stringify(
-						await symmetricEncrypt({
-							key: ctx.context.secret,
-							data: stringifiedPrivateWebKey,
-						}),
-					)
-				: stringifiedPrivateWebKey,
-			createdAt: new Date(),
-		};
-
-		key = await adapter.createJwk(jwk as Jwk);
-	}
-
-	let privateWebKey = privateKeyEncryptionEnabled
-		? await symmetricDecrypt({
-				key: ctx.context.secret,
-				data: JSON.parse(key.privateKey),
-			}).catch(() => {
-				throw new BetterAuthError(
-					"Failed to decrypt private private key. Make sure the secret currently in use is the same as the one used to encrypt the private key. If you are using a different secret, either cleanup your jwks or disable private key encryption.",
-				);
-			})
-		: key.privateKey;
-
-	const privateKey = await importJWK(
-		JSON.parse(privateWebKey),
-		options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
-	);
-
 	const payload = !options?.jwt?.definePayload
 		? ctx.context.session!.user
 		: await options?.jwt.definePayload(ctx.context.session!);
 
-	const jwt = await new SignJWT(payload)
-		.setProtectedHeader({
-			alg: options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
-			kid: key.id,
-		})
-		.setIssuedAt()
-		.setIssuer(options?.jwt?.issuer ?? ctx.context.options.baseURL!)
-		.setAudience(options?.jwt?.audience ?? ctx.context.options.baseURL!)
-		.setExpirationTime(options?.jwt?.expirationTime ?? "15m")
-		.setSubject(
-			(await options?.jwt?.getSubject?.(ctx.context.session!)) ??
+	return await genericGetJwtToken(
+		ctx,
+		{
+			payload,
+			issuedAt: true,
+			expirationTime: options?.jwt?.expirationTime ?? "15m",
+			audience: options?.jwt?.audience ?? ctx.context.options.baseURL!,
+			subject:
+				(await options?.jwt?.getSubject?.(ctx.context.session!)) ??
 				ctx.context.session!.user.id,
-		)
-		.sign(privateKey);
-	return jwt;
+		},
+		options,
+	);
 }
+
 export const jwt = (options?: JwtOptions) => {
 	return {
 		id: "jwt",

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -1,0 +1,98 @@
+import {
+	importJWK,
+	exportJWK,
+	generateKeyPair,
+	SignJWT,
+	type JWTPayload,
+} from "jose";
+import type { GenericEndpointContext } from "../../types";
+import { BetterAuthError } from "../../error";
+import { symmetricDecrypt, symmetricEncrypt } from "../../crypto";
+import type { JwtOptions } from ".";
+import type { Jwk } from "./schema";
+import { getJwksAdapter } from "./adapter";
+
+export async function getJwtToken(
+	ctx: GenericEndpointContext,
+	tknOpts: {
+		payload: JWTPayload;
+		issuedAt: boolean;
+		expirationTime: number | string | Date;
+		audience?: string | string[];
+		subject?: string;
+	},
+	options?: JwtOptions,
+) {
+	const adapter = getJwksAdapter(ctx.context.adapter);
+
+	let key = await adapter.getLatestKey();
+	const privateKeyEncryptionEnabled =
+		!options?.jwks?.disablePrivateKeyEncryption;
+
+	if (key === undefined) {
+		const { publicKey, privateKey } = await generateKeyPair(
+			options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
+			options?.jwks?.keyPairConfig ?? {
+				crv: "Ed25519",
+				extractable: true,
+			},
+		);
+
+		const publicWebKey = await exportJWK(publicKey);
+		const privateWebKey = await exportJWK(privateKey);
+		const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
+
+		let jwk: Partial<Jwk> = {
+			publicKey: JSON.stringify(publicWebKey),
+			privateKey: privateKeyEncryptionEnabled
+				? JSON.stringify(
+						await symmetricEncrypt({
+							key: ctx.context.secret,
+							data: stringifiedPrivateWebKey,
+						}),
+					)
+				: stringifiedPrivateWebKey,
+			createdAt: new Date(),
+		};
+
+		key = await adapter.createJwk(jwk as Jwk);
+	}
+
+	let privateWebKey = privateKeyEncryptionEnabled
+		? await symmetricDecrypt({
+				key: ctx.context.secret,
+				data: JSON.parse(key.privateKey),
+			}).catch(() => {
+				throw new BetterAuthError(
+					"Failed to decrypt private private key. Make sure the secret currently in use is the same as the one used to encrypt the private key. If you are using a different secret, either cleanup your jwks or disable private key encryption.",
+				);
+			})
+		: key.privateKey;
+
+	const privateKey = await importJWK(
+		JSON.parse(privateWebKey),
+		options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
+	);
+
+	let jwt = new SignJWT(tknOpts.payload)
+		.setProtectedHeader({
+			alg: options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
+			kid: key.id,
+		})
+		.setExpirationTime(tknOpts.expirationTime)
+		.setIssuer(options?.jwt?.issuer ?? ctx.context.options.baseURL!);
+
+	if (tknOpts.issuedAt) {
+		jwt = jwt.setIssuedAt();
+	}
+
+	if (tknOpts.audience) {
+		jwt = jwt.setAudience(tknOpts.audience);
+	}
+
+	if (tknOpts.subject) {
+		jwt = jwt.setSubject(tknOpts.subject);
+	}
+
+	return await jwt.sign(privateKey);
+}

--- a/packages/better-auth/src/plugins/oidc-provider/oidc-jwt.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc-jwt.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { oidcProvider } from ".";
+import { genericOAuth } from "../generic-oauth";
+import type { Client } from "./types";
+import { createAuthClient } from "../../client";
+import { oidcClient } from "./client";
+import { genericOAuthClient } from "../generic-oauth/client";
+import { listen, type Listener } from "listhen";
+import { toNodeHandler } from "../../integrations/node";
+import { jwt } from "../jwt";
+import { decodeProtectedHeader } from "jose";
+
+describe("oidc-jwt", async () => {
+	let server: Listener | null = null;
+	test.each([
+		{ useJwt: true, description: "with jwt plugin", expected: "EdDSA" },
+		{ useJwt: false, description: "without jwt plugin", expected: "HS256" },
+	])(
+		"testing oidc-provider $description to return token signed with $expected",
+		async ({ useJwt, description, expected }) => {
+			const {
+				auth: authorizationServer,
+				signInWithTestUser,
+				customFetchImpl,
+				testUser,
+			} = await getTestInstance({
+				baseURL: "http://localhost:3000",
+				plugins: [
+					oidcProvider({
+						loginPage: "/login",
+						consentPage: "/oauth2/authorize",
+						requirePKCE: true,
+						getAdditionalUserInfoClaim(user, scopes) {
+							return {
+								custom: "custom value",
+								userId: user.id,
+							};
+						},
+					}),
+					...(useJwt ? [jwt()] : []),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+			const serverClient = createAuthClient({
+				plugins: [oidcClient()],
+				baseURL: "http://localhost:3000",
+				fetchOptions: {
+					customFetchImpl,
+					headers,
+				},
+			});
+			if (server) console.log("server is not null");
+			server = await listen(toNodeHandler(authorizationServer.handler), {
+				port: 3000,
+			});
+			let application: Client = {
+				clientId: "test-client-id",
+				clientSecret: "test-client-secret-oidc",
+				redirectURLs: ["http://localhost:3000/api/auth/oauth2/callback/test"],
+				metadata: {},
+				icon: "",
+				type: "web",
+				disabled: false,
+				name: "test",
+			};
+			const createdClient = await serverClient.oauth2.register({
+				client_name: application.name,
+				redirect_uris: application.redirectURLs,
+				logo_uri: application.icon,
+			});
+			expect(createdClient.data).toMatchObject({
+				client_id: expect.any(String),
+				client_secret: expect.any(String),
+				client_name: "test",
+				logo_uri: "",
+				redirect_uris: ["http://localhost:3000/api/auth/oauth2/callback/test"],
+				grant_types: ["authorization_code"],
+				response_types: ["code"],
+				token_endpoint_auth_method: "client_secret_basic",
+				client_id_issued_at: expect.any(Number),
+				client_secret_expires_at: 0,
+			});
+			if (createdClient.data) {
+				application = {
+					clientId: createdClient.data.client_id,
+					clientSecret: createdClient.data.client_secret,
+					redirectURLs: createdClient.data.redirect_uris,
+					metadata: {},
+					icon: createdClient.data.logo_uri || "",
+					type: "web",
+					disabled: false,
+					name: createdClient.data.client_name || "",
+				};
+			}
+
+			// The RP (Relying Party) - the client application
+			const { customFetchImpl: customFetchImplRP } = await getTestInstance({
+				account: {
+					accountLinking: {
+						trustedProviders: ["test"],
+					},
+				},
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "test",
+								clientId: application.clientId,
+								clientSecret: application.clientSecret,
+								authorizationUrl:
+									"http://localhost:3000/api/auth/oauth2/authorize",
+								tokenUrl: "http://localhost:3000/api/auth/oauth2/token",
+								scopes: ["openid", "profile", "email"],
+								pkce: true,
+							},
+						],
+					}),
+				],
+			});
+
+			const client = createAuthClient({
+				plugins: [genericOAuthClient()],
+				baseURL: "http://localhost:5000",
+				fetchOptions: {
+					customFetchImpl: customFetchImplRP,
+				},
+			});
+			const data = await client.signIn.oauth2(
+				{
+					providerId: "test",
+					callbackURL: "/dashboard",
+				},
+				{
+					throw: true,
+				},
+			);
+			expect(data.url).toContain(
+				"http://localhost:3000/api/auth/oauth2/authorize",
+			);
+			expect(data.url).toContain(`client_id=${application.clientId}`);
+
+			let redirectURI = "";
+			await serverClient.$fetch(data.url, {
+				method: "GET",
+				onError(context) {
+					redirectURI = context.response.headers.get("Location") || "";
+				},
+			});
+			expect(redirectURI).toContain(
+				"http://localhost:3000/api/auth/oauth2/callback/test?code=",
+			);
+			let authToken = undefined;
+			let callbackURL = "";
+			await client.$fetch(redirectURI, {
+				onError(context) {
+					callbackURL = context.response.headers.get("Location") || "";
+					authToken = context.response.headers.get("set-auth-token")!;
+				},
+			});
+			expect(callbackURL).toContain("/dashboard");
+			const accessToken = await client.getAccessToken(
+				{ providerId: "test", userId: testUser.id },
+				{
+					auth: {
+						type: "Bearer",
+						token: authToken,
+					},
+				},
+			);
+			const decoded = decodeProtectedHeader(accessToken.data?.idToken!);
+			expect(decoded.alg).toBe(expected);
+
+			afterEach(async () => {
+				if (server) {
+					await server.close();
+					server = null;
+				}
+			});
+		},
+	);
+});


### PR DESCRIPTION
This is a draft PR added a test to it in a separate file oidc-jwt.test.ts
in case original pr doesn't update with a test case
---
With this PR, if the JWT plugin is enabled, the OIDC plugin will use it to issue valid JWT tokens, following the published JWKS keys as the metadata endpoint suggests it should.