### PR TITLE
fix: shouldn't update personal sub when upgrading with org ref id

### DIFF
--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -1,16 +1,16 @@
 import { betterAuth } from "better-auth";
 import {
-	bearer,
-	admin,
-	multiSession,
-	organization,
-	twoFactor,
-	oneTap,
-	oAuthProxy,
-	openAPI,
-	customSession,
-	deviceAuthorization,
-	lastLoginMethod,
+  bearer,
+  admin,
+  multiSession,
+  organization,
+  twoFactor,
+  oneTap,
+  oAuthProxy,
+  openAPI,
+  customSession,
+  deviceAuthorization,
+  lastLoginMethod,
 } from "better-auth/plugins";
 import { reactInvitationEmail } from "./email/invitation";
 import { LibsqlDialect } from "@libsql/kysely-libsql";
@@ -27,228 +27,228 @@ const from = process.env.BETTER_AUTH_EMAIL || "delivered@resend.dev";
 const to = process.env.TEST_EMAIL || "";
 
 const dialect = (() => {
-	if (process.env.USE_MYSQL) {
-		if (!process.env.MYSQL_DATABASE_URL) {
-			throw new Error(
-				"Using MySQL dialect without MYSQL_DATABASE_URL. Please set it in your environment variables.",
-			);
-		}
-		return new MysqlDialect(createPool(process.env.MYSQL_DATABASE_URL || ""));
-	} else {
-		if (process.env.TURSO_DATABASE_URL && process.env.TURSO_AUTH_TOKEN) {
-			return new LibsqlDialect({
-				url: process.env.TURSO_DATABASE_URL,
-				authToken: process.env.TURSO_AUTH_TOKEN,
-			});
-		}
-	}
-	return null;
+  if (process.env.USE_MYSQL) {
+    if (!process.env.MYSQL_DATABASE_URL) {
+      throw new Error(
+        "Using MySQL dialect without MYSQL_DATABASE_URL. Please set it in your environment variables.",
+      );
+    }
+    return new MysqlDialect(createPool(process.env.MYSQL_DATABASE_URL || ""));
+  } else {
+    if (process.env.TURSO_DATABASE_URL && process.env.TURSO_AUTH_TOKEN) {
+      return new LibsqlDialect({
+        url: process.env.TURSO_DATABASE_URL,
+        authToken: process.env.TURSO_AUTH_TOKEN,
+      });
+    }
+  }
+  return null;
 })();
 
 if (!dialect) {
-	throw new Error("No dialect found");
+  throw new Error("No dialect found");
 }
 
 const baseURL: string | undefined =
-	process.env.VERCEL === "1"
-		? process.env.VERCEL_ENV === "production"
-			? process.env.BETTER_AUTH_URL
-			: process.env.VERCEL_ENV === "preview"
-				? `https://${process.env.VERCEL_URL}`
-				: undefined
-		: undefined;
+  process.env.VERCEL === "1"
+    ? process.env.VERCEL_ENV === "production"
+      ? process.env.BETTER_AUTH_URL
+      : process.env.VERCEL_ENV === "preview"
+        ? `https://${process.env.VERCEL_URL}`
+        : undefined
+    : undefined;
 
 const cookieDomain: string | undefined =
