### PR TITLE
fix: resolve llms.txt missing wrapped component examples

### DIFF
--- a/docs/app/docs/lib/get-llm-text.ts
+++ b/docs/app/docs/lib/get-llm-text.ts
@@ -10,7 +10,7 @@ import { readFile } from "fs/promises";
 
 function extractAPIMethods(rawContent: string): string {
 	const apiMethodRegex = /<APIMethod\s+([^>]+)>([\s\S]*?)<\/APIMethod>/g;
-	
+
 	return rawContent.replace(apiMethodRegex, (match, attributes, content) => {
 		// Parse attributes by matching
 		const pathMatch = attributes.match(/path="([^"]+)"/);
@@ -22,30 +22,41 @@ function extractAPIMethods(rawContent: string): string {
 		const resultVariableMatch = attributes.match(/resultVariable="([^"]+)"/);
 		const forceAsBodyMatch = attributes.match(/forceAsBody/);
 		const forceAsQueryMatch = attributes.match(/forceAsQuery/);
-		
-		const path = pathMatch ? pathMatch[1] : '';
-		const method = methodMatch ? methodMatch[1] : 'GET';
+
+		const path = pathMatch ? pathMatch[1] : "";
+		const method = methodMatch ? methodMatch[1] : "GET";
 		const requireSession = !!requireSessionMatch;
 		const isServerOnly = !!isServerOnlyMatch;
 		const isClientOnly = !!isClientOnlyMatch;
 		const noResult = !!noResultMatch;
-		const resultVariable = resultVariableMatch ? resultVariableMatch[1] : 'data';
+		const resultVariable = resultVariableMatch
+			? resultVariableMatch[1]
+			: "data";
 		const forceAsBody = !!forceAsBodyMatch;
 		const forceAsQuery = !!forceAsQueryMatch;
-		
+
 		const typeMatch = content.match(/type\s+(\w+)\s*=\s*\{([\s\S]*?)\}/);
 		if (!typeMatch) {
 			return match; // Return original if no type found
 		}
-		
+
 		const functionName = typeMatch[1];
 		const typeBody = typeMatch[2];
-		
+
 		const properties = parseTypeBody(typeBody);
-		
+
 		const clientCode = generateClientCode(functionName, properties, path);
-		const serverCode = generateServerCode(functionName, properties, method, requireSession, forceAsBody, forceAsQuery, noResult, resultVariable);
-		
+		const serverCode = generateServerCode(
+			functionName,
+			properties,
+			method,
+			requireSession,
+			forceAsBody,
+			forceAsQuery,
+			noResult,
+			resultVariable,
+		);
+
 		return `
 ### Client Side
 
@@ -80,29 +91,32 @@ function parseTypeBody(typeBody: string) {
 		isClientOnly: boolean;
 	}> = [];
 
-	const lines = typeBody.split('\n');
-	
+	const lines = typeBody.split("\n");
+
 	for (const line of lines) {
 		const trimmed = line.trim();
-		
-		if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('/*')) continue;
-		const propMatch = trimmed.match(/^(\w+)(\?)?:\s*(.+?)(\s*=\s*["']([^"']+)["'])?(\s*\/\/\s*(.+))?$/);
+
+		if (!trimmed || trimmed.startsWith("//") || trimmed.startsWith("/*"))
+			continue;
+		const propMatch = trimmed.match(
+			/^(\w+)(\?)?:\s*(.+?)(\s*=\s*["']([^"']+)["'])?(\s*\/\/\s*(.+))?$/,
+		);
 		if (propMatch) {
 			const [, name, optional, type, , exampleValue, , description] = propMatch;
-			
+
 			let cleanType = type.trim();
-			let cleanExampleValue = exampleValue || '';
-			
-			cleanType = cleanType.replace(/,$/, '');
-			
+			let cleanExampleValue = exampleValue || "";
+
+			cleanType = cleanType.replace(/,$/, "");
+
 			properties.push({
 				name,
 				type: cleanType,
 				required: !optional,
-				description: description || '',
+				description: description || "",
 				exampleValue: cleanExampleValue,
 				isServerOnly: false,
-				isClientOnly: false
+				isClientOnly: false,
 			});
 		}
 	}
@@ -111,35 +125,54 @@ function parseTypeBody(typeBody: string) {
 }
 
 // Generate client code example
-function generateClientCode(functionName: string, properties: any[], path: string) {
+function generateClientCode(
+	functionName: string,
+	properties: any[],
+	path: string,
+) {
 	if (!functionName || !path) {
-		return '// Unable to generate client code - missing function name or path';
+		return "// Unable to generate client code - missing function name or path";
 	}
-	
+
 	const clientMethodPath = pathToDotNotation(path);
 	const body = createClientBody(properties);
-	
+
 	return `const { data, error } = await authClient.${clientMethodPath}(${body});`;
 }
 
 // Generate server code example
-function generateServerCode(functionName: string, properties: any[], method: string, requireSession: boolean, forceAsBody: boolean, forceAsQuery: boolean, noResult: boolean, resultVariable: string) {
+function generateServerCode(
+	functionName: string,
+	properties: any[],
+	method: string,
+	requireSession: boolean,
+	forceAsBody: boolean,
+	forceAsQuery: boolean,
+	noResult: boolean,
+	resultVariable: string,
+) {
 	if (!functionName) {
-		return '// Unable to generate server code - missing function name';
+		return "// Unable to generate server code - missing function name";
 	}
-	
-	const body = createServerBody(properties, method, requireSession, forceAsBody, forceAsQuery);
-	
-	return `${noResult ? '' : `const ${resultVariable} = `}await auth.api.${functionName}(${body});`;
+
+	const body = createServerBody(
+		properties,
+		method,
+		requireSession,
+		forceAsBody,
+		forceAsQuery,
+	);
+
+	return `${noResult ? "" : `const ${resultVariable} = `}await auth.api.${functionName}(${body});`;
 }
 
 function pathToDotNotation(input: string): string {
 	return input
-		.split("/") 
-		.filter(Boolean) 
+		.split("/")
+		.filter(Boolean)
 		.map((segment) =>
 			segment
-				.split("-") 
+				.split("-")
 				.map((word, i) =>
 					i === 0
 						? word.toLowerCase()
@@ -152,62 +185,70 @@ function pathToDotNotation(input: string): string {
 
 // Helper function to create client body (simplified version)
 function createClientBody(props: any[]) {
-	if (props.length === 0) return '{}';
-	
-	let body = '{\n';
-	
+	if (props.length === 0) return "{}";
+
+	let body = "{\n";
+
 	for (const prop of props) {
 		if (prop.isServerOnly) continue;
-		
-		let comment = '';
+
+		let comment = "";
 		if (!prop.required || prop.description) {
 			const comments = [];
-			if (!prop.required) comments.push('required');
+			if (!prop.required) comments.push("required");
 			if (prop.description) comments.push(prop.description);
-			comment = ` // ${comments.join(', ')}`;
+			comment = ` // ${comments.join(", ")}`;
 		}
 
-		body += `    ${prop.name}${prop.exampleValue ? `: ${prop.exampleValue}` : ''}${prop.type === 'Object' ? ': {}' : ''},${comment}\n`;
+		body += `    ${prop.name}${prop.exampleValue ? `: ${prop.exampleValue}` : ""}${prop.type === "Object" ? ": {}" : ""},${comment}\n`;
 	}
