### PR TITLE
chore: fix biome config

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.6/schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "tab"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update biome.json to use Biome schema 2.2.6 instead of 2.2.4. This fixes schema validation in editors and keeps the config aligned with the latest tooling.

<!-- End of auto-generated description by cubic. -->

