### PR TITLE
fix(sveltekit): use permissive typing for RequestEvent params

### DIFF
--- a/packages/better-auth/src/integrations/svelte-kit.ts
+++ b/packages/better-auth/src/integrations/svelte-kit.ts
@@ -53,10 +53,7 @@ export function isAuthPath(url: string, options: BetterAuthOptions) {
 }
 
 export const sveltekitCookies = (
-	getRequestEvent: () => RequestEvent<
-		Partial<Record<string, string>>,
-		string | null
-	>,
+	getRequestEvent: () => RequestEvent<any, any>,
 ) => {
 	return {
 		id: "sveltekit-cookies",


### PR DESCRIPTION
The `sveltekitCookies` plugin fails with TypeScript errors (if `"strict": true` / `"strictNullChecks": true`) due to recent changes in SvelteKit's type system, where `RequestEvent` parameters are now more strictly typed.

### Root Cause
SvelteKit commit [a8cc450](https://github.com/sveltejs/kit/commit/a8cc450f7ab4d4481276219cfe23363d6ae4f51e) made route parameter types more precise.
For routes without parameters (like `"/"`), `LayoutParams<"/">` can now be `undefined`, which doesn't satisfy the previous constraint `Partial<Record<string, string>>`.

### Solution
Updated `RequestEvent` type parameters to use `any`:
- From: `RequestEvent<Partial<Record<string, string>>, string | null>`  
- To: `RequestEvent<any, any>`

This change:
- Fixes the TypeScript error
- Maintains backward compatibility  
- Doesn't affect runtime behavior (Better-Auth only uses `event.cookies`, never the route parameters)

### Breaking Changes
None - this is a type-only fix that maintains full backward compatibility.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Relaxed the type definitions for SvelteKit's RequestEvent params to fix TypeScript errors when using strict mode.

- **Bug Fixes**
 - Updated sveltekitCookies to use permissive typings, preventing type errors on routes without parameters.

<!-- End of auto-generated description by cubic. -->

