### PR TITLE
test: init `vanilla-node` e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Install
         run: pnpm install
 
+      - name: Install Playwright Browsers
+        run: pnpx playwright install --with-deps
+
       - name: Build
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   smoke:
     name: Smoke test
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -60,4 +60,53 @@ jobs:
 
       - name: Stop Docker Containers
         run: docker compose down
+  integration:
+    name: Integration test
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
 
+      - name: Cache turbo build setup
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install
+
+      - name: Build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+          TURBO_REMOTE_ONLY: true
+        run: pnpm build
+
+      - name: Start Docker Containers
+        run: |
+          docker compose up -d
+          # Wait for services to be ready (optional)
+          sleep 10
+
+      - name: Integration
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+          TURBO_REMOTE_ONLY: true
+        run: pnpm e2e:integration
+
+      - name: Stop Docker Containers
+        run: docker compose down

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ android/
 .vinxi
 # Turborepo
 .turbo
+
+playwright-report/
+test-results/

--- a/e2e/integration/package.json
+++ b/e2e/integration/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "integration",
+  "scripts": {
+    "e2e:integration": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0"
+  }
+}

--- a/e2e/integration/package.json
+++ b/e2e/integration/package.json
@@ -4,6 +4,7 @@
     "e2e:integration": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.55.0"
+    "@playwright/test": "^1.55.0",
+    "terminate": "^2.8.0"
   }
 }

--- a/e2e/integration/playwright.config.ts
+++ b/e2e/integration/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	testMatch: "**/e2e/**/*.spec.ts",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: "html",
+	use: {
+		trace: "on-first-retry",
+	},
+
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+});

--- a/e2e/integration/vanilla-node/e2e/test.spec.ts
+++ b/e2e/integration/vanilla-node/e2e/test.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+test.describe("vanilla-node", async () => {
+	let serverChild: ChildProcessWithoutNullStreams;
+	let clientChild: ChildProcessWithoutNullStreams;
+	let clientPort: number;
+	test.beforeEach(async () => {
+		serverChild = spawn("pnpm", ["run", "start:server"], {
+			cwd: root,
+			stdio: "pipe",
+		});
+		clientChild = spawn("pnpm", ["run", "start:client"], {
+			cwd: root,
+			stdio: "pipe",
+		});
+		serverChild.stdout.on("data", (data) => {
+			const message = data.toString();
+			console.log(message);
+		});
+		clientChild.stdout.on("data", (data) => {
+			const message = data.toString();
+			console.log(message);
+		});
+
+		return new Promise<void>((resolve) => {
+			clientChild.stdout.on("data", (data) => {
+				const message = data.toString();
+				// find: http://localhost:5173/
+				if (message.includes("http://localhost:")) {
+					const port: string = message
+						.split("http://localhost:")[1]
+						.split("/")[0]
+						.trim();
+					clientPort = Number(port.replace(/\x1b\[[0-9;]*m/g, ""));
+					resolve();
+				}
+			});
+		});
+	});
+
+	test.afterEach(async () => {
+		clientChild.kill("SIGTERM");
+		serverChild.kill("SIGTERM");
+	});
+
+	test("signIn with existing email and password should work", async ({
+		page,
+	}) => {
+		await page.goto(`http://localhost:${clientPort}/`);
+		await page.locator("text=Ready").waitFor();
+		await expect(
+			page.evaluate(() => {
+				// @ts-expect-error We don't declare this in the types
+				return typeof window.client !== "undefined";
+			}),
+		).resolves.toBe(true);
+	});
+});

--- a/e2e/integration/vanilla-node/index.html
+++ b/e2e/integration/vanilla-node/index.html
@@ -4,37 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Better Auth - Vanilla Node E2E Test</title>
-    <style>
-      body {
-        font-family: system-ui, -apple-system, sans-serif;
-        max-width: 800px;
-        margin: 2rem auto;
-        padding: 0 1rem;
-      }
-      button {
-        padding: 0.5rem 1rem;
-        font-size: 1rem;
-        cursor: pointer;
-      }
-      #result {
-        background: #f5f5f5;
-        padding: 1rem;
-        border-radius: 4px;
-        white-space: pre-wrap;
-        font-family: monospace;
-        margin-top: 1rem;
-      }
-      #status {
-        margin: 1rem 0;
-        font-weight: bold;
-      }
-    </style>
   </head>
   <body>
