### PR TITLE
perf: lazy load create telemetry

### DIFF
--- a/packages/better-auth/src/telemetry/create-telemetry.ts
+++ b/packages/better-auth/src/telemetry/create-telemetry.ts
@@ -1,0 +1,85 @@
+import { ENV, getBooleanEnvVar, isTest } from "../utils/env";
+import { getProjectId } from "./project-id";
+import type { BetterAuthOptions } from "../types";
+import { detectEnvironment, detectRuntime } from "./detectors/detect-runtime";
+import { detectDatabase } from "./detectors/detect-database";
+import { detectFramework } from "./detectors/detect-framework";
+import { detectSystemInfo } from "./detectors/detect-system-info";
+import { detectPackageManager } from "./detectors/detect-project-info";
+import { betterFetch } from "@better-fetch/fetch";
+import type { TelemetryContext, TelemetryEvent } from "./types";
+import { logger } from "../utils";
+import { getTelemetryAuthConfig } from "./detectors/detect-auth-config";
+
+export async function createTelemetry(
+	options: BetterAuthOptions,
+	context?: TelemetryContext,
+) {
+	const debugEnabled =
+		options.telemetry?.debug ||
+		getBooleanEnvVar("BETTER_AUTH_TELEMETRY_DEBUG", false);
+
+	const TELEMETRY_ENDPOINT = ENV.BETTER_AUTH_TELEMETRY_ENDPOINT;
+	const track = async (event: TelemetryEvent) => {
+		try {
+			if (context?.customTrack) {
+				await context.customTrack(event);
+			} else {
+				if (debugEnabled) {
+					await Promise.resolve(
+						logger.info("telemetry event", JSON.stringify(event, null, 2)),
+					);
+				} else {
+					await betterFetch(TELEMETRY_ENDPOINT, {
+						method: "POST",
+						body: event,
+					});
+				}
+			}
+		} catch {}
+	};
+
+	const isEnabled = async () => {
+		const telemetryEnabled =
+			options.telemetry?.enabled !== undefined
+				? options.telemetry.enabled
+				: false;
+		const envEnabled = getBooleanEnvVar("BETTER_AUTH_TELEMETRY", false);
+		return (
+			(envEnabled || telemetryEnabled) && (context?.skipTestCheck || !isTest())
+		);
+	};
+
+	const enabled = await isEnabled();
+	let anonymousId: string | undefined;
+
+	if (enabled) {
+		anonymousId = await getProjectId(options.baseURL);
+
+		const payload = {
+			config: getTelemetryAuthConfig(options),
+			runtime: detectRuntime(),
+			database: await detectDatabase(),
+			framework: await detectFramework(),
+			environment: detectEnvironment(),
+			systemInfo: await detectSystemInfo(),
+			packageManager: detectPackageManager(),
+		};
+
+		void track({ type: "init", payload, anonymousId });
+	}
+
+	return {
+		publish: async (event: TelemetryEvent) => {
+			if (!enabled) return;
+			if (!anonymousId) {
+				anonymousId = await getProjectId(options.baseURL);
+			}
+			await track({
+				type: event.type,
+				payload: event.payload,
+				anonymousId,
+			});
+		},
+	};
+}

--- a/packages/better-auth/src/telemetry/index.ts
+++ b/packages/better-auth/src/telemetry/index.ts
@@ -1,85 +1,14 @@
-import { ENV, getBooleanEnvVar, isTest } from "../utils/env";
-import { getProjectId } from "./project-id";
-import type { BetterAuthOptions } from "../types";
-import { detectEnvironment, detectRuntime } from "./detectors/detect-runtime";
-import { detectDatabase } from "./detectors/detect-database";
-import { detectFramework } from "./detectors/detect-framework";
-import { detectSystemInfo } from "./detectors/detect-system-info";
-import { detectPackageManager } from "./detectors/detect-project-info";
-import { betterFetch } from "@better-fetch/fetch";
-import type { TelemetryContext, TelemetryEvent } from "./types";
-import { logger } from "../utils";
-import { getTelemetryAuthConfig } from "./detectors/detect-auth-config";
-
-export async function createTelemetry(
-	options: BetterAuthOptions,
-	context?: TelemetryContext,
-) {
-	const debugEnabled =
-		options.telemetry?.debug ||
-		getBooleanEnvVar("BETTER_AUTH_TELEMETRY_DEBUG", false);
-
-	const TELEMETRY_ENDPOINT = ENV.BETTER_AUTH_TELEMETRY_ENDPOINT;
-	const track = async (event: TelemetryEvent) => {
-		try {
-			if (context?.customTrack) {
-				await context.customTrack(event);
-			} else {
-				if (debugEnabled) {
-					await Promise.resolve(
-						logger.info("telemetry event", JSON.stringify(event, null, 2)),
-					);
-				} else {
-					await betterFetch(TELEMETRY_ENDPOINT, {
-						method: "POST",
-						body: event,
-					});
-				}
-			}
-		} catch {}
+let lazyImportCreateTelemetry: Promise<
+	typeof import("./create-telemetry").createTelemetry
+> | null = null;
+// lazy load the telemetry module to split the bundle and avoid loading unnecessary code
+export const createTelemetry: typeof import("./create-telemetry").createTelemetry =
+	async (...args) => {
+		if (!lazyImportCreateTelemetry) {
+			lazyImportCreateTelemetry = import("./create-telemetry").then(
+				(mod) => mod.createTelemetry,
+			);
+		}
+		const createTelemetry = await lazyImportCreateTelemetry;
+		return createTelemetry(...args);
 	};
-
-	const isEnabled = async () => {
-		const telemetryEnabled =
-			options.telemetry?.enabled !== undefined
-				? options.telemetry.enabled
-				: false;
-		const envEnabled = getBooleanEnvVar("BETTER_AUTH_TELEMETRY", false);
-		return (
-			(envEnabled || telemetryEnabled) && (context?.skipTestCheck || !isTest())
-		);
-	};
-
-	const enabled = await isEnabled();
-	let anonymousId: string | undefined;
-
-	if (enabled) {
-		anonymousId = await getProjectId(options.baseURL);
-
-		const payload = {
-			config: getTelemetryAuthConfig(options),
-			runtime: detectRuntime(),
-			database: await detectDatabase(),
-			framework: await detectFramework(),
-			environment: detectEnvironment(),
-			systemInfo: await detectSystemInfo(),
-			packageManager: detectPackageManager(),
-		};
-
-		void track({ type: "init", payload, anonymousId });
-	}
-
-	return {
-		publish: async (event: TelemetryEvent) => {
-			if (!enabled) return;
-			if (!anonymousId) {
-				anonymousId = await getProjectId(options.baseURL);
-			}
-			await track({
-				type: event.type,
-				payload: event.payload,
-				anonymousId,
-			});
-		},
-	};
-}

--- a/packages/better-auth/src/telemetry/telemetry.test.ts
+++ b/packages/better-auth/src/telemetry/telemetry.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTelemetry } from "./index";
+import { createTelemetry } from "./create-telemetry";
 import type { TelemetryEvent } from "./types";
 
 vi.mock("@better-fetch/fetch", () => ({


### PR DESCRIPTION
Splitting this into different chunks will improve the startup speed and bundle size
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Lazy-loads telemetry so code is only loaded when createTelemetry is called. This reduces initial bundle size and avoids unnecessary work when telemetry is disabled.

- **Refactors**
  - Moved implementation to create-telemetry.ts.
  - index.ts now dynamic-imports create-telemetry to split the bundle.
  - Updated telemetry.test to import create-telemetry directly.

<!-- End of auto-generated description by cubic. -->

