### PR TITLE
fix: query perf on setting active orgs

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -324,6 +324,28 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			});
 			return organization;
 		},
+		checkMembership: async ({
+			userId,
+			organizationId,
+		}: {
+			userId: string;
+			organizationId: string;
+		}) => {
+			const member = await adapter.findOne<InferMember<O>>({
+				model: "member",
+				where: [
+					{
+						field: "userId",
+						value: userId,
+					},
+					{
+						field: "organizationId",
+						value: organizationId,
+					},
+				],
+			});
+			return member;
+		},
 		/**
 		 * @requires db
 		 */


### PR DESCRIPTION
Query performance on setting active org. it is currently benchmarked with small number of organization but you can see how   it could get hard when it is used on large number of orgs. it is more than half millisecond improvements even if we introduced a new adapter.

before
<img width="377" height="84" alt="Screenshot 2025-07-20 at 2 05 48 PM" src="https://github.com/user-attachments/assets/e80eeb7c-1196-420e-b5b7-02189086f1e3" />
after 
<img width="393" height="94" alt="Screenshot 2025-07-20 at 1 51 31 PM" src="https://github.com/user-attachments/assets/9ed83ae8-d85f-4760-9c1b-57bd79955e2d" />
