### PR TITLE
fix: adjust APIMethod component styling after fumadocs update

### DIFF
--- a/docs/components/api-method.tsx
+++ b/docs/components/api-method.tsx
@@ -234,7 +234,7 @@ export const APIMethod = ({
 						</Note>
 					) : null}
 					<div className={cn("relative w-full")}>
-						<DynamicCodeBlock 
+						<DynamicCodeBlock
 							code={`${code_prefix}${
 								noResult
 									? ""

--- a/docs/components/api-method.tsx
+++ b/docs/components/api-method.tsx
@@ -1,6 +1,6 @@
 import { Endpoint } from "./endpoint";
 // import { Tab, Tabs } from "fumadocs-ui/components/tabs";
-import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { DynamicCodeBlock } from "./ui/dynamic-code-block";
 import {
 	Table,
 	TableBody,
@@ -234,7 +234,7 @@ export const APIMethod = ({
 						</Note>
 					) : null}
 					<div className={cn("relative w-full")}>
-						<DynamicCodeBlock
+						<DynamicCodeBlock 
 							code={`${code_prefix}${
 								noResult
 									? ""

--- a/docs/components/endpoint.tsx
+++ b/docs/components/endpoint.tsx
@@ -33,26 +33,6 @@ export function Endpoint({
 		>
 			<Method method={method} />
 			<span className="font-mono text-sm text-muted-foreground">{path}</span>
-			<div className="absolute right-2" slot="copy">
-				<Button
-					variant="ghost"
-					size="icon"
-					className="transition-all duration-150 ease-in-out opacity-0 cursor-pointer scale-80 group-hover:opacity-100"
-					onClick={() => {
-						setCopying(true);
-						navigator.clipboard.writeText(path);
-						setTimeout(() => {
-							setCopying(false);
-						}, 1000);
-					}}
-				>
-					{copying ? (
-						<Check className="duration-150 ease-in-out size-4 zoom-in" />
-					) : (
-						<Copy className="size-4" />
-					)}
-				</Button>
-			</div>
 		</div>
 	);
 }

--- a/docs/components/ui/code-block.tsx
+++ b/docs/components/ui/code-block.tsx
@@ -183,7 +183,7 @@ function CopyButton({
 					variant: "ghost",
 					size: "icon",
 				}),
-				"transition-opacity border-none  group-hover:opacity-100",
+				"transition-opacity size-7 border-none  group-hover:opacity-100",
 				"opacity-0 group-hover:opacity-100",
 				"group-hover:opacity-100",
 				className,

--- a/docs/components/ui/dynamic-code-block.tsx
+++ b/docs/components/ui/dynamic-code-block.tsx
@@ -1,0 +1,116 @@
+'use client';
+import { CodeBlock, type CodeBlockProps, Pre } from '@/components/ui/code-block';
+import type {
+  HighlightOptions,
+  HighlightOptionsCommon,
+  HighlightOptionsThemes,
+} from 'fumadocs-core/highlight';
+import { useShiki } from 'fumadocs-core/highlight/client';
+import { cn } from '@/lib/utils';
+import {
+  type ComponentProps,
+  createContext,
+  type FC,
+  Suspense,
+  use,
+} from 'react';
+
+export interface DynamicCodeblockProps {
+  lang: string;
+  code: string;
+  /**
+   * Extra props for the underlying `<CodeBlock />` component.
+   *
+   * Ignored if you defined your own `pre` component in `options.components`.
+   */
+  codeblock?: CodeBlockProps;
+  /**
+   * Wrap in React `<Suspense />` and provide a fallback.
+   *
+   * @defaultValue true
+   */
+  wrapInSuspense?: boolean;
+  options?: Omit<HighlightOptionsCommon, 'lang'> & HighlightOptionsThemes;
+}
+
+const PropsContext = createContext<CodeBlockProps | undefined>(undefined);
+
+function DefaultPre(props: ComponentProps<'pre'>) {
+  const extraProps = use(PropsContext);
+
+  return (
+    <CodeBlock
+      {...props}
+      {...extraProps}
+      className={cn('my-0 border-t-0 rounded-none', props.className, extraProps?.className)}
+    >
+      <Pre className='py-2'>{props.children}</Pre>
+    </CodeBlock>
+  );
+}
+
+export function DynamicCodeBlock({
+  lang,
+  code,
+  codeblock,
+  options,
+  wrapInSuspense = true,
+}: DynamicCodeblockProps) {
+  const shikiOptions = {
+    lang,
+    ...options,
+    components: {
+      pre: DefaultPre,
+      ...options?.components,
+    },
+  } satisfies HighlightOptions;
+  let children = <Internal code={code} options={shikiOptions} />;
+
+  if (wrapInSuspense)
+    children = (
+      <Suspense
+        fallback={
+          <Placeholder code={code} components={shikiOptions.components} />
+        }
+      >
+        {children}
+      </Suspense>
+    );
+
+  return <PropsContext value={codeblock}>{children}</PropsContext>;
+}
+
+function Placeholder({
+  code,
+  components = {},
+}: {
+  code: string;
+  components: HighlightOptions['components'];
+}) {
+  const { pre: Pre = 'pre', code: Code = 'code' } = components as Record<
+    string,
+    FC
+  >;
+
+  return (
+    <Pre>
+      <Code>
+        {code.split('\n').map((line, i) => (
+          <span key={i} className="line">
+            {line}
+          </span>
+        ))}
+      </Code>
+    </Pre>
+  );
+}
+
+function Internal({
+  code,
+  options,
+}: {
+  code: string;
+  options: HighlightOptions;
+}) {
+  return useShiki(code, options);
+}

--- a/docs/components/ui/dynamic-code-block.tsx
+++ b/docs/components/ui/dynamic-code-block.tsx
@@ -1,116 +1,124 @@
-'use client';
-import { CodeBlock, type CodeBlockProps, Pre } from '@/components/ui/code-block';
-import type {
-  HighlightOptions,
-  HighlightOptionsCommon,
-  HighlightOptionsThemes,
-} from 'fumadocs-core/highlight';
-import { useShiki } from 'fumadocs-core/highlight/client';
-import { cn } from '@/lib/utils';
+"use client";
 import {
-  type ComponentProps,
-  createContext,
-  type FC,
-  Suspense,
-  use,
-} from 'react';
+	CodeBlock,
+	type CodeBlockProps,
+	Pre,
+} from "@/components/ui/code-block";
+import type {
+	HighlightOptions,
+	HighlightOptionsCommon,
+	HighlightOptionsThemes,
+} from "fumadocs-core/highlight";
+import { useShiki } from "fumadocs-core/highlight/client";
+import { cn } from "@/lib/utils";
+import {
+	type ComponentProps,
+	createContext,
+	type FC,
+	Suspense,
+	use,
+} from "react";
 
 export interface DynamicCodeblockProps {
-  lang: string;
-  code: string;
-  /**
-   * Extra props for the underlying `<CodeBlock />` component.
-   *
-   * Ignored if you defined your own `pre` component in `options.components`.
-   */
-  codeblock?: CodeBlockProps;
-  /**
-   * Wrap in React `<Suspense />` and provide a fallback.
-   *
-   * @defaultValue true
-   */
-  wrapInSuspense?: boolean;
-  options?: Omit<HighlightOptionsCommon, 'lang'> & HighlightOptionsThemes;
+	lang: string;
+	code: string;
+	/**
+	 * Extra props for the underlying `<CodeBlock />` component.
+	 *
+	 * Ignored if you defined your own `pre` component in `options.components`.
+	 */
+	codeblock?: CodeBlockProps;
+	/**
+	 * Wrap in React `<Suspense />` and provide a fallback.
+	 *
+	 * @defaultValue true
+	 */
+	wrapInSuspense?: boolean;
+	options?: Omit<HighlightOptionsCommon, "lang"> & HighlightOptionsThemes;
 }
 
 const PropsContext = createContext<CodeBlockProps | undefined>(undefined);
 
-function DefaultPre(props: ComponentProps<'pre'>) {
-  const extraProps = use(PropsContext);
+function DefaultPre(props: ComponentProps<"pre">) {
+	const extraProps = use(PropsContext);
 
-  return (
-    <CodeBlock
-      {...props}
-      {...extraProps}
-      className={cn('my-0 border-t-0 rounded-none', props.className, extraProps?.className)}
-    >
-      <Pre className='py-2'>{props.children}</Pre>
-    </CodeBlock>
-  );
+	return (
+		<CodeBlock
+			{...props}
+			{...extraProps}
+			className={cn(
+				"my-0 border-t-0 rounded-none",
+				props.className,
+				extraProps?.className,
+			)}
+		>
+			<Pre className="py-2">{props.children}</Pre>
+		</CodeBlock>
+	);
 }
 
 export function DynamicCodeBlock({
-  lang,
-  code,
-  codeblock,
-  options,
-  wrapInSuspense = true,
+	lang,
+	code,
+	codeblock,
+	options,
+	wrapInSuspense = true,
 }: DynamicCodeblockProps) {
-  const shikiOptions = {
-    lang,
-    ...options,
-    components: {
-      pre: DefaultPre,
-      ...options?.components,
-    },
-  } satisfies HighlightOptions;
-  let children = <Internal code={code} options={shikiOptions} />;
+	const shikiOptions = {
+		lang,
+		...options,
+		components: {
+			pre: DefaultPre,
+			...options?.components,
+		},
+	} satisfies HighlightOptions;
+	let children = <Internal code={code} options={shikiOptions} />;
 
-  if (wrapInSuspense)
-    children = (
-      <Suspense
-        fallback={
-          <Placeholder code={code} components={shikiOptions.components} />
-        }
-      >
-        {children}
-      </Suspense>
-    );
+	if (wrapInSuspense)
+		children = (
+			<Suspense
+				fallback={
+					<Placeholder code={code} components={shikiOptions.components} />
+				}
+			>
+				{children}
+			</Suspense>
+		);
 
-  return <PropsContext value={codeblock}>{children}</PropsContext>;
+	return <PropsContext value={codeblock}>{children}</PropsContext>;
 }
 
 function Placeholder({
-  code,
-  components = {},
+	code,
+	components = {},
 }: {
-  code: string;
-  components: HighlightOptions['components'];
+	code: string;
+	components: HighlightOptions["components"];
 }) {
-  const { pre: Pre = 'pre', code: Code = 'code' } = components as Record<
-    string,
-    FC
-  >;
+	const { pre: Pre = "pre", code: Code = "code" } = components as Record<
+		string,
+		FC
+	>;
 
-  return (
-    <Pre>
-      <Code>
-        {code.split('\n').map((line, i) => (
-          <span key={i} className="line">
-            {line}
-          </span>
-        ))}
-      </Code>
-    </Pre>
-  );
+	return (
+		<Pre>
+			<Code>
+				{code.split("\n").map((line, i) => (
+					<span key={i} className="line">
+						{line}
+					</span>
+				))}
+			</Code>
+		</Pre>
+	);
 }
 
 function Internal({
-  code,
-  options,
+	code,
+	options,
 }: {
-  code: string;
-  options: HighlightOptions;
+	code: string;
+	options: HighlightOptions;
 }) {
-  return useShiki(code, options);
+	return useShiki(code, options);
 }


### PR DESCRIPTION
before: 
<img width="731" height="312" alt="Screenshot 2025-09-04 at 12 32 10 PM" src="https://github.com/user-attachments/assets/cbd3f48d-f654-4ce6-ab67-ac6b197471e7" />

after: 
<img width="983" height="407" alt="Screenshot 2025-09-04 at 12 23 01 PM" src="https://github.com/user-attachments/assets/f657a921-7c68-43ef-995f-dc09b22223b1" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes API method code block styling after the latest fumadocs update. Restores consistent padding/borders and removes a redundant copy button.

- **Bug Fixes**
  - Replaced fumadocs DynamicCodeBlock with a local wrapper using our CodeBlock/Pre + Shiki for consistent spacing, borders, and rounding.
  - Switched APIMethod to the new local DynamicCodeBlock.
  - Increased code block copy button size to align with updated UI.
  - Removed the Endpoint header copy button to avoid duplication with the new docs UI.

<!-- End of auto-generated description by cubic. -->

