### PR TITLE
fix(jwt): add options to plugin

### DIFF
--- a/.changeset/slimy-paws-sin.md
+++ b/.changeset/slimy-paws-sin.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix(jwt): add options to plugin

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -142,6 +142,7 @@ export async function generateExportedKeyPair(
 export const jwt = (options?: JwtOptions) => {
 	return {
 		id: "jwt",
+		options,
 		endpoints: {
 			getJwks: createAuthEndpoint(
 				"/jwks",

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -26,13 +26,13 @@ import { parseSetCookieHeader } from "../../cookies";
 import { createHash } from "@better-auth/utils/hash";
 import { base64 } from "@better-auth/utils/base64";
 import { getJwtToken } from "../jwt/sign";
-import type { JwtOptions } from "../jwt";
+import type { jwt } from "../jwt";
 import { defaultClientSecretHasher } from "./utils";
 
 const getJwtPlugin = (ctx: GenericEndpointContext) => {
 	return ctx.context.options.plugins?.find(
 		(plugin) => plugin.id === "jwt",
-	) as Omit<BetterAuthPlugin, "options"> & { options?: JwtOptions };
+	) as ReturnType<typeof jwt>;
 };
 
 /**


### PR DESCRIPTION
Currently the OIDC plugin relies on the jwt options, but they are currently not added to the plugin as they are optional which led to inconsistent behavior. I have added the options and updated the type in the oidc plugin which would have caught this with typechecks.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the jwt plugin options to ensure consistent behavior and updated the OIDC plugin type to catch related issues with type checks.

<!-- End of auto-generated description by cubic. -->

