### PR TITLE
fix(mcp): missing Content-Type header for mcp DCR

### DIFF
--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -884,6 +884,7 @@ export const mcp = (options: MCPOptions) => {
 					return new Response(JSON.stringify(responseData), {
 						status: 201,
 						headers: {
+							"Content-Type": "application/json",
 							"Cache-Control": "no-store",
 							Pragma: "no-cache",
 						},

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -79,6 +79,9 @@ describe("mcp", async () => {
 			},
 			onResponse(context) {
 				expect(context.response.status).toBe(201);
+				expect(context.response.headers.get("Content-Type")).toBe(
+					"application/json",
+				);
 			},
 		});
 


### PR DESCRIPTION
**Problem**
The mcp plugin supports dynamically creating clients. The endpoint  "/mcp/register" returns a json response, without the "application/json" content type in the response header, resulting in some providers (for example OpenAI) not accepting the response. 

**Solution**
Added "Content-Type": "application/json" to the response headers for the "/mcp/register" success result (including a test).





    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set the Content-Type header to application/json on successful /mcp/register responses so providers like OpenAI accept the JSON payload. Added a test to verify the header.

<!-- End of auto-generated description by cubic. -->

