### PR TITLE
fix: preserve undefined tokens when encrypting

### DIFF
--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -148,7 +148,7 @@ export const callbackOAuth = createAuthEndpoint(
 						accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 						refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
 						scope: tokens.scopes?.join(","),
-					}).filter(([_, value]) => value !== undefined),
+					}).filter(([_, value]) => value != null),
 				);
 				await c.context.internalAdapter.updateAccount(
 					existingAccount.id,

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -97,7 +97,7 @@ export async function handleOAuthUserInfo(
 						accessTokenExpiresAt: account.accessTokenExpiresAt,
 						refreshTokenExpiresAt: account.refreshTokenExpiresAt,
 						scope: account.scope,
-					}).filter(([_, value]) => value !== undefined),
+					}).filter(([_, value]) => value != null),
 				);
 
 				if (Object.keys(updateData).length > 0) {

--- a/packages/better-auth/src/oauth2/utils.ts
+++ b/packages/better-auth/src/oauth2/utils.ts
@@ -49,11 +49,16 @@ export function setTokenUtil(
 	token: string | null | undefined,
 	ctx: AuthContext,
 ) {
-	if (ctx.options.account?.encryptOAuthTokens && token) {
+	// If the provider didn't send a value we keep it as-is so that
+	// update queries don't overwrite previously stored tokens.
+	if (token == null) {
+		return token;
+	}
+	if (ctx.options.account?.encryptOAuthTokens) {
 		return symmetricEncrypt({
 			key: ctx.secret,
 			data: token,
 		});
 	}
-	return token ?? null;
+	return token;
 }

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -702,7 +702,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 									accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 									refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
 									scope: tokens.scopes?.join(","),
-								}).filter(([_, value]) => value !== undefined),
+								}).filter(([_, value]) => value != null),
 							);
 							await ctx.context.internalAdapter.updateAccount(
 								existingAccount.id,


### PR DESCRIPTION
possibly closes https://github.com/better-auth/better-auth/issues/3559


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed token handling to preserve undefined values during encryption, preventing accidental overwrites of missing tokens.

- **Bug Fixes**
  - Updated token filtering to distinguish between null and undefined values.
  - Ensured setTokenUtil returns undefined tokens as-is.

<!-- End of auto-generated description by cubic. -->

