### PR TITLE
test: rename `runWithUser`

### DIFF
--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -85,17 +85,17 @@ describe("account", async () => {
 		googleGetUserInfoMock.mockClear();
 	});
 
-	const { runWithDefaultUser } = await signInWithTestUser();
+	const { runWithUser } = await signInWithTestUser();
 
 	it("should list all accounts", async () => {
-		await runWithDefaultUser(async () => {
+		await runWithUser(async () => {
 			const accounts = await client.listAccounts();
 			expect(accounts.data?.length).toBe(1);
 		});
 	});
 
 	it("should link first account", async () => {
-		await runWithDefaultUser(async (headers) => {
+		await runWithUser(async (headers) => {
 			const linkAccountRes = await client.linkSocial(
 				{
 					provider: "google",
@@ -136,7 +136,7 @@ describe("account", async () => {
 				},
 			});
 		});
-		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async () => {
 			const accounts = await client.listAccounts();
 			expect(accounts.data?.length).toBe(2);
@@ -144,7 +144,7 @@ describe("account", async () => {
 	});
 
 	it("should encrypt access token and refresh token", async () => {
-		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		const account = await ctx.adapter.findOne<Account>({
 			model: "account",
 			where: [{ field: "providerId", value: "google" }],
@@ -160,7 +160,7 @@ describe("account", async () => {
 	});
 
 	it("should pass custom scopes to authorization URL", async () => {
-		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async () => {
 			const customScope = "https://www.googleapis.com/auth/drive.readonly";
 			const linkAccountRes = await client.linkSocial({
@@ -184,7 +184,7 @@ describe("account", async () => {
 	});
 
 	it("should link second account from the same provider", async () => {
-		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async (headers) => {
 			const linkAccountRes = await client.linkSocial(
 				{
@@ -227,7 +227,7 @@ describe("account", async () => {
 			});
 		});
 
-		const { runWithDefaultUser: runWithClient3 } = await signInWithTestUser();
+		const { runWithUser: runWithClient3 } = await signInWithTestUser();
 		await runWithClient3(async () => {
 			const accounts = await client.listAccounts();
 			expect(accounts.data?.length).toBe(2);
@@ -249,7 +249,7 @@ describe("account", async () => {
 		};
 		googleGetUserInfoMock.mockResolvedValueOnce(userInfo);
 
-		const { runWithDefaultUser: runWithClient2 } = await signInWithTestUser();
+		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async (headers) => {
 			await client.linkSocial(
 				{
@@ -274,7 +274,7 @@ describe("account", async () => {
 		expect(googleVerifyIdTokenMock).toHaveBeenCalledOnce();
 		expect(googleGetUserInfoMock).toHaveBeenCalledOnce();
 
-		const { runWithDefaultUser: runWithClient3 } = await signInWithTestUser();
+		const { runWithUser: runWithClient3 } = await signInWithTestUser();
 		await runWithClient3(async () => {
 			const accounts = await client.listAccounts();
 			expect(accounts.data?.length).toBe(3);
@@ -282,8 +282,8 @@ describe("account", async () => {
 	});
 
 	it("should unlink account", async () => {
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const previousAccounts = await client.listAccounts();
 			expect(previousAccounts.data?.length).toBe(3);
 			const unlinkAccountId = previousAccounts.data![1]!.accountId;
@@ -298,8 +298,8 @@ describe("account", async () => {
 	});
 
 	it("should fail to unlink the last account of a provider", async () => {
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const previousAccounts = await client.listAccounts();
 			await ctx.adapter.delete({
 				model: "account",
@@ -322,8 +322,8 @@ describe("account", async () => {
 	});
 
 	it("should unlink account with specific accountId", async () => {
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const previousAccounts = await client.listAccounts();
 			expect(previousAccounts.data?.length).toBeGreaterThan(0);
 
@@ -356,7 +356,7 @@ describe("account", async () => {
 	});
 
 	it("should unlink all accounts with specific providerId", async () => {
-		const { runWithDefaultUser, user } = await signInWithTestUser();
+		const { runWithUser, user } = await signInWithTestUser();
 		await ctx.adapter.create({
 			model: "account",
 			data: {
@@ -379,7 +379,7 @@ describe("account", async () => {
 			},
 		});
 
-		await runWithDefaultUser(async () => {
+		await runWithUser(async () => {
 			const previousAccounts = await client.listAccounts();
 
 			const googleAccounts = previousAccounts.data!.filter(

--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -300,8 +300,8 @@ describe("Email Verification Secondary Storage", async () => {
 	});
 
 	it("should change email", async () => {
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async (headers) => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async (headers) => {
 			await auth.api.changeEmail({
 				body: {
 					newEmail: "new@email.com",

--- a/packages/better-auth/src/api/routes/reset-password.test.ts
+++ b/packages/better-auth/src/api/routes/reset-password.test.ts
@@ -192,8 +192,8 @@ describe("forget password", async (it) => {
 				resetPasswordTokenExpiresIn: 10,
 			},
 		});
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			await client.requestPasswordReset({
 				email: testUser.email,
 				redirectTo: "/sign-in",
@@ -219,7 +219,7 @@ describe("forget password", async (it) => {
 			token,
 		});
 		expect(res.data?.status).toBe(true);
-		await runWithDefaultUser(async () => {
+		await runWithUser(async () => {
 			await client.requestPasswordReset({
 				email: testUser.email,
 				redirectTo: "/sign-in",
@@ -283,7 +283,7 @@ describe("revoke sessions on password reset", async (it) => {
 	);
 
 	it("should revoke other sessions when revokeSessionsOnPasswordReset is enabled", async () => {
-		const { runWithDefaultUser } = await signInWithTestUser();
+		const { runWithUser } = await signInWithTestUser();
 
 		await client.requestPasswordReset({
 			email: testUser.email,
@@ -301,7 +301,7 @@ describe("revoke sessions on password reset", async (it) => {
 			},
 		);
 
-		await runWithDefaultUser(async () => {
+		await runWithUser(async () => {
 			const sessionAttempt = await client.getSession();
 			expect(sessionAttempt.data).toBeNull();
 		});
@@ -323,7 +323,7 @@ describe("revoke sessions on password reset", async (it) => {
 			},
 		);
 
-		const { runWithDefaultUser } = await signInWithTestUser();
+		const { runWithUser } = await signInWithTestUser();
 
 		await client.requestPasswordReset({
 			email: testUser.email,
@@ -341,7 +341,7 @@ describe("revoke sessions on password reset", async (it) => {
 			},
 		);
 
-		await runWithDefaultUser(async () => {
+		await runWithUser(async () => {
 			const sessionAttempt = await client.getSession();
 			expect(sessionAttempt.data?.user).toBeDefined();
 		});

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -124,9 +124,9 @@ describe("session", async () => {
 				updateAge: 0,
 			},
 		});
-		const { runWithDefaultUser } = await signInWithTestUser();
+		const { runWithUser } = await signInWithTestUser();
 
-		await runWithDefaultUser(async () => {
+		await runWithUser(async () => {
 			const session = await client.getSession();
 
 			vi.useFakeTimers();
@@ -409,9 +409,9 @@ describe("session storage", async () => {
 	it("should store session in secondary storage", async () => {
 		//since the instance creates a session on init, we expect the store to have 2 item (1 for session and 1 for active sessions record for the user)
 		expect(store.size).toBe(0);
-		const { runWithDefaultUser } = await signInWithTestUser();
+		const { runWithUser } = await signInWithTestUser();
 		expect(store.size).toBe(2);
-		await runWithDefaultUser(async () => {
+		await runWithUser(async () => {
 			const session = await client.getSession();
 			expect(session.data).toMatchObject({
 				session: {
@@ -435,16 +435,16 @@ describe("session storage", async () => {
 	});
 
 	it("should list sessions", async () => {
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const response = await client.listSessions();
 			expect(response.data?.length).toBe(1);
 		});
 	});
 
 	it("revoke session and list sessions", async () => {
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const session = await client.getSession();
 			expect(session.data).not.toBeNull();
 			expect(session.data?.session?.token).toBeDefined();
@@ -462,8 +462,8 @@ describe("session storage", async () => {
 	});
 
 	it("should revoke session", async () => {
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const session = await client.getSession();
 			expect(session.data).not.toBeNull();
 			const res = await client.revokeSession({

--- a/packages/better-auth/src/api/routes/sign-out.test.ts
+++ b/packages/better-auth/src/api/routes/sign-out.test.ts
@@ -5,8 +5,8 @@ describe("sign-out", async (it) => {
 	const { signInWithTestUser, client } = await getTestInstance();
 
 	it("should sign out", async () => {
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const res = await client.signOut();
 			expect(res.data).toMatchObject({
 				success: true,

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -28,8 +28,7 @@ describe("updateUser", async () => {
 		},
 	});
 	// Sign in once for all tests in this describe block
-	const { runWithDefaultUser: globalRunWithClient } =
-		await signInWithTestUser();
+	const { runWithUser: globalRunWithClient } = await signInWithTestUser();
 
 	it("should update the user's name", async () => {
 		await globalRunWithClient(async () => {
@@ -358,8 +357,8 @@ describe("delete user", async () => {
 				},
 			},
 		});
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const res = await client.deleteUser();
 			console.log(res);
 		});
@@ -375,8 +374,8 @@ describe("delete user", async () => {
 				freshAge: 1000,
 			},
 		});
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const res = await client.deleteUser();
 			expect(res.data).toMatchObject({
 				success: true,
@@ -398,8 +397,8 @@ describe("delete user", async () => {
 				},
 			},
 		});
-		const { runWithDefaultUser } = await signInWithTestUser();
-		await runWithDefaultUser(async () => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
 			const res = await client.deleteUser({
 				password: testUser.password,
 			});

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -243,7 +243,7 @@ export async function getTestInstance<
 			user: data.user as User,
 			headers,
 			setCookie,
-			runWithDefaultUser: async (fn: (headers: Headers) => Promise<void>) => {
+			runWithUser: async (fn: (headers: Headers) => Promise<void>) => {
 				return currentUserContextStorage.run({ headers }, async () => {
 					await fn(headers);
 				});


### PR DESCRIPTION
It's a misleading name
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the test helper from runWithDefaultUser to runWithUser for clearer naming. No behavior changes; tests still run under the same signed-in user context.

- **Refactors**
  - Updated getTestInstance to expose runWithUser.
  - Replaced usages in account, session, email verification, password reset, sign-out, and update-user tests.

<!-- End of auto-generated description by cubic. -->

