### PR TITLE
fix: delete duplicate email existence check in changeEmail endpoint

### DIFF
--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -720,21 +720,14 @@ export const changeEmail = createAuthEndpoint(
 			await ctx.context.internalAdapter.findUserByEmail(newEmail);
 		if (existingUser) {
 			ctx.context.logger.error("Email already exists");
-			throw new APIError("BAD_REQUEST", {
-				message: "Couldn't update your email",
+			throw new APIError("UNPROCESSABLE_ENTITY", {
+				message: BASE_ERROR_CODES.USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL,
 			});
 		}
 		/**
 		 * If the email is not verified, we can update the email
 		 */
 		if (ctx.context.session.user.emailVerified !== true) {
-			const existing =
-				await ctx.context.internalAdapter.findUserByEmail(newEmail);
-			if (existing) {
-				throw new APIError("UNPROCESSABLE_ENTITY", {
-					message: BASE_ERROR_CODES.USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL,
-				});
-			}
 			await ctx.context.internalAdapter.updateUserByEmail(
 				ctx.context.session.user.email,
 				{


### PR DESCRIPTION
Just noticed this while skimming through the code, so I thought I might as well fix this and open a PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate email existence check in the changeEmail endpoint and standardized the error response. This reduces unnecessary DB calls and returns 422 UNPROCESSABLE_ENTITY with BASE_ERROR_CODES.USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL when the email is already taken.

<sup>Written for commit 4ccfc1f0a0418ac26d358a3694f121d3aab36084. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

