### PR TITLE
docs: fix incorrect rendering of default tab value

### DIFF
--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -200,7 +200,7 @@ Once a user is signed in, you'll want to access the user session. Better Auth al
 
 Better Auth provides a `useSession` hook to easily access session data on the client side. This hook is implemented using nanostore and has support for each supported framework and vanilla client, ensuring that any changes to the session (such as signing out) are immediately reflected in your UI.
 
-<Tabs items={["React", "Vue","Svelte", "Solid", "Vanilla"]} defaultValue="React">
+<Tabs items={["React", "Vue","Svelte", "Solid", "Vanilla"]} defaultValue="react">
     <Tab value="React">
         ```tsx title="user.tsx"
         import { authClient } from "@/lib/auth-client" // import the auth client // [!code highlight] 

--- a/docs/content/docs/concepts/client.mdx
+++ b/docs/content/docs/concepts/client.mdx
@@ -89,7 +89,7 @@ On top of normal methods, the client provides hooks to easily access different r
 **Example: useSession**
 
 
-<Tabs items={["React", "Vue","Svelte", "Solid"]} defaultValue="React">
+<Tabs items={["React", "Vue","Svelte", "Solid"]} defaultValue="react">
     <Tab value="React">
         ```tsx title="user.tsx"
         //make sure you're using the react client


### PR DESCRIPTION
before     
<img width="753" height="403" alt="Screenshot 2025-09-04 at 2 09 06 AM" src="https://github.com/user-attachments/assets/58b82afc-501e-4fa2-97c3-f8f889d66c5e" />
after 
<img width="826" height="559" alt="Screenshot 2025-09-04 at 2 11 47 AM" src="https://github.com/user-attachments/assets/a02cd42c-26ce-46f4-83c9-1d3dfb6eec3d" />



<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed incorrect default tab rendering in the docs by using the case-sensitive value "react" for Tabs defaultValue, ensuring the React tab loads by default on the Basic Usage and Client Concepts pages.

<!-- End of auto-generated description by cubic. -->

