### PR TITLE
chore: remove an unused option

### DIFF
--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -671,10 +671,6 @@ export type BetterAuthOptions = {
 			[key: string]: DBFieldAttribute;
 		};
 		/**
-		 * @default false
-		 */
-		storeSessionInJWT?: boolean;
-		/**
 		 * By default if secondary storage is provided
 		 * the session is stored in the secondary storage.
 		 *


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the unused storeSessionInJWT option from BetterAuthOptions to simplify the API and avoid confusion. No runtime changes; only the type definition was cleaned up.

<!-- End of auto-generated description by cubic. -->

