### PR TITLE
feat: stateless session management

### DIFF
--- a/demo/minimal/.env.example
+++ b/demo/minimal/.env.example
@@ -1,0 +1,7 @@
+# Better Auth Configuration
+BETTER_AUTH_SECRET=your-secret-key-here
+BETTER_AUTH_URL=http://localhost:3000
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret

--- a/demo/minimal/.gitignore
+++ b/demo/minimal/.gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/demo/minimal/README.md
+++ b/demo/minimal/README.md
@@ -1,0 +1,107 @@
+# Better Auth - Stateless Session Demo
+
+This demo showcases **stateless session management** using Better Auth with JWT-based sessions.
+
+## Features
+
+- ✅ **No Database Required** - Sessions stored in encrypted JWT cookies
+- ✅ **OAuth Authentication** - GitHub OAuth integration
+- ✅ **Scalable Architecture** - Works across multiple servers without shared storage
+- ✅ **Fast Performance** - Zero database queries for session validation
+- ✅ **Cookie Caching** - Optional caching layer for even faster access
+
+## How It Works
+
+This demo uses `storeSessionInCookie: true` to enable stateless sessions:
+
+1. **Sign In**: User authenticates via GitHub OAuth
+2. **Session Creation**: Session and user data are encrypted into a JWT
+3. **Storage**: JWT is stored in a secure HTTP-only cookie
+4. **Validation**: On each request, the JWT is decrypted - no database access needed
+5. **Expiration**: Sessions expire automatically based on JWT expiration time
+
+## Configuration
+
+```typescript
+// lib/auth.ts
+export const auth = betterAuth({
+  secret: process.env.BETTER_AUTH_SECRET,
+
+  socialProviders: {
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+    },
+  },
+
+  session: {
+    storeSessionInCookie: true, // Enable stateless sessions
+  },
+
+  advanced: {
+    oauthConfig: {
+      storeStateStrategy: "cookie", // Required for stateless mode
+    },
+  },
+});
+```
+
+## Running the Demo
+
+1. **Install dependencies**:
+   ```bash
+   pnpm install
+   ```
+
+2. **Set up environment variables**:
+   ```bash
+   cp .env.example .env.local
+   ```
+
+   Add your GitHub OAuth credentials:
+   ```
+   BETTER_AUTH_SECRET=your-secret-key
+   BETTER_AUTH_URL=http://localhost:3000
+   GITHUB_CLIENT_ID=your-github-client-id
+   GITHUB_CLIENT_SECRET=your-github-client-secret
+   ```
+
+3. **Start the development server**:
+   ```bash
+   pnpm dev
+   ```
+
+4. **Open the app**:
+   Navigate to [http://localhost:3000](http://localhost:3000)
+
+## Key Files
+
+- `src/lib/auth.ts` - Server-side auth configuration
+- `src/lib/auth-client.ts` - Client-side auth setup
+- `src/app/page.tsx` - Landing page with GitHub sign-in
+- `src/app/dashboard/page.tsx` - Protected dashboard displaying session data
+- `src/app/api/user/route.ts` - API endpoint demonstrating server-side session access
+
+## What's Different from Database Sessions?
+
+### Enabled Features:
+- ✅ Session retrieval (`getSession`, `useSession`)
+- ✅ Sign in/out
+- ✅ Server-side session access
+- ✅ OAuth authentication
+
+### Not Available:
+- ❌ Session revocation (`revokeSession`, `revokeOtherSessions`)
+- ❌ Session listing (`listSessions`)
+- ❌ Email/password authentication
+- ❌ Password management
+
+## Documentation
+
+For complete documentation on stateless sessions, see:
+- [Stateless Sessions Guide](https://better-auth.com/docs/guides/stateless-sessions)
+
+## Learn More
+
+- [Better Auth Documentation](https://better-auth.com/docs)
+- [GitHub Repository](https://github.com/better-auth/better-auth)

--- a/demo/minimal/next.config.ts
+++ b/demo/minimal/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+	transpilePackages: ["better-auth", "@better-auth/core"],
+};
+
+export default nextConfig;

--- a/demo/minimal/package.json
+++ b/demo/minimal/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@better-auth/demo-minimal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "better-auth": "workspace:*",
+    "next": "16.0.0-beta.0",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.13",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.13",
+    "typescript": "^5.9.3"
+  }
+}

--- a/demo/minimal/postcss.config.mjs
+++ b/demo/minimal/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+	plugins: {
+		"@tailwindcss/postcss": {},
+	},
+};

--- a/demo/minimal/src/app/api/auth/[...all]/route.ts
+++ b/demo/minimal/src/app/api/auth/[...all]/route.ts
@@ -1,0 +1,4 @@
+import { auth } from "@/lib/auth";
+import { toNextJsHandler } from "better-auth/next-js";
+
+export const { GET, POST } = toNextJsHandler(auth);

