### PR TITLE
test: improve coverage for jwt

### DIFF
--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -412,36 +412,13 @@ describe("jwt - remote signing", async () => {
 });
 
 describe("jwt - remote url", async () => {
-	const { auth } = await getTestInstance({
-		plugins: [
-			jwt({
-				jwks: {
-					remoteUrl: "https://example.com",
-					keyPairConfig: {
-						alg: "ES256",
-					},
-				},
-			}),
-		],
-	});
-
-	const client = createAuthClient({
-		plugins: [jwtClient()],
-		baseURL: "http://localhost:3000/api/auth",
-		fetchOptions: {
-			customFetchImpl: async (url, init) => {
-				return auth.handler(new Request(url, init));
-			},
-		},
-	});
-
-	it("should require specifying the alg used", async () => {
+	it("should require specifying the alg when using remoteUrl", async () => {
 		expect(() =>
 			getTestInstance({
 				plugins: [
 					jwt({
 						jwks: {
-							remoteUrl: "https://example.com",
+							remoteUrl: "https://example.com/.well-known/jwks.json",
 						},
 					}),
 				],
@@ -449,8 +426,273 @@ describe("jwt - remote url", async () => {
 		).toThrowError("jwks_config");
 	});
 
-	it("should disable /jwks", async () => {
+	it("should accept remoteUrl with alg specified", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [
+				jwt({
+					jwks: {
+						remoteUrl: "https://example.com/.well-known/jwks.json",
+						keyPairConfig: {
+							alg: "ES256",
+						},
+					},
+				}),
+			],
+		});
+		expect(auth).toBeDefined();
+	});
+
+	it("should disable /jwks endpoint when remoteUrl is configured", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [
+				jwt({
+					jwks: {
+						remoteUrl: "https://example.com/.well-known/jwks.json",
+						keyPairConfig: {
+							alg: "ES256",
+						},
+					},
+				}),
+			],
+		});
+
+		const client = createAuthClient({
+			plugins: [jwtClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					return auth.handler(new Request(url, init));
+				},
+			},
+		});
+
 		const response = await client.$fetch<JSONWebKeySet>("/jwks");
 		expect(response.error?.status).toBe(404);
+	});
+
+	it("should work with different algorithms when remoteUrl is set", async () => {
+		const algorithms = ["ES256", "ES512", "RS256", "PS256", "EdDSA"];
+
+		for (const alg of algorithms) {
+			const { auth } = await getTestInstance({
+				plugins: [
+					jwt({
+						jwks: {
+							remoteUrl: "https://example.com/.well-known/jwks.json",
+							keyPairConfig: {
+								alg: alg as any,
+							},
+						},
+					}),
+				],
+			});
+			expect(auth).toBeDefined();
+		}
+	});
+
+	it("should still allow token generation when remoteUrl is set", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				jwt({
+					jwks: {
+						remoteUrl: "https://example.com/.well-known/jwks.json",
+						keyPairConfig: {
+							alg: "ES256",
+						},
+					},
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+
+		const client = createAuthClient({
+			plugins: [jwtClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					return auth.handler(new Request(url, init));
+				},
+			},
+		});
+
+		const token = await client.token({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(token.data?.token).toBeDefined();
+		expect(token.data?.token).toMatch(/^[\w-]+\.[\w-]+\.[\w-]+$/); // JWT format
+	});
+
+	it("should work with custom sign function and remoteUrl", async () => {
+		const mockSignFunction = (payload: any) => {
+			// Mock JWT with test signature
+			const header = Buffer.from(
+				JSON.stringify({ alg: "ES256", typ: "JWT" }),
+			).toString("base64url");
+			const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+			const signature = "mock-signature";
+			return `${header}.${body}.${signature}`;
+		};
+
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				jwt({
+					jwks: {
+						remoteUrl: "https://example.com/.well-known/jwks.json",
+						keyPairConfig: {
+							alg: "ES256",
+						},
+					},
+					jwt: {
+						sign: mockSignFunction,
+					},
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+
+		const client = createAuthClient({
+			plugins: [jwtClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					return auth.handler(new Request(url, init));
+				},
+			},
+		});
+
+		const token = await client.token({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(token.data?.token).toBeDefined();
+		// Verify it's using our mock sign function
+		expect(token.data?.token).toContain("mock-signature");
+	});
+
+	it("should validate that remoteUrl is a valid URL format", async () => {
+		const invalidUrls = [
+			"not-a-url",
+			"http://",
+			"//example.com",
+			"example.com/jwks",
+		];
+
+		for (const url of invalidUrls) {
+			// While the current implementation doesn't validate URL format,
+			// this test documents expected behavior
+			const { auth } = await getTestInstance({
+				plugins: [
+					jwt({
+						jwks: {
+							remoteUrl: url,
+							keyPairConfig: {
+								alg: "ES256",
+							},
+						},
+					}),
+				],
+			});
+			// Currently passes, but documents that URL validation might be needed
+			expect(auth).toBeDefined();
+		}
+	});
+
+	it("should work with remoteUrl pointing to different paths", async () => {
+		const validPaths = [
+			"https://example.com/.well-known/jwks.json",
+			"https://auth.example.com/jwks",
+			"https://api.example.com/v1/keys",
+			"https://example.com:8080/jwks.json",
+		];
+
+		for (const url of validPaths) {
+			const { auth } = await getTestInstance({
+				plugins: [
+					jwt({
+						jwks: {
+							remoteUrl: url,
+							keyPairConfig: {
+								alg: "ES256",
+							},
+						},
+					}),
+				],
+			});
+			expect(auth).toBeDefined();
+		}
+	});
+
+	it("should handle remoteUrl with query parameters", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [
+				jwt({
+					jwks: {
+						remoteUrl: "https://example.com/jwks?version=1&format=json",
+						keyPairConfig: {
+							alg: "RS256",
+						},
+					},
+				}),
+			],
+		});
+		expect(auth).toBeDefined();
+	});
+
+	it("should not interfere with other JWT endpoints when remoteUrl is set", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				jwt({
+					jwks: {
+						remoteUrl: "https://example.com/.well-known/jwks.json",
+						keyPairConfig: {
+							alg: "ES256",
+						},
+					},
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+
+		const client = createAuthClient({
+			plugins: [jwtClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					return auth.handler(new Request(url, init));
+				},
+			},
+		});
+
+		// Test that /token endpoint still works
+		const tokenResponse = await client.token({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(tokenResponse.data?.token).toBeDefined();
+
+		// Test that /jwks endpoint returns 404
+		const jwksResponse = await client.$fetch("/jwks");
+		expect(jwksResponse.error?.status).toBe(404);
+
+		// Test that session endpoint still returns JWT header
+		let jwtHeader = "";
+		await client.getSession({
+			fetchOptions: {
+				headers,
+				onSuccess(context) {
+					jwtHeader = context.response.headers.get("set-auth-jwt") || "";
+				},
+			},
+		});
+		expect(jwtHeader).toBeTruthy();
 	});
 });


### PR DESCRIPTION
Closes: https://github.com/better-auth/better-auth/issues/4488
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Expanded tests for the JWT plugin’s JWKS remoteUrl config. Covers alg requirements, endpoint behavior, token/signing flows, and URL shapes.

- **Test Coverage**
  - Require alg when using remoteUrl (throws "jwks_config"); accept when provided across ES256/ES512/RS256/PS256/EdDSA.
  - Disable /jwks (404) when remoteUrl is set; token and session endpoints still work.
  - Verify token generation (JWT format) and session returns set-auth-jwt header.
  - Respect custom jwt.sign even with remoteUrl (token includes mock-signature).
  - Cover remoteUrl variants (well-known, paths, ports, query params) and document current lack of URL format validation.

<!-- End of auto-generated description by cubic. -->

