### PR TITLE
chore: fix sync-orama script in package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "postinstall": "fumadocs-mdx",
     "scripts:endpoint-to-doc": "bun ./scripts/endpoint-to-doc/index.ts",
-    "scripts:sync-orama": "node ./scripts/sync-orama.ts"
+    "scripts:sync-orama": "bun ./scripts/sync-orama.ts"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^1.0.20",


### PR DESCRIPTION
This PR fixes an incorrect script in package.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the sync-orama script in docs/package.json to run with Bun instead of Node. This ensures the TypeScript script executes correctly and aligns with other docs scripts.

<!-- End of auto-generated description by cubic. -->

