### PR TITLE
fix(docs): anchor link scrolling with conflict prevention

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -270,7 +270,6 @@ html:not([data-anchor-scrolling]) {
 	scroll-behavior: smooth;
 }
 
-
 /* Global, accessible custom scrollbars */
 * {
 	scrollbar-width: thin; /* Firefox */

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -59,7 +59,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 								: undefined,
 						}}
 					>
-						<AnchorScroll/>
+						<AnchorScroll />
 						<NavbarProvider>
 							<Navbar />
 							{children}

--- a/docs/components/anchor-scroll-fix.tsx
+++ b/docs/components/anchor-scroll-fix.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef } from "react";
 
-
 export function AnchorScroll() {
 	const scrollTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 	const isScrollingRef = useRef(false);
@@ -10,22 +9,29 @@ export function AnchorScroll() {
 	useEffect(() => {
 		function calculateScrollOffset() {
 			const root = document.documentElement;
-			const navHeight = parseInt(getComputedStyle(root).getPropertyValue("--fd-nav-height") || "56");
-			const bannerHeight = parseInt(getComputedStyle(root).getPropertyValue("--fd-banner-height") || "0");
-			const tocnavHeight = parseInt(getComputedStyle(root).getPropertyValue("--fd-tocnav-height") || "0");
-			
+			const navHeight = parseInt(
+				getComputedStyle(root).getPropertyValue("--fd-nav-height") || "56",
+			);
+			const bannerHeight = parseInt(
+				getComputedStyle(root).getPropertyValue("--fd-banner-height") || "0",
+			);
+			const tocnavHeight = parseInt(
+				getComputedStyle(root).getPropertyValue("--fd-tocnav-height") || "0",
+			);
+
 			return navHeight + bannerHeight + tocnavHeight + 24;
 		}
 
 		function smoothScrollToElement(element: HTMLElement) {
 			if (isScrollingRef.current) return;
-			
+
 			isScrollingRef.current = true;
-			document.documentElement.setAttribute('data-anchor-scrolling', 'true');
+			document.documentElement.setAttribute("data-anchor-scrolling", "true");
 
 			const elementRect = element.getBoundingClientRect();
 			const scrollOffset = calculateScrollOffset();
-			const targetPosition = window.pageYOffset + elementRect.top - scrollOffset;
+			const targetPosition =
+				window.pageYOffset + elementRect.top - scrollOffset;
 
 			// Simple smooth scroll animation
 			const startPosition = window.pageYOffset;
@@ -37,14 +43,15 @@ export function AnchorScroll() {
 				const elapsed = currentTime - startTime;
 				const progress = Math.min(elapsed / duration, 1);
 				const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
-				const currentPosition = startPosition + (distance * easeOutCubic(progress));
-				
+				const currentPosition =
+					startPosition + distance * easeOutCubic(progress);
+
 				window.scrollTo(0, currentPosition);
-				
+
 				if (progress < 1) {
 					requestAnimationFrame(animateScroll);
 				} else {
-					document.documentElement.removeAttribute('data-anchor-scrolling');
+					document.documentElement.removeAttribute("data-anchor-scrolling");
 					isScrollingRef.current = false;
 				}
 			}
@@ -56,7 +63,10 @@ export function AnchorScroll() {
 			if (window.location.hash) {
 				const element = document.getElementById(window.location.hash.slice(1));
 				if (element) {
-					scrollTimeoutRef.current = setTimeout(() => smoothScrollToElement(element), 100);
+					scrollTimeoutRef.current = setTimeout(
+						() => smoothScrollToElement(element),
+						100,
+					);
 				}
 			}
 		}
@@ -67,14 +77,16 @@ export function AnchorScroll() {
 		}
 
 		function handleAnchorClick(event: Event) {
-			const link = (event.target as HTMLElement).closest('a[href^="#"]') as HTMLAnchorElement;
-			
+			const link = (event.target as HTMLElement).closest(
+				'a[href^="#"]',
+			) as HTMLAnchorElement;
+
 			if (link?.hash) {
 				event.preventDefault();
 				const element = document.getElementById(link.hash.slice(1));
-				
+
 				if (element) {
-					history.pushState(null, '', link.hash);
+					history.pushState(null, "", link.hash);
 					smoothScrollToElement(element);
 				}
 			}

--- a/docs/components/docs/layout/nav.tsx
+++ b/docs/components/docs/layout/nav.tsx
@@ -48,7 +48,7 @@ export function NavProvider({
 		if (transparentMode !== "top") return;
 
 		const listener = () => {
-			if (document.documentElement.hasAttribute('data-anchor-scrolling')) {
+			if (document.documentElement.hasAttribute("data-anchor-scrolling")) {
 				return;
 			}
 			setTransparent(window.scrollY < 10);


### PR DESCRIPTION
closes #4658
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved docs anchor link navigation with a custom smooth scroll that respects header offsets and avoids double-smoothing. Users land at the right position, and the navbar no longer flickers during anchor jumps.

- New Features
  - Added AnchorScroll to handle hash changes and in-page anchor clicks with a custom, offset-aware smooth animation.
  - Uses CSS vars (--fd-nav-height, --fd-banner-height, --fd-tocnav-height) and +24px padding to compute accurate scroll offsets.
  - Switches scroll-behavior to auto during scripted scrolls via [data-anchor-scrolling]; smooth remains default otherwise.

- Bug Fixes
  - Prevent navbar transparency updates while anchor scrolling; scroll listener is passive.
  - Removes jitter and incorrect offsets caused by native vs. scripted smooth scrolling on anchor clicks and hash loads.

<!-- End of auto-generated description by cubic. -->

