### PR TITLE
feat: expose passkey to plugins

### DIFF
--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -11,6 +11,7 @@ import {
 	customSession,
 	deviceAuthorization,
 	lastLoginMethod,
+	passkey,
 } from "better-auth/plugins";
 import { reactInvitationEmail } from "./email/invitation";
 import { LibsqlDialect } from "@libsql/kysely-libsql";
@@ -19,7 +20,6 @@ import { resend } from "./email/resend";
 import { MysqlDialect } from "kysely";
 import { createPool } from "mysql2/promise";
 import { nextCookies } from "better-auth/next-js";
-import { passkey } from "better-auth/plugins/passkey";
 import { stripe } from "@better-auth/stripe";
 import { Stripe } from "stripe";
 

--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -41,7 +41,7 @@ The passkey plugin implementation is powered by [SimpleWebAuthn](https://simplew
            
         ```ts title="auth.ts"
         import { betterAuth } from "better-auth"
-        import { passkey } from "better-auth/plugins/passkey" // [!code highlight]
+        import { passkey } from "better-auth/plugins" // [!code highlight]
 
         export const auth = betterAuth({
             plugins: [ // [!code highlight]

--- a/packages/better-auth/src/plugins/index.ts
+++ b/packages/better-auth/src/plugins/index.ts
@@ -26,3 +26,4 @@ export * from "./mcp";
 export * from "./siwe";
 export * from "./device-authorization";
 export * from "./last-login-method";
+export * from "./passkey";

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -97,7 +97,7 @@ export const supportedPlugins = [
 		id: "passkey",
 		name: "passkey",
 		clientName: "passkeyClient",
-		path: `better-auth/plugins/passkey`,
+		path: `better-auth/plugins`,
 		clientPath: "better-auth/client/plugins",
 	},
 	{

--- a/packages/cli/test/generate-all-db.test.ts
+++ b/packages/cli/test/generate-all-db.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { generateDrizzleSchema } from "../src/generators/drizzle";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { twoFactor, username } from "better-auth/plugins";
-import { passkey } from "better-auth/plugins/passkey";
+import { passkey } from "better-auth/plugins";
 import type { BetterAuthOptions } from "better-auth";
 
 describe("generate drizzle schema for all databases", async () => {

--- a/packages/cli/test/generate-all-db.test.ts
+++ b/packages/cli/test/generate-all-db.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { generateDrizzleSchema } from "../src/generators/drizzle";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { twoFactor, username } from "better-auth/plugins";
-import { passkey } from "better-auth/plugins";
+import { twoFactor, username, passkey } from "better-auth/plugins";
 import type { BetterAuthOptions } from "better-auth";
 
 describe("generate drizzle schema for all databases", async () => {


### PR DESCRIPTION
This PR exposes the Passkey authentication method to align with other plugins.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Exposed the Passkey plugin via better-auth/plugins to match other plugins and simplify imports. Updated demo, docs, CLI, and tests to use the new path.

- **New Features**
  - Exported passkey from better-auth/plugins for direct import.

- **Migration**
  - Replace imports of "better-auth/plugins/passkey" with "better-auth/plugins".

<!-- End of auto-generated description by cubic. -->

