### PR TITLE
ci: test for node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
 jobs:
     test:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [20.x, 22.x]
         steps:
             - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
               with:
@@ -31,7 +34,7 @@ jobs:
 
             - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
-                node-version: 20.x
+                node-version: ${{ matrix.node-version }}
                 registry-url: 'https://registry.npmjs.org'
                 cache: pnpm
             

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
-on: 
-    pull_request:  
-        types: 
+on:
+    pull_request:
+        types:
           - opened
           - synchronize
     push:
@@ -15,6 +15,7 @@ jobs:
     test:
         runs-on: ubuntu-latest
         strategy:
+            fail-fast: false
             matrix:
                 node-version: [20.x, 22.x]
         steps:
@@ -37,7 +38,7 @@ jobs:
                 node-version: ${{ matrix.node-version }}
                 registry-url: 'https://registry.npmjs.org'
                 cache: pnpm
-            
+
             - name: Install
               run: pnpm install
 
@@ -47,20 +48,20 @@ jobs:
                 TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
                 TURBO_REMOTE_ONLY: true
               run: pnpm build
-            
+
             - name: Start Docker Containers
               run: |
                 docker compose up -d
                 # Wait for services to be ready (optional)
                 sleep 10
-            
+
             - name: Lint
               env:
                 TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
                 TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
                 TURBO_REMOTE_ONLY: true
               run: pnpm lint
-            
+
             - name: Test
               env:
                 TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/packages/better-auth/src/adapters/kysely-adapter/test/normal/node-sqlite-dialect.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/normal/node-sqlite-dialect.test.ts
@@ -180,7 +180,7 @@ describe.runIf(nodeSqliteSupported)("node-sqlite-dialect", async () => {
 		});
 	});
 
-	it("better-auth adapter integration", async () => {
+	describe("better-auth adapter integration", async () => {
 		const { DatabaseSync } = await import("node:sqlite");
 		const db = new DatabaseSync(":memory:");
 		const betterAuthKysely = new Kysely({

--- a/packages/better-auth/src/adapters/kysely-adapter/test/normal/node-sqlite-dialect.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/normal/node-sqlite-dialect.test.ts
@@ -187,58 +187,60 @@ describe.runIf(nodeSqliteSupported)("node-sqlite-dialect", async () => {
 		});
 	});
 
-	describe("better-auth adapter integration", async () => {
-		const { DatabaseSync } = await import("node:sqlite");
-		const db = new DatabaseSync(":memory:");
-		const betterAuthKysely = new Kysely({
-			dialect: new NodeSqliteDialect({
-				database: db,
-			}),
-		});
+	describe.runIf(nodeSqliteSupported)(
+		"better-auth adapter integration",
+		async () => {
+			const { DatabaseSync } = await import("node:sqlite");
+			const db = new DatabaseSync(":memory:");
+			const betterAuthKysely = new Kysely({
+				dialect: new NodeSqliteDialect({
+					database: db,
+				}),
+			});
 
-		const opts: BetterAuthOptions = {
-			database: {
-				db: betterAuthKysely,
-				type: "sqlite",
-			},
-			user: {
-				fields: {
-					email: "email_address",
+			const opts: BetterAuthOptions = {
+				database: {
+					db: betterAuthKysely,
+					type: "sqlite",
 				},
-				additionalFields: {
-					test: {
-						type: "string",
-						defaultValue: "test",
+				user: {
+					fields: {
+						email: "email_address",
+					},
+					additionalFields: {
+						test: {
+							type: "string",
+							defaultValue: "test",
+						},
 					},
 				},
-			},
-			session: {
-				modelName: "sessions",
-			},
-		};
+				session: {
+					modelName: "sessions",
+				},
+			};
 
-		beforeAll(async () => {
-			const { runMigrations } = await getMigrations(opts);
-			await runMigrations();
-		});
+			beforeAll(async () => {
+				const { runMigrations } = await getMigrations(opts);
+				await runMigrations();
+			});
 
-		afterAll(async () => {
-			await betterAuthKysely.destroy();
-			db.close();
-		});
+			afterAll(async () => {
+				await betterAuthKysely.destroy();
+			});
 
-		const adapter = kyselyAdapter(betterAuthKysely, {
-			type: "sqlite",
-			debugLogs: {
-				isRunningAdapterTests: true,
-			},
-		});
+			const adapter = kyselyAdapter(betterAuthKysely, {
+				type: "sqlite",
+				debugLogs: {
+					isRunningAdapterTests: true,
+				},
+			});
 
-		await runAdapterTest({
-			getAdapter: async (customOptions = {}) => {
-				return adapter(merge(customOptions, opts));
-			},
-			testPrefix: "node-sqlite",
-		});
-	});
+			await runAdapterTest({
+				getAdapter: async (customOptions = {}) => {
+					return adapter(merge(customOptions, opts));
+				},
+				testPrefix: "node-sqlite",
+			});
+		},
+	);
 });

--- a/packages/better-auth/src/adapters/kysely-adapter/test/normal/node-sqlite-dialect.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/normal/node-sqlite-dialect.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+	describe,
+	it,
+	expect,
+	beforeAll,
+	afterAll,
+	afterEach,
+	beforeEach,
+} from "vitest";
 import { Kysely, sql } from "kysely";
 import { NodeSqliteDialect } from "../../node-sqlite-dialect";
 import { kyselyAdapter } from "../../kysely-adapter";
@@ -28,7 +36,6 @@ describe.runIf(nodeSqliteSupported)("node-sqlite-dialect", async () => {
 
 	afterAll(async () => {
 		await kysely.destroy();
-		db.close();
 	});
 
 	describe("basic operations", () => {

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import { generateRandomString } from "../crypto/random";
-import { afterAll, onTestFinished } from "vitest";
+import { afterAll } from "vitest";
 import { betterAuth } from "../auth";
 import { createAuthClient } from "../client/vanilla";
 import type { BetterAuthOptions, ClientOptions, Session, User } from "../types";


### PR DESCRIPTION
In https://github.com/better-auth/better-auth/pull/3869, we bring node:sqlite, which requires Node.js 22.

I think we should still keep node.js 20 as it still in LTS
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Run CI tests on Node.js 20.x and 22.x to validate compatibility across LTS and the new node:sqlite requirement (Node 22). This adds a matrix strategy and uses the matrix version in setup-node.

<!-- End of auto-generated description by cubic. -->

