### PR TITLE
fix(demo): update forgot password link to /forget-password

### DIFF
--- a/demo/nextjs/components/sign-in.tsx
+++ b/demo/nextjs/components/sign-in.tsx
@@ -62,7 +62,10 @@ export default function SignIn() {
 					<div className="grid gap-2">
 						<div className="flex items-center">
 							<Label htmlFor="password">Password</Label>
-							<Link href="#" className="ml-auto inline-block text-sm underline">
+							<Link
+								href="/forget-password"
+								className="ml-auto inline-block text-sm underline"
+							>
 								Forgot your password?
 							</Link>
 						</div>


### PR DESCRIPTION
this PR updates the forgot your password? link in the /demo app. previously, the link pointed to "#", which did not navigate anywhere.
It now correctly navigates to /forget-password.