### PR TITLE
feat(cli): added --yes option, deprecated --y, as per #1937

### DIFF
--- a/docs/content/changelogs/1.0.mdx
+++ b/docs/content/changelogs/1.0.mdx
@@ -20,7 +20,7 @@ npx @better-auth/cli@latest generate
 
 - `--output` - Where to save the generated schema. For Prisma, it will be saved in prisma/schema.prisma. For Drizzle, it goes to schema.ts in your project root. For Kysely, it’s an SQL file saved as schema.sql in your project root.
 - `--config` - The path to your Better Auth config file. By default, the CLI will search for a better-auth.ts file in **./**, **./utils**, **./lib**, or any of these directories under `src` directory.
-- `--y` - Skip the confirmation prompt and generate the schema directly.
+- `--yes` - Skip the confirmation prompt and generate the schema directly.
 
 ## Migrate
 
@@ -33,7 +33,7 @@ npx @better-auth/cli@latest migrate
 ### Options
 
 - `--config` - The path to your Better Auth config file. By default, the CLI will search for a better-auth.ts file in **./**, **./utils**, **./lib**, or any of these directories under `src` directory.
-- `--y` - Skip the confirmation prompt and apply the schema directly.
+- `--yes` - Skip the confirmation prompt and apply the schema directly.
 
 ## Common Issues
 

--- a/docs/content/docs/concepts/cli.mdx
+++ b/docs/content/docs/concepts/cli.mdx
@@ -17,7 +17,7 @@ npx @better-auth/cli@latest generate
 
 - `--output` - Where to save the generated schema. For Prisma, it will be saved in prisma/schema.prisma. For Drizzle, it goes to schema.ts in your project root. For Kysely, it’s an SQL file saved as schema.sql in your project root.
 - `--config` - The path to your Better Auth config file. By default, the CLI will search for a auth.ts file in **./**, **./utils**, **./lib**, or any of these directories under `src` directory.
-- `--y` - Skip the confirmation prompt and generate the schema directly.
+- `--yes` - Skip the confirmation prompt and generate the schema directly.
 
 
 ## Migrate
@@ -31,7 +31,7 @@ npx @better-auth/cli@latest migrate
 ### Options
 
 - `--config` - The path to your Better Auth config file. By default, the CLI will search for a auth.ts file in **./**, **./utils**, **./lib**, or any of these directories under `src` directory.
-- `--y` - Skip the confirmation prompt and apply the schema directly.
+- `--yes` - Skip the confirmation prompt and apply the schema directly.
 
 ## Init
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -18,7 +18,9 @@ export async function generateAction(opts: any) {
 			config: z.string().optional(),
 			output: z.string().optional(),
 			y: z.boolean().optional(),
+			yes: z.boolean().optional(),
 		})
+		.transform(({ y, yes, ...otherOpts }) => ({ ...otherOpts, y: yes || y }))
 		.parse(opts);
 
 	const cwd = path.resolve(options.cwd);
@@ -139,5 +141,6 @@ export const generate = new Command("generate")
 		"the path to the configuration file. defaults to the first configuration file found.",
 	)
 	.option("--output <output>", "the file to output to the generated schema")
-	.option("-y, --y", "automatically answer yes to all prompts", false)
+	.option("-y, --yes", "automatically answer yes to all prompts", false)
+	.option("--y", "(deprecated) same as --yes", false)
 	.action(generateAction);

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -15,13 +15,17 @@ export async function migrateAction(opts: any) {
 			cwd: z.string(),
 			config: z.string().optional(),
 			y: z.boolean().optional(),
+			yes: z.boolean().optional(),
 		})
+		.transform(({ y, yes, ...otherOpts }) => ({ ...otherOpts, y: yes || y }))
 		.parse(opts);
+
 	const cwd = path.resolve(options.cwd);
 	if (!existsSync(cwd)) {
 		logger.error(`The directory "${cwd}" does not exist.`);
 		process.exit(1);
 	}
+
 	const config = await getConfig({
 		cwd,
 		configPath: options.config,
@@ -116,8 +120,13 @@ export const migrate = new Command("migrate")
 		"the path to the configuration file. defaults to the first configuration file found.",
 	)
 	.option(
-		"-y, --y",
+		"-y, --yes",
 		"automatically accept and run migrations without prompting",
+		false,
+	)
+	.option(
+		"--y",
+		"(deprecated) same as --yes",
 		false,
 	)
 	.action(migrateAction);


### PR DESCRIPTION
See #1937.

This change adds the `--yes` option to the `migrate` and `generate` command.

`--y` will be kept, although treated as deprecated.