### PR TITLE
fix(telemetry): avoid async import if telemetry disabled, fix for esbuild

### DIFF
--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -100,13 +100,17 @@ export const init = async (options: BetterAuthOptions) => {
 		return generateId(size);
 	};
 
-	const { publish } = await createTelemetry(options, {
-		adapter: adapter.id,
-		database:
-			typeof options.database === "function"
-				? "adapter"
-				: getKyselyDatabaseType(options.database) || "unknown",
-	});
+	const { publish } = options.telemetry?.enabled
+		? await createTelemetry(options, {
+				adapter: adapter.id,
+				database:
+					typeof options.database === "function"
+						? "adapter"
+						: getKyselyDatabaseType(options.database) || "unknown",
+			})
+		: {
+				publish: async () => {},
+			};
 
 	let ctx: AuthContext = {
 		appName: options.appName || "Better Auth",

--- a/packages/better-auth/src/telemetry/index.ts
+++ b/packages/better-auth/src/telemetry/index.ts
@@ -5,7 +5,9 @@ let lazyImportCreateTelemetry: Promise<
 export const createTelemetry: typeof import("./create-telemetry").createTelemetry =
 	async (...args) => {
 		if (!lazyImportCreateTelemetry) {
-			lazyImportCreateTelemetry = import("./create-telemetry").then(
+			// keep esbuild from following dynamic import during bundling
+			const importPath = "./create-telemetry";
+			lazyImportCreateTelemetry = import(importPath).then(
 				(mod) => mod.createTelemetry,
 			);
 		}


### PR DESCRIPTION
These fixes aim to make the latest version of Better Auth compatible with Convex.

Convex's esbuild bundling follows static paths in async imports during bundling, causing telemetry related node dependencies to be bundled for the Convex runtime (which errors during build). This PR uses a variable for the telemetry import path to ensure esbuild doesn't attempt to bundle it.

At runtime, async imports will fail in the Convex runtime specifically. This PR replaces the createTelemetry `publish` method with a no-op function if telemetry is disabled in options.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents telemetry code from being imported when telemetry is disabled, fixing esbuild bundling in Convex and avoiding runtime errors.

- **Bug Fixes**
  - Use a variable import path for createTelemetry to stop esbuild from following the dynamic import and bundling node-only telemetry deps.
  - When telemetry is disabled, return a no-op publish function and skip the async import to prevent Convex runtime failures.

<!-- End of auto-generated description by cubic. -->

