### PR TITLE
fix: changelogs incorrect mentions

### DIFF
--- a/docs/app/blog/_components/default-changelog.tsx
+++ b/docs/app/blog/_components/default-changelog.tsx
@@ -45,14 +45,11 @@ const ChangelogPage = async () => {
 			if (line.startsWith("- ")) {
 				const mainContent = line.split(";")[0];
 				const context = line.split(";")[2];
-				const mentions = context
-					?.split(" ")
-					.filter((word) => word.startsWith("@"))
-					.map((mention) => {
-						const username = mention.replace("@", "");
-						const avatarUrl = `https://github.com/${username}.png`;
-						return `[![${mention}](${avatarUrl})](https://github.com/${username})`;
-					});
+				const mentions = context?.match(/@([A-Za-z0-9-]+)/g)?.map((match) => {
+					const username = match.slice(1);
+					const avatarUrl = `https://github.com/${username}.png`;
+					return `[![${match}](${avatarUrl})](https://github.com/${username})`;
+				});
 				if (!mentions) {
 					return line;
 				}

--- a/docs/app/blog/_components/default-changelog.tsx
+++ b/docs/app/blog/_components/default-changelog.tsx
@@ -45,16 +45,22 @@ const ChangelogPage = async () => {
 			if (line.startsWith("- ")) {
 				const mainContent = line.split(";")[0];
 				const context = line.split(";")[2];
-				const mentions = context?.match(/@([A-Za-z0-9-]+)/g)?.map((match) => {
+				const mentionMatches =
+					(context ?? line)?.match(/@([A-Za-z0-9-]+)/g) ?? [];
+				if (mentionMatches.length === 0) {
+					return (mainContent || line).replace(/&nbsp/g, "");
+				}
+				const mentions = mentionMatches.map((match) => {
 					const username = match.slice(1);
 					const avatarUrl = `https://github.com/${username}.png`;
 					return `[![${match}](${avatarUrl})](https://github.com/${username})`;
 				});
-				if (!mentions) {
-					return line;
-				}
 				// Remove &nbsp
-				return mainContent.replace(/&nbsp/g, "") + " – " + mentions.join(" ");
+				return (
+					(mainContent || line).replace(/&nbsp/g, "") +
+					" – " +
+					mentions.join(" ")
+				);
 			}
 			return line;
 		});

--- a/docs/app/changelogs/_components/default-changelog.tsx
+++ b/docs/app/changelogs/_components/default-changelog.tsx
@@ -45,14 +45,11 @@ const ChangelogPage = async () => {
 			if (line.trim().startsWith("- ")) {
 				const mainContent = line.split(";")[0];
 				const context = line.split(";")[2];
-				const mentions = context
-					?.split(" ")
-					.filter((word) => word.startsWith("@"))
-					.map((mention) => {
-						const username = mention.replace("@", "");
-						const avatarUrl = `https://github.com/${username}.png`;
-						return `[![${mention}](${avatarUrl})](https://github.com/${username})`;
-					});
+				const mentions = context?.match(/@([A-Za-z0-9-]+)/g)?.map((match) => {
+					const username = match.slice(1);
+					const avatarUrl = `https://github.com/${username}.png`;
+					return `[![${match}](${avatarUrl})](https://github.com/${username})`;
+				});
 				if (!mentions) {
 					return line;
 				}

--- a/docs/app/changelogs/_components/default-changelog.tsx
+++ b/docs/app/changelogs/_components/default-changelog.tsx
@@ -45,16 +45,22 @@ const ChangelogPage = async () => {
 			if (line.trim().startsWith("- ")) {
 				const mainContent = line.split(";")[0];
 				const context = line.split(";")[2];
-				const mentions = context?.match(/@([A-Za-z0-9-]+)/g)?.map((match) => {
+				const mentionMatches =
+					(context ?? line)?.match(/@([A-Za-z0-9-]+)/g) ?? [];
+				if (mentionMatches.length === 0) {
+					return (mainContent || line).replace(/&nbsp/g, "");
+				}
+				const mentions = mentionMatches.map((match) => {
 					const username = match.slice(1);
 					const avatarUrl = `https://github.com/${username}.png`;
 					return `[![${match}](${avatarUrl})](https://github.com/${username})`;
 				});
-				if (!mentions) {
-					return line;
-				}
 				// Remove &nbsp
-				return mainContent.replace(/&nbsp/g, "") + " – " + mentions.join(" ");
+				return (
+					(mainContent || line).replace(/&nbsp/g, "") +
+					" – " +
+					mentions.join(" ")
+				);
 			}
 			return line;
 		});


### PR DESCRIPTION
This PR fixes the changelogs page incorrect mentions regex.

Previous:
<img width="842" height="150" alt="Comet 2025-08-31 03 23 46" src="https://github.com/user-attachments/assets/af52f95a-6229-49c2-9f52-030fae2f3625" />
<img width="702" height="212" alt="CleanShot 2025-08-31 at 03 24 25@2x" src="https://github.com/user-attachments/assets/070e9b1e-8b95-42e5-9703-d276d6871967" />

Now: 
<img width="828" height="142" alt="CleanShot 2025-08-31 at 03 24 40@2x" src="https://github.com/user-attachments/assets/41b54b4f-5b67-43f6-b186-d919f2584908" />
<img width="680" height="224" alt="CleanShot 2025-08-31 at 03 24 50@2x" src="https://github.com/user-attachments/assets/521a4ea0-4007-46bc-a16d-31268c4ab33d" />
