### PR TITLE
fix: `--yes` option does not work on `@better-auth/cli generate`

### DIFF
--- a/.changeset/twenty-camels-float.md
+++ b/.changeset/twenty-camels-float.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/cli": patch
+---
+
+fix: `--yes` option does not work on `@better-auth/cli generate`

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -57,7 +57,7 @@ export async function generateAction(opts: any) {
 		process.exit(0);
 	}
 	if (schema.append || schema.overwrite) {
-		let confirm = options.y;
+		let confirm = options.y || options.yes;
 		if (!confirm) {
 			const response = await prompts({
 				type: "confirm",


### PR DESCRIPTION
If you run `pnpx @better-auth/cli generate --yes ...` and the targeted output file already exists, the prompt asks if the file should be overwritten, while it should not ask when you add the `--yes` option.
This PR makes the `--yes` option work as expected.

# Current behavior

`--yes` does not prevent the prompt:

```sh
$ pnpx @better-auth/cli generate --yes --output="./path/to/schema.ts"
✔ The file ./path/to/schema.ts already exists. Do you want to overwrite the schema to the file? › (y/N)
```

`-y` does not prevent the prompt either:

```sh
$ pnpx @better-auth/cli generate -y --output="./path/to/schema.ts"
✔ The file ./path/to/schema.ts already exists. Do you want to overwrite the schema to the file? › (y/N)
```

Only the deprecated `--y` allows you to overwrite the file without prompt:

```sh
$ pnpx @better-auth/cli generate --y --output="./path/to/schema.ts"
2025-08-02T05:48:33.216Z SUCCESS [Better Auth]: 🚀 Schema was overwritten successfully!
```

# Step to reproduce the bug

Run the following command:

```sh
$ touch ./path/to/schema.ts # Create a dummy file to overwrite
$ pnpx @better-auth/cli generate --yes --output="./path/to/schema.ts"
```

Expected: `@better-auth/cli` overwrites ./path/to/schema.ts without any prompts.

Actual: The following prompt is shown, and the command process is paused.

```sh
✔ The file ./path/to/schema.ts already exists. Do you want to overwrite the schema to the file? › (y/N)
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the `--yes` option in `@better-auth/cli generate` so it now overwrites files without prompting when used.

<!-- End of auto-generated description by cubic. -->

