### PR TITLE
fix: allow `getSession` to return `null`

### DIFF
--- a/packages/better-auth/src/types/api.ts
+++ b/packages/better-auth/src/types/api.ts
@@ -25,7 +25,9 @@ export type FilterActions<API> = Omit<
 		: never
 >;
 
-export type InferSessionAPI<API> = API extends { [key: string]: infer E }
+export type InferSessionAPI<API> = API extends {
+	[key: string]: infer E;
+}
 	? UnionToIntersection<
 			E extends Endpoint
 				? E["path"] extends "/get-session"
@@ -42,13 +44,18 @@ export type InferSessionAPI<API> = API extends { [key: string]: infer E }
 								asResponse?: R;
 								returnHeaders?: H;
 							}) => false extends R
-								? Promise<
-										| (PrettifyDeep<Awaited<ReturnType<E>>> & {
-												options: E["options"];
-												path: E["path"];
-										  } & (H extends true ? { headers: Headers } : {}))
-										| null
-									>
+								? H extends true
+									? Promise<{
+											headers: Headers;
+											response: PrettifyDeep<Awaited<ReturnType<E>>> | null;
+										}>
+									: Promise<
+											| (PrettifyDeep<Awaited<ReturnType<E>>> & {
+													options: E["options"];
+													path: E["path"];
+											  })
+											| null
+										>
 								: Promise<Response>;
 						}
 					: never


### PR DESCRIPTION
closes #4790
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allow getSession to return null when no session exists, aligning types with runtime behavior and preventing false-positive type errors. Fixes #4790.

- **Bug Fixes**
  - Updated InferSessionAPI so getSession resolves to the session object (with headers when requested) or null.
  - No breaking changes; runtime behavior unchanged.

<!-- End of auto-generated description by cubic. -->