-    <h1>Better Auth - Connection Test</h1>
-    <button id="test-btn">Test Connection</button>
-    <div id="status"></div>
-    <pre id="result"></pre>
     <script type="module" src="./src/main.ts"></script>
   </body>
 </html>

--- a/e2e/integration/vanilla-node/index.html
+++ b/e2e/integration/vanilla-node/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Better Auth - Vanilla Node E2E Test</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+      button {
+        padding: 0.5rem 1rem;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+      #result {
+        background: #f5f5f5;
+        padding: 1rem;
+        border-radius: 4px;
+        white-space: pre-wrap;
+        font-family: monospace;
+        margin-top: 1rem;
+      }
+      #status {
+        margin: 1rem 0;
+        font-weight: bold;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Better Auth - Connection Test</h1>
+    <button id="test-btn">Test Connection</button>
+    <div id="status"></div>
+    <pre id="result"></pre>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/e2e/integration/vanilla-node/package.json
+++ b/e2e/integration/vanilla-node/package.json
@@ -3,10 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "server": "tsx ./src/server.ts",
-    "build": "tsc && vite build",
-    "preview": "vite preview"
+    "start:server": "tsx ./src/server.ts",
+    "start:client": "vite"
   },
   "devDependencies": {
     "typescript": "^5.9.2",

--- a/e2e/integration/vanilla-node/package.json
+++ b/e2e/integration/vanilla-node/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vanilla-node-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "server": "tsx ./src/server.ts",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2",
+    "vite": "^7.1.3",
+    "tsx": "^4.19.2"
+  },
+  "dependencies": {
+    "better-auth": "workspace:*",
+    "better-sqlite3": "^11.7.0"
+  }
+}

--- a/e2e/integration/vanilla-node/src/main.ts
+++ b/e2e/integration/vanilla-node/src/main.ts
@@ -1,10 +1,15 @@
 import { createAuthClient } from "better-auth/client";
 
+declare global {
+	interface Window {
+		client: ReturnType<typeof createAuthClient>;
+	}
+}
+
 const client = createAuthClient({
 	baseURL: "http://localhost:3000",
 });
 
-// @ts-expect-error We don't declare this in the types
-globalThis.client = client;
+window.client = client;
 
 document.body.innerHTML = "Ready";

--- a/e2e/integration/vanilla-node/src/main.ts
+++ b/e2e/integration/vanilla-node/src/main.ts
@@ -4,16 +4,7 @@ const client = createAuthClient({
 	baseURL: "http://localhost:3000",
 });
 
-async function testConnection() {
-	await client.signIn.email({
-		email: "test@test.com",
-		password: "password123",
-	});
-}
+// @ts-expect-error We don't declare this in the types
+globalThis.client = client;
 
-document.addEventListener("DOMContentLoaded", () => {
-	const button = document.getElementById("test-btn");
-	button?.addEventListener("click", testConnection);
-
-	console.log("Better Auth client initialized");
-});
+document.body.innerHTML = "Ready";

--- a/e2e/integration/vanilla-node/src/main.ts
+++ b/e2e/integration/vanilla-node/src/main.ts
@@ -1,0 +1,19 @@
+import { createAuthClient } from "better-auth/client";
+
+const client = createAuthClient({
+	baseURL: "http://localhost:3000",
+});
+
+async function testConnection() {
+	await client.signIn.email({
+		email: "test@test.com",
+		password: "password123",
+	});
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+	const button = document.getElementById("test-btn");
+	button?.addEventListener("click", testConnection);
+
+	console.log("Better Auth client initialized");
+});

