### PR TITLE
fix(adapter): missing where transformation

### DIFF
--- a/packages/better-auth/src/adapters/adapter-factory/index.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/index.ts
@@ -497,6 +497,8 @@ export const createAdapterFactory =
 					}
 				}
 
+				let newValue = value;
+
 				const defaultModelName = getDefaultModelName(model);
 				const defaultFieldName = getDefaultFieldName({
 					field: unsafe_field,
@@ -520,27 +522,44 @@ export const createAdapterFactory =
 				) {
 					if (options.advanced?.database?.useNumberId) {
 						if (Array.isArray(value)) {
-							return {
-								operator,
-								connector,
-								field: fieldName,
-								value: value.map(Number),
-							} satisfies CleanedWhere;
+							newValue = value.map(Number);
+						} else {
+							newValue = Number(value);
 						}
-						return {
-							operator,
-							connector,
-							field: fieldName,
-							value: Number(value),
-						} satisfies CleanedWhere;
 					}
+				}
+
+				if (
+					fieldAttr.type === "date" &&
+					value instanceof Date &&
+					!config.supportsDates
+				) {
+					newValue = value.toISOString();
+				}
+
+				
+				if (
+					fieldAttr.type === "boolean" &&
+					typeof value === "boolean" &&
+					!config.supportsBooleans
+				) {
+					newValue = value ? 1 : 0;
+				}
+
+				if (
+					fieldAttr.type === "json" &&
+					value &&
+					typeof value === "string" &&
+					!config.supportsJSON
+				) {
+					newValue = JSON.stringify(value);
 				}
 
 				return {
 					operator,
 					connector,
 					field: fieldName,
-					value: value,
+					value: newValue,
 				} satisfies CleanedWhere;
 			}) as any;
 		};

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -350,7 +350,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				async delete({ model, where }) {
 					const schemaModel = getSchema(model);
 					const clause = convertWhereClause(where, model);
-					const builder = db.delete(schemaModel).where(...clause);
+					const builder = db.delete(schemaModel).where(...clause).limit(1);
 					return await builder;
 				},
 				async deleteMany({ model, where }) {

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -6,8 +6,10 @@ import {
 import type { Adapter, BetterAuthOptions, Where } from "../../types";
 import type { KyselyDatabaseType } from "./types";
 import {
+	sql,
 	type InsertQueryBuilder,
 	type Kysely,
+	type RawBuilder,
 	type UpdateQueryBuilder,
 } from "kysely";
 import type { DBAdapterDebugLogOption } from "@better-auth/core/db/adapter";
@@ -47,7 +49,12 @@ export const kyselyAdapter = (
 	const createCustomAdapter = (
 		db: Kysely<any>,
 	): AdapterFactoryCustomizeAdapterCreator => {
-		return ({ getFieldName, schema, getDefaultModelName }) => {
+		return ({
+			getFieldName,
+			schema,
+			getDefaultModelName,
+			getDefaultFieldName,
+		}) => {
 			const withReturning = async (
 				values: Record<string, any>,
 				builder:
@@ -94,60 +101,6 @@ export const kyselyAdapter = (
 				res = await builder.returningAll().executeTakeFirst();
 				return res;
 			};
-			function transformValueToDB(value: any, model: string, field: string) {
-				if (field === "id") {
-					return value;
-				}
-				const { type = "sqlite" } = config || {};
-				let f = schema[model]?.fields[field];
-				if (!f) {
-					//@ts-expect-error - The model name can be a sanitized, thus using the custom model name, not one of the default ones.
-					f = Object.values(schema).find((f) => f.modelName === model)!;
-				}
-				if (
-					f!.type === "boolean" &&
-					(type === "sqlite" || type === "mssql") &&
-					value !== null &&
-					value !== undefined
-				) {
-					return value ? 1 : 0;
-				}
-				if (f!.type === "date" && value && value instanceof Date) {
-					if (type === "sqlite") return value.toISOString();
-					return value;
-				}
-				return value;
-			}
-
-			function transformValueFromDB(value: any) {
-				function transformObject(obj: any) {
-					for (const key in obj) {
-						if (!Object.prototype.hasOwnProperty.call(obj, key)) continue;
-
-						const field = obj[key];
-
-						if (field instanceof Date && config?.type === "mysql") {
-							// obj[key] = ensureUTC(field);
-						} else if (typeof field === "object" && field !== null) {
-							transformObject(field);
-						}
-					}
-				}
-
-				if (Array.isArray(value)) {
-					for (let i = 0; i < value.length; i++) {
-						const item = value[i];
-						if (typeof item === "object" && item !== null) {
-							transformObject(item);
-						}
-					}
-				} else if (typeof value === "object" && value !== null) {
-					transformObject(value);
-				}
-
-				return value;
-			}
-
 			function convertWhereClause(model: string, w?: Where[]) {
 				if (!w)
 					return {
@@ -163,12 +116,36 @@ export const kyselyAdapter = (
 				w.forEach((condition) => {
 					let {
 						field: _field,
-						value,
+						value: _value,
 						operator = "=",
 						connector = "AND",
 					} = condition;
-					const field = getFieldName({ model, field: _field });
-					value = transformValueToDB(value, model, _field);
+					let value: any = _value;
+					let field: string | RawBuilder<unknown> = getFieldName({
+						model,
+						field: _field,
+					});
+					const fieldAttr =
+						schema[getDefaultModelName(model)]?.fields[
+							getDefaultFieldName({ model, field: _field })
+						];
+
+					if (!fieldAttr) {
+						throw new Error(`Field ${_field} not found in model ${model}`);
+					}
+
+					// if (
+					// 	fieldAttr.type === "date" &&
+					// 	value &&
+					// 	typeof value === "string" &&
+					// 	(!config?.type || config?.type === "sqlite")
+					// ) {
+					// 	// field = sql`datetime(${sql.ref(field)}, 'utc')`;
+					// 	// value = sql`datetime(${value}, 'utc')`;
+					// 	field = sql`strftime('%Y-%m-%dT%H:%M:%fZ', ${sql.ref(field)}, 'utc')`;
+					// 	value = sql`strftime('%Y-%m-%dT%H:%M:%fZ', ${value}, 'utc')`;
+					// }
+
 					const expr = (eb: any) => {
 						if (operator.toLowerCase() === "in") {
 							return eb(field, "in", Array.isArray(value) ? value : [value]);
@@ -237,7 +214,7 @@ export const kyselyAdapter = (
 				async create({ data, model }) {
 					const builder = db.insertInto(model).values(data);
 					const returned = await withReturning(data, builder, model, []);
-					return transformValueFromDB(returned) as any;
+					return returned;
 				},
 				async findOne({ model, where, select }) {
 					const { and, or } = convertWhereClause(model, where);
@@ -250,7 +227,7 @@ export const kyselyAdapter = (
 					}
 					const res = await query.executeTakeFirst();
 					if (!res) return null;
-					return transformValueFromDB(res) as any;
+					return res as any;
 				},
 				async findMany({ model, where, limit, offset, sortBy }) {
 					const { and, or } = convertWhereClause(model, where);
@@ -287,7 +264,7 @@ export const kyselyAdapter = (
 
 					const res = await query.selectAll().execute();
 					if (!res) return [];
-					return transformValueFromDB(res) as any;
+					return res as any;
 				},
 				async update({ model, where, update: values }) {
 					const { and, or } = convertWhereClause(model, where);
@@ -299,9 +276,7 @@ export const kyselyAdapter = (
 					if (or) {
 						query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
 					}
-					return transformValueFromDB(
-						await withReturning(values as any, query, model, where),
-					);
+					return await withReturning(values as any, query, model, where);
 				},
 				async updateMany({ model, where, update: values }) {
 					const { and, or } = convertWhereClause(model, where);
@@ -346,6 +321,7 @@ export const kyselyAdapter = (
 					if (or) {
 						query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
 					}
+					query = query.limit(1);
 					await query.execute();
 				},
 				async deleteMany({ model, where }) {

--- a/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.sqlite.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.sqlite.test.ts
@@ -42,7 +42,7 @@ const { execute } = await testAdapter({
 		await runMigrations();
 	},
 	tests: [
-		normalTestSuite(),
+		normalTestSuite({}),
 		transactionsTestSuite({ disableTests: { ALL: true } }),
 		authFlowTestSuite(),
 		numberIdTestSuite(),

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -218,9 +218,13 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 					try {
 						await db[model]!.delete({
 							where: whereClause,
+
 						});
-					} catch (e) {
+					} catch (e: any) {
 						// If the record doesn't exist, we don't want to throw an error
+						if(e?.meta?.cause === "Record to delete does not exist.") return;
+						// otherwise if it's an unknown error, we want to just log it for debugging.
+						console.log(e);
 					}
 				},
 				async deleteMany({ model, where }) {

--- a/packages/better-auth/src/adapters/tests/normal.ts
+++ b/packages/better-auth/src/adapters/tests/normal.ts
@@ -180,7 +180,7 @@ export const getNormalTestSuiteTests = ({
 			expect(result?.email).toEqual(user.email);
 			expect(true).toEqual(true);
 		},
-		"findOne - should find a model with a modified model name": async () => {
+		"findOne - should find a model with modified model name": async () => {
 			await modifyBetterAuthOptions(
 				{
 					user: {
@@ -236,6 +236,33 @@ export const getNormalTestSuiteTests = ({
 				select: ["email", "name"],
 			});
 			expect(result).toEqual({ email: user.email, name: user.name });
+		},
+		"findOne - should find model with date field": async () => {
+			const [user] = await insertRandom("user");
+			const result = await adapter.findOne<User>({
+				model: "user",
+				where: [{ field: "createdAt", value: user.createdAt, operator: "eq" }],
+			});
+			expect(result).toEqual(user);
+			expect(result?.createdAt).toBeInstanceOf(Date);
+			expect(result?.createdAt).toEqual(user.createdAt);
+		},
+		"findMany - should find many models with date fields": async () => {
+			const users = (await insertRandom("user", 3)).map((x) => x[0]);
+			const youngestUser = users.sort(
+				(a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+			)[0]!;
+			const result = await adapter.findMany<User>({
+				model: "user",
+				where: [
+					{ field: "createdAt", value: youngestUser.createdAt, operator: "lt" },
+				],
+			});
+			expect(sortModels(result)).toEqual(
+				sortModels(
+					users.filter((user) => user.createdAt < youngestUser.createdAt),
+				),
+			);
 		},
 		"findMany - should find many models": async () => {
 			const users = (await insertRandom("user", 3)).map((x) => x[0]);
@@ -611,6 +638,80 @@ export const getNormalTestSuiteTests = ({
 				model: "user",
 			});
 			expect(sortModels(result)).toEqual(sortModels(users.slice(2)));
+		},
+		"deleteMany - should delete many models with numeric values": async () => {
+			let i = 0;
+			await modifyBetterAuthOptions(
+				{
+					user: {
+						additionalFields: {
+							numericField: {
+								type: "number",
+								defaultValue() {
+									return i++;
+								},
+							},
+						},
+					},
+				},
+				true,
+			);
+			const users = (await insertRandom("user", 3)).map(
+				(x) => x[0],
+			) as (User & { numericField: number })[];
+			if (!users[0] || !users[1] || !users[2]) {
+				expect(false).toBe(true);
+				throw new Error("Users not found");
+			}
+			expect(users[0].numericField).toEqual(0);
+			expect(users[1].numericField).toEqual(1);
+			expect(users[2].numericField).toEqual(2);
+
+			await adapter.deleteMany({
+				model: "user",
+				where: [
+					{
+						field: "numericField",
+						value: users[0].numericField,
+						operator: "gt",
+					},
+				],
+			});
+
+			const result = await adapter.findMany<User>({
+				model: "user",
+			});
+			expect(result).toEqual([users[0]]);
+		},
+		"deleteMany - should delete many models with boolean values": async () => {
+			const users = (await insertRandom("user", 3)).map((x) => x[0]);
+			// in this test, we have 3 users, two of which have emailVerified set to true and one to false
+			// delete all that has emailVerified set to true, and expect users[1] to be the only one left
+			if (!users[0] || !users[1] || !users[2]) {
+				expect(false).toBe(true);
+				throw new Error("Users not found");
+			}
+			await adapter.updateMany({
+				model: "user",
+				where: [],
+				update: { emailVerified: true },
+			});
+			await adapter.update({
+				model: "user",
+				where: [{ field: "id", value: users[1].id }],
+				update: { emailVerified: false },
+			});
+			await adapter.deleteMany({
+				model: "user",
+				where: [{ field: "emailVerified", value: true }],
+			});
+			const result = await adapter.findMany<User>({
+				model: "user",
+			});
+			expect(result).toHaveLength(1);
+			expect(result.find((user) => user.id === users[0]?.id)).toBeUndefined();
+			expect(result.find((user) => user.id === users[1]?.id)).toBeDefined();
+			expect(result.find((user) => user.id === users[2]?.id)).toBeUndefined();
 		},
 		"count - should count many models": async () => {
 			const users = await insertRandom("user", 15);

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -164,33 +164,6 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 					builder.model(modelName).blockAttribute(`unique([${fieldName}])`);
 				}
 
-				if (attr.defaultValue !== undefined) {
-					if (field === "createdAt") {
-						fieldBuilder.attribute("default(now())");
-					} else if (typeof attr.defaultValue === "boolean") {
-						fieldBuilder.attribute(`default(${attr.defaultValue})`);
-					} else if (typeof attr.defaultValue === "function") {
-						// For other function-based defaults, we'll need to check what they return
-						const defaultVal = attr.defaultValue();
-						if (defaultVal instanceof Date) {
-							fieldBuilder.attribute("default(now())");
-						} else {
-							console.warn(
-								`Warning: Unsupported default function for field ${fieldName} in model ${modelName}. Please adjust manually.`,
-							);
-						}
-					}
-				}
-
-				// This is a special handling for updatedAt fields
-				if (field === "updatedAt" && attr.onUpdate) {
-					fieldBuilder.attribute("updatedAt");
-				} else if (attr.onUpdate) {
-					console.warn(
-						`Warning: 'onUpdate' is only supported on 'updatedAt' fields. Please adjust manually for field ${fieldName} in model ${modelName}.`,
-					);
-				}
-
 				if (attr.references) {
 					const referencedOriginalModelName = attr.references.model;
 					const referencedCustomModelName =


### PR DESCRIPTION
fix: kysely & drizzle will delete more than 1 since we didn't add a `limit` claw.
fix: kysely breaks with DBs that have lack of support for specific field types like dates or booleans during where clause transformation.