### PR TITLE
fix(stripe): use correct request method for billing-portal

### DIFF
--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -29,6 +29,7 @@ export const stripeClient = <
 		>,
 		pathMethods: {
 			"/subscription/restore": "POST",
+			"/subscription/billing-portal": "POST",
 		},
 	} satisfies BetterAuthClientPlugin;
 };


### PR DESCRIPTION
closes #4611
similar to #2258
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use POST for /subscription/billing-portal in the Stripe client to match the API and prevent 405/method errors. Fixes #4611 where billing-portal requests failed due to the wrong HTTP method.

<!-- End of auto-generated description by cubic. -->

