### PR TITLE
feat: add automatic namespacing and conflict detection for plugin routes

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -87,7 +87,19 @@ export const getClientConfig = (options?: ClientOptions) => {
 			Object.assign(pluginsAtoms, plugin.getAtoms?.($fetch));
 		}
 		if (plugin.pathMethods) {
-			Object.assign(pluginPathMethods, plugin.pathMethods);
+			const transformed: Record<string, "POST" | "GET"> = {};
+			for (const [p, method] of Object.entries(plugin.pathMethods)) {
+				let pathKey = p.startsWith("/") ? p : `/${p}`;
+				if (
+					options?.pluginRoutes?.autoNamespace &&
+					plugin.id &&
+					!pathKey.startsWith(`/${plugin.id}/`)
+				) {
+					pathKey = `/${plugin.id}${pathKey}`;
+				}
+				transformed[pathKey] = method;
+			}
+			Object.assign(pluginPathMethods, transformed);
 		}
 		if (plugin.atomListeners) {
 			atomListeners.push(...plugin.atomListeners);

--- a/packages/better-auth/src/client/react/index.ts
+++ b/packages/better-auth/src/client/react/index.ts
@@ -70,6 +70,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		pluginPathMethods,
 		pluginsAtoms,
 		atomListeners,
+		options?.pluginRoutes?.autoNamespace ?? false,
 	);
 
 	type ClientAPI = InferClientAPI<Option>;

--- a/packages/better-auth/src/client/solid/index.ts
+++ b/packages/better-auth/src/client/solid/index.ts
@@ -64,6 +64,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		pluginPathMethods,
 		pluginsAtoms,
 		atomListeners,
+		options?.pluginRoutes?.autoNamespace ?? false,
 	);
 	type ClientAPI = InferClientAPI<Option>;
 	type Session = ClientAPI extends {

--- a/packages/better-auth/src/client/svelte/index.ts
+++ b/packages/better-auth/src/client/svelte/index.ts
@@ -62,6 +62,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		pluginPathMethods,
 		pluginsAtoms,
 		atomListeners,
+		options?.pluginRoutes?.autoNamespace ?? false,
 	);
 	type ClientAPI = InferClientAPI<Option>;
 	type Session = ClientAPI extends {

--- a/packages/better-auth/src/client/types.ts
+++ b/packages/better-auth/src/client/types.ts
@@ -66,11 +66,32 @@ export interface BetterAuthClientPlugin {
 	atomListeners?: AtomListener[];
 }
 
+/**
+ * Configuration for handling plugin routes.
+ */
+export type PluginRoutesOptions = {
+	/**
+	 * Automatically namespaces plugin API endpoints to avoid conflicts.
+	 * When `true`, each endpoint path and key is prefixed with the plugin's ID.
+	 * Defaults to `false`.
+	 *
+	 * @example
+	 * // if a plugin with id 'myPlugin' has an endpoint with path '/action',
+	 * // with autoNamespace: true, the path becomes '/myPlugin/action'
+	 * @default false
+	 */
+	autoNamespace?: boolean;
+};
+
 export interface ClientOptions {
 	fetchOptions?: BetterFetchOption;
 	plugins?: BetterAuthClientPlugin[];
 	baseURL?: string;
 	basePath?: string;
+	/**
+	 * Configuration for handling plugin routes.
+	 */
+	pluginRoutes?: PluginRoutesOptions;
 	disableDefaultFetchPlugins?: boolean;
 	$InferAuth?: BetterAuthOptions;
 }

--- a/packages/better-auth/src/client/vanilla.ts
+++ b/packages/better-auth/src/client/vanilla.ts
@@ -62,6 +62,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		pluginPathMethods,
 		pluginsAtoms,
 		atomListeners,
+		options?.pluginRoutes?.autoNamespace ?? false,
 	);
 	type ClientAPI = InferClientAPI<Option>;
 	type Session = ClientAPI extends {

--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -124,6 +124,7 @@ export function createAuthClient<Option extends ClientOptions>(
 		pluginPathMethods,
 		pluginsAtoms,
 		atomListeners,
+		options?.pluginRoutes?.autoNamespace ?? false,
 	);
 
 	return proxy as UnionToIntersection<InferResolvedHooks<Option>> &

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -293,6 +293,55 @@ export type BetterAuthOptions = {
 	 */
 	plugins?: BetterAuthPlugin[];
 	/**
+	 * Plugin routes configuration.
+	 *
+	 * Determines how routes exposed by Better Auth plugins are mounted.
+	 * When `autoNamespace` is set to `true`, each plugin route is automatically
+	 * prefixed with `/<plugin.id>` (both in the URL and the generated endpoint key),
+	 * preventing accidental collisions with core Better Auth endpoints or routes
+	 * coming from other plugins.
+	 *
+	 * If left `false` (default), plugins register their routes verbatim. Only
+	 * disable automatic namespacing when you are certain your paths will not
+	 * conflict with existing endpoints, as overriding sensitive authentication
+	 * routes such as `/sign-in` or `/sign-out` can break functionality or
+	 * pose security risks.
+	 */
+	pluginRoutes?: {
+		/**
+		 * Automatically prefix plugin routes with the plugin's namespace.
+		 *
+		 * When `true`, every route registered by a plugin is re-written under
+		 * `/<plugin.id>` and the endpoint key is updated accordingly.
+		 *
+		 * Note: The original route string registered by the plugin **must** start with a leading slash (e.g., "/callback"). Omitting the slash will cause the final path to concatenate incorrectly (e.g., "/oauthcallback").
+		 *
+		 * @example
+		 * ```ts
+		 * // Plugin "oauth" registers route "/callback"
+		 *
+		 * // autoNamespace enabled
+		 * {
+		 *   pluginRoutes: { autoNamespace: true },
+		 *   plugins: [oauthPlugin],
+		 * }
+		 * // URL  => /oauth/callback
+		 * // Key  => "oauth.callback"
+		 *
+		 * // autoNamespace disabled
+		 * {
+		 *   pluginRoutes: { autoNamespace: false },
+		 *   plugins: [oauthPlugin],
+		 * }
+		 * // URL  => /callback
+		 * // Key  => "callback"
+		 * ```
+		 *
+		 * @default false
+		 */
+		autoNamespace?: boolean;
+	};
+	/**
 	 * User configuration
 	 */
 	user?: {


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/3595
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added automatic namespacing and conflict detection for plugin routes to prevent accidental endpoint collisions. Plugins can now use the new pluginRoutes.autoNamespace option to safely isolate their routes.

- **New Features**
  - Detects and blocks duplicate plugin route paths and endpoint keys.
  - Adds pluginRoutes.autoNamespace option to prefix plugin routes and keys with the plugin ID.

<!-- End of auto-generated description by cubic. -->

