### PR TITLE
fix(oidc): fix failing oidc tests due to uncaught TypeError in to-auth-endpoint.ts

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -122,7 +122,7 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 				shouldPublishLog(authContext.logger.level, "debug")
 			) {
 				// inherit stack from errorWithStack if debug mode is enabled
-				result.response.stack = result.response.errorWithStack.stack;
+				result.response.stack = result.response.errorWithStack?.stack;
 			}
 
 			if (result.response instanceof APIError && !context?.asResponse) {
@@ -170,7 +170,7 @@ async function runBeforeHooks(
 						shouldPublishLog(context.context.logger.level, "debug")
 					) {
 						// inherit stack from errorWithStack if debug mode is enabled
-						e.stack = e.errorWithStack.stack;
+						e.stack = e.errorWithStack?.stack;
 					}
 					throw e;
 				});
@@ -212,7 +212,7 @@ async function runAfterHooks(
 				if (e instanceof APIError) {
 					if (shouldPublishLog(context.context.logger.level, "debug")) {
 						// inherit stack from errorWithStack if debug mode is enabled
-						e.stack = e.errorWithStack.stack;
+						e.stack = e.errorWithStack?.stack;
 					}
 					return {
 						response: e,

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -122,7 +122,7 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 				shouldPublishLog(authContext.logger.level, "debug")
 			) {
 				// inherit stack from errorWithStack if debug mode is enabled
-				result.response.stack = result.response.errorWithStack?.stack;
+				result.response.stack = result.response.errorWithStack?.stack ?? result.response.stack;
 			}
 
 			if (result.response instanceof APIError && !context?.asResponse) {

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -212,7 +212,7 @@ async function runAfterHooks(
 				if (e instanceof APIError) {
 					if (shouldPublishLog(context.context.logger.level, "debug")) {
 						// inherit stack from errorWithStack if debug mode is enabled
-						e.stack = e.errorWithStack?.stack;
+						e.stack = e.errorWithStack?.stack ?? e.stack;
 					}
 					return {
 						response: e,

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -170,7 +170,7 @@ async function runBeforeHooks(
 						shouldPublishLog(context.context.logger.level, "debug")
 					) {
 						// inherit stack from errorWithStack if debug mode is enabled
-						e.stack = e.errorWithStack?.stack;
+						e.stack = e.errorWithStack?.stack ?? e.stack;
 					}
 					throw e;
 				});


### PR DESCRIPTION
## Description
I was writing tests for #4263 . 
oidc tests were failing with Error : SERVER_ERROR:  TypeError: Cannot read properties of undefined (reading 'stack')
    at api.<computed> (/home/shobhit/Desktop/os/better-auth/packages/better-auth/src/api/to-auth-endpoints.ts:125:60)
    at processRequest (file:///home/shobhit/Desktop/os/better-auth/node_modules/better-call/src/router.ts:193:22)
    at handler (file:///home/shobhit/Desktop/os/better-auth/node_modules/better-call/src/router.ts:214:16)
    at betterFetch (file:///home/shobhit/Desktop/os/better-auth/node_modules/@better-fetch/fetch/src/fetch.ts:77:17)
    at Proxy.$fetch (file:///home/shobhit/Desktop/os/better-auth/node_modules/@better-fetch/fetch/src/create-fetch/index.ts:95:10)
    at /home/shobhit/Desktop/os/better-auth/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts:312:3
    at file:///home/shobhit/Desktop/os/better-auth/node_modules/@vitest/runner/dist/chunk-hooks.js:752:20

 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes an uncaught TypeError in to-auth-endpoints.ts that caused OIDC tests to fail. We now safely inherit error stacks in debug mode without assuming errorWithStack is defined.

- **Bug Fixes**
  - Use optional chaining when accessing errorWithStack.stack in endpoint result, before hooks, and after hooks.
  - Prevents SERVER_ERROR TypeError while preserving stack propagation in debug.

<!-- End of auto-generated description by cubic. -->

