### PR TITLE
feat: Add Login History plugin

### DIFF
--- a/docs/content/docs/plugins/login-history.mdx
+++ b/docs/content/docs/plugins/login-history.mdx
@@ -1,0 +1,138 @@
+---
+title: Login History
+description: Track and view user login history for enhanced security and auditing.
+---
+
+The Login History plugin automatically records every time a user signs in or signs up, capturing details like their IP address and user agent. This provides a clear audit trail of account access, helping you monitor for suspicious activity and giving users visibility into their own login patterns.
+
+## Installation
+
+<Steps>
+    <Step>
+        ### Add the plugin to your auth config
+
+        Add the login history plugin to your auth configuration.
+
+        ```ts title="auth.ts"
+        import { betterAuth } from "better-auth"
+        import { loginHistory } from "better-auth/plugins" // [!code highlight]
+
+        export const auth = betterAuth({
+            // ... other config options
+            plugins: [
+                loginHistory() // [!code highlight]
+            ]
+        })
+        ```
+    </Step>
+      <Step>
+        ### Migrate the database
+
+        Run the migration or generate the schema to add the necessary table to the database.
+
+        <Tabs items={["migrate", "generate"]}>
+            <Tab value="migrate">
+            ```bash
+            npx @better-auth/cli migrate
+            ```
+            </Tab>
+            <Tab value="generate">
+            ```bash
+            npx @better-auth/cli generate
+            ```
+            </Tab>
+        </Tabs>
+        See the [Schema](#schema) section to add the table manually.
+    </Step>
+
+        <Step>
+        ### Add the client plugin
+
+        Add the client plugin to your auth client configuration.
+
+        ```ts title="auth-client.ts"
+        import { createAuthClient } from "better-auth/client"
+        import { loginHistoryClient } from "better-auth/client/plugins"
+
+        export const authClient = createAuthClient({
+            plugins: [
+                loginHistoryClient()
+            ]
+        })
+        ```
+        </Step>
+</Steps>
+
+## Usage
+
+The plugin automatically records login history upon successful sign-in or sign-up events. You don't need to do anything extra to enable the tracking.
+
+### List Login History
+
+To retrieve the login history for the currently authenticated user, you can call the `loginHistory.list` method.
+
+<APIMethod
+  path="/login-history/list"
+  method="GET"
+  requireSession
+>
+```ts
+// Example client-side usage
+const { data: history, error } = await authClient.loginHistory.list();
+
+if (history) {
+  // Display the login history to the user
+  history.forEach(entry => {
+    console.log(`Logged in at ${new Date(entry.createdAt).toLocaleString()} from IP ${entry.ipAddress} using ${entry.userAgent}`);
+  });
+}
+```
+</APIMethod>
+
+The endpoint returns an array of login history records, sorted by the most recent login first.
+
+## Schema
+
+The plugin adds a `loginHistory` table to your database to store the login records.
+
+Table: `loginHistory`
+
+<DatabaseTable
+    fields={[
+        { name: "id", type: "string", description: "The unique ID for the login record.", isPrimaryKey: true },
+        { name: "userId", type: "string", description: "The ID of the user.", isForeignKey: true },
+        { name: "userAgent", type: "string", description: "The user agent of the client.", isOptional: false },
+        { name: "ipAddress", type: "string", description: "The IP address of the client.", isOptional: false },
+        { name: "createdAt", type: "Date", description: "The timestamp of the login event." },
+    ]}
+/>
+
+## Options
+
+### `ipHeader`
+
+By default, the plugin automatically detects the user's IP address by inspecting common headers like `x-forwarded-for`, `cf-connecting-ip`, and `x-real-ip`. If you need to use a specific header, you can specify it with this option.
+
+```ts title="auth.ts"
+loginHistory({
+    ipHeader: "x-real-ip" // [!code highlight]
+})
+```
+
+### `schema`
+
+You can customize the table and field names using the `schema` option.
+
+```ts title="auth.ts"
+loginHistory({
+    schema: {
+        loginHistory: {
+            modelName: "user_logins", // Use 'user_logins' as the table name
+            fields: {
+                ipAddress: "ip_addr" // Use 'ip_addr' as the column name for IP address
+            }
+        }
+    }
+})
+```
+Read more about custom schemas in the [database concept documentation](/docs/concepts/database#custom-table-names).

--- a/packages/better-auth/src/plugins/login-history/client.ts
+++ b/packages/better-auth/src/plugins/login-history/client.ts
@@ -1,0 +1,12 @@
+import type { loginHistory } from ".";
+import type { BetterAuthClientPlugin } from "../../client/types";
+
+export const loginHistoryClient = () => {
+	return {
+		id: "login-history",
+		$InferServerPlugin: {} as ReturnType<typeof loginHistory>,
+		pathMethods: {
+			"/login-history/list": "GET",
+		},
+	} satisfies BetterAuthClientPlugin;
+};

--- a/packages/better-auth/src/plugins/login-history/index.ts
+++ b/packages/better-auth/src/plugins/login-history/index.ts
@@ -1,0 +1,145 @@
+import type { BetterAuthPlugin } from "../../types";
+import { APIError, createAuthEndpoint, sessionMiddleware } from "../../api";
+import type {
+	LoginHistory,
+	LoginHistoryOptions,
+	LoginHistoryModel,
+} from "./types";
+import { mergeSchema } from "../../db";
+import { schema } from "./schema";
+import { getClientIP } from "./utils";
+
+export const loginHistory = (options?: LoginHistoryOptions) => {
+	const opts = {
+		loginHistoryTable: "loginHistory",
+		ipHeader: options?.ipHeader,
+	};
+
+	const ERROR_CODES = {
+		IP_NOT_FOUND: "Could not determine client IP address.",
+		USER_AGENT_NOT_FOUND: "Could not determine client user agent.",
+	} as const;
+
+	/**
+	 * ### Endpoint
+	 *
+	 * GET `/login-history/list`
+	 *
+	 * ### API Methods
+	 *
+	 * **server:**
+	 * `auth.api.getLoginHistory`
+	 *
+	 * **client:**
+	 * `authClient.loginHistory.list`
+	 *
+	 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/login-history#api-method-login-history-list)
+	 */
+	const getLoginHistory = createAuthEndpoint(
+		"/login-history/list",
+		{
+			method: "GET",
+			use: [sessionMiddleware],
+			metadata: {
+				openapi: {
+					description: "Get user login history",
+					responses: {
+						200: {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										type: "array",
+										items: {
+											type: "object",
+											properties: {
+												id: { type: "string" },
+												userAgent: { type: "string" },
+												ipAddress: { type: "string" },
+												createdAt: { type: "number" },
+											},
+										},
+										description: "Array of user login history",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const userId = ctx.context.session.user.id;
+			const history = await ctx.context.adapter.findMany<LoginHistoryModel>({
+				model: opts.loginHistoryTable,
+				where: [{ field: "userId", operator: "eq", value: userId }],
+				sortBy: { field: "createdAt", direction: "desc" },
+			});
+
+			const response = history.map((item): LoginHistory => {
+				return {
+					id: item.id,
+					userAgent: item.userAgent,
+					ipAddress: item.ipAddress,
+					createdAt: item.createdAt,
+				};
+			});
+
+			return ctx.json(response);
+		},
+	);
+
+	return {
+		id: "login-history",
+		schema: mergeSchema(schema, options?.schema),
+		endpoints: {
+			getLoginHistory,
+		},
+		$ERROR_CODES: ERROR_CODES,
+		init(ctx) {
+			return {
+				options: {
+					databaseHooks: {
+						session: {
+							create: {
+								async after(session, context) {
+									if (!context || !context.request) return;
+
+									const userAgent = context.request.headers.get("user-agent");
+									const ipAddress = opts.ipHeader
+										? context.request.headers.get(opts.ipHeader)
+										: getClientIP(context.request.headers);
+
+									if (!ipAddress) {
+										throw new APIError("BAD_REQUEST", {
+											message: ERROR_CODES.IP_NOT_FOUND,
+										});
+									}
+
+									if (!userAgent) {
+										throw new APIError("BAD_REQUEST", {
+											message: ERROR_CODES.USER_AGENT_NOT_FOUND,
+										});
+									}
+
+									await ctx.adapter.create({
+										model: opts.loginHistoryTable,
+										data: {
+											userId: session.userId,
+											userAgent,
+											ipAddress,
+											createdAt: new Date(),
+										},
+									});
+								},
+							},
+						},
+					},
+				},
+			};
+		},
+	} satisfies BetterAuthPlugin;
+};
+
+export * from "./client";
+export * from "./types";

--- a/packages/better-auth/src/plugins/login-history/login-history.test.ts
+++ b/packages/better-auth/src/plugins/login-history/login-history.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { loginHistory } from ".";
+import { loginHistoryClient } from "./client";
+import type { LoginHistoryModel } from "./types";
+
+describe("login-history", async () => {
+	const { client, db, testUser, sessionSetter } = await getTestInstance(
+		{
+			plugins: [loginHistory()],
+		},
+		{
+			clientOptions: {
+				plugins: [loginHistoryClient()],
+			},
+		},
+	);
+
+	it("should record login history on sign-in", async () => {
+		const { data } = await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers: {
+					"user-agent": "node-fetch",
+				},
+			},
+		);
+		expect(data?.token).toBeDefined();
+		const userId = data!.user.id;
+
+		const history = await db.findOne<LoginHistoryModel>({
+			model: "loginHistory",
+			where: [{ field: "userId", operator: "eq", value: userId }],
+		});
+
+		expect(history).toBeDefined();
+		expect(history?.userId).toBe(userId);
+		expect(history?.userAgent).toBe("node-fetch");
+	});
+
+	it("should record login history on sign-up", async () => {
+		const newUser = {
+			email: "new-user@test.com",
+			password: "password",
+			name: "New User",
+		};
+
+		const res = await client.signUp.email(
+			{ ...newUser },
+			{
+				headers: {
+					"user-agent": "node-fetch",
+				},
+			},
+		);
+
+		const userId = res.data?.user.id;
+		expect(userId).toBeDefined();
+
+		const history = await db.findOne<LoginHistoryModel>({
+			model: "loginHistory",
+			where: [{ field: "userId", operator: "eq", value: userId! }],
+		});
+
+		expect(history).toBeDefined();
+		expect(history?.userId).toBe(userId);
+		expect(history?.userAgent).toBe("node-fetch");
+	});
+
+	it("should return login history for authenticated user", async () => {
+		const headers = new Headers();
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers: {
+					"user-agent": "test-agent-1",
+				},
+				onSuccess: sessionSetter(headers),
+			},
+		);
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers: {
+					"user-agent": "test-agent-2",
+				},
+				onSuccess: sessionSetter(headers),
+			},
+		);
+
+		const res = await client.loginHistory.list({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(res.data).toBeDefined();
+		expect(Array.isArray(res.data)).toBe(true);
+		expect(res.data!.length).toBeGreaterThanOrEqual(2);
+		expect(res.data![0]!.userAgent).toBe("test-agent-2");
+	});
+
+	it("should use custom ipHeader", async () => {
+		const { client, db, testUser } = await getTestInstance(
+			{
+				plugins: [loginHistory({ ipHeader: "x-real-ip" })],
+			},
+			{
+				clientOptions: {
+					plugins: [loginHistoryClient()],
+				},
+			},
+		);
+
+		const { data } = await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers: {
+					"user-agent": "node-fetch",
+					"x-real-ip": "1.2.3.4",
+				},
+			},
+		);
+		expect(data?.token).toBeDefined();
+		const userId = data!.user.id;
+
+		const history = await db.findOne<LoginHistoryModel>({
+			model: "loginHistory",
+			where: [{ field: "userId", operator: "eq", value: userId }],
+		});
+
+		expect(history).toBeDefined();
+		expect(history?.userId).toBe(userId);
+		expect(history?.ipAddress).toBe("1.2.3.4");
+	});
+
+	it("should return an empty array when there is no login history", async () => {
+		const headers = new Headers();
+		const newUser = {
+			email: "no-history@test.com",
+			password: "password",
+			name: "No History",
+		};
+
+		// Sign up a new user, which will create a session and a login history entry.
+		const signUpResponse = await client.signUp.email(newUser, {
+			onSuccess: sessionSetter(headers),
+		});
+		const userId = signUpResponse.data?.user.id;
+		expect(userId).toBeDefined();
+
+		// Now, delete the login history for this new user to simulate a clean state.
+		await db.deleteMany({
+			model: "loginHistory",
+			where: [{ field: "userId", operator: "eq", value: userId! }],
+		});
+
+		const res = await client.loginHistory.list({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(res.data).toEqual([]);
+	});
+});

--- a/packages/better-auth/src/plugins/login-history/schema.ts
+++ b/packages/better-auth/src/plugins/login-history/schema.ts
@@ -1,0 +1,29 @@
+import type { AuthPluginSchema } from "../../types";
+
+export const schema = {
+	loginHistory: {
+		fields: {
+			userAgent: {
+				type: "string",
+				required: true,
+			},
+			ipAddress: {
+				type: "string",
+				required: true,
+			},
+			userId: {
+				type: "string",
+				required: true,
+				references: {
+					model: "user",
+					field: "id",
+				},
+			},
+			createdAt: {
+				type: "date",
+				required: false,
+				input: false,
+			},
+		},
+	},
+} satisfies AuthPluginSchema;

--- a/packages/better-auth/src/plugins/login-history/types.ts
+++ b/packages/better-auth/src/plugins/login-history/types.ts
@@ -1,0 +1,29 @@
+import type { InferOptionSchema } from "../../types";
+import type { schema } from "./schema";
+
+export interface LoginHistoryOptions {
+	/**
+	 * Custom schema for the login history plugin
+	 */
+	schema?: InferOptionSchema<typeof schema>;
+	/**
+	 * The header to use for the IP address.
+	 * If not provided, it will be automatically detected from common headers.
+	 */
+	ipHeader?: string;
+}
+
+export interface LoginHistory {
+	id: string;
+	userAgent: string;
+	ipAddress: string;
+	createdAt: Date;
+}
+
+export interface LoginHistoryModel {
+	id: string;
+	userId: string;
+	userAgent: string;
+	ipAddress: string;
+	createdAt: Date;
+}

--- a/packages/better-auth/src/plugins/login-history/utils.ts
+++ b/packages/better-auth/src/plugins/login-history/utils.ts
@@ -1,0 +1,88 @@
+const IPV4_REGEX =
+	/^(?:(?:\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.){3}(?:\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])$/;
+const IPV6_REGEX =
+	/^((?=.*::)(?!.*::.+::)(::)?([\dA-F]{1,4}:(:|\b)|){5}|([\dA-F]{1,4}:){6})((([\dA-F]{1,4}((?!3)::|:\b|$))|(?!23)){2}|(((2[0-4]|1\d|[1-9])?\d|25[0-5])\.?\b){4})$/i;
+
+export function isIP(ip: string | null) {
+	return ip !== null && (IPV4_REGEX.test(ip) || IPV6_REGEX.test(ip));
+}
+
+function getClientIpFromXForwardedFor(value: string | null): string | null {
+	if (!value) {
+		return null;
+	}
+	const addresses = value.split(",").map((ip) => ip.trim());
+	for (const ip of addresses) {
+		if (isIP(ip)) {
+			return ip;
+		}
+	}
+	return null;
+}
+
+/**
+ * Retrieves the client's IP address from request headers.
+ *
+ * The function checks various headers commonly used by different cloud providers and proxies to find the client's IP address.
+ * It prioritizes the 'x-forwarded-for' header, which may contain multiple IP addresses, and extracts the first one.
+ * If no valid IP is found, it returns null.
+ *
+ * @returns {string|null} The client's IP address.
+ */
+export function getClientIP(headers: Headers): string | null {
+	// X-Forwarded-For (Header may return multiple IP addresses in the format: "client IP, proxy 1 IP, proxy 2 IP", so we take the first one.)
+	if (headers.has("x-forwarded-for")) {
+		const forwardedIp = getClientIpFromXForwardedFor(
+			headers.get("x-forwarded-for"),
+		);
+		if (forwardedIp) {
+			return forwardedIp;
+		}
+	}
+
+	const headerKeys = [
+		// Standard headers used by Amazon EC2, Heroku, and others.
+		"x-client-ip",
+
+		// Cloudflare.
+		// @docs https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-
+		// CF-Connecting-IP - applied to every request to the origin.
+		"cf-connecting-ip",
+
+		// Fastly and Firebase hosting header (When forwared to cloud function)
+		"fastly-client-ip",
+
+		// Akamai and Cloudflare: True-Client-IP.
+		"true-client-ip",
+
+		// X-Real-IP (Nginx proxy/FastCGI)
+		"x-real-ip",
+
+		// X-Cluster-Client-IP (Rackspace LB, Riverbed Stingray)
+		"x-cluster-client-ip",
+
+		// X-Forwarded, Forwarded-For and Forwarded (Variations of #2)
+		"x-forwarded",
+		"forwarded-for",
+		"forwarded",
+
+		// Google Cloud App Engine
+		// https://cloud.google.com/appengine/docs/standard/go/reference/request-response-headers
+		"x-appengine-user-ip",
+
+		// Cloudflare fallback
+		// https://blog.cloudflare.com/eliminating-the-last-reasons-to-not-enable-ipv6/#introducingpseudoipv4
+		"Cf-Pseudo-IPv4",
+	];
+
+	for (const headerKey of headerKeys) {
+		if (headers.has(headerKey)) {
+			const ip = headers.get(headerKey);
+			if (ip && isIP(ip)) {
+				return ip;
+			}
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
 This PR introduces the new `login-history` plugin, designed to give users a clear and simple audit trail of their account access. It automatically records each sign-in and sign-up, capturing the user's IP address and user agent.

I've tried to keep this plugin lightweight and unopinionated. Earlier internal versions included fields like `device` (from user-agent parsing) and `location` (from a GeoIP database), but I've removed them to avoid adding heavy dependencies and making assumptions about everyone's needs.

This is the first version, please let me know how this can be improved or what you think of it. All feedback and criticism are welcome

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a lightweight Login History plugin that records sign-ins and sign-ups with IP and user agent, and provides a simple API to list entries.

- **New Features**
  - Records a login entry on session create (sign-in/sign-up) with userId, userAgent, ipAddress, createdAt.
  - GET /login-history/list endpoint for the authenticated user; results sorted by newest first.
  - Client plugin exposes authClient.loginHistory.list().
  - Auto-detects IP from common proxy headers; override with ipHeader option.
  - Supports custom table/field names via schema option.
  - Returns clear errors when IP or user agent is missing.
  - Added docs and tests.

- **Migration**
  - Run the Better Auth CLI migrate or generate to add the loginHistory table.

<!-- End of auto-generated description by cubic. -->

