### PR TITLE
feat(api-key): implement flexible key storage options for API keys

### DIFF
--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -348,7 +348,7 @@ describe("api-key", async () => {
 			{
 				plugins: [
 					apiKey({
-						disableKeyHashing: true,
+						storeKey: "plain",
 					}),
 				],
 			},
@@ -381,7 +381,7 @@ describe("api-key", async () => {
 			{
 				plugins: [
 					apiKey({
-						disableKeyHashing: true,
+						storeKey: "plain",
 					}),
 				],
 			},

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -7,13 +7,13 @@ import type { ApiKey } from "../types";
 import type { AuthContext } from "../../../types";
 import type { PredefinedApiKeyOptions } from ".";
 import { safeJSONParse } from "../../../utils/json";
-import { defaultKeyHasher } from "../";
 
 export function createApiKey({
 	keyGenerator,
 	opts,
 	schema,
 	deleteAllExpiredApiKeys,
+	storeKey,
 }: {
 	keyGenerator: (options: { length: number; prefix: string | undefined }) =>
 		| Promise<string>
@@ -24,6 +24,7 @@ export function createApiKey({
 		ctx: AuthContext,
 		byPassLastCheckTime?: boolean,
 	): Promise<number> | undefined;
+	storeKey: (ctx: any, key: string) => Promise<string>;
 }) {
 	return createAuthEndpoint(
 		"/api-key/create",
@@ -377,7 +378,7 @@ export function createApiKey({
 				prefix: prefix || opts.defaultPrefix,
 			});
 
-			const hashed = opts.disableKeyHashing ? key : await defaultKeyHasher(key);
+			const hashed = await storeKey(ctx, key);
 
 			let start: string | null = null;
 

--- a/packages/better-auth/src/plugins/api-key/routes/index.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/index.ts
@@ -21,7 +21,7 @@ export type PredefinedApiKeyOptions = ApiKeyOptions &
 			| "maximumPrefixLength"
 			| "minimumPrefixLength"
 			| "maximumNameLength"
-			| "disableKeyHashing"
+			| "storeKey"
 			| "minimumNameLength"
 			| "requireName"
 			| "enableMetadata"
@@ -74,12 +74,16 @@ export function createApiKeyRoutes({
 	keyGenerator,
 	opts,
 	schema,
+	storeKey,
+	verifyStoredKey,
 }: {
 	keyGenerator: (options: { length: number; prefix: string | undefined }) =>
 		| Promise<string>
 		| string;
 	opts: PredefinedApiKeyOptions;
 	schema: ReturnType<typeof apiKeySchema>;
+	storeKey: (ctx: any, key: string) => Promise<string>;
+	verifyStoredKey: (ctx: any, storedKey: string, key: string) => Promise<boolean>;
 }) {
 	return {
 		createApiKey: createApiKey({
@@ -87,8 +91,9 @@ export function createApiKeyRoutes({
 			opts,
 			schema,
 			deleteAllExpiredApiKeys,
+			storeKey,
 		}),
-		verifyApiKey: verifyApiKey({ opts, schema, deleteAllExpiredApiKeys }),
+		verifyApiKey: verifyApiKey({ opts, schema, deleteAllExpiredApiKeys, verifyStoredKey }),
 		getApiKey: getApiKey({ opts, schema, deleteAllExpiredApiKeys }),
 		updateApiKey: updateApiKey({ opts, schema, deleteAllExpiredApiKeys }),
 		deleteApiKey: deleteApiKey({ opts, schema, deleteAllExpiredApiKeys }),

--- a/packages/better-auth/src/plugins/api-key/types.ts
+++ b/packages/better-auth/src/plugins/api-key/types.ts
@@ -8,14 +8,20 @@ export interface ApiKeyOptions {
 	 */
 	apiKeyHeaders?: string | string[];
 	/**
-	 * Disable hashing of the API key.
+	 * Store the API key in your database in a secure way
+	 * Note: This will not affect the API key sent to the user, it will only affect the API key stored in your database
 	 *
-	 * ⚠️ Security Warning: It's strongly recommended to not disable hashing.
-	 * Storing API keys in plaintext makes them vulnerable to database breaches, potentially exposing all your users' API keys.
-	 *
-	 * @default false
+	 * @default "hashed"
 	 */
-	disableKeyHashing?: boolean;
+	storeKey?:
+		| "hashed"
+		| "plain"
+		| "encrypted"
+		| { hash: (key: string) => Promise<string> }
+		| {
+				encrypt: (key: string) => Promise<string>;
+				decrypt: (key: string) => Promise<string>;
+		  };
 	/**
 	 * The function to get the API key from the context
 	 */


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for flexible API key storage options, allowing keys to be stored as hashed, plain, encrypted, or with custom logic.

- **New Features**
  - Introduced the `storeKey` option to control how API keys are stored and verified.
  - Updated API key creation and verification to support all storage methods.

<!-- End of auto-generated description by cubic. -->

