### PR TITLE
fix: reduce any type in generator.ts

### DIFF
--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -6,7 +6,11 @@ import type {
 } from "better-call";
 import * as z from "zod";
 import { getEndpoints } from "../../api";
-import { getAuthTables } from "../../db";
+import {
+	type FieldAttributeConfig,
+	type FieldType,
+	getAuthTables,
+} from "../../db";
 import type { AuthContext, BetterAuthOptions } from "../../types";
 import type { FieldAttribute } from "../../db";
 
@@ -76,8 +80,20 @@ function getTypeFromZodType(zodType: z.ZodType<any>) {
 	return allowedType.has(type) ? (type as AllowedType) : "string";
 }
 
+type FieldSchema = {
+	type: FieldType;
+	default?: FieldAttributeConfig["defaultValue"] | "Generated at runtime";
+	readOnly?: boolean;
+};
+
+type OpenAPIModelSchema = {
+	type: "object";
+	properties: Record<string, FieldSchema>;
+	required?: string[];
+};
+
 function getFieldSchema(field: FieldAttribute) {
-	const schema: any = {
+	const schema: FieldSchema = {
 		type: field.type === "date" ? "string" : field.type,
 	};
 
@@ -325,11 +341,13 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 	});
 
 	const tables = getAuthTables(options);
-	const models = Object.entries(tables).reduce((acc, [key, value]) => {
+	const models = Object.entries(tables).reduce<
+		Record<string, OpenAPIModelSchema>
+	>((acc, [key, value]) => {
 		const modelName = key.charAt(0).toUpperCase() + key.slice(1);
 		const fields = value.fields;
 		const required: string[] = [];
-		const properties: Record<string, any> = {
+		const properties: Record<string, FieldSchema> = {
 			id: { type: "string" },
 		};
 		Object.entries(fields).forEach(([fieldKey, fieldValue]) => {
@@ -340,7 +358,6 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 			}
 		});
 
-		// @ts-expect-error
 		acc[modelName] = {
 			type: "object",
 			properties,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Tightened type safety in the OpenAPI generator by replacing any with explicit schema types. No runtime changes.

- **Refactors**
  - Introduced FieldSchema and OpenAPIModelSchema types.
  - Typed properties as Record<string, FieldSchema> and models as Record<string, OpenAPIModelSchema>.
  - Used FieldType and FieldAttributeConfig["defaultValue"] for accurate field defaults.
  - Removed @ts-expect-error.

<!-- End of auto-generated description by cubic. -->

