### PR TITLE
docs: update line social provider example

### DIFF
--- a/docs/content/docs/authentication/line.mdx
+++ b/docs/content/docs/authentication/line.mdx
@@ -29,7 +29,8 @@ description: LINE provider setup and usage.
               clientId: process.env.LINE_CLIENT_ID as string,
               clientSecret: process.env.LINE_CLIENT_SECRET as string,
               // redirectURI: "https://your.app/api/auth/callback/line", // uncomment to use a custom redirect URI
-              // scope: ["openid", "profile", "email"], // uncomment to add additional scopes
+              // scope: ["custom"], // uncomment to add additional scopes
+              // disableDefaultScope: true, // uncomment to replace default scopes [`openid`, `profile`, `email`]
             },
           },
         });


### PR DESCRIPTION
The comments are inlined and adjusted so they can be used when uncommented.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified LINE provider docs by updating inline comments to show how to set a custom redirectURI and pass scopes. The example lines are now ready to uncomment and use directly.

<!-- End of auto-generated description by cubic. -->

