### PR TITLE
fix: handle symbols in proxy get trap to prevent TypeError

### DIFF
--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -39,7 +39,10 @@ export function createDynamicPathProxy<T extends Record<string, any>>(
 ): T {
 	function createProxy(path: string[] = []): any {
 		return new Proxy(function () {}, {
-			get(target, prop: string) {
+			get(target, prop: string | symbol) {
+				if (typeof prop === "symbol") {
+					return undefined;
+				}
 				if (prop === "then" || prop === "catch" || prop === "finally") {
 					return undefined;
 				}


### PR DESCRIPTION
Fix TypeError when symbols are accessed on the proxy object. JavaScript/TypeScript Proxies receive both string and symbol properties, especially when:
- React/Next.js inspects objects for internal symbols ($$typeof, _owner, etc.)
- Console.log checks for Symbol.toStringTag
- Debugging tools access various symbols

The fix:
1. Correctly type the prop parameter as 'string | symbol'
2. Return undefined for symbol properties early to prevent them from entering the path array

This prevents the "segment.replace is not a function" error that occurs when non-string values attempt string operations.