### PR TITLE
docs(concepts/plugins): added missing import for getSessionFromCtx section

### DIFF
--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -365,6 +365,7 @@ Allows you to get the client's session data by passing the auth middleware's `co
 
 ```ts title="plugin.ts"
 import {  createAuthMiddleware } from "better-auth/plugins";
+import { getSessionFromCtx } from "better-auth/api";
 
 const myPlugin = {
     id: "my-plugin",


### PR DESCRIPTION
Added missing import for getSessionFromCtx section
`
import { getSessionFromCtx } from "better-auth/api";
`
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the missing import for getSessionFromCtx in the Plugins docs example to prevent copy-paste errors and ensure the snippet compiles.

<!-- End of auto-generated description by cubic. -->

