### PR TITLE
docs: fix typo in import statement formatting in auth client

### DIFF
--- a/docs/components/builder/code-tabs/index.tsx
+++ b/docs/components/builder/code-tabs/index.tsx
@@ -72,7 +72,7 @@ ${
 			content: `import { createAuthClient } from "better-auth/react";
 			${
 				options.magicLink || options.passkey
-					? `import { ${options.magicLink ? "magicLinkClient, " : ""}, ${
+					? `import { ${options.magicLink ? "magicLinkClient," : ""} ${
 							options.passkey ? "passkeyClient" : ""
 						} } from "better-auth/client/plugins";`
 					: ""


### PR DESCRIPTION
### SUMMARY:
This pull request makes a minor formatting update to the import statement generation logic in the `docs/components/builder/code-tabs/index.tsx` file. 

The change removes an unnecessary comma in the generated import list for plugin clients, which was leading to an error if `options.magicLink` was false and `options.passkey` true.

### BEFORE:
```ts
import {
    ,
    passkeyClient
} from "better-auth/client/plugins";
```

### AFTER:
```ts
import {
    passkeyClient
} from "better-auth/client/plugins";
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the docs code-tabs import generator to remove a stray comma in plugin imports. Prevents a broken import when magicLink is disabled and passkey is enabled in the auth client example.

<!-- End of auto-generated description by cubic. -->

