### PR TITLE
Update installation.mdx

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -454,7 +454,7 @@ The client-side library helps you interact with the auth server. Better Auth com
             import { createAuthClient } from "better-auth/solid"
             export const authClient = createAuthClient({
                 /** The base URL of the server (optional if you're using the same domain) */ // [!code highlight]
-                baseURL: "http://localhost:3000" // [!code highlight]
+                baseURL: process.env.BETTER_AUTH_URL,
             })
             ```
     </Tab>


### PR DESCRIPTION
use process.env.BETTER_AUTH_URL instead.

I think it works better?
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use process.env.BETTER_AUTH_URL for the authClient baseURL in the Solid example, replacing the hardcoded localhost value. This makes configuration environment-aware and reduces deployment mistakes.

<!-- End of auto-generated description by cubic. -->

