### PR TITLE
fix(generic-oauth): error callback url correct query

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -575,7 +575,13 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						const defaultErrorURL =
 							ctx.context.options.onAPIError?.errorURL ||
 							`${ctx.context.baseURL}/error`;
-						throw ctx.redirect(`${errorURL || defaultErrorURL}?error=${error}`);
+						let url = errorURL || defaultErrorURL;
+						if (url.includes("?")) {
+							url = `${url}&error=${error}`;
+						} else {
+							url = `${url}?error=${error}`;
+						}
+						throw ctx.redirect(url);
 					}
 
 					let finalTokenUrl = provider.tokenUrl;


### PR DESCRIPTION
Non-plugin "errorCallbackURL" handles the query correctly, but "generic-oauth" plugin "errorCallbackURL" does not.

For example:
errorCallbackURL: "/callback?test=test"
↓
/callback?test=test?error=error
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the generic-oauth plugin so the error callback URL appends the error as a query parameter correctly, avoiding malformed URLs when the original URL already has query parameters.

<!-- End of auto-generated description by cubic. -->

