### PR TITLE
fix(bearer): certain sign-in endpoints won't give bearer token v2

### DIFF
--- a/docs/content/docs/plugins/bearer.mdx
+++ b/docs/content/docs/plugins/bearer.mdx
@@ -22,6 +22,15 @@ export const auth = betterAuth({
 });
 ```
 
+And in your auth client as well:
+
+```ts title="auth-client.ts"
+import { bearerClient } from "better-auth/client/plugins";
+export const authClient = createAuthClient({
+    plugins: [bearerClient()]
+});
+```
+
 ## How to Use Bearer Tokens
 
 ### 1. Obtain the Bearer Token
@@ -56,7 +65,6 @@ export const authClient = createAuthClient({
     }
 });
 ```
-
 
 You may want to clear the token based on the response status code or other conditions:
 
@@ -137,3 +145,6 @@ export async function handler(req, res) {
 ## Options
 
 **requireSignature** (boolean): Require the token to be signed. Default: `false`.
+
+**cookieName** (string): Custom cookie name for the temporary bearer token confirmation cookie. Default: `"bearer-token-confirmation"`.
+(For more information, [read here](https://github.com/better-auth/better-auth/pull/4123))

--- a/packages/better-auth/src/client/plugins/index.ts
+++ b/packages/better-auth/src/client/plugins/index.ts
@@ -20,4 +20,5 @@ export * from "../../plugins/api-key/client";
 export * from "../../plugins/one-time-token/client";
 export * from "../../plugins/siwe/client";
 export * from "../../plugins/device-authorization/client";
+export * from "../../plugins/bearer/client";
 export type * from "@simplewebauthn/server";

--- a/packages/better-auth/src/plugins/bearer/bearer.test.ts
+++ b/packages/better-auth/src/plugins/bearer/bearer.test.ts
@@ -75,4 +75,16 @@ describe("bearer", async () => {
 		});
 		expect(session.data?.session).toBeDefined();
 	});
+
+	it("should work with social sign-in", async () => {
+		const session = await client.signIn.social({
+			provider: "google",
+			fetchOptions: {
+				headers: {
+					Authorization: `Bearer ${token}`,
+				},
+			},
+		});
+
+	});
 });

--- a/packages/better-auth/src/plugins/bearer/client.ts
+++ b/packages/better-auth/src/plugins/bearer/client.ts
@@ -1,0 +1,18 @@
+import type { BetterAuthClientPlugin } from "../../types";
+
+export const bearerClient = () => {
+	return {
+		id: "bearer",
+		getActions($fetch, $store, options) {
+			if (typeof document === "undefined") return {};
+			const cookie = document.cookie;
+			if (cookie.includes("bearer-token=true")) {
+				// This will hit the endpoint which would grab the bearer token cookie if it exists, then delete said cookie
+				// It will then return the bearer token in the response which should be caught on the authClient's `onSuccess` hook
+				$fetch("/get-bearer-token");
+			}
+			return {};
+		},
+	} satisfies BetterAuthClientPlugin;
+};
+ 

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -16,6 +16,7 @@ import { MongoClient } from "mongodb";
 import { mongodbAdapter } from "../adapters/mongodb-adapter";
 import { createPool } from "mysql2/promise";
 import { bearer } from "../plugins";
+import { bearerClient } from "../client/plugins";
 
 const cleanupSet = new Set<Function>();
 
@@ -247,6 +248,10 @@ export async function getTestInstance<
 
 	const client = createAuthClient({
 		...(config?.clientOptions as C extends undefined ? {} : C),
+		plugins: [
+			bearerClient(),
+			...((config?.clientOptions?.plugins as C["plugins"]) || []),
+		],
 		baseURL: getBaseURL(
 			options?.baseURL || "http://localhost:" + (config?.port || 3000),
 			options?.basePath || "/api/auth",


### PR DESCRIPTION
The first PR was merged by accident (I assume) by Alex, then reverted. So this is the same PR but with new changes based on Alex's change request


## What's this PR for?
Normal sign-in endpoints will return a response which includes the `set-auth-token` header from the bearer plugin, however some sign-in endpoints such as social logins or magic links where the set-cookie response comes from a separate `/api/auth` page will cause the authClient not pick up on the bearer token. This PR addresses this issue.

## How does it address it?
We can address this issue by checking if the `set-cookie` response in the hook also contains a `location` header thus meaning it will be redirected. (For example social logins where the user is redirected to /callback which will give a `set-cookie` as well as a `location` header) If we find out that it does include a location value, then we can set a cookie called `bearer-token-confirmation` which is just `true`. Then, on the client bearer plugin, on-start-up it will check if that cookie exists, and if so, hit a newly `/get-bearer-value` endpoint. This endpoint will then remove the `bearer-token-confirmation` cookie and then return the bearer token by just grabbing it from the session cookie value. Once it's returned, the authClient's `onSuccess` global hook would pickup on that response and thus the new bearer token is returned.

An example flow will look like:
<img width="775" height="797" alt="image" src="https://github.com/user-attachments/assets/2023919b-2318-440f-a799-b1805e4816a6" />

## Breaking Changes / Migrations?

Nothing will break, however the need to add `bearerClient` plugin on the authClient will be required in order for social logins/magic link or other similar sign-ins to work.
