### PR TITLE
ci: separate lint and type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,80 +1,146 @@
 name: CI
 
 on:
-    pull_request:
-        types:
-          - opened
-          - synchronize
-    push:
-      branches:
-        - main
-        - canary
-    merge_group:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  push:
+    branches:
+      - main
+      - canary
+  merge_group:
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                node-version: [22.x, 24.x]
-        steps:
-            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-              with:
-                    fetch-depth: 0
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
 
-            - name: Cache turbo build setup
-              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-              with:
-                path: .turbo
-                key: ${{ runner.os }}-turbo-${{ github.sha }}
-                restore-keys: |
-                  ${{ runner.os }}-turbo-
+      - name: Cache turbo build setup
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
-            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
-            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-              with:
-                node-version: ${{ matrix.node-version }}
-                registry-url: 'https://registry.npmjs.org'
-                cache: pnpm
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
 
-            - name: Install
-              run: pnpm install
+      - name: Install
+        run: pnpm install
 
-            - name: Build
-              env:
-                TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-                TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-                TURBO_CACHE: remote:rw
-              run: pnpm build
+      - name: Build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+          TURBO_CACHE: remote:rw
+        run: pnpm build
 
-            - name: Start Docker Containers
-              run: |
-                docker compose up -d
-                # Wait for services to be ready (optional)
-                sleep 10
+      - name: Lint
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+          TURBO_CACHE: remote:rw
+        run: pnpm lint
 
-            - name: Lint
-              env:
-                TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-                TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-                TURBO_CACHE: remote:rw
-              run: pnpm lint
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
 
-            - name: Test
-              env:
-                TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-                TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-              run: pnpm test
+      - name: Cache turbo build setup
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
-            - name: Typecheck
-              env:
-                TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-                TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-                TURBO_CACHE: remote:rw
-              run: pnpm typecheck
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
-            - name: Stop Docker Containers
-              run: docker compose down
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install
+
+      - name: Build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+          TURBO_CACHE: remote:rw
+        run: pnpm build
+
+      - name: Typecheck
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+          TURBO_CACHE: remote:rw
+        run: pnpm typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [ 22.x, 24.x, 25.x ]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Cache turbo build setup
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install
+
+      - name: Build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+          TURBO_CACHE: remote:rw
+        run: pnpm build
+
+      - name: Start Docker Containers
+        run: |
+          docker compose up -d
+          # Wait for services to be ready (optional)
+          sleep 10
+
+      - name: Test
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+        run: pnpm test
+
+      - name: Stop Docker Containers
+        run: docker compose down
             


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Split CI into separate lint, typecheck, and test jobs. This makes failures clearer and speeds up feedback by running jobs in parallel.

- **Refactors**
  - Added standalone lint job (Node 22.x) with install, build, and lint.
  - Added standalone typecheck job (Node 22.x) with install, build, and typecheck.
  - Updated test job to a Node matrix (22.x, 24.x, 25.x); runs Docker only here.
  - Removed lint and typecheck from the test job.
  - Kept Turbo remote cache for build/lint/typecheck to improve performance.

<!-- End of auto-generated description by cubic. -->

