### PR TITLE
fix(plugins): asynchronous `init`

### DIFF
--- a/packages/better-auth/src/init.test.ts
+++ b/packages/better-auth/src/init.test.ts
@@ -197,4 +197,26 @@ describe("init", async () => {
 		const githubProvider = ctx.socialProviders.find((p) => p.id === "github");
 		expect(githubProvider).toBeDefined();
 	});
+
+	it("should init async plugin", async () => {
+		const initFn = vi.fn(async () => {
+			await new Promise((r) => setTimeout(r, 100));
+			return {
+				context: {
+					baseURL: "http://async.test",
+				},
+			};
+		});
+		await init({
+			baseURL: "http://localhost:3000",
+			database,
+			plugins: [
+				{
+					id: "test-async",
+					init: initFn,
+				},
+			],
+		});
+		expect(initFn).toHaveBeenCalled();
+	});
 });

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -177,7 +177,7 @@ export const init = async (options: BetterAuthOptions) => {
 		},
 		publishTelemetry: publish,
 	};
-	let { context } = runPluginInit(ctx);
+	let { context } = await runPluginInit(ctx);
 	return context;
 };
 
@@ -243,14 +243,14 @@ export type AuthContext = {
 	publishTelemetry: (event: TelemetryEvent) => Promise<void>;
 };
 
-function runPluginInit(ctx: AuthContext) {
+async function runPluginInit(ctx: AuthContext) {
 	let options = ctx.options;
 	const plugins = options.plugins || [];
 	let context: AuthContext = ctx;
 	const dbHooks: BetterAuthOptions["databaseHooks"][] = [];
 	for (const plugin of plugins) {
 		if (plugin.init) {
-			const result = plugin.init(context);
+			const result = await plugin.init(context);
 			if (typeof result === "object") {
 				if (result.options) {
 					const { databaseHooks, ...restOpts } = result.options;

--- a/packages/better-auth/src/types/plugins.ts
+++ b/packages/better-auth/src/types/plugins.ts
@@ -3,6 +3,7 @@ import { type AuthMiddleware } from "../api/call";
 import type { FieldAttribute } from "../db/field";
 import type { HookEndpointContext } from ".";
 import type {
+	Awaitable,
 	DeepPartial,
 	LiteralString,
 	UnionToIntersection,
@@ -28,11 +29,7 @@ export type BetterAuthPlugin = {
 	 * You can return a new context or modify the existing context.
 	 */
 	init?: (ctx: AuthContext) =>
-		| {
-				context?: DeepPartial<Omit<AuthContext, "options">>;
-				options?: Partial<BetterAuthOptions>;
-		  }
-		| Promise<{
+		| Awaitable<{
 				context?: DeepPartial<Omit<AuthContext, "options">>;
 				options?: Partial<BetterAuthOptions>;
 		  }>

--- a/packages/better-auth/src/types/plugins.ts
+++ b/packages/better-auth/src/types/plugins.ts
@@ -27,10 +27,17 @@ export type BetterAuthPlugin = {
 	 * The init function is called when the plugin is initialized.
 	 * You can return a new context or modify the existing context.
 	 */
-	init?: (ctx: AuthContext) => {
-		context?: DeepPartial<Omit<AuthContext, "options">>;
-		options?: Partial<BetterAuthOptions>;
-	} | void;
+	init?: (ctx: AuthContext) =>
+		| {
+				context?: DeepPartial<Omit<AuthContext, "options">>;
+				options?: Partial<BetterAuthOptions>;
+		  }
+		| Promise<{
+				context?: DeepPartial<Omit<AuthContext, "options">>;
+				options?: Partial<BetterAuthOptions>;
+		  }>
+		| void
+		| Promise<void>;
 	endpoints?: {
 		[key: string]: Endpoint;
 	};

--- a/packages/better-auth/src/utils/is-promise.ts
+++ b/packages/better-auth/src/utils/is-promise.ts
@@ -1,0 +1,7 @@
+export function isPromise(obj?: unknown): obj is Promise<unknown> {
+	return (
+		!!obj &&
+		(typeof obj === "object" || typeof obj === "function") &&
+		typeof (obj as Promise<unknown>).then === "function"
+	);
+}


### PR DESCRIPTION
I've run into issue when implementing a custom plugin: `init` cannot be `async`.

I believe there's no harm in allowing that.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allow plugin init to be asynchronous, enabling async setup without breaking existing synchronous plugins. runPluginInit is now async and awaited in init; BetterAuthPlugin.init types accept Promise-based returns for context/options (or void).

<!-- End of auto-generated description by cubic. -->

