### PR TITLE
chore(docs): lint fix

### DIFF
--- a/docs/components/ai-chat-modal.tsx
+++ b/docs/components/ai-chat-modal.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Send, Loader2, Bot, User, AlertCircle } from "lucide-react";
+import { Send, Bot, User, AlertCircle } from "lucide-react";
 import { MarkdownRenderer } from "./markdown-renderer";
 import { betterFetch } from "@better-fetch/fetch";
 import { atom } from "jotai";

--- a/docs/components/endpoint.tsx
+++ b/docs/components/endpoint.tsx
@@ -1,7 +1,5 @@
 "use client";
-import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Button } from "./ui/button";
 import { useState } from "react";
 
 function Method({ method }: { method: "POST" | "GET" | "DELETE" | "PUT" }) {

--- a/docs/components/nav-mobile.tsx
+++ b/docs/components/nav-mobile.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { ChevronRight, Menu, Search } from "lucide-react";
+import { ChevronRight, Menu } from "lucide-react";
 import Link from "next/link";
 import { Fragment, createContext, useContext, useState } from "react";
 import {
@@ -11,7 +11,6 @@ import {
 import { contents, examples } from "./sidebar-content";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { useSearchContext } from "fumadocs-ui/provider";
 
 interface NavbarMobileContextProps {
 	isOpen: boolean;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "turbo --filter \"./packages/*\" clean && rm -rf node_modules",
     "format": "biome format . --write",
     "lint": "biome check .",
-    "lint:fix": "biome check . --fix",
+    "lint:fix": "biome check . --fix --unsafe",
     "release": "turbo --filter \"./packages/*\" build && bumpp && pnpm -r publish --access public --no-git-checks",
     "release:no-build": "bumpp && pnpm -r publish --access public --no-git-checks --tag next",
     "release:canary": "turbo --filter \"./packages/*\" build && bumpp && pnpm -r publish --access public --tag canary --no-git-checks",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Cleaned up docs components by removing unused imports and updated the lint:fix script to apply Biome’s unsafe fixes. This lowers lint noise and keeps docs builds clean.

- **Refactors**
  - Removed unused imports in ai-chat-modal.tsx, endpoint.tsx, and nav-mobile.tsx.
  - Updated package.json: lint:fix now runs biome check . --fix --unsafe.

<!-- End of auto-generated description by cubic. -->

