### PR TITLE
chore: fix turborepo cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -37,10 +37,6 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
-    "typecheck": {
-      "outputs": [".tsbuildinfo", "dist/**"],
-      "cache": true
-    },
     "deploy": {
       "cache": false
     },


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the misconfigured typecheck cache in turbo.json to stop caching .tsbuildinfo and dist/**, which caused stale builds. Turborepo now uses default behavior for typecheck without caching these outputs.

<!-- End of auto-generated description by cubic. -->

