### PR TITLE
feat(cli): add mcp client configs from `cli`

### DIFF
--- a/docs/content/docs/introduction.mdx
+++ b/docs/content/docs/introduction.mdx
@@ -27,6 +27,37 @@ Better Auth provides an MCP server so you can use it with any AI model that supp
 
 <AddToCursor />
 
+#### CLI Options
+
+Use the Better Auth CLI to easily add the MCP server to your preferred client:
+
+<Tabs items={["Cursor", "Claude Code", "Open Code", "Manual"]}>
+    <Tab value="Cursor">
+      ```bash title="terminal"
+      pnpm @better-auth/cli mcp --cursor
+      ```
+    </Tab>
+    <Tab value="Claude Code">
+      ```bash title="terminal"
+      pnpm @better-auth/cli mcp --claude-code
+      ```
+    </Tab>
+    <Tab value="Open Code">
+      ```bash title="terminal"
+      pnpm @better-auth/cli mcp --open-code
+      ```
+    </Tab>
+    <Tab value="Manual">
+      ```bash title="terminal"
+      pnpm @better-auth/cli mcp --manual
+      ```
+    </Tab>
+</Tabs>
+
+#### Manual Configuration
+
+Alternatively, you can manually configure the MCP server for each client:
+
 <Tabs items={["Claude Code", "Open Code", "Manual"]}>
     <Tab value="Claude Code">
       ```bash title="terminal"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "@babel/core": "^7.28.4",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
+    "@better-auth/utils": "0.3.0",
     "@clack/prompts": "^0.11.0",
     "@mrleebo/prisma-ast": "^0.13.0",
     "@prisma/client": "^5.22.0",

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 import { execSync } from "child_process";
 import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
 import chalk from "chalk";
 import { base64 } from "@better-auth/utils/base64";
 
@@ -84,32 +86,34 @@ async function handleCursorAction(mcpUrl: string, mcpName: string) {
 }
 
 function handleClaudeCodeAction(mcpUrl: string) {
-	console.log(chalk.bold.blue("🤖 Claude Code MCP Configuration"));
-	console.log(chalk.gray("Run this command in your terminal:"));
-	console.log();
+	console.log(chalk.bold.blue("🤖 Adding Better Auth MCP to Claude Code..."));
+	
+	const command = `claude mcp add --transport http better-auth ${mcpUrl}`;
+	
+	try {
+		execSync(command, { stdio: "inherit" });
+		console.log(chalk.green("\n✓ Claude Code MCP installed successfully!"));
+	} catch (error) {
+		console.log(
+			chalk.yellow(
+				"\n⚠ Could not automatically add to Claude Code. Please run this command manually:",
+			),
+		);
+		console.log(chalk.cyan(command));
+	}
+	
+	console.log(chalk.bold.white("\n✨ Next Steps:"));
 	console.log(
-		chalk.cyan(`claude mcp add --transport http better-auth ${mcpUrl}`),
+		chalk.gray("• The MCP server will be added to your Claude Code configuration"),
 	);
-	console.log();
-	console.log(chalk.bold.white("✨ Next Steps:"));
-	console.log(chalk.gray("• Run the command above in your terminal"));
 	console.log(
-		chalk.gray(
-			"• The MCP server will be added to your Claude Code configuration",
-		),
-	);
-	console.log(
-		chalk.gray(
-			"• You can now use Better Auth features directly in Claude Code",
-		),
+		chalk.gray("• You can now use Better Auth features directly in Claude Code"),
 	);
 }
 
 function handleOpenCodeAction(mcpUrl: string) {
-	console.log(chalk.bold.blue("🔧 Open Code MCP Configuration"));
-	console.log(chalk.gray("Add this configuration to your opencode.json file:"));
-	console.log();
-
+	console.log(chalk.bold.blue("🔧 Adding Better Auth MCP to Open Code..."));
+	
 	const openCodeConfig = {
 		$schema: "https://opencode.ai/config.json",
 		mcp: {
@@ -121,12 +125,37 @@ function handleOpenCodeAction(mcpUrl: string) {
 		},
 	};
 
-	console.log(chalk.cyan(JSON.stringify(openCodeConfig, null, 2)));
-	console.log();
-	console.log(chalk.bold.white("✨ Next Steps:"));
-	console.log(
-		chalk.gray("• Add the configuration above to your opencode.json file"),
-	);
+	const configPath = path.join(process.cwd(), "opencode.json");
+	
+	try {
+		let existingConfig = {};
+		if (fs.existsSync(configPath)) {
+			const existingContent = fs.readFileSync(configPath, "utf8");
+			existingConfig = JSON.parse(existingContent);
+		}
+		
+		const mergedConfig = {
+			...existingConfig,
+			...openCodeConfig,
+			mcp: {
+				...(existingConfig as any).mcp,
+				...openCodeConfig.mcp,
+			},
+		};
+		
+		fs.writeFileSync(configPath, JSON.stringify(mergedConfig, null, 2));
+		console.log(chalk.green(`\n✓ Open Code configuration written to ${configPath}`));
+		console.log(chalk.green("✓ Better Auth MCP added successfully!"));
+	} catch (error) {
+		console.log(
+			chalk.yellow(
+				"\n⚠ Could not automatically write opencode.json. Please add this configuration manually:",
+			),
+		);
+		console.log(chalk.cyan(JSON.stringify(openCodeConfig, null, 2)));
+	}
+	
+	console.log(chalk.bold.white("\n✨ Next Steps:"));
 	console.log(chalk.gray("• Restart Open Code to load the new MCP server"));
 	console.log(
 		chalk.gray("• You can now use Better Auth features directly in Open Code"),
@@ -134,22 +163,41 @@ function handleOpenCodeAction(mcpUrl: string) {
 }
 
 function handleManualAction(mcpUrl: string, mcpName: string) {
-	console.log(chalk.bold.blue("📝 Manual MCP Configuration"));
-	console.log(chalk.gray("Add this configuration to your mcp.json file:"));
-	console.log();
-
+	console.log(chalk.bold.blue("📝 Adding Better Auth MCP Configuration..."));
+	
 	const manualConfig = {
 		[mcpName]: {
 			url: mcpUrl,
 		},
 	};
 
-	console.log(chalk.cyan(JSON.stringify(manualConfig, null, 2)));
-	console.log();
-	console.log(chalk.bold.white("✨ Next Steps:"));
-	console.log(
-		chalk.gray("• Add the configuration above to your mcp.json file"),
-	);
+	const configPath = path.join(process.cwd(), "mcp.json");
+	
+	try {
+		let existingConfig = {};
+		if (fs.existsSync(configPath)) {
+			const existingContent = fs.readFileSync(configPath, "utf8");
+			existingConfig = JSON.parse(existingContent);
+		}
+		
+		const mergedConfig = {
+			...existingConfig,
+			...manualConfig,
+		};
+		
+		fs.writeFileSync(configPath, JSON.stringify(mergedConfig, null, 2));
+		console.log(chalk.green(`\n✓ MCP configuration written to ${configPath}`));
+		console.log(chalk.green("✓ Better Auth MCP added successfully!"));
+	} catch (error) {
+		console.log(
+			chalk.yellow(
+				"\n⚠ Could not automatically write mcp.json. Please add this configuration manually:",
+			),
+		);
+		console.log(chalk.cyan(JSON.stringify(manualConfig, null, 2)));
+	}
+	
+	console.log(chalk.bold.white("\n✨ Next Steps:"));
 	console.log(chalk.gray("• Restart your MCP client to load the new server"));
 	console.log(
 		chalk.gray(

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -87,9 +87,9 @@ async function handleCursorAction(mcpUrl: string, mcpName: string) {
 
 function handleClaudeCodeAction(mcpUrl: string) {
 	console.log(chalk.bold.blue("🤖 Adding Better Auth MCP to Claude Code..."));
-	
+
 	const command = `claude mcp add --transport http better-auth ${mcpUrl}`;
-	
+
 	try {
 		execSync(command, { stdio: "inherit" });
 		console.log(chalk.green("\n✓ Claude Code MCP installed successfully!"));
@@ -101,19 +101,23 @@ function handleClaudeCodeAction(mcpUrl: string) {
 		);
 		console.log(chalk.cyan(command));
 	}
-	
+
 	console.log(chalk.bold.white("\n✨ Next Steps:"));
 	console.log(
-		chalk.gray("• The MCP server will be added to your Claude Code configuration"),
+		chalk.gray(
+			"• The MCP server will be added to your Claude Code configuration",
+		),
 	);
 	console.log(
-		chalk.gray("• You can now use Better Auth features directly in Claude Code"),
+		chalk.gray(
+			"• You can now use Better Auth features directly in Claude Code",
+		),
 	);
 }
 
 function handleOpenCodeAction(mcpUrl: string) {
 	console.log(chalk.bold.blue("🔧 Adding Better Auth MCP to Open Code..."));
-	
+
 	const openCodeConfig = {
 		$schema: "https://opencode.ai/config.json",
 		mcp: {
@@ -126,14 +130,14 @@ function handleOpenCodeAction(mcpUrl: string) {
 	};
 
 	const configPath = path.join(process.cwd(), "opencode.json");
-	
+
 	try {
 		let existingConfig = {};
 		if (fs.existsSync(configPath)) {
 			const existingContent = fs.readFileSync(configPath, "utf8");
 			existingConfig = JSON.parse(existingContent);
 		}
-		
+
 		const mergedConfig = {
 			...existingConfig,
 			...openCodeConfig,
@@ -142,9 +146,11 @@ function handleOpenCodeAction(mcpUrl: string) {
 				...openCodeConfig.mcp,
 			},
 		};
-		
+
 		fs.writeFileSync(configPath, JSON.stringify(mergedConfig, null, 2));
-		console.log(chalk.green(`\n✓ Open Code configuration written to ${configPath}`));
+		console.log(
+			chalk.green(`\n✓ Open Code configuration written to ${configPath}`),
+		);
 		console.log(chalk.green("✓ Better Auth MCP added successfully!"));
 	} catch (error) {
 		console.log(
@@ -154,7 +160,7 @@ function handleOpenCodeAction(mcpUrl: string) {
 		);
 		console.log(chalk.cyan(JSON.stringify(openCodeConfig, null, 2)));
 	}
-	
+
 	console.log(chalk.bold.white("\n✨ Next Steps:"));
 	console.log(chalk.gray("• Restart Open Code to load the new MCP server"));
 	console.log(
@@ -164,7 +170,7 @@ function handleOpenCodeAction(mcpUrl: string) {
 
 function handleManualAction(mcpUrl: string, mcpName: string) {
 	console.log(chalk.bold.blue("📝 Adding Better Auth MCP Configuration..."));
-	
+
 	const manualConfig = {
 		[mcpName]: {
 			url: mcpUrl,
@@ -172,19 +178,19 @@ function handleManualAction(mcpUrl: string, mcpName: string) {
 	};
 
 	const configPath = path.join(process.cwd(), "mcp.json");
-	
+
 	try {
 		let existingConfig = {};
 		if (fs.existsSync(configPath)) {
 			const existingContent = fs.readFileSync(configPath, "utf8");
 			existingConfig = JSON.parse(existingContent);
 		}
-		
+
 		const mergedConfig = {
 			...existingConfig,
 			...manualConfig,
 		};
-		
+
 		fs.writeFileSync(configPath, JSON.stringify(mergedConfig, null, 2));
 		console.log(chalk.green(`\n✓ MCP configuration written to ${configPath}`));
 		console.log(chalk.green("✓ Better Auth MCP added successfully!"));
@@ -196,7 +202,7 @@ function handleManualAction(mcpUrl: string, mcpName: string) {
 		);
 		console.log(chalk.cyan(JSON.stringify(manualConfig, null, 2)));
 	}
-	
+
 	console.log(chalk.bold.white("\n✨ Next Steps:"));
 	console.log(chalk.gray("• Restart your MCP client to load the new server"));
 	console.log(

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,147 @@
+import { Command } from "commander";
+import { execSync } from "child_process";
+import * as os from "os";
+import chalk from "chalk";
+import { base64 } from "@better-auth/utils/base64";
+
+interface MCPOptions {
+	cursor?: boolean;
+	claudeCode?: boolean;
+	openCode?: boolean;
+	manual?: boolean;
+}
+
+export async function mcpAction(options: MCPOptions) {
+	const mcpUrl = "https://mcp.chonkie.ai/better-auth/better-auth-builder/mcp";
+	const mcpName = "Better Auth";
+
+	if (options.cursor) {
+		await handleCursorAction(mcpUrl, mcpName);
+	} else if (options.claudeCode) {
+		handleClaudeCodeAction(mcpUrl);
+	} else if (options.openCode) {
+		handleOpenCodeAction(mcpUrl);
+	} else if (options.manual) {
+		handleManualAction(mcpUrl, mcpName);
+	} else {
+		showAllOptions(mcpUrl, mcpName);
+	}
+}
+
+async function handleCursorAction(mcpUrl: string, mcpName: string) {
+	const mcpConfig = {
+		url: mcpUrl,
+	};
+
+	const encodedConfig = base64.encode(new TextEncoder().encode(JSON.stringify(mcpConfig)));
+	const deeplinkUrl = `cursor://anysphere.cursor-deeplink/mcp/install?name=${encodeURIComponent(mcpName)}&config=${encodedConfig}`;
+
+	console.log(chalk.bold.blue("🚀 Adding Better Auth MCP to Cursor..."));
+
+	try {
+		const platform = os.platform();
+		let command: string;
+
+		switch (platform) {
+			case "darwin":
+				command = `open "${deeplinkUrl}"`;
+				break;
+			case "win32":
+				command = `start "" "${deeplinkUrl}"`;
+				break;
+			case "linux":
+				command = `xdg-open "${deeplinkUrl}"`;
+				break;
+			default:
+				throw new Error(`Unsupported platform: ${platform}`);
+		}
+
+		execSync(command, { stdio: "inherit" });
+		console.log(chalk.green("\n✓ Cursor MCP installed successfully!"));
+	} catch (error) {
+		console.log(chalk.yellow("\n⚠ Could not automatically open Cursor. Please copy the deeplink URL above and open it manually."));
+		console.log(chalk.gray("\nYou can also manually add this configuration to your Cursor MCP settings:"));
+		console.log(chalk.gray(JSON.stringify(mcpConfig, null, 2)));
+	}
+
+	console.log(chalk.bold.white("\n✨ Next Steps:"));
+	console.log(chalk.gray("• The MCP server will be added to your Cursor configuration"));
+	console.log(chalk.gray("• You can now use Better Auth features directly in Cursor"));
+}
+
+function handleClaudeCodeAction(mcpUrl: string) {
+	console.log(chalk.bold.blue("🤖 Claude Code MCP Configuration"));
+	console.log(chalk.gray("Run this command in your terminal:"));
+	console.log();
+	console.log(chalk.cyan(`claude mcp add --transport http better-auth ${mcpUrl}`));
+	console.log();
+	console.log(chalk.bold.white("✨ Next Steps:"));
+	console.log(chalk.gray("• Run the command above in your terminal"));
+	console.log(chalk.gray("• The MCP server will be added to your Claude Code configuration"));
+	console.log(chalk.gray("• You can now use Better Auth features directly in Claude Code"));
+}
+
+function handleOpenCodeAction(mcpUrl: string) {
+	console.log(chalk.bold.blue("🔧 Open Code MCP Configuration"));
+	console.log(chalk.gray("Add this configuration to your opencode.json file:"));
+	console.log();
+	
+	const openCodeConfig = {
+		"$schema": "https://opencode.ai/config.json",
+		"mcp": {
+			"Better Auth": {
+				"type": "remote",
+				"url": mcpUrl,
+				"enabled": true,
+			}
+		}
+	};
+
+	console.log(chalk.cyan(JSON.stringify(openCodeConfig, null, 2)));
+	console.log();
+	console.log(chalk.bold.white("✨ Next Steps:"));
+	console.log(chalk.gray("• Add the configuration above to your opencode.json file"));
+	console.log(chalk.gray("• Restart Open Code to load the new MCP server"));
+	console.log(chalk.gray("• You can now use Better Auth features directly in Open Code"));
+}
+
+function handleManualAction(mcpUrl: string, mcpName: string) {
+	console.log(chalk.bold.blue("📝 Manual MCP Configuration"));
+	console.log(chalk.gray("Add this configuration to your mcp.json file:"));
+	console.log();
+	
+	const manualConfig = {
+		[mcpName]: {
+			"url": mcpUrl
+		}
+	};
+
+	console.log(chalk.cyan(JSON.stringify(manualConfig, null, 2)));
+	console.log();
+	console.log(chalk.bold.white("✨ Next Steps:"));
+	console.log(chalk.gray("• Add the configuration above to your mcp.json file"));
+	console.log(chalk.gray("• Restart your MCP client to load the new server"));
+	console.log(chalk.gray("• You can now use Better Auth features directly in your MCP client"));
+}
+
+function showAllOptions(mcpUrl: string, mcpName: string) {
+	console.log(chalk.bold.blue("🔌 Better Auth MCP Server"));
+	console.log(chalk.gray("Choose your MCP client to get started:"));
+	console.log();
+	
+	console.log(chalk.bold.white("Available Commands:"));
+	console.log(chalk.cyan("  --cursor      ") + chalk.gray("Add to Cursor"));
+	console.log(chalk.cyan("  --claude-code ") + chalk.gray("Add to Claude Code"));
+	console.log(chalk.cyan("  --open-code   ") + chalk.gray("Add to Open Code"));
+	console.log(chalk.cyan("  --manual      ") + chalk.gray("Manual configuration"));
+	console.log();
+	
+}
+
+export const mcp = new Command("mcp")
+	.description("Add Better Auth MCP server to MCP Clients")
+	.option("--cursor", "Automatically open Cursor with the MCP configuration")
+	.option("--claude-code", "Show Claude Code MCP configuration command")
+	.option("--open-code", "Show Open Code MCP configuration")
+	.option("--manual", "Show manual MCP configuration for mcp.json")
+	.action(mcpAction);

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -33,7 +33,9 @@ async function handleCursorAction(mcpUrl: string, mcpName: string) {
 		url: mcpUrl,
 	};
 
