### PR TITLE
fix(db): `onDelete` is ignored

### DIFF
--- a/packages/better-auth/src/db/get-schema.ts
+++ b/packages/better-auth/src/db/get-schema.ts
@@ -21,6 +21,7 @@ export function getSchema(config: BetterAuthOptions) {
 				const refTable = tables[field.references.model];
 				if (refTable) {
 					actualFields[field.fieldName || key]!.references = {
+						...field.references,
 						model: refTable.modelName,
 						field: field.references.field,
 					};

--- a/packages/better-auth/src/plugins/sso/index.ts
+++ b/packages/better-auth/src/plugins/sso/index.ts
@@ -1023,9 +1023,11 @@ export const sso = (options?: SSOOptions) => {
 					},
 					userId: {
 						type: "string",
+						required: false,
 						references: {
 							model: "user",
 							field: "id",
+							onDelete: "set null",
 						},
 					},
 					providerId: {
@@ -1050,7 +1052,7 @@ export const sso = (options?: SSOOptions) => {
 export interface SSOProvider {
 	issuer: string;
 	oidcConfig: OIDCConfig;
-	userId: string;
+	userId?: string;
 	providerId: string;
 	organizationId?: string;
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes a bug where foreign key onDelete options were ignored in the generated DB schema. SSO providers now persist when the creator user is deleted by setting userId to null.

- **Bug Fixes**
  - getSchema now preserves all reference options (including onDelete) by spreading field.references before overriding model and field.
  - SSO schema: userId is optional and references user.id with onDelete: "set null"; SSOProvider.userId type is now optional.
  - Added test to confirm the provider remains and userId becomes null after deleting the creator user.

<!-- End of auto-generated description by cubic. -->

