### PR TITLE
chore: fix turborepo cache hit issue

### DIFF
--- a/demo/nextjs/turbo.json
+++ b/demo/nextjs/turbo.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "env": [
+        "TURSO_DATABASE_URL",
+        "TURSO_AUTH_TOKEN",
+        "RESEND_API_KEY",
+        "BETTER_AUTH_EMAIL",
+        "BETTER_AUTH_SECRET",
+        "BETTER_AUTH_URL",
+        "GITHUB_CLIENT_SECRET",
+        "GITHUB_CLIENT_ID",
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "DISCORD_CLIENT_ID",
+        "DISCORD_CLIENT_SECRET",
+        "MICROSOFT_CLIENT_ID",
+        "MICROSOFT_CLIENT_SECRET",
+        "STRIPE_KEY",
+        "STRIPE_WEBHOOK_SECRET"
+      ]
+    }
+  }
+}

--- a/docs/turbo.json
+++ b/docs/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "env": ["GITHUB_TOKEN"]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/*"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"],
       "env": [
         "TURSO_DATABASE_URL",
         "TURSO_AUTH_TOKEN",

--- a/turbo.json
+++ b/turbo.json
@@ -8,25 +8,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"],
-      "env": [
-        "TURSO_DATABASE_URL",
-        "TURSO_AUTH_TOKEN",
-        "RESEND_API_KEY",
-        "BETTER_AUTH_EMAIL",
-        "BETTER_AUTH_SECRET",
-        "BETTER_AUTH_URL",
-        "GITHUB_CLIENT_SECRET",
-        "GITHUB_CLIENT_ID",
-        "GOOGLE_CLIENT_ID",
-        "GOOGLE_CLIENT_SECRET",
-        "DISCORD_CLIENT_ID",
-        "DISCORD_CLIENT_SECRET",
-        "MICROSOFT_CLIENT_ID",
-        "MICROSOFT_CLIENT_SECRET",
-        "STRIPE_KEY",
-        "STRIPE_WEBHOOK_SECRET"
-      ]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "clean": {},
     "format": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix Turborepo build cache accuracy by tracking .env changes and tightening Next.js outputs. This prevents stale builds and avoids caching .next/cache.

- **Bug Fixes**
  - Added build inputs: $TURBO_DEFAULT$, .env*
  - Updated outputs: .next/**, !.next/cache/**, dist/**

<!-- End of auto-generated description by cubic. -->

