### PR TITLE
chore: run `pnpm --fix-lockfile`

### DIFF
--- a/demo/nextjs/app/(auth)/sign-in/page.tsx
+++ b/demo/nextjs/app/(auth)/sign-in/page.tsx
@@ -8,7 +8,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { getCallbackURL } from "@/lib/shared";
-import { ErrorContext } from "@better-fetch/fetch";
 
 export default function Page() {
 	const router = useRouter();
@@ -16,7 +15,7 @@ export default function Page() {
 	useEffect(() => {
 		client.oneTap({
 			fetchOptions: {
-				onError: ({ error }: ErrorContext) => {
+				onError: ({ error }) => {
 					toast.error(error.message || "An error occurred");
 				},
 				onSuccess: () => {

--- a/demo/nextjs/app/(auth)/sign-in/page.tsx
+++ b/demo/nextjs/app/(auth)/sign-in/page.tsx
@@ -8,6 +8,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { getCallbackURL } from "@/lib/shared";
+import { ErrorContext } from "@better-fetch/fetch";
 
 export default function Page() {
 	const router = useRouter();
@@ -15,7 +16,7 @@ export default function Page() {
 	useEffect(() => {
 		client.oneTap({
 			fetchOptions: {
-				onError: ({ error }) => {
+				onError: ({ error }: ErrorContext) => {
 					toast.error(error.message || "An error occurred");
 				},
 				onSuccess: () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,7 @@ importers:
         version: 0.0.25(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@react-three/fiber':
         specifier: ^8.17.10
-        version: 8.18.0(dlwkoqml3p4h7us6qqhf5qewge)
+        version: 8.18.0(71de22a7713acbf2963d2d1d08ab35b9)
       '@tanstack/react-query':
         specifier: ^5.62.3
         version: 5.85.5(react@19.1.1)
@@ -633,7 +633,7 @@ importers:
         version: 5.22.0(prisma@5.22.0)
       '@tanstack/react-start':
         specifier: ^1.131.3
-        version: 1.131.27(r5vvgsq4hg77miw4qa4tjpbrdq)
+        version: 1.131.27(0b760e4bda1333aacc70de88f3b767b1)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -16971,7 +16971,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.10
 
-  '@react-three/fiber@8.18.0(dlwkoqml3p4h7us6qqhf5qewge)':
+  '@react-three/fiber@8.18.0(71de22a7713acbf2963d2d1d08ab35b9)':
     dependencies:
       '@babel/runtime': 7.28.3
       '@types/react-reconciler': 0.26.7
@@ -17581,7 +17581,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@tanstack/react-start@1.131.27(r5vvgsq4hg77miw4qa4tjpbrdq)':
+  '@tanstack/react-start@1.131.27(0b760e4bda1333aacc70de88f3b767b1)':
     dependencies:
       '@tanstack/react-start-client': 1.131.27(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-start-plugin': 1.131.27(@azure/identity@4.11.1)(@libsql/client@0.15.12)(@netlify/blobs@10.0.8)(@tanstack/react-router@1.131.27(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@5.0.1(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(better-sqlite3@11.10.0)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250826.0)(@libsql/client@0.15.12)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(@types/react@18.3.23)(better-sqlite3@11.10.0)(bun-types@1.2.21(@types/react@18.3.23))(kysely@0.28.5)(mysql2@3.14.3)(pg@8.16.3)(prisma@5.22.0)(react@19.1.1))(mysql2@3.14.3)(vite-plugin-solid@2.11.8(solid-js@1.9.9)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Regenerated pnpm-lock.yaml to fix incorrect peer resolution IDs for @react-three/fiber and @tanstack/react-start. No dependency upgrades; this stabilizes installs across machines and CI.

<!-- End of auto-generated description by cubic. -->

