### PR TITLE
docs: fix browser extension example link

### DIFF
--- a/docs/content/docs/guides/browser-extension-guide.mdx
+++ b/docs/content/docs/guides/browser-extension-guide.mdx
@@ -5,7 +5,7 @@ description: A step-by-step guide to creating a browser extension with Better Au
 
 In this guide, we'll walk you through the steps of creating a browser extension using <Link href="https://docs.plasmo.com/">Plasmo</Link> with Better Auth for authentication.
 
-If you would like to view a completed example, you can check out the <Link href="https://github.com/better-auth/better-auth/tree/main/examples/browser-extension-example">browser extension example</Link>.
+If you would like to view a completed example, you can check out the <Link href="https://github.com/better-auth/examples/tree/main/browser-extension-example">browser extension example</Link>.
 
 <Callout type="warn">
   The Plasmo framework does not provide a backend for the browser extension.
@@ -217,6 +217,6 @@ If you would like to view a completed example, you can check out the <Link href=
 Congratulations! You've successfully created a browser extension using Better Auth and Plasmo.
 We highly recommend you visit the <Link href="https://docs.plasmo.com/">Plasmo documentation</Link> to learn more about the framework.
 
-If you would like to view a completed example, you can check out the <Link href="https://github.com/better-auth/better-auth/tree/main/examples/browser-extension-example">browser extension example</Link>.
+If you would like to view a completed example, you can check out the <Link href="https://github.com/better-auth/examples/tree/main/browser-extension-example">browser extension example</Link>.
 
 If you have any questions, feel free to open an issue on our <Link href="https://github.com/better-auth/better-auth/issues">GitHub repo</Link>, or join our <Link href="https://discord.gg/better-auth">Discord server</Link> for support.


### PR DESCRIPTION
fix broken links.

update the link of browser extension example from repo better-auth/better-auth to repo better-auth/examples.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed broken links in the Browser Extension Guide by updating the example link to the better-auth/examples repository. Readers can now access the working browser extension example.

<!-- End of auto-generated description by cubic. -->

