### PR TITLE
refactor: move `BetterAuthAdvancedOptions` to core

### DIFF
--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -91,8 +91,8 @@ export const init = async (options: BetterAuthOptions) => {
 		.filter((x) => x !== null);
 
 	const generateIdFunc: AuthContext["generateId"] = ({ model, size }) => {
-		if (typeof options.advanced?.generateId === "function") {
-			return options.advanced.generateId({ model, size });
+		if (typeof (options.advanced as any)?.generateId === "function") {
+			return (options.advanced as any).generateId({ model, size });
 		}
 		if (typeof options?.advanced?.database?.generateId === "function") {
 			return options.advanced.database.generateId({ model, size });

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -142,14 +142,9 @@ export type BetterAuthAdvancedOptions = {
 	 * If not provided, random ids will be generated.
 	 * If set to false, the database's auto generated id will be used.
 	 *
-	 * @deprecated Please use `database.generateId` instead. This will be potentially removed in future releases.
+	 * @deprecated Please use `database.generateId` instead.
 	 */
-	generateId?:
-		| ((options: {
-				model: LiteralUnion<Models, string>;
-				size?: number;
-		  }) => string)
-		| false;
+	generateId?: never;
 };
 
 export type BetterAuthOptions = {

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -11,9 +11,9 @@ import type { SocialProviderList, SocialProviders } from "../social-providers";
 import type { AdapterInstance, SecondaryStorage } from "./adapter";
 import type { KyselyDatabaseType } from "../adapters/kysely-adapter/types";
 import type { DBFieldAttribute } from "@better-auth/core/db";
-import type { Models, RateLimit } from "./models";
+import type { RateLimit } from "./models";
 import type { AuthContext } from ".";
-import type { CookieOptions } from "better-call";
+import type { BetterAuthAdvancedOptions } from "@better-auth/core";
 import type { Database } from "better-sqlite3";
 import type { Logger } from "../utils";
 import type { AuthMiddleware } from "../plugins";
@@ -21,131 +21,6 @@ import type { LiteralUnion, OmitId } from "./helper";
 import type { AdapterDebugLogs } from "../adapters";
 import type { Database as BunDatabase } from "bun:sqlite";
 import type { DatabaseSync } from "node:sqlite";
-
-export type BetterAuthAdvancedOptions = {
-	/**
-	 * Ip address configuration
-	 */
-	ipAddress?: {
-		/**
-		 * List of headers to use for ip address
-		 *
-		 * Ip address is used for rate limiting and session tracking
-		 *
-		 * @example ["x-client-ip", "x-forwarded-for", "cf-connecting-ip"]
-		 *
-		 * @default
-		 * @link https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/utils/get-request-ip.ts#L8
-		 */
-		ipAddressHeaders?: string[];
-		/**
-		 * Disable ip tracking
-		 *
-		 * ⚠︎ This is a security risk and it may expose your application to abuse
-		 */
-		disableIpTracking?: boolean;
-	};
-	/**
-	 * Use secure cookies
-	 *
-	 * @default false
-	 */
-	useSecureCookies?: boolean;
-	/**
-	 * Disable trusted origins check
-	 *
-	 * ⚠︎ This is a security risk and it may expose your application to CSRF attacks
-	 */
-	disableCSRFCheck?: boolean;
-	/**
-	 * Configure cookies to be cross subdomains
-	 */
-	crossSubDomainCookies?: {
-		/**
-		 * Enable cross subdomain cookies
-		 */
-		enabled: boolean;
-		/**
-		 * Additional cookies to be shared across subdomains
-		 */
-		additionalCookies?: string[];
-		/**
-		 * The domain to use for the cookies
-		 *
-		 * By default, the domain will be the root
-		 * domain from the base URL.
-		 */
-		domain?: string;
-	};
-	/*
-	 * Allows you to change default cookie names and attributes
-	 *
-	 * default cookie names:
-	 * - "session_token"
-	 * - "session_data"
-	 * - "dont_remember"
-	 *
-	 * plugins can also add additional cookies
-	 */
-	cookies?: {
-		[key: string]: {
-			name?: string;
-			attributes?: CookieOptions;
-		};
-	};
-	defaultCookieAttributes?: CookieOptions;
-	/**
-	 * Prefix for cookies. If a cookie name is provided
-	 * in cookies config, this will be overridden.
-	 *
-	 * @default
-	 * ```txt
-	 * "appName" -> which defaults to "better-auth"
-	 * ```
-	 */
-	cookiePrefix?: string;
-	/**
-	 * Database configuration.
-	 */
-	database?: {
-		/**
-		 * The default number of records to return from the database
-		 * when using the `findMany` adapter method.
-		 *
-		 * @default 100
-		 */
-		defaultFindManyLimit?: number;
-		/**
-		 * If your database auto increments number ids, set this to `true`.
-		 *
-		 * Note: If enabled, we will not handle ID generation (including if you use `generateId`), and it would be expected that your database will provide the ID automatically.
-		 *
-		 * @default false
-		 */
-		useNumberId?: boolean;
-		/**
-		 * Custom generateId function.
-		 *
-		 * If not provided, random ids will be generated.
-		 * If set to false, the database's auto generated id will be used.
-		 */
-		generateId?:
-			| ((options: {
-					model: LiteralUnion<Models, string>;
-					size?: number;
-			  }) => string | false)
-			| false;
-	};
-	/**
-	 * Custom generateId function.
-	 *
-	 * If not provided, random ids will be generated.
-	 * If set to false, the database's auto generated id will be used.
-	 *
-	 * @deprecated Please use `database.generateId` instead.
-	 */
-	generateId?: never;
-};
 
 export type BetterAuthOptions = {
 	/**
@@ -799,7 +674,12 @@ export type BetterAuthOptions = {
 	/**
 	 * Advanced options
 	 */
-	advanced?: BetterAuthAdvancedOptions;
+	advanced?: BetterAuthAdvancedOptions & {
+		/**
+		 * @deprecated Please use `database.generateId` instead.
+		 */
+		generateId?: never;
+	};
 	logger?: Logger;
 	/**
 	 * allows you to define custom hooks that can be

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -1,6 +1,28 @@
 import type { ZodType } from "zod";
 import type { LiteralString } from "../types";
 
+declare module "../index" {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	interface BetterAuthMutators<O, C> {
+		"better-auth/db": {
+			// todo: we should infer the schema from the adapter
+		};
+	}
+}
+
+export type Models =
+	| "user"
+	| "account"
+	| "session"
+	| "verification"
+	| "rate-limit"
+	| "organization"
+	| "member"
+	| "invitation"
+	| "jwks"
+	| "passkey"
+	| "two-factor";
+
 export type DBFieldType =
 	| "string"
 	| "number"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,3 @@
-export {};
+// Shared types and interfaces for BetterAuth, allowing plugins to extend functionality.
+export interface BetterAuthMutators<O, C> {}
+export * from "./types";

--- a/packages/core/src/types/helper.ts
+++ b/packages/core/src/types/helper.ts
@@ -1,1 +1,6 @@
+type Primitive = string | number | symbol | bigint | boolean | null | undefined;
+
 export type LiteralString = "" | (string & Record<never, never>);
+export type LiteralUnion<LiteralType, BaseType extends Primitive> =
+	| LiteralType
+	| (BaseType & Record<never, never>);

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,1 +1,2 @@
-export * from "./helper";
+export type * from "./helper";
+export type { BetterAuthAdvancedOptions, GenerateIdFn } from "./init-options";

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1,0 +1,119 @@
+import type { CookieOptions } from "better-call";
+import type { LiteralUnion } from "./helper";
+import type { Models } from "../db/type";
+
+export type GenerateIdFn = (options: {
+	model: LiteralUnion<Models, string>;
+	size?: number;
+}) => string | false;
+
+export type BetterAuthAdvancedOptions = {
+	/**
+	 * Ip address configuration
+	 */
+	ipAddress?: {
+		/**
+		 * List of headers to use for ip address
+		 *
+		 * Ip address is used for rate limiting and session tracking
+		 *
+		 * @example ["x-client-ip", "x-forwarded-for", "cf-connecting-ip"]
+		 *
+		 * @default
+		 * @link https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/utils/get-request-ip.ts#L8
+		 */
+		ipAddressHeaders?: string[];
+		/**
+		 * Disable ip tracking
+		 *
+		 * ⚠︎ This is a security risk and it may expose your application to abuse
+		 */
+		disableIpTracking?: boolean;
+	};
+	/**
+	 * Use secure cookies
+	 *
+	 * @default false
+	 */
+	useSecureCookies?: boolean;
+	/**
+	 * Disable trusted origins check
+	 *
+	 * ⚠︎ This is a security risk and it may expose your application to CSRF attacks
+	 */
+	disableCSRFCheck?: boolean;
+	/**
+	 * Configure cookies to be cross subdomains
+	 */
+	crossSubDomainCookies?: {
+		/**
+		 * Enable cross subdomain cookies
+		 */
+		enabled: boolean;
+		/**
+		 * Additional cookies to be shared across subdomains
+		 */
+		additionalCookies?: string[];
+		/**
+		 * The domain to use for the cookies
+		 *
+		 * By default, the domain will be the root
+		 * domain from the base URL.
+		 */
+		domain?: string;
+	};
+	/*
+	 * Allows you to change default cookie names and attributes
+	 *
+	 * default cookie names:
+	 * - "session_token"
+	 * - "session_data"
+	 * - "dont_remember"
+	 *
+	 * plugins can also add additional cookies
+	 */
+	cookies?: {
+		[key: string]: {
+			name?: string;
+			attributes?: CookieOptions;
+		};
+	};
+	defaultCookieAttributes?: CookieOptions;
+	/**
+	 * Prefix for cookies. If a cookie name is provided
+	 * in cookies config, this will be overridden.
+	 *
+	 * @default
+	 * ```txt
+	 * "appName" -> which defaults to "better-auth"
+	 * ```
+	 */
+	cookiePrefix?: string;
+	/**
+	 * Database configuration.
+	 */
+	database?: {
+		/**
+		 * The default number of records to return from the database
+		 * when using the `findMany` adapter method.
+		 *
+		 * @default 100
+		 */
+		defaultFindManyLimit?: number;
+		/**
+		 * If your database auto increments number ids, set this to `true`.
+		 *
+		 * Note: If enabled, we will not handle ID generation (including if you use `generateId`), and it would be expected that your database will provide the ID automatically.
+		 *
+		 * @default false
+		 */
+		useNumberId?: boolean;
+		/**
+		 * Custom generateId function.
+		 *
+		 * If not provided, random ids will be generated.
+		 * If set to false, the database's auto generated id will be used.
+		 */
+		generateId?: GenerateIdFn | false;
+	};
+};


### PR DESCRIPTION
Please note that this PR removes `options.generateId` from the type.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved BetterAuthAdvancedOptions (and GenerateIdFn) to @better-auth/core to centralize shared types and make plugin/adapter reuse easier. Also removed advanced.generateId from the public type; use advanced.database.generateId instead.

- **Refactors**
  - Added core/types/init-options.ts with BetterAuthAdvancedOptions and GenerateIdFn; re-exported from core.
  - Introduced Models union and helper types (LiteralUnion) in core; added BetterAuthMutators hook.
  - better-auth now imports BetterAuthAdvancedOptions from core and forbids advanced.generateId.
  - init uses GenerateIdFn from core when calling a custom generator.

- **Migration**
  - Replace advanced.generateId with advanced.database.generateId.
  - Type errors will guide updates; behavior unchanged if you already use database.generateId.

<!-- End of auto-generated description by cubic. -->

