### PR TITLE
docs: fix membershipLimit jsdoc 

### DIFF
--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -40,7 +40,7 @@ export interface OrganizationOptions {
 	 */
 	creatorRole?: string;
 	/**
-	 * The number of memberships a user can have in an organization.
+	 * The maximum number of members allowed in an organization.
 	 *
 	 * @default 100
 	 */


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the jsdoc for the membershipLimit option to clarify it sets the maximum number of members allowed in an organization.

<!-- End of auto-generated description by cubic. -->

