### PR TITLE
docs: removed wrong import

### DIFF
--- a/docs/content/docs/plugins/polar.mdx
+++ b/docs/content/docs/plugins/polar.mdx
@@ -96,7 +96,6 @@ You will be using the BetterAuth Client to interact with the Polar functionaliti
 ```typescript
 import { createAuthClient } from "better-auth/react";
 import { polarClient } from "@polar-sh/better-auth";
-import { organizationClient } from "better-auth/client/plugins";
 
 // This is all that is needed
 // All Polar plugins, etc. should be attached to the server-side BetterAuth config


### PR DESCRIPTION
---

This PR fixes an incorrect import in the documentation. There is no functional change.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed a wrong import from the Polar plugin docs to prevent copy‑paste errors. The example now only shows the required imports (createAuthClient and polarClient); no functional changes.

<!-- End of auto-generated description by cubic. -->

