### PR TITLE
chore(docs): add note about docker requirements for macos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,9 @@ pnpm lint:fix
    ```bash
    docker compose up -d
    ```
+
+   > Note: On MacOS, the **mssql** container will likely require Rosetta emulation and at least 2GB of RAM of allocated memory. See their [container requirements](https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker?view=sql-server-ver17&tabs=cli&pivots=cs1-bash#prerequisites).
+
 5. Run the test suite:
    ```bash
    # Run all tests


### PR DESCRIPTION
While trying to get my environment up and running (docker containers), I had the `mssql` continously failing with the following error:

```bash
<jemalloc>: (This is the expected behaviour if you are running under QEMU)
/opt/mssql/bin/sqlservr: Invalid mapping of address 0x400534d000 in reserved address space below 0x400000000000. Possible causes:
1) the process (itself, or via a wrapper) starts-up its own running environment sets the stack size limit to unlimited via syscall setrlimit(2);
2) the process (itself, or via a wrapper) adjusts its own execution domain and flag the system its legacy personality via syscall personality(2);
3) sysadmin deliberately sets the system to run on legacy VA layout mode by adjusting a sysctl knob vm.legacy_va_layout.
```

Turns out, this is because `mssql` does not officially support `macos` so Rosetta emulation is currently necessary as a short term workaround. So adding a note about that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a macOS note to the Docker setup in CONTRIBUTING.md: the mssql container likely needs Rosetta emulation and at least 2GB RAM. This helps prevent startup failures and links to Microsoft’s container prerequisites.

<!-- End of auto-generated description by cubic. -->

