### PR TITLE
fix: getAcccessToken refresh should properly refresh when oauth tokens are encrypted 

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -538,9 +538,11 @@ export const getAccessToken = createAuthEndpoint(
 				accessTokenExpired &&
 				provider.refreshAccessToken
 			) {
-				newTokens = await provider.refreshAccessToken(
-					account.refreshToken as string,
+				const refreshToken = await decryptOAuthToken(
+					account.refreshToken,
+					ctx.context,
 				);
+				newTokens = await provider.refreshAccessToken(refreshToken);
 				await ctx.context.internalAdapter.updateAccount(account.id, {
 					accessToken: await setTokenUtil(newTokens.accessToken, ctx.context),
 					accessTokenExpiresAt: newTokens.accessTokenExpiresAt,
@@ -549,10 +551,9 @@ export const getAccessToken = createAuthEndpoint(
 				});
 			}
 			const tokens = {
-				accessToken: await decryptOAuthToken(
-					newTokens?.accessToken ?? account.accessToken ?? "",
-					ctx.context,
-				),
+				accessToken:
+					newTokens?.accessToken ??
+					(await decryptOAuthToken(account.accessToken ?? "", ctx.context)),
 				accessTokenExpiresAt:
 					newTokens?.accessTokenExpiresAt ??
 					account.accessTokenExpiresAt ??


### PR DESCRIPTION
If the encryptOAuthTokens option is set to true, then the token refresh behavior within the getAccessToken route was broken in two ways:
1. The refreshToken needed to be decrypted before calling provider.refreshAccessToken
2. Once (1) was fixed, the new accessToken was returned from provider.refreshAccessToken, and saved to newTokens. But then, the code was calling decryptOAuthTokens on it, even though it's not encrypted, which was causing an error

This PR fixes both issues, and getAccessToken now works property when the encryptOAuthTokens option is set
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes getAccessToken to correctly handle encrypted OAuth tokens during refresh. Prevents errors when encryptOAuthTokens=true and restores working token refresh.

- **Bug Fixes**
  - Decrypt refreshToken before calling provider.refreshAccessToken and save refreshed tokens via setTokenUtil.
  - Do not decrypt the provider’s new accessToken; only decrypt the stored accessToken when no refresh occurs.

<!-- End of auto-generated description by cubic. -->

