### PR TITLE
e2e: add coverage for additional fields

### DIFF
--- a/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/user-additional-fields.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/user-additional-fields.ts
@@ -1,0 +1,28 @@
+import { betterAuth } from "better-auth";
+import Database from "better-sqlite3";
+
+const auth = betterAuth({
+	database: new Database("./sqlite.db"),
+	trustedOrigins: [],
+	emailAndPassword: {
+		enabled: true,
+	},
+	user: {
+		additionalFields: {
+			timeZone: {
+				type: "string",
+				required: true,
+			},
+		},
+	},
+});
+
+// expect no error here because timeZone is optional
+await auth.api.signUpEmail({
+	body: {
+		email: "",
+		password: "",
+		name: "",
+		timeZone: "",
+	},
+});


### PR DESCRIPTION
Related: https://github.com/better-auth/better-auth/issues/5270
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an e2e fixture to verify user.additionalFields with TypeScript exactOptionalPropertyTypes, ensuring signUpEmail accepts the timeZone field without errors. Connects to better-auth issue #5270 by covering additional field handling in sign-up.

<!-- End of auto-generated description by cubic. -->

