### PR TITLE
chore: add missing `homepage` and `repository` to package.json

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -4,6 +4,7 @@
   "description": "The most comprehensive authentication framework for TypeScript.",
   "type": "module",
   "license": "MIT",
+  "homepage": "https://better-auth.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/better-auth/better-auth",

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -4,6 +4,12 @@
   "version": "1.4.0-beta.13",
   "type": "module",
   "main": "dist/index.js",
+  "homepage": "https://www.better-auth.com/docs/plugins/sso",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/sso"
+  },
   "license": "MIT",
   "keywords": [
     "sso",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -5,6 +5,12 @@
   "type": "module",
   "main": "dist/index.js",
   "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/plugins/stripe",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/stripe"
+  },
   "keywords": [
     "stripe",
     "auth",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added missing homepage and repository metadata to package.json for better-auth, sso, and stripe. This improves npm metadata and points users to the docs and the correct GitHub directories.

<!-- End of auto-generated description by cubic. -->

