### PR TITLE
chore: use `defineErrorCodes` for errors

### DIFF
--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -12,6 +12,7 @@ import type { EndpointContext } from "better-call";
 import { generateId } from "../../utils/id";
 import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import type { AuthContext } from "@better-auth/core";
+import { defineErrorCodes } from "@better-auth/core/utils";
 
 export interface UserWithAnonymous extends User {
 	isAnonymous: boolean;
@@ -72,13 +73,14 @@ const schema = {
 	},
 } satisfies BetterAuthPluginDBSchema;
 
+const ERROR_CODES = defineErrorCodes({
+	FAILED_TO_CREATE_USER: "Failed to create user",
+	COULD_NOT_CREATE_SESSION: "Could not create session",
+	ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY:
+		"Anonymous users cannot sign in again anonymously",
+});
+
 export const anonymous = (options?: AnonymousOptions) => {
-	const ERROR_CODES = {
-		FAILED_TO_CREATE_USER: "Failed to create user",
-		COULD_NOT_CREATE_SESSION: "Could not create session",
-		ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY:
-			"Anonymous users cannot sign in again anonymously",
-	} as const;
 	return {
 		id: "anonymous",
 		endpoints: {

--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -10,6 +10,7 @@ import { createApiKeyRoutes, deleteAllExpiredApiKeys } from "./routes";
 import { validateApiKey } from "./routes/verify-api-key";
 import { base64Url } from "@better-auth/utils/base64";
 import { createHash } from "@better-auth/utils/hash";
+import { defineErrorCodes } from "@better-auth/core/utils";
 
 export const defaultKeyHasher = async (key: string) => {
 	const hash = await createHash("SHA-256").digest(
@@ -21,7 +22,7 @@ export const defaultKeyHasher = async (key: string) => {
 	return hashed;
 };
 
-export const ERROR_CODES = {
+export const ERROR_CODES = defineErrorCodes({
 	INVALID_METADATA_TYPE: "metadata must be an object or undefined",
 	REFILL_AMOUNT_AND_INTERVAL_REQUIRED:
 		"refillAmount is required when refillInterval is provided",
@@ -53,7 +54,7 @@ export const ERROR_CODES = {
 		"The property you're trying to set can only be set from the server auth instance only.",
 	FAILED_TO_UPDATE_API_KEY: "Failed to update API key",
 	NAME_REQUIRED: "API Key name is required.",
-};
+});
 
 export const API_KEY_TABLE_NAME = "apikey";
 

--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -8,6 +8,7 @@ import { getSessionFromCtx } from "../../api/routes/session";
 import { ms, type StringValue as MSStringValue } from "ms";
 import { schema, type DeviceCode } from "./schema";
 import { mergeSchema } from "../../db";
+import { defineErrorCodes } from "@better-auth/core/utils";
 
 const msStringValueSchema = z.custom<MSStringValue>(
 	(val) => {
@@ -121,7 +122,7 @@ export type DeviceAuthorizationOptions = {
 
 export { deviceAuthorizationClient } from "./client";
 
-const DEVICE_AUTHORIZATION_ERROR_CODES = {
+const DEVICE_AUTHORIZATION_ERROR_CODES = defineErrorCodes({
 	INVALID_DEVICE_CODE: "Invalid device code",
 	EXPIRED_DEVICE_CODE: "Device code has expired",
 	EXPIRED_USER_CODE: "User code has expired",
@@ -134,7 +135,7 @@ const DEVICE_AUTHORIZATION_ERROR_CODES = {
 	FAILED_TO_CREATE_SESSION: "Failed to create session",
 	INVALID_DEVICE_CODE_STATUS: "Invalid device code status",
 	AUTHENTICATION_REQUIRED: "Authentication required",
-} as const;
+});
 
 const defaultCharset = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -15,6 +15,7 @@ import { setSessionCookie } from "../../cookies";
 import { getEndpointResponse } from "../../utils/plugin-helper";
 import { defaultKeyHasher, splitAtLastColon } from "./utils";
 import type { GenericEndpointContext } from "@better-auth/core";
+import { defineErrorCodes } from "@better-auth/core/utils";
 
 export interface EmailOTPOptions {
 	/**
@@ -96,6 +97,14 @@ const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const defaultOTPGenerator = (options: EmailOTPOptions) =>
 	generateRandomString(options.otpLength ?? 6, "0-9");
 
+const ERROR_CODES = defineErrorCodes({
+	OTP_EXPIRED: "otp expired",
+	INVALID_OTP: "Invalid OTP",
+	INVALID_EMAIL: "Invalid email",
+	USER_NOT_FOUND: "User not found",
+	TOO_MANY_ATTEMPTS: "Too many attempts",
+});
+
 export const emailOTP = (options: EmailOTPOptions) => {
 	const opts = {
 		expiresIn: 5 * 60,
@@ -103,13 +112,6 @@ export const emailOTP = (options: EmailOTPOptions) => {
 		storeOTP: "plain",
 		...options,
 	} satisfies EmailOTPOptions;
-	const ERROR_CODES = {
-		OTP_EXPIRED: "otp expired",
-		INVALID_OTP: "Invalid OTP",
-		INVALID_EMAIL: "Invalid email",
-		USER_NOT_FOUND: "User not found",
-		TOO_MANY_ATTEMPTS: "Too many attempts",
-	} as const;
 
 	async function storeOTP(ctx: GenericEndpointContext, otp: string) {
 		if (opts.storeOTP === "encrypted") {

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -21,6 +21,7 @@ import type { User } from "../../types";
 import type { BetterAuthPlugin } from "@better-auth/core";
 import type { GenericEndpointContext } from "@better-auth/core";
 import { sessionMiddleware } from "../../api";
+import { defineErrorCodes } from "@better-auth/core/utils";
 
 /**
  * Configuration interface for generic OAuth providers.
@@ -206,13 +207,14 @@ async function getUserInfo(
 	};
 }
 
+const ERROR_CODES = defineErrorCodes({
+	INVALID_OAUTH_CONFIGURATION: "Invalid OAuth configuration",
+});
+
 /**
  * A generic OAuth plugin that can be used to add OAuth support to any provider
  */
 export const genericOAuth = (options: GenericOAuthOptions) => {
-	const ERROR_CODES = {
-		INVALID_OAUTH_CONFIGURATION: "Invalid OAuth configuration",
-	} as const;
 	return {
 		id: "generic-oauth",
 		init: (ctx) => {

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -2,11 +2,12 @@ import { APIError } from "../../api";
 import { createHash } from "@better-auth/utils/hash";
 import { betterFetch } from "@better-fetch/fetch";
 import type { BetterAuthPlugin } from "@better-auth/core";
+import { defineErrorCodes } from "@better-auth/core/utils";
 
-const ERROR_CODES = {
+const ERROR_CODES = defineErrorCodes({
 	PASSWORD_COMPROMISED:
 		"The password you entered has been compromised. Please choose a different password.",
-} as const;
+});
 
 async function checkPasswordCompromise(
 	password: string,

--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -11,6 +11,7 @@ import {
 	setSessionCookie,
 } from "../../cookies";
 import type { BetterAuthPlugin } from "@better-auth/core";
+import { defineErrorCodes } from "@better-auth/core/utils";
 
 interface MultiSessionConfig {
 	/**
@@ -21,6 +22,9 @@ interface MultiSessionConfig {
 	maximumSessions?: number;
 }
 
+const ERROR_CODES = defineErrorCodes({
+	INVALID_SESSION_TOKEN: "Invalid session token",
+});
 export const multiSession = (options?: MultiSessionConfig) => {
 	const opts = {
 		maximumSessions: 5,
@@ -28,10 +32,6 @@ export const multiSession = (options?: MultiSessionConfig) => {
 	};
 
 	const isMultiSessionCookie = (key: string) => key.includes("_multi-");
-
-	const ERROR_CODES = {
-		INVALID_SESSION_TOKEN: "Invalid session token",
-	} as const;
 
 	return {
 		id: "multi-session",

--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -23,6 +23,7 @@ import { generateId } from "../../utils";
 import { mergeSchema } from "../../db/schema";
 import { base64 } from "@better-auth/utils/base64";
 import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
+import { defineErrorCodes } from "@better-auth/core/utils";
 
 interface WebAuthnChallengeValue {
 	expectedChallenge: string;
@@ -30,6 +31,17 @@ interface WebAuthnChallengeValue {
 		id: string;
 	};
 }
+
+const ERROR_CODES = defineErrorCodes({
+	CHALLENGE_NOT_FOUND: "Challenge not found",
+	YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY:
+		"You are not allowed to register this passkey",
+	FAILED_TO_VERIFY_REGISTRATION: "Failed to verify registration",
+	PASSKEY_NOT_FOUND: "Passkey not found",
+	AUTHENTICATION_FAILED: "Authentication failed",
+	UNABLE_TO_CREATE_SESSION: "Unable to create session",
+	FAILED_TO_UPDATE_PASSKEY: "Failed to update passkey",
+});
 
 function getRpID(options: PasskeyOptions, baseURL?: string) {
 	return (
@@ -108,16 +120,6 @@ export const passkey = (options?: PasskeyOptions) => {
 		(expirationTime.getTime() - currentTime.getTime()) / 1000,
 	);
 
-	const ERROR_CODES = {
-		CHALLENGE_NOT_FOUND: "Challenge not found",
-		YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY:
-			"You are not allowed to register this passkey",
-		FAILED_TO_VERIFY_REGISTRATION: "Failed to verify registration",
-		PASSKEY_NOT_FOUND: "Passkey not found",
-		AUTHENTICATION_FAILED: "Authentication failed",
-		UNABLE_TO_CREATE_SESSION: "Unable to create session",
-		FAILED_TO_UPDATE_PASSKEY: "Failed to update passkey",
-	} as const;
 	return {
 		id: "passkey",
 		endpoints: {

--- a/packages/better-auth/src/plugins/phone-number/phone-number-error.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number-error.ts
@@ -1,4 +1,6 @@
-export const ERROR_CODES = {
+import { defineErrorCodes } from "@better-auth/core/utils";
+
+export const ERROR_CODES = defineErrorCodes({
 	INVALID_PHONE_NUMBER: "Invalid phone number",
 	PHONE_NUMBER_EXIST: "Phone number already exists",
 	INVALID_PHONE_NUMBER_OR_PASSWORD: "Invalid phone number or password",
@@ -7,4 +9,4 @@ export const ERROR_CODES = {
 	OTP_EXPIRED: "OTP expired",
 	INVALID_OTP: "Invalid OTP",
 	PHONE_NUMBER_NOT_VERIFIED: "Phone number not verified",
-} as const;
+});

--- a/packages/better-auth/src/plugins/two-factor/error-code.ts
+++ b/packages/better-auth/src/plugins/two-factor/error-code.ts
@@ -1,4 +1,6 @@
-export const TWO_FACTOR_ERROR_CODES = {
+import { defineErrorCodes } from "@better-auth/core/utils";
+
+export const TWO_FACTOR_ERROR_CODES = defineErrorCodes({
 	OTP_NOT_ENABLED: "OTP not enabled",
 	OTP_HAS_EXPIRED: "OTP has expired",
 	TOTP_NOT_ENABLED: "TOTP not enabled",
@@ -9,4 +11,4 @@ export const TWO_FACTOR_ERROR_CODES = {
 	TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE:
 		"Too many attempts. Please request a new code.",
 	INVALID_TWO_FACTOR_COOKIE: "Invalid two factor cookie",
-} as const;
+});

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -27,8 +27,9 @@ import type {
 import { getPlanByName, getPlanByPriceInfo, getPlans } from "./utils";
 import { getSchema } from "./schema";
 import { defu } from "defu";
+import { defineErrorCodes } from "@better-auth/core/utils";
 
-const STRIPE_ERROR_CODES = {
+const STRIPE_ERROR_CODES = defineErrorCodes({
 	SUBSCRIPTION_NOT_FOUND: "Subscription not found",
 	SUBSCRIPTION_PLAN_NOT_FOUND: "Subscription plan not found",
 	ALREADY_SUBSCRIBED_PLAN: "You're already subscribed to this plan",
@@ -39,7 +40,7 @@ const STRIPE_ERROR_CODES = {
 	SUBSCRIPTION_NOT_ACTIVE: "Subscription is not active",
 	SUBSCRIPTION_NOT_SCHEDULED_FOR_CANCELLATION:
 		"Subscription is not scheduled for cancellation",
-} as const;
+});
 
 const getUrl = (ctx: GenericEndpointContext, url: string) => {
 	if (url.startsWith("http")) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardized error code definitions across auth plugins by replacing inline constants with defineErrorCodes. No runtime behavior changes; improves type safety and consistency.

- **Refactors**
  - Switched to defineErrorCodes in: anonymous, api-key, device-authorization, email-otp, generic-oauth, haveibeenpwned, multi-session, passkey, phone-number, two-factor, and stripe.
  - Kept existing export names and error keys the same.

<!-- End of auto-generated description by cubic. -->

