### PR TITLE
Update hono.mdx sessionToken attributes param

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -141,9 +141,11 @@ export const auth = createAuth({
   advanced: {
     cookies: {
       sessionToken: {
-        sameSite: "none",
-        secure: true,
-        partitioned: true // New browser standards will mandate this for foreign cookies
+        attributes: {
+          sameSite: "none",
+          secure: true,
+          partitioned: true // New browser standards will mandate this for foreign cookies
+        }
       }
     }
   }


### PR DESCRIPTION
i get this once i follow the sessionToken param according to the hono docs:
```bash
Object literal may only specify known properties, and 'sameSite' does not exist in type '{ name?: string | undefined; attributes?: CookieOptions | undefined; }'. (ts 2353)
```

before:
<img width="1563" height="592" alt="image" src="https://github.com/user-attachments/assets/2e3cc296-fc10-49e2-9a31-5e486f23793c" />

after:
<img width="1563" height="592" alt="image" src="https://github.com/user-attachments/assets/4a50ea8c-f82b-470a-a8a8-f7349df04e00" />

System: Ubuntu/Linux
Package version: ^1.2.12
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the sessionToken example in hono.mdx to place cookie attributes inside the correct attributes object, matching the expected type and preventing TypeScript errors.

<!-- End of auto-generated description by cubic. -->

