### PR TITLE
Fix: rate limit model should be default

### DIFF
--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -35,7 +35,7 @@ function getRetryAfter(lastRequest: number, window: number) {
 }
 
 function createDBStorage(ctx: AuthContext) {
-	const model = ctx.options.rateLimit?.modelName || "rateLimit";
+	const model = "rateLimit";
 	const db = ctx.adapter;
 	return {
 		get: async (key: string) => {


### PR DESCRIPTION
I was mistaken a [previous fix](https://github.com/better-auth/better-auth/commit/452069aed976f3f06bd3f94d0d51cc74449ad9e3), it just moved the error rather than fixing the problem. 

I think this value should be the default model name to match [transformInput](https://github.com/better-auth/better-auth/blob/76c90f2e59b99c6d84b30ca0d3bc82cc0644ef2f/packages/better-auth/src/adapters/create-adapter/index.ts#L324) schema lookup. 

My schema looks like this
```
{
   ...
        rateLimit: {
          modelName: 'rateLimits',
          fields: {
            key: [Object],
            count: [Object],
            lastRequest: [Object],
            id: [Object]
          }
        }
      }
```

Matching on the default name returns the correct schema.

This test is now passing locally a different rateLimiter model. 

```
            it ( "should hit rate limit on forth login attempt within 10s", async () => {

                for ( let i = 0; i < 3; i++ ) {

                    const response = await request( testApp )
                        .post( usernameSignInPath )
                        .send( { username: testUsername, password: testPassword } );

                    expect( response.statusCode ).toEqual( 200 );

                }

                const res = await request( testApp )
                    .post( usernameSignInPath )
                    .send( { username: testUsername, password: testPassword } );

                expect( res.statusCode ).toEqual( 429 );
                expect( res.headers ).toHaveProperty( "x-retry-after" );

            } );
```

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set the rate limiter to always use the default "rateLimit" model name to ensure correct schema matching and prevent errors.

<!-- End of auto-generated description by cubic. -->

