### PR TITLE
fix: refresh secondary storage sessions on user update

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -305,4 +305,63 @@ describe("Email Verification Secondary Storage", async () => {
 		expect(session.data?.user.email).toBe("new@email.com");
 		expect(session.data?.user.emailVerified).toBe(false);
 	});
+
+	it("should set emailVerified on all sessions", async () => {
+		const sampleUser = {
+			name: "sampler",
+			email: "sample@sample.com",
+			password: "samplesssss",
+		};
+
+		await client.signUp.email({
+			name: sampleUser.name,
+			email: sampleUser.email,
+			password: sampleUser.password,
+		});
+
+		const secondSignInHeaders = new Headers();
+		await client.signIn.email(
+			{
+				email: sampleUser.email,
+				password: sampleUser.password,
+			},
+			{
+				onSuccess: cookieSetter(secondSignInHeaders),
+			},
+		);
+
+		await auth.api.sendVerificationEmail({
+			body: {
+				email: sampleUser.email,
+			},
+		});
+
+		const headers = new Headers();
+		await client.verifyEmail({
+			query: {
+				token,
+			},
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(session.data?.user.email).toBe(sampleUser.email);
+		expect(session.data?.user.emailVerified).toBe(true);
+
+		const secondSignInSession = await client.getSession({
+			fetchOptions: {
+				headers: secondSignInHeaders,
+			},
+		});
+
+		expect(secondSignInSession.data?.user.email).toBe(sampleUser.email);
+		expect(secondSignInSession.data?.user.emailVerified).toBe(true);
+	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -34,6 +34,41 @@ export const createInternalAdapter = (
 	const { createWithHooks, updateWithHooks, updateManyWithHooks } =
 		getWithHooks(adapter, ctx);
 
+	async function refreshUserSessions(user: User) {
+		if (!secondaryStorage) return;
+
+		const listRaw = await secondaryStorage.get(`active-sessions-${user.id}`);
+		if (!listRaw) return;
+
+		const now = Date.now();
+		const list =
+			safeJSONParse<{ token: string; expiresAt: number }[]>(listRaw) || [];
+		const validSessions = list.filter((s) => s.expiresAt > now);
+
+		await Promise.all(
+			validSessions.map(async ({ token }) => {
+				const cached = await secondaryStorage.get(token);
+				if (!cached) return;
+				const parsed = safeJSONParse<{ session: Session; user: User }>(cached);
+				if (!parsed) return;
+
+				const sessionTTL = Math.max(
+					Math.floor(new Date(parsed.session.expiresAt).getTime() - now) / 1000,
+					0,
+				);
+
+				await secondaryStorage.set(
+					token,
+					JSON.stringify({
+						session: parsed.session,
+						user,
+					}),
+					sessionTTL,
+				);
+			}),
+		);
+	}
+
 	return {
 		createOAuthUser: async (
 			user: Omit<User, "id" | "createdAt" | "updatedAt">,
@@ -744,41 +779,7 @@ export const createInternalAdapter = (
 				undefined,
 				context,
 			);
-			if (secondaryStorage && user) {
-				const listRaw = await secondaryStorage.get(`active-sessions-${userId}`);
-				if (listRaw) {
-					const now = Date.now();
-					const list =
-						safeJSONParse<{ token: string; expiresAt: number }[]>(listRaw) ||
-						[];
-					const validSessions = list.filter((s) => s.expiresAt > now);
-					await Promise.all(
-						validSessions.map(async ({ token }) => {
-							const cached = await secondaryStorage.get(token);
-							if (!cached) return;
-							const parsed = safeJSONParse<{
-								session: Session;
-								user: User;
-							}>(cached);
-							if (!parsed) return;
-							const sessionTTL = Math.max(
-								Math.floor(
-									(new Date(parsed.session.expiresAt).getTime() - now) / 1000,
-								),
-								0,
-							);
-							await secondaryStorage.set(
-								token,
-								JSON.stringify({
-									session: parsed.session,
-									user,
-								}),
-								sessionTTL,
-							);
-						}),
-					);
-				}
-			}
+			await refreshUserSessions(user);
 			return user;
 		},
 		updateUserByEmail: async (
@@ -798,6 +799,7 @@ export const createInternalAdapter = (
 				undefined,
 				context,
 			);
+			await refreshUserSessions(user);
 			return user;
 		},
 		updatePassword: async (


### PR DESCRIPTION
The `secondaryStorage` sessions were not being updated when a user update was performed using the `updateUserByEmail` function. This PR fixes that issue.