### PR TITLE
fix(drizzle-adapter): correctly handle all operators in AND clause for combined filter and search

### DIFF
--- a/examples/svelte-kit-example/.svelte-kit/ambient.d.ts
+++ b/examples/svelte-kit-example/.svelte-kit/ambient.d.ts
@@ -1,0 +1,357 @@
+
+// this file is generated — do not edit it
+
+
+/// <reference types="@sveltejs/kit" />
+
+/**
+ * Environment variables [loaded by Vite](https://vitejs.dev/guide/env-and-mode.html#env-files) from `.env` files and `process.env`. Like [`$env/dynamic/private`](https://svelte.dev/docs/kit/$env-dynamic-private), this module cannot be imported into client-side code. This module only includes variables that _do not_ begin with [`config.kit.env.publicPrefix`](https://svelte.dev/docs/kit/configuration#env) _and do_ start with [`config.kit.env.privatePrefix`](https://svelte.dev/docs/kit/configuration#env) (if configured).
+ * 
+ * _Unlike_ [`$env/dynamic/private`](https://svelte.dev/docs/kit/$env-dynamic-private), the values exported from this module are statically injected into your bundle at build time, enabling optimisations like dead code elimination.
+ * 
+ * ```ts
+ * import { API_KEY } from '$env/static/private';
+ * ```
+ * 
+ * Note that all environment variables referenced in your code should be declared (for example in an `.env` file), even if they don't have a value until the app is deployed:
+ * 
+ * ```
+ * MY_FEATURE_FLAG=""
+ * ```
+ * 
+ * You can override `.env` values from the command line like so:
+ * 
+ * ```sh
+ * MY_FEATURE_FLAG="enabled" npm run dev
+ * ```
+ */
+declare module '$env/static/private' {
+	export const ACLOCAL_PATH: string;
+	export const ALLUSERSPROFILE: string;
+	export const APPDATA: string;
+	export const CATALINA_HOME: string;
+	export const COMMONPROGRAMFILES: string;
+	export const CommonProgramW6432: string;
+	export const COMPUTERNAME: string;
+	export const COMSPEC: string;
+	export const CONFIG_SITE: string;
+	export const DataGrip: string;
+	export const DISPLAY: string;
+	export const DriverData: string;
+	export const EFC_10672_1592913036: string;
+	export const EXEPATH: string;
+	export const gcc: string;
+	export const HOME: string;
+	export const HOMEDRIVE: string;
+	export const HOMEPATH: string;
+	export const HOSTNAME: string;
+	export const INFOPATH: string;
+	export const INIT_CWD: string;
+	export const JAVA_HOME: string;
+	export const LC_CTYPE: string;
+	export const LOCALAPPDATA: string;
+	export const LOGONSERVER: string;
+	export const MANPATH: string;
+	export const MAVEN_HOME: string;
+	export const MINGW_CHOST: string;
+	export const MINGW_PACKAGE_PREFIX: string;
+	export const MINGW_PREFIX: string;
+	export const Mongosh: string;
+	export const MSYS: string;
+	export const MSYSTEM: string;
+	export const MSYSTEM_CARCH: string;
+	export const MSYSTEM_CHOST: string;
+	export const MSYSTEM_PREFIX: string;
+	export const NODE: string;
+	export const npm_command: string;
+	export const npm_config_frozen_lockfile: string;
+	export const npm_config_link_workspace_packages: string;
+	export const npm_config_node_gyp: string;
+	export const npm_config_node_linker: string;
+	export const npm_config_registry: string;
+	export const npm_config_user_agent: string;
+	export const npm_execpath: string;
+	export const npm_lifecycle_event: string;
+	export const npm_lifecycle_script: string;
+	export const npm_node_execpath: string;
+	export const npm_package_dependencies_better_auth: string;
+	export const npm_package_dependencies_better_sqlite3: string;
+	export const npm_package_dependencies_bits_ui: string;
+	export const npm_package_dependencies_clsx: string;
+	export const npm_package_dependencies_cmdk_sv: string;
+	export const npm_package_dependencies_embla_carousel_svelte: string;
+	export const npm_package_dependencies_formsnap: string;
+	export const npm_package_dependencies_mode_watcher: string;
+	export const npm_package_dependencies_paneforge: string;
+	export const npm_package_dependencies_sveltekit_superforms: string;
+	export const npm_package_dependencies_svelte_radix: string;
+	export const npm_package_dependencies_svelte_sonner: string;
+	export const npm_package_dependencies_tailwind_merge: string;
+	export const npm_package_dependencies_tailwind_variants: string;
+	export const npm_package_dependencies_vaul_svelte: string;
+	export const npm_package_dependencies_zod: string;
+	export const npm_package_dependencies__internationalized_date: string;
+	export const npm_package_dependencies__types_better_sqlite3: string;
+	export const npm_package_devDependencies_autoprefixer: string;
+	export const npm_package_devDependencies_svelte: string;
+	export const npm_package_devDependencies_svelte_check: string;
+	export const npm_package_devDependencies_tailwindcss: string;
+	export const npm_package_devDependencies_typescript: string;
+	export const npm_package_devDependencies_vite: string;
+	export const npm_package_devDependencies__better_auth_cli: string;
+	export const npm_package_devDependencies__sveltejs_adapter_auto: string;
+	export const npm_package_devDependencies__sveltejs_kit: string;
+	export const npm_package_devDependencies__sveltejs_vite_plugin_svelte: string;
+	export const npm_package_devDependencies__tailwindcss_typography: string;
+	export const npm_package_name: string;
+	export const npm_package_private: string;
+	export const npm_package_scripts_build: string;
+	export const npm_package_scripts_check: string;
+	export const npm_package_scripts_check_watch: string;
+	export const npm_package_scripts_dev: string;
+	export const npm_package_scripts_migrate: string;
+	export const npm_package_scripts_prepare: string;
+	export const npm_package_scripts_preview: string;
+	export const npm_package_type: string;
+	export const npm_package_version: string;
+	export const NUMBER_OF_PROCESSORS: string;
+	export const NVM_BIN: string;
+	export const NVM_CD_FLAGS: string;
+	export const NVM_DIR: string;
+	export const NVM_HOME: string;
+	export const NVM_INC: string;
+	export const NVM_SYMLINK: string;
+	export const OLDPWD: string;
+	export const OneDrive: string;
+	export const OneDriveConsumer: string;
+	export const OPENAI_API_KEY: string;
+	export const ORIGINAL_PATH: string;
+	export const ORIGINAL_TEMP: string;
+	export const ORIGINAL_TMP: string;
+	export const OS: string;
+	export const PATH: string;
+	export const PATHEXT: string;
+	export const PKG_CONFIG_PATH: string;
+	export const PKG_CONFIG_SYSTEM_INCLUDE_PATH: string;
+	export const PKG_CONFIG_SYSTEM_LIBRARY_PATH: string;
+	export const PLINK_PROTOCOL: string;
+	export const PNPM_HOME: string;
+	export const PNPM_SCRIPT_SRC_DIR: string;
+	export const PROCESSOR_ARCHITECTURE: string;
+	export const PROCESSOR_IDENTIFIER: string;
+	export const PROCESSOR_LEVEL: string;
+	export const PROCESSOR_REVISION: string;
+	export const ProgramData: string;
+	export const PROGRAMFILES: string;
+	export const ProgramW6432: string;
+	export const PROMPT: string;
+	export const PSModulePath: string;
+	export const PUBLIC: string;
+	export const PWD: string;
+	export const SESSIONNAME: string;
+	export const SHELL: string;
+	export const SHLVL: string;
+	export const SSH_ASKPASS: string;
+	export const SYSTEMDRIVE: string;
+	export const SYSTEMROOT: string;
+	export const TEMP: string;
+	export const TERM: string;
+	export const TERM_PROGRAM: string;
+	export const TERM_PROGRAM_VERSION: string;
+	export const TMP: string;
+	export const TMPDIR: string;
+	export const USERDOMAIN: string;
+	export const USERDOMAIN_ROAMINGPROFILE: string;
+	export const USERNAME: string;
+	export const USERPROFILE: string;
+	export const WINDIR: string;
+	export const ZES_ENABLE_SYSMAN: string;
+}
+
+/**
+ * Similar to [`$env/static/private`](https://svelte.dev/docs/kit/$env-static-private), except that it only includes environment variables that begin with [`config.kit.env.publicPrefix`](https://svelte.dev/docs/kit/configuration#env) (which defaults to `PUBLIC_`), and can therefore safely be exposed to client-side code.
+ * 
+ * Values are replaced statically at build time.
+ * 
+ * ```ts
+ * import { PUBLIC_BASE_URL } from '$env/static/public';
+ * ```
+ */
+declare module '$env/static/public' {
+	
+}
+
+/**
+ * This module provides access to runtime environment variables, as defined by the platform you're running on. For example if you're using [`adapter-node`](https://github.com/sveltejs/kit/tree/main/packages/adapter-node) (or running [`vite preview`](https://svelte.dev/docs/kit/cli)), this is equivalent to `process.env`. This module only includes variables that _do not_ begin with [`config.kit.env.publicPrefix`](https://svelte.dev/docs/kit/configuration#env) _and do_ start with [`config.kit.env.privatePrefix`](https://svelte.dev/docs/kit/configuration#env) (if configured).
+ * 
+ * This module cannot be imported into client-side code.
+ * 
+ * ```ts
+ * import { env } from '$env/dynamic/private';
+ * console.log(env.DEPLOYMENT_SPECIFIC_VARIABLE);
+ * ```
+ * 
+ * > [!NOTE] In `dev`, `$env/dynamic` always includes environment variables from `.env`. In `prod`, this behavior will depend on your adapter.
+ */
+declare module '$env/dynamic/private' {
+	export const env: {
+		ACLOCAL_PATH: string;
+		ALLUSERSPROFILE: string;
+		APPDATA: string;
+		CATALINA_HOME: string;
+		COMMONPROGRAMFILES: string;
+		CommonProgramW6432: string;
+		COMPUTERNAME: string;
+		COMSPEC: string;
+		CONFIG_SITE: string;
+		DataGrip: string;
+		DISPLAY: string;
+		DriverData: string;
+		EFC_10672_1592913036: string;
+		EXEPATH: string;
+		gcc: string;
+		HOME: string;
+		HOMEDRIVE: string;
+		HOMEPATH: string;
+		HOSTNAME: string;
+		INFOPATH: string;
+		INIT_CWD: string;
+		JAVA_HOME: string;
+		LC_CTYPE: string;
+		LOCALAPPDATA: string;
+		LOGONSERVER: string;
+		MANPATH: string;
+		MAVEN_HOME: string;
+		MINGW_CHOST: string;
+		MINGW_PACKAGE_PREFIX: string;
+		MINGW_PREFIX: string;
+		Mongosh: string;
+		MSYS: string;
+		MSYSTEM: string;
+		MSYSTEM_CARCH: string;
+		MSYSTEM_CHOST: string;
+		MSYSTEM_PREFIX: string;
+		NODE: string;
+		npm_command: string;
+		npm_config_frozen_lockfile: string;
+		npm_config_link_workspace_packages: string;
+		npm_config_node_gyp: string;
+		npm_config_node_linker: string;
+		npm_config_registry: string;
+		npm_config_user_agent: string;
+		npm_execpath: string;
+		npm_lifecycle_event: string;
+		npm_lifecycle_script: string;
+		npm_node_execpath: string;
+		npm_package_dependencies_better_auth: string;
+		npm_package_dependencies_better_sqlite3: string;
+		npm_package_dependencies_bits_ui: string;
+		npm_package_dependencies_clsx: string;
+		npm_package_dependencies_cmdk_sv: string;
+		npm_package_dependencies_embla_carousel_svelte: string;
+		npm_package_dependencies_formsnap: string;
+		npm_package_dependencies_mode_watcher: string;
+		npm_package_dependencies_paneforge: string;
+		npm_package_dependencies_sveltekit_superforms: string;
+		npm_package_dependencies_svelte_radix: string;
+		npm_package_dependencies_svelte_sonner: string;
+		npm_package_dependencies_tailwind_merge: string;
+		npm_package_dependencies_tailwind_variants: string;
+		npm_package_dependencies_vaul_svelte: string;
+		npm_package_dependencies_zod: string;
+		npm_package_dependencies__internationalized_date: string;
+		npm_package_dependencies__types_better_sqlite3: string;
+		npm_package_devDependencies_autoprefixer: string;
+		npm_package_devDependencies_svelte: string;
+		npm_package_devDependencies_svelte_check: string;
+		npm_package_devDependencies_tailwindcss: string;
+		npm_package_devDependencies_typescript: string;
+		npm_package_devDependencies_vite: string;
+		npm_package_devDependencies__better_auth_cli: string;
+		npm_package_devDependencies__sveltejs_adapter_auto: string;
+		npm_package_devDependencies__sveltejs_kit: string;
+		npm_package_devDependencies__sveltejs_vite_plugin_svelte: string;
+		npm_package_devDependencies__tailwindcss_typography: string;
+		npm_package_name: string;
+		npm_package_private: string;
+		npm_package_scripts_build: string;
+		npm_package_scripts_check: string;
+		npm_package_scripts_check_watch: string;
+		npm_package_scripts_dev: string;
+		npm_package_scripts_migrate: string;
+		npm_package_scripts_prepare: string;
+		npm_package_scripts_preview: string;
+		npm_package_type: string;
+		npm_package_version: string;
+		NUMBER_OF_PROCESSORS: string;
+		NVM_BIN: string;
+		NVM_CD_FLAGS: string;
+		NVM_DIR: string;
+		NVM_HOME: string;
+		NVM_INC: string;
+		NVM_SYMLINK: string;
+		OLDPWD: string;
+		OneDrive: string;
+		OneDriveConsumer: string;
+		OPENAI_API_KEY: string;
+		ORIGINAL_PATH: string;
+		ORIGINAL_TEMP: string;
+		ORIGINAL_TMP: string;
+		OS: string;
+		PATH: string;
+		PATHEXT: string;
+		PKG_CONFIG_PATH: string;
+		PKG_CONFIG_SYSTEM_INCLUDE_PATH: string;
+		PKG_CONFIG_SYSTEM_LIBRARY_PATH: string;
+		PLINK_PROTOCOL: string;
+		PNPM_HOME: string;
+		PNPM_SCRIPT_SRC_DIR: string;
+		PROCESSOR_ARCHITECTURE: string;
+		PROCESSOR_IDENTIFIER: string;
+		PROCESSOR_LEVEL: string;
+		PROCESSOR_REVISION: string;
+		ProgramData: string;
+		PROGRAMFILES: string;
+		ProgramW6432: string;
+		PROMPT: string;
+		PSModulePath: string;
+		PUBLIC: string;
+		PWD: string;
+		SESSIONNAME: string;
+		SHELL: string;
+		SHLVL: string;
+		SSH_ASKPASS: string;
+		SYSTEMDRIVE: string;
+		SYSTEMROOT: string;
+		TEMP: string;
+		TERM: string;
+		TERM_PROGRAM: string;
+		TERM_PROGRAM_VERSION: string;
+		TMP: string;
+		TMPDIR: string;
+		USERDOMAIN: string;
+		USERDOMAIN_ROAMINGPROFILE: string;
+		USERNAME: string;
+		USERPROFILE: string;
+		WINDIR: string;
+		ZES_ENABLE_SYSMAN: string;
+		[key: `PUBLIC_${string}`]: undefined;
+		[key: `${string}`]: string | undefined;
+	}
+}
+
+/**
+ * Similar to [`$env/dynamic/private`](https://svelte.dev/docs/kit/$env-dynamic-private), but only includes variables that begin with [`config.kit.env.publicPrefix`](https://svelte.dev/docs/kit/configuration#env) (which defaults to `PUBLIC_`), and can therefore safely be exposed to client-side code.
+ * 
+ * Note that public dynamic environment variables must all be sent from the server to the client, causing larger network requests — when possible, use `$env/static/public` instead.
+ * 
+ * ```ts
+ * import { env } from '$env/dynamic/public';
+ * console.log(env.PUBLIC_DEPLOYMENT_SPECIFIC_VARIABLE);
+ * ```
+ */
+declare module '$env/dynamic/public' {
+	export const env: {
+		[key: `PUBLIC_${string}`]: string | undefined;
+	}
+}

