### PR TITLE
fix(sso): handle samlConfig that is already parsed as object

### DIFF
--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -1594,8 +1594,9 @@ export const sso = (options?: SSOOptions) => {
 						});
 					}
 					const parsedSamlConfig = safeJsonParse<SAMLConfig>(
-						provider.samlConfig as unknown as string,
+						provider.samlConfig,
 					);
+
 					if (!parsedSamlConfig) {
 						throw new APIError("BAD_REQUEST", {
 							message: "Invalid SAML configuration",


### PR DESCRIPTION
Fixes issue where provider.samlConfig could already be a JSON object (from defaultSSO config or previously parsed from database) but was being parsed again with JSON.parse(), causing runtime errors.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent runtime errors in SSO by safely handling provider.samlConfig when it’s already an object. We now only JSON.parse when the value is a string.

- **Bug Fixes**
  - Check samlConfig type (object vs string) and avoid double parsing; supports defaultSSO and previously parsed DB values.

<!-- End of auto-generated description by cubic. -->

