### PR TITLE
fix: invalid pages on docs throw a 500 server error instead of 404

### DIFF
--- a/docs/content/docs/authentication/line.mdx
+++ b/docs/content/docs/authentication/line.mdx
@@ -73,6 +73,5 @@ await authClient.signIn.social({
 - Verify redirect URI exactly matches the value configured in LINE Developers Console.
 - LINE ID token verification uses the official endpoint and checks audience and optional nonce per spec.
 
-Designing a login button? Follow LINE's button guidelines: <https://developers.line.biz/en/docs/line-login/login-button/>
-
+Designing a login button? Follow LINE's button [guidelines](https://developers.line.biz/en/docs/line-login/login-button/).
 


### PR DESCRIPTION
closes #4164
<img width="1507" height="910" alt="Screenshot 2025-08-23 at 3 25 28 AM" src="https://github.com/user-attachments/assets/8976287f-e65e-4a72-bd3b-d01265d63fb6" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the docs site to return a proper 404 for invalid pages instead of a 500. This shows the Not Found page correctly and improves SEO and monitoring.

- **Bug Fixes**
  - Return 404 for missing docs pages instead of 500.
  - Cleaned up LINE auth docs: converted the button guidelines URL to a Markdown link.

<!-- End of auto-generated description by cubic. -->

