### PR TITLE
update(create-adapter): Fix bug, improve maintainability & testability (v2)

### DIFF
--- a/packages/better-auth/src/adapters/create-adapter/debug-logs.ts
+++ b/packages/better-auth/src/adapters/create-adapter/debug-logs.ts
@@ -1,0 +1,68 @@
+import { logger } from "../../utils";
+import type { AdapterConfig } from "./types";
+
+export const initDebugLogs = ({
+	config,
+	debugLogs,
+}: {
+	config: AdapterConfig;
+	debugLogs: any[];
+}) => {
+	return (...args: any[]) => {
+		if (config.debugLogs === true || typeof config.debugLogs === "object") {
+			// If we're running adapter tests, we'll keep debug logs in memory, then print them out if a test fails.
+			if (
+				typeof config.debugLogs === "object" &&
+				"isRunningAdapterTests" in config.debugLogs
+			) {
+				if (config.debugLogs.isRunningAdapterTests) {
+					args.shift(); // Removes the {method: "..."} object from the args array.
+					debugLogs.push(args);
+				}
+				return;
+			}
+			if (
+				typeof config.debugLogs === "object" &&
+				config.debugLogs.logCondition &&
+				!config.debugLogs.logCondition()
+			) {
+				return;
+			}
+			if (typeof args[0] === "object" && "method" in args[0]) {
+				const method = args.shift().method;
+				// Make sure the method is enabled in the config.
+				if (typeof config.debugLogs === "object") {
+					// If any one of these combinations are false, we don't want to log anything.
+					if (method === "create" && !config.debugLogs.create) {
+						return;
+					}
+					if (method === "update" && !config.debugLogs.update) {
+						return;
+					}
+					if (method === "updateMany" && !config.debugLogs.updateMany) {
+						return;
+					}
+					if (method === "findOne" && !config.debugLogs.findOne) {
+						return;
+					}
+					if (method === "findMany" && !config.debugLogs.findMany) {
+						return;
+					}
+					if (method === "delete" && !config.debugLogs.delete) {
+						return;
+					}
+					if (method === "deleteMany" && !config.debugLogs.deleteMany) {
+						return;
+					}
+					if (method === "count" && !config.debugLogs.count) {
+						return;
+					}
+				}
+				logger.info(`[${config.adapterName}]`, ...args);
+				return;
+			}
+
+			logger.info(`[${config.adapterName}]`, ...args);
+		}
+	};
+};

--- a/packages/better-auth/src/adapters/create-adapter/get-default-field-name.ts
+++ b/packages/better-auth/src/adapters/create-adapter/get-default-field-name.ts
@@ -1,0 +1,53 @@
+import type { BetterAuthDbSchema } from "../../db";
+
+export const initGetDefaultFieldName = ({
+	schema,
+	debugLog,
+	getDefaultModelName,
+}: {
+	schema: BetterAuthDbSchema;
+	getDefaultModelName: (model: string) => string;
+	debugLog: (...args: any[]) => void;
+}) => {
+	/**
+	 * This function helps us get the default field name from the schema defined by devs.
+	 * Often times, the user will be using the `fieldName` which could had been customized by the users.
+	 * This function helps us get the actual field name useful to match against the schema. (eg: schema[model].fields[field])
+	 *
+	 * If it's still unclear what this does:
+	 *
+	 * 1. User can define a custom fieldName.
+	 * 2. When using a custom fieldName, doing something like `schema[model].fields[field]` will not work.
+	 */
+	const getDefaultFieldName = ({
+		field,
+		model: unsafe_model,
+	}: {
+		model: string;
+		field: string;
+	}) => {
+		// Plugin `schema`s can't define their own `id`. Better-auth auto provides `id` to every schema model.
+		// Given this, we can't just check if the `field` (that being `id`) is within the schema's fields, since it is never defined.
+		// So we check if the `field` is `id` and if so, we return `id` itself. Otherwise, we return the `field` from the schema.
+		// TODO: We need to improve custom `id` support and remove this.
+		if (field === "id" || field === "_id") {
+			return "id";
+		}
+		const model = getDefaultModelName(unsafe_model); // Just to make sure the model name is correct.
+
+		let f = schema[model]?.fields[field];
+		if (!f) {
+			f = Object.values(schema[model]?.fields ?? {}).find(
+				(f) => f.fieldName === field,
+			)!;
+		}
+		if (!f) {
+			debugLog(`Field ${field} not found in model ${model}`);
+			debugLog(`Schema:`, schema);
+			throw new Error(`Field ${field} not found in model ${model}`);
+		}
+		return field;
+	};
+
+	return getDefaultFieldName;
+};

--- a/packages/better-auth/src/adapters/create-adapter/get-default-model-name.ts
+++ b/packages/better-auth/src/adapters/create-adapter/get-default-model-name.ts
@@ -1,0 +1,54 @@
+import type { BetterAuthDbSchema } from "../../db";
+import type { AdapterConfig } from "./types";
+
+export const initGetDefaultModelName = ({
+	config,
+	debugLog,
+	schema,
+}: {
+	config: AdapterConfig;
+	debugLog: (...args: any[]) => void;
+	schema: BetterAuthDbSchema;
+}) => {
+	/**
+	 * This function helps us get the default model name from the schema defined by devs.
+	 * Often times, the user will be using the `modelName` which could had been customized by the users.
+	 * This function helps us get the actual model name useful to match against the schema. (eg: schema[model])
+	 *
+	 * If it's still unclear what this does:
+	 *
+	 * 1. User can define a custom modelName.
+	 * 2. When using a custom modelName, doing something like `schema[model]` will not work.
+	 * 3. Using this function helps us get the actual model name based on the user's defined custom modelName.
+	 */
+	const getDefaultModelName = (model: string) => {
+		// It's possible this `model` could had applied `usePlural`.
+		// Thus we'll try the search but without the trailing `s`.
+		if (config.usePlural && model.charAt(model.length - 1) === "s") {
+			let pluralessModel = model.slice(0, -1);
+			let m = schema[pluralessModel] ? pluralessModel : undefined;
+			if (!m) {
+				m = Object.entries(schema).find(
+					([_, f]) => f.modelName === pluralessModel,
+				)?.[0];
+			}
+
+			if (m) {
+				return m;
+			}
+		}
+
+		let m = schema[model] ? model : undefined;
+		if (!m) {
+			m = Object.entries(schema).find(([_, f]) => f.modelName === model)?.[0];
+		}
+
+		if (!m) {
+			debugLog(`Model "${model}" not found in schema`);
+			debugLog(`Schema:`, schema);
+			throw new Error(`Model "${model}" not found in schema`);
+		}
+		return m;
+	};
+	return getDefaultModelName;
+};

