### PR TITLE
refactor: move RateLimit to core

### DIFF
--- a/packages/better-auth/src/types/models.ts
+++ b/packages/better-auth/src/types/models.ts
@@ -68,25 +68,10 @@ export type InferPluginTypes<O extends BetterAuthOptions> =
 			>
 		: {};
 
-interface RateLimit {
-	/**
-	 * The key to use for rate limiting
-	 */
-	key: string;
-	/**
-	 * The number of requests made
-	 */
-	count: number;
-	/**
-	 * The last request time in milliseconds
-	 */
-	lastRequest: number;
-}
-
 export type {
 	User,
 	Account,
 	Session,
 	Verification,
+	RateLimit,
 } from "@better-auth/core/db";
-export type { RateLimit };

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -12,6 +12,7 @@ export { userSchema, type User } from "./schema/user";
 export { accountSchema, type Account } from "./schema/account";
 export { sessionSchema, type Session } from "./schema/session";
 export { verificationSchema, type Verification } from "./schema/verification";
+export { rateLimitSchema, type RateLimit } from "./schema/rate-limit";
 
 export type {
 	DBFieldAttribute,

--- a/packages/core/src/db/schema/rate-limit.ts
+++ b/packages/core/src/db/schema/rate-limit.ts
@@ -1,0 +1,21 @@
+import * as z from "zod";
+
+export const rateLimitSchema = z.object({
+	/**
+	 * The key to use for rate limiting
+	 */
+	key: z.string(),
+	/**
+	 * The number of requests made
+	 */
+	count: z.number(),
+	/**
+	 * The last request time in milliseconds
+	 */
+	lastRequest: z.number(),
+});
+
+/**
+ * Rate limit schema type used by better-auth for rate limiting
+ */
+export type RateLimit = z.infer<typeof rateLimitSchema>;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the rate limiting model to @better-auth/core to centralize types and schema. better-auth now re-exports RateLimit from core for consistent usage.

- **Refactors**
  - Added rateLimitSchema and RateLimit type to core db.
  - Exported rateLimitSchema and RateLimit from core db index.
  - Removed local RateLimit interface from better-auth and re-exported from core.

<!-- End of auto-generated description by cubic. -->

