### PR TITLE
fix(adapter): kysely adapter renamed fields

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -93,6 +93,14 @@ export const kyselyAdapter = (db: Kysely<any>, config?: KyselyAdapterConfig) =>
 				const { type = "sqlite" } = config || {};
 				let f = schema[model]?.fields[field];
 				if (!f) {
+					const foundField = Object.values(schema[model]?.fields || {}).find(
+						(f) => f.fieldName === field,
+					);
+					if (foundField) {
+						f = foundField;
+					}
+				}
+				if (!f) {
 					//@ts-expect-error - The model name can be a sanitized, thus using the custom model name, not one of the default ones.
 					f = Object.values(schema).find((f) => f.modelName === model)!;
 				}

--- a/packages/better-auth/src/adapters/kysely-adapter/test/normal/adapter.kysely.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/normal/adapter.kysely.test.ts
@@ -46,6 +46,11 @@ export const opts = ({
 		session: {
 			modelName: "sessions",
 		},
+		verification: {
+			fields: {
+				expiresAt: "expires_at",
+			},
+		},
 		advanced: {
 			database: {
 				useNumberId: isNumberIdTest,

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -26,6 +26,7 @@ const adapterTests = {
 	FIND_MODEL_WITHOUT_ID: "find model without id",
 	FIND_MODEL_WITH_SELECT: "find model with select",
 	FIND_MODEL_WITH_MODIFIED_FIELD_NAME: "find model with modified field name",
+	FIND_MODEL_WITH_RENAMED_VERIFICATION_FIELD: "find model with renamed verification field",
 	UPDATE_MODEL: "update model",
 	SHOULD_FIND_MANY: "should find many",
 	SHOULD_FIND_MANY_WITH_WHERE: "should find many with where",
@@ -237,6 +238,57 @@ async function adapterTest(
 			});
 			expect(res).not.toBeNull();
 			expect(res?.email).toEqual(email);
+		},
+	);
+
+	test.skipIf(disabledTests?.FIND_MODEL_WITH_RENAMED_VERIFICATION_FIELD)(
+		`${testPrefix ? `${testPrefix} - ` : ""}${
+			adapterTests.FIND_MODEL_WITH_RENAMED_VERIFICATION_FIELD
+		}`,
+		async ({ onTestFailed }) => {
+			resetDebugLogs();
+			onTestFailed(() => {
+				printDebugLogs();
+			});
+			
+			const adapter = await getAdapter(
+				Object.assign(
+					{
+						verification: {
+							fields: {
+								expiresAt: "expires_at",
+							},
+						},
+					},
+					internalOptions?.predefinedOptions,
+				),
+			);
+			const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); 
+			const verification = await adapter.create({
+				model: "verification",
+				data: {
+					identifier: "test@example.com",
+					value: "test-token",
+					expiresAt,
+				},
+			});
+			const verificationExpiresAt = verification.expiresAt.getTime()
+			expect(verificationExpiresAt).not.toBeNull();
+			const res = await adapter.findOne<{
+				identifier: string;
+				value: string;
+				expiresAt: Date;
+			}>({
+				model: "verification",
+				where: [
+					{
+						field: "identifier",
+						value: "test@example.com",
+					},
+				],
+			});
+			expect(res).not.toBeNull();
+			expect(res?.expiresAt.getTime()).toBe(verificationExpiresAt);
 		},
 	);
 

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -26,7 +26,8 @@ const adapterTests = {
 	FIND_MODEL_WITHOUT_ID: "find model without id",
 	FIND_MODEL_WITH_SELECT: "find model with select",
 	FIND_MODEL_WITH_MODIFIED_FIELD_NAME: "find model with modified field name",
-	FIND_MODEL_WITH_RENAMED_VERIFICATION_FIELD: "find model with renamed verification field",
+	FIND_MODEL_WITH_RENAMED_VERIFICATION_FIELD:
+		"find model with renamed verification field",
 	UPDATE_MODEL: "update model",
 	SHOULD_FIND_MANY: "should find many",
 	SHOULD_FIND_MANY_WITH_WHERE: "should find many with where",
@@ -250,7 +251,7 @@ async function adapterTest(
 			onTestFailed(() => {
 				printDebugLogs();
 			});
-			
+
 			const adapter = await getAdapter(
 				Object.assign(
 					{
@@ -263,7 +264,7 @@ async function adapterTest(
 					internalOptions?.predefinedOptions,
 				),
 			);
-			const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); 
+			const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
 			const verification = await adapter.create({
 				model: "verification",
 				data: {
@@ -272,7 +273,7 @@ async function adapterTest(
 					expiresAt,
 				},
 			});
-			const verificationExpiresAt = verification.expiresAt.getTime()
+			const verificationExpiresAt = verification.expiresAt.getTime();
 			expect(verificationExpiresAt).not.toBeNull();
 			const res = await adapter.findOne<{
 				identifier: string;


### PR DESCRIPTION
The fix addresses the issue where the Kysely adapter couldn't find field definitions for renamed fields, preventing proper data transformation like date and other and causing database binding errors as attached below
<img width="673" height="145" alt="Screenshot 2025-08-04 at 2 10 28 PM" src="https://github.com/user-attachments/assets/b29c2062-b045-4dab-a2b1-a89e9ae06a5e" />
. The solution addresses create-adapter's getDefaultFieldName function to properly handle renamed fields.
