### PR TITLE
docs: fix getRequestEvent SvelteKit version callout

### DIFF
--- a/docs/content/docs/integrations/svelte-kit.mdx
+++ b/docs/content/docs/integrations/svelte-kit.mdx
@@ -51,7 +51,7 @@ To ensure cookies are properly set when you call functions like `signInEmail` or
 You need to add it as a plugin to your Better Auth instance.
 
 <Callout>
-  The `getRequestEvent` function is available in SvelteKit `2.2.0` and later.
+  The `getRequestEvent` function is available in SvelteKit `2.20.0` and later.
   Make sure you are using a compatible version.
 </Callout>
 


### PR DESCRIPTION
Should be `2.20.0`, not `2.2.0`.

See: https://github.com/sveltejs/kit/blob/main/packages/kit/CHANGELOG.md#2200