### PR TITLE
docs: calls out changes to cookie name when the cookie is secure with code sample

### DIFF
--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -94,3 +94,18 @@ export const auth = betterAuth({
     }
 })
 ```
+
+*Note: The name of your cookie will automatically be prefixed with `__Secure-`. Even if you specify your own prefix. For example:*
+
+```ts title="cookie.ts"
+import { betterAuth } from "better-auth"
+
+export const auth = betterAuth({
+    advanced: {
+        cookiePrefix: 'make-believe'
+        useSecureCookies: true
+    }
+})
+
+# produces a cookie with this name: __Secure-make-believe.session_token
+```

--- a/docs/content/docs/reference/security.mdx
+++ b/docs/content/docs/reference/security.mdx
@@ -34,6 +34,8 @@ To secure OAuth flows, Better Auth stores the OAuth state and PKCE (Proof Key fo
 
 Better Auth assigns secure cookies by default when the base URL uses `https`. These secure cookies are encrypted and only sent over secure connections, adding an extra layer of protection. They are also set with the `sameSite` attribute to `lax` by default to prevent cross-site request forgery attacks. And the `httpOnly` attribute is enabled to prevent client-side JavaScript from accessing the cookie. 
 
+*Note for secure cookies: The name of the cookie will be prefixed with `__Secure-`*
+
 For Cross-Subdomain Cookies, you can set the `crossSubDomainCookies` option in the configuration. This option allows cookies to be shared across subdomains, enabling seamless authentication across multiple subdomains.
 
 ### Customizing Cookies


### PR DESCRIPTION
I made a few tweaks to the docs around cookies and the name of the session cookie. My team shipped something that relied on the cookie name being what it is in local development, only to find that in prod the cookie is secure and prefixed with `__Secure-`.

I updated the docs in two spots and called this out. I did some local testing to verify the effects that updating the cookie prefix and cookie name had, but the `__Secure-` persists as long as `useSecureCookies` is true or you meet the other criteria mentioned for secure cookies.