### PR TITLE
feat(oidc-provider): add verify option for client secret hashing

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -210,6 +210,12 @@ export const oidcProvider = (options: OIDCOptions) => {
 			typeof opts.storeClientSecret === "object" &&
 			"hash" in opts.storeClientSecret
 		) {
+			if (typeof opts.storeClientSecret.verify === "function") {
+				return await opts.storeClientSecret.verify({
+					hash: storedClientSecret,
+					clientSecret,
+				});
+			}
 			const hashedClientSecret =
 				await opts.storeClientSecret.hash(clientSecret);
 			return hashedClientSecret === storedClientSecret;

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -136,7 +136,7 @@ export interface OIDCOptions {
 	 * - "hashed" - The client secret is hashed using the `hash` function.
 	 * - "plain" - The client secret is stored in the database in plain text.
 	 * - "encrypted" - The client secret is encrypted using the `encrypt` function.
-	 * - { hash: (clientSecret: string) => Promise<string> } - A function that hashes the client secret.
+	 * - { hash: (clientSecret: string) => Promise<string>, verify?: (data: { hash: string; clientSecret: string; }) => Promise<boolean>; } - A function that hashes the client secret and optionally verifies it
 	 * - { encrypt: (clientSecret: string) => Promise<string>, decrypt: (clientSecret: string) => Promise<string> } - A function that encrypts and decrypts the client secret.
 	 *
 	 * @default "plain"
@@ -145,7 +145,13 @@ export interface OIDCOptions {
 		| "hashed"
 		| "plain"
 		| "encrypted"
-		| { hash: (clientSecret: string) => Promise<string> }
+		| {
+				hash: (clientSecret: string) => Promise<string>;
+				verify?: (data: {
+					hash: string;
+					clientSecret: string;
+				}) => Promise<boolean>;
+		  }
 		| {
 				encrypt: (clientSecret: string) => Promise<string>;
 				decrypt: (clientSecret: string) => Promise<string>;


### PR DESCRIPTION
## Add a verify option for OIDC provider client secret hashing

### Problem

When using the OIDC provider plugin with non-deterministic hashing algorithms like `Argon2` or `bcrypt` for storing client secrets, authentication fails with `invalid client_secret` errors.

The current client secret verification logic re-hashes the incoming secret and compares it to the stored hash:
```typescript
const hashedClientSecret = await hash(clientSecret);
if (hashedClientSecret !== storedClientSecret) {
  return false;
}
```

This approach only works for deterministic hashing algorithms (e.g., SHA-256) where the same input always produces the same output. However, algorithms like Argon2 and bcrypt generate different hashes each time because they use random salts, making direct comparison impossible.

### Solution

Add an optional `verify` callback to the `storeClientSecret` configuration, following the same pattern used for password hashing in Better Auth:

```typescript
storeClientSecret: {
  hash(clientSecret) {
    return argon2.hash(clientSecret);
  },
  verify(data) {
    return argon2.verify(data.hash, data.clientSecret);
  }
}
```

### Changes

- **`types.ts`**: Added an optional `verify` function to the `storeClientSecret` hash configuration
- **`index.ts`**: Updated `verifyStoredClientSecret` to use the custom verify callback if provided

### Backwards Compatibility

The `verify` option is fully optional, so existing code using deterministic hashing (SHA-256, etc.) continues to work without any changes.

```typescript
// Existing code - still works
storeClientSecret: {
  hash(clientSecret) {
    return sha256(clientSecret)
  }
}

// New code - with verify
storeClientSecret: {
  hash(clientSecret) {
    return argon2.hash(clientSecret);
  },
  verify(data) {
    return argon2.verify(data.hash, data.clientSecret);
  }
}
```

### Related

This follows the established pattern from Better Auth's password verification system, which already supports custom verify functions for the same reason.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an optional verify callback for OIDC client secret hashing to support non-deterministic algorithms (Argon2, bcrypt) and fix invalid client_secret errors. Existing deterministic hashing continues to work.

- **New Features**
  - storeClientSecret now supports verify({ hash, clientSecret }): Promise<boolean>.
  - Verification uses this callback when provided, enabling Argon2/bcrypt without re-hashing.

<!-- End of auto-generated description by cubic. -->

