### PR TITLE
fix(stripe): properly resolve plans by lookup keys

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -24,7 +24,7 @@ import type {
 	StripePlan,
 	Subscription,
 } from "./types";
-import { getPlanByName, getPlanByPriceId, getPlans } from "./utils";
+import { getPlanByName, getPlanByPriceInfo, getPlans } from "./utils";
 import { getSchema } from "./schema";
 
 const STRIPE_ERROR_CODES = {
@@ -994,9 +994,10 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							.then((res) => res.data[0]);
 
 						if (stripeSubscription) {
-							const plan = await getPlanByPriceId(
+							const plan = await getPlanByPriceInfo(
 								options,
-								stripeSubscription.items.data[0]?.plan.id,
+								stripeSubscription.items.data[0]?.price.id,
+								stripeSubscription.items.data[0]?.price.lookup_key,
 							);
 
 							if (plan && subscription) {

--- a/packages/stripe/src/utils.ts
+++ b/packages/stripe/src/utils.ts
@@ -6,14 +6,19 @@ export async function getPlans(options: StripeOptions) {
 		: options.subscription?.plans;
 }
 
-export async function getPlanByPriceId(
+export async function getPlanByPriceInfo(
 	options: StripeOptions,
 	priceId: string,
+	priceLookupKey: string | null,
 ) {
 	return await getPlans(options).then((res) =>
 		res?.find(
 			(plan) =>
-				plan.priceId === priceId || plan.annualDiscountPriceId === priceId,
+				plan.priceId === priceId ||
+				plan.annualDiscountPriceId === priceId ||
+				(priceLookupKey &&
+					(plan.lookupKey === priceLookupKey ||
+						plan.annualDiscountLookupKey === priceLookupKey)),
 		),
 	);
 }


### PR DESCRIPTION
the previous behaviour would ignore all events for packages with lookup keys instead of price ids

`getPlanByPriceId(options, stripeSubscription.items.data[0]?.plan.id);` in index.ts was also incorrect because a price id was expected, but a plan id provided.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix plan resolution in Stripe to support price lookup keys and use the correct price.id, so checkout and subscription events map to the right plan. This restores event handling for packages using lookup keys.

- **Bug Fixes**
  - Replaced getPlanByPriceId with getPlanByPriceInfo(priceId, lookupKey) and updated callers in hooks and index.
  - Corrected index.ts to pass price.id instead of plan.id.
  - Plan matching now checks priceId, annualDiscountPriceId, lookupKey, and annualDiscountLookupKey.

<!-- End of auto-generated description by cubic. -->

