### PR TITLE
Make client-side vs. server-side explicit

### DIFF
--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -34,14 +34,14 @@ export const auth = betterAuth({
 To sign in with a social provider, you can use the `signIn.social` function with the `authClient` or `auth.api` for server-side usage.
 
 ```ts
+// client-side usage
 await authClient.signIn.social({
   provider: "google", // or any other provider id
 })
 ```
 
-server-side usage:
-
 ```ts
+// server-side usage
 await auth.api.signInSocial({
   body: {
     provider: "google", // or any other provider id


### PR DESCRIPTION
Make client-side vs. server-side explicit in the docs
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified the OAuth documentation by labeling code examples as client-side or server-side usage.

<!-- End of auto-generated description by cubic. -->

