### PR TITLE
docs: hint to use credentials: 'omit' for authenticated requests

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -362,7 +362,11 @@ const makeAuthenticatedRequest = async () => {
   const headers = {
     "Cookie": cookies, // [!code highlight]
   };
-  const response = await fetch("http://localhost:8081/api/secure-endpoint", { headers });
+  const response = await fetch("http://localhost:8081/api/secure-endpoint", { 
+    headers,
+    // 'include' can interfere with the cookies we just set manually in the headers
+    credentials: "omit" // [!code highlight]
+  });
   const data = await response.json();
   return data;
 };


### PR DESCRIPTION
Some requests return 401 because cookies are not sent when `fetch` is called without `credentials: "omit"`. This PR gives a hint to set `credentials: "omit"` so auth cookies are included.  

Related:  
- React Native issue: https://github.com/facebook/react-native/issues/23185  
- Better Auth issues: #3180, #3034 (these might be related)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update Expo docs to show using credentials: "omit" in fetch when you set the Cookie header manually. This prevents 401s caused by credentials: "include" interfering with the cookies you pass.

<!-- End of auto-generated description by cubic. -->

