### PR TITLE
fix(oauth2): correct basic auth header construction for refresh token…

### DIFF
--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -35,7 +35,7 @@ export async function refreshAccessToken({
 				base64.encode(`${options.clientId}:${options.clientSecret ?? ""}`);
 		} else {
 			headers["authorization"] =
-				"Basic " + base64.encode(`${options.clientSecret ?? ""}`);
+				"Basic " + base64.encode(`:${options.clientSecret ?? ""}`);
 		}
 	} else {
 		options.clientId && body.set("client_id", options.clientId);

--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -30,11 +30,12 @@ export async function refreshAccessToken({
 	// Fixes compatibility with providers like Notion, Twitter, etc.
 	if (authentication === "basic") {
 		if (options.clientId) {
-			headers["authorization"] = base64.encode(
-				`${options.clientId}:${options.clientSecret ?? ""}`,
-			);
+			headers["authorization"] =
+				"Basic " +
+				base64.encode(`${options.clientId}:${options.clientSecret ?? ""}`);
 		} else {
-			headers["authorization"] = base64.encode(`${options.clientSecret ?? ""}`);
+			headers["authorization"] =
+				"Basic " + base64.encode(`${options.clientSecret ?? ""}`);
 		}
 	} else {
 		options.clientId && body.set("client_id", options.clientId);


### PR DESCRIPTION
Should close http://github.com/better-auth/better-auth/issues/4125
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes OAuth2 refresh token requests by correctly sending Basic authentication in the Authorization header. Restores compatibility with providers like Notion and Twitter.

- **Bug Fixes**
  - Authorization header now uses the Basic scheme: "Basic <base64(clientId:clientSecret)>" (or "Basic <base64(clientSecret)>" when no clientId).

<!-- End of auto-generated description by cubic. -->