--- a/demo/minimal/src/app/api/user/route.ts
+++ b/demo/minimal/src/app/api/user/route.ts
@@ -1,0 +1,27 @@
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+
+export async function GET() {
+	const session = await auth.api.getSession({
+		headers: await headers(),
+	});
+
+	if (!session) {
+		return Response.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	return Response.json({
+		message: "Server-side session access works!",
+		user: {
+			id: session.user.id,
+			name: session.user.name,
+			email: session.user.email,
+			image: session.user.image,
+		},
+		session: {
+			expiresAt: session.session.expiresAt,
+			createdAt: session.session.createdAt,
+		},
+		note: "This data was retrieved from JWT on the server without any database queries.",
+	});
+}

--- a/demo/minimal/src/app/dashboard/page.tsx
+++ b/demo/minimal/src/app/dashboard/page.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { signOut, useSession } from "@/lib/auth-client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+
+export default function Dashboard() {
+	const router = useRouter();
+	const { data: session, isPending } = useSession();
+	const [serverData, setServerData] = useState<any>(null);
+	const [isPendingServer, startTransition] = useTransition();
+
+	useEffect(() => {
+		if (!isPending && !session) {
+			router.push("/");
+		}
+	}, [session, isPending, router]);
+
+	const handleSignOut = async () => {
+		await signOut();
+		router.push("/");
+	};
+
+	const testServerSideAccess = () => {
+		startTransition(async () => {
+			try {
+				const response = await fetch("/api/user");
+				const data = await response.json();
+				setServerData(data);
+			} catch (error) {
+				setServerData({ error: "Failed to fetch server data" });
+			}
+		});
+	};
+
+	if (isPending) {
+		return (
+			<div className="min-h-screen flex items-center justify-center">
+				<div className="text-muted-foreground">Loading...</div>
+			</div>
+		);
+	}
+
+	if (!session) {
+		return null;
+	}
+
+	return (
+		<div className="min-h-screen p-6 md:p-12">
+			<div className="max-w-4xl mx-auto space-y-6">
+				<div className="flex flex-col gap-4 p-6 border bg-card rounded-lg">
+					<div className="flex items-start justify-between">
+						<div className="space-y-1">
+							<h1 className="text-2xl font-bold text-card-foreground">
+								Dashboard
+							</h1>
+							<p className="text-sm text-muted-foreground">
+								You are successfully authenticated with stateless sessions.
+							</p>
+						</div>
+						<button
+							onClick={handleSignOut}
+							className="px-4 py-2 bg-secondary text-secondary-foreground rounded hover:bg-secondary/80 transition-colors text-sm font-medium"
+						>
+							Sign Out
+						</button>
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-4 p-6 border bg-card rounded-lg">
+					<div className="flex items-center gap-2">
+						<div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+						<h2 className="text-lg font-semibold text-card-foreground">
+							Session Information
+						</h2>
+					</div>
+					<div className="px-3 py-2 bg-secondary/60 border-l-2 border-primary rounded">
+						<p className="text-xs text-muted-foreground">
+							<span className="font-medium text-foreground">Mode:</span>{" "}
+							Stateless (JWT-based session)
+						</p>
+					</div>
+					<div className="bg-muted/40 rounded-lg p-4 overflow-x-auto">
+						<pre className="text-xs text-muted-foreground">
+							<code>{JSON.stringify(session, null, 2)}</code>
+						</pre>
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-4 p-6 border bg-card rounded-lg">
+					<div className="flex items-center justify-between">
+						<h2 className="text-lg font-semibold text-card-foreground">
+							Server-Side Session Access
+						</h2>
+						<button
+							onClick={testServerSideAccess}
+							disabled={isPendingServer}
+							className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors text-sm font-medium disabled:opacity-50"
+						>
+							{isPendingServer ? "Testing..." : "Test API Call"}
+						</button>
+					</div>
+					<p className="text-sm text-muted-foreground">
+						Click the button to make a server-side API call that retrieves your
+						session from the JWT cookie.
+					</p>
+					{serverData && (
+						<div className="bg-muted/40 rounded-lg p-4 overflow-x-auto border-l-2 border-primary">
+							<pre className="text-xs text-muted-foreground">
+								<code>{JSON.stringify(serverData, null, 2)}</code>
+							</pre>
+						</div>
+					)}
+				</div>
+
+				<div className="flex flex-col gap-4 p-6 border bg-card rounded-lg">
+					<h2 className="text-lg font-semibold text-card-foreground">
+						How it works
+					</h2>
+					<p className="text-sm text-muted-foreground">
+						With{" "}
+						<code className="px-1.5 py-0.5 bg-muted rounded text-xs">
+							storeSessionInCookie: true
+						</code>
+						, Better Auth stores your session and user data in encrypted JWT
+						cookies.
+					</p>
+					<div className="grid gap-3 mt-2">
+						<div className="flex items-start gap-3 p-3 bg-secondary/40 rounded-lg">
+							<div className="mt-0.5 text-green-500">✓</div>
+							<div className="flex-1">
+								<p className="text-sm font-medium text-card-foreground">
+									No database queries
+								</p>
+								<p className="text-xs text-muted-foreground mt-0.5">
+									Session validation happens without any database lookups
+								</p>
+							</div>
+						</div>
+						<div className="flex items-start gap-3 p-3 bg-secondary/40 rounded-lg">
+							<div className="mt-0.5 text-green-500">✓</div>
+							<div className="flex-1">
+								<p className="text-sm font-medium text-card-foreground">
+									Encrypted storage
+								</p>
+								<p className="text-xs text-muted-foreground mt-0.5">
+									Data is encrypted using AES-256-CBC-HS512
+								</p>
+							</div>
+						</div>
+						<div className="flex items-start gap-3 p-3 bg-secondary/40 rounded-lg">
+							<div className="mt-0.5 text-green-500">✓</div>
+							<div className="flex-1">
+								<p className="text-sm font-medium text-card-foreground">
+									Scalable architecture
+								</p>
+								<p className="text-xs text-muted-foreground mt-0.5">
+									Works across multiple servers without shared storage
+								</p>
+							</div>
+						</div>
+						<div className="flex items-start gap-3 p-3 bg-secondary/40 rounded-lg">
+							<div className="mt-0.5 text-green-500">✓</div>
+							<div className="flex-1">
+								<p className="text-sm font-medium text-card-foreground">
+									Server-side access works
+								</p>
+								<p className="text-xs text-muted-foreground mt-0.5">
+									Your API routes can still access session data from JWT cookies
+								</p>
+							</div>
+						</div>
+						<div className="flex items-start gap-3 p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+							<div className="mt-0.5 text-yellow-600 dark:text-yellow-500">
+								ℹ
+							</div>
+							<div className="flex-1">
+								<p className="text-sm font-medium text-card-foreground">
+									Session expiry only
+								</p>
+								<p className="text-xs text-muted-foreground mt-0.5">
+									Sessions expire based on JWT expiration time. Manual
+									revocation requires database mode.
+								</p>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/demo/minimal/src/app/globals.css
+++ b/demo/minimal/src/app/globals.css
@@ -1,0 +1,83 @@
+@import "tailwindcss";
+@config "../../tailwind.config.ts";
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+	--background: hsl(0 0% 100%);
+	--foreground: hsl(20 14.3% 4.1%);
+	--card: hsl(0 0% 100%);
+	--card-foreground: hsl(20 14.3% 4.1%);
+	--popover: hsl(0 0% 100%);
+	--popover-foreground: hsl(20 14.3% 4.1%);
+	--primary: hsl(24 9.8% 10%);
+	--primary-foreground: hsl(60 9.1% 97.8%);
+	--secondary: hsl(60 4.8% 95.9%);
+	--secondary-foreground: hsl(24 9.8% 10%);
+	--muted: hsl(60 4.8% 95.9%);
+	--muted-foreground: hsl(25 5.3% 44.7%);
+	--accent: hsl(60 4.8% 95.9%);
+	--accent-foreground: hsl(24 9.8% 10%);
+	--destructive: hsl(0 84.2% 60.2%);
+	--destructive-foreground: hsl(60 9.1% 97.8%);
+	--border: hsl(20 5.9% 90%);
+	--input: hsl(20 5.9% 90%);
+	--ring: hsl(20 14.3% 4.1%);
+	--radius: 0rem;
+}
+
+.dark {
+	--background: hsl(20 14.3% 4.1%);
+	--foreground: hsl(60 9.1% 97.8%);
+	--card: hsl(20 14.3% 4.1%);
+	--card-foreground: hsl(60 9.1% 97.8%);
+	--popover: hsl(20 14.3% 4.1%);
+	--popover-foreground: hsl(60 9.1% 97.8%);
+	--primary: hsl(60 9.1% 97.8%);
+	--primary-foreground: hsl(24 9.8% 10%);
+	--secondary: hsl(12 6.5% 15.1%);
+	--secondary-foreground: hsl(60 9.1% 97.8%);
+	--muted: hsl(12 6.5% 15.1%);
+	--muted-foreground: hsl(24 5.4% 63.9%);
+	--accent: hsl(12 6.5% 15.1%);
+	--accent-foreground: hsl(60 9.1% 97.8%);
+	--destructive: hsl(0 62.8% 30.6%);
+	--destructive-foreground: hsl(60 9.1% 97.8%);
+	--border: hsl(12 6.5% 15.1%);
+	--input: hsl(12 6.5% 15.1%);
+	--ring: hsl(24 5.7% 82.9%);
+}
+
+@theme inline {
+	--color-background: var(--background);
+	--color-foreground: var(--foreground);
+	--color-card: var(--card);
+	--color-card-foreground: var(--card-foreground);
+	--color-popover: var(--popover);
+	--color-popover-foreground: var(--popover-foreground);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-secondary: var(--secondary);
+	--color-secondary-foreground: var(--secondary-foreground);
+	--color-muted: var(--muted);
+	--color-muted-foreground: var(--muted-foreground);
+	--color-accent: var(--accent);
+	--color-accent-foreground: var(--accent-foreground);
+	--color-destructive: var(--destructive);
+	--color-destructive-foreground: var(--destructive-foreground);
+	--color-border: var(--border);
+	--color-input: var(--input);
+	--color-ring: var(--ring);
+	--radius-sm: calc(var(--radius) - 4px);
+	--radius-md: calc(var(--radius) - 2px);
+	--radius-lg: var(--radius);
+}
+
+@layer base {
+	* {
+		@apply border-border;
+	}
+	body {
+		@apply bg-background text-foreground;
+	}
+}

--- a/demo/minimal/src/app/layout.tsx
+++ b/demo/minimal/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+	title: "Better Auth - Stateless Session Management",
+	description: "Stateless session management demo with GitHub OAuth",
+};
+
+export default function RootLayout({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return (
+		<html lang="en" className="dark" suppressHydrationWarning>
+			<body className="font-sans antialiased">{children}</body>
+		</html>
+	);
+}

--- a/demo/minimal/src/app/page.tsx
+++ b/demo/minimal/src/app/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { signIn, useSession } from "@/lib/auth-client";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function Home() {
+	const router = useRouter();
+	const { data: session, isPending } = useSession();
+
+	useEffect(() => {
+		if (session) {
+			router.push("/dashboard");
+		}
+	}, [session, router]);
+
+	const handleGitHubSignIn = async () => {
+		await signIn.social({
+			provider: "github",
+			callbackURL: "/dashboard",
+		});
+	};
+
+	if (isPending) {
+		return (
+			<div className="min-h-screen flex items-center justify-center">
+				<div className="text-muted-foreground">Loading...</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="min-h-screen flex items-center justify-center px-6 md:px-0">
+			<main className="flex flex-col gap-6 items-center justify-center max-w-2xl w-full">
+				<div className="flex flex-col gap-2 text-center">
+					<h1 className="font-bold text-4xl text-foreground">Better Auth.</h1>
+					<p className="text-muted-foreground text-sm md:text-base">
+						Minimal demo showcasing{" "}
+						<span className="italic underline">
+							stateless session management
+						</span>{" "}
+						with GitHub OAuth.
+					</p>
+				</div>
+
+				<div className="w-full flex flex-col gap-4">
+					<div className="border-y py-3 border-dotted bg-secondary/60">
+						<div className="text-xs flex items-center gap-2 justify-center text-muted-foreground">
+							<span className="text-center">
+								⚡ Sessions stored in encrypted JWT cookies • No database
+								required
+							</span>
+						</div>
+					</div>
+
+					<div className="flex flex-col gap-3 p-6 border bg-card rounded-lg">
+						<div className="space-y-2">
+							<h2 className="text-lg font-semibold text-card-foreground">
+								Stateless Session Mode
+							</h2>
+							<p className="text-sm text-muted-foreground">
+								This demo uses{" "}
+								<code className="px-1.5 py-0.5 bg-muted rounded text-xs">
+									storeSessionInCookie: true
+								</code>{" "}
+								to store session and user data in encrypted JWT tokens.
+							</p>
+						</div>
+
+						<button
+							onClick={handleGitHubSignIn}
+							className="w-full py-3 px-4 bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors font-medium"
+						>
+							Sign in with GitHub
+						</button>
+					</div>
+
+					<div className="flex flex-col gap-3 p-6 border bg-card rounded-lg">
+						<h3 className="text-sm font-semibold text-card-foreground">
+							How it works
+						</h3>
+						<ul className="text-sm text-muted-foreground space-y-2">
+							<li className="flex items-start gap-2">
+								<span className="text-primary mt-0.5">•</span>
+								<span>
+									User and session data encrypted using AES-256-CBC-HS512
+								</span>
+							</li>
+							<li className="flex items-start gap-2">
+								<span className="text-primary mt-0.5">•</span>
+								<span>No database queries needed for session validation</span>
+							</li>
+							<li className="flex items-start gap-2">
+								<span className="text-primary mt-0.5">•</span>
+								<span>
+									Works across multiple servers without shared storage
+								</span>
+							</li>
+							<li className="flex items-start gap-2">
+								<span className="text-primary mt-0.5">•</span>
+								<span>Server-side session access fully supported</span>
+							</li>
+							<li className="flex items-start gap-2">
+								<span className="text-yellow-600 dark:text-yellow-500 mt-0.5">
+									ℹ
+								</span>
+								<span>
+									Sessions expire automatically, manual revocation requires
+									database
+								</span>
+							</li>
+						</ul>
+					</div>
+				</div>
+			</main>
+		</div>
+	);
+}

--- a/demo/minimal/src/lib/auth-client.ts
+++ b/demo/minimal/src/lib/auth-client.ts
@@ -1,0 +1,7 @@
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+	baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "http://localhost:3000",
+});
+
+export const { signIn, signOut, useSession } = authClient;

--- a/demo/minimal/src/lib/auth.ts
+++ b/demo/minimal/src/lib/auth.ts
@@ -1,0 +1,25 @@
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+	baseURL: process.env.BETTER_AUTH_URL,
+	secret: process.env.BETTER_AUTH_SECRET,
+
+	socialProviders: {
+		github: {
+			clientId: process.env.GITHUB_CLIENT_ID as string,
+			clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+		},
+	},
+
+	session: {
+		cookieCache: {
+			enabled: true,
+		},
+	},
+
+	advanced: {
+		oauthConfig: {
+			storeStateStrategy: "cookie",
+		},
+	},
+});

