### PR TITLE
Fix broken links in examples docs

### DIFF
--- a/docs/content/docs/examples/nuxt.mdx
+++ b/docs/content/docs/examples/nuxt.mdx
@@ -11,7 +11,7 @@ Email & Password . Social Sign-in with Google
 <ForkButton url="better-auth/better-auth/tree/main/examples/nuxt-example"  />
 
 
-<iframe src="https://stackblitz.com/github/better-auth/better-auth/tree/main/examples/nuxt-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
+<iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/nuxt-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
    style={{
       width: "100%",
       height: "500px",

--- a/docs/content/docs/examples/remix.mdx
+++ b/docs/content/docs/examples/remix.mdx
@@ -11,7 +11,7 @@ Email & Password . Social Sign-in with Google . Passkeys . Email Verification . 
 
 <ForkButton url="better-auth/better-auth/tree/main/examples/remix-example"  />
 
-<iframe src="https://stackblitz.com/github/better-auth/better-auth/tree/main/examples/remix-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
+<iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/remix-example?codemirror=1&file=README.md&fontsize=14&hidedevtools=1&hidenavigation=1&runonclick=1"
    style={{
       width: "100%",
       height: "500px",

--- a/docs/content/docs/examples/remix.mdx
+++ b/docs/content/docs/examples/remix.mdx
@@ -11,7 +11,7 @@ Email & Password . Social Sign-in with Google . Passkeys . Email Verification . 
 
 <ForkButton url="better-auth/better-auth/tree/main/examples/remix-example"  />
 
-<iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/remix-example?codemirror=1&file=README.md&fontsize=14&hidedevtools=1&hidenavigation=1&runonclick=1"
+<iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/remix-example?codemirror=1&fontsize=14&hidedevtools=1&hidenavigation=1&runonclick=1"
    style={{
       width: "100%",
       height: "500px",

--- a/docs/content/docs/examples/svelte-kit.mdx
+++ b/docs/content/docs/examples/svelte-kit.mdx
@@ -10,7 +10,7 @@ Email & Password . <u>Social Sign-in with Google</u> . Passkeys . Email Verifica
 
 <ForkButton url="better-auth/better-auth/tree/main/examples/svelte-kit-example"  />
 
-<iframe src="https://stackblitz.com/github/better-auth/better-auth/tree/main/examples/svelte-kit-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
+<iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/svelte-kit-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
    style={{
       width: "100%",
       height: "500px",

--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -128,6 +128,6 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
 - [Nuxt and Nuxt Hub example](https://github.com/atinux/nuxthub-better-auth) on GitHub.
 - [NuxtZzle is Nuxt,Drizzle ORM example](https://github.com/leamsigc/nuxt-better-auth-drizzle) on GitHub [preview](https://nuxt-better-auth.giessen.dev/)
-- [Nuxt example](https://stackblitz.com/github/better-auth/better-auth/tree/main/examples/nuxt-example) on StackBlitz.
+- [Nuxt example](https://stackblitz.com/github/better-auth/examples/tree/main/nuxt-example) on StackBlitz.
 - [NuxSaaS (Github)](https://github.com/NuxSaaS/NuxSaaS) is a full-stack SaaS Starter Kit that leverages Better Auth for secure and efficient user authentication. [Demo](https://nuxsaas.com/)
 - [NuxtOne (Github)](https://github.com/nuxtone/nuxt-one) is a Nuxt-based starter template for building AIaaS (AI-as-a-Service) applications [preview](https://www.one.devv.zone)


### PR DESCRIPTION
Reference to examples were pointing to `examples` directory in this repo which looks to be removed. I've changed these references to point to the examples in the repo https://github.com/better-auth/examples.

Screenshot of the broken StackBlitz for quick reference:

<img width="1798" height="984" alt="image" src="https://github.com/user-attachments/assets/3a866e44-e994-4603-8451-91ecaf08f772" />
