### PR TITLE
fix(stripe): metadata not passing to stripe subscriptions upon create

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -487,6 +487,9 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							],
 							subscription_data: {
 								...freeTrial,
+								metadata: {
+									...ctx.body?.metadata,
+								}
 							},
 							mode: "subscription",
 							client_reference_id: referenceId,

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -489,7 +489,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 								...freeTrial,
 								metadata: {
 									...ctx.body?.metadata,
-								}
+								},
 							},
 							mode: "subscription",
 							client_reference_id: referenceId,


### PR DESCRIPTION
Previously, while creating a Stripe subscription, the metadata provided by the user was not being passed to the subscription. This PR ensures that the user-defined metadata from authClient.subscription.upgrade or auth.api.upgradeSubscription is included in the subscription that is created.

context: https://www.better-auth.com/docs/plugins/stripe#creating-a-subscription

/fixes #4104
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Passes user-provided metadata to Stripe when creating a subscription, so values from authClient.subscription.upgrade and auth.api.upgradeSubscription are attached to the resulting subscription.

<!-- End of auto-generated description by cubic. -->

