### PR TITLE
docs: revert landing page code block dark mode theme

### DIFF
--- a/docs/components/landing/hero.tsx
+++ b/docs/components/landing/hero.tsx
@@ -181,13 +181,15 @@ function CodePreview() {
 	const { resolvedTheme } = useTheme();
 	const [ref, { height }] = useMeasure();
 	const [copyState, setCopyState] = useState(false);
-	const [codeTheme, setCodeTheme] = useState(themes.oneDark);
+	const [codeTheme, setCodeTheme] = useState(themes.synthwave84);
 	const [currentTab, setCurrentTab] = useState<"auth.ts" | "client.ts">(
 		"auth.ts",
 	);
 
 	useEffect(() => {
-		setCodeTheme(resolvedTheme === "light" ? themes.oneLight : themes.oneDark);
+		setCodeTheme(
+			resolvedTheme === "light" ? themes.oneLight : themes.synthwave84,
+		);
 	}, [resolvedTheme]);
 
 	const copyToClipboard = (text: string) => {


### PR DESCRIPTION
This PR reverts the landing page code block theme to the `synthwave84` theme.

That should be `synthwave84`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted the landing page code block dark mode theme to synthwave84 (light mode remains oneLight) to restore the intended code preview styling and improve visual consistency.

<!-- End of auto-generated description by cubic. -->

