### PR TITLE
docs: added comment on sveltekit plugin integration

### DIFF
--- a/docs/content/docs/integrations/svelte-kit.mdx
+++ b/docs/content/docs/integrations/svelte-kit.mdx
@@ -37,7 +37,7 @@ import { getRequestEvent } from "$app/server";
 
 export const auth = betterAuth({
   // ... your config
-  plugins: [sveltekitCookies(getRequestEvent)],
+  plugins: [sveltekitCookies(getRequestEvent)], // make sure this is the last plugin in the array
 });
 ```
 


### PR DESCRIPTION
Added comment to the user to place cookie setting plugin as the last item in the array similar to Next.js.

If not, will deal with problems on other plugins such as twoFactor
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a comment in the SvelteKit integration docs to remind users to place the cookie plugin last in the plugins array to avoid issues with other plugins.

<!-- End of auto-generated description by cubic. -->