--- a/packages/better-auth/src/adapters/create-adapter/get-field-attributes.ts
+++ b/packages/better-auth/src/adapters/create-adapter/get-field-attributes.ts
@@ -1,0 +1,32 @@
+import type { BetterAuthDbSchema } from "../../db";
+import type { IdField } from "./types";
+
+export const initGetFieldAttributes = ({
+	getDefaultFieldName,
+	getDefaultModelName,
+	idField,
+	schema,
+}: {
+	getDefaultModelName: (model: string) => string;
+	getDefaultFieldName: ({
+		model,
+		field,
+	}: {
+		model: string;
+		field: string;
+	}) => string;
+	schema: BetterAuthDbSchema;
+	idField: IdField;
+}) => {
+	return ({ model, field }: { model: string; field: string }) => {
+		const defaultModelName = getDefaultModelName(model);
+		const defaultFieldName = getDefaultFieldName({
+			field: field,
+			model: model,
+		});
+
+		const fields = schema[defaultModelName].fields;
+		fields.id = idField({ customModelName: defaultModelName });
+		return fields[defaultFieldName];
+	};
+};

--- a/packages/better-auth/src/adapters/create-adapter/get-field-name.ts
+++ b/packages/better-auth/src/adapters/create-adapter/get-field-name.ts
@@ -1,0 +1,39 @@
+import type { BetterAuthDbSchema } from "../../db";
+
+export const initGetFieldName = ({
+	getDefaultFieldName,
+	getDefaultModelName,
+	schema,
+}: {
+	getDefaultModelName: (model: string) => string;
+	getDefaultFieldName: ({
+		model,
+		field,
+	}: {
+		model: string;
+		field: string;
+	}) => string;
+	schema: BetterAuthDbSchema;
+}) => {
+	/**
+	 * Get the field name which is expected to be saved in the database based on the user's schema.
+	 *
+	 * This function is useful if you need to save the field name to the database.
+	 *
+	 * For example, if the user has defined a custom field name for the `user` model, then you can use this function to get the actual field name from the schema.
+	 */
+	function getFieldName({
+		model: model_name,
+		field: field_name,
+	}: {
+		model: string;
+		field: string;
+	}) {
+		const model = getDefaultModelName(model_name);
+		const field = getDefaultFieldName({ model, field: field_name });
+
+		return schema[model]?.fields[field]?.fieldName || field;
+	}
+
+	return getFieldName;
+};

--- a/packages/better-auth/src/adapters/create-adapter/get-model-name.ts
+++ b/packages/better-auth/src/adapters/create-adapter/get-model-name.ts
@@ -1,0 +1,36 @@
+import type { BetterAuthDbSchema } from "../../db";
+import type { AdapterConfig } from "./types";
+
+export const initGetModelName = ({
+	config,
+	getDefaultModelName,
+	schema,
+}: {
+	config: AdapterConfig;
+	getDefaultModelName: (model: string) => string;
+	schema: BetterAuthDbSchema;
+}) => {
+	/**
+	 * Users can overwrite the default model of some tables. This function helps find the correct model name.
+	 * Furthermore, if the user passes `usePlural` as true in their adapter config,
+	 * then we should return the model name ending with an `s`.
+	 */
+	const getModelName = (model: string) => {
+		const defaultModelKey = getDefaultModelName(model);
+		const usePlural = config && config.usePlural;
+		const useCustomModelName =
+			schema &&
+			schema[defaultModelKey] &&
+			schema[defaultModelKey].modelName !== model;
+
+		if (useCustomModelName) {
+			return usePlural
+				? `${schema[defaultModelKey].modelName}s`
+				: schema[defaultModelKey].modelName;
+		}
+
+		return usePlural ? `${model}s` : model;
+	};
+
+	return getModelName;
+};

--- a/packages/better-auth/src/adapters/create-adapter/id-field.ts
+++ b/packages/better-auth/src/adapters/create-adapter/id-field.ts
@@ -1,0 +1,60 @@
+import type { BetterAuthOptions } from "../../types";
+import type { FieldAttribute } from "../../db";
+import { logger } from "../../utils";
+import type { AdapterConfig, IdField } from "./types";
+import { generateId as defaultGenerateId } from "../../utils";
+
+export const initIdField = ({
+	config,
+	options,
+	getDefaultModelName,
+}: {
+	config: AdapterConfig;
+	options: BetterAuthOptions;
+	getDefaultModelName: (modelName: string) => string;
+}): IdField => {
+	return ({
+		customModelName,
+		forceAllowId,
+	}: {
+		customModelName?: string;
+		forceAllowId?: boolean;
+	}) => {
+		const shouldGenerateId =
+			!config.disableIdGeneration &&
+			!options.advanced?.database?.useNumberId &&
+			!forceAllowId;
+
+		const model = getDefaultModelName(customModelName ?? "id");
+
+		const defaultValue = () => {
+			if (config.disableIdGeneration) return undefined;
+			const useNumberId = options.advanced?.database?.useNumberId;
+			let generateId = options.advanced?.database?.generateId;
+			if (options.advanced?.generateId !== undefined) {
+				logger.warn(
+					"Your Better Auth config includes advanced.generateId which is deprecated. Please use advanced.database.generateId instead. This will be removed in future releases.",
+				);
+				generateId = options.advanced?.generateId;
+			}
+			if (generateId === false || useNumberId) return undefined;
+			if (generateId) {
+				return generateId({
+					model,
+				});
+			}
+			if (config.customIdGenerator) {
+				return config.customIdGenerator({ model });
+			}
+			return defaultGenerateId();
+		};
+
+		const props = shouldGenerateId ? { defaultValue } : {};
+
+		return {
+			type: options.advanced?.database?.useNumberId ? "number" : "string",
+			required: !!shouldGenerateId,
+			...props,
+		} satisfies FieldAttribute;
+	};
+};

--- a/packages/better-auth/src/adapters/create-adapter/index.ts
+++ b/packages/better-auth/src/adapters/create-adapter/index.ts
@@ -1,15 +1,22 @@
-import { safeJSONParse } from "../../utils/json";
-import { withApplyDefault } from "../../adapters/utils";
 import { getAuthTables } from "../../db/get-tables";
 import type { Adapter, BetterAuthOptions, Where } from "../../types";
-import { generateId as defaultGenerateId, logger } from "../../utils";
+import { logger } from "../../utils";
 import type {
 	AdapterConfig,
 	AdapterTestDebugLogs,
-	CleanedWhere,
 	CreateCustomAdapter,
 } from "./types";
-import type { FieldAttribute } from "../../db";
+import { initTransformInput } from "./transform-input";
+import { initTransformOutput } from "./transform-output";
+import { initTransformWhere } from "./transform-where";
+import { initDebugLogs } from "./debug-logs";
+import { initIdField } from "./id-field";
+import { initGetDefaultFieldName } from "./get-default-field-name";
+import { initGetDefaultModelName } from "./get-default-model-name";
+import { initGetModelName } from "./get-model-name";
+import { initGetFieldName } from "./get-field-name";
+import { initGetFieldAttributes } from "./get-field-attributes";
+
 export * from "./types";
 
 let debugLogs: any[] = [];
