### PR TITLE
docs(stripe): add warning about signature verification for webhooks

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -857,6 +857,10 @@ If webhooks aren't being processed correctly:
 3. Ensure you've selected all the necessary events in the Stripe dashboard
 4. Check your server logs for any errors during webhook processing
 
+<Callout type="warning">
+    If your **webhook** is failing with **signature verification errors**, make sure you **do not parse or modify the request body** before passing it to Better Auth. For example, using **`express.json()`** before verification can break the signature check. Stripe requires the **raw request body** to validate the signature, so you may need to capture the **unprocessed body** and provide it to Better Auth for the webhook endpoint.
+</Callout>
+
 ### Subscription Status Issues
 
 If subscription statuses aren't updating correctly:
@@ -872,5 +876,3 @@ For local development, you can use the Stripe CLI to forward webhooks to your lo
 ```bash
 stripe listen --forward-to localhost:3000/api/auth/stripe/webhook
 ```
-
-This will provide you with a webhook signing secret that you can use in your local environment.


### PR DESCRIPTION
This PR adds a warning callout in the Stripe plugin documentation to clarify a common cause of webhook signature verification errors.

The note explains that parsing or modifying the request body (e.g., with express.json()) before passing it to Better Auth breaks Stripe’s signature validation. It instructs developers to use the raw request body when handling webhooks.

<img width="999" height="483" alt="image" src="https://github.com/user-attachments/assets/d4535da8-2d27-4166-9847-e0f2b3c22320" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a warning callout to the Stripe plugin docs about webhook signature verification. It explains that parsing the request body (e.g., express.json()) before Better Auth breaks Stripe’s check and tells you to use the raw body.

Also removes a redundant line in the local development section.

<!-- End of auto-generated description by cubic. -->

