### PR TITLE
refactor: remove unused generics

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -152,10 +152,10 @@ To resolve this, you can:
 	}
 }
 
-export function getEndpoints<
-	C extends AuthContext,
-	Option extends BetterAuthOptions,
->(ctx: Promise<C> | C, options: Option) {
+export function getEndpoints<Option extends BetterAuthOptions>(
+	ctx: Promise<AuthContext> | AuthContext,
+	options: Option,
+) {
 	const pluginEndpoints = options.plugins?.reduce(
 		(acc, plugin) => {
 			return {
@@ -245,8 +245,8 @@ export function getEndpoints<
 		middlewares,
 	};
 }
-export const router = <C extends AuthContext, Option extends BetterAuthOptions>(
-	ctx: C,
+export const router = <Option extends BetterAuthOptions>(
+	ctx: AuthContext,
 	options: Option,
 ) => {
 	const { api, middlewares } = getEndpoints(ctx, options);

--- a/packages/better-auth/src/auth.ts
+++ b/packages/better-auth/src/auth.ts
@@ -17,10 +17,12 @@ import { BetterAuthError } from "./error";
 export type WithJsDoc<T, D> = Expand<T & D>;
 
 export const betterAuth = <O extends BetterAuthOptions>(
-	options: O & Record<never, never>,
+	options: O &
+		// fixme(alex): do we need Record<never, never> here?
+		Record<never, never>,
 ) => {
-	const authContext = init(options as O);
-	const { api } = getEndpoints(authContext, options as O);
+	const authContext = init(options);
+	const { api } = getEndpoints(authContext, options);
 	const errorCodes = options.plugins?.reduce((acc, plugin) => {
 		if (plugin.$ERROR_CODES) {
 			return {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Simplified Better Auth type signatures by removing unused generics for clearer APIs and better type inference. No runtime behavior changes.

- **Refactors**
  - getEndpoints: removed generic C; accept AuthContext directly.
  - router: replaced generic C with AuthContext param.
  - betterAuth: dropped redundant casts; pass options and context directly to init/getEndpoints.

<!-- End of auto-generated description by cubic. -->

