### PR TITLE
fix(drizzle-cli): check for undefined defaultValue instead of truthy value

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -148,7 +148,10 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 						.map((field) => {
 							const attr = fields[field]!;
 							let type = getType(field, attr);
-							if (attr.defaultValue) {
+							if (
+								attr.defaultValue !== null &&
+								typeof attr.defaultValue !== "undefined"
+							) {
 								if (typeof attr.defaultValue === "function") {
 									type += `.$defaultFn(${attr.defaultValue})`;
 								} else if (typeof attr.defaultValue === "string") {

--- a/packages/cli/test/__snapshots__/auth-schema-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-number-id.txt
@@ -21,7 +21,7 @@ export const user = pgTable("user", {
   updatedAt: timestamp("updated_at")
     .$defaultFn(() => /* @__PURE__ */ new Date())
     .notNull(),
-  twoFactorEnabled: boolean("two_factor_enabled"),
+  twoFactorEnabled: boolean("two_factor_enabled").default(false),
   username: text("username").unique(),
   displayUsername: text("display_username"),
 });

--- a/packages/cli/test/__snapshots__/auth-schema.txt
+++ b/packages/cli/test/__snapshots__/auth-schema.txt
@@ -14,7 +14,7 @@ export const user = pgTable("user", {
   updatedAt: timestamp("updated_at")
     .$defaultFn(() => /* @__PURE__ */ new Date())
     .notNull(),
-  twoFactorEnabled: boolean("two_factor_enabled"),
+  twoFactorEnabled: boolean("two_factor_enabled").default(false),
   username: text("username").unique(),
   displayUsername: text("display_username"),
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed defaultValue check in the Drizzle schema generator to handle values like false or 0 correctly.

<!-- End of auto-generated description by cubic. -->

