### PR TITLE
chore(cli): update to zodv4

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,7 @@
     "semver": "^7.7.1",
     "tinyexec": "^0.3.1",
     "yocto-spinner": "^0.1.1",
-    "zod": "^3.23.8"
+    "zod": "^4.0.5"
   },
   "files": [
     "dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1652,8 +1652,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.2
       zod:
-        specifier: ^3.23.8
-        version: 3.25.42
+        specifier: ^4.0.5
+        version: 4.0.5
     devDependencies:
       '@types/diff':
         specifier: ^7.0.1


### PR DESCRIPTION
closes #3614
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Upgraded the CLI package to use zod v4 for improved validation support.

<!-- End of auto-generated description by cubic. -->