@@ -45,6 +52,27 @@ const colors = {
 	},
 };
 
+/**
+ * Throws an error if the adapter doesn't support numeric ids,
+ * yet the user enabled it in their auth config.
+ */
+function checkIfDatabaseSupportsNumberIds({
+	config,
+	options,
+}: {
+	config: AdapterConfig;
+	options: BetterAuthOptions;
+}) {
+	if (
+		options.advanced?.database?.useNumberId === true &&
+		config.supportsNumericIds === false
+	) {
+		throw new Error(
+			`[${config.adapterName}] Your database or database adapter does not support numeric ids. Please disable "useNumberId" in your config.`,
+		);
+	}
+}
+
 export const createAdapter =
 	({
 		adapter,
@@ -58,263 +86,62 @@ export const createAdapter =
 			...cfg,
 			supportsBooleans: cfg.supportsBooleans ?? true,
 			supportsDates: cfg.supportsDates ?? true,
+			supportsJSONB: cfg.supportsJSONB ?? false,
 			supportsJSON: cfg.supportsJSON ?? false,
+			supportsArrays: cfg.supportsArrays ?? true,
+			supportsNumbers: cfg.supportsNumbers ?? true,
 			adapterName: cfg.adapterName ?? cfg.adapterId,
 			supportsNumericIds: cfg.supportsNumericIds ?? true,
 		};
-
-		if (
-			options.advanced?.database?.useNumberId === true &&
-			config.supportsNumericIds === false
-		) {
-			throw new Error(
-				`[${config.adapterName}] Your database or database adapter does not support numeric ids. Please disable "useNumberId" in your config.`,
-			);
-		}
-
-		// End-user's Better-Auth instance's schema
+		checkIfDatabaseSupportsNumberIds({ config, options });
+		const debugLog = initDebugLogs({ config, debugLogs });
 		const schema = getAuthTables(options);
-
-		/**
-		 * This function helps us get the default field name from the schema defined by devs.
-		 * Often times, the user will be using the `fieldName` which could had been customized by the users.
-		 * This function helps us get the actual field name useful to match against the schema. (eg: schema[model].fields[field])
-		 *
-		 * If it's still unclear what this does:
-		 *
-		 * 1. User can define a custom fieldName.
-		 * 2. When using a custom fieldName, doing something like `schema[model].fields[field]` will not work.
-		 */
-		const getDefaultFieldName = ({
-			field,
-			model: unsafe_model,
-		}: {
-			model: string;
-			field: string;
-		}) => {
-			// Plugin `schema`s can't define their own `id`. Better-auth auto provides `id` to every schema model.
-			// Given this, we can't just check if the `field` (that being `id`) is within the schema's fields, since it is never defined.
-			// So we check if the `field` is `id` and if so, we return `id` itself. Otherwise, we return the `field` from the schema.
-			if (field === "id" || field === "_id") {
-				return "id";
-			}
-			const model = getDefaultModelName(unsafe_model); // Just to make sure the model name is correct.
-
-			let f = schema[model]?.fields[field];
-			if (!f) {
-				//@ts-expect-error
-				f = Object.values(schema[model]?.fields).find(
-					(f) => f.fieldName === field,
-				);
-			}
-			if (!f) {
-				debugLog(`Field ${field} not found in model ${model}`);
-				debugLog(`Schema:`, schema);
-				throw new Error(`Field ${field} not found in model ${model}`);
-			}
-			return field;
-		};
-
-		/**
-		 * This function helps us get the default model name from the schema defined by devs.
-		 * Often times, the user will be using the `modelName` which could had been customized by the users.
-		 * This function helps us get the actual model name useful to match against the schema. (eg: schema[model])
-		 *
-		 * If it's still unclear what this does:
-		 *
-		 * 1. User can define a custom modelName.
-		 * 2. When using a custom modelName, doing something like `schema[model]` will not work.
-		 * 3. Using this function helps us get the actual model name based on the user's defined custom modelName.
-		 */
-		const getDefaultModelName = (model: string) => {
-			// It's possible this `model` could had applied `usePlural`.
-			// Thus we'll try the search but without the trailing `s`.
-			if (config.usePlural && model.charAt(model.length - 1) === "s") {
-				let pluralessModel = model.slice(0, -1);
-				let m = schema[pluralessModel] ? pluralessModel : undefined;
-				if (!m) {
-					m = Object.entries(schema).find(
-						([_, f]) => f.modelName === pluralessModel,
-					)?.[0];
-				}
-
-				if (m) {
-					return m;
-				}
-			}
-
-			let m = schema[model] ? model : undefined;
-			if (!m) {
-				m = Object.entries(schema).find(([_, f]) => f.modelName === model)?.[0];
-			}
-
-			if (!m) {
-				debugLog(`Model "${model}" not found in schema`);
-				debugLog(`Schema:`, schema);
-				throw new Error(`Model "${model}" not found in schema`);
-			}
-			return m;
-		};
-
-		/**
-		 * Users can overwrite the default model of some tables. This function helps find the correct model name.
-		 * Furthermore, if the user passes `usePlural` as true in their adapter config,
-		 * then we should return the model name ending with an `s`.
-		 */
-		const getModelName = (model: string) => {
-			const defaultModelKey = getDefaultModelName(model);
-			const usePlural = config && config.usePlural;
-			const useCustomModelName =
-				schema &&
-				schema[defaultModelKey] &&
-				schema[defaultModelKey].modelName !== model;
-
-			if (useCustomModelName) {
-				return usePlural
-					? `${schema[defaultModelKey].modelName}s`
-					: schema[defaultModelKey].modelName;
-			}
-
-			return usePlural ? `${model}s` : model;
-		};
-		/**
-		 * Get the field name which is expected to be saved in the database based on the user's schema.
-		 *
-		 * This function is useful if you need to save the field name to the database.
-		 *
-		 * For example, if the user has defined a custom field name for the `user` model, then you can use this function to get the actual field name from the schema.
-		 */
-		function getFieldName({
-			model: model_name,
-			field: field_name,
-		}: {
-			model: string;
-			field: string;
-		}) {
-			const model = getDefaultModelName(model_name);
-			const field = getDefaultFieldName({ model, field: field_name });
-
-			return schema[model]?.fields[field]?.fieldName || field;
-		}
-
-		const debugLog = (...args: any[]) => {
-			if (config.debugLogs === true || typeof config.debugLogs === "object") {
-				// If we're running adapter tests, we'll keep debug logs in memory, then print them out if a test fails.
-				if (
-					typeof config.debugLogs === "object" &&
-					"isRunningAdapterTests" in config.debugLogs
-				) {
-					if (config.debugLogs.isRunningAdapterTests) {
-						args.shift(); // Removes the {method: "..."} object from the args array.
-						debugLogs.push(args);
-					}
-					return;
-				}
-
-				if (
-					typeof config.debugLogs === "object" &&
-					config.debugLogs.logCondition &&
-					!config.debugLogs.logCondition?.()
-				) {
-					return;
-				}
-
-				if (typeof args[0] === "object" && "method" in args[0]) {
-					const method = args.shift().method;
-					// Make sure the method is enabled in the config.
-					if (typeof config.debugLogs === "object") {
-						if (method === "create" && !config.debugLogs.create) {
-							return;
-						} else if (method === "update" && !config.debugLogs.update) {
-							return;
-						} else if (
-							method === "updateMany" &&
-							!config.debugLogs.updateMany
-						) {
-							return;
-						} else if (method === "findOne" && !config.debugLogs.findOne) {
-							return;
-						} else if (method === "findMany" && !config.debugLogs.findMany) {
-							return;
-						} else if (method === "delete" && !config.debugLogs.delete) {
-							return;
-						} else if (
-							method === "deleteMany" &&
-							!config.debugLogs.deleteMany
-						) {
-							return;
-						} else if (method === "count" && !config.debugLogs.count) {
-							return;
-						}
-					}
-					logger.info(`[${config.adapterName}]`, ...args);
-				} else {
-					logger.info(`[${config.adapterName}]`, ...args);
-				}
-			}
-		};
-
-		const idField = ({
-			customModelName,
-			forceAllowId,
-		}: {
-			customModelName?: string;
-			forceAllowId?: boolean;
-		}) => {
-			const shouldGenerateId =
-				!config.disableIdGeneration &&
-				!options.advanced?.database?.useNumberId &&
-				!forceAllowId;
-			const model = getDefaultModelName(customModelName ?? "id");
-			return {
-				type: options.advanced?.database?.useNumberId ? "number" : "string",
-				required: shouldGenerateId ? true : false,
-				...(shouldGenerateId
-					? {
-							defaultValue() {
-								if (config.disableIdGeneration) return undefined;
-								const useNumberId = options.advanced?.database?.useNumberId;
-								let generateId = options.advanced?.database?.generateId;
-								if (options.advanced?.generateId !== undefined) {
-									logger.warn(
-										"Your Better Auth config includes advanced.generateId which is deprecated. Please use advanced.database.generateId instead. This will be removed in future releases.",
-									);
-									generateId = options.advanced?.generateId;
-								}
-								if (generateId === false || useNumberId) return undefined;
-								if (generateId) {
-									return generateId({
-										model,
-									});
-								}
-								if (config.customIdGenerator) {
-									return config.customIdGenerator({ model });
-								}
-								return defaultGenerateId();
-							},
-						}
-					: {}),
-			} satisfies FieldAttribute;
-		};
-
-		const getFieldAttributes = ({
-			model,
-			field,
-		}: {
-			model: string;
-			field: string;
-		}) => {
-			const defaultModelName = getDefaultModelName(model);
-			const defaultFieldName = getDefaultFieldName({
-				field: field,
-				model: model,
-			});
-
-			const fields = schema[defaultModelName].fields;
-			fields.id = idField({ customModelName: defaultModelName });
-			return fields[defaultFieldName];
-		};
-
+		const getDefaultModelName = initGetDefaultModelName({
+			schema,
+			debugLog,
+			config,
+		});
+		const getDefaultFieldName = initGetDefaultFieldName({
+			schema,
+			debugLog,
+			getDefaultModelName,
+		});
+		const getModelName = initGetModelName({
+			config,
+			getDefaultModelName,
+			schema,
+		});
+		const getFieldName = initGetFieldName({
+			getDefaultFieldName,
+			getDefaultModelName,
+			schema,
+		});
+		const idField = initIdField({ config, options, getDefaultModelName });
+		const getFieldAttributes = initGetFieldAttributes({
+			getDefaultFieldName,
+			getDefaultModelName,
+			idField,
+			schema,
+		});
+		const transformInput = initTransformInput({
+			schema,
+			config,
+			options,
+			idField,
+		});
+		const transformOutput = initTransformOutput({
+			schema,
+			config,
+			options,
+		});
+		const transformWhereClause = initTransformWhere({
+			config,
+			getDefaultFieldName,
+			getDefaultModelName,
+			getFieldAttributes,
+			getFieldName,
+			options,
+		});
 		const adapterInstance = adapter({
 			options,
 			schema,
@@ -325,239 +152,6 @@ export const createAdapter =
 			getDefaultFieldName,
 			getFieldAttributes,
 		});
-
-		const transformInput = async (
-			data: Record<string, any>,
-			unsafe_model: string,
-			action: "create" | "update",
-			forceAllowId?: boolean,
-		) => {
-			const transformedData: Record<string, any> = {};
-			const fields = schema[unsafe_model].fields;
-			const newMappedKeys = config.mapKeysTransformInput ?? {};
-			if (
-				!config.disableIdGeneration &&
-				!options.advanced?.database?.useNumberId
-			) {
-				fields.id = idField({
-					customModelName: unsafe_model,
-					forceAllowId: forceAllowId && "id" in data,
-				});
-			}
-			for (const field in fields) {
-				const value = data[field];
-				const fieldAttributes = fields[field];
-
-				let newFieldName: string =
-					newMappedKeys[field] || fields[field].fieldName || field;
-				if (
-					value === undefined &&
-					((!fieldAttributes.defaultValue &&
-						!fieldAttributes.transform?.input) ||
-						action === "update")
-				) {
-					continue;
-				}
-				// If the value is undefined, but the fieldAttr provides a `defaultValue`, then we'll use that.
-				let newValue = withApplyDefault(value, fieldAttributes, action);
-
-				// If the field attr provides a custom transform input, then we'll let it handle the value transformation.
-				// Afterwards, we'll continue to apply the default transformations just to make sure it saves in the correct format.
-				if (fieldAttributes.transform?.input) {
-					newValue = await fieldAttributes.transform.input(newValue);
-				}
-
-				if (
-					fieldAttributes.references?.field === "id" &&
-					options.advanced?.database?.useNumberId
-				) {
-					if (Array.isArray(newValue)) {
-						newValue = newValue.map(Number);
-					} else {
-						newValue = Number(newValue);
-					}
-				} else if (
-					config.supportsJSON === false &&
-					typeof newValue === "object" &&
-					//@ts-expect-error -Future proofing
-					fieldAttributes.type === "json"
-				) {
-					newValue = JSON.stringify(newValue);
-				} else if (
-					config.supportsDates === false &&
-					newValue instanceof Date &&
-					fieldAttributes.type === "date"
-				) {
-					newValue = newValue.toISOString();
-				} else if (
-					config.supportsBooleans === false &&
-					typeof newValue === "boolean"
-				) {
-					newValue = newValue ? 1 : 0;
-				}
-
-				if (config.customTransformInput) {
-					newValue = config.customTransformInput({
-						data: newValue,
-						action,
-						field: newFieldName,
-						fieldAttributes: fieldAttributes,
-						model: unsafe_model,
-						schema,
-						options,
-					});
-				}
-
-				transformedData[newFieldName] = newValue;
-			}
-			return transformedData;
-		};
-
-		const transformOutput = async (
-			data: Record<string, any> | null,
-			unsafe_model: string,
-			select: string[] = [],
-		) => {
-			if (!data) return null;
-			const newMappedKeys = config.mapKeysTransformOutput ?? {};
-			const transformedData: Record<string, any> = {};
-			const tableSchema = schema[unsafe_model].fields;
-			const idKey = Object.entries(newMappedKeys).find(
-				([_, v]) => v === "id",
-			)?.[0];
-			tableSchema[idKey ?? "id"] = {
-				type: options.advanced?.database?.useNumberId ? "number" : "string",
-			};
-			for (const key in tableSchema) {
-				if (select.length && !select.includes(key)) {
-					continue;
-				}
-				const field = tableSchema[key];
-				if (field) {
-					const originalKey = field.fieldName || key;
-					// If the field is mapped, we'll use the mapped key. Otherwise, we'll use the original key.
-					let newValue =
-						data[
-							Object.entries(newMappedKeys).find(
-								([_, v]) => v === originalKey,
-							)?.[0] || originalKey
-						];
-
-					if (field.transform?.output) {
-						newValue = await field.transform.output(newValue);
-					}
-
-					let newFieldName: string = newMappedKeys[key] || key;
-
-					if (originalKey === "id" || field.references?.field === "id") {
-						// Even if `useNumberId` is true, we must always return a string `id` output.
-						if (typeof newValue !== "undefined") newValue = String(newValue);
-					} else if (
-						config.supportsJSON === false &&
-						typeof newValue === "string" &&
-						//@ts-expect-error - Future proofing
-						field.type === "json"
-					) {
-						newValue = safeJSONParse(newValue);
-					} else if (
-						config.supportsDates === false &&
-						typeof newValue === "string" &&
-						field.type === "date"
-					) {
-						newValue = new Date(newValue);
-					} else if (
-						config.supportsBooleans === false &&
-						typeof newValue === "number" &&
-						field.type === "boolean"
-					) {
-						newValue = newValue === 1;
-					}
-
-					if (config.customTransformOutput) {
-						newValue = config.customTransformOutput({
-							data: newValue,
-							field: newFieldName,
-							fieldAttributes: field,
-							select,
-							model: unsafe_model,
-							schema,
-							options,
-						});
-					}
-
-					transformedData[newFieldName] = newValue;
-				}
-			}
-			return transformedData as any;
-		};
-
-		const transformWhereClause = <W extends Where[] | undefined>({
-			model,
-			where,
-		}: {
-			where: W;
-			model: string;
-		}): W extends undefined ? undefined : CleanedWhere[] => {
-			if (!where) return undefined as any;
-			const newMappedKeys = config.mapKeysTransformInput ?? {};
-
-			return where.map((w) => {
-				const {
-					field: unsafe_field,
-					value,
-					operator = "eq",
-					connector = "AND",
-				} = w;
-				if (operator === "in") {
-					if (!Array.isArray(value)) {
-						throw new Error("Value must be an array");
-					}
-				}
-
-				const defaultModelName = getDefaultModelName(model);
-				const defaultFieldName = getDefaultFieldName({
-					field: unsafe_field,
-					model,
-				});
-				const fieldName: string =
-					newMappedKeys[defaultFieldName] ||
-					getFieldName({
-						field: defaultFieldName,
-						model: defaultModelName,
-					});
-
-				const fieldAttr = getFieldAttributes({
-					field: defaultFieldName,
-					model: defaultModelName,
-				});
-
-				if (defaultFieldName === "id" || fieldAttr.references?.field === "id") {
-					if (options.advanced?.database?.useNumberId) {
-						if (Array.isArray(value)) {
-							return {
-								operator,
-								connector,
-								field: fieldName,
-								value: value.map(Number),
-							} satisfies CleanedWhere;
-						}
-						return {
-							operator,
-							connector,
-							field: fieldName,
-							value: Number(value),
-						} satisfies CleanedWhere;
-					}
-				}
-
-				return {
-					operator,
-					connector,
-					field: fieldName,
-					value: value,
-				} satisfies CleanedWhere;
-			}) as any;
-		};
 
 		return {
 			create: async <T extends Record<string, any>, R = T>({
@@ -705,7 +299,6 @@ export const createAdapter =
 					`${formatMethod("updateMany")} ${formatAction("Parsed Input")}:`,
 					{ model, data },
 				);
-
 				const updatedCount = await adapterInstance.updateMany({
 					model,
 					where,

--- a/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
+++ b/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
@@ -61,9 +61,14 @@ async function createTestAdapter(
 				usePlural: false,
 				debugLogs: false,
 				supportsJSON: true,
+				supportsJSONB: true,
 				supportsDates: true,
 				supportsBooleans: true,
-			},
+				supportsNumericIds: true,
+				disableIdGeneration: false,
+				supportsNumbers: true,
+				supportsArrays: true,
+			} satisfies AdapterConfig,
 			config,
 		),
 		adapter: (...args) => {
@@ -390,7 +395,7 @@ describe("Create Adapter Helper", async () => {
 								user: {
 									additionalFields: {
 										preferences: {
-											//@ts-expect-error - Not *technically* implemented yet, however the `createAdapter` helper already supports it.
+											//@ts-expect-error - Future proofing
 											type: "json",
 										},
 									},
@@ -957,7 +962,7 @@ describe("Create Adapter Helper", async () => {
 								user: {
 									additionalFields: {
 										preferences: {
-											//@ts-expect-error - Not *technically* implemented yet, however the `createAdapter` helper already supports it.
+											//@ts-expect-error - Future proofing
 											type: "json",
 										},
 									},

--- a/packages/better-auth/src/adapters/create-adapter/test/transformation.test.ts
+++ b/packages/better-auth/src/adapters/create-adapter/test/transformation.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from "vitest";
+import { initTransformOutput } from "../transform-output";
+import type { BetterAuthOptions, BetterAuthPlugin } from "../../../types";
+import { getAuthTables } from "../../../db";
+import type { AdapterConfig } from "../types";
+import { merge } from "../../../utils/merger";
+import { initTransformInput } from "../transform-input";
+
+/**
+ * The purpose of this plugin is to introduce all of the different field types that we support
+ * in order to test it against the transformInput & transformOutput functions.
+ */
+const testSchemaPlugin = {
+	id: "test",
+	schema: {
+		test: {
+			fields: {
+				//@ts-expect-error - Future proofing
+				json: { type: "json" },
+				//@ts-expect-error - Future proofing
+				jsonb: { type: "jsonb" },
+				number: { type: "number" },
+				string: { type: "string" },
+				boolean: { type: "boolean" },
+				date: { type: "date" },
+				"number[]": { type: "number[]" },
+				"string[]": { type: "string[]" },
+			},
+		},
+	},
+} satisfies BetterAuthPlugin;
+
+/**
+ * A helper function to initialize the transformOutput function with the correct config and schema.
+ * By default all of the field types are supported.
+ */
+const init = (config?: Partial<AdapterConfig>, options?: BetterAuthOptions) => {
+	const optionsObject = merge([options ?? {}, { plugins: [testSchemaPlugin] }]);
+
+	const transformOutput = initTransformOutput({
+		schema: getAuthTables(optionsObject),
+		options: optionsObject,
+		config: {
+			adapterId: "test",
+			supportsJSONB: true,
+			supportsArrays: true,
+			supportsBooleans: true,
+			supportsDates: true,
+			supportsJSON: true,
+			supportsNumericIds: true,
+			supportsNumbers: true,
+			disableIdGeneration: false,
+			...config,
+		},
+	});
+	const transformInput = initTransformInput({
+		schema: getAuthTables(optionsObject),
+		options: optionsObject,
+		idField: () => {
+			return {
+				type: "string",
+				required: true,
+			};
+		},
+		config: {
+			adapterId: "test",
+			supportsJSONB: true,
+			supportsArrays: true,
+			supportsBooleans: true,
+			supportsDates: true,
+			supportsJSON: true,
+			supportsNumericIds: true,
+			supportsNumbers: true,
+			disableIdGeneration: false,
+			...config,
+		},
+	});
+
+	return {
+		transformOutput: (data: Record<string, any>, select?: string[]) =>
+			transformOutput(data, "test", select),
+		transformInput: (data: Record<string, any>) =>
+			transformInput(data, "test", "create", true),
+	};
+};
+
+const tests: {
+	config?: Partial<AdapterConfig>;
+	input: Partial<
+		Record<
+			| "number"
+			| "string"
+			| "jsonb"
+			| "json"
+			| "boolean"
+			| "date"
+			| "number[]"
+			| "string[]",
+			any
+		>
+	>;
+	transformed: Record<string, any>;
+}[] = [
+	// Number Conversion
+	{
+		/**
+		 * The config to disable anything we don't support.
+		 */
+		config: {
+			supportsNumbers: false,
+		},
+		/**
+		 * The input data that we will use to test the transformInput function.
+		 * The output data should look equal to the input.
+		 */
+		input: {
+			number: 1,
+			string: "1",
+		},
+		/**
+		 * This should be the expected result of the transformInput function.
+		 * (This would in theory then be saved in DB)
+		 * Then the transformOuput would be provided with this data and should return the input.
+		 */
+		transformed: {
+			number: "1",
+			string: "1",
+		},
+	},
+	// Boolean Conversion
+	{
+		config: {
+			supportsBooleans: false,
+		},
+		input: {
+			boolean: true,
+		},
+		transformed: {
+			boolean: 1,
+		},
+	},
+	{
+		config: {
+			supportsBooleans: false,
+		},
+		input: {
+			boolean: false,
+		},
+		transformed: {
+			boolean: 0,
+		},
+	},
+	// If bool & num not supported, it would transform to strings
+	// We should make sure it convert backs correctly.
+	{
+		config: {
+			supportsBooleans: false,
+			supportsNumbers: false,
+		},
+		input: {
+			boolean: true,
+			number: 1,
+		},
+		transformed: {
+			boolean: "1",
+			number: "1",
+		},
+	},
+	// Date Conversion
+	{
+		config: {
+			supportsDates: false,
+		},
+		input: {
+			date: new Date(),
+		},
+		transformed: {
+			date: new Date().toISOString(),
+		},
+	},
+	// JSON Conversion
+	{
+		config: {
+			supportsJSON: false,
+		},
+		input: {
+			json: {
+				a: 1,
+				b: "2",
+				c: true,
+				d: { hello: new Date() },
+			},
+		},
+		transformed: {
+			json: JSON.stringify({
+				a: 1,
+				b: "2",
+				c: true,
+				d: { hello: new Date().toISOString() },
+			}),
+		},
+	},
+	// JSONB Conversion
+	{
+		config: {
+			supportsJSONB: false,
+		},
+		input: {
+			jsonb: {
+				a: 1,
+				b: "2",
+				c: true,
+			},
+		},
+		transformed: {
+			jsonb: {
+				a: 1,
+				b: "2",
+				c: true,
+			},
+		},
+	},
+	// JSON & JSONB conversion
+	{
+		config: {
+			supportsJSONB: false,
+			supportsJSON: false,
+		},
+		input: {
+			jsonb: {
+				a: 1,
+				b: "2",
+				c: true,
+			},
+		},
+		transformed: {
+			jsonb: JSON.stringify({
+				a: 1,
+				b: "2",
+				c: true,
+			}),
+		},
+	},
+	// Array Conversion
+	{
+		config: {
+			supportsArrays: false,
+		},
+		input: {
+			"number[]": [1, 2, 3],
+			"string[]": ["1", "2", "3"],
+		},
+		transformed: {
+			"number[]": JSON.stringify([1, 2, 3]),
+			"string[]": JSON.stringify(["1", "2", "3"]),
+		},
+	},
+];
+
+const generateTestName = (test: (typeof tests)[number]) => {
+	let configs: string[] = [];
+	for (const [key, value] of Object.entries(test.config ?? {})) {
+		configs.push(`${key}: ${value}`);
+	}
+	let testName = `should correctly transform back values with ${configs.join(
+		", ",
+	)}`;
+	return testName;
+};
+
+describe("Create-Adapter: transformInput & transformOutput", () => {
+	for (const test of tests) {
+		it(generateTestName(test), async () => {
+			const { transformOutput, transformInput } = init(test.config);
+			// Input -> transformed
+			const transformed = await transformInput(test.input);
+			expect(transformed).toEqual(test.transformed);
+			// Transformed -> output
+			// Output should be equal to the input.
+			const output = await transformOutput(transformed);
+			expect(output).toEqual(test.input);
+		});
+	}
+});

--- a/packages/better-auth/src/adapters/create-adapter/transform-input.ts
+++ b/packages/better-auth/src/adapters/create-adapter/transform-input.ts
@@ -1,0 +1,138 @@
+import type { BetterAuthDbSchema } from "../../db";
+import { type BetterAuthOptions } from "../../types";
+import { withApplyDefault } from "../utils";
+import type { AdapterConfig, IdField } from "./types";
+
+export const initTransformInput = ({
+	schema,
+	config,
+	options,
+	idField,
+}: {
+	schema: BetterAuthDbSchema;
+	config: AdapterConfig;
+	options: BetterAuthOptions;
+	idField: IdField;
+}) => {
+	const transformInput = async (
+		data: Record<string, any>,
+		unsafe_model: string,
+		action: "create" | "update",
+		forceAllowId?: boolean,
+	) => {
+		const transformedData: Record<string, any> = {};
+		if (!schema[unsafe_model]) {
+			const err = new Error(`Model ${unsafe_model} not found in schema`);
+			err.stack = err.stack
+				?.split("\n")
+				.filter((_, i) => i !== 1)
+				.join("\n");
+
+			throw err;
+		}
+		const fields = schema[unsafe_model].fields;
+		const newMappedKeys = config.mapKeysTransformInput ?? {};
+		if (
+			!config.disableIdGeneration &&
+			!options.advanced?.database?.useNumberId
+		) {
+			fields.id = idField({
+				customModelName: unsafe_model,
+				forceAllowId: forceAllowId && "id" in data,
+			});
+		}
+		for (const field in fields) {
+			const value = data[field];
+			const fieldAttributes = fields[field];
+
+			let newFieldName: string =
+				newMappedKeys[field] || fields[field].fieldName || field;
+			if (
+				value === undefined &&
+				((!fieldAttributes.defaultValue && !fieldAttributes.transform?.input) ||
+					action === "update")
+			) {
+				continue;
+			}
+			// If the value is undefined, but the fieldAttr provides a `defaultValue`, then we'll use that.
+			let newValue = withApplyDefault(value, fieldAttributes, action);
+
+			// If the field attr provides a custom transform input, then we'll let it handle the value transformation.
+			// Afterwards, we'll continue to apply the default transformations just to make sure it saves in the correct format.
+			if (fieldAttributes.transform?.input) {
+				newValue = await fieldAttributes.transform.input(newValue);
+			}
+			if (
+				fieldAttributes.references?.field === "id" &&
+				options.advanced?.database?.useNumberId
+			) {
+				if (Array.isArray(newValue)) {
+					newValue = newValue.map(Number);
+				} else {
+					newValue = Number(newValue);
+				}
+			} else if (
+				!fieldAttributes.required &&
+				(newValue === null || newValue === undefined)
+			) {
+				newValue = null;
+			} else if (
+				config.supportsJSON === false &&
+				//@ts-expect-error - Future proofing
+				fieldAttributes.type === "json"
+			) {
+				newValue = JSON.stringify(newValue);
+			} else if (
+				config.supportsJSONB === false &&
+				//@ts-expect-error - Future proofing
+				fieldAttributes.type === "jsonb" &&
+				!config.supportsJSON
+			) {
+				newValue = JSON.stringify(newValue);
+			} else if (
+				config.supportsDates === false &&
+				newValue instanceof Date &&
+				fieldAttributes.type === "date"
+			) {
+				newValue = newValue.toISOString();
+			} else if (
+				config.supportsBooleans === false &&
+				typeof newValue === "boolean"
+			) {
+				if (config.supportsNumbers === false) {
+					newValue = newValue ? "1" : "0";
+				} else {
+					newValue = newValue ? 1 : 0;
+				}
+			} else if (
+				config.supportsArrays === false &&
+				(fieldAttributes.type === "number[]" ||
+					fieldAttributes.type === "string[]")
+			) {
+				newValue = JSON.stringify(newValue);
+			} else if (
+				config.supportsNumbers === false &&
+				fieldAttributes.type === "number"
+			) {
+				newValue = String(newValue);
+			}
+
+			if (config.customTransformInput) {
+				newValue = config.customTransformInput({
+					data: newValue,
+					action,
+					field: newFieldName,
+					fieldAttributes: fieldAttributes,
+					model: unsafe_model,
+					schema,
+					options,
+				});
+			}
+
+			transformedData[newFieldName] = newValue;
+		}
+		return transformedData;
+	};
+
+	return transformInput;
+};

--- a/packages/better-auth/src/adapters/create-adapter/transform-output.ts
+++ b/packages/better-auth/src/adapters/create-adapter/transform-output.ts
@@ -1,0 +1,114 @@
+import type { BetterAuthDbSchema } from "../../db";
+import type { BetterAuthOptions } from "../../types";
+import { safeJSONParse } from "../../utils/json";
+import type { AdapterConfig } from "./types";
+
+export const initTransformOutput = ({
+	config,
+	schema,
+	options,
+}: {
+	config: AdapterConfig;
+	schema: BetterAuthDbSchema;
+	options: BetterAuthOptions;
+}) => {
+	const transformOutput = async (
+		data: Record<string, any> | null,
+		unsafe_model: string,
+		select: string[] = [],
+	) => {
+		if (!data) return null;
+		const newMappedKeys = config.mapKeysTransformOutput ?? {};
+		const transformedData: Record<string, any> = {};
+		const tableSchema = schema[unsafe_model].fields;
+		const idKey = Object.entries(newMappedKeys).find(
+			([_, v]) => v === "id",
+		)?.[0];
+		tableSchema[idKey ?? "id"] = {
+			type: options.advanced?.database?.useNumberId ? "number" : "string",
+		};
+		for (const key in tableSchema) {
+			if (select.length && !select.includes(key)) {
+				continue;
+			}
+			const field = tableSchema[key];
+			if (field) {
+				const originalKey = field.fieldName || key;
+				// If the field is mapped, we'll use the mapped key. Otherwise, we'll use the original key.
+				let newValue =
+					data[
+						Object.entries(newMappedKeys).find(
+							([_, v]) => v === originalKey,
+						)?.[0] || originalKey
+					];
+
+				if (field.transform?.output) {
+					newValue = await field.transform.output(newValue);
+				}
+
+				let newFieldName: string = newMappedKeys[key] || key;
+
+				if (originalKey === "id" || field.references?.field === "id") {
+					// Even if `useNumberId` is true, we must always return a string `id` output.
+					if (typeof newValue !== "undefined") newValue = String(newValue);
+				} else if (
+					config.supportsJSON === false &&
+					typeof newValue === "string" &&
+					//@ts-expect-error - Future proofing
+					field.type === "json"
+				) {
+					newValue = safeJSONParse(newValue);
+				} else if (
+					config.supportsJSONB === false &&
+					typeof newValue === "string" &&
+					//@ts-expect-error - Future proofing
+					field.type === "jsonb"
+				) {
+					newValue = safeJSONParse(newValue);
+				} else if (
+					config.supportsDates === false &&
+					typeof newValue === "string" &&
+					field.type === "date"
+				) {
+					newValue = new Date(newValue);
+				} else if (
+					config.supportsBooleans === false &&
+					field.type === "boolean"
+				) {
+					if (config.supportsNumbers === false) {
+						newValue = newValue === "1";
+					} else {
+						newValue = newValue === 1;
+					}
+				} else if (
+					config.supportsArrays === false &&
+					typeof newValue === "string" &&
+					(field.type === "number[]" || field.type === "string[]")
+				) {
+					newValue = safeJSONParse(newValue);
+				} else if (
+					config.supportsNumbers === false &&
+					field.type === "number"
+				) {
+					newValue = Number(newValue);
+				}
+
+				if (config.customTransformOutput) {
+					newValue = config.customTransformOutput({
+						data: newValue,
+						field: newFieldName,
+						fieldAttributes: field,
+						select,
+						model: unsafe_model,
+						schema,
+						options,
+					});
+				}
+
+				transformedData[newFieldName] = newValue;
+			}
+		}
+		return transformedData as any;
+	};
+	return transformOutput;
+};

--- a/packages/better-auth/src/adapters/create-adapter/transform-where.ts
+++ b/packages/better-auth/src/adapters/create-adapter/transform-where.ts
@@ -1,0 +1,99 @@
+import type { BetterAuthOptions, Where } from "../../types";
+import type { AdapterConfig, CleanedWhere } from "./types";
+import type { FieldAttribute } from "../../db";
+
+export const initTransformWhere = ({
+	config,
+	getDefaultModelName,
+	getDefaultFieldName,
+	getFieldAttributes,
+	getFieldName,
+	options,
+}: {
+	config: AdapterConfig;
+	getDefaultModelName: (model: string) => string;
+	getDefaultFieldName: ({
+		field,
+		model,
+	}: {
+		field: string;
+		model: string;
+	}) => string;
+	getFieldAttributes: ({
+		field,
+		model,
+	}: {
+		field: string;
+		model: string;
+	}) => FieldAttribute;
+	getFieldName: ({ field, model }: { field: string; model: string }) => string;
+	options: BetterAuthOptions;
+}) => {
+	return <W extends Where[] | undefined>({
+		model,
+		where,
+	}: {
+		where: W;
+		model: string;
+	}): W extends undefined ? undefined : CleanedWhere[] => {
+		if (!where) return undefined as any;
+		const newMappedKeys = config.mapKeysTransformInput ?? {};
+
+		return where.map((w) => {
+			const {
+				field: unsafe_field,
+				value,
+				operator = "eq",
+				connector = "AND",
+			} = w;
+			if (operator === "in") {
+				if (!Array.isArray(value)) {
+					throw new Error("Value must be an array");
+				}
+			}
+
+			const defaultModelName = getDefaultModelName(model);
+			const defaultFieldName = getDefaultFieldName({
+				field: unsafe_field,
+				model,
+			});
+			const fieldName: string =
+				newMappedKeys[defaultFieldName] ||
+				getFieldName({
+					field: defaultFieldName,
+					model: defaultModelName,
+				});
+
+			const fieldAttr = getFieldAttributes({
+				field: defaultFieldName,
+				model: defaultModelName,
+			});
+
+			if (defaultFieldName === "id" || fieldAttr.references?.field === "id") {
+				if (options.advanced?.database?.useNumberId) {
+					if (Array.isArray(value)) {
+						return {
+							operator,
+							connector,
+							field: fieldName,
+							value: value.map(Number),
+						} satisfies CleanedWhere;
+					}
+					return {
+						operator,
+						connector,
+						field: fieldName,
+						value: Number(value),
+					} satisfies CleanedWhere;
+				}
+			}
+
+			return {
+				operator,
+				connector,
+				field: fieldName,
+				value: value,
+			} satisfies CleanedWhere;
+		}) as any;
+	};
+};

--- a/packages/better-auth/src/adapters/create-adapter/types.ts
+++ b/packages/better-auth/src/adapters/create-adapter/types.ts
@@ -61,18 +61,30 @@ export interface AdapterConfig {
 	adapterId: string;
 	/**
 	 * If the database supports numeric ids, set this to `true`.
+	 * For example, MongoDB doesn't support numeric ids.
+	 * Where as PostgreSQL does via `serial` columns.
 	 *
 	 * @default true
 	 */
-	supportsNumericIds?: boolean;
+	supportsNumericIds: boolean;
 	/**
 	 * If the database doesn't support JSON columns, set this to `false`.
 	 *
-	 * We will handle the translation between using `JSON` columns, and saving `string`s to the database.
+	 * Note: We do not fully support this yet, so
+	 * we will handle the translation between using `JSON` columns, and saving `string`s to the database.
 	 *
 	 * @default false
 	 */
-	supportsJSON?: boolean;
+	supportsJSON: boolean;
+	/**
+	 * If the database doesn't support JSONB columns, set this to `false`.
+	 *
+	 * Note: We do not fully support this yet, so
+	 * we will handle the translation between using `JSONB` columns, and saving `string`s to the database.
+	 *
+	 * @default false
+	 */
+	supportsJSONB: boolean;
 	/**
 	 * If the database doesn't support dates, set this to `false`.
 	 *
@@ -80,7 +92,7 @@ export interface AdapterConfig {
 	 *
 	 * @default true
 	 */
-	supportsDates?: boolean;
+	supportsDates: boolean;
 	/**
 	 * If the database doesn't support booleans, set this to `false`.
 	 *
@@ -88,7 +100,7 @@ export interface AdapterConfig {
 	 *
 	 * @default true
 	 */
-	supportsBooleans?: boolean;
+	supportsBooleans: boolean;
 	/**
 	 * Disable id generation for the `create` method.
 	 *
@@ -96,7 +108,23 @@ export interface AdapterConfig {
 	 *
 	 * @default false
 	 */
-	disableIdGeneration?: boolean;
+	disableIdGeneration: boolean;
+	/**
+	 * If the database doesn't support numbers, set this to `false`.
+	 *
+	 * We will handle the translation between using `number`s, and saving `string`s to the database.
+	 *
+	 * @default true
+	 */
+	supportsNumbers: boolean;
+	/**
+	 * If the database doesn't support arrays, set this to `false`.
+	 *
+	 * We will handle the translation between using `array`s, and saving `string`s to the database.
+	 *
+	 * @default true
+	 */
+	supportsArrays: boolean;
 	/**
 	 * Map the keys of the input data.
 	 *
@@ -381,3 +409,11 @@ export type AdapterTestDebugLogs = {
 	resetDebugLogs: () => void;
 	printDebugLogs: () => void;
 };
+
+export type IdField = ({
+	customModelName,
+	forceAllowId,
+}: {
+	customModelName?: string;
+	forceAllowId?: boolean;
+}) => FieldAttribute;


### PR DESCRIPTION
- Fixed `transformInput` to incorrectly transforms string arrays
- Added `supportsArrays` and `supportsNumbers` in the adapter config. I realized I needed this when developing the Redis adapter.
- Made create adapter config’s `supportNumber`, `supportString`, etc all required, rather than using defaults which could be incorrect, this requires the adapter maintainer to think about all of the types their database supports.
- Moved a lot of the logic in the create-adapter out to it’s separate files to allow the createAdapter code to be less dense and drastically make it easier to read & maintain.
  - Also added tests for some of it's logic - such as `transformInput`
- Improved/updated the create-a-database-adapter docs

My previous [PR](https://github.com/better-auth/better-auth/pull/3265) I messed up the rebase so it was just easier to open a new PR (this one)