### PR TITLE
test: fix flaky

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -28,10 +28,7 @@
     "dev:types": "tsc --project tsconfig.declarations.json --watch",
     "build:types": "tsc --project tsconfig.declarations.json",
     "stub": "unbuild --stub",
-    "pretest": "pnpm prisma:normal:push && pnpm prisma:number-id:push",
     "test": "vitest",
-    "prisma:normal:push": "prisma db push --schema src/adapters/prisma-adapter/test/normal-tests/schema.prisma",
-    "prisma:number-id:push": "prisma db push --schema src/adapters/prisma-adapter/test/number-id-tests/schema.prisma",
     "bump": "bumpp",
     "typecheck": "pnpm prisma:normal:push && pnpm prisma:number-id:push && tsc --noEmit"
   },

--- a/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe } from "vitest";
+import { beforeEach, describe } from "vitest";
 import { pushPrismaSchema } from "../push-schema";
 import { createTestOptions } from "../test-options";
 import { runAdapterTest } from "../../../test";

--- a/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
@@ -1,29 +1,21 @@
-import { beforeAll, describe } from "vitest";
+import { beforeAll, beforeEach, describe } from "vitest";
 import { pushPrismaSchema } from "../push-schema";
 import { createTestOptions } from "../test-options";
 import { runAdapterTest } from "../../../test";
-import { setState } from "../state";
+import { getAdapter } from "./get-adapter";
+import type { Adapter, BetterAuthOptions } from "../../../../types";
 
