### PR TITLE
fix: add `image` option to `signUpEmail` types and schema

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.test.ts
+++ b/packages/better-auth/src/api/routes/sign-up.test.ts
@@ -40,6 +40,7 @@ describe("sign-up with custom fields", async (it) => {
 				email: "email@test.com",
 				password: "password",
 				name: "Test Name",
+				image: "https://picsum.photos/200",
 			},
 		});
 		expect(res.token).toBeDefined();

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -24,6 +24,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 						name: string;
 						email: string;
 						password: string;
+						image?: string;
 						callbackURL?: string;
 						rememberMe?: boolean;
 					} & AdditionalUserFieldsInput<O>,
@@ -47,6 +48,10 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 										password: {
 											type: "string",
 											description: "The password of the user",
+										},
+										image: {
+											type: "string",
+											description: "The profile image URL of the user",
 										},
 										callbackURL: {
 											type: "string",


### PR DESCRIPTION
`signUpEmail` destructures the optional `image` field from the request body and uses it when creating the user, but the field isn’t in the `requestBody` schema or the `$Infer` `body` type.

I updated the `packages/better-auth/src/api/routes/sign-up.test.ts` file’s `should work with custom fields on account table` test to include `image` alongside `email`, `password`, and `name`, and it demonstrates that the types are now correct (no type error). However, the test description seems misleading; I assumed that “custom fields” referred to the `AdditionalUserFieldsInput` that can be defined via the `additionalFields.user` part of the `betterAuth` config, whereas the test seems to only verify the fields with built-in support. I’d be happy to update the test description if that would be helpful, but because I wasn’t sure if my interpretation is correct, I decided to leave it as is for now.

Lastly, sorry about not using the `fix/` branch name prefix. I didn’t notice that part of the contribution guidelines until after I’d created the PR. Happy to close this PR and rename the branch and open a new one if that’s preferable.

Thanks!
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the optional image field to the signUpEmail request schema and types so users can provide a profile image during sign up.

<!-- End of auto-generated description by cubic. -->

