### PR TITLE
feat(microsoft): add support for setting authority

### DIFF
--- a/docs/content/docs/authentication/microsoft.mdx
+++ b/docs/content/docs/authentication/microsoft.mdx
@@ -29,11 +29,15 @@ Enabling OAuth with Microsoft Azure Entra ID (formerly Active Directory) allows 
                 clientSecret: process.env.MICROSOFT_CLIENT_SECRET as string, // [!code highlight]
                 // Optional
                 tenantId: 'common', // [!code highlight]                
+                authority: "https://login.microsoftonline.com", // Authentication authority URL // [!code highlight]
                 prompt: "select_account", // Forces account selection // [!code highlight]
             }, // [!code highlight]
         },
     })
     ```
+    
+    **Authority URL**: Use the default `https://login.microsoftonline.com` for standard Entra ID scenarios or `https://<tenant-id>.ciamlogin.com` for CIAM (Customer Identity and Access Management) scenarios.
+    
     </Step>
 
 </Steps>

--- a/packages/better-auth/src/social-providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/social-providers/microsoft-entra-id.ts
@@ -25,6 +25,11 @@ export interface MicrosoftOptions
 	 */
 	tenantId?: string;
 	/**
+	 * The authentication authority URL. Use the default "https://login.microsoftonline.com" for standard Entra ID or "https://<tenant-id>.ciamlogin.com" for CIAM scenarios.
+	 * @default "https://login.microsoftonline.com"
+	 */
+	authority?: string;
+	/**
 	 * The size of the profile photo
 	 * @default 48
 	 */
@@ -37,8 +42,9 @@ export interface MicrosoftOptions
 
 export const microsoft = (options: MicrosoftOptions) => {
 	const tenant = options.tenantId || "common";
-	const authorizationEndpoint = `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize`;
-	const tokenEndpoint = `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
+	const authority = options.authority || "https://login.microsoftonline.com";
+	const authorizationEndpoint = `${authority}/${tenant}/oauth2/v2.0/authorize`;
+	const tokenEndpoint = `${authority}/${tenant}/oauth2/v2.0/token`;
 	return {
 		id: "microsoft",
 		name: "Microsoft EntraID",


### PR DESCRIPTION
This pull request adds support for customizing the authentication authority URL for Microsoft Azure Entra ID integration, allowing users to specify different endpoints for standard Entra ID and CIAM scenarios. The changes update both documentation and implementation to make the authority configurable.

**Microsoft Entra ID authority URL support:**

* Added a new `authority` option to the `MicrosoftOptions` interface in `microsoft-entra-id.ts`, allowing users to specify a custom authentication authority URL for Entra ID or CIAM scenarios.
* Updated the implementation in `microsoft-entra-id.ts` to use the provided `authority` value when constructing the authorization and token endpoints, defaulting to `https://login.microsoftonline.com` if not specified.

**Documentation updates:**

* Updated the authentication documentation in `microsoft.mdx` to include the new `authority` option and explain when to use different authority URLs for standard Entra ID versus CIAM.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a configurable authority URL for Microsoft Entra ID OAuth, enabling both standard and CIAM endpoints. Defaults to https://login.microsoftonline.com for backward compatibility.

- **New Features**
  - New authority option in MicrosoftOptions; used to build authorize/token endpoints with tenantId.
  - Docs updated with examples and guidance for standard vs CIAM authority URLs.

<!-- End of auto-generated description by cubic. -->

