### PR TITLE
feat: allow token url params in generic oauth to be functions

### DIFF
--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -23,7 +23,7 @@ export async function validateAuthorizationCode({
 	tokenEndpoint: string;
 	authentication?: "basic" | "post";
 	headers?: Record<string, string>;
-	additionalParams?: Record<string, string>;
+	additionalParams?: Record<string, string | (() => Promise<string>)>;
 }) {
 	const body = new URLSearchParams();
 	const requestHeaders: Record<string, any> = {
@@ -51,9 +51,17 @@ export async function validateAuthorizationCode({
 		body.set("client_secret", options.clientSecret);
 	}
 
-	for (const [key, value] of Object.entries(additionalParams)) {
+	const entries = await Promise.all(
+		Object.entries(additionalParams).map(async ([key, value]) => {
+			const resolved = typeof value === "function" ? await value() : value;
+			return [key, resolved] as const;
+		}),
+	);
+
+	for (const [key, value] of entries) {
 		if (!body.has(key)) body.append(key, value);
 	}
+
 	const { data, error } = await betterFetch<object>(tokenEndpoint, {
 		method: "POST",
 		body: body,

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -118,7 +118,7 @@ export interface GenericOAuthConfig {
 	 * Additional search-params to add to the tokenUrl.
 	 * Warning: Search-params added here overwrite any default params.
 	 */
-	tokenUrlParams?: Record<string, string>;
+	tokenUrlParams?: Record<string, string | (() => Promise<string>)>;
 	/**
 	 * Disable implicit sign up for new users. When set to true for the provider,
 	 * sign-in need to be called with with requestSignUp as true to create new users.


### PR DESCRIPTION
I ran into problems with while I was integrating with a OAuth server that uses `client_assertion` OAuth instead of the normal `clientId` + `clientSecret` OAuth2 implementation. In `client_assertion` OAuth, the developer is given a PRIVATE_KEY and they are expected to essentially auto-generate a client secret by signing their clientID and the token endpoint they will call using their private key. 

The problem is that the server will expect the newly generated JWT to have an expiration date, so the JWT cannot be generated once and reused; it must be regenerated within some timeframe, but the current `tokenUrlParams` option in Better Auth only accepts static strings; it doesn't allow the user to set a function this PR implements that feature. So the user can add a function to `tokenUrlParams` that will auto-generate the JWT.

Before

```typescript
genericOAuth({
  config: [
    {
      // ....
      tokenUrlParams: {
        client_assertion: await generateSignedJwt(clientId, privateKey),
        client_assertion_type:
          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
      },
    },
  ],
});
```

After

```typescript
genericOAuth({
  config: [
    {
      // ....
      tokenUrlParams: {
        client_assertion: () => await generateSignedJwt(clientId, privateKey),
        client_assertion_type:
          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
      },
    },
  ],
});
```