### PR TITLE
Update svelte-kit.mdx

### DIFF
--- a/docs/content/docs/integrations/svelte-kit.mdx
+++ b/docs/content/docs/integrations/svelte-kit.mdx
@@ -31,7 +31,7 @@ You need to add it as a plugin to your Better Auth instance.
 </Callout>
 
 ```ts title="lib/auth.ts"
-import { BetterAuth } from "better-auth";
+import { betterAuth } from "better-auth";
 import { sveltekitCookies } from "better-auth/svelte-kit";
 import { getRequestEvent } from "$app/server";
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed an import in the SvelteKit integration docs to use betterAuth instead of BetterAuth.

<!-- End of auto-generated description by cubic. -->

