### PR TITLE
fix(sso): OIDC scopes should fallback to provider scopes

### DIFF
--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -1139,12 +1139,13 @@ export const sso = (options?: SSOOptions) => {
 							codeVerifier: provider.oidcConfig.pkce
 								? state.codeVerifier
 								: undefined,
-							scopes: ctx.body.scopes || [
-								"openid",
-								"email",
-								"profile",
-								"offline_access",
-							],
+							scopes: ctx.body.scopes ||
+								provider.oidcConfig.scopes || [
+									"openid",
+									"email",
+									"profile",
+									"offline_access",
+								],
 							authorizationEndpoint: provider.oidcConfig.authorizationEndpoint!,
 						});
 						return ctx.json({


### PR DESCRIPTION
closes #2360
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix SSO OIDC scopes to use provider-defined scopes when none are provided, with a final fallback to the default set. This honors provider config and prevents mis-scoped authorization (Linear #2360).

<!-- End of auto-generated description by cubic. -->

