### PR TITLE
fix: strict social provider type

### DIFF
--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -1,7 +1,12 @@
 import { defu } from "defu";
 import { hashPassword, verifyPassword } from "./crypto/password";
-import { createInternalAdapter, getMigrations } from "./db";
-import { getAuthTables } from "./db/get-tables";
+import {
+	type BetterAuthDbSchema,
+	createInternalAdapter,
+	getAuthTables,
+	getMigrations,
+} from "./db";
+import type { Entries } from "type-fest";
 import { getAdapter } from "./db/utils";
 import type {
 	Adapter,
@@ -19,7 +24,7 @@ import {
 	getCookies,
 } from "./cookies";
 import { createLogger } from "./utils/logger";
-import { socialProviderList, socialProviders } from "./social-providers";
+import { type SocialProviders, socialProviders } from "./social-providers";
 import type { OAuthProvider } from "./oauth2";
 import { generateId } from "./utils";
 import { env, isProduction } from "./utils/env";
@@ -64,24 +69,26 @@ export const init = async (options: BetterAuthOptions) => {
 	checkEndpointConflicts(options, logger);
 	const cookies = getCookies(options);
 	const tables = getAuthTables(options);
-	const providers = Object.keys(options.socialProviders || {})
-		.map((key) => {
-			const value = options.socialProviders?.[key as "github"]!;
-			if (!value || value.enabled === false) {
+	const providers: OAuthProvider[] = (
+		Object.entries(
+			options.socialProviders || {},
+		) as unknown as Entries<SocialProviders>
+	)
+		.map(([key, config]) => {
+			if (config == null) {
 				return null;
 			}
-			if (!value.clientId) {
+			if (config.enabled === false) {
+				return null;
+			}
+			if (!config.clientId) {
 				logger.warn(
 					`Social provider ${key} is missing clientId or clientSecret`,
 				);
 			}
-			const provider = socialProviders[
-				key as (typeof socialProviderList)[number]
-			](
-				value as any, // TODO: fix this
-			);
+			const provider = socialProviders[key](config as never);
 			(provider as OAuthProvider).disableImplicitSignUp =
-				value.disableImplicitSignUp;
+				config.disableImplicitSignUp;
 			return provider;
 		})
 		.filter((x) => x !== null);
@@ -231,7 +238,7 @@ export type AuthContext = {
 		};
 		checkPassword: typeof checkPassword;
 	};
-	tables: ReturnType<typeof getAuthTables>;
+	tables: BetterAuthDbSchema;
 	runMigrations: () => Promise<void>;
 	publishTelemetry: (event: TelemetryEvent) => Promise<void>;
 };

--- a/packages/better-auth/src/social-providers/index.ts
+++ b/packages/better-auth/src/social-providers/index.ts
@@ -1,5 +1,4 @@
 import * as z from "zod/v4";
-import type { Prettify } from "../types/helper";
 import { apple } from "./apple";
 import { atlassian } from "./atlassian";
 import { cognito } from "./cognito";
@@ -30,6 +29,7 @@ import { kakao } from "./kakao";
 import { naver } from "./naver";
 import { line } from "./line";
 import { paypal } from "./paypal";
+import type { OAuthProvider } from "../oauth2";
 
 export const socialProviders = {
 	apple,
@@ -62,6 +62,11 @@ export const socialProviders = {
 	naver,
 	line,
 	paypal,
+} satisfies {
+	[key: string]: (
+		// todo: fix any here
+		config: any,
+	) => OAuthProvider;
 };
 
 export const socialProviderList = Object.keys(socialProviders) as [
@@ -76,11 +81,11 @@ export const SocialProviderListEnum = z
 export type SocialProvider = z.infer<typeof SocialProviderListEnum>;
 
 export type SocialProviders = {
-	[K in SocialProviderList[number]]?: Prettify<
-		Parameters<(typeof socialProviders)[K]>[0] & {
-			enabled?: boolean;
-		}
-	>;
+	[K in SocialProviderList[number]]?: Parameters<
+		(typeof socialProviders)[K]
+	>[0] & {
+		enabled?: boolean;
+	};
 };
 
 export * from "./apple";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Strengthens type safety for social provider configuration and init flow to catch misconfigurations at compile time. Also types the auth tables in the context for clearer usage.

- **Refactors**
  - Introduced SocialProviders type and typed Object.entries (type-fest Entries) for provider setup.
  - Annotated socialProviders to return OAuthProvider; inferred config type via Parameters instead of Prettify.
  - Simplified provider init and preserved disableImplicitSignUp and enabled handling.
  - Updated AuthContext.tables to BetterAuthDbSchema.

<!-- End of auto-generated description by cubic. -->

