### PR TITLE
fix: add missing defaultValue on core schema

### DIFF
--- a/packages/better-auth/src/__snapshots__/init.test.ts.snap
+++ b/packages/better-auth/src/__snapshots__/init.test.ts.snap
@@ -165,6 +165,7 @@ exports[`init > should match config 1`] = `
           "type": "string",
         },
         "createdAt": {
+          "defaultValue": [Function],
           "fieldName": "createdAt",
           "required": true,
           "type": "date",
@@ -222,6 +223,7 @@ exports[`init > should match config 1`] = `
     "session": {
       "fields": {
         "createdAt": {
+          "defaultValue": [Function],
           "fieldName": "createdAt",
           "required": true,
           "type": "date",

--- a/packages/better-auth/src/db/get-tables.ts
+++ b/packages/better-auth/src/db/get-tables.ts
@@ -27,7 +27,7 @@ export type BetterAuthDbSchema = Record<
 export const getAuthTables = (
 	options: BetterAuthOptions,
 ): BetterAuthDbSchema => {
-	const pluginSchema = options.plugins?.reduce(
+	const pluginSchema = (options.plugins ?? []).reduce(
 		(acc, plugin) => {
 			const schema = plugin.schema;
 			if (!schema) return acc;
@@ -70,7 +70,7 @@ export const getAuthTables = (
 		},
 	} satisfies BetterAuthDbSchema;
 
-	const { user, session, account, ...pluginTables } = pluginSchema || {};
+	const { user, session, account, ...pluginTables } = pluginSchema;
 
 	const sessionTable = {
 		session: {
@@ -91,6 +91,7 @@ export const getAuthTables = (
 					type: "date",
 					required: true,
 					fieldName: options.session?.fields?.createdAt || "createdAt",
+					defaultValue: () => new Date(),
 				},
 				updatedAt: {
 					type: "date",
@@ -241,6 +242,7 @@ export const getAuthTables = (
 					type: "date",
 					required: true,
 					fieldName: options.account?.fields?.createdAt || "createdAt",
+					defaultValue: () => new Date(),
 				},
 				updatedAt: {
 					type: "date",

--- a/packages/cli/test/__snapshots__/auth-schema-mysql-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql-number-id.txt
@@ -29,7 +29,9 @@ export const custom_session = mysqlTable("custom_session", {
   id: int("id").autoincrement().primaryKey(),
   expiresAt: timestamp("expires_at").notNull(),
   token: varchar("token", { length: 255 }).notNull().unique(),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -54,7 +56,9 @@ export const custom_account = mysqlTable("custom_account", {
   refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
   scope: text("scope"),
   password: text("password"),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/packages/cli/test/__snapshots__/auth-schema-mysql.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql.txt
@@ -28,7 +28,9 @@ export const custom_session = mysqlTable("custom_session", {
   id: varchar("id", { length: 36 }).primaryKey(),
   expiresAt: timestamp("expires_at").notNull(),
   token: varchar("token", { length: 255 }).notNull().unique(),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -53,7 +55,9 @@ export const custom_account = mysqlTable("custom_account", {
   refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
   scope: text("scope"),
   password: text("password"),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/packages/cli/test/__snapshots__/auth-schema-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-number-id.txt
@@ -29,7 +29,9 @@ export const custom_session = pgTable("custom_session", {
   id: serial("id").primaryKey(),
   expiresAt: timestamp("expires_at").notNull(),
   token: text("token").notNull().unique(),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -54,7 +56,9 @@ export const custom_account = pgTable("custom_account", {
   refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
   scope: text("scope"),
   password: text("password"),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-number-id.txt
@@ -26,7 +26,9 @@ export const custom_session = sqliteTable("custom_session", {
   id: int("id").autoincrement().primaryKey(),
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   token: text("token").notNull().unique(),
-  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -55,7 +57,9 @@ export const custom_account = sqliteTable("custom_account", {
   }),
   scope: text("scope"),
   password: text("password"),
-  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite.txt
@@ -26,7 +26,9 @@ export const custom_session = sqliteTable("custom_session", {
   id: text("id").primaryKey(),
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   token: text("token").notNull().unique(),
-  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -55,7 +57,9 @@ export const custom_account = sqliteTable("custom_account", {
   }),
   scope: text("scope"),
   password: text("password"),
-  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/packages/cli/test/__snapshots__/auth-schema.txt
+++ b/packages/cli/test/__snapshots__/auth-schema.txt
@@ -22,7 +22,9 @@ export const custom_session = pgTable("custom_session", {
   id: text("id").primaryKey(),
   expiresAt: timestamp("expires_at").notNull(),
   token: text("token").notNull().unique(),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -47,7 +49,9 @@ export const custom_account = pgTable("custom_account", {
   refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
   scope: text("scope"),
   password: text("password"),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => /* @__PURE__ */ new Date())
+    .notNull(),
   updatedAt: timestamp("updated_at")
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),

--- a/packages/cli/test/__snapshots__/schema-mongodb.prisma
+++ b/packages/cli/test/__snapshots__/schema-mongodb.prisma
@@ -32,7 +32,7 @@ model Session {
   id        String   @id @map("_id")
   expiresAt DateTime
   token     String
-  createdAt DateTime
+  createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   ipAddress String?
   userAgent String?
@@ -56,7 +56,7 @@ model Account {
   refreshTokenExpiresAt DateTime?
   scope                 String?
   password              String?
-  createdAt             DateTime
+  createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
   @@map("account")

--- a/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
+++ b/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
@@ -34,7 +34,7 @@ model Session {
   id                   String   @id
   expiresAt            DateTime
   token                String
-  createdAt            DateTime
+  createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
   ipAddress            String?  @db.Text
   userAgent            String?  @db.Text
@@ -59,7 +59,7 @@ model Account {
   refreshTokenExpiresAt DateTime?
   scope                 String?   @db.Text
   password              String?   @db.Text
-  createdAt             DateTime
+  createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
   @@map("account")

--- a/packages/cli/test/__snapshots__/schema-mysql.prisma
+++ b/packages/cli/test/__snapshots__/schema-mysql.prisma
@@ -32,7 +32,7 @@ model Session {
   id        String   @id
   expiresAt DateTime
   token     String
-  createdAt DateTime
+  createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   ipAddress String?  @db.Text
   userAgent String?  @db.Text
@@ -56,7 +56,7 @@ model Account {
   refreshTokenExpiresAt DateTime?
   scope                 String?   @db.Text
   password              String?   @db.Text
-  createdAt             DateTime
+  createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
   @@map("account")

--- a/packages/cli/test/__snapshots__/schema-numberid.prisma
+++ b/packages/cli/test/__snapshots__/schema-numberid.prisma
@@ -32,7 +32,7 @@ model Session {
   id        Int      @id @default(autoincrement())
   expiresAt DateTime
   token     String
-  createdAt DateTime
+  createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   ipAddress String?
   userAgent String?
@@ -56,7 +56,7 @@ model Account {
   refreshTokenExpiresAt DateTime?
   scope                 String?
   password              String?
-  createdAt             DateTime
+  createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
   @@map("account")

--- a/packages/cli/test/__snapshots__/schema.prisma
+++ b/packages/cli/test/__snapshots__/schema.prisma
@@ -32,7 +32,7 @@ model Session {
   id        String   @id
   expiresAt DateTime
   token     String
-  createdAt DateTime
+  createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   ipAddress String?
   userAgent String?
@@ -56,7 +56,7 @@ model Account {
   refreshTokenExpiresAt DateTime?
   scope                 String?
   password              String?
-  createdAt             DateTime
+  createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
   @@map("account")


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add missing default timestamps and make plugin schema building safe. This ensures createdAt is set automatically and avoids errors when no plugins are provided.

- **Bug Fixes**
  - Set defaultValue: () => new Date() for session.createdAt and account.createdAt.
  - Use (options.plugins ?? []).reduce(...) and remove fallback destructuring to prevent undefined errors.

<!-- End of auto-generated description by cubic. -->

