### PR TITLE
v1.3.13

### DIFF
--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -117,16 +117,9 @@ To sign in with a passkey you can use the `signIn.passkey` method. This will pro
 ```ts
 type signInPasskey = {
     /**
-     * The email of the user to sign in.
-     */
-    email: string = "example@gmail.com"
-    /**
      * Browser autofill, a.k.a. Conditional UI. Read more: https://simplewebauthn.dev/docs/packages/browser#browser-autofill-aka-conditional-ui
     */
     autoFill?: boolean = true
-    /**
-     * The URL to redirect to after the user has signed in.
-    */
 }
 ```
 </APIMethod>
@@ -135,7 +128,6 @@ type signInPasskey = {
 ```ts
 // With post authentication redirect
 await authClient.signIn.passkey({
-    email: "user@example.com",
     autoFill: true,
     fetchOptions: {
         onSuccess(context) {

--- a/packages/better-auth/src/client/client-ssr.test.ts
+++ b/packages/better-auth/src/client/client-ssr.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { createAuthClient as createVueClient } from "./vue";
+
+it("should call '/api/auth' if no baseURL is provided", async () => {
+	const customFetchImpl = vi.fn(async (url: string | Request | URL) => {
+		expect(url).toBe("/api/auth/get-session");
+		return new Response();
+	});
+	const originalEnv = process.env;
+	process.env = {};
+	// use DisposableStack when Node.js 24 is the minimum requirement
+	using _ = {
+		[Symbol.dispose]() {
+			process.env = originalEnv;
+		},
+	};
+	const client = createVueClient({
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	await client.getSession();
+	expect(customFetchImpl).toBeCalled();
+});

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -9,7 +9,8 @@ import { parseJSON } from "./parser";
 export const getClientConfig = (options?: ClientOptions) => {
 	/* check if the credentials property is supported. Useful for cf workers */
 	const isCredentialsSupported = "credentials" in Request.prototype;
-	const baseURL = getBaseURL(options?.baseURL, options?.basePath);
+	const baseURL =
+		getBaseURL(options?.baseURL, options?.basePath) ?? "/api/auth";
 	const pluginsFetchPlugins =
 		options?.plugins
 			?.flatMap((plugin) => plugin.fetchPlugins)

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -85,6 +85,28 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 								},
 							},
 						},
+						session: {
+							create: {
+								async after(session, context) {
+									if (!config.storeInDatabase) return;
+									if (!context) return;
+									const lastUsedLoginMethod =
+										config.customResolveMethod(context);
+									if (lastUsedLoginMethod && session?.userId) {
+										try {
+											await ctx.internalAdapter.updateUser(session.userId, {
+												lastLoginMethod: lastUsedLoginMethod,
+											});
+										} catch (error) {
+											ctx.logger.error(
+												"Failed to update lastLoginMethod",
+												error,
+											);
+										}
+									}
+								},
+							},
+						},
 					},
 				},
 			};

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -1,8 +1,48 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { lastLoginMethod } from ".";
 import { lastLoginMethodClient } from "./client";
-import { parseCookies } from "../../cookies";
+import { parseCookies, parseSetCookieHeader } from "../../cookies";
+import { DEFAULT_SECRET } from "../../utils/constants";
+import type { GoogleProfile } from "../../social-providers/google";
+import { getOAuth2Tokens } from "../../oauth2";
+import { signJWT } from "../../crypto/jwt";
+
+// Mock OAuth2 functions to return valid tokens for testing
+vi.mock("../../oauth2", async (importOriginal) => {
+	const original = (await importOriginal()) as any;
+	return {
+		...original,
+		validateAuthorizationCode: vi
+			.fn()
+			.mockImplementation(async (option: any) => {
+				const data: GoogleProfile = {
+					email: "github-issue-demo@example.com",
+					email_verified: true,
+					name: "OAuth Test User",
+					picture: "https://lh3.googleusercontent.com/a-/AOh14GjQ4Z7Vw",
+					exp: 1234567890,
+					sub: "1234567890",
+					iat: 1234567890,
+					aud: "test",
+					azp: "test",
+					nbf: 1234567890,
+					iss: "test",
+					locale: "en",
+					jti: "test",
+					given_name: "OAuth",
+					family_name: "Test",
+				};
+				const testIdToken = await signJWT(data, DEFAULT_SECRET);
+				const tokens = getOAuth2Tokens({
+					access_token: "test-access-token",
+					refresh_token: "test-refresh-token",
+					id_token: testIdToken,
+				});
+				return tokens;
+			}),
+	};
+});
 
 describe("lastLoginMethod", async () => {
 	const { client, cookieSetter, testUser } = await getTestInstance(
@@ -89,5 +129,134 @@ describe("lastLoginMethod", async () => {
 
 		const cookies = parseCookies(headers.get("cookie") || "");
 		expect(cookies.get("better-auth.last_used_login_method")).toBeUndefined();
+	});
+	it("should update the last login method in the database on subsequent logins", async () => {
+		const { client, auth } = await getTestInstance({
+			plugins: [lastLoginMethod({ storeInDatabase: true })],
+		});
+
+		await client.signUp.email(
+			{
+				email: "test@example.com",
+				password: "password123",
+				name: "Test User",
+			},
+			{ throw: true },
+		);
+
+		const emailSignInData = await client.signIn.email(
+			{
+				email: "test@example.com",
+				password: "password123",
+			},
+			{ throw: true },
+		);
+
+		let session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${emailSignInData.token}`,
+			}),
+		});
+		expect((session?.user as any).lastLoginMethod).toBe("email");
+
+		await client.signOut();
+
+		const emailSignInData2 = await client.signIn.email(
+			{
+				email: "test@example.com",
+				password: "password123",
+			},
+			{ throw: true },
+		);
+
+		session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${emailSignInData2.token}`,
+			}),
+		});
+
+		expect((session?.user as any).lastLoginMethod).toBe("email");
+	});
+
+	it("should update the last login method in the database on subsequent logins with email and OAuth", async () => {
+		const { client, auth } = await getTestInstance({
+			plugins: [lastLoginMethod({ storeInDatabase: true })],
+			account: {
+				accountLinking: {
+					enabled: true,
+					trustedProviders: ["google"],
+				},
+			},
+		});
+
+		await client.signUp.email(
+			{
+				email: "github-issue-demo@example.com",
+				password: "password123",
+				name: "GitHub Issue Demo User",
+			},
+			{ throw: true },
+		);
+
+		const emailSignInData = await client.signIn.email(
+			{
+				email: "github-issue-demo@example.com",
+				password: "password123",
+			},
+			{ throw: true },
+		);
+
+		let session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${emailSignInData.token}`,
+			}),
+		});
+
+		expect((session?.user as any).lastLoginMethod).toBe("email");
+
+		await client.signOut();
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+		});
+		expect(signInRes.data).toMatchObject({
+			url: expect.stringContaining("google.com"),
+			redirect: true,
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+
+		const headers = new Headers();
+		await client.$fetch("/callback/google", {
+			query: {
+				state,
+				code: "test",
+			},
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				const location = context.response.headers.get("location");
+				expect(location).toBeDefined();
+
+				cookieSetter(headers)(context as any);
+
+				const cookies = parseSetCookieHeader(
+					context.response.headers.get("set-cookie") || "",
+				);
+				const lastLoginMethod = cookies.get(
+					"better-auth.last_used_login_method",
+				)?.value;
+				if (lastLoginMethod) {
+					expect(lastLoginMethod).toBe("google");
+				}
+			},
+		});
+
+		const oauthSession = await client.getSession({
+			fetchOptions: {
+				headers: headers,
+			},
+		});
+		expect((oauthSession?.data?.user as any).lastLoginMethod).toBe("google");
 	});
 });

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -799,10 +799,4 @@ export interface OrganizationOptions {
 			organization: Organization & Record<string, any>;
 		}) => Promise<void>;
 	};
