### PR TITLE
fix:`signUpEmail` provided dates will cause DB insert failure

### DIFF
--- a/packages/better-auth/src/adapters/adapter-factory/index.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/index.ts
@@ -16,7 +16,6 @@ import type {
 } from "./types";
 import { colors } from "../../utils/colors";
 import type { DBFieldAttribute } from "@better-auth/core/db";
-import { parseUserInput } from "../../db";
 export * from "./types";
 
 let debugLogs: { instance: string; args: any[] }[] = [];
@@ -342,6 +341,18 @@ export const createAdapterFactory =
 				}
 				// If the value is undefined, but the fieldAttr provides a `defaultValue`, then we'll use that.
 				let newValue = withApplyDefault(value, fieldAttributes!, action);
+
+				// In some endpoints (like signUpEmail) where there isn't proper Zod validation,
+				// we might recieve a date as a string (this is because of the client converting the Date to a string
+				// when sending to the server). Because of this, we'll convert the string to a Date.
+				if (
+					fieldAttributes &&
+					fieldAttributes.type === "date" &&
+					!(newValue instanceof Date) &&
+					newValue !== null
+				) {
+					newValue = new Date(newValue);
+				}
 
 				// If the field attr provides a custom transform input, then we'll let it handle the value transformation.
 				// Afterwards, we'll continue to apply the default transformations just to make sure it saves in the correct format.


### PR DESCRIPTION
When creating an additional field with a type of `date`, then using the `authClient.signUp.email` with that new date field, the endpoint will fail saying it couldn't insert a user. The error will be `value.toIsoString` is not a function.

This is caused by the client sending dates to the server as a string (since it can't send Date type over HTTP). Normally, our endpoints which have Zod validation will automatically convert dates from string back to dates, however since the signUpEmail endpoint doesn't do this it causes bugs when inserting.

This PR fixes this and adds tests.