-	const encodedConfig = base64.encode(new TextEncoder().encode(JSON.stringify(mcpConfig)));
+	const encodedConfig = base64.encode(
+		new TextEncoder().encode(JSON.stringify(mcpConfig)),
+	);
 	const deeplinkUrl = `cursor://anysphere.cursor-deeplink/mcp/install?name=${encodeURIComponent(mcpName)}&config=${encodedConfig}`;
 
 	console.log(chalk.bold.blue("🚀 Adding Better Auth MCP to Cursor..."));
@@ -59,83 +61,118 @@ async function handleCursorAction(mcpUrl: string, mcpName: string) {
 		execSync(command, { stdio: "inherit" });
 		console.log(chalk.green("\n✓ Cursor MCP installed successfully!"));
 	} catch (error) {
-		console.log(chalk.yellow("\n⚠ Could not automatically open Cursor. Please copy the deeplink URL above and open it manually."));
-		console.log(chalk.gray("\nYou can also manually add this configuration to your Cursor MCP settings:"));
+		console.log(
+			chalk.yellow(
+				"\n⚠ Could not automatically open Cursor. Please copy the deeplink URL above and open it manually.",
+			),
+		);
+		console.log(
+			chalk.gray(
+				"\nYou can also manually add this configuration to your Cursor MCP settings:",
+			),
+		);
 		console.log(chalk.gray(JSON.stringify(mcpConfig, null, 2)));
 	}
 
 	console.log(chalk.bold.white("\n✨ Next Steps:"));
