### PR TITLE
Add supportsDates option to allow string as timestampz from db

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -20,6 +20,15 @@ interface KyselyAdapterConfig {
 	 * @default false
 	 */
 	usePlural?: boolean;
+	/**
+	 * Whether the database supports native date types.
+	 * When false, dates will be handled as ISO strings.
+	 * 
+	 * @default Automatically determined based on database type:
+	 * - `false` for sqlite, mssql
+	 * - `true` for postgres, mysql
+	 */
+	supportsDates?: boolean;
 }
 
 export const kyselyAdapter = (db: Kysely<any>, config?: KyselyAdapterConfig) =>
@@ -34,9 +43,11 @@ export const kyselyAdapter = (db: Kysely<any>, config?: KyselyAdapterConfig) =>
 					? false
 					: true,
 			supportsDates:
-				config?.type === "sqlite" || config?.type === "mssql" || !config?.type
-					? false
-					: true,
+				config?.supportsDates !== undefined
+					? config.supportsDates
+					: config?.type === "sqlite" || config?.type === "mssql" || !config?.type
+						? false
+						: true,
 			supportsJSON: false,
 		},
 		adapter: ({ getFieldName, schema }) => {

--- a/packages/better-auth/src/adapters/kysely-adapter/test/normal/adapter.kysely.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/normal/adapter.kysely.test.ts
@@ -244,3 +244,56 @@ describe("mssql", async () => {
 		});
 	});
 });
+
+describe("supportsDates configuration", () => {
+	it("should respect explicit supportsDates: false for postgres", () => {
+		const adapter = kyselyAdapter(mysqlKy, {
+			type: "postgres",  // Usually defaults to true
+			supportsDates: false,  // Override to false
+		});
+		
+		// Access the internal config to verify the setting
+		const adapterInstance = adapter({
+			database: { db: mysqlKy, type: "postgres" },
+			user: { fields: {} },
+		});
+		
+		expect(adapterInstance.options.adapterConfig.supportsDates).toBe(false);
+	});
+
+	it("should respect explicit supportsDates: true for sqlite", () => {
+		const adapter = kyselyAdapter(sqliteKy, {
+			type: "sqlite",  // Usually defaults to false
+			supportsDates: true,  // Override to true
+		});
+		
+		const adapterInstance = adapter({
+			database: { db: sqliteKy, type: "sqlite" },
+			user: { fields: {} },
+		});
+		
+		expect(adapterInstance.options.adapterConfig.supportsDates).toBe(true);
+	});
+
+	it("should use default behavior when supportsDates is not specified", () => {
+		// Test postgres default (true)
+		const postgresAdapter = kyselyAdapter(mysqlKy, {
+			type: "postgres",
+		});
+		const postgresInstance = postgresAdapter({
+			database: { db: mysqlKy, type: "postgres" },
+			user: { fields: {} },
+		});
+		expect(postgresInstance.options.adapterConfig.supportsDates).toBe(true);
+
+		// Test sqlite default (false)
+		const sqliteAdapter = kyselyAdapter(sqliteKy, {
+			type: "sqlite",
+		});
+		const sqliteInstance = sqliteAdapter({
+			database: { db: sqliteKy, type: "sqlite" },
+			user: { fields: {} },
+		});
+		expect(sqliteInstance.options.adapterConfig.supportsDates).toBe(false);
+	});
+});


### PR DESCRIPTION
Better Auth currently looks only at the database type to decide if it should handle timestams as Date or string.
This PR extends this feature to allow customizing this behavior:

```ts
    // Force timestamp-like types to be returned as raw strings
    // to preserve full precision for downstream consumers
    types: {
      // PostgreSQL OIDs for timestamp-related types
      timestamptz: { from: [1184], to: 1184, parse: (s: string) => s, serialize: (s: string) => s },
      timestamp: { from: [1114], to: 1114, parse: (s: string) => s, serialize: (s: string) => s },
      date: { from: [1082], to: 1082, parse: (s: string) => s, serialize: (s: string) => s },
      time: { from: [1083], to: 1083, parse: (s: string) => s, serialize: (s: string) => s },
      timetz: { from: [1266], to: 1266, parse: (s: string) => s, serialize: (s: string) => s },
    },

    // later on I init betterAuth:
  export const auth = betterAuth({
  // Use Better Auth's Kysely adapter with supportsDates: false for Neon compatibility
  // This prevents crashes when the database driver returns dates as strings
  database: kyselyAdapter(db, {
    type: 'postgres',
    supportsDates: false, // NEW: Fix for Neon/PostgreSQL driver returning dates as strings
  }),
```

Without that, I get `ERROR [Better Auth]: Failed to create user TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Date`

Took me quite some time to debug, I used AI to write this fix, so the tests defo need work,
but I wanted to get the discussion going first if this is something you consider.

And since I'm fairly new to web tech, also if this pattern is common.
I did talk with @igalklebanov and he confirmed that this is a common pattern.


Alternative design if we wanna be even more explicit (but then I'd expect auto to do a one-time probe)
```ts
  dates: 'auto',           // default
  // dates: 'native',     // force Date passthrough
  // dates: 'string',     // force ISO strings at DB boundary
```

Why go in on all strings?
This allows my project to keep full precision on time and greatly simplify date/time conversion.
Everything is a zod-verified timestamp, date conversion happens at the UI layer.
Especially with React RSC that's super nice, so I can push my existing models to the frontend.

Why not read from the db layer?
I considered reading the config from the database but that gets messy fast - I use Neon in prod which again has a differert type configuration syntax - so a new option seemed easier.

No conversion?
I use `postgres.js` which returns [correct ISO 8601](https://github.com/porsager/postgres/blob/32feb259a3c9abffab761bd1758b3168d9e0cebc/src/types.js#L31), as does Neon. pg returns ISO (with a space instead of T + numeric offset) so folks using that still have to do a tiny conversion or a [json_object trick](https://onecompiler.com/postgresql/43v4ab5kn) to get ISO 8601.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a supportsDates option to the Kysely adapter to control how date/time fields are handled. This prevents crashes with drivers that return strings (e.g., Neon Postgres) and allows preserving full timestamp precision by using ISO strings.

- **New Features**
  - New config: supportsDates. When false, dates are handled as strings. Defaults remain: sqlite/mssql=false, postgres/mysql=true. Can be overridden per adapter.
  - Added tests to cover defaults and overrides.

- **Migration**
  - If your Postgres driver returns dates as strings (e.g., Neon), set supportsDates: false in kyselyAdapter({ type: 'postgres', supportsDates: false }).

<!-- End of auto-generated description by cubic. -->

