### PR TITLE
chore: update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,9 +46,9 @@ body:
   - type: textarea
     attributes:
       label: System info
-      description: Output of `npx envinfo --system --browsers`
+      description: Output of `npx @better-auth/cli info --json`
       render: bash
-      placeholder: System and browsers
+      placeholder: System and Better Auth info
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the bug report template to use the Better Auth CLI for system info (npx @better-auth/cli info --json) instead of envinfo, so reports include more relevant diagnostics for faster triage. Also updates the placeholder to “System and Better Auth info.”

<!-- End of auto-generated description by cubic. -->

