### PR TITLE
docs: organization option for cancelPendingInvitationsOnReInvite

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1290,6 +1290,6 @@ const auth = betterAuth({
 
 **invitationExpiresIn** : `number` - How long the invitation link is valid for in seconds. By default, it's 48 hours (2 days).
 
-**cancelPendingInvitationsOnReInvite**: `boolean` - Whether to cancel pending invitations if the user is already invited to the organization. By default, it's `true`.
+**cancelPendingInvitationsOnReInvite**: `boolean` - Whether to cancel pending invitations if the user is already invited to the organization. By default, it's `false`.
 
 **invitationLimit**: `number` | `((user: User) => Promise<boolean> | boolean)` - The maximum number of invitations allowed for a user. By default, it's `100`. You can set it to any number you want or a function that returns a boolean.

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -147,7 +147,7 @@ export interface OrganizationOptions {
 	/**
 	 * Cancel pending invitations on re-invite.
 	 *
-	 * @default false 
+	 * @default false
 	 */
 	cancelPendingInvitationsOnReInvite?: boolean;
 	/**

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -147,7 +147,7 @@ export interface OrganizationOptions {
 	/**
 	 * Cancel pending invitations on re-invite.
 	 *
-	 * @default true
+	 * @default false 
 	 */
 	cancelPendingInvitationsOnReInvite?: boolean;
 	/**


### PR DESCRIPTION
closes #3209
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the default value of the cancelPendingInvitationsOnReInvite option for organizations to false in both code and documentation.

<!-- End of auto-generated description by cubic. -->

