### PR TITLE
feat(anonymous): support phone number verification for account linking

### DIFF
--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -192,7 +192,8 @@ export const anonymous = (options?: AnonymousOptions) => {
 							ctx.path.startsWith("/magic-link/verify") ||
 							ctx.path.startsWith("/email-otp/verify-email") ||
 							ctx.path.startsWith("/one-tap/callback") ||
-							ctx.path.startsWith("/passkey/verify-authentication")
+							ctx.path.startsWith("/passkey/verify-authentication") ||
+							ctx.path.startsWith("/phone-number/verify")
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {


### PR DESCRIPTION
closes #5232
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enables phone number verification for anonymous account linking by whitelisting the /phone-number/verify route in the auth middleware. This aligns phone-based linking with existing magic link, email OTP, one-tap, and passkey flows.

<!-- End of auto-generated description by cubic. -->

