### PR TITLE
docs: fix typo in OTT plugin introduction

### DIFF
--- a/docs/content/docs/plugins/one-time-token.mdx
+++ b/docs/content/docs/plugins/one-time-token.mdx
@@ -3,7 +3,7 @@ title: One-Time Token Plugin
 description: Generate and verify single-use token
 ---
 
-The One-Time Token (OTT) plugin provides functionality to generate and verify secure, single-use session tokens. These are commonly used for across domains authentication.
+The One-Time Token (OTT) plugin provides functionality to generate and verify secure, single-use session tokens. These are commonly used for authentication across domains.
 
 ## Installation
 


### PR DESCRIPTION
Fixed a typo in the OTT plugin docs when talking about using OTT commonly for authentication across domains.