### PR TITLE
fix(docs): set default tab to next-js since react was not listed

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -234,7 +234,7 @@ Create a new file or route in your framework's designated catch-all route handle
   objects and offers helper functions for popular frameworks.
 </Callout>
 
-<Tabs items={["next-js", "nuxt", "svelte-kit", "remix", "solid-start", "hono", "cloudflare-workers", "express", "elysia", "tanstack-start", "expo"]} defaultValue="react">
+<Tabs items={["next-js", "nuxt", "svelte-kit", "remix", "solid-start", "hono", "cloudflare-workers", "express", "elysia", "tanstack-start", "expo"]} defaultValue="next-js">
     <Tab value="next-js">
         ```ts title="/app/api/auth/[...all]/route.ts"
         import { auth } from "@/lib/auth"; // path to your auth file


### PR DESCRIPTION
React wasn’t listed, so defaulting to it looked uneven and easy to skip. Using Next.js keeps the docs consistent.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set the default framework tab in installation docs to Next.js, since React isn’t in the tab list. This ensures the page opens on a valid tab and avoids confusion.

<!-- End of auto-generated description by cubic. -->

