### PR TITLE
Fix typo in organization invitation docs

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -600,7 +600,7 @@ type cancelInvitation = {
 
 ### Reject Invitation
 
-If this user has recieved an invitation, but wants to decline it, this method will allow you to do so by rejecting it.
+If this user has received an invitation, but wants to decline it, this method will allow you to do so by rejecting it.
 
 <APIMethod path="/organization/reject-invitation" method="POST" noResult>
 ```ts

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -841,7 +841,7 @@ export const listInvitations = <O extends OrganizationOptions>(options: O) =>
 	);
 
 /**
- * List all invitations recieved for a user
+ * List all invitations a user has received
  */
 export const listUserInvitations = <O extends OrganizationOptions>(
 	options: O,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a typo in the organization invitation docs by correcting "recieved" to "received".

<!-- End of auto-generated description by cubic. -->

