### PR TITLE
docs(hono): clarify CORS middleware must be registered before routes

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -48,8 +48,14 @@ app.use(
 	}),
 );
 
+app.on(["POST", "GET"], "/api/auth/*", (c) => {
+	return auth.handler(c.req.raw);
+});
+
+serve(app);
 ```
 
+> **Important:** CORS middleware must be registered before your routes. This ensures that cross-origin requests are properly handled before they reach your authentication endpoints.
 
 ### Middleware
 


### PR DESCRIPTION
## Summary
- Complete the CORS example by including route registration and serve() calls
- Add important note explaining CORS middleware must come before routes
- Ensure consistency with the middleware section example

## Problem
The CORS section in the Hono integration documentation was incomplete, only showing the `app.use()` for CORS configuration but not including the subsequent `app.on()` and `serve()` calls. This could confuse users about the proper ordering and leave them with an incomplete setup.

## Solution
- Added the missing `app.on()` and `serve()` calls to the CORS example
- Included an important note explaining that CORS middleware must be registered before routes
- This ensures the example is complete and follows the critical ordering requirement

## Why This Matters
CORS middleware must be registered before route handlers to properly handle cross-origin requests. Without this ordering, authentication endpoints may fail for cross-origin requests, which is especially important for applications with separate frontend and backend domains.

The updated example now matches the pattern used in the middleware section, providing consistency throughout the documentation.

## Test Plan
- [x] Verify the CORS example now includes complete setup
- [x] Confirm the ordering explanation is clear
- [x] Check consistency with other examples in the file