### PR TITLE
docs(generate-secret): update selector to target specific code span

### DIFF
--- a/docs/components/generate-secret.tsx
+++ b/docs/components/generate-secret.tsx
@@ -12,7 +12,7 @@ export const GenerateSecret = () => {
 				size="sm"
 				disabled={generated}
 				onClick={() => {
-					const elements = document.getElementsByTagName("code"); // or any other selector
+					const elements = document.querySelectorAll("pre code span.line span");
 					for (let i = 0; i < elements.length; i++) {
 						if (elements[i].textContent === "BETTER_AUTH_SECRET=") {
 							elements[i].textContent =


### PR DESCRIPTION
Updated GenerateSecret to use 
`querySelectorAll("pre code span.line span")` 
instead of `getElementsByTagName("code")` 
so it correctly targets line spans in code blocks.

**Before**
<img width="785" height="160" alt="before" src="https://github.com/user-attachments/assets/c918e18d-b474-407e-bf0b-b4b7959a5b59" />

**After**
<img width="870" height="170" alt="after" src="https://github.com/user-attachments/assets/4cb764a3-de85-4621-b657-3400ccb4f32b" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated GenerateSecret to target code line spans precisely, so only the secret line is updated instead of whole code blocks. Fixes incorrect replacements in docs and places the generated secret in the right spot.

- **Bug Fixes**
  - Use querySelectorAll("pre code span.line span") instead of getElementsByTagName("code") to select only line spans.

<!-- End of auto-generated description by cubic. -->

