### PR TITLE
ci: update `merge_group`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       branches:
         - main
         - canary
-    merge_group: {}
+    merge_group:
 
 jobs:
     test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,7 @@ name: E2E
 on:
   push:
     branches: [ main, canary ]
+  merge_group:
   pull_request:
 jobs:
   smoke:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable the merge_group trigger for CI and E2E workflows so checks run in GitHub’s merge queue. This runs tests for queued merges and blocks the batch if checks fail.

<!-- End of auto-generated description by cubic. -->