-	process.env.VERCEL === "1"
-		? process.env.VERCEL_ENV === "production"
-			? ".better-auth.com"
-			: process.env.VERCEL_ENV === "preview"
-				? `.${process.env.VERCEL_URL}`
-				: undefined
-		: undefined;
+  process.env.VERCEL === "1"
+    ? process.env.VERCEL_ENV === "production"
+      ? ".better-auth.com"
+      : process.env.VERCEL_ENV === "preview"
+        ? `.${process.env.VERCEL_URL}`
+        : undefined
+    : undefined;
 
 export const auth = betterAuth({
-	appName: "Better Auth Demo",
-	baseURL,
-	database: {
-		dialect,
-		type: "sqlite",
-	},
-	emailVerification: {
-		async sendVerificationEmail({ user, url }) {
-			const res = await resend.emails.send({
-				from,
-				to: to || user.email,
-				subject: "Verify your email address",
-				html: `<a href="${url}">Verify your email address</a>`,
-			});
-			console.log(res, user.email);
-		},
-	},
-	account: {
-		accountLinking: {
-			trustedProviders: ["google", "github", "demo-app"],
-		},
-	},
-	emailAndPassword: {
-		enabled: true,
-		async sendResetPassword({ user, url }) {
-			await resend.emails.send({
-				from,
-				to: user.email,
-				subject: "Reset your password",
-				react: reactResetPasswordEmail({
-					username: user.email,
-					resetLink: url,
-				}),
-			});
-		},
-	},
-	socialProviders: {
-		facebook: {
-			clientId: process.env.FACEBOOK_CLIENT_ID || "",
-			clientSecret: process.env.FACEBOOK_CLIENT_SECRET || "",
-		},
-		github: {
-			clientId: process.env.GITHUB_CLIENT_ID || "",
-			clientSecret: process.env.GITHUB_CLIENT_SECRET || "",
-		},
-		google: {
-			clientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",
-			clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
-		},
-		discord: {
-			clientId: process.env.DISCORD_CLIENT_ID || "",
-			clientSecret: process.env.DISCORD_CLIENT_SECRET || "",
-		},
-		microsoft: {
-			clientId: process.env.MICROSOFT_CLIENT_ID || "",
-			clientSecret: process.env.MICROSOFT_CLIENT_SECRET || "",
-		},
-		twitch: {
-			clientId: process.env.TWITCH_CLIENT_ID || "",
-			clientSecret: process.env.TWITCH_CLIENT_SECRET || "",
-		},
-		twitter: {
-			clientId: process.env.TWITTER_CLIENT_ID || "",
-			clientSecret: process.env.TWITTER_CLIENT_SECRET || "",
-		},
-		paypal: {
-			clientId: process.env.PAYPAL_CLIENT_ID || "",
-			clientSecret: process.env.PAYPAL_CLIENT_SECRET || "",
-		},
-	},
-	plugins: [
-		organization({
-			async sendInvitationEmail(data) {
-				await resend.emails.send({
-					from,
-					to: data.email,
-					subject: "You've been invited to join an organization",
-					react: reactInvitationEmail({
-						username: data.email,
-						invitedByUsername: data.inviter.user.name,
-						invitedByEmail: data.inviter.user.email,
-						teamName: data.organization.name,
-						inviteLink:
-							process.env.NODE_ENV === "development"
-								? `http://localhost:3000/accept-invitation/${data.id}`
-								: `${
-										process.env.BETTER_AUTH_URL ||
-										"https://demo.better-auth.com"
-									}/accept-invitation/${data.id}`,
-					}),
-				});
-			},
-		}),
-		twoFactor({
-			otpOptions: {
-				async sendOTP({ user, otp }) {
-					await resend.emails.send({
-						from,
-						to: user.email,
-						subject: "Your OTP",
-						html: `Your OTP is ${otp}`,
-					});
-				},
-			},
-		}),
-		passkey(),
-		openAPI(),
-		bearer(),
-		admin({
-			adminUserIds: ["EXD5zjob2SD6CBWcEQ6OpLRHcyoUbnaB"],
-		}),
-		multiSession(),
-		oAuthProxy(),
-		nextCookies(),
+  appName: "Better Auth Demo",
+  baseURL,
+  database: {
+    dialect,
+    type: "sqlite",
+  },
+  emailVerification: {
+    async sendVerificationEmail({ user, url }) {
+      const res = await resend.emails.send({
+        from,
+        to: to || user.email,
+        subject: "Verify your email address",
+        html: `<a href="${url}">Verify your email address</a>`,
+      });
+      console.log(res, user.email);
+    },
+  },
+  account: {
+    accountLinking: {
+      trustedProviders: ["google", "github", "demo-app"],
+    },
+  },
+  emailAndPassword: {
+    enabled: true,
+    async sendResetPassword({ user, url }) {
+      await resend.emails.send({
+        from,
+        to: user.email,
+        subject: "Reset your password",
+        react: reactResetPasswordEmail({
+          username: user.email,
+          resetLink: url,
+        }),
+      });
+    },
+  },
+  socialProviders: {
+    facebook: {
+      clientId: process.env.FACEBOOK_CLIENT_ID || "",
+      clientSecret: process.env.FACEBOOK_CLIENT_SECRET || "",
+    },
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID || "",
+      clientSecret: process.env.GITHUB_CLIENT_SECRET || "",
+    },
+    google: {
+      clientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+    },
+    discord: {
+      clientId: process.env.DISCORD_CLIENT_ID || "",
+      clientSecret: process.env.DISCORD_CLIENT_SECRET || "",
+    },
+    microsoft: {
+      clientId: process.env.MICROSOFT_CLIENT_ID || "",
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET || "",
+    },
+    twitch: {
+      clientId: process.env.TWITCH_CLIENT_ID || "",
+      clientSecret: process.env.TWITCH_CLIENT_SECRET || "",
+    },
+    twitter: {
+      clientId: process.env.TWITTER_CLIENT_ID || "",
+      clientSecret: process.env.TWITTER_CLIENT_SECRET || "",
+    },
+    paypal: {
+      clientId: process.env.PAYPAL_CLIENT_ID || "",
+      clientSecret: process.env.PAYPAL_CLIENT_SECRET || "",
+    },
+  },
+  plugins: [
+    organization({
+      async sendInvitationEmail(data) {
+        await resend.emails.send({
+          from,
+          to: data.email,
+          subject: "You've been invited to join an organization",
+          react: reactInvitationEmail({
+            username: data.email,
+            invitedByUsername: data.inviter.user.name,
+            invitedByEmail: data.inviter.user.email,
+            teamName: data.organization.name,
+            inviteLink:
+              process.env.NODE_ENV === "development"
+                ? `http://localhost:3000/accept-invitation/${data.id}`
+                : `${
+                    process.env.BETTER_AUTH_URL ||
+                    "https://demo.better-auth.com"
+                  }/accept-invitation/${data.id}`,
+          }),
+        });
+      },
+    }),
+    twoFactor({
+      otpOptions: {
+        async sendOTP({ user, otp }) {
+          await resend.emails.send({
+            from,
+            to: user.email,
+            subject: "Your OTP",
+            html: `Your OTP is ${otp}`,
+          });
+        },
+      },
+    }),
+    passkey(),
+    openAPI(),
+    bearer(),
+    admin({
+      adminUserIds: ["EXD5zjob2SD6CBWcEQ6OpLRHcyoUbnaB"],
+    }),
+    multiSession(),
+    oAuthProxy(),
+    nextCookies(),
 
-		oneTap(),
-		customSession(async (session) => {
-			return {
-				...session,
-				user: {
-					...session.user,
-					dd: "test",
-				},
-			};
-		}),
-		stripe({
-			stripeClient: new Stripe(process.env.STRIPE_KEY || "sk_test_"),
-			stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
-			subscription: {
-				enabled: true,
-				allowReTrialsForDifferentPlans: true,
-				plans: () => {
-					const PRO_PRICE_ID = {
-						default:
-							process.env.STRIPE_PRO_PRICE_ID ??
-							"price_1RoxnRHmTADgihIt4y8c0lVE",
-						annual:
-							process.env.STRIPE_PRO_ANNUAL_PRICE_ID ??
-							"price_1RoxnoHmTADgihItzFvVP8KT",
-					};
-					const PLUS_PRICE_ID = {
-						default:
-							process.env.STRIPE_PLUS_PRICE_ID ??
-							"price_1RoxnJHmTADgihIthZTLmrPn",
-						annual:
-							process.env.STRIPE_PLUS_ANNUAL_PRICE_ID ??
-							"price_1Roxo5HmTADgihItEbJu5llL",
-					};
+    oneTap(),
+    customSession(async (session) => {
+      return {
+        ...session,
+        user: {
+          ...session.user,
+          dd: "test",
+        },
+      };
+    }),
+    stripe({
+      stripeClient: new Stripe(process.env.STRIPE_KEY || "sk_test_"),
+      stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
+      subscription: {
+        enabled: true,
+        allowReTrialsForDifferentPlans: true,
+        plans: () => {
+          const PRO_PRICE_ID = {
+            default:
+              process.env.STRIPE_PRO_PRICE_ID ??
+              "price_1RoxnRHmTADgihIt4y8c0lVE",
+            annual:
+              process.env.STRIPE_PRO_ANNUAL_PRICE_ID ??
+              "price_1RoxnoHmTADgihItzFvVP8KT",
+          };
+          const PLUS_PRICE_ID = {
+            default:
+              process.env.STRIPE_PLUS_PRICE_ID ??
+              "price_1RoxnJHmTADgihIthZTLmrPn",
+            annual:
+              process.env.STRIPE_PLUS_ANNUAL_PRICE_ID ??
+              "price_1Roxo5HmTADgihItEbJu5llL",
+          };
 
-					return [
-						{
-							name: "Plus",
-							priceId: PLUS_PRICE_ID.default,
-							annualDiscountPriceId: PLUS_PRICE_ID.annual,
-							freeTrial: {
-								days: 7,
-							},
-						},
-						{
-							name: "Pro",
-							priceId: PRO_PRICE_ID.default,
-							annualDiscountPriceId: PRO_PRICE_ID.annual,
-							freeTrial: {
-								days: 7,
-							},
-						},
-					];
-				},
-			},
-		}),
-		deviceAuthorization({
-			expiresIn: "3min",
-			interval: "5s",
-		}),
-		lastLoginMethod(),
-	],
-	trustedOrigins: ["exp://"],
-	advanced: {
-		crossSubDomainCookies: {
-			enabled: process.env.NODE_ENV === "production",
-			domain: cookieDomain,
-		},
-	},
+          return [
+            {
+              name: "Plus",
+              priceId: PLUS_PRICE_ID.default,
+              annualDiscountPriceId: PLUS_PRICE_ID.annual,
+              freeTrial: {
+                days: 7,
+              },
+            },
+            {
+              name: "Pro",
+              priceId: PRO_PRICE_ID.default,
+              annualDiscountPriceId: PRO_PRICE_ID.annual,
+              freeTrial: {
+                days: 7,
+              },
+            },
+          ];
+        },
+      },
+    }),
+    deviceAuthorization({
+      expiresIn: "3min",
+      interval: "5s",
+    }),
+    lastLoginMethod(),
+  ],
+  trustedOrigins: ["exp://"],
+  advanced: {
+    crossSubDomainCookies: {
+      enabled: process.env.NODE_ENV === "production",
+      domain: cookieDomain,
+    },
+  },
 });

