### PR TITLE
[two-factor] fix: forward invalid errorKey when verifying existing session

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -125,9 +125,9 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 				},
 			});
 		},
-		invalid: async () => {
+		invalid: async (errorKey: keyof typeof TWO_FACTOR_ERROR_CODES) => {
 			throw new APIError("UNAUTHORIZED", {
-				message: TWO_FACTOR_ERROR_CODES.INVALID_TWO_FACTOR_COOKIE,
+				message: TWO_FACTOR_ERROR_CODES[errorKey],
 			});
 		},
 		session,


### PR DESCRIPTION
I noticed, while debugging two-factor integration inside my app, that when `verifyTwoFactor` is called with an existing session (to confirm enabling two factor), that error messages are not propagated correctly.