### PR TITLE
feat: add plex authentication provider

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -873,6 +873,16 @@ export const contents: Content[] = [
 				),
 			},
 			{
+				title: "Plex",
+				href: "/docs/authentication/plex",
+				isNew: true,
+				icon: () => (
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+						<path d="M256 70H148l108 186-108 186h108l108-186z" fill="currentColor"/>
+					</svg>
+				),
+			},
+			{
 				title: "Polar",
 				href: "/docs/authentication/polar",
 				icon: () => (

--- a/docs/content/docs/authentication/plex.mdx
+++ b/docs/content/docs/authentication/plex.mdx
@@ -1,0 +1,103 @@
+---
+title: Plex
+description: Plex provider setup and usage.
+---
+
+<Steps>
+    <Step>
+        ### Get your Plex Client Identifier
+        To use Plex sign in, you need a unique client identifier for your application. Unlike traditional OAuth providers, Plex uses PIN-based authentication and doesn't require a client secret.
+
+        You can generate a unique identifier (UUID or random string) for your application. Store this identifier securely as it should remain consistent across your application's lifetime.
+
+        <Callout type="info">
+            - Plex uses a PIN-based authentication flow instead of traditional OAuth2
+            - No client secret is required
+            - The same client identifier should be used consistently for your application
+            - For production applications, consider generating a UUID v4 as your client identifier
+        </Callout>
+    </Step>
+
+  <Step>
+        ### Configure the provider
+        To configure the provider, you need to import the provider and pass it to the `socialProviders` option of the auth instance.
+
+        ```ts title="auth.ts"
+        import { betterAuth } from "better-auth"
+
+        export const auth = betterAuth({
+            socialProviders: {
+                plex: { // [!code highlight]
+                    clientId: process.env.PLEX_CLIENT_ID as string, // [!code highlight]
+                }, // [!code highlight]
+            },
+        })
+        ```
+
+        #### Options
+        The Plex provider accepts the following options:
+
+        - `clientId`: `string` **(required)** - A unique identifier for your application
+        - `product`: `string` - The name of your application/product (default: `"better-auth"`)
+        - `version`: `string` - The version of your application (default: `"1.0"`)
+        - `platform`: `string` - The platform your application runs on, e.g., "Web", "iOS", "Android" (default: `"Web"`)
+        - `device`: `string` - The device name (default: `"Browser"`)
+
+        ```ts title="auth.ts"
+        export const auth = betterAuth({
+            socialProviders: {
+                plex: {
+                    clientId: process.env.PLEX_CLIENT_ID as string,
+                    product: "My App",
+                    version: "1.0.0",
+                    platform: "Web",
+                    device: "Browser",
+                },
+            },
+        })
+        ```
+    </Step>
+       <Step>
+        ### Sign In with Plex
+        To sign in with Plex, you can use the `signIn.social` function provided by the client. The `signIn` function takes an object with the following properties:
+        - `provider`: The provider to use. It should be set to `plex`.
+
+        ```ts title="auth-client.ts"
+        import { createAuthClient } from "better-auth/client"
+        const authClient =  createAuthClient()
+
+        const signIn = async () => {
+            const data = await authClient.signIn.social({
+                provider: "plex"
+            })
+        }
+        ```
+
+        ### How Plex Authentication Works:
+        1. A PIN is generated from the Plex API
+        2. User is redirected to Plex's authentication page
+        3. User authorizes the application on Plex
+        4. Plex redirects back to your application with the PIN
+        5. The PIN is exchanged for an access token
+        6. User information is fetched from Plex
+
+        <Callout type="info">
+            - Plex authentication uses a PIN-based flow, not traditional OAuth2
+            - Users must have a Plex account to sign in
+            - The authentication flow works with both free and Plex Pass accounts
+        </Callout>
+
+        ### Additional Options:
+        - `product`: The name of your application/product.
+            - Default: `"better-auth"`
+        - `version`: The version of your application.
+            - Default: `"1.0"`
+        - `platform`: The platform your application runs on.
+            - Default: `"Web"`
+            - Options: `"Web"`, `"iOS"`, `"Android"`, etc.
+        - `device`: The device name.
+            - Default: `"Browser"`
+        - `mapProfileToUser`: Custom function to map Plex profile data to user object.
+        - `getUserInfo`: Custom function to retrieve user information.
+    </Step>
+</Steps>

--- a/packages/core/src/social-providers/index.ts
+++ b/packages/core/src/social-providers/index.ts
@@ -20,6 +20,7 @@ import { naver } from "./naver";
 import { notion } from "./notion";
 import { paybin } from "./paybin";
 import { paypal } from "./paypal";
+import { plex } from "./plex";
 import { polar } from "./polar";
 import { reddit } from "./reddit";
 import { roblox } from "./roblox";
@@ -65,6 +66,7 @@ export const socialProviders = {
 	line,
 	paybin,
 	paypal,
+	plex,
 	polar,
 	vercel,
 };
@@ -101,7 +103,6 @@ export * from "./google";
 export * from "./huggingface";
 export * from "./kakao";
 export * from "./kick";
-export * from "./kick";
 export * from "./line";
 export * from "./linear";
 export * from "./linkedin";
@@ -111,6 +112,7 @@ export * from "./naver";
 export * from "./notion";
 export * from "./paybin";
 export * from "./paypal";
+export * from "./plex";
 export * from "./polar";
 export * from "./reddit";
 export * from "./roblox";

--- a/packages/core/src/social-providers/plex.ts
+++ b/packages/core/src/social-providers/plex.ts
@@ -1,0 +1,252 @@
+import { betterFetch } from "@better-fetch/fetch";
+import { BetterAuthError } from "../error";
+import { logger } from "@better-auth/core/env";
+import type { OAuthProvider, ProviderOptions } from "@better-auth/core/oauth2";
+
+export interface PlexProfile {
+	id: number;
+	uuid: string;
+	username: string;
+	title: string;
+	email: string;
+	thumb: string;
+	locale: string | null;
+	emailOnlyAuth: boolean;
+	hasPassword: boolean;
+	protected: boolean;
+	scrobbleTypes: string;
+	country: string;
+	subscription: {
+		active: boolean;
+		status: string;
+		plan: string;
+		features: string[];
+	};
+	subscriptionDescription: string;
+	restricted: boolean;
+	home: boolean;
+	guest: boolean;
+	homeSize: number;
+	maxHomeSize: number;
+	certificateVersion: number;
+	rememberMe: boolean;
+	pin: string;
+	adsConsent: boolean | null;
+	adsConsentSetAt: number | null;
+	adsConsentReminderAt: number | null;
+	experimentalFeatures: boolean;
+	twoFactorEnabled: boolean;
+	backupCodesCreated: boolean;
+	services: Array<{
+		identifier: string;
+		endpoint: string;
+		token: string;
+		status: string;
+		secret: string | null;
+	}>;
+}
+
+export interface PlexOptions extends ProviderOptions<PlexProfile> {
+	/**
+	 * A unique identifier for your application.
+	 * This should be a consistent UUID or random string.
+	 */
+	clientId: string;
+	/**
+	 * The name of your application/product
+	 * @default "better-auth"
+	 */
+	product?: string;
+	/**
+	 * The version of your application
+	 * @default "1.0"
+	 */
+	version?: string;
+	/**
+	 * The platform your application runs on (e.g., "Web", "iOS", "Android")
+	 * @default "Web"
+	 */
+	platform?: string;
+	/**
+	 * The device name
+	 * @default "Browser"
+	 */
+	device?: string;
+}
+
+export const plex = (options: PlexOptions) => {
+	if (!options.clientId) {
+		logger.error(
+			"Client ID is required for Plex. Make sure to provide it in the options.",
+		);
+		throw new BetterAuthError("CLIENT_ID_REQUIRED");
+	}
+
+	const product = options.product || "better-auth";
+	const version = options.version || "1.0";
+	const platform = options.platform || "Web";
+	const device = options.device || "Browser";
+
+	const getPlexHeaders = (includeToken?: string) => {
+		const headers: Record<string, string> = {
+			"X-Plex-Product": product,
+			"X-Plex-Version": version,
+			"X-Plex-Client-Identifier": options.clientId,
+			"X-Plex-Platform": platform,
+			"X-Plex-Device": device,
+			"Content-Type": "application/json",
+			Accept: "application/json",
+		};
+		if (includeToken) {
+			headers["X-Plex-Token"] = includeToken;
+		}
+		return headers;
+	};
+
+	return {
+		id: "plex",
+		name: "Plex",
+		async createAuthorizationURL({ state, redirectURI }) {
+			const { data: pinData, error } = await betterFetch<{
+				id: number;
+				code: string;
+				product: string;
+				trusted: boolean;
+				clientIdentifier: string;
+				location: {
+					code: string;
+					country: string;
+					city: string;
+					subdivisions: string;
+					coordinates: string;
+				};
+				expiresIn: number;
+				createdAt: string;
+				expiresAt: string;
+				authToken: string | null;
+				newRegistration: boolean | null;
+			}>("https://plex.tv/api/v2/pins", {
+				method: "POST",
+				headers: getPlexHeaders(),
+				body: JSON.stringify({
+					strong: true,
+				}),
+			});
+
+			if (error || !pinData) {
+				logger.error("Failed to generate Plex PIN:", error);
+				throw new BetterAuthError("FAILED_TO_GENERATE_PIN");
+			}
+
+			let callbackURL = redirectURI;
+			if (callbackURL) {
+				const url = new URL(callbackURL);
+				url.searchParams.set("state", state);
+				url.searchParams.set("code", `${pinData.id}:${pinData.code}`);
+				callbackURL = url.toString();
+			}
+
+			const authURL = new URL("https://app.plex.tv/auth");
+			authURL.hash = `?clientID=${encodeURIComponent(options.clientId)}&code=${encodeURIComponent(pinData.code)}&context[device][product]=${encodeURIComponent(product)}&context[device][version]=${encodeURIComponent(version)}&context[device][platform]=${encodeURIComponent(platform)}&context[device][device]=${encodeURIComponent(device)}`;
+
+			if (callbackURL) {
+				authURL.hash += `&forwardUrl=${encodeURIComponent(callbackURL)}`;
+			}
+
+			return authURL;
+		},
+
+		validateAuthorizationCode: async ({ code }) => {
+			const parts = code.split(":");
+			if (parts.length < 2) {
+				logger.error("Invalid PIN code format, expected pinId:pinCode");
+				throw new BetterAuthError("INVALID_PIN_CODE");
+			}
+
+			const pinId = parts[0];
+			const pinCode = parts[1];
+
+			const { data: pinStatus, error } = await betterFetch<{
+				id: number;
+				code: string;
+				product: string;
+				trusted: boolean;
+				clientIdentifier: string;
+				location: {
+					code: string;
+					country: string;
+					city: string;
+					subdivisions: string;
+					coordinates: string;
+				};
+				expiresIn: number;
+				createdAt: string;
+				expiresAt: string;
+				authToken: string | null;
+				newRegistration: boolean | null;
+			}>(`https://plex.tv/api/v2/pins/${pinId}`, {
+				method: "GET",
+				headers: getPlexHeaders(pinCode),
+			});
+
+			if (error) {
+				logger.error("Failed to check PIN status:", error);
+				throw new BetterAuthError("FAILED_TO_GET_ACCESS_TOKEN");
+			}
+
+			if (!pinStatus || !pinStatus.authToken) {
+				logger.error("No auth token in PIN response");
+				throw new BetterAuthError("FAILED_TO_GET_ACCESS_TOKEN");
+			}
+
+			return {
+				accessToken: pinStatus.authToken,
+				tokenType: "Bearer",
+			};
+		},
+
+		async getUserInfo(token) {
+			if (options.getUserInfo) {
+				return options.getUserInfo(token);
+			}
+
+			if (!token.accessToken) {
+				logger.error("Access token is required to fetch Plex user info");
+				return null;
+			}
+
+			try {
+				const { data: profile, error } = await betterFetch<PlexProfile>(
+					"https://plex.tv/api/v2/user",
+					{
+						method: "GET",
+						headers: getPlexHeaders(token.accessToken),
+					},
+				);
+
+				if (error || !profile) {
+					logger.error("Failed to fetch user info from Plex:", error);
+					return null;
+				}
+
+				const userMap = await options.mapProfileToUser?.(profile);
+				return {
+					user: {
+						id: profile.id.toString(),
+						name: profile.title || profile.username,
+						email: profile.email,
+						image: profile.thumb,
+						emailVerified: profile.emailOnlyAuth,
+						...userMap,
+					},
+					data: profile,
+				};
+			} catch (error) {
+				logger.error("Failed to fetch user info from Plex:", error);
+				return null;
+			}
+		},
+
+		options,
+	} satisfies OAuthProvider<PlexProfile>;
+};


### PR DESCRIPTION
This pull request adds a new social provider to login with a plex media server account.
It's my first contribution to this project, any feedback is welcome!
    


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Plex authentication provider with a PIN-based login flow so users can sign in with their Plex account. Includes docs and a sidebar link; no client secret required.

- **New Features**
  - Added Plex social provider (id: "plex") to socialProviders.
  - Implements PIN-based auth: generate PIN, redirect to Plex, exchange for auth token.
  - Requires clientId; supports product/version/platform/device headers via X-Plex-*.
  - Fetches user profile from Plex and maps to user; supports mapProfileToUser and getUserInfo overrides.
  - Added docs at /docs/authentication/plex and a new sidebar entry.

<sup>Written for commit a64778367a1c5ad2b36c05bf00f1ce1c37654bd2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



