### PR TITLE
fix(api-key): calling client on server side

### DIFF
--- a/e2e/smoke/test/ssr.ts
+++ b/e2e/smoke/test/ssr.ts
@@ -1,0 +1,76 @@
+import { betterAuth } from "better-auth";
+import { describe, test } from "node:test";
+import { DatabaseSync } from "node:sqlite";
+import { apiKey } from "better-auth/plugins";
+import { createAuthClient } from "better-auth/client";
+import { apiKeyClient } from "better-auth/client/plugins";
+import { getMigrations } from "better-auth/db";
+import assert from "node:assert/strict";
+
+describe("server side client", () => {
+	test("can use api key on server side", async () => {
+		const database = new DatabaseSync(":memory:");
+		const auth = betterAuth({
+			baseURL: "http://localhost:3000",
+			database,
+			socialProviders: {
+				github: {
+					clientId: process.env.GITHUB_CLIENT_ID as string,
+					clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+				},
+			},
+			emailAndPassword: {
+				enabled: true,
+			},
+			plugins: [
+				apiKey({
+					rateLimit: {
+						enabled: false,
+					},
+				}),
+			],
+		});
+
+		const { runMigrations } = await getMigrations(auth.options);
+		await runMigrations();
+
+		const authClient: ReturnType<typeof createAuthClient> = createAuthClient({
+			baseURL: "http://localhost:3000",
+			plugins: [apiKeyClient()],
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					return auth.handler(new Request(url, init));
+				},
+			},
+		});
+
+		const { user } = await auth.api.signUpEmail({
+			body: {
+				name: "Alex",
+				email: "alex@test.com",
+				password: "hello123",
+			},
+		});
+
+		const { key, id, userId } = await auth.api.createApiKey({
+			body: {
+				name: "my-api-key",
+				userId: user.id,
+			},
+		});
+
+		const ret = database.prepare(`SELECT * FROM apiKey;`).all();
+		assert.equal(ret.length, 1);
+		const first = ret.at(-1)!;
+		assert.equal(first.id, id);
+		assert.equal(first.userId, userId);
+
+		await authClient.getSession({
+			fetchOptions: {
+				headers: {
+					"x-api-key": key,
+				},
+			},
+		});
+	});
+});

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -42,7 +42,6 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 
 	for (const [key, endpoint] of Object.entries(endpoints)) {
 		api[key] = async (context) => {
-			debugger;
 			const authContext = await ctx;
 			let internalContext: InternalContext = {
 				...context,

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -1,9 +1,9 @@
 import {
 	APIError,
-	toResponse,
 	type EndpointContext,
 	type EndpointOptions,
 	type InputContext,
+	toResponse,
 } from "better-call";
 import type { AuthEndpoint, AuthMiddleware } from "./call";
 import type { AuthContext, HookEndpointContext } from "../types";
@@ -42,6 +42,7 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 
 	for (const [key, endpoint] of Object.entries(endpoints)) {
 		api[key] = async (context) => {
+			debugger;
 			const authContext = await ctx;
 			let internalContext: InternalContext = {
 				...context,
@@ -81,7 +82,16 @@ export function toAuthEndpoints<E extends Record<string, AuthEndpoint>>(
 				internalContext = defuReplaceArrays(rest, internalContext);
 			} else if (before) {
 				/* Return before hook response if it's anything other than a context return */
-				return before;
+				return context?.asResponse
+					? toResponse(before, {
+							headers: context?.headers,
+						})
+					: context?.returnHeaders
+						? {
+								headers: context?.headers,
+								response: before,
+							}
+						: before;
 			}
 
 			internalContext.asResponse = false;


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/3588
Fixes: https://github.com/better-auth/better-auth/issues/4698
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes server-side usage of the auth client with API keys by correctly handling endpoint “before” responses. Adds an SSR test to cover createAuthClient with a custom fetch and x-api-key.

- **Bug Fixes**
  - Wrap before-hook results based on asResponse/returnHeaders and preserve headers in toResponse to unblock server-side client calls.
  - Added SSR smoke test: create user, issue API key, and call getSession with x-api-key via createAuthClient.

<!-- End of auto-generated description by cubic. -->

