### PR TITLE
Fix: accountId condition being ignored and OAuth providerId type mismatch issue

### DIFF
--- a/demo/nextjs/app/features.tsx
+++ b/demo/nextjs/app/features.tsx
@@ -59,28 +59,6 @@ const Card = ({
 	);
 };
 
-const AceternityIcon = () => {
-	return (
-		<svg
-			width="66"
-			height="65"
-			viewBox="0 0 66 65"
-			fill="none"
-			xmlns="http://www.w3.org/2000/svg"
-			className="h-10 w-10 text-black dark:text-white group-hover/canvas-card:text-white "
-		>
-			<path
-				d="M8 8.05571C8 8.05571 54.9009 18.1782 57.8687 30.062C60.8365 41.9458 9.05432 57.4696 9.05432 57.4696"
-				stroke="currentColor"
-				strokeWidth="15"
-				strokeMiterlimit="3.86874"
-				strokeLinecap="round"
-				style={{ mixBlendMode: "darken" }}
-			/>
-		</svg>
-	);
-};
-
 export const Icon = ({ className, ...rest }: any) => {
 	return (
 		<svg

--- a/docs/components/landing/section-svg.tsx
+++ b/docs/components/landing/section-svg.tsx
@@ -1,3 +1,5 @@
+import { Plus } from "lucide-react";
+
 const SectionSvg = ({
 	crossesOffset,
 }: {
@@ -5,30 +7,19 @@ const SectionSvg = ({
 }) => {
 	return (
 		<>
-			<PlusSvg
-				className={`hidden absolute -top-[0.3125rem] ${
+			<Plus
+				className={`hidden absolute -top-[0.3125rem] h-6 w-6 ${
 					crossesOffset && crossesOffset
-				} pointer-events-none lg:block lg:left-[3.6825rem]`}
+				} pointer-events-none lg:block lg:left-[3.275rem] text-neutral-300 dark:text-neutral-600 translate-y-[.5px]`}
 			/>
 
-			<PlusSvg
-				className={`hidden absolute  -top-[0.3125rem] right-[1.4625rem] ${
+			<Plus
+				className={`hidden absolute -top-[0.3125rem] h-6 w-6 right-[1.4625rem] ${
 					crossesOffset && crossesOffset
-				} pointer-events-none lg:block lg:right-[3.20rem]`}
+				} pointer-events-none lg:block lg:right-[2.7750rem] text-neutral-300 dark:text-neutral-600 translate-y-[.5px]`}
 			/>
 		</>
 	);
 };
 
 export default SectionSvg;
-
-export const PlusSvg = ({ className = "" }) => {
-	return (
-		<svg className={`${className} || ""`} width="11" height="11" fill="none">
-			<path
-				d="M7 1a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h2a1 1 0 0 1 1 1v2a1 1 0 0 0 1 1h1a1 1 0 0 0 1-1V8a1 1 0 0 1 1-1h2a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H8a1 1 0 0 1-1-1V1z"
-				fill="#878787"
-			/>
-		</svg>
-	);
-};

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -597,6 +597,10 @@ export const organization = <O extends OrganizationOptions>(
 						teamId: {
 							type: "string",
 							required: true,
+							references: {
+								model: "team",
+								field: "id",
+							},
 							fieldName: options?.schema?.teamMember?.fields?.teamId,
 						},
 						userId: {


### PR DESCRIPTION
### 1. Issue with all accounts being fetched when `accountId` is `undefined`

* **Issue Description**:
  When `accountId: undefined` is included in the `where` condition in Prisma, the condition is ignored, and all accounts are fetched.
  As a result, when a user signs up via OAuth with the first account (`a@google.com`) in an empty database, the `accountId` of that account is always returned, causing incorrect login matching for all subsequent logins.

* **Solution**:
  The `accountId` condition is only included when it explicitly exists, and the `providerId` filter is also applied to ensure accurate user matching.

---

### 2. OAuth provider `id` type mismatch (`number` → `string`)

* **Issue Description**:
  Some OAuth providers (such as Kakao) return `profile.id` as a `number`, but internal logic and database schemas expect it to be a `string`, causing a type mismatch.

* **Solution**:
  Explicitly convert `providerId` values to strings using `.toString()` to maintain consistent handling across all providers.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where accountId conditions were ignored in OAuth logins, causing incorrect account matching, and resolved a type mismatch by converting providerId values to strings.

- **Bug Fixes**
  - Only include accountId in queries when defined to prevent fetching all accounts.
  - Ensure providerId is always a string for consistent matching across OAuth providers.

<!-- End of auto-generated description by cubic. -->

