### PR TITLE
chore: bump `nanostores`

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -708,7 +708,7 @@
     "defu": "^6.1.4",
     "jose": "^6.1.0",
     "kysely": "^0.28.5",
-    "nanostores": "^0.11.4",
+    "nanostores": "^1.0.1",
     "zod": "^4.1.5"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,8 +660,8 @@ importers:
         specifier: ^0.28.5
         version: 0.28.5
       nanostores:
-        specifier: ^0.11.4
-        version: 0.11.4
+        specifier: ^1.0.1
+        version: 1.0.1
       svelte:
         specifier: ^4.0.0 || ^5.0.0
         version: 5.38.2
@@ -9282,9 +9282,9 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
-  nanostores@0.11.4:
-    resolution: {integrity: sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  nanostores@1.0.1:
+    resolution: {integrity: sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
@@ -15898,9 +15898,7 @@ snapshots:
       metro-runtime: 0.83.1
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.79.6': {}
 
@@ -21862,7 +21860,7 @@ snapshots:
 
   nanoid@5.1.5: {}
 
-  nanostores@0.11.4: {}
+  nanostores@1.0.1: {}
 
   napi-build-utils@2.0.0: {}
 


### PR DESCRIPTION
I think this gonna affect all issues related to client side.

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Upgrade nanostores to 1.0.1 in better-auth to stay current with the latest fixes. Upstream now requires Node 20+.

- **Dependencies**
  - nanostores: ^0.11.4 → ^1.0.1

- **Migration**
  - Ensure dev/CI/prod run Node 20+ (or 22+).
  - Reinstall deps after pulling (pnpm install).

<!-- End of auto-generated description by cubic. -->

