### PR TITLE
fix(sso): include mapping inside samlConfig payload

### DIFF
--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -65,6 +65,14 @@ export interface SAMLConfig {
 	signingKey: string;
 	certificate: string;
 	attributeConsumingServiceIndex: number;
+	mapping?: {
+		id?: string;
+		email?: string;
+		name?: string;
+		firstName?: string;
+		lastName?: string;
+		extraFields?: Record<string, string>;
+	};
 }
 
 export interface SSOProvider {
@@ -623,6 +631,7 @@ export const sso = (options?: SSOOptions) => {
 										privateKey: body.samlConfig.privateKey,
 										decryptionPvk: body.samlConfig.decryptionPvk,
 										additionalParams: body.samlConfig.additionalParams,
+										mapping: body.mapping,
 									})
 								: null,
 							organizationId: body.organizationId,


### PR DESCRIPTION
This PR fixes an issue where the `mapping` object provided during `registerSSOProvider` is not persisted for SAML providers. This causes all attribute mappings to resolve as `undefined` during the SAML login callback.

**Fix:**
- Inject `mapping` into the serialized `samlConfig` object at registration time, matching how `oidcConfig` already handles mappings.

This ensures consistent behavior between OIDC and SAML flows and prevents failed user provisioning due to missing identity attributes.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where SAML SSO providers did not persist the mapping object, causing attribute mappings to be undefined during login.

- **Bug Fixes**
  - Injected the mapping into the samlConfig payload at registration to match OIDC behavior and ensure correct user attribute mapping.

<!-- End of auto-generated description by cubic. -->

