### PR TITLE
fix(last-login-method): custom resolver method default logic

### DIFF
--- a/docs/content/docs/plugins/last-login-method.mdx
+++ b/docs/content/docs/plugins/last-login-method.mdx
@@ -344,7 +344,7 @@ export const auth = betterAuth({
                 }
                 
                 // Track magic link authentication
-                if (ctx.path === "/verify-magic-link") {
+                if (ctx.path === "/magic-link/verify") {
                     return "magic-link"
                 }
                 


### PR DESCRIPTION
# Fix: Fallback to default method resolution when customResolveMethod returns null

## Problem

The `lastLoginMethod` plugin's `customResolveMethod` option was not properly falling back to the default resolution logic when it returned `null` or `undefined`. According to the documentation, when `customResolveMethod` returns `null`, it should "use the default resolution logic", but the implementation was not handling this case correctly.

## Solution

- **Extracted default resolution logic**: Moved the default method resolution logic into a separate `defaultResolveMethod` function
- **Added nullish coalescing**: Updated all three places where `customResolveMethod` is called to use the nullish coalescing operator (`??`) to fallback to `defaultResolveMethod` when `customResolveMethod` returns `null` or `undefined`
- **Maintained backward compatibility**: The change is fully backward compatible and doesn't affect existing functionality

## Changes Made

1. **Extracted `defaultResolveMethod` function** (lines 53-58):

   ```typescript
   const defaultResolveMethod = (ctx: GenericEndpointContext) => {
     if (paths.includes(ctx.path)) {
       return ctx.params?.id ? ctx.params.id : ctx.path.split("/").pop();
     }
     return null;
   };
   ```

2. **Updated database hooks** (lines 78-79, 97-98):

   ```typescript
   const lastUsedLoginMethod =
     config.customResolveMethod?.(context) ?? defaultResolveMethod(context);
   ```

3. **Updated middleware handler** (lines 125-126):
   ```typescript
   const lastUsedLoginMethod =
     config.customResolveMethod?.(ctx) ?? defaultResolveMethod(ctx);
   ```

## Documentation Alignment

This change aligns the implementation with the documented behavior in `docs/content/docs/plugins/last-login-method.mdx`:

> **customResolveMethod**: `(ctx: GenericEndpointContext) => string | null`
>
> - Custom function to determine the login method from the request context
> - Return `null` to use the default resolution logic

The documentation explicitly states that returning `null` should trigger the default resolution logic, which this fix now properly implements.

## Testing

- All existing tests continue to pass
- The change is backward compatible
- No breaking changes to the API
- Maintains the same behavior for users who don't provide a `customResolveMethod`

## Documentation Updates

Additionally, this PR includes a documentation fix for the magic link path in the examples:

- **Fixed magic link path**: Updated the documentation example from `/verify-magic-link` to the correct path `/magic-link/verify` to match the actual Better Auth implementation

## Files Changed

- `packages/better-auth/src/plugins/last-login-method/index.ts`
- `docs/content/docs/plugins/last-login-method.mdx`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes lastLoginMethod to correctly fall back to the default logic when customResolveMethod returns null or undefined. Also corrects the magic link docs path; no breaking changes.

- **Bug Fixes**
  - Extracted defaultResolveMethod and used nullish coalescing to fall back in hooks and middleware.
  - Applied the fallback across all call sites (database hooks and middleware).
  - Updated docs example path from /verify-magic-link to /magic-link/verify.

<!-- End of auto-generated description by cubic. -->

