### PR TITLE
v1.3.9 docs cherry pick

### DIFF
--- a/docs/components/nav-mobile.tsx
+++ b/docs/components/nav-mobile.tsx
@@ -162,28 +162,40 @@ function DocsNavBarContent() {
 							</div>
 						</AccordionTrigger>
 						<AccordionContent className="pl-5 divide-y">
-							{menu.list.map((child) => (
-								<Link
-									href={child.href}
-									key={child.title}
-									className="block py-2 text-sm border-b first:pt-0 last:pb-0 last:border-0 text-muted-foreground"
-									onClick={toggleNavbar}
-								>
-									{child.group ? (
-										<div className="flex flex-row items-center gap-2 ">
-											<div className="flex-grow h-px bg-gradient-to-r from-stone-800/90 to-stone-800/60" />
-											<p className="text-sm text-transparent bg-gradient-to-tr dark:from-gray-100 dark:to-stone-200 bg-clip-text from-gray-900 to-stone-900">
-												{child.title}
-											</p>
+							{menu.list.map((child, index) =>
+								child.group ? (
+									// Group header rendered as div (just a divider)
+									<div
+										key={child.title}
+										className="block py-2 text-sm text-muted-foreground border-none select-none"
+									>
+										<div className="flex flex-row items-center gap-2">
+											<p className="text-sm text-primary">{child.title}</p>
+											<div className="flex-grow h-px bg-border" />
 										</div>
-									) : (
+									</div>
+								) : (
+									// Regular menu item rendered as Link
+									<Link
+										href={child.href}
+										key={child.title}
+										className={`block py-2 text-sm text-muted-foreground ${
+											// Add border only when not last item
+											// and next item is not a group header
+											index === menu.list.length - 1 ||
+											menu.list[index + 1]?.group
+												? "border-none"
+												: "border-b"
+										}`}
+										onClick={toggleNavbar}
+									>
 										<div className="flex items-center gap-2">
 											<child.icon />
 											{child.title}
 										</div>
-									)}
-								</Link>
-							))}
+									</Link>
+								),
+							)}
 						</AccordionContent>
 					</AccordionItem>
 				</Accordion>

--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -472,7 +472,7 @@ export const contents: Content[] = [
 				title: "Social Sign-On",
 				group: true,
 				icon: LucideAArrowDown,
-				href: "/",
+				href: "",
 			},
 			{
 				title: "Apple",
@@ -1037,7 +1037,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				title: "Others",
 				group: true,
 				icon: () => null,
-				href: "/docs/authentication/others",
+				href: "",
 			},
 			{
 				title: "Other Social Providers",
@@ -1180,7 +1180,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				group: true,
 				title: "Adapters",
-				href: "/docs/adapters/drizzle",
+				href: "",
 				icon: () => <Database className="w-4 h-4 text-current" />,
 			},
 			{
@@ -1266,7 +1266,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				group: true,
 				title: "Others",
-				href: "/docs/adapters/community-adapters",
+				href: "",
 				icon: () => <Database className="w-4 h-4 text-current" />,
 			},
 			{
@@ -1316,7 +1316,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				group: true,
 				title: "Full Stack",
-				href: "/docs/integrations",
+				href: "",
 				icon: LucideAArrowDown,
 			},
 			{
@@ -1358,7 +1358,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				group: true,
 				title: "Backend",
-				href: "/docs/integrations",
+				href: "",
 				icon: LucideAArrowDown,
 			},
 			{
@@ -1394,7 +1394,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				group: true,
 				title: "Mobile & Desktop",
-				href: "/docs/integrations",
+				href: "",
 				icon: LucideAArrowDown,
 			},
 			{
@@ -1431,7 +1431,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				title: "Authentication",
 				group: true,
-				href: "/docs/plugins/1st-party-plugins",
+				href: "",
 				icon: () => <LucideAArrowDown className="w-4 h-4" />,
 			},
 
@@ -1545,7 +1545,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				title: "Authorization",
 				group: true,
-				href: "/docs/plugins/1st-party-plugins",
+				href: "",
 				icon: () => <LucideAArrowDown className="w-4 h-4" />,
 			},
 			{
@@ -1615,7 +1615,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				title: "Enterprise",
 				group: true,
-				href: "/docs/plugins/1st-party-plugins",
+				href: "",
 				icon: () => <LucideAArrowDown className="w-4 h-4" />,
 			},
 			{
@@ -1660,7 +1660,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				title: "Utility",
 				group: true,
-				href: "/docs/plugins/1st-party-plugins",
+				href: "",
 				icon: () => <LucideAArrowDown className="w-4 h-4" />,
 			},
 			{
@@ -1838,7 +1838,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 			{
 				title: "3rd party",
 				group: true,
-				href: "/docs/plugins/1st-party-plugins",
+				href: "",
 				icon: () => <LucideAArrowDown className="w-4 h-4" />,
 			},
 			{


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make docs navigation headings non-clickable and clean up dividers in mobile and sidebar. Prevents accidental taps and removes misleading links.

- **Bug Fixes**
  - Mobile nav: render group headers as non-interactive divs; keep links only for real items; add borders only between consecutive items.
  - Sidebar: set empty href for all group headers (e.g., Social Sign-On, Adapters, Integrations, Plugins) so they act as labels, not links.

<!-- End of auto-generated description by cubic. -->

