### PR TITLE
feat: add capjs captcha plugin

### DIFF
--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -8,6 +8,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 - [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/)
 - [hCaptcha](https://www.hcaptcha.com/)
 - [CaptchaFox](https://captchafox.com/)
+- [Cap](https://capjs.js.org/)
 
 <Callout type="info">
   This plugin works out of the box with <Link href="/docs/authentication/email-password">Email & Password</Link> authentication. To use it with other authentication methods, you will need to configure the <Link href="/docs/plugins/captcha#plugin-options">endpoints</Link> array in the plugin options.
@@ -26,7 +27,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     export const auth = betterAuth({
         plugins: [ // [!code highlight]
             captcha({ // [!code highlight]
-                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha, captchafox // [!code highlight]
+                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha, captchafox, cap // [!code highlight]
                 secretKey: process.env.TURNSTILE_SECRET_KEY!, // [!code highlight]
             }), // [!code highlight]
         ], // [!code highlight]
@@ -56,6 +57,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     - To implement Google reCAPTCHA on the client side, follow the official [Google reCAPTCHA documentation](https://developers.google.com/recaptcha/intro) or use libraries like [react-google-recaptcha](https://www.npmjs.com/package/react-google-recaptcha) (v2) and [react-google-recaptcha-v3](https://www.npmjs.com/package/react-google-recaptcha-v3) (v3).
     - To implement hCaptcha on the client side, follow the official [hCaptcha documentation](https://docs.hcaptcha.com/#add-the-hcaptcha-widget-to-your-webpage) or use libraries like [@hcaptcha/react-hcaptcha](https://www.npmjs.com/package/@hcaptcha/react-hcaptcha)
     - To implement CaptchaFox on the client side, follow the official [CaptchaFox documentation](https://docs.captchafox.com/getting-started) or use libraries like [@captchafox/react](https://www.npmjs.com/package/@captchafox/react)
+    - To implement Cap on the client side, follow the official [Cap documentation](https://capjs.js.org/guide/widget.html) or use [community libraries](https://capjs.js.org/guide/community.html)
   </Step>
 </Steps>
 

--- a/packages/better-auth/src/plugins/captcha/captcha.test.ts
+++ b/packages/better-auth/src/plugins/captcha/captcha.test.ts
@@ -421,4 +421,70 @@ describe("captcha", async (it) => {
 			expect(res.error?.status).toBe(403);
 		});
 	});
+
+	describe("cap", async (it) => {
+		const { client } = await getTestInstance({
+			plugins: [
+				captcha({
+					provider: "cap",
+					secretKey: "xx-secret-key",
+				}),
+			],
+		});
+
+		it("Should successfully sign in users if they passed the CAPTCHA challenge", async () => {
+			mockBetterFetch.mockResolvedValue({
+				data: {
+					success: true,
+				},
+			});
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "captcha-token",
+					},
+				},
+			});
+
+			expect(res.data?.user).toBeDefined();
+		});
+
+		it("Should return 500 if the call to /siteverify fails", async () => {
+			mockBetterFetch.mockResolvedValue({
+				error: "Failed to fetch",
+			});
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "captcha-token",
+					},
+				},
+			});
+
+			expect(res.error?.status).toBe(500);
+		});
+
+		it("Should return 403 in case of a validation failure", async () => {
+			mockBetterFetch.mockResolvedValue({
+				data: {
+					success: false,
+				},
+			});
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "invalid-captcha-token",
+					},
+				},
+			});
+
+			expect(res.error?.status).toBe(403);
+		});
+	});
 });

