### PR TITLE
fix: ensure falsy values are valid default values

### DIFF
--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -93,7 +93,7 @@ export function parseInputData<T extends Record<string, any>>(
 	for (const key in fields) {
 		if (key in data) {
 			if (fields[key]!.input === false) {
-				if (fields[key]!.defaultValue) {
+				if (fields[key]!.defaultValue !== undefined) {
 					parsedData[key] = fields[key]!.defaultValue;
 					continue;
 				}
@@ -116,7 +116,7 @@ export function parseInputData<T extends Record<string, any>>(
 			continue;
 		}
 
-		if (fields[key]!.defaultValue && action === "create") {
+		if (fields[key]!.defaultValue !== undefined && action === "create") {
 			parsedData[key] = fields[key]!.defaultValue;
 			continue;
 		}


### PR DESCRIPTION
### What's Changed and Why

This PR resolves a bug where fields with a **falsy** `defaultValue`, specifically `0` or an empty string (`""`), were incorrectly skipped during the data parsing process.


### Relevant Context or Background

This validation logic is crucial for ensuring that field configurations are respected when initializing data for new resources. Incorrectly skipping `0` or `""` as default values can lead to unexpected behavior in downstream logic that depends on these fields being present or having their configured default, rather than being entirely absent.

### Breaking Changes or Deprecations

None.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes parseInputData so falsy default values (0 and "") are applied instead of skipped. This ensures fields initialize with their configured defaults when input is disabled or on create.

- **Bug Fixes**
  - Use `defaultValue !== undefined` instead of a truthy check in both branches of parseInputData.

<!-- End of auto-generated description by cubic. -->

