### PR TITLE
docs: Add Supabase to supported dialects

### DIFF
--- a/docs/content/docs/adapters/other-relational-databases.mdx
+++ b/docs/content/docs/adapters/other-relational-databases.mdx
@@ -18,6 +18,7 @@ Any dialect supported by Kysely can be utilized with Better Auth, including capa
 
 - [Postgres.js](https://github.com/kysely-org/kysely-postgres-js)
 - [SingleStore Data API](https://github.com/kysely-org/kysely-singlestore)
+- [Supabase](https://github.com/kysely-org/kysely-supabase)
 
 ## Kysely Community dialects
 


### PR DESCRIPTION
Adding the Supabase Kysely dialect here helps Supabase to point to it in the docs and support those using Better Auth with Supabase as the backend
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Supabase to the supported Kysely dialects in the adapters docs so users can use Better Auth with Supabase via the official Kysely Supabase dialect.

<!-- End of auto-generated description by cubic. -->

