### PR TITLE
fix(api-key): correct refill interval time calculation

### DIFF
--- a/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
@@ -67,7 +67,7 @@ export function getApiKey({
 												type: "number",
 												nullable: true,
 												description:
-													"The interval in which the `remaining` count is refilled by day. Example: 1 // every day",
+													"The interval in milliseconds between refills of the `remaining` count. Example: 3600000 // refill every hour (3600000ms = 1h)",
 											},
 											refillAmount: {
 												type: "number",

--- a/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
@@ -64,7 +64,7 @@ export function listApiKeys({
 													type: "number",
 													nullable: true,
 													description:
-														"The interval in which the `remaining` count is refilled by day. Example: 1 // every day",
+														"The interval in milliseconds between refills of the `remaining` count. Example: 3600000 // refill every hour (3600000ms = 1h)",
 												},
 												refillAmount: {
 													type: "number",

--- a/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
@@ -113,7 +113,7 @@ export function updateApiKey({
 												type: "number",
 												nullable: true,
 												description:
-													"The interval in which the `remaining` count is refilled by day. Example: 1 // every day",
+													"The interval in milliseconds between refills of the `remaining` count. Example: 3600000 // refill every hour (3600000ms = 1h)",
 											},
 											refillAmount: {
 												type: "number",

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -126,7 +126,7 @@ export async function validateApiKey({
 		if (refillInterval && refillAmount) {
 			// if they provide refill info, then we should refill once the interval is reached.
 
-			const timeSinceLastRequest = (now - lastTime) / (1000 * 60 * 60 * 24); // in days
+			const timeSinceLastRequest = now - lastTime;
 			if (timeSinceLastRequest > refillInterval) {
 				remaining = refillAmount;
 				lastRefillAt = new Date();

--- a/packages/better-auth/src/plugins/api-key/types.ts
+++ b/packages/better-auth/src/plugins/api-key/types.ts
@@ -221,9 +221,9 @@ export type ApiKey = {
 	 */
 	userId: string;
 	/**
-	 * The interval in which the `remaining` count is refilled by day
+	 * The interval in milliseconds between refills of the `remaining` count
 	 *
-	 * @example 1 // every day
+	 * @example 3600000 // refill every hour (3600000ms = 1h)
 	 */
 	refillInterval: number | null;
 	/**


### PR DESCRIPTION
# What this PR does
This PR fixes a critical bug in the API key refill mechanism where API key credits weren't being replenished after the specified interval. The bug was caused by a time unit mismatch: the code was calculating elapsed time in days while comparing against `refillInterval` which is specified in milliseconds.

## The Issue
```typescript
const timeSinceLastRequest = (now - lastTime) / (1000 * 60 * 60 * 24); // in days
if (timeSinceLastRequest > refillInterval) {
    remaining = refillAmount;
    lastRefillAt = new Date();
}
```

This meant if a user set `refillInterval: 5000` (5 seconds), the refill would only occur after 5000 days (~13.7 years).

## The Fix
```typescript
const timeSinceLastRequest = (now - lastTime); // in milliseconds
if (timeSinceLastRequest > refillInterval) {
    remaining = refillAmount;
    lastRefillAt = new Date();
}
```

## Benefits
- API keys now correctly replenish their request allowance after the specified interval
- Consistent behavior with documentation which already stated refillInterval was in milliseconds
- Rate limiting and throttling strategies now work as expected

## Documentation Updates
Also updated inconsistent type definitions and comments to ensure all references to refillInterval consistently specify the unit as milliseconds.

## Testing
Tested scenarios:
- API key with refillInterval set to 5 seconds (5000ms)
- API key with refillInterval set to 1 hour (3600000ms)
- Multiple API calls depleting and then waiting for refill
- Concurrent requests during refill periods

## Breaking changes
None for users who followed documentation. The fix aligns the implementation with the documented behavior that refillInterval is measured in milliseconds.

Closes #4336 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the API key refill logic to use milliseconds, so credits refill at the configured interval. Also clarifies docs and types to consistently state milliseconds.

- **Bug Fixes**
  - Compare elapsed time in milliseconds (now - lastTime) to refillInterval.
  - Reset remaining to refillAmount and update lastRefillAt when interval passes.

- **Documentation**
  - Update ApiKey types and route descriptions to specify refillInterval in milliseconds with examples.

<!-- End of auto-generated description by cubic. -->

