### PR TITLE
chore: remove baseUrl set to "."

### DIFF
--- a/demo/stateless/tsconfig.json
+++ b/demo/stateless/tsconfig.json
@@ -13,7 +13,6 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "baseUrl": ".",
     "plugins": [
       {
         "name": "next"

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/packages/cli/test/get-config.test.ts
+++ b/packages/cli/test/get-config.test.ts
@@ -48,7 +48,6 @@ describe("getConfig", async () => {
 			`{
               "compilerOptions": {
                 /* Path Aliases */
-                "baseUrl": ".",
                 "paths": {
                   "@server/*": ["./server/*"]
                 }
@@ -103,7 +102,6 @@ describe("getConfig", async () => {
 			`{
               "compilerOptions": {
                 /* Path Aliases */
-                "baseUrl": ".",
                 "paths": {
                   "prismaDbClient": ["./server/db/db"]
                 }
@@ -323,7 +321,6 @@ describe("getConfig", async () => {
 			`{
               "compilerOptions": {
                 /* Path Aliases */
-                "baseUrl": ".",
                 "paths": {
                   "@server/*": ["./PathIsInvalid/*"]
                 }
@@ -422,7 +419,6 @@ describe("getConfig", async () => {
 			path.join(tmpDir, "apps", "web", "tsconfig.json"),
 			`{
 				"compilerOptions": {
-					"baseUrl": ".",
 					"paths": {
 						"@web/*": ["./server/*"]
 					}
@@ -435,7 +431,6 @@ describe("getConfig", async () => {
 			path.join(tmpDir, "packages", "shared", "tsconfig.json"),
 			`{
 				"compilerOptions": {
-					"baseUrl": ".",
 					"paths": {
 						"@shared/*": ["./db/*"]
 					}
@@ -492,7 +487,6 @@ describe("getConfig", async () => {
 			path.join(tmpDir, "tsconfig.json"),
 			`{
 				"compilerOptions": {
-					"baseUrl": ".",
 					"paths": {
 						"@server/*": ["./server/*"]
 					}
@@ -534,7 +528,6 @@ describe("getConfig", async () => {
 			path.join(tmpDir, "tsconfig.json"),
 			`{
 				"compilerOptions": {
-					"baseUrl": ".",
 					"paths": {
 						"@root/*": ["./server/*"]
 					}
@@ -550,7 +543,6 @@ describe("getConfig", async () => {
 			path.join(tmpDir, "app", "tsconfig.json"),
 			`{
 				"compilerOptions": {
-					"baseUrl": ".",
 					"paths": {
 						"@app/*": ["./src/*"]
 					}
@@ -603,7 +595,6 @@ describe("getConfig", async () => {
 			path.join(tmpDir, "tsconfig.app.json"),
 			`{
 				"compilerOptions": {
-					"baseUrl": ".",
 					"paths": {
 						"@app/*": ["./server/*"]
 					}
@@ -616,7 +607,6 @@ describe("getConfig", async () => {
 			path.join(tmpDir, "tsconfig.shared.json"),
 			`{
 				"compilerOptions": {
-					"baseUrl": ".",
 					"paths": {
 						"@shared/*": ["./shared/*"]
 					}
@@ -681,7 +671,6 @@ describe("getConfig", async () => {
 			path.join(tmpDir, "apps", "web", "tsconfig.json"),
 			`{
 				"compilerOptions": {
-					"baseUrl": ".",
 					"paths": {
 						"@web/*": ["./server/*"]
 					}
@@ -694,7 +683,6 @@ describe("getConfig", async () => {
 			path.join(tmpDir, "tsconfig.utils.json"),
 			`{
 				"compilerOptions": {
-					"baseUrl": ".",
 					"paths": {
 						"@utils/*": ["./packages/utils/*"]
 					}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "downlevelIteration": true,
-    "baseUrl": ".",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
This PR removes the baseUrl set to "." in order to eliminate the following message.
There’s one remaining in the docs content, but I left it as is since it doesn’t affect the development environment.

```
Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
  Visit https://aka.ms/ts6 for migration information.
  ```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated "baseUrl": "." from tsconfig files to silence TypeScript 7 deprecation warnings and keep configs future-proof. Updated CLI tests to match the new config shape.

- **Refactors**
  - Removed baseUrl from tsconfig.base.json, demo/stateless, and docs.
  - Updated get-config test fixtures to exclude baseUrl.

<!-- End of auto-generated description by cubic. -->

