### PR TITLE
feat(captcha): add support for Yandex SmartCaptcha

### DIFF
--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -7,6 +7,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 - [Google reCAPTCHA](https://developers.google.com/recaptcha)
 - [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/)
 - [hCaptcha](https://www.hcaptcha.com/)
+- [Yandex SmartCaptcha](https://cloud.yandex.com/en/docs/smartcaptcha/)
 
 <Callout type="info">
   This plugin works out of the box with <Link href="/docs/authentication/email-password">Email & Password</Link> authentication. To use it with other authentication methods, you will need to configure the <Link href="/docs/plugins/captcha#plugin-options">endpoints</Link> array in the plugin options.
@@ -25,7 +26,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     export const auth = betterAuth({
         plugins: [ // [!code highlight]
             captcha({ // [!code highlight]
-                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha // [!code highlight]
+                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha, yandex-smart-captcha // [!code highlight]
                 secretKey: process.env.TURNSTILE_SECRET_KEY!, // [!code highlight]
             }), // [!code highlight]
         ], // [!code highlight]
@@ -54,6 +55,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     - To implement Cloudflare Turnstile on the client side, follow the official [Cloudflare Turnstile documentation](https://developers.cloudflare.com/turnstile/) or use a library like [react-turnstile](https://www.npmjs.com/package/@marsidev/react-turnstile).
     - To implement Google reCAPTCHA on the client side, follow the official [Google reCAPTCHA documentation](https://developers.google.com/recaptcha/intro) or use libraries like [react-google-recaptcha](https://www.npmjs.com/package/react-google-recaptcha) (v2) and [react-google-recaptcha-v3](https://www.npmjs.com/package/react-google-recaptcha-v3) (v3).
     - To implement hCaptcha on the client side, follow the official [hCaptcha documentation](https://docs.hcaptcha.com/#add-the-hcaptcha-widget-to-your-webpage) or use libraries like [@hcaptcha/react-hcaptcha](https://www.npmjs.com/package/@hcaptcha/react-hcaptcha)
+    - To implement Yandex SmartCaptcha on the client side, follow the official [Yandex SmartCaptcha documentation](https://cloud.yandex.com/en/docs/smartcaptcha/) or use libraries like [@yandex/smart-captcha](https://www.npmjs.com/package/@yandex/smart-captcha)
   </Step>
 </Steps>
 

--- a/packages/better-auth/src/plugins/captcha/constants.ts
+++ b/packages/better-auth/src/plugins/captcha/constants.ts
@@ -10,6 +10,7 @@ export const Providers = {
 	CLOUDFLARE_TURNSTILE: "cloudflare-turnstile",
 	GOOGLE_RECAPTCHA: "google-recaptcha",
 	HCAPTCHA: "hcaptcha",
+	YANDEX_SMART_CAPTCHA: "yandex-smart-captcha",
 } as const;
 
 export const siteVerifyMap: Record<Provider, string> = {
@@ -18,4 +19,6 @@ export const siteVerifyMap: Record<Provider, string> = {
 	[Providers.GOOGLE_RECAPTCHA]:
 		"https://www.google.com/recaptcha/api/siteverify",
 	[Providers.HCAPTCHA]: "https://api.hcaptcha.com/siteverify",
+	[Providers.YANDEX_SMART_CAPTCHA]:
+		"https://smartcaptcha.yandexcloud.net/validate",
 };

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -59,6 +59,10 @@ export const captcha = (options: CaptchaOptions) =>
 						siteKey: options.siteKey,
 					});
 				}
+
+				if (options.provider === Providers.YANDEX_SMART_CAPTCHA) {
+					return await verifyHandlers.yandexSmartCaptcha(handlerParams);
+				}
 			} catch (_error) {
 				const errorMessage =
 					_error instanceof Error ? _error.message : undefined;

--- a/packages/better-auth/src/plugins/captcha/types.ts
+++ b/packages/better-auth/src/plugins/captcha/types.ts
@@ -22,7 +22,12 @@ export interface HCaptchaOptions extends BaseCaptchaOptions {
 	siteKey?: string;
 }
 
+export interface YandexSmartCaptchaOptions extends BaseCaptchaOptions {
+	provider: typeof Providers.YANDEX_SMART_CAPTCHA;
+}
+
 export type CaptchaOptions =
 	| GoogleRecaptchaOptions
 	| CloudflareTurnstileOptions
-	| HCaptchaOptions;
+	| HCaptchaOptions
+	| YandexSmartCaptchaOptions;

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
@@ -1,3 +1,4 @@
 export { cloudflareTurnstile } from "./cloudflare-turnstile";
 export { googleRecaptcha } from "./google-recaptcha";
 export { hCaptcha } from "./h-captcha";
+export { yandexSmartCaptcha } from "./yandex-smart-captcha";

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/yandex-smart-captcha.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/yandex-smart-captcha.ts
@@ -1,0 +1,47 @@
+import { betterFetch } from "@better-fetch/fetch";
+import { middlewareResponse } from "../../../utils/middleware-response";
+import { EXTERNAL_ERROR_CODES, INTERNAL_ERROR_CODES } from "../error-codes";
+import { encodeToURLParams } from "../utils";
+
+type Params = {
+	siteVerifyURL: string;
+	secretKey: string;
+	captchaResponse: string;
+	remoteIP?: string;
+};
+
+type SiteVerifyResponse = {
+	status: "ok" | "failed";
+	message: string;
+	host?: string;
+};
+
+export const yandexSmartCaptcha = async ({
+	siteVerifyURL,
+	captchaResponse,
+	secretKey,
+	remoteIP,
+}: Params) => {
+	const response = await betterFetch<SiteVerifyResponse>(siteVerifyURL, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: encodeToURLParams({
+			secret: secretKey,
+			token: captchaResponse,
+			...(remoteIP && { ip: remoteIP }),
+		}),
+	});
+
+	if (!response.data || response.error) {
+		throw new Error(INTERNAL_ERROR_CODES.SERVICE_UNAVAILABLE);
+	}
+
+	if (response.data.status !== "ok") {
+		return middlewareResponse({
+			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED,
+			status: 403,
+		});
+	}
+
+	return undefined;
+};


### PR DESCRIPTION
What changed:

- Added [Yandex SmartCaptcha](https://yandex.cloud/docs/smartcaptcha/) handler
- Added links in documentation
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for Yandex SmartCaptcha to the captcha plugin, allowing users to choose it as a provider for bot protection.

- **New Features**
 - Implemented handler for validating Yandex SmartCaptcha tokens.
 - Updated documentation with setup instructions and links.
 - Added tests for SmartCaptcha validation scenarios.

<!-- End of auto-generated description by cubic. -->

