### PR TITLE
docs: fix runtime errors and clean up code

### DIFF
--- a/docs/app/blog/_components/default-changelog.tsx
+++ b/docs/app/blog/_components/default-changelog.tsx
@@ -9,7 +9,6 @@ import { cn } from "@/lib/utils";
 import { IconLink } from "./changelog-layout";
 import { BookIcon, GitHubIcon, XIcon } from "./icons";
 import { StarField } from "./stat-field";
-import "highlight.js/styles/dark.css";
 
 export const dynamic = "force-static";
 const ChangelogPage = async () => {

--- a/docs/app/blog/_components/stat-field.tsx
+++ b/docs/app/blog/_components/stat-field.tsx
@@ -146,7 +146,7 @@ function Constellation({
 		let sequence: Array<Segment> = [
 			[
 				ref.current,
-				{ strokeDashoffset: 0, visibility: "visible" },
+				{ strokeDashoffset: 0, opacity: 1 },
 				{ duration: 5, delay: Math.random() * 3 + 2 },
 			],
 		];
@@ -177,7 +177,7 @@ function Constellation({
 				pathLength={1}
 				fill="transparent"
 				d={`M ${points.join("L")}`}
-				className="invisible"
+				style={{ opacity: 0 }}
 			/>
 			{uniquePoints.map((point, pointIndex) => (
 				<Star key={pointIndex} point={point} blurId={blurId} />

--- a/docs/app/blog/layout.tsx
+++ b/docs/app/blog/layout.tsx
@@ -11,17 +11,7 @@ interface BlogLayoutProps {
 
 export default function BlogLayout({ children }: BlogLayoutProps) {
 	return (
-		<div
-			className="relative flex min-h-screen flex-col"
-			style={{
-				scrollbarWidth: "none",
-				scrollbarColor: "transparent transparent",
-				//@ts-expect-error
-				"&::-webkit-scrollbar": {
-					display: "none",
-				},
-			}}
-		>
+		<div className="relative flex min-h-screen flex-col no-scrollbar">
 			<main className="flex-1">{children}</main>
 		</div>
 	);

--- a/docs/app/changelogs/_components/stat-field.tsx
+++ b/docs/app/changelogs/_components/stat-field.tsx
@@ -146,7 +146,7 @@ function Constellation({
 		let sequence: Array<Segment> = [
 			[
 				ref.current,
-				{ strokeDashoffset: 0, visibility: "visible" },
+				{ strokeDashoffset: 0, opacity: 1 },
 				{ duration: 5, delay: Math.random() * 3 + 2 },
 			],
 		];
@@ -177,7 +177,7 @@ function Constellation({
 				pathLength={1}
 				fill="transparent"
 				d={`M ${points.join("L")}`}
-				className="invisible"
+				style={{ opacity: 0 }}
 			/>
 			{uniquePoints.map((point, pointIndex) => (
 				<Star key={pointIndex} point={point} blurId={blurId} />
@@ -195,7 +195,7 @@ export function StarField({ className }: { className?: string }) {
 			fill="white"
 			aria-hidden="true"
 			className={clsx(
-				"pointer-events-none absolute w-[55.0625rem] origin-top-right rotate-[30deg] overflow-visible opacity-70",
+				"pointer-events-none absolute w-[55.0625rem] max-w-[100vw] origin-top-right rotate-[30deg] overflow-visible opacity-70",
 				className,
 			)}
 		>

--- a/docs/app/changelogs/layout.tsx
+++ b/docs/app/changelogs/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+
 export default function Layout({ children }: { children: ReactNode }) {
 	return <div>{children}</div>;
 }

--- a/docs/components/builder/index.tsx
+++ b/docs/components/builder/index.tsx
@@ -270,17 +270,7 @@ export function Builder() {
 
 				<div className="flex gap-4 md:gap-12 flex-col md:flex-row items-center md:items-start">
 					<div className={cn("w-4/12")}>
-						<div
-							className="overflow-scroll h-[580px] relative"
-							style={{
-								scrollbarWidth: "none",
-								scrollbarColor: "transparent transparent",
-								//@ts-expect-error
-								"&::-webkit-scrollbar": {
-									display: "none",
-								},
-							}}
-						>
+						<div className="overflow-scroll h-[580px] relative no-scrollbar">
 							{options.signUp ? (
 								<AuthTabs
 									tabs={[
@@ -301,17 +291,7 @@ export function Builder() {
 							)}
 						</div>
 					</div>
-					<ScrollArea
-						className="w-[45%] flex-grow"
-						style={{
-							scrollbarWidth: "none",
-							scrollbarColor: "transparent transparent",
-							//@ts-expect-error
-							"&::-webkit-scrollbar": {
-								display: "none",
-							},
-						}}
-					>
+					<ScrollArea className="w-[45%] flex-grow no-scrollbar">
 						<div className="h-[580px]">
 							{currentStep === 0 ? (
 								<Card className="rounded-none flex-grow h-full">


### PR DESCRIPTION
This PR fixes a runtime error in the UI components that broke the Docs sidebar, so we no longer have to see the error toolbar in the dev server.

---

### Before

https://github.com/user-attachments/assets/81db86f5-0e80-4e04-b557-6baf6c09a09c


### After

https://github.com/user-attachments/assets/52d47c94-43a9-4263-b8d7-a985a8d10c11



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runtime error that broke the Docs sidebar and cleans up UI styles in blog and builder pages. Sidebar loads without the dev error overlay, and scroll areas use a consistent no-scrollbar utility.

- **Bug Fixes**
  - Switched SVG animation visibility to opacity to prevent runtime errors.
  - Limited StarField width to viewport to stop overflow.
  - Removed highlight.js CSS import from blog changelog component.

- **Refactors**
  - Replaced inline scrollbar styles with a no-scrollbar class in Blog layout and Builder.
  - Minor layout cleanup in Changelogs.

<!-- End of auto-generated description by cubic. -->

