### PR TITLE
fix(sso): add deprecated flag to the old `sso` plugin export

### DIFF
--- a/packages/better-auth/src/plugins/sso/index.ts
+++ b/packages/better-auth/src/plugins/sso/index.ts
@@ -74,6 +74,9 @@ export interface SSOOptions {
 	defaultOverrideUserInfo?: boolean;
 }
 
+/**
+ * @deprecated Install and use `@better-auth/sso` plugin instead. This export will be removed in the next major version.
+ */
 export const sso = (options?: SSOOptions) => {
 	return {
 		id: "sso",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Deprecated the legacy SSO export and added guidance to migrate to the @better-auth/sso plugin. This prepares for removal in the next major release.

- **Migration**
  - Install @better-auth/sso and import sso from the plugin.
  - Replace any sso imports from better-auth with @better-auth/sso.

<!-- End of auto-generated description by cubic. -->

