### PR TITLE
docs:Update client.mdx to correct svelte 5 onclick syntax

### DIFF
--- a/docs/content/docs/concepts/client.mdx
+++ b/docs/content/docs/concepts/client.mdx
@@ -154,7 +154,7 @@ On top of normal methods, the client provides hooks to easily access different r
                         {$session?.data?.user.email}
                     </p>
                     <button
-                        on:click={async () => {
+                        onclick={async () => {
                         await authClient.signOut();
                         }}
                     >
@@ -163,7 +163,7 @@ On top of normal methods, the client provides hooks to easily access different r
                     </div>
                 {:else}
                     <button
-                    on:click={async () => {
+                    onclick={async () => {
                         await authClient.signIn.social({
                         provider: "github",
                         });

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -217,7 +217,7 @@ function App(){
   const organizations = authClient.useListOrganizations();
 </script>
 
-<h1>Organizations</h1>s
+<h1>Organizations</h1>
 
 {#if $organizations.isPending}
   <p>Loading...</p>

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -221,7 +221,7 @@ function App(){
 
 {#if $organizations.isPending}
   <p>Loading...</p>
-{:else if $organizations.data === null}
+{:else if !$organizations.data?.length}
   <p>No organizations found.</p>
 {:else}
   <ul>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Corrected Svelte 5 click handler syntax in client.mdx examples, replacing on:click with onclick so users can copy-paste without errors.

<!-- End of auto-generated description by cubic. -->

