### PR TITLE
fix(email-otp): fix openapi schema for /email-otp/verify-email endpoint

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -617,8 +617,8 @@ export const emailOTP = (options: EmailOTPOptions) => {
 													user: {
 														$ref: "#/components/schemas/User",
 													},
-													required: ["status", "token", "user"],
 												},
+												required: ["status", "token", "user"],
 											},
 										},
 									},


### PR DESCRIPTION
Fixes `/email-otp/verify-email` endpoint schema by moving the `required` property as a sibling of `properties` instead of it being a child.

**Before**: 
<img width="791" height="655" alt="Screenshot 2025-10-27 at 11 54 15 AM" src="https://github.com/user-attachments/assets/2ecddcb1-86da-4561-a2d6-7d966cf05aa4" />


**After**
<img width="798" height="627" alt="Screenshot 2025-10-27 at 11 59 07 AM" src="https://github.com/user-attachments/assets/f73bb2b1-4545-4360-82d9-5e1a4a33d977" />

Solves https://github.com/better-auth/better-auth/issues/5607

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the OpenAPI schema for /email-otp/verify-email by placing required alongside properties in the 200 response object. This restores valid schema parsing and codegen compatibility.

- **Bug Fixes**
  - Moved required: ["status", "token", "user"] to be a sibling of properties to comply with OpenAPI.

<!-- End of auto-generated description by cubic. -->

