### PR TITLE
feat(admin): /admin/update-user role as array

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -742,6 +742,7 @@ describe("Admin plugin", async () => {
 				data: {
 					name: "Updated Name",
 					customField: "custom value",
+					role: ["member", "user"],
 				},
 			},
 			{
@@ -749,6 +750,7 @@ describe("Admin plugin", async () => {
 			},
 		);
 		expect(res.data?.name).toBe("Updated Name");
+		expect(res.data?.role).toBe("member,user");
 	});
 
 	it("should not allow non-admin to update user", async () => {

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -485,6 +485,9 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 							message: ADMIN_ERROR_CODES.NO_DATA_TO_UPDATE,
 						});
 					}
+					if (ctx.body.data?.role) {
+						ctx.body.data.role = parseRoles(ctx.body.data.role);
+					}
 					const updatedUser = await ctx.context.internalAdapter.updateUser(
 						ctx.body.userId,
 						ctx.body.data,


### PR DESCRIPTION
/admin/update-user does not handle role as an array of roles like the other admin endpoints do. This PR handles             them properly. From what I've been able to find, this endpoint was skipped #1907. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
/admin/update-user now accepts role as an array, matching the other admin endpoints. We parse roles before updating so they’re stored consistently.

- **Bug Fixes**
  - Parse role arrays in update-user using parseRoles.
  - Added a test to ensure ["member","user"] stores as "member,user".

<!-- End of auto-generated description by cubic. -->

