### PR TITLE
fix(expo): handle link social

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -202,7 +202,8 @@ export const expoClient = (opts: ExpoClientOptions) => {
 
 						if (
 							context.data?.redirect &&
-							context.request.url.toString().includes("/sign-in") &&
+							(context.request.url.toString().includes("/sign-in") ||
+								context.request.url.toString().includes("/link-social")) &&
 							!context.request?.body.includes("idToken") // id token is used for silent sign-in
 						) {
 							const callbackURL = JSON.parse(context.request.body)?.callbackURL;


### PR DESCRIPTION
closes #3607
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Extend redirect handling in the Expo client to also cover /link-social, opening the browser when a redirect is returned and no idToken is present. This fixes stalled social account linking flows.

<!-- End of auto-generated description by cubic. -->

