### PR TITLE
feat: add onPasswordReset callback for resetting password using email OTP flow

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -1120,6 +1120,15 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							ctx,
 						);
 					}
+					
+					if (ctx.context.options.emailAndPassword?.onPasswordReset) {
+						await ctx.context.options.emailAndPassword.onPasswordReset(
+						{
+							user: user.user,
+						},
+						ctx.request
+						);
+					}
 
 					if (!user.user.emailVerified) {
 						await ctx.context.internalAdapter.updateUser(


### PR DESCRIPTION
  - Enhanced resetPasswordEmailOTP endpoint in packages/better-auth/src/plugins/email-otp/index.ts:1124-1131
  - Added callback invocation after successful password reset and before response

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an onPasswordReset callback to the email OTP password reset flow. It runs after a successful reset and before the response, receiving { user } and the request.

<!-- End of auto-generated description by cubic. -->

