### PR TITLE
chore: workspace peer deps

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -61,7 +61,7 @@
     "unbuild": "^3.6.1"
   },
   "peerDependencies": {
-    "better-auth": ">=1.0.0",
+    "better-auth": "workspace:*",
     "expo-constants": ">=17.0.0",
     "expo-crypto": ">=13.0.0",
     "expo-linking": ">=7.0.0",


### PR DESCRIPTION
one typo from https://github.com/better-auth/better-auth/commit/161605799290a663bd87251a3b8e201eb66bcac2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set the expo package’s better-auth peerDependency to workspace:* so it resolves to the local workspace version. This avoids version mismatches and duplicate installs in the monorepo.

<!-- End of auto-generated description by cubic. -->

