### PR TITLE
fix(stripe): stripe error codes should be returned from the plugin

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1399,6 +1399,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 			};
 		},
 		schema: getSchema(options),
+		$ERROR_CODES: STRIPE_ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
 


### PR DESCRIPTION
closes #5098 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Exposes Stripe error codes from the plugin via $ERROR_CODES. This lets clients handle specific Stripe failures reliably without parsing error messages.

<!-- End of auto-generated description by cubic. -->

