### PR TITLE
fix: make sure fetch function doesn't get called repeatedly on `onMount`

### DIFF
--- a/packages/better-auth/src/client/query.ts
+++ b/packages/better-auth/src/client/query.ts
@@ -119,9 +119,11 @@ export const useAuthQuery = <T>(
 			} else {
 				onMount(value, () => {
 					setTimeout(() => {
-						fn();
+						if (!isMounted) {
+							fn();
+							isMounted = true;
+						}
 					}, 0);
-					isMounted = true;
 					return () => {
 						value.off();
 						initAtom.off();

--- a/packages/better-auth/src/client/query.ts
+++ b/packages/better-auth/src/client/query.ts
@@ -118,7 +118,7 @@ export const useAuthQuery = <T>(
 				fn();
 			} else {
 				onMount(value, () => {
-					setTimeout(() => {
+					const timeoutId = setTimeout(() => {
 						if (!isMounted) {
 							fn();
 							isMounted = true;
@@ -127,6 +127,7 @@ export const useAuthQuery = <T>(
 					return () => {
 						value.off();
 						initAtom.off();
+						clearTimeout(timeoutId);
 					};
 				});
 			}


### PR DESCRIPTION
closes #4609

When a NextJS app is run in production mode with `3G` throttling the `onMount` callback gets called multiple times, and that causes the fetch function to be called multiple times. This PR fixes that issue by making sure that the fetch function only gets called on the first `onMount` callback.

NOTE: The `onMount` function doesn't get called multiple times during dev mode and if throttling is disabled.

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Ensure the fetch function runs only once on mount in useAuthQuery by guarding fn() with an isMounted flag. Prevents duplicate requests and potential race conditions (closes #4609).

<!-- End of auto-generated description by cubic. -->

