### PR TITLE
fix(generic-oauth): `overrideUserInfo` doesn't work

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -335,7 +335,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 					},
 					options: {
 						overrideUserInfoOnSignIn: c.overrideUserInfo,
-					}
+					},
 				} as OAuthProvider;
 			});
 			return {


### PR DESCRIPTION
For generic oauth providers that return to `/api/auth/callback`, `overrideUserInfo` doesn't work since we don't pass along the generic oauth configuration values into the automatically defining social providers that we have in the `init` fn.

This PR passes that configuration data along with the provider so that `overrideUserInfo` then also gets passed along.

linear: https://linear.app/better-auth/issue/ENG-549/fix-generic-oauth-entirely-skips-overrideuserinfo