### PR TITLE
fix(cli): simplify and correct comma insertion logic in plugin array

### DIFF
--- a/packages/cli/src/generators/auth-config.ts
+++ b/packages/cli/src/generators/auth-config.ts
@@ -132,28 +132,20 @@ export async function generateAuthConfig({
 					insert_content: `${opts.pluginFunctionName}(${opts.pluginContents}),`,
 				});
 			} else {
-				let has_found_comma = false;
-				const str = opts.config
+				const pluginArrayContent = opts.config
 					.slice(start_of_plugins.index, end_of_plugins.index)
-					.split("")
-					.reverse();
-				for (let index = 0; index < str.length; index++) {
-					const char = str[index];
-					if (char === ",") {
-						has_found_comma = true;
-					}
-					if (char === ")") {
-						break;
-					}
-				}
+					.trim();
+				const isPluginArrayEmpty = pluginArrayContent === "";
+				const isPluginArrayEndsWithComma = pluginArrayContent.endsWith(",");
+				const needsComma = !isPluginArrayEmpty && !isPluginArrayEndsWithComma;
 
 				new_content = insertContent({
 					line: end_of_plugins.line,
 					character: end_of_plugins.character,
 					content: opts.config,
-					insert_content: `${!has_found_comma ? "," : ""}${
-						opts.pluginFunctionName
-					}(${opts.pluginContents})`,
+					insert_content: `${needsComma ? "," : ""}${opts.pluginFunctionName}(${
+						opts.pluginContents
+					})`,
 				});
 			}
 
@@ -166,7 +158,7 @@ export async function generateAuthConfig({
 					`Failed to generate new auth config during plugin addition phase.`,
 				);
 			}
-			return { code: await new_content, dependencies: [], envs: [] };
+			return { code: new_content, dependencies: [], envs: [] };
 		},
 		add_import: async (opts: {
 			imports: Import[];

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -7,6 +7,8 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { generateMigrations } from "../src/generators/kysely";
 import Database from "better-sqlite3";
 import type { BetterAuthOptions } from "better-auth";
+import { generateAuthConfig } from "../src/generators/auth-config";
+import type { SupportedPlugin } from "../src/commands/init";
 
 describe("generate", async () => {
 	it("should generate prisma schema", async () => {
@@ -233,5 +235,34 @@ describe("generate", async () => {
 			adapter: {} as any,
 		});
 		expect(schema.code).toMatchFileSnapshot("./__snapshots__/migrations.sql");
+	});
+
+	it("should add plugin to empty plugins array without leading comma", async () => {
+		const initialConfig = `export const auth = betterAuth({
+			plugins: []
+		});`;
+
+		const mockFormat = (code: string) => Promise.resolve(code);
+		const mockSpinner = { stop: () => {} };
+		const plugins: SupportedPlugin[] = [
+			{
+				id: "next-cookies",
+				name: "nextCookies",
+				path: "better-auth/next-js",
+				clientName: undefined,
+				clientPath: undefined,
+			},
+		];
+
+		const result = await generateAuthConfig({
+			format: mockFormat,
+			current_user_config: initialConfig,
+			spinner: mockSpinner as any,
+			plugins,
+			database: null,
+		});
+
+		expect(result.generatedCode).toContain(`plugins: [nextCookies()]`);
+		expect(result.generatedCode).not.toContain(`plugins: [, nextCookies()]`);
 	});
 });


### PR DESCRIPTION
---

This PR fixes an edge case bug by simplifying and cleaning up the plugin insertion logic.

---

For example:

```
◇  Would you like to set up plugins?
│  Yes
│
◇  Select your new plugins
│  none
│
◇  It looks like you're using NextJS. Do you want to add the next-cookies plugin? (Recommended)
│  Yes
```

Result:

```ts
import { nextCookies } from "better-auth/next-js";
import { betterAuth } from "better-auth";

export const auth = betterAuth({
    appName: "testing",
    plugins: [, nextCookies()],
});
```

Bug fix test:

<img width="400" alt="before" src="https://github.com/user-attachments/assets/ddcd6f09-8060-4fe5-bbd7-2c495b6612ce" />
<img width="400" alt="after" src="https://github.com/user-attachments/assets/c14fe094-77cd-413f-b0db-814ea057a903" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the CLI generator so adding a plugin never produces an empty element or stray commas in the plugins array. This prevents invalid configs like plugins: [, nextCookies()] and makes plugin insertion reliable.

- **Bug Fixes**
  - Simplified plugin insertion: detect empty arrays and trailing commas, then insert with or without a comma as needed.
  - Fixed return path to use the new content directly.
  - Added a test to cover insertion into an empty plugins array.

<!-- End of auto-generated description by cubic. -->
