### PR TITLE
docs: prevent blog page overflow

### DIFF
--- a/docs/app/blog/_components/stat-field.tsx
+++ b/docs/app/blog/_components/stat-field.tsx
@@ -195,7 +195,7 @@ export function StarField({ className }: { className?: string }) {
 			fill="white"
 			aria-hidden="true"
 			className={clsx(
-				"pointer-events-none absolute w-[55.0625rem] origin-top-right rotate-[30deg] overflow-visible opacity-70",
+				"pointer-events-none absolute w-[55.0625rem] max-w-[100vw] origin-top-right rotate-[30deg] overflow-visible opacity-70",
 				className,
 			)}
 		>


### PR DESCRIPTION
---

This PR fixes an issue where the blog page overflows the viewport width, which is especially noticeable on mobile devices.

---

### Before:

https://github.com/user-attachments/assets/fed99a63-5387-401a-aedd-91d294304eb2

### After:

https://github.com/user-attachments/assets/daf71ecd-3edb-4f26-a74c-da1718910792


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent blog page overflow by capping the StarField width to the viewport. Adds max-w-[100vw] to the component class to stop horizontal scrolling, especially on mobile.

<!-- End of auto-generated description by cubic. -->

