### PR TITLE
fix(organization): allow set active org using slug

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1,4 +1,4 @@
-import type { Session, User } from "../../types";
+import type { Session, User, Where } from "../../types";
 import { getDate } from "../../utils/date";
 import type { OrganizationOptions } from "./types";
 import type {
@@ -327,22 +327,42 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		checkMembership: async ({
 			userId,
 			organizationId,
+			organizationSlug,
 		}: {
 			userId: string;
-			organizationId: string;
+			organizationId?: string;
+			organizationSlug?: string;
 		}) => {
+			const where: Where[] = [
+				{
+					field: "userId",
+					value: userId,
+				},
+			];
+
+			if (!organizationId && !organizationSlug) {
+				throw new BetterAuthError(
+					"Either organizationId or organizationSlug must be provided",
+				);
+			}
+
+			if(organizationId) {
+				where.push({
+					field: "organizationId",
+					value: organizationId,
+				});
+			}
+
+			if(organizationSlug) {
+				where.push({
+					field: "organizationSlug",
+					value: organizationSlug,
+				});
+			}
+
 			const member = await adapter.findOne<InferMember<O>>({
 				model: "member",
-				where: [
-					{
-						field: "userId",
-						value: userId,
-					},
-					{
-						field: "organizationId",
-						value: organizationId,
-					},
-				],
+				where,
 			});
 			return member;
 		},

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -346,14 +346,14 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				);
 			}
 
-			if(organizationId) {
+			if (organizationId) {
 				where.push({
 					field: "organizationId",
 					value: organizationId,
 				});
 			}
 
-			if(organizationSlug) {
+			if (organizationSlug) {
 				where.push({
 					field: "organizationSlug",
 					value: organizationSlug,

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -696,7 +696,8 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 			}
 			const isMember = await adapter.checkMembership({
 				userId: session.user.id,
-				organizationId,
+				organizationId: ctx.body.organizationId,
+				organizationSlug: ctx.body.organizationSlug,
 			});
 			if (!isMember) {
 				await adapter.setActiveOrganization(session.session.token, null);

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -696,7 +696,7 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 			}
 			const isMember = await adapter.checkMembership({
 				userId: session.user.id,
-				organizationId: ctx.body.organizationId,
+				organizationId,
 				organizationSlug: ctx.body.organizationSlug,
 			});
 			if (!isMember) {


### PR DESCRIPTION
#3497 added a regression where only organizationId could be used for the checkMembership step in setting the active org.

Resolves #3589

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a regression so users can now set their active organization using either the organization ID or slug.

- **Bug Fixes**
 - Updated membership checks to accept both organizationId and organizationSlug when setting the active organization.

<!-- End of auto-generated description by cubic. -->

