### PR TITLE
fix(adapter): foreign keys that are nullable on number ids can return string of `null`

### DIFF
--- a/packages/better-auth/src/adapters/adapter-factory/index.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/index.ts
@@ -358,9 +358,9 @@ export const createAdapterFactory =
 					options.advanced?.database?.useNumberId
 				) {
 					if (Array.isArray(newValue)) {
-						newValue = newValue.map(Number);
+						newValue = newValue.map((x) => (x !== null ? Number(x) : null));
 					} else {
-						newValue = Number(newValue);
+						newValue = newValue !== null ? Number(newValue) : null;
 					}
 				} else if (
 					config.supportsJSON === false &&

--- a/packages/better-auth/src/adapters/adapter-factory/test/adapter-factory.test.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/test/adapter-factory.test.ts
@@ -234,6 +234,73 @@ describe("Create Adapter Helper", async () => {
 				expect(res?.updatedAt).toBeInstanceOf(Date);
 			});
 
+			test("should not return string for nullable foreign keys", async () => {
+				const adapter = await createTestAdapter({
+					config: {
+						debugLogs: {},
+					},
+					options: {
+						plugins: [
+							{
+								id: "test",
+								schema: {
+									testModel: {
+										fields: {
+											nullableReference: {
+												type: "string",
+												references: { field: "id", model: "user" },
+												required: false,
+											},
+										},
+									},
+								},
+							},
+						],
+					},
+				});
+				const res = await adapter.create({
+					model: "testModel",
+					data: { nullableReference: null },
+				});
+				expect(res).toHaveProperty("nullableReference");
+				expect(res.nullableReference).toBeNull();
+
+				const adapter2 = await createTestAdapter({
+					config: {
+						debugLogs: {},
+					},
+					options: {
+						plugins: [
+							{
+								id: "test",
+								schema: {
+									testModel: {
+										fields: {
+											nullableReference: {
+												type: "string",
+												references: { field: "id", model: "user" },
+												required: false,
+											},
+										},
+									},
+								},
+							},
+						],
+						advanced: {
+							database: {
+								useNumberId: true,
+							},
+						},
+					},
+				});
+				const res2 = await adapter2.create({
+					model: "testModel",
+					data: { nullableReference: null },
+				});
+				expect(res2).toHaveProperty("nullableReference");
+				expect(res2.nullableReference).toBeNull();
+			});
+
 			test('Should include an "id" in the result in all cases, unless "select" is used to exclude it', async () => {
 				const res = await adapter.create({
 					model: "user",

--- a/packages/better-auth/src/adapters/tests/normal.ts
+++ b/packages/better-auth/src/adapters/tests/normal.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { createTestSuite } from "../create-test-suite";
-import type { User } from "../../types";
+import type { BetterAuthPlugin, Session, User } from "../../types";
 
 /**
  * This test suite tests the basic CRUD operations of the adapter.
@@ -97,6 +97,37 @@ export const getNormalTestSuiteTests = ({
 				where: [{ field: "id", value: res.id }],
 			});
 			expect(findResult).toEqual(res);
+		},
+		"create - should not return string for nullable foreign keys": async () => {
+			await modifyBetterAuthOptions(
+				{
+					plugins: [
+						{
+							id: "test",
+							schema: {
+								testModel: {
+									fields: {
+										nullableReference: {
+											type: "string",
+											references: { field: "id", model: "user" },
+											required: false,
+										},
+									},
+								},
+							},
+						} satisfies BetterAuthPlugin,
+					],
+				},
+				true,
+			);
+			const { nullableReference } = await adapter.create<{
+				nullableReference: string | null;
+			}>({
+				model: "testModel",
+				data: { nullableReference: null },
+				forceAllowId: true,
+			});
+			expect(nullableReference).toBeNull();
 		},
 		"findOne - should find a model": async () => {
 			const [user] = await insertRandom("user");


### PR DESCRIPTION

When using `useNumberId` then setting `null` to a foreign key field using the adapter, it's possible it will set it to a string `null` (even when returned from the adapter) This PR fixes this and adds tests.

Closes https://github.com/better-auth/better-auth/issues/3001