--- a/demo/minimal/tailwind.config.ts
+++ b/demo/minimal/tailwind.config.ts
@@ -1,0 +1,57 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+	darkMode: "class",
+	content: [
+		"./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+		"./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+		"./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+	],
+	theme: {
+		extend: {
+			colors: {
+				border: "var(--border)",
+				input: "var(--input)",
+				ring: "var(--ring)",
+				background: "var(--background)",
+				foreground: "var(--foreground)",
+				primary: {
+					DEFAULT: "var(--primary)",
+					foreground: "var(--primary-foreground)",
+				},
+				secondary: {
+					DEFAULT: "var(--secondary)",
+					foreground: "var(--secondary-foreground)",
+				},
+				destructive: {
+					DEFAULT: "var(--destructive)",
+					foreground: "var(--destructive-foreground)",
+				},
+				muted: {
+					DEFAULT: "var(--muted)",
+					foreground: "var(--muted-foreground)",
+				},
+				accent: {
+					DEFAULT: "var(--accent)",
+					foreground: "var(--accent-foreground)",
+				},
+				popover: {
+					DEFAULT: "var(--popover)",
+					foreground: "var(--popover-foreground)",
+				},
+				card: {
+					DEFAULT: "var(--card)",
+					foreground: "var(--card-foreground)",
+				},
+			},
+			borderRadius: {
+				lg: "var(--radius)",
+				md: "calc(var(--radius) - 2px)",
+				sm: "calc(var(--radius) - 4px)",
+			},
+		},
+	},
+	plugins: [],
+};
+
+export default config;

