### PR TITLE
docs: Remove non-existent invitation.createdAt field, add missing invitation.teamId field

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1512,6 +1512,13 @@ Table Name: `invitation`
       isForeignKey: true
     },
     {
+      name: "teamId",
+      type: "string",
+      description: "The ID of the team",
+      isOptional: true,
+      isForeignKey: true
+    },
+    {
       name: "role",
       type: "string",
       description: "The role of the user in the organization"
@@ -1525,11 +1532,6 @@ Table Name: `invitation`
       name: "expiresAt",
       type: "Date",
       description: "Timestamp of when the invitation expires"
-    },
-    {
-      name: "createdAt",
-      type: "Date",
-      description: "Timestamp of when the invitation was created"
     },
   ]}
   />


### PR DESCRIPTION
The current docs list a `createdAt` field for the `invitation` table that doesn’t exist and are missing the optional `teamId` field that does exist on the [invitation schema](https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/plugins/organization/schema.ts#L32-L41)