### PR TITLE
fix(api-key): is-username-available endpoint should also validate usernames

### DIFF
--- a/.changeset/wild-pianos-join.md
+++ b/.changeset/wild-pianos-join.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fixed username plugins isUsernameAvailable endpoint to run validation

--- a/.changeset/wild-pianos-join.md
+++ b/.changeset/wild-pianos-join.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Fixed username plugins isUsernameAvailable endpoint to run validation
+fix(username): `isUsernameAvailable` should run validation

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -268,6 +268,30 @@ export const username = (options?: UsernameOptions) => {
 							message: ERROR_CODES.INVALID_USERNAME,
 						});
 					}
+					const minUsernameLength = options?.minUsernameLength || 3;
+					const maxUsernameLength = options?.maxUsernameLength || 30;
+					if (username.length < minUsernameLength) {
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							message: ERROR_CODES.USERNAME_TOO_SHORT,
+						});
+					}
+
+					if (username.length > maxUsernameLength) {
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							message: ERROR_CODES.USERNAME_TOO_LONG,
+						});
+					}
+
+					const validator =
+						options?.usernameValidator || defaultUsernameValidator;
+
+					const valid = await validator(username);
+					if (!valid) {
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							message: ERROR_CODES.INVALID_USERNAME,
+						});
+					}
+
 					const user = await ctx.context.adapter.findOne<User>({
 						model: "user",
 						where: [


### PR DESCRIPTION
Adds username validation in the `isUsernameAvailable` endpoint - such as username length & custom validators
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The isUsernameAvailable endpoint now checks if usernames meet length and custom validation rules before confirming availability.

- **Bug Fixes**
 - Added checks for minimum and maximum username length.
 - Applied custom username validators to ensure valid input.

<!-- End of auto-generated description by cubic. -->

