### PR TITLE
Google Auth Prompt Fix 

### DIFF
--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -122,7 +122,7 @@ socialProviders: {
         clientId: process.env.GOOGLE_CLIENT_ID as string,
         clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
         accessType: "offline", // [!code highlight]
-        prompt: "select_account+consent", // [!code highlight]
+        prompt: "select_account consent", // [!code highlight]
     },
 }
 ```


### PR DESCRIPTION
Google OAuth2 Uses Space Delimiters instead of +

https://developers.google.com/identity/protocols/oauth2/web-server