### PR TITLE
fix(vue): improve baseURL normalization for Nuxt SSR compatibility

### DIFF
--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -34,7 +34,10 @@ function normalizeAuthPath(baseURL?: string): string {
 
 	try {
 		// Absolute URL → use only pathname so Nuxt treats it as same-origin and forwards cookies.
-		if (baseURL.toLowerCase().startsWith("http://") || baseURL.toLowerCase().startsWith("https://")) {
+		if (
+			baseURL.toLowerCase().startsWith("http://") ||
+			baseURL.toLowerCase().startsWith("https://")
+		) {
 			const u = new URL(baseURL);
 			return (u.pathname || fallback).replace(/\/+$/, "") || fallback;
 		}


### PR DESCRIPTION
Following the discussion in [#4722](https://github.com/better-auth/better-auth/issues/4722), and after the fix that landed in [#4887](https://github.com/better-auth/better-auth/pull/4887), Nuxt `useSession(useFetch)` started working again **only** when using the default `/api/auth` base path.

However, the fix did not cover cases where a **custom base path** is configured (e.g. `/api/v1/auth`).

Like this :
```ts
export const authClient = createAuthClient({
  baseURL: "http://localhost:3000/api/v1/auth",
});
```

In these cases, the client still builds an absolute URL for `get-session` (like so `http://localhost:3000/api/v1/auth`), which in Nuxt SSR prevents cookies from being forwarded. The result is that `session` is always `null`, even though the endpoint responds correctly in the browser.

```ts
  const loggedFetch = ((url: string, opts?: any) => {
    console.log("[useSession] fetching:", url);
    return useFetch(url, opts);
  }) as any;

  const { data: session, error } = await authClient.useSession(loggedFetch);
  // return [useSession] fetching: http://localhost:3000/api/v1/auth/get-session
  // After this PR
  // return [useSession] fetching: /api/v1/auth/get-session
```

This PR ensures the client:

* Normalizes the `baseURL` to extract only the pathname.
* Defaults `/` to `/api/auth`.
* Trims trailing slashes.
* Always calls a **relative** endpoint for `…/get-session`, which allows Nuxt SSR to forward cookies properly.

**For Nuxt SSR custom base url**

* **Before #4887:** regression → always `null`.
* **After #4887:** works only for default baseURL.
* **With this PR:** works for both default and custom base paths, without needing app-side workarounds (like wrapping `useFetch` to strip the origin).

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Nuxt SSR cookie forwarding when using a custom auth baseURL. We now normalize baseURL and call a relative /get-session path so useSession returns the session for both default and custom paths.

- **Bug Fixes**
  - Normalize baseURL to a relative pathname; strip origin if absolute.
  - Ensure leading slash, trim trailing slashes, fallback to /api/auth.
  - Build /get-session from the normalized path to avoid absolute requests in SSR.

<!-- End of auto-generated description by cubic. -->

