### PR TITLE
fix(organization): deleting member from org doesn't delete them from teams

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -377,8 +377,11 @@ export const removeMember = <O extends OrganizationOptions>(options: O) =>
 					organization,
 				});
 			}
-
-			await adapter.deleteMember(toBeRemovedMember.id);
+			await adapter.deleteMember({
+				memberId: toBeRemovedMember.id,
+				organizationId: organizationId,
+				userId: toBeRemovedMember.userId,
+			});
 			if (
 				session.user.id === toBeRemovedMember.userId &&
 				session.session.activeOrganizationId ===
@@ -792,7 +795,11 @@ export const leaveOrganization = <O extends OrganizationOptions>(options: O) =>
 					});
 				}
 			}
-			await adapter.deleteMember(member.id);
+			await adapter.deleteMember({
+				memberId: member.id,
+				organizationId: ctx.body.organizationId,
+				userId: session.user.id,
+			});
 			if (session.session.activeOrganizationId === ctx.body.organizationId) {
 				await adapter.setActiveOrganization(session.session.token, null, ctx);
 			}

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -3,6 +3,7 @@ import { getTestInstance } from "../../test-utils/test-instance";
 import { organization } from "./organization";
 import { createAuthClient } from "../../client";
 import { organizationClient } from "./client";
+import { setCookieToHeader } from "../../cookies";
 
 describe("team", async (it) => {
 	const { auth, signInWithTestUser, cookieSetter } = await getTestInstance({
@@ -636,5 +637,100 @@ describe("mulit team support", async (it) => {
 		expect(invitation.id).toBeDefined();
 		expect((invitation as any).teamId).toBeNull();
 		expect((invitation as any).teamId).not.toBe("");
+	});
+
+	it("should remove a member from the organization and all their teams when calling removeMember", async () => {
+		// Create a new user to invite
+		const userHeaders = new Headers();
+		const response = await auth.api.signUpEmail({
+			body: {
+				email: "removeteamorguser@email.com",
+				name: "Remove Team Org User",
+				password: "password",
+			},
+			asResponse: true,
+		});
+
+		setCookieToHeader(userHeaders)({ response });
+		const newUser = await response.json();
+
+		// Add the user as a member to the organization
+		const member = await auth.api.addMember({
+			headers: admin.headers,
+			body: {
+				organizationId: organizationId!,
+				userId: newUser.user.id,
+				role: "member",
+			},
+		});
+
+		// Add the user to team1
+		await auth.api.addTeamMember({
+			headers: admin.headers,
+			body: {
+				teamId: team1Id!,
+				userId: newUser.user.id,
+			},
+		});
+
+		// add admin to the team1
+		await auth.api.addTeamMember({
+			headers: admin.headers,
+			body: {
+				teamId: team1Id!,
+				userId: admin.user.id,
+			},
+		});
+
+		// Confirm user is a member of the org
+		const membersBefore = await auth.api.listMembers({
+			headers: admin.headers,
+			query: { organizationId: organizationId! },
+		});
+		const foundMember = membersBefore.members.find(
+			(m: any) => m.userId === newUser.user.id,
+		);
+		expect(foundMember).toBeDefined();
+		if (!foundMember) throw Error("can not run test");
+
+		// Confirm user is a member of the team
+		const teamMembersBefore = await auth.api.listTeamMembers({
+			headers: userHeaders,
+			query: { teamId: team1Id! },
+		});
+		const foundTeamMember = teamMembersBefore.find(
+			(m: any) => m.userId === newUser.user.id,
+		);
+		expect(foundTeamMember).toBeDefined();
+
+		// Remove the member from the organization
+		const removed = await auth.api.removeMember({
+			headers: admin.headers,
+			body: {
+				memberIdOrEmail: foundMember.id,
+				organizationId: organizationId!,
+			},
+		});
+		expect(removed?.member?.id).toBe(foundMember.id);
+
+		// Confirm user is no longer a member of the org
+		const membersAfter = await auth.api.listMembers({
+			headers: admin.headers,
+			query: { organizationId: organizationId! },
+		});
+		const stillMember = membersAfter.members.find(
+			(m: any) => m.userId === newUser.user.id,
+		);
+		expect(stillMember).toBeUndefined();
+
+		// Confirm user is no longer a member of the team
+		const teamMembersAfter = await auth.api.listTeamMembers({
+			headers: admin.headers,
+			query: { teamId: team1Id! },
+		});
+		const stillTeamMember = teamMembersAfter.find(
+			(m: any) => m.userId === newUser.user.id,
+		);
+		expect(stillTeamMember).toBeUndefined();
 	});
 });


### PR DESCRIPTION

When calling auth.api.removeMember it's expected that they're removed from both the organization they're in, as well as any teams they could be in.

This applies to the `leaveOrganization` endpoint too.

- [x] tests