--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -1,16 +1,16 @@
 import { betterAuth } from "better-auth";
 import {
-  bearer,
-  admin,
-  multiSession,
-  organization,
-  twoFactor,
-  oneTap,
-  oAuthProxy,
-  openAPI,
-  customSession,
-  deviceAuthorization,
-  lastLoginMethod,
+	bearer,
+	admin,
+	multiSession,
+	organization,
+	twoFactor,
+	oneTap,
+	oAuthProxy,
+	openAPI,
+	customSession,
+	deviceAuthorization,
+	lastLoginMethod,
 } from "better-auth/plugins";
 import { reactInvitationEmail } from "./email/invitation";
 import { LibsqlDialect } from "@libsql/kysely-libsql";
@@ -27,228 +27,228 @@ const from = process.env.BETTER_AUTH_EMAIL || "delivered@resend.dev";
 const to = process.env.TEST_EMAIL || "";
 
 const dialect = (() => {
-  if (process.env.USE_MYSQL) {
-    if (!process.env.MYSQL_DATABASE_URL) {
-      throw new Error(
-        "Using MySQL dialect without MYSQL_DATABASE_URL. Please set it in your environment variables.",
-      );
-    }
-    return new MysqlDialect(createPool(process.env.MYSQL_DATABASE_URL || ""));
-  } else {
-    if (process.env.TURSO_DATABASE_URL && process.env.TURSO_AUTH_TOKEN) {
-      return new LibsqlDialect({
-        url: process.env.TURSO_DATABASE_URL,
-        authToken: process.env.TURSO_AUTH_TOKEN,
-      });
-    }
-  }
-  return null;
+	if (process.env.USE_MYSQL) {
+		if (!process.env.MYSQL_DATABASE_URL) {
+			throw new Error(
+				"Using MySQL dialect without MYSQL_DATABASE_URL. Please set it in your environment variables.",
+			);
+		}
+		return new MysqlDialect(createPool(process.env.MYSQL_DATABASE_URL || ""));
+	} else {
+		if (process.env.TURSO_DATABASE_URL && process.env.TURSO_AUTH_TOKEN) {
+			return new LibsqlDialect({
+				url: process.env.TURSO_DATABASE_URL,
+				authToken: process.env.TURSO_AUTH_TOKEN,
+			});
+		}
+	}
+	return null;
 })();
 
 if (!dialect) {
-  throw new Error("No dialect found");
+	throw new Error("No dialect found");
 }
 
 const baseURL: string | undefined =
