### PR TITLE
docs: add missing space typo

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -37,7 +37,7 @@ BETTER_AUTH_SECRET=
 2. **Set Base URL**
 
 ```txt title=".env"
-BETTER_AUTH_URL=http://localhost:3000 #Base URL of your app
+BETTER_AUTH_URL=http://localhost:3000 # Base URL of your app
 ```
 
 </Step>


### PR DESCRIPTION
### Before

<img width="938" height="180" alt="image" src="https://github.com/user-attachments/assets/f228b27d-7099-4868-8eef-5d947ee6f04d" />

### After

<img width="938" height="171" alt="image" src="https://github.com/user-attachments/assets/5318b964-b631-4745-a585-5709e694ca0d" />
