### PR TITLE
docs: use `createFileRoute` in installation.mdx for tanstack-start

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -403,17 +403,21 @@ Create a new file or route in your framework's designated catch-all route handle
     </Tab>
     <Tab value="tanstack-start">
     ```ts title="src/routes/api/auth/$.ts"
-    import { auth } from '~/lib/server/auth'
-    import { createServerFileRoute } from '@tanstack/react-start/server'
+    import { auth } from '@/lib/auth'
+    import { createFileRoute } from '@tanstack/react-router'
 
-    export const ServerRoute = createServerFileRoute('/api/auth/$').methods({
-    GET: ({ request }) => {
-        return auth.handler(request)
-    },
-    POST: ({ request }) => {
-        return auth.handler(request)
-    },
-    });
+    export const Route = createFileRoute('/api/auth/$')({
+        server: {
+            handlers: {
+                GET: ({ request }) => {
+                    return auth.handler(request)
+                },
+                POST: ({ request }) => {
+                    return auth.handler(request)
+                },
+            },
+        },
+    })
     ```
     </Tab>
     <Tab value="expo">


### PR DESCRIPTION
Similar to #4885 but for installation.mdx
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update installation.mdx (TanStack Start) to use createFileRoute from @tanstack/react-router with server.handlers for GET/POST, replacing createServerFileRoute. Also update the import to '@/lib/auth' and export Route to match the current API and examples.

<!-- End of auto-generated description by cubic. -->

