### PR TITLE
feat(passkey): validate multiple passkey origins

### DIFF
--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -61,7 +61,7 @@ export interface PasskeyOptions {
 	 * if this isn't provided. The client itself will
 	 * pass this value.
 	 */
-	origin?: string | null;
+	origin?: string | string[] | null;
 
 	/**
 	 * Allow customization of the authenticatorSelection options
@@ -146,13 +146,13 @@ export const passkey = (options?: PasskeyOptions) => {
 									parameters: {
 										query: {
 											authenticatorAttachment: {
-												description: `Type of authenticator to use for registration. 
-                          "platform" for device-specific authenticators, 
+												description: `Type of authenticator to use for registration.
+                          "platform" for device-specific authenticators,
                           "cross-platform" for authenticators that can be used across devices.`,
 												required: false,
 											},
 											name: {
-												description: `Optional custom name for the passkey. 
+												description: `Optional custom name for the passkey.
                           This can help identify the passkey when managing multiple credentials.`,
 												required: false,
 											},


### PR DESCRIPTION
In simplewebauthn, this can be `string | string[]`, therefore we should allow the same.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allow configuring multiple passkey origins by accepting string or string[] for PasskeyOptions.origin. This matches SimpleWebAuthn and enables validation across multiple domains while staying backward compatible with single-origin setups.

<!-- End of auto-generated description by cubic. -->

