### PR TITLE
docs: clarify requireEmailVerification and sendOnSignIn behavior

### DIFF
--- a/docs/content/docs/concepts/email.mdx
+++ b/docs/content/docs/concepts/email.mdx
@@ -89,7 +89,7 @@ export const auth = betterAuth({
 });
 ```
 
-if a user tries to sign in without verifying their email, you can handle the error and show a message to the user.
+If a user tries to sign in without verifying their email, you can handle the error and show a message to the user.
 
 ```ts title="auth-client.ts"
 await authClient.signIn.email({


### PR DESCRIPTION
- Updated a new section under "Require Email Verification" explaining that sendVerificationEmail is only triggered on sign-in if sendOnSignIn is set to true.
- Included a corrected code snippet showing how to configure sendVerificationEmail and sendOnSignIn alongside requireEmailVerification.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified the “Require Email Verification” docs to explain that sendVerificationEmail runs on sign-in only when sendOnSignIn is true. Added a corrected auth.ts example showing sendVerificationEmail, sendOnSignIn, and requireEmailVerification configured together.

<!-- End of auto-generated description by cubic. -->

