### PR TITLE
fix(anonymous): Provide `ctx` on accountLink

### DIFF
--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -3,7 +3,10 @@ import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
-import type { BetterAuthPlugin } from "@better-auth/core";
+import type {
+	BetterAuthPlugin,
+	GenericEndpointContext,
+} from "@better-auth/core";
 import type { InferOptionSchema, Session, User } from "../../types";
 import { parseSetCookieHeader, setSessionCookie } from "../../cookies";
 import { getOrigin } from "../../utils/url";
@@ -37,6 +40,7 @@ export interface AnonymousOptions {
 			user: User & Record<string, any>;
 			session: Session & Record<string, any>;
 		};
+		ctx: GenericEndpointContext;
 	}) => Promise<void> | void;
 	/**
 	 * Disable deleting the anonymous user after linking
@@ -242,6 +246,7 @@ export const anonymous = (options?: AnonymousOptions) => {
 							await options?.onLinkAccount?.({
 								anonymousUser: session,
 								newUser: newSession,
+								ctx,
 							});
 						}
 						if (!options?.disableDeleteAnonymousUser) {


### PR DESCRIPTION
linear:
https://linear.app/better-auth/issue/ENG-459/fix-pass-ctx-to-anonymous-plugins-onlinkaccount
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Pass ctx (GenericEndpointContext) to the anonymous plugin’s onLinkAccount callback so plugins can use request context during account linking. Addresses Linear ENG-459, enabling access to headers/cookies when linking.

<!-- End of auto-generated description by cubic. -->

