### PR TITLE
docs: improve wording

### DIFF
--- a/docs/content/docs/reference/telemetry.mdx
+++ b/docs/content/docs/reference/telemetry.mdx
@@ -7,7 +7,7 @@ Better Auth collects anonymous usage data to help us improve the project. This i
 
 ## Why is telemetry collected?
 
-Since v1.3.5, Better Auth collects anonymous telemetry data about general usage.
+Since v1.3.5, Better Auth collects anonymous telemetry data about general usage if enabled.
 
 Telemetry data helps us understand how Better Auth is being used across different environments so we can improve performance, prioritize features, and fix issues more effectively. It guides our decisions on performance optimizations, feature development, and bug fixes. All data is collected completely anonymously and with privacy in mind, and users can opt out at any time. We strive to keep what we collect as transparent as possible.
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Clarified telemetry docs to state that anonymous data is collected only when telemetry is enabled (since v1.3.5). This removes ambiguity and avoids implying always-on collection.

<!-- End of auto-generated description by cubic. -->

