### PR TITLE
feat(jwt): remote jwks, remote signing, and exportable signJwt function

### DIFF
--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -307,13 +307,16 @@ jwt({
 
 ### OAuth Provider Mode
 
-If you are making your system oAuth compliant (such as when utilizing the OIDC or MCP plugins), you **MUST** disable the `/token` endpoint to prevent issuing JWT tokens without oAuth checks.
+If you are making your system oAuth compliant (such as when utilizing the OIDC or MCP plugins), you **MUST** disable the `/token` endpoint (oAuth equivalent `/oauth2/token`) and disable setting the jwt header (oAuth equivalent `oauth2/userinfo`).
 
 ```ts title="auth.ts"
 betterAuth({
   disabledPaths: [
     "/token",
   ],
+  plugins: [jwt({
+    disableSettingJwtHeader: true,
+  })]
 })
 ```
 
@@ -335,14 +338,6 @@ jwt({
   }
 })
 ```
-
-### JWT Safety Options
-
-**allowLongerExpTime** @default false - Set true to allow signing tokens past `expirationTime`
-
-**allowIssuerMismatch** @default false - Set true to allow issuer to mismatch jwt plugin option setting
-
-**allowAudienceMismatch** @default false - Set true to allow audience to mismatch jwt plugin option setting
 
 ### Custom Signing
 

--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -307,11 +307,13 @@ jwt({
 
 ### OAuth Provider Mode
 
-If you are making your system an oAuth provider by using the OIDC or MCP plugins, you **MUST** set this parameter to disable the `/token` endpoint and the ability to obtain tokens via the `set-auth-jwt`.
+If you are making your system oAuth compliant (such as when utilizing the OIDC or MCP plugins), you **MUST** disable the `/token` endpoint to prevent issuing JWT tokens without oAuth checks.
 
 ```ts title="auth.ts"
-jwt({
-  usesOAuthProvider: true,
+betterAuth({
+  disabledPaths: [
+    "/token",
+  ],
 })
 ```
 
@@ -321,25 +323,16 @@ Disables the `/jwks` endpoint and uses this endpoint in any discovery such as OI
 
 Useful if your JWKS are not managed at `/jwks` or if your jwks are signed with a certificate and placed on your CDN.
 
-```ts title="auth.ts"
-jwt({
-  jwks: {
-    remoteUrl: "https://example.com/.well-known/jwks.json",
-  }
-})
-```
-
-NOTE: If you are also using the OIDC plugin, you **MUST** specify which algorithm is used for signing as well.
+NOTE: you **MUST** specify which asymmetric algorithm is used for signing.
 
 ```ts title="auth.ts"
 jwt({
-  usesOAuthProvider: true,
   jwks: {
     remoteUrl: "https://example.com/.well-known/jwks.json",
     keyPairConfig: {
       alg: 'ES256',
     },
-  },
+  }
 })
 ```
 
@@ -366,6 +359,9 @@ Implementers:
 jwt({
   jwks: {
     remoteUrl: "https://example.com/.well-known/jwks.json",
+    keyPairConfig: {
+      alg: 'EdDSA',
+    },
   },
   jwt: {
     sign: async (jwtPayload: JWTPayload) => {
@@ -390,6 +386,9 @@ Useful if you are using a remote Key Management Service such as Google KMS, Amaz
 jwt({
   jwks: {
     remoteUrl: "https://example.com/.well-known/jwks.json",
+    keyPairConfig: {
+      alg: 'ES256',
+    },
   },
   jwt: {
     sign: async (jwtPayload: JWTPayload) => {

--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -345,13 +345,13 @@ jwt({
 
 ### JWT Safety Options
 
-**disallowFutureIatTime** @default true - Set false to allow setting issue times in the future.
+**allowFutureIatTime** @default false - Set true to allow setting issue times in the future.
 
-**disallowLongerExpTime** @default true - Set false to allows signing tokens past `expirationTime`
+**allowLongerExpTime** @default false - Set true to allow signing tokens past `expirationTime`
 
-**disallowIssuerMismatch** @default true - Allows issuer to mismatch jwt plugin option setting
+**allowIssuerMismatch** @default false - Set true to allow issuer to mismatch jwt plugin option setting
 
-**disallowAudienceMismatch** @default true - Allows audience to mismatch jwt plugin option setting
+**allowAudienceMismatch** @default false - Set true to allow audience to mismatch jwt plugin option setting
 
 ### Custom Signing
 

--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -345,8 +345,6 @@ jwt({
 
 ### JWT Safety Options
 
-**allowFutureIatTime** @default false - Set true to allow setting issue times in the future.
-
 **allowLongerExpTime** @default false - Set true to allow signing tokens past `expirationTime`
 
 **allowIssuerMismatch** @default false - Set true to allow issuer to mismatch jwt plugin option setting
@@ -377,7 +375,7 @@ jwt({
           alg: "EdDSA",
           kid: process.env.currentKid,
           typ: "JWT",
-        });
+        })
         .sign(process.env.clientPrivateKey);
     },
   },

--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -304,3 +304,112 @@ jwt({
   }
 })
 ```
+
+### Oauth Provider Mode
+
+If you are making your system an oAuth provider by using the OIDC or MCP plugins, you **MUST** set this parameter to disable the `/token` endpoint and the ability to obtain tokens via the `set-auth-jwt`.
+
+```ts title="auth.ts"
+jwt({
+  usesOauthProvider: true,
+})
+```
+
+### Remote JWKS Url
+
+Disables the `/jwks` endpoint and uses this endpoint in any discovery such as OIDC.
+
+Useful if your JWKS are not managed at `/jwks` or if your jwks are signed with a certificate and placed on your CDN.
+
+```ts title="auth.ts"
+jwt({
+  jwks: {
+    remoteUrl: "https://example.com/.well-known/jwks.json",
+  }
+})
+```
+
+NOTE: If you are also using the OIDC plugin, you **MUST** specify which algorithm is used for signing as well.
+
+```ts title="auth.ts"
+jwt({
+  usesOauthProvider: true,
+  jwks: {
+    remoteUrl: "https://example.com/.well-known/jwks.json",
+    keyPairConfig: {
+      alg: 'ES256',
+    },
+  },
+})
+```
+
+### JWT Safety Options
+
+**disallowFutureIatTime** @default true - Set false to allow setting issue times in the future.
+
+**disallowLongerExpTime** @default true - Set false to allows signing tokens past `expirationTime`
+
+**disallowIssuerMismatch** @default true - Allows issuer to mismatch jwt plugin option setting
+
+**disallowAudienceMismatch** @default true - Allows audience to mismatch jwt plugin option setting
+
+### Custom Signing
+
+This is an advanced feature! Configuration outside of this plugin MUST be provided.
+
+Implementers:
+- `remoteUrl` must be defined if using the `sign` function. This shall store all active keys, not just the current one.
+- If using localized approach, ensure server uses the latest private key when rotated. Depending on deployment, the server may need to be restarted.
+- When using remote approach, verify the payload is unchanged after transit. Use integrity validation like CRC32 or SHA256 checks if available.
+
+#### Localized Signing
+
+```ts title="auth.ts"
+jwt({
+  jwks: {
+    remoteUrl: "https://example.com/.well-known/jwks.json",
+  },
+  jwt: {
+    sign: async (jwtPayload: JWTPayload) => {
+      // this is pseudocode
+      return await new SignJWT(jwtPayload)
+        .setProtectedHeader({
+          alg: "EdDSA",
+          kid: process.env.currentKid,
+          typ: "JWT",
+        });
+        .sign(process.env.clientPrivateKey);
+    },
+  },
+})
+```
+
+#### Remote Signing
+
+Useful if you are using a remote Key Management Service such as Google KMS, Amazon KMS, or Azure Key Vault.
+
+```ts title="auth.ts"
+jwt({
+  jwks: {
+    remoteUrl: "https://example.com/.well-known/jwks.json",
+  },
+  jwt: {
+    sign: async (jwtPayload: JWTPayload) => {
+      // this is pseudocode
+      const headers = JSON.stringify({ kid: '123', alg: 'ES256', typ: 'JWT' })
+      const payload = JSON.stringify(jwtPayload)
+      const encodedHeaders = Buffer.from(headers).toString('base64url')
+      const encodedPayload = Buffer.from(payload).toString('base64url')
+      const hash = createHash('sha256')
+      const data = `${encodedHeaders}.${encodedPayload}`
+      hash.update(Buffer.from(data))
+      const digest = hash.digest()
+      const sig = await remoteSign(digest)
+      // integrityCheck(sig)
+      const jwt = `${data}.${sig}`
+      // verifyJwt(jwt)
+      return jwt
+    },
+  },
+})
+```

--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -305,13 +305,13 @@ jwt({
 })
 ```
 
-### Oauth Provider Mode
+### OAuth Provider Mode
 
 If you are making your system an oAuth provider by using the OIDC or MCP plugins, you **MUST** set this parameter to disable the `/token` endpoint and the ability to obtain tokens via the `set-auth-jwt`.
 
 ```ts title="auth.ts"
 jwt({
-  usesOauthProvider: true,
+  usesOAuthProvider: true,
 })
 ```
 
@@ -333,7 +333,7 @@ NOTE: If you are also using the OIDC plugin, you **MUST** specify which algorith
 
 ```ts title="auth.ts"
 jwt({
-  usesOauthProvider: true,
+  usesOAuthProvider: true,
   jwks: {
     remoteUrl: "https://example.com/.well-known/jwks.json",
     keyPairConfig: {

--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -316,7 +316,9 @@ export const auth = betterAuth({
 
 ### JWKS Endpoint
 
-The OIDC Provider plugin can integrate with the JWT plugin to provide proper asymmetric key signing for ID tokens. When enabled, ID tokens will be signed using RSA/EdDSA keys and can be verified using the JWKS endpoint.
+The OIDC Provider plugin can integrate with the JWT plugin to provide asymmetric key signing for ID tokens verifiable at a JWKS endpoint.
+
+To make your plugin OIDC compliant, you **MUST** disable the `/token` endpoint, the oAuth equivalent is located at `/oauth2/token` instead.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
@@ -324,9 +326,14 @@ import { oidcProvider } from "better-auth/plugins";
 import { jwt } from "better-auth/plugins";
 
 export const auth = betterAuth({
+    disabledPaths: [
+        "/token",
+    ],
     plugins: [
         jwt({
-          usesOAuthProvider: true,
+            jwt: {
+                allowAudienceMismatch: true,
+            },
         }),
         oidcProvider({
             useJWTPlugin: true,

--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -325,9 +325,11 @@ import { jwt } from "better-auth/plugins";
 
 export const auth = betterAuth({
     plugins: [
-        jwt(), // Make sure to add the JWT plugin
+        jwt({
+          usesOauthProvider: true,
+        }), // Make sure to add the JWT plugin before oidcProvider
         oidcProvider({
-            useJWTPlugin: true, // Enable JWT plugin integration
+            useJWTPlugin: true,
             loginPage: "/sign-in",
             // ... other options
         })
@@ -563,4 +565,4 @@ Table Name: `oauthConsent`
 
 **getAdditionalUserInfoClaim**: `(user: User, scopes: string[], client: Client) => Record<string, any>` - Function to get additional user info claims.
 
-**useJWTPlugin**: `boolean` - When `true`, ID tokens are signed using the JWT plugin's asymmetric keys. When `false` (default), ID tokens are signed with HMAC-SHA256 using the application secret.
+**useJWTPlugin**: `boolean` - When `true`, ID tokens are signed using the JWT plugin's asymmetric keys. If `true`, ensure the jwt plugin is defined **BEFORE** the oidcProvider plugin. When `false` (default), ID tokens are signed with HMAC-SHA256 using the application secret.

--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -326,7 +326,7 @@ import { jwt } from "better-auth/plugins";
 export const auth = betterAuth({
     plugins: [
         jwt({
-          usesOauthProvider: true,
+          usesOAuthProvider: true,
         }), // Make sure to add the JWT plugin before oidcProvider
         oidcProvider({
             useJWTPlugin: true,

--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -330,11 +330,7 @@ export const auth = betterAuth({
         "/token",
     ],
     plugins: [
-        jwt({
-            jwt: {
-                allowAudienceMismatch: true,
-            },
-        }),
+        jwt(),
         oidcProvider({
             useJWTPlugin: true,
             loginPage: "/sign-in",

--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -327,7 +327,7 @@ export const auth = betterAuth({
     plugins: [
         jwt({
           usesOAuthProvider: true,
-        }), // Make sure to add the JWT plugin before oidcProvider
+        }),
         oidcProvider({
             useJWTPlugin: true,
             loginPage: "/sign-in",
@@ -565,4 +565,4 @@ Table Name: `oauthConsent`
 
 **getAdditionalUserInfoClaim**: `(user: User, scopes: string[], client: Client) => Record<string, any>` - Function to get additional user info claims.
 
-**useJWTPlugin**: `boolean` - When `true`, ID tokens are signed using the JWT plugin's asymmetric keys. If `true`, ensure the jwt plugin is defined **BEFORE** the oidcProvider plugin. When `false` (default), ID tokens are signed with HMAC-SHA256 using the application secret.
+**useJWTPlugin**: `boolean` - When `true`, ID tokens are signed using the JWT plugin's asymmetric keys. When `false` (default), ID tokens are signed with HMAC-SHA256 using the application secret.

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -1,228 +1,173 @@
-import type {
-	BetterAuthPlugin,
-	InferOptionSchema,
-	Session,
-	User,
-} from "../../types";
-import { type Jwk, schema } from "./schema";
+import type { BetterAuthPlugin, HookEndpointContext } from "../../types";
+import { schema } from "./schema";
 import { getJwksAdapter } from "./adapter";
-import { getJwtToken } from "./sign";
-import { exportJWK, generateKeyPair, type JWK } from "jose";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 	sessionMiddleware,
 } from "../../api";
-import { symmetricEncrypt } from "../../crypto";
 import { mergeSchema } from "../../db/schema";
+import { BetterAuthError } from "../../error";
+import { createJwk, signJwt } from "./sign";
+import type { JwtPluginOptions } from "./types";
+export type * from "./types";
+export { createJwk, getJwtToken } from "./sign";
+export { getJwtPlugin } from "./utils";
 
-type JWKOptions =
-	| {
-			alg: "EdDSA"; // EdDSA with either Ed25519 or Ed448 curve
-			crv?: "Ed25519" | "Ed448";
-	  }
-	| {
-			alg: "ES256"; // ECDSA with P-256 curve
-			crv?: never; // Only one valid option, no need for crv
-	  }
-	| {
-			alg: "RS256"; // RSA with SHA-256
-			modulusLength?: number; // Default to 2048 or higher
-	  }
-	| {
-			alg: "PS256"; // RSA-PSS with SHA-256
-			modulusLength?: number; // Default to 2048 or higher
-	  }
-	| {
-			alg: "ECDH-ES"; // Key agreement algorithm with P-256 as default curve
-			crv?: "P-256" | "P-384" | "P-521";
-	  }
-	| {
-			alg: "ES512"; // ECDSA with P-521 curve
-			crv?: never; // Only P-521 for ES512
-	  };
+export const jwt = (options?: JwtPluginOptions) => {
+	const endpoints: BetterAuthPlugin["endpoints"] = {};
+	const hooks: BetterAuthPlugin["hooks"] = {};
 
-export interface JwtOptions {
-	jwks?: {
-		/**
-		 * Key pair configuration
-		 * @description A subset of the options available for the generateKeyPair function
-		 *
-		 * @see https://github.com/panva/jose/blob/main/src/runtime/node/generate.ts
-		 *
-		 * @default { alg: 'EdDSA', crv: 'Ed25519' }
-		 */
-		keyPairConfig?: JWKOptions;
+	// Remote url must be set when using signing function
+	if (options?.jwt?.sign && !options.jwks?.remoteUrl) {
+		throw new BetterAuthError(
+			"jwks_config",
+			"jwks.remoteUrl must be set when using jwt.sign",
+		);
+	}
 
-		/**
-		 * Disable private key encryption
-		 * @description Disable the encryption of the private key in the database
-		 *
-		 * @default false
-		 */
-		disablePrivateKeyEncryption?: boolean;
-	};
+	// Alg is required to be specified when using oidc plugin and remote url (needed in openid metadata)
+	if (
+		options?.usesOauthProvider &&
+		options.jwks?.remoteUrl &&
+		!options.jwks?.keyPairConfig?.alg
+	) {
+		throw new BetterAuthError(
+			"jwks_config",
+			"must specify alg when using the oidc plugin and jwks.remoteUrl",
+		);
+	}
 
-	jwt?: {
-		/**
-		 * The issuer of the JWT
-		 */
-		issuer?: string;
-		/**
-		 * The audience of the JWT
-		 */
-		audience?: string;
-		/**
-		 * Set the "exp" (Expiration Time) Claim.
-		 *
-		 * - If a `number` is passed as an argument it is used as the claim directly.
-		 * - If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
-		 *   claim.
-		 * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
-		 *   current unix timestamp and used as the claim.
-		 *
-		 * Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
-		 * day".
-		 *
-		 * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
-		 * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-		 * "years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
-		 * alias for a year.
-		 *
-		 * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
-		 * subtracted from the current unix timestamp. A "from now" suffix can also be used for
-		 * readability when adding to the current unix timestamp.
-		 *
-		 * @default 15m
-		 */
-		expirationTime?: number | string | Date;
-		/**
-		 * A function that is called to define the payload of the JWT
-		 */
-		definePayload?: (session: {
-			user: User & Record<string, any>;
-			session: Session & Record<string, any>;
-		}) => Promise<Record<string, any>> | Record<string, any>;
-		/**
-		 * A function that is called to get the subject of the JWT
-		 *
-		 * @default session.user.id
-		 */
-		getSubject?: (session: {
-			user: User & Record<string, any>;
-			session: Session & Record<string, any>;
-		}) => Promise<string> | string;
-	};
-	/**
-	 * Custom schema for the admin plugin
-	 */
-	schema?: InferOptionSchema<typeof schema>;
-}
-
-export async function generateExportedKeyPair(
-	options?: JwtOptions,
-): Promise<{ publicWebKey: JWK; privateWebKey: JWK }> {
-	const { alg, ...cfg } = options?.jwks?.keyPairConfig ?? {
-		alg: "EdDSA",
-		crv: "Ed25519",
-	};
-	const keyPairConfig = {
-		...cfg,
-		extractable: true,
-	};
-
-	const { publicKey, privateKey } = await generateKeyPair(alg, keyPairConfig);
-
-	const publicWebKey = await exportJWK(publicKey);
-	const privateWebKey = await exportJWK(privateKey);
-
-	return { publicWebKey, privateWebKey };
-}
-
-export const jwt = (options?: JwtOptions) => {
-	return {
-		id: "jwt",
-		options,
-		endpoints: {
-			getJwks: createAuthEndpoint(
-				"/jwks",
-				{
-					method: "GET",
-					metadata: {
-						openapi: {
-							description: "Get the JSON Web Key Set",
-							responses: {
-								"200": {
-									description: "JSON Web Key Set retrieved successfully",
-									content: {
-										"application/json": {
-											schema: {
-												type: "object",
-												properties: {
-													keys: {
-														type: "array",
-														description: "Array of public JSON Web Keys",
-														items: {
-															type: "object",
-															properties: {
-																kid: {
-																	type: "string",
-																	description:
-																		"Key ID uniquely identifying the key, corresponds to the 'id' from the stored Jwk",
-																},
-																kty: {
-																	type: "string",
-																	description:
-																		"Key type (e.g., 'RSA', 'EC', 'OKP')",
-																},
-																alg: {
-																	type: "string",
-																	description:
-																		"Algorithm intended for use with the key (e.g., 'EdDSA', 'RS256')",
-																},
-																use: {
-																	type: "string",
-																	description:
-																		"Intended use of the public key (e.g., 'sig' for signature)",
-																	enum: ["sig"],
-																	nullable: true,
-																},
-																n: {
-																	type: "string",
-																	description:
-																		"Modulus for RSA keys (base64url-encoded)",
-																	nullable: true,
-																},
-																e: {
-																	type: "string",
-																	description:
-																		"Exponent for RSA keys (base64url-encoded)",
-																	nullable: true,
-																},
-																crv: {
-																	type: "string",
-																	description:
-																		"Curve name for elliptic curve keys (e.g., 'Ed25519', 'P-256')",
-																	nullable: true,
-																},
-																x: {
-																	type: "string",
-																	description:
-																		"X coordinate for elliptic curve keys (base64url-encoded)",
-																	nullable: true,
-																},
-																y: {
-																	type: "string",
-																	description:
-																		"Y coordinate for elliptic curve keys (base64url-encoded)",
-																	nullable: true,
-																},
+	// Disables endpoint if using remote url strategy
+	if (!options?.jwks?.remoteUrl) {
+		endpoints.getJwks = createAuthEndpoint(
+			"/jwks",
+			{
+				method: "GET",
+				metadata: {
+					openapi: {
+						description: "Get the JSON Web Key Set",
+						responses: {
+							"200": {
+								description: "JSON Web Key Set retrieved successfully",
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												keys: {
+													type: "array",
+													description: "Array of public JSON Web Keys",
+													items: {
+														type: "object",
+														properties: {
+															kid: {
+																type: "string",
+																description:
+																	"Key ID uniquely identifying the key, corresponds to the 'id' from the stored Jwk",
 															},
-															required: ["kid", "kty", "alg"],
+															kty: {
+																type: "string",
+																description:
+																	"Key type (e.g., 'RSA', 'EC', 'OKP')",
+															},
+															alg: {
+																type: "string",
+																description:
+																	"Algorithm intended for use with the key (e.g., 'EdDSA', 'RS256')",
+															},
+															use: {
+																type: "string",
+																description:
+																	"Intended use of the public key (e.g., 'sig' for signature)",
+																enum: ["sig"],
+																nullable: true,
+															},
+															n: {
+																type: "string",
+																description:
+																	"Modulus for RSA keys (base64url-encoded)",
+																nullable: true,
+															},
+															e: {
+																type: "string",
+																description:
+																	"Exponent for RSA keys (base64url-encoded)",
+																nullable: true,
+															},
+															crv: {
+																type: "string",
+																description:
+																	"Curve name for elliptic curve keys (e.g., 'Ed25519', 'P-256')",
+																nullable: true,
+															},
+															x: {
+																type: "string",
+																description:
+																	"X coordinate for elliptic curve keys (base64url-encoded)",
+																nullable: true,
+															},
+															y: {
+																type: "string",
+																description:
+																	"Y coordinate for elliptic curve keys (base64url-encoded)",
+																nullable: true,
+															},
 														},
+														required: ["kid", "kty", "alg"],
 													},
 												},
-												required: ["keys"],
+											},
+											required: ["keys"],
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			async (ctx) => {
+				const adapter = getJwksAdapter(ctx.context.adapter);
+
+				const keySets = await adapter.getAllKeys();
+
+				if (keySets.length === 0) {
+					const key = await createJwk(ctx, options);
+					keySets.push(key);
+				}
+
+				return ctx.json({
+					keys: keySets.map((keySet) => ({
+						...JSON.parse(keySet.publicKey),
+						kid: keySet.id,
+					})),
+				});
+			},
+		);
+	}
+
+	if (!options?.usesOauthProvider) {
+		endpoints.getToken = createAuthEndpoint(
+			"/token",
+			{
+				method: "GET",
+				requireHeaders: true,
+				use: [sessionMiddleware],
+				metadata: {
+					openapi: {
+						description: "Converts a session cookie to a JWT token",
+						responses: {
+							200: {
+								description: "Success",
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												token: {
+													type: "string",
+												},
 											},
 										},
 									},
@@ -231,136 +176,82 @@ export const jwt = (options?: JwtOptions) => {
 						},
 					},
 				},
-				async (ctx) => {
-					const adapter = getJwksAdapter(ctx.context.adapter);
+			},
+			async (ctx) => {
+				// Convert context into user payload
+				let payload: Record<string, any>;
+				if (options?.jwt?.definePayload) {
+					payload = await options?.jwt.definePayload(ctx.context.session!);
+				} else {
+					payload = {
+						...(ctx.context.session?.user ?? {}),
+						id: undefined, // id becomes sub in Sign Function
+					};
+				}
 
-					const keySets = await adapter.getAllKeys();
+				// Convert into JWT token
+				const jwt = await signJwt(ctx, payload);
+				return ctx.json({
+					token: jwt,
+				});
+			},
+		);
+	}
 
-					if (keySets.length === 0) {
-						const { alg, ...cfg } = options?.jwks?.keyPairConfig ?? {
-							alg: "EdDSA",
-							crv: "Ed25519",
+	if (!options?.usesOauthProvider) {
+		if (!hooks.after) hooks.after = [];
+		hooks.after.push({
+			matcher(context: HookEndpointContext) {
+				return context.path === "/get-session";
+			},
+			handler: createAuthMiddleware(async (ctx) => {
+				const session = ctx.context.session || ctx.context.newSession;
+				if (session && session.session) {
+					// Convert context into user payload
+					let payload: Record<string, any>;
+					if (options?.jwt?.definePayload) {
+						payload = await options?.jwt.definePayload(ctx.context.session!);
+					} else {
+						payload = {
+							...(ctx.context.session?.user ?? {}),
+							id: undefined, // id becomes sub in Sign Function
 						};
-						const keyPairConfig = {
-							...cfg,
-							extractable: true,
-						};
-
-						const { publicKey, privateKey } = await generateKeyPair(
-							alg,
-							keyPairConfig,
-						);
-
-						const publicWebKey = await exportJWK(publicKey);
-						const privateWebKey = await exportJWK(privateKey);
-						const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
-						const privateKeyEncryptionEnabled =
-							!options?.jwks?.disablePrivateKeyEncryption;
-						let jwk: Partial<Jwk> = {
-							publicKey: JSON.stringify({ alg, ...publicWebKey }),
-							privateKey: privateKeyEncryptionEnabled
-								? JSON.stringify(
-										await symmetricEncrypt({
-											key: ctx.context.secret,
-											data: stringifiedPrivateWebKey,
-										}),
-									)
-								: stringifiedPrivateWebKey,
-							createdAt: new Date(),
-						};
-
-						await adapter.createJwk(jwk as Jwk);
-
-						return ctx.json({
-							keys: [
-								{
-									...publicWebKey,
-									alg,
-									kid: jwk.id,
-								},
-							],
-						});
 					}
 
-					return ctx.json({
-						keys: keySets.map((keySet) => ({
-							...JSON.parse(keySet.publicKey),
-							kid: keySet.id,
-						})),
-					});
-				},
-			),
+					if (!payload) return;
+					const jwt = await signJwt(ctx, payload);
+					const exposedHeaders =
+						ctx.context.responseHeaders?.get("access-control-expose-headers") ||
+						"";
+					const headersSet = new Set(
+						exposedHeaders
+							.split(",")
+							.map((header) => header.trim())
+							.filter(Boolean),
+					);
+					headersSet.add("set-auth-jwt");
+					ctx.setHeader("set-auth-jwt", jwt);
+					ctx.setHeader(
+						"Access-Control-Expose-Headers",
+						Array.from(headersSet).join(", "),
+					);
+				}
+			}),
+		});
+	}
 
-			getToken: createAuthEndpoint(
-				"/token",
-				{
-					method: "GET",
-					requireHeaders: true,
-					use: [sessionMiddleware],
-					metadata: {
-						openapi: {
-							description: "Get a JWT token",
-							responses: {
-								200: {
-									description: "Success",
-									content: {
-										"application/json": {
-											schema: {
-												type: "object",
-												properties: {
-													token: {
-														type: "string",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				async (ctx) => {
-					const jwt = await getJwtToken(ctx, options);
-					return ctx.json({
-						token: jwt,
-					});
-				},
-			),
+	return {
+		id: "jwt",
+		init: (ctx) => {
+			// Add the jwt plugin options to ctx
+			const plugin = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
+			if (!plugin) {
+				throw Error("Plugin should have been registered! Should never hit!");
+			}
+			plugin.options = options;
 		},
-		hooks: {
-			after: [
-				{
-					matcher(context) {
-						return context.path === "/get-session";
-					},
-					handler: createAuthMiddleware(async (ctx) => {
-						const session = ctx.context.session || ctx.context.newSession;
-						if (session && session.session) {
-							const jwt = await getJwtToken(ctx, options);
-							const exposedHeaders =
-								ctx.context.responseHeaders?.get(
-									"access-control-expose-headers",
-								) || "";
-							const headersSet = new Set(
-								exposedHeaders
-									.split(",")
-									.map((header) => header.trim())
-									.filter(Boolean),
-							);
-							headersSet.add("set-auth-jwt");
-							ctx.setHeader("set-auth-jwt", jwt);
-							ctx.setHeader(
-								"Access-Control-Expose-Headers",
-								Array.from(headersSet).join(", "),
-							);
-						}
-					}),
-				},
-			],
-		},
+		endpoints,
+		hooks,
 		schema: mergeSchema(schema, options?.schema),
 	} satisfies BetterAuthPlugin;
 };
-
-export { getJwtToken };

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -2,6 +2,7 @@ import type { BetterAuthPlugin, HookEndpointContext } from "../../types";
 import { schema } from "./schema";
 import { getJwksAdapter } from "./adapter";
 import {
+	APIError,
 	createAuthEndpoint,
 	createAuthMiddleware,
 	sessionMiddleware,
@@ -15,9 +16,6 @@ export { createJwk, getJwtToken, signJwt } from "./sign";
 export { getJwtPlugin } from "./utils";
 
 export const jwt = (options?: JwtPluginOptions) => {
-	const endpoints: BetterAuthPlugin["endpoints"] = {};
-	const hooks: BetterAuthPlugin["hooks"] = {};
-
 	// Remote url must be set when using signing function
 	if (options?.jwt?.sign && !options.jwks?.remoteUrl) {
 		throw new BetterAuthError(
@@ -38,87 +36,142 @@ export const jwt = (options?: JwtPluginOptions) => {
 		);
 	}
 
-	// Disables endpoint if using remote url strategy
-	if (!options?.jwks?.remoteUrl) {
-		endpoints.getJwks = createAuthEndpoint(
-			"/jwks",
-			{
-				method: "GET",
-				metadata: {
-					openapi: {
-						description: "Get the JSON Web Key Set",
-						responses: {
-							"200": {
-								description: "JSON Web Key Set retrieved successfully",
-								content: {
-									"application/json": {
-										schema: {
-											type: "object",
-											properties: {
-												keys: {
-													type: "array",
-													description: "Array of public JSON Web Keys",
-													items: {
-														type: "object",
-														properties: {
-															kid: {
-																type: "string",
-																description:
-																	"Key ID uniquely identifying the key, corresponds to the 'id' from the stored Jwk",
+	return {
+		id: "jwt",
+		options,
+		endpoints: {
+			getJwks: createAuthEndpoint(
+				"/jwks",
+				{
+					method: "GET",
+					metadata: {
+						openapi: {
+							description: "Get the JSON Web Key Set",
+							responses: {
+								"200": {
+									description: "JSON Web Key Set retrieved successfully",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													keys: {
+														type: "array",
+														description: "Array of public JSON Web Keys",
+														items: {
+															type: "object",
+															properties: {
+																kid: {
+																	type: "string",
+																	description:
+																		"Key ID uniquely identifying the key, corresponds to the 'id' from the stored Jwk",
+																},
+																kty: {
+																	type: "string",
+																	description:
+																		"Key type (e.g., 'RSA', 'EC', 'OKP')",
+																},
+																alg: {
+																	type: "string",
+																	description:
+																		"Algorithm intended for use with the key (e.g., 'EdDSA', 'RS256')",
+																},
+																use: {
+																	type: "string",
+																	description:
+																		"Intended use of the public key (e.g., 'sig' for signature)",
+																	enum: ["sig"],
+																	nullable: true,
+																},
+																n: {
+																	type: "string",
+																	description:
+																		"Modulus for RSA keys (base64url-encoded)",
+																	nullable: true,
+																},
+																e: {
+																	type: "string",
+																	description:
+																		"Exponent for RSA keys (base64url-encoded)",
+																	nullable: true,
+																},
+																crv: {
+																	type: "string",
+																	description:
+																		"Curve name for elliptic curve keys (e.g., 'Ed25519', 'P-256')",
+																	nullable: true,
+																},
+																x: {
+																	type: "string",
+																	description:
+																		"X coordinate for elliptic curve keys (base64url-encoded)",
+																	nullable: true,
+																},
+																y: {
+																	type: "string",
+																	description:
+																		"Y coordinate for elliptic curve keys (base64url-encoded)",
+																	nullable: true,
+																},
 															},
-															kty: {
-																type: "string",
-																description:
-																	"Key type (e.g., 'RSA', 'EC', 'OKP')",
-															},
-															alg: {
-																type: "string",
-																description:
-																	"Algorithm intended for use with the key (e.g., 'EdDSA', 'RS256')",
-															},
-															use: {
-																type: "string",
-																description:
-																	"Intended use of the public key (e.g., 'sig' for signature)",
-																enum: ["sig"],
-																nullable: true,
-															},
-															n: {
-																type: "string",
-																description:
-																	"Modulus for RSA keys (base64url-encoded)",
-																nullable: true,
-															},
-															e: {
-																type: "string",
-																description:
-																	"Exponent for RSA keys (base64url-encoded)",
-																nullable: true,
-															},
-															crv: {
-																type: "string",
-																description:
-																	"Curve name for elliptic curve keys (e.g., 'Ed25519', 'P-256')",
-																nullable: true,
-															},
-															x: {
-																type: "string",
-																description:
-																	"X coordinate for elliptic curve keys (base64url-encoded)",
-																nullable: true,
-															},
-															y: {
-																type: "string",
-																description:
-																	"Y coordinate for elliptic curve keys (base64url-encoded)",
-																nullable: true,
-															},
+															required: ["kid", "kty", "alg"],
 														},
-														required: ["kid", "kty", "alg"],
+													},
+												},
+												required: ["keys"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					// Disables endpoint if using remote url strategy
+					if (options?.jwks?.remoteUrl) {
+						throw new APIError("NOT_FOUND");
+					}
+
+					const adapter = getJwksAdapter(ctx.context.adapter);
+
+					const keySets = await adapter.getAllKeys();
+
+					if (keySets.length === 0) {
+						const key = await createJwkOnDb(ctx, options);
+						keySets.push(key);
+					}
+
+					return ctx.json({
+						keys: keySets.map((keySet) => ({
+							...JSON.parse(keySet.publicKey),
+							kid: keySet.id,
+						})),
+					});
+				},
+			),
+			getToken: createAuthEndpoint(
+				"/token",
+				{
+					method: "GET",
+					requireHeaders: true,
+					use: [sessionMiddleware],
+					metadata: {
+						openapi: {
+							description: "Converts a session cookie to a JWT token",
+							responses: {
+								200: {
+									description: "Success",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													token: {
+														type: "string",
 													},
 												},
 											},
-											required: ["keys"],
 										},
 									},
 								},
@@ -126,87 +179,12 @@ export const jwt = (options?: JwtPluginOptions) => {
 						},
 					},
 				},
-			},
-			async (ctx) => {
-				const adapter = getJwksAdapter(ctx.context.adapter);
+				async (ctx) => {
+					// Disables endpoint if using oAuth provider
+					if (options?.usesOAuthProvider) {
+						throw new APIError("NOT_FOUND");
+					}
 
-				const keySets = await adapter.getAllKeys();
-
-				if (keySets.length === 0) {
-					const key = await createJwkOnDb(ctx, options);
-					keySets.push(key);
-				}
-
-				return ctx.json({
-					keys: keySets.map((keySet) => ({
-						...JSON.parse(keySet.publicKey),
-						kid: keySet.id,
-					})),
-				});
-			},
-		);
-	}
-
-	if (!options?.usesOAuthProvider) {
-		endpoints.getToken = createAuthEndpoint(
-			"/token",
-			{
-				method: "GET",
-				requireHeaders: true,
-				use: [sessionMiddleware],
-				metadata: {
-					openapi: {
-						description: "Converts a session cookie to a JWT token",
-						responses: {
-							200: {
-								description: "Success",
-								content: {
-									"application/json": {
-										schema: {
-											type: "object",
-											properties: {
-												token: {
-													type: "string",
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			async (ctx) => {
-				// Convert context into user payload
-				let payload: Record<string, any>;
-				if (options?.jwt?.definePayload) {
-					payload = await options?.jwt.definePayload(ctx.context.session!);
-				} else {
-					payload = {
-						...(ctx.context.session?.user ?? {}),
-						id: undefined, // id becomes sub in Sign Function
-					};
-				}
-
-				// Convert into JWT token
-				const token = await signJwtPayload(ctx, payload, options);
-				return ctx.json({
-					token,
-				});
-			},
-		);
-	}
-
-	if (!options?.usesOAuthProvider) {
-		if (!hooks.after) hooks.after = [];
-		hooks.after.push({
-			matcher(context: HookEndpointContext) {
-				return context.path === "/get-session";
-			},
-			handler: createAuthMiddleware(async (ctx) => {
-				const session = ctx.context.session || ctx.context.newSession;
-				if (session && session.session) {
 					// Convert context into user payload
 					let payload: Record<string, any>;
 					if (options?.jwt?.definePayload) {
@@ -218,33 +196,64 @@ export const jwt = (options?: JwtPluginOptions) => {
 						};
 					}
 
-					if (!payload) return;
+					// Convert into JWT token
 					const token = await signJwtPayload(ctx, payload, options);
-					const exposedHeaders =
-						ctx.context.responseHeaders?.get("access-control-expose-headers") ||
-						"";
-					const headersSet = new Set(
-						exposedHeaders
-							.split(",")
-							.map((header) => header.trim())
-							.filter(Boolean),
-					);
-					headersSet.add("set-auth-jwt");
-					ctx.setHeader("set-auth-jwt", token);
-					ctx.setHeader(
-						"Access-Control-Expose-Headers",
-						Array.from(headersSet).join(", "),
-					);
-				}
-			}),
-		});
-	}
+					return ctx.json({
+						token,
+					});
+				},
+			),
+		},
+		hooks: {
+			after: [
+				{
+					matcher(context: HookEndpointContext) {
+						return context.path === "/get-session";
+					},
+					handler: createAuthMiddleware(async (ctx) => {
+						// Disables middleware if using oAuth provider
+						if (options?.usesOAuthProvider) {
+							return;
+						}
 
-	return {
-		id: "jwt",
-		options,
-		endpoints,
-		hooks,
+						const session = ctx.context.session || ctx.context.newSession;
+						if (session && session.session) {
+							// Convert context into user payload
+							let payload: Record<string, any>;
+							if (options?.jwt?.definePayload) {
+								payload = await options?.jwt.definePayload(
+									ctx.context.session!,
+								);
+							} else {
+								payload = {
+									...(ctx.context.session?.user ?? {}),
+									id: undefined, // id becomes sub in Sign Function
+								};
+							}
+
+							if (!payload) return;
+							const token = await signJwtPayload(ctx, payload, options);
+							const exposedHeaders =
+								ctx.context.responseHeaders?.get(
+									"access-control-expose-headers",
+								) || "";
+							const headersSet = new Set(
+								exposedHeaders
+									.split(",")
+									.map((header) => header.trim())
+									.filter(Boolean),
+							);
+							headersSet.add("set-auth-jwt");
+							ctx.setHeader("set-auth-jwt", token);
+							ctx.setHeader(
+								"Access-Control-Expose-Headers",
+								Array.from(headersSet).join(", "),
+							);
+						}
+					}),
+				},
+			],
+		},
 		schema: mergeSchema(schema, options?.schema),
 	} satisfies BetterAuthPlugin;
 };

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -190,9 +190,9 @@ export const jwt = (options?: JwtPluginOptions) => {
 				}
 
 				// Convert into JWT token
-				const jwt = await signJwtPayload(ctx, payload, options);
+				const token = await signJwtPayload(ctx, payload, options);
 				return ctx.json({
-					token: jwt,
+					token,
 				});
 			},
 		);
@@ -219,7 +219,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 					}
 
 					if (!payload) return;
-					const jwt = await signJwtPayload(ctx, payload, options);
+					const token = await signJwtPayload(ctx, payload, options);
 					const exposedHeaders =
 						ctx.context.responseHeaders?.get("access-control-expose-headers") ||
 						"";
@@ -230,7 +230,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 							.filter(Boolean),
 					);
 					headersSet.add("set-auth-jwt");
-					ctx.setHeader("set-auth-jwt", jwt);
+					ctx.setHeader("set-auth-jwt", token);
 					ctx.setHeader(
 						"Access-Control-Expose-Headers",
 						Array.from(headersSet).join(", "),

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -8,10 +8,10 @@ import {
 } from "../../api";
 import { mergeSchema } from "../../db/schema";
 import { BetterAuthError } from "../../error";
-import { createJwk, signJwt } from "./sign";
+import { createJwkOnDb, signJwtPayload } from "./sign";
 import type { JwtPluginOptions } from "./types";
 export type * from "./types";
-export { createJwk, getJwtToken } from "./sign";
+export { createJwk, getJwtToken, signJwt } from "./sign";
 export { getJwtPlugin } from "./utils";
 
 export const jwt = (options?: JwtPluginOptions) => {
@@ -133,7 +133,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 				const keySets = await adapter.getAllKeys();
 
 				if (keySets.length === 0) {
-					const key = await createJwk(ctx, options);
+					const key = await createJwkOnDb(ctx, options);
 					keySets.push(key);
 				}
 
@@ -190,7 +190,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 				}
 
 				// Convert into JWT token
-				const jwt = await signJwt(ctx, payload);
+				const jwt = await signJwtPayload(ctx, payload, options);
 				return ctx.json({
 					token: jwt,
 				});
@@ -219,7 +219,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 					}
 
 					if (!payload) return;
-					const jwt = await signJwt(ctx, payload);
+					const jwt = await signJwtPayload(ctx, payload, options);
 					const exposedHeaders =
 						ctx.context.responseHeaders?.get("access-control-expose-headers") ||
 						"";

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -242,14 +242,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 
 	return {
 		id: "jwt",
-		init: (ctx) => {
-			// Add the jwt plugin options to ctx
-			const plugin = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
-			if (!plugin) {
-				throw Error("Plugin should have been registered! Should never hit!");
-			}
-			plugin.options = options;
-		},
+		options,
 		endpoints,
 		hooks,
 		schema: mergeSchema(schema, options?.schema),

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -24,7 +24,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 		);
 	}
 
-	// Alg is required to be specified when using oidc plugin and remote url (needed in openid metadata)
+	// Alg is required to be specified when using remote url (needed in openid metadata)
 	if (options?.jwks?.remoteUrl && !options.jwks?.keyPairConfig?.alg) {
 		throw new BetterAuthError(
 			"jwks_config",
@@ -178,8 +178,8 @@ export const jwt = (options?: JwtPluginOptions) => {
 				async (ctx) => {
 					// Convert context into user payload
 					let payload: Record<string, any>;
-					if (options?.jwt?.definePayload) {
-						payload = await options?.jwt.definePayload(ctx.context.session!);
+					if (options?.jwt?.definePayload && ctx.context.session) {
+						payload = await options?.jwt.definePayload(ctx.context.session);
 					} else {
 						payload = ctx.context.session?.user ?? {};
 					}

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthPlugin, HookEndpointContext } from "../../types";
+import type { BetterAuthPlugin } from "../../types";
 import { schema } from "./schema";
 import { getJwksAdapter } from "./adapter";
 import {
@@ -207,7 +207,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 		hooks: {
 			after: [
 				{
-					matcher(context: HookEndpointContext) {
+					matcher(context) {
 						return context.path === "/get-session";
 					},
 					handler: createAuthMiddleware(async (ctx) => {
@@ -225,10 +225,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 									ctx.context.session!,
 								);
 							} else {
-								payload = {
-									...(ctx.context.session?.user ?? {}),
-									id: undefined, // id becomes sub in Sign Function
-								};
+								payload = ctx.context.session?.user ?? {};
 							}
 
 							if (!payload) return;

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -28,7 +28,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 
 	// Alg is required to be specified when using oidc plugin and remote url (needed in openid metadata)
 	if (
-		options?.usesOauthProvider &&
+		options?.usesOAuthProvider &&
 		options.jwks?.remoteUrl &&
 		!options.jwks?.keyPairConfig?.alg
 	) {
@@ -147,7 +147,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 		);
 	}
 
-	if (!options?.usesOauthProvider) {
+	if (!options?.usesOAuthProvider) {
 		endpoints.getToken = createAuthEndpoint(
 			"/token",
 			{
@@ -198,7 +198,7 @@ export const jwt = (options?: JwtPluginOptions) => {
 		);
 	}
 
-	if (!options?.usesOauthProvider) {
+	if (!options?.usesOAuthProvider) {
 		if (!hooks.after) hooks.after = [];
 		hooks.after.push({
 			matcher(context: HookEndpointContext) {

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -2,30 +2,10 @@ import { describe, expect } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { createAuthClient } from "../../client";
 import { jwtClient } from "./client";
-import { generateExportedKeyPair, jwt, type JwtOptions } from "./index";
-import { importJWK, jwtVerify } from "jose";
-
-type JWKOptions =
-	| {
-			alg: "EdDSA"; // EdDSA with either Ed25519
-			crv?: "Ed25519";
-	  }
-	| {
-			alg: "ES256"; // ECDSA with P-256 curve
-			crv?: never; // Only one valid option, no need for crv
-	  }
-	| {
-			alg: "RS256"; // RSA with SHA-256
-			modulusLength?: number; // Default to 2048 or higher
-	  }
-	| {
-			alg: "PS256"; // RSA-PSS with SHA-256
-			modulusLength?: number; // Default to 2048 or higher
-	  }
-	| {
-			alg: "ES512"; // ECDSA with P-521 curve
-			crv?: never; // Only P-521 for ES512
-	  };
+import { jwt } from "./index";
+import { createLocalJWKSet, jwtVerify, type JSONWebKeySet } from "jose";
+import type { JWKOptions, JwtPluginOptions } from "./types";
+import { generateExportedKeyPair } from "./sign";
 
 describe("jwt", async (it) => {
 	// Testing the default behaviour
@@ -47,87 +27,93 @@ describe("jwt", async (it) => {
 		},
 	});
 
-	it("Client gets a token from session", async () => {
-		let token = "";
+	it("should receive token on client via header", async () => {
+		let token: string | null = null;
 		await client.getSession({
 			fetchOptions: {
 				headers,
 				onSuccess(context) {
-					token = context.response.headers.get("set-auth-jwt") || "";
+					token = context.response.headers.get("set-auth-jwt");
 				},
 			},
 		});
-
-		expect(token.length).toBeGreaterThan(10);
+		expect(token).not.toBeNull();
 	});
 
-	it("Client gets a token", async () => {
-		const token = await client.token({
-			fetchOptions: {
-				headers,
-			},
+	it("should get a token from api fetch", async () => {
+		const response = await client.$fetch<{
+			token: string;
+		}>("/token", {
+			headers,
 		});
-
-		expect(token.data?.token).toBeDefined();
+		expect(response.data?.token).toBeDefined();
 	});
 
-	it("Get JWKS", async () => {
-		// If no JWK exists, this makes sure it gets added.
-		// TODO: Replace this with a generate JWKS endpoint once it exists.
-		const token = await client.token({
-			fetchOptions: {
-				headers,
-			},
-		});
-
-		expect(token.data?.token).toBeDefined();
-
-		const jwks = await client.jwks();
-
-		expect(jwks.data?.keys).length.above(0);
-		expect(jwks.data?.keys[0].alg).toBe("EdDSA");
+	it("should get /jwks", async () => {
+		const response = await client.$fetch<JSONWebKeySet>("/jwks");
+		const jwks = response?.data;
+		expect(jwks).toBeDefined();
+		expect(jwks?.keys.length).toBeGreaterThanOrEqual(1);
 	});
 
-	it("Signed tokens can be validated with the JWKS", async () => {
-		const token = await client.token({
-			fetchOptions: {
-				headers,
-			},
+	it("should validate signed via JWKS", async () => {
+		const response = await client.$fetch<{
+			token: string;
+		}>("/token", {
+			headers,
 		});
+		const token = response.data?.token ?? undefined;
+		expect(token).toBeDefined();
 
-		const jwks = await client.jwks();
+		const jwkResponse = await client.$fetch<JSONWebKeySet>("/jwks");
+		const jwksData = jwkResponse?.data ?? undefined;
+		expect(jwksData).toBeDefined();
 
-		const publicWebKey = await importJWK({
-			...jwks.data?.keys[0],
-			alg: "EdDSA",
-		});
-		const decoded = await jwtVerify(token.data?.token!, publicWebKey);
-
+		const jwks = createLocalJWKSet(jwksData!);
+		expect(() => jwtVerify(token!, jwks)).not.toThrow();
+		const decoded = await jwtVerify(token!, jwks);
 		expect(decoded).toBeDefined();
 	});
 
 	it("should set subject to user id by default", async () => {
-		const token = await client.token({
+		let token: string | null | undefined;
+		const userSession = await client.getSession({
 			fetchOptions: {
 				headers,
+				onSuccess(context) {
+					token = context.response.headers.get("set-auth-jwt");
+				},
 			},
 		});
+		expect(token).toBeDefined();
 
-		const jwks = await client.jwks();
+		const jwkResponse = await client.$fetch<JSONWebKeySet>("/jwks");
+		const jwksData = jwkResponse?.data ?? undefined;
+		expect(jwksData).toBeDefined();
+		const jwks = createLocalJWKSet(jwksData!);
 
-		const publicWebKey = await importJWK({
-			...jwks.data?.keys[0],
-			alg: "EdDSA",
-		});
-		const decoded = await jwtVerify(token.data?.token!, publicWebKey);
+		const decoded = await jwtVerify(token!, jwks);
 		expect(decoded.payload.sub).toBeDefined();
-		expect(decoded.payload.sub).toBe(decoded.payload.id);
+		expect(decoded.payload.sub).toBe(userSession.data?.user.id);
 	});
 
+	// Asymmetric (JWS) Supported (https://github.com/panva/jose/issues/210)
 	const algorithmsToTest: {
 		keyPairConfig: JWKOptions;
 		expectedOutcome: { ec: string; length: number; crv?: string; alg: string };
 	}[] = [
+		{
+			keyPairConfig: {
+				alg: "EdDSA",
+				crv: "Ed25519",
+			},
+			expectedOutcome: {
+				ec: "OKP",
+				length: 43,
+				crv: "Ed25519",
+				alg: "EdDSA",
+			},
+		},
 		{
 			keyPairConfig: {
 				alg: "ES256",
@@ -152,30 +138,14 @@ describe("jwt", async (it) => {
 		},
 		{
 			keyPairConfig: {
-				alg: "EdDSA",
-				crv: "Ed25519",
+				alg: "PS256",
 			},
 			expectedOutcome: {
-				ec: "OKP",
-				length: 43,
-				crv: "Ed25519",
-				alg: "EdDSA",
+				ec: "RSA",
+				length: 342,
+				alg: "PS256",
 			},
 		},
-		// This is not supported (https://github.com/panva/jose/issues/210)
-		/*
-		{
-			keyPairConfig: {
-				alg: "EdDSA",
-				crv: "Ed448",
-			},
-			expectedOutcome: {
-				ec: "OKP",
-				length: 43,
-				crv: "Ed448",
-				alg: "EdDSA",
-			},
-		},*/
 		{
 			keyPairConfig: {
 				alg: "RS256",
@@ -186,50 +156,12 @@ describe("jwt", async (it) => {
 				alg: "RS256",
 			},
 		},
-		// We cannot sign using key exchange protocol, need to establish a key first (only allowed usage for these keys is `deriveBits`)
-		/*
-		{
-			keyPairConfig: {
-				alg: "ECDH-ES",
-				crv: "P-256",
-			},
-			expectedOutcome: {
-				ec: "EC",
-				length: 43,
-				crv: "P-256",
-				alg: "ECDH-ES",
-			},
-		},
-		{
-			keyPairConfig: {
-				alg: "ECDH-ES",
-				crv: "P-384",
-			},
-			expectedOutcome: {
-				ec: "EC",
-				length: 64,
-				crv: "P-384",
-				alg: "ECDH-ES",
-			},
-		},
-		{
-			keyPairConfig: {
-				alg: "ECDH-ES",
-				crv: "P-521",
-			},
-			expectedOutcome: {
-				ec: "EC",
-				length: 88,
-				crv: "P-521",
-				alg: "ECDH-ES",
-			},
-		},*/
 	];
 
 	for (const algorithm of algorithmsToTest) {
 		const expectedOutcome = algorithm.expectedOutcome;
 		for (let disablePrivateKeyEncryption of [false, true]) {
-			const jwtOptions: JwtOptions = {
+			const jwtOptions: JwtPluginOptions = {
 				jwks: {
 					keyPairConfig: {
 						...algorithm.keyPairConfig,
@@ -255,21 +187,7 @@ describe("jwt", async (it) => {
 					: "";
 
 				it(`${alg} algorithm${enc} can be used to generate JWKS`, async () => {
-					const jwks = await auth.api.getJwks();
-
-					expect(jwks.keys.at(0)?.kty).toBe(expectedOutcome.ec);
-					if (jwks.keys.at(0)?.crv)
-						expect(jwks.keys.at(0)?.crv).toBe(expectedOutcome.crv);
-					expect(jwks.keys.at(0)?.alg).toBe(expectedOutcome.alg);
-					if (jwks.keys.at(0)?.x)
-						expect(jwks.keys.at(0)?.x).toHaveLength(expectedOutcome.length);
-					if (jwks.keys.at(0)?.y)
-						expect(jwks.keys.at(0)?.y).toHaveLength(expectedOutcome.length);
-					if (jwks.keys.at(0)?.n)
-						expect(jwks?.keys.at(0)?.n).toHaveLength(expectedOutcome.length);
-				});
-
-				it(`${alg} algorithm${enc}: Endpoint "/token" can extract valid keys`, async () => {
+					// Unit Test
 					const { publicWebKey, privateWebKey } =
 						await generateExportedKeyPair(jwtOptions);
 					for (const key of [publicWebKey, privateWebKey]) {
@@ -278,6 +196,22 @@ describe("jwt", async (it) => {
 						if (key.y) expect(key.y).toHaveLength(expectedOutcome.length);
 						if (key.n) expect(key.n).toHaveLength(expectedOutcome.length);
 					}
+
+					// Functional Test
+					const jwkResponse = await client.$fetch<JSONWebKeySet>("/jwks");
+					const jwks = jwkResponse?.data ?? undefined;
+					expect(jwks).toBeDefined();
+
+					expect(jwks?.keys.at(0)?.kty).toBe(expectedOutcome.ec);
+					if (jwks?.keys.at(0)?.crv)
+						expect(jwks?.keys.at(0)?.crv).toBe(expectedOutcome.crv);
+					expect(jwks?.keys.at(0)?.alg).toBe(expectedOutcome.alg);
+					if (jwks?.keys.at(0)?.x)
+						expect(jwks?.keys.at(0)?.x).toHaveLength(expectedOutcome.length);
+					if (jwks?.keys.at(0)?.y)
+						expect(jwks?.keys.at(0)?.y).toHaveLength(expectedOutcome.length);
+					if (jwks?.keys.at(0)?.n)
+						expect(jwks?.keys.at(0)?.n).toHaveLength(expectedOutcome.length);
 				});
 
 				const client = createAuthClient({
@@ -303,63 +237,66 @@ describe("jwt", async (it) => {
 				});
 
 				it(`${alg} algorithm${enc}: Client gets a token`, async () => {
-					const token = await client.token({
-						fetchOptions: {
-							headers,
-						},
+					const response = await client.$fetch<{
+						token: string;
+					}>("/token", {
+						headers,
 					});
-
-					expect(token.data?.token).toBeDefined();
+					expect(response.data?.token).toBeDefined();
 				});
 
-				it(`${alg} algorithm${enc}: Client gets a token from session`, async () => {
-					let token = "";
+				it(`${alg} algorithm${enc}: should receive via header`, async () => {
+					let token: string | null = null;
 					await client.getSession({
 						fetchOptions: {
 							headers,
 							onSuccess(context) {
-								token = context.response.headers.get("set-auth-jwt") || "";
+								token = context.response.headers.get("set-auth-jwt");
 							},
 						},
 					});
-
-					expect(token.length).toBeGreaterThan(10);
+					expect(token).not.toBeNull();
 				});
 
-				it(`${alg} algorithm${enc}: Signed tokens can be validated with the JWKS`, async () => {
-					const token = await client.token({
-						fetchOptions: {
-							headers,
-						},
+				it(`${alg} algorithm${enc}: should validate via JWKS`, async () => {
+					const response = await client.$fetch<{
+						token: string;
+					}>("/token", {
+						headers,
 					});
+					const token = response.data?.token ?? undefined;
+					expect(token).toBeDefined();
 
-					const jwks = await client.jwks();
+					const jwkResponse = await client.$fetch<JSONWebKeySet>("/jwks");
+					const jwksData = jwkResponse?.data ?? undefined;
+					expect(jwksData).toBeDefined();
 
-					const publicWebKey = await importJWK({
-						...jwks.data?.keys[0],
-						alg: algorithm.keyPairConfig.alg,
-					});
-					const decoded = await jwtVerify(token.data?.token!, publicWebKey);
-
+					const jwks = createLocalJWKSet(jwksData!);
+					expect(() => jwtVerify(token!, jwks)).not.toThrow();
+					const decoded = await jwtVerify(token!, jwks);
 					expect(decoded).toBeDefined();
 				});
 
 				it(`${alg} algorithm${enc}: Should set subject to user id by default`, async () => {
-					const token = await client.token({
+					let token: string | null | undefined;
+					const userSession = await client.getSession({
 						fetchOptions: {
 							headers,
+							onSuccess(context) {
+								token = context.response.headers.get("set-auth-jwt");
+							},
 						},
 					});
+					expect(token).toBeDefined();
 
-					const jwks = await client.jwks();
+					const jwkResponse = await client.$fetch<JSONWebKeySet>("/jwks");
+					const jwksData = jwkResponse?.data ?? undefined;
+					expect(jwksData).toBeDefined();
+					const jwks = createLocalJWKSet(jwksData!);
 
-					const publicWebKey = await importJWK({
-						...jwks.data?.keys[0],
-						alg: algorithm.keyPairConfig.alg,
-					});
-					const decoded = await jwtVerify(token.data?.token!, publicWebKey);
+					const decoded = await jwtVerify(token!, jwks);
 					expect(decoded.payload.sub).toBeDefined();
-					expect(decoded.payload.sub).toBe(decoded.payload.id);
+					expect(decoded.payload.sub).toBe(userSession.data?.user.id);
 				});
 			} catch (err) {
 				console.error(err);
@@ -367,4 +304,130 @@ describe("jwt", async (it) => {
 			}
 		}
 	}
+});
+
+describe("jwt - remote signing", async (it) => {
+	it("should fail if sign is defined and remoteUrl is not", async () => {
+		expect(() =>
+			getTestInstance({
+				plugins: [
+					jwt({
+						jwt: {
+							sign: () => {
+								return "123";
+							},
+						},
+					}),
+				],
+				logger: {
+					level: "error",
+				},
+			}),
+		).toThrow();
+	});
+});
+
+describe("jwt - oidc plugin", async (it) => {
+	const { auth, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			jwt({
+				usesOauthProvider: true,
+			}),
+		],
+		logger: {
+			level: "error",
+		},
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [jwtClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	it("should not receive token on client via header", async () => {
+		let token: string | null | undefined;
+		await client.getSession({
+			fetchOptions: {
+				headers,
+				onSuccess(context) {
+					token = context.response.headers.get("set-auth-jwt");
+				},
+			},
+		});
+		expect(token).toBeNull();
+	});
+
+	it("should disable /token", async () => {
+		const response = await client.$fetch<{
+			token: string;
+		}>("/token", {
+			headers,
+		});
+		expect(response.error?.status).toBe(404);
+	});
+
+	it("should enable /jwks", async () => {
+		const response = await client.$fetch<JSONWebKeySet>("/jwks");
+		const jwks = response?.data;
+		expect(jwks).toBeDefined();
+		expect(jwks?.keys.length).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("jwt - oidc plugin with remote url", async (it) => {
+	const { auth } = await getTestInstance({
+		plugins: [
+			jwt({
+				usesOauthProvider: true,
+				jwks: {
+					remoteUrl: "https://example.com",
+					keyPairConfig: {
+						alg: "ES256",
+					},
+				},
+			}),
+		],
+		logger: {
+			level: "error",
+		},
+	});
+
+	const client = createAuthClient({
+		plugins: [jwtClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	it("should require specifying the alg used", async () => {
+		expect(() =>
+			getTestInstance({
+				plugins: [
+					jwt({
+						usesOauthProvider: true,
+						jwks: {
+							remoteUrl: "https://example.com",
+						},
+					}),
+				],
+				logger: {
+					level: "error",
+				},
+			}),
+		).toThrow();
+	});
+
+	it("should disable /jwks", async () => {
+		const response = await client.$fetch<JSONWebKeySet>("/jwks");
+		expect(response.error?.status).toBe(404);
+	});
 });

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -327,11 +327,11 @@ describe("jwt - remote signing", async (it) => {
 	});
 });
 
-describe("jwt - oidc plugin", async (it) => {
+describe("jwt - disable setting jwt header", async (it) => {
 	const { auth, signInWithTestUser } = await getTestInstance({
 		plugins: [
 			jwt({
-				usesOAuthProvider: true,
+				disableSettingJwtHeader: true,
 			}),
 		],
 		logger: {
@@ -362,29 +362,12 @@ describe("jwt - oidc plugin", async (it) => {
 		});
 		expect(token).toBeNull();
 	});
-
-	it("should disable /token", async () => {
-		const response = await client.$fetch<{
-			token: string;
-		}>("/token", {
-			headers,
-		});
-		expect(response.error?.status).toBe(404);
-	});
-
-	it("should enable /jwks", async () => {
-		const response = await client.$fetch<JSONWebKeySet>("/jwks");
-		const jwks = response?.data;
-		expect(jwks).toBeDefined();
-		expect(jwks?.keys.length).toBeGreaterThanOrEqual(1);
-	});
 });
 
-describe("jwt - oidc plugin with remote url", async (it) => {
+describe("jwt - remote url", async (it) => {
 	const { auth } = await getTestInstance({
 		plugins: [
 			jwt({
-				usesOAuthProvider: true,
 				jwks: {
 					remoteUrl: "https://example.com",
 					keyPairConfig: {
@@ -413,7 +396,6 @@ describe("jwt - oidc plugin with remote url", async (it) => {
 			getTestInstance({
 				plugins: [
 					jwt({
-						usesOAuthProvider: true,
 						jwks: {
 							remoteUrl: "https://example.com",
 						},

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -331,7 +331,7 @@ describe("jwt - oidc plugin", async (it) => {
 	const { auth, signInWithTestUser } = await getTestInstance({
 		plugins: [
 			jwt({
-				usesOauthProvider: true,
+				usesOAuthProvider: true,
 			}),
 		],
 		logger: {
@@ -384,7 +384,7 @@ describe("jwt - oidc plugin with remote url", async (it) => {
 	const { auth } = await getTestInstance({
 		plugins: [
 			jwt({
-				usesOauthProvider: true,
+				usesOAuthProvider: true,
 				jwks: {
 					remoteUrl: "https://example.com",
 					keyPairConfig: {
@@ -413,7 +413,7 @@ describe("jwt - oidc plugin with remote url", async (it) => {
 			getTestInstance({
 				plugins: [
 					jwt({
-						usesOauthProvider: true,
+						usesOAuthProvider: true,
 						jwks: {
 							remoteUrl: "https://example.com",
 						},

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -38,7 +38,7 @@ export async function signJwtPayload(
 	let exp = payload.exp;
 	const allowLargerExpTime = safeguards?.allowLongerExpTime;
 	const defaultExp = toExpJwt(
-		options?.jwt?.expirationTime ?? "1h",
+		options?.jwt?.expirationTime ?? "15m",
 		iat ?? nowSeconds,
 	);
 	if (!allowLargerExpTime && exp && exp > defaultExp) {

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -8,7 +8,7 @@ import {
 import type { GenericEndpointContext } from "../../types";
 import { BetterAuthError } from "../../error";
 import { symmetricDecrypt, symmetricEncrypt } from "../../crypto";
-import { getJwtPlugin, toExpJWT } from "./utils";
+import { getJwtPlugin, toExpJwt } from "./utils";
 import type { Jwk } from "./schema";
 import { getJwksAdapter } from "./adapter";
 import type { JwtPluginOptions } from "./types";
@@ -37,7 +37,7 @@ export async function signJwtPayload(
 	// Exp safety checks
 	let exp = payload.exp;
 	const allowLargerExpTime = options?.jwt?.allowLongerExpTime;
-	const defaultExp = toExpJWT(
+	const defaultExp = toExpJwt(
 		options?.jwt?.expirationTime ?? "1h",
 		iat ?? nowSeconds,
 	);
@@ -64,7 +64,7 @@ export async function signJwtPayload(
 	const aud = payload.aud;
 	const defaultAud = options?.jwt?.audience ?? ctx.context.options.baseURL!;
 	const allowAudienceMismatch = options?.jwt?.allowAudienceMismatch;
-	if (!options?.usesOauthProvider && !allowAudienceMismatch && aud) {
+	if (!options?.usesOAuthProvider && !allowAudienceMismatch && aud) {
 		const allowedAudiences =
 			typeof defaultAud === "string" ? [defaultAud] : defaultAud;
 		if (typeof aud === "string" && !allowedAudiences.includes(aud)) {

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -42,7 +42,7 @@ export async function signJwtPayload(
 	// Exp safety check
 	let exp = payload.exp;
 	const defaultExp = options?.jwt?.expirationTime ?? "15m";
-	if (disallowLargerExpTime && exp && exp > toExpJWT(defaultExp)) {
+	if (disallowLargerExpTime && exp && exp > toExpJWT(defaultExp, iat)) {
 		throw new Error("unable to set future exp time");
 	}
 
@@ -75,7 +75,7 @@ export async function signJwtPayload(
 		payload = {
 			...payload,
 			iat,
-			exp: exp ?? toExpJWT(defaultExp),
+			exp: exp ?? toExpJWT(defaultExp, iat),
 			iss: iss ?? defaultIss,
 			aud: aud ?? defaultAud,
 		};

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -41,7 +41,7 @@ export async function signJwtPayload(
 
 	// Exp safety check
 	let exp = payload.exp;
-	const defaultExp = options?.jwt?.expirationTime ?? "15m";
+	const defaultExp = options?.jwt?.expirationTime ?? "1h";
 	if (disallowLargerExpTime && exp && exp > toExpJWT(defaultExp, iat)) {
 		throw new Error("unable to set future exp time");
 	}

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -16,12 +16,12 @@ import type { JwtPluginOptions } from "./types";
 /**
  * Signs a payload in jwt format.
  *
- * DO NOT EXPORT THIS - use either signJwt or getJwtToken (depreciated)
+ * @internal - SCOPED TO PLUGIN. Use signJwt for usage in other plugins.
  *
  * @param ctx - endpoint context
  * @param payload - payload to sign
  */
-async function signJwtPayload(
+export async function signJwtPayload(
 	ctx: GenericEndpointContext,
 	payload: JWTPayload,
 	options?: JwtPluginOptions,
@@ -89,7 +89,7 @@ async function signJwtPayload(
 		!options?.jwks?.disablePrivateKeyEncryption;
 
 	if (key === undefined) {
-		key = await createJwk(ctx, options);
+		key = await createJwkOnDb(ctx, options);
 	}
 
 	let privateWebKey = privateKeyEncryptionEnabled
@@ -132,6 +132,7 @@ async function signJwtPayload(
  * @param ctx - endpoint context
  * @param payload - payload to sign
  */
+// Plugin exportable
 export async function signJwt(
 	ctx: GenericEndpointContext,
 	payload: JWTPayload,
@@ -175,8 +176,10 @@ export async function generateExportedKeyPair(options?: JwtPluginOptions) {
 
 /**
  * Creates a new JWK (JSON Web Key) on the database.
+ *
+ * @internal - SCOPED TO PLUGIN. Use createJwk for usage in other plugins.
  */
-export async function createJwk(
+export async function createJwkOnDb(
 	ctx: GenericEndpointContext,
 	options?: JwtPluginOptions,
 ) {
@@ -210,4 +213,15 @@ export async function createJwk(
 	const key = await adapter.createJwk(jwk as Jwk);
 
 	return key;
+}
+
+/**
+ * Creates a new JWK (JSON Web Key) on the database.
+ *
+ * @param ctx - endpoint context
+ */
+// Plugin exportable
+export async function createJwk(ctx: GenericEndpointContext) {
+	const options = getJwtPlugin(ctx.context).options;
+	return createJwkOnDb(ctx, options);
 }

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -64,7 +64,7 @@ export async function signJwtPayload(
 	const aud = payload.aud;
 	const defaultAud = options?.jwt?.audience ?? ctx.context.options.baseURL!;
 	const allowAudienceMismatch = options?.jwt?.allowAudienceMismatch;
-	if (!options?.usesOAuthProvider && !allowAudienceMismatch && aud) {
+	if (!allowAudienceMismatch && aud) {
 		const allowedAudiences =
 			typeof defaultAud === "string" ? [defaultAud] : defaultAud;
 		if (typeof aud === "string" && !allowedAudiences.includes(aud)) {

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -26,11 +26,12 @@ async function signJwtPayload(
 	payload: JWTPayload,
 	options?: JwtPluginOptions,
 ) {
-	const disallowFutureIatTime = options?.jwt?.disallowFutureIatTime ?? true;
-	const disallowLargerExpTime = options?.jwt?.disallowLongerExpTime ?? true;
-	const disallowIssuerMismatch = options?.jwt?.disallowIssuerMismatch ?? true;
-	const disallowAudienceMismatch =
-		options?.jwt?.disallowAudienceMismatch ?? true;
+	const disallowFutureIatTime = !(options?.jwt?.allowFutureIatTime ?? false);
+	const disallowLargerExpTime = !(options?.jwt?.allowLongerExpTime ?? false);
+	const disallowIssuerMismatch = !(options?.jwt?.allowIssuerMismatch ?? false);
+	const disallowAudienceMismatch = !(
+		options?.jwt?.allowAudienceMismatch ?? false
+	);
 
 	// Iat safety check
 	let iat = payload.iat;

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -115,29 +115,29 @@ export interface JwtOptions {
 	 */
 	expirationTime?: number | string | Date;
 	/**
-	 * Set false to allow setting issue times in the future.
+	 * Set true to allow setting issue times in the future.
 	 *
-	 * @default true
+	 * @default false
 	 */
-	disallowFutureIatTime?: boolean;
+	allowFutureIatTime?: boolean;
 	/**
-	 * Set false to allows signing tokens past `expirationTime`
+	 * Set true to allow signing tokens past `expirationTime`
 	 *
-	 * @default true
+	 * @default false
 	 */
-	disallowLongerExpTime?: boolean;
+	allowLongerExpTime?: boolean;
 	/**
-	 * Allows issuer to mismatch jwt plugin option setting
+	 * Set true to allow issuer to mismatch jwt plugin option setting
 	 *
-	 * @default true
+	 * @default false
 	 */
-	disallowIssuerMismatch?: boolean;
+	allowIssuerMismatch?: boolean;
 	/**
-	 * Allows audience to mismatch jwt plugin option setting
+	 * Set true to allow audience to mismatch jwt plugin option setting
 	 *
-	 * @default true
+	 * @default false
 	 */
-	disallowAudienceMismatch?: boolean;
+	allowAudienceMismatch?: boolean;
 	/**
 	 * A function that is called to define the payload of the JWT
 	 *

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -113,7 +113,7 @@ export interface JwtOptions {
 	 * subtracted from the current unix timestamp. A "from now" suffix can also be used for
 	 * readability when adding to the current unix timestamp.
 	 *
-	 * @default 1hr
+	 * @default 15m
 	 */
 	expirationTime?: number | string | Date;
 	/**

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -41,7 +41,7 @@ export interface JwtPluginOptions {
 	 *
 	 * Thus, only the /jwks endpoint is enabled.
 	 */
-	usesOauthProvider?: boolean;
+	usesOAuthProvider?: boolean;
 }
 
 export interface JwksOptions {
@@ -135,7 +135,7 @@ export interface JwtOptions {
 	/**
 	 * A function that is called to define the payload of the JWT
 	 *
-	 * @invalid usesOauthProvider = true
+	 * @invalid usesOAuthProvider = true
 	 */
 	definePayload?: (session: {
 		user: User & Record<string, any>;

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -1,5 +1,5 @@
 import type { InferOptionSchema, Session, User } from "../../types";
-import { schema } from "./schema";
+import type { schema } from "./schema";
 import type { JWTPayload } from "jose";
 import type { Awaitable } from "../../types/helper";
 
@@ -117,6 +117,25 @@ export interface JwtOptions {
 	 */
 	expirationTime?: number | string | Date;
 	/**
+	 * A function that is called to define the payload of the JWT
+	 */
+	definePayload?: (session: {
+		user: User & Record<string, any>;
+		session: Session & Record<string, any>;
+	}) => Promise<Record<string, any>> | Record<string, any>;
+	/**
+	 * A function that is called to get the subject of the JWT
+	 *
+	 * @default session.user.id
+	 */
+	getSubject?: (session: {
+		user: User & Record<string, any>;
+		session: Session & Record<string, any>;
+	}) => Promise<string> | string;
+}
+
+export interface JwtSignSafeguards {
+	/**
 	 * Set true to allow signing tokens past `expirationTime`
 	 *
 	 * @default false
@@ -134,20 +153,4 @@ export interface JwtOptions {
 	 * @default false
 	 */
 	allowAudienceMismatch?: boolean;
-	/**
-	 * A function that is called to define the payload of the JWT
-	 */
-	definePayload?: (session: {
-		user: User & Record<string, any>;
-		session: Session & Record<string, any>;
-	}) => Promise<Record<string, any>> | Record<string, any>;
-	/**
-	 * A function that is called to get the subject of the JWT
-	 *
-	 * @default session.user.id
-	 */
-	getSubject?: (session: {
-		user: User & Record<string, any>;
-		session: Session & Record<string, any>;
-	}) => Promise<string> | string;
 }

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -111,7 +111,7 @@ export interface JwtOptions {
 	 * subtracted from the current unix timestamp. A "from now" suffix can also be used for
 	 * readability when adding to the current unix timestamp.
 	 *
-	 * @default 15m
+	 * @default 1hr
 	 */
 	expirationTime?: number | string | Date;
 	/**

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -115,12 +115,6 @@ export interface JwtOptions {
 	 */
 	expirationTime?: number | string | Date;
 	/**
-	 * Set true to allow setting issue times in the future.
-	 *
-	 * @default false
-	 */
-	allowFutureIatTime?: boolean;
-	/**
 	 * Set true to allow signing tokens past `expirationTime`
 	 *
 	 * @default false

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -36,12 +36,14 @@ export interface JwtPluginOptions {
 	 */
 	schema?: InferOptionSchema<typeof schema>;
 	/**
-	 * Disables /token endpoint and auth middleware
-	 * in favor of Oidc authentication strategy.
+	 * Disables setting JWTs through middleware.
 	 *
-	 * Thus, only the /jwks endpoint is enabled.
+	 * Recommended to set `true` when using an oAuth provider plugin
+	 * like OIDC or MCP where session payloads should not be signed.
+	 *
+	 * @default false
 	 */
-	usesOAuthProvider?: boolean;
+	disableSettingJwtHeader?: boolean;
 }
 
 export interface JwksOptions {
@@ -134,8 +136,6 @@ export interface JwtOptions {
 	allowAudienceMismatch?: boolean;
 	/**
 	 * A function that is called to define the payload of the JWT
-	 *
-	 * @invalid usesOAuthProvider = true
 	 */
 	definePayload?: (session: {
 		user: User & Record<string, any>;

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -1,0 +1,159 @@
+import type { InferOptionSchema, Session, User } from "../../types";
+import { schema } from "./schema";
+import type { JWTPayload } from "jose";
+import type { Awaitable } from "../../types/helper";
+
+// Asymmetric (JWS) Supported (https://github.com/panva/jose/issues/210)
+export type JWKOptions =
+	| {
+			alg: "EdDSA"; // EdDSA with Ed25519 key
+			crv?: "Ed25519";
+	  }
+	| {
+			alg: "ES256"; // ECDSA with P-256 curve
+			crv?: never; // Only one valid option, no need for crv
+	  }
+	| {
+			alg: "ES512"; // ECDSA with P-521 curve
+			crv?: never; // Only P-521 for ES512
+	  }
+	| {
+			alg: "PS256"; // RSA-PSS with SHA-256
+			modulusLength?: number; // Default to 2048 or higher
+	  }
+	| {
+			alg: "RS256"; // RSA with SHA-256
+			modulusLength?: number; // Default to 2048 or higher
+	  };
+
+export type JWSAlgorithms = JWKOptions["alg"];
+
+export interface JwtPluginOptions {
+	jwks?: JwksOptions;
+	jwt?: JwtOptions;
+	/**
+	 * Custom schema for the admin plugin
+	 */
+	schema?: InferOptionSchema<typeof schema>;
+	/**
+	 * Disables /token endpoint and auth middleware
+	 * in favor of Oidc authentication strategy.
+	 *
+	 * Thus, only the /jwks endpoint is enabled.
+	 */
+	usesOauthProvider?: boolean;
+}
+
+export interface JwksOptions {
+	/**
+	 * Disables the /jwks endpoint and uses this endpoint in discovery.
+	 *
+	 * Useful if jwks are not managed at /jwks or
+	 * if your jwks are signed with a certificate and placed on your CDN.
+	 */
+	remoteUrl?: string;
+	/**
+	 * Key pair configuration
+	 * @description A subset of the options available for the generateKeyPair function
+	 *
+	 * @see https://github.com/panva/jose/blob/main/src/runtime/node/generate.ts
+	 *
+	 * @default { alg: 'EdDSA', crv: 'Ed25519' }
+	 */
+	keyPairConfig?: JWKOptions;
+	/**
+	 * Disable private key encryption
+	 * @description Disable the encryption of the private key in the database
+	 *
+	 * @default false
+	 */
+	disablePrivateKeyEncryption?: boolean;
+}
+
+export interface JwtOptions {
+	/**
+	 * A custom function to remote sign the jwt payload.
+	 *
+	 * All headers, such as `alg` and `kid`,
+	 * MUST be defined within this function.
+	 * You can safely define the header `typ: 'JWT'`.
+	 *
+	 * @requires jwks.remoteUrl
+	 * @invalidates other jwt.* options
+	 */
+	sign?: (payload: JWTPayload) => Awaitable<string>;
+	/**
+	 * The issuer of the JWT
+	 */
+	issuer?: string;
+	/**
+	 * The audience of the JWT
+	 */
+	audience?: string | string[];
+	/**
+	 * Set the "exp" (Expiration Time) Claim.
+	 *
+	 * - If a `number` is passed as an argument it is used as the claim directly.
+	 * - If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+	 *   claim.
+	 * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
+	 *   current unix timestamp and used as the claim.
+	 *
+	 * Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+	 * day".
+	 *
+	 * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+	 * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+	 * "years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+	 * alias for a year.
+	 *
+	 * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+	 * subtracted from the current unix timestamp. A "from now" suffix can also be used for
+	 * readability when adding to the current unix timestamp.
+	 *
+	 * @default 15m
+	 */
+	expirationTime?: number | string | Date;
+	/**
+	 * Set false to allow setting issue times in the future.
+	 *
+	 * @default true
+	 */
+	disallowFutureIatTime?: boolean;
+	/**
+	 * Set false to allows signing tokens past `expirationTime`
+	 *
+	 * @default true
+	 */
+	disallowLongerExpTime?: boolean;
+	/**
+	 * Allows issuer to mismatch jwt plugin option setting
+	 *
+	 * @default true
+	 */
+	disallowIssuerMismatch?: boolean;
+	/**
+	 * Allows audience to mismatch jwt plugin option setting
+	 *
+	 * @default true
+	 */
+	disallowAudienceMismatch?: boolean;
+	/**
+	 * A function that is called to define the payload of the JWT
+	 *
+	 * @invalid usesOauthProvider = true
+	 */
+	definePayload?: (session: {
+		user: User & Record<string, any>;
+		session: Session & Record<string, any>;
+	}) => Promise<Record<string, any>> | Record<string, any>;
+	/**
+	 * A function that is called to get the subject of the JWT
+	 *
+	 * @default session.user.id
+	 */
+	getSubject?: (session: {
+		user: User & Record<string, any>;
+		session: Session & Record<string, any>;
+	}) => Promise<string> | string;
+}

--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -16,8 +16,8 @@ export const getJwtPlugin = (
 	return plugin;
 };
 
-export function toExpJWT(input: number | Date | string): number {
-	const now = Math.floor(Date.now() / 1000); // current Unix timestamp in seconds
+export function toExpJWT(input: number | Date | string, iat?: number): number {
+	const now = iat ?? Math.floor(Date.now() / 1000); // current Unix timestamp in seconds
 
 	if (typeof input === "number") {
 		return now + input;

--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -18,7 +18,7 @@ export const getJwtPlugin = (ctx: AuthContext): ReturnType<typeof jwt> => {
  * @param iat - the iat time to consolidate on
  * @returns
  */
-export function toExpJWT(
+export function toExpJwt(
 	expirationTime: number | Date | string,
 	iat: number,
 ): number {

--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -1,5 +1,83 @@
+import type { AuthContext, BetterAuthPlugin } from "../../types";
 import { subtle, getRandomValues } from "@better-auth/utils";
 import { base64 } from "@better-auth/utils/base64";
+import { BetterAuthError } from "../../error";
+import type { JwtPluginOptions } from "./types";
+
+export const getJwtPlugin = (
+	ctx: AuthContext,
+): Omit<BetterAuthPlugin, "options"> & { options?: JwtPluginOptions } => {
+	const plugin:
+		| (Omit<BetterAuthPlugin, "options"> & { options?: JwtPluginOptions })
+		| undefined = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
+	if (!plugin) {
+		throw new BetterAuthError("jwt_config", "jwt plugin not found");
+	}
+	return plugin;
+};
+
+export function toExpJWT(input: number | Date | string): number {
+	const now = Math.floor(Date.now() / 1000); // current Unix timestamp in seconds
+
+	if (typeof input === "number") {
+		return now + input;
+	}
+
+	if (input instanceof Date) {
+		return Math.floor(input.getTime() / 1000);
+	}
+
+	const timeSpanRegex =
+		/^(-)?\s*(\d+(?:\.\d+)?)\s*(second|seconds|sec|secs|s|minute|minutes|min|mins|m|hour|hours|hr|hrs|h|day|days|d|week|weeks|w|year|years|yr|yrs|y)\s*(ago|from now)?$/i;
+	const match = input.trim().match(timeSpanRegex);
+
+	if (!match) {
+		throw new Error(`Invalid time span format: ${input}`);
+	}
+
+	const [, negativePrefix, valueStr, unitRaw, suffix] = match;
+	const value = parseFloat(valueStr);
+	const unit = unitRaw.toLowerCase();
+
+	const unitSeconds: Record<string, number> = {
+		s: 1,
+		sec: 1,
+		secs: 1,
+		second: 1,
+		seconds: 1,
+		m: 60,
+		min: 60,
+		mins: 60,
+		minute: 60,
+		minutes: 60,
+		h: 3600,
+		hr: 3600,
+		hrs: 3600,
+		hour: 3600,
+		hours: 3600,
+		d: 86400,
+		day: 86400,
+		days: 86400,
+		w: 604800,
+		week: 604800,
+		weeks: 604800,
+		y: 31557600,
+		yr: 31557600,
+		yrs: 31557600,
+		year: 31557600,
+		years: 31557600, // 365.25 days
+	};
+
+	const seconds = unitSeconds[unit];
+	if (!seconds) {
+		throw new Error(`Unsupported unit: ${unit}`);
+	}
+
+	const totalSeconds = value * seconds;
+	const isSubtraction = negativePrefix || suffix?.toLowerCase() === "ago";
+
+	return Math.floor(isSubtraction ? now - totalSeconds : now + totalSeconds);
+}
 
 async function deriveKey(secretKey: string): Promise<CryptoKey> {
 	const enc = new TextEncoder();

--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -1,17 +1,13 @@
-import type { AuthContext, BetterAuthPlugin } from "../../types";
+import type { AuthContext } from "../../types";
 import { BetterAuthError } from "../../error";
-import type { JwtPluginOptions } from "./types";
+import type { jwt } from "./index";
 
-export const getJwtPlugin = (
-	ctx: AuthContext,
-): Omit<BetterAuthPlugin, "options"> & { options?: JwtPluginOptions } => {
-	const plugin:
-		| (Omit<BetterAuthPlugin, "options"> & { options?: JwtPluginOptions })
-		| undefined = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
+export const getJwtPlugin = (ctx: AuthContext): ReturnType<typeof jwt> => {
+	const plugin = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
 	if (!plugin) {
 		throw new BetterAuthError("jwt_config", "jwt plugin not found");
 	}
-	return plugin;
+	return plugin as ReturnType<typeof jwt>;
 };
 
 /**

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -27,7 +27,6 @@ import { createHash } from "@better-auth/utils/hash";
 import { base64 } from "@better-auth/utils/base64";
 import { signJwt } from "../jwt/sign";
 import { defaultClientSecretHasher } from "./utils";
-import { BetterAuthError } from "../../error";
 import { getJwtPlugin } from "../jwt/utils";
 
 /**
@@ -229,13 +228,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 		init: (ctx) => {
 			// Check for jwt plugin registration
 			if (opts.useJWTPlugin) {
-				const jwtPlugin = getJwtPlugin(ctx);
-				if (!jwtPlugin.options?.jwt?.allowAudienceMismatch) {
-					throw new BetterAuthError(
-						"jwt_config",
-						"Must set jwt.allowedAudienceMismatch to true",
-					);
-				}
+				getJwtPlugin(ctx);
 			}
 		},
 		hooks: {
@@ -802,7 +795,9 @@ export const oidcProvider = (options: OIDCOptions) => {
 								error: "internal_server_error",
 							});
 						}
-						idToken = await signJwt(ctx, payload);
+						idToken = await signJwt(ctx, payload, {
+							allowAudienceMismatch: true,
+						});
 						// If the JWT token is not enabled, create a key and use it to sign
 					} else {
 						idToken = await new SignJWT(payload)

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -797,6 +797,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 						}
 						idToken = await signJwt(ctx, payload, {
 							allowAudienceMismatch: true,
+							allowLongerExpTime: true,
 						});
 						// If the JWT token is not enabled, create a key and use it to sign
 					} else {

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -724,7 +724,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 
 					const accessTokenExpiresAt = new Date(exp * 1000);
 					const refreshTokenExpiresAt = new Date(
-						(iat + (opts.accessTokenExpiresIn ?? 3600)) * 1000,
+						(iat + (opts.refreshTokenExpiresIn ?? 604800)) * 1000,
 					);
 					await ctx.context.adapter.create({
 						model: modelName.oauthAccessToken,

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -230,10 +230,10 @@ export const oidcProvider = (options: OIDCOptions) => {
 			// Check for jwt plugin registration
 			if (opts.useJWTPlugin) {
 				const jwtPlugin = getJwtPlugin(ctx);
-				if (!jwtPlugin.options?.usesOauthProvider) {
+				if (!jwtPlugin.options?.usesOAuthProvider) {
 					throw new BetterAuthError(
 						"jwt_config",
-						"Must set jwt plugin usesOauthProvider to true",
+						"Must set jwt plugin usesOAuthProvider to true",
 					);
 				}
 			}

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -225,18 +225,10 @@ export const oidcProvider = (options: OIDCOptions) => {
 
 	return {
 		id: "oidc",
+		options: opts,
 		init: (ctx) => {
-			// Add the oidc plugin options to ctx
-			const plugin = ctx.options.plugins?.find(
-				(plugin) => plugin.id === "oidc",
-			);
-			if (!plugin) {
-				throw Error("Plugin should have been registered! Should never hit!");
-			}
-			plugin.options = opts;
-
 			// Check for jwt plugin registration
-			if (plugin.options.useJWTPlugin) {
+			if (opts.useJWTPlugin) {
 				const jwtPlugin = getJwtPlugin(ctx);
 				if (!jwtPlugin.options?.usesOauthProvider) {
 					throw new BetterAuthError(

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -230,10 +230,10 @@ export const oidcProvider = (options: OIDCOptions) => {
 			// Check for jwt plugin registration
 			if (opts.useJWTPlugin) {
 				const jwtPlugin = getJwtPlugin(ctx);
-				if (!jwtPlugin.options?.usesOAuthProvider) {
+				if (!jwtPlugin.options?.jwt?.allowAudienceMismatch) {
 					throw new BetterAuthError(
 						"jwt_config",
-						"Must set jwt plugin usesOAuthProvider to true",
+						"Must set jwt.allowedAudienceMismatch to true",
 					);
 				}
 			}

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -25,6 +25,41 @@ import {
 } from "jose";
 import { jwtClient } from "../jwt/client";
 
+describe("oidc - init", async () => {
+	it("should fail without the jwt plugin", async ({ expect }) => {
+		await expect(
+			getTestInstance({
+				plugins: [
+					oidcProvider({
+						useJWTPlugin: true,
+						loginPage: "/login",
+						consentPage: "/consent",
+					}),
+				],
+			}),
+		).rejects.toThrow();
+	});
+
+	it("should fail without the jwt plugin usesOidcProviderPlugin set", async ({
+		expect,
+	}) => {
+		await expect(
+			getTestInstance({
+				plugins: [
+					jwt({
+						usesOauthProvider: undefined,
+					}),
+					oidcProvider({
+						useJWTPlugin: true,
+						loginPage: "/login",
+						consentPage: "/consent",
+					}),
+				],
+			}),
+		).rejects.toThrow();
+	});
+});
+
 describe("oidc", async () => {
 	const {
 		auth: authorizationServer,

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -559,15 +559,7 @@ describe("oidc-jwt", async () => {
 						},
 						useJWTPlugin: useJwt,
 					}),
-					...(useJwt
-						? [
-								jwt({
-									jwt: {
-										allowAudienceMismatch: true,
-									},
-								}),
-							]
-						: []),
+					...(useJwt ? [jwt()] : []),
 				],
 			});
 			const { headers } = await signInWithTestUser();
@@ -700,7 +692,6 @@ describe("oidc-jwt", async () => {
 			if (useJwt) {
 				const jwks = await authorizationServer.api.getJwks();
 				const jwkSet = createLocalJWKSet(jwks);
-
 				const checkSignature = await jwtVerify(
 					accessToken.data?.idToken!,
 					jwkSet,

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -47,7 +47,7 @@ describe("oidc - init", async () => {
 			getTestInstance({
 				plugins: [
 					jwt({
-						usesOauthProvider: undefined,
+						usesOAuthProvider: undefined,
 					}),
 					oidcProvider({
 						useJWTPlugin: true,
@@ -575,7 +575,7 @@ describe("oidc-jwt", async () => {
 					...(useJwt
 						? [
 								jwt({
-									usesOauthProvider: true,
+									usesOAuthProvider: true,
 								}),
 							]
 						: []),

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -17,7 +17,13 @@ import { genericOAuthClient } from "../generic-oauth/client";
 import { listen, type Listener } from "listhen";
 import { toNodeHandler } from "../../integrations/node";
 import { jwt } from "../jwt";
-import { createLocalJWKSet, decodeProtectedHeader, jwtVerify } from "jose";
+import {
+	createLocalJWKSet,
+	decodeProtectedHeader,
+	jwtVerify,
+	type JSONWebKeySet,
+} from "jose";
+import { jwtClient } from "../jwt/client";
 
 describe("oidc", async () => {
 	const {
@@ -531,6 +537,13 @@ describe("oidc-jwt", async () => {
 			} = await getTestInstance({
 				baseURL: "http://localhost:3000",
 				plugins: [
+					...(useJwt
+						? [
+								jwt({
+									usesOauthProvider: true,
+								}),
+							]
+						: []),
 					oidcProvider({
 						loginPage: "/login",
 						consentPage: "/oauth2/authorize",
@@ -543,12 +556,11 @@ describe("oidc-jwt", async () => {
 						},
 						useJWTPlugin: useJwt,
 					}),
-					...(useJwt ? [jwt()] : []),
 				],
 			});
 			const { headers } = await signInWithTestUser();
 			const serverClient = createAuthClient({
-				plugins: [oidcClient()],
+				plugins: [oidcClient(), jwtClient()],
 				baseURL: "http://localhost:3000",
 				fetchOptions: {
 					customFetchImpl,
@@ -674,8 +686,11 @@ describe("oidc-jwt", async () => {
 			);
 			const decoded = decodeProtectedHeader(accessToken.data?.idToken!);
 			if (useJwt) {
-				const jwks = await authorizationServer.api.getJwks();
-				const jwkSet = createLocalJWKSet(jwks);
+				const jwksResponse = await serverClient.$fetch<JSONWebKeySet>("/jwks");
+				const jwksData = jwksResponse?.data ?? undefined;
+				expect(jwksData).toBeDefined();
+
+				const jwkSet = createLocalJWKSet(jwksData!);
 				const checkSignature = await jwtVerify(
 					accessToken.data?.idToken!,
 					jwkSet,

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -33,25 +33,6 @@ describe("oidc - init", async () => {
 			}),
 		).rejects.toThrow();
 	});
-
-	it("should fail without the jwt plugin usesOidcProviderPlugin set", async ({
-		expect,
-	}) => {
-		await expect(
-			getTestInstance({
-				plugins: [
-					jwt({
-						usesOAuthProvider: undefined,
-					}),
-					oidcProvider({
-						useJWTPlugin: true,
-						loginPage: "/login",
-						consentPage: "/consent",
-					}),
-				],
-			}),
-		).rejects.toThrow();
-	});
 });
 
 describe("oidc", async () => {
@@ -581,7 +562,9 @@ describe("oidc-jwt", async () => {
 					...(useJwt
 						? [
 								jwt({
-									usesOAuthProvider: true,
+									jwt: {
+										allowAudienceMismatch: true,
+									},
 								}),
 							]
 						: []),

--- a/packages/better-auth/src/types/helper.ts
+++ b/packages/better-auth/src/types/helper.ts
@@ -9,6 +9,7 @@ export type Primitive =
 export type LiteralString = "" | (string & Record<never, never>);
 export type LiteralNumber = 0 | (number & Record<never, never>);
 
+export type Awaitable<T> = Promise<T> | T;
 export type OmitId<T extends { id: unknown }> = Omit<T, "id">;
 
 export type Prettify<T> = Omit<T, never>;


### PR DESCRIPTION
## Features

**feat**: `remoteUrl` option disables jwks endpoint and uses this endpoint in oAuth metadata

**feat**: remote `sign` payloads using a server-side privateKey environment variable or remote signing service like Google KMS, AWS KMS, Azure Key Vault, etc.

**feat**: `signJwt` (previously `getJwtToken`) now accepts payload as a parameter. Those who utilized exported `getJwtToken` should utilize `signJwt` and its payload parameter instead of through options. `getJwtToken` marked deprecated. `signJwt` now has safeguards that is enabled by default and can be disabled per plugin implementation.

**feat**: Added `disableSettingJwtHeader` to disable setting jwt in header. Useful for oAuth compliance.

**feat**: exports `getJwtPlugin` for other plugins

**chore**: combine shared createJwks functionality

__Duplicate #3464__
__Partial #3458__

## Breaking Changes

**MINOR**
- style: `JwtOptions` renamed to `JwtPluginOptions` to match other plugin syntax.
- fix: `getJwtToken` deprecated, prefer `signJwt` instead
