### PR TITLE
test: add the test case for all parameters using client side API

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
@@ -4,9 +4,10 @@ import { organization } from "../organization";
 import { createAuthClient } from "../../../client";
 import { organizationClient } from "../client";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
+import type { Member } from "../schema";
 
 describe("listMembers", async () => {
-	const { auth, signInWithTestUser, cookieSetter } = await getTestInstance({
+	const { auth, signInWithTestUser, cookieSetter, db } = await getTestInstance({
 		plugins: [organization()],
 	});
 	const ctx = await auth.$context;
@@ -210,6 +211,53 @@ describe("listMembers", async () => {
 		expect(members.error?.message).toBe(
 			ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_A_MEMBER_OF_THIS_ORGANIZATION,
 		);
+	});
+
+	it("should return members when using client-side API format with all parameters", async () => {
+		await client.organization.setActive({
+			organizationId: org.data?.id as string,
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const membersFromDB = await db.findMany<Member>({
+			model: "member",
+			where: [{ field: "organizationId", value: org.data?.id! }],
+			sortBy: {
+				field: "createdAt",
+				direction: "desc",
+			},
+		});
+
+		expect(membersFromDB.length).toBe(11);
+
+		const result = await client.organization.listMembers({
+			query: {
+				organizationId: org.data?.id,
+				limit: 100,
+				offset: 0,
+				sortBy: "createdAt",
+				sortDirection: "desc",
+				filterField: "createdAt",
+				filterOperator: "eq",
+				filterValue: membersFromDB.at(0)!.createdAt.toISOString(),
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(result.error).toBe(null);
+		expect(result.data!.members.at(0)).toStrictEqual({
+			...membersFromDB.at(0),
+			user: {
+				id: expect.any(String),
+				name: expect.any(String),
+				email: expect.any(String),
+				image: null,
+			},
+		});
 	});
 });
 


### PR DESCRIPTION
add the test case from https://github.com/better-auth/better-auth/issues/3745

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a test case for the client-side API to verify listing organization members with all supported parameters.

<!-- End of auto-generated description by cubic. -->

