### PR TITLE
chore: fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
 
   postgres-kysely:
     image: postgres:latest
@@ -32,7 +32,7 @@ services:
     ports:
       - "5433:5432"
     volumes:
-      - postgres-kysely_data:/var/lib/postgresql/data
+      - postgres-kysely_data:/var/lib/postgresql
 
   postgres-prisma:
     image: postgres:latest
@@ -44,7 +44,7 @@ services:
     ports:
       - "5434:5432"
     volumes:
-      - postgres-prisma_data:/var/lib/postgresql/data
+      - postgres-prisma_data:/var/lib/postgresql
 
   # Drizzle tests
   mysql:


### PR DESCRIPTION
```shell

 ▐▛███▜▌   Claude Code v2.0.24
▝▜█████▛▘  Sonnet 4.5 · API Usage Billing
  ▘▘ ▝▝    /Users/himself65/Code/better-auth

> I have this error when posrgres latest is 18, in our docker compose file: Error: in 18+, these Docker images are configured to store database 
data in a

       format which is compatible with "pg_ctlcluster" (specifically, using

       major-version-specific directory names).  This better reflects how

       PostgreSQL itself works, and how upgrades are to be performed.


       See also https://github.com/docker-library/postgres/pull/1259⁠


       Counter to that, there appears to be PostgreSQL data in:

         /var/lib/postgresql/data (unused mount/volume)


       This is usually the result of upgrading the Docker image without

       upgrading the underlying database using "pg_upgrade" (which requires both

       versions).


       The suggested container configuration for 18+ is to place a single mount

       at /var/lib/postgresql which will then place PostgreSQL data in a

       subdirectory, allowing usage of "pg_upgrade --link" without mount point

       boundary issues.


       See https://github.com/docker-library/postgres/issues/37⁠ for a (long)

       discussion around this process, and suggestions for how to do so.

Error: in 18+, these Docker images are configured to store database data in a

       format which is compatible with "pg_ctlcluster" (specifically, using

       major-version-specific directory names).  This better reflects how

       PostgreSQL itself works, and how upgrades are to be performed.


       See also https://github.com/docker-library/postgres/pull/1259⁠


       Counter to that, there appears to be PostgreSQL data in:

         /var/lib/postgresql/data (unused mount/volume)


       This is usually the result of upgrading the Docker image without

       upgrading the underlying database using "pg_upgrade" (which requires both

       versions).


       The suggested container configuration for 18+ is to place a single mount

       at /var/lib/postgresql which will then place PostgreSQL data in a

       subdirectory, allowing usage of "pg_upgrade --link" without mount point

       boundary issues.


       See https://github.com/docker-library/postgres/issues/37⁠ for a (long)

       discussion around this process, and suggestions for how to do so. 

⏺ I'll help you fix this PostgreSQL 18 Docker error. The issue is that PostgreSQL 18+ changed how it stores data to be compatible with
  pg_ctlcluster. Let me first look at your docker-compose file to see the current configuration.

⏺ Search(pattern: "**/docker-compose*.yml")
  ⎿  Found 1 file (ctrl+o to expand)

⏺ Search(pattern: "**/docker-compose*.yaml")
  ⎿  Found 0 files 

⏺ Read(docker-compose.yml)
  ⎿  Read 110 lines

⏺ I can see the issue. Your PostgreSQL containers are using the old mount point /var/lib/postgresql/data, but PostgreSQL 18+ requires the mount
  to be at /var/lib/postgresql (without the /data suffix). The new structure allows PostgreSQL to create version-specific subdirectories.

  Here's the fix - I'll update all three PostgreSQL service configurations:

⏺ Update(docker-compose.yml)
  ⎿  Updated docker-compose.yml with 1 addition and 1 removal
       20        ports:
       21          - "5432:5432"
       22        volumes:
       23 -        - postgres_data:/var/lib/postgresql/data
       23 +        - postgres_data:/var/lib/postgresql
       24    
       25      postgres-kysely:
       26        image: postgres:latest

⏺ Update(docker-compose.yml)
  ⎿  Updated docker-compose.yml with 1 addition and 1 removal     
       32        ports:
       33          - "5433:5432"
       34        volumes:
       35 -        - postgres-kysely_data:/var/lib/postgresql/data
       35 +        - postgres-kysely_data:/var/lib/postgresql
       36    
       37      postgres-prisma:
       38        image: postgres:latest

⏺ Update(docker-compose.yml)
  ⎿  Updated docker-compose.yml with 1 addition and 1 removal     
       44        ports:
       45          - "5434:5432"
       46        volumes:
       47 -        - postgres-prisma_data:/var/lib/postgresql/data
       47 +        - postgres-prisma_data:/var/lib/postgresql
       48    
       49      # Drizzle tests
       50      mysql:

⏺ Perfect! I've updated the docker-compose.yml file to be compatible with PostgreSQL 18+. Here's what I changed:

  Changes made:
  - postgres_data:/var/lib/postgresql/data → postgres_data:/var/lib/postgresql
  - postgres-kysely_data:/var/lib/postgresql/data → postgres-kysely_data:/var/lib/postgresql
  - postgres-prisma_data:/var/lib/postgresql/data → postgres-prisma_data:/var/lib/postgresql

  Next steps:

  Since you have existing PostgreSQL data in the old format, you'll need to either:

  1. Start fresh (easiest - if you don't need the data):
  docker compose down -v
  docker compose up -d
  2. Or keep your data (if you need it):
  You'll need to manually migrate. The safest approach is to:
    - Export your data with pg_dump
    - Remove the old volumes
    - Start the new containers
    - Import with psql

  Which approach would you like to take?

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
>  
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  ⏵⏵ bypass permissions on (shift+tab to cycle)                                                                            ⧉ In postgres-js.spec.ts



```

