### PR TITLE
fix: no error catch

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -38,13 +38,7 @@ export const getClientConfig = (options?: ClientOptions) => {
 				strict: false,
 			});
 		},
-		customFetchImpl: async (input, init) => {
-			try {
-				return await fetch(input, init);
-			} catch (error) {
-				return Response.error();
-			}
-		},
+		customFetchImpl: fetch,
 		...restOfFetchOptions,
 		plugins: [
 			lifeCyclePlugin,


### PR DESCRIPTION
This might be a potential breaking change? Previously, we returned `Response.error` for all fetches, but we actually ignored the error for the user. So I think we should just leave things as-is