### PR TITLE
fix: cookie size limit shouldn't throw error

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -245,6 +245,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					if (e instanceof APIError) {
 						throw e;
 					}
+					ctx.context.logger.error("Failed to create user", e);
 					throw new APIError("UNPROCESSABLE_ENTITY", {
 						message: BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
 						details: e,

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -245,7 +245,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					if (e instanceof APIError) {
 						throw e;
 					}
-					ctx.context.logger.error("Failed to create user", e);
+					ctx.context.logger?.error("Failed to create user", e);
 					throw new APIError("UNPROCESSABLE_ENTITY", {
 						message: BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
 						details: e,

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -145,9 +145,10 @@ export async function setCookieCache(
 			},
 		);
 		if (data.length > 4093) {
-			throw new BetterAuthError(
-				"Session data is too large to store in the cookie. Please disable session cookie caching or reduce the size of the session data",
+			ctx.context?.logger?.error(
+				`Session data exceeds cookie size limit (${data.length} bytes > 4093 bytes). Consider reducing session data size or disabling cookie cache. Session will not be cached in cookie.`,
 			);
+			return;
 		}
 		ctx.setCookie(ctx.context.authCookies.sessionData.name, data, options);
 	}


### PR DESCRIPTION
Currently, we throw an error when session data exceeds the cookie size limit. Instead, we should log the error and skip setting the cookie cache. This will allow caching of other smaller data without requiring cookie caching to be disabled entirely

This is a temporary fix until we introduce cookie chunking (#4697)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stop throwing an error when session data exceeds the cookie size limit. We now log the issue and skip setting the session cookie so other cache operations continue. Temporary until we add cookie chunking (#4697).

- **Bug Fixes**
  - Cookie cache: when data > 4093 bytes, log the size and skip setting the cookie instead of throwing.
  - Sign-up: log non-API errors when user creation fails for better visibility.

<!-- End of auto-generated description by cubic. -->

