### PR TITLE
feat(stripe): Support dynamic trial days via trialDays param

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -221,6 +221,16 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								"Disable redirect after successful subscription. Eg: true",
 						})
 						.default(false),
+					trialDays: z
+						.number()
+						.int()
+						.positive()
+						.max(365)
+						.optional()
+						.meta({
+							description: 
+								"Number of free trial days to apply. Overrides plan default if provided."
+						}),
 				}),
 				use: [
 					sessionMiddleware,
@@ -433,7 +443,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				const freeTrial =
 					!alreadyHasTrial && plan.freeTrial
 						? {
-								trial_period_days: plan.freeTrial.days,
+								trial_period_days: ctx.body.trialDays ?? plan.freeTrial.days,
 							}
 						: undefined;
 


### PR DESCRIPTION
Allow overriding default plan trial period by passing `trialDays` in the upgradeSubscription payload. Falls back to plan.freeTrial if not provided.

This update allows dynamic control over the trial period when creating a Stripe subscription. Instead of relying solely on the fixed trial duration defined in the plan (e.g. 5 days), the app can now provide a custom `trialDays` value based on internal logic.

The trial period is managed by custom business logic within my app. For example, if a user upgrades to a paid plan while still having 8 days remaining on their in-app free trial, we can pass `trialDays: 8` to Stripe to ensure they retain those remaining trial days before billing begins. This prevents cutting the trial short and provides a smoother upgrade experience.

This makes the subscription experience smoother and fairer, especially when users upgrade early.