### PR TITLE
fix(organization): resolve slug when setting active organization

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -672,11 +672,8 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 			const adapter = getOrgAdapter<O>(ctx.context, options);
 			const session = ctx.context.session;
 
-			// 1. Handle explicit "unset" (both organizationId and organizationSlug === null)
-			if (
-				ctx.body.organizationId === null &&
-				ctx.body.organizationSlug === null
-			) {
+			// 1. Handle explicit "unset" – if the identifier provided (id or slug) is explicitly null
+			if ((ctx.body.organizationId ?? ctx.body.organizationSlug) === null) {
 				const sessionOrgId = session.session.activeOrganizationId;
 				if (!sessionOrgId) {
 					return ctx.json(null);


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/3528
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where setting the active organization did not resolve organization slugs correctly. Now, both organization IDs and slugs are properly handled when updating the active organization.

<!-- End of auto-generated description by cubic. -->

