### PR TITLE
fix(stripe): reuse existing trial subscription on upgrade and prevent duplicate subscriptions

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -431,7 +431,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							model: "subscription",
 							update: {
 								plan: plan.name.toLowerCase(),
-								seats: ctx.body.seats || 1,
+								seats: ctx.body.seats || incompleteSubscription.seats || 1,
 								stripeCustomerId: customerId,
 								status: "active",
 							},

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -420,7 +420,6 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 					});
 				}
 
-
 				let subscription = existingSubscription;
 				if (!subscription) {
 					const incompleteSubscription = subscriptions.find(
@@ -447,8 +446,6 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							id: incompleteSubscription.id,
 							referenceId: incompleteSubscription.referenceId,
 
-				
-
 							plan: plan.name.toLowerCase(),
 							stripeCustomerId: customerId,
 
@@ -471,9 +468,6 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						subscription = newSubscription;
 					}
 				}
-
-				
-
 
 				if (!subscription) {
 					ctx.context.logger.error("Subscription ID not found");

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -448,6 +448,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 
 							plan: plan.name.toLowerCase(),
 							stripeCustomerId: customerId,
+							seats: ctx.body.seats || incompleteSubscription.seats || 1,
 
 							status: "active",
 						};

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -356,7 +356,10 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 									"Error retrieving subscriptions from Stripe",
 									error,
 								);
-								return null;
+								throw ctx.error("BAD_REQUEST", {
+									message: error.message,
+									code: error.code,
+								});
 							})
 					: null;
 

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -430,7 +430,6 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						await ctx.context.adapter.update({
 							model: "subscription",
 							update: {
-								...incompleteSubscription,
 								plan: plan.name.toLowerCase(),
 								seats: ctx.body.seats || 1,
 								stripeCustomerId: customerId,
@@ -444,10 +443,12 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							],
 						});
 						subscription = {
-							...incompleteSubscription,
+							id: incompleteSubscription.id,
+							referenceId: incompleteSubscription.referenceId,
 							plan: plan.name.toLowerCase(),
 							seats: ctx.body.seats || 1,
 							stripeCustomerId: customerId,
+							status: "active",
 						};
 					} else {
 						const newSubscription = await ctx.context.adapter.create<


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/3560
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where upgrading a subscription could create duplicate Stripe subscriptions by reusing any existing active or trial subscription during the upgrade process.

- **Bug Fixes**
  - Checks for existing active or trialing subscriptions before creating a new one.
  - Prevents duplicate subscriptions when upgrading.

<!-- End of auto-generated description by cubic. -->

