### PR TITLE
feat: add support for `team` params for slack oauth

### DIFF
--- a/.changeset/beige-scissors-tickle.md
+++ b/.changeset/beige-scissors-tickle.md
@@ -1,5 +1,0 @@
----
-"better-auth": patch
----
-
-feat: add support for `team` params for slack oauth


### PR DESCRIPTION
closes #3752
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for an optional team parameter in Slack OAuth to allow restricting sign-in to a specific Slack workspace.
more - https://api.slack.com/authentication/oauth-v2
<!-- End of auto-generated description by cubic. -->

