### PR TITLE
test: add assertions to check for unwanted imports in built output

### DIFF
--- a/e2e/smoke/test/vite.spec.ts
+++ b/e2e/smoke/test/vite.spec.ts
@@ -48,5 +48,15 @@ describe("(vite) client build", () => {
 			!clientContent.includes("createEndpoint"),
 			"Built output should not contain 'better-call' imports",
 		);
+
+		assert.ok(
+			!clientContent.includes("async_hooks"),
+			"Built output should not contain 'async_hooks' imports",
+		);
+
+		assert.ok(
+			!clientContent.includes("AsyncLocalStorage"),
+			"Built output should not contain 'AsyncLocalStorage' imports",
+		);
 	});
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add e2e assertions to the Vite client build to fail if the bundle contains server-only imports ("async_hooks", "AsyncLocalStorage") or internal "better-call" createEndpoint. This guards against shipping Node APIs in the browser bundle.

<!-- End of auto-generated description by cubic. -->

