### PR TITLE
docs: incorrect linear icon in sing-on box builder

### DIFF
--- a/docs/components/builder/social-provider.tsx
+++ b/docs/components/builder/social-provider.tsx
@@ -208,7 +208,7 @@ export const socialProviders = {
 				xmlns="http://www.w3.org/2000/svg"
 				width="1em"
 				height="1em"
-				viewBox="0 0 24 24"
+				viewBox="0 0 100 100"
 				{...props}
 			>
 				<path
@@ -222,7 +222,7 @@ export const socialProviders = {
 				fill="none"
 				width="1em"
 				height="1em"
-				viewBox="0 0 24 24"
+				viewBox="0 0 100 100"
 			>
 				<path
 					fill="currentColor"


### PR DESCRIPTION
This PR fixes incorrect Linear icon on Create Sign in Box.

<img width="1276" height="1200" alt="Comet 2025-10-26 09 34 32" src="https://github.com/user-attachments/assets/038afbde-8396-40b3-a321-7e3f2c487cc1" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Linear icon in the docs Sign in box by correcting the SVG viewBox to 0 0 100 100 so it renders with the right size and proportions.

<!-- End of auto-generated description by cubic. -->

