### PR TITLE
fix: return local IP in development mode for getIp function

### DIFF
--- a/packages/better-auth/src/utils/get-request-ip.ts
+++ b/packages/better-auth/src/utils/get-request-ip.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthOptions } from "../types";
-import { isTest } from "../utils/env";
+import { isDevelopment, isTest } from "../utils/env";
 
 export function getIp(
 	req: Request | Headers,
@@ -11,6 +11,9 @@ export function getIp(
 
 	if (isTest()) {
 		return "127.0.0.1"; // Use a fixed IP for test environments
+	}
+	if (isDevelopment) {
+		return "127.0.0.1"; // Use a fixed IP for development environments
 	}
 
 	const headers = "headers" in req ? req.headers : req;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
getIp now returns 127.0.0.1 in development mode, matching test behavior. This makes local runs deterministic and avoids relying on client/proxy headers during development.

<!-- End of auto-generated description by cubic. -->

