### PR TITLE
docs: update tanstack installation example

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -403,17 +403,21 @@ Create a new file or route in your framework's designated catch-all route handle
     </Tab>
     <Tab value="tanstack-start">
     ```ts title="src/routes/api/auth/$.ts"
-    import { auth } from '~/lib/server/auth'
-    import { createServerFileRoute } from '@tanstack/react-start/server'
+    import { createFileRoute } from '@tanstack/react-router'
+    import { auth } from '@/lib/auth/auth'
 
-    export const ServerRoute = createServerFileRoute('/api/auth/$').methods({
-    GET: ({ request }) => {
-        return auth.handler(request)
+    export const Route = createFileRoute('/api/auth/$')({
+    server: {
+        handlers: {
+            GET: async ({ request }:{ request: Request }) => {
+                return await auth.handler(request)
+            },
+            POST: async ({ request }:{ request: Request }) => {
+                return await auth.handler(request)
+            },
+        },
     },
-    POST: ({ request }) => {
-        return auth.handler(request)
-    },
-    });
+    })
     ```
     </Tab>
     <Tab value="expo">


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Corrected the TanStack Router installation docs to use createFileRoute with server handlers for /api/auth/$, matching the current API. This prevents errors when copying the example.

- **Bug Fixes**
  - Switched from @tanstack/react-start/server to @tanstack/react-router with server.handlers (GET/POST).
  - Updated imports and added Request type annotations in the example.

<!-- End of auto-generated description by cubic. -->

