### PR TITLE
fix: ttl sessions list expiration

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1,17 +1,25 @@
 import { beforeAll, expect, it, describe, vi, afterEach } from "vitest";
-import type { BetterAuthOptions, BetterAuthPlugin } from "../types";
+import type {
+	BetterAuthOptions,
+	BetterAuthPlugin,
+	GenericEndpointContext,
+	Session,
+	User,
+} from "../types";
 import Database from "better-sqlite3";
 import { init } from "../init";
 import { betterAuth } from "../auth";
 import { getMigrations } from "./get-migration";
 import { Kysely, SqliteDialect } from "kysely";
 import { getTestInstance } from "../test-utils/test-instance";
+import { safeJSONParse } from "../utils/json";
 
 describe("adapter test", async () => {
 	const sqliteDialect = new SqliteDialect({
 		database: new Database(":memory:"),
 	});
 	const map = new Map();
+	const expirationMap = new Map();
 	let id = 1;
 	const hookUserCreateBefore = vi.fn();
 	const hookUserCreateAfter = vi.fn();
@@ -31,12 +39,14 @@ describe("adapter test", async () => {
 		secondaryStorage: {
 			set(key, value, ttl) {
 				map.set(key, value);
+				expirationMap.set(key, ttl);
 			},
 			get(key) {
 				return map.get(key);
 			},
 			delete(key) {
 				map.delete(key);
+				expirationMap.delete(key);
 			},
 		},
 		advanced: {
@@ -102,6 +112,7 @@ describe("adapter test", async () => {
 	});
 	afterEach(async () => {
 		vi.clearAllMocks();
+		map.clear();
 	});
 	const ctx = await init(opts);
 	const internalAdapter = ctx.internalAdapter;
@@ -410,5 +421,105 @@ describe("adapter test", async () => {
 		const finalTTL = capturedTTLs.at(-1);
 		expect(finalTTL).toBeLessThanOrEqual(7199);
 		expect(finalTTL).toBeGreaterThanOrEqual(7198); // Allow for test execution time
+	});
+
+	it("should create on secondary storage", async () => {
+		// Create session
+		const now = Date.now();
+		const user = await internalAdapter.createUser(
+			{
+				name: "test-user",
+				email: "test@email.com",
+			},
+			ctx as unknown as GenericEndpointContext,
+		);
+		const session = await internalAdapter.createSession(
+			user.id,
+			ctx as unknown as GenericEndpointContext,
+		);
+		const storedSessions: { token: string; expiresAt: number }[] = JSON.parse(
+			map.get(`active-sessions-${user.id}`),
+		);
+		const token = session.token;
+		// Check stored sessions
+		expect(storedSessions.length).toBe(1);
+		expect(storedSessions.at(0)?.token).toBe(session.token);
+		// Check expiration time set is the last expiration set
+		const lastExpiration = storedSessions.reduce((prev, curr) =>
+			prev.expiresAt >= curr.expiresAt ? prev : curr,
+		);
+		const actualExp = expirationMap.get(`active-sessions-${user.id}`);
+		const expectedExp = Math.floor(
+			(lastExpiration.expiresAt - Date.now()) / 1000,
+		);
+		expect(actualExp - expectedExp).toBeLessThanOrEqual(1); // max 1s clock drift between check and set
+		expect(actualExp - expectedExp).toBeGreaterThanOrEqual(0); // max 1s clock drift between check and set
+
+		const storedSession = safeJSONParse<{
+			session: Session;
+			user: User;
+		}>(map.get(token));
+		expect(storedSession?.user).toMatchObject(user);
+		expect(storedSession?.session).toMatchObject({
+			...session,
+			activeOrganizationId: "1",
+		});
+		expect(expirationMap.get(token)).toBe(60 * 60 * 24 * 7); // 7 days();
+	});
+
+	it("should delete on secondary storage", async () => {
+		// Create multiple sessions in past and future
+		const now = Date.now();
+		const userId = "test-user";
+		// 10 consecutive days (5 in past, 1 now, 4 in future)
+		for (let i = -5; i < 5; i++) {
+			const expiresIn = i * 60 * 60 * 24 * 1000;
+			const expiresAt = new Date(now + expiresIn);
+			await internalAdapter.createSession(
+				userId,
+				ctx as unknown as GenericEndpointContext,
+				undefined,
+				{
+					expiresAt,
+				},
+				true,
+			);
+			if (i > 0) {
+				const actualExp = expirationMap.get(`active-sessions-${userId}`);
+				const expectedExp = Math.floor(
+					(expiresAt.getTime() - Date.now()) / 1000,
+				);
+				expect(actualExp - expectedExp).toBeLessThanOrEqual(1); // max 1s clock drift between check and set
+				expect(actualExp - expectedExp).toBeGreaterThanOrEqual(0); // max 1s clock drift between check and set
+			} else {
+				expect(expirationMap.get(`active-sessions-${userId}`)).toBeUndefined();
+			}
+		}
+		const storedSessions: { token: string; expiresAt: number }[] = JSON.parse(
+			map.get(`active-sessions-${userId}`),
+		);
+		expect(storedSessions.length).toBe(4);
+		const token = storedSessions.at(-1)?.token;
+		const tokenStored = map.get(token);
+		expect(tokenStored).toBeDefined();
+
+		// Delete session should clean expiresAt and token
+		await internalAdapter.deleteSession(token!);
+		const afterDeleted: { token: string; expiresAt: number }[] = JSON.parse(
+			map.get(`active-sessions-${userId}`),
+		);
+		expect(afterDeleted.length).toBe(3);
+		const removedToken = map.get(token);
+		expect(removedToken).toBeUndefined();
+		// Check expiration time set is the last expiration set
+		const lastExpiration = afterDeleted.reduce((prev, curr) =>
+			prev.expiresAt >= curr.expiresAt ? prev : curr,
+		);
+		const actualExp = expirationMap.get(`active-sessions-${userId}`);
+		const expectedExp = Math.floor(
+			(lastExpiration.expiresAt - Date.now()) / 1000,
+		);
+		expect(actualExp - expectedExp).toBeLessThanOrEqual(1); // max 1s clock drift between check and set
+		expect(actualExp - expectedExp).toBeGreaterThanOrEqual(0); // max 1s clock drift between check and set
 	});
 });


### PR DESCRIPTION
- Logic for ttl expiration should mimic existing `expiresAt` sessions list.
- Secondary storage never added token to secondary storage when calling `createSession`

Partial Fix: #4034, #4472 
Additional PR: #4961

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated session list logic to remove expired sessions and set TTL based on the latest session expiration.

<!-- End of auto-generated description by cubic. -->

