### PR TITLE
fix(docs): Remove unused import of 'auth' type in authClient setup

### DIFF
--- a/docs/content/docs/concepts/typescript.mdx
+++ b/docs/content/docs/concepts/typescript.mdx
@@ -132,7 +132,6 @@ export const authClient = createAuthClient({
 If your client and server are in separate projects, you'll need to manually specify the additional fields when creating the auth client.
 
 ```ts
-import type { auth } from "./auth";
 import { inferAdditionalFields } from "better-auth/client/plugins";
 
 export const authClient = createAuthClient({


### PR DESCRIPTION
In the previous implementation, the import statement for 'auth' type from './auth' was included as part of the setup for the authClient, but it is no longer being used in the current code. This update removes the unnecessary import to clean up the code and prevent potential confusion.

Additionally, the authClient setup remains intact with the use of 'inferAdditionalFields' plugin to define additional user fields (role type set to 'string').

- Removed unused import: `import type { auth } from "./auth"`
- Kept the authClient initialization with 'inferAdditionalFields' plugin

This resolves a minor issue and ensures that the code remains clean and maintainable.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed an unused import of the 'auth' type from the authClient setup example in the TypeScript docs to keep the code clean.

<!-- End of auto-generated description by cubic. -->

