### PR TITLE
docs: update dodopayments docs due to breaking change in the package

### DIFF
--- a/docs/content/docs/plugins/dodopayments.mdx
+++ b/docs/content/docs/plugins/dodopayments.mdx
@@ -110,7 +110,7 @@ export const authClient = createAuthClient({
 ### Creating a Checkout Session
 
 ```typescript
-const { data: checkout, error } = await authClient.checkout({
+const { data: checkout, error } = await authClient.dodopayments.checkout({
   slug: "premium-plan",
   customer: {
     email: "customer@example.com",
@@ -134,7 +134,7 @@ if (checkout) {
 ### Accessing the Customer Portal
 
 ```typescript
-const { data: customerPortal, error } = await authClient.customer.portal();
+const { data: customerPortal, error } = await authClient.dodopayments.customer.portal();
 if (customerPortal && customerPortal.redirect) {
   window.location.href = customerPortal.url;
 }
@@ -145,7 +145,7 @@ if (customerPortal && customerPortal.redirect) {
 ```typescript
 // Get subscriptions
 const { data: subscriptions, error } =
-  await authClient.customer.subscriptions.list({
+  await authClient.dodopayments.customer.subscriptions.list({
     query: {
       limit: 10,
       page: 1,
@@ -154,7 +154,7 @@ const { data: subscriptions, error } =
   });
 
 // Get payment history
-const { data: payments, error } = await authClient.customer.payments.list({
+const { data: payments, error } = await authClient.dodopayments.customer.payments.list({
   query: {
     limit: 10,
     page: 1,
@@ -166,12 +166,12 @@ const { data: payments, error } = await authClient.customer.payments.list({
 ### Webhooks
 
 <Card>
-  The webhooks plugin processes real-time payment events from Dodo Payments with secure signature verification. The default endpoint is `/api/auth/webhooks/dodopayments`.
+  The webhooks plugin processes real-time payment events from Dodo Payments with secure signature verification. The default endpoint is `/api/auth/dodopayments/webhooks`.
 </Card>
 
 <Steps>
   <Step title="Generate and set webhook secret">
-    Generate a webhook secret for your endpoint URL (e.g., `https://your-domain.com/api/auth/webhooks/dodopayments`) in the Dodo Payments Dashboard and set it in your .env file:
+    Generate a webhook secret for your endpoint URL (e.g., `https://your-domain.com/api/auth/dodopayments/webhooks`) in the Dodo Payments Dashboard and set it in your .env file:
 ```env
 DODO_PAYMENTS_WEBHOOK_SECRET=your_webhook_secret_here
 ```


### PR DESCRIPTION
Since version 1.0.0, all the endpoints exposed by the @dodopayments/better-auth adapter now include a `dodopayments` prefix to prevent conflict with other payment related better-auth plugins.

This PR looks out to keep the better-auth docs in accordance with such a change.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the DodoPayments plugin docs to use the new dodopayments-prefixed endpoints required by version 1.0.0 of the package. This keeps the documentation accurate and prevents confusion for users upgrading to the latest version.

<!-- End of auto-generated description by cubic. -->

