### PR TITLE
Feat/legal plugin

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -25,7 +25,10 @@ import { AutoTypeTable } from "fumadocs-typescript/ui";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 import { Endpoint } from "@/components/endpoint";
 import { DividerText } from "@/components/divider-text";
-import { APIMethod, TypeTable as CustomTypeTable } from "@/components/api-method";
+import {
+	APIMethod,
+	TypeTable as CustomTypeTable,
+} from "@/components/api-method";
 import { LLMCopyButton, ViewOptions } from "./page.client";
 import { GenerateAppleJwt } from "@/components/generate-apple-jwt";
 import { Callout } from "@/components/ui/callout";

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -25,7 +25,7 @@ import { AutoTypeTable } from "fumadocs-typescript/ui";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 import { Endpoint } from "@/components/endpoint";
 import { DividerText } from "@/components/divider-text";
-import { APIMethod } from "@/components/api-method";
+import { APIMethod, TypeTable as CustomTypeTable } from "@/components/api-method";
 import { LLMCopyButton, ViewOptions } from "./page.client";
 import { GenerateAppleJwt } from "@/components/generate-apple-jwt";
 import { Callout } from "@/components/ui/callout";
@@ -153,6 +153,7 @@ export default async function Page({
 						iframe: (props) => (
 							<iframe {...props} className="w-full h-[500px]" />
 						),
+						CustomTypeTable,
 					}}
 				/>
 			</DocsBody>

--- a/docs/components/api-method.tsx
+++ b/docs/components/api-method.tsx
@@ -323,7 +323,7 @@ function getChildren(
 	}
 }
 
