### PR TITLE
chore: remove @ts-expect-error

### DIFF
--- a/packages/better-auth/src/db/utils.ts
+++ b/packages/better-auth/src/db/utils.ts
@@ -3,7 +3,7 @@ import { BetterAuthError } from "../error";
 import type { Adapter, BetterAuthOptions } from "../types";
 import { createKyselyAdapter } from "../adapters/kysely-adapter/dialect";
 import { kyselyAdapter } from "../adapters/kysely-adapter";
-import { memoryAdapter, type MemoryDB } from '../adapters/memory-adapter'
+import { memoryAdapter, type MemoryDB } from "../adapters/memory-adapter";
 import { logger } from "../utils";
 
 export async function getAdapter(options: BetterAuthOptions): Promise<Adapter> {

--- a/packages/better-auth/src/db/utils.ts
+++ b/packages/better-auth/src/db/utils.ts
@@ -3,14 +3,13 @@ import { BetterAuthError } from "../error";
 import type { Adapter, BetterAuthOptions } from "../types";
 import { createKyselyAdapter } from "../adapters/kysely-adapter/dialect";
 import { kyselyAdapter } from "../adapters/kysely-adapter";
-import { memoryAdapter } from "../adapters/memory-adapter";
+import { memoryAdapter, type MemoryDB } from '../adapters/memory-adapter'
 import { logger } from "../utils";
 
 export async function getAdapter(options: BetterAuthOptions): Promise<Adapter> {
 	if (!options.database) {
 		const tables = getAuthTables(options);
-		const memoryDB = Object.keys(tables).reduce((acc, key) => {
-			// @ts-expect-error
+		const memoryDB = Object.keys(tables).reduce<MemoryDB>((acc, key) => {
 			acc[key] = [];
 			return acc;
 		}, {});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed a ts-expect-error by explicitly typing the in-memory DB initialization as MemoryDB and importing the type. Improves type safety for the default memory adapter with no behavior change.

<!-- End of auto-generated description by cubic. -->

