### PR TITLE
docs: use the default search dialog when no api key is provided

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -53,7 +53,9 @@ export default function Layout({ children }: { children: ReactNode }) {
 						}}
 						search={{
 							enabled: true,
-							SearchDialog: CustomSearchDialog,
+							SearchDialog: process.env.ORAMA_PRIVATE_API_KEY
+								? CustomSearchDialog
+								: undefined,
 						}}
 					>
 						<NavbarProvider>


### PR DESCRIPTION
Feedback from Max

> Yeah the docs just crashes with an error because I don't have an api key
> I think this isn't good... everyone else can't render docs locally now

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fall back to the default search dialog when ORAMA_PRIVATE_API_KEY is not set, so docs search works without configuration. When the key is present, we continue using CustomSearchDialog.

<!-- End of auto-generated description by cubic. -->

