### PR TITLE
Update tanstack.mdx

### DIFF
--- a/docs/content/docs/integrations/tanstack.mdx
+++ b/docs/content/docs/integrations/tanstack.mdx
@@ -14,30 +14,36 @@ Create a new file: `/src/routes/api/auth/$.ts`
 
 ```ts title="src/routes/api/auth/$.ts"
 import { auth } from '@/lib/auth' // import your auth instance
-import { createServerFileRoute } from '@tanstack/react-start/server'
+import { createFileRoute } from '@tanstack/react-router';
 
-export const ServerRoute = createServerFileRoute('/api/auth/$').methods({
-  GET: ({ request }) => {
-    return auth.handler(request)
+export const Route = createFileRoute('/api/auth/$')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        return auth.handler(request);
+      },
+      POST: async ({ request }) => {
+        return auth.handler(request);
+      },
+    },
   },
-  POST: ({ request }) => {
-    return auth.handler(request)
-  },
-})
+});
 ```
 
 If you haven't created your server route handler yet, you can do so by creating a file: `/src/server.ts`
 
 ```ts title="src/server.ts"
-import {
-  createStartHandler,
-  defaultStreamHandler,
-} from '@tanstack/react-start/server'
-import { createRouter } from './router'
+import { createStartHandler, defaultRenderHandler } from '@tanstack/react-start/server';
 
-export default createStartHandler({
-  createRouter,
-})(defaultStreamHandler)
+const handler = createStartHandler(async ({ request, router, responseHeaders }) => {
+  return defaultRenderHandler({ request, router, responseHeaders });
+});
+
+export default {
+  async fetch(req: Request): Promise<Response> {
+    return await handler(req);
+  },
+};
 ```
 
 ### Usage tips
@@ -47,11 +53,11 @@ export default createStartHandler({
 
 ```ts title="src/lib/auth.ts"
 import { betterAuth } from "better-auth";
-import { reactStartCookies } from "better-auth/react-start";
+import { reactStartCookies } from "better-auth/react-start"; // This not being exported and does not seem to be needed. Deprecated?
 
 export const auth = betterAuth({
     //...your config
-    plugins: [reactStartCookies()] // make sure this is the last plugin in the array
+    plugins: [reactStartCookies()] // make sure this is the last plugin in the array. See import above as this may be deprecated
 })
 ```
 


### PR DESCRIPTION
	•	Migrated from createServerFileRoute to createFileRoute for auth routes.
	•	Refactored src/server.ts to use createStartHandler with defaultRenderHandler and async fetch entrypoint.
	•	Flagged reactStartCookies as deprecated/possibly unneeded in better-auth integration. Added inline comments to highlight that this may need removal or further confirmation before merging.
	•	Updated docs to reflect new handler patterns and note potential deprecation cleanup.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updates TanStack integration docs to match current React Start/Router APIs, switching to createFileRoute server handlers and a simplified server bootstrap. Also flags reactStartCookies as likely deprecated.

- **Refactors**
  - Replaced createServerFileRoute with createFileRoute using server.handlers for GET/POST auth routes.
  - Updated server.ts to use createStartHandler + defaultRenderHandler and export an async fetch entrypoint.

- **Migration**
  - Change /src/routes/api/auth/$.ts to createFileRoute with server.handlers.
  - Update server.ts to the new handler pattern and export fetch.
  - Review better-auth setup; remove reactStartCookies if not needed.

<!-- End of auto-generated description by cubic. -->