--- a/e2e/integration/vanilla-node/src/server.ts
+++ b/e2e/integration/vanilla-node/src/server.ts
@@ -1,0 +1,59 @@
+import { createServer } from "node:http";
+import { betterAuth } from "better-auth";
+import { toNodeHandler } from "better-auth/node";
+import Database from "better-sqlite3";
+import { getMigrations } from "better-auth/db";
+
+const database = new Database(":memory:");
+
+const auth = betterAuth({
+	database,
+	baseURL: "http://localhost:3000",
+	emailAndPassword: {
+		enabled: true,
+	},
+});
+
+const { runMigrations } = await getMigrations(auth.options);
+
+await runMigrations();
+// Create an example user
+await auth.api.signUpEmail({
+	body: {
+		name: "Test User",
+		email: "test@test.com",
+		password: "password123",
+	},
+});
+
+const authHandler = toNodeHandler(auth);
+
+const server = createServer(async (req, res) => {
+	res.setHeader("Access-Control-Allow-Origin", "http://localhost:5173");
+	res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+	res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+	res.setHeader("Access-Control-Allow-Credentials", "true");
+
+	if (req.method === "OPTIONS") {
+		res.statusCode = 200;
+		res.end();
+		return;
+	}
+
+	const isAuthRoute = req.url?.startsWith("/api/auth");
+
+	if (isAuthRoute) {
+		return authHandler(req, res);
+	}
+
+	res.statusCode = 404;
+	res.end(JSON.stringify({ error: "Not found" }));
+});
+
+const PORT = 3000;
+server.listen(PORT, () => {
+	console.log(`✅ Server running at http://localhost:${PORT}`);
+	console.log(
+		`   Auth endpoints available at http://localhost:${PORT}/api/auth/*`,
+	);
+});

--- a/e2e/integration/vanilla-node/src/vite-env.d.ts
+++ b/e2e/integration/vanilla-node/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/e2e/integration/vanilla-node/tsconfig.json
+++ b/e2e/integration/vanilla-node/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/e2e/integration/vanilla-node/tsconfig.json
+++ b/e2e/integration/vanilla-node/tsconfig.json
@@ -5,15 +5,11 @@
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
-
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bump": "bumpp",
     "test": "turbo --filter \"./packages/*\" test",
     "e2e:smoke": "turbo --filter \"./e2e/*\" e2e:smoke",
+    "e2e:integration": "turbo --filter \"./e2e/*\" e2e:integration",
     "typecheck": "turbo --filter \"./packages/*\" typecheck"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,25 @@ importers:
         specifier: ^5.8.2
         version: 5.9.2
 
+  e2e/integration/vanilla-node:
+    dependencies:
+      better-auth:
+        specifier: workspace:*
+        version: link:../../../packages/better-auth
+      better-sqlite3:
+        specifier: ^11.7.0
+        version: 11.10.0
+    devDependencies:
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.4
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+      vite:
+        specifier: ^7.1.3
+        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
+
   e2e/smoke:
     dependencies:
       better-auth:
@@ -16995,7 +17014,9 @@ snapshots:
       metro-runtime: 0.83.1
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.79.5': {}
 
@@ -26259,7 +26280,7 @@ snapshots:
 
   tsx@4.20.4:
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.9
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,8 @@ importers:
         specifier: ^5.8.2
         version: 5.9.2
 
+  e2e/integration: {}
+
   e2e/integration/vanilla-node:
     dependencies:
       better-auth:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,9 @@ importers:
       '@playwright/test':
         specifier: ^1.55.0
         version: 1.55.0
+      terminate:
+        specifier: ^2.8.0
+        version: 2.8.0
 
   e2e/integration/vanilla-node:
     dependencies:
@@ -7763,6 +7766,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-stream@3.3.4:
+    resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -8097,6 +8103,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  from@0.1.7:
+    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -9422,6 +9431,9 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  map-stream@0.1.0:
+    resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
+
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
@@ -10513,6 +10525,9 @@ packages:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
 
+  pause-stream@0.0.11:
+    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -10950,6 +10965,11 @@ packages:
 
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
+
+  ps-tree@1.2.0:
+    resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -11750,6 +11770,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  split@0.3.3:
+    resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -11809,6 +11832,9 @@ packages:
   stream-buffers@2.2.0:
     resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
     engines: {node: '>= 0.10.0'}
+
+  stream-combiner@0.0.4:
+    resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
 
   streamx@2.22.1:
     resolution: {integrity: sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==}
@@ -12043,6 +12069,10 @@ packages:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
 
+  terminate@2.8.0:
+    resolution: {integrity: sha512-bcbjJEg0wY5nuJXvGxxHfmoEPkyHLCctUKO6suwtxy7jVSgGcgPeGwpbLDLELFhIaxCGRr3dPvyNg1yuz2V0eg==}
+    engines: {node: '>=12'}
+
   terser@5.43.1:
     resolution: {integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==}
     engines: {node: '>=10'}
