### PR TITLE
fix(stripe): prevent multiple free trials

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -431,12 +431,16 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 					ctx,
 				);
 
-				const alreadyHasTrial = subscription.status === "trialing";
+				const hasEverTrialed = subscriptions.some((s) => {
+					const samePlan = s.plan?.toLowerCase() === plan.name.toLowerCase();
+					const hadTrial =
+						!!(s.trialStart || s.trialEnd) || s.status === "trialing";
+					return samePlan && hadTrial;
+				});
+
 				const freeTrial =
-					!alreadyHasTrial && plan.freeTrial
-						? {
-								trial_period_days: plan.freeTrial.days,
-							}
+					!hasEverTrialed && plan.freeTrial
+						? { trial_period_days: plan.freeTrial.days }
 						: undefined;
 
 				let priceIdToUse: string | undefined = undefined;


### PR DESCRIPTION
### **Description**

#### Problem  
Currently, we only check if the **current subscription** is in the `trialing` state.  
This allows users to receive multiple free trials: once a trialing subscription transitions to `active` or `canceled`, the check no longer detects that a trial was already used.

#### Solution  
- Added a check for **previous subscriptions**.  
- A subscription is considered to have used a trial if it has `trialStart` or `trialEnd` set (or was once `trialing`).  
- This ensures that once a user has had a trial, they cannot start another one, even after canceling.

#### Open Question  
Right now, the check is **per plan** (a user could get one trial per plan).  
Should we instead enforce it **per customer** (only one trial total, regardless of plan)?