### PR TITLE
fix(jwt): ensure alg is added to the jwks when generating via /token endpoint

### DIFF
--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -85,7 +85,7 @@ describe("jwt", async (it) => {
 		const jwks = await client.jwks();
 
 		expect(jwks.data?.keys).length.above(0);
-		expect(jwks.data?.keys[0].alg).toBe("EdDSA")
+		expect(jwks.data?.keys[0].alg).toBe("EdDSA");
 	});
 
 	it("Signed tokens can be validated with the JWKS", async () => {

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -85,6 +85,7 @@ describe("jwt", async (it) => {
 		const jwks = await client.jwks();
 
 		expect(jwks.data?.keys).length.above(0);
+		expect(jwks.data?.keys[0].alg).toBe("EdDSA")
 	});
 
 	it("Signed tokens can be validated with the JWKS", async () => {

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -17,14 +17,14 @@ export async function getJwtToken(
 		!options?.jwks?.disablePrivateKeyEncryption;
 
 	if (key === undefined) {
-		const alg = options?.jwks?.keyPairConfig?.alg || "EdDSA"
+		const alg = options?.jwks?.keyPairConfig?.alg || "EdDSA";
 
 		const { publicWebKey, privateWebKey } =
 			await generateExportedKeyPair(options);
 		const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
 
 		let jwk: Partial<Jwk> = {
-			publicKey: JSON.stringify({alg, ...publicWebKey}),
+			publicKey: JSON.stringify({ alg, ...publicWebKey }),
 			privateKey: privateKeyEncryptionEnabled
 				? JSON.stringify(
 						await symmetricEncrypt({

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -17,12 +17,14 @@ export async function getJwtToken(
 		!options?.jwks?.disablePrivateKeyEncryption;
 
 	if (key === undefined) {
+		const alg = options?.jwks?.keyPairConfig?.alg || "EdDSA"
+
 		const { publicWebKey, privateWebKey } =
 			await generateExportedKeyPair(options);
 		const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
 
 		let jwk: Partial<Jwk> = {
-			publicKey: JSON.stringify(publicWebKey),
+			publicKey: JSON.stringify({alg, ...publicWebKey}),
 			privateKey: privateKeyEncryptionEnabled
 				? JSON.stringify(
 						await symmetricEncrypt({


### PR DESCRIPTION
When using the jwt plugin I noticed there was an issue with the public key missing the alg field whenever the JWKS was created via the `/token` endpoint compared to when it was created using the `/jwks` endpoint 

For example:

`/api/auth/token`
```
apply=# SELECT public_key from jwks;
                                   public_key
---------------------------------------------------------------------------------
 {"crv":"Ed25519","x":"fi_qr9jILwhtL71fSwZad3RMrdbZqHCpd6NgCATXPEA","kty":"OKP"}
(1 row)
```

`/api/auth/jwks`
```
apply=# SELECT public_key from jwks;
                                          public_key
-----------------------------------------------------------------------------------------------
 {"alg":"EdDSA","crv":"Ed25519","x":"Apvgc4vNpmXtpUfjAxGlcqMeBW1FPVWGlcTNR8PQGZE","kty":"OKP"}
(1 row)
```

As you can see the `alg` field is created in the second example.

This PR resolves the issue, causing both endpoints to have the same outcome in the public_key structure.

For reference, below is how the `/jwks` endpoint adds the algo which is what I've mimicked in the fix.

https://github.com/better-auth/better-auth/blob/68f09f15d3ef3339ece01f39c9a51bebd8f97010/packages/better-auth/src/plugins/jwt/index.ts#L258-L271
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the public key generated by the /token endpoint was missing the alg field, so both /token and /jwks now include alg in the public key.

- **Bug Fixes**
 - Added alg to the public key structure in /token endpoint responses.

<!-- End of auto-generated description by cubic. -->

