### PR TITLE
fix: add required constraint to slug filed in org plugin

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -718,6 +718,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 					},
 					slug: {
 						type: "string",
+						required: true,
 						unique: true,
 						sortable: true,
 						fieldName: options?.schema?.organization?.fields?.slug,

--- a/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
+++ b/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
@@ -89,7 +89,7 @@ model TwoFactor {
 model Workspace {
   id                   String                @id
   name                 String                @db.Text
-  slug                 String?
+  slug                 String
   logo                 String?               @db.Text
   createdAt            DateTime
   metadata             String?               @db.Text


### PR DESCRIPTION
This PR has been reopened
https://github.com/better-auth/better-auth/pull/4967
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make organization.slug required in the org plugin schema. This prevents creating organizations without a slug and aligns with the unique constraint.

<!-- End of auto-generated description by cubic. -->

