### PR TITLE
fix(cli): timestamp in schema for Drizzle with SQLite

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -104,7 +104,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 						: `int('${name}')`,
 				},
 				date: {
-					sqlite: `integer('${name}', { mode: 'timestamp' })`,
+					sqlite: `integer('${name}', { mode: 'timestamp_ms' })`,
 					pg: `timestamp('${name}')`,
 					mysql: `timestamp('${name}')`,
 				},
@@ -170,7 +170,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 										attr.defaultValue.toString().includes("new Date()")
 									) {
 										if (databaseType === "sqlite") {
-											type += `.default(sql\`(current_timestamp)\`)`;
+											type += `.default(sql\`(cast(unixepoch('subsecond') * 1000 as integer))\`)`;
 										} else {
 											type += `.defaultNow()`;
 										}

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-number-id.txt
@@ -9,11 +9,11 @@ export const custom_user = sqliteTable("custom_user", {
     .default(false)
     .notNull(),
   image: text("image"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   twoFactorEnabled: integer("two_factor_enabled", { mode: "boolean" }).default(
@@ -25,12 +25,12 @@ export const custom_user = sqliteTable("custom_user", {
 
 export const custom_session = sqliteTable("custom_session", {
   id: int("id").primaryKey(),
-  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
   token: text("token").notNull().unique(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   ipAddress: text("ip_address"),
@@ -51,17 +51,17 @@ export const custom_account = sqliteTable("custom_account", {
   refreshToken: text("refresh_token"),
   idToken: text("id_token"),
   accessTokenExpiresAt: integer("access_token_expires_at", {
-    mode: "timestamp",
+    mode: "timestamp_ms",
   }),
   refreshTokenExpiresAt: integer("refresh_token_expires_at", {
-    mode: "timestamp",
+    mode: "timestamp_ms",
   }),
   scope: text("scope"),
   password: text("password"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
@@ -70,12 +70,12 @@ export const custom_verification = sqliteTable("custom_verification", {
   id: int("id").primaryKey(),
   identifier: text("identifier").notNull(),
   value: text("value").notNull(),
-  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey-number-id.txt
@@ -9,23 +9,23 @@ export const custom_user = sqliteTable("custom_user", {
     .default(false)
     .notNull(),
   image: text("image"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
 
 export const custom_session = sqliteTable("custom_session", {
   id: int("id").primaryKey(),
-  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
   token: text("token").notNull().unique(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   ipAddress: text("ip_address"),
@@ -46,17 +46,17 @@ export const custom_account = sqliteTable("custom_account", {
   refreshToken: text("refresh_token"),
   idToken: text("id_token"),
   accessTokenExpiresAt: integer("access_token_expires_at", {
-    mode: "timestamp",
+    mode: "timestamp_ms",
   }),
   refreshTokenExpiresAt: integer("refresh_token_expires_at", {
-    mode: "timestamp",
+    mode: "timestamp_ms",
   }),
   scope: text("scope"),
   password: text("password"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
@@ -65,12 +65,12 @@ export const custom_verification = sqliteTable("custom_verification", {
   id: int("id").primaryKey(),
   identifier: text("identifier").notNull(),
   value: text("value").notNull(),
-  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
@@ -87,6 +87,6 @@ export const passkey = sqliteTable("passkey", {
   deviceType: text("device_type").notNull(),
   backedUp: integer("backed_up", { mode: "boolean" }).notNull(),
   transports: text("transports"),
-  createdAt: integer("created_at", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }),
   aaguid: text("aaguid"),
 });

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey.txt
@@ -9,23 +9,23 @@ export const custom_user = sqliteTable("custom_user", {
     .default(false)
     .notNull(),
   image: text("image"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
 
 export const custom_session = sqliteTable("custom_session", {
   id: text("id").primaryKey(),
-  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
   token: text("token").notNull().unique(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   ipAddress: text("ip_address"),
@@ -46,17 +46,17 @@ export const custom_account = sqliteTable("custom_account", {
   refreshToken: text("refresh_token"),
   idToken: text("id_token"),
   accessTokenExpiresAt: integer("access_token_expires_at", {
-    mode: "timestamp",
+    mode: "timestamp_ms",
   }),
   refreshTokenExpiresAt: integer("refresh_token_expires_at", {
-    mode: "timestamp",
+    mode: "timestamp_ms",
   }),
   scope: text("scope"),
   password: text("password"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
@@ -65,12 +65,12 @@ export const custom_verification = sqliteTable("custom_verification", {
   id: text("id").primaryKey(),
   identifier: text("identifier").notNull(),
   value: text("value").notNull(),
-  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
@@ -87,6 +87,6 @@ export const passkey = sqliteTable("passkey", {
   deviceType: text("device_type").notNull(),
   backedUp: integer("backed_up", { mode: "boolean" }).notNull(),
   transports: text("transports"),
-  createdAt: integer("created_at", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }),
   aaguid: text("aaguid"),
 });

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite.txt
@@ -9,11 +9,11 @@ export const custom_user = sqliteTable("custom_user", {
     .default(false)
     .notNull(),
   image: text("image"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   twoFactorEnabled: integer("two_factor_enabled", { mode: "boolean" }).default(
@@ -25,12 +25,12 @@ export const custom_user = sqliteTable("custom_user", {
 
 export const custom_session = sqliteTable("custom_session", {
   id: text("id").primaryKey(),
-  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
   token: text("token").notNull().unique(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   ipAddress: text("ip_address"),
@@ -51,17 +51,17 @@ export const custom_account = sqliteTable("custom_account", {
   refreshToken: text("refresh_token"),
   idToken: text("id_token"),
   accessTokenExpiresAt: integer("access_token_expires_at", {
-    mode: "timestamp",
+    mode: "timestamp_ms",
   }),
   refreshTokenExpiresAt: integer("refresh_token_expires_at", {
-    mode: "timestamp",
+    mode: "timestamp_ms",
   }),
   scope: text("scope"),
   password: text("password"),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
@@ -70,12 +70,12 @@ export const custom_verification = sqliteTable("custom_verification", {
   id: text("id").primaryKey(),
   identifier: text("identifier").notNull(),
   value: text("value").notNull(),
-  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .default(sql`(current_timestamp)`)
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });


### PR DESCRIPTION
fix: https://github.com/better-auth/better-auth/pull/4889

`.defaultNow()` which is `(cast((julianday('now') - 2440587.5)*86400000 as integer))` was storing timestamp in subsecond precision. 

refers to [implementation](https://github.com/drizzle-team/drizzle-orm/blob/8e8a9e902410ed2068a015d59180b225045dddf1/drizzle-orm/src/sqlite-core/columns/integer.ts#L136), retrieving timestamp will get wrong result.

using `(current_timestamp)` was storing text into integer field, use `(cast(unixepoch('subsecond') * 1000 as integer)` instead. see https://github.com/drizzle-team/drizzle-orm/issues/2810

<img width="683" height="386" alt="image" src="https://github.com/user-attachments/assets/52ec221d-b36e-4664-afac-d3e43676ae80" />


<img width="838" height="114" alt="image" src="https://github.com/user-attachments/assets/9d9cb278-7048-4d50-8401-f464f77d7138" />


<img width="460" height="442" alt="image" src="https://github.com/user-attachments/assets/754d3a3e-9510-4ca3-ac3e-ae2d65008100" />

