### PR TITLE
fix: magic link URL construction

### DIFF
--- a/.changeset/little-cherries-tickle.md
+++ b/.changeset/little-cherries-tickle.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix: magic link URL construction

--- a/.changeset/little-cherries-tickle.md
+++ b/.changeset/little-cherries-tickle.md
@@ -1,5 +1,0 @@
----
-"better-auth": patch
----
-
-fix: magic link URL construction

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -190,7 +190,8 @@ export const magicLink = (options: MagicLinkopts) => {
 						ctx,
 					);
 					const realBaseURL = new URL(ctx.context.baseURL);
-					const pathname = realBaseURL.pathname === "/" ? "" : realBaseURL.pathname;
+					const pathname =
+						realBaseURL.pathname === "/" ? "" : realBaseURL.pathname;
 					const url = new URL(
 						`${pathname}/magic-link/verify`,
 						realBaseURL.origin,

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -192,8 +192,9 @@ export const magicLink = (options: MagicLinkopts) => {
 					const realBaseURL = new URL(ctx.context.baseURL);
 					const pathname =
 						realBaseURL.pathname === "/" ? "" : realBaseURL.pathname;
+					const basePath = pathname ? "" : ctx.context.options.basePath || "";
 					const url = new URL(
-						`${pathname}/magic-link/verify`,
+						`${pathname}${basePath}/magic-link/verify`,
 						realBaseURL.origin,
 					);
 					url.searchParams.set("token", verificationToken);

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -190,8 +190,9 @@ export const magicLink = (options: MagicLinkopts) => {
 						ctx,
 					);
 					const realBaseURL = new URL(ctx.context.baseURL);
+					const pathname = realBaseURL.pathname === "/" ? "" : realBaseURL.pathname;
 					const url = new URL(
-						`${realBaseURL.pathname}/magic-link/verify`,
+						`${pathname}/magic-link/verify`,
 						realBaseURL.origin,
 					);
 					url.searchParams.set("token", verificationToken);

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -32,13 +32,15 @@ describe("magic link", async () => {
 		fetchOptions: {
 			customFetchImpl,
 		},
-		baseURL: "http://localhost:3000/api/auth",
+		baseURL: "http://localhost:3000",
+		basePath: "/api/auth",
 	});
 
 	it("should send magic link", async () => {
 		await client.signIn.magicLink({
 			email: testUser.email,
 		});
+		console.log(verificationEmail);
 		expect(verificationEmail).toMatchObject({
 			email: testUser.email,
 			url: expect.stringContaining(


### PR DESCRIPTION
The issue occurs when the baseURL has a root pathname ("/"), causing double slashes in URL construction that result in malformed magic link URLs. The fix treats root pathnames as empty strings, preventing the double slash issue and ensuring proper URL construction with the correct host and port information.

closes #3759