### PR TITLE
docs: improve the tooltip content display

### DIFF
--- a/docs/components/display-techstack.tsx
+++ b/docs/components/display-techstack.tsx
@@ -30,9 +30,7 @@ export const TechStackDisplay = ({
 									{techStackIcons[icon].icon}
 								</span>
 							</TooltipTrigger>
-							<TooltipContent className="text-white/80 bg-gradient-to-tr from-stone-950/90 via-stone-900 to-stone-950/90">
-								{techStackIcons[icon].name}
-							</TooltipContent>
+							<TooltipContent>{techStackIcons[icon].name}</TooltipContent>
 						</Tooltip>
 					</TooltipProvider>
 				);


### PR DESCRIPTION
this pr avoid unnecessary linear gradient issue that affect the light/dark mode resolve and makes it looks off 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed hardcoded gradient and text color from TechStack tooltips to fix contrast issues in light/dark mode. Tooltips now inherit the default theme for a consistent look.

<!-- End of auto-generated description by cubic. -->

