### PR TITLE
test: add `runWithDefaultUser` helper

### DIFF
--- a/docs/content/docs/reference/contributing.mdx
+++ b/docs/content/docs/reference/contributing.mdx
@@ -149,10 +149,31 @@ import { getTestInstance } from "./test-utils/test-instance";
 
 describe("Feature", () => {
     it("should work as expected", async () => {
-        const { client } = getTestInstance();
+        const { client } = await getTestInstance();
         // Test code here
         expect(result).toBeDefined();
     });
+});
+```
+
+### Using the Test Instance Helper
+
+The test instance helper now includes improved async context support for managing user sessions:
+
+```ts
+const { client, runWithUser, signInWithTestUser } = await getTestInstance();
+
+// Run tests with a specific user context
+await runWithUser("user@example.com", "password", async (headers) => {
+    // All client calls within this block will use the user's session
+    const response = await client.getSession();
+    // headers are automatically applied
+});
+
+// Or use the test user with async context
+const { runWithDefaultUser } = await signInWithTestUser();
+await runWithDefaultUser(async (headers) => {
+    // Code here runs with the test user's session context
 });
 ```
 

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -53,7 +53,7 @@ vi.mock("../../oauth2", async (importOriginal) => {
 });
 
 describe("account", async () => {
-	const { auth, client, signInWithTestUser } = await getTestInstance({
+	const { auth, signInWithTestUser, client } = await getTestInstance({
 		socialProviders: {
 			google: {
 				clientId: "test",
@@ -85,157 +85,153 @@ describe("account", async () => {
 		googleGetUserInfoMock.mockClear();
 	});
 
-	const { headers } = await signInWithTestUser();
+	const { runWithDefaultUser } = await signInWithTestUser();
 
 	it("should list all accounts", async () => {
-		const accounts = await client.listAccounts({
-			fetchOptions: {
-				headers,
-			},
+		await runWithDefaultUser(async () => {
+			const accounts = await client.listAccounts();
+			expect(accounts.data?.length).toBe(1);
 		});
-		expect(accounts.data?.length).toBe(1);
 	});
 
 	it("should link first account", async () => {
-		const linkAccountRes = await client.linkSocial(
-			{
-				provider: "google",
-				callbackURL: "/callback",
-			},
-			{
-				headers,
-				onSuccess(context) {
-					const cookies = parseSetCookieHeader(
-						context.response.headers.get("set-cookie") || "",
-					);
-					headers.set(
-						"cookie",
-						`better-auth.state=${cookies.get("better-auth.state")?.value}`,
-					);
+		await runWithDefaultUser(async (headers) => {
+			const linkAccountRes = await client.linkSocial(
+				{
+					provider: "google",
+					callbackURL: "/callback",
 				},
-			},
-		);
-		expect(linkAccountRes.data).toMatchObject({
-			url: expect.stringContaining("google.com"),
-			redirect: true,
+				{
+					onSuccess(context) {
+						const cookies = parseSetCookieHeader(
+							context.response.headers.get("set-cookie") || "",
+						);
+						headers.set(
+							"cookie",
+							`better-auth.state=${cookies.get("better-auth.state")?.value}`,
+						);
+					},
+				},
+			);
+			expect(linkAccountRes.data).toMatchObject({
+				url: expect.stringContaining("google.com"),
+				redirect: true,
+			});
+			const state =
+				linkAccountRes.data && "url" in linkAccountRes.data
+					? new URL(linkAccountRes.data.url).searchParams.get("state") || ""
+					: "";
+			email = "test@test.com";
+			await client.$fetch("/callback/google", {
+				query: {
+					state,
+					code: "test",
+				},
+				method: "GET",
+				onError(context) {
+					expect(context.response.status).toBe(302);
+					const location = context.response.headers.get("location");
+					expect(location).toBeDefined();
+					expect(location).toContain("/callback");
+				},
+			});
 		});
-		const state =
-			linkAccountRes.data && "url" in linkAccountRes.data
-				? new URL(linkAccountRes.data.url).searchParams.get("state") || ""
-				: "";
-		email = "test@test.com";
-		await client.$fetch("/callback/google", {
-			query: {
-				state,
-				code: "test",
-			},
-			method: "GET",
-			headers,
-			onError(context) {
-				expect(context.response.status).toBe(302);
-				const location = context.response.headers.get("location");
-				expect(location).toBeDefined();
-				expect(location).toContain("/callback");
-			},
+		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		await runWithClient2(async () => {
+			const accounts = await client.listAccounts();
+			expect(accounts.data?.length).toBe(2);
 		});
-		const { headers: headers2 } = await signInWithTestUser();
-		const accounts = await client.listAccounts({
-			fetchOptions: { headers: headers2 },
-		});
-		expect(accounts.data?.length).toBe(2);
 	});
 
 	it("should encrypt access token and refresh token", async () => {
-		const { headers: headers2 } = await signInWithTestUser();
+		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
 		const account = await ctx.adapter.findOne<Account>({
 			model: "account",
 			where: [{ field: "providerId", value: "google" }],
 		});
 		expect(account).toBeTruthy();
 		expect(account?.accessToken).not.toBe("test");
-		const accessToken = await client.getAccessToken({
-			providerId: "google",
-			fetchOptions: { headers: headers2 },
+		await runWithClient2(async () => {
+			const accessToken = await client.getAccessToken({
+				providerId: "google",
+			});
+			expect(accessToken.data?.accessToken).toBe("test");
 		});
-		expect(accessToken.data?.accessToken).toBe("test");
 	});
 
 	it("should pass custom scopes to authorization URL", async () => {
-		const { headers: headers2 } = await signInWithTestUser();
-		const customScope = "https://www.googleapis.com/auth/drive.readonly";
-		const linkAccountRes = await client.linkSocial(
-			{
+		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		await runWithClient2(async () => {
+			const customScope = "https://www.googleapis.com/auth/drive.readonly";
+			const linkAccountRes = await client.linkSocial({
 				provider: "google",
 				callbackURL: "/callback",
 				scopes: [customScope],
-			},
-			{
-				headers: headers2,
-			},
-		);
+			});
 
-		expect(linkAccountRes.data).toMatchObject({
-			url: expect.stringContaining("google.com"),
-			redirect: true,
+			expect(linkAccountRes.data).toMatchObject({
+				url: expect.stringContaining("google.com"),
+				redirect: true,
+			});
+
+			const url =
+				linkAccountRes.data && "url" in linkAccountRes.data
+					? new URL(linkAccountRes.data.url)
+					: new URL("");
+			const scopesParam = url.searchParams.get("scope");
+			expect(scopesParam).toContain(customScope);
 		});
-
-		const url =
-			linkAccountRes.data && "url" in linkAccountRes.data
-				? new URL(linkAccountRes.data.url)
-				: new URL("");
-		const scopesParam = url.searchParams.get("scope");
-		expect(scopesParam).toContain(customScope);
 	});
 
 	it("should link second account from the same provider", async () => {
-		const { headers: headers2 } = await signInWithTestUser();
-		const linkAccountRes = await client.linkSocial(
-			{
-				provider: "google",
-				callbackURL: "/callback",
-			},
-			{
-				headers: headers2,
-				onSuccess(context) {
-					const cookies = parseSetCookieHeader(
-						context.response.headers.get("set-cookie") || "",
-					);
-					headers.set(
-						"cookie",
-						`better-auth.state=${cookies.get("better-auth.state")?.value}`,
-					);
+		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		await runWithClient2(async (headers) => {
+			const linkAccountRes = await client.linkSocial(
+				{
+					provider: "google",
+					callbackURL: "/callback",
 				},
-			},
-		);
-		expect(linkAccountRes.data).toMatchObject({
-			url: expect.stringContaining("google.com"),
-			redirect: true,
-		});
-		const state =
-			linkAccountRes.data && "url" in linkAccountRes.data
-				? new URL(linkAccountRes.data.url).searchParams.get("state") || ""
-				: "";
-		email = "test2@test.com";
-		await client.$fetch("/callback/google", {
-			query: {
-				state,
-				code: "test",
-			},
-			method: "GET",
-			headers,
-			onError(context) {
-				expect(context.response.status).toBe(302);
-				const location = context.response.headers.get("location");
-				expect(location).toBeDefined();
-				expect(location).toContain("/callback");
-			},
+				{
+					onSuccess(context) {
+						const cookies = parseSetCookieHeader(
+							context.response.headers.get("set-cookie") || "",
+						);
+						headers.set(
+							"cookie",
+							`better-auth.state=${cookies.get("better-auth.state")?.value}`,
+						);
+					},
+				},
+			);
+			expect(linkAccountRes.data).toMatchObject({
+				url: expect.stringContaining("google.com"),
+				redirect: true,
+			});
+			const state =
+				linkAccountRes.data && "url" in linkAccountRes.data
+					? new URL(linkAccountRes.data.url).searchParams.get("state") || ""
+					: "";
+			email = "test2@test.com";
+			await client.$fetch("/callback/google", {
+				query: {
+					state,
+					code: "test",
+				},
+				method: "GET",
+				onError(context) {
+					expect(context.response.status).toBe(302);
+					const location = context.response.headers.get("location");
+					expect(location).toBeDefined();
+					expect(location).toContain("/callback");
+				},
+			});
 		});
 
-		const { headers: headers3 } = await signInWithTestUser();
-		const accounts = await client.listAccounts({
-			fetchOptions: { headers: headers3 },
+		const { runWithDefaultUser: runWithClient3 } = await signInWithTestUser();
+		await runWithClient3(async () => {
+			const accounts = await client.listAccounts();
+			expect(accounts.data?.length).toBe(2);
 		});
-		expect(accounts.data?.length).toBe(2);
 	});
 
 	it("should link third account with idToken", async () => {
@@ -253,136 +249,114 @@ describe("account", async () => {
 		};
 		googleGetUserInfoMock.mockResolvedValueOnce(userInfo);
 
-		const { headers: headers2 } = await signInWithTestUser();
-		const linkAccountRes = await client.linkSocial(
-			{
-				provider: "google",
-				callbackURL: "/callback",
-				idToken: { token: "test" },
-			},
-			{
-				headers: headers2,
-				onSuccess(context) {
-					const cookies = parseSetCookieHeader(
-						context.response.headers.get("set-cookie") || "",
-					);
-					headers.set(
-						"cookie",
-						`better-auth.state=${cookies.get("better-auth.state")?.value}`,
-					);
+		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		await runWithClient2(async (headers) => {
+			await client.linkSocial(
+				{
+					provider: "google",
+					callbackURL: "/callback",
+					idToken: { token: "test" },
 				},
-			},
-		);
+				{
+					onSuccess(context) {
+						const cookies = parseSetCookieHeader(
+							context.response.headers.get("set-cookie") || "",
+						);
+						headers.set(
+							"cookie",
+							`better-auth.state=${cookies.get("better-auth.state")?.value}`,
+						);
+					},
+				},
+			);
+		});
 
 		expect(googleVerifyIdTokenMock).toHaveBeenCalledOnce();
 		expect(googleGetUserInfoMock).toHaveBeenCalledOnce();
 
-		const { headers: headers3 } = await signInWithTestUser();
-		const accounts = await client.listAccounts({
-			fetchOptions: { headers: headers3 },
+		const { runWithDefaultUser: runWithClient3 } = await signInWithTestUser();
+		await runWithClient3(async () => {
+			const accounts = await client.listAccounts();
+			expect(accounts.data?.length).toBe(3);
 		});
-		expect(accounts.data?.length).toBe(3);
 	});
 
 	it("should unlink account", async () => {
-		const { headers } = await signInWithTestUser();
-		const previousAccounts = await client.listAccounts({
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const previousAccounts = await client.listAccounts();
+			expect(previousAccounts.data?.length).toBe(3);
+			const unlinkAccountId = previousAccounts.data![1].accountId;
+			const unlinkRes = await client.unlinkAccount({
+				providerId: "google",
+				accountId: unlinkAccountId!,
+			});
+			expect(unlinkRes.data?.status).toBe(true);
+			const accounts = await client.listAccounts();
+			expect(accounts.data?.length).toBe(2);
 		});
-		expect(previousAccounts.data?.length).toBe(3);
-		const unlinkAccountId = previousAccounts.data![1].accountId;
-		const unlinkRes = await client.unlinkAccount({
-			providerId: "google",
-			accountId: unlinkAccountId!,
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(unlinkRes.data?.status).toBe(true);
-		const accounts = await client.listAccounts({
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(accounts.data?.length).toBe(2);
 	});
 
 	it("should fail to unlink the last account of a provider", async () => {
-		const { headers } = await signInWithTestUser();
-		const previousAccounts = await client.listAccounts({
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const previousAccounts = await client.listAccounts();
+			await ctx.adapter.delete({
+				model: "account",
+				where: [
+					{
+						field: "providerId",
+						value: "google",
+					},
+				],
+			});
+			const unlinkAccountId = previousAccounts.data![0].accountId;
+			const unlinkRes = await client.unlinkAccount({
+				providerId: "credential",
+				accountId: unlinkAccountId,
+			});
+			expect(unlinkRes.error?.message).toBe(
+				BASE_ERROR_CODES.FAILED_TO_UNLINK_LAST_ACCOUNT,
+			);
 		});
-		await ctx.adapter.delete({
-			model: "account",
-			where: [
-				{
-					field: "providerId",
-					value: "google",
-				},
-			],
-		});
-		const unlinkAccountId = previousAccounts.data![0].accountId;
-		const unlinkRes = await client.unlinkAccount({
-			providerId: "credential",
-			accountId: unlinkAccountId,
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(unlinkRes.error?.message).toBe(
-			BASE_ERROR_CODES.FAILED_TO_UNLINK_LAST_ACCOUNT,
-		);
 	});
 
 	it("should unlink account with specific accountId", async () => {
-		const { headers } = await signInWithTestUser();
-		const previousAccounts = await client.listAccounts({
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const previousAccounts = await client.listAccounts();
+			expect(previousAccounts.data?.length).toBeGreaterThan(0);
+
+			const accountToUnlink = previousAccounts.data![0];
+			const unlinkAccountId = accountToUnlink.accountId;
+			const providerId = accountToUnlink.providerId;
+			const accountsWithSameProvider = previousAccounts.data!.filter(
+				(account) => account.providerId === providerId,
+			);
+			if (accountsWithSameProvider.length <= 1) {
+				return;
+			}
+
+			const unlinkRes = await client.unlinkAccount({
+				providerId,
+				accountId: unlinkAccountId!,
+			});
+
+			expect(unlinkRes.data?.status).toBe(true);
+
+			const accountsAfterUnlink = await client.listAccounts();
+
+			expect(accountsAfterUnlink.data?.length).toBe(
+				previousAccounts.data!.length - 1,
+			);
+			expect(
+				accountsAfterUnlink.data?.find((a) => a.accountId === unlinkAccountId),
+			).toBeUndefined();
 		});
-		expect(previousAccounts.data?.length).toBeGreaterThan(0);
-
-		const accountToUnlink = previousAccounts.data![0];
-		const unlinkAccountId = accountToUnlink.accountId;
-		const providerId = accountToUnlink.providerId;
-		const accountsWithSameProvider = previousAccounts.data!.filter(
-			(account) => account.providerId === providerId,
-		);
-		if (accountsWithSameProvider.length <= 1) {
-			return;
-		}
-
-		const unlinkRes = await client.unlinkAccount({
-			providerId,
-			accountId: unlinkAccountId!,
-			fetchOptions: {
-				headers,
-			},
-		});
-
-		expect(unlinkRes.data?.status).toBe(true);
-
-		const accountsAfterUnlink = await client.listAccounts({
-			fetchOptions: {
-				headers,
-			},
-		});
-
-		expect(accountsAfterUnlink.data?.length).toBe(
-			previousAccounts.data!.length - 1,
-		);
-		expect(
-			accountsAfterUnlink.data?.find((a) => a.accountId === unlinkAccountId),
-		).toBeUndefined();
 	});
 
 	it("should unlink all accounts with specific providerId", async () => {
-		const { headers, user } = await signInWithTestUser();
+		const { runWithDefaultUser, user } = await signInWithTestUser();
 		await ctx.adapter.create({
 			model: "account",
 			data: {
@@ -405,37 +379,28 @@ describe("account", async () => {
 			},
 		});
 
-		const previousAccounts = await client.listAccounts({
-			fetchOptions: {
-				headers,
-			},
+		await runWithDefaultUser(async () => {
+			const previousAccounts = await client.listAccounts();
+
+			const googleAccounts = previousAccounts.data!.filter(
+				(account) => account.providerId === "google",
+			);
+			expect(googleAccounts.length).toBeGreaterThan(1);
+
+			for (let i = 0; i < googleAccounts.length - 1; i++) {
+				const unlinkRes = await client.unlinkAccount({
+					providerId: "google",
+					accountId: googleAccounts[i].accountId!,
+				});
+				expect(unlinkRes.data?.status).toBe(true);
+			}
+
+			const accountsAfterUnlink = await client.listAccounts();
+
+			const remainingGoogleAccounts = accountsAfterUnlink.data!.filter(
+				(account) => account.providerId === "google",
+			);
+			expect(remainingGoogleAccounts.length).toBe(1);
 		});
-
-		const googleAccounts = previousAccounts.data!.filter(
-			(account) => account.providerId === "google",
-		);
-		expect(googleAccounts.length).toBeGreaterThan(1);
-
-		for (let i = 0; i < googleAccounts.length - 1; i++) {
-			const unlinkRes = await client.unlinkAccount({
-				providerId: "google",
-				accountId: googleAccounts[i].accountId!,
-				fetchOptions: {
-					headers,
-				},
-			});
-			expect(unlinkRes.data?.status).toBe(true);
-		}
-
-		const accountsAfterUnlink = await client.listAccounts({
-			fetchOptions: {
-				headers,
-			},
-		});
-
-		const remainingGoogleAccounts = accountsAfterUnlink.data!.filter(
-			(account) => account.providerId === "google",
-		);
-		expect(remainingGoogleAccounts.length).toBe(1);
 	});
 });

--- a/packages/better-auth/src/api/routes/reset-password.test.ts
+++ b/packages/better-auth/src/api/routes/reset-password.test.ts
@@ -192,13 +192,12 @@ describe("forget password", async (it) => {
 				resetPasswordTokenExpiresIn: 10,
 			},
 		});
-		const { headers } = await signInWithTestUser();
-		await client.requestPasswordReset({
-			email: testUser.email,
-			redirectTo: "/sign-in",
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			await client.requestPasswordReset({
+				email: testUser.email,
+				redirectTo: "/sign-in",
+			});
 		});
 		vi.useFakeTimers();
 		await vi.advanceTimersByTimeAsync(1000 * 9);
@@ -220,12 +219,11 @@ describe("forget password", async (it) => {
 			token,
 		});
 		expect(res.data?.status).toBe(true);
-		await client.requestPasswordReset({
-			email: testUser.email,
-			redirectTo: "/sign-in",
-			fetchOptions: {
-				headers,
-			},
+		await runWithDefaultUser(async () => {
+			await client.requestPasswordReset({
+				email: testUser.email,
+				redirectTo: "/sign-in",
+			});
 		});
 		vi.useFakeTimers();
 		await vi.advanceTimersByTimeAsync(1000 * 11);
@@ -285,7 +283,7 @@ describe("revoke sessions on password reset", async (it) => {
 	);
 
 	it("should revoke other sessions when revokeSessionsOnPasswordReset is enabled", async () => {
-		const { headers } = await signInWithTestUser();
+		const { runWithDefaultUser } = await signInWithTestUser();
 
 		await client.requestPasswordReset({
 			email: testUser.email,
@@ -303,12 +301,10 @@ describe("revoke sessions on password reset", async (it) => {
 			},
 		);
 
-		const sessionAttempt = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
+		await runWithDefaultUser(async () => {
+			const sessionAttempt = await client.getSession();
+			expect(sessionAttempt.data).toBeNull();
 		});
-		expect(sessionAttempt.data).toBeNull();
 	});
 
 	it("should not revoke other sessions by default", async () => {
@@ -327,7 +323,7 @@ describe("revoke sessions on password reset", async (it) => {
 			},
 		);
 
-		const { headers } = await signInWithTestUser();
+		const { runWithDefaultUser } = await signInWithTestUser();
 
 		await client.requestPasswordReset({
 			email: testUser.email,
@@ -345,11 +341,9 @@ describe("revoke sessions on password reset", async (it) => {
 			},
 		);
 
-		const sessionAttempt = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
+		await runWithDefaultUser(async () => {
+			const sessionAttempt = await client.getSession();
+			expect(sessionAttempt.data?.user).toBeDefined();
 		});
-		expect(sessionAttempt.data?.user).toBeDefined();
 	});
 });

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -124,27 +124,21 @@ describe("session", async () => {
 				updateAge: 0,
 			},
 		});
-		const { headers } = await signInWithTestUser();
+		const { runWithDefaultUser } = await signInWithTestUser();
 
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
-		});
+		await runWithDefaultUser(async () => {
+			const session = await client.getSession();
 
-		vi.useFakeTimers();
-		await vi.advanceTimersByTimeAsync(1000 * 60 * 5);
-		const session2 = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
+			vi.useFakeTimers();
+			await vi.advanceTimersByTimeAsync(1000 * 60 * 5);
+			const session2 = await client.getSession();
+			expect(session2.data?.session.expiresAt).not.toBe(
+				session.data?.session.expiresAt,
+			);
+			expect(
+				new Date(session2.data!.session.expiresAt).getTime(),
+			).toBeGreaterThan(new Date(session.data!.session.expiresAt).getTime());
 		});
-		expect(session2.data?.session.expiresAt).not.toBe(
-			session.data?.session.expiresAt,
-		);
-		expect(
-			new Date(session2.data!.session.expiresAt).getTime(),
-		).toBeGreaterThan(new Date(session.data!.session.expiresAt).getTime());
 	});
 
 	it("should handle 'don't remember me' option", async () => {
@@ -370,91 +364,69 @@ describe("session storage", async () => {
 	it("should store session in secondary storage", async () => {
 		//since the instance creates a session on init, we expect the store to have 2 item (1 for session and 1 for active sessions record for the user)
 		expect(store.size).toBe(0);
-		const { headers } = await signInWithTestUser();
+		const { runWithDefaultUser } = await signInWithTestUser();
 		expect(store.size).toBe(2);
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(session.data).toMatchObject({
-			session: {
-				userId: expect.any(String),
-				token: expect.any(String),
-				expiresAt: expect.any(Date),
-				ipAddress: expect.any(String),
-				userAgent: expect.any(String),
-			},
-			user: {
-				id: expect.any(String),
-				name: "test user",
-				email: "test@test.com",
-				emailVerified: false,
-				image: null,
-				createdAt: expect.any(Date),
-				updatedAt: expect.any(Date),
-			},
+		await runWithDefaultUser(async () => {
+			const session = await client.getSession();
+			expect(session.data).toMatchObject({
+				session: {
+					userId: expect.any(String),
+					token: expect.any(String),
+					expiresAt: expect.any(Date),
+					ipAddress: expect.any(String),
+					userAgent: expect.any(String),
+				},
+				user: {
+					id: expect.any(String),
+					name: "test user",
+					email: "test@test.com",
+					emailVerified: false,
+					image: null,
+					createdAt: expect.any(Date),
+					updatedAt: expect.any(Date),
+				},
+			});
 		});
 	});
 
 	it("should list sessions", async () => {
-		const { headers } = await signInWithTestUser();
-		const response = await client.listSessions({
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const response = await client.listSessions();
+			expect(response.data?.length).toBe(1);
 		});
-		expect(response.data?.length).toBe(1);
 	});
 
 	it("revoke session and list sessions", async () => {
-		const { headers } = await signInWithTestUser();
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const session = await client.getSession();
+			expect(session.data).not.toBeNull();
+			expect(session.data?.session?.token).toBeDefined();
+			const userId = session.data!.session.userId;
+			const sessions = JSON.parse(store.get(`active-sessions-${userId}`)!);
+			expect(sessions.length).toBe(1);
+			const res = await client.revokeSession({
+				token: session.data?.session?.token!,
+			});
+			expect(res.data?.status).toBe(true);
+			const response = await client.listSessions();
+			expect(response.data).toBe(null);
+			expect(store.size).toBe(0);
 		});
-		expect(session.data).not.toBeNull();
-		expect(session.data?.session?.token).toBeDefined();
-		const userId = session.data!.session.userId;
-		const sessions = JSON.parse(store.get(`active-sessions-${userId}`)!);
-		expect(sessions.length).toBe(1);
-		const res = await client.revokeSession({
-			fetchOptions: {
-				headers,
-			},
-			token: session.data?.session?.token!,
-		});
-		expect(res.data?.status).toBe(true);
-		const response = await client.listSessions({
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(response.data).toBe(null);
-		expect(store.size).toBe(0);
 	});
 
 	it("should revoke session", async () => {
-		const { headers } = await signInWithTestUser();
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const session = await client.getSession();
+			expect(session.data).not.toBeNull();
+			const res = await client.revokeSession({
+				token: session.data?.session?.token || "",
+			});
+			const revokedSession = await client.getSession();
+			expect(revokedSession.data).toBeNull();
 		});
-		expect(session.data).not.toBeNull();
-		const res = await client.revokeSession({
-			fetchOptions: {
-				headers,
-			},
-			token: session.data?.session?.token || "",
-		});
-		const revokedSession = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(revokedSession.data).toBeNull();
 	});
 });
 

--- a/packages/better-auth/src/api/routes/sign-out.test.ts
+++ b/packages/better-auth/src/api/routes/sign-out.test.ts
@@ -5,14 +5,12 @@ describe("sign-out", async (it) => {
 	const { signInWithTestUser, client } = await getTestInstance();
 
 	it("should sign out", async () => {
-		const { headers } = await signInWithTestUser();
-		const res = await client.signOut({
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(res.data).toMatchObject({
-			success: true,
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const res = await client.signOut();
+			expect(res.data).toMatchObject({
+				success: true,
+			});
 		});
 	});
 });

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -5,110 +5,76 @@ import type { Account } from "../../types";
 describe("updateUser", async () => {
 	const sendChangeEmail = vi.fn();
 	let emailVerificationToken = "";
-	const { client, testUser, sessionSetter, db, customFetchImpl } =
-		await getTestInstance({
-			emailVerification: {
-				async sendVerificationEmail({ user, url, token }) {
-					emailVerificationToken = token;
-				},
+	const {
+		client,
+		testUser,
+		sessionSetter,
+		db,
+		customFetchImpl,
+		signInWithTestUser,
+	} = await getTestInstance({
+		emailVerification: {
+			async sendVerificationEmail({ user, url, token }) {
+				emailVerificationToken = token;
 			},
-			user: {
-				changeEmail: {
-					enabled: true,
-					sendChangeEmailVerification: async ({
-						user,
-						newEmail,
-						url,
-						token,
-					}) => {
-						sendChangeEmail(user, newEmail, url, token);
-					},
+		},
+		user: {
+			changeEmail: {
+				enabled: true,
+				sendChangeEmailVerification: async ({ user, newEmail, url, token }) => {
+					sendChangeEmail(user, newEmail, url, token);
 				},
-			},
-		});
-	const headers = new Headers();
-	const session = await client.signIn.email({
-		email: testUser.email,
-		password: testUser.password,
-		fetchOptions: {
-			onSuccess: sessionSetter(headers),
-			onRequest(context) {
-				return context;
 			},
 		},
 	});
-	if (!session) {
-		throw new Error("No session");
-	}
+	// Sign in once for all tests in this describe block
+	const { runWithDefaultUser: globalRunWithClient } =
+		await signInWithTestUser();
 
 	it("should update the user's name", async () => {
-		const updated = await client.updateUser({
-			name: "newName",
-			image: "https://example.com/image.jpg",
-			fetchOptions: {
-				headers,
-			},
+		await globalRunWithClient(async () => {
+			const updated = await client.updateUser({
+				name: "newName",
+				image: "https://example.com/image.jpg",
+			});
+			const sessionRes = await client.getSession();
+			expect(updated.data?.status).toBe(true);
+			expect(sessionRes.data?.user.name).toBe("newName");
 		});
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-				throw: true,
-			},
-		});
-		expect(updated.data?.status).toBe(true);
-		expect(session?.user.name).toBe("newName");
 	});
 
 	it("should unset image", async () => {
-		const updated = await client.updateUser({
-			image: null,
-			fetchOptions: {
-				headers,
-			},
+		await globalRunWithClient(async () => {
+			const updated = await client.updateUser({
+				image: null,
+			});
+			const sessionRes = await client.getSession();
+			expect(sessionRes.data?.user.image).toBeNull();
 		});
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-				throw: true,
-			},
-		});
-		expect(session?.user.image).toBeNull();
 	});
 
 	it("should update user email", async () => {
 		const newEmail = "new-email@email.com";
-		const res = await client.changeEmail({
-			newEmail,
-			fetchOptions: {
-				headers: headers,
-			},
+		await globalRunWithClient(async () => {
+			const res = await client.changeEmail({
+				newEmail,
+			});
+			const sessionRes = await client.getSession();
+			expect(sessionRes.data?.user.email).toBe(newEmail);
+			expect(sessionRes.data?.user.emailVerified).toBe(false);
 		});
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-				throw: true,
-			},
-		});
-		expect(session?.user.email).toBe(newEmail);
-		expect(session?.user.emailVerified).toBe(false);
 	});
 
 	it("should verify email", async () => {
-		await client.verifyEmail({
-			query: {
-				token: emailVerificationToken,
-			},
-			fetchOptions: {
-				headers,
-			},
+		await globalRunWithClient(async () => {
+			await client.verifyEmail({
+				query: {
+					token: emailVerificationToken,
+				},
+			});
+			const sessionRes = await client.getSession();
+			expect(sessionRes.data?.user.emailVerified).toBe(true);
 		});
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-				throw: true,
-			},
-		});
-		expect(session?.user.emailVerified).toBe(true);
 	});
 
 	it("should send email verification before update", async () => {
@@ -124,11 +90,10 @@ describe("updateUser", async () => {
 				},
 			],
 		});
-		await client.changeEmail({
-			newEmail: "new-email-2@email.com",
-			fetchOptions: {
-				headers: headers,
-			},
+		await globalRunWithClient(async () => {
+			await client.changeEmail({
+				newEmail: "new-email-2@email.com",
+			});
 		});
 		expect(sendChangeEmail).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -142,15 +107,14 @@ describe("updateUser", async () => {
 
 	it("should update the user's password", async () => {
 		const newEmail = "new-email@email.com";
-		const updated = await client.changePassword({
-			newPassword: "newPassword",
-			currentPassword: testUser.password,
-			revokeOtherSessions: true,
-			fetchOptions: {
-				headers: headers,
-			},
+		await globalRunWithClient(async () => {
+			const updated = await client.changePassword({
+				newPassword: "newPassword",
+				currentPassword: testUser.password,
+				revokeOtherSessions: true,
+			});
+			expect(updated).toBeDefined();
 		});
-		expect(updated).toBeDefined();
 		const signInRes = await client.signIn.email({
 			email: newEmail,
 			password: "newPassword",
@@ -262,25 +226,25 @@ describe("updateUser", async () => {
 	});
 
 	it("should revoke other sessions", async () => {
-		const newHeaders = new Headers();
-		await client.changePassword({
-			newPassword: "newPassword",
-			currentPassword: testUser.password,
-			revokeOtherSessions: true,
-			fetchOptions: {
-				headers: headers,
-				onSuccess: sessionSetter(newHeaders),
-			},
+		await globalRunWithClient(async (headers) => {
+			const newHeaders = new Headers();
+			await client.changePassword({
+				newPassword: "newPassword",
+				currentPassword: testUser.password,
+				revokeOtherSessions: true,
+				fetchOptions: {
+					onSuccess: sessionSetter(newHeaders),
+				},
+			});
+			const cookie = newHeaders.get("cookie");
+			const oldCookie = headers.get("cookie");
+			expect(cookie).not.toBe(oldCookie);
+			// Try to use the old session - it should be revoked
+			const sessionAttempt = await client.getSession();
+			// The old session should still be invalidated even though we're using runWithClient
+			// because revokeOtherSessions should have invalidated it on the server
+			expect(sessionAttempt.data).toBeNull();
 		});
-		const cookie = newHeaders.get("cookie");
-		const oldCookie = headers.get("cookie");
-		expect(cookie).not.toBe(oldCookie);
-		const sessionAttempt = await client.getSession({
-			fetchOptions: {
-				headers: headers,
-			},
-		});
-		expect(sessionAttempt.data).toBeNull();
 	});
 
 	it("shouldn't pass defaults", async () => {
@@ -394,13 +358,11 @@ describe("delete user", async () => {
 				},
 			},
 		});
-		const { headers } = await signInWithTestUser();
-		const res = await client.deleteUser({
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const res = await client.deleteUser();
+			console.log(res);
 		});
-		console.log(res);
 	});
 	it("should delete the user with a fresh session", async () => {
 		const { client, signInWithTestUser } = await getTestInstance({
@@ -413,21 +375,15 @@ describe("delete user", async () => {
 				freshAge: 1000,
 			},
 		});
-		const { headers } = await signInWithTestUser();
-		const res = await client.deleteUser({
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const res = await client.deleteUser();
+			expect(res.data).toMatchObject({
+				success: true,
+			});
+			const session = await client.getSession();
+			expect(session.data).toBeNull();
 		});
-		expect(res.data).toMatchObject({
-			success: true,
-		});
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(session.data).toBeNull();
 	});
 
 	it("should delete with verification flow and password", async () => {
@@ -442,38 +398,26 @@ describe("delete user", async () => {
 				},
 			},
 		});
-		const { headers } = await signInWithTestUser();
-		const res = await client.deleteUser({
-			password: testUser.password,
-			fetchOptions: {
-				headers,
-			},
+		const { runWithDefaultUser } = await signInWithTestUser();
+		await runWithDefaultUser(async () => {
+			const res = await client.deleteUser({
+				password: testUser.password,
+			});
+			expect(res.data).toMatchObject({
+				success: true,
+			});
+			expect(token.length).toBe(32);
+			const session = await client.getSession();
+			expect(session.data).toBeDefined();
+			const deleteCallbackRes = await client.deleteUser({
+				token,
+			});
+			expect(deleteCallbackRes.data).toMatchObject({
+				success: true,
+			});
+			const nullSession = await client.getSession();
+			expect(nullSession.data).toBeNull();
 		});
-		expect(res.data).toMatchObject({
-			success: true,
-		});
-		expect(token.length).toBe(32);
-		const session = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(session.data).toBeDefined();
-		const deleteCallbackRes = await client.deleteUser({
-			token,
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(deleteCallbackRes.data).toMatchObject({
-			success: true,
-		});
-		const nullSession = await client.getSession({
-			fetchOptions: {
-				headers,
-			},
-		});
-		expect(nullSession.data).toBeNull();
 	});
 
 	it("should ignore cookie cache for sensitive operations like changePassword", async () => {

--- a/packages/better-auth/src/social-providers/social.test.ts
+++ b/packages/better-auth/src/social-providers/social.test.ts
@@ -109,7 +109,7 @@ vi.mock("../oauth2", async (importOriginal) => {
 });
 
 describe("Social Providers", async (c) => {
-	const { auth, customFetchImpl, client, cookieSetter } = await getTestInstance(
+	const { client, cookieSetter } = await getTestInstance(
 		{
 			user: {
 				additionalFields: {
@@ -424,7 +424,7 @@ describe("Redirect URI", async () => {
 	});
 
 	it("should respect custom redirect uri", async () => {
-		const { auth, customFetchImpl, client } = await getTestInstance({
+		const { client } = await getTestInstance({
 			socialProviders: {
 				google: {
 					clientId: "test",

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { afterAll } from "vitest";
 import { betterAuth } from "../auth";
 import { createAuthClient } from "../client/vanilla";
@@ -16,6 +17,11 @@ import { createPool } from "mysql2/promise";
 import { bearer } from "../plugins";
 
 const cleanupSet = new Set<Function>();
+
+type CurrentUserContext = {
+	headers: Headers;
+};
+const currentUserContextStorage = new AsyncLocalStorage<CurrentUserContext>();
 
 afterAll(async () => {
 	for (const cleanup of cleanupSet) {
@@ -168,6 +174,47 @@ export async function getTestInstance<
 	};
 	cleanupSet.add(cleanup);
 
+	const customFetchImpl = async (
+		url: string | URL | Request,
+		init?: RequestInit,
+	) => {
+		const headers = init?.headers || {};
+		const storageHeaders = currentUserContextStorage.getStore()?.headers;
+		return auth.handler(
+			new Request(
+				url,
+				init
+					? {
+							...init,
+							headers: new Headers({
+								...(storageHeaders
+									? Object.fromEntries(storageHeaders.entries())
+									: {}),
+								...(headers instanceof Headers
+									? Object.fromEntries(headers.entries())
+									: typeof headers === "object"
+										? headers
+										: {}),
+							}),
+						}
+					: {
+							headers,
+						},
+			),
+		);
+	};
+
+	const client = createAuthClient({
+		...(config?.clientOptions as C extends undefined ? {} : C),
+		baseURL: getBaseURL(
+			options?.baseURL || "http://localhost:" + (config?.port || 3000),
+			options?.basePath || "/api/auth",
+		),
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
 	async function signInWithTestUser() {
 		if (config?.disableTestUser) {
 			throw new Error("Test user is disabled");
@@ -196,10 +243,15 @@ export async function getTestInstance<
 			user: data.user as User,
 			headers,
 			setCookie,
+			runWithDefaultUser: async (fn: (headers: Headers) => Promise<void>) => {
+				return currentUserContextStorage.run({ headers }, async () => {
+					await fn(headers);
+				});
+			},
 		};
 	}
 	async function signInWithUser(email: string, password: string) {
-		let headers = new Headers();
+		const headers = new Headers();
 		//@ts-expect-error
 		const { data } = await client.signIn.email({
 			email,
@@ -223,13 +275,6 @@ export async function getTestInstance<
 		};
 	}
 
-	const customFetchImpl = async (
-		url: string | URL | Request,
-		init?: RequestInit,
-	) => {
-		return auth.handler(new Request(url, init));
-	};
-
 	function sessionSetter(headers: Headers) {
 		return (context: SuccessContext) => {
 			const header = context.response.headers.get("set-cookie");
@@ -241,16 +286,6 @@ export async function getTestInstance<
 		};
 	}
 
-	const client = createAuthClient({
-		...(config?.clientOptions as C extends undefined ? {} : C),
-		baseURL: getBaseURL(
-			options?.baseURL || "http://localhost:" + (config?.port || 3000),
-			options?.basePath || "/api/auth",
-		),
-		fetchOptions: {
-			customFetchImpl,
-		},
-	});
 	return {
 		auth,
 		client,
@@ -261,5 +296,15 @@ export async function getTestInstance<
 		customFetchImpl,
 		sessionSetter,
 		db: await getAdapter(auth.options),
+		runWithUser: async (
+			email: string,
+			password: string,
+			fn: (headers: Headers) => Promise<void>,
+		) => {
+			const { headers } = await signInWithUser(email, password);
+			return currentUserContextStorage.run({ headers }, async () => {
+				await fn(headers);
+			});
+		},
 	};
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored tests to use a new runWithDefaultUserClient helper that auto-injects auth headers via AsyncLocalStorage, removing boilerplate and making tests clearer and more reliable. Updated customFetchImpl to merge stored headers and apply them to all client calls.

- **Refactors**
  - Added AsyncLocalStorage-backed current user context in test-utils.
  - Introduced runWithDefaultUserClient and runWithClient helpers to run client calls with the signed-in user’s headers.
  - Updated customFetchImpl to merge context headers with request headers before calling auth.handler.
  - Migrated tests across routes and plugins (accounts, sessions, email verification, reset password, update user, sign-out, admin, jwt, passkey, username, additional-fields) to use the new helpers and drop manual header passing.

<!-- End of auto-generated description by cubic. -->

