### PR TITLE
fix(device-authorization): fix client error type for deny device

### DIFF
--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -835,6 +835,19 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 							description: "The user code to deny",
 						}),
 					}),
+					error: z.object({
+						error: z
+							.enum([
+								"invalid_request",
+								"expired_token",
+							])
+							.meta({
+								description: "Error code",
+							}),
+						error_description: z.string().meta({
+							description: "Detailed error description",
+						}),
+					}),
 					metadata: {
 						openapi: {
 							description: "Deny device authorization",

--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -836,14 +836,9 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 						}),
 					}),
 					error: z.object({
-						error: z
-							.enum([
-								"invalid_request",
-								"expired_token",
-							])
-							.meta({
-								description: "Error code",
-							}),
+						error: z.enum(["invalid_request", "expired_token"]).meta({
+							description: "Error code",
+						}),
 						error_description: z.string().meta({
 							description: "Detailed error description",
 						}),


### PR DESCRIPTION
Fixes #5021

Fixed the error type of the authClient.device.deny method provided by the device-authorization plugin.

```js
const { error } = await authClient.device.deny({ userCode: "1"})
```

Before error type was:
```js
{
    code?: string | undefined;
    message?: string | undefined;
    status: number;
    statusText: string;
} | null
```

After this pr, error type is:
```js
{
    error: "invalid_request" | "expired_token";
    error_description: string;
    status: number;
    statusText: string;
}
```

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the error response schema for the device authorization deny endpoint. Clients now get a structured error payload with error and error_description, supporting invalid_request and expired_token.

- **Bug Fixes**
  - Added an error object to the deny device route schema (zod/OpenAPI) to standardize client error types and align with RFC 8628.

<!-- End of auto-generated description by cubic. -->

