### PR TITLE
fix: cloudflare build warning with `node:sqlite`

### DIFF
--- a/e2e/smoke/test/cloudflare.spec.ts
+++ b/e2e/smoke/test/cloudflare.spec.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
+import assert from "node:assert/strict";
 
 const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
 
@@ -16,12 +17,26 @@ describe("(cloudflare) simple server", () => {
 			cp.kill("SIGINT");
 		});
 
+		const unexpectedStrings = new Set(["node:sqlite"]);
+
 		cp.stdout.on("data", (data) => {
 			console.log(data.toString());
+			for (const str of unexpectedStrings) {
+				assert(
+					!data.toString().includes(str),
+					`Output should not contain "${str}"`,
+				);
+			}
 		});
 
 		cp.stderr.on("data", (data) => {
 			console.error(data.toString());
+			for (const str of unexpectedStrings) {
+				assert(
+					!data.toString().includes(str),
+					`Error output should not contain "${str}"`,
+				);
+			}
 		});
 
 		await new Promise<void>((resolve) => {

--- a/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
@@ -110,7 +110,13 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		let DatabaseSync: typeof import("node:sqlite").DatabaseSync | undefined =
 			undefined;
 		try {
-			({ DatabaseSync } = await import("node:sqlite"));
+			// Ignore both Vite and Webpack for dynamic import as they both try to pre-bundle 'node:sqlite' which might fail
+			// It's okay because we are in a try-catch block
+			({ DatabaseSync } = await import(
+				/* @vite-ignore */
+				/* webpackIgnore: true */
+				"node:sqlite"
+			));
 		} catch (error: unknown) {
 			if (
 				error !== null &&

--- a/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
@@ -110,12 +110,13 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		let DatabaseSync: typeof import("node:sqlite").DatabaseSync | undefined =
 			undefined;
 		try {
+			let nodeSqlite: string = "node:sqlite";
 			// Ignore both Vite and Webpack for dynamic import as they both try to pre-bundle 'node:sqlite' which might fail
 			// It's okay because we are in a try-catch block
 			({ DatabaseSync } = await import(
 				/* @vite-ignore */
 				/* webpackIgnore: true */
-				"node:sqlite"
+				nodeSqlite
 			));
 		} catch (error: unknown) {
 			if (


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4404
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents Cloudflare build warnings by stopping Vite/Webpack from pre-bundling node:sqlite in the Kysely adapter. Uses dynamic import hints so sqlite is loaded only at runtime. Fixes better-auth/better-auth#4404.

- **Bug Fixes**
  - Added /* @vite-ignore */ and /* webpackIgnore: true */ to the node:sqlite dynamic import inside the existing try/catch.

<!-- End of auto-generated description by cubic. -->

