### PR TITLE
test: increase retry time for flaky test

### DIFF
--- a/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/normal-tests/adapter.prisma.test.ts
@@ -4,43 +4,50 @@ import { createTestOptions } from "../test-options";
 import { runAdapterTest } from "../../../test";
 import { setState } from "../state";
 
-describe("Adapter tests", async () => {
-	beforeAll(async () => {
-		setState("RUNNING");
-		pushPrismaSchema("normal");
-		console.log("Successfully pushed normal Prisma Schema using pnpm...");
-		const { getAdapter } = await import("./get-adapter");
-		const { clearDb } = getAdapter();
-		await clearDb();
-		return () => {
-			console.log(
-				`Normal Prisma adapter test finished. Now allowing number ID prisma tests to run.`,
-			);
-			setState("IDLE");
-		};
-	});
-
-	runAdapterTest({
-		getAdapter: async (customOptions = {}) => {
+describe(
+	"Adapter tests",
+	async () => {
+		beforeAll(async () => {
+			setState("RUNNING");
+			pushPrismaSchema("normal");
+			console.log("Successfully pushed normal Prisma Schema using pnpm...");
 			const { getAdapter } = await import("./get-adapter");
-			const { adapter } = getAdapter();
-			const { advanced, database, session, user } = createTestOptions(adapter);
-			return adapter({
-				...customOptions,
-				user: {
-					...user,
-					...customOptions.user,
-				},
-				session: {
-					...session,
-					...customOptions.session,
-				},
-				advanced: {
-					...advanced,
-					...customOptions.advanced,
-				},
-				database,
-			});
-		},
-	});
-});
+			const { clearDb } = getAdapter();
+			await clearDb();
+			return () => {
+				console.log(
+					`Normal Prisma adapter test finished. Now allowing number ID prisma tests to run.`,
+				);
+				setState("IDLE");
+			};
+		});
+
+		runAdapterTest({
+			getAdapter: async (customOptions = {}) => {
+				const { getAdapter } = await import("./get-adapter");
+				const { adapter } = getAdapter();
+				const { advanced, database, session, user } =
+					createTestOptions(adapter);
+				return adapter({
+					...customOptions,
+					user: {
+						...user,
+						...customOptions.user,
+					},
+					session: {
+						...session,
+						...customOptions.session,
+					},
+					advanced: {
+						...advanced,
+						...customOptions.advanced,
+					},
+					database,
+				});
+			},
+		});
+	},
+	{
+		retry: 3,
+	},
+);

--- a/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/adapter.prisma.number-id.test.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/number-id-tests/adapter.prisma.number-id.test.ts
@@ -5,51 +5,58 @@ import { createTestOptions } from "../test-options";
 import * as fs from "fs";
 import { getState, stateFilePath } from "../state";
 
-describe("Number Id Adapter Test", async () => {
-	beforeAll(async () => {
-		await new Promise(async (resolve) => {
-			await new Promise((r) => setTimeout(r, 500));
-			if (getState() === "IDLE") {
-				resolve(true);
-				return;
-			}
-			console.log(`Waiting for state to be IDLE...`);
-			fs.watch(stateFilePath, () => {
+describe(
+	"Number Id Adapter Test",
+	async () => {
+		beforeAll(async () => {
+			await new Promise(async (resolve) => {
+				await new Promise((r) => setTimeout(r, 500));
 				if (getState() === "IDLE") {
 					resolve(true);
 					return;
 				}
+				console.log(`Waiting for state to be IDLE...`);
+				fs.watch(stateFilePath, () => {
+					if (getState() === "IDLE") {
+						resolve(true);
+						return;
+					}
+				});
 			});
-		});
-		console.log(`Now running Number ID Prisma adapter test...`);
-		pushPrismaSchema("number-id");
-		console.log(`Successfully pushed number id Prisma Schema using pnpm...`);
-		const { getAdapter } = await import("./get-adapter");
-		const { clearDb } = getAdapter();
-		await clearDb();
-	}, Number.POSITIVE_INFINITY);
-
-	runNumberIdAdapterTest({
-		getAdapter: async (customOptions = {}) => {
+			console.log(`Now running Number ID Prisma adapter test...`);
+			pushPrismaSchema("number-id");
+			console.log(`Successfully pushed number id Prisma Schema using pnpm...`);
 			const { getAdapter } = await import("./get-adapter");
-			const { adapter } = getAdapter();
-			const { advanced, database, session, user } = createTestOptions(adapter);
-			return adapter({
-				...customOptions,
-				user: {
-					...user,
-					...customOptions.user,
-				},
-				session: {
-					...session,
-					...customOptions.session,
-				},
-				advanced: {
-					...advanced,
-					...customOptions.advanced,
-				},
-				database,
-			});
-		},
-	});
-});
+			const { clearDb } = getAdapter();
+			await clearDb();
+		}, Number.POSITIVE_INFINITY);
+
+		runNumberIdAdapterTest({
+			getAdapter: async (customOptions = {}) => {
+				const { getAdapter } = await import("./get-adapter");
+				const { adapter } = getAdapter();
+				const { advanced, database, session, user } =
+					createTestOptions(adapter);
+				return adapter({
+					...customOptions,
+					user: {
+						...user,
+						...customOptions.user,
+					},
+					session: {
+						...session,
+						...customOptions.session,
+					},
+					advanced: {
+						...advanced,
+						...customOptions.advanced,
+					},
+					database,
+				});
+			},
+		});
+	},
+	{
+		retry: 3,
+	},
+);


### PR DESCRIPTION
Related: https://github.com/better-auth/better-auth/issues/4774
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Increase suite-level retry to 3 for both Prisma adapter test suites to reduce flaky failures and stabilize CI runs. No runtime or adapter changes; only test configuration was updated.

<!-- End of auto-generated description by cubic. -->

