### PR TITLE
Fix JWT plugin copy

### DIFF
--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -66,7 +66,7 @@ export async function signJWT(
 				data: JSON.parse(key.privateKey),
 			}).catch(() => {
 				throw new BetterAuthError(
-					"Failed to decrypt private private key. Make sure the secret currently in use is the same as the one used to encrypt the private key. If you are using a different secret, either cleanup your jwks or disable private key encryption.",
+					"Failed to decrypt private key. Make sure the secret currently in use is the same as the one used to encrypt the private key. If you are using a different secret, either clean up your JWKS or disable private key encryption.",
 				);
 			})
 		: key.privateKey;


### PR DESCRIPTION
Removed duplicate word "private" and other minor copy fixes.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cleaned up the JWT plugin error message in signJWT by removing the duplicated “private” and clarifying the JWKS clean-up note. This improves readability when private key decryption fails.

<!-- End of auto-generated description by cubic. -->

