### PR TITLE
fix: organization allowUserToCreateOrganization user argument typing

### DIFF
--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -25,7 +25,7 @@ export interface OrganizationOptions {
 	 */
 	allowUserToCreateOrganization?:
 		| boolean
-		| ((user: User) => Promise<boolean> | boolean);
+		| ((user: User & Record<string, any>) => Promise<boolean> | boolean);
 	/**
 	 * The maximum number of organizations a user can create.
 	 *


### PR DESCRIPTION
When using the organization plugin and if we have:
```ts
allowUserToCreateOrganization(user) {
  return user.role === "internalAdmin";
},
```
The user argument does not have `role` in its type definition. 
Looks like it just looks at `schema.ts` and uses the  `userSchema` const:
```ts
export const userSchema = z.object({
	id: z.string(),
	email: z.string().transform((val) => val.toLowerCase()),
	emailVerified: z.boolean().default(false),
	name: z.string(),
	image: z.string().nullish(),
	createdAt: z.date().default(() => new Date()),
	updatedAt: z.date().default(() => new Date()),
});
```
If used in conjuction with the admin plugin I would expect I could get the user's role to check whether it is a regular user or admin. If it is an internal admin role (a custom role) then I would allow organization creation otherwise not.

The jwt plugin's `definePayload` method deconstructs a `user` argument which also accepts any fields on the user.
```ts
definePayload?: (session: {
            user: User & Record<string, any>;
            session: Session & Record<string, any>;
        }) => Promise<Record<string, any>> | Record<string, any>;
```
Taken inspiration from that, obviously. 