### PR TITLE
chore: warn test depreciation

### DIFF
--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -74,8 +74,9 @@ function adapterTest(
 		predefinedOptions: Omit<BetterAuthOptions, "database">;
 	},
 ) {
-
-	console.warn("This test function is deprecated and will be removed in the future. Use `testAdapter` instead.");
+	console.warn(
+		"This test function is deprecated and will be removed in the future. Use `testAdapter` instead.",
+	);
 	const adapter = async () =>
 		await getAdapter(internalOptions?.predefinedOptions);
 

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -65,12 +65,17 @@ const numberIdAdapterTests = {
 // biome-ignore lint/performance/noDelete: testing propose
 delete numberIdAdapterTests.SHOULD_NOT_THROW_ON_DELETE_RECORD_NOT_FOUND;
 
+/**
+ * @deprecated Use `testAdapter` instead.
+ */
 function adapterTest(
 	{ getAdapter, disableTests: disabledTests, testPrefix }: AdapterTestOptions,
 	internalOptions?: {
 		predefinedOptions: Omit<BetterAuthOptions, "database">;
 	},
 ) {
+
+	console.warn("This test function is deprecated and will be removed in the future. Use `testAdapter` instead.");
 	const adapter = async () =>
 		await getAdapter(internalOptions?.predefinedOptions);
 


### PR DESCRIPTION
Existing adapters that are maintained out-side of Better-Auth are likely using our old test function, this PR adds a warning of depreciation.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a deprecation warning to the legacy adapter test function (adapterTest) to guide external adapters to migrate to testAdapter. The function now logs a console warning and is marked as deprecated.

- **Migration**
  - Replace adapterTest with testAdapter in your adapter tests.

<!-- End of auto-generated description by cubic. -->

