### PR TITLE
fix(expo): fix the inability to dynamically import a dependency

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -1,5 +1,4 @@
 import { BetterAuthClientPlugin, Store } from "better-auth/types";
-import * as Browser from "expo-web-browser";
 import * as Linking from "expo-linking";
 import { Platform } from "react-native";
 import Constants from "expo-constants";
@@ -209,6 +208,14 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							const callbackURL = JSON.parse(context.request.body)?.callbackURL;
 							const to = callbackURL;
 							const signInURL = context.data?.url;
+							let Browser: any;
+							try {
+								Browser = await import("expo-web-browser");
+							} catch (error) {
+								throw new Error(
+									"expo-web-browser is not installed as a dependency!",
+								);
+							}
 							const result = await Browser.openAuthSessionAsync(signInURL, to);
 							if (result.type !== "success") return;
 							const url = new URL(result.url);


### PR DESCRIPTION
After upgrading to Expo SDK 54 Beta, I encountered an issue with assembling a JS bundle that linked to the `expo-web-browser`. The error message indicated that the module could not be found.

<img width="1310" height="381" alt="image" src="https://github.com/user-attachments/assets/708faefc-4ea2-41aa-8fbe-6d351c42a2ce" />

This statement seems to imply that the Expo Web Browser is optional, but the code clearly indicates that it is mandatory.

P.S. Also may close https://github.com/better-auth/better-auth/issues/2682