### PR TITLE
feat: export jwt plugin with error

### DIFF
--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -1,80 +1,11 @@
-import { subtle, getRandomValues } from "@better-auth/utils";
-import { base64 } from "@better-auth/utils/base64";
+import type { AuthContext } from "../../types";
+import { BetterAuthError } from "../../error";
+import type { jwt } from "./index";
 
-async function deriveKey(secretKey: string): Promise<CryptoKey> {
-	const enc = new TextEncoder();
-	const keyMaterial = await crypto.subtle.importKey(
-		"raw",
-		enc.encode(secretKey),
-		{ name: "PBKDF2" },
-		false,
-		["deriveKey"],
-	);
-
-	return subtle.deriveKey(
-		{
-			name: "PBKDF2",
-			salt: enc.encode("encryption_salt"),
-			iterations: 100000,
-			hash: "SHA-256",
-		},
-		keyMaterial,
-		{ name: "AES-GCM", length: 256 },
-		false,
-		["encrypt", "decrypt"],
-	);
-}
-
-export async function encryptPrivateKey(
-	privateKey: string,
-	secretKey: string,
-): Promise<{ encryptedPrivateKey: string; iv: string; authTag: string }> {
-	const key = await deriveKey(secretKey); // Derive a 32-byte key from the provided secret
-	const iv = getRandomValues(new Uint8Array(12)); // 12-byte IV for AES-GCM
-
-	const enc = new TextEncoder();
-	const ciphertext = await subtle.encrypt(
-		{
-			name: "AES-GCM",
-			iv: iv,
-		},
-		key,
-		enc.encode(privateKey),
-	);
-
-	const encryptedPrivateKey = base64.encode(ciphertext);
-	const ivBase64 = base64.encode(iv);
-
-	return {
-		encryptedPrivateKey,
-		iv: ivBase64,
-		authTag: encryptedPrivateKey.slice(-16),
-	};
-}
-
-export async function decryptPrivateKey(
-	encryptedPrivate: {
-		encryptedPrivateKey: string;
-		iv: string;
-		authTag: string;
-	},
-	secretKey: string,
-): Promise<string> {
-	const key = await deriveKey(secretKey);
-	const { encryptedPrivateKey, iv } = encryptedPrivate;
-
-	const ivBuffer = base64.decode(iv);
-	const ciphertext = base64.decode(encryptedPrivateKey);
-
-	const decrypted = await subtle.decrypt(
-		{
-			name: "AES-GCM",
-			iv: ivBuffer as BufferSource,
-		},
-		key,
-		ciphertext as BufferSource,
-	);
-
-	const dec = new TextDecoder();
-	return dec.decode(decrypted);
-}
+export const getJwtPlugin = (ctx: AuthContext) => {
+	const plugin = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
+	if (!plugin) {
+		throw new BetterAuthError("jwt_config", "jwt plugin not found");
+	}
+	return plugin as ReturnType<typeof jwt>;
+};

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -19,6 +19,22 @@ import { toNodeHandler } from "../../integrations/node";
 import { jwt } from "../jwt";
 import { createLocalJWKSet, decodeProtectedHeader, jwtVerify } from "jose";
 
+describe("oidc - init", async () => {
+	it("should fail without the jwt plugin", async ({ expect }) => {
+		await expect(
+			getTestInstance({
+				plugins: [
+					oidcProvider({
+						useJWTPlugin: true,
+						loginPage: "/login",
+						consentPage: "/consent",
+					}),
+				],
+			}),
+		).rejects.toThrowError("jwt_config");
+	});
+});
+
 describe("oidc", async () => {
 	const {
 		auth: authorizationServer,


### PR DESCRIPTION
Exports `getJwtPlugin` for other plugins. Errors early via `init` to prevent need of checks at runtime.

Removes unused JWT utils from [utils.ts](packages/better-auth/src/plugins/jwt/utils.ts). Non-breaking since it is never exported by [index.ts](packages/better-auth/src/plugins/jwt/index.ts).

Partial https://github.com/better-auth/better-auth/pull/3572

Type: **PATCH**
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Exports a safe getJwtPlugin helper that throws when the JWT plugin is missing, and updates OIDC to fail fast during init when useJWTPlugin is true. Also removes unused JWT crypto helpers.

- **New Features**
  - Exported getJwtPlugin from the JWT plugin; throws BetterAuthError if not found.
  - OIDC provider init checks for JWT plugin when useJWTPlugin is true to prevent runtime failures.

- **Refactors**
  - Removed unused JWT encryption/decryption utilities.
  - Replaced OIDC’s local JWT lookup with shared getJwtPlugin.
  - Added a test to ensure init fails without the JWT plugin.

<!-- End of auto-generated description by cubic. -->

