### PR TITLE
chore: typecheck using monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "turbo --filter \"./packages/*\" test",
     "e2e:smoke": "turbo --filter \"./e2e/*\" e2e:smoke",
     "e2e:integration": "turbo --filter \"./e2e/*\" e2e:integration",
-    "typecheck": "turbo --filter \"./packages/*\" typecheck"
+    "typecheck": "tsc -b --verbose --diagnostics"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./node_modules/.cache/test",
+    "tsBuildInfoFile": "tsconfig.test.tsbuildinfo",
+    "lib": ["esnext", "dom", "dom.iterable"]
+  },
+  "references": [
+    {
+      "path": "../better-auth/tsconfig.json"
+    }
+  ],
+  "include": ["test", "src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "strict": true,
     "target": "esnext",
     "downlevelIteration": true,
@@ -17,7 +18,11 @@
     "composite": true,
     "incremental": true,
     "noErrorTruncation": true,
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      "better-auth": ["./packages/better-auth/src"],
+      "better-auth/*": ["./packages/better-auth/src/*"]
+    }
   },
   "references": [
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,9 @@
       "path": "./packages/cli"
     },
     {
+      "path": "./packages/cli/tsconfig.test.json"
+    },
+    {
       "path": "./packages/expo"
     },
     {

--- a/turbo.json
+++ b/turbo.json
@@ -39,6 +39,7 @@
     },
     "typecheck": {
       "outputs": [".tsbuildinfo", "dist/**"],
+      "dependsOn": ["^typecheck"],
       "cache": true
     },
     "deploy": {

--- a/turbo.json
+++ b/turbo.json
@@ -37,11 +37,6 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
-    "typecheck": {
-      "outputs": [".tsbuildinfo", "dist/**"],
-      "dependsOn": ["^typecheck"],
-      "cache": true
-    },
     "deploy": {
       "cache": false
     },


### PR DESCRIPTION
Upstream: https://github.com/better-auth/better-auth/pull/4918
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switches monorepo type checking to TypeScript build mode for faster, consistent incremental checks. Adds path aliases and a CLI test tsconfig, and removes the Turbo typecheck pipeline.

- **Refactors**
  - Root script: typecheck now runs `tsc -b --verbose --diagnostics`.
  - Root tsconfig: set baseUrl and paths for better-auth to enable monorepo-aware imports.
  - CLI: add packages/cli/tsconfig.test.json (includes src and test, caches to node_modules/.cache, references better-auth).
  - tsconfig references updated to include CLI test config; remove Turbo typecheck task/outputs to rely on TS incremental caching.

<!-- End of auto-generated description by cubic. -->

