### PR TITLE
chore: add more adapter tests

### DIFF
--- a/packages/better-auth/src/adapters/adapter-factory/index.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/index.ts
@@ -599,7 +599,7 @@ export const createAdapterFactory =
 				transactionId++;
 				let thisTransactionId = transactionId;
 				const model = getModelName(unsafeModel);
-
+				unsafeModel = getDefaultModelName(unsafeModel);
 				if ("id" in unsafeData && !forceAllowId) {
 					logger.warn(
 						`[${config.adapterName}] - You are trying to create a record with an id. This is not allowed as we handle id generation for you, unless you pass in the \`forceAllowId\` parameter. The id will be ignored.`,
@@ -665,6 +665,7 @@ export const createAdapterFactory =
 			}): Promise<T | null> => {
 				transactionId++;
 				let thisTransactionId = transactionId;
+				unsafeModel = getDefaultModelName(unsafeModel);
 				const model = getModelName(unsafeModel);
 				const where = transformWhereClause({
 					model: unsafeModel,
@@ -725,6 +726,7 @@ export const createAdapterFactory =
 					model: unsafeModel,
 					where: unsafeWhere,
 				});
+				unsafeModel = getDefaultModelName(unsafeModel);
 				debugLog(
 					{ method: "updateMany" },
 					`${formatTransactionId(thisTransactionId)} ${formatStep(1, 4)}`,
@@ -777,6 +779,7 @@ export const createAdapterFactory =
 					model: unsafeModel,
 					where: unsafeWhere,
 				});
+				unsafeModel = getDefaultModelName(unsafeModel);
 				debugLog(
 					{ method: "findOne" },
 					`${formatTransactionId(thisTransactionId)} ${formatStep(1, 3)}`,
@@ -830,6 +833,7 @@ export const createAdapterFactory =
 					model: unsafeModel,
 					where: unsafeWhere,
 				});
+				unsafeModel = getDefaultModelName(unsafeModel);
 				debugLog(
 					{ method: "findMany" },
 					`${formatTransactionId(thisTransactionId)} ${formatStep(1, 3)}`,
@@ -877,6 +881,7 @@ export const createAdapterFactory =
 					model: unsafeModel,
 					where: unsafeWhere,
 				});
+				unsafeModel = getDefaultModelName(unsafeModel);
 				debugLog(
 					{ method: "delete" },
 					`${formatTransactionId(thisTransactionId)} ${formatStep(1, 2)}`,
@@ -908,6 +913,7 @@ export const createAdapterFactory =
 					model: unsafeModel,
 					where: unsafeWhere,
 				});
+				unsafeModel = getDefaultModelName(unsafeModel);
 				debugLog(
 					{ method: "deleteMany" },
 					`${formatTransactionId(thisTransactionId)} ${formatStep(1, 2)}`,
@@ -940,6 +946,7 @@ export const createAdapterFactory =
 					model: unsafeModel,
 					where: unsafeWhere,
 				});
