### PR TITLE
docs: support explicit .mdx URLs in llms.txt routes

### DIFF
--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -16,5 +16,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-	matcher: "/docs/:path*",
+	matcher: "/docs/:path((?!.*\\.mdx$).*)*",
 };


### PR DESCRIPTION
## Summary
Enables LLM integrations to request documentation using explicit `.mdx` file extensions in URLs.

## Changes
- Updated the proxy matcher in `docs/proxy.ts` to exclude paths ending with `.mdx`
- Uses negative lookahead regex pattern to prevent proxying of `.mdx` URLs
- Allows URLs like `/docs/authentication.mdx` to reach the route handler directly

## Why
LLMs sometimes include file extensions when requesting documentation. This change ensures both `/docs/page` and `/docs/page.mdx` work seamlessly.