### PR TITLE
fix(stripe): don't update incomplete stripe session in the db

### DIFF
--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -361,3 +361,5 @@ export const jwt = (options?: JwtOptions) => {
 		schema: mergeSchema(schema, options?.schema),
 	} satisfies BetterAuthPlugin;
 };
+
+export { getJwtToken };

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -396,52 +396,18 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 					});
 				}
 
-				let subscription = existingSubscription;
-				if (!subscription) {
-					const incompleteSubscription = subscriptions.find(
-						(sub) => sub.status === "incomplete",
-					);
-
-					if (incompleteSubscription) {
-						await ctx.context.adapter.update({
-							model: "subscription",
-							update: {
-								...incompleteSubscription,
-								plan: plan.name.toLowerCase(),
-								seats: ctx.body.seats || 1,
-								stripeCustomerId: customerId,
-								status: "active",
-							},
-							where: [
-								{
-									field: "id",
-									value: incompleteSubscription.id,
-								},
-							],
-						});
-						subscription = {
-							...incompleteSubscription,
+				const subscription =
+					existingSubscription ||
+					(await ctx.context.adapter.create<InputSubscription, Subscription>({
+						model: "subscription",
+						data: {
 							plan: plan.name.toLowerCase(),
-							seats: ctx.body.seats || 1,
 							stripeCustomerId: customerId,
-						};
-					} else {
-						const newSubscription = await ctx.context.adapter.create<
-							InputSubscription,
-							Subscription
-						>({
-							model: "subscription",
-							data: {
-								plan: plan.name.toLowerCase(),
-								stripeCustomerId: customerId,
-								status: "incomplete",
-								referenceId,
-								seats: ctx.body.seats || 1,
-							},
-						});
-						subscription = newSubscription;
-					}
-				}
+							status: "incomplete",
+							referenceId,
+							seats: ctx.body.seats || 1,
+						},
+					}));
 
 				if (!subscription) {
 					ctx.context.logger.error("Subscription ID not found");


### PR DESCRIPTION
closes #3545
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stopped updating existing incomplete Stripe subscription sessions in the database. Now, only new incomplete subscriptions are created when needed.

<!-- End of auto-generated description by cubic. -->

