### PR TITLE
fix: use `importRuntime` from import-utils

### DIFF
--- a/packages/better-auth/src/telemetry/detectors/detect-system-info.ts
+++ b/packages/better-auth/src/telemetry/detectors/detect-system-info.ts
@@ -1,4 +1,5 @@
 import { env } from "../../utils/env";
+import { importRuntime } from "../../utils/import-util";
 
 function getVendor() {
 	const hasAny = (...keys: string[]) =>
@@ -76,9 +77,7 @@ export async function detectSystemInfo() {
 	try {
 		//check if it's cloudflare
 		if (getVendor() === "cloudflare") return "cloudflare";
-		const importRuntime = (m: string) =>
-			(Function("mm", "return import(mm)") as any)(m);
-		const { default: os } = await importRuntime("os");
+		const os = await importRuntime<typeof import("os")>("os");
 		const cpus = os.cpus();
 		return {
 			deploymentVendor: getVendor(),
@@ -118,9 +117,7 @@ async function hasDockerEnv() {
 	if (getVendor() === "cloudflare") return false;
 
 	try {
-		const importRuntime = (m: string) =>
-			(Function("mm", "return import(mm)") as any)(m);
-		const { default: fs } = await importRuntime("fs");
+		const fs = await importRuntime<typeof import("fs")>("fs");
 		fs.statSync("/.dockerenv");
 		return true;
 	} catch {
@@ -131,9 +128,7 @@ async function hasDockerEnv() {
 async function hasDockerCGroup() {
 	if (getVendor() === "cloudflare") return false;
 	try {
-		const importRuntime = (m: string) =>
-			(Function("mm", "return import(mm)") as any)(m);
-		const { default: fs } = await importRuntime("fs");
+		const fs = await importRuntime<typeof import("fs")>("fs");
 		return fs.readFileSync("/proc/self/cgroup", "utf8").includes("docker");
 	} catch {
 		return false;
@@ -156,10 +151,8 @@ async function isWsl() {
 		if (typeof process === "undefined" || process.platform !== "linux") {
 			return false;
 		}
-		const importRuntime = (m: string) =>
-			(Function("mm", "return import(mm)") as any)(m);
-		const { default: fs } = await importRuntime("fs");
-		const { default: os } = await importRuntime("os");
+		const fs = await importRuntime<typeof import("fs")>("fs");
+		const os = await importRuntime<typeof import("os")>("os");
 		if (os.release().toLowerCase().includes("microsoft")) {
 			if (await isInsideContainer()) {
 				return false;
@@ -184,9 +177,7 @@ let isInsideContainerCached: boolean | undefined;
 const hasContainerEnv = async () => {
 	if (getVendor() === "cloudflare") return false;
 	try {
-		const importRuntime = (m: string) =>
-			(Function("mm", "return import(mm)") as any)(m);
-		const { default: fs } = await importRuntime("fs");
+		const fs = await importRuntime<typeof import("fs")>("fs");
 		fs.statSync("/run/.containerenv");
 		return true;
 	} catch {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated system info detection to use the shared importRuntime utility from import-utils for dynamic imports, improving code consistency.

- **Refactors**
 - Removed duplicate importRuntime function definitions.
 - Replaced all instances with the shared utility.

<!-- End of auto-generated description by cubic. -->

