### PR TITLE
fix(admin-plugin) list user endpoint incorrect return type

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -5,22 +5,22 @@ import {
 	createAuthMiddleware,
 	getSessionFromCtx,
 } from "../../api";
-import { type BetterAuthPlugin, type Session, type Where } from "../../types";
 import { deleteSessionCookie, setSessionCookie } from "../../cookies";
+import { mergeSchema } from "../../db/schema";
+import { type BetterAuthPlugin, type Session, type Where } from "../../types";
 import { getDate } from "../../utils/date";
 import { getEndpointResponse } from "../../utils/plugin-helper";
-import { mergeSchema } from "../../db/schema";
 import { type AccessControl } from "../access";
-import { ADMIN_ERROR_CODES } from "./error-codes";
 import { defaultStatements } from "./access";
+import { ADMIN_ERROR_CODES } from "./error-codes";
 import { hasPermission } from "./has-permission";
+import { schema } from "./schema";
 import {
 	type AdminOptions,
-	type UserWithRole,
-	type SessionWithImpersonatedBy,
 	type InferAdminRolesFromOption,
+	type SessionWithImpersonatedBy,
+	type UserWithRole,
 } from "./types";
-import { schema } from "./schema";
 
 function parseRoles(roles: string | string[]): string {
 	return Array.isArray(roles) ? roles.join(",") : roles;
@@ -659,7 +659,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 						});
 					} catch (e) {
 						return ctx.json({
-							users: [],
+							users: [] as UserWithRole[],
 							total: 0,
 						});
 					}


### PR DESCRIPTION
Previously, the return type of `auth.admin.listUsers` was awkward, which required casting types forcefully
```ts
{
    users: UserWithRole[];
    total: number;
    limit: number | undefined;
    offset: number | undefined;
} | {
    users: never[];
    total: number;
}
```
Now it's
```ts
{
    users: UserWithRole[];
    total: number;
}
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the return type of the admin list users endpoint to always return a consistent object shape with a typed users array and total count. This removes the need for type casting when handling empty user lists.

<!-- End of auto-generated description by cubic. -->

