### PR TITLE
feat(social-provider): linear app actor oauth support

### DIFF
--- a/packages/core/src/social-providers/linear.ts
+++ b/packages/core/src/social-providers/linear.ts
@@ -50,10 +50,7 @@ export const linear = (options: LinearOptions) => {
 				state,
 				redirectURI,
 				loginHint,
-				additionalParams:
-					Object.keys(additionalParams).length > 0
-						? additionalParams
-						: undefined,
+				additionalParams: additionalParams,
 			});
 		},
 		validateAuthorizationCode: async ({ code, redirectURI }) => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds support for Linear OAuth “actor” to enable app-level tokens for service accounts and automation. Handles tokens without a user profile by returning null instead of creating/linking a user.

- **New Features**
  - Add actor option to LinearOptions ("app" | "user").
  - Include actor in the authorization URL when provided.
  - Return null when app-actor tokens lack a viewer to prevent user creation/linking.
  - Backward compatible; default behavior unchanged.

Addresses Linear issue #5045.

<!-- End of auto-generated description by cubic. -->

