### PR TITLE
feat(oauth2): add raw provider response to OAuth2Tokens

### DIFF
--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -64,6 +64,7 @@ export async function refreshAccessToken({
 		tokenType: data.token_type,
 		scopes: data.scope?.split(" "),
 		idToken: data.id_token,
+		raw: data,
 	};
 
 	if (data.expires_in) {

--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -8,6 +8,12 @@ export interface OAuth2Tokens {
 	refreshTokenExpiresAt?: Date;
 	scopes?: string[];
 	idToken?: string;
+	/**
+	 * Raw response data from the OAuth provider's token endpoint.
+	 * Contains additional fields that may be specific to the provider,
+	 * such as openid, open_id, unionid, etc.
+	 */
+	raw?: Record<string, any>;
 }
 
 export interface OAuthProvider<

--- a/packages/better-auth/src/oauth2/utils.ts
+++ b/packages/better-auth/src/oauth2/utils.ts
@@ -29,6 +29,7 @@ export function getOAuth2Tokens(data: Record<string, any>): OAuth2Tokens {
 				: data.scope
 			: [],
 		idToken: data.id_token,
+		raw: data,
 	};
 }
 


### PR DESCRIPTION
### Summary
Add raw provider response to OAuth2Tokens interface to expose additional provider-specific fields.

### Changes Made
- **Enhanced `OAuth2Tokens` interface**: Added an optional `raw` field to store the complete response from OAuth provider's token endpoint
- **Updated token handling**: Modified `getOAuth2Tokens()` and `refreshAccessToken()` functions to include raw response data
- **Improved documentation**: Added JSDoc comments explaining the purpose and usage of the new `raw` field

### Motivation
OAuth providers often return additional fields in their token responses that are specific to their platform (e.g., `openid`, `open_id`, `unionid` for various providers). Currently, better-auth only extracts standard OAuth2 fields, potentially losing valuable provider-specific information that developers might need.

### Benefits
- **Enhanced flexibility**: Developers can now access all provider-specific fields returned by OAuth providers
- **Better debugging**: Raw response data helps with troubleshooting OAuth integration issues  
- **Future-proof**: Supports new fields that providers might add without requiring library updates
- **Backward compatible**: The new field is optional and doesn't break existing implementations

### Files Modified
- types.ts - Added `raw` field to `OAuth2Tokens` interface
- utils.ts - Updated `getOAuth2Tokens()` to include raw data
- refresh-access-token.ts - Updated token refresh logic to include raw data

### Testing
This change maintains full backward compatibility as the new field is optional. Existing code will continue to work unchanged while new implementations can optionally access the raw provider response.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a raw field to the OAuth2Tokens interface to include the full provider token response, making provider-specific fields available to developers.

- **New Features**
  - getOAuth2Tokens and refreshAccessToken now return the full raw response from the OAuth provider in the raw field.

<!-- End of auto-generated description by cubic. -->

