### PR TITLE
docs: fix the wildcard route of hono

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -294,7 +294,7 @@ Create a new file or route in your framework's designated catch-all route handle
 
     const app = new Hono();
 
-    app.on(["POST", "GET"], "/api/auth/**", (c) => auth.handler(c.req.raw));
+    app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
 
     serve(app);
     ```


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Corrected the Hono catch-all route in the installation docs to use /api/auth/* instead of /api/auth/**. This ensures the example matches /api/auth and nested paths for POST/GET requests.

<!-- End of auto-generated description by cubic. -->

