### PR TITLE
docs: update quote text color for light mode

### DIFF
--- a/docs/content/docs/comparison.mdx
+++ b/docs/content/docs/comparison.mdx
@@ -3,7 +3,7 @@ title: Comparison
 description: Comparison of Better Auth versus over other auth libraries and services.
 ---
 
-> <p className="text-orange-200">Comparison is the thief of joy.</p>
+> <p className="text-orange-400 dark:text-orange-200">Comparison is the thief of joy.</p>
 
 Here are non detailed reasons why you may want to use Better Auth over other auth libraries and services.
 


### PR DESCRIPTION
This PR makes the quote text readable in light mode.

### Before:

<img width="350" height="161" alt="before" src="https://github.com/user-attachments/assets/391d0a40-e68b-48bb-8757-6b008255dc38" />

### After:

<img width="350" height="146" alt="after" src="https://github.com/user-attachments/assets/a7c5c1db-78c7-44cb-9813-ffc08903d0e6" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix unreadable quote text in light mode on the Comparison docs page by increasing contrast.
Uses text-orange-400 for light mode and text-orange-200 for dark mode.

<!-- End of auto-generated description by cubic. -->