-  process.env.VERCEL === "1"
-    ? process.env.VERCEL_ENV === "production"
-      ? process.env.BETTER_AUTH_URL
-      : process.env.VERCEL_ENV === "preview"
-        ? `https://${process.env.VERCEL_URL}`
-        : undefined
-    : undefined;
+	process.env.VERCEL === "1"
+		? process.env.VERCEL_ENV === "production"
+			? process.env.BETTER_AUTH_URL
+			: process.env.VERCEL_ENV === "preview"
+				? `https://${process.env.VERCEL_URL}`
+				: undefined
+		: undefined;
 
 const cookieDomain: string | undefined =
-  process.env.VERCEL === "1"
-    ? process.env.VERCEL_ENV === "production"
-      ? ".better-auth.com"
-      : process.env.VERCEL_ENV === "preview"
-        ? `.${process.env.VERCEL_URL}`
-        : undefined
-    : undefined;
+	process.env.VERCEL === "1"
+		? process.env.VERCEL_ENV === "production"
+			? ".better-auth.com"
+			: process.env.VERCEL_ENV === "preview"
+				? `.${process.env.VERCEL_URL}`
+				: undefined
+		: undefined;
 
 export const auth = betterAuth({
-  appName: "Better Auth Demo",
-  baseURL,
-  database: {
-    dialect,
-    type: "sqlite",
-  },
-  emailVerification: {
-    async sendVerificationEmail({ user, url }) {
-      const res = await resend.emails.send({
-        from,
-        to: to || user.email,
-        subject: "Verify your email address",
-        html: `<a href="${url}">Verify your email address</a>`,
-      });
-      console.log(res, user.email);
-    },
-  },
-  account: {
-    accountLinking: {
-      trustedProviders: ["google", "github", "demo-app"],
-    },
-  },
-  emailAndPassword: {
-    enabled: true,
-    async sendResetPassword({ user, url }) {
-      await resend.emails.send({
-        from,
-        to: user.email,
-        subject: "Reset your password",
-        react: reactResetPasswordEmail({
-          username: user.email,
-          resetLink: url,
-        }),
-      });
-    },
-  },
-  socialProviders: {
-    facebook: {
-      clientId: process.env.FACEBOOK_CLIENT_ID || "",
-      clientSecret: process.env.FACEBOOK_CLIENT_SECRET || "",
-    },
-    github: {
-      clientId: process.env.GITHUB_CLIENT_ID || "",
-      clientSecret: process.env.GITHUB_CLIENT_SECRET || "",
-    },
-    google: {
-      clientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
-    },
-    discord: {
-      clientId: process.env.DISCORD_CLIENT_ID || "",
-      clientSecret: process.env.DISCORD_CLIENT_SECRET || "",
-    },
-    microsoft: {
-      clientId: process.env.MICROSOFT_CLIENT_ID || "",
-      clientSecret: process.env.MICROSOFT_CLIENT_SECRET || "",
-    },
-    twitch: {
-      clientId: process.env.TWITCH_CLIENT_ID || "",
-      clientSecret: process.env.TWITCH_CLIENT_SECRET || "",
-    },
-    twitter: {
-      clientId: process.env.TWITTER_CLIENT_ID || "",
-      clientSecret: process.env.TWITTER_CLIENT_SECRET || "",
-    },
-    paypal: {
-      clientId: process.env.PAYPAL_CLIENT_ID || "",
-      clientSecret: process.env.PAYPAL_CLIENT_SECRET || "",
-    },
-  },
-  plugins: [
-    organization({
-      async sendInvitationEmail(data) {
-        await resend.emails.send({
-          from,
-          to: data.email,
-          subject: "You've been invited to join an organization",
-          react: reactInvitationEmail({
-            username: data.email,
-            invitedByUsername: data.inviter.user.name,
-            invitedByEmail: data.inviter.user.email,
-            teamName: data.organization.name,
-            inviteLink:
-              process.env.NODE_ENV === "development"
-                ? `http://localhost:3000/accept-invitation/${data.id}`
-                : `${
-                    process.env.BETTER_AUTH_URL ||
-                    "https://demo.better-auth.com"
-                  }/accept-invitation/${data.id}`,
-          }),
-        });
-      },
-    }),
-    twoFactor({
-      otpOptions: {
-        async sendOTP({ user, otp }) {
-          await resend.emails.send({
-            from,
-            to: user.email,
-            subject: "Your OTP",
-            html: `Your OTP is ${otp}`,
-          });
-        },
-      },
-    }),
-    passkey(),
-    openAPI(),
-    bearer(),
-    admin({
-      adminUserIds: ["EXD5zjob2SD6CBWcEQ6OpLRHcyoUbnaB"],
-    }),
-    multiSession(),
-    oAuthProxy(),
-    nextCookies(),
+	appName: "Better Auth Demo",
+	baseURL,
+	database: {
+		dialect,
+		type: "sqlite",
+	},
+	emailVerification: {
+		async sendVerificationEmail({ user, url }) {
+			const res = await resend.emails.send({
+				from,
+				to: to || user.email,
+				subject: "Verify your email address",
+				html: `<a href="${url}">Verify your email address</a>`,
+			});
+			console.log(res, user.email);
+		},
+	},
+	account: {
+		accountLinking: {
+			trustedProviders: ["google", "github", "demo-app"],
+		},
+	},
+	emailAndPassword: {
+		enabled: true,
+		async sendResetPassword({ user, url }) {
+			await resend.emails.send({
+				from,
+				to: user.email,
+				subject: "Reset your password",
+				react: reactResetPasswordEmail({
+					username: user.email,
+					resetLink: url,
+				}),
+			});
+		},
+	},
+	socialProviders: {
+		facebook: {
+			clientId: process.env.FACEBOOK_CLIENT_ID || "",
+			clientSecret: process.env.FACEBOOK_CLIENT_SECRET || "",
+		},
+		github: {
+			clientId: process.env.GITHUB_CLIENT_ID || "",
+			clientSecret: process.env.GITHUB_CLIENT_SECRET || "",
+		},
+		google: {
+			clientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",
+			clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+		},
+		discord: {
+			clientId: process.env.DISCORD_CLIENT_ID || "",
+			clientSecret: process.env.DISCORD_CLIENT_SECRET || "",
+		},
+		microsoft: {
+			clientId: process.env.MICROSOFT_CLIENT_ID || "",
+			clientSecret: process.env.MICROSOFT_CLIENT_SECRET || "",
+		},
+		twitch: {
+			clientId: process.env.TWITCH_CLIENT_ID || "",
+			clientSecret: process.env.TWITCH_CLIENT_SECRET || "",
+		},
+		twitter: {
+			clientId: process.env.TWITTER_CLIENT_ID || "",
+			clientSecret: process.env.TWITTER_CLIENT_SECRET || "",
+		},
+		paypal: {
+			clientId: process.env.PAYPAL_CLIENT_ID || "",
+			clientSecret: process.env.PAYPAL_CLIENT_SECRET || "",
+		},
+	},
+	plugins: [
+		organization({
+			async sendInvitationEmail(data) {
+				await resend.emails.send({
+					from,
+					to: data.email,
+					subject: "You've been invited to join an organization",
+					react: reactInvitationEmail({
+						username: data.email,
+						invitedByUsername: data.inviter.user.name,
+						invitedByEmail: data.inviter.user.email,
+						teamName: data.organization.name,
+						inviteLink:
+							process.env.NODE_ENV === "development"
+								? `http://localhost:3000/accept-invitation/${data.id}`
+								: `${
+										process.env.BETTER_AUTH_URL ||
+										"https://demo.better-auth.com"
+									}/accept-invitation/${data.id}`,
+					}),
+				});
+			},
+		}),
+		twoFactor({
+			otpOptions: {
+				async sendOTP({ user, otp }) {
+					await resend.emails.send({
+						from,
+						to: user.email,
+						subject: "Your OTP",
+						html: `Your OTP is ${otp}`,
+					});
+				},
+			},
+		}),
+		passkey(),
+		openAPI(),
+		bearer(),
+		admin({
+			adminUserIds: ["EXD5zjob2SD6CBWcEQ6OpLRHcyoUbnaB"],
+		}),
+		multiSession(),
+		oAuthProxy(),
+		nextCookies(),
 
-    oneTap(),
-    customSession(async (session) => {
-      return {
-        ...session,
-        user: {
-          ...session.user,
-          dd: "test",
-        },
-      };
-    }),
-    stripe({
-      stripeClient: new Stripe(process.env.STRIPE_KEY || "sk_test_"),
-      stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
-      subscription: {
-        enabled: true,
-        allowReTrialsForDifferentPlans: true,
-        plans: () => {
-          const PRO_PRICE_ID = {
-            default:
-              process.env.STRIPE_PRO_PRICE_ID ??
-              "price_1RoxnRHmTADgihIt4y8c0lVE",
-            annual:
-              process.env.STRIPE_PRO_ANNUAL_PRICE_ID ??
-              "price_1RoxnoHmTADgihItzFvVP8KT",
-          };
-          const PLUS_PRICE_ID = {
-            default:
-              process.env.STRIPE_PLUS_PRICE_ID ??
-              "price_1RoxnJHmTADgihIthZTLmrPn",
-            annual:
-              process.env.STRIPE_PLUS_ANNUAL_PRICE_ID ??
-              "price_1Roxo5HmTADgihItEbJu5llL",
-          };
+		oneTap(),
+		customSession(async (session) => {
+			return {
+				...session,
+				user: {
+					...session.user,
+					dd: "test",
+				},
+			};
+		}),
+		stripe({
+			stripeClient: new Stripe(process.env.STRIPE_KEY || "sk_test_"),
+			stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
+			subscription: {
+				enabled: true,
+				allowReTrialsForDifferentPlans: true,
+				plans: () => {
+					const PRO_PRICE_ID = {
+						default:
+							process.env.STRIPE_PRO_PRICE_ID ??
+							"price_1RoxnRHmTADgihIt4y8c0lVE",
+						annual:
+							process.env.STRIPE_PRO_ANNUAL_PRICE_ID ??
+							"price_1RoxnoHmTADgihItzFvVP8KT",
+					};
+					const PLUS_PRICE_ID = {
+						default:
+							process.env.STRIPE_PLUS_PRICE_ID ??
+							"price_1RoxnJHmTADgihIthZTLmrPn",
+						annual:
+							process.env.STRIPE_PLUS_ANNUAL_PRICE_ID ??
+							"price_1Roxo5HmTADgihItEbJu5llL",
+					};
 
-          return [
-            {
-              name: "Plus",
-              priceId: PLUS_PRICE_ID.default,
-              annualDiscountPriceId: PLUS_PRICE_ID.annual,
-              freeTrial: {
-                days: 7,
-              },
-            },
-            {
-              name: "Pro",
-              priceId: PRO_PRICE_ID.default,
-              annualDiscountPriceId: PRO_PRICE_ID.annual,
-              freeTrial: {
-                days: 7,
-              },
-            },
-          ];
-        },
-      },
-    }),
-    deviceAuthorization({
-      expiresIn: "3min",
-      interval: "5s",
-    }),
-    lastLoginMethod(),
-  ],
-  trustedOrigins: ["exp://"],
-  advanced: {
-    crossSubDomainCookies: {
-      enabled: process.env.NODE_ENV === "production",
-      domain: cookieDomain,
-    },
-  },
+					return [
+						{
+							name: "Plus",
+							priceId: PLUS_PRICE_ID.default,
+							annualDiscountPriceId: PLUS_PRICE_ID.annual,
+							freeTrial: {
+								days: 7,
+							},
+						},
+						{
+							name: "Pro",
+							priceId: PRO_PRICE_ID.default,
+							annualDiscountPriceId: PRO_PRICE_ID.annual,
+							freeTrial: {
+								days: 7,
+							},
+						},
+					];
+				},
+			},
+		}),
+		deviceAuthorization({
+			expiresIn: "3min",
+			interval: "5s",
+		}),
+		lastLoginMethod(),
+	],
+	trustedOrigins: ["exp://"],
+	advanced: {
+		crossSubDomainCookies: {
+			enabled: process.env.NODE_ENV === "production",
+			domain: cookieDomain,
+		},
+	},
 });

