### PR TITLE
feat(social-provider): multiple client ID support for social providers

### DIFF
--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -141,3 +141,90 @@ socialProviders: {
   already authorized your app, you must have them revoke your app's access in
   their Google account settings, then re-authorize.
 </Callout>
+
+## Multiple Client ID Support
+
+Better Auth supports configuring multiple client IDs for the Google provider, which is useful when you need different OAuth configurations for different platforms (e.g., web, iOS, Android) or different redirect URIs.
+
+### Configuration
+
+You can configure multiple client IDs by providing a `configs` array alongside your primary `clientId` and `clientSecret`:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+
+export const auth = betterAuth({
+    socialProviders: {
+        google: {
+            // Primary client configuration (used by default)
+            clientId: process.env.GOOGLE_CLIENT_ID as string,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+            redirectURI: "https://yourapp.com/api/auth/callback/google",
+            
+            // Additional client configurations
+            configs: [
+                {
+                    clientId: "123-ios.googleusercontent.com",
+                    clientSecret: process.env.GOOGLE_IOS_CLIENT_SECRET as string,
+                    redirectURI: "com.yourapp://oauth/callback",
+                    scopes: ["email", "profile"],
+                },
+                {
+                    clientId: "456-android.googleusercontent.com", 
+                    clientSecret: process.env.GOOGLE_ANDROID_CLIENT_SECRET as string,
+                    redirectURI: "com.yourapp://oauth/callback",
+                    scopes: ["email", "profile", "openid"],
+                },
+            ],
+        },
+    },
+})
+```
+
+### Usage with Specific Client ID
+
+When calling `signIn.social`, you can specify which client configuration to use by passing the `clientId` parameter:
+
+```ts title="auth-client.ts"
+import { createAuthClient } from "better-auth/client";
+const authClient = createAuthClient();
+
+// Use iOS client configuration
+const signInWithIOS = async () => {
+  const data = await authClient.signIn.social({
+    provider: "google",
+    clientId: "123-ios.googleusercontent.com", // [!code highlight]
+    callbackURL: "com.yourapp://oauth/callback",
+  });
+};
+
+// Use Android client configuration  
+const signInWithAndroid = async () => {
+  const data = await authClient.signIn.social({
+    provider: "google",
+    clientId: "456-android.googleusercontent.com", // [!code highlight]
+    callbackURL: "com.yourapp://oauth/callback",
+  });
+};
+
+// Use default (primary) client configuration
+const signInWithWeb = async () => {
+  const data = await authClient.signIn.social({
+    provider: "google",
+    callbackURL: "https://yourapp.com/callback",
+  });
+};
+```
+
+### Fallback Behavior
+
+If you specify a `clientId` that doesn't exist in your `configs` array, the system will automatically fall back to using the primary client configuration (the main `clientId` and `clientSecret` from your provider options).
+
+```ts
+// This will fallback to primary config if "invalid-client-id" doesn't exist
+const data = await authClient.signIn.social({
+    provider: "google", 
+    clientId: "invalid-client-id",
+    callbackURL: "https://yourapp.com/callback",
+});
+```

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -60,6 +60,7 @@ export const callbackOAuth = createAuthEndpoint(
 			errorURL,
 			newUserURL,
 			requestSignUp,
+			clientId,
 		} = await parseState(c);
 
 		function redirectOnError(error: string) {
@@ -96,6 +97,7 @@ export const callbackOAuth = createAuthEndpoint(
 				codeVerifier,
 				deviceId: device_id,
 				redirectURI: `${c.context.baseURL}/callback/${provider.id}`,
+				clientId,
 			});
 		} catch (e) {
 			c.context.logger.error("", e);

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -47,6 +47,19 @@ export const signInSocial = createAuthEndpoint(
 			 */
 			provider: SocialProviderListEnum,
 			/**
+			 * Specific client ID to use for this request
+			 *
+			 * This allows you to select which client configuration to use
+			 * when multiple client IDs are configured for a provider.
+			 */
+			clientId: z
+				.string()
+				.meta({
+					description:
+						"Specific client ID to use for this request when multiple client IDs are configured",
+				})
+				.optional(),
+			/**
 			 * Disable automatic redirection to the provider
 			 *
 			 * This is useful if you want to handle the redirection
@@ -325,6 +338,7 @@ export const signInSocial = createAuthEndpoint(
 			redirectURI: `${c.context.baseURL}/callback/${provider.id}`,
 			scopes: c.body.scopes,
 			loginHint: c.body.loginHint,
+			clientId: c.body.clientId,
 		});
 
 		return c.json({

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -24,6 +24,7 @@ export async function generateState(
 		errorURL: c.body?.errorCallbackURL,
 		newUserURL: c.body?.newUserCallbackURL,
 		link,
+		clientId: c.body?.clientId,
 		/**
 		 * This is the actual expiry time of the state
 		 */
@@ -79,6 +80,7 @@ export async function parseState(c: GenericEndpointContext) {
 				})
 				.optional(),
 			requestSignUp: z.boolean().optional(),
+			clientId: z.string().optional(),
 		})
 		.parse(JSON.parse(data.value));
 

--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -30,6 +30,7 @@ export interface OAuthProvider<
 		redirectURI: string;
 		display?: string;
 		loginHint?: string;
+		clientId?: string;
 	}) => Promise<URL> | URL;
 	name: string;
 	validateAuthorizationCode: (data: {
@@ -37,6 +38,7 @@ export interface OAuthProvider<
 		redirectURI: string;
 		codeVerifier?: string;
 		deviceId?: string;
+		clientId?: string;
 	}) => Promise<OAuth2Tokens>;
 	getUserInfo: (
 		token: OAuth2Tokens & {

--- a/packages/better-auth/src/social-providers/multiple-client-config.ts
+++ b/packages/better-auth/src/social-providers/multiple-client-config.ts
@@ -1,0 +1,72 @@
+import type { GenericOAuthConfig } from "../plugins/generic-oauth";
+import type { ProviderOptions } from "../oauth2";
+
+export interface SocialProviderClientConfig
+	extends Omit<GenericOAuthConfig, "providerId"> {
+	options?: Record<string, any>;
+}
+
+export interface SocialProviderMultipleClientOptions<
+	T extends Record<string, any> = any,
+> extends Omit<ProviderOptions<T>, "clientId" | "clientSecret"> {
+	clientId?: string;
+	clientSecret?: string;
+	scopes?: string[];
+	redirectURI?: string;
+	configs?: SocialProviderClientConfig[];
+}
+
+export function getAllClientIds(
+	options: SocialProviderMultipleClientOptions,
+): string[] {
+	const clientIds: string[] = [];
+
+	if (options.clientId) {
+		clientIds.push(options.clientId);
+	}
+
+	if (options.configs) {
+		clientIds.push(...options.configs.map((config) => config.clientId));
+	}
+
+	return clientIds;
+}
+
+export function findClientConfig(
+	options: SocialProviderMultipleClientOptions,
+	clientId: string,
+): SocialProviderClientConfig {
+	const foundClientConfig = options.configs?.find(
+		(config) => config.clientId === clientId,
+	);
+	return (
+		foundClientConfig || {
+			clientId: options.clientId || "",
+			clientSecret: options.clientSecret,
+			scopes: options.scopes,
+			redirectURI: options.redirectURI,
+		}
+	);
+}
+
+export function isValidClientId(
+	options: SocialProviderMultipleClientOptions,
+	clientId: string,
+): boolean {
+	return getAllClientIds(options).includes(clientId);
+}
+
+export function resolvePrimaryClientConfig(
+	requestedClientId: string,
+	options: SocialProviderMultipleClientOptions,
+): SocialProviderClientConfig {
+	if (!requestedClientId) {
+		return {
+			clientId: options.clientId || "",
+			clientSecret: options.clientSecret,
+			scopes: options.scopes,
+			redirectURI: options.redirectURI,
+		};
+	}
+	return findClientConfig(options, requestedClientId);
+}

--- a/packages/better-auth/src/social-providers/tiktok.ts
+++ b/packages/better-auth/src/social-providers/tiktok.ts
@@ -130,9 +130,7 @@ export const tiktok = (options: TiktokOptions) => {
 		id: "tiktok",
 		name: "TikTok",
 		createAuthorizationURL({ state, scopes, redirectURI }) {
-			const _scopes = options.disableDefaultScope
-				? []
-				: ["user.info.basic", "user.info.profile"];
+			const _scopes = options.disableDefaultScope ? [] : ["user.info.profile"];
 			options.scope && _scopes.push(...options.scope);
 			scopes && _scopes.push(...scopes);
 			return new URL(

--- a/packages/better-auth/src/social-providers/tiktok.ts
+++ b/packages/better-auth/src/social-providers/tiktok.ts
@@ -130,7 +130,7 @@ export const tiktok = (options: TiktokOptions) => {
 		id: "tiktok",
 		name: "TikTok",
 		createAuthorizationURL({ state, scopes, redirectURI }) {
-			const _scopes = options.disableDefaultScope ? [] : ["user.info.profile"];
+			const _scopes = options.disableDefaultScope ? [] : ["user.info.basic" , "user.info.profile"];
 			options.scope && _scopes.push(...options.scope);
 			scopes && _scopes.push(...scopes);
 			return new URL(

--- a/packages/better-auth/src/social-providers/tiktok.ts
+++ b/packages/better-auth/src/social-providers/tiktok.ts
@@ -130,7 +130,9 @@ export const tiktok = (options: TiktokOptions) => {
 		id: "tiktok",
 		name: "TikTok",
 		createAuthorizationURL({ state, scopes, redirectURI }) {
-			const _scopes = options.disableDefaultScope ? [] : ["user.info.basic" , "user.info.profile"];
+			const _scopes = options.disableDefaultScope
+				? []
+				: ["user.info.basic", "user.info.profile"];
 			options.scope && _scopes.push(...options.scope);
 			scopes && _scopes.push(...scopes);
 			return new URL(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add multiple client ID support for social providers (initially Google) so apps can choose a client per request (web, iOS, Android) while keeping current setups working by default. Token validation now accepts any configured client ID.

- New Features
  - signInSocial accepts optional clientId; stored in state and used in callback for code exchange.
  - Added SocialProviderMultipleClientOptions with configs[] for per-platform clientId/secret/scopes/redirectURI.
  - OAuth provider types now accept clientId in authorization URL and code validation flows.
  - Google provider resolves the requested client config, merges scopes, uses per-client redirectURI, and validates token aud against all configured client IDs.
  - Tests cover iOS/Android/web selection and fallback on invalid clientId.

- Migration
  - No breaking changes.
  - To use: define google.configs[] and pass clientId in signInSocial when selecting a specific client; otherwise the default client is used.

<!-- End of auto-generated description by cubic. -->

