### PR TITLE
docs: add note about redis seconds

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -64,8 +64,10 @@ betterAuth({
 });
 ```
 
-Note: Better Auth uses **seconds** for the TTL value in `set()`.
+<Callout type="warn">
+Better Auth uses **seconds** for the TTL value in `set()`.
 If your storage expects milliseconds, multiply by 1000 when passing the TTL (`ttl * 1000`).
+</Callout>
 
 **Example: Redis Implementation**
 


### PR DESCRIPTION
Added a clarification note in the Secondary Storage documentation about TTL (time-to-live) units.
Better Auth uses seconds for TTL values, while some external storages (like Redis or memory-based stores) may expect milliseconds.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified TTL units in the Secondary Storage docs: Better Auth uses seconds for set() TTL, while some stores expect milliseconds. Added a note and updated the Redis example comment to show how to convert when needed (ttl * 1000).

<!-- End of auto-generated description by cubic. -->

