### PR TITLE
docs: typo and wrong ref for additional fields in Email & Password page

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -64,7 +64,7 @@ type signUpEmail = {
 </APIMethod>
 
 <Callout>
-  These are the default properties for the sign up email endpoint, however it's possible that with [additonal fields](/docs/concepts/typescript#additional-user-fields) or special plugins you can pass more properties to the endpoint.
+  These are the default properties for the sign up email endpoint, however it's possible that with [additional fields](/docs/concepts/typescript#additional-fields) or special plugins you can pass more properties to the endpoint.
 </Callout>
 
 
@@ -96,7 +96,7 @@ type signInEmail = {
 </APIMethod>
 
 <Callout>
-  These are the default properties for the sign in email endpoint, however it's possible that with [additonal fields](/docs/concepts/typescript#additional-user-fields) or special plugins you can pass different properties to the endpoint.
+  These are the default properties for the sign in email endpoint, however it's possible that with [additional fields](/docs/concepts/typescript#additional-fields) or special plugins you can pass different properties to the endpoint.
 </Callout>
 
 


### PR DESCRIPTION
In Email & Password docs:

- "additonal" -> "additonal"
- Link ref was set to `#additional-user-fields` but the correct one is `#additional-fields`