### PR TITLE
fix(organization): prevent duplicate slug on organization update

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -144,6 +144,27 @@ describe("organization", async (it) => {
 		expect(organization.data?.name).toBe("test2");
 	});
 
+	it("should prevent updating organization to duplicate slug", async () => { 
+		const { headers } = await signInWithTestUser();
+
+		// Try to update organization2 (slug: "test2") to use organization1's slug ("test")
+		const organization = await client.organization.update({
+			organizationId: organization2Id,
+			data: {
+				slug: "test",
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		// This should fail with duplicate slug error
+		expect(organization.error?.status).toBe(400);
+		expect(organization.error?.message).toContain(
+			ORGANIZATION_ERROR_CODES.ORGANIZATION_ALREADY_EXISTS
+		);
+	});
+
 	it("should allow updating organization metadata", async () => {
 		const { headers } = await signInWithTestUser();
 		const organization = await client.organization.update({

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -484,6 +484,17 @@ export const updateOrganization = <O extends OrganizationOptions>(
 						ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_ORGANIZATION,
 				});
 			}
+			// Check if slug is being updated and validate uniqueness
+			if (ctx.body.data.slug) {
+				const existingOrganization = await adapter.findOrganizationBySlug(
+					ctx.body.data.slug,
+				);
+				if (existingOrganization && existingOrganization.id !== organizationId) {
+					throw new APIError("BAD_REQUEST", {
+						message: ORGANIZATION_ERROR_CODES.ORGANIZATION_ALREADY_EXISTS,
+					});
+				}
+			}
 			if (options?.organizationHooks?.beforeUpdateOrganization) {
 				const response =
 					await options.organizationHooks.beforeUpdateOrganization({


### PR DESCRIPTION
## Problem
The `updateOrganization` endpoint was missing slug uniqueness validation. This allowed users to update an organization's slug to one that's already in use by another organization, causing a database constraint error (500) instead of a proper validation error (400).

## Steps to Reproduce
1. Create organization with slug `a`
2. Create organization with slug `b`
3. Update organization `b` to change its slug to `a`
4. Both organizations now have slug `a` (database error)

## Solution
Added slug uniqueness validation in the `updateOrganization` function before the update is performed

## Changes
- Added slug uniqueness check in organization update endpoint
- Returns `ORGANIZATION_SLUG_ALREADY_EXISTS` error when duplicate detected
- Allows organization to keep its own slug when updating other fields

## Testing
- [x] Prevents duplicate slug assignment
- [x] Returns proper 400 error instead of 500

Closes #5093 
