### PR TITLE
fixed errors and typos in plugin docs

### DIFF
--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -168,7 +168,7 @@ By default better-auth will create an `id` field for each table. You can add add
 
 The key is the column name and the value is the column definition. The column definition can have the following properties:
 
-`type`: The type of the filed. It can be `string`, `number`, `boolean`, `date`.
+`type`: The type of the field. It can be `string`, `number`, `boolean`, `date`.
 
 `required`:  if the field should be required on a new record. (default: `false`)
 

--- a/docs/content/docs/guides/your-first-plugin.mdx
+++ b/docs/content/docs/guides/your-first-plugin.mdx
@@ -29,7 +29,7 @@ You can read more about server/client plugins in our <Link href="/docs/concepts/
 </Callout>
 
 ### Creating the server plugin
-Go ahead and find a suitable location create an your birthday plugin folder, with an `index.ts` file within.
+Go ahead and find a suitable location to create your birthday plugin folder, with an `index.ts` file within.
 <Files>
   <Folder name="birthday-plugin" defaultOpen>
     <File name="index.ts" />

--- a/docs/content/docs/guides/your-first-plugin.mdx
+++ b/docs/content/docs/guides/your-first-plugin.mdx
@@ -127,7 +127,7 @@ import { createAuthMiddleware } from "better-auth/plugins";
   //...
   handler: createAuthMiddleware(async (ctx) => {
     const { birthday } = ctx.body;
-    if(!birthday instanceof Date) {
+    if(!(birthday instanceof Date)) {
       throw new APIError("BAD_REQUEST", { message: "Birthday must be of type Date." });
     }
 


### PR DESCRIPTION
A minor documentation fix in the `docs/content/docs/concepts/plugins.mdx` file. The change corrects a typo in the description of the `type` property, replacing "filed" with "field" for clarity.

Then there's another sentence that talks about finding a suitable place to create the birthday plugin folder but doesn't make sense but is now corrected.

Fixed a typescript operator precedence error in the birthday plugin example:
* Before: (!birthday instanceof Date)
* After: (!(birthday instanceof Date))
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a typo in the plugin documentation by correcting "filed" to "field" in the description of the `type` property.
Fixed a sentence in the plugin documentation by correcting the sentence describing where to create the birthday plugin folder
Fixed a typescript operator precendence error while checking for date
<!-- End of auto-generated description by cubic. -->

