### PR TITLE
fix: OAuth Proxy Multi-Domain Redirect Issue

### DIFF
--- a/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
@@ -74,7 +74,7 @@ describe("oauth-proxy", async () => {
 					throw new Error("Location header not found");
 				}
 				expect(location).toContain(
-					"http://preview-localhost:3000/api/auth/oauth-proxy-callback?callbackURL=%2Fdashboard",
+					"http://preview-localhost:3000/api/auth/oauth-proxy-callback?callbackURL=%2Fdashboard&originalOrigin=http%3A%2F%2Fpreview-localhost%3A3000",
 				);
 				const cookies = new URL(location).searchParams.get("cookies");
 				expect(cookies).toBeTruthy();
@@ -113,4 +113,5 @@ describe("oauth-proxy", async () => {
 			},
 		});
 	});
+
 });


### PR DESCRIPTION
**Description:**
```
- Fix inconsistent URL handling in oauth-proxy plugin for multi-domain setups

**Problem:**
- Users starting OAuth flow on baseURL (myapp.com) were redirected to productionURL (login.myapp.com) after login instead of staying on original domain
- Inconsistent use of baseURL vs productionURL between before/after hooks
- Callback URLs resolved relative to wrong domain in multi-domain environments

**Solution:**
- Updated after hook to use productionURL consistently with before hook  
- Preserve original domain context by passing originalOrigin parameter
- Improve proxy logic for better multi-domain support
- Clean up unnecessary comments for better code readability

**Impact:**
Users now correctly redirected back to their starting domain (myapp.com, tenant1.myapp.com, etc.) after OAuth login, resolving the multi-domain setup issue.
```

**Related Issue:** #4815 (OAuth Proxy Multi-Domain Redirect Bug)

**Files Changed:**
- `packages/better-auth/src/plugins/oauth-proxy/index.ts` - Core fix
- `packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts` - Test updates