### PR TITLE
fix(stripe): update with an existing subscription

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -353,9 +353,14 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 
 				const activeSubscription = activeSubscriptions.find((sub) => {
 					// If we have a specific subscription to update, match by ID
-					if (subscriptionToUpdate?.stripeSubscriptionId || ctx.body.subscriptionId) {
-						return sub.id === subscriptionToUpdate?.stripeSubscriptionId ||
-							sub.id === ctx.body.subscriptionId;
+					if (
+						subscriptionToUpdate?.stripeSubscriptionId ||
+						ctx.body.subscriptionId
+					) {
+						return (
+							sub.id === subscriptionToUpdate?.stripeSubscriptionId ||
+							sub.id === ctx.body.subscriptionId
+						);
 					}
 					// Only find subscription for the same referenceId to avoid mixing personal and org subscriptions
 					if (activeOrTrialingSubscription?.stripeSubscriptionId) {

--- a/packages/stripe/src/stripe.test.ts
+++ b/packages/stripe/src/stripe.test.ts
@@ -1210,7 +1210,7 @@ describe("stripe", async () => {
 
 		// Mock customers.list to find existing customer
 		mockStripe.customers.list.mockResolvedValueOnce({
-			data: [{ id: "cus_test_123" }]
+			data: [{ id: "cus_test_123" }],
 		});
 
 		// First create a starter subscription
@@ -1272,7 +1272,8 @@ describe("stripe", async () => {
 								price: { id: process.env.STRIPE_PRICE_ID_1 },
 								quantity: 1,
 								current_period_start: Math.floor(Date.now() / 1000),
-								current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+								current_period_end:
+									Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
 							},
 						],
 					},


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/1880
Closes: https://linear.app/better-auth/issue/ENG-77/fix-update-existing-stripe-subscription-instead-of-creating-new-one    

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updates the Stripe upgrade flow to modify an existing active or trialing subscription instead of creating a new one. This prevents duplicate subscriptions and sends users to the billing portal with the correct price and seat count.

- **Bug Fixes**
  - Reuse the customer’s existing subscription by matching ID or current reference, avoiding mix-ups between personal and org subscriptions.
  - If a Stripe subscription exists without a DB record, relink by updating the existing DB subscription.
  - Resolve price IDs via lookup keys when needed; throw a clear error if none found.
  - Switch to Billing Portal subscription_update_confirm to change price/quantity; skip creating Checkout sessions.

<!-- End of auto-generated description by cubic. -->

