### PR TITLE
feat: expose verify id token on generic oauth

### DIFF
--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -182,6 +182,8 @@ interface GenericOAuthConfig {
 
 **mapProfileToUser**: (Optional) A function to map the provider's user profile to your app's user object. Useful for custom field mapping or transformations.
 
+**verifyIdToken**: (Optional) A function to verify the ID token returned by the provider. Takes the token string and optional nonce as parameters and returns a Promise<boolean>.
+
 **authorizationUrlParams**: (Optional) Additional query parameters to add to the authorization URL. These can override default parameters.
 
 **disableImplicitSignUp**: (Optional) If true, disables automatic sign-up for new users. Sign-in must be explicitly requested with sign-up intent.
@@ -237,6 +239,41 @@ genericOAuth({
         return {
           firstName: profile.given_name,
           // ... map other fields as needed
+        };
+      }
+    }
+  ]
+})
+```
+
+### Verify ID Token
+
+If you are using an OAuth provider that returns an ID token, you can verify it using the `verifyIdToken` function. 
+By default, the user info will be extracted from the decoded JWT, which requires `sub` and `email` claims to be present. If you need custom user info handling, you can override this behavior by providing your own `getUserInfo` function.
+
+```ts
+genericOAuth({
+  config: [
+    {
+      providerId: "custom-provider",
+      // ... other config options
+      verifyIdToken: async (idToken, nonce) => {
+        // Custom logic to verify the ID token using jose
+        // You can use jose's jwtVerify or other methods to verify the token
+        const verified = await jwtVerify(idToken, nonce);
+        return verified;
+      },
+      getUserInfo: async (tokens) => {
+        // Custom logic to fetch and return user info
+        // You can use jose's decodeJwt to decode the token payload
+        if (!tokens.idToken) return null;
+        const decoded = decodeJwt(tokens.idToken);
+        return {
+          id: decoded.sub,
+          email: decoded.email,
+          name: decoded.name,
+          emailVerified: decoded.email_verified,
+          image: decoded.picture
         };
       }
     }

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -109,6 +109,10 @@ export interface GenericOAuthConfig {
 				[key: string]: any;
 		  }>;
 	/**
+	 * verifyIdToken function to verify the id token
+	 */
+	verifyIdToken?: (token: string, nonce?: string) => Promise<boolean>;
+	/**
 	 * Additional search-params to add to the authorizationUrl.
 	 * Warning: Search-params added here overwrite any default params.
 	 */
@@ -324,6 +328,8 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							data: userInfo,
 						};
 					},
+
+					verifyIdToken: c.verifyIdToken,
 				} as OAuthProvider;
 			});
 			return {


### PR DESCRIPTION
Recently, I had to integrate a generic OAuth2 system that uses identity tokens for validations (https://web3auth.io/docs/authentication/id-token). However, the generic OAuth options did not expose the `verifyIdToken` in the available options. This PR exposes this functionality so it can be passed.

Additionally, the support for identity tokens could be improved for generic OAuth. I am considering adding an option to accept a JWKS endpoint (instead of only accepting a discovery URL) and also an option to decode the token directly into the `getUserInfo` without requiring installation of a full JWT library. This would allow developers to input the necessary `userInfo` from the `idToken`'s payload.

If this approach makes sense, please let me know so I can open another PR. For now, I wanted to implement something quickly as I need this functionality for my work.