### PR TITLE
feat(organization): Make membership optional

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -965,7 +965,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 						userId: ctx.context.session.user.id,
 						organizationId: activeOrganizationId,
 					});
-					if (!member) {
+					if (!member && (options?.requireMembership ?? true)) {
 						throw new APIError("UNAUTHORIZED", {
 							message:
 								ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -52,6 +52,12 @@ export interface OrganizationOptions {
 	 */
 	ac?: AccessControl;
 	/**
+	 * Require membership in an organization to perform CRUD operations.
+	 *
+	 * @default true
+	 */
+	requireMembership?: boolean;
+	/**
 	 * Custom permissions for roles.
 	 */
 	roles?: {


### PR DESCRIPTION
I'm hoping to start discussion around allowing non-members to add, remove, change roles, etc... of org members. This PR currently has a very naive implementation, where the membership check is simply ignored based on a plugin option. However, I believe a better solution would be to tie this feature to the admin plugin and add an option to the organization plugin that allows users with the global/super admin role to edit org membership. But before I started real work on that feature, I wanted to get feedback from y'all on whether this feature is even desirable or if there's a better way of accomplishing it. Thanks!