### PR TITLE
docs: fix example urls

### DIFF
--- a/docs/content/docs/examples/astro.mdx
+++ b/docs/content/docs/examples/astro.mdx
@@ -9,9 +9,9 @@ This is an example of how to use Better Auth with Astro. It uses Solid for build
 **Implements the following features:**
 Email & Password . Social Sign-in with Google . Passkeys . Email Verification . Password Reset . Two Factor Authentication . Profile Update . Session Management
 
-<ForkButton url="better-auth/better-auth/tree/main/examples/astro-example"  />
+<ForkButton url="better-auth/examples/tree/main/astro-example"  />
 
-<iframe src="https://stackblitz.com/github/better-auth/better-auth/tree/main/examples/astro-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
+<iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/astro-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
    style={{
       width: "100%",
       height: "500px",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix broken links in the Astro example docs. Updated the Fork button and StackBlitz embed to use the correct better-auth/examples repo path.

<!-- End of auto-generated description by cubic. -->

