### PR TITLE
docs: update missing links on contribution guide 

### DIFF
--- a/docs/components/landing/section-svg.tsx
+++ b/docs/components/landing/section-svg.tsx
@@ -1,6 +1,10 @@
 import { Plus } from "lucide-react";
 
-const SectionSvg = ({ crossesOffset }: { crossesOffset: string }) => {
+const SectionSvg = ({
+	crossesOffset,
+}: {
+	crossesOffset: string;
+}) => {
 	return (
 		<>
 			<Plus

--- a/docs/components/landing/section-svg.tsx
+++ b/docs/components/landing/section-svg.tsx
@@ -1,10 +1,6 @@
 import { Plus } from "lucide-react";
 
-const SectionSvg = ({
-	crossesOffset,
-}: {
-	crossesOffset: string;
-}) => {
+const SectionSvg = ({ crossesOffset }: { crossesOffset: string }) => {
 	return (
 		<>
 			<Plus

--- a/docs/content/docs/reference/contributing.mdx
+++ b/docs/content/docs/reference/contributing.mdx
@@ -104,9 +104,9 @@ Once you have an idea of what you want to contribute, you can start making chang
 
         * Make your changes to the codebase.
 
-        * Write tests if needed. (Read more about testing <Link href="/docs/reference/contribute/testing">here</Link>)
+        * Write tests if needed. (Read more about testing <Link href="/docs/reference/contributing#testing">here</Link>)
 
-        * Update documentation.  (Read more about documenting <Link href="/docs/reference/contribute/documenting">here</Link>)
+        * Update documentation.  (Read more about documenting <Link href="/docs/reference/contributing#documentation">here</Link>)
 
     </Step>
 


### PR DESCRIPTION
closes #3920
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed broken links in the contribution guide for testing and documenting sections.

<!-- End of auto-generated description by cubic. -->

