### PR TITLE
refactor(api): narrow boolean types to literals in JSON responses

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -275,8 +275,8 @@ export const linkSocialAccount = createAuthEndpoint(
 			if (hasBeenLinked) {
 				return c.json({
 					url: "", // this is for type inference
-					status: true,
-					redirect: false,
+					status: true as const,
+					redirect: false as const,
 				});
 			}
 
@@ -333,8 +333,8 @@ export const linkSocialAccount = createAuthEndpoint(
 
 			return c.json({
 				url: "", // this is for type inference
-				status: true,
-				redirect: false,
+				status: true as const,
+				redirect: false as const,
 			});
 		}
 
@@ -414,7 +414,7 @@ export const unlinkAccount = createAuthEndpoint(
 		}
 		await ctx.context.internalAdapter.deleteAccount(accountExist.id);
 		return ctx.json({
-			status: true,
+			status: true as const,
 		});
 	},
 );

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -161,12 +161,12 @@ export const sendVerificationEmail = createAuthEndpoint(
 			if (!user) {
 				//we're returning true to avoid leaking information about the user
 				return ctx.json({
-					status: true,
+					status: true as const,
 				});
 			}
 			await sendVerificationEmailFn(ctx, user.user);
 			return ctx.json({
-				status: true,
+				status: true as const,
 			});
 		}
 		if (session?.user.emailVerified) {
@@ -182,7 +182,7 @@ export const sendVerificationEmail = createAuthEndpoint(
 		}
 		await sendVerificationEmailFn(ctx, session.user);
 		return ctx.json({
-			status: true,
+			status: true as const,
 		});
 	},
 );
@@ -385,7 +385,7 @@ export const verifyEmail = createAuthEndpoint(
 				throw ctx.redirect(ctx.query.callbackURL);
 			}
 			return ctx.json({
-				status: true,
+				status: true as const,
 				user: {
 					id: updatedUser.id,
 					email: updatedUser.email,
@@ -448,7 +448,7 @@ export const verifyEmail = createAuthEndpoint(
 			throw ctx.redirect(ctx.query.callbackURL);
 		}
 		return ctx.json({
-			status: true,
+			status: true as const,
 			user: null,
 		});
 	},

--- a/packages/better-auth/src/api/routes/ok.ts
+++ b/packages/better-auth/src/api/routes/ok.ts
@@ -33,7 +33,7 @@ export const ok = createAuthEndpoint(
 	},
 	async (ctx) => {
 		return ctx.json({
-			ok: true,
+			ok: true as const,
 		});
 	},
 );

--- a/packages/better-auth/src/api/routes/reset-password.ts
+++ b/packages/better-auth/src/api/routes/reset-password.ts
@@ -100,7 +100,7 @@ export const requestPasswordReset = createAuthEndpoint(
 		if (!user) {
 			ctx.context.logger.error("Reset Password: User not found", { email });
 			return ctx.json({
-				status: true,
+				status: true as const,
 				message:
 					"If this email exists in our system, check your email for the reset link",
 			});
@@ -128,7 +128,7 @@ export const requestPasswordReset = createAuthEndpoint(
 			ctx.request,
 		);
 		return ctx.json({
-			status: true,
+			status: true as const,
 			message:
 				"If this email exists in our system, check your email for the reset link",
 		});
@@ -296,7 +296,7 @@ export const resetPassword = createAuthEndpoint(
 			await ctx.context.internalAdapter.deleteSessions(userId);
 		}
 		return ctx.json({
-			status: true,
+			status: true as const,
 		});
 	},
 );

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -589,7 +589,7 @@ export const revokeSession = createAuthEndpoint(
 			throw new APIError("INTERNAL_SERVER_ERROR");
 		}
 		return ctx.json({
-			status: true,
+			status: true as const,
 		});
 	},
 );
@@ -643,7 +643,7 @@ export const revokeSessions = createAuthEndpoint(
 			throw new APIError("INTERNAL_SERVER_ERROR");
 		}
 		return ctx.json({
-			status: true,
+			status: true as const,
 		});
 	},
 );
@@ -701,7 +701,7 @@ export const revokeOtherSessions = createAuthEndpoint(
 			),
 		);
 		return ctx.json({
-			status: true,
+			status: true as const,
 		});
 	},
 );

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -303,7 +303,7 @@ export const signInSocial = createAuthEndpoint(
 			}
 			await setSessionCookie(c, data.data!);
 			return c.json({
-				redirect: false,
+				redirect: false as const,
 				token: data.data!.session.token,
 				url: undefined,
 				user: {

--- a/packages/better-auth/src/api/routes/sign-out.ts
+++ b/packages/better-auth/src/api/routes/sign-out.ts
@@ -45,7 +45,7 @@ export const signOut = createAuthEndpoint(
 		await ctx.context.internalAdapter.deleteSession(sessionCookieToken);
 		deleteSessionCookie(ctx);
 		return ctx.json({
-			success: true,
+			success: true as const,
 		});
 	},
 );

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -120,7 +120,7 @@ export const updateUser = <O extends BetterAuthOptions>() =>
 				user,
 			});
 			return ctx.json({
-				status: true,
+				status: true as const,
 			});
 		},
 	);
@@ -357,7 +357,7 @@ export const setPassword = createAuthEndpoint(
 				password: passwordHash,
 			});
 			return ctx.json({
-				status: true,
+				status: true as const,
 			});
 		}
 		throw new APIError("BAD_REQUEST", {
@@ -475,7 +475,7 @@ export const deleteUser = createAuthEndpoint(
 				},
 			});
 			return ctx.json({
-				success: true,
+				success: true as const,
 				message: "User deleted",
 			});
 		}
@@ -506,7 +506,7 @@ export const deleteUser = createAuthEndpoint(
 				ctx.request,
 			);
 			return ctx.json({
-				success: true,
+				success: true as const,
 				message: "Verification email sent",
 			});
 		}
@@ -534,7 +534,7 @@ export const deleteUser = createAuthEndpoint(
 			await afterDelete(session.user, ctx.request);
 		}
 		return ctx.json({
-			success: true,
+			success: true as const,
 			message: "User deleted",
 		});
 	},
@@ -632,7 +632,7 @@ export const deleteUserCallback = createAuthEndpoint(
 			throw ctx.redirect(ctx.query.callbackURL || "/");
 		}
 		return ctx.json({
-			success: true,
+			success: true as const,
 			message: "User deleted",
 		});
 	},
@@ -774,7 +774,7 @@ export const changeEmail = createAuthEndpoint(
 			}
 
 			return ctx.json({
-				status: true,
+				status: true as const,
 			});
 		}
 
@@ -807,7 +807,7 @@ export const changeEmail = createAuthEndpoint(
 			ctx.request,
 		);
 		return ctx.json({
-			status: true,
+			status: true as const,
 		});
 	},
 );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Narrowed boolean fields in API JSON responses to literal types (true/false) to improve TypeScript inference. No runtime behavior or response payloads changed.

- **Refactors**
  - Replaced boolean values with literals using `as const` for: status, success, ok, redirect.
  - Updated routes: account, email-verification, ok, reset-password, session, sign-in, sign-out, update-user.
  - Benefit: stronger, predictable response typings for clients.

<!-- End of auto-generated description by cubic. -->

