### PR TITLE
fix: cast dates from db to Date when using date methods

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -521,7 +521,7 @@ export const getAccessToken = createAuthEndpoint(
 			if (
 				account.refreshToken &&
 				account.accessTokenExpiresAt &&
-				account.accessTokenExpiresAt.getTime() - Date.now() < 5_000 &&
+				new Date(account.accessTokenExpiresAt).getTime() - Date.now() < 5_000 &&
 				provider.refreshAccessToken
 			) {
 				newTokens = await provider.refreshAccessToken(

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -110,7 +110,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 									if (user.banned) {
 										if (
 											user.banExpires &&
-											user.banExpires.getTime() < Date.now()
+											new Date(user.banExpires).getTime() < Date.now()
 										) {
 											await ctx.context.internalAdapter.updateUser(
 												session.userId,

--- a/packages/better-auth/src/plugins/api-key/rate-limit.ts
+++ b/packages/better-auth/src/plugins/api-key/rate-limit.ts
@@ -64,7 +64,7 @@ export function isRateLimited(
 		};
 	}
 
-	const timeSinceLastRequest = now.getTime() - lastRequest.getTime();
+	const timeSinceLastRequest = now.getTime() - new Date(lastRequest).getTime();
 
 	if (timeSinceLastRequest > rateLimitTimeWindow) {
 		// Time window has passed, reset the request count.

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -48,7 +48,7 @@ export async function validateApiKey({
 
 	if (apiKey.expiresAt) {
 		const now = new Date().getTime();
-		const expiresAt = apiKey.expiresAt.getTime();
+		const expiresAt = new Date(apiKey.expiresAt).getTime();
 		if (now > expiresAt) {
 			try {
 				ctx.context.adapter.delete({
@@ -124,7 +124,7 @@ export async function validateApiKey({
 		let now = new Date().getTime();
 		const refillInterval = apiKey.refillInterval;
 		const refillAmount = apiKey.refillAmount;
-		let lastTime = (lastRefillAt ?? apiKey.createdAt).getTime();
+		let lastTime = new Date(lastRefillAt ?? apiKey.createdAt).getTime();
 
 		if (refillInterval && refillAmount) {
 			// if they provide refill info, then we should refill once the interval is reached.


### PR DESCRIPTION
A number of places call `.getTime()` on date values, but adapters using `customTransformOutput` may transform dates to strings or numbers. This PR wraps those values in the date constructor.

I combed for `.getTime()` usage specifically, not sure if other methods are also used commonly in the codebase. I also skipped instances involving the context session object as I _believe_ dates in that object are Date types.