### PR TITLE
fix(sso): prevent duplicate SSO provider creation with same providerId

### DIFF
--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -780,6 +780,26 @@ export const sso = (options?: SSOOptions) => {
 							});
 						}
 					}
+
+					const existingProvider = await ctx.context.adapter.findOne({
+						model: "ssoProvider",
+						where: [
+							{
+								field: "providerId",
+								value: body.providerId,
+							},
+						],
+					});
+
+					if (existingProvider) {
+						ctx.context.logger.info(
+							`SSO provider creation attempt with existing providerId: ${body.providerId}`,
+						);
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							message: "SSO provider with this providerId already exists",
+						});
+					}
+
 					const provider = await ctx.context.adapter.create<
 						Record<string, any>,
 						SSOProvider


### PR DESCRIPTION
- Add validation check before creating SSO provider to ensure providerId is unique
- Throw UNPROCESSABLE_ENTITY error if provider with same providerId already exists
- Add tests for duplicate providerId validation in both SAML and OIDC flows
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent duplicate SSO provider creation by enforcing a unique providerId for both OIDC and SAML.

- **Bug Fixes**
  - Validate providerId uniqueness before creating a provider.
  - If a duplicate is found, throw UNPROCESSABLE_ENTITY with message: "SSO provider with this providerId already exists".
  - Add tests covering duplicate creation for OIDC and SAML flows.

<!-- End of auto-generated description by cubic. -->

