### PR TITLE
docs: fix incorrect option for session in API key plugin

### DIFF
--- a/docs/content/docs/plugins/api-key.mdx
+++ b/docs/content/docs/plugins/api-key.mdx
@@ -384,7 +384,7 @@ Any time an endpoint in Better Auth is called that has a valid API key in the he
 export const auth = betterAuth({
   plugins: [
     apiKey({
-      sessionForAPIKeys: true,
+      enableSessionForAPIKeys: true,
     }),
   ],
 });
@@ -725,9 +725,9 @@ Customize the rate-limiting.
 
 Custom schema for the API key plugin.
 
-`disableSessionForAPIKeys` <span className="opacity-70">`boolean`</span>
+`enableSessionForAPIKeys` <span className="opacity-70">`boolean`</span>
 
-An API Key can represent a valid session, so we automatically mock a session for the user if we find a valid API key in the request headers.
+An API Key can represent a valid session, so we can mock a session for the user if we find a valid API key in the request headers. Default is `false`.
 
 `permissions` <span className="opacity-70">`{ defaultPermissions?: Statements | ((userId: string, ctx: GenericEndpointContext) => Statements | Promise<Statements>) }`</span>
 


### PR DESCRIPTION
Happened to notice when upgrading to 1.3.27 but the documentation has the incorrect configuration value of `sessionForAPIKeys` and also did not update the schema for the new value as well.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix API key plugin docs to use the correct option name enableSessionForAPIKeys instead of sessionForAPIKeys. Updated the schema entry and description (default false) to match current behavior.

<!-- End of auto-generated description by cubic. -->

