### PR TITLE
fix(stripe): fallback to using ref id when sub to update isn't found

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -263,7 +263,17 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								},
 							],
 						})
-					: null;
+					: ctx.body.referenceId
+						? await ctx.context.adapter.findOne<Subscription>({
+								model: "subscription",
+								where: [
+									{
+										field: "referenceId",
+										value: ctx.body.referenceId,
+									},
+								],
+							})
+						: null;
 
 				if (ctx.body.subscriptionId && !subscriptionToUpdate) {
 					throw new APIError("BAD_REQUEST", {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a fallback to look up subscriptions by referenceId if a subscriptionId is not found during Stripe updates. This prevents errors when only the referenceId is available.

<!-- End of auto-generated description by cubic. -->

