### PR TITLE
fix: allow disable database transaction

### DIFF
--- a/packages/better-auth/src/__snapshots__/init.test.ts.snap
+++ b/packages/better-auth/src/__snapshots__/init.test.ts.snap
@@ -24,6 +24,7 @@ exports[`init > should match config 1`] = `
         "usePlural": undefined,
       },
       "debugLogs": false,
+      "transaction": undefined,
       "type": "sqlite",
     },
     "transaction": [Function],

--- a/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
@@ -57,6 +57,7 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		return {
 			kysely: null,
 			databaseType: null,
+			transaction: undefined,
 		};
 	}
 
@@ -64,6 +65,7 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		return {
 			kysely: db.db,
 			databaseType: db.type,
+			transaction: db.transaction,
 		};
 	}
 
@@ -71,6 +73,7 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		return {
 			kysely: new Kysely<any>({ dialect: db.dialect }),
 			databaseType: db.type,
+			transaction: db.transaction,
 		};
 	}
 
@@ -139,5 +142,6 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 	return {
 		kysely: dialect ? new Kysely<any>({ dialect }) : null,
 		databaseType,
+		transaction: undefined,
 	};
 };

--- a/packages/better-auth/src/db/utils.ts
+++ b/packages/better-auth/src/db/utils.ts
@@ -24,7 +24,7 @@ export async function getAdapter(options: BetterAuthOptions): Promise<Adapter> {
 		return options.database(options);
 	}
 
-	const { kysely, databaseType } = await createKyselyAdapter(options);
+	const { kysely, databaseType, transaction } = await createKyselyAdapter(options);
 	if (!kysely) {
 		throw new BetterAuthError("Failed to initialize database adapter");
 	}
@@ -32,6 +32,7 @@ export async function getAdapter(options: BetterAuthOptions): Promise<Adapter> {
 		type: databaseType || "sqlite",
 		debugLogs:
 			"debugLogs" in options.database ? options.database.debugLogs : false,
+		transaction: transaction,
 	})(options);
 }
 

--- a/packages/better-auth/src/db/utils.ts
+++ b/packages/better-auth/src/db/utils.ts
@@ -24,7 +24,8 @@ export async function getAdapter(options: BetterAuthOptions): Promise<Adapter> {
 		return options.database(options);
 	}
 
-	const { kysely, databaseType, transaction } = await createKyselyAdapter(options);
+	const { kysely, databaseType, transaction } =
+		await createKyselyAdapter(options);
 	if (!kysely) {
 		throw new BetterAuthError("Failed to initialize database adapter");
 	}

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -100,6 +100,13 @@ export type BetterAuthOptions = {
 				 * @default false
 				 */
 				debugLogs?: AdapterDebugLogs;
+				/**
+				 * Whether to execute multiple operations in a transaction.
+				 * If the database doesn't support transactions,
+				 * set this to `false` and operations will be executed sequentially.
+				 * @default true
+				 */
+				transaction?: boolean;
 		  }
 		| {
 				/**
@@ -122,6 +129,13 @@ export type BetterAuthOptions = {
 				 * @default false
 				 */
 				debugLogs?: AdapterDebugLogs;
+				/**
+				 * Whether to execute multiple operations in a transaction.
+				 * If the database doesn't support transactions,
+				 * set this to `false` and operations will be executed sequentially.
+				 * @default true
+				 */
+				transaction?: boolean;
 		  };
 	/**
 	 * Secondary storage configuration


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4732
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a transaction flag to BetterAuth database options so you can disable wrapping operations in a DB transaction. This supports drivers without transactions and avoids runtime errors while keeping the default behavior unchanged.

- **New Features**
  - database.transaction?: boolean (default true); set false to run operations sequentially without a transaction.
  - Option is propagated through createKyselyAdapter and passed to kyselyAdapter.

<!-- End of auto-generated description by cubic. -->

