### PR TITLE
test: fix issue with msw

### DIFF
--- a/packages/better-auth/vitest.config.ts
+++ b/packages/better-auth/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
+		setupFiles: ["./vitest.setup.ts"],
 		poolOptions: {
 			forks: {
 				execArgv: ["--expose-gc"],

--- a/packages/better-auth/vitest.setup.ts
+++ b/packages/better-auth/vitest.setup.ts
@@ -1,0 +1,7 @@
+if (
+	typeof globalThis.localStorage !== "undefined" &&
+	+process.versions.node.split(".")[0]! >= 25
+) {
+	// @ts-expect-error
+	globalThis.localStorage = undefined;
+}


### PR DESCRIPTION
Fixes: https://github.com/mswjs/msw/issues/2612
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix MSW tests failing on Node 25 by disabling global localStorage in Vitest setup. Ensures a consistent Node-only environment during tests.

- **Bug Fixes**
  - Added vitest.setup.ts to unset globalThis.localStorage when Node >= 25.
  - Registered the setup file in vitest.config.ts via test.setupFiles.

<!-- End of auto-generated description by cubic. -->

