### PR TITLE
fix: user-agent requirement when fetching from clients

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -5,7 +5,7 @@ import type {
 	BetterAuthClientOptions,
 	ClientAtomListener,
 } from "@better-auth/core";
-import { redirectPlugin } from "./fetch-plugins";
+import { redirectPlugin, userAgentPlugin } from "./fetch-plugins";
 import { getSessionAtom } from "./session-atom";
 import { parseJSON } from "./parser";
 
@@ -50,6 +50,7 @@ export const getClientConfig = (
 		...restOfFetchOptions,
 		plugins: [
 			lifeCyclePlugin,
+			userAgentPlugin,
 			...(restOfFetchOptions.plugins || []),
 			...(options?.disableDefaultFetchPlugins ? [] : [redirectPlugin]),
 			...pluginsFetchPlugins,

--- a/packages/better-auth/src/client/fetch-plugins.ts
+++ b/packages/better-auth/src/client/fetch-plugins.ts
@@ -17,3 +17,13 @@ export const redirectPlugin = {
 		},
 	},
 } satisfies BetterFetchPlugin;
+
+export const userAgentPlugin = {
+	id: "user-agent",
+	name: "UserAgent",
+	hooks: {
+		onRequest(context) {
+			context.headers.append("user-agent", "better-auth");
+		},
+	},
+} satisfies BetterFetchPlugin;

--- a/packages/core/src/oauth2/validate-authorization-code.ts
+++ b/packages/core/src/oauth2/validate-authorization-code.ts
@@ -29,7 +29,6 @@ export function createAuthorizationCodeRequest({
 	const requestHeaders: Record<string, any> = {
 		"content-type": "application/x-www-form-urlencoded",
 		accept: "application/json",
-		"user-agent": "better-auth",
 		...headers,
 	};
 	body.set("grant_type", "authorization_code");
@@ -139,7 +138,6 @@ export async function validateToken(token: string, jwksEndpoint: string) {
 		method: "GET",
 		headers: {
 			accept: "application/json",
-			"user-agent": "better-auth",
 		},
 	});
 	if (error) {


### PR DESCRIPTION
Client request fails early without `user-agent: better-auth` header resulting in `ERROR [Better Auth]: Invalid request`.

Fixes failing tests on #4163.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added user-agent: better-auth to OAuth client credentials and refresh token requests so the server accepts them and we avoid "Invalid request" errors. Fixes failing tests in #4163.

<!-- End of auto-generated description by cubic. -->

