### PR TITLE
fix(docs): pin fumadocs-typescript to exact version 4.0.6

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -48,7 +48,7 @@
     "fumadocs-core": "15.7.1",
     "fumadocs-docgen": "2.1.0",
     "fumadocs-mdx": "11.8.0",
-    "fumadocs-typescript": "^4.0.6",
+    "fumadocs-typescript": "4.0.6",
     "fumadocs-ui": "15.7.1",
     "gray-matter": "^4.0.3",
     "input-otp": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,7 +455,7 @@ importers:
         specifier: 11.8.0
         version: 11.8.0(acorn@8.15.0)(fumadocs-core@15.7.1(@types/react@19.1.10)(next@15.5.0(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.90.0))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(next@15.5.0(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.90.0))(react@19.1.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
       fumadocs-typescript:
-        specifier: ^4.0.6
+        specifier: 4.0.6
         version: 4.0.6(@types/react@19.1.10)(typescript@5.9.2)
       fumadocs-ui:
         specifier: 15.7.1


### PR DESCRIPTION
closes #4181 for now.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Pin fumadocs-typescript in docs to exact version 4.0.6 to prevent unexpected upgrades that could break the docs build. Updates package.json and pnpm-lock.yaml to lock the version.

<!-- End of auto-generated description by cubic. -->

