### PR TITLE
test: use `execSync`

### DIFF
--- a/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
@@ -7,7 +7,7 @@ import { setState } from "../state";
 describe("Adapter tests", async () => {
 	beforeAll(async () => {
 		setState("RUNNING");
-		await pushPrismaSchema("normal");
+		pushPrismaSchema("normal");
 		console.log("Successfully pushed normal Prisma Schema using pnpm...");
 		const { getAdapter } = await import("./get-adapter");
 		const { clearDb } = getAdapter();

--- a/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/adapter.prisma.number-id.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/adapter.prisma.number-id.test.ts
@@ -22,7 +22,7 @@ describe("Number Id Adapter Test", async () => {
 			});
 		});
 		console.log(`Now running Number ID Prisma adapter test...`);
-		await pushPrismaSchema("number-id");
+		pushPrismaSchema("number-id");
 		console.log(`Successfully pushed number id Prisma Schema using pnpm...`);
 		const { getAdapter } = await import("./get-adapter");
 		const { clearDb } = getAdapter();

--- a/packages/better-auth/src/adapters/prisma-adapter/test/push-schema.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/push-schema.ts
@@ -1,35 +1,9 @@
-import { exec } from "child_process";
+import { execSync } from "child_process";
 
-/**
- * Executes a command line command asynchronously.
- *
- * @param command The command to execute.
- * @returns A promise that resolves with the standard output of the command
- *          or rejects with an error if the command fails.
- */
-async function executeCommandLine(command: string): Promise<string> {
-	return new Promise((resolve, reject) => {
-		exec(command, (error, stdout, stderr) => {
-			if (error) {
-				console.error(`Error executing command: ${command}`);
-				console.error(`stderr: ${stderr}`);
-				reject(error);
-				return;
-			}
-
-			if (stderr) {
-				console.warn(`Command produced stderr: ${stderr}`);
-			}
-
-			resolve(stdout);
-		});
-	});
-}
-
-export async function pushPrismaSchema(schema: "normal" | "number-id") {
+export function pushPrismaSchema(schema: "normal" | "number-id") {
 	if (schema === "normal") {
-		await executeCommandLine("pnpm prisma:normal:push");
+		execSync("pnpm prisma:normal:push", { stdio: "inherit" });
 	} else {
-		await executeCommandLine("pnpm prisma:number-id:push");
+		execSync("pnpm prisma:number-id:push", { stdio: "inherit" });
 	}
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch tests to use execSync for Prisma schema pushes. Streams output and avoids async race conditions during setup.

- **Refactors**
  - Replaced custom async exec wrapper with execSync({ stdio: "inherit" }).
  - Made pushPrismaSchema synchronous and removed await in both test suites.
  - Improves reliability and fails fast with clear console output.

<!-- End of auto-generated description by cubic. -->

