### PR TITLE
docs: fix missing commas in Stripe plugin code examples

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -258,7 +258,7 @@ await client.subscription.upgrade({
     successUrl: "/dashboard",
     cancelUrl: "/pricing",
     annual: true, // Optional: upgrade to an annual plan
-    referenceId: "org_123" // Optional: defaults to the current logged in user ID
+    referenceId: "org_123", // Optional: defaults to the current logged in user ID
     seats: 5 // Optional: for team plans
 });
 ```


### PR DESCRIPTION
Fixed missing commas in JavaScript/TypeScript object literals that would cause syntax errors when users copy-paste the code examples into their IDEs. This ensures all code examples are immediately runnable without requiring manual fixes."
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a missing trailing comma in the Stripe plugin subscription.upgrade example to prevent copy-paste syntax errors in JS/TS. This makes the example runnable without edits.

<!-- End of auto-generated description by cubic. -->

