### PR TITLE
feat: jwks remote url

### DIFF
--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -173,6 +173,25 @@ const token = 'your.jwt.token' // this is the token you get from the /api/auth/t
 const payload = await validateToken(token)
 ```
 
+### Remote JWKS Url
+
+Disables the `/jwks` endpoint and uses this endpoint in any discovery such as OIDC.
+
+Useful if your JWKS are not managed at `/jwks` or if your jwks are signed with a certificate and placed on your CDN.
+
+NOTE: you **MUST** specify which asymmetric algorithm is used for signing.
+
+```ts title="auth.ts"
+jwt({
+  jwks: {
+    remoteUrl: "https://example.com/.well-known/jwks.json",
+    keyPairConfig: {
+      alg: 'ES256',
+    },
+  }
+})
+```
+
 ## Schema
 
 The JWT plugin adds the following tables to the database:

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -9,6 +9,7 @@ import { getJwksAdapter } from "./adapter";
 import { getJwtToken, signJWT } from "./sign";
 import { exportJWK, generateKeyPair, type JWK, type JWTPayload } from "jose";
 import {
+	APIError,
 	createAuthEndpoint,
 	createAuthMiddleware,
 	sessionMiddleware,
@@ -16,6 +17,7 @@ import {
 import { symmetricEncrypt } from "../../crypto";
 import { mergeSchema } from "../../db/schema";
 import z from "zod";
+import { BetterAuthError } from "../../error";
 
 type JWKOptions =
 	| {
@@ -45,6 +47,14 @@ type JWKOptions =
 
 export interface JwtOptions {
 	jwks?: {
+		/**
+		 * Disables the /jwks endpoint and uses this endpoint in discovery.
+		 *
+		 * Useful if jwks are not managed at /jwks or
+		 * if your jwks are signed with a certificate and placed on your CDN.
+		 */
+		remoteUrl?: string;
+
 		/**
 		 * Key pair configuration
 		 * @description A subset of the options available for the generateKeyPair function
@@ -141,6 +151,14 @@ export async function generateExportedKeyPair(
 }
 
 export const jwt = (options?: JwtOptions) => {
+	// Alg is required to be specified when using remote url (needed in openid metadata)
+	if (options?.jwks?.remoteUrl && !options.jwks?.keyPairConfig?.alg) {
+		throw new BetterAuthError(
+			"jwks_config",
+			"must specify alg when using the oidc plugin and jwks.remoteUrl",
+		);
+	}
+
 	return {
 		id: "jwt",
 		options,
@@ -233,6 +251,11 @@ export const jwt = (options?: JwtOptions) => {
 					},
 				},
 				async (ctx) => {
+					// Disables endpoint if using remote url strategy
+					if (options?.jwks?.remoteUrl) {
+						throw new APIError("NOT_FOUND");
+					}
+
 					const adapter = getJwksAdapter(ctx.context.adapter);
 
 					const keySets = await adapter.getAllKeys();

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -3,7 +3,7 @@ import { getTestInstance } from "../../test-utils/test-instance";
 import { createAuthClient } from "../../client";
 import { jwtClient } from "./client";
 import { generateExportedKeyPair, jwt, type JwtOptions } from "./index";
-import { importJWK, jwtVerify } from "jose";
+import { importJWK, jwtVerify, type JSONWebKeySet } from "jose";
 
 type JWKOptions =
 	| {
@@ -423,5 +423,49 @@ describe("signJWT", async (it) => {
 			},
 			protectedHeader: { alg: "EdDSA", kid: jwks.keys[0].kid },
 		});
+	});
+});
+
+describe("jwt - remote url", async (it) => {
+	const { auth } = await getTestInstance({
+		plugins: [
+			jwt({
+				jwks: {
+					remoteUrl: "https://example.com",
+					keyPairConfig: {
+						alg: "ES256",
+					},
+				},
+			}),
+		],
+	});
+
+	const client = createAuthClient({
+		plugins: [jwtClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	it("should require specifying the alg used", async () => {
+		expect(() =>
+			getTestInstance({
+				plugins: [
+					jwt({
+						jwks: {
+							remoteUrl: "https://example.com",
+						},
+					}),
+				],
+			}),
+		).toThrow();
+	});
+
+	it("should disable /jwks", async () => {
+		const response = await client.$fetch<JSONWebKeySet>("/jwks");
+		expect(response.error?.status).toBe(404);
 	});
 });


### PR DESCRIPTION
remoteUrl option disables jwks endpoint and uses this endpoint in oAuth metadata

Partial https://github.com/better-auth/better-auth/pull/3572

Type: **PATCH**

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds jwks.remoteUrl to the JWT plugin to use an external JWKS. When set, it disables the /jwks endpoint and exposes the remote URL via OIDC discovery.

- **New Features**
  - jwks.remoteUrl points to a remote JWKS.
  - /jwks returns 404 when remoteUrl is set; OIDC metadata uses the remote URL.
  - keyPairConfig.alg is required with remoteUrl.
  - Docs and tests added.

- **Migration**
  - If you enable jwks.remoteUrl, set keyPairConfig.alg (e.g., ES256).
  - Update any clients relying on /jwks to fetch keys from the remote URL.

<!-- End of auto-generated description by cubic. -->

