### PR TITLE
fix(passkey): verify passkey authentication isnt returning the user

### DIFF
--- a/.changeset/passkey-verify-authentication-returns-user.md
+++ b/.changeset/passkey-verify-authentication-returns-user.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/passkey": patch
+---
+
+Include `user` in the `/passkey/verify-authentication` JSON response so the body matches the endpoint's declared OpenAPI schema and the client-side `{ session, user }` return type.

--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -52,7 +52,6 @@ const mockRegistrationVerification = {
 	},
 };
 
-
 describe("passkey", async () => {
 	const { auth, client, signInWithTestUser, sessionSetter, customFetchImpl } =
 		await getTestInstance({
@@ -545,37 +544,26 @@ describe("passkey", async () => {
 				onResponse(context) {
 					const setCookie = context.response.headers.get("Set-Cookie");
 					if (setCookie) {
-						passkeyCookie = setCookie;
+						passkeyCookie = setCookie.split(";")[0] ?? "";
 					}
 				},
 			},
 		});
 
-		// Mock the verification response
-		const { verifyAuthenticationResponse } = await import(
-			"@simplewebauthn/server"
-		);
-		const mockedVerify = verifyAuthenticationResponse as unknown as ReturnType<
-			typeof vi.fn
-		>;
-		mockedVerify.mockResolvedValueOnce({
+		serverMocks.verifyAuthenticationResponse.mockResolvedValueOnce({
 			verified: true,
-			authenticationInfo: {
-				newCounter: 1,
-			},
+			authenticationInfo: { newCounter: 1 },
 		});
 
-		const currentCookie = (headers as any).cookie || "";
-		const combinedCookie = currentCookie
-			? `${currentCookie}; ${passkeyCookie}`
-			: passkeyCookie;
+		const existingCookie = headers.get("cookie") ?? "";
+		headers.set(
+			"cookie",
+			existingCookie ? `${existingCookie}; ${passkeyCookie}` : passkeyCookie,
+		);
+		headers.set("origin", "http://localhost:3000");
 
 		const response = await auth.api.verifyPasskeyAuthentication({
-			headers: {
-				...headers,
-				cookie: combinedCookie,
-				origin: "http://localhost:3000",
-			},
+			headers,
 			body: {
 				response: {
 					id: "mockCredentialID",
@@ -592,9 +580,10 @@ describe("passkey", async () => {
 			},
 		});
 
-		expect(response).toHaveProperty("user");
-		expect(response.user).toHaveProperty("id", user.id);
-		expect(response.user).toHaveProperty("email", user.email);
+		expect(response.session).toBeDefined();
+		expect(response.user).toBeDefined();
+		expect(response.user.id).toBe(user.id);
+		expect(response.user.email).toBe(user.email);
 	});
 });
 

--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -17,6 +17,7 @@ import { passkeyClient } from "./client";
 
 const serverMocks = vi.hoisted(() => ({
 	verifyRegistrationResponse: vi.fn(),
+	verifyAuthenticationResponse: vi.fn(),
 }));
 
 vi.mock("@simplewebauthn/server", async () => {
@@ -26,6 +27,7 @@ vi.mock("@simplewebauthn/server", async () => {
 	return {
 		...actual,
 		verifyRegistrationResponse: serverMocks.verifyRegistrationResponse,
+		verifyAuthenticationResponse: serverMocks.verifyAuthenticationResponse,
 	};
 });
 
@@ -50,6 +52,7 @@ const mockRegistrationVerification = {
 	},
 };
 
+
 describe("passkey", async () => {
 	const { auth, client, signInWithTestUser, sessionSetter, customFetchImpl } =
 		await getTestInstance({
@@ -58,6 +61,7 @@ describe("passkey", async () => {
 
 	afterEach(() => {
 		serverMocks.verifyRegistrationResponse.mockReset();
+		serverMocks.verifyAuthenticationResponse.mockReset();
 	});
 
 	it("should generate register options", async () => {
@@ -504,6 +508,93 @@ describe("passkey", async () => {
 			where: [{ field: "id", value: passkey.id }],
 		});
 		expect(unchanged?.name).toBe("original-name");
+	});
+
+	it("should verify passkey authentication and return user", async () => {
+		const { headers, user } = await signInWithTestUser();
+		const context = await auth.$context;
+
+		await context.adapter.create<Omit<Passkey, "id">, Passkey>({
+			model: "passkey",
+			data: {
+				userId: user.id,
+				publicKey: "mockPublicKey",
+				name: "mockName",
+				counter: 0,
+				deviceType: "singleDevice",
+				credentialID: "mockCredentialID",
+				createdAt: new Date(),
+				backedUp: false,
+				transports: "mockTransports",
+				aaguid: "mockAAGUID",
+			} satisfies Omit<Passkey, "id">,
+		});
+
+		const client = createAuthClient({
+			plugins: [passkeyClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				headers: headers,
+				customFetchImpl,
+			},
+		});
+
+		let passkeyCookie = "";
+		await client.passkey.generateAuthenticateOptions({
+			fetchOptions: {
+				onResponse(context) {
+					const setCookie = context.response.headers.get("Set-Cookie");
+					if (setCookie) {
+						passkeyCookie = setCookie;
+					}
+				},
+			},
+		});
+
+		// Mock the verification response
+		const { verifyAuthenticationResponse } = await import(
+			"@simplewebauthn/server"
+		);
+		const mockedVerify = verifyAuthenticationResponse as unknown as ReturnType<
+			typeof vi.fn
+		>;
+		mockedVerify.mockResolvedValueOnce({
+			verified: true,
+			authenticationInfo: {
+				newCounter: 1,
+			},
+		});
+
+		const currentCookie = (headers as any).cookie || "";
+		const combinedCookie = currentCookie
+			? `${currentCookie}; ${passkeyCookie}`
+			: passkeyCookie;
+
+		const response = await auth.api.verifyPasskeyAuthentication({
+			headers: {
+				...headers,
+				cookie: combinedCookie,
+				origin: "http://localhost:3000",
+			},
+			body: {
+				response: {
+					id: "mockCredentialID",
+					rawId: "mockRawId",
+					response: {
+						clientDataJSON: "mockClientDataJSON",
+						authenticatorData: "mockAuthenticatorData",
+						signature: "mockSignature",
+						userHandle: "mockUserHandle",
+					},
+					type: "public-key",
+					clientExtensionResults: {},
+				},
+			},
+		});
+
+		expect(response).toHaveProperty("user");
+		expect(response.user).toHaveProperty("id", user.id);
+		expect(response.user).toHaveProperty("email", user.email);
 	});
 });
 

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -838,6 +838,7 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 				return ctx.json(
 					{
 						session: s,
+						user,
 					},
 					{
 						status: 200,


### PR DESCRIPTION

    

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed passkey authentication verification to return the authenticated user alongside the session, matching the OpenAPI schema and client `{ session, user }` type.

- **Bug Fixes**
  - Response now includes both `session` and `user` (200); strengthened regression test to assert both are returned and added a changeset for `@better-auth/passkey`.

<sup>Written for commit e5099f121a52c188063e4cd431880dcf852ab8da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

