### PR TITLE
fix(slack): scopes should use comma delimiter

### DIFF
--- a/packages/core/src/social-providers/slack.ts
+++ b/packages/core/src/social-providers/slack.ts
@@ -48,7 +48,7 @@ export const slack = (options: SlackOptions) => {
 			scopes && _scopes.push(...scopes);
 			options.scope && _scopes.push(...options.scope);
 			const url = new URL("https://slack.com/openid/connect/authorize");
-			url.searchParams.set("scope", _scopes.join(" "));
+			url.searchParams.set("scope", _scopes.join(","));
 			url.searchParams.set("response_type", "code");
 			url.searchParams.set("client_id", options.clientId);
 			url.searchParams.set("redirect_uri", options.redirectURI || redirectURI);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Slack OAuth by using comma-separated scopes in the authorize URL. This prevents invalid_scope errors and ensures permissions are requested correctly.

<!-- End of auto-generated description by cubic. -->

