### PR TITLE
fix: incorrect context in auth endpoint

### DIFF
--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,11 +1,5 @@
-import {
-	createEndpoint,
-	createMiddleware,
-	type EndpointContext,
-	type EndpointOptions,
-} from "better-call";
+import { createEndpoint, createMiddleware } from "better-call";
 import type { AuthContext } from "../types";
-import { runWithEndpointContext } from "../context";
 
 export const optionsMiddleware = createMiddleware(async () => {
 	/**
@@ -31,27 +25,9 @@ export const createAuthMiddleware = createMiddleware.create({
 	],
 });
 
-const use = [optionsMiddleware];
-
-export const createAuthEndpoint = <
-	Path extends string,
-	Opts extends EndpointOptions,
-	R,
->(
-	path: Path,
-	options: Opts,
-	handler: (ctx: EndpointContext<Path, Opts, AuthContext>) => Promise<R>,
-) => {
-	return createEndpoint(
-		path,
-		{
-			...options,
-			use: [...(options?.use || []), ...use],
-		},
-		// todo: prettify the code, we want to call `runWithEndpointContext` to top level
-		async (ctx) => runWithEndpointContext(ctx as any, () => handler(ctx)),
-	);
-};
+export const createAuthEndpoint = createEndpoint.create({
+	use: [optionsMiddleware],
+});
 
 export type AuthEndpoint = ReturnType<typeof createAuthEndpoint>;
 export type AuthMiddleware = ReturnType<typeof createAuthMiddleware>;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed context propagation in auth endpoints so handlers run with the correct runtime context and headers. Also simplified endpoint creation and aligned with the latest better-call API.

- **Bug Fixes**
  - Run endpoints via wrap to ensure the original handler sees the correct context.
  - Write response headers to context.responseHeaders and append Set-Cookie correctly.
  - Proper error propagation: preserve APIError stack in debug, throw when not asResponse.

- **Refactors**
  - Removed manual InternalContext plumbing; rely on runWithEndpointContext and endpoint.wrap.
  - Switched createAuthEndpoint to createEndpoint.create with default options middleware.
  - Updated better-call to ^1.0.21.

<!-- End of auto-generated description by cubic. -->

