### PR TITLE
docs: twitter changeset should be type patch

### DIFF
--- a/.changeset/fast-suns-peel.md
+++ b/.changeset/fast-suns-peel.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": major
+"better-auth": patch
 ---
 
-Bug fix for refreshing twitter tokens
+fix(twitter): refreshing twitter utilizes basic


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Changed the Twitter changeset type from major to patch to correctly reflect the scope of the bug fix.

<!-- End of auto-generated description by cubic. -->

