### PR TITLE
chore: use type from core

### DIFF
--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -1,4 +1,4 @@
-import type { Models } from "../types";
+import type { DBPreservedModels } from "@better-auth/core/db";
 import type { BetterAuthOptions } from "@better-auth/core";
 import type { DBAdapter, Where } from "@better-auth/core/db/adapter";
 import { getCurrentAdapter } from "../context/transaction";
@@ -13,7 +13,7 @@ export function getWithHooks(
 ) {
 	const hooks = ctx.hooks;
 	type BaseModels = Extract<
-		Models,
+		DBPreservedModels,
 		"user" | "account" | "session" | "verification"
 	>;
 	async function createWithHooks<T extends Record<string, any>>(

--- a/packages/better-auth/src/types/models.ts
+++ b/packages/better-auth/src/types/models.ts
@@ -5,19 +5,6 @@ import type { StripEmptyObjects, UnionToIntersection } from "./helper";
 import type { BetterAuthPlugin } from "@better-auth/core";
 import type { User, Session } from "@better-auth/core/db";
 
-export type Models =
-	| "user"
-	| "account"
-	| "session"
-	| "verification"
-	| "rate-limit"
-	| "organization"
-	| "member"
-	| "invitation"
-	| "jwks"
-	| "passkey"
-	| "two-factor";
-
 export type AdditionalUserFieldsInput<Options extends BetterAuthOptions> =
 	InferFieldsFromPlugins<Options, "user", "input"> &
 		InferFieldsFromOptions<Options, "user", "input">;

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -4,6 +4,7 @@ import type {
 	DBFieldType,
 	DBPrimitive,
 	BetterAuthDBSchema,
+	DBPreservedModels,
 } from "./type";
 import type { BetterAuthPluginDBSchema } from "./plugin";
 export type { BetterAuthPluginDBSchema } from "./plugin";
@@ -21,6 +22,7 @@ export type {
 	DBFieldType,
 	DBPrimitive,
 	BetterAuthDBSchema,
+	DBPreservedModels,
 };
 
 /**

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -1,16 +1,7 @@
 import type { ZodType } from "zod";
 import type { LiteralString } from "../types";
 
-declare module "../index" {
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	interface BetterAuthMutators<O, C> {
-		"better-auth/db": {
-			// todo: we should infer the schema from the adapter
-		};
-	}
-}
-
-export type Models =
+export type DBPreservedModels =
 	| "user"
 	| "account"
 	| "session"

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -10,7 +10,7 @@ import type { OAuthProvider } from "../oauth2";
 import { createLogger } from "../env";
 import type { DBAdapter, Where } from "../db/adapter";
 import type { BetterAuthCookies } from "./cookie";
-import type { Models } from "../db/type";
+import type { DBPreservedModels } from "../db/type";
 import type { LiteralUnion } from "./helper";
 import type { CookieOptions, EndpointContext } from "better-call";
 import type {
@@ -247,7 +247,7 @@ export type AuthContext<Options extends BetterAuthOptions = BetterAuthOptions> =
 			freshAge: number;
 		};
 		generateId: (options: {
-			model: LiteralUnion<Models, string>;
+			model: LiteralUnion<DBPreservedModels, string>;
 			size?: number;
 		}) => string | false;
 		secondaryStorage: SecondaryStorage | undefined;

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -2,7 +2,11 @@ import type { Dialect, Kysely, MysqlPool, PostgresPool } from "kysely";
 import type { Database } from "better-sqlite3";
 import type { CookieOptions } from "better-call";
 import type { LiteralUnion } from "./helper";
-import type { DBFieldAttribute, Models, SecondaryStorage } from "../db/type";
+import type {
+	DBFieldAttribute,
+	DBPreservedModels,
+	SecondaryStorage,
+} from "../db/type";
 import type { Account, RateLimit, Session, User, Verification } from "../db";
 import type { Database as BunDatabase } from "bun:sqlite";
 import type { DatabaseSync } from "node:sqlite";
@@ -17,7 +21,7 @@ type KyselyDatabaseType = "postgres" | "mysql" | "sqlite" | "mssql";
 type OmitId<T extends { id: unknown }> = Omit<T, "id">;
 
 export type GenerateIdFn = (options: {
-	model: LiteralUnion<Models, string>;
+	model: LiteralUnion<DBPreservedModels, string>;
 	size?: number;
 }) => string | false;
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Centralized model typings by adopting DBPreservedModels from @better-auth/core and removing the duplicated Models type. This reduces duplication and keeps model names consistent across packages.

- **Refactors**
  - Exported DBPreservedModels from core and replaced Models in hooks, context, and init-options.
  - Removed unused module augmentation in core/db/type.ts.

- **Migration**
  - Replace any Models imports with DBPreservedModels from @better-auth/core/db.
  - generateId’s model parameter now uses LiteralUnion<DBPreservedModels, string>; no runtime changes.

<!-- End of auto-generated description by cubic. -->

