### PR TITLE
docs: remove unused import

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -13,7 +13,6 @@ We need to mount the handler to Hono endpoint.
 import { Hono } from "hono";
 import { auth } from "./auth";
 import { serve } from "@hono/node-server";
-import { cors } from "hono/cors";
 
 const app = new Hono();
 


### PR DESCRIPTION
`cors` is not used in the first example