### PR TITLE
fix(oauth2): compare accountId as forced string to prevent duplicates

### DIFF
--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -43,7 +43,7 @@ export async function handleOAuthUserInfo(
 		const hasBeenLinked = dbUser.accounts.find(
 			(a) =>
 				a.providerId === account.providerId &&
-				a.accountId === account.accountId,
+				a.accountId === String(account.accountId),
 		);
 		if (!hasBeenLinked) {
 			const trustedProviders =


### PR DESCRIPTION
in oauth2/link-account.ts file: `accountId` returns as a string from database but other one returns as a number from the endpoint. So they dont align and cause `hasBeenLinked` to be `undefined`.
in line 46 comparing like this `a.accountId === String(account.accountId)` seems like solved the issue.

Closes #3814
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where OAuth account linking could create duplicate accounts by ensuring accountId is always compared as a string.

<!-- End of auto-generated description by cubic. -->

