### PR TITLE
Update peer deps for zod 3 to ^3.25.0

### DIFF
--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -50,7 +50,7 @@
         }
     },
     "peerDependencies": {
-        "zod": "3.25.0 || ^4.0.0"
+        "zod": "^3.25.0 || ^4.0.0"
     },
     "dependencies": {
         "@better-fetch/fetch": "^1.1.18",


### PR DESCRIPTION
https://zod.dev/library-authors
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Relaxed the sso package peer dependency on zod v3 from 3.25.0 to ^3.25.0 while keeping v4 support. This improves compatibility and reduces peer dependency warnings during install.

<!-- End of auto-generated description by cubic. -->

