### PR TITLE
fix: allow signIn.social by utilizing discovery url

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -275,31 +275,8 @@ describe("oauth2", async () => {
 	});
 
 	it("should use social provider login", async () => {
-		const { customFetchImpl, auth } = await getTestInstance({
-			plugins: [
-				genericOAuth({
-					config: [
-						{
-							providerId: "test3",
-							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
-							clientId: clientId,
-							clientSecret: clientSecret,
-						},
-					],
-				}),
-			],
-		});
-
-		const authClient = createAuthClient({
-			plugins: [genericOAuthClient()],
-			baseURL: "http://localhost:3000",
-			fetchOptions: {
-				customFetchImpl,
-			},
-		});
-
 		const res = await authClient.signIn.social({
-			provider: "test3",
+			provider: providerId,
 		});
 		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
 		const headers = new Headers();

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -227,16 +227,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 								finalAuthUrl = discovery.data.authorization_endpoint;
 							}
 						}
-						if (c.authorizationUrlParams && finalAuthUrl) {
-							const withAdditionalParams = new URL(finalAuthUrl);
-							for (const [paramName, paramValue] of Object.entries(
-								c.authorizationUrlParams,
-							)) {
-								withAdditionalParams.searchParams.set(paramName, paramValue);
-							}
-							finalAuthUrl = withAdditionalParams.toString();
-						}
-						return createAuthorizationURL({
+						const authUrl = createAuthorizationURL({
 							id: c.providerId,
 							options: {
 								clientId: c.clientId,
@@ -248,7 +239,9 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							codeVerifier: c.pkce ? data.codeVerifier : undefined,
 							scopes: c.scopes || [],
 							redirectURI: `${ctx.baseURL}/oauth2/callback/${c.providerId}`,
+							additionalParams: c.authorizationUrlParams,
 						});
+						return authUrl;
 					},
 					async validateAuthorizationCode(data) {
 						let finalTokenUrl = c.tokenUrl;
@@ -481,15 +474,6 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						throw new APIError("BAD_REQUEST", {
 							message: ERROR_CODES.INVALID_OAUTH_CONFIGURATION,
 						});
-					}
-					if (authorizationUrlParams) {
-						const withAdditionalParams = new URL(finalAuthUrl);
-						for (const [paramName, paramValue] of Object.entries(
-							authorizationUrlParams,
-						)) {
-							withAdditionalParams.searchParams.set(paramName, paramValue);
-						}
-						finalAuthUrl = withAdditionalParams.toString();
 					}
 
 					const { state, codeVerifier } = await generateState(ctx);


### PR DESCRIPTION
Fixes issue of authorization url not being discovered by social provider.

This addition also enables `signIn.social` beyond just `signIn.oauth2`.

Closes: #3278
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use OIDC discovery to resolve the authorization URL in generic OAuth, fixing social login flows. Enables signIn.social for providers configured with discoveryUrl.

- **Bug Fixes**
  - Fetch authorization_endpoint from discoveryUrl when provided.
  - Apply authorizationUrlParams to the discovered authorization URL.
  - Add test covering signIn.social with a discovered auth URL and correct redirect.

<!-- End of auto-generated description by cubic. -->

