### PR TITLE
test: remove unused `page.pause`

### DIFF
--- a/e2e/integration/vanilla-node/e2e/test.spec.ts
+++ b/e2e/integration/vanilla-node/e2e/test.spec.ts
@@ -91,7 +91,6 @@ test.describe("vanilla-node", async () => {
 				return typeof window.client !== "undefined";
 			}),
 		).resolves.toBe(true);
-		await page.pause();
 		await expect(
 			page.evaluate(async () => window.client.getSession()),
 		).resolves.toEqual({ data: null, error: null });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed a stray page.pause() from the vanilla-node E2E test to avoid debug pauses that could stall CI. No behavior change; tests run uninterrupted.

<!-- End of auto-generated description by cubic. -->

