### PR TITLE
fix(cli): defaultNow is deprecated in schema for Drizzle with SQLite

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -251,7 +251,9 @@ function generateImport({
 				? "text"
 				: "text",
 	);
-	coreImports.push(hasBigint ? (databaseType !== "sqlite" ? "bigint" : "") : "");
+	coreImports.push(
+		hasBigint ? (databaseType !== "sqlite" ? "bigint" : "") : "",
+	);
 	coreImports.push(databaseType !== "sqlite" ? "timestamp, boolean" : "");
 	if (databaseType === "mysql") {
 		// Only include int for MySQL if actually needed
@@ -300,14 +302,16 @@ function generateImport({
 	}
 
 	// Add sql import for SQLite timestamps with defaultNow
-	const hasSQLiteTimestamp = databaseType === "sqlite" &&
-		Object.values(tables).some(table =>
-			Object.values(table.fields).some(field =>
-				field.type === "date" &&
-				field.defaultValue &&
-				typeof field.defaultValue === "function" &&
-				field.defaultValue.toString().includes("new Date()")
-			)
+	const hasSQLiteTimestamp =
+		databaseType === "sqlite" &&
+		Object.values(tables).some((table) =>
+			Object.values(table.fields).some(
+				(field) =>
+					field.type === "date" &&
+					field.defaultValue &&
+					typeof field.defaultValue === "function" &&
+					field.defaultValue.toString().includes("new Date()"),
+			),
 		);
 
 	if (hasSQLiteTimestamp) {

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-number-id.txt
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
 export const custom_user = sqliteTable("custom_user", {
@@ -9,10 +10,10 @@ export const custom_user = sqliteTable("custom_user", {
     .notNull(),
   image: text("image"),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   twoFactorEnabled: integer("two_factor_enabled", { mode: "boolean" }).default(
@@ -27,7 +28,7 @@ export const custom_session = sqliteTable("custom_session", {
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   token: text("token").notNull().unique(),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
@@ -58,7 +59,7 @@ export const custom_account = sqliteTable("custom_account", {
   scope: text("scope"),
   password: text("password"),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
@@ -71,10 +72,10 @@ export const custom_verification = sqliteTable("custom_verification", {
   value: text("value").notNull(),
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey-number-id.txt
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
 export const custom_user = sqliteTable("custom_user", {
@@ -9,10 +10,10 @@ export const custom_user = sqliteTable("custom_user", {
     .notNull(),
   image: text("image"),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
@@ -22,7 +23,7 @@ export const custom_session = sqliteTable("custom_session", {
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   token: text("token").notNull().unique(),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
@@ -53,7 +54,7 @@ export const custom_account = sqliteTable("custom_account", {
   scope: text("scope"),
   password: text("password"),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
@@ -66,10 +67,10 @@ export const custom_verification = sqliteTable("custom_verification", {
   value: text("value").notNull(),
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-passkey.txt
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
 export const custom_user = sqliteTable("custom_user", {
@@ -9,10 +10,10 @@ export const custom_user = sqliteTable("custom_user", {
     .notNull(),
   image: text("image"),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });
@@ -22,7 +23,7 @@ export const custom_session = sqliteTable("custom_session", {
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   token: text("token").notNull().unique(),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
@@ -53,7 +54,7 @@ export const custom_account = sqliteTable("custom_account", {
   scope: text("scope"),
   password: text("password"),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
@@ -66,10 +67,10 @@ export const custom_verification = sqliteTable("custom_verification", {
   value: text("value").notNull(),
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite.txt
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
 export const custom_user = sqliteTable("custom_user", {
@@ -9,10 +10,10 @@ export const custom_user = sqliteTable("custom_user", {
     .notNull(),
   image: text("image"),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   twoFactorEnabled: integer("two_factor_enabled", { mode: "boolean" }).default(
@@ -27,7 +28,7 @@ export const custom_session = sqliteTable("custom_session", {
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   token: text("token").notNull().unique(),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
@@ -58,7 +59,7 @@ export const custom_account = sqliteTable("custom_account", {
   scope: text("scope"),
   password: text("password"),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .$onUpdate(() => /* @__PURE__ */ new Date())
@@ -71,10 +72,10 @@ export const custom_verification = sqliteTable("custom_verification", {
   value: text("value").notNull(),
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
   createdAt: integer("created_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" })
-    .defaultNow()
+    .default(sql`(current_timestamp)`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
 });

--- a/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
+++ b/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
@@ -120,6 +120,7 @@ model WorkspaceInvitation {
   role           String?   @db.Text
   status         String    @db.Text
   expiresAt      DateTime
+  createdAt      DateTime
   inviterId      String
   user           User      @relation(fields: [inviterId], references: [id], onDelete: Cascade)
 

--- a/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
+++ b/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
@@ -120,7 +120,6 @@ model WorkspaceInvitation {
   role           String?   @db.Text
   status         String    @db.Text
   expiresAt      DateTime
-  createdAt      DateTime
   inviterId      String
   user           User      @relation(fields: [inviterId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4796
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch Drizzle SQLite timestamp defaults from defaultNow() to default(sql`(current_timestamp)`) to avoid the deprecated API and generate valid schemas. Other databases keep defaultNow().

- **Bug Fixes**
  - For SQLite, use .default(sql`(current_timestamp)`) on date fields instead of .defaultNow().
  - Conditionally import sql from "drizzle-orm" only when SQLite timestamp defaults are present.
  - Simplified import generation to include only needed types; updated snapshots to match output.

<!-- End of auto-generated description by cubic. -->

