### PR TITLE
chore: update fixture package name

### DIFF
--- a/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hono",
+  "name": "tsconfig-verbatim-module-syntax-node10",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Renamed the fixture package to match its directory and avoid name collisions in e2e smoke tests. Changed package.json "name" from "hono" to "tsconfig-verbatim-module-syntax-node10".

<!-- End of auto-generated description by cubic. -->

