### PR TITLE
feat(nav): replace 'helo_' with 'init_' for clearer terminal-style navigation

### DIFF
--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -108,7 +108,7 @@ export const Navbar = () => {
 
 export const navMenu = [
 	{
-		name: "helo_",
+		name: "init_",
 		path: "/",
 	},
 	{


### PR DESCRIPTION
## Summary
- Replaces 'helo_' with 'init_' in the navigation menu
- Provides familiar developer terminology while maintaining terminal aesthetic
- Offers a more recognizable alternative to the current confusing label

## Context
This addresses the confusion raised in issue #2276 where users found 'helo_' unclear and potentially unprofessional. Rather than just fixing the spelling, this approach uses 'init_' which is:
- Familiar to developers (initialization, git init, etc.)
- Maintains the terminal vibe as mentioned in [Kinfe123's comment](https://github.com/better-auth/better-auth/issues/2276#issuecomment-2805376896)
- Provides a distinctive design while being immediately understandable

## Changes
- Changed navigation menu item from `"helo_"` to `"init_"` in `docs/components/nav-bar.tsx`
- Preserves the underscore suffix for the terminal aesthetic

## Alternative Approach
A spelling-fix approach using `"hello_"` instead is available in PR #3598. Maintainers can choose between:
- This PR: `"init_"` - More developer-friendly, terminal-focused
- PR #3598: `"hello_"` - Simple spelling correction

Both approaches address the user confusion while maintaining the distinctive design philosophy.

Fixes #2276