### PR TITLE
fix: team id zod schema meta property for array type

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -66,10 +66,10 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 				.optional(),
 			z
 				.array(
-					z.string().meta({
-						description: "The team ID to invite the user to",
-					}),
-				)
+					z.string()
+				).meta({
+					description: "The team IDs to invite the user to",
+				})
 				.optional(),
 		]),
 	});
@@ -497,6 +497,7 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				invitationId: ctx.body.invitationId,
 				status: "accepted",
 			});
+
 			if (!acceptedI) {
 				throw new APIError("BAD_REQUEST", {
 					message: ORGANIZATION_ERROR_CODES.FAILED_TO_RETRIEVE_INVITATION,
@@ -567,6 +568,7 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				session.session.token,
 				invitation.organizationId,
 			);
+
 			if (!acceptedI) {
 				return ctx.json(null, {
 					status: 400,
@@ -574,36 +576,6 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 						message: ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
 					},
 				});
-			}
-			if (ctx.context.orgOptions.onInvitationAccepted) {
-				const organization = await adapter.findOrganizationById(
-					invitation.organizationId,
-				);
-
-				const inviterMember = await adapter.findMemberByOrgId({
-					userId: invitation.inviterId,
-					organizationId: invitation.organizationId,
-				});
-
-				const inviterUser = await ctx.context.internalAdapter.findUserById(
-					invitation.inviterId,
-				);
-				if (organization && inviterMember && inviterUser) {
-					await ctx.context.orgOptions.onInvitationAccepted(
-						{
-							id: invitation.id,
-							role: invitation.role as string,
-							organization: organization,
-							invitation: invitation as unknown as Invitation,
-							inviter: {
-								...inviterMember,
-								user: inviterUser,
-							},
-							acceptedUser: session.user,
-						},
-						ctx.request,
-					);
-				}
 			}
 
 			return ctx.json({

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -65,11 +65,10 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 				})
 				.optional(),
 			z
-				.array(
-					z.string().meta({
-						description: "The team ID to invite the user to",
-					}),
-				)
+				.array(z.string())
+				.meta({
+					description: "The team IDs to invite the user to",
+				})
 				.optional(),
 		]),
 	});

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -565,7 +565,6 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				session.session.token,
 				invitation.organizationId,
 			);
-
 			if (!acceptedI) {
 				return ctx.json(null, {
 					status: 400,

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -65,9 +65,8 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 				})
 				.optional(),
 			z
-				.array(
-					z.string()
-				).meta({
+				.array(z.string())
+				.meta({
 					description: "The team IDs to invite the user to",
 				})
 				.optional(),

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -65,10 +65,11 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 				})
 				.optional(),
 			z
-				.array(z.string())
-				.meta({
-					description: "The team IDs to invite the user to",
-				})
+				.array(
+					z.string().meta({
+						description: "The team ID to invite the user to",
+					}),
+				)
 				.optional(),
 		]),
 	});
@@ -496,13 +497,11 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				invitationId: ctx.body.invitationId,
 				status: "accepted",
 			});
-
 			if (!acceptedI) {
 				throw new APIError("BAD_REQUEST", {
 					message: ORGANIZATION_ERROR_CODES.FAILED_TO_RETRIEVE_INVITATION,
 				});
 			}
-
 			if (
 				ctx.context.orgOptions.teams &&
 				ctx.context.orgOptions.teams.enabled &&
@@ -576,7 +575,36 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 					},
 				});
 			}
+			if (ctx.context.orgOptions.onInvitationAccepted) {
+				const organization = await adapter.findOrganizationById(
+					invitation.organizationId,
+				);
 
+				const inviterMember = await adapter.findMemberByOrgId({
+					userId: invitation.inviterId,
+					organizationId: invitation.organizationId,
+				});
+
+				const inviterUser = await ctx.context.internalAdapter.findUserById(
+					invitation.inviterId,
+				);
+				if (organization && inviterMember && inviterUser) {
+					await ctx.context.orgOptions.onInvitationAccepted(
+						{
+							id: invitation.id,
+							role: invitation.role as string,
+							organization: organization,
+							invitation: invitation as unknown as Invitation,
+							inviter: {
+								...inviterMember,
+								user: inviterUser,
+							},
+							acceptedUser: session.user,
+						},
+						ctx.request,
+					);
+				}
+			}
 			return ctx.json({
 				invitation: acceptedI,
 				member,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the invite payload Zod schema by moving the meta description to the array level and updating the text to “team IDs” to match the array type. No runtime changes—just accurate metadata and minor formatting cleanup.

<!-- End of auto-generated description by cubic. -->

