### PR TITLE
test: flaky becase cleanup function not called

### DIFF
--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -115,7 +115,7 @@ export async function getTestInstance<
 			...options?.advanced,
 		},
 		plugins: [bearer(), ...(options?.plugins || [])],
-	});
+	} as O extends undefined ? typeof opts : O & typeof opts);
 
 	const testUser = {
 		email: "test@test.com",
@@ -127,8 +127,8 @@ export async function getTestInstance<
 		if (config?.disableTestUser) {
 			return;
 		}
+		//@ts-expect-error
 		await auth.api.signUpEmail({
-			//@ts-expect-error image is not compatible with the type
 			body: testUser,
 		});
 	}


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4097

Asked vitest member, we did wrong

<img width="562" height="476" alt="image" src="https://github.com/user-attachments/assets/28165617-1951-4910-8b90-39e0c9db6013" />

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make test cleanup reliable by calling a shared cleanup function via onTestFinished with a fallback to afterAll. Also stress-runs the getSessionCookie suite (repeats: 100) and enables debug logging to surface flakiness. Fixes better-auth/better-auth#4097.

- **Bug Fixes**
  - Register a reusable cleanup that drops databases and deletes temp files using onTestFinished, falling back to afterAll.
  - Repeat getSessionCookie tests 100x to catch intermittent failures.
  - Set test logger level to debug for easier debugging.

<!-- End of auto-generated description by cubic. -->

