### PR TITLE
chore: add `--continue` on test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release:no-build": "bumpp && pnpm -r publish --access public --no-git-checks --tag next",
     "release:canary": "turbo --filter \"./packages/*\" build && bumpp && pnpm -r publish --access public --tag canary --no-git-checks",
     "bump": "bumpp",
-    "test": "turbo --filter \"./packages/*\" test",
+    "test": "turbo --filter \"./packages/*\" test --continue",
     "e2e:smoke": "turbo --filter \"./e2e/*\" e2e:smoke",
     "e2e:integration": "turbo --filter \"./e2e/*\" e2e:integration",
     "typecheck": "tsc --build"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added --continue to the test script so tests keep running across all packages even if some fail. This surfaces all failures in one run and reduces reruns during local and CI testing.

<!-- End of auto-generated description by cubic. -->

