### PR TITLE
refactor: move context api to core

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -7,7 +7,7 @@ import type { AdditionalUserFieldsInput, User } from "../../types";
 import type { BetterAuthOptions } from "@better-auth/core";
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import { isDevelopment } from "@better-auth/core/env";
-import { runWithTransaction } from "../../context/transaction";
+import { runWithTransaction } from "@better-auth/core/context";
 import { parseUserInput } from "../../db";
 
 export const signUpEmail = <O extends BetterAuthOptions>() =>

--- a/packages/better-auth/src/auth.ts
+++ b/packages/better-auth/src/auth.ts
@@ -12,7 +12,7 @@ import type { PrettifyDeep, Expand } from "./types/helper";
 import { getBaseURL, getOrigin } from "./utils/url";
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import { BetterAuthError } from "@better-auth/core/error";
-import { runWithAdapter } from "./context/transaction";
+import { runWithAdapter } from "@better-auth/core/context";
 import type { AuthContext } from "@better-auth/core";
 
 export type WithJsDoc<T, D> = Expand<T & D>;

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -12,7 +12,10 @@ import { getWithHooks } from "./with-hooks";
 import { getIp } from "../utils/get-request-ip";
 import { safeJSONParse } from "../utils/json";
 import { generateId } from "../utils";
-import { getCurrentAdapter, runWithTransaction } from "../context/transaction";
+import {
+	getCurrentAdapter,
+	runWithTransaction,
+} from "@better-auth/core/context";
 import type { InternalLogger } from "@better-auth/core/env";
 import type {
 	AuthContext,

--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -1,7 +1,7 @@
 import type { DBPreservedModels } from "@better-auth/core/db";
 import type { BetterAuthOptions } from "@better-auth/core";
 import type { DBAdapter, Where } from "@better-auth/core/db/adapter";
-import { getCurrentAdapter } from "../context/transaction";
+import { getCurrentAdapter } from "@better-auth/core/context";
 import type { GenericEndpointContext } from "@better-auth/core";
 
 export function getWithHooks(

--- a/packages/better-auth/src/index.ts
+++ b/packages/better-auth/src/index.ts
@@ -5,7 +5,7 @@ export * from "@better-auth/core/oauth2";
 export * from "@better-auth/core/error";
 export * from "@better-auth/core/utils";
 //#endregion
-export { getCurrentAdapter } from "./context/transaction";
+export { getCurrentAdapter } from "@better-auth/core/context";
 export * from "./auth";
 export * from "./types";
 export * from "./utils";

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -17,7 +17,7 @@ import type {
 import { BetterAuthError } from "@better-auth/core/error";
 import parseJSON from "../../client/parser";
 import { type InferAdditionalFieldsFromPluginOptions } from "../../db";
-import { getCurrentAdapter } from "../../context/transaction";
+import { getCurrentAdapter } from "@better-auth/core/context";
 import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
 
 export const getOrgAdapter = <O extends OrganizationOptions>(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,16 @@
         "default": "./dist/async_hooks/index.cjs"
       }
     },
+    "./context": {
+      "import": {
+        "types": "./dist/context/index.d.ts",
+        "default": "./dist/context/index.js"
+      },
+      "require": {
+        "types": "./dist/context/index.d.cts",
+        "default": "./dist/context/index.cjs"
+      }
+    },
     "./env": {
       "import": {
         "types": "./dist/env/index.d.ts",

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1,0 +1,5 @@
+export {
+	getCurrentAdapter,
+	runWithAdapter,
+	runWithTransaction,
+} from "./transaction";

--- a/packages/core/src/context/transaction.ts
+++ b/packages/core/src/context/transaction.ts
@@ -1,16 +1,8 @@
-import {
-	getAsyncLocalStorage,
-	type AsyncLocalStorage,
-} from "@better-auth/core/async_hooks";
-import type {
-	DBTransactionAdapter,
-	DBAdapter,
-} from "@better-auth/core/db/adapter";
-import type { BetterAuthOptions } from "@better-auth/core";
+import { getAsyncLocalStorage, type AsyncLocalStorage } from "../async_hooks";
+import type { DBTransactionAdapter, DBAdapter } from "../db/adapter";
 
-let currentAdapterAsyncStorage: AsyncLocalStorage<
-	DBTransactionAdapter<BetterAuthOptions>
-> | null = null;
+let currentAdapterAsyncStorage: AsyncLocalStorage<DBTransactionAdapter> | null =
+	null;
 
 const ensureAsyncStorage = async () => {
 	if (!currentAdapterAsyncStorage) {
@@ -21,8 +13,8 @@ const ensureAsyncStorage = async () => {
 };
 
 export const getCurrentAdapter = async (
-	fallback: DBTransactionAdapter<BetterAuthOptions>,
-): Promise<DBTransactionAdapter<BetterAuthOptions>> => {
+	fallback: DBTransactionAdapter,
+): Promise<DBTransactionAdapter> => {
 	return ensureAsyncStorage()
 		.then((als) => {
 			return als.getStore() || fallback;
@@ -33,7 +25,7 @@ export const getCurrentAdapter = async (
 };
 
 export const runWithAdapter = async <R>(
-	adapter: DBAdapter<BetterAuthOptions>,
+	adapter: DBAdapter,
 	fn: () => R,
 ): Promise<R> => {
 	let called = true;
@@ -51,7 +43,7 @@ export const runWithAdapter = async <R>(
 };
 
 export const runWithTransaction = async <R>(
-	adapter: DBAdapter<BetterAuthOptions>,
+	adapter: DBAdapter,
 	fn: () => R,
 ): Promise<R> => {
 	let called = true;

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 		"./src/db/index.ts",
 		"./src/db/adapter/index.ts",
 		"./src/async_hooks/index.ts",
+		"./src/context/index.ts",
 		"./src/env/index.ts",
 		"./src/oauth2/index.ts",
 		"./src/middleware/index.ts",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the context API (getCurrentAdapter, runWithAdapter, runWithTransaction) to @better-auth/core/context to centralize transaction handling. Updated imports across packages; no functional changes.

- **Refactors**
  - Added core/src/context with subpath export in core package.json.
  - Updated better-auth and plugins to import from @better-auth/core/context.
  - Simplified adapter types and aligned internal imports; included context in tsdown build.

- **Migration**
  - If you imported these helpers from better-auth internal paths, switch to @better-auth/core/context.

<!-- End of auto-generated description by cubic. -->

