### PR TITLE
fix(admin): admin plugin update renamed fields

### DIFF
--- a/packages/better-auth/src/db/db.test.ts
+++ b/packages/better-auth/src/db/db.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../test-utils/test-instance";
+import { admin } from "../plugins/admin";
+import { getAuthTables } from "./get-tables";
 
 describe("db", async () => {
 	it("should work with custom model names", async () => {
@@ -95,5 +97,31 @@ describe("db", async () => {
 			},
 		});
 		expect(session?.user.email).toBe("test@email.com");
+	});
+
+	it("should work with admin plugin field mappings", async () => {
+		const { auth } = await getTestInstance({
+			user: {
+				fields: {
+					email: "user_email",
+					role: "user_role",
+					banReason: "user_banReason",
+				} 
+			},
+			plugins: [admin()],
+		});
+
+		const tables = getAuthTables(auth.options);
+
+		expect(tables.user.fields.email.fieldName).toBe("user_email");
+
+		expect(tables.user.fields.role).toBeDefined();
+		expect(tables.user.fields.role.fieldName).toBe("user_role");
+
+		expect(tables.user.fields.banReason).toBeDefined();
+		expect(tables.user.fields.banReason.fieldName).toBe("user_banReason");
+
+		expect(tables.user.fields.banned).toBeDefined();
+		expect(tables.user.fields.banExpires).toBeDefined();
 	});
 });

--- a/packages/better-auth/src/db/db.test.ts
+++ b/packages/better-auth/src/db/db.test.ts
@@ -106,7 +106,7 @@ describe("db", async () => {
 					email: "user_email",
 					role: "user_role",
 					banReason: "user_banReason",
-				} 
+				},
 			},
 			plugins: [admin()],
 		});

--- a/packages/better-auth/src/db/get-tables.ts
+++ b/packages/better-auth/src/db/get-tables.ts
@@ -168,10 +168,15 @@ export const getAuthTables = (
 					fieldName: options.user?.fields?.updatedAt || "updatedAt",
 				},
 
-		...(user?.fields? (() => {
+				...(user?.fields
+					? (() => {
 							const result: Record<string, FieldAttribute> = {};
-							const aliasMap = options.user?.fields as Record<string, string> | undefined;
-							for (const [fieldName, fieldConfig] of Object.entries(user.fields)) {
+							const aliasMap = options.user?.fields as
+								| Record<string, string>
+								| undefined;
+							for (const [fieldName, fieldConfig] of Object.entries(
+								user.fields,
+							)) {
 								const mapped = aliasMap?.[fieldName];
 								result[fieldName] = mapped
 									? { ...fieldConfig, fieldName: mapped }

--- a/packages/better-auth/src/db/get-tables.ts
+++ b/packages/better-auth/src/db/get-tables.ts
@@ -167,7 +167,23 @@ export const getAuthTables = (
 					required: true,
 					fieldName: options.user?.fields?.updatedAt || "updatedAt",
 				},
-				...user?.fields,
+
+				...(user?.fields ? (() => {
+					const result: Record<string, any> = {};
+					Object.entries(user.fields).forEach(([fieldName, fieldConfig]) => {
+						const mappedFieldName = options.user?.fields?.[fieldName as keyof typeof options.user.fields];
+
+						if (mappedFieldName) {
+							result[fieldName] = {
+								...fieldConfig,
+								fieldName: mappedFieldName,
+							};
+						} else {
+							result[fieldName] = fieldConfig;
+						}
+					});
+					return result;
+				})() : {}),
 				...options.user?.additionalFields,
 			},
 			order: 1,

--- a/packages/better-auth/src/db/get-tables.ts
+++ b/packages/better-auth/src/db/get-tables.ts
@@ -168,22 +168,18 @@ export const getAuthTables = (
 					fieldName: options.user?.fields?.updatedAt || "updatedAt",
 				},
 
-				...(user?.fields ? (() => {
-					const result: Record<string, any> = {};
-					Object.entries(user.fields).forEach(([fieldName, fieldConfig]) => {
-						const mappedFieldName = options.user?.fields?.[fieldName as keyof typeof options.user.fields];
-
-						if (mappedFieldName) {
-							result[fieldName] = {
-								...fieldConfig,
-								fieldName: mappedFieldName,
-							};
-						} else {
-							result[fieldName] = fieldConfig;
-						}
-					});
-					return result;
-				})() : {}),
+		...(user?.fields? (() => {
+							const result: Record<string, FieldAttribute> = {};
+							const aliasMap = options.user?.fields as Record<string, string> | undefined;
+							for (const [fieldName, fieldConfig] of Object.entries(user.fields)) {
+								const mapped = aliasMap?.[fieldName];
+								result[fieldName] = mapped
+									? { ...fieldConfig, fieldName: mapped }
+									: fieldConfig;
+							}
+							return result;
+						})()
+					: {}),
 				...options.user?.additionalFields,
 			},
 			order: 1,


### PR DESCRIPTION
closes: [4408](https://github.com/better-auth/better-auth/issues/4408)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes admin plugin support for renamed user fields by mapping field aliases in getAuthTables. Ensures admin works with custom column names and keeps banned/banExpires fields available.

- **Bug Fixes**
  - Map options.user.fields aliases onto user field configs when building tables.
  - Add tests covering custom email, role, and banReason mappings and presence of banned/banExpires.

<!-- End of auto-generated description by cubic. -->

