### PR TITLE
chore: use strict lint rules

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -310,8 +310,8 @@ function getHooks(authContext: AuthContext) {
 	/**
 	 * Add plugin added hooks at last
 	 */
-	pluginBeforeHooks.length && beforeHooks.push(...pluginBeforeHooks);
-	pluginAfterHooks.length && afterHooks.push(...pluginAfterHooks);
+	if (pluginBeforeHooks.length) beforeHooks.push(...pluginBeforeHooks);
+	if (pluginAfterHooks.length) afterHooks.push(...pluginAfterHooks);
 
 	return {
 		beforeHooks,

--- a/packages/better-auth/src/client/vue/vue-store.ts
+++ b/packages/better-auth/src/client/vue/vue-store.ts
@@ -29,7 +29,7 @@ export function useStore<
 		state.value = value;
 	});
 
-	getCurrentScope() && onScopeDispose(unsubscribe);
+	if (getCurrentScope()) onScopeDispose(unsubscribe);
 
 	if (process.env.NODE_ENV !== "production") {
 		registerStore(store);

--- a/packages/core/src/social-providers/apple.ts
+++ b/packages/core/src/social-providers/apple.ts
@@ -81,8 +81,8 @@ export const apple = (options: AppleOptions) => {
 		name: "Apple",
 		async createAuthorizationURL({ state, scopes, redirectURI }) {
 			const _scope = options.disableDefaultScope ? [] : ["email", "name"];
-			options.scope && _scope.push(...options.scope);
-			scopes && _scope.push(...scopes);
+			if (options.scope) _scope.push(...options.scope);
+			if (scopes) _scope.push(...scopes);
 			const url = await createAuthorizationURL({
 				id: "apple",
 				options,

--- a/packages/core/src/social-providers/atlassian.ts
+++ b/packages/core/src/social-providers/atlassian.ts
@@ -44,8 +44,8 @@ export const atlassian = (options: AtlassianOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["read:jira-user", "offline_access"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 
 			return createAuthorizationURL({
 				id: "atlassian",

--- a/packages/core/src/social-providers/cognito.ts
+++ b/packages/core/src/social-providers/cognito.ts
@@ -77,8 +77,8 @@ export const cognito = (options: CognitoOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["openid", "profile", "email"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 
 			const url = await createAuthorizationURL({
 				id: "cognito",

--- a/packages/core/src/social-providers/discord.ts
+++ b/packages/core/src/social-providers/discord.ts
@@ -85,8 +85,8 @@ export const discord = (options: DiscordOptions) => {
 		name: "Discord",
 		createAuthorizationURL({ state, scopes, redirectURI }) {
 			const _scopes = options.disableDefaultScope ? [] : ["identify", "email"];
-			scopes && _scopes.push(...scopes);
-			options.scope && _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
 			const hasBotScope = _scopes.includes("bot");
 			const permissionsParam =
 				hasBotScope && options.permissions !== undefined

--- a/packages/core/src/social-providers/dropbox.ts
+++ b/packages/core/src/social-providers/dropbox.ts
@@ -38,8 +38,8 @@ export const dropbox = (options: DropboxOptions) => {
 			redirectURI,
 		}) => {
 			const _scopes = options.disableDefaultScope ? [] : ["account_info.read"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			const additionalParams: Record<string, string> = {};
 			if (options.accessType) {
 				additionalParams.token_access_type = options.accessType;

--- a/packages/core/src/social-providers/facebook.ts
+++ b/packages/core/src/social-providers/facebook.ts
@@ -44,8 +44,8 @@ export const facebook = (options: FacebookOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["email", "public_profile"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return await createAuthorizationURL({
 				id: "facebook",
 				options,

--- a/packages/core/src/social-providers/figma.ts
+++ b/packages/core/src/social-providers/figma.ts
@@ -35,8 +35,8 @@ export const figma = (options: FigmaOptions) => {
 			}
 
 			const _scopes = options.disableDefaultScope ? [] : ["file_read"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 
 			const url = await createAuthorizationURL({
 				id: "figma",

--- a/packages/core/src/social-providers/github.ts
+++ b/packages/core/src/social-providers/github.ts
@@ -65,8 +65,8 @@ export const github = (options: GithubOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["read:user", "user:email"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "github",
 				options,

--- a/packages/core/src/social-providers/gitlab.ts
+++ b/packages/core/src/social-providers/gitlab.ts
@@ -88,8 +88,8 @@ export const gitlab = (options: GitlabOptions) => {
 			redirectURI,
 		}) => {
 			const _scopes = options.disableDefaultScope ? [] : ["read_user"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return await createAuthorizationURL({
 				id: issuerId,
 				options,

--- a/packages/core/src/social-providers/google.ts
+++ b/packages/core/src/social-providers/google.ts
@@ -76,8 +76,8 @@ export const google = (options: GoogleOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["email", "profile", "openid"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			const url = await createAuthorizationURL({
 				id: "google",
 				options,

--- a/packages/core/src/social-providers/huggingface.ts
+++ b/packages/core/src/social-providers/huggingface.ts
@@ -48,8 +48,8 @@ export const huggingface = (options: HuggingFaceOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["openid", "profile", "email"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "huggingface",
 				options,

--- a/packages/core/src/social-providers/kakao.ts
+++ b/packages/core/src/social-providers/kakao.ts
@@ -109,8 +109,8 @@ export const kakao = (options: KakaoOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["account_email", "profile_image", "profile_nickname"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "kakao",
 				options,

--- a/packages/core/src/social-providers/kick.ts
+++ b/packages/core/src/social-providers/kick.ts
@@ -31,8 +31,8 @@ export const kick = (options: KickOptions) => {
 		name: "Kick",
 		createAuthorizationURL({ state, scopes, redirectURI, codeVerifier }) {
 			const _scopes = options.disableDefaultScope ? [] : ["user:read"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 
 			return createAuthorizationURL({
 				id: "kick",

--- a/packages/core/src/social-providers/line.ts
+++ b/packages/core/src/social-providers/line.ts
@@ -60,8 +60,8 @@ export const line = (options: LineOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["openid", "profile", "email"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return await createAuthorizationURL({
 				id: "line",
 				options,

--- a/packages/core/src/social-providers/linear.ts
+++ b/packages/core/src/social-providers/linear.ts
@@ -33,8 +33,8 @@ export const linear = (options: LinearOptions) => {
 		name: "Linear",
 		createAuthorizationURL({ state, scopes, loginHint, redirectURI }) {
 			const _scopes = options.disableDefaultScope ? [] : ["read"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "linear",
 				options,

--- a/packages/core/src/social-providers/linkedin.ts
+++ b/packages/core/src/social-providers/linkedin.ts
@@ -41,8 +41,8 @@ export const linkedin = (options: LinkedInOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["profile", "email", "openid"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return await createAuthorizationURL({
 				id: "linkedin",
 				options,

--- a/packages/core/src/social-providers/microsoft-entra-id.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.ts
@@ -147,8 +147,8 @@ export const microsoft = (options: MicrosoftOptions) => {
 			const scopes = options.disableDefaultScope
 				? []
 				: ["openid", "profile", "email", "User.Read", "offline_access"];
-			options.scope && scopes.push(...options.scope);
-			data.scopes && scopes.push(...data.scopes);
+			if (options.scope) scopes.push(...options.scope);
+			if (data.scopes) scopes.push(...data.scopes);
 			return createAuthorizationURL({
 				id: "microsoft",
 				options,
@@ -224,7 +224,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 					const scopes = options.disableDefaultScope
 						? []
 						: ["openid", "profile", "email", "User.Read", "offline_access"];
-					options.scope && scopes.push(...options.scope);
+					if (options.scope) scopes.push(...options.scope);
 
 					return refreshAccessToken({
 						refreshToken,

--- a/packages/core/src/social-providers/naver.ts
+++ b/packages/core/src/social-providers/naver.ts
@@ -45,8 +45,8 @@ export const naver = (options: NaverOptions) => {
 		name: "Naver",
 		createAuthorizationURL({ state, scopes, redirectURI }) {
 			const _scopes = options.disableDefaultScope ? [] : ["profile", "email"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "naver",
 				options,

--- a/packages/core/src/social-providers/notion.ts
+++ b/packages/core/src/social-providers/notion.ts
@@ -28,8 +28,8 @@ export const notion = (options: NotionOptions) => {
 		name: "Notion",
 		createAuthorizationURL({ state, scopes, loginHint, redirectURI }) {
 			const _scopes: string[] = options.disableDefaultScope ? [] : [];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "notion",
 				options,

--- a/packages/core/src/social-providers/paybin.ts
+++ b/packages/core/src/social-providers/paybin.ts
@@ -55,8 +55,8 @@ export const paybin = (options: PaybinOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["openid", "email", "profile"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			const url = await createAuthorizationURL({
 				id: "paybin",
 				options,

--- a/packages/core/src/social-providers/polar.ts
+++ b/packages/core/src/social-providers/polar.ts
@@ -37,8 +37,8 @@ export const polar = (options: PolarOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["openid", "profile", "email"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "polar",
 				options,

--- a/packages/core/src/social-providers/reddit.ts
+++ b/packages/core/src/social-providers/reddit.ts
@@ -27,8 +27,8 @@ export const reddit = (options: RedditOptions) => {
 		name: "Reddit",
 		createAuthorizationURL({ state, scopes, redirectURI }) {
 			const _scopes = options.disableDefaultScope ? [] : ["identity"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "reddit",
 				options,

--- a/packages/core/src/social-providers/roblox.ts
+++ b/packages/core/src/social-providers/roblox.ts
@@ -35,8 +35,8 @@ export const roblox = (options: RobloxOptions) => {
 		name: "Roblox",
 		createAuthorizationURL({ state, scopes, redirectURI }) {
 			const _scopes = options.disableDefaultScope ? [] : ["openid", "profile"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return new URL(
 				`https://apis.roblox.com/oauth/v1/authorize?scope=${_scopes.join(
 					"+",

--- a/packages/core/src/social-providers/salesforce.ts
+++ b/packages/core/src/social-providers/salesforce.ts
@@ -76,8 +76,8 @@ export const salesforce = (options: SalesforceOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["openid", "email", "profile"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 
 			return createAuthorizationURL({
 				id: "salesforce",

--- a/packages/core/src/social-providers/slack.ts
+++ b/packages/core/src/social-providers/slack.ts
@@ -45,8 +45,8 @@ export const slack = (options: SlackOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["openid", "profile", "email"];
-			scopes && _scopes.push(...scopes);
-			options.scope && _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
 			const url = new URL("https://slack.com/openid/connect/authorize");
 			url.searchParams.set("scope", _scopes.join(" "));
 			url.searchParams.set("response_type", "code");

--- a/packages/core/src/social-providers/spotify.ts
+++ b/packages/core/src/social-providers/spotify.ts
@@ -25,8 +25,8 @@ export const spotify = (options: SpotifyOptions) => {
 		name: "Spotify",
 		createAuthorizationURL({ state, scopes, codeVerifier, redirectURI }) {
 			const _scopes = options.disableDefaultScope ? [] : ["user-read-email"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "spotify",
 				options,

--- a/packages/core/src/social-providers/tiktok.ts
+++ b/packages/core/src/social-providers/tiktok.ts
@@ -130,8 +130,8 @@ export const tiktok = (options: TiktokOptions) => {
 		name: "TikTok",
 		createAuthorizationURL({ state, scopes, redirectURI }) {
 			const _scopes = options.disableDefaultScope ? [] : ["user.info.profile"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return new URL(
 				`https://www.tiktok.com/v2/auth/authorize?scope=${_scopes.join(
 					",",

--- a/packages/core/src/social-providers/twitch.ts
+++ b/packages/core/src/social-providers/twitch.ts
@@ -45,8 +45,8 @@ export const twitch = (options: TwitchOptions) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["user:read:email", "openid"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			return createAuthorizationURL({
 				id: "twitch",
 				redirectURI,

--- a/packages/core/src/social-providers/twitter.ts
+++ b/packages/core/src/social-providers/twitter.ts
@@ -107,8 +107,8 @@ export const twitter = (options: TwitterOption) => {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["users.read", "tweet.read", "offline.access", "users.email"];
-			options.scope && _scopes.push(...options.scope);
-			data.scopes && _scopes.push(...data.scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (data.scopes) _scopes.push(...data.scopes);
 			return createAuthorizationURL({
 				id: "twitter",
 				options,

--- a/packages/core/src/social-providers/vk.ts
+++ b/packages/core/src/social-providers/vk.ts
@@ -32,8 +32,8 @@ export const vk = (options: VkOption) => {
 		name: "VK",
 		async createAuthorizationURL({ state, scopes, codeVerifier, redirectURI }) {
 			const _scopes = options.disableDefaultScope ? [] : ["email", "phone"];
-			options.scope && _scopes.push(...options.scope);
-			scopes && _scopes.push(...scopes);
+			if (options.scope) _scopes.push(...options.scope);
+			if (scopes) _scopes.push(...scopes);
 			const authorizationEndpoint = "https://id.vk.com/authorize";
 
 			return createAuthorizationURL({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened linting across auth endpoints, Vue store, and social provider modules by replacing short-circuit side effects with explicit conditionals. Improves readability and linter compliance with no behavior changes.

- **Refactors**
  - Replace patterns like condition && array.push(...) with if statements.
  - Update hook registration in to-auth-endpoints, scope disposal in Vue store, and scope merging in all OAuth providers (including Microsoft refresh flow).
  - Preserve logic and outputs; this is style-only.

<!-- End of auto-generated description by cubic. -->

