### PR TITLE
fix(last-login-method): cookie name inconsistent

### DIFF
--- a/packages/better-auth/src/plugins/last-login-method/client.ts
+++ b/packages/better-auth/src/plugins/last-login-method/client.ts
@@ -6,7 +6,7 @@ import type { BetterAuthClientPlugin } from "../../types";
 export interface LastLoginMethodClientConfig {
 	/**
 	 * Name of the cookie to read the last login method from
-	 * @default "last_used_login_method"
+	 * @default "better-auth.last_used_login_method"
 	 */
 	cookieName?: string;
 }
@@ -29,7 +29,7 @@ function getCookieValue(name: string): string | null {
 export const lastLoginMethodClient = (
 	config: LastLoginMethodClientConfig = {},
 ) => {
-	const cookieName = config.cookieName || "last_used_login_method";
+	const cookieName = config.cookieName || "better-auth.last_used_login_method";
 
 	return {
 		id: "last-login-method-client",

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -7,7 +7,7 @@ import type { GenericEndpointContext } from "../../types";
 export interface LastLoginMethodOptions {
 	/**
 	 * Name of the cookie to store the last login method
-	 * @default "last_used_login_method"
+	 * @default "better-auth.last_used_login_method"
 	 */
 	cookieName?: string;
 	/**

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -30,7 +30,7 @@ describe("lastLoginMethod", async () => {
 			},
 		);
 		const cookies = parseCookies(headers.get("cookie") || "");
-		expect(cookies.get("last_used_login_method")).toBe("email");
+		expect(cookies.get("better-auth.last_used_login_method")).toBe("email");
 	});
 
 	it("should set the last login method in the database", async () => {


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/commit/2db142465ecf29575bb1edf4e59173daf7ecd498
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardized the last login method cookie name to "better-auth.last_used_login_method" across client and server. This removes inconsistency and ensures the value is read and written reliably.

- **Bug Fixes**
  - Use "better-auth.last_used_login_method" as the default cookieName in client and server.
  - Updated tests to expect the new cookie name.

- **Migration**
  - If you rely on "last_used_login_method", set cookieName: "last_used_login_method" in your config or read both names during rollout.

<!-- End of auto-generated description by cubic. -->

