### PR TITLE
fix(api-key): API Keys with expiresAt not null

### DIFF
--- a/packages/better-auth/src/plugins/api-key/routes/index.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/index.ts
@@ -58,6 +58,11 @@ export function deleteAllExpiredApiKeys(
 					operator: "lt",
 					value: new Date(),
 				},
+			        {
+			          	field: "expiresAt",
+			          	operator: "ne",
+			          	value: null
+			        }
 			],
 		});
 	} catch (error) {

--- a/packages/better-auth/src/plugins/api-key/routes/index.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/index.ts
@@ -58,11 +58,11 @@ export function deleteAllExpiredApiKeys(
 					operator: "lt",
 					value: new Date(),
 				},
-			        {
-			          	field: "expiresAt",
-			          	operator: "ne",
-			          	value: null
-			        }
+        {
+          field: "expiresAt",
+          operator: "ne",
+          value: null
+        }
 			],
 		});
 	} catch (error) {

--- a/packages/better-auth/src/plugins/api-key/routes/index.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/index.ts
@@ -58,11 +58,11 @@ export function deleteAllExpiredApiKeys(
 					operator: "lt",
 					value: new Date(),
 				},
-        {
-          field: "expiresAt",
-          operator: "ne",
-          value: null
-        }
+				{
+					field: "expiresAt",
+					operator: "ne",
+					value: null,
+				},
 			],
 		});
 	} catch (error) {


### PR DESCRIPTION
The `deleteAllExpiredApiKeys` function in the apiKey plugin deletes API keys where `expiresAt` is `null`, despite these keys being intended as non-expiring. 

This occurs because the deleteMany query does not explicitly exclude null values in the expiresAt condition. 

This leads to unexpected key deletions, affecting keys like  

```json
{ "_id": "6876ba254c23e91c05c9e95b", "expiresAt": null }
```

this is Mongodb case not same like sql

cc @ping-maxwell can we add test for this case?

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where non-expiring API keys (with expiresAt set to null) were being deleted by mistake.

- **Bug Fixes**
  - Updated the expired API key deletion logic to exclude keys with expiresAt set to null.

<!-- End of auto-generated description by cubic. -->

