### PR TITLE
feat(open-api): include additional fields

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
@@ -1,1 +1,1 @@
-IDLE
+RUNNING

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -4,7 +4,7 @@ import type {
 	OpenAPIParameter,
 	OpenAPISchemaType,
 } from "better-call";
-import { z } from "zod";
+import { z, ZodOptional, ZodObject, ZodType } from "zod";
 import { getEndpoints } from "../../api";
 import { getAuthTables } from "../../db";
 import type { AuthContext, BetterAuthOptions } from "../../types";
@@ -70,7 +70,7 @@ export interface Path {
 }
 
 const paths: Record<string, Path> = {};
-function getTypeFromZodType(zodType: z.ZodTypeAny) {
+function getTypeFromZodType(zodType: ZodSchema) {
 	switch (zodType.constructor.name) {
 		case "ZodString":
 			return "string";
@@ -112,9 +112,9 @@ function getParameters(options: EndpointOptions) {
 		parameters.push(...options.metadata.openapi.parameters);
 		return parameters;
 	}
-	if (options.query instanceof z.ZodObject) {
+	if (options.query instanceof ZodObject) {
 		Object.entries(options.query.shape).forEach(([key, value]) => {
-			if (value instanceof z.ZodType) {
+			if (value instanceof ZodType) {
 				parameters.push({
 					name: key,
 					in: "query",
@@ -140,8 +140,8 @@ function getRequestBody(options: EndpointOptions): any {
 	}
 	if (!options.body) return undefined;
 	if (
-		options.body instanceof z.ZodObject ||
-		options.body instanceof z.ZodOptional
+		options.body instanceof ZodObject ||
+		options.body instanceof ZodOptional
 	) {
 		// @ts-ignore
 		const shape = options.body.shape;
@@ -161,7 +161,7 @@ function getRequestBody(options: EndpointOptions): any {
 		});
 		return {
 			required:
-				options.body instanceof z.ZodOptional
+				options.body instanceof ZodOptional
 					? false
 					: options.body
 						? true

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -71,20 +71,20 @@ export interface Path {
 
 const paths: Record<string, Path> = {};
 function getTypeFromZodType(zodType: z.ZodTypeAny) {
-    switch (zodType.constructor.name) {
-        case "ZodString":
-            return "string";
-        case "ZodNumber":
-            return "number";
-        case "ZodBoolean":
-            return "boolean";
-        case "ZodObject":
-            return "object";
-        case "ZodArray":
-            return "array";
-        default:
-            return "string";
-    }
+	switch (zodType.constructor.name) {
+		case "ZodString":
+			return "string";
+		case "ZodNumber":
+			return "number";
+		case "ZodBoolean":
+			return "boolean";
+		case "ZodObject":
+			return "object";
+		case "ZodArray":
+			return "array";
+		default:
+			return "string";
+	}
 }
 
 function getFieldSchema(field: FieldAttribute) {
@@ -93,9 +93,10 @@ function getFieldSchema(field: FieldAttribute) {
 	};
 
 	if (field.defaultValue) {
-		schema.default = typeof field.defaultValue === "function" 
-			? "Generated at runtime"
-			: field.defaultValue;
+		schema.default =
+			typeof field.defaultValue === "function"
+				? "Generated at runtime"
+				: field.defaultValue;
 	}
 
 	if (field.input === false) {
@@ -302,7 +303,7 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 		const fields = value.fields;
 		const required: string[] = [];
 		const properties: Record<string, any> = {
-			id: { type: "string" }
+			id: { type: "string" },
 		};
 		Object.entries(fields).forEach(([fieldKey, fieldValue]) => {
 			if (!fieldValue) return;
@@ -316,7 +317,7 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 		acc[modelName] = {
 			type: "object",
 			properties,
-			...(required.length > 0 ? { required } : {})
+			...(required.length > 0 ? { required } : {}),
 		};
 		return acc;
 	}, {});

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -92,7 +92,7 @@ function getFieldSchema(field: FieldAttribute) {
 		type: field.type === "date" ? "string" : field.type,
 	};
 
-	if (field.defaultValue) {
+	if (field.defaultValue !== undefined) {
 		schema.default =
 			typeof field.defaultValue === "function"
 				? "Generated at runtime"

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -70,7 +70,7 @@ export interface Path {
 }
 
 const paths: Record<string, Path> = {};
-function getTypeFromZodType(zodType: ZodSchema) {
+function getTypeFromZodType(zodType: ZodType) {
 	switch (zodType.constructor.name) {
 		case "ZodString":
 			return "string";

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -5,6 +5,19 @@ import { openAPI } from ".";
 describe("open-api", async (it) => {
 	const { auth } = await getTestInstance({
 		plugins: [openAPI()],
+		user: {
+			additionalFields: {
+				role: {
+					type: "string",
+					required: true,
+					defaultValue: "user"
+				},
+				preferences: {
+					type: "string",
+					required: false
+				}
+			}
+		}
 	});
 
 	it("should generate OpenAPI schema", async () => {
@@ -21,5 +34,24 @@ describe("open-api", async (it) => {
 		expect(schemas["User"].properties.id).toEqual({
 			type: "string",
 		});
+	});
+
+	it("should include additionalFields in the User schema", async () => {
+		const schema = await auth.api.generateOpenAPISchema();
+		const schemas = schema.components.schemas as Record<
+			string,
+			Record<string, any>
+		>;
+		
+		expect(schemas["User"].properties.role).toEqual({
+			type: "string",
+			default: "user",
+		});
+
+		expect(schemas["User"].properties.preferences).toEqual({
+			type: "string"
+		});
+		expect(schemas["User"].required).toContain("role");
+		expect(schemas["User"].required).not.toContain("preferences");
 	});
 });

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -10,14 +10,14 @@ describe("open-api", async (it) => {
 				role: {
 					type: "string",
 					required: true,
-					defaultValue: "user"
+					defaultValue: "user",
 				},
 				preferences: {
 					type: "string",
-					required: false
-				}
-			}
-		}
+					required: false,
+				},
+			},
+		},
 	});
 
 	it("should generate OpenAPI schema", async () => {
@@ -42,14 +42,14 @@ describe("open-api", async (it) => {
 			string,
 			Record<string, any>
 		>;
-		
+
 		expect(schemas["User"].properties.role).toEqual({
 			type: "string",
 			default: "user",
 		});
 
 		expect(schemas["User"].properties.preferences).toEqual({
-			type: "string"
+			type: "string",
 		});
 		expect(schemas["User"].required).toContain("role");
 		expect(schemas["User"].required).not.toContain("preferences");


### PR DESCRIPTION
closes #3263    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for including additional user fields in the generated OpenAPI schema, with correct types, defaults, and required status.

- **New Features**
  - User-defined additionalFields now appear in the OpenAPI User schema with accurate type, default, and required properties.

<!-- End of auto-generated description by cubic. -->
and tested with the image below by adding a `credits` additional field.
<img width="625" height="455" alt="Screenshot 2025-07-18 at 3 34 49 AM" src="https://github.com/user-attachments/assets/67f408ff-09d4-40d6-947e-fa14e9d058ac" />
