### PR TITLE
fix: check endpoint conflicts respect `method`

### DIFF
--- a/packages/better-auth/src/api/check-endpoint-conflicts.test.ts
+++ b/packages/better-auth/src/api/check-endpoint-conflicts.test.ts
@@ -356,7 +356,7 @@ describe("checkEndpointConflicts", () => {
 				endpoint1: endpoint(
 					"/api/wildcard",
 					{
-						method: '*'
+						method: "*",
 					},
 					vi.fn(),
 				),
@@ -384,9 +384,7 @@ describe("checkEndpointConflicts", () => {
 
 		expect(mockLogger.error).toHaveBeenCalledTimes(1);
 		expect(mockLogger.error).toHaveBeenCalledWith(
-			expect.stringContaining(
-				'"/api/wildcard"',
-			),
+			expect.stringContaining('"/api/wildcard"'),
 		);
 	});
 

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -66,7 +66,7 @@ export function checkEndpointConflicts(
 					if (methods.length === 0) {
 						methods = ["*"];
 					}
-					
+
 					if (!endpointRegistry.has(path)) {
 						endpointRegistry.set(path, []);
 					}
@@ -80,12 +80,16 @@ export function checkEndpointConflicts(
 		}
 	});
 
-	const conflicts: { path: string; plugins: string[]; conflictingMethods: string[] }[] = [];
+	const conflicts: {
+		path: string;
+		plugins: string[];
+		conflictingMethods: string[];
+	}[] = [];
 	for (const [path, entries] of endpointRegistry.entries()) {
 		if (entries.length > 1) {
 			const methodMap = new Map<string, string[]>();
 			let hasConflict = false;
-			
+
 			for (const entry of entries) {
 				for (const method of entry.methods) {
 					if (!methodMap.has(method)) {
@@ -104,18 +108,21 @@ export function checkEndpointConflicts(
 					}
 				}
 			}
-			
+
 			if (hasConflict) {
 				const uniquePlugins = [...new Set(entries.map((e) => e.pluginId))];
 				const conflictingMethods: string[] = [];
 
 				for (const [method, plugins] of methodMap.entries()) {
-					if (plugins.length > 1 || (method === "*" && entries.length > 1) || 
-					    (method !== "*" && methodMap.has("*"))) {
+					if (
+						plugins.length > 1 ||
+						(method === "*" && entries.length > 1) ||
+						(method !== "*" && methodMap.has("*"))
+					) {
 						conflictingMethods.push(method);
 					}
 				}
-				
+
 				conflicts.push({
 					path,
 					plugins: uniquePlugins,


### PR DESCRIPTION
Reported by @Bekacru 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make endpoint conflict checks method-aware. Same path with different HTTP methods no longer conflicts; same method or wildcard collisions are reported with clearer errors.

- **Bug Fixes**
  - Detect conflicts per HTTP method (supports string and array; defaults to "*").
  - No conflict when plugins use the same path with different methods.
  - Detect conflicts for same method on the same path, including within the same plugin.
  - Treat "*" as conflicting with any specific method.
  - Error message now shows conflicting methods and updated guidance.
  - Expanded tests to cover mixed methods, duplicates, and wildcard cases.

<!-- End of auto-generated description by cubic. -->

