### PR TITLE
docs(builder): fix disabled 'built with' generating attribute

### DIFF
--- a/docs/components/builder/code-tabs/index.tsx
+++ b/docs/components/builder/code-tabs/index.tsx
@@ -102,7 +102,7 @@ ${
 		initialFiles.push({
 			id: "4",
 			name: "sign-up.tsx",
-			content: signUpString,
+			content: signUpString(options),
 		});
 	}
 

--- a/docs/components/builder/sign-up.tsx
+++ b/docs/components/builder/sign-up.tsx
@@ -15,6 +15,8 @@ import { useState } from "react";
 import Image from "next/image";
 import { Loader2, X } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useAtom } from "jotai";
+import { optionsAtom } from "@/components/builder/store";
 
 export function SignUp() {
 	const [firstName, setFirstName] = useState("");
@@ -24,6 +26,7 @@ export function SignUp() {
 	const [passwordConfirmation, setPasswordConfirmation] = useState("");
 	const [image, setImage] = useState<File | null>(null);
 	const [imagePreview, setImagePreview] = useState<string | null>(null);
+	const [options] = useAtom(optionsAtom);
 	const router = useRouter();
 
 	const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -157,13 +160,15 @@ export function SignUp() {
 					</Button>
 				</div>
 			</CardContent>
-			<CardFooter>
-				<div className="flex justify-center w-full border-t py-4">
-					<p className="text-center text-xs text-neutral-500">
-						Secured by <span className="text-orange-400">better-auth.</span>
-					</p>
-				</div>
-			</CardFooter>
+			{options.label && (
+				<CardFooter>
+					<div className="flex justify-center w-full border-t py-4">
+						<p className="text-center text-xs text-neutral-500">
+							Secured by <span className="text-orange-400">better-auth.</span>
+						</p>
+					</div>
+				</CardFooter>
+			)}
 		</Card>
 	);
 }
@@ -177,7 +182,7 @@ async function convertImageToBase64(file: File): Promise<string> {
 	});
 }
 
-export const signUpString = `"use client";
+export const signUpString = (options: any) => `"use client";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -360,13 +365,17 @@ export default function SignUp() {
 					</Button>
 				</div>
 			</CardContent>
-			<CardFooter>
+          ${
+						options.label
+							? `<CardFooter>
 				<div className="flex justify-center w-full border-t py-4">
 					<p className="text-center text-xs text-neutral-500">
 						Secured by <span className="text-orange-400">better-auth.</span>
 					</p>
 				</div>
-			</CardFooter>
+			</CardFooter>`
+							: ""
+					}
 		</Card>
 	);
 }


### PR DESCRIPTION
As noted in the screenshot below, deselecting 'show built with label' still generates the label for sign-up form. It does work as expected for the sign-in form.

<img width="1328" height="284" alt="Screenshot 2025-10-24 at 19 29 44" src="https://github.com/user-attachments/assets/c17d363d-5f60-4321-9ec2-326e7e87517f" />

Made the changes to mirror the logic from the sign-in form.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the builder toggle so disabling “Built with” correctly hides the attribution on the sign-up form and in generated code, matching the sign-in form behavior.

- **Bug Fixes**
  - SignUp reads optionsAtom and only renders CardFooter when options.label is true.
  - signUpString now accepts options and conditionally includes the attribution.
  - Code tabs call signUpString(options) so the generated snippet respects the toggle.

<!-- End of auto-generated description by cubic. -->