@@ -12070,6 +12100,9 @@ packages:
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tiny-conventional-commits-parser@0.0.1:
     resolution: {integrity: sha512-N5+AZWdBeHNSgTIaxvx0+9mFrnW4H1BbjQ84H7i3TuWSkno8Hju886hLaHZhE/hYEKrfrfl/uHurqpZJHDuYGQ==}
@@ -20683,6 +20716,16 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-stream@3.3.4:
+    dependencies:
+      duplexer: 0.1.2
+      from: 0.1.7
+      map-stream: 0.1.0
+      pause-stream: 0.0.11
+      split: 0.3.3
+      stream-combiner: 0.0.4
+      through: 2.3.8
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
@@ -21113,6 +21156,8 @@ snapshots:
   fresh@0.5.2: {}
 
   fresh@2.0.0: {}
+
+  from@0.1.7: {}
 
   fs-constants@1.0.0: {}
 
@@ -22578,6 +22623,8 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  map-stream@0.1.0: {}
 
   markdown-extensions@2.0.0: {}
 
@@ -24230,6 +24277,10 @@ snapshots:
 
   pathval@2.0.0: {}
 
+  pause-stream@0.0.11:
+    dependencies:
+      through: 2.3.8
+
   peberminta@0.9.0: {}
 
   pend@1.2.0: {}
@@ -24650,6 +24701,10 @@ snapshots:
 
   prr@1.0.1:
     optional: true
+
+  ps-tree@1.2.0:
+    dependencies:
+      event-stream: 3.3.4
 
   pump@3.0.3:
     dependencies:
@@ -25803,6 +25858,10 @@ snapshots:
 
   split2@4.2.0: {}
 
+  split@0.3.3:
+    dependencies:
+      through: 2.3.8
+
   sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3: {}
@@ -25843,6 +25902,10 @@ snapshots:
   stoppable@1.1.0: {}
 
   stream-buffers@2.2.0: {}
+
+  stream-combiner@0.0.4:
+    dependencies:
+      duplexer: 0.1.2
 
   streamx@2.22.1:
     dependencies:
@@ -26172,6 +26235,10 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
+  terminate@2.8.0:
+    dependencies:
+      ps-tree: 1.2.0
+
   terser@5.43.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -26202,6 +26269,8 @@ snapshots:
   three@0.168.0: {}
 
   throat@5.0.0: {}
+
+  through@2.3.8: {}
 
   tiny-conventional-commits-parser@0.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,7 +554,11 @@ importers:
         specifier: ^5.8.2
         version: 5.9.2
 
-  e2e/integration: {}
+  e2e/integration:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.55.0
+        version: 1.55.0
 
   e2e/integration/vanilla-node:
     dependencies:
@@ -15609,7 +15613,6 @@ snapshots:
   '@playwright/test@1.55.0':
     dependencies:
       playwright: 1.55.0
-    optional: true
 
   '@polka/url@1.0.0-next.29':
     optional: true
@@ -24303,15 +24306,13 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
-  playwright-core@1.55.0:
-    optional: true
+  playwright-core@1.55.0: {}
 
   playwright@1.55.0:
     dependencies:
       playwright-core: 1.55.0
     optionalDependencies:
       fsevents: 2.3.2
-    optional: true
 
   plist@3.1.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -30,7 +30,11 @@
       "outputs": []
     },
     "e2e:smoke": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "e2e:integration": {
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "typecheck": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a vanilla Node E2E setup to verify Better Auth’s email/password flow using a minimal Node server and a Vite client. Seeds a test user and exposes auth endpoints the client uses to sign in.

- **New Features**
  - Minimal Node HTTP server with better-auth, in-memory better-sqlite3, migrations, and a seeded test user.
  - Vite client (index.html + main.ts) with a “Test Connection” button that calls client.signIn.email.
  - CORS configured for localhost dev (server: 3000, client: 5173).
  - Scripts: dev (Vite), server (tsx), build, preview.

- **Dependencies**
  - Adds better-sqlite3, tsx, vite, typescript; updates pnpm-lock.

<!-- End of auto-generated description by cubic. -->

