### PR TITLE
fix: respect allow different email linking option on callbacks

### DIFF
--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -136,7 +136,7 @@ export const callbackOAuth = createAuthEndpoint(
 				userInfo.email !== link.email &&
 				c.context.options.account?.accountLinking?.allowDifferentEmails !== true
 			) {
-				return redirectOnError("different_emails_not_allowed");
+				return redirectOnError("email_doesn't_match");
 			}
 
 			const existingAccount = await c.context.internalAdapter.findAccount(

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -132,6 +132,13 @@ export const callbackOAuth = createAuthEndpoint(
 				return redirectOnError("unable_to_link_account");
 			}
 
+			if (
+				userInfo.email !== link.email &&
+				c.context.options.account?.accountLinking?.allowDifferentEmails !== true
+			) {
+				return redirectOnError("different_emails_not_allowed");
+			}
+
 			const existingAccount = await c.context.internalAdapter.findAccount(
 				String(userInfo.id),
 			);


### PR DESCRIPTION
closes #4503 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed OAuth account linking to respect the accountLinking.allowDifferentEmails option. When the provider email and the account email differ and the option isn’t enabled, linking is blocked and the flow redirects with different_emails_not_allowed.

<!-- End of auto-generated description by cubic. -->

