### PR TITLE
chore: fix typo on v1.3 relaase blog 

### DIFF
--- a/docs/content/blogs/1-3.mdx
+++ b/docs/content/blogs/1-3.mdx
@@ -213,7 +213,7 @@ export const auth = betterAuth({
 
 Other new options:
 
-* `MaximumMembersPerTeam` – set team member limits
+* `maximumMembersPerTeam` – set team member limits
 * `listUserInvitations` – list all invitations for a user
 
 ---

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -12,7 +12,6 @@ import {
 	originCheck,
 	getSessionFromCtx,
 } from "better-auth/api";
-import { generateRandomString } from "better-auth/crypto";
 import {
 	onCheckoutSessionCompleted,
 	onSubscriptionDeleted,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a typo in the v1.3 release blog post and removed an unused import from the Stripe package.

<!-- End of auto-generated description by cubic. -->

