### PR TITLE
chore: add docker setup instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ pnpm lint:fix
 3. Add tests for your changes
 4. Run database containers (needed for testing database adapters)
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 5. Run the test suite:
    ```bash


### PR DESCRIPTION
Add Docker instructions to `CONTRIBUTING.md` for smoother contributor onboarding. No other changes.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Docker setup instructions to CONTRIBUTING.md so contributors can start required database containers before running tests. This prevents adapter test failures and makes local setup smoother.

<!-- End of auto-generated description by cubic. -->