-	console.log(chalk.gray("• The MCP server will be added to your Cursor configuration"));
-	console.log(chalk.gray("• You can now use Better Auth features directly in Cursor"));
+	console.log(
+		chalk.gray("• The MCP server will be added to your Cursor configuration"),
+	);
+	console.log(
+		chalk.gray("• You can now use Better Auth features directly in Cursor"),
+	);
 }
 
 function handleClaudeCodeAction(mcpUrl: string) {
 	console.log(chalk.bold.blue("🤖 Claude Code MCP Configuration"));
 	console.log(chalk.gray("Run this command in your terminal:"));
 	console.log();
-	console.log(chalk.cyan(`claude mcp add --transport http better-auth ${mcpUrl}`));
+	console.log(
+		chalk.cyan(`claude mcp add --transport http better-auth ${mcpUrl}`),
+	);
 	console.log();
 	console.log(chalk.bold.white("✨ Next Steps:"));
 	console.log(chalk.gray("• Run the command above in your terminal"));
-	console.log(chalk.gray("• The MCP server will be added to your Claude Code configuration"));
-	console.log(chalk.gray("• You can now use Better Auth features directly in Claude Code"));
+	console.log(
+		chalk.gray(
+			"• The MCP server will be added to your Claude Code configuration",
+		),
+	);
+	console.log(
+		chalk.gray(
+			"• You can now use Better Auth features directly in Claude Code",
+		),
+	);
 }
 
 function handleOpenCodeAction(mcpUrl: string) {
 	console.log(chalk.bold.blue("🔧 Open Code MCP Configuration"));
 	console.log(chalk.gray("Add this configuration to your opencode.json file:"));
 	console.log();
-	
+
 	const openCodeConfig = {
-		"$schema": "https://opencode.ai/config.json",
-		"mcp": {
+		$schema: "https://opencode.ai/config.json",
+		mcp: {
 			"Better Auth": {
-				"type": "remote",
-				"url": mcpUrl,
-				"enabled": true,
-			}
-		}
+				type: "remote",
+				url: mcpUrl,
+				enabled: true,
+			},
+		},
 	};
 
 	console.log(chalk.cyan(JSON.stringify(openCodeConfig, null, 2)));
 	console.log();
 	console.log(chalk.bold.white("✨ Next Steps:"));
