### PR TITLE
test: add type test for organization plugin

### DIFF
--- a/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/organization.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/organization.ts
@@ -1,7 +1,7 @@
 import { betterAuth } from "better-auth";
 import { organization } from "better-auth/plugins";
 
-const auth = betterAuth({
+export const auth = betterAuth({
 	plugins: [
 		organization({
 			requireEmailVerificationOnInvitation: true,
@@ -15,4 +15,8 @@ const auth = betterAuth({
 			},
 		}),
 	],
+});
+
+export const auth2 = betterAuth({
+	plugins: [organization({})],
 });

--- a/e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler/src/organization.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler/src/organization.ts
@@ -1,0 +1,6 @@
+import { betterAuth } from "better-auth";
+import { organization } from "better-auth/plugins";
+
+export const auth = betterAuth({
+	plugins: [organization({})],
+});

--- a/e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler/tsconfig.json
+++ b/e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler/tsconfig.json
@@ -12,7 +12,8 @@
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist"
   },
   "include": ["./src"]
 }

--- a/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/src/organization.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/src/organization.ts
@@ -1,0 +1,6 @@
+import { betterAuth } from "better-auth";
+import { organization } from "better-auth/plugins";
+
+export const auth = betterAuth({
+	plugins: [organization({})],
+});

--- a/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/tsconfig.json
+++ b/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/tsconfig.json
@@ -7,8 +7,6 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "types": ["node"],
-    "jsx": "react-jsx",
-    "jsxImportSource": "hono/jsx",
     "moduleResolution": "node16"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add type-safety tests for the organization plugin across multiple TS configs to ensure it compiles under strict and bundler settings. Tweaked fixtures to export auth instances (and add a second empty-config auth), added test files for isolated-module-bundler and verbatim-module-syntax (Node 10), set outDir for bundler, and removed unused JSX options.

<!-- End of auto-generated description by cubic. -->

