### PR TITLE
fix: avoid general oauth flow duplicate user

### DIFF
--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -10,6 +10,14 @@ export interface OAuth2Tokens {
 	idToken?: string;
 }
 
+export type OAuth2UserInfo = {
+	id: string | number;
+	name?: string;
+	email?: string | null;
+	image?: string;
+	emailVerified: boolean;
+};
+
 export interface OAuthProvider<
 	T extends Record<string, any> = Record<string, any>,
 	O extends Record<string, any> = ProviderOptions,
@@ -45,13 +53,7 @@ export interface OAuthProvider<
 			};
 		},
 	) => Promise<{
-		user: {
-			id: string | number;
-			name?: string;
-			email?: string | null;
-			image?: string;
-			emailVerified: boolean;
-		};
+		user: OAuth2UserInfo;
 		data: T;
 	} | null>;
 	/**

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -10,7 +10,8 @@ import { parseSetCookieHeader } from "../../cookies";
 
 let server = new OAuth2Server();
 
-describe("oauth2", async () => {
+// each test suite relies on the same port, so we need to enable sequential execution
+describe.sequential("oauth2", async () => {
 	const providerId = "test";
 	const clientId = "test-client-id";
 	const clientSecret = "test-client-secret";

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -15,7 +15,6 @@ describe("oauth2", async () => {
 	const server = new OAuth2Server();
 	await server.start();
 	const port = Number(server.issuer.url?.split(":")[2]!);
-	console.log("server started on port", port);
 
 	afterAll(async () => {
 		await server.stop();

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -16,7 +16,6 @@ import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import { refreshAccessToken } from "../../oauth2/refresh-access-token";
 import { generateState, parseState } from "../../oauth2/state";
 import type { BetterAuthPlugin } from "../../types";
-import type { UserInfo } from "../../oauth2/types";
 
 /**
  * Configuration interface for generic OAuth providers.
@@ -735,7 +734,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						},
 						account: {
 							providerId: provider.providerId,
-							accountId: String(userInfo.id),
+							accountId: mapUser.id ? String(mapUser.id) : String(userInfo.id),
 							...tokens,
 							scope: tokens.scopes?.join(","),
 						},

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -15,7 +15,7 @@ import {
 import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import { refreshAccessToken } from "../../oauth2/refresh-access-token";
 import { generateState, parseState } from "../../oauth2/state";
-import type { BetterAuthPlugin } from "../../types";
+import type { BetterAuthPlugin, User } from "../../types";
 
 /**
  * Configuration interface for generic OAuth providers.
@@ -94,7 +94,7 @@ export interface GenericOAuthConfig {
 	 */
 	mapProfileToUser?: (
 		profile: Record<string, any>,
-	) => Partial<OAuth2UserInfo> | Promise<Partial<OAuth2UserInfo>>;
+	) => Partial<Partial<User>> | Promise<Partial<User>>;
 	/**
 	 * Additional search-params to add to the authorizationUrl.
 	 * Warning: Search-params added here overwrite any default params.


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/pull/3816#issuecomment-3161748770, 
Upstream: https://github.com/better-auth/better-auth/issues/3814, https://github.com/better-auth/better-auth/issues/2062

Update the general OAuth plugin to support numbers as user.id and reduce any type in the codebaes
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the generic OAuth plugin to support numeric user IDs and prevent duplicate user accounts when OAuth providers return numbers as IDs.

- **Bug Fixes**
  - Ensured all user and account IDs are handled as strings to avoid duplicate accounts.
  - Added tests for numeric user IDs in different OAuth flows.

<!-- End of auto-generated description by cubic. -->

