### PR TITLE
fix: Pass `loginHint` to Microsoft OAuth URL

### DIFF
--- a/.changeset/stale-tomatoes-warn.md
+++ b/.changeset/stale-tomatoes-warn.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+add support for passing a loginHint to the Microsoft OAuth

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -57,6 +57,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 				scopes,
 				redirectURI: data.redirectURI,
 				prompt: options.prompt,
+				loginHint: data.loginHint
 			});
 		},
 		validateAuthorizationCode({ code, codeVerifier, redirectURI }) {

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -57,7 +57,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 				scopes,
 				redirectURI: data.redirectURI,
 				prompt: options.prompt,
-				loginHint: data.loginHint
+				loginHint: data.loginHint,
 			});
 		},
 		validateAuthorizationCode({ code, codeVerifier, redirectURI }) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for passing a `loginHint` to the Microsoft OAuth URL to improve user sign-in experience.

<!-- End of auto-generated description by cubic. -->

