### PR TITLE
fix(plugins): export siwe plugin

### DIFF
--- a/packages/better-auth/build.config.ts
+++ b/packages/better-auth/build.config.ts
@@ -113,6 +113,7 @@ export default defineBuildConfig({
 		"./src/plugins/username/index.ts",
 		"./src/plugins/haveibeenpwned/index.ts",
 		"./src/plugins/one-time-token/index.ts",
+		"./src/plugins/siwe/index.ts",
 		"./src/test-utils/index.ts",
 	],
 });

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -524,6 +524,16 @@
         "types": "./dist/plugins/username/index.d.cts",
         "default": "./dist/plugins/username/index.cjs"
       }
+    },
+    "./plugins/siwe": {
+      "import": {
+        "types": "./dist/plugins/siwe/index.d.ts",
+        "default": "./dist/plugins/siwe/index.mjs"
+      },
+      "require": {
+        "types": "./dist/plugins/siwe/index.d.cts",
+        "default": "./dist/plugins/siwe/index.cjs"
+      }
     }
   },
   "typesVersions": {
@@ -662,6 +672,9 @@
       ],
       "plugins/username": [
         "./dist/plugins/username/index.d.ts"
+      ],
+      "plugins/siwe": [
+        "./dist/plugins/siwe/index.d.ts"
       ]
     }
   },

--- a/packages/better-auth/src/client/plugins/index.ts
+++ b/packages/better-auth/src/client/plugins/index.ts
@@ -18,4 +18,5 @@ export * from "../../plugins/sso/client";
 export * from "../../plugins/oidc-provider/client";
 export * from "../../plugins/api-key/client";
 export * from "../../plugins/one-time-token/client";
+export * from "../../plugins/siwe/client";
 export type * from "@simplewebauthn/server";

--- a/packages/better-auth/src/plugins/index.ts
+++ b/packages/better-auth/src/plugins/index.ts
@@ -23,3 +23,4 @@ export * from "./api-key";
 export * from "./haveibeenpwned";
 export * from "./one-time-token";
 export * from "./mcp";
+export * from "./siwe";

--- a/packages/better-auth/src/plugins/siwe/client.ts
+++ b/packages/better-auth/src/plugins/siwe/client.ts
@@ -1,11 +1,9 @@
-import type { BetterAuthClientPlugin } from "better-auth";
 import type { siwe } from ".";
-
-type SiwePlugin = typeof siwe;
+import type { BetterAuthClientPlugin } from "../../types";
 
 export const siweClient = () => {
 	return {
 		id: "siwe",
-		$InferServerPlugin: {} as ReturnType<SiwePlugin>,
+		$InferServerPlugin: {} as ReturnType<typeof siwe>,
 	} satisfies BetterAuthClientPlugin;
 };


### PR DESCRIPTION
## Description

The SIWE plugin is fully implemented, and was released in [PR 2579](https://github.com/better-auth/better-auth/pull/2579), but is missing from the export configuration. 

## Changes Made

- **Main export**: Added `export * from "./siwe"` to `src/plugins/index.ts`
- **Build config**: Added `"./src/plugins/siwe/index.ts"` to build entries  
- **Package exports**: Added dedicated `"./plugins/siwe"` export path
- **Type definitions**: Added `"plugins/siwe"` to typesVersions
- **Client export**: Added `export * from "../../plugins/siwe/client";` to `src/client/plugins/index.ts`

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the SIWE plugin to the main export, build config, and package exports so it can be imported and used like other plugins.

- **Dependencies**
  - Updated build entries, package exports, and type definitions to include the SIWE plugin.

<!-- End of auto-generated description by cubic. -->

