### PR TITLE
fix: respect `errorCallbackURL` in failed oauth flows

### DIFF
--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -43,6 +43,13 @@ export const callbackOAuth = createAuthEndpoint(
 
 		const { code, error, state, error_description, device_id } = queryOrBody;
 
+		if (!state) {
+			c.context.logger.error("State not found", error);
+			const sep = defaultErrorURL.includes("?") ? "&" : "?";
+			const url = `${defaultErrorURL}${sep}state=state_not_found`;
+			throw c.redirect(url);
+		}
+
 		const {
 			codeVerifier,
 			callbackURL,
@@ -66,11 +73,6 @@ export const callbackOAuth = createAuthEndpoint(
 
 		if (error) {
 			redirectOnError(error, error_description);
-		}
-
-		if (!state) {
-			c.context.logger.error("State not found", error);
-			redirectOnError("state_not_found");
 		}
 
 		if (!code) {


### PR DESCRIPTION
closes #1580
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Respect the errorCallbackURL for failed OAuth callbacks so users land on the app’s custom error page. Also forwards error_description when provided.

- **Bug Fixes**
  - Use errorCallbackURL from parsed state for provider errors, missing state, and missing code.
  - Centralize redirects via redirectOnError; builds URLs with URLSearchParams and preserves existing query strings, including error_description.
  - Reorder checks to parse state first so the custom error URL is available; keeps error logging.

<!-- End of auto-generated description by cubic. -->

