### PR TITLE
feat: add client assertion support to OAuth2 configuration

### DIFF
--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -85,7 +85,7 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 	/**
 	 * The client secret of your application
 	 */
-	clientSecret: string;
+	clientSecret?: string;
 	/**
 	 * The client assertion of your application
 	 */

--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -87,6 +87,16 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 	 */
 	clientSecret: string;
 	/**
+	 * The client assertion of your application
+	 */
+	clientAssertion?: string;
+	/**
+	 * The client assertion type of your application
+	 * 	
+	 * @see https://datatracker.ietf.org/doc/html/rfc6755
+	 * */
+	clientAssertionType?: `urn:ietf:params:oauth:client-assertion-type:${string}`;
+	/**
 	 * The scopes you want to request from the provider
 	 */
 	scope?: string[];

--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -36,6 +36,7 @@ export async function validateAuthorizationCode({
 	body.set("code", code);
 	codeVerifier && body.set("code_verifier", codeVerifier);
 	options.clientKey && body.set("client_key", options.clientKey);
+	// If the provider requires a device ID
 	deviceId && body.set("device_id", deviceId);
 	body.set("redirect_uri", options.redirectURI || redirectURI);
 	// for resolving the issue with some oauth server.
@@ -47,6 +48,10 @@ export async function validateAuthorizationCode({
 			`${options.clientId}:${options.clientSecret}`,
 		);
 		requestHeaders["authorization"] = `Basic ${encodedCredentials}`;
+	} else if(options.clientAssertion && options.clientAssertionType) {
+		body.set("client_assertion", options.clientAssertion);
+		body.set("client_assertion_type", options.clientAssertionType);
+
 	} else {
 		body.set("client_secret", options.clientSecret);
 	}

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -217,7 +217,6 @@ async function getUserInfo(
 		...userInfo.data,
 	};
 }
-
 /**
  * A generic OAuth plugin that can be used to add OAuth support to any provider
  */

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -62,8 +62,16 @@ export interface GenericOAuthConfig {
 	 */
 	responseType?: string;
 	/**
+	 * A JWT signed with the client’s private key, used for client authentication instead of a client_secret
+	 */
+	clientAssertion?: string;
+	/**
+	 * The client assertion type if client assertion used
+	 * @see https://datatracker.ietf.org/doc/html/rfc6755
+	 */
+	clientAssertionType?: `urn:ietf:params:oauth:client-assertion-type:${string}`;
+	/**
 	 * The response mode to use for the authorization code request.
-
 	 */
 	responseMode?: "query" | "form_post";
 	/**
@@ -232,6 +240,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 								clientId: c.clientId,
 								clientSecret: c.clientSecret,
 								redirectURI: c.redirectURI,
+
 							},
 							authorizationEndpoint: c.authorizationUrl!,
 							state: data.state,
@@ -269,6 +278,8 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 								clientId: c.clientId,
 								clientSecret: c.clientSecret,
 								redirectURI: c.redirectURI,
+								clientAssertion: c.clientAssertion,
+								clientAssertionType: c.clientAssertionType,
 							},
 							tokenEndpoint: finalTokenUrl,
 							authentication: c.authentication,

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -45,7 +45,7 @@ export interface GenericOAuthConfig {
 	/** OAuth client ID */
 	clientId: string;
 	/** OAuth client secret */
-	clientSecret: string;
+	clientSecret?: string;
 	/**
 	 * Array of OAuth scopes to request.
 	 * @default []
@@ -238,9 +238,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							id: c.providerId,
 							options: {
 								clientId: c.clientId,
-								clientSecret: c.clientSecret,
 								redirectURI: c.redirectURI,
-
 							},
 							authorizationEndpoint: c.authorizationUrl!,
 							state: data.state,


### PR DESCRIPTION
Added Support for assertion framework
@see https://datatracker.ietf.org/doc/html/rfc7521 
For more undertanding
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for OAuth2 client assertion authentication, allowing use of JWT-based client authentication instead of a client secret.

- **New Features**
  - Added clientAssertion and clientAssertionType options to OAuth2 configuration.
  - Made clientSecret optional when using client assertions.

<!-- End of auto-generated description by cubic. -->

