### PR TITLE
feat(magic-link): require name for signup

### DIFF
--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -136,6 +136,8 @@ and a `request` object as the second parameter.
 
 **disableSignUp**: If set to `true`, the user will not be able to sign up using the magic link. The default value is `false`.
 
+**requireNameForSignUp**: If set to `true`, when a new user attempts to sign up via a magic link, the request must include a non-empty name field. Has no effect if `disableSignUp` is set to `true`.
+
 **generateToken**: The `generateToken` function is called to generate a token which is used to uniquely identify the user. The default value is a random string. There is one parameter:
 
 - `email`: The email address of the user.

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -136,6 +136,39 @@ describe("magic link", async () => {
 		});
 	});
 
+	it("should fail sign up if requireNameForSignUp is true and name is missing", async () => {
+		const email = "new-user-no-name@email.com";
+
+		const { customFetchImpl } = await getTestInstance({
+			plugins: [
+				magicLink({
+					requireNameForSignUp: true,
+					async sendMagicLink(data) {
+						verificationEmail = data;
+					},
+				}),
+			],
+		});
+
+		const client = createAuthClient({
+			plugins: [magicLinkClient()],
+			fetchOptions: { customFetchImpl },
+			baseURL: "http://localhost:3000/api/auth",
+		});
+
+		await client.signIn.magicLink(
+			{
+				email,
+			},
+			{
+				onError(context) {
+					const location = context.response.headers.get("location");
+					expect(location).toContain("?error=NAME_REQUIRED_FOR_SIGNUP");
+				},
+			},
+		);
+	});
+
 	it("should use custom generateToken function", async () => {
 		const customGenerateToken = vi.fn(() => "custom_token");
 


### PR DESCRIPTION

**What changes were made and why:**

* Added a new configuration option `requireNameForSignUp` in the Magic Link plugin.
* When enabled, any attempt to create a new user via Magic Link without a non-empty `name` field will fail.
* This ensures new users always have a `name`, improving data consistency and preventing incomplete user records.
* Updated the plugin documentation to include the new requireNameForSignUp option and describe its behavior.

**Relevant context:**

* Currently, Magic Link signup allows creating users without a name.
* The recommended workaround (from [issue comment](https://github.com/better-auth/better-auth/issues/4728#issuecomment-3304537808)) was to collect `name` later, but adding native support avoids extra steps and simplifies the flow.

**Breaking changes / deprecations:**

* No breaking changes.
* Flows without `requireNameForSignUp` enabled remain unchanged.

**Tests / screenshots:**

* Added test to verify that signup fails if `name` is missing when `requireNameForSignUp` is true.

**Related issues / discussions:**

* Closes 
#5139

