### PR TITLE
fix: use consistent messaging on `requestPasswordReset`

### DIFF
--- a/packages/better-auth/src/api/routes/reset-password.ts
+++ b/packages/better-auth/src/api/routes/reset-password.ts
@@ -132,6 +132,8 @@ export const requestPasswordReset = createAuthEndpoint(
 		);
 		return ctx.json({
 			status: true,
+			message:
+				"If this email exists in our system, check your email for the reset link",
 		});
 	},
 );


### PR DESCRIPTION
Make the message returned from `requestPasswordReset` consistent between when the user is found or not. This helps avoid user enumeration via the difference in behaviour. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Return a consistent success message in requestPasswordReset to prevent user enumeration. The endpoint now always responds with: "If this email exists in our system, check your email for the reset link".

<!-- End of auto-generated description by cubic. -->

