### PR TITLE
fix: reddit refresh access token authentication type

### DIFF
--- a/.changeset/eight-pumpkins-return.md
+++ b/.changeset/eight-pumpkins-return.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix: reddit refresh access token authentication type

--- a/.changeset/eight-pumpkins-return.md
+++ b/.changeset/eight-pumpkins-return.md
@@ -1,5 +1,0 @@
----
-"better-auth": patch
----
-
-fix: reddit refresh access token authentication type

--- a/packages/better-auth/src/social-providers/reddit.ts
+++ b/packages/better-auth/src/social-providers/reddit.ts
@@ -79,6 +79,7 @@ export const reddit = (options: RedditOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
+						authentication: "basic",
 						tokenEndpoint: "https://www.reddit.com/api/v1/access_token",
 					});
 				},


### PR DESCRIPTION
closes #3751    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Set the Reddit access token authentication type to "basic" to ensure correct token refresh behavior.

<!-- End of auto-generated description by cubic. -->

