### PR TITLE
fix(client): Fix logic around sending FormData

### DIFF
--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -55,25 +55,25 @@ export type InferUserUpdateCtx<
 export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends BetterFetchOption,
-> = C["body"] extends Record<string, any>
-	?
-			| (C["body"] & {
-					fetchOptions?: FetchOptions;
-			  })
-			| FormData
-	: C["query"] extends Record<string, any>
-		? {
-				query: C["query"];
+> = C["body"] extends FormData
+	? FormData
+	: C["body"] extends Record<string, any>
+		? C["body"] & {
 				fetchOptions?: FetchOptions;
 			}
-		: C["query"] extends Record<string, any> | undefined
+		: C["query"] extends Record<string, any>
 			? {
-					query?: C["query"];
+					query: C["query"];
 					fetchOptions?: FetchOptions;
 				}
-			: {
-					fetchOptions?: FetchOptions;
-				};
+			: C["query"] extends Record<string, any> | undefined
+				? {
+						query?: C["query"];
+						fetchOptions?: FetchOptions;
+					}
+				: {
+						fetchOptions?: FetchOptions;
+					};
 
 export type MergeRoutes<T> = UnionToIntersection<T>;
 

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -55,13 +55,12 @@ export type InferUserUpdateCtx<
 export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends BetterFetchOption,
-	supportsFormData extends boolean = false,
 > = C["body"] extends Record<string, any>
-	? supportsFormData extends true
-		? { formData: FormData; fetchOptions?: FetchOptions }
-		: C["body"] & {
-				fetchOptions?: FetchOptions;
-			}
+	?
+			| (C["body"] & {
+					fetchOptions?: FetchOptions;
+			  })
+			| FormData
 	: C["query"] extends Record<string, any>
 		? {
 				query: C["query"];
@@ -103,32 +102,13 @@ export type InferRoute<API, COpts extends ClientOptions> = API extends Record<
 									>,
 								>(
 									...data: HasRequiredKeys<
-										InferCtx<
-											C,
-											FetchOptions,
-											T["options"]["metadata"] extends Record<string, any>
-												? T["options"]["metadata"]["supportsFormData"] extends true
-													? true
-													: false
-												: false
-										>
+										InferCtx<C, FetchOptions>
 									> extends true
 										? [
 												Prettify<
 													T["path"] extends `/sign-up/email`
 														? InferSignUpEmailCtx<COpts, FetchOptions>
-														: InferCtx<
-																C,
-																FetchOptions,
-																T["options"]["metadata"] extends Record<
-																	string,
-																	any
-																>
-																	? T["options"]["metadata"]["supportsFormData"] extends true
-																		? true
-																		: false
-																	: false
-															>
+														: InferCtx<C, FetchOptions>
 												>,
 												FetchOptions?,
 											]
@@ -136,18 +116,7 @@ export type InferRoute<API, COpts extends ClientOptions> = API extends Record<
 												Prettify<
 													T["path"] extends `/update-user`
 														? InferUserUpdateCtx<COpts, FetchOptions>
-														: InferCtx<
-																C,
-																FetchOptions,
-																T["options"]["metadata"] extends Record<
-																	string,
-																	any
-																>
-																	? T["options"]["metadata"]["supportsFormData"] extends true
-																		? true
-																		: false
-																	: false
-															>
+														: InferCtx<C, FetchOptions>
 												>?,
 												FetchOptions?,
 											]

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -56,11 +56,9 @@ export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends BetterFetchOption,
 > = C["body"] extends Record<string, any>
-	?
-			| (C["body"] & {
-					fetchOptions?: FetchOptions;
-			  })
-			| FormData
+	? C["body"] & {
+			fetchOptions?: FetchOptions;
+		}
 	: C["query"] extends Record<string, any>
 		? {
 				query: C["query"];

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -61,40 +61,44 @@ export type InferCtx<
 }
 	?
 			| { formData: 1 }
-			| (C["body"] extends Record<string, any>
-					? C["body"] & {
-							fetchOptions?: FetchOptions;
-						}
-					: C["query"] extends Record<string, any>
-						? {
-								query: C["query"];
+			| Prettify<
+					C["body"] extends Record<string, any>
+						? C["body"] & {
 								fetchOptions?: FetchOptions;
 							}
-						: C["query"] extends Record<string, any> | undefined
+						: C["query"] extends Record<string, any>
 							? {
-									query?: C["query"];
+									query: C["query"];
 									fetchOptions?: FetchOptions;
 								}
-							: {
-									fetchOptions?: FetchOptions;
-								})
-	: C["body"] extends Record<string, any>
-		? C["body"] & {
-				fetchOptions?: FetchOptions;
-			}
-		: C["query"] extends Record<string, any>
-			? {
-					query: C["query"];
-					fetchOptions?: FetchOptions;
-				}
-			: C["query"] extends Record<string, any> | undefined
-				? {
-						query?: C["query"];
+							: C["query"] extends Record<string, any> | undefined
+								? {
+										query?: C["query"];
+										fetchOptions?: FetchOptions;
+									}
+								: {
+										fetchOptions?: FetchOptions;
+									}
+			  >
+	: Prettify<
+			C["body"] extends Record<string, any>
+				? C["body"] & {
 						fetchOptions?: FetchOptions;
 					}
-				: {
-						fetchOptions?: FetchOptions;
-					};
+				: C["query"] extends Record<string, any>
+					? {
+							query: C["query"];
+							fetchOptions?: FetchOptions;
+						}
+					: C["query"] extends Record<string, any> | undefined
+						? {
+								query?: C["query"];
+								fetchOptions?: FetchOptions;
+							}
+						: {
+								fetchOptions?: FetchOptions;
+							}
+		>;
 
 export type MergeRoutes<T> = UnionToIntersection<T>;
 
@@ -126,27 +130,19 @@ export type InferRoute<API, COpts extends ClientOptions> = API extends Record<
 										InferCtx<C, FetchOptions, T["options"]["metadata"]>
 									> extends true
 										? [
-												Prettify<
-													T["path"] extends `/sign-up/email`
-														? InferSignUpEmailCtx<COpts, FetchOptions>
-														: InferCtx<
-																C,
-																FetchOptions,
-																T["options"]["metadata"]
-															>
-												>,
+												T["path"] extends `/sign-up/email`
+													? InferSignUpEmailCtx<COpts, FetchOptions>
+													: InferCtx<C, FetchOptions, T["options"]["metadata"]>,
 												FetchOptions?,
 											]
 										: [
-												Prettify<
-													T["path"] extends `/update-user`
-														? InferUserUpdateCtx<COpts, FetchOptions>
-														: InferCtx<
-																C,
-																FetchOptions,
-																T["options"]["metadata"]
-															>
-												>?,
+												(T["path"] extends `/update-user`
+													? InferUserUpdateCtx<COpts, FetchOptions>
+													: InferCtx<
+															C,
+															FetchOptions,
+															T["options"]["metadata"]
+														>)?,
 												FetchOptions?,
 											]
 								) => Promise<

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -55,23 +55,25 @@ export type InferUserUpdateCtx<
 export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends BetterFetchOption,
-> = C["body"] extends Record<string, any>
-	? C["body"] & {
-			fetchOptions?: FetchOptions;
-		}
-	: C["query"] extends Record<string, any>
-		? {
-				query: C["query"];
+> = C["body"] extends FormData
+	? FormData
+	: C["body"] extends Record<string, any>
+		? C["body"] & {
 				fetchOptions?: FetchOptions;
 			}
-		: C["query"] extends Record<string, any> | undefined
+		: C["query"] extends Record<string, any>
 			? {
-					query?: C["query"];
+					query: C["query"];
 					fetchOptions?: FetchOptions;
 				}
-			: {
-					fetchOptions?: FetchOptions;
-				};
+			: C["query"] extends Record<string, any> | undefined
+				? {
+						query?: C["query"];
+						fetchOptions?: FetchOptions;
+					}
+				: {
+						fetchOptions?: FetchOptions;
+					};
 
 export type MergeRoutes<T> = UnionToIntersection<T>;
 

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -56,9 +56,9 @@ export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends BetterFetchOption,
 > = C["body"] extends Record<string, any>
-	? C["body"] & {
+	? (C["body"] & {
 			fetchOptions?: FetchOptions;
-		}
+		} | FormData)
 	: C["query"] extends Record<string, any>
 		? {
 				query: C["query"];

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -56,9 +56,11 @@ export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends BetterFetchOption,
 > = C["body"] extends Record<string, any>
-	? (C["body"] & {
-			fetchOptions?: FetchOptions;
-		} | FormData)
+	?
+			| (C["body"] & {
+					fetchOptions?: FetchOptions;
+			  })
+			| FormData
 	: C["query"] extends Record<string, any>
 		? {
 				query: C["query"];

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -60,10 +60,24 @@ export type InferCtx<
 	supportsFormData: boolean;
 }
 	?
-			| { formData: FormData; fetchOptions?: FetchOptions }
-			| (C["body"] & {
-					fetchOptions?: FetchOptions;
-			  })
+			| { formData: FormData }
+			| (C["body"] extends Record<string, any>
+					? C["body"] & {
+							fetchOptions?: FetchOptions;
+						}
+					: C["query"] extends Record<string, any>
+						? {
+								query: C["query"];
+								fetchOptions?: FetchOptions;
+							}
+						: C["query"] extends Record<string, any> | undefined
+							? {
+									query?: C["query"];
+									fetchOptions?: FetchOptions;
+								}
+							: {
+									fetchOptions?: FetchOptions;
+								})
 	: C["body"] extends Record<string, any>
 		? C["body"] & {
 				fetchOptions?: FetchOptions;

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -55,8 +55,15 @@ export type InferUserUpdateCtx<
 export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends BetterFetchOption,
-> = C["body"] extends FormData
-	? FormData
+	Metadata extends Record<string, any> | undefined = {},
+> = Metadata extends {
+	supportsFormData: true;
+}
+	?
+			| { formData: FormData; fetchOptions?: FetchOptions }
+			| (C["body"] & {
+					fetchOptions?: FetchOptions;
+			  })
 	: C["body"] extends Record<string, any>
 		? C["body"] & {
 				fetchOptions?: FetchOptions;
@@ -102,13 +109,13 @@ export type InferRoute<API, COpts extends ClientOptions> = API extends Record<
 									>,
 								>(
 									...data: HasRequiredKeys<
-										InferCtx<C, FetchOptions>
+										InferCtx<C, FetchOptions, T["options"]["metadata"]>
 									> extends true
 										? [
 												Prettify<
 													T["path"] extends `/sign-up/email`
 														? InferSignUpEmailCtx<COpts, FetchOptions>
-														: InferCtx<C, FetchOptions>
+														: InferCtx<C, FetchOptions, T["options"]["metadata"]>
 												>,
 												FetchOptions?,
 											]
@@ -116,7 +123,7 @@ export type InferRoute<API, COpts extends ClientOptions> = API extends Record<
 												Prettify<
 													T["path"] extends `/update-user`
 														? InferUserUpdateCtx<COpts, FetchOptions>
-														: InferCtx<C, FetchOptions>
+														: InferCtx<C, FetchOptions, T["options"]["metadata"]>
 												>?,
 												FetchOptions?,
 											]

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -56,33 +56,31 @@ export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends BetterFetchOption,
 	Metadata extends Record<string, any> | undefined = {},
-> = Metadata & {hey: 1}
-
-// Metadata extends {
-// 	supportsFormData: true;
-// }
-// 	?
-// 			| { formData: FormData; fetchOptions?: FetchOptions }
-// 			| (C["body"] & {
-// 					fetchOptions?: FetchOptions;
-// 			  })
-// 	: C["body"] extends Record<string, any>
-// 		? C["body"] & {
-// 				fetchOptions?: FetchOptions;
-// 			}
-// 		: C["query"] extends Record<string, any>
-// 			? {
-// 					query: C["query"];
-// 					fetchOptions?: FetchOptions;
-// 				}
-// 			: C["query"] extends Record<string, any> | undefined
-// 				? {
-// 						query?: C["query"];
-// 						fetchOptions?: FetchOptions;
-// 					}
-// 				: {
-// 						fetchOptions?: FetchOptions;
-// 					};
+> = Metadata extends {
+	supportsFormData: boolean;
+}
+	?
+			| { formData: FormData; fetchOptions?: FetchOptions }
+			| (C["body"] & {
+					fetchOptions?: FetchOptions;
+			  })
+	: C["body"] extends Record<string, any>
+		? C["body"] & {
+				fetchOptions?: FetchOptions;
+			}
+		: C["query"] extends Record<string, any>
+			? {
+					query: C["query"];
+					fetchOptions?: FetchOptions;
+				}
+			: C["query"] extends Record<string, any> | undefined
+				? {
+						query?: C["query"];
+						fetchOptions?: FetchOptions;
+					}
+				: {
+						fetchOptions?: FetchOptions;
+					};
 
 export type MergeRoutes<T> = UnionToIntersection<T>;
 
@@ -117,7 +115,11 @@ export type InferRoute<API, COpts extends ClientOptions> = API extends Record<
 												Prettify<
 													T["path"] extends `/sign-up/email`
 														? InferSignUpEmailCtx<COpts, FetchOptions>
-														: InferCtx<C, FetchOptions, T["options"]["metadata"]>
+														: InferCtx<
+																C,
+																FetchOptions,
+																T["options"]["metadata"]
+															>
 												>,
 												FetchOptions?,
 											]
@@ -125,7 +127,11 @@ export type InferRoute<API, COpts extends ClientOptions> = API extends Record<
 												Prettify<
 													T["path"] extends `/update-user`
 														? InferUserUpdateCtx<COpts, FetchOptions>
-														: InferCtx<C, FetchOptions, T["options"]["metadata"]>
+														: InferCtx<
+																C,
+																FetchOptions,
+																T["options"]["metadata"]
+															>
 												>?,
 												FetchOptions?,
 											]

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -60,7 +60,7 @@ export type InferCtx<
 	supportsFormData: boolean;
 }
 	?
-			| { formData: FormData }
+			| { formData: 1 }
 			| (C["body"] extends Record<string, any>
 					? C["body"] & {
 							fetchOptions?: FetchOptions;

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -56,31 +56,33 @@ export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends BetterFetchOption,
 	Metadata extends Record<string, any> | undefined = {},
-> = Metadata extends {
-	supportsFormData: true;
-}
-	?
-			| { formData: FormData; fetchOptions?: FetchOptions }
-			| (C["body"] & {
-					fetchOptions?: FetchOptions;
-			  })
-	: C["body"] extends Record<string, any>
-		? C["body"] & {
-				fetchOptions?: FetchOptions;
-			}
-		: C["query"] extends Record<string, any>
-			? {
-					query: C["query"];
-					fetchOptions?: FetchOptions;
-				}
-			: C["query"] extends Record<string, any> | undefined
-				? {
-						query?: C["query"];
-						fetchOptions?: FetchOptions;
-					}
-				: {
-						fetchOptions?: FetchOptions;
-					};
+> = Metadata & {hey: 1}
+
+// Metadata extends {
+// 	supportsFormData: true;
+// }
+// 	?
+// 			| { formData: FormData; fetchOptions?: FetchOptions }
+// 			| (C["body"] & {
+// 					fetchOptions?: FetchOptions;
+// 			  })
+// 	: C["body"] extends Record<string, any>
+// 		? C["body"] & {
+// 				fetchOptions?: FetchOptions;
+// 			}
+// 		: C["query"] extends Record<string, any>
+// 			? {
+// 					query: C["query"];
+// 					fetchOptions?: FetchOptions;
+// 				}
+// 			: C["query"] extends Record<string, any> | undefined
+// 				? {
+// 						query?: C["query"];
+// 						fetchOptions?: FetchOptions;
+// 					}
+// 				: {
+// 						fetchOptions?: FetchOptions;
+// 					};
 
 export type MergeRoutes<T> = UnionToIntersection<T>;
 

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -59,46 +59,31 @@ export type InferCtx<
 > = Metadata extends {
 	supportsFormData: boolean;
 }
-	?
-			| { formData: 1 }
-			| Prettify<
-					C["body"] extends Record<string, any>
-						? C["body"] & {
-								fetchOptions?: FetchOptions;
-							}
-						: C["query"] extends Record<string, any>
-							? {
-									query: C["query"];
-									fetchOptions?: FetchOptions;
-								}
-							: C["query"] extends Record<string, any> | undefined
-								? {
-										query?: C["query"];
-										fetchOptions?: FetchOptions;
-									}
-								: {
-										fetchOptions?: FetchOptions;
-									}
-			  >
-	: Prettify<
-			C["body"] extends Record<string, any>
-				? C["body"] & {
+	? { formData: FormData } | GetBodyOrQuery<C, FetchOptions>
+	: GetBodyOrQuery<C, FetchOptions>;
+
+type GetBodyOrQuery<
+	C extends InputContext<any, any>,
+	FetchOptions extends BetterFetchOption,
+> = Prettify<
+	C["body"] extends Record<string, any>
+		? C["body"] & {
+				fetchOptions?: FetchOptions;
+			}
+		: C["query"] extends Record<string, any>
+			? {
+					query: C["query"];
+					fetchOptions?: FetchOptions;
+				}
+			: C["query"] extends Record<string, any> | undefined
+				? {
+						query?: C["query"];
 						fetchOptions?: FetchOptions;
 					}
-				: C["query"] extends Record<string, any>
-					? {
-							query: C["query"];
-							fetchOptions?: FetchOptions;
-						}
-					: C["query"] extends Record<string, any> | undefined
-						? {
-								query?: C["query"];
-								fetchOptions?: FetchOptions;
-							}
-						: {
-								fetchOptions?: FetchOptions;
-							}
-		>;
+				: {
+						fetchOptions?: FetchOptions;
+					}
+>;
 
 export type MergeRoutes<T> = UnionToIntersection<T>;
 

--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -74,7 +74,7 @@ export function createDynamicPathProxy<T extends Record<string, any>>(
 				const method = getMethod(routePath, knownPathMethods, arg);
 
 				const isFormData =
-					typeof FormData !== "undefined" && args instanceof FormData;
+					typeof FormData !== "undefined" && arg instanceof FormData;
 
 				return await client(routePath, {
 					...options,

--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -18,7 +18,11 @@ function getMethod(
 	if (fetchOptions?.method) {
 		return fetchOptions.method;
 	}
-	if (typeof FormData !== "undefined" && args instanceof FormData)
+	if (
+		"formData" in body &&
+		typeof FormData !== "undefined" &&
+		body.formData instanceof FormData
+	)
 		return "POST";
 	if (body && Object.keys(body).length > 0) {
 		return "POST";
@@ -74,7 +78,7 @@ export function createDynamicPathProxy<T extends Record<string, any>>(
 				const method = getMethod(routePath, knownPathMethods, arg);
 
 				const isFormData =
-					typeof FormData !== "undefined" && arg instanceof FormData;
+					typeof FormData !== "undefined" && arg.formData instanceof FormData;
 
 				return await client(routePath, {
 					...options,
@@ -82,7 +86,7 @@ export function createDynamicPathProxy<T extends Record<string, any>>(
 						method === "GET"
 							? undefined
 							: isFormData
-								? arg
+								? arg.formData
 								: {
 										...body,
 										...(options?.body || {}),

--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -18,7 +18,7 @@ function getMethod(
 	if (fetchOptions?.method) {
 		return fetchOptions.method;
 	}
-	if (args instanceof FormData) return "POST";
+	if (typeof FormData !== "undefined" && args instanceof FormData) return "POST";
 	if (body && Object.keys(body).length > 0) {
 		return "POST";
 	}

--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -82,7 +82,7 @@ export function createDynamicPathProxy<T extends Record<string, any>>(
 						method === "GET"
 							? undefined
 							: isFormData
-								? args
+								? arg
 								: {
 										...body,
 										...(options?.body || {}),

--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -18,7 +18,8 @@ function getMethod(
 	if (fetchOptions?.method) {
 		return fetchOptions.method;
 	}
-	if (typeof FormData !== "undefined" && args instanceof FormData) return "POST";
+	if (typeof FormData !== "undefined" && args instanceof FormData)
+		return "POST";
 	if (body && Object.keys(body).length > 0) {
 		return "POST";
 	}
@@ -72,15 +73,20 @@ export function createDynamicPathProxy<T extends Record<string, any>>(
 				} as BetterFetchOption;
 				const method = getMethod(routePath, knownPathMethods, arg);
 
+				const isFormData =
+					typeof FormData !== "undefined" && args instanceof FormData;
+
 				return await client(routePath, {
 					...options,
 					body:
 						method === "GET"
 							? undefined
-							: {
-									...body,
-									...(options?.body || {}),
-								},
+							: isFormData
+								? args
+								: {
+										...body,
+										...(options?.body || {}),
+									},
 					query: query || options?.query,
 					method,
 					async onSuccess(context) {

--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -18,6 +18,7 @@ function getMethod(
 	if (fetchOptions?.method) {
 		return fetchOptions.method;
 	}
+	if (args instanceof FormData) return "POST";
 	if (body && Object.keys(body).length > 0) {
 		return "POST";
 	}


### PR DESCRIPTION
This PR fixes the logic around endpoints which require/use FormData. Primarily needed for the file-storage pluign in the future where something like SignUPEmail would require a FormData. (Since we can't send Blob/File via JSON we must use FormData)

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
When FormData is passed to an authClient API method, the request now uses POST by default instead of GET. This ensures endpoints expecting FormData receive the correct HTTP method.

<!-- End of auto-generated description by cubic. -->

