### PR TITLE
docs: adjust NavLink target handling

### DIFF
--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -112,6 +112,7 @@ export const Navbar = () => {
 						<NavLink
 							href="https://github.com/better-auth/better-auth"
 							className=" bg-muted/20"
+							external
 						>
 							<svg
 								xmlns="http://www.w3.org/2000/svg"

--- a/docs/components/nav-link.tsx
+++ b/docs/components/nav-link.tsx
@@ -8,9 +8,10 @@ type Props = {
 	href: string;
 	children: React.ReactNode;
 	className?: string;
+	external?: boolean;
 };
 
-export const NavLink = ({ href, children, className }: Props) => {
+export const NavLink = ({ href, children, className, external }: Props) => {
 	const segment = useSelectedLayoutSegment();
 	const isActive =
 		segment === href.slice(1) || (segment === null && href === "/");
@@ -24,6 +25,7 @@ export const NavLink = ({ href, children, className }: Props) => {
 					"group-hover:text-foreground",
 					isActive ? "text-foreground" : "text-muted-foreground",
 				)}
+				target={external ? "_blank" : undefined}
 			>
 				{children}
 			</Link>


### PR DESCRIPTION
### Before:

https://github.com/user-attachments/assets/fb29b792-fad3-47b4-9d20-5ba3b1fa20a9

### After:

https://github.com/user-attachments/assets/775c7971-7d20-4e84-8361-8a3a3940c172



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified NavLink by removing the target attribute and the external prop, aligning link behavior with Next.js defaults. The navbar GitHub link now uses this simplified component and opens in the same tab.

<!-- End of auto-generated description by cubic. -->

