### PR TITLE
fix(db): special case schema generation `ID`

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -12,7 +12,11 @@ export function convertToSnakeCase(str: string, camelCase?: boolean) {
 	if (camelCase) {
 		return str;
 	}
-	return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+	// Handle consecutive capitals (like ID, URL, API) by treating them as a single word
+	return str
+		.replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2") // Handle AABb -> AA_Bb
+		.replace(/([a-z\d])([A-Z])/g, "$1_$2") // Handle aBb -> a_Bb
+		.toLowerCase();
 }
 
 export const generateDrizzleSchema: SchemaGenerator = async ({

--- a/packages/cli/test/__snapshots__/auth-schema-mysql-passkey-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql-passkey-number-id.txt
@@ -1,0 +1,84 @@
+import {
+  mysqlTable,
+  varchar,
+  text,
+  timestamp,
+  boolean,
+  int,
+} from "drizzle-orm/mysql-core";
+
+export const custom_user = mysqlTable("custom_user", {
+  id: int("id").autoincrement().primaryKey(),
+  name: text("name").notNull(),
+  email: varchar("email", { length: 255 }).notNull().unique(),
+  emailVerified: boolean("email_verified").default(false).notNull(),
+  image: text("image"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_session = mysqlTable("custom_session", {
+  id: int("id").autoincrement().primaryKey(),
+  expiresAt: timestamp("expires_at").notNull(),
+  token: varchar("token", { length: 255 }).notNull().unique(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  userId: int("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+});
+
+export const custom_account = mysqlTable("custom_account", {
+  id: int("id").autoincrement().primaryKey(),
+  accountId: text("account_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  userId: int("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  idToken: text("id_token"),
+  accessTokenExpiresAt: timestamp("access_token_expires_at"),
+  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_verification = mysqlTable("custom_verification", {
+  id: int("id").autoincrement().primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: timestamp("expires_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const passkey = mysqlTable("passkey", {
+  id: int("id").autoincrement().primaryKey(),
+  name: text("name"),
+  publicKey: text("public_key").notNull(),
+  userId: int("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  credentialID: text("credential_id").notNull(),
+  counter: int("counter").notNull(),
+  deviceType: text("device_type").notNull(),
+  backedUp: boolean("backed_up").notNull(),
+  transports: text("transports"),
+  createdAt: timestamp("created_at"),
+  aaguid: text("aaguid"),
+});

--- a/packages/cli/test/__snapshots__/auth-schema-mysql-passkey.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql-passkey.txt
@@ -1,0 +1,84 @@
+import {
+  mysqlTable,
+  varchar,
+  text,
+  timestamp,
+  boolean,
+  int,
+} from "drizzle-orm/mysql-core";
+
+export const custom_user = mysqlTable("custom_user", {
+  id: varchar("id", { length: 36 }).primaryKey(),
+  name: text("name").notNull(),
+  email: varchar("email", { length: 255 }).notNull().unique(),
+  emailVerified: boolean("email_verified").default(false).notNull(),
+  image: text("image"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_session = mysqlTable("custom_session", {
+  id: varchar("id", { length: 36 }).primaryKey(),
+  expiresAt: timestamp("expires_at").notNull(),
+  token: varchar("token", { length: 255 }).notNull().unique(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  userId: varchar("user_id", { length: 36 })
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+});
+
+export const custom_account = mysqlTable("custom_account", {
+  id: varchar("id", { length: 36 }).primaryKey(),
+  accountId: text("account_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  userId: varchar("user_id", { length: 36 })
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  idToken: text("id_token"),
+  accessTokenExpiresAt: timestamp("access_token_expires_at"),
+  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_verification = mysqlTable("custom_verification", {
+  id: varchar("id", { length: 36 }).primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: timestamp("expires_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const passkey = mysqlTable("passkey", {
+  id: varchar("id", { length: 36 }).primaryKey(),
+  name: text("name"),
+  publicKey: text("public_key").notNull(),
+  userId: varchar("user_id", { length: 36 })
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  credentialID: text("credential_id").notNull(),
+  counter: int("counter").notNull(),
+  deviceType: text("device_type").notNull(),
+  backedUp: boolean("backed_up").notNull(),
+  transports: text("transports"),
+  createdAt: timestamp("created_at"),
+  aaguid: text("aaguid"),
+});

--- a/packages/cli/test/__snapshots__/auth-schema-pg-passkey.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-passkey.txt
@@ -1,0 +1,83 @@
+import {
+  pgTable,
+  text,
+  timestamp,
+  boolean,
+  integer,
+} from "drizzle-orm/pg-core";
+
+export const custom_user = pgTable("custom_user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: boolean("email_verified").default(false).notNull(),
+  image: text("image"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_session = pgTable("custom_session", {
+  id: text("id").primaryKey(),
+  expiresAt: timestamp("expires_at").notNull(),
+  token: text("token").notNull().unique(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  userId: text("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+});
+
+export const custom_account = pgTable("custom_account", {
+  id: text("id").primaryKey(),
+  accountId: text("account_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  idToken: text("id_token"),
+  accessTokenExpiresAt: timestamp("access_token_expires_at"),
+  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_verification = pgTable("custom_verification", {
+  id: text("id").primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: timestamp("expires_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const passkey = pgTable("passkey", {
+  id: text("id").primaryKey(),
+  name: text("name"),
+  publicKey: text("public_key").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  credentialID: text("credential_id").notNull(),
+  counter: integer("counter").notNull(),
+  deviceType: text("device_type").notNull(),
+  backedUp: boolean("backed_up").notNull(),
+  transports: text("transports"),
+  createdAt: timestamp("created_at"),
+  aaguid: text("aaguid"),
+});

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey-number-id.txt
@@ -1,0 +1,91 @@
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const custom_user = sqliteTable("custom_user", {
+  id: int("id").autoincrement().primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: integer("email_verified", { mode: "boolean" })
+    .default(false)
+    .notNull(),
+  image: text("image"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_session = sqliteTable("custom_session", {
+  id: int("id").autoincrement().primaryKey(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  token: text("token").notNull().unique(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+});
+
+export const custom_account = sqliteTable("custom_account", {
+  id: int("id").autoincrement().primaryKey(),
+  accountId: text("account_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  idToken: text("id_token"),
+  accessTokenExpiresAt: integer("access_token_expires_at", {
+    mode: "timestamp",
+  }),
+  refreshTokenExpiresAt: integer("refresh_token_expires_at", {
+    mode: "timestamp",
+  }),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_verification = sqliteTable("custom_verification", {
+  id: int("id").autoincrement().primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const passkey = sqliteTable("passkey", {
+  id: int("id").autoincrement().primaryKey(),
+  name: text("name"),
+  publicKey: text("public_key").notNull(),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  credentialID: text("credential_id").notNull(),
+  counter: integer("counter").notNull(),
+  deviceType: text("device_type").notNull(),
+  backedUp: integer("backed_up", { mode: "boolean" }).notNull(),
+  transports: text("transports"),
+  createdAt: integer("created_at", { mode: "timestamp" }),
+  aaguid: text("aaguid"),
+});

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey.txt
@@ -1,0 +1,91 @@
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const custom_user = sqliteTable("custom_user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: integer("email_verified", { mode: "boolean" })
+    .default(false)
+    .notNull(),
+  image: text("image"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_session = sqliteTable("custom_session", {
+  id: text("id").primaryKey(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  token: text("token").notNull().unique(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  userId: text("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+});
+
+export const custom_account = sqliteTable("custom_account", {
+  id: text("id").primaryKey(),
+  accountId: text("account_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  idToken: text("id_token"),
+  accessTokenExpiresAt: integer("access_token_expires_at", {
+    mode: "timestamp",
+  }),
+  refreshTokenExpiresAt: integer("refresh_token_expires_at", {
+    mode: "timestamp",
+  }),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const custom_verification = sqliteTable("custom_verification", {
+  id: text("id").primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const passkey = sqliteTable("passkey", {
+  id: text("id").primaryKey(),
+  name: text("name"),
+  publicKey: text("public_key").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => custom_user.id, { onDelete: "cascade" }),
+  credentialID: text("credential_id").notNull(),
+  counter: integer("counter").notNull(),
+  deviceType: text("device_type").notNull(),
+  backedUp: integer("backed_up", { mode: "boolean" }).notNull(),
+  transports: text("transports"),
+  createdAt: integer("created_at", { mode: "timestamp" }),
+  aaguid: text("aaguid"),
+});

--- a/packages/cli/test/generate-all-db.test.ts
+++ b/packages/cli/test/generate-all-db.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { generateDrizzleSchema } from "../src/generators/drizzle";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { twoFactor, username } from "better-auth/plugins";
+import { passkey } from "better-auth/plugins/passkey";
 import type { BetterAuthOptions } from "better-auth";
 
 describe("generate drizzle schema for all databases", async () => {
@@ -164,6 +165,208 @@ describe("generate drizzle schema for all databases", async () => {
 		});
 		expect(schema.code).toMatchFileSnapshot(
 			"./__snapshots__/auth-schema-sqlite-number-id.txt",
+		);
+	});
+});
+
+describe("generate drizzle schema for all databases with passkey plugin", async () => {
+	it("should generate drizzle schema for MySQL with passkey plugin", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "mysql",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "mysql",
+						schema: {},
+					},
+				),
+				plugins: [passkey()],
+				user: {
+					modelName: "custom_user",
+				},
+				account: {
+					modelName: "custom_account",
+				},
+				session: {
+					modelName: "custom_session",
+				},
+				verification: {
+					modelName: "custom_verification",
+				},
+			},
+		});
+		expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-mysql-passkey.txt",
+		);
+	});
+
+	it("should generate drizzle schema for SQLite with passkey plugin", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "sqlite",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "sqlite",
+						schema: {},
+					},
+				),
+				plugins: [passkey()],
+				user: {
+					modelName: "custom_user",
+				},
+				account: {
+					modelName: "custom_account",
+				},
+				session: {
+					modelName: "custom_session",
+				},
+				verification: {
+					modelName: "custom_verification",
+				},
+			},
+		});
+		expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-sqlite-passkey.txt",
+		);
+	});
+
+	it("should generate drizzle schema for PostgreSQL with passkey plugin", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "pg",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "pg",
+						schema: {},
+					},
+				),
+				plugins: [passkey()],
+				user: {
+					modelName: "custom_user",
+				},
+				account: {
+					modelName: "custom_account",
+				},
+				session: {
+					modelName: "custom_session",
+				},
+				verification: {
+					modelName: "custom_verification",
+				},
+			},
+		});
+		expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-pg-passkey.txt",
+		);
+	});
+
+	it("should generate drizzle schema for MySQL with passkey plugin and number id", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "mysql",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "mysql",
+						schema: {},
+					},
+				),
+				plugins: [passkey()],
+				advanced: {
+					database: {
+						useNumberId: true,
+					},
+				},
+				user: {
+					modelName: "custom_user",
+				},
+				account: {
+					modelName: "custom_account",
+				},
+				session: {
+					modelName: "custom_session",
+				},
+				verification: {
+					modelName: "custom_verification",
+				},
+			},
+		});
+		expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-mysql-passkey-number-id.txt",
+		);
+	});
+
+	it("should generate drizzle schema for SQLite with passkey plugin and number id", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "sqlite",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "sqlite",
+						schema: {},
+					},
+				),
+				plugins: [passkey()],
+				advanced: {
+					database: {
+						useNumberId: true,
+					},
+				},
+				user: {
+					modelName: "custom_user",
+				},
+				account: {
+					modelName: "custom_account",
+				},
+				session: {
+					modelName: "custom_session",
+				},
+				verification: {
+					modelName: "custom_verification",
+				},
+			},
+		});
+		expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-sqlite-passkey-number-id.txt",
 		);
 	});
 });


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4368
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Special-case snake_case conversion in the Drizzle schema generator to handle acronyms (ID, URL, API) correctly. This fixes wrong column names (e.g., credential_i_d -> credential_id) and ensures consistent output across MySQL, PostgreSQL, and SQLite, including numeric ID mode.

- **Bug Fixes**
  - Treat consecutive capitals as one word when converting to snake_case, then lowercase.
  - Added passkey snapshots and tests for MySQL, PostgreSQL, and SQLite (with and without number IDs) to lock in correct column names.

<!-- End of auto-generated description by cubic. -->

