### PR TITLE
docs: fix wrong url path in <ForkButton> component

### DIFF
--- a/docs/content/docs/examples/astro.mdx
+++ b/docs/content/docs/examples/astro.mdx
@@ -9,7 +9,7 @@ This is an example of how to use Better Auth with Astro. It uses Solid for build
 **Implements the following features:**
 Email & Password . Social Sign-in with Google . Passkeys . Email Verification . Password Reset . Two Factor Authentication . Profile Update . Session Management
 
-<ForkButton url="https://github.com/better-auth/examples/tree/main/astro-example"  />
+<ForkButton url="better-auth/examples/tree/main/astro-example"  />
 
 <iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/astro-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
    style={{

--- a/docs/content/docs/examples/nuxt.mdx
+++ b/docs/content/docs/examples/nuxt.mdx
@@ -8,7 +8,7 @@ This is an example of how to use Better Auth with Nuxt.
 **Implements the following features:**
 Email & Password . Social Sign-in with Google
 
-<ForkButton url="https://github.com/better-auth/examples/tree/main/nuxt-example"  />
+<ForkButton url="better-auth/examples/tree/main/nuxt-example"  />
 
 
 <iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/nuxt-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"

--- a/docs/content/docs/examples/remix.mdx
+++ b/docs/content/docs/examples/remix.mdx
@@ -9,7 +9,7 @@ This is an example of how to use Better Auth with Remix.
 **Implements the following features:**
 Email & Password . Social Sign-in with Google . Passkeys . Email Verification . Password Reset . Two Factor Authentication . Profile Update . Session Management
 
-<ForkButton url="https://github.com/better-auth/examples/tree/main/remix-example"  />
+<ForkButton url="better-auth/examples/tree/main/remix-example"  />
 
 <iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/remix-example?codemirror=1&fontsize=14&hidedevtools=1&hidenavigation=1&runonclick=1"
    style={{

--- a/docs/content/docs/examples/svelte-kit.mdx
+++ b/docs/content/docs/examples/svelte-kit.mdx
@@ -8,7 +8,7 @@ This is an example of how to use Better Auth with SvelteKit.
 **Implements the following features:**
 Email & Password . <u>Social Sign-in with Google</u> . Passkeys . Email Verification . Password Reset . Two Factor Authentication . Profile Update . Session Management
 
-<ForkButton url="https://github.com/better-auth/examples/tree/main/svelte-kit-example"  />
+<ForkButton url="better-auth/examples/tree/main/svelte-kit-example"  />
 
 <iframe src="https://stackblitz.com/github/better-auth/examples/tree/main/svelte-kit-example?codemirror=1&fontsize=14&hidenavigation=1&runonclick=1&hidedevtools=1"
    style={{


### PR DESCRIPTION
In document `View on GitHub` redirecting to wrong url except NextJS document.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the "View on GitHub" button in the Astro, Nuxt, Remix, and SvelteKit example docs by passing the repo slug to <ForkButton>, so it links to the correct GitHub pages.

<!-- End of auto-generated description by cubic. -->

