### PR TITLE
chore: remove unused exports

### DIFF
--- a/packages/better-auth/src/index.ts
+++ b/packages/better-auth/src/index.ts
@@ -9,12 +9,6 @@ export { getCurrentAdapter } from "@better-auth/core/context";
 export * from "./auth";
 export * from "./types";
 export * from "./utils";
-export type * from "better-call";
-export type * from "zod/v4";
-// @ts-expect-error we need to export core to make sure type annotations works with v4/core
-export type * from "zod/v4/core";
-//@ts-expect-error: we need to export helper types even when they conflict with better-call types to avoid "The inferred type of 'auth' cannot be named without a reference to..."
-export type * from "./types/helper";
 // export this as we are referencing OAuth2Tokens in the `refresh-token` api as return type
 
 // telemetry exports for CLI and consumers


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed unused type exports from better-auth’s index to shrink the public API and avoid TypeScript conflicts. No runtime changes.

- **Refactors**
  - Dropped type re-exports: better-call, zod/v4, zod/v4/core, and ./types/helper.

<!-- End of auto-generated description by cubic. -->

