### PR TITLE
feat(captcha): add support for CaptchaFox

### DIFF
--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -7,6 +7,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 - [Google reCAPTCHA](https://developers.google.com/recaptcha)
 - [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/)
 - [hCaptcha](https://www.hcaptcha.com/)
+- [CaptchaFox](https://captchafox.com/)
 
 <Callout type="info">
   This plugin works out of the box with <Link href="/docs/authentication/email-password">Email & Password</Link> authentication. To use it with other authentication methods, you will need to configure the <Link href="/docs/plugins/captcha#plugin-options">endpoints</Link> array in the plugin options.
@@ -25,7 +26,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     export const auth = betterAuth({
         plugins: [ // [!code highlight]
             captcha({ // [!code highlight]
-                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha // [!code highlight]
+                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha, captchafox // [!code highlight]
                 secretKey: process.env.TURNSTILE_SECRET_KEY!, // [!code highlight]
             }), // [!code highlight]
         ], // [!code highlight]
@@ -54,6 +55,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     - To implement Cloudflare Turnstile on the client side, follow the official [Cloudflare Turnstile documentation](https://developers.cloudflare.com/turnstile/) or use a library like [react-turnstile](https://www.npmjs.com/package/@marsidev/react-turnstile).
     - To implement Google reCAPTCHA on the client side, follow the official [Google reCAPTCHA documentation](https://developers.google.com/recaptcha/intro) or use libraries like [react-google-recaptcha](https://www.npmjs.com/package/react-google-recaptcha) (v2) and [react-google-recaptcha-v3](https://www.npmjs.com/package/react-google-recaptcha-v3) (v3).
     - To implement hCaptcha on the client side, follow the official [hCaptcha documentation](https://docs.hcaptcha.com/#add-the-hcaptcha-widget-to-your-webpage) or use libraries like [@hcaptcha/react-hcaptcha](https://www.npmjs.com/package/@hcaptcha/react-hcaptcha)
+    - To implement CaptchaFox on the client side, follow the official [CaptchaFox documentation](https://docs.captchafox.com/getting-started) or use libraries like [@captchafox/react](https://www.npmjs.com/package/@captchafox/react)
   </Step>
 </Steps>
 
@@ -81,5 +83,5 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 - **`secretKey` (required)**: your provider's secret key used for the server-side validation.
 - `endpoints` (optional): overrides the default array of paths where captcha validation is enforced. Default is: `["/sign-up/email", "/sign-in/email", "/forget-password",]`.
 - `minScore` (optional - only *Google ReCAPTCHA v3*): minimum score threshold. Default is `0.5`.
-- `siteKey` (optional - only *hCaptcha*): prevents tokens issued on one sitekey from being redeemed elsewhere.
+- `siteKey` (optional - only *hCaptcha* and *CaptchaFox*): prevents tokens issued on one sitekey from being redeemed elsewhere.
 - `siteVerifyURLOverride` (optional): overrides endpoint URL for the captcha verification request.

--- a/packages/better-auth/src/plugins/captcha/constants.ts
+++ b/packages/better-auth/src/plugins/captcha/constants.ts
@@ -10,6 +10,7 @@ export const Providers = {
 	CLOUDFLARE_TURNSTILE: "cloudflare-turnstile",
 	GOOGLE_RECAPTCHA: "google-recaptcha",
 	HCAPTCHA: "hcaptcha",
+	CAPTCHAFOX: "captchafox",
 } as const;
 
 export const siteVerifyMap: Record<Provider, string> = {
@@ -18,4 +19,5 @@ export const siteVerifyMap: Record<Provider, string> = {
 	[Providers.GOOGLE_RECAPTCHA]:
 		"https://www.google.com/recaptcha/api/siteverify",
 	[Providers.HCAPTCHA]: "https://api.hcaptcha.com/siteverify",
+	[Providers.CAPTCHAFOX]: "https://api.captchafox.com/siteverify",
 };

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -59,6 +59,13 @@ export const captcha = (options: CaptchaOptions) =>
 						siteKey: options.siteKey,
 					});
 				}
+
+				if (options.provider === Providers.CAPTCHAFOX) {
+					return await verifyHandlers.captchaFox({
+						...handlerParams,
+						siteKey: options.siteKey,
+					});
+				}
 			} catch (_error) {
 				const errorMessage =
 					_error instanceof Error ? _error.message : undefined;

--- a/packages/better-auth/src/plugins/captcha/types.ts
+++ b/packages/better-auth/src/plugins/captcha/types.ts
@@ -22,7 +22,13 @@ export interface HCaptchaOptions extends BaseCaptchaOptions {
 	siteKey?: string;
 }
 
+export interface CaptchaFoxOptions extends BaseCaptchaOptions {
+	provider: typeof Providers.CAPTCHAFOX;
+	siteKey?: string;
+}
+
 export type CaptchaOptions =
 	| GoogleRecaptchaOptions
 	| CloudflareTurnstileOptions
-	| HCaptchaOptions;
+	| HCaptchaOptions
+	| CaptchaFoxOptions;

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/captchafox.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/captchafox.ts
@@ -1,0 +1,63 @@
+import { betterFetch } from "@better-fetch/fetch";
+import { middlewareResponse } from "../../../utils/middleware-response";
+import { EXTERNAL_ERROR_CODES, INTERNAL_ERROR_CODES } from "../error-codes";
+import { encodeToURLParams } from "../utils";
+
+type Params = {
+	siteVerifyURL: string;
+	secretKey: string;
+	captchaResponse: string;
+	siteKey?: string;
+	remoteIP?: string;
+};
+
+type SiteVerifyResponse = {
+	success: boolean;
+	challenge_ts: number;
+	hostname: string;
+	"error-codes":
+		| Array<
+				| "missing-input-secret"
+				| "invalid-input-secret"
+				| "invalid-input-sitekey"
+				| "missing-input-response"
+				| "invalid-input-response"
+				| "expired-input-response"
+				| "timeout-or-duplicate"
+				| "bad-request"
+		  >
+		| undefined;
+	insights: Record<string, unknown> | undefined; // ENTERPRISE feature: insights into verification.
+};
+
+export const captchaFox = async ({
+	siteVerifyURL,
+	captchaResponse,
+	secretKey,
+	siteKey,
+	remoteIP,
+}: Params) => {
+	const response = await betterFetch<SiteVerifyResponse>(siteVerifyURL, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: encodeToURLParams({
+			secret: secretKey,
+			response: captchaResponse,
+			...(siteKey && { sitekey: siteKey }),
+			...(remoteIP && { remoteIp: remoteIP }),
+		}),
+	});
+
+	if (!response.data || response.error) {
+		throw new Error(INTERNAL_ERROR_CODES.SERVICE_UNAVAILABLE);
+	}
+
+	if (!response.data.success) {
+		return middlewareResponse({
+			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED,
+			status: 403,
+		});
+	}
+
+	return undefined;
+};

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
@@ -1,3 +1,4 @@
 export { cloudflareTurnstile } from "./cloudflare-turnstile";
 export { googleRecaptcha } from "./google-recaptcha";
 export { hCaptcha } from "./h-captcha";
+export { captchaFox } from "./captchafox";


### PR DESCRIPTION
Implements #4943 

Changes:
- Added a new captchafox provider
- Updated the plugin documentation
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added CaptchaFox support to the Captcha plugin so apps can use CaptchaFox for bot protection. Addresses #4943 with server-side verification, docs, and tests.

- **New Features**
  - Added provider "captchafox" and siteverify endpoint mapping.
  - Implemented server-side verify handler (supports optional siteKey and remote IP; returns 403 on invalid tokens, 500 if siteverify fails).
  - Extended types with CaptchaFoxOptions and wired provider in plugin index.
  - Updated docs: provider list, usage example, client-side resources, and siteKey option note.
  - Added tests for success, service unavailable, and validation failure cases.

<!-- End of auto-generated description by cubic. -->

