### PR TITLE
Validator

### DIFF
--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -105,7 +105,7 @@ export function parseInputData<T extends Record<string, any>>(
 				continue;
 			}
 			if (fields[key]!.validator?.input && data[key] !== undefined) {
-				parsedData[key] = fields[key]!.validator.input.parse(data[key]);
+				parsedData[key] = fields[key]!.validator.input["~standard"].validate(data[key]);
 				continue;
 			}
 			if (fields[key]!.transform?.input && data[key] !== undefined) {

--- a/packages/better-auth/src/init.ts
+++ b/packages/better-auth/src/init.ts
@@ -22,6 +22,7 @@ import { getKyselyDatabaseType } from "./adapters/kysely-adapter";
 import { checkEndpointConflicts } from "./api";
 import { isPromise } from "./utils/is-promise";
 import type { AuthContext } from "@better-auth/core";
+import z from "zod";
 
 export const init = async (options: BetterAuthOptions) => {
 	const adapter = await getAdapter(options);
@@ -133,10 +134,7 @@ export const init = async (options: BetterAuthOptions) => {
 		password: {
 			hash: options.emailAndPassword?.password?.hash || hashPassword,
 			verify: options.emailAndPassword?.password?.verify || verifyPassword,
-			config: {
-				minPasswordLength: options.emailAndPassword?.minPasswordLength || 8,
-				maxPasswordLength: options.emailAndPassword?.maxPasswordLength || 128,
-			},
+			validator: options.emailAndPassword?.validator || z.string().min(8).max(128),
 			checkPassword,
 		},
 		setNewSession(session) {

--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -54,6 +54,7 @@ export const ERROR_CODES = defineErrorCodes({
 		"The property you're trying to set can only be set from the server auth instance only.",
 	FAILED_TO_UPDATE_API_KEY: "Failed to update API key",
 	NAME_REQUIRED: "API Key name is required.",
+	VALIDATION_FAILED: "The validation schema failed."
 });
 
 export const API_KEY_TABLE_NAME = "apikey";

--- a/packages/better-auth/src/plugins/username/error-codes.ts
+++ b/packages/better-auth/src/plugins/username/error-codes.ts
@@ -5,8 +5,7 @@ export const USERNAME_ERROR_CODES = defineErrorCodes({
 	EMAIL_NOT_VERIFIED: "Email not verified",
 	UNEXPECTED_ERROR: "Unexpected error",
 	USERNAME_IS_ALREADY_TAKEN: "Username is already taken. Please try another.",
-	USERNAME_TOO_SHORT: "Username is too short",
-	USERNAME_TOO_LONG: "Username is too long",
+	USERNAME_SCHEMA_VALIDATION_FAILED: "Username schema validation failed",
 	INVALID_USERNAME: "Username is invalid",
 	INVALID_DISPLAY_USERNAME: "Display username is invalid",
 });

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -1,5 +1,5 @@
-import type { ZodType } from "zod";
 import type { LiteralString } from "../types";
+import type { StandardSchemaV1 } from "../types/standard-schema";
 
 export type DBPreservedModels =
 	| "user"
@@ -102,8 +102,8 @@ export type DBFieldAttributeConfig = {
 	 * A zod schema to validate the value.
 	 */
 	validator?: {
-		input?: ZodType;
-		output?: ZodType;
+		input?: StandardSchemaV1;
+		output?: StandardSchemaV1;
 	};
 	/**
 	 * The name of the field on the database.

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -17,6 +17,7 @@ import type {
 	BetterAuthOptions,
 	BetterAuthRateLimitOptions,
 } from "./init-options";
+import type { StandardSchemaV1 } from "./standard-schema";
 
 export type GenericEndpointContext<
 	Options extends BetterAuthOptions = BetterAuthOptions,
@@ -254,10 +255,7 @@ export type AuthContext<Options extends BetterAuthOptions = BetterAuthOptions> =
 		password: {
 			hash: (password: string) => Promise<string>;
 			verify: (data: { password: string; hash: string }) => Promise<boolean>;
-			config: {
-				minPasswordLength: number;
-				maxPasswordLength: number;
-			};
+			validator: StandardSchemaV1;
 			checkPassword: CheckPasswordFn<Options>;
 		};
 		tables: BetterAuthDBSchema;

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -16,6 +16,7 @@ import type { Logger } from "../env";
 import type { AuthContext, GenericEndpointContext } from "./context";
 import type { AuthMiddleware } from "../middleware";
 import type { BetterAuthPlugin } from "..";
+import type { StandardSchemaV1 } from "./standard-schema";
 
 type KyselyDatabaseType = "postgres" | "mysql" | "sqlite" | "mssql";
 type OmitId<T extends { id: unknown }> = Omit<T, "id">;
@@ -424,17 +425,11 @@ export type BetterAuthOptions = {
 		 */
 		requireEmailVerification?: boolean;
 		/**
-		 * The maximum length of the password.
+		 * A standard schema for the password
 		 *
-		 * @default 128
+		 * @default z.string().min(8).max(128)
 		 */
-		maxPasswordLength?: number;
-		/**
-		 * The minimum length of the password.
-		 *
-		 * @default 8
-		 */
-		minPasswordLength?: number;
+		validator?: StandardSchemaV1;
 		/**
 		 * send reset password
 		 */

--- a/packages/core/src/types/standard-schema.ts
+++ b/packages/core/src/types/standard-schema.ts
@@ -1,0 +1,70 @@
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+	/** The Standard Schema properties. */
+	readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+}
+
+export declare namespace StandardSchemaV1 {
+	/** The Standard Schema properties interface. */
+	export interface Props<Input = unknown, Output = Input> {
+		/** The version number of the standard. */
+		readonly version: 1;
+		/** The vendor name of the schema library. */
+		readonly vendor: string;
+		/** Validates unknown input values. */
+		readonly validate: (
+			value: unknown,
+		) => Result<Output> | Promise<Result<Output>>;
+		/** Inferred types associated with the schema. */
+		readonly types?: Types<Input, Output> | undefined;
+	}
+
+	/** The result interface of the validate function. */
+	export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+	/** The result interface if validation succeeds. */
+	export interface SuccessResult<Output> {
+		/** The typed output value. */
+		readonly value: Output;
+		/** The non-existent issues. */
+		readonly issues?: undefined;
+	}
+
+	/** The result interface if validation fails. */
+	export interface FailureResult {
+		/** The issues of failed validation. */
+		readonly issues: ReadonlyArray<Issue>;
+	}
+
+	/** The issue interface of the failure output. */
+	export interface Issue {
+		/** The error message of the issue. */
+		readonly message: string;
+		/** The path of the issue, if any. */
+		readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+	}
+
+	/** The path segment interface of the issue. */
+	export interface PathSegment {
+		/** The key representing a path segment. */
+		readonly key: PropertyKey;
+	}
+
+	/** The Standard Schema types interface. */
+	export interface Types<Input = unknown, Output = Input> {
+		/** The input type of the schema. */
+		readonly input: Input;
+		/** The output type of the schema. */
+		readonly output: Output;
+	}
+
+	/** Infers the input type of a Standard Schema. */
+	export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+		Schema["~standard"]["types"]
+	>["input"];
+
+	/** Infers the output type of a Standard Schema. */
+	export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+		Schema["~standard"]["types"]
+	>["output"];
+}

--- a/packages/telemetry/src/detectors/detect-auth-config.ts
+++ b/packages/telemetry/src/detectors/detect-auth-config.ts
@@ -24,8 +24,7 @@ export function getTelemetryAuthConfig(
 			disableSignUp: !!options.emailAndPassword?.disableSignUp,
 			requireEmailVerification:
 				!!options.emailAndPassword?.requireEmailVerification,
-			maxPasswordLength: options.emailAndPassword?.maxPasswordLength,
-			minPasswordLength: options.emailAndPassword?.minPasswordLength,
+			emailSchema: options.emailAndPassword?.emailSchema,
 			sendResetPassword: !!options.emailAndPassword?.sendResetPassword,
 			resetPasswordTokenExpiresIn:
 				options.emailAndPassword?.resetPasswordTokenExpiresIn,


### PR DESCRIPTION
Requires #5570 

Replaces manual validation by fields like `minPasswordLength` with a `passwordSchema` field that takes a standard schema type for validation. Does not replace the `validatePasswordFunction` (and equivalent) fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch password and username validation to a standard schema-based approach, replacing min/max length checks with a configurable validator. Adds a StandardSchemaV1 interface and updates routes, context, and plugins to use it while keeping custom password validation functions.

- **Refactors**
  - Added StandardSchemaV1 and replaced min/max password config with password.validator in context (default: z.string().min(8).max(128)).
  - Updated sign-up, reset-password, and change/set password endpoints to use schema validation with async support.
  - Migrated username plugin to usernameSchema, removed min/max options, and updated error codes to USERNAME_SCHEMA_VALIDATION_FAILED.
  - Switched DB field validators and parseInputData to use the standard schema validate API.
  - Adjusted telemetry to report schema-based configuration.

- **Migration**
  - Replace emailAndPassword.minPasswordLength/maxPasswordLength with emailAndPassword.validator (StandardSchemaV1).
  - Update any usage of ctx.context.password.config to ctx.context.password.validator.
  - For the username plugin, replace minUsernameLength/maxUsernameLength with usernameSchema and handle the new error code.

<!-- End of auto-generated description by cubic. -->

