### PR TITLE
fix(drizzle): replace pgEnum with text enum type in Drizzle schema generation

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -74,7 +74,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				if (Array.isArray(type) && type.every((x) => typeof x === "string")) {
 					return {
 						sqlite: `text({ enum: [${type.map((x) => `'${x}'`).join(", ")}] })`,
-						pg: `pgEnum('${name}', [${type.map((x) => `'${x}'`).join(", ")}])`,
+						pg: `text('${name}', { enum: [${type.map((x) => `'${x}'`).join(", ")}] })`,
 						mysql: `mysqlEnum([${type.map((x) => `'${x}'`).join(", ")}])`,
 					}[databaseType];
 				} else {
@@ -311,18 +311,6 @@ function generateImport({
 			(options.advanced?.database?.useNumberId && hasFkToId);
 		if (needsInteger) {
 			coreImports.push("integer");
-		}
-
-		const hasEnum = Object.values(tables).some((table) =>
-			Object.values(table.fields).some(
-				(field) =>
-					typeof field.type !== "string" &&
-					Array.isArray(field.type) &&
-					field.type.every((x) => typeof x === "string"),
-			),
-		);
-		if (hasEnum) {
-			coreImports.push("pgEnum");
 		}
 	} else {
 		coreImports.push("integer");

--- a/packages/cli/test/__snapshots__/auth-schema-pg-enum.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-enum.txt
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, boolean, pgEnum } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean } from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),
@@ -11,7 +11,7 @@ export const user = pgTable("user", {
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
-  role: pgEnum("role", ["admin", "user", "guest"]).notNull(),
+  role: text("role", { enum: ["admin", "user", "guest"] }).notNull(),
 });
 
 export const session = pgTable("session", {

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -385,9 +385,8 @@ describe("Enum field support in Drizzle schemas", () => {
 				},
 			} as BetterAuthOptions,
 		});
-		expect(schema.code).toContain("pgEnum");
 		expect(schema.code).toContain(
-			'role: pgEnum("role", ["admin", "user", "guest"])',
+			'role: text("role", { enum: ["admin", "user", "guest"] })',
 		);
 		await expect(schema.code).toMatchFileSnapshot(
 			"./__snapshots__/auth-schema-pg-enum.txt",
@@ -455,30 +454,6 @@ describe("Enum field support in Drizzle schemas", () => {
 		);
 	});
 
-	it("should include correct imports for enum fields in PostgreSQL", async () => {
-		const schema = await generateDrizzleSchema({
-			file: "test.drizzle",
-			adapter: {
-				id: "drizzle",
-				options: {
-					provider: "pg",
-					schema: {},
-				},
-			} as any,
-			options: {
-				database: {} as any,
-				user: {
-					additionalFields: {
-						role: {
-							type: ["admin", "user"],
-						},
-					},
-				},
-			} as BetterAuthOptions,
-		});
-		expect(schema.code).toMatch(/import.*pgEnum.*from.*drizzle-orm\/pg-core/);
-	});
-
 	it("should include correct imports for enum fields in MySQL", async () => {
 		const schema = await generateDrizzleSchema({
 			file: "test.drizzle",
@@ -526,6 +501,6 @@ describe("Enum field support in Drizzle schemas", () => {
 				},
 			} as BetterAuthOptions,
 		});
-		expect(schema.code).not.toContain("pgEnum");
+		expect(schema.code).not.toContain("enum");
 	});
 });


### PR DESCRIPTION
drizzle schema generation PgEnum not properly implemented. 
Also see 
- https://github.com/better-auth/better-auth/pull/5287/files#r2427569929
- https://orm.drizzle.team/docs/column-types/pg#enum

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced pgEnum with the text enum column type for PostgreSQL in Drizzle schema generation to fix incorrect enum handling. This aligns with Drizzle docs and removes the need for pgEnum imports.

- **Bug Fixes**
  - Generate pg enums as text("name", { enum: [...] }) instead of pgEnum("name", [...]).
  - Removed pgEnum import logic from the generator.
  - Updated tests and snapshots to reflect the new output.

<!-- End of auto-generated description by cubic. -->

