### PR TITLE
docs: update users-accounts.mdx

### DIFF
--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -440,7 +440,7 @@ await authClient.unlinkAccount({
 });
 ```
 
-If the account doesn't exist, it will throw an error. Additionally, if the user only has one account, the unlinking process will fail to prevent account lockout unless `allowUnlinkingAll` is set to `true`.
+If the account doesn't exist, it will throw an error. Additionally, if the user only has one account, unlinking will be prevented to stop account lockout (unless `allowUnlinkingAll` is set to `true`).
 
 ```ts title="auth.ts"
 export const auth = betterAuth({


### PR DESCRIPTION
The wording makes it sound the will fail to prevent account lockout. Like account lockout will happen anyway
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified unlinkAccount docs: if a user has only one account, unlinking is prevented to avoid lockout (unless allowUnlinkingAll is true). Fixes confusing wording that implied lockout would still occur.

<!-- End of auto-generated description by cubic. -->