--- a/examples/svelte-kit-example/.svelte-kit/non-ambient.d.ts
+++ b/examples/svelte-kit-example/.svelte-kit/non-ambient.d.ts
@@ -1,0 +1,47 @@
+
+// this file is generated — do not edit it
+
+
+declare module "svelte/elements" {
+	export interface HTMLAttributes<T> {
+		'data-sveltekit-keepfocus'?: true | '' | 'off' | undefined | null;
+		'data-sveltekit-noscroll'?: true | '' | 'off' | undefined | null;
+		'data-sveltekit-preload-code'?:
+			| true
+			| ''
+			| 'eager'
+			| 'viewport'
+			| 'hover'
+			| 'tap'
+			| 'off'
+			| undefined
+			| null;
+		'data-sveltekit-preload-data'?: true | '' | 'hover' | 'tap' | 'off' | undefined | null;
+		'data-sveltekit-reload'?: true | '' | 'off' | undefined | null;
+		'data-sveltekit-replacestate'?: true | '' | 'off' | undefined | null;
+	}
+}
+
+export {};
+
+
+declare module "$app/types" {
+	export interface AppTypes {
+		RouteId(): "/(protected)" | "/" | "/(protected)/dashboard" | "/forget-password" | "/reset-password" | "/sign-in" | "/sign-up";
+		RouteParams(): {
+			
+		};
+		LayoutParams(): {
+			"/(protected)": Record<string, never>;
+			"/": Record<string, never>;
+			"/(protected)/dashboard": Record<string, never>;
+			"/forget-password": Record<string, never>;
+			"/reset-password": Record<string, never>;
+			"/sign-in": Record<string, never>;
+			"/sign-up": Record<string, never>
+		};
+		Pathname(): "/" | "/dashboard" | "/dashboard/" | "/forget-password" | "/forget-password/" | "/reset-password" | "/reset-password/" | "/sign-in" | "/sign-in/" | "/sign-up" | "/sign-up/";
+		ResolvedPathname(): `${"" | `/${string}`}${ReturnType<AppTypes['Pathname']>}`;
+		Asset(): "/favicon.png" | string & {};
+	}
+}

