### PR TITLE
docs: remove server route handler instructions from TanStack Start Integration Guide

### DIFF
--- a/docs/content/docs/integrations/tanstack.mdx
+++ b/docs/content/docs/integrations/tanstack.mdx
@@ -30,20 +30,6 @@ export const Route = createFileRoute('/api/auth/$')({
 })
 ```
 
-If you haven't created your server route handler yet, you can do so by creating a file: `/src/server.ts`
-
-```ts title="src/server.ts"
-import {
-  createStartHandler,
-  defaultStreamHandler,
-} from '@tanstack/react-start/server'
-import { createRouter } from './router'
-
-export default createStartHandler({
-  createRouter,
-})(defaultStreamHandler)
-```
-
 ### Usage tips
 
 - We recommend using the client SDK or `authClient` to handle authentication, rather than server actions with `auth.api`.


### PR DESCRIPTION
The "server route handler" (i.e. `/src/server.ts` file) is no longer needed in the recent TanStack Start versions so it's redundant to keep it in this guide

(Previous PR #5481 turned into a disaster when I changed the base repository branch from `main` to `canary`)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed outdated server route handler (/src/server.ts) instructions from the TanStack Start integration guide. Newer TanStack Start versions don’t require a custom server handler, reducing confusion and keeping the guide current.

<!-- End of auto-generated description by cubic. -->

