### PR TITLE
fix(core): correctly set typesVersions paths

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -119,35 +119,38 @@
   },
   "typesVersions": {
     "*": {
-      "index": [
+      ".": [
         "dist/index.d.ts"
       ],
+      "api": [
+        "dist/api/index.d.ts"
+      ],
       "async_hooks": [
-        "dist/async_hooks.d.ts"
+        "dist/async_hooks/index.d.ts"
+      ],
+      "context": [
+        "dist/context/index.d.ts"
+      ],
+      "env": [
+        "dist/env/index.d.ts"
+      ],
+      "error": [
+        "dist/error/index.d.ts"
+      ],
+      "utils": [
+        "dist/utils/index.d.ts"
+      ],
+      "social-providers": [
+        "dist/social-providers/index.d.ts"
       ],
       "db": [
-        "dist/db.d.ts"
+        "dist/db/index.d.ts"
       ],
       "db/adapter": [
         "dist/db/adapter/index.d.ts"
       ],
-      "env": [
-        "dist/env.d.ts"
-      ],
-      "error": [
-        "dist/error.d.ts"
-      ],
-      "middleware": [
-        "dist/middleware.d.ts"
-      ],
       "oauth2": [
-        "dist/oauth2.d.ts"
-      ],
-      "social-providers": [
-        "dist/social-providers.d.ts"
-      ],
-      "utils": [
-        "dist/utils.d.ts"
+        "dist/oauth2/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
This fixes an issue where types exported from `@better-auth/core` fail to resolve with `moduleResolution: Node10`.

Before:
<img width="1920" height="583" alt="스크린샷 2025-10-20 오후 8 51 10" src="https://github.com/user-attachments/assets/fbfba1fd-0473-48c4-9ce6-377072efefb1" />

After:

<img width="1920" height="496" alt="스크린샷 2025-10-20 오후 8 50 14" src="https://github.com/user-attachments/assets/10244101-3f16-4707-ba83-283b953b1f30" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes TypeScript type resolution for @better-auth/core when using moduleResolution: Node10. Corrects typesVersions paths so root and subpath exports point to the right .d.ts files.

- **Bug Fixes**
  - Mapped "." to dist/index.d.ts and subpaths (api, async_hooks, context, env, error, utils, social-providers, db, db/adapter, oauth2) to dist/<subpath>/index.d.ts.
  - Types now resolve correctly for Node10-style module resolution.

<!-- End of auto-generated description by cubic. -->

