### PR TITLE
chore: removed noisy `logger.info` triggered by `useActiveOrganization`

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -708,7 +708,6 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 				session.session.activeOrganizationId;
 			// return null if no organization is found to avoid erroring since this is a usual scenario
 			if (!organizationId) {
-				ctx.context.logger.info("No active organization found, returning null");
 				return ctx.json(null, {
 					status: 200,
 				});


### PR DESCRIPTION
In [`crud-org.ts`](https://github.com/better-auth/better-auth/blob/canary/packages/better-auth/src/plugins/organization/routes/crud-org.ts#L711), there is a `logger.info` call that pollutes the server console when the user is not using an active organization and `useActiveOrganization` is called, which is very annoying.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed a noisy logger.info when no active organization is set. useActiveOrganization now returns null quietly without cluttering server logs.

<!-- End of auto-generated description by cubic. -->

