### PR TITLE
fix: handle inconsistent user update error in phone number plugin

### DIFF
--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -688,9 +688,10 @@ export const phoneNumber = (options?: PhoneNumberOptions) => {
 							ctx,
 						);
 					}
-
 					if (!user) {
-						return ctx.json(null);
+						throw new APIError("INTERNAL_SERVER_ERROR", {
+							message: BASE_ERROR_CODES.FAILED_TO_UPDATE_USER,
+						});
 					}
 
 					await options?.callbackOnVerification?.(
@@ -700,12 +701,6 @@ export const phoneNumber = (options?: PhoneNumberOptions) => {
 						},
 						ctx.request,
 					);
-
-					if (!user) {
-						throw new APIError("INTERNAL_SERVER_ERROR", {
-							message: BASE_ERROR_CODES.FAILED_TO_UPDATE_USER,
-						});
-					}
 
 					if (!ctx.body.disableSession) {
 						const session = await ctx.context.internalAdapter.createSession(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed inconsistent error handling when user updates fail in the phone number plugin by always throwing an API error instead of returning null.

<!-- End of auto-generated description by cubic. -->

