### PR TITLE
fix(auth): implement standard Base64 encoding for HTTP Basic Auth in token refresh and validation

### DIFF
--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -1,7 +1,6 @@
 import { betterFetch } from "@better-fetch/fetch";
 import type { OAuth2Tokens } from "./types";
 import type { ProviderOptions } from "./types";
-import { base64Url } from "@better-auth/utils/base64";
 
 export async function refreshAccessToken({
 	refreshToken,
@@ -26,10 +25,12 @@ export async function refreshAccessToken({
 
 	body.set("grant_type", grantType);
 	body.set("refresh_token", refreshToken);
+	// Use standard Base64 encoding for HTTP Basic Auth (OAuth2 spec, RFC 7617)
+	// Fixes compatibility with providers like Notion, Twitter, etc.
 	if (authentication === "basic") {
-		const encodedCredentials = base64Url.encode(
+		const encodedCredentials = Buffer.from(
 			`${options.clientId}:${options.clientSecret}`,
-		);
+		).toString("base64");
 		headers["authorization"] = `Basic ${encodedCredentials}`;
 	} else {
 		body.set("client_id", options.clientId);

--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -1,4 +1,3 @@
-import { base64Url } from "@better-auth/utils/base64";
 import { betterFetch } from "@better-fetch/fetch";
 import { jwtVerify } from "jose";
 import type { ProviderOptions } from "./types";
@@ -20,7 +19,7 @@ export async function validateAuthorizationCode({
 	codeVerifier?: string;
 	deviceId?: string;
 	tokenEndpoint: string;
-	authentication?: "basic" | "post";
+	authentication: "basic" | "post";
 	headers?: Record<string, string>;
 }) {
 	const body = new URLSearchParams();
@@ -36,10 +35,12 @@ export async function validateAuthorizationCode({
 	options.clientKey && body.set("client_key", options.clientKey);
 	deviceId && body.set("device_id", deviceId);
 	body.set("redirect_uri", options.redirectURI || redirectURI);
+	// Use standard Base64 encoding for HTTP Basic Auth (OAuth2 spec, RFC 7617)
+	// Fixes compatibility with providers like Notion, Twitter, etc.
 	if (authentication === "basic") {
-		const encodedCredentials = base64Url.encode(
+		const encodedCredentials = Buffer.from(
 			`${options.clientId}:${options.clientSecret}`,
-		);
+		).toString("base64");
 		requestHeaders["authorization"] = `Basic ${encodedCredentials}`;
 	} else {
 		body.set("client_id", options.clientId);

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -265,6 +265,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 								redirectURI: c.redirectURI,
 							},
 							tokenEndpoint: finalTokenUrl,
+							authentication: c.authentication || "post",
 						});
 					},
 					async refreshAccessToken(
@@ -603,7 +604,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 								redirectURI: provider.redirectURI,
 							},
 							tokenEndpoint: finalTokenUrl,
-							authentication: provider.authentication,
+							authentication: provider.authentication || "basic",
 						});
 					} catch (e) {
 						ctx.context.logger.error(


### PR DESCRIPTION
- Updated `refreshAccessToken` and `validateAuthorizationCode` functions to use standard Base64 encoding instead of URL-safe encoding for HTTP Basic Authentication.
- Ensured compatibility with providers like Notion and Twitter by adhering to OAuth2 specifications (RFC 7617).
- Set default authentication method to "basic" in the generic OAuth plugin for better consistency.