### PR TITLE
fix(organization): multi teams breaking active organization id type inference

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -756,7 +756,25 @@ export const organization = <O extends OrganizationOptions>(
 								},
 							}
 						: {}),
-				},
+				} as unknown as O["teams"] extends {
+					enabled: true;
+				}
+					? {
+							activeTeamId: {
+								type: "string";
+								required: false;
+							};
+							activeOrganizationId: {
+								type: "string";
+								required: false;
+							};
+						}
+					: {
+							activeOrganizationId: {
+								type: "string";
+								required: false;
+							};
+						},
 			},
 			organization: {
 				modelName: options?.schema?.organization?.modelName,

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -52,6 +52,7 @@ describe("general types", async (it) => {
 			token: string;
 			ipAddress?: string | undefined | null;
 			userAgent?: string | undefined | null;
+			activeOrganizationId?: string | undefined | null;
 		}>();
 	});
 });


### PR DESCRIPTION
closes #3490
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a type inference issue where enabling multi-team support broke the active organization ID type in the organization plugin.

<!-- End of auto-generated description by cubic. -->

