### PR TITLE
fix(org): list user teams had incorrect path method in jsdoc

### DIFF
--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -215,7 +215,7 @@ export const organizationClient = <CO extends OrganizationClientOptions>(
 		},
 		pathMethods: {
 			"/organization/get-full-organization": "GET",
-			"/organization/list-user-team": "GET",
+			"/organization/list-user-teams": "GET",
 		},
 		atomListeners: [
 			{

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -215,6 +215,7 @@ export const organizationClient = <CO extends OrganizationClientOptions>(
 		},
 		pathMethods: {
 			"/organization/get-full-organization": "GET",
+			"/organization/list-user-team": "GET",
 		},
 		atomListeners: [
 			{

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -491,7 +491,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 		/**
 		 * ### Endpoint
 		 *
-		 * POST `/organization/list-user-teams`
+		 * GET `/organization/list-user-teams`
 		 *
 		 * ### API Methods
 		 *


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Corrected the HTTP method for the “list user teams” endpoint to GET and aligned the client path mapping with the API to prevent incorrect calls.

- **Bug Fixes**
  - Updated JSDoc to: GET /organization/list-user-teams.
  - Added GET path for /organization/list-user-team in the organization client.

<!-- End of auto-generated description by cubic. -->

