### PR TITLE
fix(organization): before org create hooks not applying customized data

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
@@ -269,6 +269,7 @@ describe("organization hooks", async () => {
 										metadata: {
 											hookCalled: true,
 										},
+										name: "changed-name",
 									},
 								};
 							},
@@ -291,6 +292,7 @@ describe("organization hooks", async () => {
 			headers,
 		});
 		expect(beforeCreateOrganization).toHaveBeenCalled();
+		expect(result?.name).toBe("changed-name");
 		expect(result?.metadata).toEqual({
 			hookCalled: true,
 		});

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -188,13 +188,12 @@ export const createOrganization = <O extends OrganizationOptions>(
 						user,
 					});
 				if (response && typeof response === "object" && "data" in response) {
-						orgData = {
+					orgData = {
 						...ctx.body,
 						...response.data,
 					};
 				}
 			}
-
 
 			const organization = await adapter.createOrganization({
 				organization: {
@@ -318,10 +317,13 @@ export const createOrganization = <O extends OrganizationOptions>(
 					teamMember.teamId,
 				);
 			}
-			
+
 			return ctx.json({
 				...organization,
-				metadata: organization.metadata && typeof organization.metadata === "string" ? JSON.parse(organization.metadata) : organization.metadata,
+				metadata:
+					organization.metadata && typeof organization.metadata === "string"
+						? JSON.parse(organization.metadata)
+						: organization.metadata,
 				members: [member],
 			});
 		},

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -156,7 +156,7 @@ export const createOrganization = <O extends OrganizationOptions>(
 				});
 			}
 
-			const {
+			let {
 				keepCurrentActiveOrganization: _,
 				userId: __,
 				...orgData
@@ -174,7 +174,7 @@ export const createOrganization = <O extends OrganizationOptions>(
 					ctx.request,
 				);
 				if (response && typeof response === "object" && "data" in response) {
-					ctx.body = {
+					orgData = {
 						...ctx.body,
 						...response.data,
 					};
@@ -188,12 +188,13 @@ export const createOrganization = <O extends OrganizationOptions>(
 						user,
 					});
 				if (response && typeof response === "object" && "data" in response) {
-					ctx.body = {
+						orgData = {
 						...ctx.body,
 						...response.data,
 					};
 				}
 			}
+
 
 			const organization = await adapter.createOrganization({
 				organization: {
@@ -317,10 +318,10 @@ export const createOrganization = <O extends OrganizationOptions>(
 					teamMember.teamId,
 				);
 			}
-
+			
 			return ctx.json({
 				...organization,
-				metadata: ctx.body.metadata,
+				metadata: organization.metadata && typeof organization.metadata === "string" ? JSON.parse(organization.metadata) : organization.metadata,
 				members: [member],
 			});
 		},


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes organization creation so data returned by before-create hooks is applied. Also ensures returned metadata has the correct type.

- **Bug Fixes**
  - Merge hook response into orgData (not ctx.body) so customized fields (e.g., name, metadata) persist through creation.
  - Parse metadata from JSON string when returning the organization to keep types consistent.

<!-- End of auto-generated description by cubic. -->

