### PR TITLE
feat(sso): support disabling setting email verified

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -686,6 +686,8 @@ The plugin requires additional fields in the `ssoProvider` table to store the pr
 
 **disableImplicitSignUp**: Disable implicit sign up for new users.
 
+**disableSettingEmailVerified**: Disable setting email verified to true. Set this to true if you don't trust the provider to set the email verified flag.
+
 <TypeTable
   type={{
     provisionUser: {

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -686,7 +686,7 @@ The plugin requires additional fields in the `ssoProvider` table to store the pr
 
 **disableImplicitSignUp**: Disable implicit sign up for new users.
 
-**disableSettingEmailVerified**: Disable automatically setting the email verified flag to true. Set this to true if you don't trust the provider to set the `email_verified` claim.
+**trustEmailVerified**: Trust the email verified flag from the provider.
 
 <TypeTable
   type={{

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -686,7 +686,7 @@ The plugin requires additional fields in the `ssoProvider` table to store the pr
 
 **disableImplicitSignUp**: Disable implicit sign up for new users.
 
-**disableSettingEmailVerified**: Disable setting email verified to true. Set this to true if you don't trust the provider to set the email verified flag.
+**disableSettingEmailVerified**: Disable automatically setting the email verified flag to true. Set this to true if you don't trust the provider to set the `email_verified` claim.
 
 <TypeTable
   type={{

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -1335,6 +1335,9 @@ export const sso = (options?: SSOOptions) => {
 								.filter(Boolean)
 								.join(" ") || parsedResponse.extract.attributes?.displayName,
 						attributes: parsedResponse.extract.attributes,
+						emailVerified: options?.trustEmailVerified
+							? ((attributes?.[mapping.emailVerified] || false) as boolean)
+							: false,
 					};
 
 					let user: User;
@@ -1388,6 +1391,9 @@ export const sso = (options?: SSOOptions) => {
 							data: {
 								email: userInfo.email,
 								name: userInfo.name,
+								emailVerified: options?.trustEmailVerified
+									? userInfo.emailVerified || false
+									: false,
 								createdAt: new Date(),
 								updatedAt: new Date(),
 							},

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -150,10 +150,10 @@ export interface SSOOptions {
 	 */
 	providersLimit?: number | ((user: User) => Promise<number> | number);
 	/**
-	 * Disable setting email verified to true. Set this to true if you don't trust the provider to set the email verified flag.
+	 * Trust the email verified flag from the provider.
 	 * @default false
 	 */
-	disableSettingEmailVerified?: boolean;
+	trustEmailVerified?: boolean;
 }
 
 export const sso = (options?: SSOOptions) => {
@@ -1099,9 +1099,9 @@ export const sso = (options?: SSOOptions) => {
 							),
 							id: idToken[mapping.id || "sub"],
 							email: idToken[mapping.email || "email"],
-							emailVerified: options?.disableSettingEmailVerified
-								? false
-								: idToken[mapping.emailVerified || "email_verified"],
+							emailVerified: options?.trustEmailVerified
+								? idToken[mapping.emailVerified || "email_verified"]
+								: false,
 							name: idToken[mapping.name || "name"],
 							image: idToken[mapping.image || "picture"],
 						} as {
@@ -1157,7 +1157,9 @@ export const sso = (options?: SSOOptions) => {
 							name: userInfo.name || userInfo.email,
 							id: userInfo.id,
 							image: userInfo.image,
-							emailVerified: userInfo.emailVerified || false,
+							emailVerified: options?.trustEmailVerified
+								? userInfo.emailVerified || false
+								: false,
 						},
 						account: {
 							idToken: tokenResponse.idToken,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added an option to disable setting the email verified flag during SSO if the provider should not be trusted for email verification.

- **New Features**
  - Introduced the `disableSettingEmailVerified` option in SSO configuration.
  - Updated documentation to explain the new option.

<!-- End of auto-generated description by cubic. -->

