### PR TITLE
fix(teams): listTeams should prioritize the provided org ID

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -502,7 +502,7 @@ export const listOrganizationTeams = <O extends OrganizationOptions>(
 		async (ctx) => {
 			const session = ctx.context.session;
 			const organizationId =
-				session.session.activeOrganizationId || ctx.query?.organizationId;
+				ctx.query?.organizationId || session.session.activeOrganizationId;
 
 			if (!organizationId) {
 				return ctx.json(null, {


### PR DESCRIPTION
Use the provided org id in the params, then if not provided, fallback to session active org id