### PR TITLE
fix(docs): fix broken link to ERC-4361 in siwe docs

### DIFF
--- a/docs/content/docs/plugins/siwe.mdx
+++ b/docs/content/docs/plugins/siwe.mdx
@@ -3,7 +3,7 @@ title: Sign In With Ethereum (SIWE)
 description: Sign in with Ethereum plugin for Better Auth
 ---
 
-The Sign in with Ethereum (SIWE) plugin allows users to authenticate using their Ethereum wallets following the [ERC-4361 standard](https://eips.ethereum.org/EIPS/eip-4361/). This plugin provides flexibility by allowing you to implement your own message verification and nonce generation logic.
+The Sign in with Ethereum (SIWE) plugin allows users to authenticate using their Ethereum wallets following the [ERC-4361 standard](https://eips.ethereum.org/EIPS/eip-4361). This plugin provides flexibility by allowing you to implement your own message verification and nonce generation logic.
 
 ## Installation
 


### PR DESCRIPTION
This issue was raised by `rokitg` on Discord. 
https://discord.com/channels/1288403910284935179/1288408077040619566/1396366153638613012
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the broken link to the ERC-4361 standard in the SIWE plugin documentation.

<!-- End of auto-generated description by cubic. -->

