### PR TITLE
fix(telemetry): ensure telemetry consent notice displays correctly

### DIFF
--- a/packages/better-auth/src/telemetry/index.ts
+++ b/packages/better-auth/src/telemetry/index.ts
@@ -27,7 +27,7 @@ async function configFilePath() {
 	const path = await import("path");
 	const os = await import("os");
 	const baseDir =
-		(typeof process !== "undefined" && process.platform === "win32")
+		typeof process !== "undefined" && process.platform === "win32"
 			? process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")
 			: path.join(os.homedir(), ".config");
 	const dir = path.join(baseDir, "better-auth");

--- a/packages/better-auth/src/telemetry/index.ts
+++ b/packages/better-auth/src/telemetry/index.ts
@@ -27,7 +27,7 @@ async function configFilePath() {
 	const path = await import("path");
 	const os = await import("os");
 	const baseDir =
-		process.platform === "win32"
+		(typeof process !== "undefined" && process.platform === "win32")
 			? process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")
 			: path.join(os.homedir(), ".config");
 	const dir = path.join(baseDir, "better-auth");


### PR DESCRIPTION
This PR fixes two bugs:

- Telemetry debug mode was being enabled by default because `getBooleanEnvVar` has a `true` set as its default fallback, so this means telemetry debug was being enabled by default and telemetry notice was being disabled by default.
- `hasShownNoticeBefore` was returning true if it failed to read the `telemetry.json` file, which means for the first install it will always return true, and the notice will never be printed.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed telemetry consent notice so it displays correctly on first install and respects debug and disable settings.

- **Bug Fixes**
 - Telemetry debug mode and notice are now disabled by default unless explicitly enabled.
 - Consent notice now shows on first install as intended.

<!-- End of auto-generated description by cubic. -->

