### PR TITLE
feat(oidc): add refresh token support to discovery document and token endpoint

### DIFF
--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -51,7 +51,7 @@ export const getMCPProviderMetadata = (
 		scopes_supported: ["openid", "profile", "email", "offline_access"],
 		response_types_supported: ["code"],
 		response_modes_supported: ["query"],
-		grant_types_supported: ["authorization_code"],
+		grant_types_supported: ["authorization_code", "refresh_token"],
 		acr_values_supported: [
 			"urn:mace:incommon:iap:silver",
 			"urn:mace:incommon:iap:bronze",

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -39,7 +39,7 @@ export const getMetadata = (
 		scopes_supported: ["openid", "profile", "email", "offline_access"],
 		response_types_supported: ["code"],
 		response_modes_supported: ["query"],
-		grant_types_supported: ["authorization_code"],
+		grant_types_supported: ["authorization_code", "refresh_token"],
 		acr_values_supported: [
 			"urn:mace:incommon:iap:silver",
 			"urn:mace:incommon:iap:bronze",

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -462,7 +462,10 @@ export interface OIDCMetadata {
 	 * The first element MUST be "authorization_code"; additional grant types like
 	 * "refresh_token" can follow. Guarantees a non-empty array at the type level.
 	 */
-	grant_types_supported: ["authorization_code", ...("authorization_code" | "refresh_token")[]];
+	grant_types_supported: [
+		"authorization_code",
+		...("authorization_code" | "refresh_token")[],
+	];
 	/**
 	 * acr_values supported.
 	 *

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -459,9 +459,9 @@ export interface OIDCMetadata {
 	/**
 	 * Supported grant types.
 	 *
-	 * only `authorization_code` is supported.
+	 * now supports both `authorization_code` and `refresh_token`.
 	 */
-	grant_types_supported: ["authorization_code"];
+	grant_types_supported: ("authorization_code" | "refresh_token")[];
 	/**
 	 * acr_values supported.
 	 *

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -459,9 +459,10 @@ export interface OIDCMetadata {
 	/**
 	 * Supported grant types.
 	 *
-	 * now supports both `authorization_code` and `refresh_token`.
+	 * The first element MUST be "authorization_code"; additional grant types like
+	 * "refresh_token" can follow. Guarantees a non-empty array at the type level.
 	 */
-	grant_types_supported: ("authorization_code" | "refresh_token")[];
+	grant_types_supported: ["authorization_code", ...("authorization_code" | "refresh_token")[]];
 	/**
 	 * acr_values supported.
 	 *


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/3359
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added refresh token support to the OIDC discovery document and token endpoint, allowing clients to use the refresh_token grant type. 

- **New Features**
  - Updated grant_types_supported to include "refresh_token" in OIDC metadata and types.

<!-- End of auto-generated description by cubic. -->

