### PR TITLE
docs(jwt): add jwtClient plugin method for token retrieval

### DIFF
--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -56,7 +56,39 @@ Once you've installed the plugin, you can start using the JWT & JWKS plugin to g
 
 ### Retrieve the token
 
-1. Using your session token
+There are multiple ways to retrieve JWT tokens:
+
+1. **Using the client plugin (recommended)**
+
+Add the `jwtClient` plugin to your auth client configuration:
+
+```ts title="auth-client.ts"
+import { createAuthClient } from "better-auth/client"
+import { jwtClient } from "better-auth/client/plugins" // [!code highlight]
+
+export const authClient = createAuthClient({
+  plugins: [
+    jwtClient() // [!code highlight]
+  ]
+})
+```
+
+Then use the client to get JWT tokens:
+
+```ts
+const { data, error } = await authClient.token()
+if (error) {
+  // handle error
+}
+if (data) {
+  const jwtToken = data.token
+  // Use this token for authenticated requests to external services
+}
+```
+
+This is the recommended approach for client applications that need JWT tokens for external API authentication.
+
+2. **Using your session token**
 
 To get the token, call the `/token` endpoint. This will return the following:
   
@@ -76,7 +108,7 @@ await fetch("/api/auth/token", {
 })
 ```
 
-2. From `set-auth-jwt` header
+3. **From `set-auth-jwt` header**
 
 When you call `getSession` method, a JWT is returned in the `set-auth-jwt` header, which you can use to send to your services directly.
 


### PR DESCRIPTION
## Summary
Enhanced the JWT plugin documentation by adding the `jwtClient` plugin as the recommended method for retrieving JWT tokens, reorganising the existing token retrieval methods.

## Changes Made
- Added `jwtClient` plugin configuration example as method 1 (recommended)
- Included proper error handling with `{ data, error }` destructuring pattern
- Reorganized existing token retrieval methods (session token and header methods are now method 2 and 3)
- Added clear setup instructions and usage examples for the client plugin

## Context
The JWT documentation previously only showed server-side and indirect methods for getting tokens. Adding the `jwtClient` plugin method provides users with the recommended client-side approach for JWT token retrieval with proper error handling.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds the jwtClient plugin as the recommended way to retrieve JWTs in the docs, with clear client-side examples and error handling. Reorganizes the existing methods to make selection straightforward.

- **New Features**
  - Added jwtClient plugin setup and token retrieval example using the { data, error } pattern.
  - Marked jwtClient as the recommended client-side approach; moved session token and header methods to 2 and 3.
  - Included brief setup steps and guidance for using tokens with external APIs.

<!-- End of auto-generated description by cubic. -->

