### PR TITLE
chore: fix lint

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -3,7 +3,6 @@ import type { AuthContext } from "../init";
 import type { BetterAuthOptions } from "../types";
 import type { UnionToIntersection } from "../types/helper";
 import { originCheckMiddleware } from "./middlewares/origin-check";
-import { BetterAuthError } from "../error";
 import {
 	callbackOAuth,
 	forgetPassword,

--- a/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
@@ -1,4 +1,4 @@
-import { APIError, createAuthEndpoint, sessionMiddleware } from "../../../api";
+import { createAuthEndpoint, sessionMiddleware } from "../../../api";
 import type { apiKeySchema } from "../schema";
 import type { ApiKey } from "../types";
 import type { AuthContext } from "../../../types";

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -9,7 +9,6 @@ import type { PredefinedApiKeyOptions } from ".";
 import { safeJSONParse } from "../../../utils/json";
 import { role } from "../../access";
 import { defaultKeyHasher } from "../";
-import { createApiKey } from "./create-api-key";
 
 export async function validateApiKey({
 	hashedKey,

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -4,16 +4,7 @@ import type {
 	OpenAPIParameter,
 	OpenAPISchemaType,
 } from "better-call";
-import {
-	z,
-	ZodArray,
-	ZodBoolean,
-	ZodNumber,
-	ZodObject,
-	ZodOptional,
-	ZodString,
-	ZodType,
-} from "zod/v4";
+import { z, ZodObject, ZodOptional, ZodType } from "zod/v4";
 import { getEndpoints } from "../../api";
 import { getAuthTables } from "../../db";
 import type { AuthContext, BetterAuthOptions } from "../../types";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed unused imports across the API and OpenAPI generator to fix lint errors. No functional changes; builds are cleaner and slightly smaller.

- **Refactors**
  - Remove BetterAuthError import in api/index.ts.
  - Remove APIError import in api-key/list-api-keys.ts.
  - Remove createApiKey import in api-key/verify-api-key.ts.
  - Drop unused Zod types in plugins/open-api/generator.ts (keep z, ZodObject, ZodOptional, ZodType).

<!-- End of auto-generated description by cubic. -->

