### PR TITLE
fix(stripe): remove TS error suppression updating getCheckoutSessionParams

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -540,7 +540,6 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 						subscription,
 					},
 					ctx.request,
-					//@ts-expect-error
 					ctx,
 				);
 

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -247,6 +247,7 @@ export type SubscriptionOptions = {
 	 * parameters for session create params
 	 *
 	 * @param data - data containing user, session and plan
+	 * @param req - the request object
 	 * @param ctx - the context object
 	 */
 	getCheckoutSessionParams?: (
@@ -256,6 +257,7 @@ export type SubscriptionOptions = {
 			plan: StripePlan;
 			subscription: Subscription;
 		},
+		req: GenericEndpointContext["request"],
 		ctx: GenericEndpointContext,
 	) =>
 		| Promise<{


### PR DESCRIPTION
In `getCheckoutSessionParams`, I needed to read the request JSON via `ctx.body`. Currently, the function receives `ctx.request` as the second argument, but that’s not compatible with the defined type. Using `Request` directly doesn’t help either, since the body has already been consumed by the time this runs. The most practical solution is to use the entire `ctx` object, however, that causes type mismatches.

This PR just corrects the typing.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns getCheckoutSessionParams types with runtime usage so ctx and req are correctly typed and ctx.body can be read. Removes a TS suppression and improves type safety.

- **Bug Fixes**
  - Updated SubscriptionOptions.getCheckoutSessionParams to accept (data, req, ctx) with req: GenericEndpointContext["request"].
  - Call site now passes ctx.request and ctx; removed @ts-expect-error.

- **Migration**
  - If you implement getCheckoutSessionParams, add the new req argument before ctx.

<!-- End of auto-generated description by cubic. -->

