### PR TITLE
fix: remove use of `global.crypto`

### DIFF
--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -31,7 +31,7 @@ export function toExpJWT(
 
 async function deriveKey(secretKey: string): Promise<CryptoKey> {
 	const enc = new TextEncoder();
-	const keyMaterial = await crypto.subtle.importKey(
+	const keyMaterial = await subtle.importKey(
 		"raw",
 		enc.encode(secretKey),
 		{ name: "PBKDF2" },


### PR DESCRIPTION
Related: https://github.com/better-auth/better-auth/issues/4471

This has been brought in a very old version, since 0.8. So I don't think this will fix the issue, but let's not use `crypto`
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Remove direct use of global.crypto in JWT key derivation to prevent runtime errors in environments where crypto isn’t on the global object (e.g., some edge/bundler targets). We now call subtle.importKey directly so PBKDF2 works across runtimes.

<!-- End of auto-generated description by cubic. -->

