### PR TITLE
fix(stripe): throw error if event failed to be constructed

### DIFF
--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -34,22 +34,24 @@ export default async function HomePage() {
 						<div className="flex flex-col md:flex-row items-center justify-center h-12">
 							<span className="font-medium flex gap-2 text-sm text-zinc-700 dark:text-zinc-300">
 								<span className=" text-zinc-900 dark:text-white/90 hover:text-zinc-950 text-xs md:text-sm dark:hover:text-zinc-100 transition-colors">
-									Auth.js (formerly NextAuth.js) is now part of{" "}
-									<span className="font-semibold">Better Auth</span>
+									Introducing{" "}
+									<span className="font-semibold">
+										Better Auth Infrastructure
+									</span>
 								</span>
 								<span className=" text-zinc-400 hidden md:block">|</span>
 								<Link
-									href="/blog/authjs-joins-better-auth"
+									href="https://better-auth.build"
 									className="font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 hidden dark:hover:text-blue-300 transition-colors md:block"
 								>
-									Read the announcement →
+									Join the waitlist →
 								</Link>
 							</span>
 							<Link
-								href="/blog/authjs-joins-better-auth"
+								href="https://better-auth.build"
 								className="font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 text-xs dark:hover:text-blue-300 transition-colors md:hidden"
 							>
-								Read the announcement →
+								Join the waitlist →
 							</Link>
 						</div>
 					</div>

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@better-auth/utils": "0.3.0",
+    "@better-fetch/fetch": "catalog:",
     "@hookform/resolvers": "^5.2.1",
     "@oramacloud/client": "^2.1.4",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1255,6 +1255,11 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							message: `Webhook Error: ${err.message}`,
 						});
 					}
+					if (!event) {
+						throw new APIError("BAD_REQUEST", {
+							message: "Failed to construct event",
+						});
+					}
 					try {
 						switch (event.type) {
 							case "checkout.session.completed":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 catalogs:
   default:
     '@better-fetch/fetch':
-      specifier: ^1.1.18
+      specifier: 1.1.18
       version: 1.1.18
     better-call:
       specifier: 1.0.19
@@ -465,6 +465,9 @@ importers:
       '@better-auth/utils':
         specifier: 0.3.0
         version: 0.3.0
+      '@better-fetch/fetch':
+        specifier: 'catalog:'
+        version: 1.1.18
       '@hookform/resolvers':
         specifier: ^5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.1.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
   - e2e/**
 
 catalog:
-  '@better-fetch/fetch': ^1.1.18
+  '@better-fetch/fetch': 1.1.18
   better-call: 1.0.19
   typescript: ^5.9.2
   unbuild: 3.6.1


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improve Stripe webhook handling by throwing a BAD_REQUEST error when the event cannot be constructed. Also updates the docs homepage CTA and pins @better-fetch/fetch for consistent builds.

- **Bug Fixes**
  - Throw APIError("BAD_REQUEST", "Failed to construct event") when Stripe webhook event is undefined before processing.

- **Dependencies**
  - Add @better-fetch/fetch to docs and pin version to 1.1.18 via catalog; update workspace and lockfile accordingly.

<!-- End of auto-generated description by cubic. -->