-	
-	body += '}';
+
+	body += "}";
 	return body;
 }
 
-function createServerBody(props: any[], method: string, requireSession: boolean, forceAsBody: boolean, forceAsQuery: boolean) {
-	const relevantProps = props.filter(x => !x.isClientOnly);
-	
+function createServerBody(
+	props: any[],
+	method: string,
+	requireSession: boolean,
+	forceAsBody: boolean,
+	forceAsQuery: boolean,
+) {
+	const relevantProps = props.filter((x) => !x.isClientOnly);
+
 	if (relevantProps.length === 0 && !requireSession) {
-		return '{}';
+		return "{}";
 	}
-	
-	let serverBody = '{\n';
-	
+
+	let serverBody = "{\n";
+
 	if (relevantProps.length > 0) {
-		const bodyKey = (method === 'POST' || forceAsBody) && !forceAsQuery ? 'body' : 'query';
+		const bodyKey =
+			(method === "POST" || forceAsBody) && !forceAsQuery ? "body" : "query";
 		serverBody += `    ${bodyKey}: {\n`;
-		
+
 		for (const prop of relevantProps) {
-			let comment = '';
+			let comment = "";
 			if (!prop.required || prop.description) {
 				const comments = [];
-				if (!prop.required) comments.push('required');
+				if (!prop.required) comments.push("required");
 				if (prop.description) comments.push(prop.description);
-				comment = ` // ${comments.join(', ')}`;
+				comment = ` // ${comments.join(", ")}`;
 			}
-			
-			serverBody += `        ${prop.name}${prop.exampleValue ? `: ${prop.exampleValue}` : ''}${prop.type === 'Object' ? ': {}' : ''},${comment}\n`;
+
+			serverBody += `        ${prop.name}${prop.exampleValue ? `: ${prop.exampleValue}` : ""}${prop.type === "Object" ? ": {}" : ""},${comment}\n`;
 		}
-		
-		serverBody += '    }';
+
+		serverBody += "    }";
 	}
-	
+
 	if (requireSession) {
-		if (relevantProps.length > 0) serverBody += ',';
-		serverBody += '\n    // This endpoint requires session cookies.\n    headers: await headers()';
+		if (relevantProps.length > 0) serverBody += ",";
+		serverBody +=
+			"\n    // This endpoint requires session cookies.\n    headers: await headers()";
 	}
-	
-	serverBody += '\n}';
+
+	serverBody += "\n}";
 	return serverBody;
 }
 


### PR DESCRIPTION
closes #4365 and more others edgecases
This pr fixes an issue of llm.txt on handling the case of wrapped component becasuse how the markdown exports works by default.

before 
<img width="1170" height="625" alt="Screenshot 2025-09-03 at 3 17 24 PM" src="https://github.com/user-attachments/assets/6dbf945e-9ba5-4d18-8afd-397e7058e5a6" />
after 
<img width="1162" height="913" alt="Screenshot 2025-09-03 at 3 13 49 PM" src="https://github.com/user-attachments/assets/cd2bb506-3797-47a8-b13f-2a178a18d702" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes llms.txt generation for wrapped MDX components by extracting APIMethod blocks before remark processing. Client and server examples (and types) now render correctly instead of being dropped.

- **Bug Fixes**
  - Added APIMethod parser to generate client, server, and type code blocks from attributes and type definitions.
  - Handles flags: requireSession, isServerOnly, isClientOnly, noResult, resultVariable, forceAsBody, forceAsQuery; converts paths to dot notation for client calls.
  - Pre-processes raw MDX with extractAPIMethods before remark, restoring missing examples for wrapped components.

<!-- End of auto-generated description by cubic. -->

