### PR TITLE
docs: add docs for one time token client plugin

### DIFF
--- a/docs/content/docs/plugins/one-time-token.mdx
+++ b/docs/content/docs/plugins/one-time-token.mdx
@@ -7,17 +7,42 @@ The One-Time Token (OTT) plugin provides functionality to generate and verify se
 
 ## Installation
 
-```ts title="auth.ts"
-import { betterAuth } from "better-auth";
-import { oneTimeToken } from "better-auth/plugins/one-time-token";
+<Steps>
+  <Step>
+    ### Add the plugin to your auth config
 
-export const auth = betterAuth({
-    plugins: [
-      oneTimeToken()
-    ]
-    // ... other auth config
-});
-```
+    To use the One-Time Token plugin, add it to your auth config.
+
+    ```ts title="auth.ts"
+    import { betterAuth } from "better-auth";
+    import { oneTimeToken } from "better-auth/plugins/one-time-token";
+    
+    export const auth = betterAuth({
+        plugins: [
+          oneTimeToken()
+        ]
+        // ... other auth config
+    });
+    ```
+  </Step>
+
+  <Step>
+    ### Add the client plugin
+
+    Next, include the one-time-token client plugin in your authentication client instance.
+
+    ```ts title="auth-client.ts"
+    import { createAuthClient } from "better-auth/client"
+    import { oneTimeTokenClient } from "better-auth/client/plugins"
+    
+    export const authClient = createAuthClient({
+        plugins: [
+            oneTimeTokenClient()
+        ]
+    })
+    ```
+  </Step>
+</Steps>
 
 ## Usage
 


### PR DESCRIPTION
I noticed docs on the client plugin were missing
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added missing docs for the One-Time Token client plugin to complete the end-to-end setup. Includes a step-by-step install flow with client setup (createAuthClient + oneTimeTokenClient) and an updated server config snippet.

<!-- End of auto-generated description by cubic. -->

