### PR TITLE
fix(reset-password): update emailVerified

### DIFF
--- a/packages/better-auth/src/api/routes/reset-password.ts
+++ b/packages/better-auth/src/api/routes/reset-password.ts
@@ -408,6 +408,18 @@ export const resetPassword = createAuthEndpoint(
 			hashedPassword,
 			ctx,
 		);
+		await ctx.context.adapter.update({
+			model: "user",
+			update: {
+				emailVerified: true,
+			},
+			where: [
+				{
+					field: "id",
+					value: userId,
+				},
+			],
+		});
 		await ctx.context.internalAdapter.deleteVerificationValue(verification.id);
 		if (ctx.context.options.emailAndPassword?.revokeSessionsOnPasswordReset) {
 			await ctx.context.internalAdapter.deleteSessions(userId);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
After a user resets their password, their email is now marked as verified. This ensures users who reset passwords can log in without extra email verification steps.

<!-- End of auto-generated description by cubic. -->

