### PR TITLE
feat(organization): allow client side requests to add-member

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
@@ -383,12 +383,10 @@ describe("updateMemberRole", async () => {
 				}),
 			},
 		);
-		await auth.api.addMember({
-			body: {
-				organizationId: newOrg.data?.id as string,
-				userId: user.id,
-				role: "admin",
-			},
+		await client.organization.addMember({
+			organizationId: newOrg.data?.id as string,
+			userId: user.id,
+			role: "admin",
 		});
 		const updatedMember = await client.organization.updateMemberRole(
 			{

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -54,7 +54,7 @@ export const addMember = <O extends OrganizationOptions>(option: O) => {
 				...baseMemberSchema.shape,
 				...additionalFieldsSchema.shape,
 			}),
-			use: [orgMiddleware, orgSessionMiddleware],
+			use: [orgMiddleware],
 			metadata: {
 				$Infer: {
 					body: {} as {

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -54,7 +54,7 @@ export const addMember = <O extends OrganizationOptions>(option: O) => {
 				...baseMemberSchema.shape,
 				...additionalFieldsSchema.shape,
 			}),
-			use: [orgMiddleware],
+			use: [orgMiddleware, orgSessionMiddleware],
 			metadata: {
 				$Infer: {
 					body: {} as {


### PR DESCRIPTION
This PR is intended to open a discussion about making `/admin/add-member` allow client side requests. I wasn't able to find anything in closed PRs that would explain why this is a server only endpoint, so I hoping to discuss allowing client side requests. Thanks!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable client-side requests to `/admin/add-member` by removing the server-only restriction. Updated tests to use `client.organization.addMember`, confirming front-end apps can add members without a server proxy; org session middleware is not required.

<sup>Written for commit fd79cfb16d29aea2be5b440da4bb67954b77b15e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



