### PR TITLE
chore: enable lint rule `noTsIgnore`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,8 @@
       "recommended": false,
       "suspicious": {
         "noImplicitAnyLet": "warn",
-        "noDuplicateObjectKeys": "warn"
+        "noDuplicateObjectKeys": "warn",
+        "noTsIgnore": "error"
       },
       "performance": {
         "noDelete": "error"

--- a/demo/nextjs/app/dashboard/user-card.tsx
+++ b/demo/nextjs/app/dashboard/user-card.tsx
@@ -393,7 +393,6 @@ export default function UserCard(props: {
 												setIsPendingTwoFa(true);
 												if (session?.user.twoFactorEnabled) {
 													const res = await client.twoFactor.disable({
-														//@ts-ignore
 														password: twoFaPassword,
 														fetchOptions: {
 															onError(context) {

--- a/demo/nextjs/app/oauth/authorize/page.tsx
+++ b/demo/nextjs/app/oauth/authorize/page.tsx
@@ -29,7 +29,7 @@ export default async function AuthorizePage({
 	const session = await auth.api.getSession({
 		headers: await headers(),
 	});
-	// @ts-ignore
+	// @ts-expect-error
 	const clientDetails = await auth.api.getOAuthClient({
 		params: {
 			id: client_id,

--- a/demo/nextjs/hooks/use-toast.ts
+++ b/demo/nextjs/hooks/use-toast.ts
@@ -156,7 +156,7 @@ function toast({ ...props }: Toast) {
 			...props,
 			id,
 			open: true,
-			// @ts-ignore
+			// @ts-expect-error
 			onOpenChange: (open) => {
 				if (!open) dismiss();
 			},

--- a/docs/app/changelogs/[[...slug]]/page.tsx
+++ b/docs/app/changelogs/[[...slug]]/page.tsx
@@ -34,7 +34,6 @@ export default async function Page({
 	const { slug } = await params;
 	const page = changelogs.getPage(slug);
 	if (!slug) {
-		//@ts-ignore
 		return <ChangelogPage />;
 	}
 	if (!page) {

--- a/docs/components/nav-mobile.tsx
+++ b/docs/components/nav-mobile.tsx
@@ -33,7 +33,6 @@ export const NavbarProvider = ({ children }: { children: React.ReactNode }) => {
 	const toggleDocsNavbar = () => {
 		setIsDocsOpen((prevIsOpen) => !prevIsOpen);
 	};
-	// @ts-ignore
 	return (
 		<NavbarContext.Provider
 			value={{ isOpen, toggleNavbar, isDocsOpen, toggleDocsNavbar }}

--- a/docs/scripts/endpoint-to-doc/index.ts
+++ b/docs/scripts/endpoint-to-doc/index.ts
@@ -59,7 +59,7 @@ async function generateMDX() {
 	const functionName = Object.keys(exports)[0]! as string;
 
 	const [path, options]: [string, Options] =
-		//@ts-ignore
+		//@ts-expect-error
 		await exports[Object.keys(exports)[0]!];
 	if (!path || !options) return console.error(`No path or options.`);
 
@@ -194,17 +194,17 @@ function parseZodShape(zod: z.ZodAny, path: string[]) {
 		{ description: "some descriptiom" },
 	).shape;
 
-	//@ts-ignore
+	//@ts-expect-error
 	if (zod._def.typeName === "ZodOptional") {
 		isRootOptional = true;
 		const eg = z.optional(z.object({}));
 		const x = zod as never as typeof eg;
-		//@ts-ignore
+		//@ts-expect-error
 		shape = x._def.innerType.shape;
 	} else {
 		const eg = z.object({});
 		const x = zod as never as typeof eg;
-		//@ts-ignore
+		//@ts-expect-error
 		shape = x.shape;
 	}
 

--- a/packages/better-auth/src/adapters/create-adapter/index.ts
+++ b/packages/better-auth/src/adapters/create-adapter/index.ts
@@ -587,7 +587,7 @@ export const createAdapter =
 						.join("\n")
 						.replace("Error:", "Create method with `id` being called at:");
 					console.log(stack);
-					//@ts-ignore
+					//@ts-expect-error
 					unsafeData.id = undefined;
 				}
 				debugLog(

--- a/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
+++ b/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
@@ -161,7 +161,6 @@ describe("Create Adapter Helper", async () => {
 			data: { name: "test-name" },
 		});
 		expect(res).toHaveProperty("id");
-		//@ts-ignore
 		expect(res.id).toBe("HARD-CODED-ID");
 	});
 
@@ -225,17 +224,11 @@ describe("Create Adapter Helper", async () => {
 				expect(res).toHaveProperty("image");
 				expect(res).toHaveProperty("createdAt");
 				expect(res).toHaveProperty("updatedAt");
-				//@ts-ignore
 				expect(res?.emailVerified).toEqual(false);
-				//@ts-ignore
 				expect(res?.name).toEqual("test-name");
-				//@ts-ignore
 				expect(res?.email).toEqual(undefined);
-				//@ts-ignore
 				expect(res?.image).toEqual(undefined);
-				//@ts-ignore
 				expect(res?.createdAt).toBeInstanceOf(Date);
-				//@ts-ignore
 				expect(res?.updatedAt).toBeInstanceOf(Date);
 			});
 
@@ -245,7 +238,6 @@ describe("Create Adapter Helper", async () => {
 					data: { name: "test-name" },
 				});
 				expect(res).toHaveProperty("id");
-				//@ts-ignore
 				expect(typeof res?.id).toEqual("string");
 
 				const adapterWithoutIdGeneration = await createTestAdapter({
@@ -343,11 +335,9 @@ describe("Create Adapter Helper", async () => {
 							data: { emailVerified: true },
 						});
 						expect(res).toHaveProperty("emailVerified");
-						//@ts-ignore
 						expect(res.emailVerified).toBe(true);
 					});
 				expect(createTRUEParameters.data).toHaveProperty("emailVerified");
-				//@ts-ignore
 				expect(createTRUEParameters.data.emailVerified).toBe(1);
 
 				// Testing false
@@ -371,11 +361,9 @@ describe("Create Adapter Helper", async () => {
 							data: { emailVerified: false },
 						});
 						expect(res).toHaveProperty("emailVerified");
-						//@ts-ignore
 						expect(res.emailVerified).toBe(false);
 					});
 				expect(createFALSEParameters.data).toHaveProperty("emailVerified");
-				//@ts-ignore
 				expect(createFALSEParameters.data.emailVerified).toBe(0);
 			});
 
@@ -904,11 +892,10 @@ describe("Create Adapter Helper", async () => {
 							update: { emailVerified: true },
 						});
 						expect(res).toHaveProperty("emailVerified");
-						//@ts-ignore
+						//@ts-expect-error
 						expect(res.emailVerified).toBe(true);
 					});
 				expect(updateTRUEParameters.update).toHaveProperty("emailVerified");
-				//@ts-ignore
 				expect(updateTRUEParameters.update.emailVerified).toBe(1);
 
 				// Testing false
@@ -938,11 +925,10 @@ describe("Create Adapter Helper", async () => {
 							update: { emailVerified: false },
 						});
 						expect(res).toHaveProperty("emailVerified");
-						//@ts-ignore
+						//@ts-expect-error
 						expect(res.emailVerified).toBe(false);
 					});
 				expect(createFALSEParameters.update).toHaveProperty("emailVerified");
-				//@ts-ignore
 				expect(createFALSEParameters.update.emailVerified).toBe(0);
 			});
 
@@ -1471,7 +1457,6 @@ describe("Create Adapter Helper", async () => {
 						});
 
 						expect(res).toHaveProperty("id");
-						//@ts-ignore
 						expect(res?.id).toEqual("1");
 					});
 				// The where clause should convert the string id value of `"1"` to an int since `useNumberId` is true
@@ -1513,7 +1498,6 @@ describe("Create Adapter Helper", async () => {
 						});
 
 						expect(res[0]).toHaveProperty("id");
-						//@ts-ignore
 						expect(res[0].id).toEqual("1");
 					});
 				// The where clause should convert the string id value of `"1"` to an int since `useNumberId` is true

--- a/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.test.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.test.ts
@@ -69,7 +69,7 @@ describe("Drizzle Adapter Tests", async () => {
 	await runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			const db = opts.database;
-			//@ts-ignore
+			//@ts-expect-error
 			opts.database = undefined;
 			const merged = merge(opts, customOptions);
 			merged.database = db;
@@ -144,7 +144,7 @@ describe("Drizzle Adapter Number Id Test", async () => {
 	await runNumberIdAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			const db = opts.database;
-			//@ts-ignore
+			//@ts-expect-error
 			opts.database = undefined;
 			const merged = merge(opts, customOptions);
 			merged.database = db;

--- a/packages/better-auth/src/adapters/kysely-adapter/bun-sqlite-dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/bun-sqlite-dialect.ts
@@ -21,7 +21,6 @@ import {
 } from "kysely";
 import { DefaultQueryCompiler } from "kysely";
 import { DialectAdapterBase } from "kysely";
-//@ts-ignore - we need to import this to get the type of the database
 import type { Database } from "bun:sqlite";
 
 export class BunSqliteAdapter implements DialectAdapterBase {
@@ -178,21 +177,20 @@ export class BunSqliteIntrospector implements DatabaseIntrospector {
 		options: DatabaseMetadataOptions = { withInternalKyselyTables: false },
 	): Promise<TableMetadata[]> {
 		let query = this.#db
-			// @ts-ignore
+			// @ts-expect-error
 			.selectFrom("sqlite_schema")
-			// @ts-ignore
+			// @ts-expect-error
 			.where("type", "=", "table")
-			// @ts-ignore
+			// @ts-expect-error
 			.where("name", "not like", "sqlite_%")
-			// @ts-ignore
 			.select("name")
 			.$castTo<{ name: string }>();
 
 		if (!options.withInternalKyselyTables) {
 			query = query
-				// @ts-ignore
+				// @ts-expect-error
 				.where("name", "!=", DEFAULT_MIGRATION_TABLE)
-				// @ts-ignore
+				// @ts-expect-error
 				.where("name", "!=", DEFAULT_MIGRATION_LOCK_TABLE);
 		}
 
@@ -213,11 +211,10 @@ export class BunSqliteIntrospector implements DatabaseIntrospector {
 
 		// Get the SQL that was used to create the table.
 		const createSql = await db
-			// @ts-ignore
+			// @ts-expect-error
 			.selectFrom("sqlite_master")
-			// @ts-ignore
+			// @ts-expect-error
 			.where("name", "=", table)
-			// @ts-ignore
 			.select("sql")
 			.$castTo<{ sql: string | undefined }>()
 			.execute();

--- a/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
@@ -89,7 +89,7 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 	}
 
 	if ("getConnection" in db) {
-		// @ts-ignore - mysql2/promise
+		// @ts-expect-error - mysql2/promise
 		dialect = new MysqlDialect(db);
 	}
 

--- a/packages/better-auth/src/adapters/kysely-adapter/node-sqlite-dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/node-sqlite-dialect.ts
@@ -179,21 +179,20 @@ export class NodeSqliteIntrospector implements DatabaseIntrospector {
 		options: DatabaseMetadataOptions = { withInternalKyselyTables: false },
 	): Promise<TableMetadata[]> {
 		let query = this.#db
-			// @ts-ignore
+			// @ts-expect-error
 			.selectFrom("sqlite_schema")
-			// @ts-ignore
+			// @ts-expect-error
 			.where("type", "=", "table")
-			// @ts-ignore
+			// @ts-expect-error
 			.where("name", "not like", "sqlite_%")
-			// @ts-ignore
 			.select("name")
 			.$castTo<{ name: string }>();
 
 		if (!options.withInternalKyselyTables) {
 			query = query
-				// @ts-ignore
+				// @ts-expect-error
 				.where("name", "!=", DEFAULT_MIGRATION_TABLE)
-				// @ts-ignore
+				// @ts-expect-error
 				.where("name", "!=", DEFAULT_MIGRATION_LOCK_TABLE);
 		}
 
@@ -214,11 +213,10 @@ export class NodeSqliteIntrospector implements DatabaseIntrospector {
 
 		// Get the SQL that was used to create the table.
 		const createSql = await db
-			// @ts-ignore
+			// @ts-expect-error
 			.selectFrom("sqlite_master")
-			// @ts-ignore
+			// @ts-expect-error
 			.where("name", "=", table)
-			// @ts-ignore
 			.select("sql")
 			.$castTo<{ sql: string | undefined }>()
 			.execute();

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -49,7 +49,7 @@ export const memoryAdapter = (db: MemoryDB, config?: MemoryAdapterConfig) =>
 							if (!Array.isArray(value)) {
 								throw new Error("Value must be an array");
 							}
-							// @ts-ignore
+							// @ts-expect-error
 							return value.includes(record[field]);
 						} else if (operator === "contains") {
 							return record[field].includes(value);
@@ -66,7 +66,7 @@ export const memoryAdapter = (db: MemoryDB, config?: MemoryAdapterConfig) =>
 			return {
 				create: async ({ model, data }) => {
 					if (options.advanced?.database?.useNumberId) {
-						// @ts-ignore
+						// @ts-expect-error
 						data.id = db[model].length + 1;
 					}
 					if (!db[model]) {

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -54,7 +54,7 @@ const numberIdAdapterTests = {
 	SHOULD_RETURN_A_NUMBER_ID_AS_A_RESULT:
 		"Should return a number id as a result",
 	SHOULD_INCREMENT_THE_ID_BY_1: "Should increment the id by 1",
-} as const;
+};
 
 // @ts-expect-error
 // biome-ignore lint/performance/noDelete: testing propose
@@ -134,7 +134,6 @@ async function adapterTest(
 				},
 			});
 			expect(res).toHaveProperty("id");
-			//@ts-ignore
 			expect(typeof res?.id).toEqual("string");
 		},
 	);

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -89,7 +89,6 @@ describe(
 			for (let i = 0; i < 25; i++) {
 				const response = await client.listSessions({
 					fetchOptions: {
-						// @ts-ignore
 						query: {
 							"test-query": Math.random().toString(),
 						},

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -335,7 +335,7 @@ describe("updateUser", async () => {
 				throw: true,
 			},
 		});
-		// @ts-ignore
+		// @ts-expect-error
 		expect(session?.user.newField).toBe("new");
 	});
 

--- a/packages/better-auth/src/db/utils.ts
+++ b/packages/better-auth/src/db/utils.ts
@@ -10,7 +10,7 @@ export async function getAdapter(options: BetterAuthOptions): Promise<Adapter> {
 	if (!options.database) {
 		const tables = getAuthTables(options);
 		const memoryDB = Object.keys(tables).reduce((acc, key) => {
-			// @ts-ignore
+			// @ts-expect-error
 			acc[key] = [];
 			return acc;
 		}, {});

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -451,9 +451,7 @@ export function createApiKey({
 				key: key,
 				metadata: metadata ?? null,
 				permissions: apiKey.permissions
-					? safeJSONParse(
-							apiKey.permissions,
-						)
+					? safeJSONParse(apiKey.permissions)
 					: null,
 			});
 		},

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -429,7 +429,7 @@ export function createApiKey({
 						? (opts.rateLimit.enabled ?? true)
 						: rateLimitEnabled,
 				requestCount: 0,
-				//@ts-ignore - we intentionally save the permissions as string on DB.
+				//@ts-expect-error - we intentionally save the permissions as string on DB.
 				permissions: permissionsToApply,
 			};
 
@@ -452,7 +452,6 @@ export function createApiKey({
 				metadata: metadata ?? null,
 				permissions: apiKey.permissions
 					? safeJSONParse(
-							//@ts-ignore - from DB, this value is always a string
 							apiKey.permissions,
 						)
 					: null,

--- a/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
@@ -205,10 +205,7 @@ export function getApiKey({
 				permissions: returningApiKey.permissions
 					? safeJSONParse<{
 							[key: string]: string[];
-						}>(
-							//@ts-ignore - From DB this is always a string
-							returningApiKey.permissions,
-						)
+						}>(returningApiKey.permissions)
 					: null,
 			});
 		},

--- a/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
@@ -191,10 +191,7 @@ export function listApiKeys({
 					permissions: returningApiKey.permissions
 						? safeJSONParse<{
 								[key: string]: string[];
-							}>(
-								//@ts-ignore - From DB this is always a string
-								returningApiKey.permissions,
-							)
+							}>(returningApiKey.permissions)
 						: null,
 				};
 			});

--- a/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
@@ -351,7 +351,7 @@ export function updateApiKey({
 						message: ERROR_CODES.INVALID_METADATA_TYPE,
 					});
 				}
-				//@ts-ignore - we need this to be a string to save into DB.
+				//@ts-expect-error - we need this to be a string to save into DB.
 				newValues.metadata =
 					schema.apikey.fields.metadata.transform.input(metadata);
 			}
@@ -383,7 +383,7 @@ export function updateApiKey({
 			}
 
 			if (permissions !== undefined) {
-				//@ts-ignore - we need this to be a string to save into DB.
+				//@ts-expect-error - we need this to be a string to save into DB.
 				newValues.permissions = JSON.stringify(permissions);
 			}
 
@@ -430,10 +430,7 @@ export function updateApiKey({
 				permissions: returningApiKey.permissions
 					? safeJSONParse<{
 							[key: string]: string[];
-						}>(
-							//@ts-ignore - from DB, this value is always a string
-							returningApiKey.permissions,
-						)
+						}>(returningApiKey.permissions)
 					: null,
 			});
 		},

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -75,10 +75,7 @@ export async function validateApiKey({
 		const apiKeyPermissions = apiKey.permissions
 			? safeJSONParse<{
 					[key: string]: string[];
-				}>(
-					//@ts-ignore - from DB, this value is always a string
-					apiKey.permissions,
-				)
+				}>(apiKey.permissions)
 			: null;
 
 		if (!apiKeyPermissions) {
@@ -295,10 +292,7 @@ export function verifyApiKey({
 			returningApiKey.permissions = returningApiKey.permissions
 				? safeJSONParse<{
 						[key: string]: string[];
-					}>(
-						//@ts-ignore - from DB, this value is always a string
-						returningApiKey.permissions,
-					)
+					}>(returningApiKey.permissions)
 				: null;
 
 			return ctx.json({

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -149,7 +149,7 @@ function getRequestBody(options: EndpointOptions): any {
 		options.body instanceof ZodObject ||
 		options.body instanceof ZodOptional
 	) {
-		// @ts-ignore
+		// @ts-expect-error
 		const shape = options.body.shape;
 		if (!shape) return undefined;
 		const properties: Record<string, any> = {};
@@ -319,7 +319,7 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 			}
 		});
 
-		// @ts-ignore
+		// @ts-expect-error
 		acc[modelName] = {
 			type: "object",
 			properties,

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -19,7 +19,6 @@ import type { Logger } from "../utils";
 import type { AuthMiddleware } from "../plugins";
 import type { LiteralUnion, OmitId } from "./helper";
 import type { AdapterDebugLogs } from "../adapters";
-//@ts-ignore - we need to import this to get the type of the database
 import type { Database as BunDatabase } from "bun:sqlite";
 import type { DatabaseSync } from "node:sqlite";
 

--- a/packages/better-auth/src/utils/shim.ts
+++ b/packages/better-auth/src/utils/shim.ts
@@ -49,7 +49,6 @@ export const shimEndpoint = (ctx: AuthContext, value: any) => {
 				}
 			}
 		}
-		//@ts-ignore
 		const endpointRes = value({
 			...context,
 			context: {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -704,7 +704,7 @@ export async function initAction(opts: any) {
 				const { dependencies, envs, generatedCode } = await generateAuthConfig({
 					current_user_config,
 					format,
-					//@ts-ignore
+					//@ts-expect-error
 					s,
 					plugins: add_plugins,
 					database,

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -2,9 +2,9 @@ import { loadConfig } from "c12";
 import type { BetterAuthOptions } from "better-auth";
 import { logger } from "better-auth";
 import path from "path";
-// @ts-ignore
+// @ts-expect-error
 import babelPresetTypeScript from "@babel/preset-typescript";
-// @ts-ignore
+// @ts-expect-error
 import babelPresetReact from "@babel/preset-react";
 import fs, { existsSync } from "fs";
 import { BetterAuthError } from "better-auth";

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -22,7 +22,7 @@ import type {
 	Request as ExpressRequest,
 	Response as ExpressResponse,
 } from "express";
-// @ts-ignore
+// @ts-expect-error
 import express from "express";
 import bodyParser from "body-parser";
 import { randomUUID } from "crypto";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable Biome lint rule noTsIgnore and clean up suppressions across the repo. Replaced @ts-ignore with @ts-expect-error where errors are intentional, removed unnecessary suppressions, and made minor typing tweaks. No runtime changes.

- **Refactors**
  - Set biome lint rule suspicious.noTsIgnore to error.
  - Replaced @ts-ignore with @ts-expect-error in adapters, API key routes, Kysely SQLite dialects, CLI, docs, demo, and tests.
  - Removed unused suppressions and adjusted types (e.g., safeJSONParse inputs, bun:sqlite type imports, number ID test types).

<!-- End of auto-generated description by cubic. -->

