### PR TITLE
docs(options): Remove invalid `customPaths` docs

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -605,17 +605,3 @@ export const auth = betterAuth({
 	disabledPaths: ["/sign-up/email", "/sign-in/email"],
 })
 ```
-
-## `customPaths`
-
-Customize specific auth paths. This allows you to map any existing route to a custom path.
-
-```ts
-import { betterAuth } from "better-auth";
-export const auth = betterAuth({
-	customPaths: {
-		"/ok": "/okay",
-	},
-})
-```
-


### PR DESCRIPTION
Previously a merged PR had this, but that PR was revered however didn't reverse the docs for it.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the invalid `customPaths` section from the options documentation to reflect current supported features.

<!-- End of auto-generated description by cubic. -->

