### PR TITLE
fix(vue): correct baseURL

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -112,6 +112,9 @@ export const getClientConfig = (options?: ClientOptions) => {
 		}
 	}
 	return {
+		get baseURL() {
+			return baseURL;
+		},
 		pluginsActions,
 		pluginsAtoms,
 		pluginPathMethods,

--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -46,6 +46,7 @@ export function createAuthClient<Option extends ClientOptions>(
 	options?: Option,
 ) {
 	const {
+		baseURL,
 		pluginPathMethods,
 		pluginsActions,
 		pluginsAtoms,
@@ -93,11 +94,7 @@ export function createAuthClient<Option extends ClientOptions>(
 	) {
 		if (useFetch) {
 			const ref = useStore(pluginsAtoms.$sessionSignal);
-			const baseURL = options?.fetchOptions?.baseURL || options?.baseURL;
-			let authPath = baseURL ? new URL(baseURL).pathname : "/api/auth";
-			authPath = authPath === "/" ? "/api/auth" : authPath; //fix for root path
-			authPath = authPath.endsWith("/") ? authPath.slice(0, -1) : authPath; //fix for trailing slash
-			return useFetch(`${authPath}/get-session`, {
+			return useFetch(`${baseURL}/get-session`, {
 				ref,
 			}).then((res: any) => {
 				return {


### PR DESCRIPTION
Closes: https://github.com/better-auth/better-auth/pull/2218
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes baseURL handling in the Vue client so get-session requests hit the correct path. The baseURL is now sourced from shared client config, preventing errors with root or trailing-slash URLs.

- **Bug Fixes**
  - Expose baseURL via getClientConfig getter.
  - Use config.baseURL in Vue useFetch for get-session; remove ad-hoc path building.

<!-- End of auto-generated description by cubic. -->

