### PR TITLE
fix(api-key): cascade api keys on user deletion

### DIFF
--- a/packages/better-auth/src/plugins/api-key/schema.ts
+++ b/packages/better-auth/src/plugins/api-key/schema.ts
@@ -49,7 +49,7 @@ export const apiKeySchema = ({
 				 */
 				userId: {
 					type: "string",
-					references: { model: "user", field: "id" },
+					references: { model: "user", field: "id", onDelete: "cascade" },
 					required: true,
 					input: false,
 				},


### PR DESCRIPTION
When a user is about to be deleted, you run into an SQL error saying that the user has a foreign key relation to an API key, thus preventing the user from being deleted. This PR adds an `onDelete`  effect to ensure the api keys are deleted as users get deleted.

https://discord.com/channels/1288403910284935179/1417382336315654267