### PR TITLE
chore: Standardize error code capitalization and improve USER_ALREADY_EXISTS error code

### DIFF
--- a/packages/better-auth/src/error/codes.ts
+++ b/packages/better-auth/src/error/codes.ts
@@ -16,7 +16,7 @@ export const BASE_ERROR_CODES = {
 	EMAIL_NOT_VERIFIED: "Email not verified",
 	PASSWORD_TOO_SHORT: "Password too short",
 	PASSWORD_TOO_LONG: "Password too long",
-	USER_ALREADY_EXISTS: "User already exists",
+	USER_ALREADY_EXISTS: "User already exists. Use another email.",
 	EMAIL_CAN_NOT_BE_UPDATED: "Email can not be updated",
 	CREDENTIAL_ACCOUNT_NOT_FOUND: "Credential account not found",
 	SESSION_EXPIRED: "Session expired. Re-authenticate to perform this action.",

--- a/packages/better-auth/src/plugins/admin/error-codes.ts
+++ b/packages/better-auth/src/plugins/admin/error-codes.ts
@@ -1,6 +1,6 @@
 export const ADMIN_ERROR_CODES = {
 	FAILED_TO_CREATE_USER: "Failed to create user",
-	USER_ALREADY_EXISTS: "User already exists",
+	USER_ALREADY_EXISTS: "User already exists. Use another email.",
 	YOU_CANNOT_BAN_YOURSELF: "You cannot ban yourself",
 	YOU_ARE_NOT_ALLOWED_TO_CHANGE_USERS_ROLE:
 		"You are not allowed to change users role",

--- a/packages/better-auth/src/plugins/username/error-codes.ts
+++ b/packages/better-auth/src/plugins/username/error-codes.ts
@@ -1,10 +1,10 @@
 export const USERNAME_ERROR_CODES = {
-	INVALID_USERNAME_OR_PASSWORD: "invalid username or password",
-	EMAIL_NOT_VERIFIED: "email not verified",
-	UNEXPECTED_ERROR: "unexpected error",
-	USERNAME_IS_ALREADY_TAKEN: "username is already taken. please try another.",
-	USERNAME_TOO_SHORT: "username is too short",
-	USERNAME_TOO_LONG: "username is too long",
-	INVALID_USERNAME: "username is invalid",
-	INVALID_DISPLAY_USERNAME: "display username is invalid",
+	INVALID_USERNAME_OR_PASSWORD: "Invalid username or password",
+	EMAIL_NOT_VERIFIED: "Email not verified",
+	UNEXPECTED_ERROR: "Unexpected error",
+	USERNAME_IS_ALREADY_TAKEN: "Username is already taken. Please try another.",
+	USERNAME_TOO_SHORT: "Username is too short",
+	USERNAME_TOO_LONG: "Username is too long",
+	INVALID_USERNAME: "Username is invalid",
+	INVALID_DISPLAY_USERNAME: "Display username is invalid",
 };


### PR DESCRIPTION
# USER_ALREADY_EXISTS 

This changes the USER_ALREADY_EXISTS error code from `"User already exists"` to `"User already exists. Use another email."` this signifies that the error was caused by entering an email that's already in the database (duplicate emails aren't allowed). It also helps to differentiate it from the USERNAME_IS_ALREADY_TAKEN error when using the username plugin. 

# Username plugin error codes

All strings in the USERNAME_ERROR_CODES struct have been changed to start with an uppercase letter, this ensures that the capitalization is the same as in the BASE_ERROR_CODES struct. 


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the USER_ALREADY_EXISTS error code to give clearer guidance and standardized error code capitalization in the username plugin.

- **Error Code Improvements**
 - Changed USER_ALREADY_EXISTS to "User already exists. Use another email."
 - Updated all username plugin error messages to start with an uppercase letter for consistency.

<!-- End of auto-generated description by cubic. -->

