### PR TITLE
fix(passkey): wrong Session type being used on passkey

### DIFF
--- a/packages/better-auth/src/plugins/passkey/client.ts
+++ b/packages/better-auth/src/plugins/passkey/client.ts
@@ -8,8 +8,7 @@ import type {
 	PublicKeyCredentialCreationOptionsJSON,
 	PublicKeyCredentialRequestOptionsJSON,
 } from "@simplewebauthn/browser";
-import type { Session } from "inspector";
-import type { User } from "../../types";
+import type { User, Session } from "../../types";
 import type { passkey as passkeyPl, Passkey } from ".";
 import type { BetterAuthClientPlugin, ClientStore } from "@better-auth/core";
 import { useAuthQuery } from "../../client";


### PR DESCRIPTION
Passkey client was using a `Session` type from [Node inspector](https://nodejs.org/api/inspector.html#class-inspectorsession), so I changed to use the correct `Session` type.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use the correct Session type in the passkey client (from ../../types, not Node’s inspector) to fix a type mismatch and ensure correct typings in the passkey flow.

<!-- End of auto-generated description by cubic. -->

