### PR TITLE
test: should emit warning on als not available

### DIFF
--- a/packages/better-auth/src/context/transaction.test.ts
+++ b/packages/better-auth/src/context/transaction.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test, vi } from "vitest";
+
+describe("transaction context", () => {
+	test("disabled async storage should trigger warning", async () => {
+		vi.mock("node:async_hooks", () => {
+			throw new Error("AsyncLocalStorage is not available");
+		});
+		const errorLog = vi.fn();
+		vi.spyOn(console, "warn").mockImplementation(errorLog);
+		const { getCurrentAdapter } = await import("./transaction");
+		await getCurrentAdapter(null!);
+		expect(errorLog).toHaveBeenCalled();
+		vi.restoreAllMocks();
+	});
+});

--- a/packages/better-auth/src/context/transaction.ts
+++ b/packages/better-auth/src/context/transaction.ts
@@ -6,11 +6,9 @@ import type {
 	DBTransactionAdapter,
 	DBAdapter,
 } from "@better-auth/core/db/adapter";
-import type { BetterAuthOptions } from "@better-auth/core";
 
-let currentAdapterAsyncStorage: AsyncLocalStorage<
-	DBTransactionAdapter<BetterAuthOptions>
-> | null = null;
+let currentAdapterAsyncStorage: AsyncLocalStorage<DBTransactionAdapter> | null =
+	null;
 
 const ensureAsyncStorage = async () => {
 	if (!currentAdapterAsyncStorage) {
@@ -21,8 +19,8 @@ const ensureAsyncStorage = async () => {
 };
 
 export const getCurrentAdapter = async (
-	fallback: DBTransactionAdapter<BetterAuthOptions>,
-): Promise<DBTransactionAdapter<BetterAuthOptions>> => {
+	fallback: DBTransactionAdapter,
+): Promise<DBTransactionAdapter> => {
 	return ensureAsyncStorage()
 		.then((als) => {
 			return als.getStore() || fallback;
@@ -33,10 +31,10 @@ export const getCurrentAdapter = async (
 };
 
 export const runWithAdapter = async <R>(
-	adapter: DBAdapter<BetterAuthOptions>,
+	adapter: DBAdapter,
 	fn: () => R,
 ): Promise<R> => {
-	let called = true;
+	let called = false;
 	return ensureAsyncStorage()
 		.then((als) => {
 			called = true;
@@ -51,10 +49,10 @@ export const runWithAdapter = async <R>(
 };
 
 export const runWithTransaction = async <R>(
-	adapter: DBAdapter<BetterAuthOptions>,
+	adapter: DBAdapter,
 	fn: () => R,
 ): Promise<R> => {
-	let called = true;
+	let called = false;
 	return ensureAsyncStorage()
 		.then((als) => {
 			called = true;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Emit a warning and fall back to the provided adapter when Node AsyncLocalStorage is unavailable. Adds a test to verify the warning and fallback behavior.

- **Bug Fixes**
  - Initialize the called flag to false in runWithAdapter and runWithTransaction to ensure the catch path warns and uses the fallback.
  - getCurrentAdapter now reliably returns the fallback when ALS fails or has no store.

- **Refactors**
  - Removed BetterAuthOptions generics from DBAdapter and DBTransactionAdapter types.

<!-- End of auto-generated description by cubic. -->

