### PR TITLE
fix(expo): missing peer deps

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -61,7 +61,12 @@
     "unbuild": "^3.6.1"
   },
   "peerDependencies": {
-    "better-auth": "workspace:*"
+    "better-auth": ">=1.0.0",
+    "expo-constants": ">=17.0.0",
+    "expo-crypto": ">=13.0.0",
+    "expo-linking": ">=7.0.0",
+    "expo-secure-store": ">=14.0.0",
+    "expo-web-browser": ">=14.0.0"
   },
   "dependencies": {
     "@better-fetch/fetch": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15876,7 +15876,9 @@ snapshots:
       metro-runtime: 0.83.1
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.79.5': {}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Declare missing Expo peer dependencies for the expo package and set a stable peer range for better-auth to avoid install/runtime warnings and ensure correct app setup.

- **Dependencies**
  - Added peerDependencies: expo-constants >=17, expo-crypto >=13, expo-linking >=7, expo-secure-store >=14, expo-web-browser >=14
  - Updated better-auth peer to >=1.0.0 (from workspace:*)

<!-- End of auto-generated description by cubic. -->

