### PR TITLE
test: username type infer

### DIFF
--- a/e2e/smoke/test/fixtures/tsconfig-declaration/src/username.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/src/username.ts
@@ -1,0 +1,28 @@
+import { betterAuth } from "better-auth";
+import { username } from "better-auth/plugins";
+import { expectTypeOf } from "vitest";
+
+export const auth = betterAuth({
+	emailAndPassword: {
+		enabled: true,
+	},
+	plugins: [
+		username({
+			minUsernameLength: 4,
+			maxUsernameLength: 15,
+		}),
+	],
+});
+
+type User = typeof auth.$Infer.Session.user;
+expectTypeOf<User>().toEqualTypeOf<{
+	createdAt: Date;
+	displayUsername?: string | null | undefined;
+	email: string;
+	emailVerified: boolean;
+	id: string;
+	image?: string | null | undefined;
+	name: string;
+	updatedAt: Date;
+	username?: string | null | undefined;
+}>();

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -5,13 +5,14 @@ import {
 } from "@better-auth/core/api";
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { APIError } from "better-call";
-import type { Account, InferOptionSchema, User } from "../../types";
+import type { Account, User } from "@better-auth/core/db";
 import { setSessionCookie } from "../../cookies";
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import { getSchema, type UsernameSchema } from "./schema";
 import { mergeSchema } from "../../db";
 import { USERNAME_ERROR_CODES as ERROR_CODES } from "./error-codes";
 import { createEmailVerificationToken } from "../../api";
+import type { InferOptionSchema } from "../../types/plugins";
 
 export { USERNAME_ERROR_CODES } from "./error-codes";
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added an e2e fixture that asserts the inferred Session.user type when the username plugin is enabled. Updated plugin imports to use core DB types so username fields are typed correctly.

- **Refactors**
  - Use Account and User from @better-auth/core/db.
  - Import InferOptionSchema from ../../types/plugins.

<!-- End of auto-generated description by cubic. -->

