### PR TITLE
fix: narrow type for publicKey to use Uint8Array for decoding

### DIFF
--- a/packages/better-auth/src/plugins/passkey/index.ts
+++ b/packages/better-auth/src/plugins/passkey/index.ts
@@ -706,7 +706,7 @@ export const passkey = (options?: PasskeyOptions) => {
 							expectedRPID: getRpID(opts, ctx.context.options.baseURL),
 							credential: {
 								id: passkey.credentialID,
-								publicKey: base64.decode(passkey.publicKey),
+								publicKey: new Uint8Array(base64.decode(passkey.publicKey)),
 								counter: passkey.counter,
 								transports: passkey.transports?.split(
 									",",


### PR DESCRIPTION
after migrating to tsdown which uses rolldown it is casuing a ts type issue which is good since the previous which is unbuild uses rollup which also uses esbuild for transpilation and does not do strictly check for dts generated and type match. so ig from now we can narrow the types like this one to add new Unit8Array since the decode return is - Uint8Array<ArrayBufferLike> which is not the same with Uint8Array<ArrayBuffer> that webauthn is expecting so there is a typecheck issue and the ci is also failing because of this. this also a runtime agnostic. it can run on cf , deno and other runtimes and the api is already supported