### PR TITLE
test: remove `async` from adapter test

### DIFF
--- a/docs/content/docs/guides/create-a-db-adapter.mdx
+++ b/docs/content/docs/guides/create-a-db-adapter.mdx
@@ -370,7 +370,7 @@ describe("My Adapter Tests", async () => {
     },
   });
 
-  await runAdapterTest({
+  runAdapterTest({
     getAdapter: async (betterAuthOptions = {}) => {
       return adapter(betterAuthOptions);
     },
@@ -398,7 +398,7 @@ describe("My Adapter Numeric ID Tests", async () => {
     },
   });
 
-  await runNumberIdAdapterTest({
+  runNumberIdAdapterTest({
     getAdapter: async (betterAuthOptions = {}) => {
       return adapter(betterAuthOptions);
     },

--- a/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.mysql.test.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.mysql.test.ts
@@ -81,7 +81,7 @@ describe("Drizzle Adapter Tests (MySQL)", async () => {
 		},
 	});
 
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			const db = opts.database;
 			opts.database = undefined;
@@ -184,7 +184,7 @@ describe("Drizzle Adapter Number Id Test (MySQL)", async () => {
 		},
 	});
 
-	await runNumberIdAdapterTest({
+	runNumberIdAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			const db = opts.database;
 			opts.database = undefined;

--- a/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.test.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.test.ts
@@ -70,7 +70,7 @@ describe("Drizzle Adapter Tests", async () => {
 	const db = drizzle(pg);
 	const adapter = drizzleAdapter(db, { provider: "pg", schema });
 
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			const db = opts.database;
 			//@ts-expect-error
@@ -170,7 +170,7 @@ describe("Drizzle Adapter Number Id Test", async () => {
 		},
 	});
 
-	await runNumberIdAdapterTest({
+	runNumberIdAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			const db = opts.database;
 			//@ts-expect-error

--- a/packages/better-auth/src/adapters/kysely-adapter/test/normal/adapter.kysely.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/normal/adapter.kysely.test.ts
@@ -100,7 +100,8 @@ describe("adapter test", async () => {
 			isRunningAdapterTests: true,
 		},
 	});
-	await runAdapterTest({
+
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			return mysqlAdapter(merge(customOptions, mysqlOptions));
 		},
@@ -113,7 +114,7 @@ describe("adapter test", async () => {
 			isRunningAdapterTests: true,
 		},
 	});
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			return sqliteAdapter(merge(customOptions, sqliteOptions));
 		},
@@ -183,7 +184,7 @@ describe("mssql", async () => {
 		await sql`DROP TABLE dbo.users;`.execute(mssql);
 	}
 
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			// const merged = merge( customOptions,opts);
 			// merged.database = opts.database;
@@ -321,7 +322,7 @@ describe("postgres", async () => {
 		await sql`DROP TABLE users;`.execute(pg);
 	}
 
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			// const merged = merge( customOptions,opts);
 			// merged.database = opts.database;
@@ -459,7 +460,7 @@ describe("mysql", async () => {
 		await sql`DROP TABLE users;`.execute(mysql);
 	}
 
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			// const merged = merge( customOptions,opts);
 			// merged.database = opts.database;

--- a/packages/better-auth/src/adapters/kysely-adapter/test/normal/node-sqlite-dialect.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/normal/node-sqlite-dialect.test.ts
@@ -234,7 +234,7 @@ describe.runIf(nodeSqliteSupported)("node-sqlite-dialect", async () => {
 			},
 		});
 
-		await runAdapterTest({
+		runAdapterTest({
 			getAdapter: async (customOptions = {}) => {
 				return adapter(merge(customOptions, opts));
 			},

--- a/packages/better-auth/src/adapters/kysely-adapter/test/number-id/adapter.kysely.number-id.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/number-id/adapter.kysely.number-id.test.ts
@@ -102,7 +102,7 @@ describe("Number ID Adapter tests", async () => {
 			isRunningAdapterTests: false,
 		},
 	});
-	await runNumberIdAdapterTest({
+	runNumberIdAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			const merged = merge(customOptions, mysqlOptions);
 			return mysqlAdapter(merged);
@@ -117,7 +117,7 @@ describe("Number ID Adapter tests", async () => {
 		},
 	});
 
-	await runNumberIdAdapterTest({
+	runNumberIdAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			return sqliteAdapter(merge(customOptions, sqliteOptions));
 		},

--- a/packages/better-auth/src/adapters/memory-adapter/adapter.memory.test.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/adapter.memory.test.ts
@@ -13,7 +13,7 @@ describe("adapter test", async () => {
 			isRunningAdapterTests: true,
 		},
 	});
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			return adapter({
 				user: {
@@ -42,7 +42,7 @@ describe("Number Id Adapter Test", async () => {
 			isRunningAdapterTests: true,
 		},
 	});
-	await runNumberIdAdapterTest({
+	runNumberIdAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			return adapter({
 				...customOptions,

--- a/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
@@ -30,7 +30,7 @@ describe("adapter test", async () => {
 		// MongoDB transactions require a replica set or a sharded cluster
 		// client,
 	});
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			return adapter({
 				user: {

--- a/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
@@ -20,7 +20,7 @@ describe("Adapter tests", async () => {
 		};
 	});
 
-	await runAdapterTest({
+	runAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			const { getAdapter } = await import("./get-adapter");
 			const { adapter } = getAdapter();

--- a/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/adapter.prisma.number-id.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/adapter.prisma.number-id.test.ts
@@ -29,7 +29,7 @@ describe("Number Id Adapter Test", async () => {
 		await clearDb();
 	}, Number.POSITIVE_INFINITY);
 
-	await runNumberIdAdapterTest({
+	runNumberIdAdapterTest({
 		getAdapter: async (customOptions = {}) => {
 			const { getAdapter } = await import("./get-adapter");
 			const { adapter } = getAdapter();

--- a/packages/better-auth/src/adapters/prisma-adapter/test/test-options.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/test-options.ts
@@ -1,9 +1,11 @@
-import type { Adapter } from "../../../types";
+import type { Adapter, BetterAuthAdvancedOptions } from "../../../types";
 import type { BetterAuthOptions } from "../../../types";
 
 export const createTestOptions = (
 	adapter: (options: BetterAuthOptions) => Adapter,
-	useNumberId = false,
+	databaseAdvancedOptions: Required<BetterAuthAdvancedOptions>["database"] = {
+		useNumberId: false,
+	},
 ) =>
 	({
 		database: adapter,
@@ -20,8 +22,6 @@ export const createTestOptions = (
 			modelName: "sessions",
 		},
 		advanced: {
-			database: {
-				useNumberId,
-			},
+			database: databaseAdvancedOptions,
 		},
 	}) satisfies BetterAuthOptions;

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -65,7 +65,7 @@ const numberIdAdapterTests = {
 // biome-ignore lint/performance/noDelete: testing propose
 delete numberIdAdapterTests.SHOULD_NOT_THROW_ON_DELETE_RECORD_NOT_FOUND;
 
-async function adapterTest(
+function adapterTest(
 	{ getAdapter, disableTests: disabledTests, testPrefix }: AdapterTestOptions,
 	internalOptions?: {
 		predefinedOptions: Omit<BetterAuthOptions, "database">;
@@ -1045,11 +1045,11 @@ async function adapterTest(
 	);
 }
 
-export async function runAdapterTest(opts: AdapterTestOptions) {
+export function runAdapterTest(opts: AdapterTestOptions) {
 	return adapterTest(opts);
 }
 
-export async function runNumberIdAdapterTest(opts: NumberIdAdapterTestOptions) {
+export function runNumberIdAdapterTest(opts: NumberIdAdapterTestOptions) {
 	const cleanup: { modelName: string; id: string }[] = [];
 
 	// Generate unique test identifier for this test run to avoid conflicts

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -22,6 +22,136 @@ import type { AdapterDebugLogs } from "../adapters";
 import type { Database as BunDatabase } from "bun:sqlite";
 import type { DatabaseSync } from "node:sqlite";
 
+export type BetterAuthAdvancedOptions = {
+	/**
+	 * Ip address configuration
+	 */
+	ipAddress?: {
+		/**
+		 * List of headers to use for ip address
+		 *
+		 * Ip address is used for rate limiting and session tracking
+		 *
+		 * @example ["x-client-ip", "x-forwarded-for", "cf-connecting-ip"]
+		 *
+		 * @default
+		 * @link https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/utils/get-request-ip.ts#L8
+		 */
+		ipAddressHeaders?: string[];
+		/**
+		 * Disable ip tracking
+		 *
+		 * ⚠︎ This is a security risk and it may expose your application to abuse
+		 */
+		disableIpTracking?: boolean;
+	};
+	/**
+	 * Use secure cookies
+	 *
+	 * @default false
+	 */
+	useSecureCookies?: boolean;
+	/**
+	 * Disable trusted origins check
+	 *
+	 * ⚠︎ This is a security risk and it may expose your application to CSRF attacks
+	 */
+	disableCSRFCheck?: boolean;
+	/**
+	 * Configure cookies to be cross subdomains
+	 */
+	crossSubDomainCookies?: {
+		/**
+		 * Enable cross subdomain cookies
+		 */
+		enabled: boolean;
+		/**
+		 * Additional cookies to be shared across subdomains
+		 */
+		additionalCookies?: string[];
+		/**
+		 * The domain to use for the cookies
+		 *
+		 * By default, the domain will be the root
+		 * domain from the base URL.
+		 */
+		domain?: string;
+	};
+	/*
+	 * Allows you to change default cookie names and attributes
+	 *
+	 * default cookie names:
+	 * - "session_token"
+	 * - "session_data"
+	 * - "dont_remember"
+	 *
+	 * plugins can also add additional cookies
+	 */
+	cookies?: {
+		[key: string]: {
+			name?: string;
+			attributes?: CookieOptions;
+		};
+	};
+	defaultCookieAttributes?: CookieOptions;
+	/**
+	 * Prefix for cookies. If a cookie name is provided
+	 * in cookies config, this will be overridden.
+	 *
+	 * @default
+	 * ```txt
+	 * "appName" -> which defaults to "better-auth"
+	 * ```
+	 */
+	cookiePrefix?: string;
+	/**
+	 * Database configuration.
+	 */
+	database?: {
+		/**
+		 * The default number of records to return from the database
+		 * when using the `findMany` adapter method.
+		 *
+		 * @default 100
+		 */
+		defaultFindManyLimit?: number;
+		/**
+		 * If your database auto increments number ids, set this to `true`.
+		 *
+		 * Note: If enabled, we will not handle ID generation (including if you use `generateId`), and it would be expected that your database will provide the ID automatically.
+		 *
+		 * @default false
+		 */
+		useNumberId?: boolean;
+		/**
+		 * Custom generateId function.
+		 *
+		 * If not provided, random ids will be generated.
+		 * If set to false, the database's auto generated id will be used.
+		 */
+		generateId?:
+			| ((options: {
+					model: LiteralUnion<Models, string>;
+					size?: number;
+			  }) => string | false)
+			| false;
+	};
+	/**
+	 * Custom generateId function.
+	 *
+	 * If not provided, random ids will be generated.
+	 * If set to false, the database's auto generated id will be used.
+	 *
+	 * @deprecated Please use `database.generateId` instead. This will be potentially removed in future releases.
+	 */
+	generateId?:
+		| ((options: {
+				model: LiteralUnion<Models, string>;
+				size?: number;
+		  }) => string)
+		| false;
+};
+
 export type BetterAuthOptions = {
 	/**
 	 * The name of the application
@@ -670,135 +800,7 @@ export type BetterAuthOptions = {
 	/**
 	 * Advanced options
 	 */
-	advanced?: {
-		/**
-		 * Ip address configuration
-		 */
-		ipAddress?: {
-			/**
-			 * List of headers to use for ip address
-			 *
-			 * Ip address is used for rate limiting and session tracking
-			 *
-			 * @example ["x-client-ip", "x-forwarded-for", "cf-connecting-ip"]
-			 *
-			 * @default
-			 * @link https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/utils/get-request-ip.ts#L8
-			 */
-			ipAddressHeaders?: string[];
-			/**
-			 * Disable ip tracking
-			 *
-			 * ⚠︎ This is a security risk and it may expose your application to abuse
-			 */
-			disableIpTracking?: boolean;
-		};
-		/**
-		 * Use secure cookies
-		 *
-		 * @default false
-		 */
-		useSecureCookies?: boolean;
-		/**
-		 * Disable trusted origins check
-		 *
-		 * ⚠︎ This is a security risk and it may expose your application to CSRF attacks
-		 */
-		disableCSRFCheck?: boolean;
-		/**
-		 * Configure cookies to be cross subdomains
-		 */
-		crossSubDomainCookies?: {
-			/**
-			 * Enable cross subdomain cookies
-			 */
-			enabled: boolean;
-			/**
-			 * Additional cookies to be shared across subdomains
-			 */
-			additionalCookies?: string[];
-			/**
-			 * The domain to use for the cookies
-			 *
-			 * By default, the domain will be the root
-			 * domain from the base URL.
-			 */
-			domain?: string;
-		};
-		/*
-		 * Allows you to change default cookie names and attributes
-		 *
-		 * default cookie names:
-		 * - "session_token"
-		 * - "session_data"
-		 * - "dont_remember"
-		 *
-		 * plugins can also add additional cookies
-		 */
-		cookies?: {
-			[key: string]: {
-				name?: string;
-				attributes?: CookieOptions;
-			};
-		};
-		defaultCookieAttributes?: CookieOptions;
-		/**
-		 * Prefix for cookies. If a cookie name is provided
-		 * in cookies config, this will be overridden.
-		 *
-		 * @default
-		 * ```txt
-		 * "appName" -> which defaults to "better-auth"
-		 * ```
-		 */
-		cookiePrefix?: string;
-		/**
-		 * Database configuration.
-		 */
-		database?: {
-			/**
-			 * The default number of records to return from the database
-			 * when using the `findMany` adapter method.
-			 *
-			 * @default 100
-			 */
-			defaultFindManyLimit?: number;
-			/**
-			 * If your database auto increments number ids, set this to `true`.
-			 *
-			 * Note: If enabled, we will not handle ID generation (including if you use `generateId`), and it would be expected that your database will provide the ID automatically.
-			 *
-			 * @default false
-			 */
-			useNumberId?: boolean;
-			/**
-			 * Custom generateId function.
-			 *
-			 * If not provided, random ids will be generated.
-			 * If set to false, the database's auto generated id will be used.
-			 */
-			generateId?:
-				| ((options: {
-						model: LiteralUnion<Models, string>;
-						size?: number;
-				  }) => string | false)
-				| false;
-		};
-		/**
-		 * Custom generateId function.
-		 *
-		 * If not provided, random ids will be generated.
-		 * If set to false, the database's auto generated id will be used.
-		 *
-		 * @deprecated Please use `database.generateId` instead. This will be potentially removed in future releases.
-		 */
-		generateId?:
-			| ((options: {
-					model: LiteralUnion<Models, string>;
-					size?: number;
-			  }) => string)
-			| false;
-	};
+	advanced?: BetterAuthAdvancedOptions;
 	logger?: Logger;
 	/**
 	 * allows you to define custom hooks that can be


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make adapter test runners synchronous by removing async/await usage in tests and docs. Also extract BetterAuthAdvancedOptions as a standalone type and reference it from BetterAuthOptions.

- **Refactors**
  - runAdapterTest and runNumberIdAdapterTest are no longer async; adapterTest updated to match.
  - Tests and docs now call the test runners without await.
  - Extracted BetterAuthAdvancedOptions and used it in BetterAuthOptions (types only).

- **Migration**
  - Remove await when calling runAdapterTest and runNumberIdAdapterTest.
  - If you use createTestOptions in tests, pass advanced.database options instead of a useNumberId boolean.

<!-- End of auto-generated description by cubic. -->

