### PR TITLE
fix(generic-oauth): async `mapProfileToUser` breaks

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -329,7 +329,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 								emailVerified: userInfo?.emailVerified,
 								image: userInfo?.image,
 								name: userInfo?.name,
-								...c.mapProfileToUser?.(userInfo),
+								...(await c.mapProfileToUser?.(userInfo)),
 							},
 							data: userInfo,
 						};


### PR DESCRIPTION
After debugging for an unacceptable amount of time, I found out that our generic oauth plugin with `mapProfileToUser` breaks when users apply `async` to their function despite our function signature supporting this. It breaks because we didn't use `await`...

Thanks so much @michidk for patiently debugging alongside me!

closes https://github.com/better-auth/better-auth/pull/5681
linear https://linear.app/better-auth/issue/ENG-547/fix-generic-oauth-breaks-entirely-with-async-mapprofiletouser

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the generic OAuth plugin to correctly handle async mapProfileToUser by awaiting its result when constructing the user object. Prevents auth flow from breaking when mapProfileToUser returns a Promise.

- **Bug Fixes**
  - Await mapProfileToUser(userInfo) so async implementations are supported.
  - Ensures mapped fields merge correctly into the user payload.

<sup>Written for commit 3c2959e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