-	console.log(chalk.gray("• Add the configuration above to your opencode.json file"));
+	console.log(
+		chalk.gray("• Add the configuration above to your opencode.json file"),
+	);
 	console.log(chalk.gray("• Restart Open Code to load the new MCP server"));
-	console.log(chalk.gray("• You can now use Better Auth features directly in Open Code"));
+	console.log(
+		chalk.gray("• You can now use Better Auth features directly in Open Code"),
+	);
 }
 
 function handleManualAction(mcpUrl: string, mcpName: string) {
 	console.log(chalk.bold.blue("📝 Manual MCP Configuration"));
 	console.log(chalk.gray("Add this configuration to your mcp.json file:"));
 	console.log();
-	
+
 	const manualConfig = {
 		[mcpName]: {
-			"url": mcpUrl
-		}
+			url: mcpUrl,
+		},
 	};
 
 	console.log(chalk.cyan(JSON.stringify(manualConfig, null, 2)));
 	console.log();
 	console.log(chalk.bold.white("✨ Next Steps:"));
-	console.log(chalk.gray("• Add the configuration above to your mcp.json file"));
+	console.log(
+		chalk.gray("• Add the configuration above to your mcp.json file"),
+	);
 	console.log(chalk.gray("• Restart your MCP client to load the new server"));
