### PR TITLE
Remove session middleware from Organization Slug Check.

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -5,7 +5,7 @@ import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { APIError } from "better-call";
 import { setSessionCookie } from "../../../cookies";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
-import { getSessionFromCtx, requestOnlySessionMiddleware } from "../../../api";
+import { getSessionFromCtx } from "../../../api";
 import type { OrganizationOptions } from "../types";
 import type {
 	InferInvitation,
@@ -280,7 +280,7 @@ export const checkOrganizationSlug = <O extends OrganizationOptions>(
 					description: 'The organization slug to check. Eg: "my-org"',
 				}),
 			}),
-			use: [requestOnlySessionMiddleware, orgMiddleware],
+			use: [orgMiddleware],
 		},
 		async (ctx) => {
 			const orgAdapter = getOrgAdapter<O>(ctx.context, options);


### PR DESCRIPTION
In some cases we want to create a organization in signup moment, so we need to check the slug availabe and for some reason it's authenticated, but it shouldn't.

Don't have any reason for it be authenticated route once the response is just a boolean.

---

This pull request makes a minor update to the organization routes by removing the unnecessary `requestOnlySessionMiddleware` from the middleware stack in the `checkOrganizationSlug` route. This simplifies the middleware usage and ensures only the required organization middleware is applied.

- Middleware simplification:
  * Removed `requestOnlySessionMiddleware` from the `use` array in the `checkOrganizationSlug` route, leaving only `orgMiddleware` to be used.
  * Cleaned up the import statement to remove the unused `requestOnlySessionMiddleware`.