### PR TITLE
fix(org): incorrect use of find org by slug

### DIFF
--- a/.changeset/old-planets-camp.md
+++ b/.changeset/old-planets-camp.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix(org): incorrect use of find org by slug

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -55,6 +55,7 @@ describe("organization", async (it) => {
 	});
 
 	let organizationId: string;
+	let organization2Id: string;
 	it("create organization", async () => {
 		const organization = await client.organization.create({
 			name: "test",
@@ -100,7 +101,6 @@ describe("organization", async (it) => {
 		expect(existingSlug.error?.status).toBe(400);
 		expect(existingSlug.error?.message).toBe("slug is taken");
 	});
-
 	it("should create organization directly in the server without cookie", async () => {
 		const session = await client.getSession({
 			fetchOptions: {
@@ -116,11 +116,11 @@ describe("organization", async (it) => {
 			},
 		});
 
+		organization2Id = organization?.id as string;
 		expect(organization?.name).toBe("test2");
 		expect(organization?.members.length).toBe(1);
 		expect(organization?.members[0]?.role).toBe("owner");
 	});
-
 	it("should allow listing organizations", async () => {
 		const organizations = await client.organization.list({
 			fetchOptions: {
@@ -176,6 +176,23 @@ describe("organization", async (it) => {
 		});
 		expect((session.data?.session as any).activeOrganizationId).toBe(
 			organizationId,
+		);
+	});
+	it("should allow activating organization by slug", async () => {
+		const { headers } = await signInWithTestUser();
+		const organization = await client.organization.setActive({
+			organizationSlug: "test2",
+			fetchOptions: {
+				headers,
+			},
+		});
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect((session.data?.session as any).activeOrganizationId).toBe(
+			organization2Id,
 		);
 	});
 
@@ -1285,9 +1302,6 @@ describe("owner can update roles", async () => {
 		const member = await auth.api.getActiveMember({
 			headers: { cookie: adminCookie },
 		});
-
-		console.log({ member });
-
 		expect(member?.role).toBe("");
 	});
 });

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -724,7 +724,7 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 			let organization = await adapter.findOrganizationById(organizationId);
 			if (!organization) {
 				if (ctx.body.organizationSlug) {
-					organization = await adapter.findOrganizationBySlug(organizationId);
+					organization = await adapter.findOrganizationBySlug(ctx.body.organizationSlug);
 				}
 				if (!organization) {
 					throw new APIError("BAD_REQUEST", {

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -724,7 +724,9 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 			let organization = await adapter.findOrganizationById(organizationId);
 			if (!organization) {
 				if (ctx.body.organizationSlug) {
-					organization = await adapter.findOrganizationBySlug(ctx.body.organizationSlug);
+					organization = await adapter.findOrganizationBySlug(
+						ctx.body.organizationSlug,
+					);
 				}
 				if (!organization) {
 					throw new APIError("BAD_REQUEST", {

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -687,7 +687,9 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 		async (ctx) => {
 			const adapter = getOrgAdapter<O>(ctx.context, options);
 			const session = ctx.context.session;
-			let organizationId = ctx.body.organizationSlug || ctx.body.organizationId;
+			let organizationId = ctx.body.organizationId;
+			let organizationSlug = ctx.body.organizationSlug;
+
 			if (organizationId === null) {
 				const sessionOrgId = session.session.activeOrganizationId;
 				if (!sessionOrgId) {
@@ -703,13 +705,32 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 				});
 				return ctx.json(null);
 			}
-			if (!organizationId) {
+
+			if (!organizationId && !organizationSlug) {
 				const sessionOrgId = session.session.activeOrganizationId;
 				if (!sessionOrgId) {
 					return ctx.json(null);
 				}
 				organizationId = sessionOrgId;
 			}
+
+			if (organizationSlug && !organizationId) {
+				const organization =
+					await adapter.findOrganizationBySlug(organizationSlug);
+				if (!organization) {
+					throw new APIError("BAD_REQUEST", {
+						message: ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,
+					});
+				}
+				organizationId = organization.id;
+			}
+
+			if (!organizationId) {
+				throw new APIError("BAD_REQUEST", {
+					message: ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,
+				});
+			}
+
 			const isMember = await adapter.checkMembership({
 				userId: session.user.id,
 				organizationId,
@@ -721,18 +742,12 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 						ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
 				});
 			}
+
 			let organization = await adapter.findOrganizationById(organizationId);
 			if (!organization) {
-				if (ctx.body.organizationSlug) {
-					organization = await adapter.findOrganizationBySlug(
-						ctx.body.organizationSlug,
-					);
-				}
-				if (!organization) {
-					throw new APIError("BAD_REQUEST", {
-						message: ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,
-					});
-				}
+				throw new APIError("BAD_REQUEST", {
+					message: ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,
+				});
 			}
 			const updatedSession = await adapter.setActiveOrganization(
 				session.session.token,


### PR DESCRIPTION
- **use org slug from context body**
- **lint**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the organization slug was not correctly read from the request body when finding an organization by slug.

<!-- End of auto-generated description by cubic. -->

