### PR TITLE
docs: update password change instructions

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -259,7 +259,6 @@ When a user clicks on the link in the email, they will be redirected to the rese
 - `newPassword`: The new password of the user.
 
 ```ts title="auth-client.ts"
-
 const { data, error } = await authClient.resetPassword({
   newPassword: "password1234",
   token,
@@ -288,22 +287,27 @@ type resetPassword = {
 </APIMethod>
 
 ### Update password
+A user's password isn't stored in the user table. Instead, it's stored in the account table. To change the password of a user, you can use one of the following approaches:
 
-<Callout type="warn">
-  This only works on server-side, and the following code may change over time.
-</Callout>
 
-To set a password, you must hash it first:
-
+<APIMethod path="/change-password" method="POST">
 ```ts
-const ctx = await auth.$context;
-const hash = await ctx.password.hash("your-new-password");
+type changePassword = {
+    /**
+     * The new password to set 
+     */
+    newPassword: string = "newpassword1234"
+    /**
+     * The current user password 
+     */
+    currentPassword: string = "oldpassword1234"
+    /**
+     * When set to true, all other active sessions for this user will be invalidated
+     */
+    revokeOtherSessions?: boolean = true
+}
 ```
-
-Then, to set the password: 
-```ts
-await ctx.internalAdapter.updatePassword("userId", hash) //(you can also use your orm directly)
-```
+</APIMethod>
 
 ### Configuration
 

--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -70,16 +70,27 @@ After verification, the new email is updated in the user table, and a confirmati
 </Callout>
  
 ### Change Password
+A user's password isn't stored in the user table. Instead, it's stored in the account table. To change the password of a user, you can use one of the following approaches:
 
-Password of a user isn't stored in the user table. Instead, it's stored in the account table. To change the password of a user, you can use the `changePassword` function provided by the client. The `changePassword` function takes an object with the following properties:
 
+<APIMethod path="/change-password" method="POST">
 ```ts
-await authClient.changePassword({
-    newPassword: "newPassword123",
-    currentPassword: "oldPassword123",
-    revokeOtherSessions: true, // revoke all other sessions the user is signed into
-});
+type changePassword = {
+    /**
+     * The new password to set 
+     */
+    newPassword: string = "newpassword1234"
+    /**
+     * The current user password 
+     */
+    currentPassword: string = "oldpassword1234"
+    /**
+     * When set to true, all other active sessions for this user will be invalidated
+     */
+    revokeOtherSessions?: boolean = true
+}
 ```
+</APIMethod>
 
 ### Set Password
 


### PR DESCRIPTION
Added an `<APIMethod>` for `change-password` to both "Email & Password" and "User & Accounts".

"Email & Password":
- The docs did not display the correct way to update a user's password.

"User & Accounts":
- The server-side solution was missing; using `<APIMethod>` resolves this issue.