### PR TITLE
feat: add support for custom callback for token url

### DIFF
--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -184,6 +184,8 @@ interface GenericOAuthConfig {
 
 **authorizationUrlParams**: (Optional) Additional query parameters to add to the authorization URL. These can override default parameters. You can also provide a function that returns the parameters.
 
+**tokenUrlParams**: (Optional) Additional query parameters to add to the token URL. These can override default parameters. You can also provide a function that returns the parameters.
+
 **disableImplicitSignUp**: (Optional) If true, disables automatic sign-up for new users. Sign-in must be explicitly requested with sign-up intent.
 
 **disableSignUp**: (Optional) If true, disables sign-up for new users entirely. Only existing users can sign in.

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -110,7 +110,9 @@ export interface GenericOAuthConfig {
 	 * Additional search-params to add to the tokenUrl.
 	 * Warning: Search-params added here overwrite any default params.
 	 */
-	tokenUrlParams?: Record<string, string>;
+	tokenUrlParams?:
+		| Record<string, string>
+		| ((ctx: GenericEndpointContext) => Record<string, string>);
 	/**
 	 * Disable implicit sign up for new users. When set to true for the provider,
 	 * sign-in need to be called with with requestSignUp as true to create new users.
@@ -628,6 +630,10 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 								message: "Invalid OAuth configuration.",
 							});
 						}
+						const additionalParams =
+							typeof provider.tokenUrlParams === "function"
+								? provider.tokenUrlParams(ctx)
+								: provider.tokenUrlParams;
 						tokens = await validateAuthorizationCode({
 							headers: provider.authorizationHeaders,
 							code,
@@ -640,7 +646,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							},
 							tokenEndpoint: finalTokenUrl,
 							authentication: provider.authentication,
-							additionalParams: provider.tokenUrlParams,
+							additionalParams,
 						});
 					} catch (e) {
 						ctx.context.logger.error(


### PR DESCRIPTION
closes #5026
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds support for a callback to set token URL query params in the Generic OAuth plugin. This enables dynamic, per-request params for better compatibility with different OAuth servers.

- **New Features**
  - tokenUrlParams now accepts a function (ctx => Record<string, string>) in addition to a static object.
  - Docs updated to describe tokenUrlParams and its callback option.

<!-- End of auto-generated description by cubic. -->

