### PR TITLE
chore: enable `noFloatingPromises` lint rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,8 @@
         "noUnusedImports": "warn"
       },
       "nursery": {
-        "noMisusedPromises": "error"
+        "noMisusedPromises": "error",
+        "noFloatingPromises": "error"
       }
     }
   },

--- a/docs/components/ui/sparkles.tsx
+++ b/docs/components/ui/sparkles.tsx
@@ -42,6 +42,7 @@ export const SparklesCore = (props: ParticlesProps) => {
 	const particlesLoaded = async (container?: Container) => {
 		if (container) {
 			console.log(container);
+			// biome-ignore lint/nursery/noFloatingPromises: add error handling is not important
 			controls.start({
 				opacity: 1,
 				transition: {

--- a/docs/scripts/endpoint-to-doc/index.ts
+++ b/docs/scripts/endpoint-to-doc/index.ts
@@ -485,7 +485,7 @@ function pathToDotNotation(input: string): string {
 		.join(".");
 }
 
-async function playSound(name: string = "Ping") {
+function playSound(name: string = "Ping") {
 	const path = `/System/Library/Sounds/${name}.aiff`;
-	await Bun.$`afplay ${path}`;
+	void Bun.$`afplay ${path}`;
 }

--- a/e2e/integration/package.json
+++ b/e2e/integration/package.json
@@ -3,6 +3,9 @@
   "scripts": {
     "e2e:integration": "playwright test"
   },
+  "dependencies": {
+    "better-auth": "workspace:*"
+  },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
     "terminate": "^2.8.0"

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -98,9 +98,9 @@ async function adapterTest(
 	test.skipIf(disabledTests?.CREATE_MODEL)(
 		`${testPrefix ? `${testPrefix} - ` : ""}${adapterTests.CREATE_MODEL}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).create({
 				model: "user",
@@ -122,9 +122,9 @@ async function adapterTest(
 			adapterTests.CREATE_MODEL_SHOULD_ALWAYS_RETURN_AN_ID
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).create({
 				model: "user",
@@ -141,9 +141,9 @@ async function adapterTest(
 	test.skipIf(disabledTests?.FIND_MODEL)(
 		`${testPrefix ? `${testPrefix} - ` : ""}${adapterTests.FIND_MODEL}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findOne<User>({
 				model: "user",
@@ -169,9 +169,9 @@ async function adapterTest(
 			adapterTests.FIND_MODEL_WITHOUT_ID
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findOne<User>({
 				model: "user",
@@ -197,9 +197,9 @@ async function adapterTest(
 			adapterTests.FIND_MODEL_WITH_MODIFIED_FIELD_NAME
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const email = "test-email-with-modified-field@email.com";
 			const adapter = await getAdapter(
@@ -244,9 +244,9 @@ async function adapterTest(
 			adapterTests.FIND_MODEL_WITH_SELECT
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findOne({
 				model: "user",
@@ -265,9 +265,9 @@ async function adapterTest(
 	test.skipIf(disabledTests?.UPDATE_MODEL)(
 		`${testPrefix ? `${testPrefix} - ` : ""}${adapterTests.UPDATE_MODEL}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const newEmail = "updated@email.com";
 
@@ -293,9 +293,9 @@ async function adapterTest(
 	test.skipIf(disabledTests?.SHOULD_FIND_MANY)(
 		`${testPrefix ? `${testPrefix} - ` : ""}${adapterTests.SHOULD_FIND_MANY}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findMany({
 				model: "user",
@@ -309,9 +309,9 @@ async function adapterTest(
 			adapterTests.SHOULD_FIND_MANY_WITH_WHERE
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const user = await (await adapter()).create<User>({
 				model: "user",
@@ -341,9 +341,9 @@ async function adapterTest(
 			adapterTests.SHOULD_FIND_MANY_WITH_OPERATORS
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const newUser = await (await adapter()).create<User>({
 				model: "user",
@@ -374,9 +374,9 @@ async function adapterTest(
 			adapterTests.SHOULD_WORK_WITH_REFERENCE_FIELDS
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			let token = null;
 			const user = await (await adapter()).create<Record<string, any>>({
@@ -432,9 +432,9 @@ async function adapterTest(
 			adapterTests.SHOULD_FIND_MANY_WITH_SORT_BY
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			await (await adapter()).create({
 				model: "user",
@@ -472,9 +472,9 @@ async function adapterTest(
 			adapterTests.SHOULD_FIND_MANY_WITH_LIMIT
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findMany({
 				model: "user",
@@ -489,9 +489,9 @@ async function adapterTest(
 			adapterTests.SHOULD_FIND_MANY_WITH_OFFSET
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findMany({
 				model: "user",
@@ -506,9 +506,9 @@ async function adapterTest(
 			adapterTests.SHOULD_UPDATE_WITH_MULTIPLE_WHERE
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			await (await adapter()).updateMany({
 				model: "user",
@@ -545,9 +545,9 @@ async function adapterTest(
 	test.skipIf(disabledTests?.DELETE_MODEL)(
 		`${testPrefix ? `${testPrefix} - ` : ""}${adapterTests.DELETE_MODEL}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			await (await adapter()).delete({
 				model: "user",
@@ -574,9 +574,9 @@ async function adapterTest(
 	test.skipIf(disabledTests?.SHOULD_DELETE_MANY)(
 		`${testPrefix ? `${testPrefix} - ` : ""}${adapterTests.SHOULD_DELETE_MANY}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			for (const i of ["to-be-delete-1", "to-be-delete-2", "to-be-delete-3"]) {
 				await (await adapter()).create({
@@ -627,9 +627,9 @@ async function adapterTest(
 			adapterTests.SHOULD_NOT_THROW_ON_DELETE_RECORD_NOT_FOUND
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			await (await adapter()).delete({
 				model: "user",
@@ -648,9 +648,9 @@ async function adapterTest(
 			adapterTests.SHOULD_NOT_THROW_ON_RECORD_NOT_FOUND
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findOne({
 				model: "user",
@@ -670,9 +670,9 @@ async function adapterTest(
 			adapterTests.SHOULD_FIND_MANY_WITH_CONTAINS_OPERATOR
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findMany({
 				model: "user",
@@ -693,9 +693,9 @@ async function adapterTest(
 			adapterTests.SHOULD_SEARCH_USERS_WITH_STARTS_WITH
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findMany({
 				model: "user",
@@ -716,9 +716,9 @@ async function adapterTest(
 			adapterTests.SHOULD_SEARCH_USERS_WITH_ENDS_WITH
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const res = await (await adapter()).findMany({
 				model: "user",
@@ -739,9 +739,9 @@ async function adapterTest(
 			adapterTests.SHOULD_PREFER_GENERATE_ID_IF_PROVIDED
 		}`,
 		async ({ onTestFailed }) => {
-			resetDebugLogs();
-			onTestFailed(() => {
-				printDebugLogs();
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
 			});
 			const customAdapter = await getAdapter(
 				Object.assign(
@@ -803,9 +803,9 @@ export async function runNumberIdAdapterTest(opts: NumberIdAdapterTestOptions) {
 				numberIdAdapterTests.SHOULD_RETURN_A_NUMBER_ID_AS_A_RESULT
 			}`,
 			async ({ onTestFailed }) => {
-				resetDebugLogs();
-				onTestFailed(() => {
-					printDebugLogs();
+				await resetDebugLogs();
+				onTestFailed(async () => {
+					await printDebugLogs();
 				});
 				const res = await (await adapter()).create({
 					model: "user",
@@ -825,10 +825,10 @@ export async function runNumberIdAdapterTest(opts: NumberIdAdapterTestOptions) {
 				numberIdAdapterTests.SHOULD_INCREMENT_THE_ID_BY_1
 			}`,
 			async ({ onTestFailed }) => {
-				resetDebugLogs();
-				onTestFailed(() => {
+				await resetDebugLogs();
+				onTestFailed(async () => {
 					console.log(`ID number from last create: ${idNumber}`);
-					printDebugLogs();
+					await printDebugLogs();
 				});
 				const res = await (await adapter()).create({
 					model: "user",

--- a/packages/better-auth/src/client/query.ts
+++ b/packages/better-auth/src/client/query.ts
@@ -107,10 +107,12 @@ export const useAuthQuery = <T>(
 				return;
 			}
 			if (isMounted) {
+				// biome-ignore lint/nursery/noFloatingPromises: find a way to handle this in the future
 				fn();
 			} else {
 				onMount(value, () => {
 					setTimeout(() => {
+						// biome-ignore lint/nursery/noFloatingPromises: find a way to handle this in the future
 						fn();
 					}, 0);
 					isMounted = true;

--- a/packages/better-auth/src/client/query.ts
+++ b/packages/better-auth/src/client/query.ts
@@ -49,7 +49,7 @@ export const useAuthQuery = <T>(
 					})
 				: options;
 
-		return $fetch<T>(path, {
+		$fetch<T>(path, {
 			...opts,
 			query: {
 				...opts?.query,
@@ -93,6 +93,14 @@ export const useAuthQuery = <T>(
 				});
 				await opts?.onRequest?.(context);
 			},
+		}).catch((error) => {
+			value.set({
+				error,
+				data: null,
+				isPending: false,
+				isRefetching: false,
+				refetch: value.value.refetch,
+			});
 		});
 	};
 	initializedAtom = Array.isArray(initializedAtom)
@@ -107,12 +115,10 @@ export const useAuthQuery = <T>(
 				return;
 			}
 			if (isMounted) {
-				// biome-ignore lint/nursery/noFloatingPromises: find a way to handle this in the future
 				fn();
 			} else {
 				onMount(value, () => {
 					setTimeout(() => {
-						// biome-ignore lint/nursery/noFloatingPromises: find a way to handle this in the future
 						fn();
 					}, 0);
 					isMounted = true;

--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -176,7 +176,12 @@ export const apiKey = (options?: ApiKeyOptions) => {
 						});
 
 						//for cleanup purposes
-						deleteAllExpiredApiKeys(ctx.context);
+						deleteAllExpiredApiKeys(ctx.context).catch((err) => {
+							ctx.context.logger.error(
+								"Failed to delete expired API keys:",
+								err,
+							);
+						});
 
 						const user = await ctx.context.internalAdapter.findUserById(
 							apiKey.userId,

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -371,7 +371,11 @@ export function createApiKey({
 				});
 			}
 
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
+				throw new APIError("INTERNAL_SERVER_ERROR", {
+					message: `Failed to delete expired API keys: ${error.message}`,
+				});
+			});
 
 			const key = await keyGenerator({
 				length: opts.defaultKeyLength,

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -24,7 +24,7 @@ export function createApiKey({
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
 		byPassLastCheckTime?: boolean,
-	): Promise<number> | undefined;
+	): void;
 }) {
 	return createAuthEndpoint(
 		"/api-key/create",
@@ -371,11 +371,7 @@ export function createApiKey({
 				});
 			}
 
-			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
-				throw new APIError("INTERNAL_SERVER_ERROR", {
-					message: `Failed to delete expired API keys: ${error.message}`,
-				});
-			});
+			deleteAllExpiredApiKeys(ctx.context);
 
 			const key = await keyGenerator({
 				length: opts.defaultKeyLength,

--- a/packages/better-auth/src/plugins/api-key/routes/delete-all-expired-api-keys.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/delete-all-expired-api-keys.ts
@@ -7,7 +7,7 @@ export function deleteAllExpiredApiKeysEndpoint({
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
 		byPassLastCheckTime?: boolean,
-	): Promise<number> | undefined;
+	): Promise<void>;
 }) {
 	return createAuthEndpoint(
 		"/api-key/delete-all-expired-api-keys",

--- a/packages/better-auth/src/plugins/api-key/routes/delete-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/delete-api-key.ts
@@ -109,7 +109,11 @@ export function deleteApiKey({
 					message: error?.message,
 				});
 			}
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
+				throw new APIError("INTERNAL_SERVER_ERROR", {
+					message: `Failed to delete expired API keys: ${error.message}`,
+				});
+			});
 			return ctx.json({
 				success: true,
 			});

--- a/packages/better-auth/src/plugins/api-key/routes/delete-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/delete-api-key.ts
@@ -16,7 +16,7 @@ export function deleteApiKey({
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
 		byPassLastCheckTime?: boolean,
-	): Promise<number> | undefined;
+	): void;
 }) {
 	return createAuthEndpoint(
 		"/api-key/delete",
@@ -109,11 +109,7 @@ export function deleteApiKey({
 					message: error?.message,
 				});
 			}
-			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
-				throw new APIError("INTERNAL_SERVER_ERROR", {
-					message: `Failed to delete expired API keys: ${error.message}`,
-				});
-			});
+			deleteAllExpiredApiKeys(ctx.context);
 			return ctx.json({
 				success: true,
 			});

--- a/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
@@ -191,7 +191,11 @@ export function getApiKey({
 				});
 			}
 
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
+				throw new APIError("INTERNAL_SERVER_ERROR", {
+					message: `Failed to delete expired API keys: ${error.message}`,
+				});
+			});
 
 			// convert metadata string back to object
 			apiKey.metadata = schema.apikey.fields.metadata.transform.output(

--- a/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
@@ -17,7 +17,7 @@ export function getApiKey({
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
 		byPassLastCheckTime?: boolean,
-	): Promise<number> | undefined;
+	): void;
 }) {
 	return createAuthEndpoint(
 		"/api-key/get",
@@ -191,11 +191,7 @@ export function getApiKey({
 				});
 			}
 
-			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
-				throw new APIError("INTERNAL_SERVER_ERROR", {
-					message: `Failed to delete expired API keys: ${error.message}`,
-				});
-			});
+			deleteAllExpiredApiKeys(ctx.context);
 
 			// convert metadata string back to object
 			apiKey.metadata = schema.apikey.fields.metadata.transform.output(

--- a/packages/better-auth/src/plugins/api-key/routes/index.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/index.ts
@@ -37,10 +37,10 @@ export type PredefinedApiKeyOptions = ApiKeyOptions &
 
 let lastChecked: Date | null = null;
 
-export function deleteAllExpiredApiKeys(
+export async function deleteAllExpiredApiKeys(
 	ctx: AuthContext,
 	byPassLastCheckTime = false,
-) {
+): Promise<void> {
 	if (lastChecked && !byPassLastCheckTime) {
 		const now = new Date();
 		const diff = now.getTime() - lastChecked.getTime();
@@ -49,8 +49,8 @@ export function deleteAllExpiredApiKeys(
 		}
 	}
 	lastChecked = new Date();
-	try {
-		return ctx.adapter.deleteMany({
+	await ctx.adapter
+		.deleteMany({
 			model: API_KEY_TABLE_NAME,
 			where: [
 				{
@@ -64,10 +64,10 @@ export function deleteAllExpiredApiKeys(
 					value: null,
 				},
 			],
+		})
+		.catch((error) => {
+			ctx.logger.error(`Failed to delete expired API keys:`, error);
 		});
-	} catch (error) {
-		ctx.logger.error(`Failed to delete expired API keys:`, error);
-	}
 }
 
 export function createApiKeyRoutes({

--- a/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
@@ -1,4 +1,4 @@
-import { createAuthEndpoint, sessionMiddleware } from "../../../api";
+import { APIError, createAuthEndpoint, sessionMiddleware } from "../../../api";
 import type { apiKeySchema } from "../schema";
 import type { ApiKey } from "../types";
 import type { AuthContext } from "../../../types";
@@ -174,7 +174,11 @@ export function listApiKeys({
 				],
 			});
 
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
+				throw new APIError("INTERNAL_SERVER_ERROR", {
+					message: `Failed to delete expired API keys: ${error.message}`,
+				});
+			});
 			apiKeys = apiKeys.map((apiKey) => {
 				return {
 					...apiKey,

--- a/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
@@ -15,7 +15,7 @@ export function listApiKeys({
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
 		byPassLastCheckTime?: boolean,
-	): Promise<number> | undefined;
+	): void;
 }) {
 	return createAuthEndpoint(
 		"/api-key/list",
@@ -174,11 +174,7 @@ export function listApiKeys({
 				],
 			});
 
-			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
-				throw new APIError("INTERNAL_SERVER_ERROR", {
-					message: `Failed to delete expired API keys: ${error.message}`,
-				});
-			});
+			deleteAllExpiredApiKeys(ctx.context);
 			apiKeys = apiKeys.map((apiKey) => {
 				return {
 					...apiKey,

--- a/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
@@ -416,7 +416,11 @@ export function updateApiKey({
 				});
 			}
 
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
+				throw new APIError("INTERNAL_SERVER_ERROR", {
+					message: `Failed to delete expired API keys: ${error.message}`,
+				});
+			});
 
 			// transform metadata from string back to object
 			newApiKey.metadata = schema.apikey.fields.metadata.transform.output(

--- a/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
@@ -18,7 +18,7 @@ export function updateApiKey({
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
 		byPassLastCheckTime?: boolean,
-	): Promise<number> | undefined;
+	): void;
 }) {
 	return createAuthEndpoint(
 		"/api-key/update",
@@ -416,11 +416,7 @@ export function updateApiKey({
 				});
 			}
 
-			deleteAllExpiredApiKeys(ctx.context)?.catch((error) => {
-				throw new APIError("INTERNAL_SERVER_ERROR", {
-					message: `Failed to delete expired API keys: ${error.message}`,
-				});
-			});
+			deleteAllExpiredApiKeys(ctx.context);
 
 			// transform metadata from string back to object
 			newApiKey.metadata = schema.apikey.fields.metadata.transform.output(

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -9,6 +9,7 @@ import type { PredefinedApiKeyOptions } from ".";
 import { safeJSONParse } from "../../../utils/json";
 import { role } from "../../access";
 import { defaultKeyHasher } from "../";
+import { createApiKey } from "./create-api-key";
 
 export async function validateApiKey({
 	hashedKey,
@@ -191,7 +192,7 @@ export function verifyApiKey({
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
 		byPassLastCheckTime?: boolean,
-	): Promise<number> | undefined;
+	): void;
 }) {
 	return createAuthEndpoint(
 		"/api-key/verify",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,4 +39,7 @@ async function main() {
 	program.parse();
 }
 
-main();
+main().catch((error) => {
+	console.error("Error running Better Auth CLI:", error);
+	process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,6 +556,10 @@ importers:
         version: 5.9.2
 
   e2e/integration:
+    dependencies:
+      better-auth:
+        specifier: workspace:*
+        version: link:../../packages/better-auth
     devDependencies:
       '@playwright/test':
         specifier: ^1.55.0


### PR DESCRIPTION
Upstream comment: https://github.com/better-auth/better-auth/pull/3822#discussion_r2258508346
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enabled the `noFloatingPromises` lint rule to catch unhandled promise rejections and updated codebase to handle or explicitly ignore floating promises.

- **Refactors**
  - Added error handling or lint ignores for floating promises in API key routes, CLI entrypoint, and UI components.
  - Updated tests and utility functions to await or handle async calls as needed.

<!-- End of auto-generated description by cubic. -->

