### PR TITLE
feat(stripe): usage tracking

### DIFF
--- a/packages/better-auth/src/plugins/usage/index.ts
+++ b/packages/better-auth/src/plugins/usage/index.ts
@@ -1,0 +1,52 @@
+import type { BetterAuthPlugin, InferOptionSchema } from '../../types'
+import { mergeSchema } from '../../db'
+import { schema } from './schema'
+import { createAuthEndpoint } from '../../api'
+import * as z from 'zod/v4'
+
+type UsageOptions = {
+  allowClientTracking?: boolean
+  schema: InferOptionSchema<typeof schema>
+}
+
+export const usage = (
+  options?: UsageOptions
+) => {
+  const SERVER_ONLY: boolean = !(options?.allowClientTracking ?? false);
+  return {
+    id: 'usage',
+    schema: mergeSchema(schema, options?.schema),
+    endpoints: {
+      trackUsage: createAuthEndpoint(
+        '/usage/track',
+        {
+          method: 'POST',
+          body: z.object({
+            timestamp: z.date().default(() => new Date()),
+            eventType: z.string().min(1),
+            userId: z.string(),
+            transactionId: z.string().optional(),
+            payload: z.record(z.string(), z.any()).default({}),
+          }),
+          metadata: {
+            SERVER_ONLY,
+          }
+        },
+        async (ctx) => {
+          await ctx.context.adapter.create(
+            {
+              model: 'usage',
+              data: {
+                timestamp: ctx.body.timestamp,
+                eventType: ctx.body.eventType,
+                userId: ctx.body.userId,
+                transactionId: ctx.body.transactionId,
+                payload: ctx.body.payload,
+              },
+            },
+          )
+        }
+      )
+    }
+  } satisfies BetterAuthPlugin;
+}

--- a/packages/better-auth/src/plugins/usage/schema.ts
+++ b/packages/better-auth/src/plugins/usage/schema.ts
@@ -1,0 +1,34 @@
+import type { AuthPluginSchema } from '../../types'
+
+export const schema = {
+  usage: {
+    fields: {
+      timestamp: {
+        type: "date",
+        required: true,
+      },
+      eventType: {
+        type: "string",
+        required: true,
+      },
+      userId: {
+        type: "string",
+        required: true,
+      },
+      /**
+       * Optional transaction ID to group related usage events (e.g., all events from a single API request)
+       */
+      transactionId: {
+        type: "string",
+        required: false,
+      },
+      /**
+       * Key-value pairs to store additional metadata about the usage event
+       */
+      payload: {
+        type: "json",
+        required: true,
+      }
+    },
+  }
+} satisfies AuthPluginSchema;

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -65,39 +65,6 @@ export const user = {
 	},
 } satisfies AuthPluginSchema;
 
-export const usage = {
-	usage: {
-		fields: {
-			timestamp: {
-				type: "date",
-				required: true,
-			},
-			eventType: {
-				type: "string",
-				required: true,
-			},
-			userId: {
-				type: "string",
-				required: true,
-			},
-			/**
-			 * Optional transaction ID to group related usage events (e.g., all events from a single API request)
-			 */
-			transactionId: {
-				type: "string",
-				required: false,
-			},
-			/**
-			 * Key-value pairs to store additional metadata about the usage event
-			 */
-			payload: {
-				type: "json",
-				required: true,
-			}
-		},
-	}
-} satisfies AuthPluginSchema;
-
 export const getSchema = (options: StripeOptions) => {
 	const baseSchema: AuthPluginSchema = Object.assign(
 		{},
@@ -108,13 +75,6 @@ export const getSchema = (options: StripeOptions) => {
 		Object.assign(
 			baseSchema,
 			subscriptions,
-		)
-	}
-
-	if (options.usage?.enabled) {
-		Object.assign(
-			baseSchema,
-			usage,
 		)
 	}
 

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -206,12 +206,6 @@ export interface StripeOptions {
 		ctx: GenericEndpointContext,
 	) => Promise<{}>;
 	/**
-	 * Usage tracking
-	 */
-	usage?: {
-		enabled: boolean;
-	}
-	/**
 	 * Subscriptions
 	 */
 	subscription?: {


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4282
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds opt-in usage tracking to the Stripe plugin. Introduces a new schema and a config flag to record usage events with required metadata.

- **New Features**
  - New usage schema with fields: timestamp (date), eventType (string), userId (string), optional transactionId (string), and payload (json).
  - New StripeOptions.usage.enabled flag; when true, getSchema adds the usage collection.
  - getSchema now always includes user and conditionally merges subscriptions and usage.

<!-- End of auto-generated description by cubic. -->

