### PR TITLE
feat(username): add custom username normalization option

### DIFF
--- a/docs/content/docs/plugins/username.mdx
+++ b/docs/content/docs/plugins/username.mdx
@@ -98,7 +98,7 @@ const data = await authClient.updateUser({
 
 ## Schema
 
-The plugin requires 1 field to be added to the user table:
+The plugin requires 2 fields to be added to the user table:
 
 <DatabaseTable
     fields={[
@@ -168,6 +168,30 @@ const auth = betterAuth({
                 if (username === "admin") {
                     return false
                 }
+            }
+        })
+    ]
+})
+```
+
+### Username Normalization
+
+A function that normalizes the username, or `false` if you want to disable normalization.
+
+By default, usernames are case-insensitive, so "TestUser" and "testuser", for example, are considered the same username. The `username` field will contain the normalized (lower case) username, while `displayUsername` will contain the original `username`.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+import { username } from "better-auth/plugins"
+
+const auth = betterAuth({
+    plugins: [
+        username({
+            usernameNormalization: (username) => {
+                return username.toLowerCase()
+                    .replaceAll("0", "o")
+                    .replaceAll("3", "e")
+                    .replaceAll("4", "a");
             }
         })
     ]

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -30,6 +30,12 @@ export type UsernameOptions = {
 	 * By default, the username should only contain alphanumeric characters and underscores
 	 */
 	usernameValidator?: (username: string) => boolean | Promise<boolean>;
+	/**
+	 * A function to normalize the username
+	 *
+	 * @default (username) => username.toLowerCase()
+	 */
+	usernameNormalization?: ((username: string) => string) | false;
 };
 
 function defaultUsernameValidator(username: string) {
@@ -37,6 +43,16 @@ function defaultUsernameValidator(username: string) {
 }
 
 export const username = (options?: UsernameOptions) => {
+	const normalizer = (username: string) => {
+		if (options?.usernameNormalization === false) {
+			return username;
+		}
+		if (options?.usernameNormalization) {
+			return options.usernameNormalization(username);
+		}
+		return username.toLowerCase();
+	};
+
 	return {
 		id: "username",
 		endpoints: {
@@ -132,7 +148,7 @@ export const username = (options?: UsernameOptions) => {
 						where: [
 							{
 								field: "username",
-								value: ctx.body.username.toLowerCase(),
+								value: normalizer(ctx.body.username),
 							},
 						],
 					});
@@ -270,7 +286,7 @@ export const username = (options?: UsernameOptions) => {
 								where: [
 									{
 										field: "username",
-										value: username.toLowerCase(),
+										value: normalizer(username),
 									},
 								],
 							});
@@ -290,8 +306,9 @@ export const username = (options?: UsernameOptions) => {
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {
-						if (!ctx.body.displayUsername && ctx.body.username) {
-							ctx.body.displayUsername = ctx.body.username;
+						if (ctx.body.username) {
+							ctx.body.displayUsername ||= ctx.body.username;
+							ctx.body.username = normalizer(ctx.body.username);
 						}
 					}),
 				},

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -6,12 +6,12 @@ import type { Account, InferOptionSchema, User } from "../../types";
 import { setSessionCookie } from "../../cookies";
 import { sendVerificationEmailFn } from "../../api";
 import { BASE_ERROR_CODES } from "../../error/codes";
-import { schema } from "./schema";
+import { getSchema, type UsernameSchema } from "./schema";
 import { mergeSchema } from "../../db/schema";
 import { USERNAME_ERROR_CODES as ERROR_CODES } from "./error-codes";
 export * from "./error-codes";
 export type UsernameOptions = {
-	schema?: InferOptionSchema<typeof schema>;
+	schema?: InferOptionSchema<UsernameSchema>;
 	/**
 	 * The minimum length of the username
 	 *
@@ -245,7 +245,7 @@ export const username = (options?: UsernameOptions) => {
 				},
 			),
 		},
-		schema: mergeSchema(schema, options?.schema),
+		schema: mergeSchema(getSchema(normalizer), options?.schema),
 		hooks: {
 			before: [
 				{

--- a/packages/better-auth/src/plugins/username/schema.ts
+++ b/packages/better-auth/src/plugins/username/schema.ts
@@ -9,11 +9,6 @@ export const schema = {
 				sortable: true,
 				unique: true,
 				returned: true,
-				transform: {
-					input(value) {
-						return value?.toString().toLowerCase();
-					},
-				},
 			},
 			displayUsername: {
 				type: "string",

--- a/packages/better-auth/src/plugins/username/schema.ts
+++ b/packages/better-auth/src/plugins/username/schema.ts
@@ -16,7 +16,7 @@ export const getSchema = (normalizer: (username: string) => string) => {
 					required: false,
 					transform: {
 						input(value) {
-							return normalizer(value as string);
+							return value == null ? value : normalizer(value as string);
 						},
 					},
 				},

--- a/packages/better-auth/src/plugins/username/schema.ts
+++ b/packages/better-auth/src/plugins/username/schema.ts
@@ -1,19 +1,28 @@
 import type { AuthPluginSchema } from "../../types";
 
-export const schema = {
-	user: {
-		fields: {
-			username: {
-				type: "string",
-				required: false,
-				sortable: true,
-				unique: true,
-				returned: true,
-			},
-			displayUsername: {
-				type: "string",
-				required: false,
+export const getSchema = (normalizer: (username: string) => string) => {
+	return {
+		user: {
+			fields: {
+				username: {
+					type: "string",
+					required: false,
+					sortable: true,
+					unique: true,
+					returned: true,
+				},
+				displayUsername: {
+					type: "string",
+					required: false,
+					transform: {
+						input(value) {
+							return normalizer(value as string);
+						},
+					},
+				},
 			},
 		},
-	},
-} satisfies AuthPluginSchema;
+	} satisfies AuthPluginSchema;
+};
+
+export type UsernameSchema = ReturnType<typeof getSchema>;

--- a/packages/better-auth/src/plugins/username/username.test.ts
+++ b/packages/better-auth/src/plugins/username/username.test.ts
@@ -112,3 +112,42 @@ describe("username", async (it) => {
 		expect(res.error?.status).toBe(422);
 	});
 });
+
+describe("username custom normalization", async (it) => {
+	const { client } = await getTestInstance(
+		{
+			plugins: [
+				username({
+					minUsernameLength: 4,
+					usernameNormalization: (username) =>
+						username.replaceAll("0", "o").replaceAll("4", "a").toLowerCase(),
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [usernameClient()],
+			},
+		},
+	);
+
+	it("should sign up with username", async () => {
+		const res = await client.signUp.email({
+			email: "new-email@gamil.com",
+			username: "H4XX0R",
+			password: "new-password",
+			name: "new-name",
+		});
+		expect(res.error).toBeNull();
+	});
+
+	it("should fail on duplicate username", async () => {
+		const res = await client.signUp.email({
+			email: "new-email-2@gamil.com",
+			username: "haxxor",
+			password: "new-password",
+			name: "new-name",
+		});
+		expect(res.error?.status).toBe(422);
+	});
+});


### PR DESCRIPTION
This PR add a new option to the username plugin that allow customizing the username normalization.

Example:

```ts
const auth = betterAuth({
    plugins: [
        username({
            usernameNormalization: (username) => {
                return username.toLowerCase()
                    .replaceAll("0", "o")
                    .replaceAll("3", "e")
                    .replaceAll("4", "a");
            }
        })
    ]
})
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new option to the username plugin that lets you define a custom function for username normalization or disable normalization entirely.

- **New Features**
  - Supports custom username normalization logic through a new option.
  - Updated docs and tests to show how to use custom normalization.

<!-- End of auto-generated description by cubic. -->