--- a/packages/stripe/src/stripe.test.ts
+++ b/packages/stripe/src/stripe.test.ts
@@ -994,4 +994,112 @@ describe("stripe", async () => {
 			return_url: "http://localhost:3000/dashboard",
 		});
 	});
+
+	it("should not update personal subscription when upgrading with an org referenceId", async () => {
+		const orgId = "org_b67GF32Cljh7u588AuEblmLVobclDRcP";
+
+		const testOptions = {
+			...stripeOptions,
+			stripeClient: _stripe,
+			subscription: {
+				...stripeOptions.subscription,
+				authorizeReference: async () => true,
+			},
+		} as unknown as StripeOptions;
+
+		const testAuth = betterAuth({
+			baseURL: "http://localhost:3000",
+			database: memory,
+			emailAndPassword: { enabled: true },
+			plugins: [stripe(testOptions)],
+		});
+		const testCtx = await testAuth.$context;
+
+		const testAuthClient = createAuthClient({
+			baseURL: "http://localhost:3000",
+			plugins: [bearer(), stripeClient({ subscription: true })],
+			fetchOptions: {
+				customFetchImpl: async (url, init) =>
+					testAuth.handler(new Request(url, init)),
+			},
+		});
+
+		// Sign up and sign in the user
+		const userRes = await testAuthClient.signUp.email(
+			{ ...testUser, email: "org-ref@email.com" },
+			{ throw: true },
+		);
+		const headers = new Headers();
+		await testAuthClient.signIn.email(
+			{ ...testUser, email: "org-ref@email.com" },
+			{ throw: true, onSuccess: setCookieToHeader(headers) },
+		);
+
+		// Create a personal subscription (referenceId = user id)
+		await testAuthClient.subscription.upgrade({
+			plan: "starter",
+			fetchOptions: { headers },
+		});
+
+		const personalSub = await testCtx.adapter.findOne<Subscription>({
+			model: "subscription",
+			where: [{ field: "referenceId", value: userRes.user.id }],
+		});
+		expect(personalSub).toBeTruthy();
+
+		await testCtx.adapter.update({
+			model: "subscription",
+			update: {
+				status: "active",
+				stripeSubscriptionId: "sub_personal_active_123",
+			},
+			where: [{ field: "id", value: personalSub!.id }],
+		});
+
+		mockStripe.subscriptions.list.mockResolvedValue({
+			data: [
+				{
+					id: "sub_personal_active_123",
+					status: "active",
+					items: {
+						data: [
+							{
+								id: "si_1",
+								price: { id: process.env.STRIPE_PRICE_ID_1 },
+								quantity: 1,
+							},
+						],
+					},
+				},
+			],
+		});
+
+		// Attempt to upgrade using an org referenceId
+		const upgradeRes = await testAuthClient.subscription.upgrade({
+			plan: "starter",
+			referenceId: orgId,
+			fetchOptions: { headers },
+		});
+		console.log(upgradeRes);
+
+		// // It should NOT go through billing portal (which would update the personal sub)
+		expect(mockStripe.billingPortal.sessions.create).not.toHaveBeenCalled();
+		expect(upgradeRes.data?.url).toBeDefined();
+
+		const orgSub = await testCtx.adapter.findOne<Subscription>({
+			model: "subscription",
+			where: [{ field: "referenceId", value: orgId }],
+		});
+		expect(orgSub).toMatchObject({
+			referenceId: orgId,
+			status: "incomplete",
+			plan: "starter",
+		});
+
+		const personalAfter = await testCtx.adapter.findOne<Subscription>({
+			model: "subscription",
+			where: [{ field: "id", value: personalSub!.id }],
+		});
+		expect(personalAfter?.status).toBe("active");
+	});
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes upgrades with an organization referenceId so they no longer modify a user’s personal subscription. The upgrade correctly targets the org scope and creates a checkout session for the org.

- **Bug Fixes**
  - When referenceId is provided (and no subscriptionId), fetch the subscription by referenceId instead of falling back to the personal one.
  - Do not default-match an active subscription when no explicit id is provided, preventing accidental updates to personal subs.
  - For org upgrades, skip the billing portal and return a checkout URL.
  - Added tests to verify the personal sub stays active and a new org sub is created/incomplete during org upgrades.

<!-- End of auto-generated description by cubic. -->

