### PR TITLE
Origin/feat/openapi 422 response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ android/
 
 playwright-report/
 test-results/
+
+.pnpm-store
+.devcontainer

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -135,7 +135,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 							},
 						},
 						"422": {
-							description: "Unprocessable Content. User already exists or failed to create user.",
+							description: "Unprocessable Entity. User already exists or failed to create user.",
 							content: {
 								"application/json": {
 									schema: {

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -134,6 +134,21 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 								},
 							},
 						},
+						"422": {
+							description: "Unprocessable Content. User already exists or failed to create user.",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											message: {
+												type: "string",
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -689,6 +689,21 @@ export const changeEmail = createAuthEndpoint(
 							},
 						},
 					},
+					"422": {
+						description: "Unprocessable Content. Email already exists",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										message: {
+											type: "string",
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -690,7 +690,7 @@ export const changeEmail = createAuthEndpoint(
 						},
 					},
 					"422": {
-						description: "Unprocessable Content. Email already exists",
+						description: "Unprocessable Entity. Email already exists",
 						content: {
 							"application/json": {
 								schema: {

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -202,7 +202,7 @@ export const username = (options?: UsernameOptions) => {
 									},
 								},
 								422: {
-									description: "Unprocessable Content. Validation error",
+									description: "Unprocessable Entity. Validation error",
 									content: {
 										"application/json": {
 											schema: {

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -201,6 +201,21 @@ export const username = (options?: UsernameOptions) => {
 										},
 									},
 								},
+								422: {
+									description: "Unprocessable Content. Validation error",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													message: {
+														type: "string",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
This adds the `422 Unprocessable Entity` response to the OpenAPI specification for the following endpoints:
- `/sign-up/email`
- `/update-user`
- `/sign-in/username`

The `422 Unprocessable Entity` response is used to indicate that the server understood the request but was unable to process it due to semantic errors, such as:
- Attempting to sign up with an existing email.
- Attempting to sign up with an invalid username.
- Other validation errors that fall under the UNPROCESSABLE_ENTITY APIError.

#### Changes Made

1. Updated the OpenAPI spec to include the `422` response for the endpoints that include the `422 Unprocessable Entity` responses.

#### Documentation Reference

For more details on the `422 Unprocessable Content` status code, see the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/422).