### PR TITLE
feat(organization): make stringifying metadata optional

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -50,17 +50,22 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				data: {
 					...data.organization,
 					metadata: data.organization.metadata
-						? JSON.stringify(data.organization.metadata)
+						? (options?.stringifyOrganizationMetadata ?? true)
+							? JSON.stringify(data.organization.metadata)
+							: data.organization.metadata
 						: undefined,
 				},
 			});
 
 			return {
 				...organization,
-				metadata:
-					organization.metadata && typeof organization.metadata === "string"
+				metadata: organization.metadata
+					? typeof organization.metadata === "string"
 						? JSON.parse(organization.metadata)
-						: undefined,
+						: typeof organization.metadata === "object"
+							? organization.metadata
+							: undefined
+					: undefined,
 			} as typeof organization;
 		},
 		findMemberByEmail: async (data: {
@@ -319,7 +324,9 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					...data,
 					metadata:
 						typeof data.metadata === "object"
-							? JSON.stringify(data.metadata)
+							? (options?.stringifyOrganizationMetadata ?? true)
+								? JSON.stringify(data.metadata)
+								: data.metadata
 							: data.metadata,
 				},
 			});
@@ -329,7 +336,11 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return {
 				...organization,
 				metadata: organization.metadata
-					? parseJSON<Record<string, any>>(organization.metadata)
+					? typeof organization.metadata === "string"
+						? parseJSON<Record<string, any>>(organization.metadata)
+						: typeof organization.metadata === "object"
+							? organization.metadata
+							: undefined
 					: undefined,
 			};
 		},

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -340,4 +340,10 @@ export interface OrganizationOptions {
 	 * @default false
 	 */
 	autoCreateOrganizationOnSignUp?: boolean;
+	/**
+	 * Stringify organization metadata before saving it to the database.
+	 *
+	 * @default true
+	 */
+	stringifyOrganizationMetadata?: boolean;
 }


### PR DESCRIPTION
I was confused by the documentation's use of the organization metadata field as an object, and set it up in my database as a jsonb column. While I understand @Kinfe123 reason of "flexibility" in #2772, allowing an object to be saved to the db enables flexibility to do much more with raw sql, including adding indices on metadata fields.

Is there a strong reason why stringifying before saving to the DB should be required? This PR provides the option to directly write the incoming Record<string, any> to the db, so that the flexibility extends to direct db queries as well, instead of forcing the flexibility to exist only within application code.

I'd be happy to update the docs as well to describe the behavior here, but I'm unsure if that should be a commit in this PR or a separate one with a docs header. LMK. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an option to control whether organization metadata is stringified before saving to the database, allowing direct storage of objects for more flexible querying.

- **New Features**
 - Added the stringifyOrganizationMetadata option to OrganizationOptions.
 - Metadata can now be stored as either JSON strings or raw objects based on this setting.

<!-- End of auto-generated description by cubic. -->

