### PR TITLE
fix(admin): change the order of role and user id check when both are provider on userHasPermission

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1553,20 +1553,22 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					}
 					const session = await getSessionFromCtx(ctx);
 
-					if (
-						!session &&
-						(ctx.request || ctx.headers) &&
-						!ctx.body.userId &&
-						!ctx.body.role
-					) {
+					if (!session && (ctx.request || ctx.headers)) {
 						throw new APIError("UNAUTHORIZED");
+					}
+					if (!session && (!ctx.body.userId || !ctx.body.role)) {
+						throw new APIError("BAD_REQUEST", {
+							message: "user id or role is required",
+						});
 					}
 					const user =
 						session?.user ||
+						(ctx.body.role
+							? { id: ctx.body.userId || "", role: ctx.body.role }
+							: null) ||
 						((await ctx.context.internalAdapter.findUserById(
 							ctx.body.userId as string,
-						)) as { role?: string; id: string }) ||
-						(ctx.body.role ? { id: "", role: ctx.body.role } : null);
+						)) as { role?: string; id: string });
 					if (!user) {
 						throw new APIError("BAD_REQUEST", {
 							message: "user not found",

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1556,7 +1556,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					if (!session && (ctx.request || ctx.headers)) {
 						throw new APIError("UNAUTHORIZED");
 					}
-					if (!session && (!ctx.body.userId || !ctx.body.role)) {
+					if (!session && (!ctx.body.userId && !ctx.body.role)) {
 						throw new APIError("BAD_REQUEST", {
 							message: "user id or role is required",
 						});

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1556,7 +1556,7 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					if (!session && (ctx.request || ctx.headers)) {
 						throw new APIError("UNAUTHORIZED");
 					}
-					if (!session && (!ctx.body.userId && !ctx.body.role)) {
+					if (!session && !ctx.body.userId && !ctx.body.role) {
 						throw new APIError("BAD_REQUEST", {
 							message: "user id or role is required",
 						});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes userHasPermission in the admin plugin to correctly handle requests when both role and userId are provided and to enforce stricter auth checks. HTTP requests now require a session; internal calls without a session must include userId and role.

- Bug Fixes
  - Require a session for HTTP requests; otherwise return UNAUTHORIZED.
  - For non-HTTP/internal calls without a session, return BAD_REQUEST when userId or role is missing.
  - When role is provided, build the user from role and userId before attempting a DB lookup to avoid unnecessary queries and honor explicit role input.

<!-- End of auto-generated description by cubic. -->