-function TypeTable({
+export function TypeTable({
 	props,
 	isServer,
 }: {

--- a/docs/components/builder/code-tabs/index.tsx
+++ b/docs/components/builder/code-tabs/index.tsx
@@ -58,8 +58,12 @@ ${
 			}),
 			`
 					: ""
-			}${ options.passkey ? `passkey(),
-			 ` : ""}${
+			}${
+				options.passkey
+					? `passkey(),
+			 `
+					: ""
+			}${
 				options.legal
 					? `legal(${
 							options.legalDocuments.length > 0
@@ -115,7 +119,7 @@ ${
 			content: signInString(options),
 		},
 	];
-	
+
 	if (options.email || options.legal) {
 		initialFiles.push({
 			id: "4",
@@ -128,9 +132,9 @@ ${
 		initialFiles.push({
 			id: (initialFiles.length + 1).toString(),
 			name: `${doc.name.toLowerCase()}.tsx`,
-			content: legalContent(doc.name, doc.view)
-		})
-	})
+			content: legalContent(doc.name, doc.view),
+		});
+	});
 
 	const [files, setFiles] = useState(initialFiles);
 	const [activeFileId, setActiveFileId] = useState(files[0].id);

--- a/docs/components/builder/code-tabs/index.tsx
+++ b/docs/components/builder/code-tabs/index.tsx
@@ -64,7 +64,7 @@ ${
 					? `legal(${
 							options.legalDocuments.length > 0
 								? `{
-								fields: [${options.legalDocuments.map(
+								documents: [${options.legalDocuments.map(
 									(doc) => `{
 	name: ${doc.name};
 	must_accept: ${doc.accept};

--- a/docs/components/builder/index.tsx
+++ b/docs/components/builder/index.tsx
@@ -28,6 +28,9 @@ import { useAtom } from "jotai";
 import { optionsAtom } from "./store";
 import { useTheme } from "next-themes";
 import { ScrollArea } from "../ui/scroll-area";
+import { Document as LegalDocument } from "./legal";
+import { Button } from "../ui/button";
+
 const frameworks = [
 	{
 		title: "Next.js",
@@ -269,8 +272,8 @@ export function Builder() {
 
 				<div className="flex gap-4 md:gap-12 flex-col md:flex-row items-center md:items-start">
 					<div className={cn("w-4/12")}>
-						<div
-							className="overflow-scroll h-[580px] relative"
+						<ScrollArea
+							className="overflow-scroll h-[580px] relative m-2"
 							style={{
 								scrollbarWidth: "none",
 								scrollbarColor: "transparent transparent",
@@ -280,7 +283,7 @@ export function Builder() {
 								},
 							}}
 						>
-							{options.signUp ? (
+							{options.email || options.legal ? (
 								<AuthTabs
 									tabs={[
 										{
@@ -298,7 +301,7 @@ export function Builder() {
 							) : (
 								<SignIn />
 							)}
-						</div>
+						</ScrollArea>
 					</div>
 					<ScrollArea
 						className="w-[45%] flex-grow"
@@ -519,6 +522,26 @@ export function Builder() {
 													}}
 												/>
 											</div>
+											<div className="flex items-center justify-between">
+												<div className="flex items-center gap-2">
+													<Label
+														className="cursor-pointer"
+														htmlFor="plugin-legal"
+													>
+														Legal
+													</Label>
+												</div>
+												<Switch
+													id="plugin-legal"
+													checked={options.legal}
+													onCheckedChange={(checked) => {
+														setOptions((prev) => ({
+															...prev,
+															legal: checked,
+														}));
+													}}
+												/>
+											</div>
 										</div>
 										<div className="mt-4">
 											<Separator />
@@ -546,7 +569,9 @@ export function Builder() {
 										<button
 											className="bg-stone-950 no-underline group cursor-pointer relative shadow-2xl shadow-zinc-900 rounded-sm p-px text-xs font-semibold leading-6  text-white inline-block w-full"
 											onClick={() => {
-												setCurrentStep(currentStep + 1);
+												options.legal
+													? setCurrentStep(currentStep + 1)
+													: setCurrentStep(currentStep + 2);
 											}}
 										>
 											<span className="absolute inset-0 overflow-hidden rounded-sm">
@@ -560,6 +585,70 @@ export function Builder() {
 									</CardFooter>
 								</Card>
 							) : currentStep === 1 ? (
+								<Card>
+									<CardHeader>
+										<CardTitle>Add Legal Documents</CardTitle>
+										<p
+											className="text-blue-400 hover:underline mt-1 text-sm cursor-pointer"
+											onClick={() => {
+												setCurrentStep(0);
+											}}
+										>
+											Go Back
+										</p>
+									</CardHeader>
+									<CardContent>
+										<Button
+											onClick={() =>
+												setOptions({
+													...options,
+													legalDocuments: [
+														...options.legalDocuments,
+														{
+															name: "",
+															url: "",
+															view: true,
+															accept: true,
+														},
+													],
+												})
+											}
+										>
+											<PlusIcon size={14} />
+											<span>New</span>
+										</Button>
+										{options.legalDocuments.map((doc, i, arr) => (
+											<LegalDocument
+												name={doc.name}
+												view={doc.view}
+												accept={doc.accept}
+												url={doc.url}
+												key={i}
+												update={(val) =>
+													setOptions({
+														...options,
+														legalDocuments: arr.toSpliced(i, 1, val),
+													})
+												}
+											/>
+										))}
+										<button
+											className="bg-stone-950 no-underline group cursor-pointer relative shadow-2xl shadow-zinc-900 rounded-sm p-px text-xs font-semibold leading-6  text-white inline-block w-full"
+											onClick={() => {
+												setCurrentStep(currentStep + 1);
+											}}
+										>
+											<span className="absolute inset-0 overflow-hidden rounded-sm">
+												<span className="absolute inset-0 rounded-sm bg-[image:radial-gradient(75%_100%_at_50%_0%,rgba(56,189,248,0.6)_0%,rgba(56,189,248,0)_75%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"></span>
+											</span>
+											<div className="relative flex space-x-2 items-center z-10 rounded-none bg-zinc-950 py-2 px-4 ring-1 ring-white/10 justify-center">
+												<span>Continue</span>
+											</div>
+											<span className="absolute -bottom-0 left-[1.125rem] h-px w-[calc(100%-2.25rem)] bg-gradient-to-r from-emerald-400/0 via-stone-800/90 to-emerald-400/0 transition-opacity duration-500 group-hover:opacity-40"></span>
+										</button>
+									</CardContent>
+								</Card>
+							) : currentStep === 2 ? (
 								<Card className="rounded-none flex-grow  h-full">
 									<CardHeader>
 										<CardTitle>Choose Framework</CardTitle>

--- a/docs/components/builder/legal.tsx
+++ b/docs/components/builder/legal.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Card, CardContent } from "../ui/card";
+import { Label } from "../ui/label";
+import { Input } from "../ui/input";
+import { Switch } from "../ui/switch";
+
+export function Document({
+	name,
+	view,
+	accept,
+	url,
+	update,
+}: {
+	name: string;
+	view: boolean;
+	accept: boolean;
+	url: string;
+	update: (val: {
+		name: string;
+		view: boolean;
+		accept: boolean;
+		url: string;
+	}) => void;
+}) {
+	return (
+		<Card id={name}>
+			<CardContent>
+				<div className="flex flex-col gap-2">
+					<div className="grid grid-cols-2 gap-5">
+						<div className="grid gap-2">
+							<Label htmlFor={`${name}-name`}>Document Name</Label>
+							<Input
+								value={name}
+								id={`${name}-name`}
+								onChange={(e) =>
+									update({ name: e.target.value, view, accept, url })
+								}
+							/>
+						</div>
+						<div className="flex gap-5 my-auto">
+							<Switch
+								id={`${name}-view`}
+								checked={view}
+								onCheckedChange={(val) =>
+									update({ name, view: val, accept, url })
+								}
+							/>
+							<div>
+								<Label
+									className="cursor-pointer text-left"
+									htmlFor={`${name}-view`}
+								>
+									Must View
+								</Label>
+							</div>
+						</div>
+					</div>
+					<div className="grid grid-cols-2 gap-5">
+						<div className="grid gap-2">
+							<Label htmlFor={`${name}-url`}>Document URL</Label>
+							<Input
+								value={url}
+								id={`${name}-url`}
+								onChange={(e) =>
+									update({ name, view, accept, url: e.target.value })
+								}
+							/>
+						</div>
+						<div className="flex gap-5 my-auto">
+							<Switch
+								id={`${name}-accept`}
+								checked={accept}
+								onCheckedChange={(val) =>
+									update({ name, view, accept: val, url })
+								}
+							/>
+							<div>
+								<Label
+									className="cursor-pointer text-left"
+									htmlFor={`${name}-accept`}
+								>
+									Must Accept
+								</Label>
+							</div>
+						</div>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+export function legalContent(name: string, read: boolean = false) {
+	return `"use client"
+import { useEffect } from "react"${
+		read
+			? `
+import { authClient } from "auth-client"`
+			: ""
+	}
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+		
+export default function Legal() {
+${
+	read
+		? `  useEffect(() => {
+    authClient.api.readLegalDocument({
+      name: "${name}",
+      viewedAt: new Date(),
+    }).then(() => {}).catch((e) => console.error(\`${`Failed to mark legal document as read: $\{e.message}`}\`))
+  })`
+		: ""
+}
+  return (
+    <Card className="max-w-md">
+      <CardHeader>
+        <CardTitle className="text-lg md:text-xl">${name}</CardTitle>
+        <CardDescription className="text-xs md:text-sm">
+          Please read the ${name}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <section className="flex flex-col gap-4">
+        {*Enter the legal documents here*}
+        </section>
+      </CardContent>
+    </Card>
+  )
+}`;
+}

--- a/docs/components/builder/sign-in.tsx
+++ b/docs/components/builder/sign-in.tsx
@@ -34,9 +34,9 @@ export default function SignIn() {
 					{options.email && (
 						<>
 							<div className="grid gap-2">
-								<Label htmlFor="email">Email</Label>
+								<Label htmlFor="signin-email">Email</Label>
 								<Input
-									id="email"
+									id="signin-email"
 									type="email"
 									placeholder="m@example.com"
 									required
@@ -75,9 +75,9 @@ export default function SignIn() {
 
 					{options.magicLink && (
 						<div className="grid gap-2">
-							<Label htmlFor="email">Email</Label>
+							<Label htmlFor="signin-email">Email</Label>
 							<Input
-								id="email"
+								id="signin-email"
 								type="email"
 								placeholder="m@example.com"
 								required

--- a/docs/components/builder/sign-up.tsx
+++ b/docs/components/builder/sign-up.tsx
@@ -9,14 +9,21 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { socialProviders } from "./social-provider";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Image from "next/image";
 import { Loader2, X } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useAtom } from "jotai";
+import { optionsAtom } from "./store";
+import { Separator } from "@radix-ui/react-dropdown-menu";
+import { cn } from "@/lib/utils";
+import { Checkbox } from "../ui/checkbox";
 
 export function SignUp() {
+	const [options] = useAtom(optionsAtom);
 	const [firstName, setFirstName] = useState("");
 	const [lastName, setLastName] = useState("");
 	const [email, setEmail] = useState("");
@@ -24,7 +31,20 @@ export function SignUp() {
 	const [passwordConfirmation, setPasswordConfirmation] = useState("");
 	const [image, setImage] = useState<File | null>(null);
 	const [imagePreview, setImagePreview] = useState<string | null>(null);
+	const [legalDocumentsAccepted, setLegalDocumentsAccepted] = useState<
+		string[]
+	>([]);
+	const [accepted, setAccepted] = useState(!options.legal);
 	const router = useRouter();
+
+	useEffect(() => {
+		if (!options.legal) setAccepted(true);
+		const accept =
+			options.legalDocuments.filter(
+				(doc) => !legalDocumentsAccepted.includes(doc.name),
+			).length === 0;
+		setAccepted(accept);
+	}, [legalDocumentsAccepted, options]);
 
 	const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const file = e.target.files?.[0];
@@ -48,114 +68,186 @@ export function SignUp() {
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
-				<div className="grid gap-4">
-					<div className="grid grid-cols-2 gap-4">
-						<div className="grid gap-2">
-							<Label htmlFor="first-name">First name</Label>
-							<Input
-								id="first-name"
-								placeholder="Max"
-								required
-								onChange={(e) => {
-									setFirstName(e.target.value);
-								}}
-								value={firstName}
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label htmlFor="last-name">Last name</Label>
-							<Input
-								id="last-name"
-								placeholder="Robinson"
-								required
-								onChange={(e) => {
-									setLastName(e.target.value);
-								}}
-								value={lastName}
-							/>
-						</div>
-					</div>
-					<div className="grid gap-2">
-						<Label htmlFor="email">Email</Label>
-						<Input
-							id="email"
-							type="email"
-							placeholder="m@example.com"
-							required
-							onChange={(e) => {
-								setEmail(e.target.value);
-							}}
-							value={email}
-						/>
-					</div>
-					<div className="grid gap-2">
-						<Label htmlFor="password">Password</Label>
-						<Input
-							id="password"
-							type="password"
-							value={password}
-							onChange={(e) => setPassword(e.target.value)}
-							autoComplete="new-password"
-							placeholder="Password"
-						/>
-					</div>
-					<div className="grid gap-2">
-						<Label htmlFor="password">Confirm Password</Label>
-						<Input
-							id="password_confirmation"
-							type="password"
-							value={passwordConfirmation}
-							onChange={(e) => setPasswordConfirmation(e.target.value)}
-							autoComplete="new-password"
-							placeholder="Confirm Password"
-						/>
-					</div>
-					<div className="grid gap-2">
-						<Label htmlFor="image">Profile Image (optional)</Label>
-						<div className="flex items-end gap-4">
-							{imagePreview && (
-								<div className="relative w-16 h-16 rounded-sm overflow-hidden">
-									<Image
-										src={imagePreview}
-										alt="Profile preview"
-										layout="fill"
-										objectFit="cover"
-									/>
-								</div>
-							)}
-							<div className="flex items-center gap-2 w-full">
+				{options.email ? (
+					<div className="grid gap-4">
+						<div className="grid grid-cols-2 gap-4">
+							<div className="grid gap-2">
+								<Label htmlFor="first-name">First name</Label>
 								<Input
-									id="image"
-									type="file"
-									accept="image/*"
-									onChange={handleImageChange}
-									className="w-full"
+									id="first-name"
+									placeholder="Max"
+									required
+									onChange={(e) => {
+										setFirstName(e.target.value);
+									}}
+									value={firstName}
 								/>
-								{imagePreview && (
-									<X
-										className="cursor-pointer"
-										onClick={() => {
-											setImage(null);
-											setImagePreview(null);
-										}}
-									/>
-								)}
+							</div>
+							<div className="grid gap-2">
+								<Label htmlFor="last-name">Last name</Label>
+								<Input
+									id="last-name"
+									placeholder="Robinson"
+									required
+									onChange={(e) => {
+										setLastName(e.target.value);
+									}}
+									value={lastName}
+								/>
 							</div>
 						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="signup-email">Email</Label>
+							<Input
+								id="signup-email"
+								type="email"
+								placeholder="m@example.com"
+								required
+								onChange={(e) => {
+									setEmail(e.target.value);
+								}}
+								value={email}
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="password">Password</Label>
+							<Input
+								id="password"
+								type="password"
+								value={password}
+								onChange={(e) => setPassword(e.target.value)}
+								autoComplete="new-password"
+								placeholder="Password"
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="password">Confirm Password</Label>
+							<Input
+								id="password_confirmation"
+								type="password"
+								value={passwordConfirmation}
+								onChange={(e) => setPasswordConfirmation(e.target.value)}
+								autoComplete="new-password"
+								placeholder="Confirm Password"
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="image">Profile Image (optional)</Label>
+							<div className="flex items-end gap-4">
+								{imagePreview && (
+									<div className="relative w-16 h-16 rounded-sm overflow-hidden">
+										<Image
+											src={imagePreview}
+											alt="Profile preview"
+											layout="fill"
+											objectFit="cover"
+										/>
+									</div>
+								)}
+								<div className="flex items-center gap-2 w-full">
+									<Input
+										id="image"
+										type="file"
+										accept="image/*"
+										onChange={handleImageChange}
+										className="w-full"
+									/>
+									{imagePreview && (
+										<X
+											className="cursor-pointer"
+											onClick={() => {
+												setImage(null);
+												setImagePreview(null);
+											}}
+										/>
+									)}
+								</div>
+							</div>
+						</div>
+						<Button
+							type="submit"
+							className="w-full"
+							disabled={loading || !accepted}
+							onClick={async () => {}}
+						>
+							{loading ? (
+								<Loader2 size={16} className="animate-spin" />
+							) : (
+								"Create an account"
+							)}
+						</Button>
 					</div>
-					<Button
-						type="submit"
-						className="w-full"
-						disabled={loading}
-						onClick={async () => {}}
-					>
-						{loading ? (
-							<Loader2 size={16} className="animate-spin" />
-						) : (
-							"Create an account"
-						)}
-					</Button>
+				) : (
+					<></>
+				)}
+				<div
+					className={cn(
+						"w-full gap-2 flex items-center justify-between",
+						options.socialProviders.length > 3
+							? "flex-row flex-wrap"
+							: "flex-col",
+						options.email ? "mt-2" : "",
+					)}
+				>
+					{Object.keys(socialProviders).map((provider) => {
+						if (options.socialProviders.includes(provider)) {
+							const { Icon } =
+								socialProviders[provider as keyof typeof socialProviders];
+							return (
+								<Button
+									key={provider}
+									variant="outline"
+									disabled={!accepted}
+									className={cn(
+										options.socialProviders.length > 3
+											? "flex-grow"
+											: "w-full gap-2",
+									)}
+								>
+									<Icon width="1.2em" height="1.2em" />
+									{options.socialProviders.length <= 3 &&
+										"Sign up with " +
+											provider.charAt(0).toUpperCase() +
+											provider.slice(1)}
+								</Button>
+							);
+						}
+						return null;
+					})}
 				</div>
+
+				{options.legalDocuments.length > 0 ? (
+					<>
+						{options.email || options.socialProviders.length > 0 ? (
+							<Separator className="my-2" />
+						) : (
+							<></>
+						)}
+						{options.legalDocuments.map((doc) => {
+							return (
+								<div key={doc.name}>
+									<Checkbox
+										onCheckedChange={(checked) => {
+											setLegalDocumentsAccepted(
+												checked
+													? [...legalDocumentsAccepted, doc.name]
+													: legalDocumentsAccepted.filter(
+															(d) => d !== doc.name,
+														),
+											);
+										}}
+									/>{" "}
+									I have read and accept the{" "}
+									<a href={doc.url} target="_blank">
+										{doc.name}
+									</a>
+								</div>
+							);
+						})}
+					</>
+				) : (
+					<></>
+				)}
 			</CardContent>
 			<CardFooter>
 				<div className="flex justify-center w-full border-t py-4">
@@ -177,7 +269,23 @@ async function convertImageToBase64(file: File): Promise<string> {
 	});
 }
 
-export const signUpString = `"use client";
+export const signUpString = (options: {
+	email: boolean;
+	passkey: boolean;
+	socialProviders: string[];
+	magicLink: boolean;
+	signUp: boolean;
+	label: boolean;
+	rememberMe: boolean;
+	requestPasswordReset: boolean;
+	legal: boolean;
+	legalDocuments: {
+		name: string;
+		view: boolean;
+		accept: boolean;
+		url: string;
+	}[];
+}) => `"use client";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -188,6 +296,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useState } from "react";
@@ -198,6 +307,9 @@ import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 
 export default function SignUp() {
+	${
+		options.email
+			? `
 	const [firstName, setFirstName] = useState("");
 	const [lastName, setLastName] = useState("");
 	const [email, setEmail] = useState("");
@@ -218,7 +330,14 @@ export default function SignUp() {
 			};
 			reader.readAsDataURL(file);
 		}
-	};
+	};`
+			: ""
+	}
+	${options.legal ? `	const [legalDocumentsAccepted, setLegalDocumentsAccepted] = useState<
+		string[]
+	>([]);
+	const [accepted, setAccepted] = useState(false);
+` : ""}
 
 	return (
 		<Card className="z-50 rounded-md rounded-t-none max-w-md">
@@ -229,7 +348,9 @@ export default function SignUp() {
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
-				<div className="grid gap-4">
+				${
+					options.email
+						? `<div className="grid gap-4">
 					<div className="grid grid-cols-2 gap-4">
 						<div className="grid gap-2">
 							<Label htmlFor="first-name">First name</Label>
@@ -327,7 +448,7 @@ export default function SignUp() {
 					<Button
 						type="submit"
 						className="w-full"
-						disabled={loading}
+						disabled={loading${options.legal ? ` || !accepted` : ""}}
 						onClick={async () => {
 							await signUp.email({
 								email,
@@ -358,15 +479,111 @@ export default function SignUp() {
 							"Create an account"
 						)}
 					</Button>
-				</div>
+				</div>`
+						: ""
+				}
+				          ${
+										options.socialProviders?.length > 0
+											? `<div className={cn(
+              "w-full gap-2 flex items-center",
+              ${
+								options.socialProviders.length > 3
+									? '"justify-between flex-wrap"'
+									: '"justify-between flex-col"'
+							}
+            )}>
+              ${options.socialProviders
+								.map((provider: string) => {
+									const icon =
+										socialProviders[provider as keyof typeof socialProviders]
+											?.stringIcon || "";
+									return `\n\t\t\t\t<Button
+                  variant="outline"
+                  className={cn(
+                    ${
+											options.socialProviders.length > 3
+												? '"flex-grow"'
+												: '"w-full gap-2"'
+										}
+                  )}
+                  disabled={loading ${options.legal ? ` || !accepted` : ""}}
+                  onClick={async () => {
+                    await signIn.social(
+                    {
+                      provider: "${provider}",
+                      callbackURL: "/dashboard"
+                    },
+                    {
+                      onRequest: (ctx) => {
+                         setLoading(true);
+                      },
+                      onResponse: (ctx) => {
+                         setLoading(false);
+                      },
+                     },
+                    );
+                  }}
+                >
+                  ${icon}
+                  ${
+										options.socialProviders.length <= 3
+											? `Sign up with ${
+													provider.charAt(0).toUpperCase() + provider.slice(1)
+												}`
+											: ""
+									}
+                </Button>`;
+								})
+								.join("")}
+            </div>`
+											: ""
+									}
+													${options.legalDocuments.length > 0 ? (
+					`
+						${options.email || options.socialProviders.length > 0 ? (
+							`<Separator className="my-2" />`
+						) : (
+							""
+						)}
+						${options.legalDocuments.map((doc) => {
+							return (
+								`<div>
+									<Checkbox
+										onCheckedChange={(checked) => {
+											setLegalDocumentsAccepted(
+												checked
+													? [...legalDocumentsAccepted, doc.name]
+													: legalDocumentsAccepted.filter(
+															(d) => d !== doc.name,
+														),
+											);
+										}}
+									/>{" "}
+									I have read and accept the{" "}
+									<a href=${doc.url} target="_blank">
+										${doc.name}
+									</a>
+								</div>
+								`
+							);
+						})}
+					`
+				) : (
+					""
+				)}
+
 			</CardContent>
-			<CardFooter>
+			${
+				options.label
+					? `<CardFooter>
 				<div className="flex justify-center w-full border-t py-4">
 					<p className="text-center text-xs text-neutral-500">
 						Secured by <span className="text-orange-400">better-auth.</span>
 					</p>
 				</div>
-			</CardFooter>
+			</CardFooter>`
+					: ""
+			}
 		</Card>
 	);
 }

--- a/docs/components/builder/sign-up.tsx
+++ b/docs/components/builder/sign-up.tsx
@@ -448,7 +448,7 @@ export default function SignUp() {
 					<Button
 						type="submit"
 						className="w-full"
-						disabled={loading${options.legal ? ` || !accepted` : ""}}
+						disabled={loading${options.legal ? " || !accepted" : ""}}
 						onClick={async () => {
 							await signUp.email({
 								email,

--- a/docs/components/builder/sign-up.tsx
+++ b/docs/components/builder/sign-up.tsx
@@ -333,11 +333,15 @@ export default function SignUp() {
 	};`
 			: ""
 	}
-	${options.legal ? `	const [legalDocumentsAccepted, setLegalDocumentsAccepted] = useState<
+	${
+		options.legal
+			? `	const [legalDocumentsAccepted, setLegalDocumentsAccepted] = useState<
 		string[]
 	>([]);
 	const [accepted, setAccepted] = useState(false);
-` : ""}
+`
+			: ""
+	}
 
 	return (
 		<Card className="z-50 rounded-md rounded-t-none max-w-md">
@@ -538,16 +542,12 @@ export default function SignUp() {
             </div>`
 											: ""
 									}
-													${options.legalDocuments.length > 0 ? (
-					`
-						${options.email || options.socialProviders.length > 0 ? (
-							`<Separator className="my-2" />`
-						) : (
-							""
-						)}
+													${
+														options.legalDocuments.length > 0
+															? `
+						${options.email || options.socialProviders.length > 0 ? `<Separator className="my-2" />` : ""}
 						${options.legalDocuments.map((doc) => {
-							return (
-								`<div>
+							return `<div>
 									<Checkbox
 										onCheckedChange={(checked) => {
 											setLegalDocumentsAccepted(
@@ -564,13 +564,11 @@ export default function SignUp() {
 										${doc.name}
 									</a>
 								</div>
-								`
-							);
+								`;
 						})}
 					`
-				) : (
-					""
-				)}
+															: ""
+													}
 
 			</CardContent>
 			${

--- a/docs/components/builder/store.ts
+++ b/docs/components/builder/store.ts
@@ -9,4 +9,11 @@ export const optionsAtom = atom({
 	label: true,
 	rememberMe: true,
 	requestPasswordReset: true,
+	legal: false,
+	legalDocuments: [] as {
+		url: string;
+		name: string;
+		view: boolean;
+		accept: boolean;
+	}[],
 });

--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1663,6 +1663,11 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				href: "/docs/plugins/sso",
 			},
 			{
+				title: "Legal",
+				icon: () => <ShieldCheck className="w-4 h-4" />,
+				href: "/docs/plugins/legal",
+			},
+			{
 				title: "Utility",
 				group: true,
 				href: "",

--- a/docs/content/docs/plugins/legal.mdx
+++ b/docs/content/docs/plugins/legal.mdx
@@ -1,0 +1,250 @@
+---
+title: Legal
+description: Legal plugin for Better Auth.
+---
+
+The Legal Documents plugin lets you force users to accept T&C's before signing up.
+
+
+## Installation
+
+<Steps>
+  <Step>
+    ### Add the plugin to your auth config
+
+    Add the `legal` plugin to your auth config and add the different `fields` you want.
+
+    ```ts title="auth.ts"
+    import { betterAuth } from "better-auth"
+    import { legal } from "better-auth/plugins" // [!code highlight]
+    
+    export const auth = betterAuth({
+        // ... other config options
+        plugins: [
+            legal() // [!code highlight]
+        ]
+    })
+    ```
+    </Step>
+    <Step>
+    ### Add different documents to the plugin
+
+    ```ts title="auth.ts"
+    import { betterAuth } from "better-auth"
+    import { legal } from "better-auth/plugins"
+    
+    export const auth = betterAuth({
+        // ... other config options
+        plugins: [
+            legal({
+              documents: [
+                {
+                    name: "Terms of Service",
+                    mustAccept: true,
+                    mustRead: true,
+                    url: "/terms"
+                }
+              ]
+            })
+        ]
+    })
+    ```
+
+    <CustomTypeTable type={[{
+	    isOptional: false,
+	    description: "The name of the document, used in the schema for the database",
+	    propName: "name",
+	    type: "string",
+	    exampleValue: "Terms of Service",
+	    comments: null,
+	    isServerOnly: false,
+	    path: [],
+	    isNullable: false,
+	    isClientOnly: false,
+    },{
+	    isOptional: true,
+	    description: "Whether the user must accept the terms before signing up",
+	    propName: "mustAccept",
+	    type: "boolean",
+	    exampleValue: "false",
+	    comments: "default: true",
+	    isServerOnly: false,
+	    path: [],
+	    isNullable: false,
+	    isClientOnly: false,
+    },{
+	    isOptional: false,
+	    description: "Whether the user must view the terms before signing up",
+	    propName: "mustView",
+	    type: "boolean",
+	    exampleValue: "false",
+	    comments: "default: true",
+	    isServerOnly: false,
+	    path: [],
+	    isNullable: false,
+	    isClientOnly: false,
+    }]}/>
+  </Step>
+</Steps>
+
+## Usage
+
+### Commit an action
+
+Use the `actionLegalDocument()` method to commit an action to the user's documents.
+
+<APIMethod path="/legal/action" method="POST">
+```ts
+type actionLegalDocument = {
+		/**
+     * The name of the document
+    */
+    name: string;
+    /**
+     * The date (and time) the document was accepted
+    */
+	  acceptedAt: Date = undefined;
+    /**
+     * The date (and time) the document was accepted
+    */
+    viewedAt: Date = undefined;
+}
+```
+</APIMethod>
+
+### Prevent Sign Up and sign in
+
+By default, the plugin will block sign up and sign in. To not block sign up or sign in, pass `blockSignUp: false` or `blockSignIn: false` in the options.
+
+<Callout>
+If either `blockSignUp` or `blockSignIn` is set to `true`, SSO will be disabled.
+</Callout>
+
+### Include Legal Documents in auth request
+
+You can include documents in the `sign up` and `sign in` request such as `authClient.signUp.email`
+You can do this by passing `\{name}AcceptedAt` and `\{name}ViewedAt` (where `name` is the name of the document) to the request body, and it will be merged with the user's current documents.
+
+The `UserWithDocuments` type is exported from the plugin, and is the type that should be used for `signUp` and `signIn` request containing documents.
+
+### List a User's Documents
+
+Use the `listDocuments()` method to list a user's documents.
+
+<APIMethod path="/legal/list" method="GET">
+```ts
+type listDocuments = {
+  /**
+   * The user's id
+   * Either `user` or `cookie` is required
+  */
+  user?: string;
+  /**
+   * The user's cookie
+   * Either `user` or `cookie` is required
+  */
+	cookie?: string;
+
+  /**
+   * The name of the document
+  */
+	name: string;
+  /**
+   * The date (and time) the document was viewed (undefined if not viewed)
+   */
+	viewedAt?: Date;
+  /**
+   * The date (and time) the document was accepted (undefined if not accepted)
+  */
+	acceptedAt?: Date;
+
+}
+```
+</APIMethod>
+
+## Options
+
+### LegalOptions
+
+<CustomTypeTable type={[{
+	isOptional: false,
+	description: "The definitions for the documents",
+	propName: "documents",
+	type: "LegalDocument[]",
+	exampleValue: "[]",
+	comments: null,
+	isServerOnly: true,
+	path: [],
+	isNullable: false,
+	isClientOnly: false
+},{
+	isOptional: true,
+	description: "Whether to block sign up based on the documents",
+	propName: "blockSignUp",
+	type: "boolean",
+	exampleValue: "false",
+	comments: "default: true",
+	isServerOnly: true,
+	path: [],
+	isNullable: false,
+	isClientOnly: false
+},{
+	isOptional: true,
+	description: "Whether to block sign in based on the documents",
+	propName: "blockSignIn",
+	type: "boolean",
+	exampleValue: "false",
+	comments: "default: true",
+	isServerOnly: true,
+	path: [],
+	isNullable: false,
+	isClientOnly: false
+},{
+	isOptional: true,
+	description: "The cookie name",
+	propName: "cookieName",
+	type: "string",
+	exampleValue: "'legalDocumentCookieName",
+	comments: "default: 'legal-id'",
+	isServerOnly: true,
+	path: [],
+	isNullable: false,
+	isClientOnly: false
+}]}/>
+
+### LegalDocument
+
+<CustomTypeTable type={[{
+	isOptional: false,
+	description: "The name of the document, used in the schema for the database",
+	propName: "name",
+	type: "string",
+	exampleValue: "Terms of Service",
+	comments: null,
+	isServerOnly: false,
+	path: ["LegalOptions", "documents[number]"],
+	isNullable: false,
+	isClientOnly: false,
+},{
+	isOptional: true,
+	description: "Whether the user must accept the terms before signing up",
+	propName: "mustAccept",
+	type: "boolean",
+	exampleValue: "false",
+	comments: "default: true",
+	isServerOnly: false,
+	path: ["LegalOptions", "documents[number]"],
+	isNullable: false,
+	isClientOnly: false,
+},{
+	isOptional: false,
+	description: "Whether the user must view the terms before signing up",
+	propName: "mustView",
+	type: "boolean",
+	exampleValue: "false",
+	comments: "default: true",
+	isServerOnly: false,
+	path: ["LegalOptions", "documents[number]"],
+	isNullable: false,
+	isClientOnly: false,
+}]}/>

--- a/docs/content/docs/plugins/legal.mdx
+++ b/docs/content/docs/plugins/legal.mdx
@@ -41,7 +41,7 @@ The Legal Documents plugin lets you force users to accept T&C's before signing u
                 {// [!code highlight]
                     name: "Terms of Service",// [!code highlight]
                     mustAccept: true,// [!code highlight]
-                    mustRead: true,// [!code highlight]
+                    mustView: true,// [!code highlight]
                     url: "/terms"// [!code highlight]
                 }// [!code highlight]
               ]

--- a/docs/content/docs/plugins/legal.mdx
+++ b/docs/content/docs/plugins/legal.mdx
@@ -38,12 +38,12 @@ The Legal Documents plugin lets you force users to accept T&C's before signing u
         plugins: [
             legal({
               documents: [
-                {
-                    name: "Terms of Service",
-                    mustAccept: true,
-                    mustRead: true,
-                    url: "/terms"
-                }
+                {// [!code highlight]
+                    name: "Terms of Service",// [!code highlight]
+                    mustAccept: true,// [!code highlight]
+                    mustRead: true,// [!code highlight]
+                    url: "/terms"// [!code highlight]
+                }// [!code highlight]
               ]
             })
         ]
@@ -235,7 +235,7 @@ type listDocuments = {
 	isNullable: false,
 	isClientOnly: false,
 },{
-	isOptional: false,
+	isOptional: true,
 	description: "Whether the user must view the terms before signing up",
 	propName: "mustView",
 	type: "boolean",

--- a/docs/content/docs/plugins/legal.mdx
+++ b/docs/content/docs/plugins/legal.mdx
@@ -50,40 +50,40 @@ The Legal Documents plugin lets you force users to accept T&C's before signing u
     })
     ```
 
-    <CustomTypeTable type={[{
-	    isOptional: false,
-	    description: "The name of the document, used in the schema for the database",
-	    propName: "name",
-	    type: "string",
-	    exampleValue: "Terms of Service",
-	    comments: null,
-	    isServerOnly: false,
-	    path: [],
-	    isNullable: false,
-	    isClientOnly: false,
-    },{
-	    isOptional: true,
-	    description: "Whether the user must accept the terms before signing up",
-	    propName: "mustAccept",
-	    type: "boolean",
-	    exampleValue: "false",
-	    comments: "default: true",
-	    isServerOnly: false,
-	    path: [],
-	    isNullable: false,
-	    isClientOnly: false,
-    },{
-	    isOptional: false,
-	    description: "Whether the user must view the terms before signing up",
-	    propName: "mustView",
-	    type: "boolean",
-	    exampleValue: "false",
-	    comments: "default: true",
-	    isServerOnly: false,
-	    path: [],
-	    isNullable: false,
-	    isClientOnly: false,
-    }]}/>
+    <CustomTypeTable props={[{
+          isOptional: false,
+          description: "The name of the document, used in the schema for the database",
+          propName: "name",
+          type: "string",
+          exampleValue: "Terms of Service",
+          comments: null,
+          isServerOnly: false,
+          path: [],
+          isNullable: false,
+          isClientOnly: false,
+        }, {
+          isOptional: true,
+          description: "Whether the user must accept the terms before signing up",
+          propName: "mustAccept",
+          type: "boolean",
+          exampleValue: "false",
+          comments: "default: true",
+          isServerOnly: false,
+          path: [],
+          isNullable: false,
+          isClientOnly: false,
+        }, {
+          isOptional: false,
+          description: "Whether the user must view the terms before signing up",
+          propName: "mustView",
+          type: "boolean",
+          exampleValue: "false",
+          comments: "default: true",
+          isServerOnly: false,
+          path: [],
+          isNullable: false,
+          isClientOnly: false,
+        }]} isServer={true} />
   </Step>
 </Steps>
 
@@ -99,15 +99,15 @@ type actionLegalDocument = {
 		/**
      * The name of the document
     */
-    name: string;
+    name: string
     /**
      * The date (and time) the document was accepted
     */
-	  acceptedAt: Date = undefined;
+	  acceptedAt?: Date
     /**
      * The date (and time) the document was accepted
     */
-    viewedAt: Date = undefined;
+    viewedAt?: Date
 }
 ```
 </APIMethod>
@@ -123,7 +123,7 @@ If either `blockSignUp` or `blockSignIn` is set to `true`, SSO will be disabled.
 ### Include Legal Documents in auth request
 
 You can include documents in the `sign up` and `sign in` request such as `authClient.signUp.email`
-You can do this by passing `\{name}AcceptedAt` and `\{name}ViewedAt` (where `name` is the name of the document) to the request body, and it will be merged with the user's current documents.
+You can do this by passing `{name}AcceptedAt` and `{name}ViewedAt` (where `name` is the name of the document) to the request body, and it will be merged with the user's current documents.
 
 The `UserWithDocuments` type is exported from the plugin, and is the type that should be used for `signUp` and `signIn` request containing documents.
 
@@ -138,26 +138,24 @@ type listDocuments = {
    * The user's id
    * Either `user` or `cookie` is required
   */
-  user?: string;
+  user?: string
   /**
    * The user's cookie
    * Either `user` or `cookie` is required
   */
-	cookie?: string;
-
+	cookie?: string
   /**
    * The name of the document
   */
-	name: string;
+	name: string
   /**
    * The date (and time) the document was viewed (undefined if not viewed)
    */
-	viewedAt?: Date;
+	viewedAt?: Date
   /**
    * The date (and time) the document was accepted (undefined if not accepted)
   */
-	acceptedAt?: Date;
-
+	acceptedAt?: Date
 }
 ```
 </APIMethod>
@@ -166,14 +164,14 @@ type listDocuments = {
 
 ### LegalOptions
 
-<CustomTypeTable type={[{
+<CustomTypeTable props={[{
 	isOptional: false,
 	description: "The definitions for the documents",
 	propName: "documents",
 	type: "LegalDocument[]",
 	exampleValue: "[]",
 	comments: null,
-	isServerOnly: true,
+	isServerOnly: false,
 	path: [],
 	isNullable: false,
 	isClientOnly: false
@@ -184,7 +182,7 @@ type listDocuments = {
 	type: "boolean",
 	exampleValue: "false",
 	comments: "default: true",
-	isServerOnly: true,
+	isServerOnly: false,
 	path: [],
 	isNullable: false,
 	isClientOnly: false
@@ -195,7 +193,7 @@ type listDocuments = {
 	type: "boolean",
 	exampleValue: "false",
 	comments: "default: true",
-	isServerOnly: true,
+	isServerOnly: false,
 	path: [],
 	isNullable: false,
 	isClientOnly: false
@@ -206,15 +204,15 @@ type listDocuments = {
 	type: "string",
 	exampleValue: "'legalDocumentCookieName",
 	comments: "default: 'legal-id'",
-	isServerOnly: true,
+	isServerOnly: false,
 	path: [],
 	isNullable: false,
 	isClientOnly: false
-}]}/>
+}]} isServer={true} />
 
 ### LegalDocument
 
-<CustomTypeTable type={[{
+<CustomTypeTable props={[{
 	isOptional: false,
 	description: "The name of the document, used in the schema for the database",
 	propName: "name",
@@ -247,4 +245,4 @@ type listDocuments = {
 	path: ["LegalOptions", "documents[number]"],
 	isNullable: false,
 	isClientOnly: false,
-}]}/>
+}]} isServer={true} />

--- a/docs/content/docs/plugins/legal.mdx
+++ b/docs/content/docs/plugins/legal.mdx
@@ -199,10 +199,10 @@ type listDocuments = {
 	isClientOnly: false
 },{
 	isOptional: true,
-	description: "The cookie name",
+	description: "A custom name for the cookie used to identify the user, defaults to 'legal-id'",
 	propName: "cookieName",
 	type: "string",
-	exampleValue: "'legalDocumentCookieName",
+	exampleValue: "'legalDocumentCookieName'",
 	comments: "default: 'legal-id'",
 	isServerOnly: false,
 	path: [],

--- a/packages/better-auth/src/plugins/legal/index.ts
+++ b/packages/better-auth/src/plugins/legal/index.ts
@@ -1,0 +1,293 @@
+// import type { BetterAuthPlugin, User } from "../../types";
+import type { BetterAuthPlugin } from "../../../../core/src/types/plugin";
+import type { User } from "../../../../core/src/db/index";
+import { APIError } from "better-call";
+import z, { ZodDate, ZodObject, ZodOptional } from "zod";
+// import { createAuthEndpoint, createAuthMiddleware } from "../../api";
+import {
+	createAuthEndpoint,
+	createAuthMiddleware,
+} from "../../../../core/src/middleware";
+import { createFieldAttribute } from "../../db";
+import { userSchema as coreUserSchema } from "@better-auth/core/db";
+import { generateRandomString } from "../../crypto";
+
+// url and text field are for future use
+type LegalDocument = {
+	// url: string;
+	must_accept?: boolean;
+	must_view?: boolean;
+	// text: string;
+	name: string;
+};
+
+export type LegalOptions = {
+	documents: LegalDocument[];
+	/**
+	 * @default true
+	 */
+	blockSignUp?: boolean;
+	/**
+	 * @default true
+	 */
+	blockSignIn?: boolean;
+	/**
+	 * @default "legal-id"
+	 */
+	cookieName?: string;
+};
+
+export type UserWithDocuments = User & {
+	[K in `${string}AcceptedAt` | `${string}ViewedAt`]?: Date;
+};
+
+type LegalSchema = {
+	user?: string;
+	cookie?: string;
+
+	name: string;
+	viewedAt?: Date;
+	acceptedAt?: Date;
+};
+
+export function legal({
+	documents,
+	blockSignUp = true,
+	blockSignIn = true,
+	cookieName = "legal-id",
+}: LegalOptions) {
+	const userSchema = (coreUserSchema as ZodObject).extend(
+		(
+			documents
+				.map((f) => `${f.name}AcceptedAt`)
+				.concat(documents.map((f) => `${f.name}ViewedAt`)) as string[]
+		).reduce(
+			(acc, key) => {
+				return { ...acc, [key]: z.date().optional() };
+			},
+			{} as { [key: string]: ZodOptional<ZodDate> },
+		),
+	);
+	return {
+		id: "legal",
+		init: async (context) => {
+			return {
+				options: {
+					databaseHooks: {
+						user: {
+							create: {
+								after: async (user, ctx) => {
+									if (!ctx) throw new APIError("INTERNAL_SERVER_ERROR");
+
+									const cookie = ctx.getCookie(cookieName);
+
+									await ctx.context.adapter.updateMany({
+										model: "requirement",
+										where: [
+											{
+												field: "cookie",
+												value: cookie,
+											},
+										],
+										update: {
+											user: user.id,
+										},
+									});
+								},
+							},
+						},
+					},
+				},
+			};
+		},
+		endpoints: {
+			actionLegalDocument: createAuthEndpoint(
+				"/legal/action",
+				{
+					method: "POST",
+					body: z.object({
+						name: z.enum(documents.map((f) => f.name)),
+						acceptedAt: z.date().optional(),
+						viewedAt: z.date().optional(),
+					}),
+				},
+				async (ctx) => {
+					if (!ctx.body.acceptedAt && !ctx.body.viewedAt) {
+						throw new APIError("BAD_REQUEST", {
+							message:
+								"You must either accept or view the document when calling this endpoint",
+						});
+					}
+					let cookie = ctx.getCookie("legal-id");
+					if (!cookie) {
+						cookie = generateRandomString(32, "a-z", "A-Z");
+						ctx.setCookie("legal-id", cookie);
+					}
+
+					ctx.context.adapter.create<LegalSchema>({
+						model: "requirement",
+						data: {
+							cookie,
+							name: ctx.body.name,
+							acceptedAt: ctx.body.acceptedAt,
+							viewedAt: ctx.body.viewedAt,
+						},
+					});
+				},
+			),
+			listDocuments: createAuthEndpoint(
+				"/legal/list",
+				{
+					method: "GET",
+				},
+				async (ctx) => {
+					if (!(ctx.context.session || ctx.getCookie(cookieName))) {
+						throw new APIError("UNAUTHORIZED");
+					}
+					const data = await ctx.context.adapter.findMany<LegalSchema>({
+						model: "requirement",
+						where: [
+							ctx.context.session
+								? {
+										field: "user",
+										value: ctx.context.session.user.id,
+									}
+								: {
+										field: "cookie",
+										value: ctx.getCookie(cookieName),
+									},
+						],
+					});
+					return ctx.json({
+						data,
+					});
+				},
+			),
+		},
+		schema: {
+			legal: {
+				fields: {
+					name: createFieldAttribute(documents.map((f) => f.name)),
+					//Requires user or cookie
+					user: createFieldAttribute("string", {
+						required: false,
+					}),
+					cookie: createFieldAttribute("string", {
+						required: false,
+					}),
+
+					viewedAt: createFieldAttribute("date", {
+						required: false,
+					}),
+					acceptedAt: createFieldAttribute("date", {
+						required: false,
+					}),
+				},
+			},
+		},
+		hooks: {
+			before: [
+				{
+					matcher: (ctx) =>
+						((ctx.path.includes("/sign-up") ||
+							ctx.path === "/sign-in/social") &&
+							blockSignUp) ||
+						(ctx.path.includes("/sign-in") && blockSignIn),
+					handler: createAuthMiddleware(async (ctx) => {
+						const cookie = ctx.getCookie(cookieName);
+						const user = userSchema.parse(ctx.request?.json());
+						const data = await ctx.context.adapter.findMany<LegalSchema>({
+							model: "legal",
+							where: [
+								...(ctx.context.session
+									? [
+											{
+												field: "cookie",
+												value: cookie,
+												connector: "OR" as const,
+											},
+											{
+												field: "userId",
+												value: ctx.context.session.user.id,
+												connector: "OR" as const,
+											},
+										]
+									: [
+											{
+												field: "cookie",
+												value: cookie,
+											},
+										]),
+							],
+						});
+						documents.forEach((f) => {
+							const document = data.find((d) => d.name === f.name);
+							if (
+								(f.must_accept ?? true) &&
+								!document?.acceptedAt &&
+								!user[`${f.name}AcceptedAt`]
+							) {
+								throw new APIError("PRECONDITION_FAILED", {
+									message: `You must accept the ${f.name} before signing up`,
+								});
+							}
+							if (
+								(f.must_view ?? true) &&
+								!document?.viewedAt &&
+								!user[`${f.name}ViewedAt`]
+							) {
+								throw new APIError("PRECONDITION_REQUIRED", {
+									message: `You must read the ${f.name} before signing up`,
+								});
+							}
+
+							return {
+								name: f.name,
+								viewedAt: document?.viewedAt,
+								acceptedAt: document?.acceptedAt,
+							};
+						});
+
+						const newDocs: Record<string, LegalSchema> = {};
+
+						Object.entries(user).forEach(([key, value]) => {
+							if (key.endsWith("AcceptedAt")) {
+								const name = key.slice(0, -10);
+								newDocs[name] = {
+									...(name in documents ? newDocs[name] : {}),
+									acceptedAt: value,
+									name,
+									cookie: cookie ?? undefined,
+									user: ctx.context.session?.user.id,
+								};
+							} else if (key.endsWith("ViewedAt")) {
+								const name = key.slice(0, -8);
+								newDocs[name] = {
+									...(name in documents ? newDocs[name] : {}),
+									viewedAt: value,
+									name,
+									cookie: cookie ?? undefined,
+									user: ctx.context.session?.user.id,
+								};
+							}
+						});
+
+						await ctx.context.adapter.transaction(async (trx) => {
+							await Promise.all(
+								Object.entries(newDocs).map(async ([name, doc]) => {
+									await trx.create<LegalSchema>({
+										model: "requirement",
+										data: {
+											...doc,
+											name,
+										},
+									});
+								}),
+							);
+						});
+					}),
+				},
+			],
+		},
+	} satisfies BetterAuthPlugin;
+}

--- a/packages/better-auth/src/plugins/legal/index.ts
+++ b/packages/better-auth/src/plugins/legal/index.ts
@@ -15,8 +15,8 @@ import { generateRandomString } from "../../crypto";
 // url and text field are for future use
 type LegalDocument = {
 	// url: string;
-	must_accept?: boolean;
-	must_view?: boolean;
+	mustAccept?: boolean;
+	mustView?: boolean;
 	// text: string;
 	name: string;
 };
@@ -118,7 +118,7 @@ export function legal({
 								"You must either accept or view the document when calling this endpoint",
 						});
 					}
-					let cookie = ctx.getCookie("legal-id");
+					let cookie = ctx.getCookie(cookieName);
 					if (!cookie) {
 						cookie = generateRandomString(32, "a-z", "A-Z");
 						ctx.setCookie("legal-id", cookie);
@@ -195,7 +195,7 @@ export function legal({
 						(ctx.path.includes("/sign-in") && blockSignIn),
 					handler: createAuthMiddleware(async (ctx) => {
 						const cookie = ctx.getCookie(cookieName);
-						const user = userSchema.parse(ctx.request?.json());
+						const user = userSchema.parse(await ctx.request?.json());
 						const data = await ctx.context.adapter.findMany<LegalSchema>({
 							model: "legal",
 							where: [
@@ -223,7 +223,7 @@ export function legal({
 						documents.forEach((f) => {
 							const document = data.find((d) => d.name === f.name);
 							if (
-								(f.must_accept ?? true) &&
+								(f.mustAccept ?? true) &&
 								!document?.acceptedAt &&
 								!user[`${f.name}AcceptedAt`]
 							) {
@@ -232,7 +232,7 @@ export function legal({
 								});
 							}
 							if (
-								(f.must_view ?? true) &&
+								(f.mustView ?? true) &&
 								!document?.viewedAt &&
 								!user[`${f.name}ViewedAt`]
 							) {

--- a/packages/better-auth/src/plugins/legal/index.ts
+++ b/packages/better-auth/src/plugins/legal/index.ts
@@ -1,13 +1,7 @@
-// import type { BetterAuthPlugin, User } from "../../types";
-import type { BetterAuthPlugin } from "../../../../core/src/types/plugin";
-import type { User } from "../../../../core/src/db/index";
+import type { BetterAuthPlugin, User } from "../../types";
 import { APIError } from "better-call";
 import z, { ZodDate, ZodObject, ZodOptional } from "zod";
-// import { createAuthEndpoint, createAuthMiddleware } from "../../api";
-import {
-	createAuthEndpoint,
-	createAuthMiddleware,
-} from "../../../../core/src/middleware";
+import { createAuthEndpoint, createAuthMiddleware } from "../../api";
 import { createFieldAttribute } from "../../db";
 import { userSchema as coreUserSchema } from "@better-auth/core/db";
 import { generateRandomString } from "../../crypto";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a Legal plugin that lets apps require users to read and/or accept documents (e.g., Terms, Privacy) before sign up or sign in. Includes API endpoints, schema hooks, docs, and builder UI/code generation.

- New Features
  - legal() plugin with document rules, optional blocking for sign up/sign in, and cookie-based tracking.
  - Enforces requirements pre sign up/sign in; migrates cookie-based records to the user after account creation.
  - Endpoints:
    - POST /legal/action to mark a document as viewed or accepted.
    - GET /legal/list to fetch a user’s or cookie’s document status.
  - User payload can include per-document fields like {name}AcceptedAt and {name}ViewedAt.
  - Docs site: new Legal plugin page, sidebar link, and custom type table support.
  - Builder: new “Legal” toggle, document editor step, generated sign-up checkboxes, and example legal pages in code tabs.

- Migration
  - Add legal() to betterAuth plugins and define your documents.
  - If desired, include {name}AcceptedAt and {name}ViewedAt in sign up/sign in requests.
  - Use POST /legal/action to record views/acceptance; use GET /legal/list to inspect status.

<!-- End of auto-generated description by cubic. -->

