### PR TITLE
fix: constant time compare

### DIFF
--- a/packages/better-auth/src/crypto/buffer.ts
+++ b/packages/better-auth/src/crypto/buffer.ts
@@ -8,8 +8,11 @@ export function constantTimeEqual(
 	const aBuffer = new Uint8Array(a);
 	const bBuffer = new Uint8Array(b);
 	let c = aBuffer.length ^ bBuffer.length;
-	for (let i = 0; i < aBuffer.length; i++) {
-		c |= aBuffer[i]! ^ bBuffer[i]!;
+	const length = Math.max(aBuffer.length, bBuffer.length);
+	for (let i = 0; i < length; i++) {
+		c |=
+			(i < aBuffer.length ? aBuffer[i] : 0) ^
+			(i < bBuffer.length ? bBuffer[i] : 0);
 	}
 	return c === 0;
 }

--- a/packages/better-auth/src/crypto/buffer.ts
+++ b/packages/better-auth/src/crypto/buffer.ts
@@ -7,10 +7,7 @@ export function constantTimeEqual(
 ): boolean {
 	const aBuffer = new Uint8Array(a);
 	const bBuffer = new Uint8Array(b);
-	if (aBuffer.length !== bBuffer.length) {
-		return false;
-	}
-	let c = 0;
+	let c = aBuffer.length ^ bBuffer.length;
 	for (let i = 0; i < aBuffer.length; i++) {
 		c |= aBuffer[i]! ^ bBuffer[i]!;
 	}


### PR DESCRIPTION
An early return value will still lead to a timing attack issue

Related: https://github.com/better-auth/utils/pull/12