### PR TITLE
fix(oauth-proxy): remove console.log from oauth-proxy

### DIFF
--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -231,7 +231,6 @@ export const oAuthProxy = (opts?: OAuthProxyOptions) => {
 					},
 					handler: createAuthMiddleware(async (ctx) => {
 						const skipProxy = checkSkipProxy(ctx);
-						console.log("skipProxy", skipProxy);
 						if (skipProxy) {
 							return;
 						}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed a stray console.log from the OAuth Proxy middleware to reduce log noise and avoid logging the skipProxy flag.

<!-- End of auto-generated description by cubic. -->

