### PR TITLE
Fix: validates username on isUsernameAvailable call

### DIFF
--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -268,6 +268,14 @@ export const username = (options?: UsernameOptions) => {
 							message: ERROR_CODES.INVALID_USERNAME,
 						});
 					}
+					const validator =
+						options?.usernameValidator || defaultUsernameValidator;
+
+					if (!validator(username)) {
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							message: ERROR_CODES.INVALID_USERNAME,
+						});
+					}
 					const user = await ctx.context.adapter.findOne<User>({
 						model: "user",
 						where: [


### PR DESCRIPTION
Found this issue with `isUsernameAvailable` function not validating the username before db query.
```ts
	isUsernameAvailable: createAuthEndpoint(
		"/is-username-available",
		{
			method: "POST",
			body: z.object({
				username: z.string().meta({
					description: "The username to check",
				}),
			}),
		},
		async (ctx) => {
			const username = ctx.body.username;
			if (!username) {
				throw new APIError("UNPROCESSABLE_ENTITY", {
					message: ERROR_CODES.INVALID_USERNAME,
				});
			}
			const user = await ctx.context.adapter.findOne<User>({
				model: "user",
				where: [
					{
						field: "username",
						value: username.toLowerCase(),
					},
				],
			});
			if (user) {
				return ctx.json({
					available: false,
				});
			}
			return ctx.json({
				available: true,
			});
		},
	),
},
```

Added the validator code to execute validation before db query

```ts
const validator =
options?.usernameValidator || defaultUsernameValidator;

if (!validator(username)) {
  throw new APIError("UNPROCESSABLE_ENTITY", {
	  message: ERROR_CODES.INVALID_USERNAME,
  });
}
```
		
		