### PR TITLE
fix(organization): allow passing id through `beforeCreateOrganization`

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -56,6 +56,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 						? JSON.stringify(data.organization.metadata)
 						: undefined,
 				},
+				forceAllowId: true
 			});
 
 			return {

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -56,7 +56,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 						? JSON.stringify(data.organization.metadata)
 						: undefined,
 				},
-				forceAllowId: true
+				forceAllowId: true,
 			});
 
 			return {


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4751
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make the org adapter respect IDs passed via beforeCreateOrganization. Adds forceAllowId: true so custom IDs are saved instead of being overwritten.

<!-- End of auto-generated description by cubic. -->

