### PR TITLE
fix(apple): allow audience to be string | string[]

### DIFF
--- a/packages/better-auth/src/social-providers/apple.ts
+++ b/packages/better-auth/src/social-providers/apple.ts
@@ -70,7 +70,7 @@ export interface AppleNonConformUser {
 
 export interface AppleOptions extends ProviderOptions<AppleProfile> {
 	appBundleIdentifier?: string;
-	audience?: string;
+	audience?: string | string[];
 }
 
 export const apple = (options: AppleOptions) => {


### PR DESCRIPTION
This PR widens the TypeScript type for `AppleOptions.audience`.  

At runtime, the implementation already supports passing either a `string` or a `string[]` (since `jose`'s `jwtVerify` accepts both).  

However, the current type is only `string`, which forces developers to use casts (`as any` or `as unknown as string`) when supplying multiple values. 

## Related Discussions
- Original proposal to allow `string[]`: #3605 
- Implementation that landed runtime multi-audience support, but left the type as `string`: #3710


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Widen AppleOptions.audience to accept string or string[] to match runtime behavior. This removes the need for casts when providing multiple audiences.

<!-- End of auto-generated description by cubic. -->

