### PR TITLE
feat(org): additional fields support separate client-server projects

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1645,6 +1645,23 @@ createAuthClient({
 })
 ```
 
+For separate client-server projects, we support providing the schema object directly:
+
+```ts title="auth-client.ts"
+const schema = {
+  organization: {
+    additionalFields: {
+      myCustomField: {
+        type: "string",
+      },
+    },
+  },
+};
+
+createAuthClient({
+  plugins: [organizationClient({ $inferAuth: {} as typeof schema })]
+})
+```
 
 
 ## Options

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -25,7 +25,9 @@ interface OrganizationClientOptions {
 	teams?: {
 		enabled: boolean;
 	};
-	$inferAuth?: { options: { plugins: BetterAuthPlugin[] } };
+	$inferAuth?:
+		| { options: { plugins: BetterAuthPlugin[] } }
+		| OrganizationOptions["schema"];
 }
 
 export const organizationClient = <CO extends OrganizationClientOptions>(
@@ -90,10 +92,14 @@ export const organizationClient = <CO extends OrganizationClientOptions>(
 		Auth["options"]["plugins"],
 		"organization"
 	>;
-	type Schema = OrganizationPlugin extends { options: { schema: infer S } }
-		? S extends OrganizationOptions["schema"]
-			? S
-			: undefined
+	type Schema = CO["$inferAuth"] extends Object
+		? CO["$inferAuth"] extends Exclude<OrganizationOptions["schema"], undefined>
+			? CO["$inferAuth"]
+			: OrganizationPlugin extends { options: { schema: infer S } }
+				? S extends OrganizationOptions["schema"]
+					? S
+					: undefined
+				: undefined
 		: undefined;
 
 	return {


### PR DESCRIPTION
With this, users with their `auth` separated in different projects can still support org additional fields inference on the client plugin.

<img width="887" height="378" alt="image" src="https://github.com/user-attachments/assets/59014df5-db60-4293-a90e-a2f0ed2c131e" />
