### PR TITLE
docs: add NextJS pages example

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -243,7 +243,7 @@ Create a new file or route in your framework's designated catch-all route handle
     <Tab value="next-js-pages-router">
         ```ts title="/pages/api/auth/[...all].ts"
         import { auth } from "@/lib/auth"; // path to your auth file
-        import { toNodeHandler } from 'better-auth/node';
+        import { toNodeHandler } from "better-auth/node";
 
         // Disallow body parsing, we will parse it manually
         export const config = { api: { bodyParser: false } };


### PR DESCRIPTION
The current setup only includes the Next.js example that works with the App Router.
This PR adds a **Pages Router** variant and updates the existing example to be clearly marked as **App Router**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Next.js Pages Router example to the installation docs and clearly label the existing example as App Router. Tabs now show both variants with the correct code snippets, including the Pages Router handler and bodyParser config.

<!-- End of auto-generated description by cubic. -->

