### PR TITLE
chore: fix async local storage import

### DIFF
--- a/packages/better-auth/src/context/transaction.ts
+++ b/packages/better-auth/src/context/transaction.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from "node:async_hooks";
+import type { AsyncLocalStorage } from "node:async_hooks";
 import type { Adapter } from "../types";
 
 /**
@@ -14,6 +14,9 @@ const AsyncLocalStoragePromise: Promise<typeof AsyncLocalStorage> = import(
 )
 	.then((mod) => mod.AsyncLocalStorage)
 	.catch((err) => {
+		if ("AsyncLocalStorage" in globalThis) {
+			return (globalThis as any).AsyncLocalStorage;
+		}
 		console.warn(
 			"[better-auth] Warning: AsyncLocalStorage is not available in this environment. Some features may not work as expected.",
 		);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes AsyncLocalStorage import in the transaction context to prevent errors in non-Node environments. Uses a type-only import, dynamically loads AsyncLocalStorage, and falls back to globalThis with a warning when unavailable.

<!-- End of auto-generated description by cubic. -->

