### PR TITLE
docs: add better-auth-speckle plugin to community plugins list

### DIFF
--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -323,6 +323,17 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/C-W-D-Harshit.png",
 		},
 	},
+	{
+		name: "better-auth-speckle",
+		url: "https://github.com/XingxinHE/better-auth-speckle",
+		description:
+			"A plugin for the Speckle System, supporting its non-standard oauth flow with sign-in and link account.",
+		author: {
+			name: "XingxinHE",
+			github: "XingxinHE",
+			avatar: "https://github.com/XingxinHE.png",
+		},
+	},
 ];
 export function CommunityPluginsTable() {
 	const [sorting, setSorting] = useState<SortingState>([]);

--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -327,7 +327,7 @@ export const communityPlugins: CommunityPlugin[] = [
 		name: "better-auth-speckle",
 		url: "https://github.com/XingxinHE/better-auth-speckle",
 		description:
-			"A plugin for the Speckle System, supporting its non-standard oauth flow with sign-in and link account.",
+			"A plugin for Speckle System, supporting its non-standard oauth flow with sign-in and link account.",
 		author: {
 			name: "XingxinHE",
 			github: "XingxinHE",

--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -327,7 +327,7 @@ export const communityPlugins: CommunityPlugin[] = [
 		name: "better-auth-speckle",
 		url: "https://github.com/XingxinHE/better-auth-speckle",
 		description:
-			"A plugin for Speckle System, supporting its non-standard oauth flow with sign-in and link account.",
+			"A plugin for Speckle System, supporting its non-standard Oauth flow with sign-in and link account.",
 		author: {
 			name: "XingxinHE",
 			github: "XingxinHE",


### PR DESCRIPTION
Hi team,

I've built a plugin for [Speckle System](https://github.com/specklesystems/speckle-server). Since it doesn't fulfill a standard oauth flow, I can't use the generic oauth plugin to handle it. Therefore, I take the reference of generic-oauth-plugin to create a community plugin to handle its vanilla REST oauth flow into a clean, easy-to-use API.

high level of this plugin:
- [code](https://github.com/XingxinHE/better-auth-speckle/blob/main/src/server.ts) implements the interface of `BetterAuthPlugin`, `OAuthProvider`, and `ProviderOptions`.
- [test](https://github.com/XingxinHE/better-auth-speckle/blob/main/test/speckle.browser.test.ts) covers 3 auth endpoint, sign in, link account, callback.

In this PR, there is only documentation change.
    

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the `better-auth-speckle` plugin to the Community Plugins list in docs/components/community-plugins-table.tsx. Includes repo link and author details, noting support for Speckle System’s non-standard OAuth flow with sign-in and link account.

<sup>Written for commit 4350aa3d3978436c4eaa382f350a52aaab919a30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

