### PR TITLE
fix(org): inferAuth with multiple plugins

### DIFF
--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -15,6 +15,7 @@ import { useAuthQuery } from "../../client";
 import { defaultStatements, adminAc, memberAc, ownerAc } from "./access";
 import { hasPermission } from "./has-permission";
 import type { BetterAuthPlugin } from "..";
+import type { OrganizationOptions } from "./types";
 
 interface OrganizationClientOptions {
 	ac?: AccessControl;
@@ -76,14 +77,22 @@ export const organizationClient = <CO extends OrganizationClientOptions>(
 				invitations: InferInvitation<CO>[];
 			} & Organization;
 
-	type Schema = CO["$inferAuth"] extends Object
-		? CO["$inferAuth"]["options"]["plugins"][number] extends {
-				id: "organization";
-				options: infer O;
-			}
-			? O extends { schema?: infer S }
-				? S
-				: undefined
+	type FindById<
+		T extends readonly BetterAuthPlugin[],
+		TargetId extends string,
+	> = Extract<T[number], { id: TargetId }>;
+
+	type Auth = CO["$inferAuth"] extends { options: any }
+		? CO["$inferAuth"]
+		: { options: { plugins: [] } };
+
+	type OrganizationPlugin = FindById<
+		Auth["options"]["plugins"],
+		"organization"
+	>;
+	type Schema = OrganizationPlugin extends { options: { schema: infer S } }
+		? S extends OrganizationOptions["schema"]
+			? S
 			: undefined
 		: undefined;
 


### PR DESCRIPTION
It didn't infer the org plugin when there was multiple plugins in the plugins array, this is now fixed.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed organization schema inference when multiple plugins are present in the plugins array.

- **Bug Fixes**
  - Updated type logic to correctly find and infer the organization plugin schema even if other plugins are included.
  - Added tests to confirm schema inference works with multiple plugins.

<!-- End of auto-generated description by cubic. -->

