### PR TITLE
docs(passkey): added missing important info

### DIFF
--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -16,11 +16,12 @@ The passkey plugin implementation is powered by [SimpleWebAuthn](https://simplew
 
         **Options**
 
-        `rpID`: A unique identifier for your website. 'localhost' is okay for local dev
+        `rpID`: A unique identifier for your website based on your auth server origin. 'localhost' is okay for local dev. RP ID can be formed by discarding zero or more labels from the left of its effective domain
+        until it hits an effective TLD. So `www.example.com` can use the RP IDs `www.example.com` or `example.com`. But not `com`, because that's an eTLD.
 
         `rpName`: Human-readable title for your website
 
-        `origin`: The URL at which registrations and authentications should occur. `http://localhost` and `http://localhost:PORT` are also valid. Do **NOT** include any trailing /
+        `origin`: The origin URL at which your better-auth server is hosted. `http://localhost` and `http://localhost:PORT` are also valid. Do **NOT** include any trailing /
 
         `authenticatorSelection`: Allows customization of WebAuthn authenticator selection criteria. Leave unspecified for default settings.
             - `authenticatorAttachment`: Specifies the type of authenticator
@@ -312,11 +313,13 @@ Table Name: `passkey`
             name: "transports",
             type: "string",
             description: "The transports used to register the passkey",
+            isOptional: true
         },
         { 
             name: "createdAt", 
             type: "Date", 
             description: "The time when the passkey was created",
+            isOptional: true
         },
         {
                 name: "aaguid",
@@ -329,11 +332,13 @@ Table Name: `passkey`
 
 ## Options
 
-**rpID**: A unique identifier for your website. 'localhost' is okay for local dev.
+**rpID**: A unique identifier for your website based on your auth server origin.
+`'localhost'` is okay for local dev. RP ID can be formed by discarding zero or more labels from the left of its effective domain
+until it hits an effective TLD. So `www.example.com` can use the RP IDs `www.example.com` or `example.com`. But not `com`, because that's an eTLD.
 
 **rpName**: Human-readable title for your website.
 
-**origin**: The URL at which registrations and authentications should occur. `http://localhost` and `http://localhost:PORT` are also valid. Do NOT include any trailing /.
+**origin**: The origin URL at which your better-auth server is hosted. `http://localhost` and `http://localhost:PORT` are also valid. Do NOT include any trailing /.
 
 **authenticatorSelection**: Allows customization of WebAuthn authenticator selection criteria. When unspecified, both platform and cross-platform authenticators are allowed with `preferred` settings for `residentKey` and `userVerification`.
 


### PR DESCRIPTION
Added important information to the passkey docs regarding `rpID` and `origin` which can cause issues if not documented.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified passkey docs to prevent WebAuthn misconfig: rpID must be based on the auth server origin and can drop left labels (e.g., www.example.com → example.com) but cannot be an eTLD. Also defined origin as the auth server origin and marked “transports” and “createdAt” as optional in the passkey table.

<!-- End of auto-generated description by cubic. -->

