### PR TITLE
fix(stripe): peerDependencies

### DIFF
--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -43,10 +43,10 @@
     }
   },
   "dependencies": {
-    "better-auth": "workspace:^",
     "zod": "^4.0.0"
   },
   "peerDependencies": {
+    "better-auth": "workspace:*",
     "stripe": "^18"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -875,7 +875,7 @@ importers:
   packages/stripe:
     dependencies:
       better-auth:
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../better-auth
       zod:
         specifier: ^4.0.0


### PR DESCRIPTION
Related: https://github.com/better-auth/better-auth/issues/4279
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch the Stripe package to require better-auth as a peer dependency to avoid duplicate installs and version conflicts. Loosen the workspace range to workspace:* and update the lockfile. Related: better-auth/better-auth#4279

- **Dependencies**
  - Move better-auth to peerDependencies with workspace:*
  - Remove better-auth from dependencies and update pnpm-lock.yaml

<!-- End of auto-generated description by cubic. -->

