### PR TITLE
Enforce required 'name' field for email/password signup (Fix #3336)

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -11,6 +11,7 @@ import type {
 import { parseUserInput } from "../../db/schema";
 import { BASE_ERROR_CODES } from "../../error/codes";
 import { isDevelopment } from "../../utils/env";
+import { a } from "vitest/dist/suite-dWqIFb_-.js";
 
 export const signUpEmail = <O extends BetterAuthOptions>() =>
 	createAuthEndpoint(
@@ -163,6 +164,18 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				rememberMe,
 				...additionalFields
 			} = body;
+
+			if (!name) {
+				throw new APIError("BAD_REQUEST", {
+					message: "Name is required",
+				});
+			}
+
+			if (!password) {
+				throw new APIError("BAD_REQUEST", {
+					message: "Password is required",
+				});
+			}
 			const isValidEmail = z.email().safeParse(email);
 
 			if (!isValidEmail.success) {


### PR DESCRIPTION
The backend previously allowed users to sign up with only email and password, even though the documentation specifies that the name field is also required. This PR updates the backend validation to enforce that the name field is mandatory for email/password signups, ensuring consistency between the implementation and the documentation.

Fixes #3336.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enforced the 'name' field as required for email/password signups to match documentation and prevent incomplete registrations.

- **Bug Fixes**
 - Added backend validation to reject signups missing a name.

<!-- End of auto-generated description by cubic. -->

