### PR TITLE
feat(admin): add control to prevent admin users from deleting themselves

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1347,10 +1347,10 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 
 					if (ctx.body.userId === ctx.context.session.user.id) {
 						throw new APIError("BAD_REQUEST", {
-							message: ADMIN_ERROR_CODES.YOU_CAN_NOT_REMOVE_YOURSELF,
+							message: ADMIN_ERROR_CODES.YOU_CANNOT_REMOVE_YOURSELF,
 						});
 					}
-					
+
 					const user = await ctx.context.internalAdapter.findUserById(
 						ctx.body.userId,
 					);

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1344,6 +1344,13 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 							message: ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_DELETE_USERS,
 						});
 					}
+
+					if (ctx.body.userId === ctx.context.session.user.id) {
+						throw new APIError("BAD_REQUEST", {
+							message: ADMIN_ERROR_CODES.YOU_CAN_NOT_REMOVE_YOURSELF,
+						});
+					}
+					
 					const user = await ctx.context.internalAdapter.findUserById(
 						ctx.body.userId,
 					);

--- a/packages/better-auth/src/plugins/admin/error-codes.ts
+++ b/packages/better-auth/src/plugins/admin/error-codes.ts
@@ -19,4 +19,5 @@ export const ADMIN_ERROR_CODES = {
 	BANNED_USER: "You have been banned from this application",
 	NO_DATA_TO_UPDATE: "No data to update",
 	YOU_ARE_NOT_ALLOWED_TO_UPDATE_USERS: "You are not allowed to update users",
+	YOU_CAN_NOT_REMOVE_YOURSELF: "You cannot remove yourself"
 } as const;

--- a/packages/better-auth/src/plugins/admin/error-codes.ts
+++ b/packages/better-auth/src/plugins/admin/error-codes.ts
@@ -19,5 +19,5 @@ export const ADMIN_ERROR_CODES = {
 	BANNED_USER: "You have been banned from this application",
 	NO_DATA_TO_UPDATE: "No data to update",
 	YOU_ARE_NOT_ALLOWED_TO_UPDATE_USERS: "You are not allowed to update users",
-	YOU_CAN_NOT_REMOVE_YOURSELF: "You cannot remove yourself"
+	YOU_CANNOT_REMOVE_YOURSELF: "You cannot remove yourself",
 } as const;


### PR DESCRIPTION
https://github.com/better-auth/better-auth/issues/4006
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a check to prevent admin users from deleting their own accounts, improving account safety. 

- **Bug Fixes**
 - Returns an error message if an admin tries to remove themselves.

<!-- End of auto-generated description by cubic. -->

