### PR TITLE
Fix/postgres timestampz

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -100,7 +100,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				},
 				date: {
 					sqlite: `integer('${name}', { mode: 'timestamp' })`,
-					pg: `timestamp('${name}')`,
+					pg: `timestamp('${name}', { withTimezone: true })`,
 					mysql: `timestamp('${name}')`,
 				},
 				"number[]": {

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -12,6 +12,7 @@ import {
 	originCheck,
 	getSessionFromCtx,
 } from "better-auth/api";
+import { generateRandomString } from "better-auth/crypto";
 import {
 	onCheckoutSessionCompleted,
 	onSubscriptionDeleted,

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -12,7 +12,6 @@ import {
 	originCheck,
 	getSessionFromCtx,
 } from "better-auth/api";
-import { generateRandomString } from "better-auth/crypto";
 import {
 	onCheckoutSessionCompleted,
 	onSubscriptionDeleted,


### PR DESCRIPTION
###  What does this PR do?

Fixes a bug where PostgreSQL schemas were being generated with `timestamp` (without timezone), causing expiration checks to break due to timezone mismatches between the database and the server.

---

###  Why is it needed?

When using BetterAuth with PostgreSQL, fields like `expires_at` for verification tokens or password resets were being generated with `timestamp` (without time zone). This causes tokens to be considered expired immediately if the server and database are not in the same timezone (e.g., UTC vs local time).

By using `timestamp(..., { withTimezone: true })`, the expiration logic becomes reliable across environments and timezones.

---

###  Changes

- Changed Drizzle schema generator for PostgreSQL to use `timestamp(..., { withTimezone: true })` instead of the default `timestamp`.
- Fixes alignment with Drizzle’s expected `timestamp with time zone` behavior.

---

Closes [#3461](https://github.com/better-auth/better-auth/issues/3461)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where PostgreSQL schemas used timestamps without time zone, causing token expiration checks to fail when server and database time zones differed.

- **Bug Fixes**
 - Updated the Drizzle schema generator to use `timestamp(..., { withTimezone: true })` for PostgreSQL date fields.

<!-- End of auto-generated description by cubic. -->

