### PR TITLE
chore: endpoint spelling `Authroize` -> `Authorize`

### DIFF
--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -203,7 +203,7 @@ export const mcp = (options: MCPOptions) => {
 					return c.json(metadata);
 				},
 			),
-			mcpOAuthAuthroize: createAuthEndpoint(
+			mcpOAuthAuthorize: createAuthEndpoint(
 				"/mcp/authorize",
 				{
 					method: "GET",


### PR DESCRIPTION
Working with `auth.api` and noticed misspelling
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed typo in MCP OAuth endpoint name: mcpOAuthAuthroize -> mcpOAuthAuthorize. Aligns with the "/mcp/authorize" route and avoids confusion in plugin usage.

<!-- End of auto-generated description by cubic. -->

