### PR TITLE
feat(stripe): add `StripePlugin` type

### DIFF
--- a/packages/stripe/src/stripe.test.ts
+++ b/packages/stripe/src/stripe.test.ts
@@ -1,16 +1,56 @@
-import { betterAuth, type User } from "better-auth";
+import { type Auth, betterAuth, type User } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { createAuthClient } from "better-auth/client";
 import { setCookieToHeader } from "better-auth/cookies";
 import { bearer } from "better-auth/plugins";
 import Stripe from "stripe";
 import { vi } from "vitest";
-import { stripe } from ".";
+import { stripe, type StripePlugin } from ".";
 import { stripeClient } from "./client";
 import type { StripeOptions, Subscription } from "./types";
-import { expect, describe, it, beforeEach } from "vitest";
+import { expect, describe, it, beforeEach, expectTypeOf } from "vitest";
 import { runWithEndpointContext } from "@better-auth/core/context";
 import type { GenericEndpointContext } from "@better-auth/core";
+
+describe("stripe type", () => {
+	it("should api endpoint exists", () => {
+		type Plugins = [
+			StripePlugin<{
+				stripeClient: Stripe;
+				stripeWebhookSecret: string;
+				subscription: {
+					enabled: false;
+				};
+			}>,
+		];
+		type MyAuth = Auth<{
+			plugins: Plugins;
+		}>;
+		expectTypeOf<MyAuth["api"]["stripeWebhook"]>().toBeFunction();
+	});
+
+	it("should have subscription endpoints", () => {
+		type Plugins = [
+			StripePlugin<{
+				stripeClient: Stripe;
+				stripeWebhookSecret: string;
+				subscription: {
+					enabled: true;
+					plans: [];
+				};
+			}>,
+		];
+		type MyAuth = Auth<{
+			plugins: Plugins;
+		}>;
+		expectTypeOf<MyAuth["api"]["stripeWebhook"]>().toBeFunction();
+		expectTypeOf<MyAuth["api"]["subscriptionSuccess"]>().toBeFunction();
+		expectTypeOf<MyAuth["api"]["listActiveSubscriptions"]>().toBeFunction();
+		expectTypeOf<MyAuth["api"]["cancelSubscriptionCallback"]>().toBeFunction();
+		expectTypeOf<MyAuth["api"]["cancelSubscription"]>().toBeFunction();
+		expectTypeOf<MyAuth["api"]["restoreSubscription"]>().toBeFunction();
+	});
+});
 
 describe("stripe", async () => {
 	const mockStripe = {

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -164,6 +164,116 @@ export interface Subscription {
 	seats?: number;
 }
 
+export type SubscriptionOptions = {
+	/**
+	 * Subscription Configuration
+	 */
+	/**
+	 * List of plan
+	 */
+	plans: StripePlan[] | (() => StripePlan[] | Promise<StripePlan[]>);
+	/**
+	 * Require email verification before a user is allowed to upgrade
+	 * their subscriptions
+	 *
+	 * @default false
+	 */
+	requireEmailVerification?: boolean;
+	/**
+	 * A callback to run after a user has subscribed to a package
+	 * @param event - Stripe Event
+	 * @param subscription - Subscription Data
+	 * @returns
+	 */
+	onSubscriptionComplete?: (
+		data: {
+			event: Stripe.Event;
+			stripeSubscription: Stripe.Subscription;
+			subscription: Subscription;
+			plan: StripePlan;
+		},
+		ctx: GenericEndpointContext,
+	) => Promise<void>;
+	/**
+	 * A callback to run after a user is about to cancel their subscription
+	 * @returns
+	 */
+	onSubscriptionUpdate?: (data: {
+		event: Stripe.Event;
+		subscription: Subscription;
+	}) => Promise<void>;
+	/**
+	 * A callback to run after a user is about to cancel their subscription
+	 * @returns
+	 */
+	onSubscriptionCancel?: (data: {
+		event?: Stripe.Event;
+		subscription: Subscription;
+		stripeSubscription: Stripe.Subscription;
+		cancellationDetails?: Stripe.Subscription.CancellationDetails | null;
+	}) => Promise<void>;
+	/**
+	 * A function to check if the reference id is valid
+	 * and belongs to the user
+	 *
+	 * @param data - data containing user, session and referenceId
+	 * @param ctx - the context object
+	 * @returns
+	 */
+	authorizeReference?: (
+		data: {
+			user: User & Record<string, any>;
+			session: Session & Record<string, any>;
+			referenceId: string;
+			action:
+				| "upgrade-subscription"
+				| "list-subscription"
+				| "cancel-subscription"
+				| "restore-subscription"
+				| "billing-portal";
+		},
+		ctx: GenericEndpointContext,
+	) => Promise<boolean>;
+	/**
+	 * A callback to run after a user has deleted their subscription
+	 * @returns
+	 */
+	onSubscriptionDeleted?: (data: {
+		event: Stripe.Event;
+		stripeSubscription: Stripe.Subscription;
+		subscription: Subscription;
+	}) => Promise<void>;
+	/**
+	 * parameters for session create params
+	 *
+	 * @param data - data containing user, session and plan
+	 * @param ctx - the context object
+	 */
+	getCheckoutSessionParams?: (
+		data: {
+			user: User & Record<string, any>;
+			session: Session & Record<string, any>;
+			plan: StripePlan;
+			subscription: Subscription;
+		},
+		ctx: GenericEndpointContext,
+	) =>
+		| Promise<{
+				params?: Stripe.Checkout.SessionCreateParams;
+				options?: Stripe.RequestOptions;
+		  }>
+		| {
+				params?: Stripe.Checkout.SessionCreateParams;
+				options?: Stripe.RequestOptions;
+		  };
+	/**
+	 * Enable organization subscription
+	 */
+	organization?: {
+		enabled: boolean;
+	};
+};
+
 export interface StripeOptions {
 	/**
 	 * Stripe Client
@@ -205,116 +315,13 @@ export interface StripeOptions {
 	/**
 	 * Subscriptions
 	 */
-	subscription?: {
-		enabled: boolean;
-		/**
-		 * Subscription Configuration
-		 */
-		/**
-		 * List of plan
-		 */
-		plans: StripePlan[] | (() => StripePlan[] | Promise<StripePlan[]>);
-		/**
-		 * Require email verification before a user is allowed to upgrade
-		 * their subscriptions
-		 *
-		 * @default false
-		 */
-		requireEmailVerification?: boolean;
-		/**
-		 * A callback to run after a user has subscribed to a package
-		 * @param event - Stripe Event
-		 * @param subscription - Subscription Data
-		 * @returns
-		 */
-		onSubscriptionComplete?: (
-			data: {
-				event: Stripe.Event;
-				stripeSubscription: Stripe.Subscription;
-				subscription: Subscription;
-				plan: StripePlan;
-			},
-			ctx: GenericEndpointContext,
-		) => Promise<void>;
-		/**
-		 * A callback to run after a user is about to cancel their subscription
-		 * @returns
-		 */
-		onSubscriptionUpdate?: (data: {
-			event: Stripe.Event;
-			subscription: Subscription;
-		}) => Promise<void>;
-		/**
-		 * A callback to run after a user is about to cancel their subscription
-		 * @returns
-		 */
-		onSubscriptionCancel?: (data: {
-			event?: Stripe.Event;
-			subscription: Subscription;
-			stripeSubscription: Stripe.Subscription;
-			cancellationDetails?: Stripe.Subscription.CancellationDetails | null;
-		}) => Promise<void>;
-		/**
-		 * A function to check if the reference id is valid
-		 * and belongs to the user
-		 *
-		 * @param data - data containing user, session and referenceId
-		 * @param ctx - the context object
-		 * @returns
-		 */
-		authorizeReference?: (
-			data: {
-				user: User & Record<string, any>;
-				session: Session & Record<string, any>;
-				referenceId: string;
-				action:
-					| "upgrade-subscription"
-					| "list-subscription"
-					| "cancel-subscription"
-					| "restore-subscription"
-					| "billing-portal";
-			},
-			ctx: GenericEndpointContext,
-		) => Promise<boolean>;
-		/**
-		 * A callback to run after a user has deleted their subscription
-		 * @returns
-		 */
-		onSubscriptionDeleted?: (data: {
-			event: Stripe.Event;
-			stripeSubscription: Stripe.Subscription;
-			subscription: Subscription;
-		}) => Promise<void>;
-		/**
-		 * parameters for session create params
-		 *
-		 * @param data - data containing user, session and plan
-		 * @param ctx - the context object
-		 */
-		getCheckoutSessionParams?: (
-			data: {
-				user: User & Record<string, any>;
-				session: Session & Record<string, any>;
-				plan: StripePlan;
-				subscription: Subscription;
-			},
-			ctx: GenericEndpointContext,
-		) =>
-			| Promise<{
-					params?: Stripe.Checkout.SessionCreateParams;
-					options?: Stripe.RequestOptions;
-			  }>
-			| {
-					params?: Stripe.Checkout.SessionCreateParams;
-					options?: Stripe.RequestOptions;
-			  };
-		/**
-		 * Enable organization subscription
-		 */
-		organization?: {
-			enabled: boolean;
-		};
-	};
+	subscription?:
+		| {
+				enabled: false;
+		  }
+		| ({
+				enabled: true;
+		  } & SubscriptionOptions);
 	/**
 	 * A callback to run after a stripe event is received
 	 * @param event - Stripe Event

--- a/packages/stripe/src/utils.ts
+++ b/packages/stripe/src/utils.ts
@@ -1,9 +1,14 @@
 import type { StripeOptions } from "./types";
 
-export async function getPlans(options: StripeOptions) {
-	return typeof options?.subscription?.plans === "function"
-		? await options.subscription?.plans()
-		: options.subscription?.plans;
+export async function getPlans(
+	subscriptionOptions: StripeOptions["subscription"],
+) {
+	if (subscriptionOptions?.enabled) {
+		return typeof subscriptionOptions.plans === "function"
+			? await subscriptionOptions.plans()
+			: subscriptionOptions.plans;
+	}
+	throw new Error("Subscriptions are not enabled in the Stripe options.");
 }
 
 export async function getPlanByPriceInfo(
@@ -11,7 +16,7 @@ export async function getPlanByPriceInfo(
 	priceId: string,
 	priceLookupKey: string | null,
 ) {
-	return await getPlans(options).then((res) =>
+	return await getPlans(options.subscription).then((res) =>
 		res?.find(
 			(plan) =>
 				plan.priceId === priceId ||
@@ -24,7 +29,7 @@ export async function getPlanByPriceInfo(
 }
 
 export async function getPlanByName(options: StripeOptions, name: string) {
-	return await getPlans(options).then((res) =>
+	return await getPlans(options.subscription).then((res) =>
 		res?.find((plan) => plan.name.toLowerCase() === name.toLowerCase()),
 	);
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a new StripePlugin type and switches subscription config to a discriminated union to make API endpoints type-safe based on the enabled flag.

- **Refactors**
  - Added SubscriptionOptions and updated StripeOptions.subscription to be either {enabled: false} or {enabled: true} & SubscriptionOptions.
  - API endpoints for subscriptions are now exposed only when subscription.enabled is true (type-checked).
  - Changed getPlans to accept options.subscription and throw when subscriptions are disabled.
  - Updated internal usage to use subscriptionOptions and getPlans(options.subscription).

- **Migration**
  - Replace getPlans(options) with getPlans(options.subscription) in any custom code.
  - Ensure your StripeOptions.subscription matches the new shape: {enabled: false} or {enabled: true, plans: [...], ...}.

<!-- End of auto-generated description by cubic. -->

