### PR TITLE
[rolldown bug]: JavaScript heap OOM

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "downlevelIteration": true,
-    "baseUrl": ".",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "verbatimModuleSyntax": true,
@@ -13,7 +11,11 @@
     "exactOptionalPropertyTypes": false,
     "incremental": true,
     "noErrorTruncation": true,
-    "types": ["node", "bun"]
+    "paths": {
+      "@better-auth/core": ["./packages/core/src"],
+      "@better-auth/core/*": ["./packages/core/src/*"]
+    }
   },
-  "exclude": ["**/dist/**", "**/node_modules/**"]
+  "include": [],
+  "files": []
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes rolldown JavaScript heap OOM by shrinking the TypeScript project scope and adding a path alias for internal imports.

- **Bug Fixes**
  - Added tsconfig “paths” for @better-auth/core to resolve to packages/core/src.
  - Set “include” and “files” to empty arrays to prevent repo-wide type scanning during builds.
  - Removed unused options (baseUrl, downlevelIteration, types) to simplify the config.

<!-- End of auto-generated description by cubic. -->