--- a/packages/better-auth/src/plugins/captcha/constants.ts
+++ b/packages/better-auth/src/plugins/captcha/constants.ts
@@ -11,6 +11,7 @@ export const Providers = {
 	GOOGLE_RECAPTCHA: "google-recaptcha",
 	HCAPTCHA: "hcaptcha",
 	CAPTCHAFOX: "captchafox",
+	CAP: "cap",
 } as const;
 
 export const siteVerifyMap: Record<Provider, string> = {
@@ -20,4 +21,5 @@ export const siteVerifyMap: Record<Provider, string> = {
 		"https://www.google.com/recaptcha/api/siteverify",
 	[Providers.HCAPTCHA]: "https://api.hcaptcha.com/siteverify",
 	[Providers.CAPTCHAFOX]: "https://api.captchafox.com/siteverify",
+	[Providers.CAP]: "",
 };

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -66,6 +66,10 @@ export const captcha = (options: CaptchaOptions) =>
 						siteKey: options.siteKey,
 					});
 				}
+
+				if (options.provider === Providers.CAP) {
+					return await verifyHandlers.cap(handlerParams);
+				}
 			} catch (_error) {
 				const errorMessage =
 					_error instanceof Error ? _error.message : undefined;

--- a/packages/better-auth/src/plugins/captcha/types.ts
+++ b/packages/better-auth/src/plugins/captcha/types.ts
@@ -27,8 +27,13 @@ export interface CaptchaFoxOptions extends BaseCaptchaOptions {
 	siteKey?: string;
 }
 
+export interface CapOptions extends BaseCaptchaOptions {
+	provider: typeof Providers.CAP;
+}
+
 export type CaptchaOptions =
 	| GoogleRecaptchaOptions
 	| CloudflareTurnstileOptions
 	| HCaptchaOptions
-	| CaptchaFoxOptions;
+	| CaptchaFoxOptions
+	| CapOptions;

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/cap.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/cap.ts
@@ -1,0 +1,44 @@
+import { betterFetch } from "@better-fetch/fetch";
+import { middlewareResponse } from "../../../utils/middleware-response";
+import { EXTERNAL_ERROR_CODES, INTERNAL_ERROR_CODES } from "../error-codes";
+
+type Params = {
+	siteVerifyURL: string;
+	secretKey: string;
+	captchaResponse: string;
+	remoteIP?: string;
+};
+
+type SiteVerifyResponse = {
+	success: boolean;
+};
+
+export const cap = async ({
+	siteVerifyURL,
+	captchaResponse,
+	secretKey,
+	remoteIP,
+}: Params) => {
+	const response = await betterFetch<SiteVerifyResponse>(siteVerifyURL, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			secret: secretKey,
+			response: captchaResponse,
+			...(remoteIP && { remoteip: remoteIP }),
+		}),
+	});
+
+	if (!response.data || response.error) {
+		throw new Error(INTERNAL_ERROR_CODES.SERVICE_UNAVAILABLE);
+	}
+
+	if (!response.data.success) {
+		return middlewareResponse({
+			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED,
+			status: 403,
+		});
+	}
+
+	return undefined;
+};

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
@@ -2,3 +2,4 @@ export { cloudflareTurnstile } from "./cloudflare-turnstile";
 export { googleRecaptcha } from "./google-recaptcha";
 export { hCaptcha } from "./h-captcha";
 export { captchaFox } from "./captchafox";
+export { cap } from "./cap";


### PR DESCRIPTION
Add support for [cap.js](https://capjs.js.org/) captcha plugin.

[demo implementation repo](https://github.com/chris-windsor/better-auth-capjs-demo)

My only concern is what would be the preferred way to update typing so that `siteVerifyURLOverride` is required for this provider or make a new config option that is `siteVerifyURL` and ignore `siteVerifyURLOverride`.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Cap (cap.js) as a new captcha provider to the Better Auth captcha plugin with a server-side verify handler and docs updates.

- **New Features**
  - New provider: "cap" with a verify handler that POSTs JSON { secret, response, remoteip }.
  - Wired provider into constants, types, and plugin selection; added tests for success, 403, and 500 flows.
  - Docs updated to list Cap and link to client integration guidance.

- **Migration**
  - For provider "cap", set siteVerifyURLOverride to your Cap siteverify endpoint (no default URL is provided).

<!-- End of auto-generated description by cubic. -->