-	console.log(chalk.gray("• You can now use Better Auth features directly in your MCP client"));
+	console.log(
+		chalk.gray(
+			"• You can now use Better Auth features directly in your MCP client",
+		),
+	);
 }
 
 function showAllOptions(mcpUrl: string, mcpName: string) {
 	console.log(chalk.bold.blue("🔌 Better Auth MCP Server"));
 	console.log(chalk.gray("Choose your MCP client to get started:"));
 	console.log();
-	
+
 	console.log(chalk.bold.white("Available Commands:"));
 	console.log(chalk.cyan("  --cursor      ") + chalk.gray("Add to Cursor"));
-	console.log(chalk.cyan("  --claude-code ") + chalk.gray("Add to Claude Code"));
+	console.log(
+		chalk.cyan("  --claude-code ") + chalk.gray("Add to Claude Code"),
+	);
 	console.log(chalk.cyan("  --open-code   ") + chalk.gray("Add to Open Code"));
-	console.log(chalk.cyan("  --manual      ") + chalk.gray("Manual configuration"));
+	console.log(
+		chalk.cyan("  --manual      ") + chalk.gray("Manual configuration"),
+	);
 	console.log();
-	
 }
 
 export const mcp = new Command("mcp")

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -132,7 +132,10 @@ function handleOpenCodeAction(mcpUrl: string) {
 	const configPath = path.join(process.cwd(), "opencode.json");
 
 	try {
-		let existingConfig = {};
+		let existingConfig: {
+			mcp?: Record<string, unknown>;
+			[key: string]: unknown;
+		} = {};
 		if (fs.existsSync(configPath)) {
 			const existingContent = fs.readFileSync(configPath, "utf8");
 			existingConfig = JSON.parse(existingContent);
@@ -142,7 +145,7 @@ function handleOpenCodeAction(mcpUrl: string) {
 			...existingConfig,
 			...openCodeConfig,
 			mcp: {
-				...(existingConfig as any).mcp,
+				...existingConfig.mcp,
 				...openCodeConfig.mcp,
 			},
 		};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { generate } from "./commands/generate";
 import { generateSecret } from "./commands/secret";
 import { login } from "./commands/login";
 import { info } from "./commands/info";
+import { mcp } from "./commands/mcp";
 import { getPackageInfo } from "./utils/get-package-info";
 
 import "dotenv/config";
@@ -32,6 +33,7 @@ async function main() {
 		.addCommand(generateSecret)
 		.addCommand(info)
 		.addCommand(login)
+		.addCommand(mcp)
 		.version(packageInfo.version || "1.1.2")
 		.description("Better Auth CLI")
 		.action(() => program.help());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -973,6 +973,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.28.4)
+      '@better-auth/utils':
+        specifier: 0.3.0
+        version: 0.3.0
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a new mcp CLI command to quickly install and configure the Better Auth MCP server for Cursor, Claude Code, Open Code, or manually. Updates docs to show one-command setup options.

- **New Features**
  - New cli mcp command with options: --cursor, --claude-code, --open-code, --manual.
  - Cursor: opens a deep link with a base64-encoded config (macOS, Windows, Linux).
  - Claude Code: prints the claude mcp add command.
  - Open Code: outputs an opencode.json config block.
  - Manual: outputs a minimal mcp.json snippet.
  - Docs updated (introduction) with CLI tabs for quick setup.

- **Dependencies**
  - Added @better-auth/utils 0.3.0 for base64 encoding.

<!-- End of auto-generated description by cubic. -->

