### PR TITLE
fix(username): compacity with `exactOptionalPropertyTypes`

### DIFF
--- a/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/username.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/username.ts
@@ -2,13 +2,13 @@ import { betterAuth } from "better-auth";
 import { username } from "better-auth/plugins";
 
 export const auth = betterAuth({
-  emailAndPassword: {
-    enabled: true,
-  },
-  plugins: [
-    username({
-      minUsernameLength: 4,
-      maxUsernameLength: 15,
-    }),
-  ],
+	emailAndPassword: {
+		enabled: true,
+	},
+	plugins: [
+		username({
+			minUsernameLength: 4,
+			maxUsernameLength: 15,
+		}),
+	],
 });

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -9,7 +9,7 @@ import type { Account, InferOptionSchema, User } from "../../types";
 import { setSessionCookie } from "../../cookies";
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import { getSchema, type UsernameSchema } from "./schema";
-import { mergeSchema } from '../../db';
+import { mergeSchema } from "../../db";
 import { USERNAME_ERROR_CODES as ERROR_CODES } from "./error-codes";
 import { createEmailVerificationToken } from "../../api";
 

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -21,7 +21,7 @@ type KyselyDatabaseType = "postgres" | "mysql" | "sqlite" | "mssql";
 type OmitId<T extends { id: unknown }> = Omit<T, "id">;
 type Optional<T> = {
 	[P in keyof T]?: T[P] | undefined;
-}
+};
 
 export type GenerateIdFn = (options: {
 	model: LiteralUnion<DBPreservedModels, string>;


### PR DESCRIPTION
Related: https://github.com/better-auth/better-auth/issues/5218
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Made Better Auth compatible with TypeScript’s exactOptionalPropertyTypes. Updates core hook data types to allow undefined on optional fields, plus small username plugin tweaks and a new e2e fixture.

- **Bug Fixes**
  - Replaced Partial<T> with Optional<T> in hook data (User, Session, Account, Verification) to support exactOptionalPropertyTypes.
  - Updated username plugin: adjust error-code export to named export and fix mergeSchema import path.
  - Added e2e smoke test fixture configured with exactOptionalPropertyTypes to validate the change.

<!-- End of auto-generated description by cubic. -->

