### PR TITLE
Bugfix: 500 error when setting rate limit storage with a different name

### DIFF
--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -55,7 +55,7 @@ function createDBStorage(ctx: AuthContext) {
 			try {
 				if (_update) {
 					await db.updateMany({
-						model: "rateLimit",
+						model,
 						where: [{ field: "key", value: key }],
 						update: {
 							count: value.count,
@@ -64,7 +64,7 @@ function createDBStorage(ctx: AuthContext) {
 					});
 				} else {
 					await db.create({
-						model: "rateLimit",
+						model,
 						data: {
 							key,
 							count: value.count,


### PR DESCRIPTION
The `set` function of `createDbStorage` is referencing a hardcoded string 'rateLimit'. This causes an error when a custom name for the model has been used:

```
TypeError: Cannot read properties of undefined (reading 'fields')
``` 

It should use the model the `get` method uses which reads `modelName` if it has been specified.

This change fixes the error locally for me.