### PR TITLE
fix(admin): before hook not triggering on create user

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -105,14 +105,6 @@ describe("Admin plugin", async () => {
 									},
 								};
 							}
-							if (user.email === "userwithusername@email.com") {
-								return {
-									data: {
-										...user,
-										userName: "userwithusername",
-									},
-								};
-							}
 						},
 					},
 				},
@@ -209,22 +201,6 @@ describe("Admin plugin", async () => {
 		);
 		expect(res.error?.status).toBe(403);
 	});
-	it("should run the before create hook on create user", async () => {
-		const res = await client.admin.createUser(
-			{
-				name: "Test User",
-				email: "userwithusername@email.com",
-				password: "test",
-				role: "user",
-			},
-			{
-				headers: adminHeaders,
-			},
-		);
-		newUser = res.data?.user;
-		expect((newUser as any)?.userName).toBe("userwithusername");
-	});
-
 	it("should allow admin to list users", async () => {
 		const res = await client.admin.listUsers({
 			query: {

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -105,6 +105,14 @@ describe("Admin plugin", async () => {
 									},
 								};
 							}
+							if (user.email === "userwithusername@email.com") {
+								return {
+									data: {
+										...user,
+										userName: "userwithusername",
+									},
+								};
+							}
 						},
 					},
 				},
@@ -200,6 +208,21 @@ describe("Admin plugin", async () => {
 			},
 		);
 		expect(res.error?.status).toBe(403);
+	});
+	it("should run the before create hook on create user", async () => {
+		const res = await client.admin.createUser(
+			{
+				name: "Test User",
+				email: "userwithusername@email.com",
+				password: "test",
+				role: "user",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		newUser = res.data?.user;
+		expect((newUser as any)?.userName).toBe("userwithusername");
 	});
 
 	it("should allow admin to list users", async () => {

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -349,15 +349,18 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 						});
 					}
 					const user =
-						await ctx.context.internalAdapter.createUser<UserWithRole>({
-							email: ctx.body.email,
-							name: ctx.body.name,
-							role:
-								(ctx.body.role && parseRoles(ctx.body.role)) ??
-								options?.defaultRole ??
-								"user",
-							...ctx.body.data,
-						});
+						await ctx.context.internalAdapter.createUser<UserWithRole>(
+							{
+								email: ctx.body.email,
+								name: ctx.body.name,
+								role:
+									(ctx.body.role && parseRoles(ctx.body.role)) ??
+									options?.defaultRole ??
+									"user",
+								...ctx.body.data,
+							},
+							ctx,
+						);
 
 					if (!user) {
 						throw new APIError("INTERNAL_SERVER_ERROR", {


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed an issue where the before create hook was not triggered when creating a user through the admin plugin.

- **Bug Fixes**
 - Passed the context to the internal createUser call to ensure hooks run as expected.
 - Added a test to confirm the before create hook is executed on user creation.

closes #3389
<!-- End of auto-generated description by cubic. -->
now it triggers it and see the output.
<img width="322" height="139" alt="Screenshot 2025-07-17 at 6 02 20 AM" src="https://github.com/user-attachments/assets/c25ae909-378b-43f4-a182-43058887b4c0" />


