### PR TITLE
fix: org options type export issue 

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1,6 +1,6 @@
 import type { Session, User } from "../../types";
 import { getDate } from "../../utils/date";
-import type { OrganizationOptions } from "./organization";
+import type { OrganizationOptions } from "./types";
 import type {
 	Invitation,
 	InvitationInput,
@@ -12,7 +12,7 @@ import type {
 	TeamInput,
 } from "./schema";
 import { BetterAuthError } from "../../error";
-import type { AuthContext } from "../../types";
+import type { AuthContext } from "../../init";
 import parseJSON from "../../client/parser";
 
 export const getOrgAdapter = (

--- a/packages/better-auth/src/plugins/organization/call.ts
+++ b/packages/better-auth/src/plugins/organization/call.ts
@@ -2,7 +2,7 @@ import type { GenericEndpointContext, Session, User } from "../../types";
 import { createAuthMiddleware } from "../../api/call";
 import { sessionMiddleware } from "../../api";
 import type { Role } from "../access";
-import type { OrganizationOptions } from "./organization";
+import type { OrganizationOptions } from "./types";
 import type { defaultRoles } from "./access/statement";
 
 export const orgMiddleware = createAuthMiddleware(async (ctx) => {

--- a/packages/better-auth/src/plugins/organization/has-permission.ts
+++ b/packages/better-auth/src/plugins/organization/has-permission.ts
@@ -1,5 +1,5 @@
+import type { OrganizationOptions } from "./types";
 import { defaultRoles } from "./access";
-import type { OrganizationOptions } from "./organization";
 
 type PermissionExclusive =
 	| {

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -1,12 +1,12 @@
 import { APIError } from "better-call";
 import { z } from "zod";
-import type { AuthPluginSchema, Session, User } from "../../types";
+import type { AuthPluginSchema } from "../../types";
 import { createAuthEndpoint } from "../../api/call";
 import { getSessionFromCtx } from "../../api/routes";
 import type { AuthContext } from "../../init";
 import type { BetterAuthPlugin } from "../../types/plugins";
 import { shimContext } from "../../utils/shim";
-import { type AccessControl, type Role } from "../access";
+import { type AccessControl } from "../access";
 import { getOrgAdapter } from "./adapter";
 import { orgSessionMiddleware } from "./call";
 import {
@@ -42,320 +42,16 @@ import {
 import type {
 	InferInvitation,
 	InferMember,
-	Invitation,
-	Member,
 	Organization,
 	Team,
 } from "./schema";
 import { ORGANIZATION_ERROR_CODES } from "./error-codes";
 import { defaultRoles, defaultStatements } from "./access";
 import { hasPermission } from "./has-permission";
+import type { OrganizationOptions } from "./types";
 
 export function parseRoles(roles: string | string[]): string {
 	return Array.isArray(roles) ? roles.join(",") : roles;
-}
-
-export interface OrganizationOptions {
-	/**
-	 * Configure whether new users are able to create new organizations.
-	 * You can also pass a function that returns a boolean.
-	 *
-	 * 	@example
-	 * ```ts
-	 * allowUserToCreateOrganization: async (user) => {
-	 * 		const plan = await getUserPlan(user);
-	 *      return plan.name === "pro";
-	 * }
-	 * ```
-	 * @default true
-	 */
-	allowUserToCreateOrganization?:
-		| boolean
-		| ((user: User) => Promise<boolean> | boolean);
-	/**
-	 * The maximum number of organizations a user can create.
-	 *
-	 * You can also pass a function that returns a boolean
-	 */
-	organizationLimit?: number | ((user: User) => Promise<boolean> | boolean);
-	/**
-	 * The role that is assigned to the creator of the
-	 * organization.
-	 *
-	 * @default "owner"
-	 */
-	creatorRole?: string;
-	/**
-	 * The number of memberships a user can have in an organization.
-	 *
-	 * @default 100
-	 */
-	membershipLimit?: number;
-	/**
-	 * Configure the roles and permissions for the
-	 * organization plugin.
-	 */
-	ac?: AccessControl;
-	/**
-	 * Custom permissions for roles.
-	 */
-	roles?: {
-		[key in string]?: Role<any>;
-	};
-	/**
-	 * Support for team.
-	 */
-	teams?: {
-		/**
-		 * Enable team features.
-		 */
-		enabled: boolean;
-		/**
-		 * Default team configuration
-		 */
-		defaultTeam?: {
-			/**
-			 * Enable creating a default team when an organization is created
-			 *
-			 * @default true
-			 */
-			enabled: boolean;
-			/**
-			 * Pass a custom default team creator function
-			 */
-			customCreateDefaultTeam?: (
-				organization: Organization & Record<string, any>,
-				request?: Request,
-			) => Promise<Team & Record<string, any>>;
-		};
-		/**
-		 * Maximum number of teams an organization can have.
-		 *
-		 * You can pass a number or a function that returns a number
-		 *
-		 * @default "unlimited"
-		 *
-		 * @param organization
-		 * @param request
-		 * @returns
-		 */
-		maximumTeams?:
-			| ((
-					data: {
-						organizationId: string;
-						session: {
-							user: User;
-							session: Session;
-						} | null;
-					},
-					request?: Request,
-			  ) => number | Promise<number>)
-			| number;
-
-		/**
-		 * The maximum number of members per team.
-		 *
-		 * if `undefined`, there is no limit.
-		 *
-		 * @default undefined
-		 */
-		maximumMembersPerTeam?:
-			| number
-			| ((data: {
-					teamId: string;
-					session: { user: User; session: Session };
-					organizationId: string;
-			  }) => Promise<number> | number)
-			| undefined;
-		/**
-		 * By default, if an organization does only have one team, they'll not be able to remove it.
-		 *
-		 * You can disable this behavior by setting this to `false.
-		 *
-		 * @default false
-		 */
-		allowRemovingAllTeams?: boolean;
-	};
-	/**
-	 * The expiration time for the invitation link.
-	 *
-	 * @default 48 hours
-	 */
-	invitationExpiresIn?: number;
-	/**
-	 * The maximum invitation a user can send.
-	 *
-	 * @default 100
-	 */
-	invitationLimit?:
-		| number
-		| ((
-				data: {
-					user: User;
-					organization: Organization;
-					member: Member;
-				},
-				ctx: AuthContext,
-		  ) => Promise<number> | number);
-	/**
-	 * Cancel pending invitations on re-invite.
-	 *
-	 * @default true
-	 */
-	cancelPendingInvitationsOnReInvite?: boolean;
-	/**
-	 * Send an email with the
-	 * invitation link to the user.
-	 *
-	 * Note: Better Auth doesn't
-	 * generate invitation URLs.
-	 * You'll need to construct the
-	 * URL using the invitation ID
-	 * and pass it to the
-	 * acceptInvitation endpoint for
-	 * the user to accept the
-	 * invitation.
-	 *
-	 * @example
-	 * ```ts
-	 * sendInvitationEmail: async (data) => {
-	 * 	const url = `https://yourapp.com/organization/
-	 * accept-invitation?id=${data.id}`;
-	 * 	await sendEmail(data.email, "Invitation to join
-	 * organization", `Click the link to join the
-	 * organization: ${url}`);
-	 * }
-	 * ```
-	 */
-	sendInvitationEmail?: (
-		data: {
-			/**
-			 * the invitation id
-			 */
-			id: string;
-			/**
-			 * the role of the user
-			 */
-			role: string;
-			/**
-			 * the email of the user
-			 */
-			email: string;
-			/**
-			 * the organization the user is invited to join
-			 */
-			organization: Organization;
-			/**
-			 * the invitation object
-			 */
-			invitation: Invitation;
-			/**
-			 * the member who is inviting the user
-			 */
-			inviter: Member & {
-				user: User;
-			};
-		},
-		/**
-		 * The request object
-		 */
-		request?: Request,
-	) => Promise<void>;
-
-	/**
-	 * The schema for the organization plugin.
-	 */
-	schema?: {
-		session?: {
-			fields?: {
-				activeOrganizationId?: string;
-			};
-		};
-		organization?: {
-			modelName?: string;
-			fields?: {
-				[key in keyof Omit<Organization, "id">]?: string;
-			};
-		};
-		member?: {
-			modelName?: string;
-			fields?: {
-				[key in keyof Omit<Member, "id">]?: string;
-			};
-		};
-		invitation?: {
-			modelName?: string;
-			fields?: {
-				[key in keyof Omit<Invitation, "id">]?: string;
-			};
-		};
-
-		team?: {
-			modelName?: string;
-			fields?: {
-				[key in keyof Omit<Team, "id">]?: string;
-			};
-		};
-	};
-	/**
-	 * Configure how organization deletion is handled
-	 */
-	organizationDeletion?: {
-		/**
-		 * disable deleting organization
-		 */
-		disabled?: boolean;
-		/**
-		 * A callback that runs before the organization is
-		 * deleted
-		 *
-		 * @param data - organization and user object
-		 * @param request - the request object
-		 * @returns
-		 */
-		beforeDelete?: (
-			data: {
-				organization: Organization;
-				user: User;
-			},
-			request?: Request,
-		) => Promise<void>;
-		/**
-		 * A callback that runs after the organization is
-		 * deleted
-		 *
-		 * @param data - organization and user object
-		 * @param request - the request object
-		 * @returns
-		 */
-		afterDelete?: (
-			data: {
-				organization: Organization;
-				user: User;
-			},
-			request?: Request,
-		) => Promise<void>;
-	};
-	organizationCreation?: {
-		disabled?: boolean;
-		beforeCreate?: (
-			data: {
-				organization: Omit<Organization, "id">;
-				user: User;
-			},
-			request?: Request,
-		) => Promise<void | {
-			data: Omit<Organization, "id">;
-		}>;
-		afterCreate?: (
-			data: {
-				organization: Organization;
-				member: Member;
-				user: User;
-			},
-			request?: Request,
-		) => Promise<void>;
-	};
 }
 
 /**
@@ -373,7 +69,9 @@ export interface OrganizationOptions {
  * });
  * ```
  */
-export const organization = <O extends OrganizationOptions>(options?: O) => {
+export const organization = <O extends OrganizationOptions>(
+	options?: OrganizationOptions & O,
+) => {
 	let endpoints = {
 		createOrganization,
 		updateOrganization,
@@ -752,6 +450,6 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 			>,
 		},
 		$ERROR_CODES: ORGANIZATION_ERROR_CODES,
-		options: options as any,
+		options,
 	} satisfies BetterAuthPlugin;
 };

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -5,7 +5,8 @@ import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { type InferOrganizationRolesFromOption } from "../schema";
 import { APIError } from "better-call";
-import { parseRoles, type OrganizationOptions } from "../organization";
+import { parseRoles } from "../organization";
+import { type OrganizationOptions } from "../types";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { hasPermission } from "../has-permission";
 

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -4,11 +4,12 @@ import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import type { InferOrganizationRolesFromOption, Member } from "../schema";
 import { APIError } from "better-call";
-import { parseRoles, type OrganizationOptions } from "../organization";
+import { parseRoles } from "../organization";
 import { getSessionFromCtx, sessionMiddleware } from "../../../api";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { BASE_ERROR_CODES } from "../../../error/codes";
 import { hasPermission } from "../has-permission";
+import type { OrganizationOptions } from "../types";
 
 export const addMember = <O extends OrganizationOptions>() =>
 	createAuthEndpoint(

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -6,7 +6,7 @@ import { APIError } from "better-call";
 import { setSessionCookie } from "../../../cookies";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { getSessionFromCtx, requestOnlySessionMiddleware } from "../../../api";
-import type { OrganizationOptions } from "../organization";
+import type { OrganizationOptions } from "../types";
 import type {
 	InferInvitation,
 	InferMember,

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -5,13 +5,11 @@ import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { APIError } from "better-call";
 import { getSessionFromCtx } from "../../../api";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
-import type { OrganizationOptions } from "../organization";
+import type { OrganizationOptions } from "../types";
 import { teamSchema } from "../schema";
 import { hasPermission } from "../has-permission";
 
-export const createTeam = <O extends OrganizationOptions | undefined>(
-	options?: O,
-) =>
+export const createTeam = <O extends OrganizationOptions>(options: O) =>
 	createAuthEndpoint(
 		"/organization/create-team",
 		{

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -1,6 +1,6 @@
 import { z, ZodLiteral } from "zod";
 import { generateId } from "../../utils";
-import type { OrganizationOptions } from "./organization";
+import type { OrganizationOptions } from "./types";
 
 export const role = z.string();
 export const invitationStatus = z

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -309,4 +309,4 @@ export interface OrganizationOptions {
 	 * @default false
 	 */
 	autoCreateOrganizationOnSignUp?: boolean;
-} 
+}

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -1,0 +1,312 @@
+import type { User, Session, AuthContext } from "../../types";
+import type { AccessControl, Role } from "../access";
+import type { Invitation, Member, Organization, Team } from "./schema";
+
+export interface OrganizationOptions {
+	/**
+	 * Configure whether new users are able to create new organizations.
+	 * You can also pass a function that returns a boolean.
+	 *
+	 * 	@example
+	 * ```ts
+	 * allowUserToCreateOrganization: async (user) => {
+	 * 		const plan = await getUserPlan(user);
+	 *      return plan.name === "pro";
+	 * }
+	 * ```
+	 * @default true
+	 */
+	allowUserToCreateOrganization?:
+		| boolean
+		| ((user: User) => Promise<boolean> | boolean);
+	/**
+	 * The maximum number of organizations a user can create.
+	 *
+	 * You can also pass a function that returns a boolean
+	 */
+	organizationLimit?: number | ((user: User) => Promise<boolean> | boolean);
+	/**
+	 * The role that is assigned to the creator of the
+	 * organization.
+	 *
+	 * @default "owner"
+	 */
+	creatorRole?: string;
+	/**
+	 * The number of memberships a user can have in an organization.
+	 *
+	 * @default 100
+	 */
+	membershipLimit?: number;
+	/**
+	 * Configure the roles and permissions for the
+	 * organization plugin.
+	 */
+	ac?: AccessControl;
+	/**
+	 * Custom permissions for roles.
+	 */
+	roles?: {
+		[key in string]?: Role<any>;
+	};
+	/**
+	 * Support for team.
+	 */
+	teams?: {
+		/**
+		 * Enable team features.
+		 */
+		enabled: boolean;
+		/**
+		 * Default team configuration
+		 */
+		defaultTeam?: {
+			/**
+			 * Enable creating a default team when an organization is created
+			 *
+			 * @default true
+			 */
+			enabled: boolean;
+			/**
+			 * Pass a custom default team creator function
+			 */
+			customCreateDefaultTeam?: (
+				organization: Organization & Record<string, any>,
+				request?: Request,
+			) => Promise<Team & Record<string, any>>;
+		};
+		/**
+		 * Maximum number of teams an organization can have.
+		 *
+		 * You can pass a number or a function that returns a number
+		 *
+		 * @default "unlimited"
+		 *
+		 * @param organization
+		 * @param request
+		 * @returns
+		 */
+		maximumTeams?:
+			| ((
+					data: {
+						organizationId: string;
+						session: {
+							user: User;
+							session: Session;
+						} | null;
+					},
+					request?: Request,
+			  ) => number | Promise<number>)
+			| number;
+
+		/**
+		 * The maximum number of members per team.
+		 *
+		 * if `undefined`, there is no limit.
+		 *
+		 * @default undefined
+		 */
+		maximumMembersPerTeam?:
+			| number
+			| ((data: {
+					teamId: string;
+					session: { user: User; session: Session };
+					organizationId: string;
+			  }) => Promise<number> | number)
+			| undefined;
+		/**
+		 * By default, if an organization does only have one team, they'll not be able to remove it.
+		 *
+		 * You can disable this behavior by setting this to `false.
+		 *
+		 * @default false
+		 */
+		allowRemovingAllTeams?: boolean;
+	};
+	/**
+	 * The expiration time for the invitation link.
+	 *
+	 * @default 48 hours
+	 */
+	invitationExpiresIn?: number;
+	/**
+	 * The maximum invitation a user can send.
+	 *
+	 * @default 100
+	 */
+	invitationLimit?:
+		| number
+		| ((
+				data: {
+					user: User;
+					organization: Organization;
+					member: Member;
+				},
+				ctx: AuthContext,
+		  ) => Promise<number> | number);
+	/**
+	 * Cancel pending invitations on re-invite.
+	 *
+	 * @default true
+	 */
+	cancelPendingInvitationsOnReInvite?: boolean;
+	/**
+	 * Send an email with the
+	 * invitation link to the user.
+	 *
+	 * Note: Better Auth doesn't
+	 * generate invitation URLs.
+	 * You'll need to construct the
+	 * URL using the invitation ID
+	 * and pass it to the
+	 * acceptInvitation endpoint for
+	 * the user to accept the
+	 * invitation.
+	 *
+	 * @example
+	 * ```ts
+	 * sendInvitationEmail: async (data) => {
+	 * 	const url = `https://yourapp.com/organization/
+	 * accept-invitation?id=${data.id}`;
+	 * 	await sendEmail(data.email, "Invitation to join
+	 * organization", `Click the link to join the
+	 * organization: ${url}`);
+	 * }
+	 * ```
+	 */
+	sendInvitationEmail?: (
+		data: {
+			/**
+			 * the invitation id
+			 */
+			id: string;
+			/**
+			 * the role of the user
+			 */
+			role: string;
+			/**
+			 * the email of the user
+			 */
+			email: string;
+			/**
+			 * the organization the user is invited to join
+			 */
+			organization: Organization;
+			/**
+			 * the invitation object
+			 */
+			invitation: Invitation;
+			/**
+			 * the member who is inviting the user
+			 */
+			inviter: Member & {
+				user: User;
+			};
+		},
+		/**
+		 * The request object
+		 */
+		request?: Request,
+	) => Promise<void>;
+
+	/**
+	 * The schema for the organization plugin.
+	 */
+	schema?: {
+		session?: {
+			fields?: {
+				activeOrganizationId?: string;
+			};
+		};
+		organization?: {
+			modelName?: string;
+			fields?: {
+				[key in keyof Omit<Organization, "id">]?: string;
+			};
+		};
+		member?: {
+			modelName?: string;
+			fields?: {
+				[key in keyof Omit<Member, "id">]?: string;
+			};
+		};
+		invitation?: {
+			modelName?: string;
+			fields?: {
+				[key in keyof Omit<Invitation, "id">]?: string;
+			};
+		};
+
+		team?: {
+			modelName?: string;
+			fields?: {
+				[key in keyof Omit<Team, "id">]?: string;
+			};
+		};
+	};
+	/**
+	 * Configure how organization deletion is handled
+	 */
+	organizationDeletion?: {
+		/**
+		 * disable deleting organization
+		 */
+		disabled?: boolean;
+		/**
+		 * A callback that runs before the organization is
+		 * deleted
+		 *
+		 * @param data - organization and user object
+		 * @param request - the request object
+		 * @returns
+		 */
+		beforeDelete?: (
+			data: {
+				organization: Organization;
+				user: User;
+			},
+			request?: Request,
+		) => Promise<void>;
+		/**
+		 * A callback that runs after the organization is
+		 * deleted
+		 *
+		 * @param data - organization and user object
+		 * @param request - the request object
+		 * @returns
+		 */
+		afterDelete?: (
+			data: {
+				organization: Organization;
+				user: User;
+			},
+			request?: Request,
+		) => Promise<void>;
+	};
+	organizationCreation?: {
+		disabled?: boolean;
+		beforeCreate?: (
+			data: {
+				organization: Omit<Organization, "id">;
+				user: User;
+			},
+			request?: Request,
+		) => Promise<void | {
+			data: Omit<Organization, "id">;
+		}>;
+		afterCreate?: (
+			data: {
+				organization: Organization;
+				member: Member;
+				user: User;
+			},
+			request?: Request,
+		) => Promise<void>;
+	};
+	/**
+	 * Automatically create an organization for the user on sign up.
+	 *
+	 * @default false
+	 */
+	autoCreateOrganizationOnSignUp?: boolean;
+} 


### PR DESCRIPTION
A circular dependency between files due to have a export of types with the org index itself was confusing TypeScript's type inference, causing it to default to any for your callback parameters. so now export options would work. and this also should applies to other plugin as well.