### PR TITLE
fix google and roblox auth prompt

### DIFF
--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -15,9 +15,9 @@ description: Google provider setup and usage.
         ### Configure the provider
         To configure the provider, you need to pass the `clientId` and `clientSecret` to `socialProviders.google` in your auth configuration.
 
-        ```ts title="auth.ts"   
+        ```ts title="auth.ts"
         import { betterAuth } from "better-auth"
-        
+
         export const auth = betterAuth({
             socialProviders: {
                 google: { // [!code highlight]
@@ -28,6 +28,7 @@ description: Google provider setup and usage.
         })
         ```
     </Step>
+
 </Steps>
 
 ## Usage
@@ -35,17 +36,18 @@ description: Google provider setup and usage.
 ### Sign In with Google
 
 To sign in with Google, you can use the `signIn.social` function provided by the client. The `signIn` function takes an object with the following properties:
+
 - `provider`: The provider to use. It should be set to `google`.
 
 ```ts title="auth-client.ts"  /
-import { createAuthClient } from "better-auth/client"
-const authClient =  createAuthClient()
+import { createAuthClient } from "better-auth/client";
+const authClient = createAuthClient();
 
 const signIn = async () => {
-    const data = await authClient.signIn.social({
-        provider: "google"
-    })
-}
+  const data = await authClient.signIn.social({
+    provider: "google",
+  });
+};
 ```
 
 ### Sign In with Google With ID Token
@@ -55,7 +57,8 @@ To sign in with Google using the ID Token, you can use the `signIn.social` funct
 This is useful when you have the ID Token from Google on the client-side and want to use it to sign in on the server.
 
 <Callout>
- If ID token is provided no redirection will happen, and the user will be signed in directly.
+  If ID token is provided no redirection will happen, and the user will be
+  signed in directly.
 </Callout>
 
 ```ts title="auth-client.ts"
@@ -69,12 +72,13 @@ const data = await authClient.signIn.social({
 ```
 
 <Callout>
-    If you want to use google one tap, you can use the [One Tap Plugin](/docs/plugins/one-tap) guide.
+  If you want to use google one tap, you can use the [One Tap
+  Plugin](/docs/plugins/one-tap) guide.
 </Callout>
 
 ### Always ask to select an account
 
-If you want to always ask the user to select an account, you pass the `prompt` parameter to the provider, setting it to `select_account`.  
+If you want to always ask the user to select an account, you pass the `prompt` parameter to the provider, setting it to `select_account`.
 
 ```ts
 socialProviders: {
@@ -92,29 +96,34 @@ If your application needs additional Google scopes after the user has already si
 
 ```ts title="auth-client.ts"
 const requestGoogleDriveAccess = async () => {
-    await authClient.linkSocial({
-        provider: "google",
-        scopes: ["https://www.googleapis.com/auth/drive.file"],
-    });
+  await authClient.linkSocial({
+    provider: "google",
+    scopes: ["https://www.googleapis.com/auth/drive.file"],
+  });
 };
 
 // Example usage in a React component
-return <button onClick={requestGoogleDriveAccess}>Add Google Drive Permissions</button>;
+return (
+  <button onClick={requestGoogleDriveAccess}>
+    Add Google Drive Permissions
+  </button>
+);
 ```
 
 This will trigger a new OAuth flow that requests the additional scopes. After completion, your account will have the new scope in the database, and the access token will give you access to the requested Google APIs.
 
 <Callout>
-Ensure you're using Better Auth version 1.2.7 or later to avoid "Social account already linked" errors when requesting additional scopes from the same provider.
+  Ensure you're using Better Auth version 1.2.7 or later to avoid "Social
+  account already linked" errors when requesting additional scopes from the same
+  provider.
 </Callout>
-
 
 ### Always get refresh token
 
 Google only issues a refresh token the first time a user consents to your app.
 If the user has already authorized your app, subsequent OAuth flows will only return an access token, not a refresh token.
 
-To always get a refresh token, you can set the `accessType` to `offline`, and `prompt` to `select_account+consent` in the provider options.
+To always get a refresh token, you can set the `accessType` to `offline`, and `prompt` to `select_account consent` in the provider options.
 
 ```ts
 socialProviders: {
@@ -128,6 +137,7 @@ socialProviders: {
 ```
 
 <Callout>
-    **Revoking Access:** If you want to get a new refresh token for a user who has already authorized your app,
-    you must have them revoke your app's access in their Google account settings, then re-authorize.
+  **Revoking Access:** If you want to get a new refresh token for a user who has
+  already authorized your app, you must have them revoke your app's access in
+  their Google account settings, then re-authorize.
 </Callout>

--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -175,7 +175,7 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 		| "consent"
 		| "login"
 		| "none"
-		| "select_account+consent";
+		| "select_account consent";
 	/**
 	 * The response mode to use for the authorization code request
 	 */

--- a/packages/better-auth/src/social-providers/google.ts
+++ b/packages/better-auth/src/social-providers/google.ts
@@ -74,9 +74,6 @@ export const google = (options: GoogleOptions) => {
 				: ["email", "profile", "openid"];
 			options.scope && _scopes.push(...options.scope);
 			scopes && _scopes.push(...scopes);
-			if (options.prompt === "select_account+consent")
-				//@ts-expect-error - Google expects there to be a space not `+` in the prompt
-				options.prompt = "select_account consent";
 			const url = await createAuthorizationURL({
 				id: "google",
 				options,

--- a/packages/better-auth/src/social-providers/roblox.ts
+++ b/packages/better-auth/src/social-providers/roblox.ts
@@ -25,7 +25,7 @@ export interface RobloxOptions extends ProviderOptions<RobloxProfile> {
 		| "consent"
 		| "login"
 		| "select_account"
-		| "select_account+consent";
+		| "select_account consent";
 }
 
 export const roblox = (options: RobloxOptions) => {
@@ -43,7 +43,7 @@ export const roblox = (options: RobloxOptions) => {
 					options.clientId
 				}&redirect_uri=${encodeURIComponent(
 					options.redirectURI || redirectURI,
-				)}&state=${state}&prompt=${options.prompt || "select_account+consent"}`,
+				)}&state=${state}&prompt=${options.prompt || "select_account consent"}`,
 			);
 		},
 		validateAuthorizationCode: async ({ code, redirectURI }) => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed Google and Roblox authentication to use a space in the prompt value instead of a plus, improving compatibility with OAuth providers.

- **Docs Update**
  - Updated Google authentication docs to show correct prompt parameter usage and improved examples.

<!-- End of auto-generated description by cubic. -->

