### PR TITLE
docs(2fa): fix incorrect table name

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -360,7 +360,7 @@ The plugin requires 1 additional fields in the `user` table and 1 additional tab
     ]}
 />
 
-Table: `twoFactor`
+Table: `two_factor`
 
 <DatabaseTable
     fields={[


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed the table name in the 2FA plugin docs from `twoFactor` to `two_factor` to match the actual database schema.

<!-- End of auto-generated description by cubic. -->

