### PR TITLE
docs: properly use await next() in hono middleware

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -79,12 +79,13 @@ app.use("*", async (c, next) => {
   	if (!session) {
     	c.set("user", null);
     	c.set("session", null);
-    	return next();
+    	await next();
+        return;
   	}
 
   	c.set("user", session.user);
   	c.set("session", session.session);
-  	return next();
+  	await next();
 });
 
 app.on(["POST", "GET"], "/api/auth/*", (c) => {


### PR DESCRIPTION
From documentation https://hono.dev/docs/guides/middleware
Middleware - should return nothing, will be proceeded to next middleware with await next()

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Hono middleware docs to use await next() and then return, instead of return next(). This aligns the example with Hono’s middleware contract and avoids incorrect async flow.

<!-- End of auto-generated description by cubic. -->