+				unsafeModel = getDefaultModelName(unsafeModel);
 				debugLog(
 					{ method: "count" },
 					`${formatTransactionId(thisTransactionId)} ${formatStep(1, 2)}`,

--- a/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.mysql.test.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/test/adapter.drizzle.mysql.test.ts
@@ -59,12 +59,6 @@ const { execute } = await testAdapter({
 		];
 		const tables = tables_result.map((table) => table.Tables_in_better_auth);
 		assert(tables.length > 0, "No tables found");
-		assert(
-			!["user", "session", "account", "verification"].find(
-				(x) => !tables.includes(x),
-			),
-			"No tables found",
-		);
 	},
 	prefixTests: "mysql",
 	tests: [

--- a/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.mysql.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.mysql.test.ts
@@ -41,12 +41,6 @@ const { execute } = await testAdapter({
 		];
 		const tables = tables_result.map((table) => table.Tables_in_better_auth);
 		assert(tables.length > 0, "No tables found");
-		assert(
-			!["user", "session", "account", "verification"].find(
-				(x) => !tables.includes(x),
-			),
-			"No tables found",
-		);
 	},
 	prefixTests: "mysql",
 	tests: [

--- a/packages/better-auth/src/adapters/memory-adapter/adapter.memory.test.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/adapter.memory.test.ts
@@ -16,9 +16,11 @@ const { execute } = await testAdapter({
 	},
 	runMigrations: (options) => {
 		db = {};
-		const allModels = Object.keys(getAuthTables(options));
+		const authTables = getAuthTables(options);
+		const allModels = Object.keys(authTables);
 		for (const model of allModels) {
-			db[model] = [];
+			const modelName = authTables[model]?.modelName || model;
+			db[modelName] = [];
 		}
 	},
 	tests: [

--- a/packages/better-auth/src/adapters/tests/normal.ts
+++ b/packages/better-auth/src/adapters/tests/normal.ts
@@ -217,9 +217,11 @@ export const getNormalTestSuiteTests = ({
 				},
 				true,
 			);
-			const [user] = await insertRandom("user");
+			const [user_] = await insertRandom("user");
+			const user = user_ as User & { customField: string };
+			expect(user).toHaveProperty("customField");
 			expect(user.customField).toBe("default-value");
-			const result = await adapter.findOne<User>({
+			const result = await adapter.findOne<User & { customField: string }>({
 				model: "user",
 				where: [{ field: "customField", value: user.customField }],
 			});

--- a/packages/better-auth/src/adapters/tests/normal.ts
+++ b/packages/better-auth/src/adapters/tests/normal.ts
@@ -180,6 +180,52 @@ export const getNormalTestSuiteTests = ({
 			expect(result?.email).toEqual(user.email);
 			expect(true).toEqual(true);
 		},
+		"findOne - should find a model with a modified model name": async () => {
+			await modifyBetterAuthOptions(
+				{
+					user: {
+						modelName: "user_custom",
+					},
+				},
+				true,
+			);
+			const [user] = await insertRandom("user");
+			expect(user).toBeDefined();
+			expect(user).toHaveProperty("id");
+			expect(user).toHaveProperty("name");
+			const result = await adapter.findOne<User>({
+				model: "user",
+				where: [{ field: "email", value: user.email }],
+			});
+			expect(result).toEqual(user);
+			expect(result?.email).toEqual(user.email);
+			expect(true).toEqual(true);
+		},
+		"findOne - should find a model with additional fields": async () => {
+			await modifyBetterAuthOptions(
+				{
+					user: {
+						additionalFields: {
+							customField: {
+								type: "string",
+								input: false,
+								required: true,
+								defaultValue: "default-value",
+							},
+						},
+					},
+				},
+				true,
+			);
+			const [user] = await insertRandom("user");
+			expect(user.customField).toBe("default-value");
+			const result = await adapter.findOne<User>({
+				model: "user",
+				where: [{ field: "customField", value: user.customField }],
+			});
+			expect(result).toEqual(user);
+			expect(result?.customField).toEqual("default-value");
+		},
 		"findOne - should select fields": async () => {
 			const [user] = await insertRandom("user");
 			const result = await adapter.findOne<Pick<User, "email" | "name">>({


### PR DESCRIPTION
more unit tests for adapters. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Expanded adapter test coverage to handle custom model names and additional fields, and fixed model-name normalization across adapter CRUD methods. Memory adapter migrations now respect mapped model names, and MySQL adapter tests no longer assume fixed table names.

- **Bug Fixes**
  - Normalize model names with getDefaultModelName in create, updateMany, findOne, findMany, delete, deleteMany, and count.
  - Memory adapter uses authTables.modelName when initializing tables.
  - Removed rigid table-name assertions in MySQL adapter tests to support custom schemas.

<!-- End of auto-generated description by cubic. -->

