### PR TITLE
docs: fix AdapterDebugLogs type to DBAdapterDebugLogOption

### DIFF
--- a/docs/content/docs/guides/create-a-db-adapter.mdx
+++ b/docs/content/docs/guides/create-a-db-adapter.mdx
@@ -22,14 +22,14 @@ All you need to do is provide the database logic, and the `createAdapter` functi
 3. Create the adapter!
 
 ```ts
-import { createAdapter, type AdapterDebugLogs } from "better-auth/adapters";
+import { createAdapter, type DBAdapterDebugLogOption } from "better-auth/adapters";
 
 // Your custom adapter config options
 interface CustomAdapterConfig {
   /**
    * Helps you debug issues with the adapter.
    */
-  debugLogs?: AdapterDebugLogs;
+  debugLogs?: DBAdapterDebugLogOption;
   /**
    * If the table names in the schema are plural.
    */


### PR DESCRIPTION
## Description
     Update the database adapter guide documentation to use the correct type name.
     
     ## Changes
     - Changed `AdapterDebugLogs` to `DBAdapterDebugLogOption` in the import statement
     - Updated the type reference in `CustomAdapterConfig` interface
     
     ## Reason
     The type `AdapterDebugLogs` has been renamed to `DBAdapterDebugLogOption` in the current version of better-auth, but the documentation was not updated.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes outdated type name in the database adapter guide. Replaces AdapterDebugLogs with DBAdapterDebugLogOption in the import and interface to match the current better-auth API.

<!-- End of auto-generated description by cubic. -->

