### PR TITLE
chore: remove deprecated comment

### DIFF
--- a/packages/better-auth/src/social-providers/index.ts
+++ b/packages/better-auth/src/social-providers/index.ts
@@ -1,4 +1,1 @@
-/**
- * @deprecated Use `@better-auth/core/social-providers` instead, as this endpoint will be removed in future versions.
- */
 export * from "@better-auth/core/social-providers";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the deprecated JSDoc comment in packages/better-auth/src/social-providers/index.ts so the re-export is no longer flagged as deprecated. No API or runtime changes.

<!-- End of auto-generated description by cubic. -->

