### PR TITLE
fix(stripe): allow subscription upgrade between different intervals for a plan

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -379,7 +379,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 				);
 
 				// Resolve price ID if using lookup keys
-				let priceIdToUse: string | undefined = undefined;
+				let priceIdToUse: string | undefined;
 				if (ctx.body.annual) {
 					priceIdToUse = plan.annualDiscountPriceId;
 					if (!priceIdToUse && plan.annualDiscountLookupKey) {

--- a/packages/stripe/src/stripe.test.ts
+++ b/packages/stripe/src/stripe.test.ts
@@ -902,7 +902,6 @@ describe("stripe", async () => {
 		);
 
 		const headers = new Headers();
-
 		await authClient.signIn.email(
 			{
 				...testUser,


### PR DESCRIPTION
This PR enables upgrades for subscriptions on the same plan between different billing intervals. (annually/monthly)

- Deduplicates priceId checks for lookup keys and moves them before `ALREADY_SUBSCRIBED_PLAN` check
- Implements checks for `priceId` by using the active priceId from the current active stripe subscription and the future priceId of the upgrade.
- Adds test for switching to annually for same plan


fixes #3393 #3236
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allows upgrading a subscription between monthly and annual intervals on the same plan. Prevents false “already subscribed” errors by comparing Stripe price IDs correctly.

- **Bug Fixes**
  - Resolve price ID (including lookup keys) before the already-subscribed check and deduplicate logic.
  - Compare the active Stripe subscription’s price ID to the target price ID to allow interval switches.
  - Add test covering monthly-to-annual upgrade on the same plan.

<!-- End of auto-generated description by cubic. -->

