### PR TITLE
fix: update session db hook should expect partial session type

### DIFF
--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -926,7 +926,7 @@ export type BetterAuthOptions = {
 					| boolean
 					| void
 					| {
-							data: Session & Record<string, any>;
+							data: Partial<Session & Record<string, any>>;
 					  }
 				>;
 				/**


### PR DESCRIPTION
closes #4793
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Expect partial session data in the update session DB hook to match update semantics and prevent type errors.

- **Bug Fixes**
  - Changed BetterAuthOptions hook return to data: Partial<Session & Record<string, any>>.
  - Aligns typing with update behavior and fixes #4793.

<!-- End of auto-generated description by cubic. -->