--- a/examples/svelte-kit-example/.svelte-kit/tsconfig.json
+++ b/examples/svelte-kit-example/.svelte-kit/tsconfig.json
@@ -1,0 +1,52 @@
+{
+	"compilerOptions": {
+		"paths": {
+			"$lib": [
+				"../src/lib"
+			],
+			"$lib/*": [
+				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
+			]
+		},
+		"rootDirs": [
+			"..",
+			"./types"
+		],
+		"verbatimModuleSyntax": true,
+		"isolatedModules": true,
+		"lib": [
+			"esnext",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"moduleResolution": "bundler",
+		"module": "esnext",
+		"noEmit": true,
+		"target": "esnext"
+	},
+	"include": [
+		"ambient.d.ts",
+		"non-ambient.d.ts",
+		"./types/**/$types.d.ts",
+		"../vite.config.js",
+		"../vite.config.ts",
+		"../src/**/*.js",
+		"../src/**/*.ts",
+		"../src/**/*.svelte",
+		"../tests/**/*.js",
+		"../tests/**/*.ts",
+		"../tests/**/*.svelte"
+	],
+	"exclude": [
+		"../node_modules/**",
+		"../src/service-worker.js",
+		"../src/service-worker/**/*.js",
+		"../src/service-worker.ts",
+		"../src/service-worker/**/*.ts",
+		"../src/service-worker.d.ts",
+		"../src/service-worker/**/*.d.ts"
+	]
+}

--- a/examples/svelte-kit-example/.svelte-kit/types/route_meta_data.json
+++ b/examples/svelte-kit-example/.svelte-kit/types/route_meta_data.json
@@ -1,0 +1,8 @@
+{
+	"/": [],
+	"/(protected)/dashboard": [],
+	"/forget-password": [],
+	"/reset-password": [],
+	"/sign-in": [],
+	"/sign-up": []
+}

--- a/examples/svelte-kit-example/.svelte-kit/types/src/routes/$types.d.ts
+++ b/examples/svelte-kit-example/.svelte-kit/types/src/routes/$types.d.ts
@@ -1,0 +1,24 @@
+import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+// @ts-ignore
+type MatcherParam<M> = M extends (param : string) => param is infer U ? U extends string ? U : string : string;
+type RouteParams = {  };
+type RouteId = '/';
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+export type Snapshot<T = any> = Kit.Snapshot<T>;
+type PageParentData = EnsureDefined<LayoutData>;
+type LayoutRouteId = RouteId | "/" | "/(protected)/dashboard" | "/forget-password" | "/reset-password" | "/sign-in" | "/sign-up" | null
+type LayoutParams = RouteParams & {  }
+type LayoutParentData = EnsureDefined<{}>;
+
+export type PageServerData = null;
+export type PageData = Expand<PageParentData>;
+export type PageProps = { params: RouteParams; data: PageData }
+export type LayoutServerData = null;
+export type LayoutData = Expand<LayoutParentData>;
+export type LayoutProps = { params: LayoutParams; data: LayoutData; children: import("svelte").Snippet }

--- a/examples/svelte-kit-example/.svelte-kit/types/src/routes/(protected)/dashboard/$types.d.ts
+++ b/examples/svelte-kit-example/.svelte-kit/types/src/routes/(protected)/dashboard/$types.d.ts
@@ -1,0 +1,18 @@
+import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+// @ts-ignore
+type MatcherParam<M> = M extends (param : string) => param is infer U ? U extends string ? U : string : string;
+type RouteParams = {  };
+type RouteId = '/(protected)/dashboard';
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+export type Snapshot<T = any> = Kit.Snapshot<T>;
+type PageParentData = EnsureDefined<import('../../$types.js').LayoutData>;
+
+export type PageServerData = null;
+export type PageData = Expand<PageParentData>;
+export type PageProps = { params: RouteParams; data: PageData }

--- a/examples/svelte-kit-example/.svelte-kit/types/src/routes/forget-password/$types.d.ts
+++ b/examples/svelte-kit-example/.svelte-kit/types/src/routes/forget-password/$types.d.ts
@@ -1,0 +1,18 @@
+import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+// @ts-ignore
+type MatcherParam<M> = M extends (param : string) => param is infer U ? U extends string ? U : string : string;
+type RouteParams = {  };
+type RouteId = '/forget-password';
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+export type Snapshot<T = any> = Kit.Snapshot<T>;
+type PageParentData = EnsureDefined<import('../$types.js').LayoutData>;
+
+export type PageServerData = null;
+export type PageData = Expand<PageParentData>;
+export type PageProps = { params: RouteParams; data: PageData }

--- a/examples/svelte-kit-example/.svelte-kit/types/src/routes/reset-password/$types.d.ts
+++ b/examples/svelte-kit-example/.svelte-kit/types/src/routes/reset-password/$types.d.ts
@@ -1,0 +1,18 @@
+import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+// @ts-ignore
+type MatcherParam<M> = M extends (param : string) => param is infer U ? U extends string ? U : string : string;
+type RouteParams = {  };
+type RouteId = '/reset-password';
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+export type Snapshot<T = any> = Kit.Snapshot<T>;
+type PageParentData = EnsureDefined<import('../$types.js').LayoutData>;
+
+export type PageServerData = null;
+export type PageData = Expand<PageParentData>;
+export type PageProps = { params: RouteParams; data: PageData }

--- a/examples/svelte-kit-example/.svelte-kit/types/src/routes/sign-in/$types.d.ts
+++ b/examples/svelte-kit-example/.svelte-kit/types/src/routes/sign-in/$types.d.ts
@@ -1,0 +1,18 @@
+import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+// @ts-ignore
+type MatcherParam<M> = M extends (param : string) => param is infer U ? U extends string ? U : string : string;
+type RouteParams = {  };
+type RouteId = '/sign-in';
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+export type Snapshot<T = any> = Kit.Snapshot<T>;
+type PageParentData = EnsureDefined<import('../$types.js').LayoutData>;
+
+export type PageServerData = null;
+export type PageData = Expand<PageParentData>;
+export type PageProps = { params: RouteParams; data: PageData }

--- a/examples/svelte-kit-example/.svelte-kit/types/src/routes/sign-up/$types.d.ts
+++ b/examples/svelte-kit-example/.svelte-kit/types/src/routes/sign-up/$types.d.ts
@@ -1,0 +1,18 @@
+import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+// @ts-ignore
+type MatcherParam<M> = M extends (param : string) => param is infer U ? U extends string ? U : string : string;
+type RouteParams = {  };
+type RouteId = '/sign-up';
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+export type Snapshot<T = any> = Kit.Snapshot<T>;
+type PageParentData = EnsureDefined<import('../$types.js').LayoutData>;
+
+export type PageServerData = null;
+export type PageData = Expand<PageParentData>;
+export type PageProps = { params: RouteParams; data: PageData }

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -234,28 +234,53 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				);
 				const orGroup = where.filter((w) => w.connector === "OR");
 
