### PR TITLE
feat(expo): error handling when not set

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -317,6 +317,28 @@ export const expoClient = (opts: ExpoClientOptions) => {
 				id: "expo",
 				name: "Expo",
 				hooks: {
+					async onError(context) {
+						if (isWeb) return;
+
+						const { error, request } = context;
+						const url = String(request.url);
+
+						if (error.status === 403) {
+							const isAuthEndpoint =
+								url.includes("/sign-in") ||
+								url.includes("/sign-up") ||
+								url.includes("/get-session");
+
+							if (isAuthEndpoint && request.headers?.get?.("expo-origin")) {
+								console.error(
+									"[Better Auth Expo] Configuration Error:\n" +
+										"It appears you're using the Expo client plugin but the server is rejecting Expo requests.\n\n" +
+										"Make sure you have added the expo() plugin to your server-side Better Auth configuration.\n\n" +
+										"Please see: https://www.better-auth.com/docs/integrations/expo",
+								);
+							}
+						}
+					},
 					async onSuccess(context) {
 						if (isWeb) return;
 						const setCookie = context.response.headers.get("set-cookie");

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -829,6 +829,61 @@ describe("expo with cookieCache", async () => {
 		expect(map.has("better-auth_session_token")).toBe(true);
 		expect(map.has("better-auth:session_token")).toBe(false);
 	});
+
+	it("should provide helpful error message when server plugin is missing", async () => {
+		const storage = new Map<string, string>();
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		const client = createAuthClient({
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					const headers = new Headers(init?.headers);
+					const hasExpoOrigin = headers.get("expo-origin") !== null;
+					const urlStr = url.toString();
+
+					if (hasExpoOrigin && urlStr.includes("/sign-in")) {
+						return new Response(
+							JSON.stringify({
+								message: "Invalid request",
+								error: "FORBIDDEN",
+							}),
+							{
+								status: 403,
+								headers: { "Content-Type": "application/json" },
+							},
+						);
+					}
+
+					return new Response(null, { status: 404 });
+				},
+			},
+			plugins: [
+				expoClient({
+					storage: {
+						getItem: (key) => storage.get(key) || null,
+						setItem: async (key, value) => storage.set(key, value),
+					},
+				}),
+			],
+		});
+
+		await client.signIn.email({
+			email: "test@example.com",
+			password: "password123",
+		});
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining("[Better Auth Expo] Configuration Error"),
+		);
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Make sure you have added the expo() plugin"),
+		);
+
+		consoleErrorSpy.mockRestore();
+	});
 });
 
 describe("expo with cookie storeStateStrategy", async () => {


### PR DESCRIPTION
This PR adds error handling when `expo()` is not set in `auth.ts` on server side.

Related issue #5600.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a helpful error in native Expo apps when the server isn’t configured with `expo()`. Prevents silent failures by logging guidance during auth calls.

- **Bug Fixes**
  - Added `onError` in the Expo client to log a clear configuration error (with docs link) when a 403 occurs on `/sign-in`, `/sign-up`, or `/get-session` and the request has the `expo-origin` header. Runs only on native (not web).
  - Added a test that verifies the console error includes guidance to add `expo()` on the server.

<sup>Written for commit 38b7466170bc9cd2a58489da0b6ff195f3297e3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

