### PR TITLE
fix: add missing team reference in `teamMember` schema

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -597,6 +597,10 @@ export const organization = <O extends OrganizationOptions>(
 						teamId: {
 							type: "string",
 							required: true,
+							references: {
+								model: "team",
+								field: "id",
+							},
 							fieldName: options?.schema?.teamMember?.fields?.teamId,
 						},
 						userId: {


### PR DESCRIPTION
closes #3800
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a missing reference to the team model in the teamMember schema to ensure teamId is correctly linked.

<!-- End of auto-generated description by cubic. -->

