### PR TITLE
chore: fix typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Better Auth is framework-agnostic authentication (and authorization) library for
 
 ### Why Better Auth
 
-Authentication in the TypeScript ecosystem is a half-solved problem. Other open-source libraries often requires a lot of additional code for anything beyond basic authentication. Rather than just pushing third-party services as the solution, I believe we can do better as a community—hence, Better Auth.
+Authentication in the TypeScript ecosystem is a half-solved problem. Other open-source libraries often require a lot of additional code for anything beyond basic authentication. Rather than just pushing third-party services as the solution, I believe we can do better as a community—hence, Better Auth.
 
 ## Contribution
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes a grammar typo in the README to improve clarity. Updates the “Why Better Auth” section from “requires” to “require.”

<!-- End of auto-generated description by cubic. -->

