### PR TITLE
Fix usernameValidator example return type from `bool | undefined` to `bool`

### DIFF
--- a/docs/content/docs/plugins/username.mdx
+++ b/docs/content/docs/plugins/username.mdx
@@ -185,6 +185,7 @@ const auth = betterAuth({
                 if (username === "admin") {
                     return false
                 }
+                return true
             }
         })
     ]


### PR DESCRIPTION
I was playing around with the example when I came across this error with an easy fix:

```
Type '(username: string) => false | undefined' is not assignable to type '(username: string) => boolean | Promise<boolean>'.
  Type 'false | undefined' is not assignable to type 'boolean | Promise<boolean>'.
    Type 'undefined' is not assignable to type 'boolean | Promise<boolean>'.
```

I'm submitting the update so copy/pasting just works :)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the usernameValidator example to always return a boolean, preventing type errors when copying the code.

<!-- End of auto-generated description by cubic. -->

