### PR TITLE
feat: add json field type

### DIFF
--- a/packages/better-auth/src/adapters/create-adapter/index.ts
+++ b/packages/better-auth/src/adapters/create-adapter/index.ts
@@ -380,7 +380,6 @@ export const createAdapter =
 				} else if (
 					config.supportsJSON === false &&
 					typeof newValue === "object" &&
-					//@ts-expect-error -Future proofing
 					fieldAttributes.type === "json"
 				) {
 					newValue = JSON.stringify(newValue);
@@ -456,7 +455,6 @@ export const createAdapter =
 					} else if (
 						config.supportsJSON === false &&
 						typeof newValue === "string" &&
-						//@ts-expect-error - Future proofing
 						field.type === "json"
 					) {
 						newValue = safeJSONParse(newValue);

--- a/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
+++ b/packages/better-auth/src/adapters/create-adapter/test/create-adapter.test.ts
@@ -378,7 +378,6 @@ describe("Create Adapter Helper", async () => {
 								user: {
 									additionalFields: {
 										preferences: {
-											//@ts-expect-error - Not *technically* implemented yet, however the `createAdapter` helper already supports it.
 											type: "json",
 										},
 									},
@@ -943,7 +942,6 @@ describe("Create Adapter Helper", async () => {
 								user: {
 									additionalFields: {
 										preferences: {
-											//@ts-expect-error - Not *technically* implemented yet, however the `createAdapter` helper already supports it.
 											type: "json",
 										},
 									},

--- a/packages/better-auth/src/db/field.ts
+++ b/packages/better-auth/src/db/field.ts
@@ -1,4 +1,4 @@
-import type { ZodSchema } from "zod/v4";
+import type { ZodType } from "zod/v4";
 import type { BetterAuthOptions } from "../types";
 import type { LiteralString } from "../types/helper";
 
@@ -90,8 +90,8 @@ export type FieldAttributeConfig<T extends FieldType = FieldType> = {
 	 * A zod schema to validate the value.
 	 */
 	validator?: {
-		input?: ZodSchema;
-		output?: ZodSchema;
+		input?: ZodType;
+		output?: ZodType;
 	};
 	/**
 	 * The name of the field on the database.

--- a/packages/better-auth/src/db/field.ts
+++ b/packages/better-auth/src/db/field.ts
@@ -7,6 +7,7 @@ export type FieldType =
 	| "number"
 	| "boolean"
 	| "date"
+	| "json"
 	| `${"string" | "number"}[]`
 	| Array<LiteralString>;
 

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -23,6 +23,7 @@ const postgresMap = {
 	],
 	boolean: ["bool", "boolean"],
 	date: ["timestamp", "date"],
+	json: ["json", "jsonb"],
 };
 const mysqlMap = {
 	string: ["varchar", "text"],
@@ -37,6 +38,7 @@ const mysqlMap = {
 	],
 	boolean: ["boolean", "tinyint"],
 	date: ["timestamp", "datetime", "date"],
+	json: ["json"],
 };
 
 const sqliteMap = {
@@ -44,6 +46,7 @@ const sqliteMap = {
 	number: ["INTEGER", "REAL"],
 	boolean: ["INTEGER", "BOOLEAN"], // 0 or 1
 	date: ["DATE", "INTEGER"],
+	json: ["TEXT"],
 };
 
 const mssqlMap = {
@@ -51,6 +54,7 @@ const mssqlMap = {
 	number: ["int", "bigint", "smallint", "decimal", "float", "double"],
 	boolean: ["bit", "smallint"],
 	date: ["datetime", "date"],
+	json: ["json"],
 };
 
 const map = {
@@ -205,6 +209,12 @@ export async function getMigrations(config: BetterAuthOptions) {
 				postgres: "timestamp",
 				mysql: "datetime",
 				mssql: "datetime",
+			},
+			json: {
+				sqlite: "text",
+				postgres: "jsonb",
+				mysql: "jsonb",
+				mssql: "jsonb",
 			},
 			id: {
 				postgres: config.advanced?.database?.useNumberId ? "serial" : "text",

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -54,7 +54,7 @@ const mssqlMap = {
 	number: ["int", "bigint", "smallint", "decimal", "float", "double"],
 	boolean: ["bit", "smallint"],
 	date: ["datetime", "date"],
-	json: ["json"],
+	json: ["varchar", "nvarchar"],
 };
 
 const map = {
@@ -212,9 +212,9 @@ export async function getMigrations(config: BetterAuthOptions) {
 			},
 			json: {
 				sqlite: "text",
-				postgres: "jsonb",
-				mysql: "jsonb",
-				mssql: "jsonb",
+				postgres: "json",
+				mysql: "json",
+				mssql: "varchar(8000)",
 			},
 			id: {
 				postgres: config.advanced?.database?.useNumberId ? "serial" : "text",

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -1,5 +1,5 @@
 import * as z from "zod/v4";
-import type { ZodSchema } from "zod/v4";
+import type { ZodType } from "zod/v4";
 import type { FieldAttribute } from ".";
 
 export function toZodSchema<
@@ -24,7 +24,7 @@ export function toZodSchema<
 			return acc;
 		}
 
-		let schema: ZodSchema;
+		let schema: ZodType;
 		if (field.type === "json") {
 			schema = (z as any).json ? (z as any).json() : z.any();
 		} else if (field.type === "string[]" || field.type === "number[]") {

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -23,7 +23,7 @@ export function toZodSchema<
 		if (isClientSide && field.input === false) {
 			return acc;
 		}
-		
+
 		let schema: ZodSchema;
 		if (field.type === "json") {
 			schema = z.json();

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -26,7 +26,7 @@ export function toZodSchema<
 
 		let schema: ZodSchema;
 		if (field.type === "json") {
-			schema = z.json();
+			schema = (z as any).json ? (z as any).json() : z.any();
 		} else if (field.type === "string[]" || field.type === "number[]") {
 			schema = z.array(field.type === "string[]" ? z.string() : z.number());
 		} else if (Array.isArray(field.type)) {

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -23,19 +23,18 @@ export function toZodSchema<
 		if (isClientSide && field.input === false) {
 			return acc;
 		}
-		if (field.type === "string[]" || field.type === "number[]") {
-			return {
-				...acc,
-				[key]: z.array(field.type === "string[]" ? z.string() : z.number()),
-			};
+		
+		let schema: ZodSchema;
+		if (field.type === "json") {
+			schema = z.json();
+		} else if (field.type === "string[]" || field.type === "number[]") {
+			schema = z.array(field.type === "string[]" ? z.string() : z.number());
+		} else if (Array.isArray(field.type)) {
+			schema = z.any();
+		} else {
+			schema = z[field.type]();
 		}
-		if (Array.isArray(field.type)) {
-			return {
-				...acc,
-				[key]: z.any(),
-			};
-		}
-		let schema: ZodSchema = z[field.type]();
+
 		if (field?.required === false) {
 			schema = schema.optional();
 		}


### PR DESCRIPTION
Support for json was already supported and tested in the adapter but not made an official fieldType.

Partial: #4237
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds 'json' as an official field type across the DB schema, migrations, and Zod schema generation, formalizing existing adapter support. Partial for Linear #4237.

- **New Features**
  - Added 'json' to FieldType and Zod generation (uses z.json()).
  - Mapped JSON to native types for Postgres, MySQL, SQLite, and MSSQL in migration tooling.

<!-- End of auto-generated description by cubic. -->

