### PR TITLE
chore(organization): fix client side import server side code

### DIFF
--- a/e2e/smoke/test/fixtures/vite/vite.config.ts
+++ b/e2e/smoke/test/fixtures/vite/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
 	build: {
 		rollupOptions: {
 			input: {
-				server: resolve(__dirname, "src", "server.ts"),
 				client: resolve(__dirname, "src", "client.ts"),
 			},
 			output: {

--- a/e2e/smoke/test/vite.spec.ts
+++ b/e2e/smoke/test/vite.spec.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
 
 describe("(vite) client build", () => {
-	it("builds client without better-call imports", async () => {
+	it("builds client without unexpected imports", async () => {
 		const viteDir = join(fixturesDir, "vite");
 
 		// Run vite build
@@ -16,6 +16,8 @@ describe("(vite) client build", () => {
 			cwd: viteDir,
 			stdio: "pipe",
 		});
+
+		const unexpectedStrings = ["async_hooks"] as const;
 
 		// Wait for build to complete
 		await new Promise<void>((resolve, reject) => {
@@ -33,10 +35,24 @@ describe("(vite) client build", () => {
 
 			// Log build output for debugging
 			buildProcess.stdout.on("data", (data) => {
+				if (unexpectedStrings.some((str) => data.toString().includes(str))) {
+					reject(
+						new Error(
+							`Vite build output contains unexpected string: ${data.toString()}`,
+						),
+					);
+				}
 				console.log(data.toString());
 			});
 
 			buildProcess.stderr.on("data", (data) => {
+				if (unexpectedStrings.some((str) => data.toString().includes(str))) {
+					reject(
+						new Error(
+							`Vite build error output contains unexpected string: ${data.toString()}`,
+						),
+					);
+				}
 				console.error(data.toString());
 			});
 		});

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -20,7 +20,7 @@ import {
 	memberAc,
 	ownerAc,
 } from "./access";
-import { type OrganizationPlugin } from "./organization";
+import type { OrganizationPlugin } from "./organization";
 import type { HasPermissionBaseInput } from "./permission";
 import { hasPermissionFn } from "./permission";
 import type { OrganizationOptions } from "./types";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents server-only code from being bundled into the client by switching to a type-only import and tightening the Vite e2e test. Keeps the client build free of Node APIs like async_hooks.

- **Bug Fixes**
  - Use `import type` for `OrganizationPlugin` to avoid runtime imports on the client.
  - Remove `server` entry from the Vite fixture to build only the client.
  - Update e2e Vite test to fail if build output contains unexpected server-side strings (e.g., async_hooks).

<!-- End of auto-generated description by cubic. -->

