### PR TITLE
fix(organization): `beforeCreateOrganization` didn't pass new body

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -194,10 +194,15 @@ export const createOrganization = <O extends OrganizationOptions>(
 					};
 				}
 			}
+			let {
+				keepCurrentActiveOrganization: ___,
+				userId: ____,
+				...orgData2
+			} = ctx.body;
 
 			const organization = await adapter.createOrganization({
 				organization: {
-					...orgData,
+					...orgData2,
 					createdAt: new Date(),
 				},
 			});


### PR DESCRIPTION
When the dev returns a value from the `beforeCreateOrganization` fn, it should then be forwarded to the createOrganization fn. This PR implements such fix.