### PR TITLE
chore: fix type import

### DIFF
--- a/packages/better-auth/src/types/options.ts
+++ b/packages/better-auth/src/types/options.ts
@@ -23,7 +23,7 @@ import type { AuthMiddleware } from "../plugins";
 import type { LiteralUnion, OmitId } from "./helper";
 import type { Database as BunDatabase } from "bun:sqlite";
 import type { DatabaseSync } from "node:sqlite";
-import type { DBAdapterDebugLogOption } from "packages/core/dist/db/adapter";
+import type { DBAdapterDebugLogOption } from "@better-auth/core/db/adapter";
 
 export type BetterAuthOptions = {
 	/**


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a broken type import in better-auth options by switching DBAdapterDebugLogOption to @better-auth/core/db/adapter. This resolves TypeScript type resolution errors and aligns with the published package path.

<!-- End of auto-generated description by cubic. -->

