### PR TITLE
fix(phone-number): call callbackOnVerification when updatePhoneNumber is enabled

### DIFF
--- a/.changeset/phone-number-callback-on-update.md
+++ b/.changeset/phone-number-callback-on-update.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fire `callbackOnVerification` when a phone number is verified with `updatePhoneNumber: true`. The callback previously only ran on initial verification, so consumers relying on it (e.g. to sync verified numbers to an external system) would miss the event when an authenticated user changed their number.

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -106,6 +106,75 @@ describe("phone-number", async () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/4839
+ */
+describe("phone-number callbackOnVerification on updatePhoneNumber", async () => {
+	let otp = "";
+	const callbackOnVerification = vi.fn();
+
+	const { client, sessionSetter } = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						otp = code;
+					},
+					callbackOnVerification,
+					signUpOnVerification: {
+						getTempEmail(phoneNumber) {
+							return `temp-${phoneNumber}`;
+						},
+					},
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [phoneNumberClient()],
+			},
+		},
+	);
+
+	const headers = new Headers();
+	const initialPhoneNumber = "+251911121314";
+	const updatedPhoneNumber = "+0123456789";
+
+	it("fires when verifying a new phone number on an authenticated session", async () => {
+		await client.phoneNumber.sendOtp({ phoneNumber: initialPhoneNumber });
+		await client.phoneNumber.verify(
+			{ phoneNumber: initialPhoneNumber, code: otp },
+			{ onSuccess: sessionSetter(headers) },
+		);
+		callbackOnVerification.mockClear();
+
+		await client.phoneNumber.sendOtp({
+			phoneNumber: updatedPhoneNumber,
+			fetchOptions: { headers },
+		});
+		const res = await client.phoneNumber.verify({
+			phoneNumber: updatedPhoneNumber,
+			updatePhoneNumber: true,
+			code: otp,
+			fetchOptions: { headers },
+		});
+
+		expect(res.error).toBe(null);
+		expect(res.data?.status).toBe(true);
+		expect(callbackOnVerification).toHaveBeenCalledTimes(1);
+		expect(callbackOnVerification).toHaveBeenCalledWith(
+			expect.objectContaining({
+				phoneNumber: updatedPhoneNumber,
+				user: expect.objectContaining({
+					phoneNumber: updatedPhoneNumber,
+					phoneNumberVerified: true,
+				}),
+			}),
+			expect.any(Object),
+		);
+	});
+});
+
 describe("phone-number send otp error handling", async () => {
 	const sendOTP = vi.fn(async () => {
 		throw new Error("SMS provider error");

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -567,6 +567,13 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 							[opts.phoneNumberVerified]: true,
 						},
 					);
+				await opts?.callbackOnVerification?.(
+					{
+						phoneNumber: ctx.body.phoneNumber,
+						user,
+					},
+					ctx,
+				);
 				return ctx.json({
 					status: true,
 					token: session.session.token,

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -567,6 +567,12 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 							[opts.phoneNumberVerified]: true,
 						},
 					);
+				if (!user) {
+					throw APIError.from(
+						"INTERNAL_SERVER_ERROR",
+						BASE_ERROR_CODES.FAILED_TO_UPDATE_USER,
+					);
+				}
 				await opts?.callbackOnVerification?.(
 					{
 						phoneNumber: ctx.body.phoneNumber,


### PR DESCRIPTION
Fixes #4839

Fire `callbackOnVerification` when a phone number is verified via `updatePhoneNumber: true`. Previously the callback only ran on initial verification, so consumers using it to sync verified numbers to external systems missed the event when an authenticated user changed their number.

Follow-ups (separate issues): #9290 (unify `verifyPhoneNumber` completion paths so callbacks can't be forgotten), #9291 (rename `callbackOnVerification` to `onPhoneNumberVerification` for consistency with `onEmailVerification`).