### PR TITLE
fix(stripe): peerDependencies

### DIFF
--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -46,6 +46,9 @@
     "better-auth": "workspace:^",
     "zod": "^4.0.0"
   },
+  "peerDependencies": {
+    "stripe": "^18"
+  },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
     "better-call": "catalog:",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Declared stripe as a peer dependency (^18) for the stripe package so consumers must provide it, preventing duplicate SDKs and version mismatches.

- **Migration**
  - Install stripe@^18 in the consuming app.
  - Update lockfile and reinstall dependencies.

<!-- End of auto-generated description by cubic. -->

