### PR TITLE
docs: fix funtion name getSignedCookie

### DIFF
--- a/docs/content/docs/concepts/hooks.mdx
+++ b/docs/content/docs/concepts/hooks.mdx
@@ -136,7 +136,7 @@ const hook = createAuthMiddleware(async (ctx) => {
 #### Cookies
 
 - Set cookies: `ctx.setCookies` or `ctx.setSignedCookie`.
-- Get cookies: `ctx.getCookies` or `ctx.getSignedCookies`.
+- Get cookies: `ctx.getCookies` or `ctx.getSignedCookie`.
 
 Example:
 
@@ -150,7 +150,7 @@ const hook = createAuthMiddleware(async (ctx) => {
     });
 
     const cookie = ctx.getCookies("my-cookie");
-    const signedCookie = await ctx.getSignedCookies("my-signed-cookie");
+    const signedCookie = await ctx.getSignedCookie("my-signed-cookie");
 });
 ```
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Corrected the cookies section in hooks docs to use ctx.getSignedCookie (singular) instead of ctx.getSignedCookies. Aligns with the API and prevents confusion in examples.

<!-- End of auto-generated description by cubic. -->

