### PR TITLE
docs: fix sveltekit client session store example

### DIFF
--- a/docs/content/docs/concepts/client.mdx
+++ b/docs/content/docs/concepts/client.mdx
@@ -145,13 +145,13 @@ In addition to the standard methods, the client provides hooks to easily access 
                 style="display: flex; flex-direction: column; gap: 10px; border-radius: 10px; border: 1px solid #4B453F; padding: 20px; margin-top: 10px;"
             >
                 <div>
-                {#if $session}
+                {#if $session.data}
                     <div>
                     <p>
-                        {$session?.data?.user.name}
+                        {$session.data.user.name}
                     </p>
                     <p>
-                        {$session?.data?.user.email}
+                        {$session.data.user.email}
                     </p>
                     <button
                         onclick={async () => {

--- a/docs/content/docs/integrations/svelte-kit.mdx
+++ b/docs/content/docs/integrations/svelte-kit.mdx
@@ -92,7 +92,7 @@ Some of the actions are reactive. The client use [nano-store](https://github.com
       {#if $session.data}
         <div>
           <p>
-            {$session?.data?.user.name}
+            {$session.data.user.name}
           </p>
           <button
             on:click={async () => {


### PR DESCRIPTION
Fixes

- Fixes session check in sveltekit client example
- Remove unnecessary optional chaining operators in sveltekit examples 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the SvelteKit client session store examples to correctly check $session.data and access user fields without optional chaining. This makes the docs examples render reliably in Svelte templates.

- **Bug Fixes**
  - Use {#if $session.data} instead of {#if $session}.
  - Replace {$session?.data?.user.*} with {$session.data.user.*}.

<!-- End of auto-generated description by cubic. -->

