### PR TITLE
docs: fix typo in README

### DIFF
--- a/docs/content/docs/plugins/email-otp.mdx
+++ b/docs/content/docs/plugins/email-otp.mdx
@@ -296,7 +296,7 @@ export const auth = betterAuth({
 
 When the maximum attempts are exceeded, the `verifyOTP`, `signIn.emailOtp`, `verifyEmail`, and `resetPassword` methods will return an error with code `TOO_MANY_ATTEMPTS`.
 
-- `storeOTP`: The method to store the OTP in your database, wether `encrypted`, `hashed` or `plain` text. Default is `plain` text.
+- `storeOTP`: The method to store the OTP in your database, whether `encrypted`, `hashed` or `plain` text. Default is `plain` text.
 
 <Callout>
 Note: This will not affect the OTP sent to the user, it will only affect the OTP stored in your database.


### PR DESCRIPTION
Fixed a small typo in the README: corrected "wether" → "whether".
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a typo in the Email OTP plugin docs: corrected "wether" → "whether" in the storeOTP option description to improve clarity.

<!-- End of auto-generated description by cubic. -->

