### PR TITLE
feat(db): add withTransaction helper

### DIFF
--- a/packages/better-auth/src/__snapshots__/init.test.ts.snap
+++ b/packages/better-auth/src/__snapshots__/init.test.ts.snap
@@ -98,6 +98,7 @@ exports[`init > should match config 1`] = `
     "updateUser": [Function],
     "updateUserByEmail": [Function],
     "updateVerificationValue": [Function],
+    "withTransaction": [Function],
   },
   "logger": {
     "debug": [Function],

--- a/packages/better-auth/src/db/adapter-bridge.ts
+++ b/packages/better-auth/src/db/adapter-bridge.ts
@@ -1,0 +1,149 @@
+import { shimLastParam } from "../utils/shim";
+import type { LiteralString, Prettify } from "../types/helper";
+import type { Adapter, AuthContext, TransactionAdapter } from "../types";
+import { createInternalAdapter } from "./internal-adapter";
+
+type AdapterBridgeContext = {
+	adapter: TransactionAdapter;
+};
+
+type WithTrx<F extends (...args: any[]) => any> = F &
+	((
+		...args: [...Parameters<F>, trxAdapter?: TransactionAdapter]
+	) => ReturnType<F>);
+
+type InferAdapterBridgeMethods<T extends AdapterBridgeMethods> = {
+	[K in keyof T]: WithTrx<ReturnType<T[K]>>;
+};
+type AdapterBridgeMethods = Record<
+	string,
+	(
+		ctx: AdapterBridgeContext,
+	) => any extends infer S
+		? S extends (...args: any[]) => any
+			? S
+			: never
+		: never
+>;
+
+type GetTransactionContextHandler<
+	ID extends LiteralString = LiteralString,
+	R extends Record<string, any> | void = Record<string, any> | void,
+> = (
+	ctx: AdapterBridgeContext &
+		Record<ID, Record<string, (...args: any[]) => any>>,
+) => R;
+
+export type AdapterBridgeOptions<ID extends LiteralString = LiteralString> = {
+	id: ID;
+	adapter: Adapter;
+	staticMethods?: Record<string, (...args: any[]) => any>;
+	methods: AdapterBridgeMethods;
+	getTransactionContext?: GetTransactionContextHandler<ID>;
+};
+
+type InferAdditionalTransactionContext<
+	O extends {
+		id: AdapterBridgeOptions["id"];
+		getTransactionContext?: AdapterBridgeOptions["getTransactionContext"];
+	},
+> = O["getTransactionContext"] extends GetTransactionContextHandler<
+	O["id"],
+	infer R
+>
+	? R extends Record<string, any>
+		? R
+		: {}
+	: {};
+
+export type AdapterBridge<O extends AdapterBridgeOptions> =
+	InferAdapterBridgeMethods<O["methods"]> & {
+		withTransaction: <R>(
+			cb: (
+				trx: Prettify<
+					{
+						adapter: TransactionAdapter;
+					} & Record<O["id"], InferAdapterBridgeMethods<O["methods"]>> &
+						InferAdditionalTransactionContext<O>
+				>,
+			) => Promise<R>,
+		) => Promise<R>;
+	} & O["staticMethods"];
+
+export const createAdapterBridge = <
+	ID extends LiteralString,
+	O extends AdapterBridgeOptions<ID>,
+>(
+	bridge: O & { id: ID },
+): AdapterBridge<O> => {
+	const methods: any = {};
+
+	for (const key in bridge.methods) {
+		methods[key] = (...args: any[]) => {
+			const maybeTrx = args[args.length - 1];
+			const hasTrx =
+				maybeTrx &&
+				typeof maybeTrx === "object" &&
+				typeof maybeTrx.id === "string" &&
+				["findOne", "findMany", "update", "delete"].every(
+					(key) => typeof maybeTrx[key] === "function",
+				);
+
+			const ctx: AdapterBridgeContext = {
+				adapter: hasTrx ? maybeTrx : bridge.adapter,
+			};
+			const fn = bridge.methods[key](ctx);
+			const finalArgs = hasTrx ? args.slice(0, -1) : args;
+
+			return fn(...finalArgs);
+		};
+	}
+
+	return {
+		...methods,
+		withTransaction: async <R>(cb: (trx: any) => Promise<R>): Promise<R> => {
+			return bridge.adapter.transaction((trxAdapter) => {
+				const trx: AdapterBridgeContext & Record<string, any> = {
+					adapter: trxAdapter,
+					[bridge.id]: shimLastParam(methods, trxAdapter),
+				};
+
+				return cb({
+					...trx,
+					...(bridge.getTransactionContext?.(trx) ?? {}),
+				});
+			});
+		},
+		...bridge.staticMethods,
+	};
+};
+createAdapterBridge.create = <
+	ID extends LiteralString,
+	O extends Omit<AdapterBridgeOptions<ID>, "adapter">,
+>(
+	context: AuthContext,
+	bridge: O & { id: ID },
+) => {
+	return createAdapterBridge({
+		...bridge,
+		adapter: context.adapter,
+		getTransactionContext: (ctx) => {
+			return {
+				internalAdapter: createInternalAdapter(
+					ctx.adapter,
+					{
+						options: context.options,
+						generateId: context.generateId,
+						hooks: context.options.databaseHooks
+							? [context.options.databaseHooks]
+							: [],
+						logger: context.logger,
+					},
+					true,
+				),
+				...((bridge.getTransactionContext?.(ctx) ??
+					{}) as InferAdditionalTransactionContext<O>),
+			};
+		},
+	});
+};

--- a/packages/better-auth/src/db/index.ts
+++ b/packages/better-auth/src/db/index.ts
@@ -1,3 +1,4 @@
+export * from "./adapter-bridge";
 export * from "./internal-adapter";
 export * from "./field";
 export * from "./get-tables";

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1005,17 +1005,16 @@ export const createInternalAdapter = (
 		withTransaction: async <R>(
 			cb: (trx: {
 				adapter: TransactionAdapter;
-				internalAdapter: InferShimLastParamResult<
-					typeof baseMethods,
-					TransactionAdapter,
-					true
-				>;
+				internalAdapter: typeof baseMethods;
 			}) => Promise<R>,
 		): Promise<R> => {
 			return adapter.transaction((trxAdapter) => {
 				return cb({
 					adapter: trxAdapter,
-					internalAdapter: shimLastParam(baseMethods, trxAdapter, true),
+					internalAdapter: shimLastParam(
+						baseMethods,
+						trxAdapter,
+					) as typeof baseMethods,
 				});
 			});
 		},

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -21,7 +21,9 @@ import { generateId, type InternalLogger } from "../utils";
 import { createAdapterBridge } from "./adapter-bridge";
 import { shimLastParam } from "../utils/shim";
 
-export const createInternalAdapter = <OmitStaticMethods extends boolean = false>(
+export const createInternalAdapter = <
+	OmitStaticMethods extends boolean = false,
+>(
 	adapter: OmitStaticMethods extends true ? TransactionAdapter : Adapter,
 	ctx: {
 		options: Omit<BetterAuthOptions, "logger">;
@@ -35,189 +37,144 @@ export const createInternalAdapter = <OmitStaticMethods extends boolean = false>
 	const options = ctx.options;
 	const secondaryStorage = options.secondaryStorage;
 	const sessionExpiration = options.session?.expiresIn || 60 * 60 * 24 * 7; // 7 days
-	const withHooks =
-		getWithHooks(adapter, ctx);
+	const withHooks = getWithHooks(adapter, ctx);
 
-	return createAdapterBridge({
-		id: "internalAdapter",
-		adapter: adapter as Adapter,
-		omitStaticMethods: omitStaticMethods as OmitStaticMethods,
-		getBridgeContext(ctx) {
-			return shimLastParam(withHooks, ctx.adapter) as ReturnType<typeof getWithHooks>;
-		},
-	}, {
-		staticMethods: {
-			createOAuthUser: async (
-				user: Omit<User, "id" | "createdAt" | "updatedAt">,
-				account: Omit<Account, "userId" | "id" | "createdAt" | "updatedAt"> &
-					Partial<Account>,
-				context?: GenericEndpointContext,
-			) => {
-				return (adapter as Adapter).transaction(async (trxAdapter) => {
-					const createdUser = await withHooks.createWithHooks(
-						{
-							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-							createdAt: new Date(),
-							updatedAt: new Date(),
-							...user,
-						},
-						"user",
-						undefined,
-						context,
-						trxAdapter,
-					);
-					const createdAccount = await withHooks.createWithHooks(
-						{
-							...account,
-							userId: createdUser!.id,
-							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-							createdAt: new Date(),
-							updatedAt: new Date(),
-						},
-						"account",
-						undefined,
-						context,
-						trxAdapter,
-					);
-					return {
-						user: createdUser,
-						account: createdAccount,
-					};
-				});
+	return createAdapterBridge(
+		{
+			id: "internalAdapter",
+			adapter: adapter as Adapter,
+			omitStaticMethods: omitStaticMethods as OmitStaticMethods,
+			getBridgeContext(ctx) {
+				return shimLastParam(withHooks, ctx.adapter) as ReturnType<
+					typeof getWithHooks
+				>;
 			},
 		},
-		methods: {
-			createUser:
-				({ createWithHooks }) =>
-				async <T>(
-					user: Omit<User, "id" | "createdAt" | "updatedAt" | "emailVerified"> &
-						Partial<User> &
-						Record<string, any>,
+		{
+			staticMethods: {
+				createOAuthUser: async (
+					user: Omit<User, "id" | "createdAt" | "updatedAt">,
+					account: Omit<Account, "userId" | "id" | "createdAt" | "updatedAt"> &
+						Partial<Account>,
 					context?: GenericEndpointContext,
 				) => {
-					const createdUser = await createWithHooks(
-						{
-							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-							createdAt: new Date(),
-							updatedAt: new Date(),
-							...user,
-							email: user.email?.toLowerCase(),
-						},
-						"user",
-						undefined,
-						context,
-					);
-					return createdUser as T & User;
-				},
-			createAccount:
-				({ createWithHooks }) =>
-				async <T extends Record<string, any>>(
-					account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
-						Partial<Account> &
-						T,
-					context?: GenericEndpointContext,
-				) => {
-					const createdAccount = await createWithHooks(
-						{
-							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-							createdAt: new Date(),
-							updatedAt: new Date(),
-							...account,
-						},
-						"account",
-						undefined,
-						context,
-					);
-					return createdAccount as T & Account;
-				},
-			listSessions:
-				({ adapter }) =>
-				async (userId: string) => {
-					if (secondaryStorage) {
-						const currentList = await secondaryStorage.get(
-							`active-sessions-${userId}`,
-						);
-						if (!currentList) return [];
-
-						const list: { token: string; expiresAt: number }[] =
-							safeJSONParse(currentList) || [];
-						const now = Date.now();
-
-						const validSessions = list.filter((s) => s.expiresAt > now);
-						const sessions = [];
-
-						for (const session of validSessions) {
-							const sessionStringified = await secondaryStorage.get(
-								session.token,
-							);
-							if (sessionStringified) {
-								const s = safeJSONParse<{
-									session: Session;
-									user: User;
-								}>(sessionStringified);
-								if (!s) return [];
-								const parsedSession = parseSessionOutput(ctx.options, {
-									...s.session,
-									expiresAt: new Date(s.session.expiresAt),
-								});
-								sessions.push(parsedSession);
-							}
-						}
-						return sessions;
-					}
-
-					const sessions = await adapter.findMany<Session>({
-						model: "session",
-						where: [
+					return (adapter as Adapter).transaction(async (trxAdapter) => {
+						const createdUser = await withHooks.createWithHooks(
 							{
-								field: "userId",
-								value: userId,
+								// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+								createdAt: new Date(),
+								updatedAt: new Date(),
+								...user,
 							},
-						],
+							"user",
+							undefined,
+							context,
+							trxAdapter,
+						);
+						const createdAccount = await withHooks.createWithHooks(
+							{
+								...account,
+								userId: createdUser!.id,
+								// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+								createdAt: new Date(),
+								updatedAt: new Date(),
+							},
+							"account",
+							undefined,
+							context,
+							trxAdapter,
+						);
+						return {
+							user: createdUser,
+							account: createdAccount,
+						};
 					});
-					return sessions;
 				},
-			listUsers:
-				({ adapter }) =>
-				async (
-					limit?: number,
-					offset?: number,
-					sortBy?: {
-						field: string;
-						direction: "asc" | "desc";
+			},
+			methods: {
+				createUser:
+					({ createWithHooks }) =>
+					async <T>(
+						user: Omit<
+							User,
+							"id" | "createdAt" | "updatedAt" | "emailVerified"
+						> &
+							Partial<User> &
+							Record<string, any>,
+						context?: GenericEndpointContext,
+					) => {
+						const createdUser = await createWithHooks(
+							{
+								// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+								createdAt: new Date(),
+								updatedAt: new Date(),
+								...user,
+								email: user.email?.toLowerCase(),
+							},
+							"user",
+							undefined,
+							context,
+						);
+						return createdUser as T & User;
 					},
-					where?: Where[],
-				) => {
-					const users = await adapter.findMany<User>({
-						model: "user",
-						limit,
-						offset,
-						sortBy,
-						where,
-					});
-					return users;
-				},
-			countTotalUsers:
-				({ adapter }) =>
-				async (where?: Where[]) => {
-					const total = await adapter.count({
-						model: "user",
-						where,
-					});
-					if (typeof total === "string") {
-						return parseInt(total);
-					}
-					return total;
-				},
-			deleteUser:
-				({ adapter }) =>
-				async (userId: string) => {
-					if (secondaryStorage) {
-						await secondaryStorage.delete(`active-sessions-${userId}`);
-					}
+				createAccount:
+					({ createWithHooks }) =>
+					async <T extends Record<string, any>>(
+						account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
+							Partial<Account> &
+							T,
+						context?: GenericEndpointContext,
+					) => {
+						const createdAccount = await createWithHooks(
+							{
+								// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+								createdAt: new Date(),
+								updatedAt: new Date(),
+								...account,
+							},
+							"account",
+							undefined,
+							context,
+						);
+						return createdAccount as T & Account;
+					},
+				listSessions:
+					({ adapter }) =>
+					async (userId: string) => {
+						if (secondaryStorage) {
+							const currentList = await secondaryStorage.get(
+								`active-sessions-${userId}`,
+							);
+							if (!currentList) return [];
 
-					if (!secondaryStorage || options.session?.storeSessionInDatabase) {
-						await adapter.deleteMany({
+							const list: { token: string; expiresAt: number }[] =
+								safeJSONParse(currentList) || [];
+							const now = Date.now();
+
+							const validSessions = list.filter((s) => s.expiresAt > now);
+							const sessions = [];
+
+							for (const session of validSessions) {
+								const sessionStringified = await secondaryStorage.get(
+									session.token,
+								);
+								if (sessionStringified) {
+									const s = safeJSONParse<{
+										session: Session;
+										user: User;
+									}>(sessionStringified);
+									if (!s) return [];
+									const parsedSession = parseSessionOutput(ctx.options, {
+										...s.session,
+										expiresAt: new Date(s.session.expiresAt),
+									});
+									sessions.push(parsedSession);
+								}
+							}
+							return sessions;
+						}
+
+						const sessions = await adapter.findMany<Session>({
 							model: "session",
 							where: [
 								{
@@ -226,453 +183,525 @@ export const createInternalAdapter = <OmitStaticMethods extends boolean = false>
 								},
 							],
 						});
-					}
+						return sessions;
+					},
+				listUsers:
+					({ adapter }) =>
+					async (
+						limit?: number,
+						offset?: number,
+						sortBy?: {
+							field: string;
+							direction: "asc" | "desc";
+						},
+						where?: Where[],
+					) => {
+						const users = await adapter.findMany<User>({
+							model: "user",
+							limit,
+							offset,
+							sortBy,
+							where,
+						});
+						return users;
+					},
+				countTotalUsers:
+					({ adapter }) =>
+					async (where?: Where[]) => {
+						const total = await adapter.count({
+							model: "user",
+							where,
+						});
+						if (typeof total === "string") {
+							return parseInt(total);
+						}
+						return total;
+					},
+				deleteUser:
+					({ adapter }) =>
+					async (userId: string) => {
+						if (secondaryStorage) {
+							await secondaryStorage.delete(`active-sessions-${userId}`);
+						}
 
-					await adapter.deleteMany({
-						model: "account",
-						where: [
-							{
-								field: "userId",
-								value: userId,
-							},
-						],
-					});
-					await adapter.delete({
-						model: "user",
-						where: [
-							{
-								field: "id",
-								value: userId,
-							},
-						],
-					});
-				},
-			createSession:
-				({ createWithHooks }) =>
-				async (
-					userId: string,
-					ctx: GenericEndpointContext,
-					dontRememberMe?: boolean,
-					override?: Partial<Session> & Record<string, any>,
-					overrideAll?: boolean,
-				) => {
-					const headers = ctx.headers || ctx.request?.headers;
-					const { id: _, ...rest } = override || {};
-					const data: Omit<Session, "id"> = {
-						ipAddress:
-							ctx.request || ctx.headers
-								? getIp(ctx.request || ctx.headers!, ctx.context.options) || ""
-								: "",
-						userAgent: headers?.get("user-agent") || "",
-						...rest,
-						/**
-						 * If the user doesn't want to be remembered
-						 * set the session to expire in 1 day.
-						 * The cookie will be set to expire at the end of the session
-						 */
-						expiresAt: dontRememberMe
-							? getDate(60 * 60 * 24, "sec") // 1 day
-							: getDate(sessionExpiration, "sec"),
-						userId,
-						token: generateId(32),
-						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-						createdAt: new Date(),
-						updatedAt: new Date(),
-						...(overrideAll ? rest : {}),
-					};
-					const res = await createWithHooks(
-						data,
-						"session",
-						secondaryStorage
-							? {
-									fn: async (sessionData) => {
-										/**
-										 * store the session token for the user
-										 * so we can retrieve it later for listing sessions
-										 */
-										const currentList = await secondaryStorage.get(
-											`active-sessions-${userId}`,
-										);
-
-										let list: { token: string; expiresAt: number }[] = [];
-										const now = Date.now();
-
-										if (currentList) {
-											list = safeJSONParse(currentList) || [];
-											list = list.filter((session) => session.expiresAt > now);
-										}
-
-										list.push({
-											token: data.token,
-											expiresAt: now + sessionExpiration * 1000,
-										});
-
-										await secondaryStorage.set(
-											`active-sessions-${userId}`,
-											JSON.stringify(list),
-											sessionExpiration,
-										);
-
-										return sessionData;
+						if (!secondaryStorage || options.session?.storeSessionInDatabase) {
+							await adapter.deleteMany({
+								model: "session",
+								where: [
+									{
+										field: "userId",
+										value: userId,
 									},
-									executeMainFn: options.session?.storeSessionInDatabase,
-								}
-							: undefined,
-						ctx,
-					);
-					return res as Session;
-				},
-			findSession:
-				({ adapter }) =>
-				async (
-					token: string,
-				): Promise<{
-					session: Session & Record<string, any>;
-					user: User & Record<string, any>;
-				} | null> => {
-					if (secondaryStorage) {
-						const sessionStringified = await secondaryStorage.get(token);
-						if (
-							!sessionStringified &&
-							!options.session?.storeSessionInDatabase
-						) {
-							return null;
-						}
-						if (sessionStringified) {
-							const s = safeJSONParse<{
-								session: Session;
-								user: User;
-							}>(sessionStringified);
-							if (!s) return null;
-							const parsedSession = parseSessionOutput(ctx.options, {
-								...s.session,
-								expiresAt: new Date(s.session.expiresAt),
-								createdAt: new Date(s.session.createdAt),
-								updatedAt: new Date(s.session.updatedAt),
+								],
 							});
-							const parsedUser = parseUserOutput(ctx.options, {
-								...s.user,
-								createdAt: new Date(s.user.createdAt),
-								updatedAt: new Date(s.user.updatedAt),
-							});
-							return {
-								session: parsedSession,
-								user: parsedUser,
-							};
 						}
-					}
 
-					const session = await adapter.findOne<Session>({
-						model: "session",
-						where: [
-							{
-								value: token,
-								field: "token",
-							},
-						],
-					});
+						await adapter.deleteMany({
+							model: "account",
+							where: [
+								{
+									field: "userId",
+									value: userId,
+								},
+							],
+						});
+						await adapter.delete({
+							model: "user",
+							where: [
+								{
+									field: "id",
+									value: userId,
+								},
+							],
+						});
+					},
+				createSession:
+					({ createWithHooks }) =>
+					async (
+						userId: string,
+						ctx: GenericEndpointContext,
+						dontRememberMe?: boolean,
+						override?: Partial<Session> & Record<string, any>,
+						overrideAll?: boolean,
+					) => {
+						const headers = ctx.headers || ctx.request?.headers;
+						const { id: _, ...rest } = override || {};
+						const data: Omit<Session, "id"> = {
+							ipAddress:
+								ctx.request || ctx.headers
+									? getIp(ctx.request || ctx.headers!, ctx.context.options) ||
+										""
+									: "",
+							userAgent: headers?.get("user-agent") || "",
+							...rest,
+							/**
+							 * If the user doesn't want to be remembered
+							 * set the session to expire in 1 day.
+							 * The cookie will be set to expire at the end of the session
+							 */
+							expiresAt: dontRememberMe
+								? getDate(60 * 60 * 24, "sec") // 1 day
+								: getDate(sessionExpiration, "sec"),
+							userId,
+							token: generateId(32),
+							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+							createdAt: new Date(),
+							updatedAt: new Date(),
+							...(overrideAll ? rest : {}),
+						};
+						const res = await createWithHooks(
+							data,
+							"session",
+							secondaryStorage
+								? {
+										fn: async (sessionData) => {
+											/**
+											 * store the session token for the user
+											 * so we can retrieve it later for listing sessions
+											 */
+											const currentList = await secondaryStorage.get(
+												`active-sessions-${userId}`,
+											);
 
-					if (!session) {
-						return null;
-					}
+											let list: { token: string; expiresAt: number }[] = [];
+											const now = Date.now();
 
-					const user = await adapter.findOne<User>({
-						model: "user",
-						where: [
-							{
-								value: session.userId,
-								field: "id",
-							},
-						],
-					});
-					if (!user) {
-						return null;
-					}
-					const parsedSession = parseSessionOutput(ctx.options, session);
-					const parsedUser = parseUserOutput(ctx.options, user);
+											if (currentList) {
+												list = safeJSONParse(currentList) || [];
+												list = list.filter(
+													(session) => session.expiresAt > now,
+												);
+											}
 
-					return {
-						session: parsedSession,
-						user: parsedUser,
-					};
-				},
-			findSessions:
-				({ adapter }) =>
-				async (sessionTokens: string[]) => {
-					if (secondaryStorage) {
-						const sessions: {
-							session: Session;
-							user: User;
-						}[] = [];
-						for (const sessionToken of sessionTokens) {
-							const sessionStringified =
-								await secondaryStorage.get(sessionToken);
+											list.push({
+												token: data.token,
+												expiresAt: now + sessionExpiration * 1000,
+											});
+
+											await secondaryStorage.set(
+												`active-sessions-${userId}`,
+												JSON.stringify(list),
+												sessionExpiration,
+											);
+
+											return sessionData;
+										},
+										executeMainFn: options.session?.storeSessionInDatabase,
+									}
+								: undefined,
+							ctx,
+						);
+						return res as Session;
+					},
+				findSession:
+					({ adapter }) =>
+					async (
+						token: string,
+					): Promise<{
+						session: Session & Record<string, any>;
+						user: User & Record<string, any>;
+					} | null> => {
+						if (secondaryStorage) {
+							const sessionStringified = await secondaryStorage.get(token);
+							if (
+								!sessionStringified &&
+								!options.session?.storeSessionInDatabase
+							) {
+								return null;
+							}
 							if (sessionStringified) {
 								const s = safeJSONParse<{
 									session: Session;
 									user: User;
 								}>(sessionStringified);
-								if (!s) return [];
-								const session = {
-									session: {
-										...s.session,
-										expiresAt: new Date(s.session.expiresAt),
-									},
-									user: {
-										...s.user,
-										createdAt: new Date(s.user.createdAt),
-										updatedAt: new Date(s.user.updatedAt),
-									},
-								} as {
-									session: Session;
-									user: User;
+								if (!s) return null;
+								const parsedSession = parseSessionOutput(ctx.options, {
+									...s.session,
+									expiresAt: new Date(s.session.expiresAt),
+									createdAt: new Date(s.session.createdAt),
+									updatedAt: new Date(s.session.updatedAt),
+								});
+								const parsedUser = parseUserOutput(ctx.options, {
+									...s.user,
+									createdAt: new Date(s.user.createdAt),
+									updatedAt: new Date(s.user.updatedAt),
+								});
+								return {
+									session: parsedSession,
+									user: parsedUser,
 								};
-								sessions.push(session);
-							}
-						}
-						return sessions;
-					}
-
-					const sessions = await adapter.findMany<Session>({
-						model: "session",
-						where: [
-							{
-								field: "token",
-								value: sessionTokens,
-								operator: "in",
-							},
-						],
-					});
-					const userIds = sessions.map((session) => {
-						return session.userId;
-					});
-					if (!userIds.length) return [];
-					const users = await adapter.findMany<User>({
-						model: "user",
-						where: [
-							{
-								field: "id",
-								value: userIds,
-								operator: "in",
-							},
-						],
-					});
-					return sessions.map((session) => {
-						const user = users.find((u) => u.id === session.userId);
-						if (!user) return null;
-						return {
-							session,
-							user,
-						};
-					}) as {
-						session: Session;
-						user: User;
-					}[];
-				},
-			updateSession:
-				({ updateWithHooks }) =>
-				async (
-					sessionToken: string,
-					session: Partial<Session> & Record<string, any>,
-					context?: GenericEndpointContext,
-				) => {
-					const updatedSession = await updateWithHooks<Session>(
-						session,
-						[{ field: "token", value: sessionToken }],
-						"session",
-						secondaryStorage
-							? {
-									async fn(data) {
-										const currentSession =
-											await secondaryStorage.get(sessionToken);
-										let updatedSession: Session | null = null;
-										if (currentSession) {
-											const parsedSession = safeJSONParse<{
-												session: Session;
-												user: User;
-											}>(currentSession);
-											if (!parsedSession) return null;
-											updatedSession = {
-												...parsedSession.session,
-												...data,
-											};
-											return updatedSession;
-										} else {
-											return null;
-										}
-									},
-									executeMainFn: options.session?.storeSessionInDatabase,
-								}
-							: undefined,
-						context,
-					);
-					return updatedSession;
-				},
-			deleteSession:
-				({ adapter }) =>
-				async (token: string) => {
-					if (secondaryStorage) {
-						// remove the session from the active sessions list
-						const data = await secondaryStorage.get(token);
-						if (data) {
-							const { session } =
-								safeJSONParse<{
-									session: Session;
-									user: User;
-								}>(data) ?? {};
-							if (!session) {
-								logger.error("Session not found in secondary storage");
-								return;
-							}
-							const userId = session.userId;
-
-							const currentList = await secondaryStorage.get(
-								`active-sessions-${userId}`,
-							);
-							if (currentList) {
-								let list: { token: string; expiresAt: number }[] =
-									safeJSONParse(currentList) || [];
-								list = list.filter((s) => s.token !== token);
-
-								if (list.length > 0) {
-									await secondaryStorage.set(
-										`active-sessions-${userId}`,
-										JSON.stringify(list),
-										sessionExpiration,
-									);
-								} else {
-									await secondaryStorage.delete(`active-sessions-${userId}`);
-								}
-							} else {
-								logger.error(
-									"Active sessions list not found in secondary storage",
-								);
 							}
 						}
 
-						await secondaryStorage.delete(token);
-
-						if (
-							!options.session?.storeSessionInDatabase ||
-							ctx.options.session?.preserveSessionInDatabase
-						) {
-							return;
-						}
-					}
-					await adapter.delete<Session>({
-						model: "session",
-						where: [
-							{
-								field: "token",
-								value: token,
-							},
-						],
-					});
-				},
-			deleteAccounts:
-				({ adapter }) =>
-				async (userId: string) => {
-					await adapter.deleteMany({
-						model: "account",
-						where: [
-							{
-								field: "userId",
-								value: userId,
-							},
-						],
-					});
-				},
-			deleteAccount:
-				({ adapter }) =>
-				async (accountId: string) => {
-					await adapter.delete({
-						model: "account",
-						where: [
-							{
-								field: "id",
-								value: accountId,
-							},
-						],
-					});
-				},
-			deleteSessions:
-				({ adapter }) =>
-				async (userIdOrSessionTokens: string | string[]) => {
-					if (secondaryStorage) {
-						if (typeof userIdOrSessionTokens === "string") {
-							const activeSession = await secondaryStorage.get(
-								`active-sessions-${userIdOrSessionTokens}`,
-							);
-							const sessions = activeSession
-								? safeJSONParse<{ token: string }[]>(activeSession)
-								: [];
-							if (!sessions) return;
-							for (const session of sessions) {
-								await secondaryStorage.delete(session.token);
-							}
-						} else {
-							for (const sessionToken of userIdOrSessionTokens) {
-								const session = await secondaryStorage.get(sessionToken);
-								if (session) {
-									await secondaryStorage.delete(sessionToken);
-								}
-							}
-						}
-
-						if (
-							!options.session?.storeSessionInDatabase ||
-							ctx.options.session?.preserveSessionInDatabase
-						) {
-							return;
-						}
-					}
-					await adapter.deleteMany({
-						model: "session",
-						where: [
-							{
-								field: Array.isArray(userIdOrSessionTokens)
-									? "token"
-									: "userId",
-								value: userIdOrSessionTokens,
-								operator: Array.isArray(userIdOrSessionTokens)
-									? "in"
-									: undefined,
-							},
-						],
-					});
-				},
-			findOAuthUser:
-				({ adapter }) =>
-				async (email: string, accountId: string, providerId: string) => {
-					// we need to find account first to avoid missing user if the email changed with the provider for the same account
-					const account = await adapter
-						.findMany<Account>({
-							model: "account",
+						const session = await adapter.findOne<Session>({
+							model: "session",
 							where: [
 								{
-									value: accountId,
-									field: "accountId",
+									value: token,
+									field: "token",
 								},
 							],
-						})
-						.then((accounts) => {
-							return accounts.find((a) => a.providerId === providerId);
 						});
-					if (account) {
+
+						if (!session) {
+							return null;
+						}
+
 						const user = await adapter.findOne<User>({
 							model: "user",
 							where: [
 								{
-									value: account.userId,
+									value: session.userId,
 									field: "id",
 								},
 							],
 						});
-						if (user) {
+						if (!user) {
+							return null;
+						}
+						const parsedSession = parseSessionOutput(ctx.options, session);
+						const parsedUser = parseUserOutput(ctx.options, user);
+
+						return {
+							session: parsedSession,
+							user: parsedUser,
+						};
+					},
+				findSessions:
+					({ adapter }) =>
+					async (sessionTokens: string[]) => {
+						if (secondaryStorage) {
+							const sessions: {
+								session: Session;
+								user: User;
+							}[] = [];
+							for (const sessionToken of sessionTokens) {
+								const sessionStringified =
+									await secondaryStorage.get(sessionToken);
+								if (sessionStringified) {
+									const s = safeJSONParse<{
+										session: Session;
+										user: User;
+									}>(sessionStringified);
+									if (!s) return [];
+									const session = {
+										session: {
+											...s.session,
+											expiresAt: new Date(s.session.expiresAt),
+										},
+										user: {
+											...s.user,
+											createdAt: new Date(s.user.createdAt),
+											updatedAt: new Date(s.user.updatedAt),
+										},
+									} as {
+										session: Session;
+										user: User;
+									};
+									sessions.push(session);
+								}
+							}
+							return sessions;
+						}
+
+						const sessions = await adapter.findMany<Session>({
+							model: "session",
+							where: [
+								{
+									field: "token",
+									value: sessionTokens,
+									operator: "in",
+								},
+							],
+						});
+						const userIds = sessions.map((session) => {
+							return session.userId;
+						});
+						if (!userIds.length) return [];
+						const users = await adapter.findMany<User>({
+							model: "user",
+							where: [
+								{
+									field: "id",
+									value: userIds,
+									operator: "in",
+								},
+							],
+						});
+						return sessions.map((session) => {
+							const user = users.find((u) => u.id === session.userId);
+							if (!user) return null;
 							return {
+								session,
 								user,
-								accounts: [account],
 							};
+						}) as {
+							session: Session;
+							user: User;
+						}[];
+					},
+				updateSession:
+					({ updateWithHooks }) =>
+					async (
+						sessionToken: string,
+						session: Partial<Session> & Record<string, any>,
+						context?: GenericEndpointContext,
+					) => {
+						const updatedSession = await updateWithHooks<Session>(
+							session,
+							[{ field: "token", value: sessionToken }],
+							"session",
+							secondaryStorage
+								? {
+										async fn(data) {
+											const currentSession =
+												await secondaryStorage.get(sessionToken);
+											let updatedSession: Session | null = null;
+											if (currentSession) {
+												const parsedSession = safeJSONParse<{
+													session: Session;
+													user: User;
+												}>(currentSession);
+												if (!parsedSession) return null;
+												updatedSession = {
+													...parsedSession.session,
+													...data,
+												};
+												return updatedSession;
+											} else {
+												return null;
+											}
+										},
+										executeMainFn: options.session?.storeSessionInDatabase,
+									}
+								: undefined,
+							context,
+						);
+						return updatedSession;
+					},
+				deleteSession:
+					({ adapter }) =>
+					async (token: string) => {
+						if (secondaryStorage) {
+							// remove the session from the active sessions list
+							const data = await secondaryStorage.get(token);
+							if (data) {
+								const { session } =
+									safeJSONParse<{
+										session: Session;
+										user: User;
+									}>(data) ?? {};
+								if (!session) {
+									logger.error("Session not found in secondary storage");
+									return;
+								}
+								const userId = session.userId;
+
+								const currentList = await secondaryStorage.get(
+									`active-sessions-${userId}`,
+								);
+								if (currentList) {
+									let list: { token: string; expiresAt: number }[] =
+										safeJSONParse(currentList) || [];
+									list = list.filter((s) => s.token !== token);
+
+									if (list.length > 0) {
+										await secondaryStorage.set(
+											`active-sessions-${userId}`,
+											JSON.stringify(list),
+											sessionExpiration,
+										);
+									} else {
+										await secondaryStorage.delete(`active-sessions-${userId}`);
+									}
+								} else {
+									logger.error(
+										"Active sessions list not found in secondary storage",
+									);
+								}
+							}
+
+							await secondaryStorage.delete(token);
+
+							if (
+								!options.session?.storeSessionInDatabase ||
+								ctx.options.session?.preserveSessionInDatabase
+							) {
+								return;
+							}
+						}
+						await adapter.delete<Session>({
+							model: "session",
+							where: [
+								{
+									field: "token",
+									value: token,
+								},
+							],
+						});
+					},
+				deleteAccounts:
+					({ adapter }) =>
+					async (userId: string) => {
+						await adapter.deleteMany({
+							model: "account",
+							where: [
+								{
+									field: "userId",
+									value: userId,
+								},
+							],
+						});
+					},
+				deleteAccount:
+					({ adapter }) =>
+					async (accountId: string) => {
+						await adapter.delete({
+							model: "account",
+							where: [
+								{
+									field: "id",
+									value: accountId,
+								},
+							],
+						});
+					},
+				deleteSessions:
+					({ adapter }) =>
+					async (userIdOrSessionTokens: string | string[]) => {
+						if (secondaryStorage) {
+							if (typeof userIdOrSessionTokens === "string") {
+								const activeSession = await secondaryStorage.get(
+									`active-sessions-${userIdOrSessionTokens}`,
+								);
+								const sessions = activeSession
+									? safeJSONParse<{ token: string }[]>(activeSession)
+									: [];
+								if (!sessions) return;
+								for (const session of sessions) {
+									await secondaryStorage.delete(session.token);
+								}
+							} else {
+								for (const sessionToken of userIdOrSessionTokens) {
+									const session = await secondaryStorage.get(sessionToken);
+									if (session) {
+										await secondaryStorage.delete(sessionToken);
+									}
+								}
+							}
+
+							if (
+								!options.session?.storeSessionInDatabase ||
+								ctx.options.session?.preserveSessionInDatabase
+							) {
+								return;
+							}
+						}
+						await adapter.deleteMany({
+							model: "session",
+							where: [
+								{
+									field: Array.isArray(userIdOrSessionTokens)
+										? "token"
+										: "userId",
+									value: userIdOrSessionTokens,
+									operator: Array.isArray(userIdOrSessionTokens)
+										? "in"
+										: undefined,
+								},
+							],
+						});
+					},
+				findOAuthUser:
+					({ adapter }) =>
+					async (email: string, accountId: string, providerId: string) => {
+						// we need to find account first to avoid missing user if the email changed with the provider for the same account
+						const account = await adapter
+							.findMany<Account>({
+								model: "account",
+								where: [
+									{
+										value: accountId,
+										field: "accountId",
+									},
+								],
+							})
+							.then((accounts) => {
+								return accounts.find((a) => a.providerId === providerId);
+							});
+						if (account) {
+							const user = await adapter.findOne<User>({
+								model: "user",
+								where: [
+									{
+										value: account.userId,
+										field: "id",
+									},
+								],
+							});
+							if (user) {
+								return {
+									user,
+									accounts: [account],
+								};
+							} else {
+								const user = await adapter.findOne<User>({
+									model: "user",
+									where: [
+										{
+											value: email.toLowerCase(),
+											field: "email",
+										},
+									],
+								});
+								if (user) {
+									return {
+										user,
+										accounts: [account],
+									};
+								}
+								return null;
+							}
 						} else {
 							const user = await adapter.findOne<User>({
 								model: "user",
@@ -684,14 +713,27 @@ export const createInternalAdapter = <OmitStaticMethods extends boolean = false>
 								],
 							});
 							if (user) {
+								const accounts = await adapter.findMany<Account>({
+									model: "account",
+									where: [
+										{
+											value: user.id,
+											field: "userId",
+										},
+									],
+								});
 								return {
 									user,
-									accounts: [account],
+									accounts: accounts || [],
 								};
+							} else {
+								return null;
 							}
-							return null;
 						}
-					} else {
+					},
+				findUserByEmail:
+					({ adapter }) =>
+					async (email: string, options?: { includeAccounts: boolean }) => {
 						const user = await adapter.findOne<User>({
 							model: "user",
 							where: [
@@ -701,7 +743,8 @@ export const createInternalAdapter = <OmitStaticMethods extends boolean = false>
 								},
 							],
 						});
-						if (user) {
+						if (!user) return null;
+						if (options?.includeAccounts) {
 							const accounts = await adapter.findMany<Account>({
 								model: "account",
 								where: [
@@ -713,359 +756,328 @@ export const createInternalAdapter = <OmitStaticMethods extends boolean = false>
 							});
 							return {
 								user,
-								accounts: accounts || [],
+								accounts,
 							};
-						} else {
-							return null;
 						}
-					}
-				},
-			findUserByEmail:
-				({ adapter }) =>
-				async (email: string, options?: { includeAccounts: boolean }) => {
-					const user = await adapter.findOne<User>({
-						model: "user",
-						where: [
+						return {
+							user,
+							accounts: [],
+						};
+					},
+				findUserById:
+					({ adapter }) =>
+					async (userId: string) => {
+						const user = await adapter.findOne<User>({
+							model: "user",
+							where: [
+								{
+									field: "id",
+									value: userId,
+								},
+							],
+						});
+						return user;
+					},
+				linkAccount:
+					({ createWithHooks }) =>
+					async (
+						account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
+							Partial<Account>,
+						context?: GenericEndpointContext,
+					) => {
+						const _account = await createWithHooks(
 							{
-								value: email.toLowerCase(),
-								field: "email",
+								// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+								createdAt: new Date(),
+								updatedAt: new Date(),
+								...account,
 							},
-						],
-					});
-					if (!user) return null;
-					if (options?.includeAccounts) {
+							"account",
+							undefined,
+							context,
+						);
+						return _account;
+					},
+				updateUser:
+					({ updateWithHooks }) =>
+					async (
+						userId: string,
+						data: Partial<User> & Record<string, any>,
+						context?: GenericEndpointContext,
+					) => {
+						const user = await updateWithHooks<User>(
+							data,
+							[
+								{
+									field: "id",
+									value: userId,
+								},
+							],
+							"user",
+							undefined,
+							context,
+						);
+						if (secondaryStorage && user) {
+							const listRaw = await secondaryStorage.get(
+								`active-sessions-${userId}`,
+							);
+							if (listRaw) {
+								const now = Date.now();
+								const list =
+									safeJSONParse<{ token: string; expiresAt: number }[]>(
+										listRaw,
+									) || [];
+								const validSessions = list.filter((s) => s.expiresAt > now);
+								await Promise.all(
+									validSessions.map(async ({ token }) => {
+										const cached = await secondaryStorage.get(token);
+										if (!cached) return;
+										const parsed = safeJSONParse<{
+											session: Session;
+											user: User;
+										}>(cached);
+										if (!parsed) return;
+										const sessionTTL = Math.max(
+											Math.floor(
+												(new Date(parsed.session.expiresAt).getTime() - now) /
+													1000,
+											),
+											0,
+										);
+										await secondaryStorage.set(
+											token,
+											JSON.stringify({
+												session: parsed.session,
+												user,
+											}),
+											sessionTTL,
+										);
+									}),
+								);
+							}
+						}
+						return user;
+					},
+				updateUserByEmail:
+					({ updateWithHooks }) =>
+					async (
+						email: string,
+						data: Partial<User & Record<string, any>>,
+						context?: GenericEndpointContext,
+					) => {
+						const user = await updateWithHooks<User>(
+							data,
+							[
+								{
+									field: "email",
+									value: email.toLowerCase(),
+								},
+							],
+							"user",
+							undefined,
+							context,
+						);
+						return user;
+					},
+				updatePassword:
+					({ updateManyWithHooks }) =>
+					async (
+						userId: string,
+						password: string,
+						context?: GenericEndpointContext,
+					) => {
+						await updateManyWithHooks(
+							{
+								password,
+							},
+							[
+								{
+									field: "userId",
+									value: userId,
+								},
+								{
+									field: "providerId",
+									value: "credential",
+								},
+							],
+							"account",
+							undefined,
+							context,
+						);
+					},
+				findAccounts:
+					({ adapter }) =>
+					async (userId: string) => {
 						const accounts = await adapter.findMany<Account>({
 							model: "account",
 							where: [
 								{
-									value: user.id,
 									field: "userId",
+									value: userId,
 								},
 							],
 						});
-						return {
-							user,
-							accounts,
-						};
-					}
-					return {
-						user,
-						accounts: [],
-					};
-				},
-			findUserById:
-				({ adapter }) =>
-				async (userId: string) => {
-					const user = await adapter.findOne<User>({
-						model: "user",
-						where: [
-							{
-								field: "id",
-								value: userId,
-							},
-						],
-					});
-					return user;
-				},
-			linkAccount:
-				({ createWithHooks }) =>
-				async (
-					account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
-						Partial<Account>,
-					context?: GenericEndpointContext,
-				) => {
-					const _account = await createWithHooks(
-						{
-							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-							createdAt: new Date(),
-							updatedAt: new Date(),
-							...account,
-						},
-						"account",
-						undefined,
-						context,
-					);
-					return _account;
-				},
-			updateUser:
-				({ updateWithHooks }) =>
-				async (
-					userId: string,
-					data: Partial<User> & Record<string, any>,
-					context?: GenericEndpointContext,
-				) => {
-					const user = await updateWithHooks<User>(
-						data,
-						[
-							{
-								field: "id",
-								value: userId,
-							},
-						],
-						"user",
-						undefined,
-						context,
-					);
-					if (secondaryStorage && user) {
-						const listRaw = await secondaryStorage.get(
-							`active-sessions-${userId}`,
+						return accounts;
+					},
+				findAccount:
+					({ adapter }) =>
+					async (accountId: string) => {
+						const account = await adapter.findOne<Account>({
+							model: "account",
+							where: [
+								{
+									field: "accountId",
+									value: accountId,
+								},
+							],
+						});
+						return account;
+					},
+				findAccountByProviderId:
+					({ adapter }) =>
+					async (accountId: string, providerId: string) => {
+						const account = await adapter.findOne<Account>({
+							model: "account",
+							where: [
+								{
+									field: "accountId",
+									value: accountId,
+								},
+								{
+									field: "providerId",
+									value: providerId,
+								},
+							],
+						});
+						return account;
+					},
+				findAccountByUserId:
+					({ adapter }) =>
+					async (userId: string) => {
+						const account = await adapter.findMany<Account>({
+							model: "account",
+							where: [
+								{
+									field: "userId",
+									value: userId,
+								},
+							],
+						});
+						return account;
+					},
+				updateAccount:
+					({ updateWithHooks }) =>
+					async (
+						id: string,
+						data: Partial<Account>,
+						context?: GenericEndpointContext,
+					) => {
+						const account = await updateWithHooks<Account>(
+							data,
+							[{ field: "id", value: id }],
+							"account",
+							undefined,
+							context,
 						);
-						if (listRaw) {
-							const now = Date.now();
-							const list =
-								safeJSONParse<{ token: string; expiresAt: number }[]>(
-									listRaw,
-								) || [];
-							const validSessions = list.filter((s) => s.expiresAt > now);
-							await Promise.all(
-								validSessions.map(async ({ token }) => {
-									const cached = await secondaryStorage.get(token);
-									if (!cached) return;
-									const parsed = safeJSONParse<{
-										session: Session;
-										user: User;
-									}>(cached);
-									if (!parsed) return;
-									const sessionTTL = Math.max(
-										Math.floor(
-											(new Date(parsed.session.expiresAt).getTime() - now) /
-												1000,
-										),
-										0,
-									);
-									await secondaryStorage.set(
-										token,
-										JSON.stringify({
-											session: parsed.session,
-											user,
-										}),
-										sessionTTL,
-									);
-								}),
-							);
-						}
-					}
-					return user;
-				},
-			updateUserByEmail:
-				({ updateWithHooks }) =>
-				async (
-					email: string,
-					data: Partial<User & Record<string, any>>,
-					context?: GenericEndpointContext,
-				) => {
-					const user = await updateWithHooks<User>(
-						data,
-						[
+						return account;
+					},
+				createVerificationValue:
+					({ createWithHooks }) =>
+					async (
+						data: Omit<Verification, "createdAt" | "id" | "updatedAt"> &
+							Partial<Verification>,
+						context?: GenericEndpointContext,
+					) => {
+						const verification = await createWithHooks(
 							{
-								field: "email",
-								value: email.toLowerCase(),
+								// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+								createdAt: new Date(),
+								updatedAt: new Date(),
+								...data,
 							},
-						],
-						"user",
-						undefined,
-						context,
-					);
-					return user;
-				},
-			updatePassword:
-				({ updateManyWithHooks }) =>
-				async (
-					userId: string,
-					password: string,
-					context?: GenericEndpointContext,
-				) => {
-					await updateManyWithHooks(
-						{
-							password,
-						},
-						[
-							{
-								field: "userId",
-								value: userId,
-							},
-							{
-								field: "providerId",
-								value: "credential",
-							},
-						],
-						"account",
-						undefined,
-						context,
-					);
-				},
-			findAccounts:
-				({ adapter }) =>
-				async (userId: string) => {
-					const accounts = await adapter.findMany<Account>({
-						model: "account",
-						where: [
-							{
-								field: "userId",
-								value: userId,
-							},
-						],
-					});
-					return accounts;
-				},
-			findAccount:
-				({ adapter }) =>
-				async (accountId: string) => {
-					const account = await adapter.findOne<Account>({
-						model: "account",
-						where: [
-							{
-								field: "accountId",
-								value: accountId,
-							},
-						],
-					});
-					return account;
-				},
-			findAccountByProviderId:
-				({ adapter }) =>
-				async (accountId: string, providerId: string) => {
-					const account = await adapter.findOne<Account>({
-						model: "account",
-						where: [
-							{
-								field: "accountId",
-								value: accountId,
-							},
-							{
-								field: "providerId",
-								value: providerId,
-							},
-						],
-					});
-					return account;
-				},
-			findAccountByUserId:
-				({ adapter }) =>
-				async (userId: string) => {
-					const account = await adapter.findMany<Account>({
-						model: "account",
-						where: [
-							{
-								field: "userId",
-								value: userId,
-							},
-						],
-					});
-					return account;
-				},
-			updateAccount:
-				({ updateWithHooks }) =>
-				async (
-					id: string,
-					data: Partial<Account>,
-					context?: GenericEndpointContext,
-				) => {
-					const account = await updateWithHooks<Account>(
-						data,
-						[{ field: "id", value: id }],
-						"account",
-						undefined,
-						context,
-					);
-					return account;
-				},
-			createVerificationValue:
-				({ createWithHooks }) =>
-				async (
-					data: Omit<Verification, "createdAt" | "id" | "updatedAt"> &
-						Partial<Verification>,
-					context?: GenericEndpointContext,
-				) => {
-					const verification = await createWithHooks(
-						{
-							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-							createdAt: new Date(),
-							updatedAt: new Date(),
-							...data,
-						},
-						"verification",
-						undefined,
-						context,
-					);
-					return verification as Verification;
-				},
-			findVerificationValue:
-				({ adapter }) =>
-				async (identifier: string) => {
-					const verification = await adapter.findMany<Verification>({
-						model: "verification",
-						where: [
-							{
-								field: "identifier",
-								value: identifier,
-							},
-						],
-						sortBy: {
-							field: "createdAt",
-							direction: "desc",
-						},
-						limit: 1,
-					});
-					if (!options.verification?.disableCleanup) {
-						await adapter.deleteMany({
+							"verification",
+							undefined,
+							context,
+						);
+						return verification as Verification;
+					},
+				findVerificationValue:
+					({ adapter }) =>
+					async (identifier: string) => {
+						const verification = await adapter.findMany<Verification>({
 							model: "verification",
 							where: [
 								{
-									field: "expiresAt",
-									value: new Date(),
-									operator: "lt",
+									field: "identifier",
+									value: identifier,
+								},
+							],
+							sortBy: {
+								field: "createdAt",
+								direction: "desc",
+							},
+							limit: 1,
+						});
+						if (!options.verification?.disableCleanup) {
+							await adapter.deleteMany({
+								model: "verification",
+								where: [
+									{
+										field: "expiresAt",
+										value: new Date(),
+										operator: "lt",
+									},
+								],
+							});
+						}
+						const lastVerification = verification[0];
+						return lastVerification as Verification | null;
+					},
+				deleteVerificationValue:
+					({ adapter }) =>
+					async (id: string) => {
+						await adapter.delete<Verification>({
+							model: "verification",
+							where: [
+								{
+									field: "id",
+									value: id,
 								},
 							],
 						});
-					}
-					const lastVerification = verification[0];
-					return lastVerification as Verification | null;
-				},
-			deleteVerificationValue:
-				({ adapter }) =>
-				async (id: string) => {
-					await adapter.delete<Verification>({
-						model: "verification",
-						where: [
-							{
-								field: "id",
-								value: id,
-							},
-						],
-					});
-				},
-			deleteVerificationByIdentifier:
-				({ adapter }) =>
-				async (identifier: string) => {
-					await adapter.delete<Verification>({
-						model: "verification",
-						where: [
-							{
-								field: "identifier",
-								value: identifier,
-							},
-						],
-					});
-				},
-			updateVerificationValue:
-				({ updateWithHooks }) =>
-				async (
-					id: string,
-					data: Partial<Verification>,
-					context?: GenericEndpointContext,
-				) => {
-					const verification = await updateWithHooks<Verification>(
-						data,
-						[{ field: "id", value: id }],
-						"verification",
-						undefined,
-						context,
-					);
-					return verification;
-				},
+					},
+				deleteVerificationByIdentifier:
+					({ adapter }) =>
+					async (identifier: string) => {
+						await adapter.delete<Verification>({
+							model: "verification",
+							where: [
+								{
+									field: "identifier",
+									value: identifier,
+								},
+							],
+						});
+					},
+				updateVerificationValue:
+					({ updateWithHooks }) =>
+					async (
+						id: string,
+						data: Partial<Verification>,
+						context?: GenericEndpointContext,
+					) => {
+						const verification = await updateWithHooks<Verification>(
+							data,
+							[{ field: "id", value: id }],
+							"verification",
+							undefined,
+							context,
+						);
+						return verification;
+					},
+			},
 		},
-	});
+	);
 };
 
 export type InternalAdapter = ReturnType<typeof createInternalAdapter>;

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -18,7 +18,7 @@ import { getWithHooks } from "./with-hooks";
 import { getIp } from "../utils/get-request-ip";
 import { safeJSONParse } from "../utils/json";
 import { generateId, type InternalLogger } from "../utils";
-import { shimLastParam } from "../utils/shim";
+import { shimLastParam, type InferShimLastParamResult } from "../utils/shim";
 
 export const createInternalAdapter = (
 	adapter: Adapter,
@@ -1005,8 +1005,10 @@ export const createInternalAdapter = (
 		withTransaction: async <R>(
 			cb: (trx: {
 				adapter: TransactionAdapter;
-				internalAdapter: ReturnType<
-					typeof shimLastParam<typeof baseMethods, TransactionAdapter, true>
+				internalAdapter: InferShimLastParamResult<
+					typeof baseMethods,
+					TransactionAdapter,
+					true
 				>;
 			}) => Promise<R>,
 		): Promise<R> => {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -18,16 +18,17 @@ import { getWithHooks } from "./with-hooks";
 import { getIp } from "../utils/get-request-ip";
 import { safeJSONParse } from "../utils/json";
 import { generateId, type InternalLogger } from "../utils";
-import { shimLastParam } from "../utils/shim";
+import { createAdapterBridge } from "./adapter-bridge";
 
-export const createInternalAdapter = (
-	adapter: Adapter,
+export const createInternalAdapter = <OmitStaticMethods extends boolean = false>(
+	adapter: OmitStaticMethods extends true ? TransactionAdapter : Adapter,
 	ctx: {
 		options: Omit<BetterAuthOptions, "logger">;
 		logger: InternalLogger;
 		hooks: Exclude<BetterAuthOptions["databaseHooks"], undefined>[];
 		generateId: AuthContext["generateId"];
 	},
+	omitStaticMethods?: OmitStaticMethods
 ) => {
 	const logger = ctx.logger;
 	const options = ctx.options;
@@ -36,132 +37,124 @@ export const createInternalAdapter = (
 	const { createWithHooks, updateWithHooks, updateManyWithHooks } =
 		getWithHooks(adapter, ctx);
 
-	const baseMethods = {
-		createUser: async <T>(
-			user: Omit<User, "id" | "createdAt" | "updatedAt" | "emailVerified"> &
-				Partial<User> &
-				Record<string, any>,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const createdUser = await createWithHooks(
-				{
-					// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-					createdAt: new Date(),
-					updatedAt: new Date(),
-					...user,
-					email: user.email?.toLowerCase(),
-				},
-				"user",
-				undefined,
-				context,
-				trxAdapter,
-			);
-			return createdUser as T & User;
-		},
-		createAccount: async <T extends Record<string, any>>(
-			account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
-				Partial<Account> &
-				T,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const createdAccount = await createWithHooks(
-				{
-					// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-					createdAt: new Date(),
-					updatedAt: new Date(),
-					...account,
-				},
-				"account",
-				undefined,
-				context,
-				trxAdapter,
-			);
-			return createdAccount as T & Account;
-		},
-		listSessions: async (userId: string, trxAdapter?: TransactionAdapter) => {
-			if (secondaryStorage) {
-				const currentList = await secondaryStorage.get(
-					`active-sessions-${userId}`,
-				);
-				if (!currentList) return [];
-
-				const list: { token: string; expiresAt: number }[] =
-					safeJSONParse(currentList) || [];
-				const now = Date.now();
-
-				const validSessions = list.filter((s) => s.expiresAt > now);
-				const sessions = [];
-
-				for (const session of validSessions) {
-					const sessionStringified = await secondaryStorage.get(session.token);
-					if (sessionStringified) {
-						const s = safeJSONParse<{
-							session: Session;
-							user: User;
-						}>(sessionStringified);
-						if (!s) return [];
-						const parsedSession = parseSessionOutput(ctx.options, {
-							...s.session,
-							expiresAt: new Date(s.session.expiresAt),
-						});
-						sessions.push(parsedSession);
-					}
-				}
-				return sessions;
-			}
-
-			const sessions = await (trxAdapter || adapter).findMany<Session>({
-				model: "session",
-				where: [
-					{
-						field: "userId",
-						value: userId,
-					},
-				],
-			});
-			return sessions;
-		},
-		listUsers: async (
-			limit?: number,
-			offset?: number,
-			sortBy?: {
-				field: string;
-				direction: "asc" | "desc";
+	return createAdapterBridge({
+		id: "internalAdapter",
+		adapter: adapter as Adapter,
+		staticMethods: !omitStaticMethods ? {
+			createOAuthUser: async (
+				user: Omit<User, "id" | "createdAt" | "updatedAt">,
+				account: Omit<Account, "userId" | "id" | "createdAt" | "updatedAt"> &
+					Partial<Account>,
+				context?: GenericEndpointContext,
+			) => {
+				return (adapter as Adapter).transaction(async (trxAdapter) => {
+					const createdUser = await createWithHooks(
+						{
+							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+							createdAt: new Date(),
+							updatedAt: new Date(),
+							...user,
+						},
+						"user",
+						undefined,
+						context,
+						trxAdapter,
+					);
+					const createdAccount = await createWithHooks(
+						{
+							...account,
+							userId: createdUser!.id,
+							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+							createdAt: new Date(),
+							updatedAt: new Date(),
+						},
+						"account",
+						undefined,
+						context,
+						trxAdapter,
+					);
+					return {
+						user: createdUser,
+						account: createdAccount,
+					};
+				});
 			},
-			where?: Where[],
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const users = await (trxAdapter || adapter).findMany<User>({
-				model: "user",
-				limit,
-				offset,
-				sortBy,
-				where,
-			});
-			return users;
-		},
-		countTotalUsers: async (
-			where?: Where[],
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const total = await (trxAdapter || adapter).count({
-				model: "user",
-				where,
-			});
-			if (typeof total === "string") {
-				return parseInt(total);
-			}
-			return total;
-		},
-		deleteUser: async (userId: string, trxAdapter?: TransactionAdapter) => {
-			if (secondaryStorage) {
-				await secondaryStorage.delete(`active-sessions-${userId}`);
-			}
-
-			if (!secondaryStorage || options.session?.storeSessionInDatabase) {
-				await (trxAdapter || adapter).deleteMany({
+		} : undefined,
+		methods: {
+			createUser: ({ adapter }) => async <T>(
+				user: Omit<User, "id" | "createdAt" | "updatedAt" | "emailVerified"> &
+					Partial<User> &
+					Record<string, any>,
+				context?: GenericEndpointContext,
+			) => {
+				const createdUser = await createWithHooks(
+					{
+						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+						createdAt: new Date(),
+						updatedAt: new Date(),
+						...user,
+						email: user.email?.toLowerCase(),
+					},
+					"user",
+					undefined,
+					context,
+					adapter,
+				);
+				return createdUser as T & User;
+			},
+			createAccount: ({ adapter }) => async <T extends Record<string, any>>(
+				account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
+					Partial<Account> &
+					T,
+				context?: GenericEndpointContext,
+			) => {
+				const createdAccount = await createWithHooks(
+					{
+						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+						createdAt: new Date(),
+						updatedAt: new Date(),
+						...account,
+					},
+					"account",
+					undefined,
+					context,
+					adapter,
+				);
+				return createdAccount as T & Account;
+			},
+			listSessions: ({ adapter }) => async (userId: string) => {
+				if (secondaryStorage) {
+					const currentList = await secondaryStorage.get(
+						`active-sessions-${userId}`,
+					);
+					if (!currentList) return [];
+	
+					const list: { token: string; expiresAt: number }[] =
+						safeJSONParse(currentList) || [];
+					const now = Date.now();
+	
+					const validSessions = list.filter((s) => s.expiresAt > now);
+					const sessions = [];
+	
+					for (const session of validSessions) {
+						const sessionStringified = await secondaryStorage.get(session.token);
+						if (sessionStringified) {
+							const s = safeJSONParse<{
+								session: Session;
+								user: User;
+							}>(sessionStringified);
+							if (!s) return [];
+							const parsedSession = parseSessionOutput(ctx.options, {
+								...s.session,
+								expiresAt: new Date(s.session.expiresAt),
+							});
+							sessions.push(parsedSession);
+						}
+					}
+					return sessions;
+				}
+	
+				const sessions = await adapter.findMany<Session>({
 					model: "session",
 					where: [
 						{
@@ -170,445 +163,503 @@ export const createInternalAdapter = (
 						},
 					],
 				});
-			}
-
-			await (trxAdapter || adapter).deleteMany({
-				model: "account",
-				where: [
-					{
-						field: "userId",
-						value: userId,
-					},
-				],
-			});
-			await (trxAdapter || adapter).delete({
-				model: "user",
-				where: [
-					{
-						field: "id",
-						value: userId,
-					},
-				],
-			});
-		},
-		createSession: async (
-			userId: string,
-			ctx: GenericEndpointContext,
-			dontRememberMe?: boolean,
-			override?: Partial<Session> & Record<string, any>,
-			overrideAll?: boolean,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const headers = ctx.headers || ctx.request?.headers;
-			const { id: _, ...rest } = override || {};
-			const data: Omit<Session, "id"> = {
-				ipAddress:
-					ctx.request || ctx.headers
-						? getIp(ctx.request || ctx.headers!, ctx.context.options) || ""
-						: "",
-				userAgent: headers?.get("user-agent") || "",
-				...rest,
-				/**
-				 * If the user doesn't want to be remembered
-				 * set the session to expire in 1 day.
-				 * The cookie will be set to expire at the end of the session
-				 */
-				expiresAt: dontRememberMe
-					? getDate(60 * 60 * 24, "sec") // 1 day
-					: getDate(sessionExpiration, "sec"),
-				userId,
-				token: generateId(32),
-				// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-				createdAt: new Date(),
-				updatedAt: new Date(),
-				...(overrideAll ? rest : {}),
-			};
-			const res = await createWithHooks(
-				data,
-				"session",
-				secondaryStorage
-					? {
-							fn: async (sessionData) => {
-								/**
-								 * store the session token for the user
-								 * so we can retrieve it later for listing sessions
-								 */
-								const currentList = await secondaryStorage.get(
-									`active-sessions-${userId}`,
-								);
-
-								let list: { token: string; expiresAt: number }[] = [];
-								const now = Date.now();
-
-								if (currentList) {
-									list = safeJSONParse(currentList) || [];
-									list = list.filter((session) => session.expiresAt > now);
-								}
-
-								list.push({
-									token: data.token,
-									expiresAt: now + sessionExpiration * 1000,
-								});
-
-								await secondaryStorage.set(
-									`active-sessions-${userId}`,
-									JSON.stringify(list),
-									sessionExpiration,
-								);
-
-								return sessionData;
+				return sessions;
+			},
+			listUsers: ({ adapter }) => async (
+				limit?: number,
+				offset?: number,
+				sortBy?: {
+					field: string;
+					direction: "asc" | "desc";
+				},
+				where?: Where[],
+			) => {
+				const users = await adapter.findMany<User>({
+					model: "user",
+					limit,
+					offset,
+					sortBy,
+					where,
+				});
+				return users;
+			},
+			countTotalUsers: ({ adapter }) => async (
+				where?: Where[],
+			) => {
+				const total = await adapter.count({
+					model: "user",
+					where,
+				});
+				if (typeof total === "string") {
+					return parseInt(total);
+				}
+				return total;
+			},
+			deleteUser: ({ adapter }) => async (userId: string) => {
+				if (secondaryStorage) {
+					await secondaryStorage.delete(`active-sessions-${userId}`);
+				}
+	
+				if (!secondaryStorage || options.session?.storeSessionInDatabase) {
+					await adapter.deleteMany({
+						model: "session",
+						where: [
+							{
+								field: "userId",
+								value: userId,
 							},
-							executeMainFn: options.session?.storeSessionInDatabase,
-						}
-					: undefined,
-				ctx,
-				trxAdapter,
-			);
-			return res as Session;
-		},
-		findSession: async (
-			token: string,
-			trxAdapter?: TransactionAdapter,
-		): Promise<{
-			session: Session & Record<string, any>;
-			user: User & Record<string, any>;
-		} | null> => {
-			if (secondaryStorage) {
-				const sessionStringified = await secondaryStorage.get(token);
-				if (!sessionStringified && !options.session?.storeSessionInDatabase) {
-					return null;
-				}
-				if (sessionStringified) {
-					const s = safeJSONParse<{
-						session: Session;
-						user: User;
-					}>(sessionStringified);
-					if (!s) return null;
-					const parsedSession = parseSessionOutput(ctx.options, {
-						...s.session,
-						expiresAt: new Date(s.session.expiresAt),
-						createdAt: new Date(s.session.createdAt),
-						updatedAt: new Date(s.session.updatedAt),
+						],
 					});
-					const parsedUser = parseUserOutput(ctx.options, {
-						...s.user,
-						createdAt: new Date(s.user.createdAt),
-						updatedAt: new Date(s.user.updatedAt),
-					});
-					return {
-						session: parsedSession,
-						user: parsedUser,
-					};
 				}
-			}
-
-			const session = await (trxAdapter || adapter).findOne<Session>({
-				model: "session",
-				where: [
-					{
-						value: token,
-						field: "token",
-					},
-				],
-			});
-
-			if (!session) {
-				return null;
-			}
-
-			const user = await (trxAdapter || adapter).findOne<User>({
-				model: "user",
-				where: [
-					{
-						value: session.userId,
-						field: "id",
-					},
-				],
-			});
-			if (!user) {
-				return null;
-			}
-			const parsedSession = parseSessionOutput(ctx.options, session);
-			const parsedUser = parseUserOutput(ctx.options, user);
-
-			return {
-				session: parsedSession,
-				user: parsedUser,
-			};
-		},
-		findSessions: async (
-			sessionTokens: string[],
-			trxAdapter?: TransactionAdapter,
-		) => {
-			if (secondaryStorage) {
-				const sessions: {
-					session: Session;
-					user: User;
-				}[] = [];
-				for (const sessionToken of sessionTokens) {
-					const sessionStringified = await secondaryStorage.get(sessionToken);
+	
+				await adapter.deleteMany({
+					model: "account",
+					where: [
+						{
+							field: "userId",
+							value: userId,
+						},
+					],
+				});
+				await adapter.delete({
+					model: "user",
+					where: [
+						{
+							field: "id",
+							value: userId,
+						},
+					],
+				});
+			},
+			createSession: ({ adapter }) => async (
+				userId: string,
+				ctx: GenericEndpointContext,
+				dontRememberMe?: boolean,
+				override?: Partial<Session> & Record<string, any>,
+				overrideAll?: boolean,
+			) => {
+				const headers = ctx.headers || ctx.request?.headers;
+				const { id: _, ...rest } = override || {};
+				const data: Omit<Session, "id"> = {
+					ipAddress:
+						ctx.request || ctx.headers
+							? getIp(ctx.request || ctx.headers!, ctx.context.options) || ""
+							: "",
+					userAgent: headers?.get("user-agent") || "",
+					...rest,
+					/**
+					 * If the user doesn't want to be remembered
+					 * set the session to expire in 1 day.
+					 * The cookie will be set to expire at the end of the session
+					 */
+					expiresAt: dontRememberMe
+						? getDate(60 * 60 * 24, "sec") // 1 day
+						: getDate(sessionExpiration, "sec"),
+					userId,
+					token: generateId(32),
+					// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					...(overrideAll ? rest : {}),
+				};
+				const res = await createWithHooks(
+					data,
+					"session",
+					secondaryStorage
+						? {
+								fn: async (sessionData) => {
+									/**
+									 * store the session token for the user
+									 * so we can retrieve it later for listing sessions
+									 */
+									const currentList = await secondaryStorage.get(
+										`active-sessions-${userId}`,
+									);
+	
+									let list: { token: string; expiresAt: number }[] = [];
+									const now = Date.now();
+	
+									if (currentList) {
+										list = safeJSONParse(currentList) || [];
+										list = list.filter((session) => session.expiresAt > now);
+									}
+	
+									list.push({
+										token: data.token,
+										expiresAt: now + sessionExpiration * 1000,
+									});
+	
+									await secondaryStorage.set(
+										`active-sessions-${userId}`,
+										JSON.stringify(list),
+										sessionExpiration,
+									);
+	
+									return sessionData;
+								},
+								executeMainFn: options.session?.storeSessionInDatabase,
+							}
+						: undefined,
+					ctx,
+					adapter,
+				);
+				return res as Session;
+			},
+			findSession: ({ adapter }) => async (
+				token: string,
+			): Promise<{
+				session: Session & Record<string, any>;
+				user: User & Record<string, any>;
+			} | null> => {
+				if (secondaryStorage) {
+					const sessionStringified = await secondaryStorage.get(token);
+					if (!sessionStringified && !options.session?.storeSessionInDatabase) {
+						return null;
+					}
 					if (sessionStringified) {
 						const s = safeJSONParse<{
 							session: Session;
 							user: User;
 						}>(sessionStringified);
-						if (!s) return [];
-						const session = {
-							session: {
-								...s.session,
-								expiresAt: new Date(s.session.expiresAt),
-							},
-							user: {
-								...s.user,
-								createdAt: new Date(s.user.createdAt),
-								updatedAt: new Date(s.user.updatedAt),
-							},
-						} as {
-							session: Session;
-							user: User;
+						if (!s) return null;
+						const parsedSession = parseSessionOutput(ctx.options, {
+							...s.session,
+							expiresAt: new Date(s.session.expiresAt),
+							createdAt: new Date(s.session.createdAt),
+							updatedAt: new Date(s.session.updatedAt),
+						});
+						const parsedUser = parseUserOutput(ctx.options, {
+							...s.user,
+							createdAt: new Date(s.user.createdAt),
+							updatedAt: new Date(s.user.updatedAt),
+						});
+						return {
+							session: parsedSession,
+							user: parsedUser,
 						};
-						sessions.push(session);
 					}
 				}
-				return sessions;
-			}
-
-			const sessions = await (trxAdapter || adapter).findMany<Session>({
-				model: "session",
-				where: [
-					{
-						field: "token",
-						value: sessionTokens,
-						operator: "in",
-					},
-				],
-			});
-			const userIds = sessions.map((session) => {
-				return session.userId;
-			});
-			if (!userIds.length) return [];
-			const users = await (trxAdapter || adapter).findMany<User>({
-				model: "user",
-				where: [
-					{
-						field: "id",
-						value: userIds,
-						operator: "in",
-					},
-				],
-			});
-			return sessions.map((session) => {
-				const user = users.find((u) => u.id === session.userId);
-				if (!user) return null;
-				return {
-					session,
-					user,
-				};
-			}) as {
-				session: Session;
-				user: User;
-			}[];
-		},
-		updateSession: async (
-			sessionToken: string,
-			session: Partial<Session> & Record<string, any>,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const updatedSession = await updateWithHooks<Session>(
-				session,
-				[{ field: "token", value: sessionToken }],
-				"session",
-				secondaryStorage
-					? {
-							async fn(data) {
-								const currentSession = await secondaryStorage.get(sessionToken);
-								let updatedSession: Session | null = null;
-								if (currentSession) {
-									const parsedSession = safeJSONParse<{
-										session: Session;
-										user: User;
-									}>(currentSession);
-									if (!parsedSession) return null;
-									updatedSession = {
-										...parsedSession.session,
-										...data,
-									};
-									return updatedSession;
-								} else {
-									return null;
-								}
-							},
-							executeMainFn: options.session?.storeSessionInDatabase,
-						}
-					: undefined,
-				context,
-				trxAdapter,
-			);
-			return updatedSession;
-		},
-		deleteSession: async (token: string, trxAdapter?: TransactionAdapter) => {
-			if (secondaryStorage) {
-				// remove the session from the active sessions list
-				const data = await secondaryStorage.get(token);
-				if (data) {
-					const { session } =
-						safeJSONParse<{
-							session: Session;
-							user: User;
-						}>(data) ?? {};
-					if (!session) {
-						logger.error("Session not found in secondary storage");
-						return;
-					}
-					const userId = session.userId;
-
-					const currentList = await secondaryStorage.get(
-						`active-sessions-${userId}`,
-					);
-					if (currentList) {
-						let list: { token: string; expiresAt: number }[] =
-							safeJSONParse(currentList) || [];
-						list = list.filter((s) => s.token !== token);
-
-						if (list.length > 0) {
-							await secondaryStorage.set(
-								`active-sessions-${userId}`,
-								JSON.stringify(list),
-								sessionExpiration,
-							);
-						} else {
-							await secondaryStorage.delete(`active-sessions-${userId}`);
-						}
-					} else {
-						logger.error("Active sessions list not found in secondary storage");
-					}
-				}
-
-				await secondaryStorage.delete(token);
-
-				if (
-					!options.session?.storeSessionInDatabase ||
-					ctx.options.session?.preserveSessionInDatabase
-				) {
-					return;
-				}
-			}
-			await (trxAdapter || adapter).delete<Session>({
-				model: "session",
-				where: [
-					{
-						field: "token",
-						value: token,
-					},
-				],
-			});
-		},
-		deleteAccounts: async (userId: string, trxAdapter?: TransactionAdapter) => {
-			await (trxAdapter || adapter).deleteMany({
-				model: "account",
-				where: [
-					{
-						field: "userId",
-						value: userId,
-					},
-				],
-			});
-		},
-		deleteAccount: async (
-			accountId: string,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			await (trxAdapter || adapter).delete({
-				model: "account",
-				where: [
-					{
-						field: "id",
-						value: accountId,
-					},
-				],
-			});
-		},
-		deleteSessions: async (
-			userIdOrSessionTokens: string | string[],
-			trxAdapter?: TransactionAdapter,
-		) => {
-			if (secondaryStorage) {
-				if (typeof userIdOrSessionTokens === "string") {
-					const activeSession = await secondaryStorage.get(
-						`active-sessions-${userIdOrSessionTokens}`,
-					);
-					const sessions = activeSession
-						? safeJSONParse<{ token: string }[]>(activeSession)
-						: [];
-					if (!sessions) return;
-					for (const session of sessions) {
-						await secondaryStorage.delete(session.token);
-					}
-				} else {
-					for (const sessionToken of userIdOrSessionTokens) {
-						const session = await secondaryStorage.get(sessionToken);
-						if (session) {
-							await secondaryStorage.delete(sessionToken);
-						}
-					}
-				}
-
-				if (
-					!options.session?.storeSessionInDatabase ||
-					ctx.options.session?.preserveSessionInDatabase
-				) {
-					return;
-				}
-			}
-			await (trxAdapter || adapter).deleteMany({
-				model: "session",
-				where: [
-					{
-						field: Array.isArray(userIdOrSessionTokens) ? "token" : "userId",
-						value: userIdOrSessionTokens,
-						operator: Array.isArray(userIdOrSessionTokens) ? "in" : undefined,
-					},
-				],
-			});
-		},
-		findOAuthUser: async (
-			email: string,
-			accountId: string,
-			providerId: string,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			// we need to find account first to avoid missing user if the email changed with the provider for the same account
-			const account = await (trxAdapter || adapter)
-				.findMany<Account>({
-					model: "account",
+	
+				const session = await adapter.findOne<Session>({
+					model: "session",
 					where: [
 						{
-							value: accountId,
-							field: "accountId",
+							value: token,
+							field: "token",
 						},
 					],
-				})
-				.then((accounts) => {
-					return accounts.find((a) => a.providerId === providerId);
 				});
-			if (account) {
-				const user = await (trxAdapter || adapter).findOne<User>({
+	
+				if (!session) {
+					return null;
+				}
+	
+				const user = await adapter.findOne<User>({
 					model: "user",
 					where: [
 						{
-							value: account.userId,
+							value: session.userId,
 							field: "id",
 						},
 					],
 				});
-				if (user) {
+				if (!user) {
+					return null;
+				}
+				const parsedSession = parseSessionOutput(ctx.options, session);
+				const parsedUser = parseUserOutput(ctx.options, user);
+	
+				return {
+					session: parsedSession,
+					user: parsedUser,
+				};
+			},
+			findSessions: ({ adapter }) => async (
+				sessionTokens: string[],
+			) => {
+				if (secondaryStorage) {
+					const sessions: {
+						session: Session;
+						user: User;
+					}[] = [];
+					for (const sessionToken of sessionTokens) {
+						const sessionStringified = await secondaryStorage.get(sessionToken);
+						if (sessionStringified) {
+							const s = safeJSONParse<{
+								session: Session;
+								user: User;
+							}>(sessionStringified);
+							if (!s) return [];
+							const session = {
+								session: {
+									...s.session,
+									expiresAt: new Date(s.session.expiresAt),
+								},
+								user: {
+									...s.user,
+									createdAt: new Date(s.user.createdAt),
+									updatedAt: new Date(s.user.updatedAt),
+								},
+							} as {
+								session: Session;
+								user: User;
+							};
+							sessions.push(session);
+						}
+					}
+					return sessions;
+				}
+	
+				const sessions = await adapter.findMany<Session>({
+					model: "session",
+					where: [
+						{
+							field: "token",
+							value: sessionTokens,
+							operator: "in",
+						},
+					],
+				});
+				const userIds = sessions.map((session) => {
+					return session.userId;
+				});
+				if (!userIds.length) return [];
+				const users = await adapter.findMany<User>({
+					model: "user",
+					where: [
+						{
+							field: "id",
+							value: userIds,
+							operator: "in",
+						},
+					],
+				});
+				return sessions.map((session) => {
+					const user = users.find((u) => u.id === session.userId);
+					if (!user) return null;
 					return {
+						session,
 						user,
-						accounts: [account],
 					};
+				}) as {
+					session: Session;
+					user: User;
+				}[];
+			},
+			updateSession: ({ adapter }) => async (
+				sessionToken: string,
+				session: Partial<Session> & Record<string, any>,
+				context?: GenericEndpointContext,
+			) => {
+				const updatedSession = await updateWithHooks<Session>(
+					session,
+					[{ field: "token", value: sessionToken }],
+					"session",
+					secondaryStorage
+						? {
+								async fn(data) {
+									const currentSession = await secondaryStorage.get(sessionToken);
+									let updatedSession: Session | null = null;
+									if (currentSession) {
+										const parsedSession = safeJSONParse<{
+											session: Session;
+											user: User;
+										}>(currentSession);
+										if (!parsedSession) return null;
+										updatedSession = {
+											...parsedSession.session,
+											...data,
+										};
+										return updatedSession;
+									} else {
+										return null;
+									}
+								},
+								executeMainFn: options.session?.storeSessionInDatabase,
+							}
+						: undefined,
+					context,
+					adapter,
+				);
+				return updatedSession;
+			},
+			deleteSession: ({ adapter }) => async (token: string) => {
+				if (secondaryStorage) {
+					// remove the session from the active sessions list
+					const data = await secondaryStorage.get(token);
+					if (data) {
+						const { session } =
+							safeJSONParse<{
+								session: Session;
+								user: User;
+							}>(data) ?? {};
+						if (!session) {
+							logger.error("Session not found in secondary storage");
+							return;
+						}
+						const userId = session.userId;
+	
+						const currentList = await secondaryStorage.get(
+							`active-sessions-${userId}`,
+						);
+						if (currentList) {
+							let list: { token: string; expiresAt: number }[] =
+								safeJSONParse(currentList) || [];
+							list = list.filter((s) => s.token !== token);
+	
+							if (list.length > 0) {
+								await secondaryStorage.set(
+									`active-sessions-${userId}`,
+									JSON.stringify(list),
+									sessionExpiration,
+								);
+							} else {
+								await secondaryStorage.delete(`active-sessions-${userId}`);
+							}
+						} else {
+							logger.error("Active sessions list not found in secondary storage");
+						}
+					}
+	
+					await secondaryStorage.delete(token);
+	
+					if (
+						!options.session?.storeSessionInDatabase ||
+						ctx.options.session?.preserveSessionInDatabase
+					) {
+						return;
+					}
+				}
+				await adapter.delete<Session>({
+					model: "session",
+					where: [
+						{
+							field: "token",
+							value: token,
+						},
+					],
+				});
+			},
+			deleteAccounts: ({ adapter }) => async (userId: string) => {
+				await adapter.deleteMany({
+					model: "account",
+					where: [
+						{
+							field: "userId",
+							value: userId,
+						},
+					],
+				});
+			},
+			deleteAccount: ({ adapter }) => async (
+				accountId: string,
+			) => {
+				await adapter.delete({
+					model: "account",
+					where: [
+						{
+							field: "id",
+							value: accountId,
+						},
+					],
+				});
+			},
+			deleteSessions: ({ adapter }) => async (
+				userIdOrSessionTokens: string | string[],
+			) => {
+				if (secondaryStorage) {
+					if (typeof userIdOrSessionTokens === "string") {
+						const activeSession = await secondaryStorage.get(
+							`active-sessions-${userIdOrSessionTokens}`,
+						);
+						const sessions = activeSession
+							? safeJSONParse<{ token: string }[]>(activeSession)
+							: [];
+						if (!sessions) return;
+						for (const session of sessions) {
+							await secondaryStorage.delete(session.token);
+						}
+					} else {
+						for (const sessionToken of userIdOrSessionTokens) {
+							const session = await secondaryStorage.get(sessionToken);
+							if (session) {
+								await secondaryStorage.delete(sessionToken);
+							}
+						}
+					}
+	
+					if (
+						!options.session?.storeSessionInDatabase ||
+						ctx.options.session?.preserveSessionInDatabase
+					) {
+						return;
+					}
+				}
+				await adapter.deleteMany({
+					model: "session",
+					where: [
+						{
+							field: Array.isArray(userIdOrSessionTokens) ? "token" : "userId",
+							value: userIdOrSessionTokens,
+							operator: Array.isArray(userIdOrSessionTokens) ? "in" : undefined,
+						},
+					],
+				});
+			},
+			findOAuthUser: ({ adapter }) => async (
+				email: string,
+				accountId: string,
+				providerId: string,
+			) => {
+				// we need to find account first to avoid missing user if the email changed with the provider for the same account
+				const account = await adapter
+					.findMany<Account>({
+						model: "account",
+						where: [
+							{
+								value: accountId,
+								field: "accountId",
+							},
+						],
+					})
+					.then((accounts) => {
+						return accounts.find((a) => a.providerId === providerId);
+					});
+				if (account) {
+					const user = await adapter.findOne<User>({
+						model: "user",
+						where: [
+							{
+								value: account.userId,
+								field: "id",
+							},
+						],
+					});
+					if (user) {
+						return {
+							user,
+							accounts: [account],
+						};
+					} else {
+						const user = await adapter.findOne<User>({
+							model: "user",
+							where: [
+								{
+									value: email.toLowerCase(),
+									field: "email",
+								},
+							],
+						});
+						if (user) {
+							return {
+								user,
+								accounts: [account],
+							};
+						}
+						return null;
+					}
 				} else {
-					const user = await (trxAdapter || adapter).findOne<User>({
+					const user = await adapter.findOne<User>({
 						model: "user",
 						where: [
 							{
@@ -618,15 +669,29 @@ export const createInternalAdapter = (
 						],
 					});
 					if (user) {
+						const accounts = await adapter.findMany<Account>({
+							model: "account",
+							where: [
+								{
+									value: user.id,
+									field: "userId",
+								},
+							],
+						});
 						return {
 							user,
-							accounts: [account],
+							accounts: accounts || [],
 						};
+					} else {
+						return null;
 					}
-					return null;
 				}
-			} else {
-				const user = await (trxAdapter || adapter).findOne<User>({
+			},
+			findUserByEmail: ({ adapter }) => async (
+				email: string,
+				options?: { includeAccounts: boolean },
+			) => {
+				const user = await adapter.findOne<User>({
 					model: "user",
 					where: [
 						{
@@ -635,8 +700,9 @@ export const createInternalAdapter = (
 						},
 					],
 				});
-				if (user) {
-					const accounts = await (trxAdapter || adapter).findMany<Account>({
+				if (!user) return null;
+				if (options?.includeAccounts) {
+					const accounts = await adapter.findMany<Account>({
 						model: "account",
 						where: [
 							{
@@ -647,284 +713,287 @@ export const createInternalAdapter = (
 					});
 					return {
 						user,
-						accounts: accounts || [],
+						accounts,
 					};
-				} else {
-					return null;
 				}
-			}
-		},
-		findUserByEmail: async (
-			email: string,
-			options?: { includeAccounts: boolean },
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const user = await (trxAdapter || adapter).findOne<User>({
-				model: "user",
-				where: [
-					{
-						value: email.toLowerCase(),
-						field: "email",
-					},
-				],
-			});
-			if (!user) return null;
-			if (options?.includeAccounts) {
-				const accounts = await (trxAdapter || adapter).findMany<Account>({
-					model: "account",
+				return {
+					user,
+					accounts: [],
+				};
+			},
+			findUserById: ({ adapter }) => async (userId: string) => {
+				const user = await adapter.findOne<User>({
+					model: "user",
 					where: [
 						{
-							value: user.id,
-							field: "userId",
+							field: "id",
+							value: userId,
 						},
 					],
 				});
-				return {
-					user,
-					accounts,
-				};
-			}
-			return {
-				user,
-				accounts: [],
-			};
-		},
-		findUserById: async (userId: string, trxAdapter?: TransactionAdapter) => {
-			const user = await (trxAdapter || adapter).findOne<User>({
-				model: "user",
-				where: [
+				return user;
+			},
+			linkAccount: ({ adapter }) => async (
+				account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
+					Partial<Account>,
+				context?: GenericEndpointContext,
+			) => {
+				const _account = await createWithHooks(
 					{
-						field: "id",
-						value: userId,
+						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+						createdAt: new Date(),
+						updatedAt: new Date(),
+						...account,
 					},
-				],
-			});
-			return user;
-		},
-		linkAccount: async (
-			account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
-				Partial<Account>,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const _account = await createWithHooks(
-				{
-					// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-					createdAt: new Date(),
-					updatedAt: new Date(),
-					...account,
-				},
-				"account",
-				undefined,
-				context,
-				trxAdapter,
-			);
-			return _account;
-		},
-		updateUser: async (
-			userId: string,
-			data: Partial<User> & Record<string, any>,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const user = await updateWithHooks<User>(
-				data,
-				[
-					{
-						field: "id",
-						value: userId,
-					},
-				],
-				"user",
-				undefined,
-				context,
-				trxAdapter,
-			);
-			if (secondaryStorage && user) {
-				const listRaw = await secondaryStorage.get(`active-sessions-${userId}`);
-				if (listRaw) {
-					const now = Date.now();
-					const list =
-						safeJSONParse<{ token: string; expiresAt: number }[]>(listRaw) ||
-						[];
-					const validSessions = list.filter((s) => s.expiresAt > now);
-					await Promise.all(
-						validSessions.map(async ({ token }) => {
-							const cached = await secondaryStorage.get(token);
-							if (!cached) return;
-							const parsed = safeJSONParse<{
-								session: Session;
-								user: User;
-							}>(cached);
-							if (!parsed) return;
-							const sessionTTL = Math.max(
-								Math.floor(
-									(new Date(parsed.session.expiresAt).getTime() - now) / 1000,
-								),
-								0,
-							);
-							await secondaryStorage.set(
-								token,
-								JSON.stringify({
-									session: parsed.session,
-									user,
-								}),
-								sessionTTL,
-							);
-						}),
-					);
+					"account",
+					undefined,
+					context,
+					adapter,
+				);
+				return _account;
+			},
+			updateUser: ({ adapter }) => async (
+				userId: string,
+				data: Partial<User> & Record<string, any>,
+				context?: GenericEndpointContext,
+			) => {
+				const user = await updateWithHooks<User>(
+					data,
+					[
+						{
+							field: "id",
+							value: userId,
+						},
+					],
+					"user",
+					undefined,
+					context,
+					adapter
+				);
+				if (secondaryStorage && user) {
+					const listRaw = await secondaryStorage.get(`active-sessions-${userId}`);
+					if (listRaw) {
+						const now = Date.now();
+						const list =
+							safeJSONParse<{ token: string; expiresAt: number }[]>(listRaw) ||
+							[];
+						const validSessions = list.filter((s) => s.expiresAt > now);
+						await Promise.all(
+							validSessions.map(async ({ token }) => {
+								const cached = await secondaryStorage.get(token);
+								if (!cached) return;
+								const parsed = safeJSONParse<{
+									session: Session;
+									user: User;
+								}>(cached);
+								if (!parsed) return;
+								const sessionTTL = Math.max(
+									Math.floor(
+										(new Date(parsed.session.expiresAt).getTime() - now) / 1000,
+									),
+									0,
+								);
+								await secondaryStorage.set(
+									token,
+									JSON.stringify({
+										session: parsed.session,
+										user,
+									}),
+									sessionTTL,
+								);
+							}),
+						);
+					}
 				}
-			}
-			return user;
-		},
-		updateUserByEmail: async (
-			email: string,
-			data: Partial<User & Record<string, any>>,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const user = await updateWithHooks<User>(
-				data,
-				[
+				return user;
+			},
+			updateUserByEmail: ({ adapter }) => async (
+				email: string,
+				data: Partial<User & Record<string, any>>,
+				context?: GenericEndpointContext,
+			) => {
+				const user = await updateWithHooks<User>(
+					data,
+					[
+						{
+							field: "email",
+							value: email.toLowerCase(),
+						},
+					],
+					"user",
+					undefined,
+					context,
+					adapter,
+				);
+				return user;
+			},
+			updatePassword: ({ adapter }) => async (
+				userId: string,
+				password: string,
+				context?: GenericEndpointContext,
+			) => {
+				await updateManyWithHooks(
 					{
-						field: "email",
-						value: email.toLowerCase(),
+						password,
 					},
-				],
-				"user",
-				undefined,
-				context,
-				trxAdapter,
-			);
-			return user;
-		},
-		updatePassword: async (
-			userId: string,
-			password: string,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			await updateManyWithHooks(
-				{
-					password,
-				},
-				[
+					[
+						{
+							field: "userId",
+							value: userId,
+						},
+						{
+							field: "providerId",
+							value: "credential",
+						},
+					],
+					"account",
+					undefined,
+					context,
+					adapter
+				);
+			},
+			findAccounts: ({ adapter }) => async (userId: string) => {
+				const accounts = await adapter.findMany<Account>({
+					model: "account",
+					where: [
+						{
+							field: "userId",
+							value: userId,
+						},
+					],
+				});
+				return accounts;
+			},
+			findAccount: ({ adapter }) => async (accountId: string) => {
+				const account = await adapter.findOne<Account>({
+					model: "account",
+					where: [
+						{
+							field: "accountId",
+							value: accountId,
+						},
+					],
+				});
+				return account;
+			},
+			findAccountByProviderId: ({ adapter }) => async (
+				accountId: string,
+				providerId: string,
+			) => {
+				const account = await adapter.findOne<Account>({
+					model: "account",
+					where: [
+						{
+							field: "accountId",
+							value: accountId,
+						},
+						{
+							field: "providerId",
+							value: providerId,
+						},
+					],
+				});
+				return account;
+			},
+			findAccountByUserId: ({ adapter }) => async (
+				userId: string,
+			) => {
+				const account = await adapter.findMany<Account>({
+					model: "account",
+					where: [
+						{
+							field: "userId",
+							value: userId,
+						},
+					],
+				});
+				return account;
+			},
+			updateAccount: ({ adapter }) => async (
+				id: string,
+				data: Partial<Account>,
+				context?: GenericEndpointContext,
+			) => {
+				const account = await updateWithHooks<Account>(
+					data,
+					[{ field: "id", value: id }],
+					"account",
+					undefined,
+					context,
+					adapter,
+				);
+				return account;
+			},
+			createVerificationValue: ({ adapter }) => async (
+				data: Omit<Verification, "createdAt" | "id" | "updatedAt"> &
+					Partial<Verification>,
+				context?: GenericEndpointContext,
+			) => {
+				const verification = await createWithHooks(
 					{
-						field: "userId",
-						value: userId,
+						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+						createdAt: new Date(),
+						updatedAt: new Date(),
+						...data,
 					},
+					"verification",
+					undefined,
+					context,
+					adapter,
+				);
+				return verification as Verification;
+			},
+			findVerificationValue: ({ adapter }) => async (
+				identifier: string,
+			) => {
+				const verification = await adapter.findMany<Verification>(
 					{
-						field: "providerId",
-						value: "credential",
+						model: "verification",
+						where: [
+							{
+								field: "identifier",
+								value: identifier,
+							},
+						],
+						sortBy: {
+							field: "createdAt",
+							direction: "desc",
+						},
+						limit: 1,
 					},
-				],
-				"account",
-				undefined,
-				context,
-				trxAdapter,
-			);
-		},
-		findAccounts: async (userId: string, trxAdapter?: TransactionAdapter) => {
-			const accounts = await (trxAdapter || adapter).findMany<Account>({
-				model: "account",
-				where: [
-					{
-						field: "userId",
-						value: userId,
-					},
-				],
-			});
-			return accounts;
-		},
-		findAccount: async (accountId: string, trxAdapter?: TransactionAdapter) => {
-			const account = await (trxAdapter || adapter).findOne<Account>({
-				model: "account",
-				where: [
-					{
-						field: "accountId",
-						value: accountId,
-					},
-				],
-			});
-			return account;
-		},
-		findAccountByProviderId: async (
-			accountId: string,
-			providerId: string,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const account = await (trxAdapter || adapter).findOne<Account>({
-				model: "account",
-				where: [
-					{
-						field: "accountId",
-						value: accountId,
-					},
-					{
-						field: "providerId",
-						value: providerId,
-					},
-				],
-			});
-			return account;
-		},
-		findAccountByUserId: async (
-			userId: string,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const account = await (trxAdapter || adapter).findMany<Account>({
-				model: "account",
-				where: [
-					{
-						field: "userId",
-						value: userId,
-					},
-				],
-			});
-			return account;
-		},
-		updateAccount: async (
-			id: string,
-			data: Partial<Account>,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const account = await updateWithHooks<Account>(
-				data,
-				[{ field: "id", value: id }],
-				"account",
-				undefined,
-				context,
-				trxAdapter,
-			);
-			return account;
-		},
-		createVerificationValue: async (
-			data: Omit<Verification, "createdAt" | "id" | "updatedAt"> &
-				Partial<Verification>,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const verification = await createWithHooks(
-				{
-					// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-					createdAt: new Date(),
-					updatedAt: new Date(),
-					...data,
-				},
-				"verification",
-				undefined,
-				context,
-				trxAdapter,
-			);
-			return verification as Verification;
-		},
-		findVerificationValue: async (
-			identifier: string,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const verification = await (trxAdapter || adapter).findMany<Verification>(
-				{
+				);
+				if (!options.verification?.disableCleanup) {
+					await adapter.deleteMany({
+						model: "verification",
+						where: [
+							{
+								field: "expiresAt",
+								value: new Date(),
+								operator: "lt",
+							},
+						],
+					});
+				}
+				const lastVerification = verification[0];
+				return lastVerification as Verification | null;
+			},
+			deleteVerificationValue: ({ adapter }) => async (
+				id: string,
+			) => {
+				await adapter.delete<Verification>({
+					model: "verification",
+					where: [
+						{
+							field: "id",
+							value: id,
+						},
+					],
+				});
+			},
+			deleteVerificationByIdentifier: ({ adapter }) => async (
+				identifier: string,
+			) => {
+				await adapter.delete<Verification>({
 					model: "verification",
 					where: [
 						{
@@ -932,131 +1001,25 @@ export const createInternalAdapter = (
 							value: identifier,
 						},
 					],
-					sortBy: {
-						field: "createdAt",
-						direction: "desc",
-					},
-					limit: 1,
-				},
-			);
-			if (!options.verification?.disableCleanup) {
-				await (trxAdapter || adapter).deleteMany({
-					model: "verification",
-					where: [
-						{
-							field: "expiresAt",
-							value: new Date(),
-							operator: "lt",
-						},
-					],
 				});
-			}
-			const lastVerification = verification[0];
-			return lastVerification as Verification | null;
-		},
-		deleteVerificationValue: async (
-			id: string,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			await (trxAdapter || adapter).delete<Verification>({
-				model: "verification",
-				where: [
-					{
-						field: "id",
-						value: id,
-					},
-				],
-			});
-		},
-		deleteVerificationByIdentifier: async (
-			identifier: string,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			await (trxAdapter || adapter).delete<Verification>({
-				model: "verification",
-				where: [
-					{
-						field: "identifier",
-						value: identifier,
-					},
-				],
-			});
-		},
-		updateVerificationValue: async (
-			id: string,
-			data: Partial<Verification>,
-			context?: GenericEndpointContext,
-			trxAdapter?: TransactionAdapter,
-		) => {
-			const verification = await updateWithHooks<Verification>(
-				data,
-				[{ field: "id", value: id }],
-				"verification",
-				undefined,
-				context,
-				trxAdapter,
-			);
-			return verification;
-		},
-	};
-
-	return {
-		...baseMethods,
-		withTransaction: async <R>(
-			cb: (trx: {
-				adapter: TransactionAdapter;
-				internalAdapter: typeof baseMethods;
-			}) => Promise<R>,
-		): Promise<R> => {
-			return adapter.transaction((trxAdapter) => {
-				return cb({
-					adapter: trxAdapter,
-					internalAdapter: shimLastParam(
-						baseMethods,
-						trxAdapter,
-					) as typeof baseMethods,
-				});
-			});
-		},
-		createOAuthUser: async (
-			user: Omit<User, "id" | "createdAt" | "updatedAt">,
-			account: Omit<Account, "userId" | "id" | "createdAt" | "updatedAt"> &
-				Partial<Account>,
-			context?: GenericEndpointContext,
-		) => {
-			return adapter.transaction(async (trxAdapter) => {
-				const createdUser = await createWithHooks(
-					{
-						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-						createdAt: new Date(),
-						updatedAt: new Date(),
-						...user,
-					},
-					"user",
+			},
+			updateVerificationValue: ({ adapter }) => async (
+				id: string,
+				data: Partial<Verification>,
+				context?: GenericEndpointContext,
+			) => {
+				const verification = await updateWithHooks<Verification>(
+					data,
+					[{ field: "id", value: id }],
+					"verification",
 					undefined,
 					context,
-					trxAdapter,
+					adapter,
 				);
-				const createdAccount = await createWithHooks(
-					{
-						...account,
-						userId: createdUser!.id,
-						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-						createdAt: new Date(),
-						updatedAt: new Date(),
-					},
-					"account",
-					undefined,
-					context,
-					trxAdapter,
-				);
-				return {
-					user: createdUser,
-					account: createdAccount,
-				};
-			});
+				return verification;
+			},
 		},
-	};
+	});
 };
 
 export type InternalAdapter = ReturnType<typeof createInternalAdapter>;

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -83,7 +83,7 @@ export const createInternalAdapter = <OmitStaticMethods extends boolean>(
 	return createAdapterBridge({
 		id: "internalAdapter",
 		adapter: adapter as Adapter,
-		staticMethods: staticMethods as OmitStaticMethods extends true
+		staticMethods: staticMethods as [OmitStaticMethods] extends [true]
 			? {}
 			: typeof staticMethods,
 		methods: {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -18,7 +18,7 @@ import { getWithHooks } from "./with-hooks";
 import { getIp } from "../utils/get-request-ip";
 import { safeJSONParse } from "../utils/json";
 import { generateId, type InternalLogger } from "../utils";
-import { shimLastParam, type InferShimLastParamResult } from "../utils/shim";
+import { shimLastParam } from "../utils/shim";
 
 export const createInternalAdapter = (
 	adapter: Adapter,

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -20,7 +20,9 @@ import { safeJSONParse } from "../utils/json";
 import { generateId, type InternalLogger } from "../utils";
 import { createAdapterBridge } from "./adapter-bridge";
 
-export const createInternalAdapter = <OmitStaticMethods extends boolean = false>(
+export const createInternalAdapter = <
+	OmitStaticMethods extends boolean = false
+>(
 	adapter: OmitStaticMethods extends true ? TransactionAdapter : Adapter,
 	ctx: {
 		options: Omit<BetterAuthOptions, "logger">;
@@ -28,7 +30,7 @@ export const createInternalAdapter = <OmitStaticMethods extends boolean = false>
 		hooks: Exclude<BetterAuthOptions["databaseHooks"], undefined>[];
 		generateId: AuthContext["generateId"];
 	},
-	omitStaticMethods?: OmitStaticMethods
+	omitStaticMethods?: OmitStaticMethods,
 ) => {
 	const logger = ctx.logger;
 	const options = ctx.options;

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -21,7 +21,7 @@ import { generateId, type InternalLogger } from "../utils";
 import { createAdapterBridge } from "./adapter-bridge";
 
 export const createInternalAdapter = <
-	OmitStaticMethods extends boolean = false
+	OmitStaticMethods extends boolean = false,
 >(
 	adapter: OmitStaticMethods extends true ? TransactionAdapter : Adapter,
 	ctx: {
@@ -42,168 +42,134 @@ export const createInternalAdapter = <
 	return createAdapterBridge({
 		id: "internalAdapter",
 		adapter: adapter as Adapter,
-		staticMethods: !omitStaticMethods ? {
-			createOAuthUser: async (
-				user: Omit<User, "id" | "createdAt" | "updatedAt">,
-				account: Omit<Account, "userId" | "id" | "createdAt" | "updatedAt"> &
-					Partial<Account>,
-				context?: GenericEndpointContext,
-			) => {
-				return (adapter as Adapter).transaction(async (trxAdapter) => {
+		staticMethods: !omitStaticMethods
+			? {
+					createOAuthUser: async (
+						user: Omit<User, "id" | "createdAt" | "updatedAt">,
+						account: Omit<
+							Account,
+							"userId" | "id" | "createdAt" | "updatedAt"
+						> &
+							Partial<Account>,
+						context?: GenericEndpointContext,
+					) => {
+						return (adapter as Adapter).transaction(async (trxAdapter) => {
+							const createdUser = await createWithHooks(
+								{
+									// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+									createdAt: new Date(),
+									updatedAt: new Date(),
+									...user,
+								},
+								"user",
+								undefined,
+								context,
+								trxAdapter,
+							);
+							const createdAccount = await createWithHooks(
+								{
+									...account,
+									userId: createdUser!.id,
+									// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+									createdAt: new Date(),
+									updatedAt: new Date(),
+								},
+								"account",
+								undefined,
+								context,
+								trxAdapter,
+							);
+							return {
+								user: createdUser,
+								account: createdAccount,
+							};
+						});
+					},
+				}
+			: undefined,
+		methods: {
+			createUser:
+				({ adapter }) =>
+				async <T>(
+					user: Omit<User, "id" | "createdAt" | "updatedAt" | "emailVerified"> &
+						Partial<User> &
+						Record<string, any>,
+					context?: GenericEndpointContext,
+				) => {
 					const createdUser = await createWithHooks(
 						{
 							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
 							createdAt: new Date(),
 							updatedAt: new Date(),
 							...user,
+							email: user.email?.toLowerCase(),
 						},
 						"user",
 						undefined,
 						context,
-						trxAdapter,
+						adapter,
 					);
+					return createdUser as T & User;
+				},
+			createAccount:
+				({ adapter }) =>
+				async <T extends Record<string, any>>(
+					account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
+						Partial<Account> &
+						T,
+					context?: GenericEndpointContext,
+				) => {
 					const createdAccount = await createWithHooks(
 						{
-							...account,
-							userId: createdUser!.id,
 							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
 							createdAt: new Date(),
 							updatedAt: new Date(),
+							...account,
 						},
 						"account",
 						undefined,
 						context,
-						trxAdapter,
+						adapter,
 					);
-					return {
-						user: createdUser,
-						account: createdAccount,
-					};
-				});
-			},
-		} : undefined,
-		methods: {
-			createUser: ({ adapter }) => async <T>(
-				user: Omit<User, "id" | "createdAt" | "updatedAt" | "emailVerified"> &
-					Partial<User> &
-					Record<string, any>,
-				context?: GenericEndpointContext,
-			) => {
-				const createdUser = await createWithHooks(
-					{
-						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-						createdAt: new Date(),
-						updatedAt: new Date(),
-						...user,
-						email: user.email?.toLowerCase(),
-					},
-					"user",
-					undefined,
-					context,
-					adapter,
-				);
-				return createdUser as T & User;
-			},
-			createAccount: ({ adapter }) => async <T extends Record<string, any>>(
-				account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
-					Partial<Account> &
-					T,
-				context?: GenericEndpointContext,
-			) => {
-				const createdAccount = await createWithHooks(
-					{
-						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-						createdAt: new Date(),
-						updatedAt: new Date(),
-						...account,
-					},
-					"account",
-					undefined,
-					context,
-					adapter,
-				);
-				return createdAccount as T & Account;
-			},
-			listSessions: ({ adapter }) => async (userId: string) => {
-				if (secondaryStorage) {
-					const currentList = await secondaryStorage.get(
-						`active-sessions-${userId}`,
-					);
-					if (!currentList) return [];
-	
-					const list: { token: string; expiresAt: number }[] =
-						safeJSONParse(currentList) || [];
-					const now = Date.now();
-	
-					const validSessions = list.filter((s) => s.expiresAt > now);
-					const sessions = [];
-	
-					for (const session of validSessions) {
-						const sessionStringified = await secondaryStorage.get(session.token);
-						if (sessionStringified) {
-							const s = safeJSONParse<{
-								session: Session;
-								user: User;
-							}>(sessionStringified);
-							if (!s) return [];
-							const parsedSession = parseSessionOutput(ctx.options, {
-								...s.session,
-								expiresAt: new Date(s.session.expiresAt),
-							});
-							sessions.push(parsedSession);
-						}
-					}
-					return sessions;
-				}
-	
-				const sessions = await adapter.findMany<Session>({
-					model: "session",
-					where: [
-						{
-							field: "userId",
-							value: userId,
-						},
-					],
-				});
-				return sessions;
-			},
-			listUsers: ({ adapter }) => async (
-				limit?: number,
-				offset?: number,
-				sortBy?: {
-					field: string;
-					direction: "asc" | "desc";
+					return createdAccount as T & Account;
 				},
-				where?: Where[],
-			) => {
-				const users = await adapter.findMany<User>({
-					model: "user",
-					limit,
-					offset,
-					sortBy,
-					where,
-				});
-				return users;
-			},
-			countTotalUsers: ({ adapter }) => async (
-				where?: Where[],
-			) => {
-				const total = await adapter.count({
-					model: "user",
-					where,
-				});
-				if (typeof total === "string") {
-					return parseInt(total);
-				}
-				return total;
-			},
-			deleteUser: ({ adapter }) => async (userId: string) => {
-				if (secondaryStorage) {
-					await secondaryStorage.delete(`active-sessions-${userId}`);
-				}
-	
-				if (!secondaryStorage || options.session?.storeSessionInDatabase) {
-					await adapter.deleteMany({
+			listSessions:
+				({ adapter }) =>
+				async (userId: string) => {
+					if (secondaryStorage) {
+						const currentList = await secondaryStorage.get(
+							`active-sessions-${userId}`,
+						);
+						if (!currentList) return [];
+
+						const list: { token: string; expiresAt: number }[] =
+							safeJSONParse(currentList) || [];
+						const now = Date.now();
+
+						const validSessions = list.filter((s) => s.expiresAt > now);
+						const sessions = [];
+
+						for (const session of validSessions) {
+							const sessionStringified = await secondaryStorage.get(
+								session.token,
+							);
+							if (sessionStringified) {
+								const s = safeJSONParse<{
+									session: Session;
+									user: User;
+								}>(sessionStringified);
+								if (!s) return [];
+								const parsedSession = parseSessionOutput(ctx.options, {
+									...s.session,
+									expiresAt: new Date(s.session.expiresAt),
+								});
+								sessions.push(parsedSession);
+							}
+						}
+						return sessions;
+					}
+
+					const sessions = await adapter.findMany<Session>({
 						model: "session",
 						where: [
 							{
@@ -212,436 +178,524 @@ export const createInternalAdapter = <
 							},
 						],
 					});
-				}
-	
-				await adapter.deleteMany({
-					model: "account",
-					where: [
-						{
-							field: "userId",
-							value: userId,
-						},
-					],
-				});
-				await adapter.delete({
-					model: "user",
-					where: [
-						{
-							field: "id",
-							value: userId,
-						},
-					],
-				});
-			},
-			createSession: ({ adapter }) => async (
-				userId: string,
-				ctx: GenericEndpointContext,
-				dontRememberMe?: boolean,
-				override?: Partial<Session> & Record<string, any>,
-				overrideAll?: boolean,
-			) => {
-				const headers = ctx.headers || ctx.request?.headers;
-				const { id: _, ...rest } = override || {};
-				const data: Omit<Session, "id"> = {
-					ipAddress:
-						ctx.request || ctx.headers
-							? getIp(ctx.request || ctx.headers!, ctx.context.options) || ""
-							: "",
-					userAgent: headers?.get("user-agent") || "",
-					...rest,
-					/**
-					 * If the user doesn't want to be remembered
-					 * set the session to expire in 1 day.
-					 * The cookie will be set to expire at the end of the session
-					 */
-					expiresAt: dontRememberMe
-						? getDate(60 * 60 * 24, "sec") // 1 day
-						: getDate(sessionExpiration, "sec"),
-					userId,
-					token: generateId(32),
-					// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-					createdAt: new Date(),
-					updatedAt: new Date(),
-					...(overrideAll ? rest : {}),
-				};
-				const res = await createWithHooks(
-					data,
-					"session",
-					secondaryStorage
-						? {
-								fn: async (sessionData) => {
-									/**
-									 * store the session token for the user
-									 * so we can retrieve it later for listing sessions
-									 */
-									const currentList = await secondaryStorage.get(
-										`active-sessions-${userId}`,
-									);
-	
-									let list: { token: string; expiresAt: number }[] = [];
-									const now = Date.now();
-	
-									if (currentList) {
-										list = safeJSONParse(currentList) || [];
-										list = list.filter((session) => session.expiresAt > now);
-									}
-	
-									list.push({
-										token: data.token,
-										expiresAt: now + sessionExpiration * 1000,
-									});
-	
-									await secondaryStorage.set(
-										`active-sessions-${userId}`,
-										JSON.stringify(list),
-										sessionExpiration,
-									);
-	
-									return sessionData;
+					return sessions;
+				},
+			listUsers:
+				({ adapter }) =>
+				async (
+					limit?: number,
+					offset?: number,
+					sortBy?: {
+						field: string;
+						direction: "asc" | "desc";
+					},
+					where?: Where[],
+				) => {
+					const users = await adapter.findMany<User>({
+						model: "user",
+						limit,
+						offset,
+						sortBy,
+						where,
+					});
+					return users;
+				},
+			countTotalUsers:
+				({ adapter }) =>
+				async (where?: Where[]) => {
+					const total = await adapter.count({
+						model: "user",
+						where,
+					});
+					if (typeof total === "string") {
+						return parseInt(total);
+					}
+					return total;
+				},
+			deleteUser:
+				({ adapter }) =>
+				async (userId: string) => {
+					if (secondaryStorage) {
+						await secondaryStorage.delete(`active-sessions-${userId}`);
+					}
+
+					if (!secondaryStorage || options.session?.storeSessionInDatabase) {
+						await adapter.deleteMany({
+							model: "session",
+							where: [
+								{
+									field: "userId",
+									value: userId,
 								},
-								executeMainFn: options.session?.storeSessionInDatabase,
-							}
-						: undefined,
-					ctx,
-					adapter,
-				);
-				return res as Session;
-			},
-			findSession: ({ adapter }) => async (
-				token: string,
-			): Promise<{
-				session: Session & Record<string, any>;
-				user: User & Record<string, any>;
-			} | null> => {
-				if (secondaryStorage) {
-					const sessionStringified = await secondaryStorage.get(token);
-					if (!sessionStringified && !options.session?.storeSessionInDatabase) {
-						return null;
-					}
-					if (sessionStringified) {
-						const s = safeJSONParse<{
-							session: Session;
-							user: User;
-						}>(sessionStringified);
-						if (!s) return null;
-						const parsedSession = parseSessionOutput(ctx.options, {
-							...s.session,
-							expiresAt: new Date(s.session.expiresAt),
-							createdAt: new Date(s.session.createdAt),
-							updatedAt: new Date(s.session.updatedAt),
+							],
 						});
-						const parsedUser = parseUserOutput(ctx.options, {
-							...s.user,
-							createdAt: new Date(s.user.createdAt),
-							updatedAt: new Date(s.user.updatedAt),
-						});
-						return {
-							session: parsedSession,
-							user: parsedUser,
-						};
 					}
-				}
-	
-				const session = await adapter.findOne<Session>({
-					model: "session",
-					where: [
-						{
-							value: token,
-							field: "token",
-						},
-					],
-				});
-	
-				if (!session) {
-					return null;
-				}
-	
-				const user = await adapter.findOne<User>({
-					model: "user",
-					where: [
-						{
-							value: session.userId,
-							field: "id",
-						},
-					],
-				});
-				if (!user) {
-					return null;
-				}
-				const parsedSession = parseSessionOutput(ctx.options, session);
-				const parsedUser = parseUserOutput(ctx.options, user);
-	
-				return {
-					session: parsedSession,
-					user: parsedUser,
-				};
-			},
-			findSessions: ({ adapter }) => async (
-				sessionTokens: string[],
-			) => {
-				if (secondaryStorage) {
-					const sessions: {
-						session: Session;
-						user: User;
-					}[] = [];
-					for (const sessionToken of sessionTokens) {
-						const sessionStringified = await secondaryStorage.get(sessionToken);
+
+					await adapter.deleteMany({
+						model: "account",
+						where: [
+							{
+								field: "userId",
+								value: userId,
+							},
+						],
+					});
+					await adapter.delete({
+						model: "user",
+						where: [
+							{
+								field: "id",
+								value: userId,
+							},
+						],
+					});
+				},
+			createSession:
+				({ adapter }) =>
+				async (
+					userId: string,
+					ctx: GenericEndpointContext,
+					dontRememberMe?: boolean,
+					override?: Partial<Session> & Record<string, any>,
+					overrideAll?: boolean,
+				) => {
+					const headers = ctx.headers || ctx.request?.headers;
+					const { id: _, ...rest } = override || {};
+					const data: Omit<Session, "id"> = {
+						ipAddress:
+							ctx.request || ctx.headers
+								? getIp(ctx.request || ctx.headers!, ctx.context.options) || ""
+								: "",
+						userAgent: headers?.get("user-agent") || "",
+						...rest,
+						/**
+						 * If the user doesn't want to be remembered
+						 * set the session to expire in 1 day.
+						 * The cookie will be set to expire at the end of the session
+						 */
+						expiresAt: dontRememberMe
+							? getDate(60 * 60 * 24, "sec") // 1 day
+							: getDate(sessionExpiration, "sec"),
+						userId,
+						token: generateId(32),
+						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+						createdAt: new Date(),
+						updatedAt: new Date(),
+						...(overrideAll ? rest : {}),
+					};
+					const res = await createWithHooks(
+						data,
+						"session",
+						secondaryStorage
+							? {
+									fn: async (sessionData) => {
+										/**
+										 * store the session token for the user
+										 * so we can retrieve it later for listing sessions
+										 */
+										const currentList = await secondaryStorage.get(
+											`active-sessions-${userId}`,
+										);
+
+										let list: { token: string; expiresAt: number }[] = [];
+										const now = Date.now();
+
+										if (currentList) {
+											list = safeJSONParse(currentList) || [];
+											list = list.filter((session) => session.expiresAt > now);
+										}
+
+										list.push({
+											token: data.token,
+											expiresAt: now + sessionExpiration * 1000,
+										});
+
+										await secondaryStorage.set(
+											`active-sessions-${userId}`,
+											JSON.stringify(list),
+											sessionExpiration,
+										);
+
+										return sessionData;
+									},
+									executeMainFn: options.session?.storeSessionInDatabase,
+								}
+							: undefined,
+						ctx,
+						adapter,
+					);
+					return res as Session;
+				},
+			findSession:
+				({ adapter }) =>
+				async (
+					token: string,
+				): Promise<{
+					session: Session & Record<string, any>;
+					user: User & Record<string, any>;
+				} | null> => {
+					if (secondaryStorage) {
+						const sessionStringified = await secondaryStorage.get(token);
+						if (
+							!sessionStringified &&
+							!options.session?.storeSessionInDatabase
+						) {
+							return null;
+						}
 						if (sessionStringified) {
 							const s = safeJSONParse<{
 								session: Session;
 								user: User;
 							}>(sessionStringified);
-							if (!s) return [];
-							const session = {
-								session: {
-									...s.session,
-									expiresAt: new Date(s.session.expiresAt),
-								},
-								user: {
-									...s.user,
-									createdAt: new Date(s.user.createdAt),
-									updatedAt: new Date(s.user.updatedAt),
-								},
-							} as {
-								session: Session;
-								user: User;
+							if (!s) return null;
+							const parsedSession = parseSessionOutput(ctx.options, {
+								...s.session,
+								expiresAt: new Date(s.session.expiresAt),
+								createdAt: new Date(s.session.createdAt),
+								updatedAt: new Date(s.session.updatedAt),
+							});
+							const parsedUser = parseUserOutput(ctx.options, {
+								...s.user,
+								createdAt: new Date(s.user.createdAt),
+								updatedAt: new Date(s.user.updatedAt),
+							});
+							return {
+								session: parsedSession,
+								user: parsedUser,
 							};
-							sessions.push(session);
 						}
 					}
-					return sessions;
-				}
-	
-				const sessions = await adapter.findMany<Session>({
-					model: "session",
-					where: [
-						{
-							field: "token",
-							value: sessionTokens,
-							operator: "in",
-						},
-					],
-				});
-				const userIds = sessions.map((session) => {
-					return session.userId;
-				});
-				if (!userIds.length) return [];
-				const users = await adapter.findMany<User>({
-					model: "user",
-					where: [
-						{
-							field: "id",
-							value: userIds,
-							operator: "in",
-						},
-					],
-				});
-				return sessions.map((session) => {
-					const user = users.find((u) => u.id === session.userId);
-					if (!user) return null;
-					return {
-						session,
-						user,
-					};
-				}) as {
-					session: Session;
-					user: User;
-				}[];
-			},
-			updateSession: ({ adapter }) => async (
-				sessionToken: string,
-				session: Partial<Session> & Record<string, any>,
-				context?: GenericEndpointContext,
-			) => {
-				const updatedSession = await updateWithHooks<Session>(
-					session,
-					[{ field: "token", value: sessionToken }],
-					"session",
-					secondaryStorage
-						? {
-								async fn(data) {
-									const currentSession = await secondaryStorage.get(sessionToken);
-									let updatedSession: Session | null = null;
-									if (currentSession) {
-										const parsedSession = safeJSONParse<{
-											session: Session;
-											user: User;
-										}>(currentSession);
-										if (!parsedSession) return null;
-										updatedSession = {
-											...parsedSession.session,
-											...data,
-										};
-										return updatedSession;
-									} else {
-										return null;
-									}
-								},
-								executeMainFn: options.session?.storeSessionInDatabase,
-							}
-						: undefined,
-					context,
-					adapter,
-				);
-				return updatedSession;
-			},
-			deleteSession: ({ adapter }) => async (token: string) => {
-				if (secondaryStorage) {
-					// remove the session from the active sessions list
-					const data = await secondaryStorage.get(token);
-					if (data) {
-						const { session } =
-							safeJSONParse<{
-								session: Session;
-								user: User;
-							}>(data) ?? {};
-						if (!session) {
-							logger.error("Session not found in secondary storage");
-							return;
-						}
-						const userId = session.userId;
-	
-						const currentList = await secondaryStorage.get(
-							`active-sessions-${userId}`,
-						);
-						if (currentList) {
-							let list: { token: string; expiresAt: number }[] =
-								safeJSONParse(currentList) || [];
-							list = list.filter((s) => s.token !== token);
-	
-							if (list.length > 0) {
-								await secondaryStorage.set(
-									`active-sessions-${userId}`,
-									JSON.stringify(list),
-									sessionExpiration,
-								);
-							} else {
-								await secondaryStorage.delete(`active-sessions-${userId}`);
-							}
-						} else {
-							logger.error("Active sessions list not found in secondary storage");
-						}
-					}
-	
-					await secondaryStorage.delete(token);
-	
-					if (
-						!options.session?.storeSessionInDatabase ||
-						ctx.options.session?.preserveSessionInDatabase
-					) {
-						return;
-					}
-				}
-				await adapter.delete<Session>({
-					model: "session",
-					where: [
-						{
-							field: "token",
-							value: token,
-						},
-					],
-				});
-			},
-			deleteAccounts: ({ adapter }) => async (userId: string) => {
-				await adapter.deleteMany({
-					model: "account",
-					where: [
-						{
-							field: "userId",
-							value: userId,
-						},
-					],
-				});
-			},
-			deleteAccount: ({ adapter }) => async (
-				accountId: string,
-			) => {
-				await adapter.delete({
-					model: "account",
-					where: [
-						{
-							field: "id",
-							value: accountId,
-						},
-					],
-				});
-			},
-			deleteSessions: ({ adapter }) => async (
-				userIdOrSessionTokens: string | string[],
-			) => {
-				if (secondaryStorage) {
-					if (typeof userIdOrSessionTokens === "string") {
-						const activeSession = await secondaryStorage.get(
-							`active-sessions-${userIdOrSessionTokens}`,
-						);
-						const sessions = activeSession
-							? safeJSONParse<{ token: string }[]>(activeSession)
-							: [];
-						if (!sessions) return;
-						for (const session of sessions) {
-							await secondaryStorage.delete(session.token);
-						}
-					} else {
-						for (const sessionToken of userIdOrSessionTokens) {
-							const session = await secondaryStorage.get(sessionToken);
-							if (session) {
-								await secondaryStorage.delete(sessionToken);
-							}
-						}
-					}
-	
-					if (
-						!options.session?.storeSessionInDatabase ||
-						ctx.options.session?.preserveSessionInDatabase
-					) {
-						return;
-					}
-				}
-				await adapter.deleteMany({
-					model: "session",
-					where: [
-						{
-							field: Array.isArray(userIdOrSessionTokens) ? "token" : "userId",
-							value: userIdOrSessionTokens,
-							operator: Array.isArray(userIdOrSessionTokens) ? "in" : undefined,
-						},
-					],
-				});
-			},
-			findOAuthUser: ({ adapter }) => async (
-				email: string,
-				accountId: string,
-				providerId: string,
-			) => {
-				// we need to find account first to avoid missing user if the email changed with the provider for the same account
-				const account = await adapter
-					.findMany<Account>({
-						model: "account",
+
+					const session = await adapter.findOne<Session>({
+						model: "session",
 						where: [
 							{
-								value: accountId,
-								field: "accountId",
+								value: token,
+								field: "token",
 							},
 						],
-					})
-					.then((accounts) => {
-						return accounts.find((a) => a.providerId === providerId);
 					});
-				if (account) {
+
+					if (!session) {
+						return null;
+					}
+
 					const user = await adapter.findOne<User>({
 						model: "user",
 						where: [
 							{
-								value: account.userId,
+								value: session.userId,
 								field: "id",
 							},
 						],
 					});
-					if (user) {
+					if (!user) {
+						return null;
+					}
+					const parsedSession = parseSessionOutput(ctx.options, session);
+					const parsedUser = parseUserOutput(ctx.options, user);
+
+					return {
+						session: parsedSession,
+						user: parsedUser,
+					};
+				},
+			findSessions:
+				({ adapter }) =>
+				async (sessionTokens: string[]) => {
+					if (secondaryStorage) {
+						const sessions: {
+							session: Session;
+							user: User;
+						}[] = [];
+						for (const sessionToken of sessionTokens) {
+							const sessionStringified =
+								await secondaryStorage.get(sessionToken);
+							if (sessionStringified) {
+								const s = safeJSONParse<{
+									session: Session;
+									user: User;
+								}>(sessionStringified);
+								if (!s) return [];
+								const session = {
+									session: {
+										...s.session,
+										expiresAt: new Date(s.session.expiresAt),
+									},
+									user: {
+										...s.user,
+										createdAt: new Date(s.user.createdAt),
+										updatedAt: new Date(s.user.updatedAt),
+									},
+								} as {
+									session: Session;
+									user: User;
+								};
+								sessions.push(session);
+							}
+						}
+						return sessions;
+					}
+
+					const sessions = await adapter.findMany<Session>({
+						model: "session",
+						where: [
+							{
+								field: "token",
+								value: sessionTokens,
+								operator: "in",
+							},
+						],
+					});
+					const userIds = sessions.map((session) => {
+						return session.userId;
+					});
+					if (!userIds.length) return [];
+					const users = await adapter.findMany<User>({
+						model: "user",
+						where: [
+							{
+								field: "id",
+								value: userIds,
+								operator: "in",
+							},
+						],
+					});
+					return sessions.map((session) => {
+						const user = users.find((u) => u.id === session.userId);
+						if (!user) return null;
 						return {
+							session,
 							user,
-							accounts: [account],
 						};
+					}) as {
+						session: Session;
+						user: User;
+					}[];
+				},
+			updateSession:
+				({ adapter }) =>
+				async (
+					sessionToken: string,
+					session: Partial<Session> & Record<string, any>,
+					context?: GenericEndpointContext,
+				) => {
+					const updatedSession = await updateWithHooks<Session>(
+						session,
+						[{ field: "token", value: sessionToken }],
+						"session",
+						secondaryStorage
+							? {
+									async fn(data) {
+										const currentSession =
+											await secondaryStorage.get(sessionToken);
+										let updatedSession: Session | null = null;
+										if (currentSession) {
+											const parsedSession = safeJSONParse<{
+												session: Session;
+												user: User;
+											}>(currentSession);
+											if (!parsedSession) return null;
+											updatedSession = {
+												...parsedSession.session,
+												...data,
+											};
+											return updatedSession;
+										} else {
+											return null;
+										}
+									},
+									executeMainFn: options.session?.storeSessionInDatabase,
+								}
+							: undefined,
+						context,
+						adapter,
+					);
+					return updatedSession;
+				},
+			deleteSession:
+				({ adapter }) =>
+				async (token: string) => {
+					if (secondaryStorage) {
+						// remove the session from the active sessions list
+						const data = await secondaryStorage.get(token);
+						if (data) {
+							const { session } =
+								safeJSONParse<{
+									session: Session;
+									user: User;
+								}>(data) ?? {};
+							if (!session) {
+								logger.error("Session not found in secondary storage");
+								return;
+							}
+							const userId = session.userId;
+
+							const currentList = await secondaryStorage.get(
+								`active-sessions-${userId}`,
+							);
+							if (currentList) {
+								let list: { token: string; expiresAt: number }[] =
+									safeJSONParse(currentList) || [];
+								list = list.filter((s) => s.token !== token);
+
+								if (list.length > 0) {
+									await secondaryStorage.set(
+										`active-sessions-${userId}`,
+										JSON.stringify(list),
+										sessionExpiration,
+									);
+								} else {
+									await secondaryStorage.delete(`active-sessions-${userId}`);
+								}
+							} else {
+								logger.error(
+									"Active sessions list not found in secondary storage",
+								);
+							}
+						}
+
+						await secondaryStorage.delete(token);
+
+						if (
+							!options.session?.storeSessionInDatabase ||
+							ctx.options.session?.preserveSessionInDatabase
+						) {
+							return;
+						}
+					}
+					await adapter.delete<Session>({
+						model: "session",
+						where: [
+							{
+								field: "token",
+								value: token,
+							},
+						],
+					});
+				},
+			deleteAccounts:
+				({ adapter }) =>
+				async (userId: string) => {
+					await adapter.deleteMany({
+						model: "account",
+						where: [
+							{
+								field: "userId",
+								value: userId,
+							},
+						],
+					});
+				},
+			deleteAccount:
+				({ adapter }) =>
+				async (accountId: string) => {
+					await adapter.delete({
+						model: "account",
+						where: [
+							{
+								field: "id",
+								value: accountId,
+							},
+						],
+					});
+				},
+			deleteSessions:
+				({ adapter }) =>
+				async (userIdOrSessionTokens: string | string[]) => {
+					if (secondaryStorage) {
+						if (typeof userIdOrSessionTokens === "string") {
+							const activeSession = await secondaryStorage.get(
+								`active-sessions-${userIdOrSessionTokens}`,
+							);
+							const sessions = activeSession
+								? safeJSONParse<{ token: string }[]>(activeSession)
+								: [];
+							if (!sessions) return;
+							for (const session of sessions) {
+								await secondaryStorage.delete(session.token);
+							}
+						} else {
+							for (const sessionToken of userIdOrSessionTokens) {
+								const session = await secondaryStorage.get(sessionToken);
+								if (session) {
+									await secondaryStorage.delete(sessionToken);
+								}
+							}
+						}
+
+						if (
+							!options.session?.storeSessionInDatabase ||
+							ctx.options.session?.preserveSessionInDatabase
+						) {
+							return;
+						}
+					}
+					await adapter.deleteMany({
+						model: "session",
+						where: [
+							{
+								field: Array.isArray(userIdOrSessionTokens)
+									? "token"
+									: "userId",
+								value: userIdOrSessionTokens,
+								operator: Array.isArray(userIdOrSessionTokens)
+									? "in"
+									: undefined,
+							},
+						],
+					});
+				},
+			findOAuthUser:
+				({ adapter }) =>
+				async (email: string, accountId: string, providerId: string) => {
+					// we need to find account first to avoid missing user if the email changed with the provider for the same account
+					const account = await adapter
+						.findMany<Account>({
+							model: "account",
+							where: [
+								{
+									value: accountId,
+									field: "accountId",
+								},
+							],
+						})
+						.then((accounts) => {
+							return accounts.find((a) => a.providerId === providerId);
+						});
+					if (account) {
+						const user = await adapter.findOne<User>({
+							model: "user",
+							where: [
+								{
+									value: account.userId,
+									field: "id",
+								},
+							],
+						});
+						if (user) {
+							return {
+								user,
+								accounts: [account],
+							};
+						} else {
+							const user = await adapter.findOne<User>({
+								model: "user",
+								where: [
+									{
+										value: email.toLowerCase(),
+										field: "email",
+									},
+								],
+							});
+							if (user) {
+								return {
+									user,
+									accounts: [account],
+								};
+							}
+							return null;
+						}
 					} else {
 						const user = await adapter.findOne<User>({
 							model: "user",
@@ -653,14 +707,27 @@ export const createInternalAdapter = <
 							],
 						});
 						if (user) {
+							const accounts = await adapter.findMany<Account>({
+								model: "account",
+								where: [
+									{
+										value: user.id,
+										field: "userId",
+									},
+								],
+							});
 							return {
 								user,
-								accounts: [account],
+								accounts: accounts || [],
 							};
+						} else {
+							return null;
 						}
-						return null;
 					}
-				} else {
+				},
+			findUserByEmail:
+				({ adapter }) =>
+				async (email: string, options?: { includeAccounts: boolean }) => {
 					const user = await adapter.findOne<User>({
 						model: "user",
 						where: [
@@ -670,7 +737,8 @@ export const createInternalAdapter = <
 							},
 						],
 					});
-					if (user) {
+					if (!user) return null;
+					if (options?.includeAccounts) {
 						const accounts = await adapter.findMany<Account>({
 							model: "account",
 							where: [
@@ -682,274 +750,261 @@ export const createInternalAdapter = <
 						});
 						return {
 							user,
-							accounts: accounts || [],
+							accounts,
 						};
-					} else {
-						return null;
 					}
-				}
-			},
-			findUserByEmail: ({ adapter }) => async (
-				email: string,
-				options?: { includeAccounts: boolean },
-			) => {
-				const user = await adapter.findOne<User>({
-					model: "user",
-					where: [
+					return {
+						user,
+						accounts: [],
+					};
+				},
+			findUserById:
+				({ adapter }) =>
+				async (userId: string) => {
+					const user = await adapter.findOne<User>({
+						model: "user",
+						where: [
+							{
+								field: "id",
+								value: userId,
+							},
+						],
+					});
+					return user;
+				},
+			linkAccount:
+				({ adapter }) =>
+				async (
+					account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
+						Partial<Account>,
+					context?: GenericEndpointContext,
+				) => {
+					const _account = await createWithHooks(
 						{
-							value: email.toLowerCase(),
-							field: "email",
+							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+							createdAt: new Date(),
+							updatedAt: new Date(),
+							...account,
 						},
-					],
-				});
-				if (!user) return null;
-				if (options?.includeAccounts) {
+						"account",
+						undefined,
+						context,
+						adapter,
+					);
+					return _account;
+				},
+			updateUser:
+				({ adapter }) =>
+				async (
+					userId: string,
+					data: Partial<User> & Record<string, any>,
+					context?: GenericEndpointContext,
+				) => {
+					const user = await updateWithHooks<User>(
+						data,
+						[
+							{
+								field: "id",
+								value: userId,
+							},
+						],
+						"user",
+						undefined,
+						context,
+						adapter,
+					);
+					if (secondaryStorage && user) {
+						const listRaw = await secondaryStorage.get(
+							`active-sessions-${userId}`,
+						);
+						if (listRaw) {
+							const now = Date.now();
+							const list =
+								safeJSONParse<{ token: string; expiresAt: number }[]>(
+									listRaw,
+								) || [];
+							const validSessions = list.filter((s) => s.expiresAt > now);
+							await Promise.all(
+								validSessions.map(async ({ token }) => {
+									const cached = await secondaryStorage.get(token);
+									if (!cached) return;
+									const parsed = safeJSONParse<{
+										session: Session;
+										user: User;
+									}>(cached);
+									if (!parsed) return;
+									const sessionTTL = Math.max(
+										Math.floor(
+											(new Date(parsed.session.expiresAt).getTime() - now) /
+												1000,
+										),
+										0,
+									);
+									await secondaryStorage.set(
+										token,
+										JSON.stringify({
+											session: parsed.session,
+											user,
+										}),
+										sessionTTL,
+									);
+								}),
+							);
+						}
+					}
+					return user;
+				},
+			updateUserByEmail:
+				({ adapter }) =>
+				async (
+					email: string,
+					data: Partial<User & Record<string, any>>,
+					context?: GenericEndpointContext,
+				) => {
+					const user = await updateWithHooks<User>(
+						data,
+						[
+							{
+								field: "email",
+								value: email.toLowerCase(),
+							},
+						],
+						"user",
+						undefined,
+						context,
+						adapter,
+					);
+					return user;
+				},
+			updatePassword:
+				({ adapter }) =>
+				async (
+					userId: string,
+					password: string,
+					context?: GenericEndpointContext,
+				) => {
+					await updateManyWithHooks(
+						{
+							password,
+						},
+						[
+							{
+								field: "userId",
+								value: userId,
+							},
+							{
+								field: "providerId",
+								value: "credential",
+							},
+						],
+						"account",
+						undefined,
+						context,
+						adapter,
+					);
+				},
+			findAccounts:
+				({ adapter }) =>
+				async (userId: string) => {
 					const accounts = await adapter.findMany<Account>({
 						model: "account",
 						where: [
 							{
-								value: user.id,
 								field: "userId",
+								value: userId,
 							},
 						],
 					});
-					return {
-						user,
-						accounts,
-					};
-				}
-				return {
-					user,
-					accounts: [],
-				};
-			},
-			findUserById: ({ adapter }) => async (userId: string) => {
-				const user = await adapter.findOne<User>({
-					model: "user",
-					where: [
+					return accounts;
+				},
+			findAccount:
+				({ adapter }) =>
+				async (accountId: string) => {
+					const account = await adapter.findOne<Account>({
+						model: "account",
+						where: [
+							{
+								field: "accountId",
+								value: accountId,
+							},
+						],
+					});
+					return account;
+				},
+			findAccountByProviderId:
+				({ adapter }) =>
+				async (accountId: string, providerId: string) => {
+					const account = await adapter.findOne<Account>({
+						model: "account",
+						where: [
+							{
+								field: "accountId",
+								value: accountId,
+							},
+							{
+								field: "providerId",
+								value: providerId,
+							},
+						],
+					});
+					return account;
+				},
+			findAccountByUserId:
+				({ adapter }) =>
+				async (userId: string) => {
+					const account = await adapter.findMany<Account>({
+						model: "account",
+						where: [
+							{
+								field: "userId",
+								value: userId,
+							},
+						],
+					});
+					return account;
+				},
+			updateAccount:
+				({ adapter }) =>
+				async (
+					id: string,
+					data: Partial<Account>,
+					context?: GenericEndpointContext,
+				) => {
+					const account = await updateWithHooks<Account>(
+						data,
+						[{ field: "id", value: id }],
+						"account",
+						undefined,
+						context,
+						adapter,
+					);
+					return account;
+				},
+			createVerificationValue:
+				({ adapter }) =>
+				async (
+					data: Omit<Verification, "createdAt" | "id" | "updatedAt"> &
+						Partial<Verification>,
+					context?: GenericEndpointContext,
+				) => {
+					const verification = await createWithHooks(
 						{
-							field: "id",
-							value: userId,
+							// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
+							createdAt: new Date(),
+							updatedAt: new Date(),
+							...data,
 						},
-					],
-				});
-				return user;
-			},
-			linkAccount: ({ adapter }) => async (
-				account: Omit<Account, "id" | "createdAt" | "updatedAt"> &
-					Partial<Account>,
-				context?: GenericEndpointContext,
-			) => {
-				const _account = await createWithHooks(
-					{
-						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-						createdAt: new Date(),
-						updatedAt: new Date(),
-						...account,
-					},
-					"account",
-					undefined,
-					context,
-					adapter,
-				);
-				return _account;
-			},
-			updateUser: ({ adapter }) => async (
-				userId: string,
-				data: Partial<User> & Record<string, any>,
-				context?: GenericEndpointContext,
-			) => {
-				const user = await updateWithHooks<User>(
-					data,
-					[
-						{
-							field: "id",
-							value: userId,
-						},
-					],
-					"user",
-					undefined,
-					context,
-					adapter
-				);
-				if (secondaryStorage && user) {
-					const listRaw = await secondaryStorage.get(`active-sessions-${userId}`);
-					if (listRaw) {
-						const now = Date.now();
-						const list =
-							safeJSONParse<{ token: string; expiresAt: number }[]>(listRaw) ||
-							[];
-						const validSessions = list.filter((s) => s.expiresAt > now);
-						await Promise.all(
-							validSessions.map(async ({ token }) => {
-								const cached = await secondaryStorage.get(token);
-								if (!cached) return;
-								const parsed = safeJSONParse<{
-									session: Session;
-									user: User;
-								}>(cached);
-								if (!parsed) return;
-								const sessionTTL = Math.max(
-									Math.floor(
-										(new Date(parsed.session.expiresAt).getTime() - now) / 1000,
-									),
-									0,
-								);
-								await secondaryStorage.set(
-									token,
-									JSON.stringify({
-										session: parsed.session,
-										user,
-									}),
-									sessionTTL,
-								);
-							}),
-						);
-					}
-				}
-				return user;
-			},
-			updateUserByEmail: ({ adapter }) => async (
-				email: string,
-				data: Partial<User & Record<string, any>>,
-				context?: GenericEndpointContext,
-			) => {
-				const user = await updateWithHooks<User>(
-					data,
-					[
-						{
-							field: "email",
-							value: email.toLowerCase(),
-						},
-					],
-					"user",
-					undefined,
-					context,
-					adapter,
-				);
-				return user;
-			},
-			updatePassword: ({ adapter }) => async (
-				userId: string,
-				password: string,
-				context?: GenericEndpointContext,
-			) => {
-				await updateManyWithHooks(
-					{
-						password,
-					},
-					[
-						{
-							field: "userId",
-							value: userId,
-						},
-						{
-							field: "providerId",
-							value: "credential",
-						},
-					],
-					"account",
-					undefined,
-					context,
-					adapter
-				);
-			},
-			findAccounts: ({ adapter }) => async (userId: string) => {
-				const accounts = await adapter.findMany<Account>({
-					model: "account",
-					where: [
-						{
-							field: "userId",
-							value: userId,
-						},
-					],
-				});
-				return accounts;
-			},
-			findAccount: ({ adapter }) => async (accountId: string) => {
-				const account = await adapter.findOne<Account>({
-					model: "account",
-					where: [
-						{
-							field: "accountId",
-							value: accountId,
-						},
-					],
-				});
-				return account;
-			},
-			findAccountByProviderId: ({ adapter }) => async (
-				accountId: string,
-				providerId: string,
-			) => {
-				const account = await adapter.findOne<Account>({
-					model: "account",
-					where: [
-						{
-							field: "accountId",
-							value: accountId,
-						},
-						{
-							field: "providerId",
-							value: providerId,
-						},
-					],
-				});
-				return account;
-			},
-			findAccountByUserId: ({ adapter }) => async (
-				userId: string,
-			) => {
-				const account = await adapter.findMany<Account>({
-					model: "account",
-					where: [
-						{
-							field: "userId",
-							value: userId,
-						},
-					],
-				});
-				return account;
-			},
-			updateAccount: ({ adapter }) => async (
-				id: string,
-				data: Partial<Account>,
-				context?: GenericEndpointContext,
-			) => {
-				const account = await updateWithHooks<Account>(
-					data,
-					[{ field: "id", value: id }],
-					"account",
-					undefined,
-					context,
-					adapter,
-				);
-				return account;
-			},
-			createVerificationValue: ({ adapter }) => async (
-				data: Omit<Verification, "createdAt" | "id" | "updatedAt"> &
-					Partial<Verification>,
-				context?: GenericEndpointContext,
-			) => {
-				const verification = await createWithHooks(
-					{
-						// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
-						createdAt: new Date(),
-						updatedAt: new Date(),
-						...data,
-					},
-					"verification",
-					undefined,
-					context,
-					adapter,
-				);
-				return verification as Verification;
-			},
-			findVerificationValue: ({ adapter }) => async (
-				identifier: string,
-			) => {
-				const verification = await adapter.findMany<Verification>(
-					{
+						"verification",
+						undefined,
+						context,
+						adapter,
+					);
+					return verification as Verification;
+				},
+			findVerificationValue:
+				({ adapter }) =>
+				async (identifier: string) => {
+					const verification = await adapter.findMany<Verification>({
 						model: "verification",
 						where: [
 							{
@@ -962,64 +1017,65 @@ export const createInternalAdapter = <
 							direction: "desc",
 						},
 						limit: 1,
-					},
-				);
-				if (!options.verification?.disableCleanup) {
-					await adapter.deleteMany({
+					});
+					if (!options.verification?.disableCleanup) {
+						await adapter.deleteMany({
+							model: "verification",
+							where: [
+								{
+									field: "expiresAt",
+									value: new Date(),
+									operator: "lt",
+								},
+							],
+						});
+					}
+					const lastVerification = verification[0];
+					return lastVerification as Verification | null;
+				},
+			deleteVerificationValue:
+				({ adapter }) =>
+				async (id: string) => {
+					await adapter.delete<Verification>({
 						model: "verification",
 						where: [
 							{
-								field: "expiresAt",
-								value: new Date(),
-								operator: "lt",
+								field: "id",
+								value: id,
 							},
 						],
 					});
-				}
-				const lastVerification = verification[0];
-				return lastVerification as Verification | null;
-			},
-			deleteVerificationValue: ({ adapter }) => async (
-				id: string,
-			) => {
-				await adapter.delete<Verification>({
-					model: "verification",
-					where: [
-						{
-							field: "id",
-							value: id,
-						},
-					],
-				});
-			},
-			deleteVerificationByIdentifier: ({ adapter }) => async (
-				identifier: string,
-			) => {
-				await adapter.delete<Verification>({
-					model: "verification",
-					where: [
-						{
-							field: "identifier",
-							value: identifier,
-						},
-					],
-				});
-			},
-			updateVerificationValue: ({ adapter }) => async (
-				id: string,
-				data: Partial<Verification>,
-				context?: GenericEndpointContext,
-			) => {
-				const verification = await updateWithHooks<Verification>(
-					data,
-					[{ field: "id", value: id }],
-					"verification",
-					undefined,
-					context,
-					adapter,
-				);
-				return verification;
-			},
+				},
+			deleteVerificationByIdentifier:
+				({ adapter }) =>
+				async (identifier: string) => {
+					await adapter.delete<Verification>({
+						model: "verification",
+						where: [
+							{
+								field: "identifier",
+								value: identifier,
+							},
+						],
+					});
+				},
+			updateVerificationValue:
+				({ adapter }) =>
+				async (
+					id: string,
+					data: Partial<Verification>,
+					context?: GenericEndpointContext,
+				) => {
+					const verification = await updateWithHooks<Verification>(
+						data,
+						[{ field: "id", value: id }],
+						"verification",
+						undefined,
+						context,
+						adapter,
+					);
+					return verification;
+				},
 		},
 	});
 };

--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -1,5 +1,4 @@
 import type {
-	Adapter,
 	BetterAuthOptions,
 	GenericEndpointContext,
 	Models,
@@ -8,7 +7,7 @@ import type {
 } from "../types";
 
 export function getWithHooks(
-	adapter: Adapter,
+	adapter: TransactionAdapter,
 	ctx: {
 		options: BetterAuthOptions;
 		hooks: Exclude<BetterAuthOptions["databaseHooks"], undefined>[];

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -216,7 +216,7 @@ export type AuthContext = {
 		storage: "memory" | "database" | "secondary-storage";
 	} & BetterAuthOptions["rateLimit"];
 	adapter: Adapter;
-	internalAdapter: ReturnType<typeof createInternalAdapter>;
+	internalAdapter: ReturnType<typeof createInternalAdapter<false>>;
 	createAuthCookie: ReturnType<typeof createCookieGetter>;
 	secret: string;
 	sessionConfig: {

--- a/packages/better-auth/src/utils/shim.ts
+++ b/packages/better-auth/src/utils/shim.ts
@@ -116,7 +116,11 @@ export const shimLastParam = <
 		const fn = obj[key] as any;
 		out[key] = (...args: any[]) => {
 			if (args.length < fn.length) {
-				return fn(...args, shim);
+				return fn(
+					...args,
+					...Array(Math.max(0, fn.length - 1 - args.length)).fill(undefined),
+					shim,
+				);
 			}
 			return fn(...args);
 		};

--- a/packages/better-auth/src/utils/shim.ts
+++ b/packages/better-auth/src/utils/shim.ts
@@ -104,12 +104,12 @@ export type InferShimLastParamResult<
 export const shimLastParam = <
 	T extends Record<string, (...args: any[]) => any>,
 	P extends LastParameter<T[keyof T]>,
-	Omit extends boolean = false,
+	ShouldOmit extends boolean = false,
 >(
 	obj: T,
 	shim: P,
 	isMatch?: (last: unknown) => boolean,
-	shouldOmit: Omit = false as Omit,
+	shouldOmit: ShouldOmit = false as ShouldOmit,
 ) => {
 	const out: Partial<Record<keyof T, any>> = {};
 
@@ -136,7 +136,7 @@ export const shimLastParam = <
 
 	return out as {
 		[K in keyof T]: (
-			...args: Omit extends true
+			...args: ShouldOmit extends true
 				? RestParameter<T[K]>
 				: [...RestParameter<T[K]>, LastParameter<T[K]>?]
 		) => ReturnType<T[K]>;

--- a/packages/better-auth/src/utils/shim.ts
+++ b/packages/better-auth/src/utils/shim.ts
@@ -1,4 +1,5 @@
 import type { AuthContext } from "../init";
+import type { Prettify } from "../types/helper";
 
 export const shimContext = <T extends Record<string, any>>(
 	originalObject: T,
@@ -93,6 +94,12 @@ type Rest<T extends any[]> = T extends [...infer I, infer L]
 		: never;
 type LastParameter<F extends (...args: any) => any> = Last<Parameters<F>>;
 type RestParameter<F extends (...args: any) => any> = Rest<Parameters<F>>;
+
+export type InferShimLastParamResult<
+	T extends Record<string, (...args: any[]) => any>,
+	P extends LastParameter<T[keyof T]>,
+	Omit extends boolean = false,
+> = Prettify<ReturnType<typeof shimLastParam<T, P, Omit>>>;
 
 export const shimLastParam = <
 	T extends Record<string, (...args: any[]) => any>,

--- a/packages/better-auth/src/utils/shim.ts
+++ b/packages/better-auth/src/utils/shim.ts
@@ -108,6 +108,7 @@ export const shimLastParam = <
 >(
 	obj: T,
 	shim: P,
+	isMatch?: (last: unknown) => boolean,
 	shouldOmit: Omit = false as Omit,
 ) => {
 	const out: Partial<Record<keyof T, any>> = {};
@@ -115,12 +116,19 @@ export const shimLastParam = <
 	for (const key in obj) {
 		const fn = obj[key] as any;
 		out[key] = (...args: any[]) => {
-			if (args.length < fn.length) {
-				return fn(
-					...args,
-					...Array(Math.max(0, fn.length - 1 - args.length)).fill(undefined),
-					shim,
-				);
+			if (isMatch) {
+				if (isMatch(args[args.length - 1])) {
+					return fn(...args);
+				}
+				return fn(...args, shim);
+			} else {
+				if (args.length < fn.length) {
+					return fn(
+						...args,
+						...Array(Math.max(0, fn.length - 1 - args.length)).fill(undefined),
+						shim,
+					);
+				}
 			}
 			return fn(...args);
 		};


### PR DESCRIPTION
I guess this could be closed and put into a 3rd party library. I think it's useful for transaction heavy plugins but I also don't see a use case for this in the core library, as there aren't (at least for the current state) many transactions needed. (Maybe revert to a simpler version, like I had before).   


<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds internalAdapter.withTransaction to run auth DB operations in a single transaction and reduce boilerplate. Provides a transaction-scoped internalAdapter where the transaction adapter is auto-injected.

- **New Features**
  - Added internalAdapter.withTransaction(cb): executes cb within adapter.transaction.
  - cb receives { adapter, internalAdapter }; internalAdapter methods omit the trx param.
  - Introduced shimLastParam utility to auto-inject the last parameter (used for trx) when missing.

<!-- End of auto-generated description by cubic. -->

