### PR TITLE
fix: token access type option in dropbox oauth

### DIFF
--- a/packages/better-auth/src/social-providers/dropbox.ts
+++ b/packages/better-auth/src/social-providers/dropbox.ts
@@ -20,7 +20,9 @@ export interface DropboxProfile {
 	profile_photo_url: string;
 }
 
-export interface DropboxOptions extends ProviderOptions<DropboxProfile> {}
+export interface DropboxOptions extends ProviderOptions<DropboxProfile> {
+	accessType?: "offline" | "online" | "legacy";
+}
 
 export const dropbox = (options: DropboxOptions) => {
 	const tokenEndpoint = "https://api.dropboxapi.com/oauth2/token";
@@ -37,6 +39,10 @@ export const dropbox = (options: DropboxOptions) => {
 			const _scopes = options.disableDefaultScope ? [] : ["account_info.read"];
 			options.scope && _scopes.push(...options.scope);
 			scopes && _scopes.push(...scopes);
+			const additionalParams: Record<string, string> = {};
+			if (options.accessType) {
+				additionalParams.token_access_type = options.accessType;
+			}
 			return await createAuthorizationURL({
 				id: "dropbox",
 				options,
@@ -45,6 +51,7 @@ export const dropbox = (options: DropboxOptions) => {
 				state,
 				redirectURI,
 				codeVerifier,
+				additionalParams,
 			});
 		},
 		validateAuthorizationCode: async ({ code, codeVerifier, redirectURI }) => {


### PR DESCRIPTION
closes #3358
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for the token access type option in Dropbox OAuth, allowing selection between "offline", "online", or "legacy" modes. This enables more control over the type of access tokens requested during authentication.

<!-- End of auto-generated description by cubic. -->

