### PR TITLE
fix(org): use correct adapter during db tranaction

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -18,14 +18,16 @@ import { BetterAuthError } from "../../error";
 import type { AuthContext } from "../../init";
 import parseJSON from "../../client/parser";
 import { type InferAdditionalFieldsFromPluginOptions } from "../../db";
+import { getCurrentAdapter } from "../../context/transaction";
 
 export const getOrgAdapter = <O extends OrganizationOptions>(
 	context: AuthContext,
 	options?: O,
 ) => {
-	const adapter = context.adapter;
+	const baseAdapter = context.adapter;
 	return {
 		findOrganizationBySlug: async (slug: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const organization = await adapter.findOne<InferOrganization<O>>({
 				model: "organization",
 				where: [
@@ -42,6 +44,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				// This represents the additional fields from the plugin options
 				Record<string, any>;
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const organization = await adapter.create<
 				OrganizationInput,
 				InferOrganization<O, false>
@@ -67,6 +70,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			email: string;
 			organizationId: string;
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const user = await adapter.findOne<User>({
 				model: "user",
 				where: [
@@ -117,6 +121,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				value: any;
 			};
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const members = await Promise.all([
 				adapter.findMany<Member>({
 					model: "member",
@@ -187,6 +192,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			userId: string;
 			organizationId: string;
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const [member, user] = await Promise.all([
 				await adapter.findOne<Member>({
 					model: "member",
@@ -225,6 +231,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			};
 		},
 		findMemberById: async (memberId: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const member = await adapter.findOne<Member>({
 				model: "member",
 				where: [
@@ -264,6 +271,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				// Additional fields from the plugin options
 				Record<string, any>,
 		) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const member = await adapter.create<
 				typeof data,
 				Member & InferAdditionalFieldsFromPluginOptions<"member", O, false>
@@ -277,6 +285,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return member;
 		},
 		updateMember: async (memberId: string, role: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const member = await adapter.update<InferMember<O>>({
 				model: "member",
 				where: [
@@ -292,6 +301,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return member;
 		},
 		deleteMember: async (memberId: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const member = await adapter.delete<InferMember<O>>({
 				model: "member",
 				where: [
@@ -307,6 +317,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			organizationId: string,
 			data: Partial<OrganizationInput>,
 		) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const organization = await adapter.update<InferOrganization<O>>({
 				model: "organization",
 				where: [
@@ -334,6 +345,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			};
 		},
 		deleteOrganization: async (organizationId: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			await adapter.delete({
 				model: "member",
 				where: [
@@ -376,6 +388,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return session as Session;
 		},
 		findOrganizationById: async (organizationId: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const organization = await adapter.findOne<InferOrganization<O>>({
 				model: "organization",
 				where: [
@@ -394,6 +407,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			userId: string;
 			organizationId: string;
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const member = await adapter.findOne<InferMember<O>>({
 				model: "member",
 				where: [
@@ -423,6 +437,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			includeTeams?: boolean;
 			membersLimit?: number;
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const org = await adapter.findOne<InferOrganization<O>>({
 				model: "organization",
 				where: [{ field: isSlug ? "slug" : "id", value: organizationId }],
@@ -487,6 +502,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			};
 		},
 		listOrganizations: async (userId: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const members = await adapter.findMany<InferMember<O>>({
 				model: "member",
 				where: [
@@ -516,6 +532,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return organizations;
 		},
 		createTeam: async (data: Omit<TeamInput, "id">) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const team = await adapter.create<Omit<TeamInput, "id">, InferTeam<O>>({
 				model: "team",
 				data,
@@ -535,6 +552,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					(IncludeMembers extends true ? { members: TeamMember[] } : {}))
 			| null
 		> => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const team = await adapter.findOne<InferTeam<O>>({
 				model: "team",
 				where: [
@@ -581,6 +599,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			teamId: string,
 			data: { name?: string; description?: string; status?: string },
 		) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			if ("id" in data) data.id = undefined;
 			const team = await adapter.update<
 				Team & InferAdditionalFieldsFromPluginOptions<"team", O>
@@ -600,6 +619,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 
 		deleteTeam: async (teamId: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			await adapter.deleteMany({
 				model: "teamMember",
 				where: [
@@ -622,6 +642,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 
 		listTeams: async (organizationId: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const teams = await adapter.findMany<Team>({
 				model: "team",
 				where: [
@@ -649,6 +670,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			inviterId: string;
 			expiresIn?: number;
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const expiresAt = getDate(expiresIn); // Get expiration date
 
 			const invitation = await adapter.create<
@@ -681,6 +703,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 
 		listTeamMembers: async (data: { teamId: string }) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const members = await adapter.findMany<TeamMember>({
 				model: "teamMember",
 				where: [
@@ -694,6 +717,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return members;
 		},
 		countTeamMembers: async (data: { teamId: string }) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const count = await adapter.count({
 				model: "teamMember",
 				where: [{ field: "teamId", value: data.teamId }],
@@ -701,6 +725,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return count;
 		},
 		countMembers: async (data: { organizationId: string }) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const count = await adapter.count({
 				model: "member",
 				where: [{ field: "organizationId", value: data.organizationId }],
@@ -708,6 +733,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return count;
 		},
 		listTeamsByUser: async (data: { userId: string }) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const members = await adapter.findMany<TeamMember>({
 				model: "teamMember",
 				where: [
@@ -733,6 +759,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 
 		findTeamMember: async (data: { teamId: string; userId: string }) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const member = await adapter.findOne<TeamMember>({
 				model: "teamMember",
 				where: [
@@ -754,6 +781,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			teamId: string;
 			userId: string;
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const member = await adapter.findOne<TeamMember>({
 				model: "teamMember",
 				where: [
@@ -781,6 +809,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 
 		removeTeamMember: async (data: { teamId: string; userId: string }) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			await adapter.delete({
 				model: "teamMember",
 				where: [
@@ -797,6 +826,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 
 		findInvitationsByTeamId: async (teamId: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const invitations = await adapter.findMany<InferInvitation<O>>({
 				model: "invitation",
 				where: [
@@ -809,6 +839,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return invitations;
 		},
 		listUserInvitations: async (email: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const invitations = await adapter.findMany<InferInvitation<O>>({
 				model: "invitation",
 				where: [{ field: "email", value: email.toLowerCase() }],
@@ -827,6 +858,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			} & Record<string, any>; // This represents the additionalFields for the invitation
 			user: User;
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const defaultExpiration = 60 * 60 * 48;
 			const expiresAt = getDate(
 				options?.invitationExpiresIn || defaultExpiration,
@@ -850,6 +882,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return invite;
 		},
 		findInvitationById: async (id: string) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const invitation = await adapter.findOne<InferInvitation<O>>({
 				model: "invitation",
 				where: [
@@ -865,6 +898,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			email: string;
 			organizationId: string;
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const invitation = await adapter.findMany<InferInvitation<O>>({
 				model: "invitation",
 				where: [
@@ -887,6 +921,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			);
 		},
 		findPendingInvitations: async (data: { organizationId: string }) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const invitations = await adapter.findMany<InferInvitation<O>>({
 				model: "invitation",
 				where: [
@@ -905,6 +940,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			);
 		},
 		listInvitations: async (data: { organizationId: string }) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const invitations = await adapter.findMany<InferInvitation<O>>({
 				model: "invitation",
 				where: [
@@ -920,6 +956,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			invitationId: string;
 			status: "accepted" | "canceled" | "rejected";
 		}) => {
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const invitation = await adapter.update<InferInvitation<O>>({
 				model: "invitation",
 				where: [

--- a/packages/better-auth/src/plugins/organization/organization-hook.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization-hook.test.ts
@@ -26,7 +26,7 @@ describe("organization creation in database hooks", async () => {
 										name: `${user.email}'s Organization`,
 										slug: `org-${user.id.substring(0, 8)}`,
 										userId: user.id,
-									}
+									},
 								});
 								orgCreated = org;
 							} catch (error) {
@@ -70,7 +70,9 @@ describe("organization creation in database hooks", async () => {
 
 		const createdOrg = orgs.find((o: any) => o.slug?.startsWith("org-"));
 		expect(createdOrg).toBeDefined();
-		expect((createdOrg as any)?.name).toBe("test-hook@example.com's Organization");
+		expect((createdOrg as any)?.name).toBe(
+			"test-hook@example.com's Organization",
+		);
 
 		// Verify the user is a member of the organization
 		const members = await db.findMany({
@@ -79,8 +81,8 @@ describe("organization creation in database hooks", async () => {
 				{
 					field: "organizationId",
 					value: orgCreated?.id,
-				}
-			]
+				},
+			],
 		});
 		expect(members).toHaveLength(1);
 		expect(members[0]).toMatchObject({
@@ -110,7 +112,7 @@ describe("organization creation in database hooks", async () => {
 									name: "Test Org",
 									slug: "duplicate-test-org", // Same slug for all users
 									userId: user.id,
-								}
+								},
 							});
 							if (!firstUserCreated) {
 								firstUserCreated = true;
@@ -150,9 +152,9 @@ describe("organization creation in database hooks", async () => {
 			where: [
 				{
 					field: "slug",
-					value: "duplicate-test-org"
-				}
-			]
+					value: "duplicate-test-org",
+				},
+			],
 		});
 		expect(orgs).toHaveLength(1);
 
@@ -162,9 +164,9 @@ describe("organization creation in database hooks", async () => {
 			where: [
 				{
 					field: "email",
-					value: "user2-hook@example.com"
-				}
-			]
+					value: "user2-hook@example.com",
+				},
+			],
 		});
 		expect(users).toHaveLength(0);
 	});
@@ -184,12 +186,13 @@ describe("organization creation in database hooks", async () => {
 								return;
 							}
 							// Simulate some async operation
-							await new Promise(resolve => setTimeout(resolve, 10));
+							await new Promise((resolve) => setTimeout(resolve, 10));
 							asyncOperationsCompleted++;
 
 							// Check if user exists in the transaction context
 							// This should work because we're in the same transaction
-							const foundUser = await ctx?.context?.internalAdapter?.findUserById?.(user.id);
+							const foundUser =
+								await ctx?.context?.internalAdapter?.findUserById?.(user.id);
 							foundUserInTransaction = !!foundUser;
 
 							// Create organization
@@ -198,11 +201,11 @@ describe("organization creation in database hooks", async () => {
 									name: `Async Org for ${user.name}`,
 									slug: `async-${user.id.substring(0, 8)}`,
 									userId: user.id,
-								}
+								},
 							});
 
 							// Another async operation
-							await new Promise(resolve => setTimeout(resolve, 10));
+							await new Promise((resolve) => setTimeout(resolve, 10));
 							asyncOperationsCompleted++;
 
 							return org;
@@ -232,9 +235,9 @@ describe("organization creation in database hooks", async () => {
 				{
 					field: "slug",
 					operator: "contains",
-					value: "async-"
-				}
-			]
+					value: "async-",
+				},
+			],
 		});
 		expect(orgs.length).toBeGreaterThanOrEqual(1);
 
@@ -258,7 +261,7 @@ describe("organization creation in database hooks", async () => {
 								data: {
 									...user,
 									image: "prepared-in-before-hook",
-								}
+								},
 							};
 						},
 						after: async (user) => {
@@ -272,7 +275,7 @@ describe("organization creation in database hooks", async () => {
 									name: `Before-After Org`,
 									slug: `before-after-${user.id.substring(0, 8)}`,
 									userId: user.id,
-								}
+								},
 							});
 							orgId = org?.id || null;
 						},
@@ -298,8 +301,8 @@ describe("organization creation in database hooks", async () => {
 				{
 					field: "id",
 					value: orgId!,
-				}
-			]
+				},
+			],
 		});
 		expect(org).toBeDefined();
 		expect((org as any)?.name).toBe("Before-After Org");

--- a/packages/better-auth/src/plugins/organization/organization-hook.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization-hook.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { organization } from ".";
+
+describe("organization creation in database hooks", async () => {
+	it("should create organization in user creation after hook within transaction", async () => {
+		let hookCalledForTestEmail = false;
+		let orgCreated: any = null;
+		let errorInHook: any = null;
+
+		const { auth, client, db } = await getTestInstance({
+			plugins: [organization()],
+			databaseHooks: {
+				user: {
+					create: {
+						after: async (user) => {
+							// Only run for our specific test user
+							if (user.email !== "test-hook@example.com") {
+								return;
+							}
+							hookCalledForTestEmail = true;
+							try {
+								// This should work now that the adapter uses getCurrentAdapter
+								const org = await auth.api.createOrganization({
+									body: {
+										name: `${user.email}'s Organization`,
+										slug: `org-${user.id.substring(0, 8)}`,
+										userId: user.id,
+									}
+								});
+								orgCreated = org;
+							} catch (error) {
+								errorInHook = error;
+								throw error;
+							}
+						},
+					},
+				},
+			},
+		});
+
+		// Create a user which should trigger the hook
+		const result = await client.signUp.email({
+			email: "test-hook@example.com",
+			password: "password123",
+			name: "Test Hook User",
+		});
+
+		// Verify the user was created
+		expect(result.data).toBeDefined();
+		expect(result.data?.user).toBeDefined();
+		expect(result.data?.user?.email).toBe("test-hook@example.com");
+
+		// Verify the hook was called
+		expect(hookCalledForTestEmail).toBe(true);
+
+		expect(errorInHook).toBeNull();
+
+		// Verify organization was created successfully
+		expect(orgCreated).not.toBeNull();
+		expect(orgCreated?.name).toBe("test-hook@example.com's Organization");
+		expect(orgCreated?.slug).toMatch(/^org-/);
+
+		// Verify the organization exists in the database
+		const orgs = await db.findMany({
+			model: "organization",
+		});
+		// Should have the test user's org from getTestInstance plus our new one
+		expect(orgs.length).toBeGreaterThanOrEqual(1);
+
+		const createdOrg = orgs.find((o: any) => o.slug?.startsWith("org-"));
+		expect(createdOrg).toBeDefined();
+		expect((createdOrg as any)?.name).toBe("test-hook@example.com's Organization");
+
+		// Verify the user is a member of the organization
+		const members = await db.findMany({
+			model: "member",
+			where: [
+				{
+					field: "organizationId",
+					value: orgCreated?.id,
+				}
+			]
+		});
+		expect(members).toHaveLength(1);
+		expect(members[0]).toMatchObject({
+			userId: result.data?.user?.id,
+			organizationId: orgCreated?.id,
+			role: "owner",
+		});
+	});
+
+	it("should handle errors gracefully when organization creation fails in hook", async () => {
+		let firstUserCreated = false;
+		let errorOnSecondUser: any = null;
+
+		const { auth, client, db } = await getTestInstance({
+			plugins: [organization()],
+			databaseHooks: {
+				user: {
+					create: {
+						after: async (user) => {
+							// Skip test instance default user
+							if (!user.email?.includes("-hook@")) {
+								return;
+							}
+							// Try to create an org with duplicate slug (will fail on second user)
+							await auth.api.createOrganization({
+								body: {
+									name: "Test Org",
+									slug: "duplicate-test-org", // Same slug for all users
+									userId: user.id,
+								}
+							});
+							if (!firstUserCreated) {
+								firstUserCreated = true;
+							}
+						},
+					},
+				},
+			},
+		});
+
+		// First user should succeed
+		const result1 = await client.signUp.email({
+			email: "user1-hook@example.com",
+			password: "password123",
+			name: "User 1",
+		});
+		expect(result1.data).toBeDefined();
+		expect(result1.data?.user?.email).toBe("user1-hook@example.com");
+		expect(firstUserCreated).toBe(true);
+
+		// Second user should fail due to duplicate org slug
+		try {
+			await client.signUp.email({
+				email: "user2-hook@example.com",
+				password: "password123",
+				name: "User 2",
+			});
+		} catch (error) {
+			errorOnSecondUser = error;
+		}
+
+		expect(errorOnSecondUser).toBeDefined();
+
+		// Verify only one organization with our test slug was created
+		const orgs = await db.findMany({
+			model: "organization",
+			where: [
+				{
+					field: "slug",
+					value: "duplicate-test-org"
+				}
+			]
+		});
+		expect(orgs).toHaveLength(1);
+
+		// Verify only the first user exists (transaction should have rolled back for second user)
+		const users = await db.findMany({
+			model: "user",
+			where: [
+				{
+					field: "email",
+					value: "user2-hook@example.com"
+				}
+			]
+		});
+		expect(users).toHaveLength(0);
+	});
+
+	it("should work with multiple async operations in the hook", async () => {
+		let asyncOperationsCompleted = 0;
+		let foundUserInTransaction = false;
+
+		const { auth, client, db } = await getTestInstance({
+			plugins: [organization()],
+			databaseHooks: {
+				user: {
+					create: {
+						after: async (user, ctx): Promise<any> => {
+							// Skip test instance default user
+							if (user.email !== "async-hook@example.com") {
+								return;
+							}
+							// Simulate some async operation
+							await new Promise(resolve => setTimeout(resolve, 10));
+							asyncOperationsCompleted++;
+
+							// Check if user exists in the transaction context
+							// This should work because we're in the same transaction
+							const foundUser = await ctx?.context?.internalAdapter?.findUserById?.(user.id);
+							foundUserInTransaction = !!foundUser;
+
+							// Create organization
+							const org = await auth.api.createOrganization({
+								body: {
+									name: `Async Org for ${user.name}`,
+									slug: `async-${user.id.substring(0, 8)}`,
+									userId: user.id,
+								}
+							});
+
+							// Another async operation
+							await new Promise(resolve => setTimeout(resolve, 10));
+							asyncOperationsCompleted++;
+
+							return org;
+						},
+					},
+				},
+			},
+		});
+
+		const result = await client.signUp.email({
+			email: "async-hook@example.com",
+			password: "password123",
+			name: "Async User",
+		});
+
+		expect(result.data).toBeDefined();
+		expect(result.data?.user?.email).toBe("async-hook@example.com");
+
+		// Verify async operations completed
+		expect(asyncOperationsCompleted).toBe(2);
+		expect(foundUserInTransaction).toBe(true);
+
+		// Verify organization was created
+		const orgs = await db.findMany({
+			model: "organization",
+			where: [
+				{
+					field: "slug",
+					operator: "contains",
+					value: "async-"
+				}
+			]
+		});
+		expect(orgs.length).toBeGreaterThanOrEqual(1);
+
+		const asyncOrg = orgs.find((o: any) => o.name?.includes("Async Org"));
+		expect(asyncOrg).toBeDefined();
+		expect((asyncOrg as any)?.name).toBe("Async Org for Async User");
+	});
+
+	it("should work when creating organization from before hook", async () => {
+		let orgId: string | null = null;
+
+		const { auth, client, db } = await getTestInstance({
+			plugins: [organization()],
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => {
+							// We can't create the org here since user doesn't have an ID yet
+							// But we can prepare the data
+							return {
+								data: {
+									...user,
+									image: "prepared-in-before-hook",
+								}
+							};
+						},
+						after: async (user) => {
+							// Skip test instance default user
+							if (user.email !== "before-hook@example.com") {
+								return;
+							}
+							// Now we can create the org with the user ID
+							const org = await auth.api.createOrganization({
+								body: {
+									name: `Before-After Org`,
+									slug: `before-after-${user.id.substring(0, 8)}`,
+									userId: user.id,
+								}
+							});
+							orgId = org?.id || null;
+						},
+					},
+				},
+			},
+		});
+
+		const result = await client.signUp.email({
+			email: "before-hook@example.com",
+			password: "password123",
+			name: "Before Hook User",
+		});
+
+		expect(result.data).toBeDefined();
+		expect(result.data?.user?.image).toBe("prepared-in-before-hook");
+		expect(orgId).not.toBeNull();
+
+		// Verify organization was created
+		const org = await db.findOne({
+			model: "organization",
+			where: [
+				{
+					field: "id",
+					value: orgId!,
+				}
+			]
+		});
+		expect(org).toBeDefined();
+		expect((org as any)?.name).toBe("Before-After Org");
+	});
+});


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4718
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use the active, transaction-aware adapter in the organization plugin so all org/team/member operations run inside the current DB transaction. Adds tests to verify hook-driven org creation works and rolls back on errors. Fixes better-auth/better-auth#4718.

- **Bug Fixes**
  - Resolve adapter from async context via getCurrentAdapter in all organization adapter methods.
  - Ensure org creation and membership writes inside user create hooks share the same transaction and rollback on failure.
  - Added tests covering: after/before user hooks, duplicate-slug rollback, and multiple async steps within the same transaction.

<!-- End of auto-generated description by cubic. -->

