### PR TITLE
docs: update siwe.mdx

### DIFF
--- a/docs/content/docs/plugins/siwe.mdx
+++ b/docs/content/docs/plugins/siwe.mdx
@@ -89,7 +89,7 @@ Before signing a SIWE message, you need to generate a nonce for the wallet addre
 ```ts title="generate-nonce.ts"
 const { data, error } = await authClient.siwe.nonce({
   walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
-  chainId: 1, // optional, defaults to 1 (Ethereum mainnet)
+  chainId: 1, // optional for Ethereum mainnet, required for other chains. Defaults to 1
 });
 
 if (data) {
@@ -106,7 +106,7 @@ const { data, error } = await authClient.siwe.verify({
   message: "Your SIWE message string",
   signature: "0x...", // The signature from the user's wallet
   walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
-  chainId: 1, // optional, defaults to 1
+  chainId: 1, // optional for Ethereum mainnet, required for other chains. Must match Chain ID in SIWE message
   email: "user@example.com", // optional, required if anonymous is false
 });
 
@@ -114,6 +114,54 @@ if (data) {
   console.log("Authentication successful:", data.user);
 }
 ```
+
+### Chain-Specific Examples
+
+Here are examples for different blockchain networks:
+
+```ts title="ethereum-mainnet.ts"
+// ✅ Ethereum Mainnet (chainId can be omitted, defaults to 1)
+const { data, error } = await authClient.siwe.verify({
+  message,
+  signature,
+  walletAddress,
+  // chainId: 1 (default)
+});
+```
+
+```ts title="polygon.ts"
+// ✅ Polygon (chainId REQUIRED)
+const { data, error } = await authClient.siwe.verify({
+  message,
+  signature,
+  walletAddress,
+  chainId: 137, // Required for Polygon
+});
+```
+
+```ts title="arbitrum.ts"
+// ✅ Arbitrum (chainId REQUIRED)
+const { data, error } = await authClient.siwe.verify({
+  message,
+  signature,
+  walletAddress,
+  chainId: 42161, // Required for Arbitrum
+});
+```
+
+```ts title="base.ts"
+// ✅ Base (chainId REQUIRED)
+const { data, error } = await authClient.siwe.verify({
+  message,
+  signature,
+  walletAddress,
+  chainId: 8453, // Required for Base
+});
+```
+
+<Callout type="warning">
+  The `chainId` must match the Chain ID specified in your SIWE message. Verification will fail with a 401 error if there's a mismatch between the message's Chain ID and the `chainId` parameter.
+</Callout>
 
 ## Configuration Options
 

--- a/docs/content/docs/plugins/siwe.mdx
+++ b/docs/content/docs/plugins/siwe.mdx
@@ -120,7 +120,7 @@ if (data) {
 Here are examples for different blockchain networks:
 
 ```ts title="ethereum-mainnet.ts"
-// ✅ Ethereum Mainnet (chainId can be omitted, defaults to 1)
+// Ethereum Mainnet (chainId can be omitted, defaults to 1)
 const { data, error } = await authClient.siwe.verify({
   message,
   signature,
@@ -130,7 +130,7 @@ const { data, error } = await authClient.siwe.verify({
 ```
 
 ```ts title="polygon.ts"
-// ✅ Polygon (chainId REQUIRED)
+// Polygon (chainId REQUIRED)
 const { data, error } = await authClient.siwe.verify({
   message,
   signature,
@@ -140,7 +140,7 @@ const { data, error } = await authClient.siwe.verify({
 ```
 
 ```ts title="arbitrum.ts"
-// ✅ Arbitrum (chainId REQUIRED)
+// Arbitrum (chainId REQUIRED)
 const { data, error } = await authClient.siwe.verify({
   message,
   signature,


### PR DESCRIPTION
docs(siwe): clarify chainId parameter requirements and add chain examples

- Fix misleading "optional" description for chainId parameter
- Use conditional format: "optional for Ethereum mainnet, required for other chains"
- Add chain-specific examples (Polygon, Arbitrum, Base) showing required chainId values
- Add warning callout explaining chainId must match SIWE message Chain ID
- Prevent 401 verification errors from chainId mismatches that confused developers

The chainId parameter was documented as "optional" but actually required for all non-mainnet chains, causing verification failures. Now clearly explains when it's optional vs required.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarifies SIWE chainId docs: optional on Ethereum mainnet (defaults to 1), required on other chains, and must match the Chain ID in the SIWE message. Adds examples for Polygon (137), Arbitrum (42161), and Base (8453), plus a warning to prevent 401 verification errors from mismatches.

<!-- End of auto-generated description by cubic. -->

