### PR TITLE
feat(last-login-method): update OAuth login method tracking for multiple auth type

### DIFF
--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -64,49 +64,52 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 	return {
 		id: "last-login-method",
 		init(ctx) {
-		return {
-			options: {
-				databaseHooks: {
-					user: {
-						create: {
-							async before(user, context) {
-								if (!config.storeInDatabase) return;
-								if (!context) return;
-								const lastUsedLoginMethod =
-									config.customResolveMethod(context);
-								if (lastUsedLoginMethod) {
-									return {
-										data: {
-											...user,
-											lastLoginMethod: lastUsedLoginMethod,
-										},
-									};
-								}
+			return {
+				options: {
+					databaseHooks: {
+						user: {
+							create: {
+								async before(user, context) {
+									if (!config.storeInDatabase) return;
+									if (!context) return;
+									const lastUsedLoginMethod =
+										config.customResolveMethod(context);
+									if (lastUsedLoginMethod) {
+										return {
+											data: {
+												...user,
+												lastLoginMethod: lastUsedLoginMethod,
+											},
+										};
+									}
+								},
 							},
 						},
-					},
-					session: {
-						create: {
-							async after(session, context) {
-								if (!config.storeInDatabase) return;
-								if (!context) return;
-								const lastUsedLoginMethod =
-									config.customResolveMethod(context);
-								if (lastUsedLoginMethod && session?.userId) {
-									try {
-										await ctx.internalAdapter.updateUser(session.userId , {
-											lastLoginMethod: lastUsedLoginMethod,
-										})		
-									} catch (error) {
-										ctx.logger.error("Failed to update lastLoginMethod", error);
+						session: {
+							create: {
+								async after(session, context) {
+									if (!config.storeInDatabase) return;
+									if (!context) return;
+									const lastUsedLoginMethod =
+										config.customResolveMethod(context);
+									if (lastUsedLoginMethod && session?.userId) {
+										try {
+											await ctx.internalAdapter.updateUser(session.userId, {
+												lastLoginMethod: lastUsedLoginMethod,
+											});
+										} catch (error) {
+											ctx.logger.error(
+												"Failed to update lastLoginMethod",
+												error,
+											);
+										}
 									}
-								}
+								},
 							},
 						},
 					},
 				},
-			},
-		};
+			};
 		},
 		hooks: {
 			after: [

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -64,30 +64,49 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 	return {
 		id: "last-login-method",
 		init(ctx) {
-			return {
-				options: {
-					databaseHooks: {
-						user: {
-							create: {
-								async before(user, context) {
-									if (!config.storeInDatabase) return;
-									if (!context) return;
-									const lastUsedLoginMethod =
-										config.customResolveMethod(context);
-									if (lastUsedLoginMethod) {
-										return {
-											data: {
-												...user,
-												lastLoginMethod: lastUsedLoginMethod,
-											},
-										};
+		return {
+			options: {
+				databaseHooks: {
+					user: {
+						create: {
+							async before(user, context) {
+								if (!config.storeInDatabase) return;
+								if (!context) return;
+								const lastUsedLoginMethod =
+									config.customResolveMethod(context);
+								if (lastUsedLoginMethod) {
+									return {
+										data: {
+											...user,
+											lastLoginMethod: lastUsedLoginMethod,
+										},
+									};
+								}
+							},
+						},
+					},
+					session: {
+						create: {
+							async after(session, context) {
+								if (!config.storeInDatabase) return;
+								if (!context) return;
+								const lastUsedLoginMethod =
+									config.customResolveMethod(context);
+								if (lastUsedLoginMethod && session?.userId) {
+									try {
+										await ctx.internalAdapter.updateUser(session.userId , {
+											lastLoginMethod: lastUsedLoginMethod,
+										})		
+									} catch (error) {
+										ctx.logger.error("Failed to update lastLoginMethod", error);
 									}
-								},
+								}
 							},
 						},
 					},
 				},
-			};
+			},
+		};
 		},
 		hooks: {
 			after: [

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -174,7 +174,7 @@ describe("lastLoginMethod", async () => {
 				authorization: `Bearer ${emailSignInData2.token}`,
 			}),
 		});
-		
+
 		expect((session?.user as any).lastLoginMethod).toBe("email");
 	});
 
@@ -188,7 +188,6 @@ describe("lastLoginMethod", async () => {
 				},
 			},
 		});
-
 
 		await client.signUp.email(
 			{
@@ -212,7 +211,7 @@ describe("lastLoginMethod", async () => {
 				authorization: `Bearer ${emailSignInData.token}`,
 			}),
 		});
-		
+
 		expect((session?.user as any).lastLoginMethod).toBe("email");
 
 		await client.signOut();
@@ -238,13 +237,15 @@ describe("lastLoginMethod", async () => {
 				expect(context.response.status).toBe(302);
 				const location = context.response.headers.get("location");
 				expect(location).toBeDefined();
-				
+
 				cookieSetter(headers)(context as any);
-				
+
 				const cookies = parseSetCookieHeader(
 					context.response.headers.get("set-cookie") || "",
 				);
-				const lastLoginMethod = cookies.get("better-auth.last_used_login_method")?.value;
+				const lastLoginMethod = cookies.get(
+					"better-auth.last_used_login_method",
+				)?.value;
 				if (lastLoginMethod) {
 					expect(lastLoginMethod).toBe("google");
 				}
@@ -257,7 +258,5 @@ describe("lastLoginMethod", async () => {
 			},
 		});
 		expect((oauthSession?.data?.user as any).lastLoginMethod).toBe("google");
-
 	});
-
 });

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -1,8 +1,48 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { lastLoginMethod } from ".";
 import { lastLoginMethodClient } from "./client";
-import { parseCookies } from "../../cookies";
+import { parseCookies, parseSetCookieHeader } from "../../cookies";
+import { DEFAULT_SECRET } from "../../utils/constants";
+import type { GoogleProfile } from "../../social-providers/google";
+import { getOAuth2Tokens } from "../../oauth2";
+import { signJWT } from "../../crypto/jwt";
+
+// Mock OAuth2 functions to return valid tokens for testing
+vi.mock("../../oauth2", async (importOriginal) => {
+	const original = (await importOriginal()) as any;
+	return {
+		...original,
+		validateAuthorizationCode: vi
+			.fn()
+			.mockImplementation(async (option: any) => {
+				const data: GoogleProfile = {
+					email: "github-issue-demo@example.com",
+					email_verified: true,
+					name: "OAuth Test User",
+					picture: "https://lh3.googleusercontent.com/a-/AOh14GjQ4Z7Vw",
+					exp: 1234567890,
+					sub: "1234567890",
+					iat: 1234567890,
+					aud: "test",
+					azp: "test",
+					nbf: 1234567890,
+					iss: "test",
+					locale: "en",
+					jti: "test",
+					given_name: "OAuth",
+					family_name: "Test",
+				};
+				const testIdToken = await signJWT(data, DEFAULT_SECRET);
+				const tokens = getOAuth2Tokens({
+					access_token: "test-access-token",
+					refresh_token: "test-refresh-token",
+					id_token: testIdToken,
+				});
+				return tokens;
+			}),
+	};
+});
 
 describe("lastLoginMethod", async () => {
 	const { client, cookieSetter, testUser } = await getTestInstance(
@@ -90,4 +130,134 @@ describe("lastLoginMethod", async () => {
 		const cookies = parseCookies(headers.get("cookie") || "");
 		expect(cookies.get("better-auth.last_used_login_method")).toBeUndefined();
 	});
+	it("should update the last login method in the database on subsequent logins", async () => {
+		const { client, auth } = await getTestInstance({
+			plugins: [lastLoginMethod({ storeInDatabase: true })],
+		});
+
+		await client.signUp.email(
+			{
+				email: "test@example.com",
+				password: "password123",
+				name: "Test User",
+			},
+			{ throw: true },
+		);
+
+		const emailSignInData = await client.signIn.email(
+			{
+				email: "test@example.com",
+				password: "password123",
+			},
+			{ throw: true },
+		);
+
+		let session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${emailSignInData.token}`,
+			}),
+		});
+		expect((session?.user as any).lastLoginMethod).toBe("email");
+
+		await client.signOut();
+
+		const emailSignInData2 = await client.signIn.email(
+			{
+				email: "test@example.com",
+				password: "password123",
+			},
+			{ throw: true },
+		);
+
+		session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${emailSignInData2.token}`,
+			}),
+		});
+		
+		expect((session?.user as any).lastLoginMethod).toBe("email");
+	});
+
+	it("should update the last login method in the database on subsequent logins with email and OAuth", async () => {
+		const { client, auth } = await getTestInstance({
+			plugins: [lastLoginMethod({ storeInDatabase: true })],
+			account: {
+				accountLinking: {
+					enabled: true,
+					trustedProviders: ["google"],
+				},
+			},
+		});
+
+
+		await client.signUp.email(
+			{
+				email: "github-issue-demo@example.com",
+				password: "password123",
+				name: "GitHub Issue Demo User",
+			},
+			{ throw: true },
+		);
+
+		const emailSignInData = await client.signIn.email(
+			{
+				email: "github-issue-demo@example.com",
+				password: "password123",
+			},
+			{ throw: true },
+		);
+
+		let session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${emailSignInData.token}`,
+			}),
+		});
+		
+		expect((session?.user as any).lastLoginMethod).toBe("email");
+
+		await client.signOut();
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+		});
+		expect(signInRes.data).toMatchObject({
+			url: expect.stringContaining("google.com"),
+			redirect: true,
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+
+		const headers = new Headers();
+		await client.$fetch("/callback/google", {
+			query: {
+				state,
+				code: "test",
+			},
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				const location = context.response.headers.get("location");
+				expect(location).toBeDefined();
+				
+				cookieSetter(headers)(context as any);
+				
+				const cookies = parseSetCookieHeader(
+					context.response.headers.get("set-cookie") || "",
+				);
+				const lastLoginMethod = cookies.get("better-auth.last_used_login_method")?.value;
+				if (lastLoginMethod) {
+					expect(lastLoginMethod).toBe("google");
+				}
+			},
+		});
+
+		const oauthSession = await client.getSession({
+			fetchOptions: {
+				headers: headers,
+			},
+		});
+		expect((oauthSession?.data?.user as any).lastLoginMethod).toBe("google");
+
+	});
+
 });


### PR DESCRIPTION


- Fix GitHub issue #4627 where lastLoginMethod was only set during user creation
- Add session.create.after hook to update lastLoginMethod on all login types
- Use direct adapter.update() to bypass validation issues with updateUser()
- Add comprehensive test coverage for OAuth account linking scenarios
- Ensure cross-device consistency for lastLoginMethod tracking

Fixes #4627
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updates lastLoginMethod on every sign-in using a new session.create.after hook. Fixes #4627 by correctly tracking email and OAuth logins, including account linking and cross-device sessions.

- **Bug Fixes**
  - Update lastLoginMethod after session creation for all auth types.
  - Persist via internalAdapter.updateUser to avoid updateUser validation issues.
  - Set last_used_login_method during OAuth callbacks for cross-device consistency.
  - Add tests for repeated logins and email→OAuth account linking.

<!-- End of auto-generated description by cubic. -->

