### PR TITLE
refactor: move `BetterAuthPluginDBSchema` to core

### DIFF
--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -1,4 +1,4 @@
-import type { AuthPluginSchema } from "../types/plugins";
+import type { BetterAuthPluginDBSchema } from "../types/plugins";
 import type { BetterAuthOptions } from "../types/options";
 import { APIError } from "better-call";
 import type { Account, Session, User } from "../types";
@@ -163,7 +163,7 @@ export function parseSessionInput(
 	return parseInputData(session, { fields: schema });
 }
 
-export function mergeSchema<S extends AuthPluginSchema>(
+export function mergeSchema<S extends BetterAuthPluginDBSchema>(
 	schema: S,
 	newSchema?: {
 		[K in keyof S]?: {

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthPluginDBSchema } from "../types/plugins";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import type { BetterAuthOptions } from "../types/options";
 import { APIError } from "better-call";
 import type { Account, Session, User } from "../types";

--- a/packages/better-auth/src/plugins/admin/schema.ts
+++ b/packages/better-auth/src/plugins/admin/schema.ts
@@ -1,4 +1,4 @@
-import { type AuthPluginSchema } from "../../types";
+import { type BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 export const schema = {
 	user: {
@@ -34,6 +34,6 @@ export const schema = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;
 
 export type AdminSchema = typeof schema;

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -7,7 +7,6 @@ import {
 import type {
 	BetterAuthPlugin,
 	InferOptionSchema,
-	BetterAuthPluginDBSchema,
 	Session,
 	User,
 	AuthContext,
@@ -17,6 +16,7 @@ import { getOrigin } from "../../utils/url";
 import { mergeSchema } from "../../db/schema";
 import type { EndpointContext } from "better-call";
 import { generateId } from "../../utils/id";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 export interface UserWithAnonymous extends User {
 	isAnonymous: boolean;

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -7,7 +7,7 @@ import {
 import type {
 	BetterAuthPlugin,
 	InferOptionSchema,
-	AuthPluginSchema,
+	BetterAuthPluginDBSchema,
 	Session,
 	User,
 	AuthContext,
@@ -75,7 +75,7 @@ const schema = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;
 
 export const anonymous = (options?: AnonymousOptions) => {
 	const ERROR_CODES = {

--- a/packages/better-auth/src/plugins/api-key/schema.ts
+++ b/packages/better-auth/src/plugins/api-key/schema.ts
@@ -1,4 +1,4 @@
-import type { AuthPluginSchema } from "..";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import parseJSON from "../../client/parser";
 
 export const apiKeySchema = ({
@@ -193,4 +193,4 @@ export const apiKeySchema = ({
 				},
 			},
 		},
-	}) satisfies AuthPluginSchema;
+	}) satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/device-authorization/schema.ts
+++ b/packages/better-auth/src/plugins/device-authorization/schema.ts
@@ -1,4 +1,4 @@
-import type { AuthPluginSchema } from "../../types";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import * as z from "zod";
 
 export const schema = {
@@ -42,7 +42,7 @@ export const schema = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;
 
 export const deviceCode = z.object({
 	id: z.string(),

--- a/packages/better-auth/src/plugins/jwt/schema.ts
+++ b/packages/better-auth/src/plugins/jwt/schema.ts
@@ -1,4 +1,4 @@
-import type { AuthPluginSchema } from "../../types";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 export const schema = {
 	jwks: {
@@ -17,4 +17,4 @@ export const schema = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/oidc-provider/schema.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/schema.ts
@@ -1,4 +1,4 @@
-import type { AuthPluginSchema } from "../../types";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 export const schema = {
 	oauthApplication: {
@@ -129,4 +129,4 @@ export const schema = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -1,6 +1,6 @@
 import { APIError } from "better-call";
 import * as z from "zod";
-import type { AuthPluginSchema } from "../../types";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import { createAuthEndpoint } from "../../api/call";
 import { getSessionFromCtx } from "../../api/routes";
 import type { AuthContext } from "../../init";
@@ -657,7 +657,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 						},
 					},
 				},
-			} satisfies AuthPluginSchema)
+			} satisfies BetterAuthPluginDBSchema)
 		: {};
 
 	const organizationRoleSchema = options?.dynamicAccessControl?.enabled
@@ -700,7 +700,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 					},
 					modelName: options?.schema?.organizationRole?.modelName,
 				},
-			} satisfies AuthPluginSchema)
+			} satisfies BetterAuthPluginDBSchema)
 		: {};
 
 	const schema = {
@@ -835,7 +835,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 					...(options?.schema?.invitation?.additionalFields || {}),
 				},
 			},
-		} satisfies AuthPluginSchema),
+		} satisfies BetterAuthPluginDBSchema),
 	};
 
 	/**
@@ -1007,7 +1007,7 @@ export const organization = <O extends OrganizationOptions>(options?: O) => {
 			),
 		},
 		schema: {
-			...(schema as AuthPluginSchema),
+			...(schema as BetterAuthPluginDBSchema),
 			session: {
 				fields: {
 					activeOrganizationId: {

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -19,7 +19,7 @@ import { freshSessionMiddleware, getSessionFromCtx } from "../../api/routes";
 import type {
 	BetterAuthPlugin,
 	InferOptionSchema,
-	AuthPluginSchema,
+	BetterAuthPluginDBSchema,
 } from "../../types/plugins";
 import { setSessionCookie } from "../../cookies";
 import { generateId } from "../../utils";
@@ -1054,4 +1054,4 @@ const schema = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -16,15 +16,12 @@ import * as z from "zod";
 import { createAuthEndpoint } from "../../api/call";
 import { sessionMiddleware } from "../../api";
 import { freshSessionMiddleware, getSessionFromCtx } from "../../api/routes";
-import type {
-	BetterAuthPlugin,
-	InferOptionSchema,
-	BetterAuthPluginDBSchema,
-} from "../../types/plugins";
+import type { BetterAuthPlugin, InferOptionSchema } from "../../types/plugins";
 import { setSessionCookie } from "../../cookies";
 import { generateId } from "../../utils";
 import { mergeSchema } from "../../db/schema";
 import { base64 } from "@better-auth/utils/base64";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 interface WebAuthnChallengeValue {
 	expectedChallenge: string;

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -1,10 +1,6 @@
 import * as z from "zod";
 import { createAuthEndpoint } from "../../api/call";
-import type {
-	BetterAuthPlugin,
-	InferOptionSchema,
-	BetterAuthPluginDBSchema,
-} from "../../types/plugins";
+import type { BetterAuthPlugin, InferOptionSchema } from "../../types/plugins";
 import { APIError } from "better-call";
 import { mergeSchema } from "../../db/schema";
 import { generateRandomString } from "../../crypto/random";
@@ -14,6 +10,7 @@ import { setSessionCookie } from "../../cookies";
 import { BASE_ERROR_CODES } from "../../error/codes";
 import type { User } from "../../types";
 import { ERROR_CODES } from "./phone-number-error";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 export interface UserWithPhoneNumber extends User {
 	phoneNumber: string;

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -3,7 +3,7 @@ import { createAuthEndpoint } from "../../api/call";
 import type {
 	BetterAuthPlugin,
 	InferOptionSchema,
-	AuthPluginSchema,
+	BetterAuthPluginDBSchema,
 } from "../../types/plugins";
 import { APIError } from "better-call";
 import { mergeSchema } from "../../db/schema";
@@ -1037,4 +1037,4 @@ const schema = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/siwe/schema.ts
+++ b/packages/better-auth/src/plugins/siwe/schema.ts
@@ -1,4 +1,4 @@
-import type { AuthPluginSchema } from "../../types";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 export const schema = {
 	walletAddress: {
@@ -29,4 +29,4 @@ export const schema = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/two-factor/schema.ts
+++ b/packages/better-auth/src/plugins/two-factor/schema.ts
@@ -1,4 +1,4 @@
-import type { AuthPluginSchema } from "../../types";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 export const schema = {
 	user: {
@@ -34,4 +34,4 @@ export const schema = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/username/schema.ts
+++ b/packages/better-auth/src/plugins/username/schema.ts
@@ -1,4 +1,4 @@
-import type { AuthPluginSchema } from "../../types";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 export const getSchema = (normalizer: {
 	username: (username: string) => string;
@@ -34,7 +34,7 @@ export const getSchema = (normalizer: {
 				},
 			},
 		},
-	} satisfies AuthPluginSchema;
+	} satisfies BetterAuthPluginDBSchema;
 };
 
 export type UsernameSchema = ReturnType<typeof getSchema>;

--- a/packages/better-auth/src/types/plugins.ts
+++ b/packages/better-auth/src/types/plugins.ts
@@ -10,17 +10,7 @@ import type {
 
 import type { AuthContext, BetterAuthOptions } from ".";
 import type { Endpoint, Middleware } from "better-call";
-import type { DBFieldAttribute } from "@better-auth/core/db";
-
-export type AuthPluginSchema = {
-	[table in string]: {
-		fields: {
-			[field in string]: DBFieldAttribute;
-		};
-		disableMigration?: boolean;
-		modelName?: string;
-	};
-};
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 
 export type BetterAuthPlugin = {
 	id: LiteralString;
@@ -97,7 +87,7 @@ export type BetterAuthPlugin = {
 	 * } as AuthPluginSchema
 	 * ```
 	 */
