### PR TITLE
fix: prevent undefined from passed to adapter in username plugin

### DIFF
--- a/packages/better-auth/src/adapters/create-adapter/index.ts
+++ b/packages/better-auth/src/adapters/create-adapter/index.ts
@@ -409,7 +409,9 @@ export const createAdapter =
 					});
 				}
 
-				transformedData[newFieldName] = newValue;
+				if (newValue !== undefined) {
+					transformedData[newFieldName] = newValue;
+				}
 			}
 			return transformedData;
 		};

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -488,8 +488,12 @@ export const username = (options?: UsernameOptions) => {
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {
-						ctx.body.displayUsername ||= ctx.body.username;
-						ctx.body.username ||= ctx.body.displayUsername;
+						if (ctx.body.username && !ctx.body.displayUsername) {
+							ctx.body.displayUsername = ctx.body.username;
+						}
+						if (ctx.body.displayUsername && !ctx.body.username) {
+							ctx.body.username = ctx.body.displayUsername;
+						}
 					}),
 				},
 			],


### PR DESCRIPTION
closes #4341
before 
<img width="272" height="167" alt="Screenshot 2025-09-02 at 2 13 29 PM" src="https://github.com/user-attachments/assets/b6cb336e-00c7-477a-a681-a76da8e9fe19" />
after
<img width="369" height="20" alt="Screenshot 2025-09-02 at 2 13 36 PM" src="https://github.com/user-attachments/assets/5b19e66f-4c43-4e1d-8a85-a91af0633d37" />
