### PR TITLE
feat(email-otp): add rateLimit configuration option

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -84,6 +84,18 @@ export interface EmailOTPOptions {
 	 * @default false
 	 */
 	overrideDefaultEmailVerification?: boolean;
+	/**
+	 * Rate limit configuration
+	 * 
+	 * @default {
+	 * 	window: 60,
+	 * 	max: 3,
+	 * }
+	 */
+	rateLimit?: {
+		window :number,
+		max :number
+	};
 }
 
 const types = ["email-verification", "sign-in", "forget-password"] as const;
@@ -1182,29 +1194,29 @@ export const emailOTP = (options: EmailOTPOptions) => {
 				pathMatcher(path) {
 					return path === "/email-otp/send-verification-otp";
 				},
-				window: 60,
-				max: 3,
+				window: opts.rateLimit?.window || 60,
+				max: opts.rateLimit?.max || 3,
 			},
 			{
 				pathMatcher(path) {
 					return path === "/email-otp/check-verification-otp";
 				},
-				window: 60,
-				max: 3,
+				window: opts.rateLimit?.window || 60,
+				max: opts.rateLimit?.max || 3,
 			},
 			{
 				pathMatcher(path) {
 					return path === "/email-otp/verify-email";
 				},
-				window: 60,
-				max: 3,
+				window: opts.rateLimit?.window || 60,
+				max: opts.rateLimit?.max || 3,
 			},
 			{
 				pathMatcher(path) {
 					return path === "/sign-in/email-otp";
 				},
-				window: 60,
-				max: 3,
+				window: opts.rateLimit?.window || 60,
+				max: opts.rateLimit?.max || 3,
 			},
 		],
 	} satisfies BetterAuthPlugin;


### PR DESCRIPTION
## Related Issue
Addresses issue https://github.com/better-auth/better-auth/issues/3848

## Summary
Adds `rateLimit` configuration option to the `emailOtp` plugin, similar to the `magicLink` plugin.

## Changes
- Added `rateLimit` option to `EmailOtpOptions`
- Applied rateLimit rule for all `/email-otp` endpoints

## Example Usage
```ts
emailOtp({
  sendVerificationOTP: async ({ email, otp }) => {
    //code
  },
  rateLimit: {
    window: 60, // seconds
    max: 3,     // requests per window
  }
})

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a rateLimit configuration to the emailOtp plugin so developers can set custom limits on requests for all email-otp endpoints, matching the behavior of magicLink.

- **New Feature**
 - Added rateLimit option to EmailOtpOptions with configurable window and max values.

<!-- End of auto-generated description by cubic. -->

