### PR TITLE
docs: update handler and resolve types in SvelteKit integration

### DIFF
--- a/packages/better-auth/src/integrations/svelte-kit.ts
+++ b/packages/better-auth/src/integrations/svelte-kit.ts
@@ -5,7 +5,7 @@ import { parseSetCookieHeader } from "../cookies";
 import type { RequestEvent } from "@sveltejs/kit";
 
 export const toSvelteKitHandler = (auth: {
-	handler: (request: Request) => any;
+	handler: (request: Request) => Response | Promise<Response>;
 	options: BetterAuthOptions;
 }) => {
 	return (event: { request: Request }) => auth.handler(event.request);
@@ -18,11 +18,11 @@ export const svelteKitHandler = async ({
 	building,
 }: {
 	auth: {
-		handler: (request: Request) => any;
+		handler: (request: Request) => Response | Promise<Response>;
 		options: BetterAuthOptions;
 	};
-	event: { request: Request; url: URL };
-	resolve: (event: any) => any;
+	event: RequestEvent;
+	resolve: (event: RequestEvent) => Response | Promise<Response>;
 	building: boolean;
 }) => {
 	if (building) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Align SvelteKit integration types with actual runtime by specifying Response | Promise<Response> for handlers and using RequestEvent for resolve. Improves type safety and prevents incorrect usage.

- **Refactors**
  - Set auth.handler to return Response | Promise<Response>.
  - Typed resolve as (event: RequestEvent) => Response | Promise<Response>.
  - Updated toSvelteKitHandler wrapper to match the new types.

<!-- End of auto-generated description by cubic. -->

