### PR TITLE
feat(magic-link): add handler function support for disableSignUp

### DIFF
--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -59,19 +59,19 @@ To sign in with a magic link, you need to call `signIn.magicLink` with the user'
   method="POST"
   requireSession
 >
-  
+
 ```ts
 type signInMagicLink = {
     /**
-     * Email address to send the magic link. 
+     * Email address to send the magic link.
      */
     email: string = "user@email.com"
     /**
-     * User display name. Only used if the user is registering for the first time. 
+     * User display name. Only used if the user is registering for the first time.
      */
     name?: string = "my-name"
     /**
-     * URL to redirect after magic link verification. 
+     * URL to redirect after magic link verification.
      */
     callbackURL?: string = "/dashboard"
     /**
@@ -80,7 +80,7 @@ type signInMagicLink = {
     newUserCallbackURL?: string = "/welcome"
     /**
      * URL to redirect if an error happen on verification
-     * If only callbackURL is provided but without an `errorCallbackURL` then they will be 
+     * If only callbackURL is provided but without an `errorCallbackURL` then they will be
      * redirected to the callbackURL with an `error` query parameter.
      */
     errorCallbackURL?: string = "/error"
@@ -89,7 +89,7 @@ type signInMagicLink = {
 </APIMethod>
 
 <Callout>
-If the user has not signed up, unless `disableSignUp` is set to `true`, the user will be signed up automatically.
+If the user has not signed up, unless `disableSignUp` is set to `true` or a function that returns `true`, the user will be signed up automatically.
 </Callout>
 
 ### Verify Magic Link
@@ -111,11 +111,11 @@ If you want to handle the verification manually, (e.g, if you send the user a di
 ```ts
 type magicLinkVerify = {
     /**
-     * Verification token. 
+     * Verification token.
      */
     token: string = "123456"
     /**
-     * URL to redirect after magic link verification, if not provided will return the session. 
+     * URL to redirect after magic link verification, if not provided will return the session.
      */
     callbackURL?: string = "/dashboard"
 }
@@ -134,7 +134,38 @@ and a `request` object as the second parameter.
 
 **expiresIn**: specifies the time in seconds after which the magic link will expire. The default value is `300` seconds (5 minutes).
 
-**disableSignUp**: If set to `true`, the user will not be able to sign up using the magic link. The default value is `false`.
+**disableSignUp**: Controls whether new users can sign up via magic link. Can be a boolean or a function that receives the request context and returns a boolean (sync or async). The default value is `false`.
+
+- When set to `true`, only existing users can sign in with magic links.
+- When set to a function, you can conditionally disable signups based on your application logic.
+- The function receives `Request | undefined` as a parameter (the request may be undefined in some contexts).
+
+Example with function handler:
+```ts
+magicLink({
+    sendMagicLink: async ({ email, token, url }, request) => {
+        // send email
+    },
+    disableSignUp: (request) => {
+        if (!request) return false;
+        const referer = request.headers.get("referer");
+        return referer?.includes("/admin") ?? false;
+    }
+})
+```
+
+Or with async logic:
+```ts
+magicLink({
+    sendMagicLink: async ({ email, token, url }, request) => {
+        // send email
+    },
+    disableSignUp: async (request) => {
+        const isMaintenanceMode = await checkMaintenanceMode();
+        return isMaintenanceMode;
+    }
+})
+```
 
 **generateToken**: The `generateToken` function is called to generate a token which is used to uniquely identify the user. The default value is a random string. There is one parameter:
 

--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -134,11 +134,11 @@ and a `request` object as the second parameter.
 
 **expiresIn**: specifies the time in seconds after which the magic link will expire. The default value is `300` seconds (5 minutes).
 
-**disableSignUp**: Controls whether new users can sign up via magic link. Can be a boolean or a function that receives the request context and returns a boolean (sync or async). The default value is `false`.
+**disableSignUp**: Controls whether new users can sign up via magic link. Can be a boolean or a function that receives the endpoint context and returns a boolean (sync or async). The default value is `false`.
 
 - When set to `true`, only existing users can sign in with magic links.
 - When set to a function, you can conditionally disable signups based on your application logic.
-- The function receives `Request | undefined` as a parameter (the request may be undefined in some contexts).
+- The function receives the endpoint context with access to `body`, `context`, and `request`.
 
 Example with function handler:
 ```ts
@@ -146,10 +146,12 @@ magicLink({
     sendMagicLink: async ({ email, token, url }, request) => {
         // send email
     },
-    disableSignUp: (request) => {
-        if (!request) return false;
-        const referer = request.headers.get("referer");
-        return referer?.includes("/admin") ?? false;
+    disableSignUp: (ctx) => {
+        // Only allow signups from specific email domains
+        const email = ctx.body.email;
+        const allowedDomains = ["company.com", "partner.com"];
+        const domain = email.split("@")[1];
+        return !allowedDomains.includes(domain);
     }
 })
 ```
