### PR TITLE
fix(paypal): use `base64.encode`

### DIFF
--- a/packages/better-auth/src/social-providers/paypal.ts
+++ b/packages/better-auth/src/social-providers/paypal.ts
@@ -4,6 +4,7 @@ import type { OAuthProvider, ProviderOptions } from "../oauth2";
 import { createAuthorizationURL } from "../oauth2";
 import { logger } from "../utils/logger";
 import { decodeJwt } from "jose";
+import { base64 } from "@better-auth/utils/base64";
 
 export interface PayPalProfile {
 	user_id: string;
@@ -108,9 +109,9 @@ export const paypal = (options: PayPalOptions) => {
 			 * PayPal requires Basic Auth for token exchange
 			 **/
 
-			const credentials = Buffer.from(
+			const credentials = base64.encode(
 				`${options.clientId}:${options.clientSecret}`,
-			).toString("base64");
+			);
 
 			try {
 				const response = await betterFetch(tokenEndpoint, {
@@ -153,9 +154,9 @@ export const paypal = (options: PayPalOptions) => {
 		refreshAccessToken: options.refreshAccessToken
 			? options.refreshAccessToken
 			: async (refreshToken) => {
-					const credentials = Buffer.from(
+					const credentials = base64.encode(
 						`${options.clientId}:${options.clientSecret}`,
-					).toString("base64");
+					);
 
 					try {
 						const response = await betterFetch(tokenEndpoint, {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replace Node Buffer usage with base64.encode for PayPal OAuth Basic Auth credentials to remove Node-only dependency and prevent runtime errors in edge/browser runtimes. Applies to both token exchange and refresh flows.

- **Bug Fixes**
  - Use @better-auth/utils/base64.encode to generate Basic auth credentials for PayPal token requests.
  - Updated both access token exchange and refresh paths.

<!-- End of auto-generated description by cubic. -->

