### PR TITLE
docs: add callout to populate event.locals.user/session in handlers

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -259,13 +259,6 @@ Create a new file or route in your framework's designated catch-all route handle
     import { building } from '$app/environment'
 
     export async function handle({ event, resolve }) {
-        // Optional: populate event.locals for server access
-        const session = await auth.api.getSession({ headers: event.request.headers });
-        if (session) {
-          event.locals.session = session.session;
-          event.locals.user = session.user;
-        }
-
         return svelteKitHandler({ event, resolve, auth, building });
     }
     ```

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -259,6 +259,13 @@ Create a new file or route in your framework's designated catch-all route handle
     import { building } from '$app/environment'
 
     export async function handle({ event, resolve }) {
+        // Optional: populate event.locals for server access
+        const session = await auth.api.getSession({ headers: event.request.headers });
+        if (session) {
+          event.locals.session = session.session;
+          event.locals.user = session.user;
+        }
+
         return svelteKitHandler({ event, resolve, auth, building });
     }
     ```

--- a/docs/content/docs/integrations/svelte-kit.mdx
+++ b/docs/content/docs/integrations/svelte-kit.mdx
@@ -19,6 +19,31 @@ export async function handle({ event, resolve }) {
 }
 ```
 
+### Access session on the server (event.locals)
+
+The `svelteKitHandler` does not automatically populate `event.locals.user` or `event.locals.session`. If you want to access the current session in your server code (e.g., in `+layout.server.ts`, actions, or endpoints), populate `event.locals` in your `handle` hook:
+
+```ts title="hooks.server.ts"
+import { auth } from "$lib/auth";
+import { svelteKitHandler } from "better-auth/svelte-kit";
+import { building } from "$app/environment";
+
+export async function handle({ event, resolve }) {
+  // Fetch current session from Better Auth
+  const session = await auth.api.getSession({
+    headers: event.request.headers,
+  });
+
+  // Make session and user available on server
+  if (session) {
+    event.locals.session = session.session;
+    event.locals.user = session.user;
+  }
+
+  return svelteKitHandler({ event, resolve, auth, building });
+}
+```
+
 ### Server Action Cookies
 
 To ensure cookies are properly set when you call functions like `signInEmail` or `signUpEmail` in a server action, you should use the `sveltekitCookies` plugin. This plugin will automatically handle setting cookies for you in SvelteKit.

--- a/docs/content/docs/integrations/svelte-kit.mdx
+++ b/docs/content/docs/integrations/svelte-kit.mdx
@@ -19,7 +19,7 @@ export async function handle({ event, resolve }) {
 }
 ```
 
-### Access session on the server (event.locals)
+### Populate session data in the event (`event.locals`)
 
 The `svelteKitHandler` does not automatically populate `event.locals.user` or `event.locals.session`. If you want to access the current session in your server code (e.g., in `+layout.server.ts`, actions, or endpoints), populate `event.locals` in your `handle` hook:
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added documentation explaining how to manually set event.locals.user and event.locals.session in the SvelteKit handle hook when using Better Auth.

<!-- End of auto-generated description by cubic. -->

