### PR TITLE
fix(stripe): fallback to subscription id instead of picking the first if subId is provided

### DIFF
--- a/.changeset/angry-items-boil.md
+++ b/.changeset/angry-items-boil.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/stripe": patch
+---
+
+should fallback to subscription id when it's present in the body

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -328,8 +328,9 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						),
 					);
 				const activeSubscription = activeSubscriptions.find((sub) =>
-					subscriptionToUpdate?.stripeSubscriptionId
-						? sub.id === subscriptionToUpdate?.stripeSubscriptionId
+					subscriptionToUpdate?.stripeSubscriptionId || ctx.body.subscriptionId
+						? sub.id === subscriptionToUpdate?.stripeSubscriptionId ||
+							sub.id === ctx.body.subscriptionId
 						: true,
 				);
 				const subscriptions = subscriptionToUpdate


### PR DESCRIPTION
closes #3690 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated Stripe logic to use the provided subscription ID as a fallback when selecting the active subscription, instead of always picking the first one. This ensures the correct subscription is used when a specific ID is given.

<!-- End of auto-generated description by cubic. -->

