### PR TITLE
chore: fix typo

### DIFF
--- a/packages/core/src/context/endpoint-context.ts
+++ b/packages/core/src/context/endpoint-context.ts
@@ -33,7 +33,7 @@ export async function getCurrentAuthContext(): Promise<AuthEndpointContext> {
 	const context = als.getStore();
 	if (!context) {
 		throw new Error(
-			"No auth context found. Please make sure you are calling this function within a `getCurrentAuthContext` callback.",
+			"No auth context found. Please make sure you are calling this function within a `runWithEndpointContext` callback.",
 		);
 	}
 	return context;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Corrected the error message in getCurrentAuthContext to reference runWithEndpointContext, giving accurate guidance when no auth context is found.

<!-- End of auto-generated description by cubic. -->

