### PR TITLE
docs: cleanup sidebar ui

### DIFF
--- a/docs/components/side-bar.tsx
+++ b/docs/components/side-bar.tsx
@@ -89,9 +89,9 @@ export default function ArticleLayout() {
 												initial={{ opacity: 0, height: 0 }}
 												animate={{ opacity: 1, height: "auto" }}
 												exit={{ opacity: 0, height: 0 }}
-												className="relative overflow-hidden mb-2"
+												className="relative overflow-hidden"
 											>
-												<motion.div className="text-sm">
+												<motion.div className="text-sm mb-2">
 													{item.list.map((listItem, j) => (
 														<div key={listItem.title}>
 															<Suspense fallback={<>Loading...</>}>


### PR DESCRIPTION
Cleaned up the Docs sidebar UI:
- Aligned the border color with NavbarMobile.
- Adjusted borders to wrap sections when expanded.
- Added a small margin at the bottom of expanded sections for better readability.

### Before

https://github.com/user-attachments/assets/a9ccd6a4-6ffa-4d06-9a0a-9ab63ace7206

### After

https://github.com/user-attachments/assets/ae9aa703-1a31-4045-8169-403422134596



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cleaned up the Docs sidebar UI for consistency and readability. Borders now match NavbarMobile, wrap each expanded section, and an inner margin improves list spacing and smooths the close animation.

<!-- End of auto-generated description by cubic. -->

