### PR TITLE
docs: how to use non-public pg schemas with BA

### DIFF
--- a/docs/content/docs/adapters/postgresql.mdx
+++ b/docs/content/docs/adapters/postgresql.mdx
@@ -59,8 +59,27 @@ npx @better-auth/cli@latest generate
 npx @better-auth/cli@latest migrate
 ```
 
+## Set tables under a non-default schema
+
+To create Better Auth tables in a non-default schema like `auth`,
+set the PostgreSQL user's default schema before generating or migrating:
+
+```sql
+ALTER USER authuser SET SEARCH_PATH TO auth;
+```
+
+alternatively, append the option to your connection URI, for example:
+
+```
+postgres://<DATABASE_URL>?option=-c search_path=auth
+```
+URL-encode if needed: `?option=-c%20search_path%3Dauth`.
+
+Ensure the target schema exists and the database user has the required permissions.
+
 ## Additional Information
 
 PostgreSQL is supported under the hood via the [Kysely](https://kysely.dev/) adapter, any database supported by Kysely would also be supported. (<Link href="/docs/adapters/other-relational-databases">Read more here</Link>)
 
 If you're looking for performance improvements or tips, take a look at our guide to <Link href="/docs/guides/optimizing-for-performance">performance optimizations</Link>.
+


### PR DESCRIPTION
linear: https://linear.app/better-auth/issue/ENG-222/docs-document-how-to-use-non-public-postgresql-schemas-with-better
issue: https://github.com/better-auth/better-auth/issues/4452