### PR TITLE
fix: custom field for `refreshTokenExpiresAt`

### DIFF
--- a/packages/better-auth/src/db/get-tables.test.ts
+++ b/packages/better-auth/src/db/get-tables.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { getAuthTables } from "./get-tables";
+
+describe("getAuthTables", () => {
+	it("should use correct field name for refreshTokenExpiresAt", () => {
+		const tables = getAuthTables({
+			account: {
+				fields: {
+					refreshTokenExpiresAt: "custom_refresh_token_expires_at",
+				},
+			},
+		});
+
+		const accountTable = tables.account;
+		const refreshTokenExpiresAtField =
+			accountTable.fields.refreshTokenExpiresAt;
+
+		expect(refreshTokenExpiresAtField.fieldName).toBe(
+			"custom_refresh_token_expires_at",
+		);
+	});
+
+	it("should not use accessTokenExpiresAt field name for refreshTokenExpiresAt", () => {
+		const tables = getAuthTables({
+			account: {
+				fields: {
+					accessTokenExpiresAt: "custom_access_token_expires_at",
+					refreshTokenExpiresAt: "custom_refresh_token_expires_at",
+				},
+			},
+		});
+
+		const accountTable = tables.account;
+		const refreshTokenExpiresAtField =
+			accountTable.fields.refreshTokenExpiresAt;
+		const accessTokenExpiresAtField = accountTable.fields.accessTokenExpiresAt;
+
+		expect(refreshTokenExpiresAtField.fieldName).toBe(
+			"custom_refresh_token_expires_at",
+		);
+		expect(accessTokenExpiresAtField.fieldName).toBe(
+			"custom_access_token_expires_at",
+		);
+		expect(refreshTokenExpiresAtField.fieldName).not.toBe(
+			accessTokenExpiresAtField.fieldName,
+		);
+	});
+
+	it("should use default field names when no custom names provided", () => {
+		const tables = getAuthTables({});
+
+		const accountTable = tables.account;
+		const refreshTokenExpiresAtField =
+			accountTable.fields.refreshTokenExpiresAt;
+		const accessTokenExpiresAtField = accountTable.fields.accessTokenExpiresAt;
+
+		expect(refreshTokenExpiresAtField.fieldName).toBe("refreshTokenExpiresAt");
+		expect(accessTokenExpiresAtField.fieldName).toBe("accessTokenExpiresAt");
+	});
+});

--- a/packages/better-auth/src/db/get-tables.ts
+++ b/packages/better-auth/src/db/get-tables.ts
@@ -225,7 +225,7 @@ export const getAuthTables = (
 					type: "date",
 					required: false,
 					fieldName:
-						options.account?.fields?.accessTokenExpiresAt ||
+						options.account?.fields?.refreshTokenExpiresAt ||
 						"refreshTokenExpiresAt",
 				},
 				scope: {


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4564
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the custom field mapping for refreshTokenExpiresAt in getAuthTables so it uses the correct override and not accessTokenExpiresAt. Enables proper customization without breaking defaults.

- **Bug Fixes**
  - Map refreshTokenExpiresAt to options.account.fields.refreshTokenExpiresAt (fallback to "refreshTokenExpiresAt").
  - Add tests to verify custom mapping, no cross-over with accessTokenExpiresAt, and default names when unset.

<!-- End of auto-generated description by cubic. -->

