### PR TITLE
fix: CLI recognizes default export auth config

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -166,15 +166,28 @@ export async function getConfig({
 				auth: {
 					options: BetterAuthOptions;
 				};
-				default?: {
-					options: BetterAuthOptions;
-				};
+				default?: BetterAuthOptions;
+				options?: BetterAuthOptions;
 			}>({
 				configFile: resolvedPath,
 				dotenv: true,
 				jitiOptions: jitiOptions(cwd),
 			});
-			if (!config.auth && !config.default) {
+			console.log("Config", config);
+			if (config.auth?.options) {
+				configFile = config.auth.options;
+			} else if (config.default) {
+				if (typeof config.default === "object" && config.default !== null) {
+					if ("options" in config.default && config.default.options) {
+						configFile = config.default.options;
+						console.log("Config", config);
+					}
+				}
+			} else if (config.options) {
+				configFile = config.options;
+			}
+
+			if (!configFile) {
 				if (shouldThrowOnError) {
 					throw new Error(
 						`Couldn't read your auth config in ${resolvedPath}. Make sure to default export your auth instance or to export as a variable named auth.`,
@@ -185,7 +198,6 @@ export async function getConfig({
 				);
 				process.exit(1);
 			}
-			configFile = config.auth?.options || config.default?.options || null;
 		}
 
 		if (!configFile) {
@@ -195,17 +207,27 @@ export async function getConfig({
 						auth: {
 							options: BetterAuthOptions;
 						};
-						default?: {
-							options: BetterAuthOptions;
-						};
+						default?: BetterAuthOptions;
+						options?: BetterAuthOptions;
 					}>({
 						configFile: possiblePath,
 						jitiOptions: jitiOptions(cwd),
 					});
 					const hasConfig = Object.keys(config).length > 0;
 					if (hasConfig) {
-						configFile =
-							config.auth?.options || config.default?.options || null;
+						if (config.auth?.options) {
+							configFile = config.auth.options;
+						} else if (config.default) {
+							if (
+								typeof config.default === "object" &&
+								config.default !== null
+							) {
+								if ("options" in config.default && config.default.options) {
+									configFile = config.default.options;
+								}
+							}
+						}
+
 						if (!configFile) {
 							if (shouldThrowOnError) {
 								throw new Error(

--- a/packages/cli/test/get-config.test.ts
+++ b/packages/cli/test/get-config.test.ts
@@ -762,4 +762,32 @@ describe("getConfig", async () => {
 			emailAndPassword: { enabled: true },
 		});
 	});
+
+	it("should handle default export auth configuration", async () => {
+		const authPath = path.join(tmpDir, "src", "lib", "server");
+		await fs.mkdir(authPath, { recursive: true });
+
+		await fs.writeFile(
+			path.join(authPath, "auth.ts"),
+			`import { betterAuth } from 'better-auth';
+
+const authInstance = betterAuth({
+	emailAndPassword: {
+		enabled: true
+	}
+});
+
+export default authInstance;`,
+		);
+
+		const config = await getConfig({
+			cwd: tmpDir,
+			configPath: "src/lib/server/auth.ts",
+		});
+
+		expect(config).not.toBe(null);
+		expect(config).toMatchObject({
+			emailAndPassword: { enabled: true },
+		});
+	});
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes CLI config loading to recognize default-exported auth instances, so projects exporting auth as default no longer fail to load. Also supports configs exposed directly via options.

- **Bug Fixes**
  - getConfig now resolves from auth.options, default export objects (default.options), and top-level options.
  - Applies the same resolution logic for both the main and fallback config paths.
  - Adds a test for default-exported auth configuration.

<!-- End of auto-generated description by cubic. -->

