### PR TITLE
docs: tweak ask ai ux on smaller screen

### DIFF
--- a/docs/components/floating-ai-search.tsx
+++ b/docs/components/floating-ai-search.tsx
@@ -617,12 +617,12 @@ export function AISearchTrigger() {
 				</Presence>
 				<div
 					className={cn(
-						"fixed transition-[width,height] duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)] -translate-x-1/2 shadow-xl z-30",
-						isMobile ? "bottom-6" : "bottom-4",
+						"fixed bg-transparent transition-[width,height] duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)] -translate-x-1/2 shadow-xl z-30",
+						isMobile ? "bottom-4" : "bottom-4",
 						open
 							? isMobile
-								? `w-[calc(100vw-2rem)] bg-fd-accent/30 overflow-visible ${showSuggestions ? "h-auto" : "h-40"}`
-								: `w-[min(800px,90vw)] bg-fd-accent/30 overflow-visible ${showSuggestions ? "h-auto" : "h-32"}`
+								? `w-[calc(100vw-2rem)] bg-fd-accent/30 overflow-visible h-auto`
+								: `w-[min(800px,90vw)] bg-fd-accent/30 overflow-visible h-auto`
 							: isMobile
 								? "w-32 h-12 bg-fd-secondary text-fd-secondary-foreground shadow-fd-background rounded-2xl overflow-hidden"
 								: "w-40 h-10 bg-fd-secondary text-fd-secondary-foreground shadow-fd-background rounded-2xl overflow-hidden",


### PR DESCRIPTION
---

This PR includes the following changes in floating-ai-search:

- No text-sm on Input for mobile sizes.
(On iOS, small text inputs trigger zoom when focused, which results in a poor UX. The trigger point is below text-base. The base code of the shadcn-ui Input component also prevents this behavior.)

- Fixes height issues.
- Moves the message “AI can be inaccurate, please verify the information.” to a Popover on mobile.

... misc UI optimizations for a cleaner look.

---

### Before:

https://github.com/user-attachments/assets/336b5c03-46cb-4817-a77e-bc68b4464ca8

### After:

https://github.com/user-attachments/assets/bb1b4fb1-f036-4d04-a4ae-bbf819a001ee



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Polished the floating search UI on mobile and desktop. Prevents iOS input zoom, fixes layout/height issues, and moves the disclaimer into a popover on small screens.

- **Bug Fixes**
  - Prevented iOS zoom by using base text size on inputs.
  - Fixed container heights, padding, and overscroll masking.
  - Improved suggestions with horizontal scroll and fade masks.
  - Moved the disclaimer to a popover on small screens; kept inline on larger screens.

- **Refactors**
  - Removed isMobile prop; standardized on sm: responsive classes.
  - Simplified overlay/trigger sizing to min(800px, 90vw) and consistent paddings.
  - Streamlined footer and borders; cleaner shadows.
  - Replaced Presence wrappers with direct conditional rendering.

<!-- End of auto-generated description by cubic. -->

