### PR TITLE
feat: add support for not in operator

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -7,6 +7,7 @@ import {
 	gt,
 	gte,
 	inArray,
+	notInArray,
 	like,
 	lt,
 	lte,
@@ -163,6 +164,15 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) =>
 						return [inArray(schemaModel[field], w.value)];
 					}
 
+					if (w.operator === "not_in") {
+						if (!Array.isArray(w.value)) {
+							throw new BetterAuthError(
+								`The value for the field "${w.field}" must be an array when using the "not_in" operator.`,
+							);
+						}
+						return [notInArray(schemaModel[field], w.value)];
+					}
+
 					if (w.operator === "contains") {
 						return [like(schemaModel[field], `%${w.value}%`)];
 					}
@@ -212,6 +222,14 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) =>
 								);
 							}
 							return inArray(schemaModel[field], w.value);
+						}
+						if (w.operator === "not_in") {
+							if (!Array.isArray(w.value)) {
+								throw new BetterAuthError(
+									`The value for the field "${w.field}" must be an array when using the "not_in" operator.`,
+								);
+							}
+							return notInArray(schemaModel[field], w.value);
 						}
 						return eq(schemaModel[field], w.value);
 					}),

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -136,6 +136,14 @@ export const kyselyAdapter = (db: Kysely<any>, config?: KyselyAdapterConfig) =>
 							return eb(field, "in", Array.isArray(value) ? value : [value]);
 						}
 
+						if (operator.toLowerCase() === "not_in") {
+							return eb(
+								field,
+								"not in",
+								Array.isArray(value) ? value : [value],
+							);
+						}
+
 						if (operator === "contains") {
 							return eb(field, "like", `%${value}%`);
 						}

--- a/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/state.txt
@@ -1,1 +1,1 @@
-IDLE
+RUNNING

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -51,6 +51,12 @@ export const memoryAdapter = (db: MemoryDB, config?: MemoryAdapterConfig) =>
 							}
 							// @ts-expect-error
 							return value.includes(record[field]);
+						} else if (operator === "not_in") {
+							if (!Array.isArray(value)) {
+								throw new Error("Value must be an array");
+							}
+							// @ts-expect-error
+							return !value.includes(record[field]);
 						} else if (operator === "contains") {
 							return record[field].includes(value);
 						} else if (operator === "starts_with") {

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -177,6 +177,15 @@ export const mongodbAdapter = (db: Db, config?: MongoDBAdapterConfig) => {
 								},
 							};
 							break;
+						case "not_in":
+							condition = {
+								[field]: {
+									$nin: Array.isArray(value)
+										? value.map((v) => serializeID({ field, value: v, model }))
+										: [serializeID({ field, value, model })],
+								},
+							};
+							break;
 						case "gt":
 							condition = { [field]: { $gt: value } };
 							break;

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -70,6 +70,8 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) =>
 						return "endsWith";
 					case "ne":
 						return "not";
