### PR TITLE
docs: add prisma postgres to community dialects section

### DIFF
--- a/docs/content/docs/adapters/other-relational-databases.mdx
+++ b/docs/content/docs/adapters/other-relational-databases.mdx
@@ -25,6 +25,7 @@ Any dialect supported by Kysely can be utilized with Better Auth, including capa
 - [PlanetScale Serverless Driver](https://github.com/depot/kysely-planetscale)
 - [Cloudflare D1](https://github.com/aidenwallis/kysely-d1)
 - [AWS RDS Data API](https://github.com/serverless-stack/kysely-data-api)
+- [Prisma Postgres](https://github.com/kysely-org/kysely-prisma-postgres)
 - [SurrealDB](https://github.com/igalklebanov/kysely-surrealdb)
 - [Neon](https://github.com/seveibar/kysely-neon)
 - [Xata](https://github.com/xataio/client-ts/tree/main/packages/plugin-client-kysely)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added Prisma Postgres to the community dialects list in the adapters docs so users know it’s supported via Kysely. Includes a link to the Kysely Prisma Postgres driver.

<!-- End of auto-generated description by cubic. -->

