### PR TITLE
chore: add lint rule `noDebugger`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,8 @@
       "suspicious": {
         "noImplicitAnyLet": "warn",
         "noDuplicateObjectKeys": "warn",
-        "noTsIgnore": "error"
+        "noTsIgnore": "error",
+        "noDebugger": "error"
       },
       "performance": {
         "noDelete": "error"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enforce the noDebugger lint rule (error) in Biome to block accidental debugger statements from landing in the codebase.

<!-- End of auto-generated description by cubic. -->

