### PR TITLE
docs: add expiration note for Apple client secret JWT

### DIFF
--- a/docs/components/generate-apple-jwt.tsx
+++ b/docs/components/generate-apple-jwt.tsx
@@ -72,6 +72,11 @@ export const GenerateAppleJwt = () => {
 				};
 
 				const issuedAtSeconds = Math.floor(Date.now() / 1000);
+				/**
+				 * Apple allows a maximum expiration of 6 months (180 days) for the client secret JWT.
+				 *
+				 * @see {@link https://developer.apple.com/documentation/accountorganizationaldatasharing/creating-a-client-secret}
+				 */
 				const expirationSeconds = issuedAtSeconds + 180 * 24 * 60 * 60; // 180 days. Should we let the user choose this ? MAX is 6 months
 
 				const payload = {

--- a/docs/content/docs/authentication/apple.mdx
+++ b/docs/content/docs/authentication/apple.mdx
@@ -56,6 +56,8 @@ description: Apple provider setup and usage.
 
             You can use the guide below from [Apple's documentation](https://developer.apple.com/documentation/accountorganizationaldatasharing/creating-a-client-secret) to understand how to generate this client secret. You can also use our built in generator [below](#generate-apple-client-secret-jwt) to generate the client secret JWT required for 'Sign in with Apple'.
 
+            **Note:** Apple allows a maximum expiration of 6 months (180 days) for the client secret JWT. You will need to regenerate the client secret before it expires to maintain uninterrupted authentication.
+
 
     </Step>
     <Step>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Document Apple client secret JWT 6-month maximum expiration. Added a note in the Apple auth docs and a comment in the generator with the official link, so developers set valid expirations and plan regeneration.

<!-- End of auto-generated description by cubic. -->

