### PR TITLE
docs: delete incorrectly documented error case for `baseURL`

### DIFF
--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -168,8 +168,6 @@ export type BetterAuthOptions = {
 	 * the system will check the following environment variable:
 	 *
 	 * process.env.BETTER_AUTH_URL
-	 *
-	 * If not set it will throw an error.
 	 */
 	baseURL?: string;
 	/**


### PR DESCRIPTION
As conversed about in #4896, this deletes documentation discussing a non-existent error case when not utilizing baseURL AND not utilizing BETTER_AUTH_URL.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed an incorrect note in BetterAuth options.ts that claimed an error is thrown when both baseURL and BETTER_AUTH_URL are unset. The baseURL docs now reflect the actual behavior: it checks BETTER_AUTH_URL without throwing.

<!-- End of auto-generated description by cubic. -->

