### PR TITLE
fix: pick the first clientId for oauth provider

### DIFF
--- a/packages/better-auth/src/oauth2/client-credentials-token.ts
+++ b/packages/better-auth/src/oauth2/client-credentials-token.ts
@@ -32,21 +32,18 @@ export function createClientCredentialsTokenRequest({
 		}
 	}
 	if (authentication === "basic") {
+		const primaryClientId = Array.isArray(options.clientId)
+			? options.clientId[0]
+			: options.clientId;
 		const encodedCredentials = base64Url.encode(
-			`${options.clientId}:${options.clientSecret}`,
+			`${primaryClientId}:${options.clientSecret}`,
 		);
 		headers["authorization"] = `Basic ${encodedCredentials}`;
 	} else {
-		const clientId: unknown = options.clientId;
-		if (typeof clientId !== "undefined" && clientId !== null) {
-			if (typeof clientId === "string") {
-				body.set("client_id", clientId);
-			} else if (Array.isArray(clientId)) {
-				for (const id of clientId) {
-					body.append("client_id", String(id));
-				}
-			}
-		}
+		const primaryClientId = Array.isArray(options.clientId)
+			? options.clientId[0]
+			: options.clientId;
+		body.set("client_id", primaryClientId);
 		body.set("client_secret", options.clientSecret);
 	}
 

--- a/packages/better-auth/src/oauth2/create-authorization-url.ts
+++ b/packages/better-auth/src/oauth2/create-authorization-url.ts
@@ -42,14 +42,10 @@ export async function createAuthorizationURL({
 }) {
 	const url = new URL(authorizationEndpoint);
 	url.searchParams.set("response_type", responseType || "code");
-	const clientId = options.clientId;
-	if (typeof clientId === "string") {
-		url.searchParams.set("client_id", clientId);
-	} else if (Array.isArray(clientId)) {
-		for (const id of clientId) {
-			url.searchParams.append("client_id", id);
-		}
-	}
+	const primaryClientId = Array.isArray(options.clientId)
+		? options.clientId[0]
+		: options.clientId;
+	url.searchParams.set("client_id", primaryClientId);
 	url.searchParams.set("state", state);
 	url.searchParams.set("scope", scopes.join(scopeJoiner || " "));
 	url.searchParams.set("redirect_uri", options.redirectURI || redirectURI);

--- a/packages/better-auth/src/oauth2/refresh-access-token.ts
+++ b/packages/better-auth/src/oauth2/refresh-access-token.ts
@@ -27,23 +27,22 @@ export function createRefreshAccessTokenRequest({
 	// Use standard Base64 encoding for HTTP Basic Auth (OAuth2 spec, RFC 7617)
 	// Fixes compatibility with providers like Notion, Twitter, etc.
 	if (authentication === "basic") {
-		if (options.clientId) {
+		const primaryClientId = Array.isArray(options.clientId)
+			? options.clientId[0]
+			: options.clientId;
+		if (primaryClientId) {
 			headers["authorization"] =
 				"Basic " +
-				base64.encode(`${options.clientId}:${options.clientSecret ?? ""}`);
+				base64.encode(`${primaryClientId}:${options.clientSecret ?? ""}`);
 		} else {
 			headers["authorization"] =
 				"Basic " + base64.encode(`:${options.clientSecret ?? ""}`);
 		}
 	} else {
-		const clientId = options.clientId;
-		if (typeof clientId === "string") {
-			body.set("client_id", clientId);
-		} else if (Array.isArray(clientId)) {
-			for (const id of clientId) {
-				body.append("client_id", id);
-			}
-		}
+		const primaryClientId = Array.isArray(options.clientId)
+			? options.clientId[0]
+			: options.clientId;
+		body.set("client_id", primaryClientId);
 		if (options.clientSecret) {
 			body.set("client_secret", options.clientSecret);
 		}

--- a/packages/better-auth/src/oauth2/validate-authorization-code.ts
+++ b/packages/better-auth/src/oauth2/validate-authorization-code.ts
@@ -50,19 +50,18 @@ export function createAuthorizationCodeRequest({
 	// Use standard Base64 encoding for HTTP Basic Auth (OAuth2 spec, RFC 7617)
 	// Fixes compatibility with providers like Notion, Twitter, etc.
 	if (authentication === "basic") {
+		const primaryClientId = Array.isArray(options.clientId)
+			? options.clientId[0]
+			: options.clientId;
 		const encodedCredentials = base64.encode(
-			`${options.clientId}:${options.clientSecret ?? ""}`,
+			`${primaryClientId}:${options.clientSecret ?? ""}`,
 		);
 		requestHeaders["authorization"] = `Basic ${encodedCredentials}`;
 	} else {
-		const clientId = options.clientId;
-		if (typeof clientId === "string") {
-			body.set("client_id", clientId);
-		} else if (Array.isArray(clientId)) {
-			for (const id of clientId) {
-				body.append("client_id", id);
-			}
-		}
+		const primaryClientId = Array.isArray(options.clientId)
+			? options.clientId[0]
+			: options.clientId;
+		body.set("client_id", primaryClientId);
 		if (options.clientSecret) {
 			body.set("client_secret", options.clientSecret);
 		}


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/pull/4596#discussion_r2342624730

/cc @RikhiSingh 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Always use the first clientId when an array is provided and switch to standard Base64 for Basic auth. This fixes OAuth flows that failed with providers expecting a single client_id.

- **Bug Fixes**
  - Pick the first clientId across all OAuth requests (authorization URL, auth code, refresh token, client credentials).
  - Send a single client_id and use RFC 7617 Basic auth (base64 instead of base64Url).
  - Improves compatibility with providers that reject multiple client_id values (e.g., Notion, Twitter).

<!-- End of auto-generated description by cubic. -->

