### PR TITLE
fix: await `ctx` in middleware

### DIFF
--- a/.changeset/tidy-impalas-fail.md
+++ b/.changeset/tidy-impalas-fail.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix: await `ctx` in middleware

--- a/packages/better-auth/src/api/index.test.ts
+++ b/packages/better-auth/src/api/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { getEndpoints } from "./index";
+import type { AuthContext } from "../init";
+import type { BetterAuthOptions, BetterAuthPlugin } from "../types";
+import { createAuthMiddleware } from "./call";
+
+describe("getEndpoints", () => {
+	it("should await promise-based context before passing to middleware", async () => {
+		const mockContext: AuthContext = {
+			baseURL: "http://localhost:3000",
+			options: {},
+		} as any;
+
+		const middlewareFn = vi.fn().mockResolvedValue({});
+		
+		const testPlugin: BetterAuthPlugin = {
+			id: "test-plugin",
+			middlewares: [
+				{
+					path: "/test",
+					middleware: createAuthMiddleware(async (ctx) => {
+						middlewareFn(ctx);
+						return {};
+					}),
+				},
+			],
+		};
+
+		const options: BetterAuthOptions = {
+			plugins: [testPlugin],
+		};
+
+		const promiseContext = new Promise<AuthContext>((resolve) => {
+			setTimeout(() => resolve(mockContext), 10);
+		});
+
+		const { middlewares } = getEndpoints(promiseContext, options);
+
+		const testCtx = {
+			request: new Request("http://localhost:3000/test"),
+			context: { customProp: "value" },
+		};
+
+		await middlewares[0].middleware(testCtx);
+
+		expect(middlewareFn).toHaveBeenCalled();
+		const call = middlewareFn.mock.calls[0][0];
+		expect(call.context).toMatchObject({
+			baseURL: "http://localhost:3000",
+			options: {},
+			customProp: "value",
+		});
+	});
+});

--- a/packages/better-auth/src/api/index.test.ts
+++ b/packages/better-auth/src/api/index.test.ts
@@ -12,7 +12,7 @@ describe("getEndpoints", () => {
 		} as any;
 
 		const middlewareFn = vi.fn().mockResolvedValue({});
-		
+
 		const testPlugin: BetterAuthPlugin = {
 			id: "test-plugin",
 			middlewares: [

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -72,10 +72,11 @@ export function getEndpoints<
 			?.map((plugin) =>
 				plugin.middlewares?.map((m) => {
 					const middleware = (async (context: any) => {
+						const authContext = await ctx;
 						return m.middleware({
 							...context,
 							context: {
-								...ctx,
+								...authContext,
 								...context.context,
 							},
 						});


### PR DESCRIPTION
`ctx` could be a promise in some cases
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed middleware to await the context if it is a promise, ensuring correct context merging before passing to plugins.

- **Bug Fixes**
 - Updated middleware to handle promise-based contexts.
 - Added tests to verify correct context handling.

<!-- End of auto-generated description by cubic. -->

