### PR TITLE
fix: member not exist on org

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -479,12 +479,9 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 				organizationId: organizationId,
 			});
 			if (!member) {
-				return ctx.json(null, {
-					status: 400,
-					body: {
-						message:
-							ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
-					},
+				throw new APIError("BAD_REQUEST", {
+					message:
+						ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
 				});
 			}
 			const canDeleteOrg = hasPermission({


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4261
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes org deletion to return BAD_REQUEST (400) with a standardized APIError when a non-member tries to delete an organization. Adds a test to cover this case.

- **Bug Fixes**
  - Throw APIError with USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION when no membership is found in deleteOrganization.
  - Added test: non-member delete attempt returns 400 with the expected error code.

<!-- End of auto-generated description by cubic. -->

