### PR TITLE
  fix(cli): clean up unused `pg` and `mysql` import in drizzle schema generator

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -212,7 +212,18 @@ function generateImport({
 	imports.push(hasBigint ? (databaseType !== "sqlite" ? "bigint" : "") : "");
 	imports.push(databaseType !== "sqlite" ? "timestamp, boolean" : "");
 	if (databaseType === "mysql") {
-		imports.push("int");
+		// Only include int for MySQL if actually needed
+		const hasNonBigintNumber = Object.values(tables).some((table) =>
+			Object.values(table.fields).some(
+				(field) =>
+					(field.type === "number" || field.type === "number[]") &&
+					!field.bigint,
+			),
+		);
+		const needsInt = !!useNumberId || hasNonBigintNumber;
+		if (needsInt) {
+			imports.push("int");
+		}
 	} else if (databaseType === "pg") {
 		// Only include integer for PG if actually needed
 		const hasNonBigintNumber = Object.values(tables).some((table) =>

--- a/packages/cli/test/__snapshots__/auth-schema.txt
+++ b/packages/cli/test/__snapshots__/auth-schema.txt
@@ -1,10 +1,4 @@
-import {
-  pgTable,
-  text,
-  timestamp,
-  boolean,
-  integer,
-} from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean } from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -166,7 +166,6 @@ describe("generate", async () => {
 				plugins: [twoFactor(), username()],
 			},
 		});
-		console.log(schema.code);
 		expect(schema.code).toMatchFileSnapshot("./__snapshots__/auth-schema.txt");
 	});
 
@@ -210,5 +209,21 @@ describe("generate", async () => {
 			adapter: {} as any,
 		});
 		expect(schema.code).toMatchFileSnapshot("./__snapshots__/migrations.sql");
+	});
+	it("should throw for unsupported additionalFields type in migrations", async () => {
+		await expect(
+			generateMigrations({
+				file: "test.sql",
+				options: {
+					database: new Database(":memory:"),
+					user: {
+						additionalFields: {
+							is_subscribed: { type: "object" } as unknown as any,
+						} as any,
+					},
+				},
+				adapter: {} as any,
+			}),
+		).rejects.toThrow(/Unsupported field type/);
 	});
 });

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -210,20 +210,4 @@ describe("generate", async () => {
 		});
 		expect(schema.code).toMatchFileSnapshot("./__snapshots__/migrations.sql");
 	});
-	it("should throw for unsupported additionalFields type in migrations", async () => {
-		await expect(
-			generateMigrations({
-				file: "test.sql",
-				options: {
-					database: new Database(":memory:"),
-					user: {
-						additionalFields: {
-							is_subscribed: { type: "object" } as unknown as any,
-						} as any,
-					},
-				},
-				adapter: {} as any,
-			}),
-		).rejects.toThrow(/Unsupported field type/);
-	});
 });


### PR DESCRIPTION
closes #3971    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed unused `integer` import from generated Drizzle schemas for PostgreSQL when not needed, keeping imports clean and accurate.

<!-- End of auto-generated description by cubic. -->

