### PR TITLE
chore: fix config in demo

### DIFF
--- a/demo/stateless/src/lib/auth-client.ts
+++ b/demo/stateless/src/lib/auth-client.ts
@@ -1,7 +1,5 @@
 import { createAuthClient } from "better-auth/react";
 
-export const authClient = createAuthClient({
-	baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "http://localhost:3000",
-});
+export const authClient = createAuthClient();
 
 export const { signIn, signOut, useSession } = authClient;

--- a/demo/stateless/src/lib/auth.ts
+++ b/demo/stateless/src/lib/auth.ts
@@ -1,7 +1,16 @@
 import { betterAuth } from "better-auth";
 
+const baseURL: string | undefined =
+	process.env.VERCEL === "1"
+		? process.env.VERCEL_ENV === "production"
+			? process.env.BETTER_AUTH_URL
+			: process.env.VERCEL_ENV === "preview"
+				? `https://${process.env.VERCEL_URL}`
+				: undefined
+		: undefined;
+
 export const auth = betterAuth({
-	baseURL: process.env.BETTER_AUTH_URL,
+	baseURL,
 	secret: process.env.BETTER_AUTH_SECRET,
 
 	socialProviders: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the stateless demo auth config to resolve baseURL dynamically on Vercel and removed the hardcoded client baseURL. This fixes mismatched URLs in preview/production and uses safe defaults locally.

- **Bug Fixes**
  - Compute baseURL from VERCEL_ENV/VERCEL_URL for preview and BETTER_AUTH_URL for production; undefined for local dev.
  - Drop baseURL in createAuthClient to avoid client/server config mismatch.

<!-- End of auto-generated description by cubic. -->

