### PR TITLE
fix: allow partial session data in database hooks

### DIFF
--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -837,7 +837,7 @@ export type BetterAuthOptions = {
 					| boolean
 					| void
 					| {
-							data: Session & Record<string, any>;
+							data: Partial<Session> & Record<string, any>;
 					  }
 				>;
 				/**


### PR DESCRIPTION
## Summary

- Fixed session database hooks to accept `Partial<Session>` instead of requiring complete `Session` objects
- Makes session hooks consistent with user hooks behavior
- Resolves issues where `setActiveOrganization` and similar functions fail when using database hooks with partial updates

## Problem

Session update database hooks were typed to require complete `Session` objects in their return value:
```typescript
data: Session & Record<string, any>;
```

This was inconsistent with user update hooks which correctly accept partial data:
```typescript
data: Partial<User> & Record<string, any>;
```

This caused TypeScript errors when database hooks returned only the partial data being updated, as the missing fields would be `undefined`.

## Solution

Changed the session database hook type definition to accept partial data:
```typescript
data: Partial<Session> & Record<string, any>;
```

## Test plan

- [x] Verify TypeScript compilation passes
- [ ] Test `setActiveOrganization` with database hooks
- [ ] Ensure other session update operations work with hooks
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)