### PR TITLE
fix(email-otp): make plugin init option compatible with exactOptionalPropertyTypes 

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -280,25 +280,24 @@ export const emailOTP = (options: EmailOTPOptions) => {
 	return {
 		id: "email-otp",
 		init(ctx) {
+			if (!opts.overrideDefaultEmailVerification) {
+				return;
+			}
 			return {
 				options: {
 					emailVerification: {
-						...(opts.overrideDefaultEmailVerification
-							? {
-									async sendVerificationEmail(data, request) {
-										await endpoints.sendVerificationOTP({
-											//@ts-expect-error - we need to pass the context
-											context: ctx,
-											request: request,
-											body: {
-												email: data.user.email,
-												type: "email-verification",
-											},
-											ctx,
-										});
-									},
-								}
-							: {}),
+						async sendVerificationEmail(data, request) {
+							await endpoints.sendVerificationOTP({
+								//@ts-expect-error - we need to pass the context
+								context: ctx,
+								request: request,
+								body: {
+									email: data.user.email,
+									type: "email-verification",
+								},
+								ctx,
+							});
+						},
 					},
 				},
 			};


### PR DESCRIPTION
This pr fixes the by avoiding undefined function assignment with in the init plugin option making it compat with the exactOptionalPropertyTypes
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the email OTP plugin to avoid assigning undefined functions in the init option, making it compatible with exactOptionalPropertyTypes.

<!-- End of auto-generated description by cubic. -->

