### PR TITLE
fix: allow returning response object to skip after hooks

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -96,7 +96,7 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 			};
 
 			//if response object is returned we skip after hooks and post processing
-			if (result instanceof Response) {
+			if (result && result instanceof Response) {
 				return result;
 			}
 

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -94,6 +94,12 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 				headers: Headers;
 				response: any;
 			};
+
+			//if response object is returned we skip after hooks and post processing
+			if (result instanceof Response) {
+				return result;
+			}
+
 			internalContext.context.returned = result.response;
 			internalContext.context.responseHeaders = result.headers;
 
@@ -106,6 +112,7 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 			if (result.response instanceof APIError && !context?.asResponse) {
 				throw result.response;
 			}
+
 			const response = context?.asResponse
 				? toResponse(result.response, {
 						headers: result.headers,

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -846,7 +846,7 @@ export const mcp = (options: MCPOptions) => {
 							: {}),
 					};
 
-					return ctx.json(responseData, {
+					return new Response(JSON.stringify(responseData), {
 						status: 201,
 						headers: {
 							"Cache-Control": "no-store",

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -77,6 +77,9 @@ describe("mcp", async () => {
 				logo_uri: "",
 				token_endpoint_auth_method: "none",
 			},
+			onResponse(context) {
+				console.log(context.response);
+			},
 		});
 
 		expect(createdClient.data).toMatchObject({

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -78,7 +78,7 @@ describe("mcp", async () => {
 				token_endpoint_auth_method: "none",
 			},
 			onResponse(context) {
-				console.log(context.response);
+				expect(context.response.status).toBe(201);
 			},
 		});
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the auth endpoint handler to allow returning a Response object, which skips after hooks and post-processing.

- **Bug Fixes**
  - Returning a Response now bypasses extra processing steps.
  - Updated MCP plugin to use Response directly.
  - Added a test for the new behavior.
  - Removed unused telemetry README.

<!-- End of auto-generated description by cubic. -->

