### PR TITLE
fix/opt-in-telemetry

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -639,7 +639,7 @@ export const auth = betterAuth({
 
 ## `telemetry`
 
-Enable or disable Better Auth's telemetry collection. (default: `true`)
+Enable or disable Better Auth's telemetry collection. (default: `false`)
 
 ```ts
 import { betterAuth } from "better-auth";

--- a/docs/content/docs/reference/telemetry.mdx
+++ b/docs/content/docs/reference/telemetry.mdx
@@ -3,7 +3,7 @@ title: Telemetry
 description: Better Auth now collects anonymous telemetry data about general usage.
 ---
 
-Better Auth collects anonymous usage data to help us improve the project. This is optional, transparent, and is disabled by default.
+Better Auth collects anonymous usage data to help us improve the project. This is optional, transparent, and disabled by default.
 
 ## Why is telemetry collected?
 

--- a/docs/content/docs/reference/telemetry.mdx
+++ b/docs/content/docs/reference/telemetry.mdx
@@ -3,7 +3,7 @@ title: Telemetry
 description: Better Auth now collects anonymous telemetry data about general usage.
 ---
 
-Better Auth collects anonymous usage data to help us improve the project. This is optional, transparent, and can be disabled at any time.
+Better Auth collects anonymous usage data to help us improve the project. This is optional, transparent, and is disabled by default.
 
 ## Why is telemetry collected?
 
@@ -51,9 +51,9 @@ All collected data is fully anonymous and only useful in aggregate. It cannot be
 - **No full config**: We never send your full `betterAuth` configuration. Instead we send a reduced, redacted snapshot of non‑sensitive toggles and counts.
 - **Redaction by design**: See [detect-auth-config.ts](https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/telemetry/detectors/detect-auth-config.ts) in the Better Auth source for the exact shape of what is included. It purposely converts sensitive values to booleans, counts, or generic identifiers.
 
-## How can I disable it?
+## How can I enable it?
 
-You can disable telemetry collection in your auth config or by setting an environment variable.
+You can enable telemetry collection in your auth config or by setting an environment variable.
 
 - Via your auth config.
 
@@ -61,7 +61,7 @@ You can disable telemetry collection in your auth config or by setting an enviro
   export const auth = betterAuth({
     // [!code highlight]
     telemetry: { // [!code highlight]
-      enabled: false // [!code highlight]
+      enabled: true// [!code highlight]
     } // [!code highlight]
   });
   ```

--- a/packages/better-auth/src/telemetry/index.ts
+++ b/packages/better-auth/src/telemetry/index.ts
@@ -154,10 +154,10 @@ export async function createTelemetry(
 		const telemetryEnabled =
 			options.telemetry?.enabled !== undefined
 				? options.telemetry.enabled
-				: true;
-		const envEnabled = getBooleanEnvVar("BETTER_AUTH_TELEMETRY", true);
+				: false;
+		const envEnabled = getBooleanEnvVar("BETTER_AUTH_TELEMETRY", false);
 		return (
-			envEnabled && telemetryEnabled && (context?.skipTestCheck || !isTest())
+			(envEnabled || telemetryEnabled) && (context?.skipTestCheck || !isTest())
 		);
 	};
 

--- a/packages/better-auth/src/telemetry/index.ts
+++ b/packages/better-auth/src/telemetry/index.ts
@@ -10,111 +10,6 @@ import { betterFetch } from "@better-fetch/fetch";
 import type { TelemetryContext, TelemetryEvent } from "./types";
 import { logger } from "../utils";
 import { getTelemetryAuthConfig } from "./detectors/detect-auth-config";
-import { importRuntime } from "../utils/import-util";
-
-const message = `\n\n\x1b[36mBetter Auth\x1b[0m — Anonymous telemetry notice
-\nWe collect minimal, completely anonymous usage telemetry to help improve Better Auth.
-
-You can disable it at any time:
-  • In your auth config: \x1b[33mtelemetry: { enabled: false }\x1b[0m
-  • Or via env: \x1b[33mBETTER_AUTH_TELEMETRY=0\x1b[0m
-
-You can also debug what would be sent by setting:
-  • \x1b[33mBETTER_AUTH_TELEMETRY_DEBUG=1\x1b[0m
-
-Learn more in the docs: https://www.better-auth.com/docs/reference/telemetry\n\n`;
-
-async function configFilePath() {
-	try {
-		const path = await importRuntime<typeof import("path")>("path");
-		const os = await importRuntime<typeof import("os")>("os");
-		const baseDir =
-			typeof process !== "undefined" && process.platform === "win32"
-				? process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")
-				: path.join(os.homedir(), ".config");
-		const dir = path.join(baseDir, "better-auth");
-		const file = path.join(dir, "telemetry.json");
-
-		return { file, dir };
-	} catch {
-		return {
-			file: null,
-			dir: null,
-		};
-	}
-}
-
-const shownNoticeInProcess = new Set<string>();
-
-async function hasShownNoticeBefore(anonymousId: string) {
-	try {
-		const { file } = await configFilePath();
-
-		if (!file) {
-			return true;
-		}
-
-		const fs = await importRuntime<typeof import("fs/promises")>("fs/promises");
-		const raw = await fs.readFile(file, "utf-8");
-		const json = JSON.parse(raw) as { seen?: string[] };
-
-		return Array.isArray(json.seen) && json.seen.includes(anonymousId);
-	} catch (err: unknown) {
-		if (
-			err &&
-			typeof err === "object" &&
-			"code" in err &&
-			(err as NodeJS.ErrnoException).code === "ENOENT"
-		) {
-			// if the file doesn't exist we know that the notice hasn't been shown before
-			return false;
-		}
-
-		// an unknown error happened
-		return true;
-	}
-}
-
-async function markNoticeShown(anonymousId: string) {
-	try {
-		const fs = await importRuntime<typeof import("fs/promises")>("fs/promises");
-		const { file, dir } = await configFilePath();
-		if (!file || !dir) return;
-		await fs.mkdir(dir, { recursive: true });
-		let json: { seen: string[] } = { seen: [] };
-
-		try {
-			if (!file) return;
-			const raw = await fs.readFile(file, "utf-8");
-			const parsed = JSON.parse(raw) as { seen?: string[] };
-			json.seen = Array.isArray(parsed.seen) ? parsed.seen : [];
-		} catch {}
-
-		if (!json.seen.includes(anonymousId)) {
-			json.seen.push(anonymousId);
-		}
-		await fs.writeFile(file, JSON.stringify(json, null, 2), "utf-8");
-	} catch {}
-}
-
-async function maybeShowTelemetryNotice(anonymousId: string) {
-	if (shownNoticeInProcess.has(anonymousId)) return;
-
-	if (typeof process !== "undefined" && process.stdout && !process.stdout.isTTY)
-		return;
-
-	if (await hasShownNoticeBefore(anonymousId)) {
-		shownNoticeInProcess.add(anonymousId);
-		return;
-	}
-
-	try {
-		console.log(message);
-	} catch {}
-
-	shownNoticeInProcess.add(anonymousId);
-	await markNoticeShown(anonymousId);
-}
 
 export async function createTelemetry(
 	options: BetterAuthOptions,
@@ -123,12 +18,6 @@ export async function createTelemetry(
 	const debugEnabled =
 		options.telemetry?.debug ||
 		getBooleanEnvVar("BETTER_AUTH_TELEMETRY_DEBUG", false);
-
-	const disableNotice =
-		options.telemetry?.disableNotice ||
-		options.telemetry?.enabled === false ||
-		options.telemetry?.debug ||
-		getBooleanEnvVar("BETTER_AUTH_TELEMETRY_DISABLE_NOTICE", false);
 
 	const TELEMETRY_ENDPOINT = ENV.BETTER_AUTH_TELEMETRY_ENDPOINT;
 	const track = async (event: TelemetryEvent) => {
@@ -177,9 +66,6 @@ export async function createTelemetry(
 			packageManager: detectPackageManager(),
 		};
 
-		if (!disableNotice) {
-			await maybeShowTelemetryNotice(anonymousId);
-		}
 		void track({ type: "init", payload, anonymousId });
 	}
 

--- a/packages/better-auth/src/telemetry/telemetry.test.ts
+++ b/packages/better-auth/src/telemetry/telemetry.test.ts
@@ -68,6 +68,7 @@ describe("telemetry", () => {
 						enabled: true,
 					},
 				},
+				telemetry: { enabled: true },
 			},
 			{ customTrack: track, skipTestCheck: true },
 		);
@@ -285,6 +286,7 @@ describe("telemetry", () => {
 			createTelemetry(
 				{
 					baseURL: "http://localhost",
+					telemetry: { enabled: true },
 				},
 				{
 					customTrack() {
@@ -305,7 +307,7 @@ describe("telemetry", () => {
 			const track = vi.fn();
 			await expect(
 				createTelemetry(
-					{ baseURL: "https://example.com" },
+					{ baseURL: "https://example.com", telemetry: { enabled: true } },
 					{ customTrack: track, skipTestCheck: true },
 				),
 			).resolves.not.toThrow();

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -1067,11 +1067,5 @@ export type BetterAuthOptions = {
 		 * @default false
 		 */
 		debug?: boolean;
-		/**
-		 * Disable telemetry notice
-		 *
-		 * @default false
-		 */
-		disableNotice?: boolean;
 	};
 };

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -1058,7 +1058,7 @@ export type BetterAuthOptions = {
 		/**
 		 * Enable telemetry collection
 		 *
-		 * @default true
+		 * @default false
 		 */
 		enabled?: boolean;
 		/**


### PR DESCRIPTION
Make telemetry opt in instead of opt out.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make telemetry opt-in. Telemetry is now disabled by default, the console notice was removed, and the BETTER_AUTH_TELEMETRY env default is false.

- **Migration**
  - To enable telemetry, set telemetry.enabled=true in your auth config or BETTER_AUTH_TELEMETRY=1.
  - If you relied on telemetry being on by default, opt in explicitly now.
  - Remove usage of telemetry.disableNotice; this option was removed.

<!-- End of auto-generated description by cubic. -->

