### PR TITLE
Better Blog List Previews

### DIFF
--- a/docs/app/blog/_components/blog-list.tsx
+++ b/docs/app/blog/_components/blog-list.tsx
@@ -6,6 +6,7 @@ import { GitHubIcon, BookIcon, XIcon } from "./icons";
 import { Glow } from "./default-changelog";
 import { StarField } from "./stat-field";
 import { DiscordLogoIcon } from "@radix-ui/react-icons";
+import Image from "next/image";
 
 export async function BlogPage() {
 	const posts = blogs.getPages();
@@ -54,47 +55,58 @@ export async function BlogPage() {
 					</p>
 				</div>
 			</div>
-			<div className="py-6 lg:py-10 px-6">
+			<div className="py-6 lg:py-10 px-3">
 				<div className="flex flex-col gap-2">
 					{posts.map((post) => (
-						<article
-							key={post.slugs.join("/")}
-							className="group relative flex flex-col space-y-2"
-						>
-							<div className="flex gap-2">
-								{/* {post.data?.image && (
+						<div className="group/blog flex flex-col gap-3 hover:bg-neutral-200/50 dark:hover:bg-neutral-900/50 transition-colors border dark:border-white/10 border-black/10 p-4">
+							<article
+								key={post.slugs.join("/")}
+								className="group relative flex flex-col space-y-2 flex-3/4 py-1"
+							>
+								<div className="flex gap-2">
+									<div className="flex flex-col gap-2  border-b border-dashed pb-2">
+										<p className="text-xs opacity-50">
+											{formatBlogDate(post.data.date)}
+										</p>
+										<h2 className="text-2xl font-bold">{post.data?.title}</h2>
+									</div>
+								</div>
+								{post.data?.image && (
 									<Image
 										src={post.data.image}
 										alt={post.data.title}
 										width={402}
 										height={252}
-										className="rounded-md border bg-muted w-4/12 transition-colors"
+										className="rounded-md w-full bg-muted transition-colors"
 									/>
-								)} */}
-								<div className="flex flex-col gap-2  border-b border-dashed pb-2">
-									<p className="text-xs opacity-50">
-										{formatBlogDate(post.data.date)}
-									</p>
-									<h2 className="text-2xl font-bold">{post.data?.title}</h2>
-									<p className="text-muted-foreground">
-										{post.data?.description.substring(0, 100)}...
-									</p>
+								)}
+								<div className="flex gap-2">
+									<div className="flex flex-col gap-2  border-b border-dashed pb-2">
+										<p className="text-muted-foreground">
+											{post.data?.description.substring(0, 100)}...
+										</p>
+									</div>
 								</div>
-							</div>
-							<p className="text-xs opacity-50">
-								{post.data.structuredData.contents[0].content.substring(0, 250)}
-								...
-							</p>
-							<Link href={`/blog/${post.slugs.join("/")}`}>
-								<p className="text-xs underline">Read More</p>
-							</Link>
-							<Link
-								href={`/blog/${post.slugs.join("/")}`}
-								className="absolute inset-0"
-							>
-								<span className="sr-only">View Article</span>
-							</Link>
-						</article>
+								<p className="text-xs opacity-50">
+									{post.data.structuredData.contents[0].content.substring(
+										0,
+										250,
+									)}
+									...
+								</p>
+								<Link href={`/blog/${post.slugs.join("/")}`}>
+									<p className="text-xs group-hover/blog:underline underline-offset-4 transition-all">
+										Read More
+									</p>
+								</Link>
+								<Link
+									href={`/blog/${post.slugs.join("/")}`}
+									className="absolute inset-0"
+								>
+									<span className="sr-only">View Article</span>
+								</Link>
+							</article>
+						</div>
 					))}
 				</div>
 			</div>


### PR DESCRIPTION
changed the blog list preview 

From....
<img width="1919" height="1199" alt="image" src="https://github.com/user-attachments/assets/546fb339-71b0-464c-b2f8-fe7194f58a8f" />

To this
<img width="1919" height="1199" alt="Screenshot 2025-07-20 032205" src="https://github.com/user-attachments/assets/0510fe14-7a55-4394-ae73-5913f5f7f8fe" />


Mobile Looks Great too (since that's where most people read blogs)
![photo_2025-07-20_03-35-48](https://github.com/user-attachments/assets/93a12849-538b-4226-a7a5-153f07e7dec5)
![photo_2025-07-20_03-35-49](https://github.com/user-attachments/assets/7c88b6b6-64a0-49d3-afef-d3358855112c)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved the blog list preview with a cleaner layout, larger images, and better mobile support for easier reading. 

- **UI Improvements**
  - Updated blog cards with larger images and clearer text sections.
  - Enhanced mobile layout for better readability on small screens.

<!-- End of auto-generated description by cubic. -->

