### PR TITLE
fix(client): baseURL is undefined for SSR

### DIFF
--- a/packages/better-auth/src/client/client-ssr.test.ts
+++ b/packages/better-auth/src/client/client-ssr.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { createAuthClient as createVueClient } from "./vue";
+
+it("should call '/api/auth' if no baseURL is provided", async () => {
+	const customFetchImpl = vi.fn(async (url: string | Request | URL) => {
+		expect(url).toBe("/api/auth/get-session");
+		return new Response();
+	});
+	const originalEnv = process.env;
+	process.env = {};
+	// use DisposableStack when Node.js 24 is the minimum requirement
+	using _ = {
+		[Symbol.dispose]() {
+			process.env = originalEnv;
+		},
+	};
+	const client = createVueClient({
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	await client.getSession();
+	expect(customFetchImpl).toBeCalled();
+});

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -9,7 +9,8 @@ import { parseJSON } from "./parser";
 export const getClientConfig = (options?: ClientOptions) => {
 	/* check if the credentials property is supported. Useful for cf workers */
 	const isCredentialsSupported = "credentials" in Request.prototype;
-	const baseURL = getBaseURL(options?.baseURL, options?.basePath);
+	const baseURL =
+		getBaseURL(options?.baseURL, options?.basePath) ?? "/api/auth";
 	const pluginsFetchPlugins =
 		options?.plugins
 			?.flatMap((plugin) => plugin.fetchPlugins)


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4722
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes SSR clients failing when baseURL is undefined by defaulting to /api/auth. Ensures session requests work on the server.

- **Bug Fixes**
  - Default baseURL to "/api/auth" when not provided (SSR-safe).
  - Added Node SSR test to assert getSession calls "/api/auth/get-session".

- **Refactors**
  - Removed unused await-object.ts.

<!-- End of auto-generated description by cubic. -->

