### PR TITLE
fix(expo): fix signout clobbering store session properties

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -274,6 +274,7 @@ export const expoClient = (opts: ExpoClientOptions) => {
 					if (url.includes("/sign-out")) {
 						await storage.setItem(cookieName, "{}");
 						store?.atoms.session?.set({
+							...store.atoms.session.get(),
 							data: null,
 							error: null,
 							isPending: false,

--- a/packages/expo/src/expo.test.ts
+++ b/packages/expo/src/expo.test.ts
@@ -1,4 +1,4 @@
-import { createAuthClient } from "better-auth/client";
+import { createAuthClient } from "better-auth/react";
 import Database from "better-sqlite3";
 import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
 import { expo } from ".";
@@ -154,6 +154,19 @@ describe("expo", async () => {
 		const map = (await import("./client")).parseSetCookieHeader(header);
 		expect(map.get("better-auth.session_token")?.value).toBe("abc");
 		expect(map.get("better-auth.session_data")?.value).toBe("xyz");
+	});
+
+	it("should preserve unchanged client store session properties on signout", async () => {
+		const before = client.$store.atoms.session.get();
+		await client.signOut();
+		const after = client.$store.atoms.session.get();
+
+		expect(after).toMatchObject({
+			...before,
+			data: null,
+			error: null,
+			isPending: false,
+		});
 	});
 });
 


### PR DESCRIPTION
**Clearly describe what changes you made and why:**
Keep previous store session properties when signing out, both `refetch` and `isRefetching` are no longer present in `authClient.useSession()` after calling `authClient.signout()`.

**Include any relevant context or background**
Hit this trying to implement a signout flow for an expo app.

After calling `auth.signout()` the following code no longer works

```typescript
function Confirmation() {
  const { data: session, refetch } = auth.useSession()

  async function handleContinue(body) {
    const { data } = await auth.emailOtp.verifyEmail(...)

    if (data) {
      // refetch is undefined after calling signout preventing the useSession
      // hook triggering updates when needed.
      refetch()
    }
  })
 ...
}
```

*Note* also updated the expo client tests to use the react client from `better-auth/react`


~~**List any breaking changes or deprecations**~~

~~**Add screenshots for UI changes**~~

~~**Reference related issues or discussions**~~
