### PR TITLE
fix(swie): export in better-auth/plugins

### DIFF
--- a/packages/better-auth/src/plugins/index.ts
+++ b/packages/better-auth/src/plugins/index.ts
@@ -23,3 +23,4 @@ export * from "./api-key";
 export * from "./haveibeenpwned";
 export * from "./one-time-token";
 export * from "./mcp";
+export * from "./siwe";


### PR DESCRIPTION
The docs were using this import path, yet `siwe` wasn't exported there. This PR fixes this.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the missing export for `siwe` in the better-auth plugins index to match the documented import path.

<!-- End of auto-generated description by cubic. -->

