### PR TITLE
fix: prevent build error for node:sqlite

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
@@ -106,7 +106,7 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		});
 	}
 
-	if ("createSession" in db) {
+	if ("createSession" in db && typeof window === "undefined") {
 		let DatabaseSync: typeof import("node:sqlite").DatabaseSync | undefined =
 			undefined;
 		try {


### PR DESCRIPTION
---

This PR fixes build errors caused by importing node:sqlite.

- Wraps the import in a server-only guard (`typeof window === "undefined"`)

---

**Build error:**  
```
"next": "^15.5.2"
"better-auth": "1.3.8-beta.10"
```
<img width="500" alt="build-error" src="https://github.com/user-attachments/assets/e0c60428-51ab-4737-8eb6-d25ca12d2220" />
<img width="500" alt="import-trace" src="https://github.com/user-attachments/assets/ab799d56-66f8-4493-b281-3569bd346119" />

---

> **NOTE: Even in beta/development, I want build errors to be caught early.**
> 
> I have been developing to use the Kakao Provider, and just before deployment, the production build was failing unexpectedly. After investigation, it seems this issue was the cause.
