### PR TITLE
feat: add query parameter to useSession().refetch() for cache control consistency

### DIFF
--- a/packages/better-auth/src/client/client.test.ts
+++ b/packages/better-auth/src/client/client.test.ts
@@ -306,4 +306,23 @@ describe("type", () => {
 			} | null>
 		>();
 	});
+	it("should support refetch with query parameters", () => {
+		const client = createReactClient({
+			plugins: [testClientPlugin()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					return new Response();
+				},
+			},
+		});
+
+		type UseSessionReturn = ReturnType<typeof client.useSession>;
+		expectTypeOf<UseSessionReturn>().toMatchTypeOf<{
+			data: any;
+			isPending: boolean;
+			error: BetterFetchError | null;
+			refetch: (queryParams?: { query?: Record<string, any> }) => void;
+		}>();
+	});
 });

--- a/packages/better-auth/src/client/query.ts
+++ b/packages/better-auth/src/client/query.ts
@@ -27,18 +27,18 @@ export const useAuthQuery = <T>(
 		error: null | BetterFetchError;
 		isPending: boolean;
 		isRefetching: boolean;
-		refetch: () => void;
+		refetch: (queryParams?: { query?: Record<string, any> }) => void;
 	}>({
 		data: null,
 		error: null,
 		isPending: true,
 		isRefetching: false,
-		refetch: () => {
-			return fn();
+		refetch: (queryParams?: { query?: Record<string, any> }) => {
+			return fn(queryParams);
 		},
 	});
 
-	const fn = () => {
+	const fn = (queryParams?: { query?: Record<string, any> }) => {
 		const opts =
 			typeof options === "function"
 				? options({
@@ -50,6 +50,10 @@ export const useAuthQuery = <T>(
 
 		return $fetch<T>(path, {
 			...opts,
+			query: {
+				...opts?.query,
+				...queryParams?.query,
+			},
 			async onSuccess(context) {
 				value.set({
 					data: context.data,

--- a/packages/better-auth/src/client/react/index.ts
+++ b/packages/better-auth/src/client/react/index.ts
@@ -87,7 +87,7 @@ export function createAuthClient<Option extends ClientOptions>(
 				data: Session;
 				isPending: boolean;
 				error: BetterFetchError | null;
-				refetch: () => void;
+				refetch: (queryParams?: { query?: Record<string, any> }) => void;
 			};
 			$Infer: {
 				Session: NonNullable<Session>;


### PR DESCRIPTION
Closes #3889

This PR adds query parameter (`disableCookieCache` and `disableRefresh`) to `useSession().refetch()` for consistency with `getSession()`. 

Currently, `getSession()` supports query parameters like `{ disableCookieCache: true }`, but `useSession().refetch()` doesn't, creating an inconsistent API where developers need to import both methods.

Now you can use:

```ts
const { refetch } = useSession();
await refetch({ query: { disableCookieCache: true }});
```