### PR TITLE
feat(generic-oauth): add support for additional token URL params in generic OAuth

### DIFF
--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -50,6 +50,8 @@ export async function validateAuthorizationCode({
 	}
 
 	for (const [key, value] of Object.entries(additionalParams)) {
+		if (!body.has(key)) body.append(key, value);
+	}
 		body.set(key, value);
 	}
 

--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -13,6 +13,7 @@ export async function validateAuthorizationCode({
 	authentication,
 	deviceId,
 	headers,
+	additionalParams = {},
 }: {
 	code: string;
 	redirectURI: string;
@@ -22,6 +23,7 @@ export async function validateAuthorizationCode({
 	tokenEndpoint: string;
 	authentication?: "basic" | "post";
 	headers?: Record<string, string>;
+	additionalParams?: Record<string, string>;
 }) {
 	const body = new URLSearchParams();
 	const requestHeaders: Record<string, any> = {
@@ -46,6 +48,11 @@ export async function validateAuthorizationCode({
 		body.set("client_id", options.clientId);
 		body.set("client_secret", options.clientSecret);
 	}
+
+	for (const [key, value] of Object.entries(additionalParams)) {
+		body.set(key, value);
+	}
+
 	const { data, error } = await betterFetch<object>(tokenEndpoint, {
 		method: "POST",
 		body: body,

--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -52,8 +52,6 @@ export async function validateAuthorizationCode({
 	for (const [key, value] of Object.entries(additionalParams)) {
 		if (!body.has(key)) body.append(key, value);
 	}
-		body.set(key, value);
-	}
 
 	const { data, error } = await betterFetch<object>(tokenEndpoint, {
 		method: "POST",

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -113,6 +113,12 @@ export interface GenericOAuthConfig {
 	 * Warning: Search-params added here overwrite any default params.
 	 */
 	authorizationUrlParams?: Record<string, string>;
+
+	/**
+	 * Additional search-params to add to the tokenUrl.
+	 * Warning: Search-params added here overwrite any default params.
+	 */
+	tokenUrlParams?: Record<string, string>;
 	/**
 	 * Disable implicit sign up for new users. When set to true for the provider,
 	 * sign-in need to be called with with requestSignUp as true to create new users.
@@ -605,6 +611,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							},
 							tokenEndpoint: finalTokenUrl,
 							authentication: provider.authentication,
+							additionalParams: provider.tokenUrlParams,
 						});
 					} catch (e) {
 						ctx.context.logger.error(


### PR DESCRIPTION
fix #3402
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for passing extra parameters to the token URL in generic OAuth, allowing more flexible provider integrations.

- **New Features**
  - Added a new `tokenUrlParams` option to generic OAuth config.
  - These parameters are now included in token requests.

<!-- End of auto-generated description by cubic. -->

