### PR TITLE
fix(docs/navigation): correct "Next" button navigation from Email & P…

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -472,7 +472,7 @@ export const contents: Content[] = [
 				title: "Social Sign-On",
 				group: true,
 				icon: LucideAArrowDown,
-				href: "",
+				href: "/docs/authentication/apple",
 			},
 			{
 				title: "Apple",


### PR DESCRIPTION
📝 What Changed

Updated the “Social Sign-On” group entry in the docs navigation to include a valid href pointing to the Apple provider page.

This ensures the footer “Next” button on the Email & Password authentication page correctly navigates to the Apple provider documentation instead of staying on the same page.

💡 Why This Change Was Made

The “Next” button in the footer navigation previously did not advance to the next doc page when on /docs/authentication/email-password.

This occurred because the parent “Social Sign-On” group item lacked an href, causing the navigation resolver to return the same page as the next target.

Adding the href provides a valid destination and restores the expected navigation flow between authentication provider pages.

⚙️ Technical Context

Affected file: /better-auth/docs/components/sidebar-content.tsx

The change adds href: "/docs/authentication/apple" to the “Social Sign-On” group definition.

This does not alter sidebar behavior, only fixes footer navigation resolution.

🧠 Additional Notes

No breaking changes or deprecations.

No impact on core library packages — docs-only fix.

Verified locally by running pnpm -F docs dev and confirming correct footer navigation behavior.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the footer “Next” button on the Email & Password docs page by adding a valid href to the “Social Sign-On” group, so it now navigates to the Apple provider documentation.

<!-- End of auto-generated description by cubic. -->

