### PR TITLE
refactor: move `DBAdapterDebugLogOption` to core

### DIFF
--- a/packages/better-auth/src/adapters/adapter-factory/types.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/types.ts
@@ -7,31 +7,7 @@ import type {
 	Where,
 } from "../../types";
 import type { Prettify } from "../../types/helper";
-
-export type AdapterDebugLogs =
-	| boolean
-	| {
-			/**
-			 * Useful when you want to log only certain conditions.
-			 */
-			logCondition?: (() => boolean) | undefined;
-			create?: boolean;
-			update?: boolean;
-			updateMany?: boolean;
-			findOne?: boolean;
-			findMany?: boolean;
-			delete?: boolean;
-			deleteMany?: boolean;
-			count?: boolean;
-	  }
-	| {
-			/**
-			 * Only used for adapter tests to show debug logs if a test fails.
-			 *
-			 * @deprecated Not actually deprecated. Doing this for IDEs to show this option at the very bottom and stop end-users from using this.
-			 */
-			isRunningAdapterTests: boolean;
-	  };
+import type { DBAdapterDebugLogOption } from "@better-auth/core/db/adapter";
 
 export type AdapterFactoryOptions = {
 	config: AdapterFactoryConfig;
@@ -52,7 +28,7 @@ export interface AdapterFactoryConfig {
 	 *
 	 * @default false
 	 */
-	debugLogs?: AdapterDebugLogs;
+	debugLogs?: DBAdapterDebugLogOption;
 	/**
 	 * Name of the adapter.
 	 *

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -20,10 +20,10 @@ import { BetterAuthError } from "../../error";
 import type { Adapter, BetterAuthOptions, Where } from "../../types";
 import {
 	createAdapterFactory,
-	type AdapterDebugLogs,
 	type AdapterFactoryOptions,
 	type AdapterFactoryCustomizeAdapterCreator,
 } from "../adapter-factory";
+import type { DBAdapterDebugLogOption } from "@better-auth/core/db/adapter";
 
 export interface DB {
 	[key: string]: any;
@@ -49,7 +49,7 @@ export interface DrizzleAdapterConfig {
 	 *
 	 * @default false
 	 */
-	debugLogs?: AdapterDebugLogs;
+	debugLogs?: DBAdapterDebugLogOption;
 	/**
 	 * By default snake case is used for table and field names
 	 * when the CLI is used to generate the schema. If you want

--- a/packages/better-auth/src/adapters/index.ts
+++ b/packages/better-auth/src/adapters/index.ts
@@ -2,17 +2,17 @@ import {
 	createAdapterFactory,
 	type AdapterFactory,
 	type AdapterFactoryOptions,
-	type AdapterDebugLogs,
 	type AdapterTestDebugLogs,
 	type AdapterFactoryConfig,
 	type CustomAdapter,
 	type AdapterFactoryCustomizeAdapterCreator,
 } from "./adapter-factory";
 
+export * from "@better-auth/core/db/adapter";
+
 export type {
 	AdapterFactoryOptions,
 	AdapterFactory,
-	AdapterDebugLogs,
 	AdapterTestDebugLogs,
 	AdapterFactoryConfig,
 	CustomAdapter,

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -1,6 +1,5 @@
 import {
 	createAdapterFactory,
-	type AdapterDebugLogs,
 	type AdapterFactoryCustomizeAdapterCreator,
 	type AdapterFactoryOptions,
 } from "../adapter-factory";
@@ -11,6 +10,7 @@ import {
 	type Kysely,
 	type UpdateQueryBuilder,
 } from "kysely";
+import type { DBAdapterDebugLogOption } from "@better-auth/core/db/adapter";
 
 interface KyselyAdapterConfig {
 	/**
@@ -22,7 +22,7 @@ interface KyselyAdapterConfig {
 	 *
 	 * @default false
 	 */
-	debugLogs?: AdapterDebugLogs;
+	debugLogs?: DBAdapterDebugLogOption;
 	/**
 	 * Use plural for table names.
 	 *

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -1,17 +1,14 @@
 import { logger } from "../../utils";
-import {
-	createAdapterFactory,
-	type AdapterDebugLogs,
-	type CleanedWhere,
-} from "../adapter-factory";
+import { createAdapterFactory, type CleanedWhere } from "../adapter-factory";
 import type { BetterAuthOptions } from "../../types";
+import type { DBAdapterDebugLogOption } from "@better-auth/core/db/adapter";
 
 export interface MemoryDB {
 	[key: string]: any[];
 }
 
 export interface MemoryAdapterConfig {
-	debugLogs?: AdapterDebugLogs;
+	debugLogs?: DBAdapterDebugLogOption;
 }
 
 export const memoryAdapter = (db: MemoryDB, config?: MemoryAdapterConfig) => {

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -2,10 +2,10 @@ import { ClientSession, ObjectId, type Db, type MongoClient } from "mongodb";
 import type { Adapter, BetterAuthOptions, Where } from "../../types";
 import {
 	createAdapterFactory,
-	type AdapterDebugLogs,
 	type AdapterFactoryOptions,
 	type AdapterFactoryCustomizeAdapterCreator,
 } from "../adapter-factory";
+import type { DBAdapterDebugLogOption } from "@better-auth/core/db/adapter";
 
 export interface MongoDBAdapterConfig {
 	/**
@@ -18,7 +18,7 @@ export interface MongoDBAdapterConfig {
 	 *
 	 * @default false
 	 */
-	debugLogs?: AdapterDebugLogs;
+	debugLogs?: DBAdapterDebugLogOption;
 	/**
 	 * Use plural table names
 	 *

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -2,10 +2,10 @@ import { BetterAuthError } from "../../error";
 import type { Adapter, BetterAuthOptions, Where } from "../../types";
 import {
 	createAdapterFactory,
-	type AdapterDebugLogs,
 	type AdapterFactoryOptions,
 	type AdapterFactoryCustomizeAdapterCreator,
 } from "../adapter-factory";
+import type { DBAdapterDebugLogOption } from "@better-auth/core/db/adapter";
 
 export interface PrismaConfig {
 	/**
@@ -24,7 +24,7 @@ export interface PrismaConfig {
 	 *
 	 * @default false
 	 */
-	debugLogs?: AdapterDebugLogs;
+	debugLogs?: DBAdapterDebugLogOption;
 
 	/**
 	 * Use plural table names

--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -18,9 +18,9 @@ import type { Database } from "better-sqlite3";
 import type { Logger } from "../utils";
 import type { AuthMiddleware } from "../plugins";
 import type { LiteralUnion, OmitId } from "./helper";
-import type { AdapterDebugLogs } from "../adapters";
 import type { Database as BunDatabase } from "bun:sqlite";
 import type { DatabaseSync } from "node:sqlite";
+import type { DBAdapterDebugLogOption } from "packages/core/dist/db/adapter";
 
 export type BetterAuthOptions = {
 	/**
@@ -97,7 +97,7 @@ export type BetterAuthOptions = {
 				 *
 				 * @default false
 				 */
-				debugLogs?: AdapterDebugLogs;
+				debugLogs?: DBAdapterDebugLogOption;
 				/**
 				 * Whether to execute multiple operations in a transaction.
 				 * If the database doesn't support transactions,
@@ -126,7 +126,7 @@ export type BetterAuthOptions = {
 				 *
 				 * @default false
 				 */
-				debugLogs?: AdapterDebugLogs;
+				debugLogs?: DBAdapterDebugLogOption;
 				/**
 				 * Whether to execute multiple operations in a transaction.
 				 * If the database doesn't support transactions,

--- a/packages/core/build.config.ts
+++ b/packages/core/build.config.ts
@@ -11,6 +11,7 @@ export default defineBuildConfig({
 	entries: [
 		"./src/index.ts",
 		"./src/db/index.ts",
+		"./src/db/adapter/index.ts",
 		"./src/async_hooks/index.ts",
 	],
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,16 @@
         "types": "./dist/db/index.d.cts",
         "default": "./dist/db/index.cjs"
       }
+    },
+    "./db/adapter": {
+      "import": {
+        "types": "./dist/db/adapter/index.d.ts",
+        "default": "./dist/db/adapter/index.mjs"
+      },
+      "require": {
+        "types": "./dist/db/adapter/index.d.cts",
+        "default": "./dist/db/adapter/index.cjs"
+      }
     }
   },
   "typesVersions": {

--- a/packages/core/src/db/adapter/index.ts
+++ b/packages/core/src/db/adapter/index.ts
@@ -1,0 +1,24 @@
+export type DBAdapterDebugLogOption =
+	| boolean
+	| {
+			/**
+			 * Useful when you want to log only certain conditions.
+			 */
+			logCondition?: (() => boolean) | undefined;
+			create?: boolean;
+			update?: boolean;
+			updateMany?: boolean;
+			findOne?: boolean;
+			findMany?: boolean;
+			delete?: boolean;
+			deleteMany?: boolean;
+			count?: boolean;
+	  }
+	| {
+			/**
+			 * Only used for adapter tests to show debug logs if a test fails.
+			 *
+			 * @deprecated Not actually deprecated. Doing this for IDEs to show this option at the very bottom and stop end-users from using this.
+			 */
+			isRunningAdapterTests: boolean;
+	  };

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -7,7 +7,6 @@ import type {
 } from "./type";
 import type { BetterAuthPluginDBSchema } from "./plugin";
 export type { BetterAuthPluginDBSchema } from "./plugin";
-
 export { coreSchema } from "./schema/shared";
 export { userSchema, type User } from "./schema/user";
 export { accountSchema, type Account } from "./schema/account";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Centralized the DB adapter debug log type in core and updated all adapters to use it. No runtime changes; only types and exports were adjusted.

- **Refactors**
  - Added @better-auth/core/db/adapter entry and exported DBAdapterDebugLogOption.
  - Removed AdapterDebugLogs from adapter-factory types; replaced with DBAdapterDebugLogOption across adapters and options.
  - Updated core build config and package.json to publish the new entry.
  - Re-exported the type from better-auth/adapters for convenience.

- **Migration**
  - If you imported AdapterDebugLogs directly, switch to DBAdapterDebugLogOption from @better-auth/core/db/adapter (or from better-auth/adapters).

<!-- End of auto-generated description by cubic. -->

