### PR TITLE
docs: fix typos in codeblocks

### DIFF
--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -94,7 +94,7 @@ socialProviders: {
 
 If your application needs additional Google scopes after the user has already signed up (e.g., for Google Drive, Gmail, or other Google services), you can request them using the `linkSocial` method with the same Google provider.
 
-```ts title="auth-client.ts"
+```tsx title="auth-client.ts"
 const requestGoogleDriveAccess = async () => {
   await authClient.linkSocial({
     provider: "google",

--- a/docs/content/docs/plugins/oauth-proxy.mdx
+++ b/docs/content/docs/plugins/oauth-proxy.mdx
@@ -16,7 +16,7 @@ A proxy plugin, that allows you to proxy OAuth requests. Useful for development 
 
     export const auth = betterAuth({
         plugins: [ // [!code highlight]
-            oAuthProxy({
+            oAuthProxy({ // [!code highlight]
                 productionURL: "https://my-main-app.com", // Optional - if the URL isn't inferred correctly // [!code highlight]
                 currentURL: "http://localhost:3000", // Optional - if the URL isn't inferred correctly // [!code highlight] 
             }), // [!code highlight]


### PR DESCRIPTION
Fixes these:
<img width="680" height="506" alt="image" src="https://github.com/user-attachments/assets/5f985786-2720-448f-af1f-770b44422387" />
<img width="743" height="406" alt="image" src="https://github.com/user-attachments/assets/62506301-506b-444d-ba6c-fb414b0395cf" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix code block language and highlight markers in docs so examples render correctly.

- **Bug Fixes**
  - authentication/google.mdx: change code fence from ts to tsx for proper syntax highlighting.
  - plugins/oauth-proxy.mdx: move [!code highlight] to the opening brace line to highlight the correct line.

<!-- End of auto-generated description by cubic. -->

