### PR TITLE
feat(oauth): add support for custom provider-specific options in authorization

### DIFF
--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -183,6 +183,35 @@ describe("account", async () => {
 		});
 	});
 
+	it("should pass custom options to authorization URL", async () => {
+		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		await runWithClient2(async () => {
+			const linkAccountRes = await client.linkSocial({
+				provider: "google",
+				callbackURL: "/callback",
+				options: {
+					accessType: "offline",
+					prompt: "consent",
+				},
+			});
+
+			if (linkAccountRes.error) {
+				console.error("Error from linkSocial:", linkAccountRes.error);
+			}
+
+			expect(linkAccountRes.data).toMatchObject({
+				url: expect.stringContaining("google.com"),
+				redirect: true,
+			});
+
+			const url = new URL(linkAccountRes.data!.url);
+			const accessTypeParam = url.searchParams.get("access_type");
+			const promptParam = url.searchParams.get("prompt");
+			expect(accessTypeParam).toBe("offline");
+			expect(promptParam).toBe("consent");
+		});
+	});
+
 	it("should link second account from the same provider", async () => {
 		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async (headers) => {

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -184,7 +184,7 @@ describe("account", async () => {
 	});
 
 	it("should pass custom options to authorization URL", async () => {
-		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async () => {
 			const linkAccountRes = await client.linkSocial({
 				provider: "google",

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -161,6 +161,18 @@ export const linkSocialAccount = createAuthEndpoint(
 						"Disable automatic redirection to the provider. Useful for handling the redirection yourself",
 				})
 				.optional(),
+			/**
+			 * Provider-specific OAuth parameters to pass during authorization.
+			 * This allows dynamic customization of parameters like accessType, prompt, etc.
+			 * For example, for Google: { accessType: "offline", prompt: "consent" }
+			 */
+			options: z
+				.record(z.string(), z.unknown())
+				.meta({
+					description:
+						"Provider-specific OAuth parameters (e.g., accessType, prompt)",
+				})
+				.optional(),
 		}),
 		use: [sessionMiddleware],
 		metadata: {
@@ -355,6 +367,7 @@ export const linkSocialAccount = createAuthEndpoint(
 			codeVerifier: state.codeVerifier,
 			redirectURI: `${c.context.baseURL}/callback/${provider.id}`,
 			scopes: c.body.scopes,
+			...(c.body.options ?? {}),
 		});
 
 		return c.json({

--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -30,6 +30,10 @@ export interface OAuthProvider<
 		redirectURI: string;
 		display?: string;
 		loginHint?: string;
+		/**
+		 * Additional provider-specific parameters
+		 */
+		[key: string]: unknown;
 	}) => Promise<URL> | URL;
 	name: string;
 	validateAuthorizationCode: (data: {

--- a/packages/better-auth/src/social-providers/google.ts
+++ b/packages/better-auth/src/social-providers/google.ts
@@ -60,6 +60,8 @@ export const google = (options: GoogleOptions) => {
 			redirectURI,
 			loginHint,
 			display,
+			prompt,
+			accessType,
 		}) {
 			if (!options.clientId || !options.clientSecret) {
 				logger.error(
@@ -83,8 +85,9 @@ export const google = (options: GoogleOptions) => {
 				state,
 				codeVerifier,
 				redirectURI,
-				prompt: options.prompt,
-				accessType: options.accessType,
+				prompt: typeof prompt === "string" ? prompt : options.prompt,
+				accessType:
+					typeof accessType === "string" ? accessType : options.accessType,
 				display: display || options.display,
 				loginHint,
 				hd: options.hd,


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/2351
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds support for provider-specific OAuth options in authorization requests so clients can pass custom params like access_type and prompt. This enables flows such as Google offline access and consent without changing provider config.

- **New Features**
  - linkSocial now accepts an options object with provider-specific params.
  - OAuthProvider.buildAuthorizationUrl type allows additional keys.
  - Google provider reads prompt and accessType from request and overrides defaults.
  - Added test to verify options are included in the authorization URL (access_type=offline, prompt=consent).

<!-- End of auto-generated description by cubic. -->

