### PR TITLE
fix(stripe): Closes #3979

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -330,13 +330,6 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						),
 					);
 
-				// const activeSubscription = activeSubscriptions.find((sub) =>
-				// 	subscriptionToUpdate?.stripeSubscriptionId || ctx.body.subscriptionId
-				// 		? sub.id === subscriptionToUpdate?.stripeSubscriptionId ||
-				// 			sub.id === ctx.body.subscriptionId
-				// 		: false,
-				// );
-
 				const activeSubscription = subscriptionToUpdate
 					? activeSubscriptions.find(
 							(sub) => sub.id === subscriptionToUpdate.stripeSubscriptionId,


### PR DESCRIPTION
**Problem:** 
Users were unable to create multiple subscriptions for different organizations, even when using
different referenceId values. The system incorrectly forced users into an upgrade flow for any
existing subscription, regardless of the organization context.

**Solution:**
Modified the subscription logic to:
 - Only set subscriptionToUpdate when an explicit subscriptionId is provided (removed the automatic lookup by referenceId)
 - Only trigger the upgrade flow when explicitly updating an existing subscription
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes subscription creation across multiple organizations by removing implicit referenceId lookups and only triggering upgrades when explicitly updating a known subscription. This prevents users from being forced into upgrading an unrelated subscription.

- **Bug Fixes**
  - Only set subscriptionToUpdate when a subscriptionId is provided (no automatic lookup by referenceId).
  - Only consider an activeSubscription when updating a known subscription.
  - Show “already subscribed” only if plan, seats, and referenceId all match.
  - Trigger billing portal/upgrade flow only when subscriptionId or subscriptionToUpdate is present.

<!-- End of auto-generated description by cubic. -->