-	/**
-	 * Automatically create an organization for the user on sign up.
-	 *
-	 * @default false
-	 */
-	autoCreateOrganizationOnSignUp?: boolean;
 }

--- a/packages/better-auth/src/plugins/passkey/client.ts
+++ b/packages/better-auth/src/plugins/passkey/client.ts
@@ -26,7 +26,6 @@ export const getPasskeyActions = (
 	const signInPasskey = async (
 		opts?: {
 			autoFill?: boolean;
-			email?: string;
 			fetchOptions?: BetterFetchOption;
 		},
 		options?: BetterFetchOption,
@@ -35,9 +34,6 @@ export const getPasskeyActions = (
 			"/passkey/generate-authenticate-options",
 			{
 				method: "POST",
-				body: {
-					email: opts?.email,
-				},
 			},
 		);
 		if (!response.data) {

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -332,16 +332,6 @@ export const passkey = (options?: PasskeyOptions) => {
 				"/passkey/generate-authenticate-options",
 				{
 					method: "POST",
-					body: z
-						.object({
-							email: z
-								.string()
-								.meta({
-									description: "The email address of the user",
-								})
-								.optional(),
-						})
-						.optional(),
 					metadata: {
 						openapi: {
 							description: "Generate authentication options for a passkey",

--- a/packages/better-auth/src/plugins/passkey/passkey.test.ts
+++ b/packages/better-auth/src/plugins/passkey/passkey.test.ts
@@ -53,6 +53,15 @@ describe("passkey", async () => {
 		expect(options).toHaveProperty("userVerification");
 	});
 
+	it("should generate authenticate options without session (discoverable credentials)", async () => {
+		// Test without any session/auth headers - simulating a new sign-in with discoverable credentials
+		const options = await auth.api.generatePasskeyAuthenticationOptions({});
+		expect(options).toBeDefined();
+		expect(options).toHaveProperty("challenge");
+		expect(options).toHaveProperty("rpId");
+		expect(options).toHaveProperty("userVerification");
+	});
+
 	it("should list user passkeys", async () => {
 		const { headers, user } = await signInWithTestUser();
 		const context = await auth.$context;

--- a/packages/better-auth/src/types/api.ts
+++ b/packages/better-auth/src/types/api.ts
@@ -32,18 +32,29 @@ export type InferSessionAPI<API> = API extends {
 			E extends Endpoint
 				? E["path"] extends "/get-session"
 					? {
-							getSession: <R extends boolean>(context: {
+							getSession: <
+								R extends boolean,
+								H extends boolean = false,
+							>(context: {
 								headers: Headers;
 								query?: {
 									disableCookieCache?: boolean;
 									disableRefresh?: boolean;
 								};
 								asResponse?: R;
+								returnHeaders?: H;
 							}) => false extends R
-								? Promise<PrettifyDeep<Awaited<ReturnType<E>>>> & {
-										options: E["options"];
-										path: E["path"];
-									}
+								? H extends true
+									? Promise<{
+											headers: Headers;
+											response: PrettifyDeep<Awaited<ReturnType<E>>>;
+										}>
+									: Promise<
+											PrettifyDeep<Awaited<ReturnType<E>>> & {
+												options: E["options"];
+												path: E["path"];
+											}
+										>
 								: Promise<Response>;
 						}
 					: never


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds returnHeaders to getSession and sets a safe default baseURL (/api/auth) for SSR clients. Also persists the last used login method in the database, removes the passkey email param, and drops an unimplemented organization option.

- **New Features**
  - getSession supports returnHeaders, with correct typing and asResponse precedence.
  - lastLoginMethod plugin saves lastLoginMethod on session create (works with email and OAuth).

- **Bug Fixes**
  - SSR: default client baseURL to /api/auth when undefined.
  - Passkey: remove email from generate-authenticate-options and client signIn.passkey; docs updated.
  - Organization: remove unused autoCreateOrganizationOnSignUp option.

<!-- End of auto-generated description by cubic. -->

