### PR TITLE
Ensure session is added to context when present in cookie

### DIFF
--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -135,6 +135,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 						sessionDataPayload.expiresAt < Date.now() ||
 						session.session.expiresAt < new Date();
 					if (!hasExpired) {
+						ctx.context.session = session;
 						return ctx.json(
 							session as {
 								session: InferSession<Option>;


### PR DESCRIPTION
When session data is present in the cookie, `get-session` was early-returning without adding the session to the context, causing hooks to receive a null session.
This change ensures the session is consistently added to the context.