### PR TITLE
fix(organization): fix convert emails to lower case

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -72,7 +72,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				where: [
 					{
 						field: "email",
-						value: data.email,
+						value: data.email.toLowerCase(),
 					},
 				],
 			});
@@ -861,7 +861,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				where: [
 					{
 						field: "email",
-						value: data.email,
+						value: data.email.toLowerCase(),
 					},
 					{
 						field: "organizationId",


### PR DESCRIPTION
Both the findMemberByEmail and findPendingInvitation functions can accept email addresses that haven't been converted to lowercase. Currently searching for a member or pending invitations with any uppercase characters won't find the appropriate user or invitations.