### PR TITLE
docs: fix token encryption doc code snippet

### DIFF
--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -302,7 +302,7 @@ export const auth = betterAuth({
                         withEncryptedTokens.refreshToken = encryptedRefreshToken;
                     }
                     return {
-                        data: resultAccount
+                        data: withEncryptedTokens
                     }
                 },
             }


### PR DESCRIPTION
`resultAccount` isn’t specified anywhere
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the token encryption example in users-accounts.mdx to return withEncryptedTokens instead of the undefined resultAccount. This makes the docs snippet accurate and runnable.

<!-- End of auto-generated description by cubic. -->

