### PR TITLE
docs: fix indentation for sendOnSignIn property

### DIFF
--- a/docs/content/docs/concepts/email.mdx
+++ b/docs/content/docs/concepts/email.mdx
@@ -80,8 +80,8 @@ export const auth = betterAuth({
         subject: "Verify your email address",
         text: `Click the link to verify your email: ${url}`,
       });
-    sendOnSignIn: true,
     },
+    sendOnSignIn: true,
   },
   emailAndPassword: {
     requireEmailVerification: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes indentation of sendOnSignIn in the email auth config example so it sits next to send, not inside it. This makes the snippet valid and prevents copy/paste mistakes.

<sup>Written for commit 9c05975. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

