### PR TITLE
chore: backport for zod 3

### DIFF
--- a/packages/better-auth/src/api/routes/reset-password.ts
+++ b/packages/better-auth/src/api/routes/reset-password.ts
@@ -40,6 +40,7 @@ export const requestPasswordReset = createAuthEndpoint(
 			 * The email address of the user to send a password reset email to.
 			 */
 			email: z
+				.string()
 				.email()
 				.describe(
 					"The email address of the user to send a password reset email to",


### PR DESCRIPTION
Maybe the project should add some testing for successfully compiling under Zod3?
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix Zod v3 compatibility in the reset-password endpoint by defining the email field as z.string().email(). This prevents compile-time errors and ensures correct validation.

<!-- End of auto-generated description by cubic. -->

