### PR TITLE
feat: add support for custom callback for authorization url

### DIFF
--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -182,7 +182,7 @@ interface GenericOAuthConfig {
 
 **mapProfileToUser**: (Optional) A function to map the provider's user profile to your app's user object. Useful for custom field mapping or transformations.
 
-**authorizationUrlParams**: (Optional) Additional query parameters to add to the authorization URL. These can override default parameters.
+**authorizationUrlParams**: (Optional) Additional query parameters to add to the authorization URL. These can override default parameters. You can also provide a function that returns the parameters.
 
 **disableImplicitSignUp**: (Optional) If true, disables automatic sign-up for new users. Sign-in must be explicitly requested with sign-up intent.
 

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -15,7 +15,11 @@ import {
 import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import { refreshAccessToken } from "../../oauth2/refresh-access-token";
 import { generateState, parseState } from "../../oauth2/state";
-import type { BetterAuthPlugin, User } from "../../types";
+import type {
+	BetterAuthPlugin,
+	GenericEndpointContext,
+	User,
+} from "../../types";
 
 /**
  * Configuration interface for generic OAuth providers.
@@ -99,8 +103,9 @@ export interface GenericOAuthConfig {
 	 * Additional search-params to add to the authorizationUrl.
 	 * Warning: Search-params added here overwrite any default params.
 	 */
-	authorizationUrlParams?: Record<string, string>;
-
+	authorizationUrlParams?:
+		| Record<string, string>
+		| ((ctx: GenericEndpointContext) => Record<string, string>);
 	/**
 	 * Additional search-params to add to the tokenUrl.
 	 * Warning: Search-params added here overwrite any default params.
@@ -470,6 +475,10 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						}
 						finalAuthUrl = withAdditionalParams.toString();
 					}
+					const additionalParams =
+						typeof authorizationUrlParams === "function"
+							? authorizationUrlParams(ctx)
+							: authorizationUrlParams;
 
 					const { state, codeVerifier } = await generateState(ctx);
 					const authUrl = await createAuthorizationURL({
@@ -490,7 +499,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						accessType,
 						responseType,
 						responseMode,
-						additionalParams: authorizationUrlParams,
+						additionalParams,
 					});
 					return ctx.json({
 						url: authUrl.toString(),
@@ -921,6 +930,11 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						email: session.user.email,
 					});
 
+					const additionalParams =
+						typeof authorizationUrlParams === "function"
+							? authorizationUrlParams(c)
+							: authorizationUrlParams;
+
 					const url = await createAuthorizationURL({
 						id: providerId,
 						options: {
@@ -939,7 +953,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							`${c.context.baseURL}/oauth2/callback/${providerId}`,
 						prompt,
 						accessType,
-						additionalParams: authorizationUrlParams,
+						additionalParams,
 					});
 
 					return c.json({


### PR DESCRIPTION
closes #4453
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a callback option for authorizationUrlParams in the generic OAuth plugin, allowing per-request authorization URL params based on the current context. Works for both sign-in and link-account flows.

- **New Features**
  - authorizationUrlParams now accepts a Record<string, string> or a (ctx: GenericEndpointContext) => Record<string, string>.
  - The callback receives GenericEndpointContext and its result is passed to createAuthorizationURL as additionalParams.
  - Backward compatible with existing static parameter configs.

<!-- End of auto-generated description by cubic. -->

