### PR TITLE
fix(gitlab): fix the token endpoint

### DIFF
--- a/docs/content/docs/authentication/gitlab.mdx
+++ b/docs/content/docs/authentication/gitlab.mdx
@@ -28,6 +28,32 @@ description: GitLab provider setup and usage.
             },
         })
         ```
+
+        #### Configuration Options
+
+        - `clientId`: Your GitLab application's Client ID
+        - `clientSecret`: Your GitLab application's Client Secret  
+        - `issuer`: (Optional) The URL of your GitLab instance. Use this for self-hosted GitLab servers.
+            - Default: `"https://gitlab.com"` (GitLab.com)
+            - Example: `"https://gitlab.company.com"`
+
+        <Callout type="info">
+            The `issuer` option is useful when using a self-hosted GitLab instance. If you're using GitLab.com, you can omit this option as it defaults to `https://gitlab.com`.
+        </Callout>
+
+        #### Example with self-hosted GitLab
+
+        ```ts title="auth.ts"
+        export const auth = betterAuth({
+            socialProviders: {
+                gitlab: {
+                    clientId: process.env.GITLAB_CLIENT_ID as string,
+                    clientSecret: process.env.GITLAB_CLIENT_SECRET as string,
+                    issuer: "https://gitlab.company.com", // Your self-hosted GitLab URL // [!code highlight]
+                },
+            },
+        })
+        ```
     </Step>
        <Step>
         ### Sign In with GitLab

--- a/packages/better-auth/src/social-providers/gitlab.ts
+++ b/packages/better-auth/src/social-providers/gitlab.ts
@@ -120,7 +120,7 @@ export const gitlab = (options: GitlabOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: "https://gitlab.com/oauth/token",
+						tokenEndpoint: tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {


### PR DESCRIPTION
I fixed the Token endpoint, as the others are read from the `issuerToEndpoints` function and added an example to the docs on how to use the issuer env variable.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the GitLab OAuth token endpoint to use the issuer-based configuration, so self-hosted GitLab instances authenticate correctly. Updates docs with issuer guidance and a self-hosted example.

- **Bug Fixes**
  - Use tokenEndpoint from issuerToEndpoints instead of hardcoding https://gitlab.com/oauth/token.

- **Docs**
  - Added issuer option explanation and a self-hosted GitLab setup example in the GitLab provider docs.

<!-- End of auto-generated description by cubic. -->