-	schema?: AuthPluginSchema;
+	schema?: BetterAuthPluginDBSchema;
 	/**
 	 * The migrations of the plugin. If you define schema that will automatically create
 	 * migrations for you.
@@ -128,19 +118,17 @@ export type BetterAuthPlugin = {
 	$ERROR_CODES?: Record<string, string>;
 };
 
-export type InferOptionSchema<S extends AuthPluginSchema> = S extends Record<
-	string,
-	{ fields: infer Fields }
->
-	? {
-			[K in keyof S]?: {
-				modelName?: string;
-				fields?: {
-					[P in keyof Fields]?: string;
+export type InferOptionSchema<S extends BetterAuthPluginDBSchema> =
+	S extends Record<string, { fields: infer Fields }>
+		? {
+				[K in keyof S]?: {
+					modelName?: string;
+					fields?: {
+						[P in keyof Fields]?: string;
+					};
 				};
-			};
-		}
-	: never;
+			}
+		: never;
 
 export type InferPluginErrorCodes<O extends BetterAuthOptions> =
 	O["plugins"] extends Array<infer P>

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -5,6 +5,8 @@ import type {
 	DBPrimitive,
 	BetterAuthDBSchema,
 } from "./type";
+import type { BetterAuthPluginDBSchema } from "./plugin";
+export type { BetterAuthPluginDBSchema } from "./plugin";
 
 export { coreSchema } from "./schema/shared";
 export { userSchema, type User } from "./schema/user";
@@ -20,6 +22,10 @@ export type {
 	BetterAuthDBSchema,
 };
 
+/**
+ * @deprecated Backport for 1.3.x, we will remove this in 1.4.x
+ */
+export type AuthPluginSchema = BetterAuthPluginDBSchema;
 /**
  * @deprecated Backport for 1.3.x, we will remove this in 1.4.x
  */

