### PR TITLE
fix(organization): prevent empty name and slug in create/update

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -101,6 +101,31 @@ describe("organization", async (it) => {
 		expect(existingSlug.error?.status).toBe(400);
 		expect(existingSlug.error?.message).toBe("slug is taken");
 	});
+
+	it("should prevent creating organization with empty slug", async () => {
+		const { headers } = await signInWithTestUser();
+		const organization = await client.organization.create({
+			name: "test-empty-slug",
+			slug: "",
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(organization.error?.status).toBe(400);
+	});
+
+	it("should prevent creating organization with empty name", async () => {
+		const { headers } = await signInWithTestUser();
+		const organization = await client.organization.create({
+			name: "",
+			slug: "test-empty-name",
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(organization.error?.status).toBe(400);
+	});
+
 	it("should create organization directly in the server without cookie", async () => {
 		const session = await client.getSession({
 			fetchOptions: {
@@ -158,6 +183,34 @@ describe("organization", async (it) => {
 			},
 		});
 		expect(organization.data?.metadata?.test).toBe("test2");
+	});
+
+	it("should prevent updating organization to empty slug", async () => {
+		const { headers } = await signInWithTestUser();
+		const organization = await client.organization.update({
+			organizationId,
+			data: {
+				slug: "",
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(organization.error?.status).toBe(400);
+	});
+
+	it("should prevent updating organization to empty name", async () => {
+		const { headers } = await signInWithTestUser();
+		const organization = await client.organization.update({
+			organizationId,
+			data: {
+				name: "",
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(organization.error?.status).toBe(400);
 	});
 
 	it("should allow activating organization and set session", async () => {

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -29,10 +29,10 @@ export const createOrganization = <O extends OrganizationOptions>(
 		isClientSide: true,
 	});
 	const baseSchema = z.object({
-		name: z.string().meta({
+		name: z.string().min(1).meta({
 			description: "The name of the organization",
 		}),
-		slug: z.string().meta({
+		slug: z.string().min(1).meta({
 			description: "The slug of the organization",
 		}),
 		userId: z.coerce
@@ -386,12 +386,14 @@ export const updateOrganization = <O extends OrganizationOptions>(
 						...additionalFieldsSchema.shape,
 						name: z
 							.string()
+							.min(1)
 							.meta({
 								description: "The name of the organization",
 							})
 							.optional(),
 						slug: z
 							.string()
+							.min(1)
 							.meta({
 								description: "The slug of the organization",
 							})


### PR DESCRIPTION
### Problem
Organizations can be created or updated with empty name and slug fields

**To Reproduce**
1. Create organization with empty string as slug: `slug: ""`
2. Create organization with empty string as name: `name: ""`
3. Update organization to have empty slug or name

### Solution
Added validation to name and slug fields in both create and update organization endpoints

### Tests
- [x] Prevent creating organization with empty slug
- [x] Prevent creating organization with empty name
- [x] Prevent updating organization to empty slug
- [x] Prevent updating organization to empty name