### PR TITLE
fix: schema `onUpdate` not working

### DIFF
--- a/packages/better-auth/src/adapters/create-adapter/index.ts
+++ b/packages/better-auth/src/adapters/create-adapter/index.ts
@@ -353,8 +353,9 @@ export const createAdapter =
 				if (
 					value === undefined &&
 					((!fieldAttributes.defaultValue &&
-						!fieldAttributes.transform?.input) ||
-						action === "update")
+						!fieldAttributes.transform?.input &&
+						!(action === "update" && fieldAttributes.onUpdate)) ||
+						(action === "update" && !fieldAttributes.onUpdate))
 				) {
 					continue;
 				}

--- a/packages/better-auth/src/adapters/utils.ts
+++ b/packages/better-auth/src/adapters/utils.ts
@@ -6,6 +6,13 @@ export function withApplyDefault(
 	action: "create" | "update",
 ) {
 	if (action === "update") {
+		// Apply onUpdate if value is undefined
+		if (value === undefined && field.onUpdate !== undefined) {
+			if (typeof field.onUpdate === "function") {
+				return field.onUpdate();
+			}
+			return field.onUpdate;
+		}
 		return value;
 	}
 	if (value === undefined || value === null) {

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
+import type { Account } from "../../types";
 
 describe("updateUser", async () => {
 	const sendChangeEmail = vi.fn();
@@ -160,6 +161,79 @@ describe("updateUser", async () => {
 			password: testUser.password,
 		});
 		expect(signInCurrentPassword.data).toBeNull();
+	});
+
+	it("should update account's updatedAt when changing password", async () => {
+		const newHeaders = new Headers();
+		await client.signUp.email({
+			name: "Test User",
+			email: "test-updated-at@email.com",
+			password: "originalPassword",
+			fetchOptions: {
+				onSuccess: sessionSetter(newHeaders),
+			},
+		});
+
+		// Get the initial account data
+		const initialSession = await client.getSession({
+			fetchOptions: {
+				headers: newHeaders,
+				throw: true,
+			},
+		});
+		const userId = initialSession?.user.id;
+
+		// Get initial account updatedAt
+		const initialAccounts: Account[] = await db.findMany({
+			model: "account",
+			where: [
+				{
+					field: "userId",
+					value: userId!,
+				},
+				{
+					field: "providerId",
+					value: "credential",
+				},
+			],
+		});
+		expect(initialAccounts.length).toBe(1);
+		const initialUpdatedAt = initialAccounts[0]!.updatedAt;
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		// Change password
+		const updated = await client.changePassword({
+			newPassword: "newPassword123",
+			currentPassword: "originalPassword",
+			fetchOptions: {
+				headers: newHeaders,
+			},
+		});
+		expect(updated.data).toBeDefined();
+
+		// Get updated account data
+		const updatedAccounts: Account[] = await db.findMany({
+			model: "account",
+			where: [
+				{
+					field: "userId",
+					value: userId!,
+				},
+				{
+					field: "providerId",
+					value: "credential",
+				},
+			],
+		});
+		expect(updatedAccounts.length).toBe(1);
+		const newUpdatedAt = updatedAccounts[0]!.updatedAt;
+
+		// Verify updatedAt was refreshed
+		expect(newUpdatedAt).not.toBe(initialUpdatedAt);
+		expect(new Date(newUpdatedAt).getTime()).toBeGreaterThan(
+			new Date(initialUpdatedAt).getTime(),
+		);
 	});
 
 	it("should not update password if current password is wrong", async () => {
@@ -329,7 +403,7 @@ describe("delete user", async () => {
 		console.log(res);
 	});
 	it("should delete the user with a fresh session", async () => {
-		const { auth, client, signInWithTestUser } = await getTestInstance({
+		const { client, signInWithTestUser } = await getTestInstance({
 			user: {
 				deleteUser: {
 					enabled: true,


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/pull/4241
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes onUpdate not being applied during updates. Fields like account.updatedAt now refresh correctly on password reset and password change.

- **Bug Fixes**
  - Ensure onUpdate runs when updating and the incoming value is undefined (adapter logic and withApplyDefault).
  - Add tests for resetPassword and changePassword that verify account.updatedAt is updated and new credentials work.

<!-- End of auto-generated description by cubic. -->

