### PR TITLE
docs: update api.mdx to improve cookies example

### DIFF
--- a/docs/content/docs/concepts/api.mdx
+++ b/docs/content/docs/concepts/api.mdx
@@ -81,7 +81,7 @@ const { headers, response } = await auth.api.signUpEmail({
 The `headers` will be a `Headers` object, which you can use to get the cookies or the headers.
 
 ```ts
-const cookies = headers.getAll("set-cookie");
+const cookies = headers.getSetCookie();
 const headers = headers.get("x-custom-header");
 ```
 


### PR DESCRIPTION
This changes the example to use `headers.getSetCookie()` instead of `.get(...)`.

That way it returns an array. Otherwise it returns it as a string and setting the headers on the response will not work correctly.

I had this situation while using Elysia:

```ts
const signInResult = await auth.api.signInEmail({
  body: {
    email: result.email,
    password: result.password,
    rememberMe: result['remember-me'] === 'on',
  },
  headers: request.headers,
  returnHeaders: true,
});

// ✅ this works correctly
set.headers['set-cookie'] = signInResult.headers.getSetCookie();

// ❌ this will not work correctly (but no errors)
set.headers['set-cookie'] = signInResult.headers.get('set-cookie');

return redirect('/', 302);
``` 
    

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update API docs to use headers.getSetCookie() instead of headers.get('set-cookie') so examples return an array of cookies. This avoids broken Set-Cookie handling when forwarding headers in servers like Elysia.

<sup>Written for commit 6687f5fd3acf2251b0d26519cca51681b1112678. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



