### PR TITLE
docs: guidance to get env info when submitting bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,12 +45,10 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: Provide environment information
-      description: Please collect the following information and paste the results. 
+      label: System info
+      description: Output of `npx envinfo --system --browsers`
       render: bash
-      placeholder: |
-        - OS: [e.g. Windows 10]
-        - Browser [e.g. chrome, safari]
+      placeholder: System and browsers
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the bug report template to ask users for the output of `npx envinfo --system --browsers` instead of manual system info.

<!-- End of auto-generated description by cubic. -->

