### PR TITLE
feat(organization): add option for requiring email verificaiton

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -584,6 +584,25 @@ type acceptInvitation = {
 ```
 </APIMethod>
 
+#### Email Verification Requirement
+
+If the `requireEmailVerificationOnInvitation` option is enabled in your organization configuration, users must verify their email address before they can accept invitations. This adds an extra security layer to ensure that only verified users can join your organization.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+import { organization } from "better-auth/plugins"
+
+export const auth = betterAuth({
+    plugins: [
+        organization({
+            requireEmailVerificationOnInvitation: true, // [!code highlight]
+            async sendInvitationEmail(data) {
+                // ... your email sending logic
+            }
+        })
+    ]
+})
+```
 
 ### Cancel Invitation
 
@@ -616,6 +635,10 @@ type rejectInvitation = {
 }
 ```
 </APIMethod>
+
+<Callout type="info">
+Like accepting invitations, rejecting invitations also requires email verification when the `requireEmailVerificationOnInvitation` option is enabled. Users with unverified emails will receive an error when attempting to reject invitations.
+</Callout>
 
 ### Get Invitation
 
@@ -1759,3 +1782,5 @@ await client.organization.create({
 **cancelPendingInvitationsOnReInvite**: `boolean` - Whether to cancel pending invitations if the user is already invited to the organization. By default, it's `false`.
 
 **invitationLimit**: `number` | `((user: User) => Promise<boolean> | boolean)` - The maximum number of invitations allowed for a user. By default, it's `100`. You can set it to any number you want or a function that returns a boolean.
+
+**requireEmailVerificationOnInvitation**: `boolean` - Whether to require email verification before accepting or rejecting invitations. By default, it's `false`. When enabled, users must have verified their email address before they can accept or reject organization invitations.

--- a/packages/better-auth/src/plugins/organization/error-codes.ts
+++ b/packages/better-auth/src/plugins/organization/error-codes.ts
@@ -31,8 +31,8 @@ export const ORGANIZATION_ERROR_CODES = {
 	INVITATION_NOT_FOUND: "Invitation not found",
 	YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION:
 		"You are not the recipient of the invitation",
-	EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_INVITATION:
-		"Email verification required before accepting invitation",
+	EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_OR_REJECTING_INVITATION:
+		"Email verification required before accepting or rejecting invitation",
 	YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_INVITATION:
 		"You are not allowed to cancel this invitation",
 	INVITER_IS_NO_LONGER_A_MEMBER_OF_THE_ORGANIZATION:

--- a/packages/better-auth/src/plugins/organization/error-codes.ts
+++ b/packages/better-auth/src/plugins/organization/error-codes.ts
@@ -31,6 +31,8 @@ export const ORGANIZATION_ERROR_CODES = {
 	INVITATION_NOT_FOUND: "Invitation not found",
 	YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION:
 		"You are not the recipient of the invitation",
+	EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_INVITATION:
+		"Email verification required before accepting invitation",
 	YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_INVITATION:
 		"You are not allowed to cancel this invitation",
 	INVITER_IS_NO_LONGER_A_MEMBER_OF_THE_ORGANIZATION:

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -420,12 +420,12 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 			}
 
 			if (
-				ctx.context.orgOptions.requireEmailVerificationOnAcceptInvitation &&
+				ctx.context.orgOptions.requireEmailVerificationOnInvitation &&
 				!session.user.emailVerified
 			) {
 				throw new APIError("FORBIDDEN", {
 					message:
-						ORGANIZATION_ERROR_CODES.EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_INVITATION,
+						ORGANIZATION_ERROR_CODES.EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_OR_REJECTING_INVITATION,
 				});
 			}
 
@@ -588,6 +588,16 @@ export const rejectInvitation = <O extends OrganizationOptions>(options: O) =>
 				throw new APIError("FORBIDDEN", {
 					message:
 						ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION,
+				});
+			}
+
+			if (
+				ctx.context.orgOptions.requireEmailVerificationOnInvitation &&
+				!session.user.emailVerified
+			) {
+				throw new APIError("FORBIDDEN", {
+					message:
+						ORGANIZATION_ERROR_CODES.EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_OR_REJECTING_INVITATION,
 				});
 			}
 

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -419,6 +419,16 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				});
 			}
 
+			if (
+				ctx.context.orgOptions.requireEmailVerificationOnAcceptInvitation &&
+				!session.user.emailVerified
+			) {
+				throw new APIError("FORBIDDEN", {
+					message:
+						ORGANIZATION_ERROR_CODES.EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_INVITATION,
+				});
+			}
+
 			const membershipLimit = ctx.context.orgOptions?.membershipLimit || 100;
 			const membersCount = await adapter.countMembers({
 				organizationId: invitation.organizationId,

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -158,11 +158,11 @@ export interface OrganizationOptions {
 	 */
 	cancelPendingInvitationsOnReInvite?: boolean;
 	/**
-	 * Require email verification on accepting an invitation.
+	 * Require email verification on accepting or rejecting an invitation
 	 *
 	 * @default false
 	 */
-	requireEmailVerificationOnAcceptInvitation?: boolean;
+	requireEmailVerificationOnInvitation?: boolean;
 	/**
 	 * Send an email with the
 	 * invitation link to the user.

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -158,6 +158,12 @@ export interface OrganizationOptions {
 	 */
 	cancelPendingInvitationsOnReInvite?: boolean;
 	/**
+	 * Require email verification on accepting an invitation.
+	 *
+	 * @default false
+	 */
+	requireEmailVerificationOnAcceptInvitation?: boolean;
+	/**
 	 * Send an email with the
 	 * invitation link to the user.
 	 *


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added an option to require users to verify their email before accepting an organization invitation.

- **New Features**
  - Added requireEmailVerificationOnAcceptInvitation setting to OrganizationOptions.
  - Blocked invitation acceptance if the user's email is not verified and the option is enabled.
  - Added a new error message for unverified email attempts.

<!-- End of auto-generated description by cubic. -->

