### PR TITLE
fix: support for organizations with large member counts

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -709,7 +709,7 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 			}
 			const isMember = await adapter.checkMembership({
 				userId: session.user.id,
-				organizationId: organizationId,
+				organizationId: organization.id,
 			});
 			if (!isMember) {
 				await adapter.setActiveOrganization(session.session.token, null);

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -710,7 +710,7 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 			const isMember = await adapter.checkMembership({
 				userId: session.user.id,
 				organizationId: organizationId,
-			})
+			});
 			if (!isMember) {
 				await adapter.setActiveOrganization(session.session.token, null);
 				throw new APIError("FORBIDDEN", {

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -707,19 +707,15 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 					message: ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,
 				});
 			}
-			const isMember = organization?.members.find(
-				(member) => member.userId === session.user.id,
-			);
+			const isMember = await adapter.checkMembership({
+				userId: session.user.id,
+				organizationId: organizationId,
+			})
 			if (!isMember) {
 				await adapter.setActiveOrganization(session.session.token, null);
 				throw new APIError("FORBIDDEN", {
 					message:
 						ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
-				});
-			}
-			if (!organization) {
-				throw new APIError("BAD_REQUEST", {
-					message: ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,
 				});
 			}
 			type OrganizationReturn = O["teams"] extends { enabled: true }


### PR DESCRIPTION
Hi,
My app includes an organization with approximately 6,000 members. We've encountered an issue where the `activeOrganizationId` field is set to `null` after calling `getFullOrganization`. More details can be found in the [Discord thread](https://canary.discord.com/channels/1288403910284935179/1417776115069485208).

The current implementation of `getFullOrganization` only loads the first 100 members, checking if the logged-in user is among them. This approach leads to undefined behavior in organizations with more than 100 members. If the member was not found in the 100 members loaded, it would update their session to clear `activeOrganizationId`.

This issue was especially hard to pinpoint as my app did not call `getFullOrganization` directly, but it was indirectly called by other functions (See this [Discord message](https://canary.discord.com/channels/1288403910284935179/1296058482289676320/1417935886267449425)).


I also removed a redundant sanity check that was checked above.