### PR TITLE
Relax offline_access scope validation by removing prompt=consent requirement

### DIFF
--- a/packages/better-auth/src/plugins/mcp/authorize.ts
+++ b/packages/better-auth/src/plugins/mcp/authorize.ts
@@ -125,10 +125,7 @@ export async function authorizeMCPOAuth(
 	const requestScope =
 		query.scope?.split(" ").filter((s) => s) || opts.defaultScope.split(" ");
 	const invalidScopes = requestScope.filter((scope) => {
-		const isInvalid =
-			!opts.scopes.includes(scope) ||
-			(scope === "offline_access" && query.prompt !== "consent");
-		return isInvalid;
+		return !opts.scopes.includes(scope);
 	});
 	if (invalidScopes.length) {
 		throw ctx.redirect(

--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -153,10 +153,7 @@ export async function authorize(
 	const requestScope =
 		query.scope?.split(" ").filter((s) => s) || opts.defaultScope.split(" ");
 	const invalidScopes = requestScope.filter((scope) => {
-		const isInvalid =
-			!opts.scopes.includes(scope) ||
-			(scope === "offline_access" && query.prompt !== "consent");
-		return isInvalid;
+		return !opts.scopes.includes(scope);
 	});
 	if (invalidScopes.length) {
 		return handleRedirect(


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/3411
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the requirement for prompt=consent when requesting the offline_access scope, allowing clients to request offline access without extra prompts.

<!-- End of auto-generated description by cubic. -->

