### PR TITLE
chore: fix nextjs warnings

### DIFF
--- a/packages/better-auth/src/telemetry/detectors/detect-system-info.ts
+++ b/packages/better-auth/src/telemetry/detectors/detect-system-info.ts
@@ -148,7 +148,7 @@ async function isDocker() {
 async function isWsl() {
 	try {
 		if (getVendor() === "cloudflare") return false;
-		if (typeof process === "undefined" || process.platform !== "linux") {
+		if (typeof process === "undefined" || process?.platform !== "linux") {
 			return false;
 		}
 		const fs = await importRuntime<typeof import("fs")>("fs");

--- a/packages/core/src/async_hooks/index.ts
+++ b/packages/core/src/async_hooks/index.ts
@@ -15,10 +15,8 @@ export type { AsyncLocalStorage };
 let moduleName: string = "node:async_hooks";
 
 const AsyncLocalStoragePromise: Promise<typeof AsyncLocalStorage> = import(
-	/**
-	 * @webpackIgnore: true
-	 * @vite-ignore
-	 */
+	/* @vite-ignore */
+	/* webpackIgnore: true */
 	moduleName
 )
 	.then((mod) => mod.AsyncLocalStorage)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes a circular dependency in core by correcting the dynamic import of node:async_hooks. Uses proper Vite and Webpack ignore hints so the module loads at runtime and isn’t statically bundled.

- **Bug Fixes**
  - Replaced invalid "@webpackIgnore" with "webpackIgnore: true" and added separate /* @vite-ignore */ and /* webpackIgnore: true */ comments on the import().

<!-- End of auto-generated description by cubic. -->

