### PR TITLE
fix: type mismatch for 'banned' on UserWithRole

### DIFF
--- a/packages/better-auth/src/plugins/admin/types.ts
+++ b/packages/better-auth/src/plugins/admin/types.ts
@@ -4,7 +4,7 @@ import { type AdminSchema } from "./schema";
 
 export interface UserWithRole extends User {
 	role?: string | undefined;
-	banned?: (boolean | null) | undefined;
+	banned: boolean | null;
 	banReason?: (string | null) | undefined;
 	banExpires?: (Date | null) | undefined;
 }


### PR DESCRIPTION
**Resolves: #4830**

### Description

This PR fixes a TypeScript type mismatch between the `admin` plugin's `UserWithRole` type and the client-side inferred type `authClient.$Infer.Session.user`.

### The Problem

The `UserWithRole` interface in `packages/better-auth/src/plugins/admin/types.ts` incorrectly defined the `banned` property as optional:
`banned?: (boolean | null) | undefined;`

This conflicts with the client-side type inference, which correctly expects the field to always be present.

### The Fix

This is a pure type-definition fix. The database adapters (like the Drizzle adapter) use `db.select()` (which is `SELECT *`), guaranteeing the `banned` field will always be returned as `true`, `false`, or `null` - but **never** `undefined`.

This PR corrects the type definition in `types.ts` to `banned: boolean | null;` to match the actual data returned by the adapter, resolving the type error. No runtime changes are necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make UserWithRole.banned a required boolean | null to match the client session user type and prevent TypeScript errors in the admin plugin. No runtime changes; this aligns with DB adapters that always return the field.

<sup>Written for commit b687fcd341a8d0669d6412f3e98392ca1bc97566. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

