### PR TITLE
fix: check `x-api-key` for all auth endpoint

### DIFF
--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -1892,7 +1892,7 @@ describe("api-key", async () => {
 			{ name: "test-auth-key" },
 			{ headers },
 		);
-		
+
 		if (!testApiKey) throw new Error("Failed to create API key");
 
 		const apiKeyHeaders = new Headers();
@@ -1909,7 +1909,7 @@ describe("api-key", async () => {
 	it("should set session context for all authenticated API key requests", async () => {
 		// This test verifies that ctx.context.session is properly set
 		// for all API key authenticated requests, not just /get-session
-		
+
 		// Create an API key using the main auth instance
 		const testApiKey = await auth.api.createApiKey({
 			body: {
@@ -1931,7 +1931,7 @@ describe("api-key", async () => {
 		const verifyResult = await auth.api.verifyApiKey({
 			body: { key: testApiKey.key },
 		});
-		
+
 		expect(verifyResult.valid).toBe(true);
 		expect(verifyResult.key).toBeDefined();
 	});

--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -186,7 +186,7 @@ export const apiKey = (options?: ApiKeyOptions) => {
 								message: ERROR_CODES.INVALID_USER_ID_FROM_API_KEY,
 							});
 						}
-						
+
 						const session = {
 							user,
 							session: {
@@ -202,13 +202,12 @@ export const apiKey = (options?: ApiKeyOptions) => {
 								expiresAt:
 									apiKey.expiresAt ||
 									getDate(
-										ctx.context.options.session?.expiresIn ||
-											60 * 60 * 24 * 7, // 7 days
+										ctx.context.options.session?.expiresIn || 60 * 60 * 24 * 7, // 7 days
 										"ms",
 									),
 							},
 						};
-						
+
 						// Always set the session context for API key authentication
 						ctx.context.session = session;
 


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4080
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Always set the session context when authenticating with an API key, not just for /get-session. Fixes API key requests failing on other endpoints and enables using x-api-key across the API.

- **Bug Fixes**
  - Set ctx.context.session for all API key–authenticated requests after user validation.
  - Keep /get-session behavior (returns session) while other endpoints now work with API key auth.
  - Added tests: authenticate with x-api-key on list/verify endpoints and ensure session context is set.

<!-- End of auto-generated description by cubic. -->

