### PR TITLE
docs(admin): added missing `updateUser` api

### DIFF
--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -259,6 +259,29 @@ type setUserPassword = {
 ```
 </APIMethod>
 
+### Update user
+
+Update a user's details.
+
+<APIMethod
+  path="/admin/update-user"
+  method="POST"
+  requireSession
+>
+```ts
+type adminUpdateUser = {
+    /**
+     * The user id which you want to update.
+     */
+    userId: string = "user-id"
+    /**
+     * The data to update.
+     */
+    data: Record<string, any> = { name: "John Doe" }
+}
+```
+</APIMethod>
+
 ### Ban User
 
 Bans a user, preventing them from signing in and revokes all of their existing sessions.

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -492,6 +492,21 @@ export const admin = <O extends AdminOptions>(options?: O) => {
 					});
 				},
 			),
+			/**
+			 * ### Endpoint
+			 *
+			 * POST `/admin/update-user`
+			 *
+			 * ### API Methods
+			 *
+			 * **server:**
+			 * `auth.api.adminUpdateUser`
+			 *
+			 * **client:**
+			 * `authClient.admin.updateUser`
+			 *
+			 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/admin#api-method-admin-update-user)
+			 */
 			adminUpdateUser: createAuthEndpoint(
 				"/admin/update-user",
 				{


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds the missing Admin “Update user” API and docs. Exposes POST /admin/update-user (auth.api.adminUpdateUser / authClient.admin.updateUser) to update a user's details with { userId, data }.

<!-- End of auto-generated description by cubic. -->

