### PR TITLE
docs: add verificationUri option guide to device authorization plugin

### DIFF
--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -42,6 +42,7 @@ This will demonstrate the complete device authorization flow by:
           plugins: [ // [!code highlight]
             deviceAuthorization({ // [!code highlight]
               // Optional configuration
+              verificationUri : "/device/verification" // The URL where users verify their device code. // [!code highlight]
               expiresIn: "30m", // Device code expiration time // [!code highlight]
               interval: "5s",    // Minimum polling interval // [!code highlight]
             }), // [!code highlight]
@@ -129,8 +130,9 @@ const { data } = await authClient.device.code({
 });
 
 if (data) {
-  console.log(`Please visit: ${data.verification_uri}`);
-  console.log(`And enter code: ${data.user_code}`);
+  console.log(`User code: ${data.user_code}`);
+  console.log(`Verification URL: ${data.verification_uri}`);
+  console.log(`Complete verification URL: ${data.verification_uri_complete}`);
 }
 ```
 
@@ -455,7 +457,10 @@ async function authenticateCLI() {
     console.log(`Please visit: ${verification_uri}`);
     console.log(`Enter code: ${user_code}\n`);
     
-    // Open browser with the complete URL
+    // Open browser
+    //
+    // These URIs come from the `verificationUri` option.
+    // If not provided, they are null.
     const urlToOpen = verification_uri_complete || verification_uri;
     if (urlToOpen) {
       console.log("🌐 Opening browser...");
@@ -555,6 +560,8 @@ authenticateCLI().catch((err) => {
 ## Options
 
 ### Server
+
+**verificationUri**: The URL (absolute or relative) where users verify their device code. It is typically the page where users enter the code. Returned as `verification_uri` in the response. If not provided, it will be null.
 
 **expiresIn**: The expiration time for device codes. Default: `"30m"` (30 minutes).
 


### PR DESCRIPTION
This PR adds documentation for the new verificationUri option in the Device Authorization Plugin.

This should be merged after PR https://github.com/better-auth/better-auth/pull/5451

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for the new verificationUri option in the Device Authorization Plugin. Shows how to configure it, how verification_uri and verification_uri_complete are returned and used, and notes that they are null if not set.

- **Dependencies**
  - Requires a plugin version that includes verificationUri.

<!-- End of auto-generated description by cubic. -->

