### PR TITLE
fix: Argument `where` of type TwoFactorWhereUniqueInput needs at least one of `id` arguments

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -445,7 +445,7 @@ export const backupCode2fa = (options?: BackupCodeOptions) => {
 						ctx,
 						backupCodes.encryptedBackupCodes,
 					);
-					await ctx.context.adapter.update({
+					await ctx.context.adapter.updateMany({
 						model: twoFactorTable,
 						update: {
 							backupCodes: storedBackupCodes,


### PR DESCRIPTION
Fixes #2474
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switches two-factor backup code updates to use adapter.updateMany, removing the unique ID requirement and preventing the “TwoFactorWhereUniqueInput needs at least one of `id` arguments” error.
This ensures encrypted backup codes are stored without failing when a unique identifier isn’t available.

<!-- End of auto-generated description by cubic. -->

