### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -105,7 +105,7 @@ When 2FA is enabled:
 - An encrypted `secret` and `backupCodes` are generated.
 - `enable` returns `totpURI` and `backupCodes`.
 
-Note: `twoFactorEnabled` won’t be set to `true` until the user verifies their TOTP code. Learn more about veryifying TOTP [here](#totp). You can skip verification by setting `skipVerificationOnEnable` to true in your plugin config.
+Note: `twoFactorEnabled` won’t be set to `true` until the user verifies their TOTP code. Learn more about verifying TOTP [here](#totp). You can skip verification by setting `skipVerificationOnEnable` to true in your plugin config.
 
 <Callout type="warn">
 Two Factor can only be enabled for credential accounts at the moment. For social accounts, it's assumed the provider already handles 2FA.

--- a/docs/content/docs/plugins/api-key.mdx
+++ b/docs/content/docs/plugins/api-key.mdx
@@ -620,7 +620,7 @@ Customize the starting characters configuration.
   <Accordion title="startingCharactersConfig Options">
     `shouldStore` <span className="opacity-70">`boolean`</span>
 
-    Wether to store the starting characters in the database.
+    Whether to store the starting characters in the database.
     If false, we will set `start` to `null`.
     Default is `true`.
 
@@ -681,7 +681,7 @@ Customize the key expiration.
 
     `disableCustomExpiresTime` <span className="opacity-70">`boolean`</span>
 
-    Wether to disable the expires time passed from the client.
+    Whether to disable the expires time passed from the client.
     If `true`, the expires time will be based on the default values.
     Default is `false`.
 

--- a/docs/content/docs/plugins/one-time-token.mdx
+++ b/docs/content/docs/plugins/one-time-token.mdx
@@ -92,7 +92,7 @@ oneTimeToken({
     expiresIn: 10 // 10 minutes
 })
 ```
-* **`generateToken`**: A custom token generator function that takes `session` object and a `ctx` as paramters.
+* **`generateToken`**: A custom token generator function that takes `session` object and a `ctx` as parameters.
 
 * **`storeToken`**: Optional. This option allows you to configure how the token is stored in your database.
 

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1464,7 +1464,7 @@ const canCreateProjectAndCreateSale =
 ```
 
 <Callout type="warn">
-  This will not include any dynamic roles as everything is ran syncronously on the client side.
+  This will not include any dynamic roles as everything is ran synchronously on the client side.
   Please use the [hasPermission](#access-control-usage) APIs to include checks for any dynamic roles & permissions.
 </Callout>
 
@@ -1520,7 +1520,7 @@ export const authClient = createAuthClient({
 
 
 <Callout type="warn">
-  The `authClient.organization.checkRolePermission` function will not include any dynamic roles as everything is ran syncronously on the client side.
+  The `authClient.organization.checkRolePermission` function will not include any dynamic roles as everything is ran synchronously on the client side.
   Please use the [hasPermission](#access-control-usage) APIs to include checks for any dynamic roles.
 </Callout>
 

--- a/docs/content/docs/plugins/polar.mdx
+++ b/docs/content/docs/plugins/polar.mdx
@@ -177,7 +177,7 @@ const auth = betterAuth({
                     products: [ { productId: "123-456-789", slug: "pro" } ],
                     // Relative URL to return to when checkout is successfully completed
                     successUrl: "/success?checkout_id={CHECKOUT_ID}",
-                    // Wheather you want to allow unauthenticated checkout sessions or not
+                    // Whether you want to allow unauthenticated checkout sessions or not
                     authenticatedUsersOnly: true
                 })
             ],
@@ -384,7 +384,7 @@ The authenticated user is automatically associated with the ingested event.
 
 A simple method for listing the authenticated user's Usage Meters, or as we call them, Customer Meters.
 
-Customer Meter's contains all information about their consumtion on your defined meters.
+Customer Meter's contains all information about their consumption on your defined meters.
 
 - Customer Information
 - Meter Information


### PR DESCRIPTION
Corrected several typos in documentation for 2FA, API key, one-time token, organization, and Polar docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed typos and wording across plugin documentation to improve clarity and reduce confusion.
Updates include: “verifying” in 2FA, “Whether” in API Key options, “parameters” in One-Time Token, “synchronously” in Organization role checks, and “consumption” in Polar usage meters.

<!-- End of auto-generated description by cubic. -->

