### PR TITLE
fix(mcp): consent requirement should be respected 

### DIFF
--- a/packages/better-auth/src/plugins/mcp/authorize.ts
+++ b/packages/better-auth/src/plugins/mcp/authorize.ts
@@ -61,7 +61,6 @@ export async function authorizeMCPOAuth(
 	}
 
 	const query = ctx.query as AuthorizationQuery;
-	console.log(query);
 	if (!query.client_id) {
 		throw ctx.redirect(`${ctx.context.baseURL}/error?error=invalid_client`);
 	}
@@ -96,7 +95,6 @@ export async function authorizeMCPOAuth(
 				metadata: res.metadata ? JSON.parse(res.metadata) : {},
 			} as Client;
 		});
-	console.log(client);
 	if (!client) {
 		throw ctx.redirect(`${ctx.context.baseURL}/error?error=invalid_client`);
 	}
@@ -214,13 +212,36 @@ export async function authorizeMCPOAuth(
 		);
 	}
 
-	const redirectURIWithCode = new URL(redirectURI);
-	redirectURIWithCode.searchParams.set("code", code);
-	redirectURIWithCode.searchParams.set("state", ctx.query.state);
-
+	// Consent is NOT required - redirect with the code immediately
 	if (query.prompt !== "consent") {
+		const redirectURIWithCode = new URL(redirectURI);
+		redirectURIWithCode.searchParams.set("code", code);
+		redirectURIWithCode.searchParams.set("state", ctx.query.state);
 		throw ctx.redirect(redirectURIWithCode.toString());
 	}
 
+	// Consent is REQUIRED - redirect to consent page or show consent HTML
+	if (options?.consentPage) {
+		// Set cookie to support cookie-based consent flows
+		await ctx.setSignedCookie("oidc_consent_prompt", code, ctx.context.secret, {
+			maxAge: 600,
+			path: "/",
+			sameSite: "lax",
+		});
+
+		// Pass the consent code as a URL parameter to support URL-BASED consent flows
+		const urlParams = new URLSearchParams();
+		urlParams.set("consent_code", code);
+		urlParams.set("client_id", client.clientId);
+		urlParams.set("scope", requestScope.join(" "));
+		const consentURI = `${options.consentPage}?${urlParams.toString()}`;
+
+		throw ctx.redirect(consentURI);
+	}
+
+	// No consent page configured - fall back to direct redirect with code
+	const redirectURIWithCode = new URL(redirectURI);
+	redirectURIWithCode.searchParams.set("code", code);
+	redirectURIWithCode.searchParams.set("state", ctx.query.state);
 	throw ctx.redirect(redirectURIWithCode.toString());
 }

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -172,6 +172,7 @@ export const mcp = (options: MCPOptions) => {
 			],
 		},
 		endpoints: {
+			oAuthConsent: provider.endpoints.oAuthConsent,
 			getMcpOAuthConfig: createAuthEndpoint(
 				"/.well-known/oauth-authorization-server",
 				{


### PR DESCRIPTION
This PR fixed #4736 to avoid the consent bypassing.
- fix `consent` handling logic
- expose consent endpoint
- adding more test cases based on user feedback
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes an OAuth consent bypass in MCP by enforcing the prompt=consent flow and exposing a consent endpoint. Non-consent flows still redirect directly with an authorization code.

- **Bug Fixes**
  - Enforce prompt=consent: set a signed consent cookie, redirect to the configured consentPage with a consent_code, and only issue the code after consent; otherwise, redirect directly with the code.
  - Added tests covering both consent and non-consent flows.

- **New Features**
  - Exposed the OAuth consent endpoint to handle consent acceptance and final redirect.

<!-- End of auto-generated description by cubic. -->

