### PR TITLE
feat(magic-link): allow validated additional data for the send email function

### DIFF
--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -124,7 +124,7 @@ type magicLinkVerify = {
 
 ### Additional properties
 
-If you want to pass any arbitrary data to your `sendMagicLink` function, you can specify the `additionalData` field in the request body of the `signIn.magicLink` function.
+If you want to pass any arbitrary data to your `sendMagicLink` function, you can specify the `additionalData` field in the request body of the `signIn.magicLink` function. This can be useful to pass information from the client to your mailing logic.
 
 ```ts title="magic-link.ts"
 const { data, error } = await authClient.signIn.magicLink({
@@ -145,8 +145,8 @@ export const auth = betterAuth({
     plugins: [
         magicLink({
             sendMagicLink: async ({ email, token, url, additionalData }, request) => {
-                const message = additionalData["message"];
-                
+                const message = additionalData?.message ?? "No message provided!"; // [!code highlight]
+
                 // send email to user
             }
         })
@@ -154,14 +154,39 @@ export const auth = betterAuth({
 })
 ```
 
+For type-safety and runtime schema validation, you can supply a [Zod schema](https://zod.dev/) to the plugin through options.
+
+```ts title="server.ts"
+import { betterAuth, z } from "better-auth";
+import { magicLink } from "better-auth/plugins";
+ 
+export const auth = betterAuth({
+    plugins: [
+        magicLink({
+            additionalDataSchema: z.object({ message: z.string() }), // Create your schema here! // [!code highlight]
+            sendMagicLink: async ({ email, token, url, additionalData }, request) => {
+                const message = additionalData?.message ?? "No message provided!";
+
+                // send email to user
+            }
+        })
+    ]
+})
+```
+<Callout type="warn">
+  If no `additionalDataSchema` is provided, the type will default to `Record<string, any>` and the value is not validated during runtime.
+</Callout>
+
 ## Configuration Options
+
+**additionalDataSchema**: [Zod schema](https://zod.dev/) used for validation and type-safety of the `additionalData` field in `sendMagicLink`.
 
 **sendMagicLink**: The `sendMagicLink` function is called when a user requests a magic link. It takes an object with the following properties:
 
 - `email`: The email address of the user.
 - `url`: The URL to be sent to the user. This URL contains the token.
 - `token`: The token if you want to send the token with custom URL.
-- `additionalData`: Optional record with properties provided in the request body.
+- `additionalData`: Additional properties provided when calling the `signIn.magicLink()` function.
 
 and a `request` object as the second parameter.
 

--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -157,9 +157,10 @@ export const auth = betterAuth({
 For type-safety and runtime schema validation, you can supply a [Zod schema](https://zod.dev/) to the plugin through options.
 
 ```ts title="server.ts"
-import { betterAuth, z } from "better-auth";
+import { betterAuth } from "better-auth";
 import { magicLink } from "better-auth/plugins";
- 
+import z from "zod"; // [!code highlight]
+
 export const auth = betterAuth({
     plugins: [
         magicLink({

--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -84,6 +84,11 @@ type signInMagicLink = {
      * redirected to the callbackURL with an `error` query parameter.
      */
     errorCallbackURL?: string = "/error"
+    /**
+     * If you want to provide additional data to the `sendMagicLink` function you can do so in key-value
+     * pairs here. See below on how to make a schema to validate these values.
+     */
+    additionalData?: Record<string, JsonValue> = { message: "Hello from better-auth!" }
 }
 ```
 </APIMethod>
@@ -122,20 +127,9 @@ type magicLinkVerify = {
 ```
 </APIMethod>
 
-### Additional properties
+### Additional Data
 
-If you want to pass any arbitrary data to your `sendMagicLink` function, you can specify the `additionalData` field in the request body of the `signIn.magicLink` function. This can be useful to pass information from the client to your mailing logic.
-
-```ts title="magic-link.ts"
-const { data, error } = await authClient.signIn.magicLink({
-  email: "user@email.com",
-  additionalData: {
-    message: "Hello from better-auth!",
-  },
-});
-```
-
-The record is now available to use in the `sendMagicLink` function.
+If you want to include additional data for your sendMagicLink function, for type-safety and runtime schema validation you can supply a [Zod schema](https://zod.dev/) to the plugin through options.
 
 ```ts title="server.ts"
 import { betterAuth } from "better-auth";
@@ -153,8 +147,6 @@ export const auth = betterAuth({
     ]
 })
 ```
-
-For type-safety and runtime schema validation, you can supply a [Zod schema](https://zod.dev/) to the plugin through options.
 
 ```ts title="server.ts"
 import { betterAuth } from "better-auth";
@@ -175,7 +167,7 @@ export const auth = betterAuth({
 })
 ```
 <Callout type="warn">
-  If no `additionalDataSchema` is provided, the type will default to `Record<string, any>` and the value is not validated during runtime.
+  If no `additionalDataSchema` is provided, the type will default to `Record<string, JsonValue>` and the value is not validated during runtime. JsonValue is a "generic" type that is constrained to only types that can be serialized into JSON.
 </Callout>
 
 ## Configuration Options

--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -20,7 +20,7 @@ Magic link or email link is a way to authenticate users without a password. When
     export const auth = betterAuth({
         plugins: [
             magicLink({
-                sendMagicLink: async ({ email, token, url }, request) => {
+                sendMagicLink: async ({ email, token, url, additionalData }, request) => {
                     // send email to user
                 }
             })
@@ -122,6 +122,38 @@ type magicLinkVerify = {
 ```
 </APIMethod>
 
+### Additional properties
+
+If you want to pass any arbitrary data to your `sendMagicLink` function, you can specify the `additionalData` field in the request body of the `signIn.magicLink` function.
+
+```ts title="magic-link.ts"
+const { data, error } = await authClient.signIn.magicLink({
+  email: "user@email.com",
+  additionalData: {
+    message: "Hello from better-auth!",
+  },
+});
+```
+
+The record is now available to use in the `sendMagicLink` function.
+
+```ts title="server.ts"
+import { betterAuth } from "better-auth";
+import { magicLink } from "better-auth/plugins";
+ 
+export const auth = betterAuth({
+    plugins: [
+        magicLink({
+            sendMagicLink: async ({ email, token, url, additionalData }, request) => {
+                const message = additionalData["message"];
+                
+                // send email to user
+            }
+        })
+    ]
+})
+```
+
 ## Configuration Options
 
 **sendMagicLink**: The `sendMagicLink` function is called when a user requests a magic link. It takes an object with the following properties:
@@ -129,6 +161,7 @@ type magicLinkVerify = {
 - `email`: The email address of the user.
 - `url`: The URL to be sent to the user. This URL contains the token.
 - `token`: The token if you want to send the token with custom URL.
+- `additionalData`: Optional record with properties provided in the request body.
 
 and a `request` object as the second parameter.
 

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -28,9 +28,9 @@ interface MagicLinkopts<DS extends z.ZodType> {
 		request?: Request,
 	) => Promise<void> | void;
 	/**
-	 * Zod schema for the additionalData property of the sendMagicLink function. 
+	 * Zod schema for the additionalData property of the sendMagicLink function.
 	 * This schema is used to validate and type-safeguard the additional data passed to the sign-in endpoint.
-	 * 
+	 *
 	 * @default z.record(z.any())
 	 * @see {@link https://zod.dev/basics}
 	 */
@@ -91,7 +91,8 @@ export const magicLink = <DS extends z.ZodType = z.ZodRecord<z.ZodString, z.ZodA
 		return token;
 	}
 
-	const additionalDataSchema = options.additionalDataSchema ?? (z.record(z.any(), z.any()) as unknown as DS);
+	const additionalDataSchema = 
+		options.additionalDataSchema ?? (z.record(z.any(), z.any()) as unknown as DS);
 
 	return {
 		id: "magic-link",
@@ -224,7 +225,7 @@ export const magicLink = <DS extends z.ZodType = z.ZodRecord<z.ZodString, z.ZodA
 							email,
 							url: url.toString(),
 							token: verificationToken,
-							additionalData
+							additionalData,
 						},
 						ctx.request,
 					);

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -71,7 +71,7 @@ interface MagicLinkopts<DS extends z.ZodType> {
 		| { type: "custom-hasher"; hash: (token: string) => Promise<string> };
 }
 
-export const magicLink = <DS extends z.ZodType = z.ZodRecord<z.ZodString, z.ZodAny>>(options: MagicLinkopts) => {
+export const magicLink = <DS extends z.ZodType = z.ZodRecord<z.ZodString, z.ZodAny>>(options: MagicLinkopts<DS>) => {
 	const opts = {
 		storeToken: "plain",
 		...options,
@@ -92,7 +92,7 @@ export const magicLink = <DS extends z.ZodType = z.ZodRecord<z.ZodString, z.ZodA
 	}
 
 	const additionalDataSchema = 
-		options.additionalDataSchema ?? (z.record(z.any(), z.any()) as unknown as DS);
+		(options.additionalDataSchema ?? z.record(z.any(), z.any())) as DS;
 
 	return {
 		id: "magic-link",
@@ -148,6 +148,8 @@ export const magicLink = <DS extends z.ZodType = z.ZodRecord<z.ZodString, z.ZodA
 							.string()
 							.meta({
 								description: "URL to redirect after error.",
+							})
+							.optional(),
 						additionalData: additionalDataSchema.optional(),
 					}),
 					metadata: {

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -28,7 +28,7 @@ const jsonSchema: z.ZodType<JsonValue> = z.lazy(() =>
 	]),
 );
 
-interface MagicLinkopts<DS extends z.ZodType> {
+interface MagicLinkOptions<DS extends z.ZodType> {
 	/**
 	 * Time in seconds until the magic link expires.
 	 * @default (60 * 5) // 5 minutes
@@ -93,12 +93,12 @@ interface MagicLinkopts<DS extends z.ZodType> {
 export const magicLink = <
 	DS extends z.ZodType<JsonValue> = z.ZodRecord<z.ZodString, typeof jsonSchema>,
 >(
-	options: MagicLinkopts<DS>,
+	options: MagicLinkOptions<DS>,
 ) => {
 	const opts = {
 		storeToken: "plain",
 		...options,
-	} satisfies MagicLinkopts<DS>;
+	} satisfies MagicLinkOptions<DS>;
 
 	async function storeToken(ctx: GenericEndpointContext, token: string) {
 		if (opts.storeToken === "hashed") {

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -23,6 +23,7 @@ interface MagicLinkopts {
 			email: string;
 			url: string;
 			token: string;
+			additionalData?: Record<string, any>;
 		},
 		request?: Request,
 	) => Promise<void> | void;
@@ -135,6 +136,10 @@ export const magicLink = (options: MagicLinkopts) => {
 							.string()
 							.meta({
 								description: "URL to redirect after error.",
+						additionalData: z
+							.record(z.any(), z.any())
+							.meta({
+								description: "Additional data for use in the magic link process",
 							})
 							.optional(),
 					}),
@@ -162,7 +167,7 @@ export const magicLink = (options: MagicLinkopts) => {
 					},
 				},
 				async (ctx) => {
-					const { email } = ctx.body;
+					const { email, additionalData } = ctx.body;
 
 					if (opts.disableSignUp) {
 						const user =
@@ -213,6 +218,7 @@ export const magicLink = (options: MagicLinkopts) => {
 							email,
 							url: url.toString(),
 							token: verificationToken,
+							additionalData
 						},
 						ctx.request,
 					);

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -31,11 +31,10 @@ interface MagicLinkopts<DS extends z.ZodType> {
 	 * Zod schema for the additionalData property of the sendMagicLink function.
 	 * This schema is used to validate and type-safeguard the additional data passed to the sign-in endpoint.
 	 *
-	 * @default z.record(z.any())
+	 * @default z.record(z.any(), z.any())
 	 * @see {@link https://zod.dev/basics}
 	 */
 	additionalDataSchema?: DS;
-
 	/**
 	 * Disable sign up if user is not found.
 	 *
@@ -154,7 +153,12 @@ export const magicLink = <
 								description: "URL to redirect after error.",
 							})
 							.optional(),
-						additionalData: additionalDataSchema.optional(),
+						additionalData: additionalDataSchema
+							.meta({
+								description:
+									"Additional data to pass to the sendMagicLink function",
+							})
+							.optional(),
 					}),
 					metadata: {
 						openapi: {

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -71,7 +71,11 @@ interface MagicLinkopts<DS extends z.ZodType> {
 		| { type: "custom-hasher"; hash: (token: string) => Promise<string> };
 }
 
-export const magicLink = <DS extends z.ZodType = z.ZodRecord<z.ZodString, z.ZodAny>>(options: MagicLinkopts<DS>) => {
+export const magicLink = <
+	DS extends z.ZodType = z.ZodRecord<z.ZodString, z.ZodAny>,
+>(
+	options: MagicLinkopts<DS>,
+) => {
 	const opts = {
 		storeToken: "plain",
 		...options,
@@ -91,8 +95,8 @@ export const magicLink = <DS extends z.ZodType = z.ZodRecord<z.ZodString, z.ZodA
 		return token;
 	}
 
-	const additionalDataSchema = 
-		(options.additionalDataSchema ?? z.record(z.any(), z.any())) as DS;
+	const additionalDataSchema = (options.additionalDataSchema ??
+		z.record(z.any(), z.any())) as DS;
 
 	return {
 		id: "magic-link",

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -50,7 +50,7 @@ interface MagicLinkOptions<DS extends z.ZodType> {
 	 * Zod schema for the additionalData property of the sendMagicLink function.
 	 * This schema is used to validate and type-safeguard the additional data passed to the sign-in endpoint.
 	 *
-	 * @default z.record(z.string(), typeof jsonSchema)
+	 * @default z.record(z.string(), jsonSchema)
 	 * @see {@link https://zod.dev/basics}
 	 * @type jsonSchema is a Zod schema that validates JSON-serializable values.
 	 */


### PR DESCRIPTION
# Magic Link

## Motivation

When working on my own application, I came across the issue that I can currently not provide any "custom" data from the client to the function that eventually sends the magic link email. This had me brainstorming, but eventually I figured that I might as well contribute a solution.

My specific use-case is that when someone attempts to log in, I want to show the country that the request came from. Since I use Next.js server actions to call most of my auth functions, the provided `Request` object is `undefined` because no actual HTTP request takes place. This is frustrating because I am able to add headers and a body on the server API but not actually use them there that way. At first, I considered simply changing `ctx.request` to `ctx` and just providing the whole context, but that solution didn't feel right, is difficult to make type-safe and would be a "breaking change".

## Implementation

- Added the `additionalDataSchema` property to the `MagicLinkOptions` allowing a Zod scheme to be configured, defaults to `Record<string, any>`.
- Added the Zod scheme to the request body under the `additionalData` property.
- Added the `additionalData` property to the function signature of `sendMagicLink()`
- Works on both the server & client API.

## Testing

I do not see the need for new tests here.

## Related

- ~~I've noticed that my code is impacted by #3399 which changes the way `ZodObject` works.~~ Fixed

## Checklist

- Updated documentation
- Types work well
- Code has been tested
- Backward compatibility maintained
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for passing custom additional data to the magic link email function, with optional Zod schema validation for type safety.

- **New Features**
  - Accepts an `additionalData` field in the magic link request body.
  - Allows defining an `additionalDataSchema` for validation and type inference.
  - Passes `additionalData` to the `sendMagicLink` function on both server and client.

<!-- End of auto-generated description by cubic. -->

