### PR TITLE
fix: client id is unused for TikTok social provider

### DIFF
--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -29,9 +29,13 @@ export async function refreshAccessToken({
 	// Use standard Base64 encoding for HTTP Basic Auth (OAuth2 spec, RFC 7617)
 	// Fixes compatibility with providers like Notion, Twitter, etc.
 	if (authentication === "basic") {
-		headers["authorization"] = base64.encode(
-			`${options.clientId}:${options.clientSecret ?? ""}`,
-		);
+		if (options.clientId) {
+			headers["authorization"] = base64.encode(
+				`${options.clientId}:${options.clientSecret ?? ""}`,
+			);
+		} else {
+			headers["authorization"] = base64.encode(`${options.clientSecret ?? ""}`);
+		}
 	} else {
 		options.clientId && body.set("client_id", options.clientId);
 		if (options.clientSecret) {

--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -12,7 +12,7 @@ export async function refreshAccessToken({
 	grantType = "refresh_token",
 }: {
 	refreshToken: string;
-	options: ProviderOptions;
+	options: Partial<ProviderOptions>;
 	tokenEndpoint: string;
 	authentication?: "basic" | "post";
 	extraParams?: Record<string, string>;
@@ -33,7 +33,7 @@ export async function refreshAccessToken({
 			`${options.clientId}:${options.clientSecret ?? ""}`,
 		);
 	} else {
-		body.set("client_id", options.clientId);
+		options.clientId && body.set("client_id", options.clientId);
 		if (options.clientSecret) {
 			body.set("client_secret", options.clientSecret);
 		}

--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -12,6 +12,7 @@ export interface OAuth2Tokens {
 
 export interface OAuthProvider<
 	T extends Record<string, any> = Record<string, any>,
+	O extends Record<string, any> = ProviderOptions,
 > {
 	id: LiteralString;
 	createAuthorizationURL: (data: {
@@ -74,7 +75,10 @@ export interface OAuthProvider<
 	 * Disable sign up for new users.
 	 */
 	disableSignUp?: boolean;
-	options?: ProviderOptions;
+	/**
+	 * Options for the provider
+	 */
+	options?: O;
 }
 
 export type ProviderOptions<Profile extends Record<string, any> = any> = {

--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -17,7 +17,7 @@ export async function validateAuthorizationCode({
 }: {
 	code: string;
 	redirectURI: string;
-	options: ProviderOptions;
+	options: Partial<ProviderOptions>;
 	codeVerifier?: string;
 	deviceId?: string;
 	tokenEndpoint: string;
@@ -39,7 +39,7 @@ export async function validateAuthorizationCode({
 	deviceId && body.set("device_id", deviceId);
 	body.set("redirect_uri", options.redirectURI || redirectURI);
 	// for resolving the issue with some oauth server.
-	body.set("client_id", options.clientId);
+	options.clientId && body.set("client_id", options.clientId);
 	// Use standard Base64 encoding for HTTP Basic Auth (OAuth2 spec, RFC 7617)
 	// Fixes compatibility with providers like Notion, Twitter, etc.
 	if (authentication === "basic") {

--- a/packages/better-auth/src/social-providers/tiktok.ts
+++ b/packages/better-auth/src/social-providers/tiktok.ts
@@ -117,7 +117,13 @@ export interface TiktokProfile extends Record<string, any> {
 	};
 }
 
-export interface TiktokOptions extends ProviderOptions {}
+export interface TiktokOptions
+	extends Omit<ProviderOptions, "clientId" | "clientSecret" | "clientKey"> {
+	// Client ID is not used in TikTok, we delete it from the options
+	clientId: never;
+	clientSecret: string;
+	clientKey: string;
+}
 
 export const tiktok = (options: TiktokOptions) => {
 	return {
@@ -152,7 +158,6 @@ export const tiktok = (options: TiktokOptions) => {
 					return refreshAccessToken({
 						refreshToken,
 						options: {
-							clientId: options.clientId,
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
@@ -196,5 +201,5 @@ export const tiktok = (options: TiktokOptions) => {
 			};
 		},
 		options,
-	} satisfies OAuthProvider<TiktokProfile>;
+	} satisfies OAuthProvider<TiktokProfile, TiktokOptions>;
 };


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/3828
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the unused clientId field from the TikTok social provider to match TikTok's requirements and prevent configuration errors.

- **Bug Fixes**
  - Updated TikTok provider options to exclude clientId.
  - Adjusted related OAuth2 functions to handle providers without clientId.

<!-- End of auto-generated description by cubic. -->

