### PR TITLE
ci: branch rules

### DIFF
--- a/.github/workflows/branch-rules.yml
+++ b/.github/workflows/branch-rules.yml
@@ -29,12 +29,6 @@ jobs:
             docs:
               - 'docs/**'
 
-      - name: Enforce docs-only PRs target main
-        if: steps.filter.outputs.docs == 'true' && steps.filter.outputs.src == 'false' && github.base_ref != 'main'
-        run: |
-          echo "Error: Pull requests that only change documentation must target the 'main' branch."
-          exit 1
-
       - name: Enforce code change PRs target canary or staging
         if: steps.filter.outputs.src == 'true' && github.base_ref != 'canary' && !startsWith(github.base_ref, 'v')
         run: |


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the CI step that forced docs-only PRs to target main. Docs updates can now target canary or versioned branches without failing the workflow. Existing code-change enforcement stays the same.

<!-- End of auto-generated description by cubic. -->

