### PR TITLE
fix(lastLoginMethod): inherit cross-subdomain cookie settings in lastLoginMethod plugin

### DIFF
--- a/docs/content/docs/plugins/last-login-method.mdx
+++ b/docs/content/docs/plugins/last-login-method.mdx
@@ -260,6 +260,7 @@ export const auth = betterAuth({
 **cookieName**: `string`
 - The name of the cookie used to store the last login method
 - Default: `"better-auth.last_used_login_method"`
+- **Note**: This cookie is `httpOnly: false` to allow client-side JavaScript access for UI features
 
 **maxAge**: `number`  
 - Cookie expiration time in seconds
@@ -314,32 +315,14 @@ The plugin automatically detects the method from these endpoints:
 - `/sign-in/email` - Email sign in
 - `/sign-up/email` - Email sign up
 
-## Cross-Subdomain Support
+## Cross-Domain Support
 
-The lastLoginMethod plugin automatically inherits cross-subdomain cookie settings from your Better Auth configuration. When `crossSubDomainCookies.enabled` is set to `true`, the plugin will set the domain attribute on the last login method cookie to work across subdomains.
+The plugin automatically inherits cookie settings from Better Auth's centralized cookie system. This solves the problem where the last login method wouldn't persist across:
 
-```ts title="auth.ts"
-import { betterAuth } from "better-auth"
-import { lastLoginMethod } from "better-auth/plugins"
+- **Cross-subdomain setups**: `auth.example.com` → `app.example.com`
+- **Cross-origin setups**: `api.company.com` → `app.different.com`
 
-export const auth = betterAuth({
-    baseURL: "https://auth.example.com",
-    advanced: {
-        crossSubDomainCookies: {
-            enabled: true,
-            domain: "example.com" // Optional: defaults to baseURL domain
-        }
-    },
-    plugins: [
-        lastLoginMethod() // Will automatically inherit cross-subdomain settings
-    ]
-})
-```
-
-With this configuration:
-- The last login method cookie will be set with `Domain=example.com`
-- The cookie will be accessible from `auth.example.com`, `app.example.com`, `api.example.com`, etc.
-- Users can see their last used method across all subdomains of the application
+When you enable `crossSubDomainCookies` or `crossOriginCookies` in your Better Auth config, the plugin will automatically use the same domain, secure, and sameSite settings as your session cookies, ensuring consistent behavior across your application.
 
 ## Advanced Examples
 

--- a/packages/better-auth/src/plugins/last-login-method/custom-prefix.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/custom-prefix.test.ts
@@ -129,7 +129,92 @@ describe("lastLoginMethod custom cookie prefix", async () => {
 				onResponse(context) {
 					const setCookie = context.response.headers.get("set-cookie");
 					expect(setCookie).toContain("Domain=example.com");
+					expect(setCookie).toContain("SameSite=Lax");
 					// Uses exact cookie name from config, not affected by cookiePrefix
+					expect(setCookie).toContain(
+						"better-auth.last_used_login_method=email",
+					);
+				},
+			},
+		);
+	});
+
+	it("should work with cross-origin cookies", async () => {
+		const { client, testUser } = await getTestInstance(
+			{
+				baseURL: "https://api.example.com",
+				advanced: {
+					crossOriginCookies: {
+						enabled: true,
+					},
+					defaultCookieAttributes: {
+						sameSite: "none",
+						secure: true,
+					},
+				},
+				plugins: [lastLoginMethod()],
+			},
+			{
+				clientOptions: {
+					plugins: [lastLoginMethodClient()],
+				},
+			},
+		);
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onResponse(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					expect(setCookie).toContain("SameSite=None");
+					expect(setCookie).toContain("Secure");
+					// Should not contain Domain attribute for cross-origin
+					expect(setCookie).not.toContain("Domain=");
+					expect(setCookie).toContain(
+						"better-auth.last_used_login_method=email",
+					);
+				},
+			},
+		);
+	});
+
+	it("should handle cross-origin on localhost for development", async () => {
+		const { client, testUser } = await getTestInstance(
+			{
+				baseURL: "http://localhost:3000",
+				advanced: {
+					crossOriginCookies: {
+						enabled: true,
+						allowLocalhostUnsecure: true,
+					},
+					defaultCookieAttributes: {
+						sameSite: "none",
+						secure: false,
+					},
+				},
+				plugins: [lastLoginMethod()],
+			},
+			{
+				clientOptions: {
+					plugins: [lastLoginMethodClient()],
+				},
+			},
+		);
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onResponse(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					expect(setCookie).toContain("SameSite=None");
+					// Should not contain Secure on localhost when allowLocalhostUnsecure is true
+					expect(setCookie).not.toContain("Secure");
 					expect(setCookie).toContain(
 						"better-auth.last_used_login_method=email",
 					);

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -98,23 +98,12 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 					handler: createAuthMiddleware(async (ctx) => {
 						const lastUsedLoginMethod = config.customResolveMethod(ctx);
 						if (lastUsedLoginMethod) {
-							// Create cookie with user's specified name and inherit cross-subdomain settings
+							// Inherit cookie attributes from Better Auth's centralized cookie system
+							// This ensures consistency with cross-origin, cross-subdomain, and security settings
 							const cookieAttributes = {
+								...ctx.context.authCookies.sessionToken.options,
 								maxAge: config.maxAge,
-								secure: false,
-								httpOnly: false,
-								path: "/",
-								// Inherit cross-subdomain domain if enabled
-								...(ctx.context.options.advanced?.crossSubDomainCookies?.enabled
-									? {
-											domain:
-												ctx.context.options.advanced.crossSubDomainCookies
-													.domain ||
-												(ctx.context.options.baseURL
-													? new URL(ctx.context.options.baseURL).hostname
-													: undefined),
-										}
-									: {}),
+								httpOnly: false, // Override: plugin cookies are not httpOnly
 							};
 
 							ctx.setCookie(


### PR DESCRIPTION
## Summary

  The lastLoginMethod plugin was using hardcoded cookie attributes, bypassing Better Auth's centralized cookie system. This prevented the plugin from inheriting cross-subdomain cookie settings when `crossSubDomainCookies.enabled` was true.

  ## Changes

  - Replace hardcoded cookie attributes with proper inheritance from `crossSubDomainCookies` configuration
  - Add comprehensive tests for cross-subdomain functionality with custom prefixes
  - Update documentation with cross-subdomain usage examples

  ## Test Plan

  - [x] All existing tests pass
  - [x] Added 4 new test cases covering:
    - Default cookie name with custom prefix
    - Custom cookie name with prefix
    - Custom cookie name regardless of prefix
    - Cross-subdomain functionality with custom prefix
  - [x] Manual testing of cross-subdomain cookie inheritance

  ## Before/After

  **Before:** The plugin used hardcoded cookie attributes, ignoring global cross-subdomain settings
  ```typescript
  ctx.setCookie(config.cookieName, lastUsedLoginMethod, {
    maxAge: config.maxAge,
    secure: false,
    httpOnly: false,
    path: "/",
  });

  After: The plugin inherits cross-subdomain settings from Better Auth configuration
  const cookieAttributes = {
    maxAge: config.maxAge,
    secure: false,
    httpOnly: false,
    path: "/",
    // Inherit cross-subdomain domain if enabled
    ...(ctx.context.options.advanced?.crossSubDomainCookies?.enabled
      ? {
          domain:
            ctx.context.options.advanced.crossSubDomainCookies.domain ||
            (ctx.context.options.baseURL
              ? new URL(ctx.context.options.baseURL).hostname
              : undefined),
        }
      : {}),
  };
```

  Related Issues

  Fixes cross-subdomain cookie inheritance for lastLoginMethod plugin to align with Better Auth's centralized cookie system.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes lastLoginMethod to inherit cross-subdomain cookie settings so the last used login method works across subdomains when enabled. Adds tests and docs for custom cookie names/prefixes and domain handling.

- **Bug Fixes**
  - Replace hardcoded cookie attributes with values derived from advanced.crossSubDomainCookies.
  - Set cookie Domain from configured domain or baseURL hostname when enabled, and respect the exact configured cookieName (not affected by cookiePrefix).

<!-- End of auto-generated description by cubic. -->

