### PR TITLE
docs: update README.md badge color

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
     <a href="https://github.com/better-auth/better-auth/issues">Issues</a>
   </p>
 
-[![npm](https://img.shields.io/npm/dm/better-auth)](https://npm.chart.dev/better-auth?primary=neutral&gray=neutral&theme=dark)
-[![npm version](https://img.shields.io/npm/v/better-auth.svg)](https://www.npmjs.com/package/better-auth)
-[![GitHub stars](https://img.shields.io/github/stars/better-auth/better-auth)](https://github.com/better-auth/better-auth/stargazers)
+[![npm](https://img.shields.io/npm/dm/better-auth?style=flat&colorA=000000&colorB=000000)](https://npm.chart.dev/better-auth?primary=neutral&gray=neutral&theme=dark)
+[![npm version](https://img.shields.io/npm/v/better-auth.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/better-auth)
+[![GitHub stars](https://img.shields.io/github/stars/better-auth/better-auth?style=flat&colorA=000000&colorB=000000)](https://github.com/better-auth/better-auth/stargazers)
 </p>
 
 ## About the Project


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardized README badges to flat style with black colors (colorA/colorB=000000) for npm downloads, npm version, and GitHub stars. Aligns badge styling with the dark theme for a cleaner, consistent look.

<!-- End of auto-generated description by cubic. -->

