### PR TITLE
WIP: feat(sso): add support for pre-configured SSO providers during initilization

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -71,9 +71,140 @@ This plugin is in active development and may not be suitable for production use.
     </Step>
 </Steps>
 
+## Configuration
+
+The SSO plugin can be configured with pre-defined providers during initialization, allowing you to define your SSO providers directly in your auth configuration instead of using the `registerSSOProvider` endpoint later.
+
+### Basic Configuration
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+import { sso } from "@better-auth/sso"
+
+const auth = betterAuth({
+    plugins: [
+        sso({
+            providers: [
+                {
+                    providerId: "google-workspace",
+                    issuer: "https://accounts.google.com",
+                    domain: "yourcompany.com",
+                    oidcConfig: {
+                        clientId: process.env.GOOGLE_CLIENT_ID,
+                        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+                        discoveryEndpoint: "https://accounts.google.com/.well-known/openid-configuration",
+                        pkce: true,
+                        scopes: ["openid", "email", "profile"],
+                        mapping: {
+                            id: "sub",
+                            email: "email",
+                            name: "name",
+                            image: "picture"
+                        }
+                    }
+                },
+                {
+                    providerId: "company-saml",
+                    issuer: "https://idp.yourcompany.com",
+                    domain: "yourcompany.com", 
+                    samlConfig: {
+                        entryPoint: "https://idp.yourcompany.com/sso",
+                        cert: process.env.SAML_CERT,
+                        // ... other SAML configuration
+                    }
+                }
+            ]
+        })
+    ]
+})
+```
+
+### Organization-Linked Providers
+
+You can also link providers directly to organizations during initialization:
+
+```ts title="auth.ts"
+const auth = betterAuth({
+    plugins: [
+        sso({
+            providers: [
+                {
+                    providerId: "acme-corp-sso",
+                    issuer: "https://acme.okta.com",
+                    domain: "acmecorp.com",
+                    organizationId: "org_acme_corp_id", // Link to organization
+                    oidcConfig: {
+                        // ... OIDC configuration
+                    }
+                }
+            ]
+        })
+    ]
+})
+```
+
+This approach offers several advantages:
+- **Declarative configuration**: Define providers alongside your auth setup
+- **Version control**: Provider configurations are stored in your codebase
+- **Environment-based**: Different configurations for different environments
+- **No database persistence**: Configuration-based providers exist only at runtime, avoiding configuration drift
+- **Easy updates**: Change your config and restart - no database migrations needed
+
 ## Usage
 
+You can configure SSO providers in two ways:
+
+1. **During plugin initialization** (recommended) - Define providers directly in your auth configuration
+2. **At runtime** - Register providers dynamically using the API endpoints
+
+### When to use each approach:
+
+- **Configuration-based (initialization)**: Use for static providers that are known at build time, environment-specific providers, or when you want to avoid database complexity. These providers exist only at runtime and don't persist to the database.
+
+- **Runtime registration**: Use for dynamic providers that users can add/remove through your application UI, multi-tenant scenarios where providers vary by tenant, or when you need persistent provider storage.
+
 ### Register an OIDC Provider
+
+You can register OIDC providers either during initialization or at runtime.
+
+#### During Initialization (Recommended)
+
+```ts title="auth.ts"
+import { sso } from "@better-auth/sso"
+
+const auth = betterAuth({
+    plugins: [
+        sso({
+            providers: [
+                {
+                    providerId: "google-sso",
+                    issuer: "https://accounts.google.com",
+                    domain: "example.com",
+                    oidcConfig: {
+                        clientId: "your-client-id",
+                        clientSecret: "your-client-secret",
+                        discoveryEndpoint: "https://accounts.google.com/.well-known/openid-configuration",
+                        pkce: true,
+                        scopes: ["openid", "email", "profile"],
+                        mapping: {
+                            id: "sub",
+                            email: "email",
+                            name: "name",
+                            image: "picture"
+                        }
+                    }
+                }
+            ]
+        })
+    ]
+})
+```
+
+#### At Runtime
+
+If you need to register providers dynamically, you can use the `registerSSOProvider` endpoint and provide the necessary configuration details for the provider.
+
+A redirect URL will be automatically generated using the provider ID. For instance, if the provider ID is `hydra`, the redirect URL would be `{baseURL}/api/auth/sso/callback/hydra`. Note that `/api/auth` may vary depending on your base path configuration.
 
 To register an OIDC provider, use the `registerSSOProvider` endpoint and provide the necessary configuration details for the provider.
 
@@ -147,7 +278,41 @@ await auth.api.registerSSOProvider({
 
 ### Register a SAML Provider
 
-To register a SAML provider, use the `registerSSOProvider` endpoint with SAML configuration details. The provider will act as a Service Provider (SP) and integrate with your Identity Provider (IdP).
+SAML providers can be configured during initialization or registered at runtime. The provider will act as a Service Provider (SP) and integrate with your Identity Provider (IdP).
+
+#### During Initialization (Recommended)
+
+```ts title="auth.ts"
+import { sso } from "@better-auth/sso"
+
+const auth = betterAuth({
+    plugins: [
+        sso({
+            providers: [
+                {
+                    providerId: "company-saml",
+                    issuer: "https://idp.example.com",
+                    domain: "example.com",
+                    samlConfig: {
+                        entryPoint: "https://idp.example.com/sso",
+                        cert: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+                        // ... other SAML configuration
+                        mapping: {
+                            id: "nameID",
+                            email: "email",
+                            name: "displayName"
+                        }
+                    }
+                }
+            ]
+        })
+    ]
+})
+```
+
+#### At Runtime
+
+To register a SAML provider dynamically, use the `registerSSOProvider` endpoint with SAML configuration details.
 
 <Tabs items={["client", "server"]}>
     <Tab value="client">
@@ -683,6 +848,8 @@ The plugin requires additional fields in the `ssoProvider` table to store the pr
 
 ### Server
 
+**providers**: Pre-configured SSO providers to register during plugin initialization.
+
 **provisionUser**: A custom function to provision a user when they sign in with an SSO provider.
 
 **organizationProvisioning**: Options for provisioning users to an organization.
@@ -695,6 +862,39 @@ The plugin requires additional fields in the `ssoProvider` table to store the pr
 
 <TypeTable
   type={{
+    providers: {
+        description: "Pre-configured SSO providers to register during plugin initialization. This allows you to define your SSO providers directly when configuring the plugin, rather than using the `registerSSOProvider` endpoint later.",
+        type: "array",
+        items: {
+            type: "object",
+            properties: {
+                providerId: {
+                    description: "Unique identifier for the provider",
+                    type: "string",
+                },
+                issuer: {
+                    description: "The issuer URL of the provider",
+                    type: "string",
+                },
+                domain: {
+                    description: "The domain of the provider for email matching",
+                    type: "string",
+                },
+                organizationId: {
+                    description: "Optional organization ID to link the provider to",
+                    type: "string",
+                },
+                oidcConfig: {
+                    description: "OIDC configuration for the provider",
+                    type: "object",
+                },
+                samlConfig: {
+                    description: "SAML configuration for the provider",
+                    type: "object",
+                },
+            },
+        },
+    },
     provisionUser: {
         description: "A custom function to provision a user when they sign in with an SSO provider.",
         type: "function",

--- a/packages/better-auth/src/plugins/sso/index.ts
+++ b/packages/better-auth/src/plugins/sso/index.ts
@@ -72,7 +72,31 @@ export interface SSOOptions {
 	 * @default false
 	 */
 	defaultOverrideUserInfo?: boolean;
+	/**
+	 * Pre-configured SSO providers to register during plugin initialization.
+	 * This allows you to define your SSO providers directly when configuring the plugin,
+	 * rather than using the `registerSSOProvider` endpoint later.
+	 * 
+	 * @example
+	 * ```ts
+	 * providers: [
+	 *   {
+	 *     providerId: "google-sso",
+	 *     issuer: "https://accounts.google.com",
+	 *     domain: "example.com",
+	 *     oidcConfig: {
+	 *       clientId: "your-client-id",
+	 *       clientSecret: "your-client-secret",
+	 *       discoveryEndpoint: "https://accounts.google.com/.well-known/openid-configuration",
+	 *       pkce: true,
+	 *     }
+	 *   }
+	 * ]
+	 * ```
+	 */
+	providers?: SSOProvider[];
 }
+
 
 export const sso = (options?: SSOOptions) => {
 	return {
@@ -1023,6 +1047,7 @@ export const sso = (options?: SSOOptions) => {
 					},
 					userId: {
 						type: "string",
+						required: false,
 						references: {
 							model: "user",
 							field: "id",
@@ -1050,7 +1075,7 @@ export const sso = (options?: SSOOptions) => {
 export interface SSOProvider {
 	issuer: string;
 	oidcConfig: OIDCConfig;
-	userId: string;
+	userId?: string;
 	providerId: string;
 	organizationId?: string;
 }

--- a/packages/sso/example-usage.md
+++ b/packages/sso/example-usage.md
@@ -1,0 +1,70 @@
+# SSO Plugin Configuration Examples
+
+## Configuration-based Providers (No Database Storage)
+
+Configuration-based providers are defined directly in your code and exist only at runtime. They don't require a `userId` since they're not tied to any specific user.
+
+```ts
+import { betterAuth } from "better-auth"
+import { sso } from "@better-auth/sso"
+
+const auth = betterAuth({
+    database: { /* your db config */ },
+    plugins: [
+        sso({
+            providers: [
+                {
+                    providerId: "google-workspace",
+                    issuer: "https://accounts.google.com", 
+                    domain: "yourcompany.com",
+                    oidcConfig: {
+                        clientId: process.env.GOOGLE_CLIENT_ID!,
+                        clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+                        discoveryEndpoint: "https://accounts.google.com/.well-known/openid-configuration",
+                        pkce: true
+                    }
+                },
+                {
+                    providerId: "company-saml",
+                    issuer: "https://idp.yourcompany.com",
+                    domain: "yourcompany.com",
+                    organizationId: "org_123", // Optional: link to organization
+                    samlConfig: {
+                        entryPoint: "https://idp.yourcompany.com/sso",
+                        cert: process.env.SAML_CERT!
+                    }
+                }
+            ]
+        })
+    ]
+})
+```
+
+## Runtime Provider Registration (Database Storage) 
+
+Runtime providers are registered via API endpoints and stored in the database with a `userId`.
+
+```ts
+// Register a provider at runtime (requires authenticated user)
+await authClient.sso.register({
+    providerId: "custom-provider",
+    issuer: "https://custom.idp.com",
+    domain: "custom.com",
+    oidcConfig: {
+        clientId: "client-123",
+        clientSecret: "secret-456",
+        discoveryEndpoint: "https://custom.idp.com/.well-known/openid-configuration",
+        pkce: true
+    }
+})
+```
+
+## Key Differences
+
+| Aspect | Configuration-based | Runtime Registration |
+|--------|-------------------|---------------------|
+| Storage | Runtime only | Database persisted |
+| `userId` | `undefined` (no owner) | Required (user who registered) |
+| Updates | Change config & restart | API calls or DB updates |
+| Use case | Static/env-based providers | Dynamic/user-managed providers |
+| Migration | Config changes only | May need DB migrations |

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -85,6 +85,34 @@ export interface SSOProvider {
 	organizationId?: string;
 }
 
+export interface SSOProviderConfig {
+	/**
+	 * Unique identifier for the SSO provider
+	 */
+	providerId: string;
+	/**
+	 * The issuer URL of the identity provider
+	 */
+	issuer: string;
+	/**
+	 * The domain for email matching (e.g., "company.com")
+	 * Users with emails from this domain will be able to use this provider
+	 */
+	domain: string;
+	/**
+	 * Optional organization ID to link this provider to a specific organization
+	 */
+	organizationId?: string;
+	/**
+	 * OIDC configuration for OpenID Connect providers
+	 */
+	oidcConfig?: OIDCConfig;
+	/**
+	 * SAML configuration for SAML providers
+	 */
+	samlConfig?: SAMLConfig;
+}
+
 
 export interface SSOOptions {
 	/**
@@ -185,7 +213,7 @@ export interface SSOOptions {
 	 * ]
 	 * ```
 	 */
