### PR TITLE
fix(oidc-provider): handle string timestamps in user profile claims

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -785,7 +785,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 						family_name: user.name.split(" ")[1],
 						name: user.name,
 						profile: user.image,
-						updated_at: user.updatedAt.toISOString(),
+						updated_at: new Date(user.updatedAt).toISOString(),
 					};
 					const email = {
 						email: user.email,


### PR DESCRIPTION
## Summary

Fixes an error in the OIDC provider when using timestamp fields with `{ mode: 'string' }` configuration. The `user.updatedAt.toISOString()` call fails when `updatedAt` is already a string instead of a Date object.

- Wraps `user.updatedAt` in `new Date()` before calling `toISOString()` 
- Ensures compatibility with both Date objects and string timestamps
- Follows existing pattern used elsewhere in the codebase for timestamp handling

## Test plan

- [x] Verified the fix resolves the "toISOString is not a function" error
- [x] Confirmed existing tests still pass with the change
- [x] Validated type safety - `new Date()` constructor accepts both Date and string inputs
- [x] Follows existing patterns in the codebase (line 812 already uses this approach)

Fixes #4159
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a crash in the OIDC provider when updatedAt is a string (timestamp mode: 'string') by converting it to a Date before calling toISOString. Ensures updated_at in user profile claims is always valid. Fixes #4159.

- **Bug Fixes**
  - Wrap user.updatedAt with new Date(...) before toISOString()
  - Supports both Date objects and string timestamps

<!-- End of auto-generated description by cubic. -->

