### PR TITLE
fix(stripe): onCustomerCreate should be called even if update user isn't returned

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -90,6 +90,7 @@ export const createInternalAdapter = (
 				undefined,
 				context,
 			);
+
 			return createdUser as T & User;
 		},
 		createAccount: async <T extends Record<string, any>>(

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1242,21 +1242,19 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 												userId: user.id,
 											},
 										});
-										const updatedUser =
-											await ctx.context.internalAdapter.updateUser(user.id, {
-												stripeCustomerId: stripeCustomer.id,
-											});
-										if (!updatedUser) {
-											logger.error("#BETTER_AUTH: Failed to create  customer");
-										} else {
-											await options.onCustomerCreate?.(
-												{
-													stripeCustomer,
-													user,
+										await ctx.context.internalAdapter.updateUser(user.id, {
+											stripeCustomerId: stripeCustomer.id,
+										});
+										await options.onCustomerCreate?.(
+											{
+												stripeCustomer,
+												user: {
+													...user,
+													stripeCustomerId: stripeCustomer.id,
 												},
-												ctx,
-											);
-										}
+											},
+											ctx,
+										);
 									}
 								},
 							},

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -188,7 +188,7 @@ export interface StripeOptions {
 	onCustomerCreate?: (
 		data: {
 			stripeCustomer: Stripe.Customer;
-			user: User;
+			user: User & { stripeCustomerId: string };
 		},
 		ctx: GenericEndpointContext,
 	) => Promise<void>;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Guarantees Stripe onCustomerCreate runs after customer creation, even if updateUser returns nothing. The callback now receives the user with stripeCustomerId included.

- **Bug Fixes**
  - Always invoke onCustomerCreate after creating a Stripe customer; no longer blocked by updateUser’s return value.
  - Pass user with stripeCustomerId to the callback and update types to User & { stripeCustomerId: string }.

<!-- End of auto-generated description by cubic. -->