--- a/packages/core/src/db/plugin.ts
+++ b/packages/core/src/db/plugin.ts
@@ -1,0 +1,11 @@
+import type { DBFieldAttribute } from "./type";
+
+export type BetterAuthPluginDBSchema = {
+	[table in string]: {
+		fields: {
+			[field in string]: DBFieldAttribute;
+		};
+		disableMigration?: boolean;
+		modelName?: string;
+	};
+};

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -47,10 +47,12 @@
     "zod": "^4.1.5"
   },
   "peerDependencies": {
+    "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
     "stripe": "^18"
   },
   "devDependencies": {
+    "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
     "better-call": "catalog:",
     "stripe": "^18.5.0",

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -1,4 +1,4 @@
-import type { AuthPluginSchema } from "better-auth";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import type { StripeOptions } from "./types";
 import { mergeSchema } from "better-auth/db";
 
@@ -52,7 +52,7 @@ export const subscriptions = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;
 
 export const user = {
 	user: {
@@ -63,7 +63,7 @@ export const user = {
 			},
 		},
 	},
-} satisfies AuthPluginSchema;
+} satisfies BetterAuthPluginDBSchema;
 
 export const getSchema = (options: StripeOptions) => {
 	let baseSchema = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1161,6 +1161,9 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
     devDependencies:
+      '@better-auth/core':
+        specifier: workspace:*
+        version: link:../core
       better-auth:
         specifier: workspace:*
         version: link:../better-auth
@@ -14938,7 +14941,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.4))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -15023,7 +15026,7 @@ snapshots:
       '@expo/json-file': 10.0.7
       '@react-native/normalize-colors': 0.81.4
       debug: 4.4.1
-      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.4))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       resolve-from: 5.0.0
       semver: 7.7.2
       xml2js: 0.6.0
@@ -17180,9 +17183,7 @@ snapshots:
       metro-runtime: 0.83.1
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89': {}
@@ -19182,7 +19183,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.28.4
-      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.4))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -20744,7 +20745,7 @@ snapshots:
 
   expo-keep-awake@15.0.7(expo@54.0.10)(react@19.1.1):
     dependencies:
-      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.4))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       react: 19.1.1
 
   expo-linking@7.1.7(expo@54.0.10)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moves the plugin DB schema type into @better-auth/core to standardize schema typing and simplify imports. All plugins now use BetterAuthPluginDBSchema, with a temporary alias for backward compatibility.

- **Refactors**
  - Added core/db/plugin.ts exporting BetterAuthPluginDBSchema and re-export in core/db/index.ts.
  - Replaced all AuthPluginSchema imports with BetterAuthPluginDBSchema across plugins and stripe.
  - Updated mergeSchema and InferOptionSchema to use the new type.
  - Added deprecated alias AuthPluginSchema in core (to be removed in 1.4.x).

- **Migration**
  - Plugin authors: import type { BetterAuthPluginDBSchema } from "@better-auth/core/db".
  - Temporary option: import type { AuthPluginSchema } from "@better-auth/core/db" (deprecated).
  - No runtime changes or DB migrations required.

<!-- End of auto-generated description by cubic. -->

