### PR TITLE
fix(adapter): returning null as string for optional id references

### DIFF
--- a/packages/better-auth/src/adapters/adapter-factory/index.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/index.ts
@@ -461,7 +461,8 @@ export const createAdapterFactory =
 
 					if (originalKey === "id" || field.references?.field === "id") {
 						// Even if `useNumberId` is true, we must always return a string `id` output.
-						if (typeof newValue !== "undefined" && newValue !== null) newValue = String(newValue);
+						if (typeof newValue !== "undefined" && newValue !== null)
+							newValue = String(newValue);
 					} else if (
 						config.supportsJSON === false &&
 						typeof newValue === "string" &&

--- a/packages/better-auth/src/adapters/adapter-factory/index.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/index.ts
@@ -461,7 +461,7 @@ export const createAdapterFactory =
 
 					if (originalKey === "id" || field.references?.field === "id") {
 						// Even if `useNumberId` is true, we must always return a string `id` output.
-						if (typeof newValue !== "undefined") newValue = String(newValue);
+						if (typeof newValue !== "undefined" && newValue !== null) newValue = String(newValue);
 					} else if (
 						config.supportsJSON === false &&
 						typeof newValue === "string" &&

--- a/packages/better-auth/src/adapters/adapter-factory/test/adapter-factory.test.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/test/adapter-factory.test.ts
@@ -316,48 +316,51 @@ describe("Create Adapter Helper", async () => {
 			});
 
 			test("Should not modify result null to string for id or fields referencing id", async () => {
-				const result: { id: string; testPluginField: string | null } = await new Promise(
-					async (r) => {
+				const result: { id: string; testPluginField: string | null } =
+					await new Promise(async (r) => {
 						const adapter = await createTestAdapter({
 							adapter(args_0) {
 								return {
 									async create({ data, model, select }) {
 										return data;
 									},
-								}
+								};
 							},
 							options: {
-								plugins: [{
-									id: "test-plugin-id",
-									schema: {
-										testPluginTable: {
-											fields: {
-												testPluginField: {
-													type: "string",
-													required: false,
-													references: {
-														model: "user",
-														field: "id"
-													}
-												}
-											}
-										}
-									}
-								}]
-							}
-						})
-						r(await adapter.create({
-							model: "testPluginTable",
-							data: {
-								testPluginField: null
-							}
-						}))
-					}
-				);
+								plugins: [
+									{
+										id: "test-plugin-id",
+										schema: {
+											testPluginTable: {
+												fields: {
+													testPluginField: {
+														type: "string",
+														required: false,
+														references: {
+															model: "user",
+															field: "id",
+														},
+													},
+												},
+											},
+										},
+									},
+								],
+							},
+						});
+						r(
+							await adapter.create({
+								model: "testPluginTable",
+								data: {
+									testPluginField: null,
+								},
+							}),
+						);
+					});
 
 				expect(result.id).toBeTypeOf("string");
 				expect(result.testPluginField).toBeNull();
-			})
+			});
 
 			test("Should modify boolean type to 1 or 0 if the DB doesn't support it. And expect the result to be transformed back to boolean", async () => {
 				// Testing true

--- a/packages/better-auth/src/adapters/adapter-factory/test/adapter-factory.test.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/test/adapter-factory.test.ts
@@ -315,6 +315,50 @@ describe("Create Adapter Helper", async () => {
 				expect(createWithoutId.id).toBeUndefined();
 			});
 
+			test("Should not modify result null to string for id or fields referencing id", async () => {
+				const result: { id: string; testPluginField: string | null } = await new Promise(
+					async (r) => {
+						const adapter = await createTestAdapter({
+							adapter(args_0) {
+								return {
+									async create({ data, model, select }) {
+										return data;
+									},
+								}
+							},
+							options: {
+								plugins: [{
+									id: "test-plugin-id",
+									schema: {
+										testPluginTable: {
+											fields: {
+												testPluginField: {
+													type: "string",
+													required: false,
+													references: {
+														model: "user",
+														field: "id"
+													}
+												}
+											}
+										}
+									}
+								}]
+							}
+						})
+						r(await adapter.create({
+							model: "testPluginTable",
+							data: {
+								testPluginField: null
+							}
+						}))
+					}
+				);
+
+				expect(result.id).toBeTypeOf("string");
+				expect(result.testPluginField).toBeNull();
+			})
+
 			test("Should modify boolean type to 1 or 0 if the DB doesn't support it. And expect the result to be transformed back to boolean", async () => {
 				// Testing true
 				const createTRUEParameters: { data: { emailVerified: number } } =


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevents optional id fields from being cast to the string "null" in the adapter factory. Now only defined, non-null ids are stringified; null remains null.

<!-- End of auto-generated description by cubic. -->