-	providers?: SSOProvider[];
+	providers?: SSOProviderConfig[];
 }
 
 export const sso = (options?: SSOOptions) => {
@@ -201,17 +229,18 @@ export const sso = (options?: SSOOptions) => {
 			});
 			
 			if (configProvider) {
-				// Convert config to SSOProvider format
+				// Convert SSOProviderConfig to SSOProvider format
 				return {
-					...configProvider,
-					userId: undefined, // Config-based providers don't belong to a specific user
+					issuer: configProvider.issuer,
+					domain: configProvider.domain,
+					providerId: configProvider.providerId,
+					organizationId: configProvider.organizationId,
 					oidcConfig: configProvider.oidcConfig,
 					samlConfig: configProvider.samlConfig,
+					userId: undefined, // Configuration-based providers don't have a userId
 				} as SSOProvider;
 			}
-		}
-
-		// Then check database providers
+		}		// Then check database providers
 		let whereClause: any[] = [];
 		if (providerId) {
 			whereClause.push({ field: "providerId", value: providerId });


### PR DESCRIPTION
## Description

This PR adds support for **pre-configured SSO providers during initialization**.  
Instead of always relying on `registerSSOProvider` (which requires a logged-in session and persists providers to the database), you can now declare providers directly in your `SSOOptions` when setting up Better Auth.

This makes it possible to:

- Define static OIDC/SAML providers in code (e.g. Google Workspace, internal clinic SSO).
- Keep provider configs in **version control** and environment-based configs.
- Avoid database persistence and drift — providers exist only at runtime.
- Simplify deployments by removing the need for boot-time API calls.

Closes #4346 

## Motivation

Currently, custom OIDC providers must be registered dynamically through the API, which:
- Requires an authenticated session (not practical for server-side bootstrap).
- Is error-prone and difficult to automate in CI/CD or infra-as-code.
- Makes simple static use cases harder than necessary.

This PR addresses that by introducing **configuration-based providers** alongside the existing runtime registration.

## Changes

- Added `providers` option to `SSOOptions`.
- Updated provider resolution logic to check config-based providers before database providers.
- Extended documentation with configuration examples.
- Added tests to verify that pre-configured providers are available immediately.
- Provided example usage docs comparing config-based vs runtime-based providers.

## Usage

```ts
import { betterAuth } from "better-auth"
import { sso } from "@better-auth/sso"

const auth = betterAuth({
  plugins: [
    sso({
      providers: [
        {
          providerId: "google-workspace",
          issuer: "https://accounts.google.com",
          domain: "yourcompany.com",
          oidcConfig: {
            clientId: process.env.GOOGLE_CLIENT_ID!,
            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
            discoveryEndpoint: "https://accounts.google.com/.well-known/openid-configuration",
            pkce: true,
            scopes: ["openid", "email", "profile"],
            mapping: {
              id: "sub",
              email: "email",
              name: "name",
              image: "picture"
            }
          }
        }
      ]
    })
  ]
})

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds support for pre-configured SSO providers during initialization so you can define OIDC/SAML providers in code without database entries. This simplifies setup and works alongside runtime-registered providers.

- **New Features**
  - sso({ providers: [...] }) supports OIDC and SAML, with optional domain and organizationId.
  - Provider lookups now check config first, then DB (by providerId, domain, or organization slug).
  - SSOProvider.userId is optional; config-based providers have no owner.
  - Updated docs, examples, and tests to cover config-based providers.

- **Migration**
  - If your ssoProvider.userId column is NOT NULL, make it nullable to support config-backed providers.

<!-- End of auto-generated description by cubic. -->

