### PR TITLE
feat: validate reset password token function

### DIFF
--- a/.changeset/validate-reset-password-token.md
+++ b/.changeset/validate-reset-password-token.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Add `validateResetPasswordToken` endpoint to check if a password reset token is valid without consuming it

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -374,6 +374,105 @@ const { data, error } = await authClient.resetPassword({
   ```
 </APIMethod>
 
+#### Validate Password Reset Token
+
+Before showing the password reset form to users, you can validate the token to ensure it's still valid and not expired. This provides a better user experience by giving immediate feedback about the token status.
+
+The `validateResetPasswordToken` method checks if a token is valid without consuming it. This is useful for:
+
+* Showing appropriate error messages if the token is invalid or expired
+* Preventing users from filling out the form with an invalid token
+* Providing early validation before password submission
+
+<APIMethod path="/validate-reset-password-token" method="POST">
+  ```ts
+  type validateResetPasswordToken = {
+      /**
+       * The token to validate
+       */
+      token: string
+  }
+  ```
+</APIMethod>
+
+The response includes:
+
+* `valid`: A boolean indicating if the token is valid
+* `message`: A descriptive message about the token status
+
+**Example usage:**
+
+```ts title="reset-password-page.tsx"
+const token = new URLSearchParams(window.location.search).get("token");
+
+if (!token) {
+  // Handle missing token
+}
+
+// Validate the token
+const validation = await authClient.validateResetPasswordToken({
+  token,
+});
+
+if (validation.data?.valid) {
+  // Token is valid, show the password reset form
+  console.log("Token is valid!");
+} else {
+  // Token is invalid or expired
+  console.log("Error:", validation.data?.message);
+  // Show error message to user
+}
+```
+
+**Example with React:**
+
+```tsx title="components/ResetPassword.tsx"
+import { useEffect, useState } from "react";
+import { authClient } from "@/lib/auth-client";
+
+export function ResetPasswordForm() {
+  const [tokenValid, setTokenValid] = useState<boolean | null>(null);
+  const [message, setMessage] = useState("");
+  
+  useEffect(() => {
+    const token = new URLSearchParams(window.location.search).get("token");
+    
+    if (token) {
+      authClient.validateResetPasswordToken({ token })
+        .then((validation) => {
+          setTokenValid(validation.data?.valid || false);
+          setMessage(validation.data?.message || "");
+        });
+    }
+  }, []);
+  
+  if (tokenValid === null) {
+    return <div>Validating token...</div>;
+  }
+  
+  if (!tokenValid) {
+    return (
+      <div className="error">
+        <h2>Invalid Reset Link</h2>
+        <p>{message}</p>
+        <a href="/forgot-password">Request a new reset link</a>
+      </div>
+    );
+  }
+  
+  return (
+    <form>
+      <h2>Reset Your Password</h2>
+      {/* Password reset form fields */}
+    </form>
+  );
+}
+```
+
+<Callout type="info">
+  The validation endpoint does **not** consume the token. The token is only consumed when you call `resetPassword` to actually change the password.
+</Callout>
+
 ### Update password
 
 A user's password isn't stored in the user table. Instead, it's stored in the account table. To change the password of a user, you can use one of the following approaches:

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -398,7 +398,7 @@ The `validateResetPasswordToken` method checks if a token is valid without consu
 The response includes:
 
 * `valid`: A boolean indicating if the token is valid
-* `message`: A descriptive message about the token status
+* `message`: `"Token is valid"` or `"Invalid token"`
 
 **Example usage:**
 

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -50,6 +50,7 @@ import {
 	unlinkAccount,
 	updateSession,
 	updateUser,
+	validatePasswordResetToken,
 	verifyEmail,
 	verifyPassword,
 } from "./routes";
@@ -246,6 +247,7 @@ export function getEndpoints<Option extends BetterAuthOptions>(
 		deleteUser,
 		requestPasswordReset,
 		requestPasswordResetCallback,
+		validatePasswordResetToken,
 		listSessions: listSessions<Option>(),
 		revokeSession,
 		revokeSessions,

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -252,7 +252,7 @@ describe("forgot password", async () => {
 			token,
 		});
 		expect(validation.data?.valid).toBe(false);
-		expect(validation.data?.message).toBe("Token has expired");
+		expect(validation.data?.message).toBe("Invalid token");
 
 		vi.useRealTimers();
 	});

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -206,6 +206,57 @@ describe("forgot password", async () => {
 		expect(res.error?.status).toBe(400);
 	});
 
+	it("should validate a valid reset password token", async () => {
+		await client.requestPasswordReset({
+			email: testUser.email,
+			redirectTo: "http://localhost:3000",
+		});
+		expect(token.length).toBeGreaterThan(10);
+
+		const validation = await client.validateResetPasswordToken({
+			token,
+		});
+		expect(validation.data?.valid).toBe(true);
+		expect(validation.data?.message).toBe("Token is valid");
+	});
+
+	it("should reject an invalid reset password token", async () => {
+		const validation = await client.validateResetPasswordToken({
+			token: "invalid-token",
+		});
+		expect(validation.data?.valid).toBe(false);
+		expect(validation.data?.message).toBe("Invalid token");
+	});
+
+	it("should reject an expired reset password token", async () => {
+		const { client: tempClient, testUser: tempUser } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword({ token: _token }) {
+					token = _token;
+					await mockSendEmail();
+				},
+				resetPasswordTokenExpiresIn: 1,
+			},
+		});
+
+		await tempClient.requestPasswordReset({
+			email: tempUser.email,
+			redirectTo: "http://localhost:3000",
+		});
+
+		vi.useFakeTimers();
+		await vi.advanceTimersByTimeAsync(2000);
+
+		const validation = await tempClient.validateResetPasswordToken({
+			token,
+		});
+		expect(validation.data?.valid).toBe(false);
+		expect(validation.data?.message).toBe("Token has expired");
+
+		vi.useRealTimers();
+	});
+
 	it("should expire", async () => {
 		const { client, signInWithTestUser, testUser } = await getTestInstance({
 			emailAndPassword: {

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -226,6 +226,75 @@ export const requestPasswordResetCallback = createAuthEndpoint(
 	},
 );
 
+export const validatePasswordResetToken = createAuthEndpoint(
+	"/validate-reset-password-token",
+	{
+		method: "POST",
+		body: z.object({
+			token: z.string().meta({
+				description: "The token to validate",
+			}),
+		}),
+		metadata: {
+			openapi: {
+				description: "Validate a password reset token without consuming it",
+				responses: {
+					"200": {
+						description: "Token validation result",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										valid: {
+											type: "boolean",
+										},
+										message: {
+											type: "string",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		const { token } = ctx.body;
+		if (!token) {
+			return ctx.json({
+				valid: false,
+				message: "Token is required",
+			});
+		}
+
+		const id = `reset-password:${token}`;
+
+		const verification =
+			await ctx.context.internalAdapter.findVerificationValue(id);
+		if (!verification) {
+			return ctx.json({
+				valid: false,
+				message: "Invalid token",
+			});
+		}
+
+		if (verification.expiresAt < new Date()) {
+			return ctx.json({
+				valid: false,
+				message: "Token has expired",
+			});
+		}
+
+		return ctx.json({
+			valid: true,
+			message: "Token is valid",
+		});
+	},
+);
+
 export const resetPassword = createAuthEndpoint(
 	"/reset-password",
 	{

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -284,7 +284,7 @@ export const validatePasswordResetToken = createAuthEndpoint(
 		if (verification.expiresAt < new Date()) {
 			return ctx.json({
 				valid: false,
-				message: "Token has expired",
+				message: "Invalid token",
 			});
 		}
 

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -5046,6 +5046,156 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
         ],
       },
     },
+    "/validate-reset-password-token": {
+      "post": {
+        "description": "Validate a password reset token without consuming it",
+        "operationId": undefined,
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "token": {
+                    "description": "The token to validate",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "token",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                    "valid": {
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Token validation result",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters.",
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication.",
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action.",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Not Found. The requested resource was not found.",
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later.",
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix.",
+          },
+        },
+        "security": [
+          {
+            "bearerAuth": [],
+          },
+        ],
+        "tags": [
+          "Default",
+        ],
+      },
+    },
     "/verify-email": {
       "get": {
         "description": "Verify the email of the user",


### PR DESCRIPTION
Hello! I noticed that when users land on a password reset page, they don't know if their token is valid or expired until they actually try to submit the form. This can be frustrating for user, imagine filling out new password only to find out the link expired.

### What's new

This PR adds a new `validateResetPasswordToken` method that lets you check if a reset token is still valid without consuming it. 

**Client usage:**
```ts
const validation = await client.validateResetPasswordToken({ token });

if (validation.data?.valid) {
  // Show the reset form
} else {
  // Show error: token expired or invalid
}
```

### Changes made

- **Server**: Added `/validate-reset-password-token` POST endpoint that checks token validity and expiration
- **Client**: The endpoint is automatically available as `client.validateResetPasswordToken()`
- **Tests**: Added 3 test cases covering valid, invalid, and expired tokens
- **Docs**: Updated the email-password authentication docs with usage examples including a React component

The validation returns:
```ts
{
  valid: boolean,
  message: string  // "Token is valid" | "Invalid token" | "Token has expired"
}
```

### Testing

All tests pass including the 3 new validation tests:
- Valid token returns `{ valid: true }`
- Invalid token returns `{ valid: false }`  
- Expired token returns `{ valid: false }`
    

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a password reset token validator so users can see if their link is valid or expired before filling the form. Docs and OpenAPI updated.

- **New Features**
  - Server: POST /validate-reset-password-token checks validity and expiry without consuming the token.
  - Client: `validateResetPasswordToken({ token })` returns `{ valid, message }` to gate the reset form.
  - Tests & docs: 3 tests (valid/invalid/expired) and updated docs with usage examples (incl. a React snippet).
  - OpenAPI: Endpoint added to the generated schema.

<sup>Written for commit cd774b9e9e22a73c40169f1a27e52de45d9b35a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

