### PR TITLE
demo: fix missing env vars

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,19 @@
         "TURSO_DATABASE_URL",
         "TURSO_AUTH_TOKEN",
         "RESEND_API_KEY",
-        "BETTER_AUTH_EMAIL"
+        "BETTER_AUTH_EMAIL",
+        "BETTER_AUTH_SECRET",
+        "BETTER_AUTH_URL",
+        "GITHUB_CLIENT_SECRET",
+        "GITHUB_CLIENT_ID",
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "DISCORD_CLIENT_ID",
+        "DISCORD_CLIENT_SECRET",
+        "MICROSOFT_CLIENT_ID",
+        "MICROSOFT_CLIENT_SECRET",
+        "STRIPE_KEY",
+        "STRIPE_WEBHOOK_SECRET"
       ]
     },
     "clean": {},


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added missing auth and Stripe environment variables to turbo.json globalEnv so Turbo rebuilds when these values change. Fixes stale builds and runtime errors in the demo caused by env updates not invalidating the cache.

<!-- End of auto-generated description by cubic. -->

