### PR TITLE
fix(types): missing isRefetching state in react useSession hook

### DIFF
--- a/packages/better-auth/src/client/react/index.ts
+++ b/packages/better-auth/src/client/react/index.ts
@@ -87,6 +87,7 @@ export function createAuthClient<Option extends ClientOptions>(
 			useSession: () => {
 				data: Session;
 				isPending: boolean;
+				isRefetching: boolean;
 				error: BetterFetchError | null;
 				refetch: (queryParams?: { query?: SessionQueryParams }) => void;
 			};


### PR DESCRIPTION
This PR adds the isRefetching field to the useSession hook type definition.
The value was already available in the hook but wasn’t exposed in the TypeScript types.