### PR TITLE
feat(logger): option to disable colors

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -497,6 +497,7 @@ import { betterAuth } from "better-auth";
 export const auth = betterAuth({
 	logger: {
 		disabled: false,
+		disableColors: false, // Colors are enabled by default
 		level: "error",
 		log: (level, message, ...args) => {
 			// Custom logging implementation
@@ -509,6 +510,7 @@ export const auth = betterAuth({
 The logger configuration allows you to customize how Better Auth handles logging. It supports the following options:
 
 - `disabled`: Disable all logging when set to `true` (default: `false`)
+- `disableColors`: Disable colors in the default logger implementation (default: `false`)
 - `level`: Set the minimum log level to display. Available levels are:
   - `"info"`: Show all logs
   - `"warn"`: Show warnings and errors

--- a/packages/better-auth/src/utils/logger.ts
+++ b/packages/better-auth/src/utils/logger.ts
@@ -11,6 +11,7 @@ export function shouldPublishLog(
 
 export interface Logger {
 	disabled?: boolean;
+	disableColors?: boolean;
 	level?: Exclude<LogLevel, "success">;
 	log?: (
 		level: Exclude<LogLevel, "success">,
@@ -64,13 +65,22 @@ const levelColors: Record<LogLevel, string> = {
 	debug: colors.fg.magenta,
 };
 
-const formatMessage = (level: LogLevel, message: string): string => {
+const formatMessage = (
+	level: LogLevel,
+	message: string,
+	colorsEnabled?: boolean,
+): string => {
 	const timestamp = new Date().toISOString();
-	return `${colors.dim}${timestamp}${colors.reset} ${
-		levelColors[level]
-	}${level.toUpperCase()}${colors.reset} ${colors.bright}[Better Auth]:${
-		colors.reset
-	} ${message}`;
+
+	if (colorsEnabled) {
+		return `${colors.dim}${timestamp}${colors.reset} ${
+			levelColors[level]
+		}${level.toUpperCase()}${colors.reset} ${colors.bright}[Better Auth]:${
+			colors.reset
+		} ${message}`;
+	}
+
+	return `${timestamp} ${level.toUpperCase()} [Better Auth]: ${message}`;
 };
 
 export type InternalLogger = {
@@ -81,6 +91,7 @@ export type InternalLogger = {
 
 export const createLogger = (options?: Logger): InternalLogger => {
 	const enabled = options?.disabled !== true;
+	const colorsEnabled = options?.disableColors !== true;
 	const logLevel = options?.level ?? "error";
 
 	const LogFunc = (
@@ -92,7 +103,7 @@ export const createLogger = (options?: Logger): InternalLogger => {
 			return;
 		}
 
-		const formattedMessage = formatMessage(level, message);
+		const formattedMessage = formatMessage(level, message, colorsEnabled);
 
 		if (!options || typeof options.log !== "function") {
 			if (level === "error") {


### PR DESCRIPTION
This PR adds option to disable colors from default logger implementation.
I've made this change because convex doesn't support colors in logs (using https://convex-better-auth.netlify.app/)
Default logger implementations logs look like this:
<img width="711" height="112" alt="image" src="https://github.com/user-attachments/assets/fbcad63c-4df2-4f48-bdec-5348923b70d7" />
<img width="991" height="331" alt="image" src="https://github.com/user-attachments/assets/24119a02-a7b4-47bf-a6d8-7b5146bb452c" />

In this environment colors are not needed nor supported in convex dashboard.

No breaking changes introduces, only optional `disableColors` property for logger.
I have found no issues or discussions for this setting
