### PR TITLE
chore: remove duplicate 'type' field from package.json

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -5,7 +5,6 @@
   "description": "Better Auth integration for Expo and React Native applications.",
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/better-auth/better-auth",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the duplicate "type" field from packages/expo/package.json. This prevents conflicting module configuration and avoids build warnings.

<!-- End of auto-generated description by cubic. -->

