### PR TITLE
refactor: improve type in beforeHook

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -174,9 +174,8 @@ async function runBeforeHooks(
 		handler: AuthMiddleware;
 	}[],
 ) {
-	let modifiedContext: {
-		headers?: Headers;
-	} = {};
+	let modifiedContext: Partial<InternalContext> = {};
+
 	for (const hook of hooks) {
 		if (hook.matcher(context)) {
 			const result = await hook
@@ -196,9 +195,8 @@ async function runBeforeHooks(
 				});
 			if (result && typeof result === "object") {
 				if ("context" in result && typeof result.context === "object") {
-					const { headers, ...rest } = result.context as {
-						headers: Headers;
-					};
+					const { headers, ...rest } =
+						result.context as Partial<InternalContext>;
 					if (headers instanceof Headers) {
 						if (modifiedContext.headers) {
 							headers.forEach((value, key) => {


### PR DESCRIPTION
This PR improves the type inside beforeHook. I think it’s more appropriate for the `modifiedContext` variable to be part of `InternalContext` rather than just an object containing headers.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch modifiedContext to Partial<InternalContext> in beforeHook processing to improve type safety and let hooks modify more context fields, not just headers. Existing headers merge behavior remains unchanged.

- **Refactors**
  - Update modifiedContext type to Partial<InternalContext> in runBeforeHooks.
  - Cast result.context as Partial<InternalContext> during destructuring.
  - Keep headers merging logic intact.

<!-- End of auto-generated description by cubic. -->

