### PR TITLE
fix: remove deprecated `ssoClient` export from client plugin

### DIFF
--- a/packages/better-auth/src/client/plugins/index.ts
+++ b/packages/better-auth/src/client/plugins/index.ts
@@ -14,7 +14,6 @@ export * from "../../plugins/email-otp/client";
 export * from "../../plugins/one-tap/client";
 export * from "../../plugins/custom-session/client";
 export * from "./infer-plugin";
-export * from "../../plugins/sso/client";
 export * from "../../plugins/oidc-provider/client";
 export * from "../../plugins/api-key/client";
 export * from "../../plugins/one-time-token/client";


### PR DESCRIPTION
closes #5169
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the deprecated ssoClient export from better-auth/client/plugins to prevent accidental imports. Aligns with the SSO client deprecation tracked in #5169.

<!-- End of auto-generated description by cubic. -->

