### PR TITLE
fix(org): update type to include undefined

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -85,7 +85,7 @@ export const createOrgRole = <O extends OrganizationOptions>(options: O) => {
 			metadata: {
 				$Infer: {
 					body: {} as {
-						organizationId?: string;
+						organizationId?: string | undefined;
 						role: string;
 						permission: Record<string, string[]>;
 					} & (IsExactlyEmptyObject<AdditionalFields> extends true
@@ -311,7 +311,7 @@ export const deleteOrgRole = <O extends OrganizationOptions>(options: O) => {
 						| {
 								roleId: string;
 						  }
-					) & { organizationId?: string },
+					) & { organizationId?: string | undefined },
 				},
 			},
 		},
@@ -494,6 +494,15 @@ export const listOrgRoles = <O extends OrganizationOptions>(options: O) => {
 					}),
 				})
 				.optional(),
+			metadata: {
+				$Infer: {
+					query: {} as
+						| {
+								organizationId?: string | undefined;
+						  }
+						| undefined,
+				},
+			},
 		},
 		async (ctx) => {
 			const { session, user } = ctx.context.session;
@@ -622,7 +631,7 @@ export const getOrgRole = <O extends OrganizationOptions>(options: O) => {
 			metadata: {
 				$Infer: {
 					query: {} as {
-						organizationId?: string;
+						organizationId?: string | undefined;
 					} & ({ roleName: string } | { roleId: string }),
 				},
 			},
@@ -793,10 +802,10 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 			metadata: {
 				$Infer: {
 					body: {} as {
-						organizationId?: string;
+						organizationId?: string | undefined;
 						data: {
-							permission?: Record<string, string[]>;
-							roleName?: string;
+							permission?: Record<string, string[]> | undefined;
+							roleName?: string | undefined;
 						} & AdditionalFields;
 					} & ({ roleName: string } | { roleId: string }),
 				},

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -100,7 +100,7 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 						 * The organization ID to invite
 						 * the user to
 						 */
-						organizationId?: string;
+						organizationId?: string | undefined;
 						/**
 						 * Resend the invitation email, if
 						 * the user is already invited

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -59,9 +59,9 @@ export const addMember = <O extends OrganizationOptions>(option: O) => {
 						role:
 							| InferOrganizationRolesFromOption<O>
 							| InferOrganizationRolesFromOption<O>[];
-						organizationId?: string;
+						organizationId?: string | undefined;
 					} & (O extends { teams: { enabled: true } }
-						? { teamId?: string }
+						? { teamId?: string | undefined }
 						: {}) &
 						InferAdditionalFieldsFromPluginOptions<"member", O>,
 				},

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -374,7 +374,7 @@ export const updateOrganization = <O extends OrganizationOptions>(
 			logo?: string;
 			metadata?: Record<string, any>;
 		} & Partial<InferAdditionalFieldsFromPluginOptions<"organization", O>>;
-		organizationId: string;
+		organizationId?: string | undefined;
 	};
 	return createAuthEndpoint(
 		"/organization/update",


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/4804
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update organization route types to correctly treat optional fields as possibly undefined. This fixes TypeScript inference issues and prevents errors when optional values are omitted.

- **Bug Fixes**
  - Mark organizationId as string | undefined across access control, invites, members, and organization update.
  - Allow undefined for roleName and permission in updateOrgRole.
  - Mark teamId as string | undefined when teams are enabled in addMember.
  - Add typed metadata query for listOrgRoles with optional organizationId.

<!-- End of auto-generated description by cubic. -->

