### PR TITLE
docs: update saml-sso-with-okta doc path

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -714,7 +714,7 @@ The plugin requires additional fields in the `ssoProvider` table to store the pr
     ]}
 />
 
-For a detailed guide on setting up SAML SSO with examples for Okta and testing with DummyIDP, see our [SAML SSO Setup Guide](/docs/guides/sso-saml-guide).
+For a detailed guide on setting up SAML SSO with examples for Okta and testing with DummyIDP, see our [SAML SSO with Okta](/docs/guides/saml-sso-with-okta).
 
 ## Options
 


### PR DESCRIPTION
https://www.better-auth.com/docs/guides/sso-saml-guide -> https://www.better-auth.com/docs/guides/saml-sso-with-okta
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an outdated link in the SSO plugin docs, updating the SAML guide path to point to “SAML SSO with Okta.” This ensures readers land on the correct setup guide.

<!-- End of auto-generated description by cubic. -->

