### PR TITLE
chore(oauth): separate betterFetch from request format

### DIFF
--- a/packages/better-auth/src/oauth2/client-credentials-token.ts
+++ b/packages/better-auth/src/oauth2/client-credentials-token.ts
@@ -1,0 +1,97 @@
+import { betterFetch } from "@better-fetch/fetch";
+import type { OAuth2Tokens } from "./types";
+import type { ProviderOptions } from "./types";
+import { base64Url } from "@better-auth/utils/base64";
+
+export function createClientCredentialsTokenRequest({
+	options,
+	scope,
+	authentication,
+	resource,
+}: {
+	options: ProviderOptions & { clientSecret: string };
+	scope?: string;
+	authentication?: "basic" | "post";
+	resource?: string | string[];
+}) {
+	const body = new URLSearchParams();
+	const headers: Record<string, any> = {
+		"content-type": "application/x-www-form-urlencoded",
+		accept: "application/json",
+	};
+
+	body.set("grant_type", "client_credentials");
+	scope && body.set("scope", scope);
+	if (resource) {
+		if (typeof resource === "string") {
+			body.append("resource", resource);
+		} else {
+			for (const _resource of resource) {
+				body.append("resource", _resource);
+			}
+		}
+	}
+	if (authentication === "basic") {
+		const encodedCredentials = base64Url.encode(
+			`${options.clientId}:${options.clientSecret}`,
+		);
+		headers["authorization"] = `Basic ${encodedCredentials}`;
+	} else {
+		body.set("client_id", options.clientId);
+		body.set("client_secret", options.clientSecret);
+	}
+
+	return {
+		body,
+		headers,
+	};
+}
+
+export async function clientCredentialsToken({
+	options,
+	tokenEndpoint,
+	scope,
+	authentication,
+	resource,
+}: {
+	options: ProviderOptions & { clientSecret: string };
+	tokenEndpoint: string;
+	scope: string;
+	authentication?: "basic" | "post";
+	resource?: string | string[];
+}): Promise<OAuth2Tokens> {
+	const { body, headers } = createClientCredentialsTokenRequest({
+		options,
+		scope,
+		authentication,
+		resource,
+	});
+
+	const { data, error } = await betterFetch<{
+		access_token: string;
+		expires_in?: number;
+		token_type?: string;
+		scope?: string;
+	}>(tokenEndpoint, {
+		method: "POST",
+		body,
+		headers,
+	});
+	if (error) {
+		throw error;
+	}
+	const tokens: OAuth2Tokens = {
+		accessToken: data.access_token,
+		tokenType: data.token_type,
+		scopes: data.scope?.split(" "),
+	};
+
+	if (data.expires_in) {
+		const now = new Date();
+		tokens.accessTokenExpiresAt = new Date(
+			now.getTime() + data.expires_in * 1000,
+		);
+	}
+
+	return tokens;
+}

--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -3,28 +3,26 @@ import type { OAuth2Tokens } from "./types";
 import type { ProviderOptions } from "./types";
 import { base64 } from "@better-auth/utils/base64";
 
-export async function refreshAccessToken({
+export function createRefreshAccessTokenRequest({
 	refreshToken,
 	options,
-	tokenEndpoint,
 	authentication,
 	extraParams,
-	grantType = "refresh_token",
+	resource,
 }: {
 	refreshToken: string;
 	options: Partial<ProviderOptions>;
-	tokenEndpoint: string;
 	authentication?: "basic" | "post";
 	extraParams?: Record<string, string>;
-	grantType?: string;
-}): Promise<OAuth2Tokens> {
+	resource?: string | string[];
+}) {
 	const body = new URLSearchParams();
 	const headers: Record<string, any> = {
 		"content-type": "application/x-www-form-urlencoded",
 		accept: "application/json",
 	};
 
-	body.set("grant_type", grantType);
+	body.set("grant_type", "refresh_token");
 	body.set("refresh_token", refreshToken);
 	// Use standard Base64 encoding for HTTP Basic Auth (OAuth2 spec, RFC 7617)
 	// Fixes compatibility with providers like Notion, Twitter, etc.
@@ -43,11 +41,48 @@ export async function refreshAccessToken({
 		}
 	}
 
+	if (resource) {
+		if (typeof resource === "string") {
+			body.append("resource", resource);
+		} else {
+			for (const _resource of resource) {
+				body.append("resource", _resource);
+			}
+		}
+	}
 	if (extraParams) {
 		for (const [key, value] of Object.entries(extraParams)) {
 			body.set(key, value);
 		}
 	}
+
+	return {
+		body,
+		headers,
+	};
+}
+
+export async function refreshAccessToken({
+	refreshToken,
+	options,
+	tokenEndpoint,
+	authentication,
+	extraParams,
+}: {
+	refreshToken: string;
+	options: Partial<ProviderOptions>;
+	tokenEndpoint: string;
+	authentication?: "basic" | "post";
+	extraParams?: Record<string, string>;
+	/** @deprecated always "refresh_token" */
+	grantType?: string;
+}): Promise<OAuth2Tokens> {
+	const { body, headers } = createRefreshAccessTokenRequest({
+		refreshToken,
+		options,
+		authentication,
+		extraParams,
+	});
 
 	const { data, error } = await betterFetch<{
 		access_token: string;


### PR DESCRIPTION
Separates betterFetch from the actual request format needed for testing functions.

Adds a `resource` parameter to the function which has a specific format described by [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html#name-authorization-request)

Partial: #3458
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Decoupled OAuth2 request construction from network calls and added RFC 8707 resource support across token flows. Improves testability and enables resource-scoped tokens. Partial: #3458.

- New Features
  - Added resource (string | string[]) to authorization code, refresh token, and client credentials flows.
  - Introduced clientCredentialsToken and createClientCredentialsTokenRequest with Basic or form-post auth; maps expires_in to accessTokenExpiresAt.

- Refactors
  - Added createAuthorizationCodeRequest and createRefreshAccessTokenRequest to return body + headers; betterFetch is used only in the caller.
  - refreshAccessToken now always sends grant_type=refresh_token (grantType param deprecated).

<!-- End of auto-generated description by cubic. -->

