### PR TITLE
fix(sign-up): set emailVerified to null (#3469)

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -215,7 +215,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 						name,
 						image,
 						...additionalData,
-						emailVerified: false,
+						emailVerified: null,
 					},
 					ctx,
 				);

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -75,7 +75,7 @@ export const createInternalAdapter = (
 				{
 					createdAt: new Date(),
 					updatedAt: new Date(),
-					emailVerified: false,
+					emailVerified: null,
 					...user,
 					email: user.email?.toLowerCase(),
 				},


### PR DESCRIPTION
## Description

This PR fixes a bug where the `emailVerified` field was set to `false` during user signup, which is incompatible with Prisma when the field is defined as `DateTime?`. Prisma expects either a valid date or `null`, not a boolean.

Now, on signup, `emailVerified` is set to `null` if the email is not verified, ensuring compatibility with the Prisma schema.

## Related Issue

Closes #3469

## Changes

- Updated `/packages/better-auth/src/api/routes/sign-up.ts` to set `emailVerified: null` on user creation.
- Updated `/packages/better-auth/src/db/internal-adapter.ts` to set `emailVerified: null` on user creation.

## Check

- Should not cause regression in `packages/better-auth/src/api/routes/email-verification.ts` : 

```js
if (session?.user.emailVerified) {
	throw new APIError("BAD_REQUEST", {
		message:
			"You can only send a verification email to an unverified email",
	});
}
```

This PR ensures that the`emailVerified` field is always compatible with the Prisma schema, preventing type errors on user creation and maintaining correct email verification logic.