### PR TITLE
fix(docs): open plugins link in same tab

### DIFF
--- a/docs/content/docs/plugins/community-plugins.mdx
+++ b/docs/content/docs/plugins/community-plugins.mdx
@@ -7,7 +7,7 @@ This page showcases a list of recommended community made plugins.
 
 We encourage you to create custom plugins and maybe get added to the list!
 
-To create your own custom plugin, get started by reading our [plugins documentation](https://www.better-auth.com/docs/concepts/plugins). And if you want to share your plugin with the community, please open a pull request to add it to this list.
+To create your own custom plugin, get started by reading our [plugins documentation](/docs/concepts/plugins). And if you want to share your plugin with the community, please open a pull request to add it to this list.
 
 | <div className="w-[200px]">Plugin</div>                                             | Description                                                                                                                  | <div className="w-[150px]">Author</div>                                                                                                                              |
 | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the plugins documentation link to open in the same tab for a smoother navigation experience.

<!-- End of auto-generated description by cubic. -->

