### PR TITLE
demo: add passkey login

### DIFF
--- a/demo/nextjs/components/sign-in.tsx
+++ b/demo/nextjs/components/sign-in.tsx
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useState, useTransition } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, Key } from "lucide-react";
 import { client, signIn } from "@/lib/auth-client";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
@@ -248,6 +248,29 @@ export default function SignIn() {
 							{client.isLastUsedLoginMethod("microsoft") && (
 								<LastUsedIndicator />
 							)}
+						</Button>
+						<Button
+							variant="outline"
+							className={cn("w-full gap-2 flex items-center relative")}
+							onClick={async () => {
+								await signIn.passkey({
+									fetchOptions: {
+										onSuccess() {
+											toast.success("Successfully signed in");
+											router.push(getCallbackURL(params));
+										},
+										onError(context) {
+											toast.error(
+												"Authentication failed: " + context.error.message,
+											);
+										},
+									},
+								});
+							}}
+						>
+							<Key size={16} />
+							<span>Sign in with Passkey</span>
+							{client.isLastUsedLoginMethod("passkey") && <LastUsedIndicator />}
 						</Button>
 					</div>
 				</div>


### PR DESCRIPTION
This PR added Passkey login method to nextjs demo. Currently, we could add passkey in dashboard but can't test it when successfully added, this made it works.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add Passkey login to the Next.js demo sign-in page so users can test passkey auth after adding a passkey in the dashboard. Adds a “Sign in with Passkey” button with success/error toasts, redirect on success, and a last-used indicator.

<!-- End of auto-generated description by cubic. -->

