### PR TITLE
fix(docs): state that TOTP verification uses a rolling delay window

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -245,7 +245,7 @@ By default the issuer for TOTP is set to the app name provided in the auth confi
 
 #### Verifying TOTP
 
-After the user has entered their 2FA code, you can verify it using `twoFactor.verifyTotp` method.
+After the user has entered their 2FA code, you can verify it using `twoFactor.verifyTotp` method. `Better Auth` follows standard practice by accepting TOTP codes from one period before and one after the current code, ensuring users can authenticate even with minor time delays on their end.
 
 <APIMethod path="/two-factor/verify-totp" method="POST">
 ```ts


### PR DESCRIPTION
Better Auth uses a delay window for TOTP code verification to ensure that it is resilient to time delays which is now explicitly mentioned in the docs, fixed #3515 

The code which verifies the TOTP code implements with 'rolling' delay window,
https://github.com/better-auth/utils/blob/f6fb2523c639cce98b0b4ccf06ee2c5e31f2cf6b/src/otp.ts#L53-L78
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the 2FA documentation to explain that Better Auth accepts TOTP codes from one period before and after the current code, making authentication more reliable for users with minor time differences.

<!-- End of auto-generated description by cubic. -->

