### PR TITLE
docs: use the correct SHA base on env vars

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -51,7 +51,7 @@ export default async function Page({
 			editOnGithub={{
 				owner: "better-auth",
 				repo: "better-auth",
-				sha: "main",
+				sha: process.env.VERCEL_GIT_COMMIT_SHA || "main",
 				path: `/docs/content/docs/${page.path}`,
 			}}
 			tableOfContent={{


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update the docs “Edit on GitHub” link to use the current deploy’s commit SHA (VERCEL_GIT_COMMIT_SHA), so it points to the correct version in previews and production. Falls back to main when the env var is not set.

<!-- End of auto-generated description by cubic. -->

