### PR TITLE
docs: use `createFileRoute` on TanStack API 

### DIFF
--- a/docs/content/docs/integrations/tanstack.mdx
+++ b/docs/content/docs/integrations/tanstack.mdx
@@ -13,15 +13,19 @@ We need to mount the handler to a TanStack API endpoint/Server Route.
 Create a new file: `/src/routes/api/auth/$.ts`
 
 ```ts title="src/routes/api/auth/$.ts"
-import { auth } from '@/lib/auth' // import your auth instance
-import { createServerFileRoute } from '@tanstack/react-start/server'
+import { auth } from '@/lib/auth'
+import { createFileRoute } from '@tanstack/react-router'
 
-export const ServerRoute = createServerFileRoute('/api/auth/$').methods({
-  GET: ({ request }) => {
-    return auth.handler(request)
-  },
-  POST: ({ request }) => {
-    return auth.handler(request)
+export const Route = createFileRoute('/api/auth/$')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        return auth.handler(request)
+      },
+      POST: ({ request }) => {
+        return auth.handler(request)
+      },
+    },
   },
 })
 ```


### PR DESCRIPTION
Updated the TanStack integration example to use createFileRoute instead of createServerFileRoute and added POST method handling.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the TanStack Router integration example to use createFileRoute with server.handlers and add POST support, aligning docs with the current API.

- **Refactors**
  - Replace createServerFileRoute with createFileRoute from @tanstack/react-router.
  - Define GET and POST under server.handlers, both delegating to auth.handler.
  - Export Route instead of ServerRoute.

<!-- End of auto-generated description by cubic. -->

