### PR TITLE
fix: revert set default `iat` for `/token` endpoint

### DIFF
--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -99,6 +99,7 @@ export async function getJwtToken(
 	return await signJWT(ctx, {
 		options,
 		payload: {
+			iat: Math.floor(Date.now() / 1000),
 			...payload,
 			sub:
 				(await options?.jwt?.getSubject?.(ctx.context.session!)) ??


### PR DESCRIPTION
Revert, return missing `iat` claim from token endpoint.

`iat` itself is an optional claim, hense **SHOULD NOT** be put in the `signJWT` function.

Addresses @erquhart [comment](https://github.com/better-auth/better-auth/pull/4074#issuecomment-3263875308) on PR #4074