### PR TITLE
fix: import `node:async_hooks` directly

### DIFF
--- a/packages/core/src/async_hooks/index.ts
+++ b/packages/core/src/async_hooks/index.ts
@@ -6,18 +6,10 @@ import type { AsyncLocalStorage } from "node:async_hooks";
 // We only export the type here to avoid issues in environments where AsyncLocalStorage is not available.
 export type { AsyncLocalStorage };
 
-/**
- * Dynamically import AsyncLocalStorage to avoid issues in environments where it's not available.
- *
- * Right now, this is primarily for Cloudflare Workers.
- *
- */
-let moduleName: string = "node:async_hooks";
-
 const AsyncLocalStoragePromise: Promise<typeof AsyncLocalStorage> = import(
 	/* @vite-ignore */
 	/* webpackIgnore: true */
-	moduleName
+	"node:async_hooks"
 )
 	.then((mod) => mod.AsyncLocalStorage)
 	.catch((err) => {


### PR DESCRIPTION
This will fix nextjs build issue
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix Next.js build errors by using a static import specifier for node:async_hooks in the AsyncLocalStorage dynamic import, replacing the variable-based path. Behavior stays the same while allowing bundlers to statically analyze the import.

<!-- End of auto-generated description by cubic. -->

