### PR TITLE
Bug Fix: Twitter Refresh Token requires basic authentication

### DIFF
--- a/.changeset/fast-suns-peel.md
+++ b/.changeset/fast-suns-peel.md
@@ -1,0 +1,5 @@
+---
+"better-auth": major
+---
+
+Bug fix for refreshing twitter tokens

--- a/packages/better-auth/src/social-providers/twitter.ts
+++ b/packages/better-auth/src/social-providers/twitter.ts
@@ -138,6 +138,7 @@ export const twitter = (options: TwitterOption) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
+						authentication: "basic",
 						tokenEndpoint: "https://api.x.com/2/oauth2/token",
 					});
 				},


### PR DESCRIPTION
Refresh token for twitter requires auth header
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where refreshing Twitter tokens did not use basic authentication, which caused token refresh failures.

- **Bug Fixes**
  - Added the required basic authentication header to the Twitter refresh token request.

<!-- End of auto-generated description by cubic. -->

