### PR TITLE
fix(cli): `info` shows the correct version

### DIFF
--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -331,9 +331,15 @@ async function getBetterAuthInfo(
 				shouldThrowOnError: false,
 			});
 			const packageInfo = await getPackageInfo();
+			const betterAuthVersion =
+				packageInfo.dependencies?.["better-auth"] ||
+				packageInfo.devDependencies?.["better-auth"] ||
+				packageInfo.peerDependencies?.["better-auth"] ||
+				packageInfo.optionalDependencies?.["better-auth"] ||
+				"Unknown";
 
 			return {
-				version: packageInfo.version || "Unknown",
+				version: betterAuthVersion,
 				config: sanitizeBetterAuthConfig(config),
 			};
 		} finally {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the CLI info command to show the installed better-auth version instead of the workspace/package version. It now reads the version from dependencies (deps/dev/peer/optional) and falls back to "Unknown" if not found.

<!-- End of auto-generated description by cubic. -->

