### PR TITLE
Add custom stripeCustomerId to request & fix missing trial fields

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -167,6 +167,16 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						})
 						.optional(),
 					/**
+					 * Stripe customer id
+					 */
+					stripeCustomerId: z
+					.string()
+					.meta({
+					  description:
+						"The id of the Stripe customer to upgrade. Eg: 'cus_123'",
+					})
+					.optional(),
+				  	/**
 					 * Any additional data you want to store in your database
 					 * subscriptions
 					 */
@@ -272,7 +282,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				}
 
 				let customerId =
-					subscriptionToUpdate?.stripeCustomerId || user.stripeCustomerId;
+					subscriptionToUpdate?.stripeCustomerId || ctx.body.stripeCustomerId || user.stripeCustomerId;
 
 				if (!customerId) {
 					try {

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -42,6 +42,18 @@ export const subscriptions = {
 				type: "number",
 				required: false,
 			},
+			trialStart: {
+			  type: "date",
+			  required: false,
+			},
+			trialEnd: {
+			  type: "date",
+			  required: false,
+			},
+			updatedAt: {
+			  type: "date",
+			  required: false,
+			},
 		},
 	},
 } satisfies AuthPluginSchema;


### PR DESCRIPTION
Solves #3772

Additionally, the trial fields were missing from the schema, so added these as well
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for passing a custom Stripe customer ID when upgrading subscriptions and included missing trial fields in the subscription schema.

- **New Features**
  - Accepts a custom Stripe customer ID in the upgrade flow.
  - Adds trialStart, trialEnd, and updatedAt fields to the subscription schema.

<!-- End of auto-generated description by cubic. -->

