### PR TITLE
fix/overwrite-only-when-prisma-schema-exists

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -9,7 +9,7 @@ import prompts from "prompts";
 import fs from "fs/promises";
 import chalk from "chalk";
 import { getAdapter } from "better-auth/db";
-import { getGenerator } from "../generators";
+import { generateSchema } from "../generators";
 
 export async function generateAction(opts: any) {
 	const options = z
@@ -45,7 +45,7 @@ export async function generateAction(opts: any) {
 
 	const spinner = yoctoSpinner({ text: "preparing schema..." }).start();
 
-	const schema = await getGenerator({
+	const schema = await generateSchema({
 		adapter,
 		file: options.output,
 		options: config,
@@ -56,7 +56,7 @@ export async function generateAction(opts: any) {
 		logger.info("Your schema is already up to date.");
 		process.exit(0);
 	}
-	if (schema.append || schema.overwrite) {
+	if (schema.overwrite) {
 		let confirm = options.y || options.yes;
 		if (!confirm) {
 			const response = await prompts({

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -15,6 +15,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 	const tables = getAuthTables(options);
 	const filePath = file || "./prisma/schema.prisma";
 	const schemaPrismaExist = existsSync(path.join(process.cwd(), filePath));
+
 	let schemaPrisma = "";
 	if (schemaPrismaExist) {
 		schemaPrisma = await fs.readFile(
@@ -194,10 +195,12 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 		}
 	});
 
+	const schemaChanged = schema.trim() !== schemaPrisma.trim();
+
 	return {
-		code: schema.trim() === schemaPrisma.trim() ? "" : schema,
+		code: schemaChanged ? schema : "",
 		fileName: filePath,
-		overwrite: true,
+		overwrite: schemaPrismaExist && schemaChanged,
 	};
 };
 


### PR DESCRIPTION
This PR fixes a bug in which the overwrite message was being shown even when the prisma schema didn't exist.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where the overwrite confirmation was shown even if the Prisma schema file did not exist.

- **Bug Fixes**
 - Now shows the overwrite message only when the schema file exists and changes are detected.

<!-- End of auto-generated description by cubic. -->