-				const andClause = and(
-					...andGroup.map((w) => {
-						const field = getFieldName({ model, field: w.field });
-						if (w.operator === "in") {
-							if (!Array.isArray(w.value)) {
-								throw new BetterAuthError(
-									`The value for the field "${w.field}" must be an array when using the "in" operator.`,
-								);
-							}
-							return inArray(schemaModel[field], w.value);
-						}
-						if (w.operator === "not_in") {
-							if (!Array.isArray(w.value)) {
-								throw new BetterAuthError(
-									`The value for the field "${w.field}" must be an array when using the "not_in" operator.`,
-								);
-							}
-							return notInArray(schemaModel[field], w.value);
-						}
-						return eq(schemaModel[field], w.value);
-					}),
-				);
+				const andClause = and(  
+					...andGroup.map((w) => {  
+						const field = getFieldName({ model, field: w.field });  
+						if (w.operator === "in") {  
+						if (!Array.isArray(w.value)) {  
+							throw new BetterAuthError(  
+							`The value for the field "${w.field}" must be an array when using the "in" operator.`,  
+							);  
+						}  
+						return inArray(schemaModel[field], w.value);  
+						}  
+						if (w.operator === "not_in") {  
+						if (!Array.isArray(w.value)) {  
+							throw new BetterAuthError(  
+							`The value for the field "${w.field}" must be an array when using the "not_in" operator.`,  
+							);  
+						}  
+						return notInArray(schemaModel[field], w.value);  
+						}  
+						// ADD THESE CASES:  
+						if (w.operator === "contains") {  
+						return like(schemaModel[field], `%${w.value}%`);  
+						}  
+						if (w.operator === "starts_with") {  
+						return like(schemaModel[field], `${w.value}%`);  
+						}  
+						if (w.operator === "ends_with") {  
+						return like(schemaModel[field], `%${w.value}`);  
+						}  
+						if (w.operator === "lt") {  
+						return lt(schemaModel[field], w.value);  
+						}  
+						if (w.operator === "lte") {  
+						return lte(schemaModel[field], w.value);  
+						}  
+						if (w.operator === "ne") {  
+						return ne(schemaModel[field], w.value);  
+						}  
+						if (w.operator === "gt") {  
+						return gt(schemaModel[field], w.value);  
+						}  
+						if (w.operator === "gte") {  
+						return gte(schemaModel[field], w.value);  
+						}  
+						return eq(schemaModel[field], w.value);  
+					}),  
+					);
 				const orClause = or(
 					...orGroup.map((w) => {
 						const field = getFieldName({ model, field: w.field });

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -355,6 +355,25 @@ describe("Admin plugin", async () => {
 		expect(res.data?.users[0]!.email).toBe("test@test.com");
 	});
 
+	it("should allow to filter and search users simultaneously", async () => {  
+		const res = await client.admin.listUsers({  
+			query: {  
+			filterValue: "admin",  
+			filterField: "role",  
+			filterOperator: "eq",  
+			searchValue: "Admin",  
+			searchField: "name",  
+			searchOperator: "contains",  
+			},  
+			fetchOptions: {  
+			headers: adminHeaders,  
+			},  
+		});  
+		expect(res.data?.users.length).toBe(1);  
+		expect(res.data?.users[0]!.role).toBe("admin");  
+		expect(res.data?.users[0]!.name).toContain("Admin");  
+	});
+
 	it("should allow to set user role", async () => {
 		const res = await client.admin.setRole(
 			{
@@ -804,6 +823,7 @@ describe("Admin plugin", async () => {
 		expect(res.error?.status).toBe(403);
 		expect(res.error?.code).toBe("YOU_ARE_NOT_ALLOWED_TO_UPDATE_USERS");
 	});
+
 });
 
 describe("access control", async (it) => {


### PR DESCRIPTION
This PR fixes an issue in the Drizzle adapter where combining **filter** and **search** parameters in the `/admin/list-users` endpoint returned **zero results**, even when matching records existed.

#### **Root Cause**

The `convertWhereClause` function in
`packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts`
only handled a limited subset of operators (`eq`, `in`, `not_in`) when multiple `AND` conditions were present.

As a result, operators like `contains`, `starts_with`, and `ends_with` (used for search queries) were incorrectly treated as equality checks, causing the generated SQL to fail to match expected results.

#### **Fix**

* Extended the `andGroup.map()` logic in `convertWhereClause()` to handle **all supported operators**:

  * `contains`, `starts_with`, `ends_with`
  * `lt`, `lte`, `ne`, `gt`, `gte`
* Ensured multi-condition queries now behave consistently with single-condition logic.

#### **Example (Before vs After)**

**Before (bug):**

```ts
GET /admin/list-users?filterField=role&filterValue=admin&searchField=email&searchValue=mark
// ❌ Returned 0 results
```

**After (fixed):**
```ts
// working on test cases, cuz I'm having a problem while testing with plugins (serialized error) and adapters errors and not passing
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the Drizzle adapter so all operators in AND groups are handled correctly, restoring expected results when combining filter and search in /admin/list-users. Multi-condition queries no longer return zero results.

- **Bug Fixes**
  - Updated convertWhereClause to support contains, starts_with, ends_with, lt, lte, ne, gt, gte alongside in/not_in, mapping to the correct SQL (like, lt/lte, ne, gt/gte).
  - Added a test for admin.listUsers to verify filter + search works together.

<!-- End of auto-generated description by cubic. -->

