### PR TITLE
Add additionalParams support to signIn.social and Amazon Cognito options

### DIFF
--- a/docs/content/docs/authentication/cognito.mdx
+++ b/docs/content/docs/authentication/cognito.mdx
@@ -18,8 +18,8 @@ description: Amazon Cognito provider setup and usage.
     5. Add your callback URL (e.g., `http://localhost:3000/api/auth/callback/cognito`).
 
     <Callout type="info">
-      - **User Pool is required** for Cognito authentication.  
-      - Make sure the callback URL matches exactly what you configure in Cognito.   
+      - **User Pool is required** for Cognito authentication.
+      - Make sure the callback URL matches exactly what you configure in Cognito.
     </Callout>
   </Step>
 
@@ -46,7 +46,7 @@ description: Amazon Cognito provider setup and usage.
 
   <Step>
     ### Sign In with Cognito
-    To sign in with Cognito, use the `signIn.social` function from the client.  
+    To sign in with Cognito, use the `signIn.social` function from the client.
 
     ```ts title="auth-client.ts"
     import { createAuthClient } from "better-auth/client"
@@ -59,7 +59,7 @@ description: Amazon Cognito provider setup and usage.
       })
     }
     ```
-    
+
       ### Additional Options:
         - `scope`: Additional OAuth2 scopes to request (combined with default permissions).
             - Default: `"openid" "profile" "email"`
@@ -70,8 +70,9 @@ description: Amazon Cognito provider setup and usage.
               - `phone`: Access to user’s phone number
               - `aws.cognito.signin.user.admin`: Grants access to Cognito-specific APIs
         - Note: You must configure the scopes in your Cognito App Client settings. [available scopes](https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html#token-endpoint-userinfo)
-        - `getUserInfo`: Custom function to retrieve user information from the Cognito UserInfo endpoint.  
-       <Callout type="info">
+        - `getUserInfo`: Custom function to retrieve user information from the Cognito UserInfo endpoint.
+        - `additionalParams`: Additional URL [query arguments](https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html#get-authorize) to add to the Authorization URL, for example set `identity_provider` to silently redirect your user to the sign-in page for that identity provider.
+        <Callout type="info">
         For more information about Amazon Cognito's scopes and API capabilities, refer to the [official documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-define-resource-servers.html?utm_source).
         </Callout>
   </Step>

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -1,12 +1,12 @@
-import { APIError } from "better-call";
-import * as z from "zod";
 import { createAuthEndpoint } from "@better-auth/core/api";
-import { setSessionCookie } from "../../cookies";
-import { createEmailVerificationToken } from "./email-verification";
-import { generateState } from "../../utils";
-import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import { SocialProviderListEnum } from "@better-auth/core/social-providers";
+import { APIError } from "better-call";
+import * as z from "zod";
+import { setSessionCookie } from "../../cookies";
+import { handleOAuthUserInfo } from "../../oauth2/link-account";
+import { generateState } from "../../utils";
+import { createEmailVerificationToken } from "./email-verification";
 
 export const signInSocial = createAuthEndpoint(
 	"/sign-in/social",
@@ -145,6 +145,16 @@ export const signInSocial = createAuthEndpoint(
 				.meta({
 					description:
 						"The login hint to use for the authorization code request",
+				})
+				.optional(),
+			/**
+			 * Additional URL query arguments to add to the Authorization URL
+			 */
+			additionalParams: z
+				.record(z.string(), z.string())
+				.meta({
+					description:
+						"Additional URL query arguments to add to the Authorization URL",
 				})
 				.optional(),
 		}),
@@ -325,6 +335,7 @@ export const signInSocial = createAuthEndpoint(
 			redirectURI: `${c.context.baseURL}/callback/${provider.id}`,
 			scopes: c.body.scopes,
 			loginHint: c.body.loginHint,
+			additionalParams: c.body.additionalParams,
 		});
 
 		return c.json({

--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -30,6 +30,7 @@ export interface OAuthProvider<
 		redirectURI: string;
 		display?: string;
 		loginHint?: string;
+		additionalParams?: Record<string, string>;
 	}) => Promise<URL> | URL;
 	name: string;
 	validateAuthorizationCode: (data: {


### PR DESCRIPTION
fixes #5441
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add support for additionalParams in signIn.social and the Cognito provider to pass extra query args to the OAuth authorization URL. This enables flows like pre-selecting an IdP via identity_provider.

- **New Features**
  - signIn.social accepts additionalParams: Record<string, string>, forwarded to the authorization URL.
  - Core OAuthProvider.createAuthorizationURL now supports additionalParams.
  - Cognito provider supports additionalParams at both provider options and per-request; values are merged with per-request taking precedence.
  - Docs updated to show additionalParams usage for Cognito (e.g., identity_provider).

<!-- End of auto-generated description by cubic. -->

