### PR TITLE
feat:(OLD) Allow passing additional data through OAuth flows

### DIFF
--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -132,6 +132,66 @@ const requestAdditionalScopes = async () => {
 Make sure you're running Better Auth version 1.2.7 or later. Earlier versions (like 1.2.2) may show a "Social account already linked" error when trying to link with an existing provider for additional scopes.
 </Callout>
 
+
+### Passing Additional Data
+
+You can pass additional data through the OAuth flow by using the `socialProviders.additionalData` option.
+This is useful if you want to assign custom fields to specific tables during the OAuth flow,
+or run custom validation logic based on the additional data.
+
+```ts
+betterAuth({
+  socialProviders: {
+    additionalData: {
+      enabled: true,
+      schema: z.object({ /** schema... */}),
+      assign: async ({ data, flow }) => {
+        // ... custom logic ...
+
+        // Optionally return partial data to map to one of the following tables:
+        return {
+          user: { /** user data... */ },
+          account: { /** account data... */ },
+          session: { /** session data... */ },
+        }
+      },
+    }
+  }
+});
+```
+<Callout>
+  If you're assigning data to a custom field,
+  be sure to define that additional field in your auth config's respective schema.
+</Callout>
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+    socialProviders: {
+        // ... other social provider configurations
+        additionalData: {
+            enabled: true,
+            schema: z.object({ inviteeId: z.string() }),
+            assign: async ({ data, flow }) => {
+                if (flow !== "sign-up") return;
+                // query DB for a matching user.id
+                const invitee = getUserById(data.inviteeId);
+                if (!invitee) {
+                    throw new APIError("BAD_REQUEST", {
+                        message: "Invitee not found",
+                    });
+                }
+                return {
+                    user: {
+                        inviteeId: data.inviteeId,
+                    },
+                };
+            },
+        },
+        // ... other social provider configurations
+    },
+});
+```
+
 ## Provider Options
 
 ### scope

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -158,6 +158,10 @@ export const linkSocialAccount = createAuthEndpoint(
 						"Disable automatic redirection to the provider. Useful for handling the redirection yourself",
 				})
 				.optional(),
+			/**
+			 * Any additional data to pass through the oauth flow.
+			 */
+			data: z.record(z.string(), z.any()).optional(),
 		}),
 		use: [sessionMiddleware],
 		metadata: {
@@ -345,7 +349,7 @@ export const linkSocialAccount = createAuthEndpoint(
 		const state = await generateState(c, {
 			userId: session.user.id,
 			email: session.user.email,
-		});
+		}, {data: c.body.data});
 
 		const url = await provider.createAuthorizationURL({
 			state: state.state,

--- a/packages/better-auth/src/oauth2/additional-data.ts
+++ b/packages/better-auth/src/oauth2/additional-data.ts
@@ -1,0 +1,109 @@
+import { APIError } from "better-call";
+import type {
+	Account,
+	GenericEndpointContext,
+	Session,
+	SocialAdditionalDataAssign,
+	SocialAdditionalDataAssignmentResult,
+	User,
+} from "../types";
+
+/**
+ * Validate and normalize additional OAuth data according to configuration.
+ *
+ * This helper checks whether the `socialProvidersAdditionalData` feature is
+ * enabled and, if a validation `schema` is configured, validates the provided
+ * payload. When no schema is present, the raw `additionalData` is accepted as-is.
+ *
+ * Behavior:
+ * - If the feature is disabled or `shouldAssignAdditionalData` is false, the
+ *   call is treated as skipped and `{ skipped: true, value: undefined }` is
+ *   returned.
+ * - If enabled and no schema is configured, returns `{ skipped: false, value: additionalData }`.
+ * - If a schema is configured, validates and returns the parsed value on
+ *   success; throws on validation errors.
+ *
+ * @param params Function arguments
+ * @param params.ctx Request context used to read options and log errors
+ * @param params.shouldAssignAdditionalData Whether the caller intends to assign additional data
+ * @param params.additionalData The raw additional data payload from the client
+ *
+ */
+// export async function parseSocialAdditionalData({
+// 	ctx: c,
+// 	additionalData,
+// 	shouldAssignAdditionalData,
+// }: {
+// 	ctx: GenericEndpointContext;
+// 	shouldAssignAdditionalData: boolean;
+// 	additionalData: unknown;
+// }) {
+// 	if (!shouldAssignAdditionalData) return { skipped: true, value: undefined };
+
+// 		return { skipped: true, value: undefined };
+
+// 	const schema = additionalDataOptions.schema;
+// 	if (!schema) {
+// 		// No schema: accept raw payload as-is
+// 		return { skipped: false, value: additionalData };
+// 	}
+
+// 	let result = schema["~standard"].validate(additionalData);
+// 	if (result instanceof Promise) result = await result;
+
+// 	// if the `issues` field exists, the validation failed
+// 	if (result.issues) {
+// 		c.context.logger.error(
+// 			"Invalid additional data provided during oauth flow",
+// 			{
+// 				issues: result.issues,
+// 			},
+// 		);
+// 		throw new APIError("BAD_REQUEST", {
+// 			message: "Invalid additional data",
+// 			issues: result.issues,
+// 		});
+// 	}
+
+// 	return { skipped: false, value: result.value };
+// }
+
+/**
+ * Provides the additional data to the better-auth options, so it can be used in the `assign` function.
+ * Returns either `null` or a partial object with `user`, `account`, or `session` keys to assign new data to the database.
+ */
+// export async function assignSocialAdditionalData({
+// 	ctx,
+// 	additionalData,
+// 	provider,
+// 	current,
+// 	flow,
+// }: {
+// 	ctx: GenericEndpointContext;
+// 	additionalData: unknown;
+// 	provider: Parameters<SocialAdditionalDataAssign>[0]["provider"];
+// 	current: Parameters<SocialAdditionalDataAssign>[0]["current"];
+// 	flow: Parameters<SocialAdditionalDataAssign>[0]["flow"];
+// }): Promise<SocialAdditionalDataAssignmentResult | null> {
+// 	const { additionalData: additionalDataOptions } =
+// 		ctx.context.options.socialProviders || {};
+	
+// 	if (
+// 		!additionalDataOptions ||
+// 		!additionalDataOptions.enabled ||
+// 		!additionalDataOptions.assign
+// 	)
+// 		return null;
+
+	
+
+// 	const result = await additionalDataOptions.assign({
+// 		data: additionalData,
+// 		provider,
+// 		ctx,
+// 		current,
+// 		flow,
+// 	});
+// 	if (!result) return null;
+// 	return result;
+// }


### PR DESCRIPTION
WIP
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds support for passing custom data through OAuth flows and mapping it into user, account, or session records. This enables optional schema validation and targeted assignment during sign-in or account linking.

- **New Features**
  - Config: socialProviders.additionalData with enabled, schema (StandardSchemaV1), and assign hook to map fields into user/account/session.
  - Endpoints: signInSocial and linkSocialAccount now accept a data payload; state now carries additionalData through the flow.
  - Callbacks: OAuth callback and generic OAuth plugin merge additionalData when updating/creating user and linking accounts, including when overrideUserInfo is used.
  - Docs: Added a concepts/oauth section with examples and a callout on defining custom fields.

<!-- End of auto-generated description by cubic. -->

