### PR TITLE
fix(stripe): update customer id should also trigger secondary storage update

### DIFF
--- a/.changeset/huge-needles-smell.md
+++ b/.changeset/huge-needles-smell.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/stripe": patch
+---
+
+Fix an issue where updating Stripe customer ID wasn't properly syncing with secondary storage during user creation

--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -187,10 +187,9 @@ await authClient.deleteUser();
 3. Enabled email verification (needed for OAuth users)
 
 As OAuth users don't have a password, we need to send a verification email to confirm the user's intent to delete their account. If you have already added the `sendDeleteAccountVerification` callback, you can just call the `deleteUser` method without providing any other information.
-Note that this would fail if they have a password. In that case, you need to provide the password to delete the account.
 
 ```ts title="delete-user.ts"
-await authClient.deleteUser({});
+await authClient.deleteUser();
 ```
 
 4. If you have a custom delete account page and sent that url via the `sendDeleteAccountVerification` callback.

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -18,7 +18,6 @@ import {
 	onSubscriptionUpdated,
 } from "./hooks";
 import type {
-	Customer,
 	InputSubscription,
 	StripeOptions,
 	StripePlan,
@@ -1123,26 +1122,15 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 												userId: user.id,
 											},
 										});
-										const customer = await ctx.context.adapter.update<Customer>(
-											{
-												model: "user",
-												update: {
-													stripeCustomerId: stripeCustomer.id,
-												},
-												where: [
-													{
-														field: "id",
-														value: user.id,
-													},
-												],
-											},
-										);
-										if (!customer) {
+										const updatedUser =
+											await ctx.context.internalAdapter.updateUser(user.id, {
+												stripeCustomerId: stripeCustomer.id,
+											});
+										if (!updatedUser) {
 											logger.error("#BETTER_AUTH: Failed to create  customer");
 										} else {
 											await options.onCustomerCreate?.(
 												{
-													customer,
 													stripeCustomer,
 													user,
 												},

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -187,7 +187,6 @@ export interface StripeOptions {
 	 */
 	onCustomerCreate?: (
 		data: {
-			customer: Customer;
 			stripeCustomer: Stripe.Customer;
 			user: User;
 		},
@@ -330,13 +329,4 @@ export interface StripeOptions {
 	schema?: InferOptionSchema<typeof subscriptions & typeof user>;
 }
 
-export interface Customer {
-	id: string;
-	stripeCustomerId?: string;
-	userId: string;
-	createdAt: Date;
-	updatedAt: Date;
-}
-
 export interface InputSubscription extends Omit<Subscription, "id"> {}
-export interface InputCustomer extends Omit<Customer, "id"> {}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updating a user's Stripe customer ID now also updates the secondary storage to keep user data in sync.

- **Refactors**
  - Removed the old Customer type and related code.
  - Switched to using internalAdapter.updateUser for updating the Stripe customer ID.

<!-- End of auto-generated description by cubic. -->

