### PR TITLE
fix: add optional chaining for process.platform

### DIFF
--- a/packages/core/src/env/color-depth.ts
+++ b/packages/core/src/env/color-depth.ts
@@ -88,7 +88,7 @@ export function getColorDepth(): number {
 		return COLORS_2;
 	}
 
-	if (typeof process !== "undefined" && process.platform === "win32") {
+	if (typeof process !== "undefined" && process?.platform === "win32") {
 		// Windows 10 build 14931 (from 2016) has true color support
 		return COLORS_16m;
 	}


### PR DESCRIPTION
Added optional chaining to `process.platform` check. Prevents errors in edge environments where `process` may be undefined.

Consistent with existing codebase:  
https://github.com/better-auth/better-auth/blob/canary/packages/telemetry/src/detectors/detect-system-info.ts#L151

Closes https://github.com/better-auth/better-auth/issues/5376

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Safely check process.platform in getColorDepth using optional chaining to prevent crashes in edge runtimes where process may be undefined. Keeps Windows true-color detection intact. Closes #5376.

<!-- End of auto-generated description by cubic. -->

