### PR TITLE
docs: restore get started button style

### DIFF
--- a/docs/components/landing/hero.tsx
+++ b/docs/components/landing/hero.tsx
@@ -118,10 +118,10 @@ export default function Hero() {
 								</GradientBG>
 							</div>
 
-							<div className="flex w-fit flex-col gap-4 font-sans md:flex-row md:justify-center lg:justify-start items-center">
+							<div className="mt-4 flex w-fit flex-col gap-4 font-sans md:flex-row md:justify-center lg:justify-start items-center">
 								<Link
 									href="/docs"
-									className="hover:shadow-sm dark:border-stone-100 dark:hover:shadow-sm border-2 border-black bg-white px-4 py-1.5 text-sm uppercase text-black shadow-[1px_1px_rgba(0,0,0),2px_2px_rgba(0,0,0),3px_3px_rgba(0,0,0),4px_4px_rgba(0,0,0),5px_5px_0px_0px_rgba(0,0,0)] transition duration-200 md:px-8"
+									className="hover:shadow-sm dark:border-stone-100 dark:hover:shadow-sm border-2 border-black bg-white px-4 py-1.5 text-sm uppercase text-black shadow-[1px_1px_rgba(0,0,0),2px_2px_rgba(0,0,0),3px_3px_rgba(0,0,0),4px_4px_rgba(0,0,0),5px_5px_0px_0px_rgba(0,0,0)] transition duration-200 md:px-8 dark:shadow-[1px_1px_rgba(255,255,255),2px_2px_rgba(255,255,255),3px_3px_rgba(255,255,255),4px_4px_rgba(255,255,255),5px_5px_0px_0px_rgba(255,255,255)]"
 								>
 									Get Started
 								</Link>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restored the “Get Started” button styling on the docs landing hero for consistent look across themes. Adds top spacing to the CTA group and a white stacked shadow in dark mode to match the original design and improve contrast.

<!-- End of auto-generated description by cubic. -->

