### PR TITLE
fix(db): Refactor account deletion functions to use database hooks

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -530,4 +530,73 @@ describe("adapter test", async () => {
 		expect(actualExp - expectedExp).toBeLessThanOrEqual(1); // max 1s clock drift between check and set
 		expect(actualExp - expectedExp).toBeGreaterThanOrEqual(0); // max 1s clock drift between check and set
 	});
+
+	it("should delete a single account", async () => {
+		const user = await internalAdapter.createUser(
+			{
+				name: "Account Delete User",
+				email: "account.delete@example.com",
+			},
+			ctx as unknown as GenericEndpointContext,
+		);
+
+		const account = await internalAdapter.createAccount(
+			{
+				userId: user.id,
+				providerId: "test-provider",
+				accountId: "test-account-id-1",
+			},
+			ctx as unknown as GenericEndpointContext,
+		);
+
+		let foundAccount = await internalAdapter.findAccount(account.accountId);
+		expect(foundAccount).toBeDefined();
+
+		await internalAdapter.deleteAccount(
+			account.id,
+			ctx as unknown as GenericEndpointContext,
+		);
+
+		foundAccount = await internalAdapter.findAccount(account.accountId);
+		expect(foundAccount).toBeNull();
+	});
+
+	it("should delete multiple accounts for a user", async () => {
+		const user = await internalAdapter.createUser(
+			{
+				name: "Accounts Delete User",
+				email: "accounts.delete@example.com",
+			},
+			ctx as unknown as GenericEndpointContext,
+		);
+
+		await internalAdapter.createAccount(
+			{
+				userId: user.id,
+				providerId: "test-provider-1",
+				accountId: "test-account-id-2",
+			},
+			ctx as unknown as GenericEndpointContext,
+		);
+
+		await internalAdapter.createAccount(
+			{
+				userId: user.id,
+				providerId: "test-provider-2",
+				accountId: "test-account-id-3",
+			},
+			ctx as unknown as GenericEndpointContext,
+		);
+
+		let accounts = await internalAdapter.findAccounts(user.id);
+		expect(accounts.length).toBe(2);
+
+		await internalAdapter.deleteAccounts(
+			user.id,
+			ctx as unknown as GenericEndpointContext,
+		);
+
+		accounts = await internalAdapter.findAccounts(user.id);
+		expect(accounts.length).toBe(0);
+	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -622,27 +622,32 @@ export const createInternalAdapter = (
 				],
 			});
 		},
-		deleteAccounts: async (userId: string) => {
-			await (await getCurrentAdapter(adapter)).deleteMany({
-				model: "account",
-				where: [
+		deleteAccounts: async (
+			userId: string,
+			context?: GenericEndpointContext,
+		) => {
+			await deleteManyWithHooks(
+				[
 					{
 						field: "userId",
 						value: userId,
 					},
 				],
-			});
+				"account",
+				undefined,
+				context,
+			);
 		},
-		deleteAccount: async (accountId: string) => {
-			await (await getCurrentAdapter(adapter)).delete({
-				model: "account",
-				where: [
-					{
-						field: "id",
-						value: accountId,
-					},
-				],
-			});
+		deleteAccount: async (
+			accountId: string,
+			context?: GenericEndpointContext,
+		) => {
+			await deleteWithHooks(
+				[{ field: "id", value: accountId }],
+				"account",
+				undefined,
+				context,
+			);
 		},
 		deleteSessions: async (
 			userIdOrSessionTokens: string | string[],


### PR DESCRIPTION
**Description:**

When using `better-auth` (specifically version `v1.4.0-beta.6`), the `databaseHooks.account.delete.after` hook is not triggered when an account is unlinked via the `/unlink-account` endpoint, despite the underlying account record being successfully deleted from the database.

**Steps to Reproduce:**

1.  Configure `better-auth` with a `databaseHooks.account.delete.after` hook in `auth.ts` (similar to the provided example in the initial problem description).
2.  Link an account to a user. Observe that `databaseHooks.account.create.after` is successfully triggered.
3.  Unlink the previously linked account.
4.  Verify that the account record is indeed deleted from the database.
5.  Observe that `databaseHooks.account.delete.after` is *not* triggered, and no associated logs are produced.

**Expected Behavior:**

The `databaseHooks.account.delete.after` hook should be triggered after an account is successfully deleted from the database by the `unlinkAccount` endpoint.

**Actual Behavior:**

The `databaseHooks.account.delete.after` hook is not triggered when an account is unlinked, even though the account record is removed from the database.

**Root Cause Analysis:**

Upon reviewing the source code, specifically `packages/better-auth/src/db/internal-adapter.ts`, it was found that the `internalAdapter.deleteAccount` function (which is called by the `/unlink-account` endpoint) directly invokes the underlying database adapter's `delete` method. It bypasses the `deleteWithHooks` wrapper, which is responsible for dispatching the `before` and `after` database hooks.

This change will ensure that the `deleteAccount` operation correctly dispatches the `databaseHooks.account.delete.after` hook.

## Testing

New unit tests have been added and verified locally. All existing tests are expected to pass.

## Checklist

-   [x] Code is type-safe and takes full advantage of TypeScript features.
-   [x] Code follows existing style and conventions.
-   [x] Unit tests have been added for new/modified functionality.
-   [x] Code has been formatted with `pnpm format` and linted with `pnpm lint:fix` (User will handle manually).
-   [x] Commit message follows the specified format.
-   [x] PR description clearly outlines changes, rationale, and testing.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactored account deletion to use database hooks so unlinking an account triggers databaseHooks.account.delete.after.

- **Bug Fixes**
  - deleteAccount and deleteAccounts now call deleteWithHooks/deleteManyWithHooks instead of direct adapter deletes.
  - Added tests for deleting a single account and all accounts for a user.

<!-- End of auto-generated description by cubic. -->

