### PR TITLE
fix(organization): pass `ctx` to DB hooks

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1,4 +1,4 @@
-import type { Session, User } from "../../types";
+import type { GenericEndpointContext, Session, User } from "../../types";
 import { getDate } from "../../utils/date";
 import type { OrganizationOptions } from "./types";
 import type {
@@ -378,12 +378,14 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		setActiveOrganization: async (
 			sessionToken: string,
 			organizationId: string | null,
+			ctx: GenericEndpointContext,
 		) => {
 			const session = await context.internalAdapter.updateSession(
 				sessionToken,
 				{
 					activeOrganizationId: organizationId,
 				},
+				ctx,
 			);
 			return session as Session;
 		},
@@ -692,12 +694,17 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return invitation;
 		},
 
-		setActiveTeam: async (sessionToken: string, teamId: string | null) => {
+		setActiveTeam: async (
+			sessionToken: string,
+			teamId: string | null,
+			ctx: GenericEndpointContext,
+		) => {
 			const session = await context.internalAdapter.updateSession(
 				sessionToken,
 				{
 					activeTeamId: teamId,
 				},
+				ctx,
 			);
 			return session as Session;
 		},

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -601,6 +601,7 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 					const updatedSession = await adapter.setActiveTeam(
 						session.session.token,
 						teamId,
+						ctx,
 					);
 
 					await setSessionCookie(ctx, {
@@ -620,6 +621,7 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 			await adapter.setActiveOrganization(
 				session.session.token,
 				invitation.organizationId,
+				ctx,
 			);
 			if (!acceptedI) {
 				return ctx.json(null, {

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -384,7 +384,7 @@ export const removeMember = <O extends OrganizationOptions>(options: O) =>
 				session.session.activeOrganizationId ===
 					toBeRemovedMember.organizationId
 			) {
-				await adapter.setActiveOrganization(session.session.token, null);
+				await adapter.setActiveOrganization(session.session.token, null, ctx);
 			}
 
 			// Run afterRemoveMember hook
@@ -794,7 +794,7 @@ export const leaveOrganization = <O extends OrganizationOptions>(options: O) =>
 			}
 			await adapter.deleteMember(member.id);
 			if (session.session.activeOrganizationId === ctx.body.organizationId) {
-				await adapter.setActiveOrganization(session.session.token, null);
+				await adapter.setActiveOrganization(session.session.token, null, ctx);
 			}
 			return ctx.json(member);
 		},

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -304,6 +304,7 @@ export const createOrganization = <O extends OrganizationOptions>(
 				await adapter.setActiveOrganization(
 					ctx.context.session.session.token,
 					organization.id,
+					ctx,
 				);
 			}
 
@@ -315,6 +316,7 @@ export const createOrganization = <O extends OrganizationOptions>(
 				await adapter.setActiveTeam(
 					ctx.context.session.session.token,
 					teamMember.teamId,
+					ctx,
 				);
 			}
 
@@ -605,7 +607,7 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 				/**
 				 * If the organization is deleted, we set the active organization to null
 				 */
-				await adapter.setActiveOrganization(session.session.token, null);
+				await adapter.setActiveOrganization(session.session.token, null, ctx);
 			}
 
 			const org = await adapter.findOrganizationById(organizationId);
@@ -712,7 +714,7 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 				organizationId: organization.id,
 			});
 			if (!isMember) {
-				await adapter.setActiveOrganization(session.session.token, null);
+				await adapter.setActiveOrganization(session.session.token, null, ctx);
 				throw new APIError("FORBIDDEN", {
 					message:
 						ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
@@ -791,6 +793,7 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 				const updatedSession = await adapter.setActiveOrganization(
 					session.session.token,
 					null,
+					ctx,
 				);
 				await setSessionCookie(ctx, {
 					session: updatedSession,
@@ -829,7 +832,7 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 				organizationId,
 			});
 			if (!isMember) {
-				await adapter.setActiveOrganization(session.session.token, null);
+				await adapter.setActiveOrganization(session.session.token, null, ctx);
 				throw new APIError("FORBIDDEN", {
 					message:
 						ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
@@ -845,6 +848,7 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 			const updatedSession = await adapter.setActiveOrganization(
 				session.session.token,
 				organization.id,
+				ctx,
 			);
 			await setSessionCookie(ctx, {
 				session: updatedSession,

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -700,6 +700,7 @@ export const setActiveTeam = <O extends OrganizationOptions>(options: O) =>
 				const updatedSession = await adapter.setActiveTeam(
 					session.session.token,
 					null,
+					ctx,
 				);
 
 				await setSessionCookie(ctx, {
@@ -745,6 +746,7 @@ export const setActiveTeam = <O extends OrganizationOptions>(options: O) =>
 			const updatedSession = await adapter.setActiveTeam(
 				session.session.token,
 				team.id,
+				ctx,
 			);
 
 			await setSessionCookie(ctx, {


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/4767
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Pass the request context (ctx) to session updates in the organization plugin so DB hooks run with the correct context. Fixes missing context in setActiveOrganization/setActiveTeam flows and closes better-auth/better-auth#4767.

- **Bug Fixes**
  - Adapter: setActiveOrganization and setActiveTeam now accept ctx and pass it to internalAdapter.updateSession.
  - Routes: All call sites updated to forward ctx (create/delete org, set active org/team, invitations, member removal/leave).
  - Ensures DB hooks receive tenant/audit context and execute as expected.

<!-- End of auto-generated description by cubic. -->

