### PR TITLE
feat(phone-number): exposing code on callbackOnVerification function

### DIFF
--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -243,9 +243,6 @@ export const auth = betterAuth({
             },
             callbackOnVerification: async ({ phoneNumber, code, user }, request) => {
                 // Implement callback after phone number verification
-                // phoneNumber: The verified phone number
-                // code: The verification code that was used
-                // user: The user object with verified phone number
             }
         })
     ]

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -233,7 +233,7 @@ type resetPasswordPhoneNumber = {
 - `otpLength`: The length of the OTP code to be generated. Default is `6`.
 - `sendOTP`: A function that sends the OTP code to the user's phone number. It takes the phone number and the OTP code as arguments.
 - `expiresIn`: The time in seconds after which the OTP code expires. Default is `300` seconds.
-- `callbackOnVerification`: A function that is called after the phone number is verified. It takes the phone number and the user object as the first argument and a request object as the second argument.
+- `onPhoneNumberVerification`: A function that is called after the phone number is verified. It takes the phone number and the user object as the first argument and a request object as the second argument.
 ```ts
 export const auth = betterAuth({
     plugins: [
@@ -241,8 +241,11 @@ export const auth = betterAuth({
             sendOTP: ({ phoneNumber, code }, request) => {
                 // Implement sending OTP code via SMS
             },
-            callbackOnVerification: async ({ phoneNumber, user }, request) => {
-                // Implement callback after phone number verification
+            onPhoneNumberVerification: async ({ phoneNumber, code, user }, request) => {
+                // Called after phone number verification
+                // phoneNumber: The verified phone number
+                // code: The verification code that was used
+                // user: The user object with verified phone number
             }
         })
     ]

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -233,7 +233,7 @@ type resetPasswordPhoneNumber = {
 - `otpLength`: The length of the OTP code to be generated. Default is `6`.
 - `sendOTP`: A function that sends the OTP code to the user's phone number. It takes the phone number and the OTP code as arguments.
 - `expiresIn`: The time in seconds after which the OTP code expires. Default is `300` seconds.
-- `onPhoneNumberVerification`: A function that is called after the phone number is verified. It takes the phone number and the user object as the first argument and a request object as the second argument.
+- `callbackOnVerification`: A function that is called after the phone number is verified. It takes the phone number and the user object as the first argument and a request object as the second argument.
 ```ts
 export const auth = betterAuth({
     plugins: [

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -241,8 +241,8 @@ export const auth = betterAuth({
             sendOTP: ({ phoneNumber, code }, request) => {
                 // Implement sending OTP code via SMS
             },
-            onPhoneNumberVerification: async ({ phoneNumber, code, user }, request) => {
-                // Called after phone number verification
+            callbackOnVerification: async ({ phoneNumber, code, user }, request) => {
+                // Implement callback after phone number verification
                 // phoneNumber: The verified phone number
                 // code: The verification code that was used
                 // user: The user object with verified phone number

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -82,11 +82,9 @@ export interface PhoneNumberOptions {
 	 */
 	requireVerification?: boolean;
 	/**
-	 * A function that is called when a user verifies their phone number
-	 * @param data - contains phone number, verification code, and user object
-	 * @param request - the request object
+	 * Callback when phone number is verified
 	 */
-	onPhoneNumberVerification?: (
+	callbackOnVerification?: (
 		data: {
 			phoneNumber: string;
 			code: string;
@@ -696,11 +694,11 @@ export const phoneNumber = (options?: PhoneNumberOptions) => {
 						return ctx.json(null);
 					}
 
-					await options?.onPhoneNumberVerification?.(
+					await options?.callbackOnVerification?.(
 						{
 							phoneNumber: ctx.body.phoneNumber,
-							code: ctx.body.code,
 							user,
+							code: ctx.body.code,
 						},
 						ctx.request,
 					);

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -82,11 +82,14 @@ export interface PhoneNumberOptions {
 	 */
 	requireVerification?: boolean;
 	/**
-	 * Callback when phone number is verified
+	 * A function that is called when a user verifies their phone number
+	 * @param data - contains phone number, verification code, and user object
+	 * @param request - the request object
 	 */
-	callbackOnVerification?: (
+	onPhoneNumberVerification?: (
 		data: {
 			phoneNumber: string;
+			code: string;
 			user: UserWithPhoneNumber;
 		},
 		request?: Request,
@@ -693,9 +696,10 @@ export const phoneNumber = (options?: PhoneNumberOptions) => {
 						return ctx.json(null);
 					}
 
-					await options?.callbackOnVerification?.(
+					await options?.onPhoneNumberVerification?.(
 						{
 							phoneNumber: ctx.body.phoneNumber,
+							code: ctx.body.code,
 							user,
 						},
 						ctx.request,

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -7,6 +7,11 @@ import { bearer } from "../bearer";
 
 describe("phone-number", async (it) => {
 	let otp = "";
+	let verificationData: {
+		phoneNumber: string;
+		code: string;
+		user: any;
+	} | null = null;
 
 	const { customFetchImpl, sessionSetter } = await getTestInstance({
 		plugins: [
@@ -18,6 +23,9 @@ describe("phone-number", async (it) => {
 					getTempEmail(phoneNumber) {
 						return `temp-${phoneNumber}`;
 					},
+				},
+				onPhoneNumberVerification: async ({ phoneNumber, code, user }) => {
+					verificationData = { phoneNumber, code, user };
 				},
 			}),
 		],
@@ -54,6 +62,10 @@ describe("phone-number", async (it) => {
 		);
 		expect(res.error).toBe(null);
 		expect(res.data?.status).toBe(true);
+		expect(verificationData).not.toBeNull();
+		expect(verificationData?.phoneNumber).toBe(testPhoneNumber);
+		expect(verificationData?.code).toBe(otp);
+		expect(verificationData?.user).toBeDefined();
 	});
 
 	it("shouldn't verify again with the same code", async () => {

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -24,7 +24,7 @@ describe("phone-number", async (it) => {
 						return `temp-${phoneNumber}`;
 					},
 				},
-				onPhoneNumberVerification: async ({ phoneNumber, code, user }) => {
+				callbackOnVerification: async ({ phoneNumber, code, user }) => {
 					verificationData = { phoneNumber, code, user };
 				},
 			}),


### PR DESCRIPTION
This helps on exposing the OTP in onPhoneNumberVerification avoids unnecessary internal lookups and gives developers the flexibility to integrate with custom verification flows. It’s a pragmatic improvement that helps how this is used in prod.