### PR TITLE
chore: add the missing dev script in package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -153,6 +153,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "dev": "tsdown --watch",
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a missing dev script to packages/core/package.json to run tsdown in watch mode. This enables live rebuilds for faster local development.

<!-- End of auto-generated description by cubic. -->

