### PR TITLE
fix: properly generate OpenAPI schema for nested ZodObject and ZodOptional

### DIFF
--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -108,13 +108,12 @@ function getParameters(options: EndpointOptions) {
 					name: key,
 					in: "query",
 					schema: {
-						type: getTypeFromZodType(value as ZodType<any>),
+						...processZodType(value as ZodType<any>),
 						...("minLength" in value && (value as any).minLength
 							? {
 									minLength: (value as any).minLength as number,
 								}
 							: {}),
-						description: (value as any).description,
 					},
 				});
 			}
@@ -139,10 +138,7 @@ function getRequestBody(options: EndpointOptions): any {
 		const required: string[] = [];
 		Object.entries(shape).forEach(([key, value]) => {
 			if (value instanceof ZodType) {
-				properties[key] = {
-					type: getTypeFromZodType(value as ZodType<any>),
-					description: (value as any).description,
-				};
+				properties[key] = processZodType(value as ZodType<any>);
 				if (!(value instanceof z.ZodOptional)) {
 					required.push(key);
 				}
@@ -167,6 +163,48 @@ function getRequestBody(options: EndpointOptions): any {
 		};
 	}
 	return undefined;
+}
+
+function processZodType(zodType: ZodType<any>): any {
+	const baseSchema = {
+		type: getTypeFromZodType(zodType),
+		description: (zodType as any).description,
+	};
+
+	if (zodType instanceof ZodObject) {
+		const shape = (zodType as any).shape;
+		if (shape) {
+			const properties: Record<string, any> = {};
+			const required: string[] = [];
+			Object.entries(shape).forEach(([key, value]) => {
+				if (value instanceof ZodType) {
+					properties[key] = processZodType(value as ZodType<any>);
+					if (!(value instanceof z.ZodOptional)) {
+						required.push(key);
+					}
+				}
+			});
+			return {
+				type: "object",
+				properties,
+				...(required.length > 0 ? { required } : {}),
+				description: (zodType as any).description,
+			};
+		}
+	}
+
+	if (zodType instanceof ZodOptional) {
+		const innerType = (zodType as any)._def.innerType;
+		if (innerType instanceof ZodObject) {
+			const properties = 	processZodType(innerType)
+			return {
+				...properties,
+				nullable: true,
+			};
+		}
+	}
+
+	return baseSchema;
 }
 
 function getResponse(responses?: Record<string, any>) {

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -196,7 +196,7 @@ function processZodType(zodType: ZodType<any>): any {
 	if (zodType instanceof ZodOptional) {
 		const innerType = (zodType as any)._def.innerType;
 		if (innerType instanceof ZodObject) {
-			const properties = 	processZodType(innerType)
+			const properties = processZodType(innerType);
 			return {
 				...properties,
 				nullable: true,

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -58,25 +58,30 @@ describe("open-api", async (it) => {
 	it("should properly handle nested objects in request body schema", async () => {
 		const schema = await auth.api.generateOpenAPISchema();
 		const paths = schema.paths as Record<string, any>;
-		
+
 		const signInSocialPath = paths["/sign-in/social"];
 		expect(signInSocialPath).toBeDefined();
-		
+
 		const requestBody = signInSocialPath.post.requestBody;
 		expect(requestBody).toBeDefined();
-		
-		const schema_properties = requestBody.content["application/json"].schema.properties;
+
+		const schema_properties =
+			requestBody.content["application/json"].schema.properties;
 		expect(schema_properties.idToken).toBeDefined();
-		console.log({schema_properties})	
+		console.log({ schema_properties });
 		expect(schema_properties.idToken.type).toBe("object");
 		expect(schema_properties.idToken.properties).toBeDefined();
 		expect(schema_properties.idToken.properties.token).toBeDefined();
 		expect(schema_properties.idToken.properties.token.type).toBe("string");
 		expect(schema_properties.idToken.properties.accessToken).toBeDefined();
-		expect(schema_properties.idToken.properties.accessToken.type).toBe("string");
+		expect(schema_properties.idToken.properties.accessToken.type).toBe(
+			"string",
+		);
 		expect(schema_properties.idToken.properties.refreshToken).toBeDefined();
-		expect(schema_properties.idToken.properties.refreshToken.type).toBe("string");
-		
+		expect(schema_properties.idToken.properties.refreshToken.type).toBe(
+			"string",
+		);
+
 		expect(schema_properties.idToken.required).toContain("token");
 		expect(schema_properties.idToken.required).not.toContain("accessToken");
 		expect(schema_properties.idToken.required).not.toContain("refreshToken");

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -68,7 +68,6 @@ describe("open-api", async (it) => {
 		const schema_properties =
 			requestBody.content["application/json"].schema.properties;
 		expect(schema_properties.idToken).toBeDefined();
-		console.log({ schema_properties });
 		expect(schema_properties.idToken.type).toBe("object");
 		expect(schema_properties.idToken.properties).toBeDefined();
 		expect(schema_properties.idToken.properties.token).toBeDefined();

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -54,4 +54,31 @@ describe("open-api", async (it) => {
 		expect(schemas["User"].required).toContain("role");
 		expect(schemas["User"].required).not.toContain("preferences");
 	});
+
+	it("should properly handle nested objects in request body schema", async () => {
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, any>;
+		
+		const signInSocialPath = paths["/sign-in/social"];
+		expect(signInSocialPath).toBeDefined();
+		
+		const requestBody = signInSocialPath.post.requestBody;
+		expect(requestBody).toBeDefined();
+		
+		const schema_properties = requestBody.content["application/json"].schema.properties;
+		expect(schema_properties.idToken).toBeDefined();
+		console.log({schema_properties})	
+		expect(schema_properties.idToken.type).toBe("object");
+		expect(schema_properties.idToken.properties).toBeDefined();
+		expect(schema_properties.idToken.properties.token).toBeDefined();
+		expect(schema_properties.idToken.properties.token.type).toBe("string");
+		expect(schema_properties.idToken.properties.accessToken).toBeDefined();
+		expect(schema_properties.idToken.properties.accessToken.type).toBe("string");
+		expect(schema_properties.idToken.properties.refreshToken).toBeDefined();
+		expect(schema_properties.idToken.properties.refreshToken.type).toBe("string");
+		
+		expect(schema_properties.idToken.required).toContain("token");
+		expect(schema_properties.idToken.required).not.toContain("accessToken");
+		expect(schema_properties.idToken.required).not.toContain("refreshToken");
+	});
 });


### PR DESCRIPTION
closes #4485
Fixes OpenAPI schema generation to properly handle nested Zod objects as well ZodOptional after zod upgrade by recursively processing object properties instead of treating them as simple types. This resolves the issue where the idToken field was incorrectly documented as a string instead of an object with nested properties (token, accessToken, refreshToken).
before 
<img width="631" height="438" alt="Screenshot 2025-09-06 at 8 56 32 PM" src="https://github.com/user-attachments/assets/aa00b3f1-b90f-4d27-8ae1-caf52ab43393" />
after 
<img width="615" height="595" alt="Screenshot 2025-09-06 at 8 56 13 PM" src="https://github.com/user-attachments/assets/dfd7501c-f174-4e0b-bda1-8db73a36b7dd" />
