### PR TITLE
feat: sendOnSignIn check for email sent with username sign in

### DIFF
--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -4,11 +4,11 @@ import type { BetterAuthPlugin } from "../../types/plugins";
 import { APIError } from "better-call";
 import type { Account, InferOptionSchema, User } from "../../types";
 import { setSessionCookie } from "../../cookies";
-import { sendVerificationEmailFn } from "../../api";
 import { BASE_ERROR_CODES } from "../../error/codes";
 import { getSchema, type UsernameSchema } from "./schema";
 import { mergeSchema } from "../../db/schema";
 import { USERNAME_ERROR_CODES as ERROR_CODES } from "./error-codes";
+import { createEmailVerificationToken } from "../../api";
 export * from "./error-codes";
 export type UsernameOptions = {
 	schema?: InferOptionSchema<UsernameSchema>;
@@ -287,10 +287,37 @@ export const username = (options?: UsernameOptions) => {
 					}
 
 					if (
-						!user.emailVerified &&
-						ctx.context.options.emailAndPassword?.requireEmailVerification
+						ctx.context.options?.emailAndPassword?.requireEmailVerification &&
+						!user.emailVerified
 					) {
-						await sendVerificationEmailFn(ctx, user);
+						if (
+							!ctx.context.options?.emailVerification?.sendVerificationEmail
+						) {
+							throw new APIError("FORBIDDEN", {
+								message: ERROR_CODES.EMAIL_NOT_VERIFIED,
+							});
+						}
+
+						if (ctx.context.options?.emailVerification?.sendOnSignIn) {
+							const token = await createEmailVerificationToken(
+								ctx.context.secret,
+								user.email,
+								undefined,
+								ctx.context.options.emailVerification?.expiresIn,
+							);
+							const url = `${ctx.context.baseURL}/verify-email?token=${token}&callbackURL=${
+								ctx.body.callbackURL || "/"
+							}`;
+							await ctx.context.options.emailVerification.sendVerificationEmail(
+								{
+									user: user,
+									url,
+									token,
+								},
+								ctx.request,
+							);
+						}
+
 						throw new APIError("FORBIDDEN", {
 							message: ERROR_CODES.EMAIL_NOT_VERIFIED,
 						});


### PR DESCRIPTION
### Clearly describe what changes you made and why
I have added a check for the "sendOnSignIn" variable when authenticating yourself with usernames. When you sign in with email, this was already present. However, by username (since its a plugin) this wasn't implemented yet, and therefore emails could be spammed when signing in with username.

### Include any relevant context or background
/packages/better-auth/src/plugins/username/index.ts:
Previous behaviour:
```
if (
	!user.emailVerified &&
	ctx.context.options.emailAndPassword?.requireEmailVerification
) {
	await sendVerificationEmailFn(ctx, user);
	throw new APIError("FORBIDDEN", {
		message: ERROR_CODES.EMAIL_NOT_VERIFIED,
	});
}
```
New behaviour: _(copied the flow from email sign-in)_
```
if (
	ctx.context.options?.emailAndPassword?.requireEmailVerification &&
	!user.emailVerified
	) {
		if (
			!ctx.context.options?.emailVerification?.sendVerificationEmail
		) {
			throw new APIError("FORBIDDEN", {
			message: ERROR_CODES.EMAIL_NOT_VERIFIED,
		});
	}
	
	if (ctx.context.options?.emailVerification?.sendOnSignIn) {
		const token = await createEmailVerificationToken(
			ctx.context.secret,
			user.email,
			undefined,
			ctx.context.options.emailVerification?.expiresIn,
		);
		const url = `${ctx.context.baseURL}/verify-email?token=${token}&callbackURL=${
			ctx.body.callbackURL || "/"
		}`;
		await ctx.context.options.emailVerification.sendVerificationEmail(
			{
				user: user,
				url,
				token,
			},
			ctx.request,
		);
	}
	throw new APIError("FORBIDDEN", {
		message: ERROR_CODES.EMAIL_NOT_VERIFIED,
	});
}
```


### List any breaking changes or deprecations
No breaking changes found. All tests still run.

### Add screenshots for UI changes
No UI changes.

### Reference related issues or discussions
Not applicable.