### PR TITLE
feat(vk): add user name mapping by default

### DIFF
--- a/packages/better-auth/src/social-providers/vk.ts
+++ b/packages/better-auth/src/social-providers/vk.ts
@@ -125,6 +125,7 @@ export const vk = (options: VkOption) => {
 					emailVerified: !!profile.user.email,
 					birthday: profile.user.birthday,
 					sex: profile.user.sex,
+					name: `${profile.user.first_name} ${profile.user.last_name}`,
 					...userMap,
 				},
 				data: profile,


### PR DESCRIPTION
As for now, if you register user using vk, name comes empty and email is used instead of it, i added default value for name.