### PR TITLE
fix(oauth-proxy): should skip state check for oauth proxy

### DIFF
--- a/docs/content/docs/plugins/oauth-proxy.mdx
+++ b/docs/content/docs/plugins/oauth-proxy.mdx
@@ -60,8 +60,10 @@ await authClient.signIn.social({
 
 When the OAuth provider returns the user to your server, the plugin automatically redirects them to the intended callback URL.
 
-<Callout>
 To share cookies between the proxy server and your main server it uses URL query parameters to pass the cookies encrypted in the URL. This is secure as the cookies are encrypted and can only be decrypted by the server.
+
+<Callout type="warn">
+This plugin requires skipping the state cookie check. This has security implications and should only be used in dev or staging environments. If `baseURL` and `productionURL` are the same, the plugin will not proxy the request.
 </Callout>
 
 ## Options

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -189,6 +189,12 @@ export type AuthContext = {
 	appName: string;
 	baseURL: string;
 	trustedOrigins: string[];
+	oauthConfig?: {
+		/**
+		 * This is dangerous and should only be used in dev or staging environments.
+		 */
+		skipStateCookieCheck?: boolean;
+	};
 	/**
 	 * New session that will be set after the request
 	 * meaning: there is a `set-cookie` header that will set

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -101,7 +101,16 @@ export async function parseState(c: GenericEndpointContext) {
 		stateCookie.name,
 		c.context.secret,
 	);
-	if (!stateCookieValue || stateCookieValue !== state) {
+	/**
+	 * This is generally cause security issue and should only be used in
+	 * dev or staging environments. It's currently used by the oauth-proxy
+	 * plugin
+	 */
+	const skipStateCookieCheck = c.context.oauthConfig?.skipStateCookieCheck;
+	if (
+		!skipStateCookieCheck &&
+		(!stateCookieValue || stateCookieValue !== state)
+	) {
 		const errorURL =
 			c.context.options.onAPIError?.errorURL || `${c.context.baseURL}/error`;
 		throw c.redirect(`${errorURL}?error=state_mismatch`);

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -60,7 +60,6 @@ export const oAuthProxy = (opts?: OAuthProxyOptions) => {
 		if (skipProxy) {
 			return;
 		}
-		const url = resolveCurrentURL(ctx);
 		const productionURL = opts?.productionURL || env.BETTER_AUTH_URL;
 		if (productionURL === ctx.context.options.baseURL) {
 			return true;
@@ -236,16 +235,16 @@ export const oAuthProxy = (opts?: OAuthProxyOptions) => {
 							return;
 						}
 						const url = resolveCurrentURL(ctx);
+						if (!ctx.context.body) {
+							return;
+						}
+						ctx.context.body.callbackURL = `${url.origin}${
+							ctx.context.options.basePath || "/api/auth"
+						}/oauth-proxy-callback?callbackURL=${encodeURIComponent(
+							ctx.body.callbackURL || ctx.context.baseURL,
+						)}`;
 						return {
-							context: {
-								body: {
-									callbackURL: `${url.origin}${
-										ctx.context.options.basePath || "/api/auth"
-									}/oauth-proxy-callback?callbackURL=${encodeURIComponent(
-										ctx.body.callbackURL || ctx.context.baseURL,
-									)}`,
-								},
-							},
+							context: ctx,
 						};
 					}),
 				},

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -209,8 +209,7 @@ export const oAuthProxy = (opts?: OAuthProxyOptions) => {
 					},
 					handler: createAuthMiddleware(async (ctx) => {
 						const skipProxy = checkSkipProxy(ctx);
-
-						if (skipProxy) {
+						if (skipProxy || ctx.path !== "/callback/:id") {
 							return;
 						}
 						return {

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -58,7 +58,7 @@ export const oAuthProxy = (opts?: OAuthProxyOptions) => {
 		// if skip proxy header is set, we don't need to proxy
 		const skipProxy = ctx.request?.headers.get("x-skip-oauth-proxy");
 		if (skipProxy) {
-			return;
+			return true;
 		}
 		const productionURL = opts?.productionURL || env.BETTER_AUTH_URL;
 		if (productionURL === ctx.context.options.baseURL) {
@@ -231,14 +231,15 @@ export const oAuthProxy = (opts?: OAuthProxyOptions) => {
 					},
 					handler: createAuthMiddleware(async (ctx) => {
 						const skipProxy = checkSkipProxy(ctx);
+						console.log("skipProxy", skipProxy);
 						if (skipProxy) {
 							return;
 						}
 						const url = resolveCurrentURL(ctx);
-						if (!ctx.context.body) {
+						if (!ctx.body) {
 							return;
 						}
-						ctx.context.body.callbackURL = `${url.origin}${
+						ctx.body.callbackURL = `${url.origin}${
 							ctx.context.options.basePath || "/api/auth"
 						}/oauth-proxy-callback?callbackURL=${encodeURIComponent(
 							ctx.body.callbackURL || ctx.context.baseURL,

--- a/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
@@ -106,7 +106,6 @@ describe("oauth-proxy", async () => {
 		);
 		const state = new URL(res.url!).searchParams.get("state");
 		await client.$fetch(`/callback/google?code=test&state=${state}`, {
-			headers,
 			onError(context) {
 				const location = context.response.headers.get("location");
 				if (!location) {
@@ -119,7 +118,7 @@ describe("oauth-proxy", async () => {
 	});
 
 	it("should proxy to the original request url", async () => {
-		const { client, cookieSetter } = await getTestInstance({
+		const { client } = await getTestInstance({
 			baseURL: "https://myapp.com",
 			plugins: [
 				oAuthProxy({
@@ -133,7 +132,6 @@ describe("oauth-proxy", async () => {
 				},
 			},
 		});
-		const headers = new Headers();
 		const res = await client.signIn.social(
 			{
 				provider: "google",
@@ -141,12 +139,10 @@ describe("oauth-proxy", async () => {
 			},
 			{
 				throw: true,
-				onSuccess: cookieSetter(headers),
 			},
 		);
 		const state = new URL(res.url!).searchParams.get("state");
 		await client.$fetch(`/callback/google?code=test&state=${state}`, {
-			headers,
 			onError(context) {
 				const location = context.response.headers.get("location");
 				if (!location) {
@@ -162,7 +158,7 @@ describe("oauth-proxy", async () => {
 	});
 
 	it("should require state cookie if it's not in proxy url", async () => {
-		const { client, cookieSetter } = await getTestInstance({
+		const { client } = await getTestInstance({
 			baseURL: "https://myapp.com",
 			plugins: [
 				oAuthProxy({


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes state_mismatch errors in OAuth Proxy flows by skipping the state cookie check only when proxying, while keeping strict state validation on same-origin flows. Adds safeguards to avoid proxying when not needed.

- **Bug Fixes**
  - Added oauthConfig.skipStateCookieCheck and used it in parseState for proxied flows.
  - Introduced checkSkipProxy: do not proxy when productionURL equals baseURL or when x-skip-oauth-proxy is set.
  - Rewrite callbackURL only when proxying.
  - Updated docs with a warning about the security trade-off (dev/staging only).
  - Added tests for proxy redirect, same-origin behavior, and state enforcement without proxy.

<!-- End of auto-generated description by cubic. -->

