### PR TITLE
feat: return false from generateId to imply database-generated ID

### DIFF
--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -205,7 +205,7 @@ export type AuthContext = {
 	generateId: (options: {
 		model: LiteralUnion<Models, string>;
 		size?: number;
-	}) => string;
+	}) => string | false;
 	secondaryStorage: SecondaryStorage | undefined;
 	password: {
 		hash: (password: string) => Promise<string>;

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -16,6 +16,7 @@ import { parseSetCookieHeader, setSessionCookie } from "../../cookies";
 import { getOrigin } from "../../utils/url";
 import { mergeSchema } from "../../db/schema";
 import type { EndpointContext } from "better-call";
+import { generateId } from "../../utils/id";
 
 export interface UserWithAnonymous extends User {
 	isAnonymous: boolean;
@@ -119,7 +120,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 				async (ctx) => {
 					const { emailDomainName = getOrigin(ctx.context.baseURL) } =
 						options || {};
-					const id = ctx.context.generateId({ model: "user" });
+					const id = generateId();
 					const email = `temp-${id}@${emailDomainName}`;
 					const name = (await options?.generateName?.(ctx)) || "Anonymous";
 					const newUser = await ctx.context.internalAdapter.createUser(

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -762,7 +762,7 @@ export type BetterAuthOptions = {
 				| ((options: {
 						model: LiteralUnion<Models, string>;
 						size?: number;
-				  }) => string)
+				  }) => string | false)
 				| false;
 		};
 		/**


### PR DESCRIPTION
Change the return type of the `advanced.database.generateId` option to accept `false`, which implies a database-generated identifier. The logic for handling the false result was already present.