--- a/demo/minimal/tsconfig.json
+++ b/demo/minimal/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "baseUrl": ".",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/docs/content/docs/concepts/session-management.mdx
+++ b/docs/content/docs/concepts/session-management.mdx
@@ -190,11 +190,20 @@ or on the server
 await auth.api.getSession({
     query: {
         disableCookieCache: true,
-    }, 
+    },
     headers: req.headers, // pass the headers
 });
 ```
 
+## Stateless Sessions (JWT)
+
+For high-scale applications, Better Auth supports **stateless JWT-based sessions** that eliminate database queries for session validation.
+
+<Callout type="warn">
+**Advanced Feature**: Stateless sessions have important security trade-offs. They cannot be revoked server-side and are only suitable for specific use cases.
+</Callout>
+
+Learn more in the [Stateless Sessions Guide](/docs/guides/stateless-sessions).
 
 ## Customizing Session Response
 

--- a/docs/content/docs/guides/stateless-sessions.mdx
+++ b/docs/content/docs/guides/stateless-sessions.mdx
@@ -1,0 +1,495 @@
+---
+title: Stateless Sessions (JWT)
+description: Learn how to implement stateless, JWT-based session management in Better Auth for maximum scalability
+---
+
+<Callout type="warn">
+**Security Warning**: When running without a database, stateless sessions cannot be revoked server-side. Sessions will remain valid until their JWT expires. Only use database-free mode if you understand the security implications and your use case doesn't require immediate session revocation.
+</Callout>
+
+Stateless session management stores session and user data in encrypted JWT cookies, enabling session validation without database queries. This approach can work **with or without a database**, giving you flexibility in your architecture.
+
+## Two Modes of Operation
+
+### Mode 1: JWT + Database (Recommended)
+
+```ts
+// Fast reads from JWT, full control with database
+export const auth = betterAuth({
+    database: myDatabaseConfig, // Database configured
+    session: {
+        cookieCache: {
+            enabled: true, // JWT for fast reads
+        },
+    },
+});
+```
+
+**Benefits:**
+- ✅ **Fast session reads** - No database query for `getSession()`
+- ✅ **Full session management** - Can revoke, list, manage sessions
+- ✅ **Email/password auth** - Supported
+- ✅ **Best of both worlds** - Performance + Control
+
+### Mode 2: JWT Only (No Database)
+
+```ts
+// Fully stateless - no database required
+export const auth = betterAuth({
+    // No database configured
+    session: {
+        cookieCache: {
+            enabled: true, // JWT only
+        },
+    },
+    advanced: {
+        oauthConfig: {
+            storeStateStrategy: "cookie", // Required for no-DB mode
+        },
+    },
+});
+```
+
+**Benefits:**
+- ✅ **No database needed** - Eliminate database entirely
+- ✅ **Maximum scalability** - Works across any number of servers
+- ✅ **Simple infrastructure** - Just application servers, no DB
+- ❌ **Limited features** - No session revocation, password auth, etc.
+
+<Callout type="info">
+**Recommendation**: Start with **Mode 1 (JWT + Database)** for most applications. Only use Mode 2 if you truly need to eliminate the database and understand the trade-offs.
+</Callout>
+
+## When to Use Stateless Sessions
+
+### Best For
+
+**With Database:**
+- Applications wanting **fast session reads** (no DB query) while keeping full session management
+- Hybrid approach: Performance of JWT with control of database sessions
+- Gradually migrating to stateless architecture
+
+**Without Database (True Stateless):**
+- **High-traffic applications** that need to scale horizontally across multiple servers
+- **Serverless deployments** where database connections are expensive or limited
+- **Edge computing** where low latency is critical
+- **Multi-region deployments** without shared database infrastructure
+- **Read-heavy workloads** where session validation happens frequently
+- **OAuth-only applications** that don't need password authentication
+
+### Not Suitable For
+
+<Callout type="error">
+**Do not use database-free stateless mode if:**
+- Your application requires **immediate session revocation** (e.g., banking, admin panels, security-critical apps)
+- You need to **list or manage user sessions** across devices
+- You want to use **password-based authentication**
+- Compliance requirements mandate **server-side session control**
+
+**Note:** If you need these features, use `cookieCache.enabled: true` **with a database** instead. You'll get fast JWT reads plus full session management capabilities.
+</Callout>
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App
+    participant OAuth Provider
+
+    User->>App: Sign in with OAuth
+    App->>OAuth Provider: Redirect to provider
+    OAuth Provider->>App: Callback with auth code
+    App->>OAuth Provider: Exchange code for user data
+    App->>App: Encrypt session + user data into JWT
+    App->>User: Set JWT in HTTP-only cookie
+
+    Note over User,App: Subsequent requests
+    User->>App: Request with JWT cookie
+    App->>App: Decrypt & validate JWT
+    App->>User: Return session data (no DB query)
+```
+
+### Key Benefits
+
+1. **Zero Database Queries**: Session validation happens entirely in-memory by decrypting the JWT
+2. **Horizontal Scalability**: Works seamlessly across multiple servers with no shared state
+3. **Reduced Latency**: No network round-trip to database for every request
+4. **Simplified Infrastructure**: No need for session storage or replication
+
+### Trade-offs
+
+1. **No Revocation**: Once issued, a JWT remains valid until expiration - you cannot invalidate it early
+2. **Larger Cookies**: Session data is stored in the cookie (typically 1-4KB encrypted)
+3. **OAuth Only**: Email/password authentication is not supported in stateless mode
+4. **Limited Session Management**: Cannot list active sessions or force logout from all devices
+
+## Basic Configuration
+
+Enable stateless sessions by setting `cookieCache.enabled` to `true`:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+
+export const auth = betterAuth({
+    secret: process.env.BETTER_AUTH_SECRET, // Required - min 32 characters
+
+    // OAuth providers only (email/password not supported)
+    socialProviders: {
+        github: {
+            clientId: process.env.GITHUB_CLIENT_ID!,
+            clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+        },
+        google: {
+            clientId: process.env.GOOGLE_CLIENT_ID!,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+        },
+    },
+
+    session: {
+        cookieCache: {
+            enabled: true, // Enable stateless JWT sessions
+            maxAge: 5 * 60, // Cache for 5 minutes (optional)
+        },
+        expiresIn: 60 * 60 * 24 * 7, // 7 days
+        updateAge: 60 * 60 * 24, // 1 day
+    },
+
+    // Required: Store OAuth state in cookies
+    advanced: {
+        oauthConfig: {
+            storeStateStrategy: "cookie",
+        },
+    },
+});
+```
+
+<Callout>
+**Database Optional**: With stateless sessions enabled, you can run Better Auth without a database. User data from OAuth is stored only in the JWT cookie.
+</Callout>
+
+## Advanced Configuration
+
+### Custom JWT Encoding
+
+The `cookieCache.enabled: true` configuration uses Better Auth's built-in JWT encryption automatically. For most use cases, this is sufficient and secure.
+
+If you need custom JWT handling, you can implement it at the application level by intercepting session data:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+
+export const auth = betterAuth({
+    session: {
+        cookieCache: {
+            enabled: true, // Uses built-in JWE encryption (A256CBC-HS512)
+            maxAge: 5 * 60, // 5 minute cache
+        },
+        expiresIn: 60 * 60 * 24 * 7, // 7 days
+        updateAge: 60 * 60 * 24, // 1 day
+    },
+
+    // OAuth state storage in cookies
+    advanced: {
+        oauthConfig: {
+            storeStateStrategy: "cookie", // Uses built-in encryption
+        },
+    },
+});
+```
+
+### Built-in Security Features
+
+The `cookieCache.enabled: true` configuration includes:
+- **JWE Encryption**: A256CBC-HS512 algorithm (industry standard)
+- **Key Derivation**: HKDF with SHA-256 for secure key generation
+- **Automatic Expiration**: Sessions expire based on your `expiresIn` configuration
+- **Cookie Security**: HttpOnly, Secure, SameSite attributes automatically applied
+
+## Cookie Caching Performance
+
+When `cookieCache.enabled` is true, sessions are automatically cached in cookies for optimal performance:
+
+### Performance Comparison
+
+| Approach | Speed | Notes |
+|----------|-------|-------|
+| Database Session | ~10-50ms | Database round-trip required |
+| JWT Decryption | ~1-5ms | Cryptographic operation |
+| Cookie Cache Hit | <1ms | Direct cookie read (fastest) |
+
+**Cookie Cache Flow:**
+1. **First Request**: Decrypt JWT (1-5ms), cache result in signed cookie
+2. **Subsequent Requests** (within 5 min): Read from cache cookie (<1ms)
+3. **Cache Expired**: Re-decrypt JWT and refresh cache
+
+## Security Considerations
+
+### Encryption
+
+- **Algorithm**: AES-256-CBC-HS512 (industry standard)
+- **Key Derivation**: HKDF with SHA-256
+- **Salt**: Configurable per-application salt for key derivation
+
+### Best Practices
+
+```ts
+// ✅ DO: Use a strong secret (minimum 32 characters)
+secret: process.env.BETTER_AUTH_SECRET // e.g., generated via: openssl rand -base64 32
+
+// ❌ DON'T: Use weak or predictable secrets
+secret: "my-app-secret" // TOO WEAK!
+
+// ✅ DO: Set appropriate expiration times
+session: {
+    expiresIn: 60 * 60 * 24 * 7, // 7 days max for security
+}
+
+// ❌ DON'T: Use excessively long expiration
+session: {
+    expiresIn: 60 * 60 * 24 * 365, // 1 year - security risk!
+}
+
+// ✅ DO: Use HTTPS in production
+baseURL: "https://your-domain.com"
+
+// ❌ DON'T: Use HTTP for production
+baseURL: "http://your-domain.com" // Insecure!
+```
+
+### Cookie Security
+
+All session cookies are automatically secured with:
+- **HttpOnly**: Prevents JavaScript access (XSS protection)
+- **Secure**: Only sent over HTTPS in production
+- **SameSite**: Protection against CSRF attacks
+- **Signed**: HMAC signature prevents tampering
+
+### Limitations & Security Impact
+
+<Callout type="warn">
+**Critical Limitations (Database-Free Mode Only):**
+
+When running without a database:
+1. **No Session Revocation**: If a JWT is compromised, you cannot invalidate it until expiration
+2. **Expiration-Based Security**: Your only defense is JWT expiration time
+3. **No "Logout All Devices"**: Cannot force logout from all sessions
+4. **Token Theft Risk**: If an attacker gets the JWT, they have access until expiration
+
+**Mitigation Strategies:**
+- **Use a database** if you need session revocation
+- Use short expiration times (7 days or less)
+- Implement anomaly detection at application level
+- Use `updateAge` to limit stale token usage
+- Monitor for suspicious activity patterns
+
+**With Database:**
+All these limitations disappear - you can revoke sessions, list sessions, and have full control while still benefiting from fast JWT-based reads.
+</Callout>
+
+## Complete Example
+
+### Server Configuration
+
+```ts title="lib/auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+    baseURL: process.env.BETTER_AUTH_URL!,
+    secret: process.env.BETTER_AUTH_SECRET!,
+
+    socialProviders: {
+        github: {
+            clientId: process.env.GITHUB_CLIENT_ID!,
+            clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+        },
+    },
+
+    session: {
+        cookieCache: {
+            enabled: true, // Enable stateless JWT sessions
+            maxAge: 5 * 60, // 5 minute cache
+        },
+        expiresIn: 60 * 60 * 24 * 7, // 7 days
+    },
+
+    advanced: {
+        oauthConfig: {
+            storeStateStrategy: "cookie",
+        },
+    },
+});
+```
+
+### Client Setup
+
+```ts title="lib/auth-client.ts"
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+    baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL,
+});
+
+export const { useSession, signIn, signOut } = authClient;
+```
+
+### Protected API Route
+
+```ts title="app/api/user/route.ts"
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+
+export async function GET() {
+    // Zero database queries - session read from JWT!
+    const session = await auth.api.getSession({
+        headers: await headers(),
+    });
+
+    if (!session) {
+        return Response.json(
+            { error: "Unauthorized" },
+            { status: 401 }
+        );
+    }
+
+    return Response.json({
+        user: session.user,
+        session: session.session,
+        note: "Retrieved from JWT - no database query!",
+    });
+}
+```
+
+### Client Component
+
+```tsx title="app/dashboard/page.tsx"
+"use client";
+
+import { useSession, signOut } from "@/lib/auth-client";
+import { useRouter } from "next/navigation";
+
+export default function Dashboard() {
+    const router = useRouter();
+    const { data: session, isPending } = useSession();
+
+    if (isPending) return <div>Loading...</div>;
+    if (!session) {
+        router.push("/");
+        return null;
+    }
+
+    return (
+        <div>
+            <h1>Welcome, {session.user.name}</h1>
+            <button onClick={() => signOut()}>
+                Sign Out
+            </button>
+            <pre>{JSON.stringify(session, null, 2)}</pre>
+        </div>
+    );
+}
+```
+
+## Feature Availability
+
+### With Database
+
+If you configure `cookieCache.enabled: true` **with a database**, all features work normally:
+
+✅ Session retrieval (`getSession`, `useSession`) - from JWT cookie
+✅ Session revocation (`revokeSession()`, `revokeOtherSessions()`) - from database
+✅ Session listing (`listSessions()`) - from database
+✅ Sign in with OAuth providers
+✅ Email/password authentication - if configured
+✅ Password management - if email/password auth is configured
+✅ Server-side session access
+✅ Cookie caching
+
+**How it works with database:**
+- Session data is stored in **both** the database and JWT cookie
+- `getSession` reads from JWT (fast, no DB query)
+- `revokeSession`, `listSessions` use the database (slower, but full control)
+- Best of both worlds: fast reads, full session management
+
+### Without Database (True Stateless)
+
+If you configure `cookieCache.enabled: true` **without a database**, you get true stateless mode:
+
+✅ Session retrieval (`getSession`, `useSession`) - from JWT cookie
+✅ Sign in with OAuth providers
+✅ Sign out (clears cookie locally)
+✅ Server-side session access
+✅ Cookie caching
+
+❌ **Session Revocation**: `revokeSession()`, `revokeOtherSessions()`, `revokeSessions()` - no database to revoke from
+❌ **Session Listing**: `listSessions()` - no database to query
+❌ **Email/Password Auth**: `signInEmail()`, `signUpEmail()` - requires database
+❌ **Password Management**: `changePassword()`, `resetPassword()` - requires database
+
+<Callout type="info">
+**Key Insight**: The limitations only apply when running **without a database**. If you have a database, all features work - JWT cookies just make reads faster.
+</Callout>
+
+## Migration Guide
+
+### From Database Sessions to Stateless
+
+1. **Review Requirements**: Ensure your app doesn't need session revocation
+2. **Remove Password Auth**: Migrate users to OAuth-only authentication
+3. **Update Configuration**:
+   ```ts
+   session: {
+       cookieCache: {
+           enabled: true,
+           maxAge: 5 * 60, // 5 minutes (optional)
+       },
+   },
+   advanced: {
+       oauthConfig: {
+           storeStateStrategy: "cookie",
+       },
+   },
+   ```
+4. **Deploy Changes**: All users will need to sign in again
+5. **Monitor**: Watch for any issues during the transition
+
+<Callout type="warn">
+**Breaking Change**: Users will be logged out and must re-authenticate. Plan for this in your deployment strategy.
+</Callout>
+
+### Rollback Strategy
+
+If you need to rollback:
+1. Set `cookieCache.enabled` to `false` (or remove the entire `cookieCache` config)
+2. Change `storeStateStrategy` back to `"database"` (or remove it, as database is the default)
+3. Re-deploy
+4. Users will need to sign in again
+
+## Troubleshooting
+
+### "Session data is null"
+- Ensure `secret` is set and consistent across deployments
+- Check JWT hasn't expired (`expiresIn` setting)
+- Verify cookies are being sent (check browser dev tools)
+
+### "OAuth state mismatch"
+- Ensure `storeStateStrategy: "cookie"` is set
+- Check that cookies are enabled in the browser
+- Verify `baseURL` is correct
+
+### "Cookie size too large"
+- Reduce session data size
+- Avoid storing large objects in session
+- Use references/IDs instead of full data
+
+### Performance Issues
+- Enable `cookieCache` for faster access
+- Reduce `cookieCache.maxAge` if data gets stale
+- Consider using shorter JWTs with less data
+
+## Learn More
+
+- [Session Management Concepts](/docs/concepts/session-management)
+- [OAuth Configuration](/docs/concepts/oauth)
+- [Cookie Configuration](/docs/concepts/cookies)
+- [Example: Minimal Stateless Demo](https://github.com/better-auth/better-auth/tree/main/demo/minimal)

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -4,7 +4,7 @@ import { createAuthEndpoint } from "@better-auth/core/api";
 import { setSessionCookie } from "../../cookies";
 import { createEmailVerificationToken } from "./email-verification";
 import { generateState } from "../../utils";
-import { handleOAuthUserInfo } from "../../oauth2/link-account";
+import { handleOAuthUserInfo } from "../../oauth2";
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import { SocialProviderListEnum } from "@better-auth/core/social-providers";
 

--- a/packages/better-auth/src/db/utils.ts
+++ b/packages/better-auth/src/db/utils.ts
@@ -1,7 +1,7 @@
 import { getAuthTables } from ".";
 import { BetterAuthError } from "@better-auth/core/error";
 import type { BetterAuthOptions } from "@better-auth/core";
-import { createKyselyAdapter } from "../adapters/kysely-adapter/dialect";
+import { createKyselyAdapter } from "../adapters/kysely-adapter";
 import { kyselyAdapter } from "../adapters/kysely-adapter";
 import { memoryAdapter, type MemoryDB } from "../adapters/memory-adapter";
 import { logger } from "@better-auth/core/env";

--- a/packages/better-auth/src/jwt/index.spec.ts
+++ b/packages/better-auth/src/jwt/index.spec.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "vitest";
+import { getTestInstanceMemory } from "../test-utils";
+import { symmetricDecode, symmetricEncode } from "./index";
+import { runWithEndpointContext } from "@better-auth/core/context";
+
+describe("JWT", async () => {
+	const { auth } = await getTestInstanceMemory();
+	test("encode", async () => {
+		await runWithEndpointContext({ context: await auth.$context }, async () => {
+			const k = await symmetricEncode(
+				{
+					username: "test",
+				},
+				"better-auth-salt",
+			);
+			const v = await symmetricDecode(k, "better-auth-salt");
+			expect(v).toMatchObject({
+				username: "test",
+				exp: expect.any(Number),
+				iat: expect.any(Number),
+				jti: expect.any(String),
+			});
+		});
+	});
+});

--- a/packages/better-auth/src/jwt/index.ts
+++ b/packages/better-auth/src/jwt/index.ts
@@ -1,0 +1,137 @@
+import type { JWTPayload } from "jose";
+import {
+	base64url,
+	calculateJwkThumbprint,
+	EncryptJWT,
+	jwtDecrypt,
+} from "jose";
+import { hkdf, sha256 } from "@noble/hashes/webcrypto.js";
+import { getCurrentAuthContext } from "@better-auth/core/context";
+import type { BetterAuthOptions } from "@better-auth/core";
+
+export type JWT = JWTPayload & Record<string, unknown>;
+
+export function isCookieCacheEnabled(options: BetterAuthOptions): boolean {
+	return options.session?.cookieCache?.enabled === true;
+}
+
+// "BetterAuth.js Generated Encryption Key"
+const info: Uint8Array = new Uint8Array([
+	66, 101, 116, 116, 101, 114, 65, 117, 116, 104, 46, 106, 115, 32, 71, 101,
+	110, 101, 114, 97, 116, 101, 100, 32, 69, 110, 99, 114, 121, 112, 116, 105,
+	111, 110, 32, 75, 101, 121,
+]);
+
+const now = () => (Date.now() / 1000) | 0;
+
+const alg = "dir";
+const enc = "A256CBC-HS512"; // 64 bytes key
+
+type JWTString<T extends JWT> = string & {
+	__type?: "jwt_token";
+	payload?: T;
+};
+
+export async function symmetricEncode<T extends JWT>(
+	payload: T,
+	salt: string,
+): Promise<JWTString<T>> {
+	const { context } = await getCurrentAuthContext();
+	const secret = context.secret;
+	const expiresIn = context.sessionConfig.expiresIn;
+	const encryptionSecret = await hkdf(
+		sha256,
+		new TextEncoder().encode(secret),
+		new TextEncoder().encode(salt),
+		info,
+		64,
+	);
+
+	const thumbprint = await calculateJwkThumbprint(
+		{ kty: "oct", k: base64url.encode(encryptionSecret) },
+		"sha256",
+	);
+	return await new EncryptJWT(payload)
+		.setProtectedHeader({ alg, enc, kid: thumbprint })
+		.setIssuedAt()
+		.setExpirationTime(now() + expiresIn)
+		.setJti(crypto.randomUUID())
+		.encrypt(encryptionSecret);
+}
+
+export async function symmetricDecode<T extends string>(
+	token: T,
+	salt: string,
+): Promise<T extends JWTString<infer Payload> ? Payload | null : JWT | null> {
+	const { context } = await getCurrentAuthContext();
+	const secret = context.secret;
+	if (!token) return null as any;
+	try {
+		const { payload } = await jwtDecrypt(
+			token,
+			async ({ kid }) => {
+				const encryptionSecret = await hkdf(
+					sha256,
+					new TextEncoder().encode(secret),
+					new TextEncoder().encode(salt),
+					info,
+					64,
+				);
+				if (kid === undefined) return encryptionSecret;
+
+				const thumbprint = await calculateJwkThumbprint(
+					{ kty: "oct", k: base64url.encode(encryptionSecret) },
+					"sha256",
+				);
+				if (kid === thumbprint) return encryptionSecret;
+
+				throw new Error("no matching decryption secret");
+			},
+			{
+				clockTolerance: 15,
+				keyManagementAlgorithms: [alg],
+				contentEncryptionAlgorithms: [enc, "A256GCM"],
+			},
+		);
+		return payload as any;
+	} catch (error) {
+		return null as any;
+	}
+}
+
+/**
+ * Encode session data with user info into JWT for stateless sessions
+ */
+export async function encodeSessionJWT<
+	TSession extends Record<string, unknown>,
+	TUser extends Record<string, unknown>,
+>(data: { session: TSession; user: TUser }): Promise<string> {
+	const salt = "better-auth-session";
+
+	return symmetricEncode(
+		{
+			session: data.session,
+			user: data.user,
+		},
+		salt,
+	);
+}
+
+/**
+ * Decode session JWT to get session and user data
+ */
+export async function decodeSessionJWT(token: string): Promise<{
+	session: Record<string, unknown>;
+	user: Record<string, unknown>;
+} | null> {
+	const salt = "better-auth-session";
+
+	const payload = await symmetricDecode(token, salt);
+	if (!payload || !payload.session || !payload.user) {
+		return null;
+	}
+	return {
+		session: payload.session as Record<string, unknown>,
+		user: payload.user as Record<string, unknown>,
+	};
+}

--- a/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
+++ b/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
@@ -19,10 +19,6 @@ describe("Custom Session Plugin Tests", async () => {
 			session: {
 				maxAge: 10,
 				updateAge: 0,
-				cookieCache: {
-					enabled: true,
-					maxAge: 10,
-				},
 			},
 			plugins: [
 				...options.plugins,
@@ -75,7 +71,6 @@ describe("Custom Session Plugin Tests", async () => {
 
 					const cookies = parseSetCookieHeader(header!);
 					expect(cookies.has("better-auth.session_token")).toBe(true);
-					expect(cookies.has("better-auth.session_data")).toBe(true);
 				},
 			},
 		});

--- a/packages/core/src/types/helper.ts
+++ b/packages/core/src/types/helper.ts
@@ -4,3 +4,4 @@ export type LiteralString = "" | (string & Record<never, never>);
 export type LiteralUnion<LiteralType, BaseType extends Primitive> =
 	| LiteralType
 	| (BaseType & Record<never, never>);
+export type Awaitable<T> = Promise<T> | T;

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -671,10 +671,6 @@ export type BetterAuthOptions = {
 			[key: string]: DBFieldAttribute;
 		};
 		/**
-		 * @default false
-		 */
-		storeSessionInJWT?: boolean;
-		/**
 		 * By default if secondary storage is provided
 		 * the session is stored in the secondary storage.
 		 *
@@ -697,16 +693,43 @@ export type BetterAuthOptions = {
 		 */
 		preserveSessionInDatabase?: boolean;
 		/**
-		 * Enable caching session in cookie
+		 * Cookie cache configuration for session management.
+		 *
+		 * When `enabled: true`, sessions are stored entirely in encrypted JWT cookies
+		 * for stateless session management (similar to next-auth).
+		 *
+		 * **Stateless mode benefits:**
+		 * - No database queries for session validation
+		 * - Works with social OAuth providers without database
+		 * - Reduced server load and faster session checks
+		 * - Simplified infrastructure (no session storage needed)
+		 *
+		 * **Important limitations:**
+		 * - Sessions cannot be revoked server-side (relies on JWT expiration)
+		 * - Session data is stored in cookies (size limits apply)
+		 * - Best suited for authentication with trusted OAuth providers
+		 *
+		 * **Security notes:**
+		 * - Session data is encrypted using JWE (A256CBC-HS512)
+		 * - Requires a secure secret for encryption
+		 * - Sessions automatically expire based on `expiresIn` config
 		 */
 		cookieCache?: {
 			/**
-			 * max age of the cookie
+			 * Max age of the cookie cache in seconds.
+			 * This is separate from session expiration.
 			 * @default 5 minutes (5 * 60)
 			 */
 			maxAge?: number;
 			/**
-			 * Enable caching session in cookie
+			 * Enable stateless session management via encrypted JWT cookies.
+			 *
+			 * When enabled:
+			 * - Session and user data stored in encrypted cookies
+			 * - No database required for session validation
+			 * - Social OAuth sign-in works without database
+			 * - Sessions cannot be revoked server-side
+			 *
 			 * @default false
 			 */
 			enabled?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,40 @@ importers:
         specifier: ^19.2.2
         version: 19.2.2
 
+  demo/minimal:
+    dependencies:
+      better-auth:
+        specifier: workspace:*
+        version: link:../../packages/better-auth
+      next:
+        specifier: 16.0.0-beta.0
+        version: 16.0.0-beta.0(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.90.0)
+      react:
+        specifier: 19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.1.13
+        version: 4.1.13
+      '@types/react':
+        specifier: ^19.2.2
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19.2.2
+        version: 19.2.2(@types/react@19.2.2)
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.1.13
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   demo/nextjs:
     dependencies:
       '@better-auth/sso':


### PR DESCRIPTION
Stateless session management, similar to next-auth.

This feature would only work with social provider sign-in. And may not work with many plugins

Things we need to figure out:

1. How to emit the error when db is required
2. Ignore some APIs when stateless mode is enabled
3. A better way to handle the options?
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Introduce stateless session management via encrypted JWT cookies to remove database dependency for sessions and support social OAuth sign-in. Disables password-based auth and server-side session revocation.

- **New Features**
  - Added session.storeSessionInJWT option to enable stateless sessions.
  - Store session+user in encrypted JWE cookies; getSession decodes and checks expiry.
  - Block email/password sign-in and sign-up when stateless mode is on, with clear errors.
  - Disable session revocation endpoints in stateless mode (return BAD_REQUEST).
  - Skip DB writes/reads for user/account/session creation; generate mock IDs in adapter.
  - Bypass cookie cache and secondary storage when using JWT sessions.
  - New JWT helpers (symmetricEncode/Decode, encodeSessionJWT/decodeSessionJWT) with HKDF and jose; includes unit test.

- **Migration**
  - Set session.storeSessionInJWT: true.
  - Use social OAuth providers; remove or guard email/password flows.
  - Do not rely on session revocation or secondary storage for session data.

<!-- End of auto-generated description by cubic. -->

