### PR TITLE
fix(organization): remove `autoCreateOnSignUp` option as it's not implemented yet

### DIFF
--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -799,10 +799,4 @@ export interface OrganizationOptions {
 			organization: Organization & Record<string, any>;
 		}) => Promise<void>;
 	};
-	/**
-	 * Automatically create an organization for the user on sign up.
-	 *
-	 * @default false
-	 */
-	autoCreateOrganizationOnSignUp?: boolean;
 }


### PR DESCRIPTION
closes #4334
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed autoCreateOrganizationOnSignUp from OrganizationOptions because it isn’t implemented. This prevents misleading configuration and type confusion.

- **Migration**
  - Remove autoCreateOrganizationOnSignUp from your organization plugin options.
  - No runtime behavior changes; only a type-level removal.

<!-- End of auto-generated description by cubic. -->

