### PR TITLE
fix(email-otp): otp email should only be sent once

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -970,3 +970,52 @@ describe("override default email verification", async () => {
 		expect(sendVerificationOTP).toHaveBeenCalled();
 	});
 });
+
+describe("otp email should only be sent once for each sign up", async () => {
+	async function testFunction(sendVerificationOnSignUp: boolean) {
+		let otp: string[] = [];
+
+		const { customFetchImpl } = await getTestInstance(
+			{
+				emailAndPassword: {
+					enabled: true,
+					requireEmailVerification: true,
+				},
+				plugins: [
+					emailOTP({
+						async sendVerificationOTP(data) {
+							otp.push(data.otp);
+						},
+						overrideDefaultEmailVerification: true,
+						sendVerificationOnSignUp,
+					}),
+				],
+			},
+			{ disableTestUser: true },
+		);
+
+		const client = createAuthClient({
+			plugins: [emailOTPClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+
+		await client.signUp.email({
+			email: "test-otp-override@email.com",
+			password: "password",
+			name: "Test User",
+		});
+
+		expect(otp).toHaveLength(1);
+	}
+
+	it("when sendVerificationOnSignUp is enabled", async () => {
+		testFunction(true);
+	});
+
+	it("when sendVerificationOnSignUp is disabled", async () => {
+		testFunction(false);
+	});
+});

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -95,6 +95,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 		storeOTP: "plain",
 		...options,
 	} satisfies EmailOTPOptions;
+
 	const ERROR_CODES = {
 		OTP_EXPIRED: "otp expired",
 		INVALID_OTP: "Invalid OTP",
@@ -277,13 +278,18 @@ export const emailOTP = (options: EmailOTPOptions) => {
 		),
 	};
 
+	// We shouldn't override the `sendVerificationEmail` function if they have enabled
+	// `sendVerificationOnSignUp` so that we don't send the verification email twice.
+	const shouldOverrideVerificationEmail =
+		opts.overrideDefaultEmailVerification && !opts.sendVerificationOnSignUp;
+
 	return {
 		id: "email-otp",
 		init(ctx) {
 			return {
 				options: {
 					emailVerification: {
-						...(opts.overrideDefaultEmailVerification
+						...(shouldOverrideVerificationEmail
 							? {
 									async sendVerificationEmail(data, request) {
 										await endpoints.sendVerificationOTP({


### PR DESCRIPTION
This PR addresses an issue that was raised in discord [[message link](https://discord.com/channels/1288403910284935179/1288403910284935182/1404022323983548489)].

The problem was that `sendVerificationOnSignUp` is enabled along with `overrideDefaultEmailVerification` being enabled. this creates two points in which the `sendVerificationOTP` function is called. This PR fixes the issue by checking if `sendVerificationOnSignUp` is enabled before overriding the email verification function on the `emailAndPassword` options.