### PR TITLE
chore: remove process.platform check

### DIFF
--- a/packages/core/src/env/color-depth.ts
+++ b/packages/core/src/env/color-depth.ts
@@ -88,10 +88,11 @@ export function getColorDepth(): number {
 		return COLORS_2;
 	}
 
-	if (typeof process !== "undefined" && process?.platform === "win32") {
-		// Windows 10 build 14931 (from 2016) has true color support
-		return COLORS_16m;
-	}
+	// Edge runtime doesn't support `process?.platform` syntax
+	// if (typeof process !== "undefined" && process?.platform === "win32") {
+	// 	// Windows 10 build 14931 (from 2016) has true color support
+	// 	return COLORS_16m;
+	// }
 
 	if (getEnvVar("TMUX")) {
 		return COLORS_16m;


### PR DESCRIPTION
```
@better-auth/demo:build: > Build error occurred
@better-auth/demo:build: Error: Turbopack build failed with 1 errors:
@better-auth/demo:build: ./packages/core/dist/env-rsIfwYOu.js:138:40
@better-auth/demo:build: Ecmascript file had an error
@better-auth/demo:build:   136 | 	}
@better-auth/demo:build:   137 | 	if (getEnvVar("NODE_DISABLE_COLORS") !== void 0 && getEnvVar("NODE_DISABLE_COLORS") !== "" || getEnvVar("NO_COLOR") !== void 0 && getEnvVar("NO_COLOR") !== "" || getEnvVar("TERM") === "dumb") return COLORS_2;
@better-auth/demo:build: > 138 | 	if (typeof process !== "undefined" && process?.platform === "win32") return COLORS_16m;
@better-auth/demo:build:       | 	                                      ^^^^^^^^^^^^^^^^^
@better-auth/demo:build:   139 | 	if (getEnvVar("TMUX")) return COLORS_16m;
@better-auth/demo:build:   140 | 	if ("TF_BUILD" in env && "AGENT_NAME" in env) return COLORS_16;
@better-auth/demo:build:   141 | 	if ("CI" in env) {
@better-auth/demo:build: 
@better-auth/demo:build: A Node.js API is used (process.platform at line: 138) which is not supported in the Edge Runtime.
@better-auth/demo:build: Learn more: https://nextjs.org/docs/api-reference/edge-runtime
@better-auth/demo:build: 
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the process.platform check in getColorDepth to fix Edge runtime build failures. This avoids Node-only APIs so the demo builds and runs with Next.js Turbopack on Edge.

- **Bug Fixes**
  - Removed process.platform usage; Windows-specific true color path disabled.
  - Unblocks Edge runtime builds.
  - Color depth detection now relies only on env vars (TMUX, CI, TERM, etc.).

<!-- End of auto-generated description by cubic. -->

