### PR TITLE
fix(social-providers): core module import

### DIFF
--- a/packages/core/src/social-providers/polar.ts
+++ b/packages/core/src/social-providers/polar.ts
@@ -1,10 +1,10 @@
-import type { OAuthProvider, ProviderOptions } from "@better-auth/core/oauth2";
+import { betterFetch } from "@better-fetch/fetch";
+import type { OAuthProvider, ProviderOptions } from "../oauth2";
 import {
 	createAuthorizationURL,
 	refreshAccessToken,
 	validateAuthorizationCode,
-} from "@better-auth/core/oauth2";
-import { betterFetch } from "@better-fetch/fetch";
+} from "../oauth2";
 
 export interface PolarProfile {
 	id: string;


### PR DESCRIPTION
This will fix expo runtime issue because of it resolves the wrong path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect OAuth module imports in social-providers/polar to prevent Expo runtime from resolving the wrong path. Switched from @better-auth/core/oauth2 to local ../oauth2 imports.

<!-- End of auto-generated description by cubic. -->

