### PR TITLE
docs: fix wrong cancelUrl and returnUrl descriptions

### DIFF
--- a/.changeset/mighty-tables-dream.md
+++ b/.changeset/mighty-tables-dream.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/stripe": patch
+"@better-auth/docs": patch
+---
+
+chore: fix wrong cancelUrl and returnUrl descriptions

--- a/.changeset/mighty-tables-dream.md
+++ b/.changeset/mighty-tables-dream.md
@@ -1,6 +1,5 @@
 ---
 "@better-auth/stripe": patch
-"@better-auth/docs": patch
 ---
 
 chore: fix wrong cancelUrl and returnUrl descriptions

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -234,10 +234,11 @@ type upgradeSubscription = {
      */
     successUrl: string
     /**
-     * Callback URL to redirect back after successful subscription. 
+     * If set, checkout shows a back button and customers will be directed here if they cancel payment.
      */
     cancelUrl: string 
-     * Return URL to redirect back after successful subscription. 
+    /**
+     * URL to take customers to when they click on the billing portal’s link to return to your website.
      */
     returnUrl?: string
     /**
@@ -345,7 +346,7 @@ type cancelSubscription = {
      */
     subscriptionId?: string = 'sub_123'
     /**
-     * Return URL to redirect back after successful subscription. 
+     * URL to take customers to when they click on the billing portal’s link to return to your website.
      */
     returnUrl: string = '/account'
 }

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -198,7 +198,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						.string()
 						.meta({
 							description:
-								'Callback URL to redirect back after successful subscription. Eg: "https://example.com/success"',
+								'If set, checkout shows a back button and customers will be directed here if they cancel payment. Eg: "https://example.com/pricing"',
 						})
 						.default("/"),
 					/**
@@ -208,7 +208,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						.string()
 						.meta({
 							description:
-								'Return URL to redirect back after successful subscription. Eg: "https://example.com/success"',
+								'URL to take customers to when they click on the billing portal’s link to return to your website. Eg: "https://example.com/dashboard"',
 						})
 						.optional(),
 					/**
@@ -625,7 +625,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						.optional(),
 					returnUrl: z.string().meta({
 						description:
-							"Return URL to redirect back after successful subscription. Eg: 'https://example.com/success'",
+							'URL to take customers to when they click on the billing portal’s link to return to your website. Eg: "https://example.com/dashboard"',
 					}),
 				}),
 				use: [


### PR DESCRIPTION
In the stripe plugin’s `upgradeSubscription` and `cancelSubscription` prop annotations and in the stripe plugin doc’s descriptions, the `callbackUrl` and `returnUrl` were copypasta’d from the `successUrl` prop. So I looked at how both are used in the plugin and fixed the annotations based on that:

- `returnUrl` is passed to the stripe client’s `client.billingPortal.sessions.create(…)` invocation in both endpoints, so I used shortened versions of the description from the [stripe docs for that parameter](https://docs.stripe.com/api/customer_portal/sessions/object#portal_session_object-return_url) for both instances
- `cancelUrl` is passed to `client.checkout.sessions.create(…)`, so I shortened the description from the [stripe docs for that parameter](https://docs.stripe.com/api/checkout/sessions/create#create_checkout_session-cancel_url)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the descriptions for cancelUrl and returnUrl in the Stripe plugin code and docs to match their actual usage and the Stripe API documentation.

<!-- End of auto-generated description by cubic. -->

