### PR TITLE
fix: shouldn't refresh token if acess token expires isn't defined

### DIFF
--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -14,6 +14,7 @@ import { DEFAULT_SECRET } from "../../utils/constants";
 import { getOAuth2Tokens } from "../../oauth2";
 import { signJWT } from "../../crypto/jwt";
 import { BASE_ERROR_CODES } from "../../error/codes";
+import type { Account } from "../../types";
 
 let email = "";
 vi.mock("../../oauth2", async (importOriginal) => {
@@ -146,11 +147,17 @@ describe("account", async () => {
 
 	it("should encrypt access token and refresh token", async () => {
 		const { headers: headers2 } = await signInWithTestUser();
+		const account = await ctx.adapter.findOne<Account>({
+			model: "account",
+			where: [{ field: "providerId", value: "google" }],
+		});
+		expect(account).toBeTruthy();
+		expect(account?.accessToken).not.toBe("test");
 		const accessToken = await client.getAccessToken({
 			providerId: "google",
 			fetchOptions: { headers: headers2 },
 		});
-		expect(accessToken.data).not.toBe("test");
+		expect(accessToken.data?.accessToken).toBe("test");
 	});
 
 	it("should pass custom scopes to authorization URL", async () => {

--- a/packages/better-auth/src/oauth2/utils.ts
+++ b/packages/better-auth/src/oauth2/utils.ts
@@ -35,7 +35,8 @@ export function getOAuth2Tokens(data: Record<string, any>): OAuth2Tokens {
 export const encodeOAuthParameter = (value: string) =>
 	encodeURIComponent(value).replace(/%20/g, "+");
 
-export function getAccessTokenUtil(token: string, ctx: AuthContext) {
+export function decryptOAuthToken(token: string, ctx: AuthContext) {
+	if (!token) return token;
 	if (ctx.options.account?.encryptOAuthTokens) {
 		return symmetricDecrypt({
 			key: ctx.secret,
@@ -55,5 +56,5 @@ export function setTokenUtil(
 			data: token,
 		});
 	}
-	return token ?? null;
+	return token;
 }


### PR DESCRIPTION
closes #3559 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the system tried to refresh the access token even when its expiration time was not set, preventing unnecessary refresh attempts.

- **Bug Fixes**
  - Only refreshes the access token if the expiration time is defined.
  - Improved error handling when the access token is missing.

<!-- End of auto-generated description by cubic. -->