@@ -160,9 +162,10 @@ magicLink({
     sendMagicLink: async ({ email, token, url }, request) => {
         // send email
     },
-    disableSignUp: async (request) => {
-        const isMaintenanceMode = await checkMaintenanceMode();
-        return isMaintenanceMode;
+    disableSignUp: async (ctx) => {
+        // Check feature flag or application state
+        const signupsEnabled = await checkFeatureFlag("magic-link-signups");
+        return !signupsEnabled;
     }
 })
 ```

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -29,16 +29,14 @@ interface MagicLinkopts {
 	/**
 	 * Disable sign up if user is not found.
 	 *
-	 * Can be a boolean or a function that receives the request (if available) and returns a boolean.
+	 * Can be a boolean or a function that receives the endpoint context and returns a boolean.
 	 * This allows you to conditionally disable signups based on request context.
-	 *
-	 * Note: The request may be undefined in some contexts. Make sure to handle this case.
 	 *
 	 * @default false
 	 */
 	disableSignUp?:
 		| boolean
-		| ((request: Request | undefined) => boolean | Promise<boolean>);
+		| ((ctx: GenericEndpointContext) => boolean | Promise<boolean>);
 	/**
 	 * Rate limit configuration.
 	 *
@@ -175,7 +173,7 @@ export const magicLink = (options: MagicLinkopts) => {
 					if (opts.disableSignUp) {
 						let signUpDisabled = false;
 						if (typeof opts.disableSignUp === "function") {
-							signUpDisabled = await opts.disableSignUp(ctx.request);
+							signUpDisabled = await opts.disableSignUp(ctx);
 						} else {
 							signUpDisabled = true;
 						}
@@ -381,7 +379,10 @@ export const magicLink = (options: MagicLinkopts) => {
 						.then((res) => res?.user);
 
 					if (!user) {
-						const signUpDisabled = typeof opts.disableSignUp === "function" ? await opts.disableSignUp(ctx.request) : opts.disableSignUp
+						const signUpDisabled =
+							typeof opts.disableSignUp === "function"
+								? await opts.disableSignUp(ctx)
+								: opts.disableSignUp;
 
 						if (!signUpDisabled) {
 							const newUser = await ctx.context.internalAdapter.createUser(

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -381,15 +381,7 @@ export const magicLink = (options: MagicLinkopts) => {
 						.then((res) => res?.user);
 
 					if (!user) {
-						// Handle disableSignUp - can be boolean or function
-						let signUpDisabled = false;
-						if (opts.disableSignUp) {
-							if (typeof opts.disableSignUp === "function") {
-								signUpDisabled = await opts.disableSignUp(ctx.request);
-							} else {
-								signUpDisabled = true;
-							}
-						}
+						const signUpDisabled = typeof opts.disableSignUp === "function" ? await opts.disableSignUp(ctx.request) : opts.disableSignUp
 
 						if (!signUpDisabled) {
 							const newUser = await ctx.context.internalAdapter.createUser(

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -381,7 +381,17 @@ export const magicLink = (options: MagicLinkopts) => {
 						.then((res) => res?.user);
 
 					if (!user) {
-						if (!opts.disableSignUp) {
+						// Handle disableSignUp - can be boolean or function
+						let signUpDisabled = false;
+						if (opts.disableSignUp) {
+							if (typeof opts.disableSignUp === "function") {
+								signUpDisabled = await opts.disableSignUp(ctx.request);
+							} else {
+								signUpDisabled = true;
+							}
+						}
+
+						if (!signUpDisabled) {
 							const newUser = await ctx.context.internalAdapter.createUser(
 								{
 									email: email,


### PR DESCRIPTION
## Summary
Allow `disableSignUp` to accept a function that receives the endpoint context and returns a boolean. This enables conditional signup blocking based on request data, application state, or external conditions.

## Changes
- Updated `disableSignUp` option to accept `boolean | ((ctx: GenericEndpointContext) => boolean | Promise<boolean>)`
- Added support for both synchronous and asynchronous handler functions
- Function receives full endpoint context with access to `body`, `context`, and `request`
- Function is evaluated in both the send and verify endpoints
- Only queries the database when signup is actually disabled (efficient)

## Example Usage
```typescript
magicLink({
  sendMagicLink: async ({ email, url, token }) => {
    await sendEmail(email, url);
  },
  disableSignUp: (ctx) => {
    // Only allow signups from specific email domains
    const email = ctx.body.email;
    const allowedDomains = ["company.com", "partner.com"];
    const domain = email.split("@")[1];
    return !allowedDomains.includes(domain);
  }
})
```

Or with async logic:
```typescript
magicLink({
  disableSignUp: async (ctx) => {
    // Check feature flag or application state
    const signupsEnabled = await checkFeatureFlag("magic-link-signups");
    return !signupsEnabled;
  }
})
```

## Tests
- ✅ All existing tests pass
- ✅ Added comprehensive tests for function handler behavior
- ✅ Tests cover sync/async functions, context access, and edge cases
- ✅ Test verifies function is evaluated during verification flow
- ✅ TypeScript compilation successful with proper types