### PR TITLE
fix(docs): enable code block copying in documentation page

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -95,7 +95,11 @@ export default async function Page({
 						},
 						pre: (props) => {
 							return (
-								<CodeBlock className="rounded-xl bg-fd-muted" allowCopy={true} {...props}>
+								<CodeBlock
+									className="rounded-xl bg-fd-muted"
+									allowCopy={true}
+									{...props}
+								>
 									<div style={{ minWidth: "100%", display: "table" }}>
 										<Pre className="px-0 py-3 bg-fd-muted focus-visible:outline-none">
 											{props.children}


### PR DESCRIPTION
This pull request adds a copy component to ``Install the Package`` under the ``Installation`` section in the docs.

## Before

https://github.com/user-attachments/assets/ed4b7f37-2b0a-489f-a720-2b90368aedbd

## After

https://github.com/user-attachments/assets/78e2c2e7-a721-4e5a-9783-56e1d0fc3460


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable copy button on code blocks in the docs so users can copy install commands and examples with one click. Adds allowCopy to the CodeBlock in the docs page renderer.

<!-- End of auto-generated description by cubic. -->

