### PR TITLE
fix: Cognito documentation

### DIFF
--- a/docs/content/docs/authentication/cognito.mdx
+++ b/docs/content/docs/authentication/cognito.mdx
@@ -28,8 +28,7 @@ description: Amazon Cognito provider setup and usage.
     Configure the `cognito` key in `socialProviders` key of your `auth` instance.
 
     ```ts title="auth.ts"
-    import { betterAuth } from "better-auth"
-    import { type CognitoOptions } from 'better-auth/social-providers';
+    import { betterAuth } from "better-auth";
 
     export const auth = betterAuth({
       socialProviders: {
@@ -39,7 +38,7 @@ description: Amazon Cognito provider setup and usage.
           domain: process.env.COGNITO_DOMAIN as string, // e.g. "your-app.auth.us-east-1.amazoncognito.com" [!code highlight]
           region: process.env.COGNITO_REGION as string, // e.g. "us-east-1" [!code highlight]
           userPoolId: process.env.COGNITO_USERPOOL_ID as string, // [!code highlight]
-        } as CognitoOptions,
+        },
       },
     })
     ```

--- a/docs/content/docs/authentication/cognito.mdx
+++ b/docs/content/docs/authentication/cognito.mdx
@@ -25,20 +25,21 @@ description: Amazon Cognito provider setup and usage.
 
   <Step>
     ### Configure the provider
-    Import the Cognito provider and pass it to the `providers` option of your `auth` instance.
+    Configure the `cognito` key in `socialProviders` key of your `auth` instance.
 
     ```ts title="auth.ts"
     import { betterAuth } from "better-auth"
+    import { type CognitoOptions } from 'better-auth/social-providers';
 
     export const auth = betterAuth({
-      socialProvider: {
-        cognito({
+      socialProviders: {
+        cognito: {
           clientId: process.env.COGNITO_CLIENT_ID as string, // [!code highlight]
           clientSecret: process.env.COGNITO_CLIENT_SECRET as string, // [!code highlight]
           domain: process.env.COGNITO_DOMAIN as string, // e.g. "your-app.auth.us-east-1.amazoncognito.com" [!code highlight]
           region: process.env.COGNITO_REGION as string, // e.g. "us-east-1" [!code highlight]
           userPoolId: process.env.COGNITO_USERPOOL_ID as string, // [!code highlight]
-        }),
+        } as CognitoOptions,
       },
     })
     ```


### PR DESCRIPTION
The Cognito documentation contains invalid code snippets.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the Cognito docs to match the current API and prevent copy/paste setup errors. The example now uses socialProviders.cognito with CognitoOptions instead of the outdated socialProvider + cognito(...) call.

<!-- End of auto-generated description by cubic. -->

