### PR TITLE
docs: update link to correct Better Auth options reference

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -3,7 +3,7 @@ title: Options
 description: Better Auth configuration options reference.
 ---
 
-List of all the available options for configuring Better Auth. See [Better Auth Options](https://github.com/better-auth/better-auth/blob/main/packages/core/src/types/init-options.ts#L237).
+List of all the available options for configuring Better Auth. See [Better Auth Options](https://github.com/better-auth/better-auth/blob/main/packages/core/src/types/init-options.ts).
 
 ## `appName`
 


### PR DESCRIPTION
Docs previously linked to a file that no longer exists since the options definitions have been moved to the core package.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix broken link in the Options reference page. The link now points to the core package’s init-options.ts where Better Auth options are defined.

<!-- End of auto-generated description by cubic. -->

