### PR TITLE
fix(mcp): remove duplicate `/api/auth` from `wwwAuthenticateValue` and properly format the header

### DIFF
--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -57,7 +57,7 @@ The **MCP** plugin lets your app act as an OAuth provider for MCP clients. It ha
 
 ### OAuth Discovery Metadata
 
-Add a route to expose OAuth metadata for MCP clients:
+Better Auth already handles the `/api/auth/.well-known/oauth-authorization-server` route automatically but some client may fail to parse the `WWW-Authenticate` header and default to `/.well-known/oauth-authorization-server` (this can happen, for example, if your CORS configuration doesn't expose the `WWW-Authenticate`). For this reason it's better to add a route to expose OAuth metadata for MCP clients:
 
 ```ts title=".well-known/oauth-authorization-server/route.ts"
 import { oAuthDiscoveryMetadata } from "better-auth/plugins";
@@ -68,9 +68,9 @@ export const GET = oAuthDiscoveryMetadata(auth);
 
 ### OAuth Protected Resource Metadata
 
-Add a route to expose protected resource metadata for MCP clients:
+Better Auth already handles the `/api/auth/.well-known/oauth-protected-resource` route automatically but some client may fail to parse the `WWW-Authenticate` header and default to `/.well-known/oauth-protected-resource` (this can happen, for example, if your CORS configuration doesn't expose the `WWW-Authenticate`). For this reason it's better to add a route to expose OAuth metadata for MCP clients:
 
-```ts title=".well-known/oauth-authorization-server/route.ts"
+```ts title=".well-known/oauth-protected-resource/route.ts"
 import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
 import { auth } from "@/lib/auth";
 

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -947,7 +947,7 @@ export const withMcpAuth = <
 		const session = await auth.api.getMcpSession({
 			headers: req.headers,
 		});
-		const wwwAuthenticateValue = `Bearer resource_metadata=${baseURL}/api/auth/.well-known/oauth-protected-resource`;
+		const wwwAuthenticateValue = `Bearer resource_metadata="${baseURL}/.well-known/oauth-protected-resource"`;
 		if (!session) {
 			return Response.json(
 				{
@@ -963,6 +963,8 @@ export const withMcpAuth = <
 					status: 401,
 					headers: {
 						"WWW-Authenticate": wwwAuthenticateValue,
+						// we also add this headers otherwise browser based clients will not be able to read the `www-authenticate` header
+						"Access-Control-Expose-Headers": "WWW-Authenticate",
 					},
 				},
 			);

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -531,7 +531,7 @@ describe("mcp", async () => {
 		it("should return 401 if the request is not authenticated returning the right WWW-Authenticate header", async ({
 			expect,
 		}) => {
-			// we test the handle using a newly instantiated request instead of the server since it's not handled by
+			// Test the handler using a newly instantiated Request instead of the server, since this route isn't handled by the server
 			const response = await withMcpAuth(auth, async () => {
 				// it will never be reached since the request is not authenticated
 				return new Response("unnecessary");


### PR DESCRIPTION
While implementing Auth for MCP using better auth I've found some weirdness in the whole implementation.

1. The header is not properly formatted. [Per specification](https://datatracker.ietf.org/doc/html/rfc9728#section-5.1) the header should be in the format `Bearer resource_metadata="URL_TO_RESOURCE"`...currently the `withMcpAuth` helper returns `Bearer resource_metadata=URL_TO_RESOURCE` (notice the missing quotes).
2. The `wwwAuthenticateValue` adds `/api/auth` after baseURL but `getBaseUrl` does the same. This means the resource is actually a pretty funky looking `/api/auth/api/auth/.well-known/oauth-protected-resource`.
3. In browser based clients (like the mcp inspector for instance) because of CORS headers are not exposed so the client can't read the `www-authenticate` header and so they default to `/.well-known/oauth-protected-resource` (notice the missing `/api/auth`. I've added the CORS header on the request so that this shouldn't happen again.
4. Always referring to the same point as before I was pretty puzzled because the documentation tells the user to add a route for `/.well-known/oauth-protected-resource` but technically the resource should've been handled by the library handler by default (see https://github.com/better-auth/better-auth/blob/9833a7edeef38e6d287badc4b8d11fe598ad55be/packages/better-auth/src/plugins/mcp/index.ts#L175-L205). I think the reason above is the reason those parts of the docs were added. So i guess those parts are not actually necessary if we merge this but maybe some funky CORS configuration could still lead the clients to do that default request so it might be a good idea to add them nonetheless.

I've also added a test for the `withMcpAuth` helper, since it doesn't really need a server running I just used a custom made request and asserted on the response. I didn't do that for the authenticated version because it's not fully clear to me how I could "authenticate" for MCP...I tried to pass the `headers` but it still didn't found any MCP session.

That said I'm willing to make any change to this. I'm developing a [library to build mcp servers](https://github.com/paoloricciuti/tmcp) (which btw would be a good fit for `better-auth` since it uses WebRequest and WebResponse and you users would not need `mcp-handler` to interface with it like the official sdk) and I have built some helpers for the authentication but I would very much refer to `better-auth` instead that will definitely do a better (pun intended) job than me.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the MCP WWW-Authenticate challenge to use the correct Bearer format, point to the right protected resource URL, and make the header readable by browser clients. Also updates docs and adds a test to prevent regressions.

- **Bug Fixes**
  - Use Bearer resource_metadata="URL" (adds quotes) per RFC 9728.
  - Remove duplicate /api/auth; URL now resolves to /.well-known/oauth-protected-resource correctly.
  - Expose WWW-Authenticate via Access-Control-Expose-Headers on 401 responses for browser clients.

<!-- End of auto-generated description by cubic. -->

