### PR TITLE
fix(prisma): handle optional field relation types correctly

### DIFF
--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -207,7 +207,9 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 						.model(modelName)
 						.field(
 							`${referencedCustomModelName.toLowerCase()}`,
-							capitalizeFirstLetter(referencedCustomModelName),
+							`${capitalizeFirstLetter(referencedCustomModelName)}${
+								!attr.required ? "?" : ""
+							}`,
 						)
 						.attribute(
 							`relation(fields: [${fieldName}], references: [${attr.references.field}], onDelete: ${action})`,


### PR DESCRIPTION
When configuring an `additionalFields` on the user with `required: false` and a references model, the better-auth  cli generate command correctly creates an optional foreign key field (e.g., extension String?). However, it incorrectly generates the corresponding relation field as non-optional (e.g., userextension UserExtension), which results in an invalid Prisma schema.

## Steps to Reproduce

1. Configure better-auth with the following `user.additionalFields`
```ts
// auth.ts
// ...
user: {
    additionalFields: {
        extension: {
            type: "string",
            required: false,
            unique: true,
            references: {
                model: "UserExtension",
                field: "id",
                onDelete: "cascade",
            }
        }
    }
},
// ...
```

2. Run the schema generation command

```sh
npx better-auth generate
```

3. Observe the generated `schema.prisma` file. The User model will contain

```prisma
model User {
  // ...
  extension     String?
  userextension UserExtension @relation(fields: [extension], references: [id], onDelete: Cascade) // This line is incorrect
  // ...
}
```
This pull request introduces a small change to the way field types are generated in the Prisma schema generator. The update ensures that optional fields in referenced custom models are correctly marked with a `?` in their type definition. This patch fix the generated Prisma schema for optional relations.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Prisma schema generation for optional relations. The CLI now marks relation fields as optional when the referenced user additional field has required: false, preventing invalid schemas.

- **Bug Fixes**
  - Append "?" to relation field types when additionalFields[...].required is false.

<!-- End of auto-generated description by cubic. -->

