### PR TITLE
[rolldown bug]: Error: Panic in async function

### DIFF
--- a/packages/better-auth/src/db/utils.ts
+++ b/packages/better-auth/src/db/utils.ts
@@ -1,18 +1,17 @@
 import { getAuthTables } from ".";
 import { BetterAuthError } from "@better-auth/core/error";
 import type { BetterAuthOptions } from "@better-auth/core";
-import { createKyselyAdapter } from "../adapters/kysely-adapter/dialect";
-import { kyselyAdapter } from "../adapters/kysely-adapter";
-import { memoryAdapter, type MemoryDB } from "../adapters/memory-adapter";
 import { logger } from "@better-auth/core/env";
 import type { DBFieldAttribute } from "@better-auth/core/db";
 import type { DBAdapter } from "@better-auth/core/db/adapter";
+import type { MemoryDB } from "../adapters/memory-adapter";
 
 export async function getAdapter(
 	options: BetterAuthOptions,
 ): Promise<DBAdapter<BetterAuthOptions>> {
 	let adapter: DBAdapter<BetterAuthOptions>;
 	if (!options.database) {
+		const { memoryAdapter } = await import("../adapters/memory-adapter");
 		const tables = getAuthTables(options);
 		const memoryDB = Object.keys(tables).reduce<MemoryDB>((acc, key) => {
 			acc[key] = [];
@@ -25,11 +24,13 @@ export async function getAdapter(
 	} else if (typeof options.database === "function") {
 		adapter = options.database(options);
 	} else {
+		const { createKyselyAdapter } = await import("../adapters/kysely-adapter");
 		const { kysely, databaseType, transaction } =
 			await createKyselyAdapter(options);
 		if (!kysely) {
 			throw new BetterAuthError("Failed to initialize database adapter");
 		}
+		const { kyselyAdapter } = await import("../adapters/kysely-adapter");
 		adapter = kyselyAdapter(kysely, {
 			type: databaseType || "sqlite",
 			debugLogs:

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -1,8 +1,8 @@
 import { defu } from "defu";
-import { hashPassword, verifyPassword } from "./crypto/password";
+import { hashPassword, verifyPassword } from "./crypto";
 import { createInternalAdapter, getAuthTables, getMigrations } from "./db";
 import type { Entries } from "type-fest";
-import { getAdapter } from "./db/utils";
+import { getAdapter } from "./db";
 import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
 import { DEFAULT_SECRET } from "./utils/constants";
 import { createCookieGetter, getCookies } from "./cookies";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Lazy-loads database adapters so we only import Kysely/memory backends when needed, reducing startup cost and bundle size. Also simplifies init imports.

- **Refactors**
  - Switched to dynamic imports in getAdapter for memoryAdapter, createKyselyAdapter, and kyselyAdapter.
  - Kept MemoryDB as a type-only import.
  - Updated init imports: use ./crypto for password helpers and ./db for getAdapter.

<!-- End of auto-generated description by cubic. -->

