### PR TITLE
fix(social-providers): twitch provider not returning if email is valid

### DIFF
--- a/packages/better-auth/src/social-providers/twitch.ts
+++ b/packages/better-auth/src/social-providers/twitch.ts
@@ -7,6 +7,9 @@ import {
 } from "../oauth2";
 import { decodeJwt } from "jose";
 
+/**
+ * @see https://dev.twitch.tv/docs/authentication/getting-tokens-oidc/#requesting-claims
+ */
 export interface TwitchProfile {
 	/**
 	 * The sub of the user
@@ -20,6 +23,10 @@ export interface TwitchProfile {
 	 * The email of the user
 	 */
 	email: string;
+	/**
+	 * Indicate if this user has a verified email.
+	 */
+	email_verified: boolean;
 	/**
 	 * The picture of the user
 	 */
@@ -92,7 +99,7 @@ export const twitch = (options: TwitchOptions) => {
 					name: profile.preferred_username,
 					email: profile.email,
 					image: profile.picture,
-					emailVerified: false,
+					emailVerified: profile.email_verified,
 					...userMap,
 				},
 				data: profile,


### PR DESCRIPTION
Currently, the Twitch provider isn't returning if the Twitch user have a verified email from the OIDC claimed information, making the link with Twitch fail if user have already verified email with better auth.

Ref: https://dev.twitch.tv/docs/authentication/getting-tokens-oidc/#requesting-claims
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the Twitch provider to correctly return if a user's email is verified, allowing proper account linking when the email is already verified.

<!-- End of auto-generated description by cubic. -->

