### PR TITLE
fix(Tiktok provider): remove client_secrect from authorizationUrl

### DIFF
--- a/packages/better-auth/src/social-providers/tiktok.ts
+++ b/packages/better-auth/src/social-providers/tiktok.ts
@@ -136,9 +136,7 @@ export const tiktok = (options: TiktokOptions) => {
 			return new URL(
 				`https://www.tiktok.com/v2/auth/authorize?scope=${_scopes.join(
 					",",
-				)}&response_type=code&client_key=${options.clientKey}&client_secret=${
-					options.clientSecret
-				}&redirect_uri=${encodeURIComponent(
+				)}&response_type=code&client_key=${options.clientKey}&redirect_uri=${encodeURIComponent(
 					options.redirectURI || redirectURI,
 				)}&state=${state}`,
 			);


### PR DESCRIPTION
This PR is based on issue https://github.com/better-auth/better-auth/issues/4509

client secret is not only not needed in authorization url. it is dangerous to send it to client