### PR TITLE
feat: add `disableRedirect` to `linkSocial`

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -279,7 +279,7 @@ export const linkSocialAccount = createAuthEndpoint(
 				return c.json({
 					url: "", // this is for type inference
 					status: true,
-					redirect: !c.body.disableRedirect,
+					redirect: false,
 				});
 			}
 
@@ -340,7 +340,7 @@ export const linkSocialAccount = createAuthEndpoint(
 			return c.json({
 				url: "", // this is for type inference
 				status: true,
-				redirect: !c.body.disableRedirect,
+				redirect: false,
 			});
 		}
 

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -148,6 +148,19 @@ export const linkSocialAccount = createAuthEndpoint(
 						"The URL to redirect to if there is an error during the link process",
 				})
 				.optional(),
+			/**
+			 * Disable automatic redirection to the provider
+			 *
+			 * This is useful if you want to handle the redirection
+			 * yourself like in a popup or a different tab.
+			 */
+			disableRedirect: z
+				.boolean()
+				.meta({
+					description:
+						"Disable automatic redirection to the provider. Useful for handling the redirection yourself",
+				})
+				.optional(),
 		}),
 		use: [sessionMiddleware],
 		metadata: {
@@ -264,9 +277,9 @@ export const linkSocialAccount = createAuthEndpoint(
 
 			if (hasBeenLinked) {
 				return c.json({
-					redirect: false,
 					url: "", // this is for type inference
 					status: true,
+					redirect: !c.body.disableRedirect,
 				});
 			}
 
@@ -325,9 +338,9 @@ export const linkSocialAccount = createAuthEndpoint(
 			}
 
 			return c.json({
-				redirect: false,
 				url: "", // this is for type inference
 				status: true,
+				redirect: !c.body.disableRedirect,
 			});
 		}
 
@@ -346,7 +359,7 @@ export const linkSocialAccount = createAuthEndpoint(
 
 		return c.json({
 			url: url.toString(),
-			redirect: true,
+			redirect: !c.body.disableRedirect,
 		});
 	},
 );


### PR DESCRIPTION
closes #3738
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a `disableRedirect` option to the `linkSocial` endpoint so clients can control provider redirection during social account linking.

- **New Features**
 - Clients can now disable automatic redirect and handle provider navigation themselves, such as opening in a popup or new tab.

<!-- End of auto-generated description by cubic. -->

