### PR TITLE
Correctly call autoincrement

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -127,7 +127,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			if (databaseType === "pg") {
 				id = `serial("id").primaryKey()`;
 			} else {
-				id = `int("id").autoincrement.primaryKey()`;
+				id = `int("id").autoincrement().primaryKey()`;
 			}
 		} else {
 			if (databaseType === "mysql") {


### PR DESCRIPTION
This pull request makes a minor fix to the schema generation logic for Drizzle schema in the CLI. The change corrects the syntax for the `autoincrement` method to use parentheses, ensuring compatibility with the expected API.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the schema generator to correctly call the autoincrement method with parentheses for Drizzle CLI, ensuring proper API usage.

<!-- End of auto-generated description by cubic. -->

