### PR TITLE
fix(api): replace defu array concatenation with override in hook context merges

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -117,6 +117,39 @@ describe("before hook", async () => {
 				key: "value",
 			});
 		});
+		it("should replace existing array when hook provides another array", async () => {
+			const endpoints3 = {
+				body: createAuthEndpoint(
+					"/body-array-replace",
+					{ method: "POST" },
+					async (c) => c.body as any,
+				),
+			};
+
+			const authContext3 = init({
+				hooks: {
+					before: createAuthMiddleware(async (c) => {
+						if (c.path === "/body-array-replace") {
+							return {
+								context: {
+									body: {
+										tags: ["a"],
+									},
+								},
+							};
+						}
+					}),
+				},
+			});
+
+			const api3 = toAuthEndpoints(endpoints3 as any, authContext3);
+			const res3 = await api3.body({
+				body: {
+					tags: ["b", "c"],
+				},
+			});
+			expect(res3.tags).toEqual(["a"]);
+		});
 
 		it("should return hook set param", async () => {
 			const res = await authEndpoints.params();

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -9,19 +9,21 @@ import type { AuthEndpoint, AuthMiddleware } from "./call";
 import type { AuthContext, HookEndpointContext } from "../types";
 import { createDefu } from "defu";
 
-const defuReplaceArray = createDefu((object: any, key: PropertyKey, value: any) => {
-    if (
-        object &&
-        typeof object === "object" &&
-        !Array.isArray(object) &&
-        Array.isArray((object as any)[key as any]) &&
-        Array.isArray(value)
-    ) {
-        (object as any)[key as any] = value;
-        return true;
-    }
-    return false;
-});
+const defuReplaceArray = createDefu(
+	(object: any, key: PropertyKey, value: any) => {
+		if (
+			object &&
+			typeof object === "object" &&
+			!Array.isArray(object) &&
+			Array.isArray((object as any)[key as any]) &&
+			Array.isArray(value)
+		) {
+			(object as any)[key as any] = value;
+			return true;
+		}
+		return false;
+	},
+);
 
 type InternalContext = InputContext<string, any> &
 	EndpointContext<string, any> & {
@@ -83,8 +85,8 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 					headers.forEach((value, key) => {
 						(internalContext.headers as Headers).set(key, value);
 					});
-                }
-                internalContext = defuReplaceArray(rest, internalContext);
+				}
+				internalContext = defuReplaceArray(rest, internalContext);
 			} else if (before) {
 				/* Return before hook response if it's anything other than a context return */
 				return before;
@@ -168,7 +170,7 @@ async function runBeforeHooks(
 							modifiedContext.headers = headers;
 						}
 					}
-                    modifiedContext = defuReplaceArray(rest, modifiedContext);
+					modifiedContext = defuReplaceArray(rest, modifiedContext);
 					continue;
 				}
 				return result;


### PR DESCRIPTION
This pr fixes on the Use a custom defu merger (createDefu) that replaces arrays instead of concatenating
when merging contexts from before hooks into internalContext/modifiedContext.
Prevents duplication for array additionalFields (e.g., user.tags).

Closes #3126
