### PR TITLE
fix(adapter): Kysely with `CamelCasePlugin` breaks for OIDC.

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -110,7 +110,7 @@ export async function authorize(
 		);
 		throw ctx.redirect(errorURL);
 	}
-	const redirectURI = client.redirectURLs.find(
+	const redirectURI = client.redirectUrls.find(
 		(url) => url === ctx.query.redirect_uri,
 	);
 

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -61,7 +61,7 @@ export async function getClient(
 			}
 			return {
 				...res,
-				redirectURLs: (res.redirectURLs ?? "").split(","),
+				redirectUrls: (res.redirectUrls ?? "").split(","),
 				metadata: res.metadata ? JSON.parse(res.metadata) : {},
 			} as Client;
 		});

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -1366,7 +1366,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 							metadata: body.metadata ? JSON.stringify(body.metadata) : null,
 							clientId: clientId,
 							clientSecret: storedClientSecret,
-							redirectURLs: body.redirect_uris.join(","),
+							redirectUrls: body.redirect_uris.join(","),
 							type: "web",
 							authenticationScheme:
 								body.token_endpoint_auth_method || "client_secret_basic",

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -115,7 +115,7 @@ describe("oidc", async () => {
 	let application: Client = {
 		clientId: "test-client-id",
 		clientSecret: "test-client-secret-oidc",
-		redirectURLs: ["http://localhost:3000/api/auth/oauth2/callback/test"],
+		redirectUrls: ["http://localhost:3000/api/auth/oauth2/callback/test"],
 		metadata: {},
 		icon: "",
 		type: "web",
@@ -126,7 +126,7 @@ describe("oidc", async () => {
 	it("should create oidc client", async ({ expect }) => {
 		const createdClient = await serverClient.oauth2.register({
 			client_name: application.name,
-			redirect_uris: application.redirectURLs,
+			redirect_uris: application.redirectUrls,
 			logo_uri: application.icon,
 		});
 		expect(createdClient.data).toMatchObject({
@@ -145,7 +145,7 @@ describe("oidc", async () => {
 			application = {
 				clientId: createdClient.data.client_id,
 				clientSecret: createdClient.data.client_secret,
-				redirectURLs: createdClient.data.redirect_uris,
+				redirectUrls: createdClient.data.redirect_uris,
 				metadata: {},
 				icon: createdClient.data.logo_uri || "",
 				type: "web",
@@ -480,7 +480,7 @@ describe("oidc storage", async () => {
 		let application: Client = {
 			clientId: "test-client-id",
 			clientSecret: "test-client-secret-oidc",
-			redirectURLs: ["http://localhost:3000/api/auth/oauth2/callback/test"],
+			redirectUrls: ["http://localhost:3000/api/auth/oauth2/callback/test"],
 			metadata: {},
 			icon: "",
 			type: "web",
@@ -489,7 +489,7 @@ describe("oidc storage", async () => {
 		};
 		const createdClient = await serverClient.oauth2.register({
 			client_name: application.name,
-			redirect_uris: application.redirectURLs,
+			redirect_uris: application.redirectUrls,
 			logo_uri: application.icon,
 		});
 		expect(createdClient.data).toMatchObject({
@@ -508,7 +508,7 @@ describe("oidc storage", async () => {
 			application = {
 				clientId: createdClient.data.client_id,
 				clientSecret: createdClient.data.client_secret,
-				redirectURLs: createdClient.data.redirect_uris,
+				redirectUrls: createdClient.data.redirect_uris,
 				metadata: {},
 				icon: createdClient.data.logo_uri || "",
 				type: "web",
@@ -655,7 +655,7 @@ describe("oidc-jwt", async () => {
 			let application: Client = {
 				clientId: "test-client-id",
 				clientSecret: "test-client-secret-oidc",
-				redirectURLs: ["http://localhost:3000/api/auth/oauth2/callback/test"],
+				redirectUrls: ["http://localhost:3000/api/auth/oauth2/callback/test"],
 				metadata: {},
 				icon: "",
 				type: "web",
@@ -664,7 +664,7 @@ describe("oidc-jwt", async () => {
 			};
 			const createdClient = await serverClient.oauth2.register({
 				client_name: application.name,
-				redirect_uris: application.redirectURLs,
+				redirect_uris: application.redirectUrls,
 				logo_uri: application.icon,
 			});
 			expect(createdClient.data).toMatchObject({
@@ -683,7 +683,7 @@ describe("oidc-jwt", async () => {
 				application = {
 					clientId: createdClient.data.client_id,
 					clientSecret: createdClient.data.client_secret,
-					redirectURLs: createdClient.data.redirect_uris,
+					redirectUrls: createdClient.data.redirect_uris,
 					metadata: {},
 					icon: createdClient.data.logo_uri || "",
 					type: "web",

--- a/packages/better-auth/src/plugins/oidc-provider/schema.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/schema.ts
@@ -23,7 +23,7 @@ export const schema = {
 				type: "string",
 				required: false,
 			},
-			redirectURLs: {
+			redirectUrls: {
 				type: "string",
 			},
 			type: {

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -306,7 +306,7 @@ export interface Client {
 	 *
 	 * For example, `https://example.com/auth/callback`
 	 */
-	redirectURLs: string[];
+	redirectUrls: string[];
 	/**
 	 * The name of the client.
 	 */


### PR DESCRIPTION
## TLDR
Kysely using their CamelCasePlugin breaks for OIDC due to one of the fields being defined as `redirectURLs`, which causes an inconsistency when generating the lowercase version.

## Breaking Changes
This does require all OIDC users to run migrations in order to update the field.

closes: https://github.com/better-auth/better-auth/issues/4198
linear: https://linear.app/better-auth/issue/ENG-180/fix-align-oidc-redirect-url-field-with-kysely-camelcase-plugin