### PR TITLE
chore: bump `better-call`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^1.1.18
       version: 1.1.18
     better-call:
-      specifier: ^1.0.13
-      version: 1.0.13
+      specifier: 1.0.15
+      version: 1.0.15
     typescript:
       specifier: ^5.9.2
       version: 5.9.2
@@ -194,7 +194,7 @@ importers:
         version: link:../../packages/better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.0.13
+        version: 1.0.15
       better-sqlite3:
         specifier: ^11.6.0
         version: 11.10.0
@@ -624,7 +624,7 @@ importers:
         version: 13.1.2
       better-call:
         specifier: 'catalog:'
-        version: 1.0.13
+        version: 1.0.15
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -827,7 +827,7 @@ importers:
         version: 1.1.18
       better-call:
         specifier: 'catalog:'
-        version: 1.0.13
+        version: 1.0.15
       zod:
         specifier: ^4.0.0
         version: 4.0.17
@@ -886,7 +886,7 @@ importers:
         version: 5.0.3
       better-call:
         specifier: 'catalog:'
-        version: 1.0.13
+        version: 1.0.15
       zod:
         specifier: ^4.0.0
         version: 4.0.17
@@ -902,7 +902,7 @@ importers:
         version: 7.6.13
       better-call:
         specifier: 'catalog:'
-        version: 1.0.13
+        version: 1.0.15
       better-sqlite3:
         specifier: ^11.6.0
         version: 11.10.0
@@ -6234,8 +6234,8 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
-  better-call@1.0.13:
-    resolution: {integrity: sha512-auqdP9lnNOli9tKpZIiv0nEIwmmyaD/RotM3Mucql+Ef88etoZi/t7Ph5LjlmZt/hiSahhNTt6YVnx6++rziXA==}
+  better-call@1.0.15:
+    resolution: {integrity: sha512-u4ZNRB1yBx5j3CltTEbY2ZoFPVcgsuvciAqTEmPvnZpZ483vlZf4LGJ5aVau1yMlrvlyHxOCica3OqXBLhmsUw==}
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -15454,7 +15454,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.2.1
+      '@types/node': 20.17.57
       '@types/yargs': 15.0.19
       chalk: 4.1.2
     optional: true
@@ -18265,7 +18265,7 @@ snapshots:
 
   '@types/node-forge@1.3.13':
     dependencies:
-      '@types/node': 24.2.1
+      '@types/node': 20.17.57
 
   '@types/node@20.17.57':
     dependencies:
@@ -18278,6 +18278,7 @@ snapshots:
   '@types/node@24.2.1':
     dependencies:
       undici-types: 7.10.0
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -19219,7 +19220,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  better-call@1.0.13:
+  better-call@1.0.15:
     dependencies:
       '@better-fetch/fetch': 1.1.18
       rou3: 0.5.1
@@ -26701,7 +26702,8 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici-types@7.10.0: {}
+  undici-types@7.10.0:
+    optional: true
 
   undici@5.29.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalogs:
     react: 19.1.0
     react-dom: 19.1.0
 catalog:
-  "better-call": "^1.0.13"
+  "better-call": "1.0.15"
   "@better-fetch/fetch": "^1.1.18"
   "unbuild": "^3.5.0"
   "typescript": "^5.9.2"


### PR DESCRIPTION
Related: https://github.com/better-auth/better-auth/issues/4082

Remove the caret in case of same thing happens


<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumped better-call to 1.0.15 across the workspace to pick up the latest fixes and keep versions consistent. Updated the workspace catalog and lockfile accordingly.

- **Dependencies**
  - Set catalog "better-call" to 1.0.15 and updated all importers.
  - Regenerated pnpm lock for better-call@1.0.15 integrity/snapshots.
  - Minor lockfile adjustments for @types/node and undici-types (deduped/optional).

<!-- End of auto-generated description by cubic. -->

