### PR TITLE
feat: remote jwks, remote signing, and exportable signJwt function

### DIFF
--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -304,3 +304,70 @@ jwt({
   }
 })
 ```
+
+### Oauth Provider Mode
+
+If you are making your system an oAuth provider by using the OIDC or MCP plugins, you **MUST** set this parameter to disable the `/token` endpoint and the ability to obtain tokens via the `set-auth-jwt`.
+
+```ts title="auth.ts"
+jwt({
+  usesOauthProvider: true,
+})
+```
+
+### Remote JWKS Url
+
+Disables the `/jwks` endpoint and uses this endpoint in any discovery such as OIDC.
+
+Useful if your JWKS are not managed at `/jwks` or if your jwks are signed with a certificate and placed on your CDN.
+
+```ts title="auth.ts"
+jwt({
+  jwks: {
+    remoteUrl: "https://example.com/.well-known/jwks.json",
+  }
+})
+```
+
+NOTE: If you are also using the OIDC plugin, you **MUST** specify which algorithm is used for signing as well.
+
+```ts title="auth.ts"
+jwt({
+  usesOauthProvider: true,
+  jwks: {
+    remoteUrl: "https://example.com/.well-known/jwks.json",
+    keyPairConfig: {
+      alg: 'ES256',
+    },
+  },
+})
+```
+
+### Custom Signing
+
+This is an advanced feature used if you are using a remote Key Management Service such as Google KMS, Amazon KMS, or Azure Key Vault.
+
+NOTE: `remoteUrl` must be defined if using the custom signing function.
+
+```ts title="auth.ts"
+jwt({
+  jwks: {
+    remoteUrl: "https://example.com/.well-known/jwks.json",
+  },
+  jwt: {
+    sign: async (jwtPayload: JWTPayload) => {
+      // this is pseudocode
+      const headers = { kid: '123', alg: 'ES256', typ: 'JWT' }
+      const payload = JSON.stringify(jwtPayload)
+      const encodedHeaders = Buffer.from(headers).toString('base64url')
+      const encodedPayload = Buffer.from(payload).toString('base64url')
+      const hash = createHash('sha256')
+      const data = `${encodedHeaders}.${encodedPayload}`
+      hash.update(Buffer.from(data))
+      const digest = hash.digest()
+      const sig = await remoteSign(digest)
+      return `${data}.${sig}`
+    },
+  },
+})
+```

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -1,207 +1,319 @@
 import type {
+	AuthContext,
 	BetterAuthPlugin,
+	HookEndpointContext,
 	InferOptionSchema,
 	Session,
 	User,
 } from "../../types";
-import { type Jwk, schema } from "./schema";
+import { schema } from "./schema";
 import { getJwksAdapter } from "./adapter";
-import { getJwtToken } from "./sign";
-import { exportJWK, generateKeyPair } from "jose";
+import { createJwk, signJwt } from "./sign";
+import type { JWTPayload } from "jose";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 	sessionMiddleware,
 } from "../../api";
-import { symmetricEncrypt } from "../../crypto";
 import { mergeSchema } from "../../db/schema";
+import { BetterAuthError } from "../../error";
+import type { Awaitable } from "../../types/helper";
 
-type JWKOptions =
+// Asymmetric (JWS) Supported (https://github.com/panva/jose/issues/210)
+export type JWKOptions =
 	| {
-			alg: "EdDSA"; // EdDSA with either Ed25519 or Ed448 curve
-			crv?: "Ed25519" | "Ed448";
+			alg: "EdDSA"; // EdDSA with Ed25519 key
+			crv?: "Ed25519";
 	  }
 	| {
 			alg: "ES256"; // ECDSA with P-256 curve
 			crv?: never; // Only one valid option, no need for crv
 	  }
 	| {
-			alg: "RS256"; // RSA with SHA-256
-			modulusLength?: number; // Default to 2048 or higher
+			alg: "ES512"; // ECDSA with P-521 curve
+			crv?: never; // Only P-521 for ES512
 	  }
 	| {
 			alg: "PS256"; // RSA-PSS with SHA-256
 			modulusLength?: number; // Default to 2048 or higher
 	  }
 	| {
-			alg: "ECDH-ES"; // Key agreement algorithm with P-256 as default curve
-			crv?: "P-256" | "P-384" | "P-521";
-	  }
-	| {
-			alg: "ES512"; // ECDSA with P-521 curve
-			crv?: never; // Only P-521 for ES512
+			alg: "RS256"; // RSA with SHA-256
+			modulusLength?: number; // Default to 2048 or higher
 	  };
 
-export interface JwtOptions {
-	jwks?: {
-		/**
-		 * Key pair configuration
-		 * @description A subset of the options available for the generateKeyPair function
-		 *
-		 * @see https://github.com/panva/jose/blob/main/src/runtime/node/generate.ts
-		 *
-		 * @default { alg: 'EdDSA', crv: 'Ed25519' }
-		 */
-		keyPairConfig?: JWKOptions;
+export type JWSAlgorithms = JWKOptions["alg"];
 
-		/**
-		 * Disable private key encryption
-		 * @description Disable the encryption of the private key in the database
-		 *
-		 * @default false
-		 */
-		disablePrivateKeyEncryption?: boolean;
-	};
-
-	jwt?: {
-		/**
-		 * The issuer of the JWT
-		 */
-		issuer?: string;
-		/**
-		 * The audience of the JWT
-		 */
-		audience?: string;
-		/**
-		 * Set the "exp" (Expiration Time) Claim.
-		 *
-		 * - If a `number` is passed as an argument it is used as the claim directly.
-		 * - If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
-		 *   claim.
-		 * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
-		 *   current unix timestamp and used as the claim.
-		 *
-		 * Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
-		 * day".
-		 *
-		 * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
-		 * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-		 * "years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
-		 * alias for a year.
-		 *
-		 * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
-		 * subtracted from the current unix timestamp. A "from now" suffix can also be used for
-		 * readability when adding to the current unix timestamp.
-		 *
-		 * @default 15m
-		 */
-		expirationTime?: number | string | Date;
-		/**
-		 * A function that is called to define the payload of the JWT
-		 */
-		definePayload?: (session: {
-			user: User & Record<string, any>;
-			session: Session & Record<string, any>;
-		}) => Promise<Record<string, any>> | Record<string, any>;
-		/**
-		 * A function that is called to get the subject of the JWT
-		 *
-		 * @default session.user.id
-		 */
-		getSubject?: (session: {
-			user: User & Record<string, any>;
-			session: Session & Record<string, any>;
-		}) => Promise<string> | string;
-	};
+export interface JwtPluginOptions {
+	jwks?: JwksOptions;
+	jwt?: JwtOptions;
 	/**
 	 * Custom schema for the admin plugin
 	 */
 	schema?: InferOptionSchema<typeof schema>;
+	/**
+	 * Disables /token endpoint and auth middleware
+	 * in favor of Oidc authentication strategy.
+	 *
+	 * Thus, only the /jwks endpoint is enabled.
+	 */
+	usesOauthProvider?: boolean;
 }
 
-export const jwt = (options?: JwtOptions) => {
-	return {
-		id: "jwt",
-		endpoints: {
-			getJwks: createAuthEndpoint(
-				"/jwks",
-				{
-					method: "GET",
-					metadata: {
-						openapi: {
-							description: "Get the JSON Web Key Set",
-							responses: {
-								"200": {
-									description: "JSON Web Key Set retrieved successfully",
-									content: {
-										"application/json": {
-											schema: {
-												type: "object",
-												properties: {
-													keys: {
-														type: "array",
-														description: "Array of public JSON Web Keys",
-														items: {
-															type: "object",
-															properties: {
-																kid: {
-																	type: "string",
-																	description:
-																		"Key ID uniquely identifying the key, corresponds to the 'id' from the stored Jwk",
-																},
-																kty: {
-																	type: "string",
-																	description:
-																		"Key type (e.g., 'RSA', 'EC', 'OKP')",
-																},
-																alg: {
-																	type: "string",
-																	description:
-																		"Algorithm intended for use with the key (e.g., 'EdDSA', 'RS256')",
-																},
-																use: {
-																	type: "string",
-																	description:
-																		"Intended use of the public key (e.g., 'sig' for signature)",
-																	enum: ["sig"],
-																	nullable: true,
-																},
-																n: {
-																	type: "string",
-																	description:
-																		"Modulus for RSA keys (base64url-encoded)",
-																	nullable: true,
-																},
-																e: {
-																	type: "string",
-																	description:
-																		"Exponent for RSA keys (base64url-encoded)",
-																	nullable: true,
-																},
-																crv: {
-																	type: "string",
-																	description:
-																		"Curve name for elliptic curve keys (e.g., 'Ed25519', 'P-256')",
-																	nullable: true,
-																},
-																x: {
-																	type: "string",
-																	description:
-																		"X coordinate for elliptic curve keys (base64url-encoded)",
-																	nullable: true,
-																},
-																y: {
-																	type: "string",
-																	description:
-																		"Y coordinate for elliptic curve keys (base64url-encoded)",
-																	nullable: true,
-																},
+export interface JwksOptions {
+	/**
+	 * Disables the /jwks endpoint and uses this endpoint in discovery.
+	 *
+	 * Useful if jwks are not managed at /jwks or
+	 * if your jwks are signed with a certificate and placed on your CDN.
+	 */
+	remoteUrl?: string;
+	/**
+	 * Key pair configuration
+	 * @description A subset of the options available for the generateKeyPair function
+	 *
+	 * @see https://github.com/panva/jose/blob/main/src/runtime/node/generate.ts
+	 *
+	 * @default { alg: 'EdDSA', crv: 'Ed25519' }
+	 */
+	keyPairConfig?: JWKOptions;
+	/**
+	 * Disable private key encryption
+	 * @description Disable the encryption of the private key in the database
+	 *
+	 * @default false
+	 */
+	disablePrivateKeyEncryption?: boolean;
+}
+
+export interface JwtOptions {
+	/**
+	 * A custom function to remote sign the jwt payload.
+	 *
+	 * All headers, such as `alg` and `kid`,
+	 * MUST be defined within this function.
+	 * You can safely define the header `typ: 'JWT'`.
+	 *
+	 * @requires jwks.remoteUrl
+	 * @invalidates other jwt.* options
+	 */
+	sign?: (payload: JWTPayload) => Awaitable<string>;
+	/**
+	 * The issuer of the JWT
+	 */
+	issuer?: string;
+	/**
+	 * The audience of the JWT
+	 */
+	audience?: string | string[];
+	/**
+	 * Set the "exp" (Expiration Time) Claim.
+	 *
+	 * - If a `number` is passed as an argument it is used as the claim directly.
+	 * - If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+	 *   claim.
+	 * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
+	 *   current unix timestamp and used as the claim.
+	 *
+	 * Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+	 * day".
+	 *
+	 * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+	 * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+	 * "years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+	 * alias for a year.
+	 *
+	 * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+	 * subtracted from the current unix timestamp. A "from now" suffix can also be used for
+	 * readability when adding to the current unix timestamp.
+	 *
+	 * @default 15m
+	 */
+	expirationTime?: number | string | Date;
+	/**
+	 * A function that is called to define the payload of the JWT
+	 *
+	 * @invalid usesOauthProvider = true
+	 */
+	definePayload?: (session: {
+		user: User & Record<string, any>;
+		session: Session & Record<string, any>;
+	}) => Promise<Record<string, any>> | Record<string, any>;
+	/**
+	 * A function that is called to get the subject of the JWT
+	 *
+	 * @default session.user.id
+	 */
+	getSubject?: (session: {
+		user: User & Record<string, any>;
+		session: Session & Record<string, any>;
+	}) => Promise<string> | string;
+}
+
+export const getJwtPlugin = (ctx: AuthContext) => {
+	const plugin:
+		| (Omit<BetterAuthPlugin, "options"> & { options?: JwtPluginOptions })
+		| undefined = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
+	if (!plugin) {
+		throw new BetterAuthError("jwt_config", "jwt plugin not found");
+	}
+	return plugin;
+};
+
+export const jwt = (options?: JwtPluginOptions) => {
+	const endpoints: BetterAuthPlugin["endpoints"] = {};
+	const hooks: BetterAuthPlugin["hooks"] = {};
+
+	// Remote url must be set when using signing function
+	if (options?.jwt?.sign && !options.jwks?.remoteUrl) {
+		throw new BetterAuthError(
+			"jwks_config",
+			"jwks.remoteUrl must be set when using jwt.sign",
+		);
+	}
+
+	// Alg is required to be specified when using oidc plugin and remote url (needed in openid metadata)
+	if (
+		options?.usesOauthProvider &&
+		options.jwks?.remoteUrl &&
+		!options.jwks?.keyPairConfig?.alg
+	) {
+		throw new BetterAuthError(
+			"jwks_config",
+			"must specify alg when using the oidc plugin and jwks.remoteUrl",
+		);
+	}
+
+	// Disables endpoint if using remote url strategy
+	if (!options?.jwks?.remoteUrl) {
+		endpoints.getJwks = createAuthEndpoint(
+			"/jwks",
+			{
+				method: "GET",
+				metadata: {
+					openapi: {
+						description: "Get the JSON Web Key Set",
+						responses: {
+							"200": {
+								description: "JSON Web Key Set retrieved successfully",
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												keys: {
+													type: "array",
+													description: "Array of public JSON Web Keys",
+													items: {
+														type: "object",
+														properties: {
+															kid: {
+																type: "string",
+																description:
+																	"Key ID uniquely identifying the key, corresponds to the 'id' from the stored Jwk",
 															},
-															required: ["kid", "kty", "alg"],
+															kty: {
+																type: "string",
+																description:
+																	"Key type (e.g., 'RSA', 'EC', 'OKP')",
+															},
+															alg: {
+																type: "string",
+																description:
+																	"Algorithm intended for use with the key (e.g., 'EdDSA', 'RS256')",
+															},
+															use: {
+																type: "string",
+																description:
+																	"Intended use of the public key (e.g., 'sig' for signature)",
+																enum: ["sig"],
+																nullable: true,
+															},
+															n: {
+																type: "string",
+																description:
+																	"Modulus for RSA keys (base64url-encoded)",
+																nullable: true,
+															},
+															e: {
+																type: "string",
+																description:
+																	"Exponent for RSA keys (base64url-encoded)",
+																nullable: true,
+															},
+															crv: {
+																type: "string",
+																description:
+																	"Curve name for elliptic curve keys (e.g., 'Ed25519', 'P-256')",
+																nullable: true,
+															},
+															x: {
+																type: "string",
+																description:
+																	"X coordinate for elliptic curve keys (base64url-encoded)",
+																nullable: true,
+															},
+															y: {
+																type: "string",
+																description:
+																	"Y coordinate for elliptic curve keys (base64url-encoded)",
+																nullable: true,
+															},
 														},
+														required: ["kid", "kty", "alg"],
 													},
 												},
-												required: ["keys"],
+											},
+											required: ["keys"],
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			async (ctx) => {
+				const adapter = getJwksAdapter(ctx.context.adapter);
+
+				const keySets = await adapter.getAllKeys();
+
+				if (keySets.length === 0) {
+					const key = await createJwk(ctx, options);
+					keySets.push(key);
+				}
+
+				return ctx.json({
+					keys: keySets.map((keySet) => ({
+						...JSON.parse(keySet.publicKey),
+						kid: keySet.id,
+					})),
+				});
+			},
+		);
+	}
+
+	if (!options?.usesOauthProvider) {
+		endpoints.getToken = createAuthEndpoint(
+			"/token",
+			{
+				method: "GET",
+				requireHeaders: true,
+				use: [sessionMiddleware],
+				metadata: {
+					openapi: {
+						description: "Converts a session cookie to a JWT token",
+						responses: {
+							200: {
+								description: "Success",
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												token: {
+													type: "string",
+												},
 											},
 										},
 									},
@@ -210,134 +322,82 @@ export const jwt = (options?: JwtOptions) => {
 						},
 					},
 				},
-				async (ctx) => {
-					const adapter = getJwksAdapter(ctx.context.adapter);
+			},
+			async (ctx) => {
+				// Convert context into user payload
+				let payload: Record<string, any>;
+				if (options?.jwt?.definePayload) {
+					payload = await options?.jwt.definePayload(ctx.context.session!);
+				} else {
+					payload = {
+						...ctx.context.session?.user,
+						id: undefined, // id becomes sub in Sign Function
+					};
+				}
 
-					const keySets = await adapter.getAllKeys();
+				// Convert into JWT token
+				const jwt = await signJwt(ctx, payload, options);
+				return ctx.json({
+					token: jwt,
+				});
+			},
+		);
+	}
 
-					if (keySets.length === 0) {
-						const { alg, ...cfg } = options?.jwks?.keyPairConfig ?? {
-							alg: "EdDSA",
-							crv: "Ed25519",
+	if (!options?.usesOauthProvider) {
+		if (!hooks.after) hooks.after = [];
+		hooks.after.push({
+			matcher(context: HookEndpointContext) {
+				return context.path === "/get-session";
+			},
+			handler: createAuthMiddleware(async (ctx) => {
+				const session = ctx.context.session || ctx.context.newSession;
+				if (session && session.session) {
+					// Convert context into user payload
+					let payload: Record<string, any>;
+					if (options?.jwt?.definePayload) {
+						payload = await options?.jwt.definePayload(ctx.context.session!);
+					} else {
+						payload = {
+							...ctx.context.session?.user,
+							id: undefined, // id becomes sub in Sign Function
 						};
-						const keyPairConfig = {
-							extractable: true,
-							...cfg,
-						};
-
-						const { publicKey, privateKey } = await generateKeyPair(
-							alg,
-							keyPairConfig,
-						);
-
-						const publicWebKey = await exportJWK(publicKey);
-						const privateWebKey = await exportJWK(privateKey);
-						const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
-						const privateKeyEncryptionEnabled =
-							!options?.jwks?.disablePrivateKeyEncryption;
-						let jwk: Partial<Jwk> = {
-							publicKey: JSON.stringify({ alg, ...publicWebKey }),
-							privateKey: privateKeyEncryptionEnabled
-								? JSON.stringify(
-										await symmetricEncrypt({
-											key: ctx.context.secret,
-											data: stringifiedPrivateWebKey,
-										}),
-									)
-								: stringifiedPrivateWebKey,
-							createdAt: new Date(),
-						};
-
-						await adapter.createJwk(jwk as Jwk);
-
-						return ctx.json({
-							keys: [
-								{
-									...publicWebKey,
-									alg,
-									kid: jwk.id,
-								},
-							],
-						});
 					}
 
-					return ctx.json({
-						keys: keySets.map((keySet) => ({
-							...JSON.parse(keySet.publicKey),
-							kid: keySet.id,
-						})),
-					});
-				},
-			),
+					if (!payload) return;
+					const jwt = await signJwt(ctx, payload, options);
+					const exposedHeaders =
+						ctx.context.responseHeaders?.get("access-control-expose-headers") ||
+						"";
+					const headersSet = new Set(
+						exposedHeaders
+							.split(",")
+							.map((header) => header.trim())
+							.filter(Boolean),
+					);
+					headersSet.add("set-auth-jwt");
+					ctx.setHeader("set-auth-jwt", jwt);
+					ctx.setHeader(
+						"Access-Control-Expose-Headers",
+						Array.from(headersSet).join(", "),
+					);
+				}
+			}),
+		});
+	}
 
-			getToken: createAuthEndpoint(
-				"/token",
-				{
-					method: "GET",
-					requireHeaders: true,
-					use: [sessionMiddleware],
-					metadata: {
-						openapi: {
-							description: "Get a JWT token",
-							responses: {
-								200: {
-									description: "Success",
-									content: {
-										"application/json": {
-											schema: {
-												type: "object",
-												properties: {
-													token: {
-														type: "string",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				async (ctx) => {
-					const jwt = await getJwtToken(ctx, options);
-					return ctx.json({
-						token: jwt,
-					});
-				},
-			),
+	return {
+		id: "jwt",
+		init: (ctx) => {
+			// Add the jwt plugin options to ctx
+			const plugin = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
+			if (!plugin) {
+				throw Error("Plugin should have been registered! Should never hit!");
+			}
+			plugin.options = options;
 		},
-		hooks: {
-			after: [
-				{
-					matcher(context) {
-						return context.path === "/get-session";
-					},
-					handler: createAuthMiddleware(async (ctx) => {
-						const session = ctx.context.session || ctx.context.newSession;
-						if (session && session.session) {
-							const jwt = await getJwtToken(ctx, options);
-							const exposedHeaders =
-								ctx.context.responseHeaders?.get(
-									"access-control-expose-headers",
-								) || "";
-							const headersSet = new Set(
-								exposedHeaders
-									.split(",")
-									.map((header) => header.trim())
-									.filter(Boolean),
-							);
-							headersSet.add("set-auth-jwt");
-							ctx.setHeader("set-auth-jwt", jwt);
-							ctx.setHeader(
-								"Access-Control-Expose-Headers",
-								Array.from(headersSet).join(", "),
-							);
-						}
-					}),
-				},
-			],
-		},
+		endpoints,
+		hooks,
 		schema: mergeSchema(schema, options?.schema),
 	} satisfies BetterAuthPlugin;
 };

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -3,29 +3,8 @@ import { getTestInstance } from "../../test-utils/test-instance";
 import { createAuthClient } from "../../client";
 import { jwtClient } from "./client";
 import { jwt } from "./index";
-import { importJWK, jwtVerify } from "jose";
-
-type JWKOptions =
-	| {
-			alg: "EdDSA"; // EdDSA with either Ed25519
-			crv?: "Ed25519";
-	  }
-	| {
-			alg: "ES256"; // ECDSA with P-256 curve
-			crv?: never; // Only one valid option, no need for crv
-	  }
-	| {
-			alg: "RS256"; // RSA with SHA-256
-			modulusLength?: number; // Default to 2048 or higher
-	  }
-	| {
-			alg: "PS256"; // RSA-PSS with SHA-256
-			modulusLength?: number; // Default to 2048 or higher
-	  }
-	| {
-			alg: "ES512"; // ECDSA with P-521 curve
-			crv?: never; // Only P-521 for ES512
-	  };
+import { createLocalJWKSet, jwtVerify, type JSONWebKeySet } from "jose";
+import type { JWKOptions } from ".";
 
 describe("jwt", async (it) => {
 	// Testing the default behaviour
@@ -47,86 +26,93 @@ describe("jwt", async (it) => {
 		},
 	});
 
-	it("Client gets a token from session", async () => {
-		let token = "";
+	it("should receive token on client via header", async () => {
+		let token: string | null = null;
 		await client.getSession({
 			fetchOptions: {
 				headers,
 				onSuccess(context) {
-					token = context.response.headers.get("set-auth-jwt") || "";
+					token = context.response.headers.get("set-auth-jwt");
 				},
 			},
 		});
-
-		expect(token.length).toBeGreaterThan(10);
+		expect(token).not.toBeNull();
 	});
 
-	it("Client gets a token", async () => {
-		const token = await client.token({
-			fetchOptions: {
-				headers,
-			},
+	it("should get a token from api fetch", async () => {
+		const response = await client.$fetch<{
+			token: string;
+		}>("/token", {
+			headers,
 		});
-
-		expect(token.data?.token).toBeDefined();
+		expect(response.data?.token).toBeDefined();
 	});
 
-	it("Get JWKS", async () => {
-		// If no JWK exists, this makes sure it gets added.
-		// TODO: Replace this with a generate JWKS endpoint once it exists.
-		const token = await client.token({
-			fetchOptions: {
-				headers,
-			},
-		});
-
-		expect(token.data?.token).toBeDefined();
-
-		const jwks = await client.jwks();
-
-		expect(jwks.data?.keys).length.above(0);
+	it("should get /jwks", async () => {
+		const response = await client.$fetch<JSONWebKeySet>("/jwks");
+		const jwks = response?.data;
+		expect(jwks).toBeDefined();
+		expect(jwks?.keys.length).toBeGreaterThanOrEqual(1);
 	});
 
-	it("Signed tokens can be validated with the JWKS", async () => {
-		const token = await client.token({
-			fetchOptions: {
-				headers,
-			},
+	it("should validate signed via JWKS", async () => {
+		const response = await client.$fetch<{
+			token: string;
+		}>("/token", {
+			headers,
 		});
+		const token = response.data?.token ?? undefined;
+		expect(token).toBeDefined();
 
-		const jwks = await client.jwks();
+		const jwkResponse = await client.$fetch<JSONWebKeySet>("/jwks");
+		const jwksData = jwkResponse?.data ?? undefined;
+		expect(jwksData).toBeDefined();
 
-		const publicWebKey = await importJWK({
-			...jwks.data?.keys[0],
-			alg: "EdDSA",
-		});
-		const decoded = await jwtVerify(token.data?.token!, publicWebKey);
-
+		const jwks = createLocalJWKSet(jwksData!);
+		expect(() => jwtVerify(token!, jwks)).not.toThrow();
+		const decoded = await jwtVerify(token!, jwks);
 		expect(decoded).toBeDefined();
 	});
 
 	it("should set subject to user id by default", async () => {
-		const token = await client.token({
+		let token: string | null | undefined;
+		const userSession = await client.getSession({
 			fetchOptions: {
 				headers,
+				onSuccess(context) {
+					token = context.response.headers.get("set-auth-jwt");
+				},
 			},
 		});
+		expect(token).toBeDefined();
 
-		const jwks = await client.jwks();
+		const jwkResponse = await client.$fetch<JSONWebKeySet>("/jwks");
+		const jwksData = jwkResponse?.data ?? undefined;
+		expect(jwksData).toBeDefined();
+		const jwks = createLocalJWKSet(jwksData!);
 
-		const publicWebKey = await importJWK({
-			...jwks.data?.keys[0],
-			alg: "EdDSA",
-		});
-		const decoded = await jwtVerify(token.data?.token!, publicWebKey);
+		const decoded = await jwtVerify(token!, jwks);
 		expect(decoded.payload.sub).toBeDefined();
-		expect(decoded.payload.sub).toBe(decoded.payload.id);
+		expect(decoded.payload.sub).toBe(userSession.data?.user.id);
 	});
 
+	// Asymmetric (JWS) Supported (https://github.com/panva/jose/issues/210)
 	const algorithmsToTest: {
 		keyPairConfig: JWKOptions;
 		expectedOutcome: { ec: string; length: number; crv?: string; alg: string };
 	}[] = [
+		{
+			keyPairConfig: {
+				alg: "EdDSA",
+				crv: "Ed25519",
+			},
+			expectedOutcome: {
+				ec: "OKP",
+				length: 43,
+				crv: "Ed25519",
+				alg: "EdDSA",
+			},
+		},
 		{
 			keyPairConfig: {
 				alg: "ES256",
@@ -151,30 +137,14 @@ describe("jwt", async (it) => {
 		},
 		{
 			keyPairConfig: {
-				alg: "EdDSA",
-				crv: "Ed25519",
+				alg: "PS256",
 			},
 			expectedOutcome: {
-				ec: "OKP",
-				length: 43,
-				crv: "Ed25519",
-				alg: "EdDSA",
+				ec: "RSA",
+				length: 342,
+				alg: "PS256",
 			},
 		},
-		// This is not supported (https://github.com/panva/jose/issues/210)
-		/*
-		{
-			keyPairConfig: {
-				alg: "EdDSA",
-				crv: "Ed448",
-			},
-			expectedOutcome: {
-				ec: "OKP",
-				length: 43,
-				crv: "Ed448",
-				alg: "EdDSA",
-			},
-		},*/
 		{
 			keyPairConfig: {
 				alg: "RS256",
@@ -185,44 +155,6 @@ describe("jwt", async (it) => {
 				alg: "RS256",
 			},
 		},
-		// We cannot sign using key exchange protocol, need to establish a key first (only allowed usage for these keys is `deriveBits`)
-		/*
-		{
-			keyPairConfig: {
-				alg: "ECDH-ES",
-				crv: "P-256",
-			},
-			expectedOutcome: {
-				ec: "EC",
-				length: 43,
-				crv: "P-256",
-				alg: "ECDH-ES",
-			},
-		},
-		{
-			keyPairConfig: {
-				alg: "ECDH-ES",
-				crv: "P-384",
-			},
-			expectedOutcome: {
-				ec: "EC",
-				length: 64,
-				crv: "P-384",
-				alg: "ECDH-ES",
-			},
-		},
-		{
-			keyPairConfig: {
-				alg: "ECDH-ES",
-				crv: "P-521",
-			},
-			expectedOutcome: {
-				ec: "EC",
-				length: 88,
-				crv: "P-521",
-				alg: "ECDH-ES",
-			},
-		},*/
 	];
 
 	for (const algorithm of algorithmsToTest) {
@@ -236,7 +168,7 @@ describe("jwt", async (it) => {
 								keyPairConfig: {
 									...algorithm.keyPairConfig,
 								},
-								disablePrivateKeyEncryption: disablePrivateKeyEncryption,
+								disablePrivateKeyEncryption,
 							},
 						}),
 					],
@@ -292,63 +224,66 @@ describe("jwt", async (it) => {
 				});
 
 				it(`${alg} algorithm${enc}: Client gets a token`, async () => {
-					const token = await client.token({
-						fetchOptions: {
-							headers,
-						},
+					const response = await client.$fetch<{
+						token: string;
+					}>("/token", {
+						headers,
 					});
-
-					expect(token.data?.token).toBeDefined();
+					expect(response.data?.token).toBeDefined();
 				});
 
-				it(`${alg} algorithm${enc}: Client gets a token from session`, async () => {
-					let token = "";
+				it(`${alg} algorithm${enc}: should receive via header`, async () => {
+					let token: string | null = null;
 					await client.getSession({
 						fetchOptions: {
 							headers,
 							onSuccess(context) {
-								token = context.response.headers.get("set-auth-jwt") || "";
+								token = context.response.headers.get("set-auth-jwt");
 							},
 						},
 					});
-
-					expect(token.length).toBeGreaterThan(10);
+					expect(token).not.toBeNull();
 				});
 
-				it(`${alg} algorithm${enc}: Signed tokens can be validated with the JWKS`, async () => {
-					const token = await client.token({
-						fetchOptions: {
-							headers,
-						},
+				it(`${alg} algorithm${enc}: should validate via JWKS`, async () => {
+					const response = await client.$fetch<{
+						token: string;
+					}>("/token", {
+						headers,
 					});
+					const token = response.data?.token ?? undefined;
+					expect(token).toBeDefined();
 
-					const jwks = await client.jwks();
+					const jwkResponse = await client.$fetch<JSONWebKeySet>("/jwks");
+					const jwksData = jwkResponse?.data ?? undefined;
+					expect(jwksData).toBeDefined();
 
-					const publicWebKey = await importJWK({
-						...jwks.data?.keys[0],
-						alg: algorithm.keyPairConfig.alg,
-					});
-					const decoded = await jwtVerify(token.data?.token!, publicWebKey);
-
+					const jwks = createLocalJWKSet(jwksData!);
+					expect(() => jwtVerify(token!, jwks)).not.toThrow();
+					const decoded = await jwtVerify(token!, jwks);
 					expect(decoded).toBeDefined();
 				});
 
 				it(`${alg} algorithm${enc}: Should set subject to user id by default`, async () => {
-					const token = await client.token({
+					let token: string | null | undefined;
+					const userSession = await client.getSession({
 						fetchOptions: {
 							headers,
+							onSuccess(context) {
+								token = context.response.headers.get("set-auth-jwt");
+							},
 						},
 					});
+					expect(token).toBeDefined();
 
-					const jwks = await client.jwks();
+					const jwkResponse = await client.$fetch<JSONWebKeySet>("/jwks");
+					const jwksData = jwkResponse?.data ?? undefined;
+					expect(jwksData).toBeDefined();
+					const jwks = createLocalJWKSet(jwksData!);
 
-					const publicWebKey = await importJWK({
-						...jwks.data?.keys[0],
-						alg: algorithm.keyPairConfig.alg,
-					});
-					const decoded = await jwtVerify(token.data?.token!, publicWebKey);
+					const decoded = await jwtVerify(token!, jwks);
 					expect(decoded.payload.sub).toBeDefined();
-					expect(decoded.payload.sub).toBe(decoded.payload.id);
+					expect(decoded.payload.sub).toBe(userSession.data?.user.id);
 				});
 			} catch (err) {
 				console.error(err);
@@ -356,4 +291,130 @@ describe("jwt", async (it) => {
 			}
 		}
 	}
+});
+
+describe("jwt - remote signing", async (it) => {
+	it("should fail if sign is defined and remoteUrl is not", async () => {
+		expect(() =>
+			getTestInstance({
+				plugins: [
+					jwt({
+						jwt: {
+							sign: () => {
+								return "123";
+							},
+						},
+					}),
+				],
+				logger: {
+					level: "error",
+				},
+			}),
+		).toThrow();
+	});
+});
+
+describe("jwt - oidc plugin", async (it) => {
+	const { auth, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			jwt({
+				usesOauthProvider: true,
+			}),
+		],
+		logger: {
+			level: "error",
+		},
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [jwtClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	it("should not receive token on client via header", async () => {
+		let token: string | null | undefined;
+		await client.getSession({
+			fetchOptions: {
+				headers,
+				onSuccess(context) {
+					token = context.response.headers.get("set-auth-jwt");
+				},
+			},
+		});
+		expect(token).toBeNull();
+	});
+
+	it("should disable /token", async () => {
+		const response = await client.$fetch<{
+			token: string;
+		}>("/token", {
+			headers,
+		});
+		expect(response.error?.status).toBe(404);
+	});
+
+	it("should enable /jwks", async () => {
+		const response = await client.$fetch<JSONWebKeySet>("/jwks");
+		const jwks = response?.data;
+		expect(jwks).toBeDefined();
+		expect(jwks?.keys.length).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("jwt - oidc plugin with remote url", async (it) => {
+	const { auth } = await getTestInstance({
+		plugins: [
+			jwt({
+				usesOauthProvider: true,
+				jwks: {
+					remoteUrl: "https://example.com",
+					keyPairConfig: {
+						alg: "ES256",
+					},
+				},
+			}),
+		],
+		logger: {
+			level: "error",
+		},
+	});
+
+	const client = createAuthClient({
+		plugins: [jwtClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	it("should require specifying the alg used", async () => {
+		expect(() =>
+			getTestInstance({
+				plugins: [
+					jwt({
+						usesOauthProvider: true,
+						jwks: {
+							remoteUrl: "https://example.com",
+						},
+					}),
+				],
+				logger: {
+					level: "error",
+				},
+			}),
+		).toThrow();
+	});
+
+	it("should disable /jwks", async () => {
+		const response = await client.$fetch<JSONWebKeySet>("/jwks");
+		expect(response.error?.status).toBe(404);
+	});
 });

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -1,15 +1,38 @@
-import { importJWK, exportJWK, generateKeyPair, SignJWT } from "jose";
+import {
+	importJWK,
+	exportJWK,
+	generateKeyPair,
+	SignJWT,
+	type JWTPayload,
+} from "jose";
 import type { GenericEndpointContext } from "../../types";
 import { BetterAuthError } from "../../error";
 import { symmetricDecrypt, symmetricEncrypt } from "../../crypto";
-import type { JwtOptions } from ".";
+import { getJwtPlugin, type JwtPluginOptions } from ".";
 import type { Jwk } from "./schema";
 import { getJwksAdapter } from "./adapter";
 
-export async function getJwtToken(
+/**
+ * Signs a payload in jwt format
+ *
+ * @param ctx - endpoint context
+ * @param payload - payload to sign
+ * @param options - Jwt signing options. If not provided, uses the jwtPlugin options
+ */
+export async function signJwt(
 	ctx: GenericEndpointContext,
-	options?: JwtOptions,
+	payload: JWTPayload,
+	options?: JwtPluginOptions,
 ) {
+	if (!options) {
+		options = getJwtPlugin(ctx.context).options;
+	}
+
+	// Custom/remote signing function
+	if (options?.jwt?.sign && payload) {
+		return options.jwt.sign(payload);
+	}
+
 	const adapter = getJwksAdapter(ctx.context.adapter);
 
 	let key = await adapter.getLatestKey();
@@ -17,32 +40,7 @@ export async function getJwtToken(
 		!options?.jwks?.disablePrivateKeyEncryption;
 
 	if (key === undefined) {
-		const { publicKey, privateKey } = await generateKeyPair(
-			options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
-			options?.jwks?.keyPairConfig ?? {
-				crv: "Ed25519",
-				extractable: true,
-			},
-		);
-
-		const publicWebKey = await exportJWK(publicKey);
-		const privateWebKey = await exportJWK(privateKey);
-		const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
-
-		let jwk: Partial<Jwk> = {
-			publicKey: JSON.stringify(publicWebKey),
-			privateKey: privateKeyEncryptionEnabled
-				? JSON.stringify(
-						await symmetricEncrypt({
-							key: ctx.context.secret,
-							data: stringifiedPrivateWebKey,
-						}),
-					)
-				: stringifiedPrivateWebKey,
-			createdAt: new Date(),
-		};
-
-		key = await adapter.createJwk(jwk as Jwk);
+		key = await createJwk(ctx, options);
 	}
 
 	let privateWebKey = privateKeyEncryptionEnabled
@@ -61,23 +59,72 @@ export async function getJwtToken(
 		options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
 	);
 
-	const payload = !options?.jwt?.definePayload
-		? ctx.context.session!.user
-		: await options?.jwt.definePayload(ctx.context.session!);
-
-	const jwt = await new SignJWT(payload)
+	const jwt = new SignJWT(payload)
 		.setProtectedHeader({
 			alg: options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
 			kid: key.id,
+			typ: "JWT",
 		})
-		.setIssuedAt()
-		.setIssuer(options?.jwt?.issuer ?? ctx.context.options.baseURL!)
-		.setAudience(options?.jwt?.audience ?? ctx.context.options.baseURL!)
-		.setExpirationTime(options?.jwt?.expirationTime ?? "15m")
-		.setSubject(
-			(await options?.jwt?.getSubject?.(ctx.context.session!)) ??
-				ctx.context.session!.user.id,
+		.setIssuedAt(payload.iat)
+		.setIssuer(
+			payload.iss ?? options?.jwt?.issuer ?? ctx.context.options.baseURL!,
 		)
-		.sign(privateKey);
-	return jwt;
+		.setAudience(
+			payload.aud ?? options?.jwt?.audience ?? ctx.context.options.baseURL!,
+		)
+		.setAudience(options?.jwt?.audience ?? ctx.context.options.baseURL!)
+		.setExpirationTime(payload.exp ?? options?.jwt?.expirationTime ?? "15m");
+	const sub =
+		(await options?.jwt?.getSubject?.(ctx.context.session!)) ??
+		payload.sub ??
+		ctx.context.session?.user.id;
+	if (sub) jwt.setSubject(sub);
+	return await jwt.sign(privateKey);
+}
+
+/**
+ * Creates a new JWK (JSON Web Key) on the database.
+ */
+export async function createJwk(
+	ctx: GenericEndpointContext,
+	options?: JwtPluginOptions,
+) {
+	if (!options) {
+		options = getJwtPlugin(ctx.context).options;
+	}
+
+	const { publicKey, privateKey } = await generateKeyPair(
+		options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
+		{
+			...options?.jwks?.keyPairConfig,
+			extractable: true,
+		},
+	);
+
+	const publicWebKey = await exportJWK(publicKey);
+	const privateWebKey = await exportJWK(privateKey);
+	const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
+	const privateKeyEncryptionEnabled =
+		!options?.jwks?.disablePrivateKeyEncryption;
+
+	let jwk: Partial<Jwk> = {
+		publicKey: JSON.stringify({
+			alg: options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
+			...publicWebKey,
+		}),
+		privateKey: privateKeyEncryptionEnabled
+			? JSON.stringify(
+					await symmetricEncrypt({
+						key: ctx.context.secret,
+						data: stringifiedPrivateWebKey,
+					}),
+				)
+			: stringifiedPrivateWebKey,
+		createdAt: new Date(),
+	};
+
+	const adapter = getJwksAdapter(ctx.context.adapter);
+	const key = await adapter.createJwk(jwk as Jwk);
+
+	return key;
 }

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -25,14 +25,14 @@ import { authorize } from "./authorize";
 import { parseSetCookieHeader } from "../../cookies";
 import { createHash } from "@better-auth/utils/hash";
 import { base64 } from "@better-auth/utils/base64";
-import { getJwtToken } from "../jwt/sign";
-import type { JwtOptions } from "../jwt";
+import { signJwt } from "../jwt/sign";
+import type { JwtPluginOptions } from "../jwt";
 import { defaultClientSecretHasher } from "./utils";
 
 const getJwtPlugin = (ctx: GenericEndpointContext) => {
 	return ctx.context.options.plugins?.find(
 		(plugin) => plugin.id === "jwt",
-	) as Omit<BetterAuthPlugin, "options"> & { options?: JwtOptions };
+	) as Omit<BetterAuthPlugin, "options"> & { options?: JwtPluginOptions };
 };
 
 /**
@@ -784,7 +784,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 								error: "internal_server_error",
 							});
 						}
-						idToken = await getJwtToken(
+						idToken = await signJwt(
 							{
 								...ctx,
 								context: {
@@ -805,6 +805,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 									},
 								},
 							},
+							payload,
 							{
 								...jwtPlugin.options,
 								jwt: {
@@ -813,7 +814,6 @@ export const oidcProvider = (options: OIDCOptions) => {
 									audience: client_id.toString(),
 									issuer: ctx.context.options.baseURL,
 									expirationTime,
-									definePayload: () => payload,
 								},
 							},
 						);

--- a/packages/better-auth/src/types/helper.ts
+++ b/packages/better-auth/src/types/helper.ts
@@ -9,6 +9,7 @@ export type Primitive =
 export type LiteralString = "" | (string & Record<never, never>);
 export type LiteralNumber = 0 | (number & Record<never, never>);
 
+export type Awaitable<T> = Promise<T> | T;
 export type OmitId<T extends { id: unknown }> = Omit<T, "id">;
 
 export type Prettify<T> = Omit<T, never>;


### PR DESCRIPTION
**feat**: remoteUrl disablesjwks endpoint and uses this endpoint in discovery mode

**feat**: remote sign payloads to such as Google KMS, AWS KMS, and Azure Key Vault

**feat** `usesOauthProvider` adapts the plugin for use with OIDC and MCP

**fix**: signJwt now accepts payload as a parameter

**chore**: combine shared createJwks functionality

__Partial #3458__