### PR TITLE
docs: update installation.mdx

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -256,9 +256,10 @@ Create a new file or route in your framework's designated catch-all route handle
     ```ts title="hooks.server.ts"
     import { auth } from "$lib/auth"; // path to your auth file
     import { svelteKitHandler } from "better-auth/svelte-kit";
+    import { building } from '$app/environment'
 
     export async function handle({ event, resolve }) {
-        return svelteKitHandler({ event, resolve, auth });
+        return svelteKitHandler({ event, resolve, auth, building });
     }
     ```
     </Tab>


### PR DESCRIPTION
add `building` to svelte-kit example
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the building flag to the SvelteKit installation example to show correct usage in hooks.server.ts.

<!-- End of auto-generated description by cubic. -->