+					case "not_in":
+						return "notIn";
 					default:
 						return operator;
 				}

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -380,26 +380,7 @@ async function adapterTest(
 			onTestFailed(async () => {
 				await printDebugLogs();
 			});
-			// const newUser1 = await (await adapter()).create<User>({
-			// 	model: "user",
-			// 	data: {
-			// 		name: "user",
-			// 		email: "test-email1@email.com",
-			// 		emailVerified: true,
-			// 		createdAt: new Date(),
-			// 		updatedAt: new Date(),
-			// 	},
-			// });
-			// const newUser2 = await (await adapter()).create<User>({
-			// 	model: "user",
-			// 	data: {
-			// 		name: "user",
-			// 		email: "test-email2@email.com",
-			// 		emailVerified: true,
-			// 		createdAt: new Date(),
-			// 		updatedAt: new Date(),
-			// 	},
-			// });
+
 			const newUser3 = await (await adapter()).create<User>({
 				model: "user",
 				data: {

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -31,6 +31,8 @@ const adapterTests = {
 	SHOULD_FIND_MANY_WITH_WHERE: "should find many with where",
 	SHOULD_FIND_MANY_WITH_OPERATORS: "should find many with operators",
 	SHOULD_WORK_WITH_REFERENCE_FIELDS: "should work with reference fields",
+	SHOULD_FIND_MANY_WITH_NOT_IN_OPERATOR:
+		"should find many with not in operator",
 	SHOULD_FIND_MANY_WITH_SORT_BY: "should find many with sortBy",
 	SHOULD_FIND_MANY_WITH_LIMIT: "should find many with limit",
 	SHOULD_FIND_MANY_WITH_OFFSET: "should find many with offset",
@@ -369,35 +371,35 @@ async function adapterTest(
 		},
 	);
 
-	test.skipIf(disabledTests?.SHOULD_FIND_MANY_WITH_OPERATORS)(
+	test.skipIf(disabledTests?.SHOULD_FIND_MANY_WITH_NOT_IN_OPERATOR)(
 		`${testPrefix ? `${testPrefix} - ` : ""}${
-			adapterTests.SHOULD_FIND_MANY_WITH_OPERATORS
+			adapterTests.SHOULD_FIND_MANY_WITH_NOT_IN_OPERATOR
 		}`,
 		async ({ onTestFailed }) => {
 			await resetDebugLogs();
 			onTestFailed(async () => {
 				await printDebugLogs();
 			});
-			const newUser1 = await (await adapter()).create<User>({
-				model: "user",
-				data: {
-					name: "user",
-					email: "test-email1@email.com",
-					emailVerified: true,
-					createdAt: new Date(),
-					updatedAt: new Date(),
-				},
-			});
-			const newUser2 = await (await adapter()).create<User>({
-				model: "user",
-				data: {
-					name: "user",
-					email: "test-email2@email.com",
-					emailVerified: true,
-					createdAt: new Date(),
-					updatedAt: new Date(),
-				},
-			});
+			// const newUser1 = await (await adapter()).create<User>({
+			// 	model: "user",
+			// 	data: {
+			// 		name: "user",
+			// 		email: "test-email1@email.com",
+			// 		emailVerified: true,
+			// 		createdAt: new Date(),
+			// 		updatedAt: new Date(),
+			// 	},
+			// });
+			// const newUser2 = await (await adapter()).create<User>({
+			// 	model: "user",
+			// 	data: {
+			// 		name: "user",
+			// 		email: "test-email2@email.com",
+			// 		emailVerified: true,
+			// 		createdAt: new Date(),
+			// 		updatedAt: new Date(),
+			// 	},
+			// });
 			const newUser3 = await (await adapter()).create<User>({
 				model: "user",
 				data: {
@@ -408,18 +410,31 @@ async function adapterTest(
 					updatedAt: new Date(),
 				},
 			});
-			const res = await (await adapter()).findMany<User>({
+			const allUsers = await (await adapter()).findMany<User>({
+				model: "user",
+			});
+			expect(allUsers.length).toBe(6);
+			const usersWithoutNotIn = await (await adapter()).findMany<User>({
 				model: "user",
 				where: [
 					{
 						field: "id",
 						operator: "not_in",
-						value: [newUser1.id, newUser2.id],
+						value: [user.id, newUser3.id],
 					},
 				],
 			});
-			expect(res.length).toBe(1);
-			expect(res[0]?.id).toBe(newUser3.id);
+			expect(usersWithoutNotIn.length).toBe(4);
+			//cleanup
+			await (await adapter()).delete({
+				model: "user",
+				where: [
+					{
+						field: "id",
+						value: newUser3.id,
+					},
+				],
+			});
 		},
 	);
 

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -369,6 +369,60 @@ async function adapterTest(
 		},
 	);
 
+	test.skipIf(disabledTests?.SHOULD_FIND_MANY_WITH_OPERATORS)(
+		`${testPrefix ? `${testPrefix} - ` : ""}${
+			adapterTests.SHOULD_FIND_MANY_WITH_OPERATORS
+		}`,
+		async ({ onTestFailed }) => {
+			await resetDebugLogs();
+			onTestFailed(async () => {
+				await printDebugLogs();
+			});
+			const newUser1 = await (await adapter()).create<User>({
+				model: "user",
+				data: {
+					name: "user",
+					email: "test-email1@email.com",
+					emailVerified: true,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+			const newUser2 = await (await adapter()).create<User>({
+				model: "user",
+				data: {
+					name: "user",
+					email: "test-email2@email.com",
+					emailVerified: true,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+			const newUser3 = await (await adapter()).create<User>({
+				model: "user",
+				data: {
+					name: "user",
+					email: "test-email3email.com",
+					emailVerified: true,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+			const res = await (await adapter()).findMany<User>({
+				model: "user",
+				where: [
+					{
+						field: "id",
+						operator: "not_in",
+						value: [newUser1.id, newUser2.id],
+					},
+				],
+			});
+			expect(res.length).toBe(1);
+			expect(res[0]?.id).toBe(newUser3.id);
+		},
+	);
+
 	test.skipIf(disabledTests?.SHOULD_WORK_WITH_REFERENCE_FIELDS)(
 		`${testPrefix ? `${testPrefix} - ` : ""}${
 			adapterTests.SHOULD_WORK_WITH_REFERENCE_FIELDS

--- a/packages/better-auth/src/types/adapter.ts
+++ b/packages/better-auth/src/types/adapter.ts
@@ -13,6 +13,7 @@ export type Where = {
 		| "gt"
 		| "gte"
 		| "in"
+		| "not_in"
 		| "contains"
 		| "starts_with"
 		| "ends_with"; //eq by default


### PR DESCRIPTION
we currently don't support `not_in` as operator for adapter queries
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add support for the not_in operator across all adapters to allow filtering records that exclude a set of values (e.g., id not in [...]). This enables consistent query behavior in find/findMany across databases.

- **New Features**
  - Drizzle: maps to notInArray; validates value is an array and throws otherwise.
  - Kysely: maps to "not in" (coerces single value to array).
  - MongoDB: maps to $nin with proper ID serialization.
  - Prisma: maps to notIn in operator translation.
  - Types: adds "not_in" to Where.operator.
  - Tests: adds findMany test case for excluding IDs.

<!-- End of auto-generated description by cubic. -->

