### PR TITLE
Fix API key remaining initialization issue #3640

### DIFF
--- a/.changeset/salty-banks-heal.md
+++ b/.changeset/salty-banks-heal.md
@@ -1,0 +1,11 @@
+---
+"better-auth": patch
+---
+
+Fixes API key remaining initialization issue #3640.
+This is a one line change to fix the initialiation of the remaining variable
+when creating a new API key. Setting remaining to null during the creation of a
+key to signify 'no cap' on key usage should propagate to the database. The
+current code is treating null as an invalid value and replacing it with the
+value of remaining. Setting the value to remaining introduces a cap on API key
+usage, which is incorrect behaviour.

--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -600,6 +600,72 @@ describe("api-key", async () => {
 		expect(apiKey.remaining).toEqual(remaining);
 	});
 
+	it("should create API Key with remaining explicitly set to null", async () => {
+		const apiKey = await auth.api.createApiKey({
+			body: {
+				remaining: null,
+				userId: user.id,
+			},
+		});
+
+		expect(apiKey).not.toBeNull();
+		expect(apiKey.remaining).toBeNull();
+	});
+
+	it("should create API Key with remaining explicitly set to null and refillAmount and refillInterval are also set", async () => {
+		const refillAmount = 10; // Arbitrary non-null value
+		const refillInterval = 1000;
+		const apiKey = await auth.api.createApiKey({
+			body: {
+				remaining: null,
+				refillAmount: refillAmount,
+				refillInterval: refillInterval,
+				userId: user.id,
+			},
+		});
+
+		expect(apiKey).not.toBeNull();
+		expect(apiKey.remaining).toBeNull();
+		expect(apiKey.refillAmount).toBe(refillAmount);
+		expect(apiKey.refillInterval).toBe(refillInterval);
+	});
+
+	it("should create API Key with remaining explicitly set to 0 and refillAmount also set", async () => {
+		const remaining = 0;
+		const refillAmount = 10; // Arbitrary non-null value
+		const refillInterval = 1000;
+		const apiKey = await auth.api.createApiKey({
+			body: {
+				remaining: remaining,
+				refillAmount: refillAmount,
+				refillInterval: refillInterval,
+				userId: user.id,
+			},
+		});
+
+		expect(apiKey).not.toBeNull();
+		expect(apiKey.remaining).toBe(remaining);
+		expect(apiKey.refillAmount).toBe(refillAmount);
+		expect(apiKey.refillInterval).toBe(refillInterval);
+	});
+
+	it("should create API Key with remaining undefined and default value of null is respected with refillAmount and refillInterval provided", async () => {
+		const refillAmount = 10; // Arbitrary non-null value
+		const refillInterval = 1000;
+		const apiKey = await auth.api.createApiKey({
+			body: {
+				refillAmount: refillAmount,
+				refillInterval: refillInterval,
+				userId: user.id,
+			},
+		});
+
+		expect(apiKey).not.toBeNull();
+		expect(apiKey.remaining).toBeNull();
+		expect(apiKey.refillAmount).toBe(refillAmount);
+		expect(apiKey.refillInterval).toBe(refillInterval);
+	});
+
 	it("should create API key with invalid metadata", async () => {
 		let result: { data: ApiKey | null; error: Err | null } = {
 			data: null,

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -419,7 +419,8 @@ export function createApiKey({
 				rateLimitMax: rateLimitMax ?? opts.rateLimit.maxRequests ?? null,
 				rateLimitTimeWindow:
 					rateLimitTimeWindow ?? opts.rateLimit.timeWindow ?? null,
-				remaining: remaining || refillAmount || null,
+				remaining:
+					remaining === null ? remaining : remaining ?? refillAmount ?? null,
 				refillAmount: refillAmount ?? null,
 				refillInterval: refillInterval ?? null,
 				rateLimitEnabled:


### PR DESCRIPTION
Minor bug fix to Closes #3640 related to the re-initialization of the `remaining` property of an API key.  The existing code was ignoring the user and default value of `null` and changing it to the value of `refillAmount`.  

Additional tests added, which are consistent with documentation.  All tests pass.  No updates to documentation.