-describe("Adapter tests", async () => {
-	beforeAll(async () => {
-		setState("RUNNING");
-		await pushPrismaSchema("normal");
-		console.log("Successfully pushed normal Prisma Schema using pnpm...");
-		const { getAdapter } = await import("./get-adapter");
-		const { clearDb } = getAdapter();
-		await clearDb();
-		return () => {
-			console.log(
-				`Normal Prisma adapter test finished. Now allowing number ID prisma tests to run.`,
-			);
-			setState("IDLE");
-		};
+describe("Adapter tests", () => {
+	let adapter: (options: BetterAuthOptions) => Adapter;
+	beforeEach(async () => {
+		pushPrismaSchema("normal");
+		const { clear, adapter: _adapter } = await getAdapter();
+		adapter = _adapter;
+		await clear();
 	});
 
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
-			const { getAdapter } = await import("./get-adapter");
-			const { adapter } = getAdapter();
 			const { advanced, database, session, user } = createTestOptions(adapter);
 			return adapter({
 				...customOptions,

--- a/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/adapter.prisma.number-id.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/adapter.prisma.number-id.test.ts
@@ -1,38 +1,21 @@
-import { beforeAll, describe } from "vitest";
+import { beforeEach, describe } from "vitest";
 import { runNumberIdAdapterTest } from "../../../test";
 import { pushPrismaSchema } from "../push-schema";
 import { createTestOptions } from "../test-options";
-import * as fs from "fs";
-import { getState, stateFilePath } from "../state";
+import type { Adapter, BetterAuthOptions } from "../../../../types";
+import { getAdapter } from "./get-adapter";
 
-describe("Number Id Adapter Test", async () => {
-	beforeAll(async () => {
-		await new Promise(async (resolve) => {
-			await new Promise((r) => setTimeout(r, 500));
-			if (getState() === "IDLE") {
-				resolve(true);
-				return;
-			}
-			console.log(`Waiting for state to be IDLE...`);
-			fs.watch(stateFilePath, () => {
-				if (getState() === "IDLE") {
-					resolve(true);
-					return;
-				}
-			});
-		});
-		console.log(`Now running Number ID Prisma adapter test...`);
-		await pushPrismaSchema("number-id");
-		console.log(`Successfully pushed number id Prisma Schema using pnpm...`);
-		const { getAdapter } = await import("./get-adapter");
-		const { clearDb } = getAdapter();
-		await clearDb();
-	}, Number.POSITIVE_INFINITY);
+describe("Number Id Adapter Test", () => {
+	let adapter: (options: BetterAuthOptions) => Adapter;
+	beforeEach(async () => {
+		pushPrismaSchema("number-id");
+		const { clear, adapter: _adapter } = await getAdapter();
+		adapter = _adapter;
+		await clear();
+	});
 
-	await runNumberIdAdapterTest({
+	runNumberIdAdapterTest({
 		getAdapter: async (customOptions = {}) => {
-			const { getAdapter } = await import("./get-adapter");
-			const { adapter } = getAdapter();
 			const { advanced, database, session, user } = createTestOptions(adapter);
 			return adapter({
 				...customOptions,

--- a/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/get-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/get-adapter.ts
@@ -1,20 +1,17 @@
 import { PrismaClient } from "@prisma/client";
 import { prismaAdapter } from "../..";
+import { copyFile } from "node:fs/promises";
+import { join } from "node:path";
 
-export function getAdapter() {
-	const db = new PrismaClient();
-
-	async function clearDb() {
-		await db.sessions.deleteMany();
-		await db.user.deleteMany();
-		try {
-			await db.$executeRaw`DELETE FROM sqlite_sequence WHERE name = 'User'`;
-		} catch {}
-		try {
-			// it's `sessions` not `session` because our `createTestOptions` uses `modelName: "sessions"`
-			await db.$executeRaw`DELETE FROM sqlite_sequence WHERE name = 'Sessions'`;
-		} catch {}
-	}
+export async function getAdapter() {
+	const dbFile = `${crypto.randomUUID()}.db`;
+	await copyFile(
+		join(import.meta.dirname, "./.db/dev.db"),
+		join(import.meta.dirname, `./.db/${dbFile}`),
+	);
+	const db = new PrismaClient({
+		datasourceUrl: `file:./.db/${dbFile}`,
+	});
 
 	const adapter = prismaAdapter(db, {
 		provider: "sqlite",
@@ -23,5 +20,18 @@ export function getAdapter() {
 		},
 	});
 
-	return { adapter, clearDb };
+	return {
+		adapter,
+		clear: async function clearDb() {
+			await db.sessions.deleteMany();
+			await db.user.deleteMany();
+			try {
+				await db.$executeRaw`DELETE FROM sqlite_sequence WHERE name = 'User'`;
+			} catch {}
+			try {
+				// it's `sessions` not `session` because our `createTestOptions` uses `modelName: "sessions"`
+				await db.$executeRaw`DELETE FROM sqlite_sequence WHERE name = 'Sessions'`;
+			} catch {}
+		},
+	};
 }

--- a/packages/better-auth/src/adapters/prisma-adapter/test/push-schema.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/push-schema.ts
@@ -1,9 +1,19 @@
 import { execSync } from "child_process";
+import { join } from "node:path";
+import { createRequire } from "node:module";
 
 export function pushPrismaSchema(schema: "normal" | "number-id") {
+	const node = process.execPath;
+	const cli = createRequire(import.meta.url).resolve("prisma");
 	if (schema === "normal") {
-		execSync("pnpm prisma:normal:push", { stdio: "inherit" });
+		execSync(`${node} ${cli} db push --schema ./schema.prisma`, {
+			stdio: "inherit",
+			cwd: join(import.meta.dirname, "normal-tests"),
+		});
 	} else {
-		execSync("pnpm prisma:number-id:push", { stdio: "inherit" });
+		execSync(`${node} ${cli} db push --schema ./schema.prisma`, {
+			stdio: "inherit",
+			cwd: join(import.meta.dirname, "number-id-tests"),
+		});
 	}
 }

--- a/packages/better-auth/src/adapters/prisma-adapter/test/push-schema.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/push-schema.ts
@@ -1,35 +1,9 @@
-import { exec } from "child_process";
+import { execSync } from "child_process";
 
-/**
- * Executes a command line command asynchronously.
- *
- * @param command The command to execute.
- * @returns A promise that resolves with the standard output of the command
- *          or rejects with an error if the command fails.
- */
-async function executeCommandLine(command: string): Promise<string> {
-	return new Promise((resolve, reject) => {
-		exec(command, (error, stdout, stderr) => {
-			if (error) {
-				console.error(`Error executing command: ${command}`);
-				console.error(`stderr: ${stderr}`);
-				reject(error);
-				return;
-			}
-
-			if (stderr) {
-				console.warn(`Command produced stderr: ${stderr}`);
-			}
-
-			resolve(stdout);
-		});
-	});
-}
-
-export async function pushPrismaSchema(schema: "normal" | "number-id") {
+export function pushPrismaSchema(schema: "normal" | "number-id") {
 	if (schema === "normal") {
-		await executeCommandLine("pnpm prisma:normal:push");
+		execSync("pnpm prisma:normal:push", { stdio: "inherit" });
 	} else {
-		await executeCommandLine("pnpm prisma:number-id:push");
+		execSync("pnpm prisma:number-id:push", { stdio: "inherit" });
 	}
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Stabilizes Prisma adapter tests by isolating each run with its own SQLite DB and making schema pushes synchronous to eliminate race conditions and data leakage.

- **Refactors**
  - Each test uses a copied dev.db (crypto UUID) with datasourceUrl override.
  - getAdapter is now async and returns { adapter, clear } for cleanup.
  - Switched to beforeEach to push schema and reset DB per suite.
  - Replaced async exec with execSync in pushPrismaSchema.
  - runAdapterTest/runNumberIdAdapterTest now non-async wrappers.

- **Bug Fixes**
  - Removed cross-suite file-based state and watchers; no shared DB state.
  - Tests no longer depend on unique email prefixes; fresh DB prevents collisions.
  - Adjusted assertions to avoid fixed counts; created entities per test.
  - Reset sqlite_sequence where required in number-id tests.
  - Dropped the brittle “increment id by 1” assertion that caused flakes.

<!-- End of auto-generated description by cubic. -->

