### PR TITLE
docs(atlassian): correct typo in OAuth documentation link

### DIFF
--- a/docs/content/docs/authentication/atlassian.mdx
+++ b/docs/content/docs/authentication/atlassian.mdx
@@ -52,7 +52,7 @@ description: Atlassian provider setup and usage.
         }
         ```
         <Callout type="info">
-        For more information about Atlassian's OAuth scopes and API capabilities, refer to the [official FiAtlassian OAut 2.0 (3LO) apps documentation](https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/).
+        For more information about Atlassian's OAuth scopes and API capabilities, refer to the [official Atlassian OAut 2.0 (3LO) apps documentation](https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/).
         </Callout>
     </Step>
 


### PR DESCRIPTION
Fixed a typo in Atlassian hyperlink