### PR TITLE
docs: fix spelling and capitalization of 'OAuth' 

### DIFF
--- a/docs/content/docs/authentication/other-social-providers.mdx
+++ b/docs/content/docs/authentication/other-social-providers.mdx
@@ -3,9 +3,9 @@ title: Other Social Providers
 description: Other social providers setup and usage.
 ---
 
-Better Auth providers out of the box support for the [Generic Oauth Plugin](/docs/plugins/generic-oauth) which allows you to use any social provider that implements the OAuth2 protocol or OpenID Connect (OIDC) flows.
+Better Auth provides out of the box support for a [Generic OAuth Plugin](/docs/plugins/generic-oauth) which allows you to use any social provider that implements the OAuth2 protocol or OpenID Connect (OIDC) flows.
 
-To use a provider that is not supported out of the box, you can use the [Generic Oauth Plugin](/docs/plugins/generic-oauth).
+To use a provider that is not supported out of the box, you can use the [Generic OAuth Plugin](/docs/plugins/generic-oauth).
 
 ## Installation
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the “Other Social Providers” docs to correct “Oauth” → “OAuth”, fix “Better Auth providers” → “Better Auth provides”, and consistently capitalize “Generic OAuth Plugin”. Improves clarity and consistency.

<!-- End of auto-generated description by cubic. -->

