### PR TITLE
feat: esm only

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -34,564 +34,258 @@
   "exports": {
     ".": {
       "better-auth-dev-source": "./src/index.ts",
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./social-providers": {
       "better-auth-dev-source": "./src/social-providers/index.ts",
-      "import": {
-        "types": "./dist/social-providers/index.d.ts",
-        "default": "./dist/social-providers/index.js"
-      },
-      "require": {
-        "types": "./dist/social-providers/index.d.cts",
-        "default": "./dist/social-providers/index.cjs"
-      }
+      "types": "./dist/social-providers/index.d.ts",
+      "default": "./dist/social-providers/index.js"
     },
     "./client": {
       "better-auth-dev-source": "./src/client/index.ts",
-      "import": {
-        "types": "./dist/client/index.d.ts",
-        "default": "./dist/client/index.js"
-      },
-      "require": {
-        "types": "./dist/client/index.d.cts",
-        "default": "./dist/client/index.cjs"
-      }
+      "types": "./dist/client/index.d.ts",
+      "default": "./dist/client/index.js"
     },
     "./client/plugins": {
       "better-auth-dev-source": "./src/client/plugins/index.ts",
-      "import": {
-        "types": "./dist/client/plugins/index.d.ts",
-        "default": "./dist/client/plugins/index.js"
-      },
-      "require": {
-        "types": "./dist/client/plugins/index.d.cts",
-        "default": "./dist/client/plugins/index.cjs"
-      }
+      "types": "./dist/client/plugins/index.d.ts",
+      "default": "./dist/client/plugins/index.js"
     },
     "./types": {
       "better-auth-dev-source": "./src/types/index.ts",
-      "import": {
-        "types": "./dist/types/index.d.ts",
-        "default": "./dist/types/index.js"
-      },
-      "require": {
-        "types": "./dist/types/index.d.cts",
-        "default": "./dist/types/index.cjs"
-      }
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/types/index.js"
     },
     "./crypto": {
       "better-auth-dev-source": "./src/crypto/index.ts",
-      "import": {
-        "types": "./dist/crypto/index.d.ts",
-        "default": "./dist/crypto/index.js"
-      },
-      "require": {
-        "types": "./dist/crypto/index.d.cts",
-        "default": "./dist/crypto/index.cjs"
-      }
+      "types": "./dist/crypto/index.d.ts",
+      "default": "./dist/crypto/index.js"
     },
     "./cookies": {
       "better-auth-dev-source": "./src/cookies/index.ts",
-      "import": {
-        "types": "./dist/cookies/index.d.ts",
-        "default": "./dist/cookies/index.js"
-      },
-      "require": {
-        "types": "./dist/cookies/index.d.cts",
-        "default": "./dist/cookies/index.cjs"
-      }
+      "types": "./dist/cookies/index.d.ts",
+      "default": "./dist/cookies/index.js"
     },
     "./oauth2": {
       "better-auth-dev-source": "./src/oauth2/index.ts",
-      "import": {
-        "types": "./dist/oauth2/index.d.ts",
-        "default": "./dist/oauth2/index.js"
-      },
-      "require": {
-        "types": "./dist/oauth2/index.d.cts",
-        "default": "./dist/oauth2/index.cjs"
-      }
+      "types": "./dist/oauth2/index.d.ts",
+      "default": "./dist/oauth2/index.js"
     },
     "./react": {
       "better-auth-dev-source": "./src/client/react/index.ts",
-      "import": {
-        "types": "./dist/client/react/index.d.ts",
-        "default": "./dist/client/react/index.js"
-      },
-      "require": {
-        "types": "./dist/client/react/index.d.cts",
-        "default": "./dist/client/react/index.cjs"
-      }
+      "types": "./dist/client/react/index.d.ts",
+      "default": "./dist/client/react/index.js"
     },
     "./solid": {
       "better-auth-dev-source": "./src/client/solid/index.ts",
-      "import": {
-        "types": "./dist/client/solid/index.d.ts",
-        "default": "./dist/client/solid/index.js"
-      },
-      "require": {
-        "types": "./dist/client/solid/index.d.cts",
-        "default": "./dist/client/solid/index.cjs"
-      }
+      "types": "./dist/client/solid/index.d.ts",
+      "default": "./dist/client/solid/index.js"
     },
     "./lynx": {
       "better-auth-dev-source": "./src/client/lynx/index.ts",
-      "import": {
-        "types": "./dist/client/lynx/index.d.ts",
-        "default": "./dist/client/lynx/index.js"
-      },
-      "require": {
-        "types": "./dist/client/lynx/index.d.cts",
-        "default": "./dist/client/lynx/index.cjs"
-      }
+      "types": "./dist/client/lynx/index.d.ts",
+      "default": "./dist/client/lynx/index.js"
     },
     "./test": {
       "better-auth-dev-source": "./src/test-utils/index.ts",
-      "import": {
-        "types": "./dist/test-utils/index.d.ts",
-        "default": "./dist/test-utils/index.js"
-      },
-      "require": {
-        "types": "./dist/test-utils/index.d.cts",
-        "default": "./dist/test-utils/index.cjs"
-      }
+      "types": "./dist/test-utils/index.d.ts",
+      "default": "./dist/test-utils/index.js"
     },
     "./api": {
       "better-auth-dev-source": "./src/api/index.ts",
-      "import": {
-        "types": "./dist/api/index.d.ts",
-        "default": "./dist/api/index.js"
-      },
-      "require": {
-        "types": "./dist/api/index.d.cts",
-        "default": "./dist/api/index.cjs"
-      }
+      "types": "./dist/api/index.d.ts",
+      "default": "./dist/api/index.js"
     },
     "./db": {
       "better-auth-dev-source": "./src/db/index.ts",
-      "import": {
-        "types": "./dist/db/index.d.ts",
-        "default": "./dist/db/index.js"
-      },
-      "require": {
-        "types": "./dist/db/index.d.cts",
-        "default": "./dist/db/index.cjs"
-      }
+      "types": "./dist/db/index.d.ts",
+      "default": "./dist/db/index.js"
     },
     "./vue": {
       "better-auth-dev-source": "./src/client/vue/index.ts",
-      "import": {
-        "types": "./dist/client/vue/index.d.ts",
-        "default": "./dist/client/vue/index.js"
-      },
-      "require": {
-        "types": "./dist/client/vue/index.d.cts",
-        "default": "./dist/client/vue/index.cjs"
-      }
+      "types": "./dist/client/vue/index.d.ts",
+      "default": "./dist/client/vue/index.js"
     },
     "./plugins": {
       "better-auth-dev-source": "./src/plugins/index.ts",
-      "import": {
-        "types": "./dist/plugins/index.d.ts",
-        "default": "./dist/plugins/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/index.d.cts",
-        "default": "./dist/plugins/index.cjs"
-      }
+      "types": "./dist/plugins/index.d.ts",
+      "default": "./dist/plugins/index.js"
     },
     "./svelte-kit": {
       "better-auth-dev-source": "./src/integrations/svelte-kit.ts",
-      "import": {
-        "types": "./dist/integrations/svelte-kit.d.ts",
-        "default": "./dist/integrations/svelte-kit.js"
-      },
-      "require": {
-        "types": "./dist/integrations/svelte-kit.d.cts",
-        "default": "./dist/integrations/svelte-kit.cjs"
-      }
+      "types": "./dist/integrations/svelte-kit.d.ts",
+      "default": "./dist/integrations/svelte-kit.js"
     },
     "./solid-start": {
       "better-auth-dev-source": "./src/integrations/solid-start.ts",
-      "import": {
-        "types": "./dist/integrations/solid-start.d.ts",
-        "default": "./dist/integrations/solid-start.js"
-      },
-      "require": {
-        "types": "./dist/integrations/solid-start.d.cts",
-        "default": "./dist/integrations/solid-start.cjs"
-      }
+      "types": "./dist/integrations/solid-start.d.ts",
+      "default": "./dist/integrations/solid-start.js"
     },
     "./svelte": {
       "better-auth-dev-source": "./src/client/svelte/index.ts",
-      "import": {
-        "types": "./dist/client/svelte/index.d.ts",
-        "default": "./dist/client/svelte/index.js"
-      },
-      "require": {
-        "types": "./dist/client/svelte/index.d.cts",
-        "default": "./dist/client/svelte/index.cjs"
-      }
+      "types": "./dist/client/svelte/index.d.ts",
+      "default": "./dist/client/svelte/index.js"
     },
     "./next-js": {
       "better-auth-dev-source": "./src/integrations/next-js.ts",
-      "import": {
-        "types": "./dist/integrations/next-js.d.ts",
-        "default": "./dist/integrations/next-js.js"
-      },
-      "require": {
-        "types": "./dist/integrations/next-js.d.cts",
-        "default": "./dist/integrations/next-js.cjs"
-      }
+      "types": "./dist/integrations/next-js.d.ts",
+      "default": "./dist/integrations/next-js.js"
     },
     "./react-start": {
       "better-auth-dev-source": "./src/integrations/react-start.ts",
-      "import": {
-        "types": "./dist/integrations/react-start.d.ts",
-        "default": "./dist/integrations/react-start.js"
-      },
-      "require": {
-        "types": "./dist/integrations/react-start.d.cts",
-        "default": "./dist/integrations/react-start.cjs"
-      }
+      "types": "./dist/integrations/react-start.d.ts",
+      "default": "./dist/integrations/react-start.js"
     },
     "./node": {
       "better-auth-dev-source": "./src/integrations/node.ts",
-      "import": {
-        "types": "./dist/integrations/node.d.ts",
-        "default": "./dist/integrations/node.js"
-      },
-      "require": {
-        "types": "./dist/integrations/node.d.cts",
-        "default": "./dist/integrations/node.cjs"
-      }
+      "types": "./dist/integrations/node.d.ts",
+      "default": "./dist/integrations/node.js"
     },
     "./adapters/prisma": {
       "better-auth-dev-source": "./src/adapters/prisma-adapter/index.ts",
-      "import": {
-        "types": "./dist/adapters/prisma-adapter/index.d.ts",
-        "default": "./dist/adapters/prisma-adapter/index.js"
-      },
-      "require": {
-        "types": "./dist/adapters/prisma-adapter/index.d.cts",
-        "default": "./dist/adapters/prisma-adapter/index.cjs"
-      }
+      "types": "./dist/adapters/prisma-adapter/index.d.ts",
+      "default": "./dist/adapters/prisma-adapter/index.js"
     },
     "./adapters/drizzle": {
       "better-auth-dev-source": "./src/adapters/drizzle-adapter/index.ts",
-      "import": {
-        "types": "./dist/adapters/drizzle-adapter/index.d.ts",
-        "default": "./dist/adapters/drizzle-adapter/index.js"
-      },
-      "require": {
-        "types": "./dist/adapters/drizzle-adapter/index.d.cts",
-        "default": "./dist/adapters/drizzle-adapter/index.cjs"
-      }
+      "types": "./dist/adapters/drizzle-adapter/index.d.ts",
+      "default": "./dist/adapters/drizzle-adapter/index.js"
     },
     "./adapters/mongodb": {
       "better-auth-dev-source": "./src/adapters/mongodb-adapter/index.ts",
-      "import": {
-        "types": "./dist/adapters/mongodb-adapter/index.d.ts",
-        "default": "./dist/adapters/mongodb-adapter/index.js"
-      },
-      "require": {
-        "types": "./dist/adapters/mongodb-adapter/index.d.cts",
-        "default": "./dist/adapters/mongodb-adapter/index.cjs"
-      }
+      "types": "./dist/adapters/mongodb-adapter/index.d.ts",
+      "default": "./dist/adapters/mongodb-adapter/index.js"
     },
     "./adapters/memory": {
       "better-auth-dev-source": "./src/adapters/memory-adapter/index.ts",
-      "import": {
-        "types": "./dist/adapters/memory-adapter/index.d.ts",
-        "default": "./dist/adapters/memory-adapter/index.js"
-      },
-      "require": {
-        "types": "./dist/adapters/memory-adapter/index.d.cts",
-        "default": "./dist/adapters/memory-adapter/index.cjs"
-      }
+      "types": "./dist/adapters/memory-adapter/index.d.ts",
+      "default": "./dist/adapters/memory-adapter/index.js"
     },
     "./adapters/test": {
       "better-auth-dev-source": "./src/adapters/test.ts",
-      "import": {
-        "types": "./dist/adapters/test.d.ts",
-        "default": "./dist/adapters/test.js"
-      },
-      "require": {
-        "types": "./dist/adapters/test.d.cts",
-        "default": "./dist/adapters/test.cjs"
-      }
+      "types": "./dist/adapters/test.d.ts",
+      "default": "./dist/adapters/test.js"
     },
     "./adapters": {
       "better-auth-dev-source": "./src/adapters/index.ts",
-      "import": {
-        "types": "./dist/adapters/index.d.ts",
-        "default": "./dist/adapters/index.js"
-      },
-      "require": {
-        "types": "./dist/adapters/index.d.cts",
-        "default": "./dist/adapters/index.cjs"
-      }
+      "types": "./dist/adapters/index.d.ts",
+      "default": "./dist/adapters/index.js"
     },
     "./plugins/access": {
       "better-auth-dev-source": "./src/plugins/access/index.ts",
-      "import": {
-        "types": "./dist/plugins/access/index.d.ts",
-        "default": "./dist/plugins/access/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/access/index.d.cts",
-        "default": "./dist/plugins/access/index.cjs"
-      }
+      "types": "./dist/plugins/access/index.d.ts",
+      "default": "./dist/plugins/access/index.js"
     },
     "./plugins/admin": {
       "better-auth-dev-source": "./src/plugins/admin/index.ts",
-      "import": {
-        "types": "./dist/plugins/admin/index.d.ts",
-        "default": "./dist/plugins/admin/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/admin/index.d.cts",
-        "default": "./dist/plugins/admin/index.cjs"
-      }
+      "types": "./dist/plugins/admin/index.d.ts",
+      "default": "./dist/plugins/admin/index.js"
     },
     "./plugins/admin/access": {
       "better-auth-dev-source": "./src/plugins/admin/access/index.ts",
-      "import": {
-        "types": "./dist/plugins/admin/access/index.d.ts",
-        "default": "./dist/plugins/admin/access/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/admin/access/index.d.cts",
-        "default": "./dist/plugins/admin/access/index.cjs"
-      }
+      "types": "./dist/plugins/admin/access/index.d.ts",
+      "default": "./dist/plugins/admin/access/index.js"
     },
     "./plugins/anonymous": {
       "better-auth-dev-source": "./src/plugins/anonymous/index.ts",
-      "import": {
-        "types": "./dist/plugins/anonymous/index.d.ts",
-        "default": "./dist/plugins/anonymous/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/anonymous/index.d.cts",
-        "default": "./dist/plugins/anonymous/index.cjs"
-      }
+      "types": "./dist/plugins/anonymous/index.d.ts",
+      "default": "./dist/plugins/anonymous/index.js"
     },
     "./plugins/bearer": {
       "better-auth-dev-source": "./src/plugins/bearer/index.ts",
-      "import": {
-        "types": "./dist/plugins/bearer/index.d.ts",
-        "default": "./dist/plugins/bearer/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/bearer/index.d.cts",
-        "default": "./dist/plugins/bearer/index.cjs"
-      }
+      "types": "./dist/plugins/bearer/index.d.ts",
+      "default": "./dist/plugins/bearer/index.js"
     },
     "./plugins/custom-session": {
       "better-auth-dev-source": "./src/plugins/custom-session/index.ts",
-      "import": {
-        "types": "./dist/plugins/custom-session/index.d.ts",
-        "default": "./dist/plugins/custom-session/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/custom-session/index.d.cts",
-        "default": "./dist/plugins/custom-session/index.cjs"
-      }
+      "types": "./dist/plugins/custom-session/index.d.ts",
+      "default": "./dist/plugins/custom-session/index.js"
     },
     "./plugins/email-otp": {
       "better-auth-dev-source": "./src/plugins/email-otp/index.ts",
-      "import": {
-        "types": "./dist/plugins/email-otp/index.d.ts",
-        "default": "./dist/plugins/email-otp/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/email-otp/index.d.cts",
-        "default": "./dist/plugins/email-otp/index.cjs"
-      }
+      "types": "./dist/plugins/email-otp/index.d.ts",
+      "default": "./dist/plugins/email-otp/index.js"
     },
     "./plugins/generic-oauth": {
       "better-auth-dev-source": "./src/plugins/generic-oauth/index.ts",
-      "import": {
-        "types": "./dist/plugins/generic-oauth/index.d.ts",
-        "default": "./dist/plugins/generic-oauth/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/generic-oauth/index.d.cts",
-        "default": "./dist/plugins/generic-oauth/index.cjs"
-      }
+      "types": "./dist/plugins/generic-oauth/index.d.ts",
+      "default": "./dist/plugins/generic-oauth/index.js"
     },
     "./plugins/jwt": {
       "better-auth-dev-source": "./src/plugins/jwt/index.ts",
-      "import": {
-        "types": "./dist/plugins/jwt/index.d.ts",
-        "default": "./dist/plugins/jwt/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/jwt/index.d.cts",
-        "default": "./dist/plugins/jwt/index.cjs"
-      }
+      "types": "./dist/plugins/jwt/index.d.ts",
+      "default": "./dist/plugins/jwt/index.js"
     },
     "./plugins/haveibeenpwned": {
       "better-auth-dev-source": "./src/plugins/haveibeenpwned/index.ts",
-      "import": {
-        "types": "./dist/plugins/haveibeenpwned/index.d.ts",
-        "default": "./dist/plugins/haveibeenpwned/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/haveibeenpwned/index.d.cts",
-        "default": "./dist/plugins/haveibeenpwned/index.cjs"
-      }
+      "types": "./dist/plugins/haveibeenpwned/index.d.ts",
+      "default": "./dist/plugins/haveibeenpwned/index.js"
     },
     "./plugins/oidc-provider": {
       "better-auth-dev-source": "./src/plugins/oidc-provider/index.ts",
-      "import": {
-        "types": "./dist/plugins/oidc-provider/index.d.ts",
-        "default": "./dist/plugins/oidc-provider/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/oidc-provider/index.d.cts",
-        "default": "./dist/plugins/oidc-provider/index.cjs"
-      }
+      "types": "./dist/plugins/oidc-provider/index.d.ts",
+      "default": "./dist/plugins/oidc-provider/index.js"
     },
     "./plugins/magic-link": {
       "better-auth-dev-source": "./src/plugins/magic-link/index.ts",
-      "import": {
-        "types": "./dist/plugins/magic-link/index.d.ts",
-        "default": "./dist/plugins/magic-link/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/magic-link/index.d.cts",
-        "default": "./dist/plugins/magic-link/index.cjs"
-      }
+      "types": "./dist/plugins/magic-link/index.d.ts",
+      "default": "./dist/plugins/magic-link/index.js"
     },
     "./plugins/multi-session": {
       "better-auth-dev-source": "./src/plugins/multi-session/index.ts",
-      "import": {
-        "types": "./dist/plugins/multi-session/index.d.ts",
-        "default": "./dist/plugins/multi-session/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/multi-session/index.d.cts",
-        "default": "./dist/plugins/multi-session/index.cjs"
-      }
+      "types": "./dist/plugins/multi-session/index.d.ts",
+      "default": "./dist/plugins/multi-session/index.js"
     },
     "./plugins/oauth-proxy": {
       "better-auth-dev-source": "./src/plugins/oauth-proxy/index.ts",
-      "import": {
-        "types": "./dist/plugins/oauth-proxy/index.d.ts",
-        "default": "./dist/plugins/oauth-proxy/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/oauth-proxy/index.d.cts",
-        "default": "./dist/plugins/oauth-proxy/index.cjs"
-      }
+      "types": "./dist/plugins/oauth-proxy/index.d.ts",
+      "default": "./dist/plugins/oauth-proxy/index.js"
     },
     "./plugins/organization": {
       "better-auth-dev-source": "./src/plugins/organization/index.ts",
-      "import": {
-        "types": "./dist/plugins/organization/index.d.ts",
-        "default": "./dist/plugins/organization/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/organization/index.d.cts",
-        "default": "./dist/plugins/organization/index.cjs"
-      }
+      "types": "./dist/plugins/organization/index.d.ts",
+      "default": "./dist/plugins/organization/index.js"
     },
     "./plugins/organization/access": {
       "better-auth-dev-source": "./src/plugins/organization/access/index.ts",
-      "import": {
-        "types": "./dist/plugins/organization/access/index.d.ts",
-        "default": "./dist/plugins/organization/access/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/organization/access/index.d.cts",
-        "default": "./dist/plugins/organization/access/index.cjs"
-      }
+      "types": "./dist/plugins/organization/access/index.d.ts",
+      "default": "./dist/plugins/organization/access/index.js"
     },
     "./plugins/one-time-token": {
       "better-auth-dev-source": "./src/plugins/one-time-token/index.ts",
-      "import": {
-        "types": "./dist/plugins/one-time-token/index.d.ts",
-        "default": "./dist/plugins/one-time-token/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/one-time-token/index.d.cts",
-        "default": "./dist/plugins/one-time-token/index.cjs"
-      }
+      "types": "./dist/plugins/one-time-token/index.d.ts",
+      "default": "./dist/plugins/one-time-token/index.js"
     },
     "./plugins/passkey": {
       "better-auth-dev-source": "./src/plugins/passkey/index.ts",
-      "import": {
-        "types": "./dist/plugins/passkey/index.d.ts",
-        "default": "./dist/plugins/passkey/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/passkey/index.d.cts",
-        "default": "./dist/plugins/passkey/index.cjs"
-      }
+      "types": "./dist/plugins/passkey/index.d.ts",
+      "default": "./dist/plugins/passkey/index.js"
     },
     "./plugins/phone-number": {
       "better-auth-dev-source": "./src/plugins/phone-number/index.ts",
-      "import": {
-        "types": "./dist/plugins/phone-number/index.d.ts",
-        "default": "./dist/plugins/phone-number/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/phone-number/index.d.cts",
-        "default": "./dist/plugins/phone-number/index.cjs"
-      }
+      "types": "./dist/plugins/phone-number/index.d.ts",
+      "default": "./dist/plugins/phone-number/index.js"
     },
     "./plugins/two-factor": {
       "better-auth-dev-source": "./src/plugins/two-factor/index.ts",
-      "import": {
-        "types": "./dist/plugins/two-factor/index.d.ts",
-        "default": "./dist/plugins/two-factor/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/two-factor/index.d.cts",
-        "default": "./dist/plugins/two-factor/index.cjs"
-      }
+      "types": "./dist/plugins/two-factor/index.d.ts",
+      "default": "./dist/plugins/two-factor/index.js"
     },
     "./plugins/username": {
       "better-auth-dev-source": "./src/plugins/username/index.ts",
-      "import": {
-        "types": "./dist/plugins/username/index.d.ts",
-        "default": "./dist/plugins/username/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/username/index.d.cts",
-        "default": "./dist/plugins/username/index.cjs"
-      }
+      "types": "./dist/plugins/username/index.d.ts",
+      "default": "./dist/plugins/username/index.js"
     },
     "./plugins/siwe": {
       "better-auth-dev-source": "./src/plugins/siwe/index.ts",
-      "import": {
-        "types": "./dist/plugins/siwe/index.d.ts",
-        "default": "./dist/plugins/siwe/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/siwe/index.d.cts",
-        "default": "./dist/plugins/siwe/index.cjs"
-      }
+      "types": "./dist/plugins/siwe/index.d.ts",
+      "default": "./dist/plugins/siwe/index.js"
     },
     "./plugins/device-authorization": {
       "better-auth-dev-source": "./src/plugins/device-authorization/index.ts",
-      "import": {
-        "types": "./dist/plugins/device-authorization/index.d.ts",
-        "default": "./dist/plugins/device-authorization/index.js"
-      },
-      "require": {
-        "types": "./dist/plugins/device-authorization/index.d.cts",
-        "default": "./dist/plugins/device-authorization/index.cjs"
-      }
+      "types": "./dist/plugins/device-authorization/index.d.ts",
+      "default": "./dist/plugins/device-authorization/index.js"
     }
   },
   "typesVersions": {

--- a/packages/better-auth/tsdown.config.ts
+++ b/packages/better-auth/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	dts: { build: true, incremental: true },
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	entry: [
 		"./src/index.ts",
 		"./src/social-providers/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,124 +8,58 @@
   "exports": {
     ".": {
       "better-auth-dev-source": "./src/index.ts",
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./api": {
       "better-auth-dev-source": "./src/api/index.ts",
-      "import": {
-        "types": "./dist/api/index.d.ts",
-        "default": "./dist/api/index.js"
-      },
-      "require": {
-        "types": "./dist/api/index.d.cts",
-        "default": "./dist/api/index.cjs"
-      }
+      "types": "./dist/api/index.d.ts",
+      "default": "./dist/api/index.js"
     },
     "./async_hooks": {
       "better-auth-dev-source": "./src/async_hooks/index.ts",
-      "import": {
-        "types": "./dist/async_hooks/index.d.ts",
-        "default": "./dist/async_hooks/index.js"
-      },
-      "require": {
-        "types": "./dist/async_hooks/index.d.cts",
-        "default": "./dist/async_hooks/index.cjs"
-      }
+      "types": "./dist/async_hooks/index.d.ts",
+      "default": "./dist/async_hooks/index.js"
     },
     "./context": {
       "better-auth-dev-source": "./src/context/index.ts",
-      "import": {
-        "types": "./dist/context/index.d.ts",
-        "default": "./dist/context/index.js"
-      },
-      "require": {
-        "types": "./dist/context/index.d.cts",
-        "default": "./dist/context/index.cjs"
-      }
+      "types": "./dist/context/index.d.ts",
+      "default": "./dist/context/index.js"
     },
     "./env": {
       "better-auth-dev-source": "./src/env/index.ts",
-      "import": {
-        "types": "./dist/env/index.d.ts",
-        "default": "./dist/env/index.js"
-      },
-      "require": {
-        "types": "./dist/env/index.d.cts",
-        "default": "./dist/env/index.cjs"
-      }
+      "types": "./dist/env/index.d.ts",
+      "default": "./dist/env/index.js"
     },
     "./error": {
       "better-auth-dev-source": "./src/error/index.ts",
-      "import": {
-        "types": "./dist/error/index.d.ts",
-        "default": "./dist/error/index.js"
-      },
-      "require": {
-        "types": "./dist/error/index.d.cts",
-        "default": "./dist/error/index.cjs"
-      }
+      "types": "./dist/error/index.d.ts",
+      "default": "./dist/error/index.js"
     },
     "./utils": {
       "better-auth-dev-source": "./src/utils/index.ts",
-      "import": {
-        "types": "./dist/utils/index.d.ts",
-        "default": "./dist/utils/index.js"
-      },
-      "require": {
-        "types": "./dist/utils/index.d.cts",
-        "default": "./dist/utils/index.cjs"
-      }
+      "types": "./dist/utils/index.d.ts",
+      "default": "./dist/utils/index.js"
     },
     "./social-providers": {
       "better-auth-dev-source": "./src/social-providers/index.ts",
-      "import": {
-        "types": "./dist/social-providers/index.d.ts",
-        "default": "./dist/social-providers/index.js"
-      },
-      "require": {
-        "types": "./dist/social-providers/index.d.cts",
-        "default": "./dist/social-providers/index.cjs"
-      }
+      "types": "./dist/social-providers/index.d.ts",
+      "default": "./dist/social-providers/index.js"
     },
     "./db": {
       "better-auth-dev-source": "./src/db/index.ts",
-      "import": {
-        "types": "./dist/db/index.d.ts",
-        "default": "./dist/db/index.js"
-      },
-      "require": {
-        "types": "./dist/db/index.d.cts",
-        "default": "./dist/db/index.cjs"
-      }
+      "types": "./dist/db/index.d.ts",
+      "default": "./dist/db/index.js"
     },
     "./db/adapter": {
       "better-auth-dev-source": "./src/db/adapter/index.ts",
-      "import": {
-        "types": "./dist/db/adapter/index.d.ts",
-        "default": "./dist/db/adapter/index.js"
-      },
-      "require": {
-        "types": "./dist/db/adapter/index.d.cts",
-        "default": "./dist/db/adapter/index.cjs"
-      }
+      "types": "./dist/db/adapter/index.d.ts",
+      "default": "./dist/db/adapter/index.js"
     },
     "./oauth2": {
       "better-auth-dev-source": "./src/oauth2/index.ts",
-      "import": {
-        "types": "./dist/oauth2/index.d.ts",
-        "default": "./dist/oauth2/index.js"
-      },
-      "require": {
-        "types": "./dist/oauth2/index.d.cts",
-        "default": "./dist/oauth2/index.cjs"
-      }
+      "types": "./dist/oauth2/index.d.ts",
+      "default": "./dist/oauth2/index.js"
     }
   },
   "typesVersions": {

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	dts: { build: true, incremental: true },
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	entry: [
 		"./src/index.ts",
 		"./src/db/index.ts",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -21,14 +21,12 @@
     ".": {
       "better-auth-dev-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./client": {
       "better-auth-dev-source": "./src/client.ts",
       "types": "./dist/client.d.ts",
-      "import": "./dist/client.js",
-      "require": "./dist/client.cjs"
+      "default": "./dist/client.js"
     }
   },
   "typesVersions": {

--- a/packages/expo/tsdown.config.ts
+++ b/packages/expo/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	dts: { build: true, incremental: true },
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	entry: ["./src/index.ts", "./src/client.ts"],
 	external: [
 		"better-auth",

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -38,14 +38,12 @@
     ".": {
       "better-auth-dev-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./client": {
       "better-auth-dev-source": "./src/client.ts",
       "types": "./dist/client.d.ts",
-      "import": "./dist/client.js",
-      "require": "./dist/client.cjs"
+      "default": "./dist/client.js"
     }
   },
   "typesVersions": {

--- a/packages/sso/tsdown.config.ts
+++ b/packages/sso/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	dts: { build: true, incremental: true },
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	entry: ["./src/index.ts", "./src/client.ts"],
 	external: ["better-auth", "better-call", "@better-fetch/fetch", "stripe"],
 });

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -31,14 +31,12 @@
     ".": {
       "better-auth-dev-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./client": {
       "better-auth-dev-source": "./src/client.ts",
       "types": "./dist/client.d.ts",
-      "import": "./dist/client.js",
-      "require": "./dist/client.cjs"
+      "default": "./dist/client.js"
     }
   },
   "typesVersions": {

--- a/packages/stripe/tsdown.config.ts
+++ b/packages/stripe/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	dts: { build: true, incremental: true },
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	entry: ["./src/index.ts", "./src/client.ts"],
 	external: ["better-auth", "better-call", "@better-fetch/fetch", "stripe"],
 });

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -8,14 +8,8 @@
   "exports": {
     ".": {
       "better-auth-dev-source": "./src/index.ts",
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "typesVersions": {

--- a/packages/telemetry/tsdown.config.ts
+++ b/packages/telemetry/tsdown.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	dts: { build: true, incremental: true },
-	format: ["esm", "cjs"],
+	format: ["esm"],
 	entry: ["./src/index.ts"],
 });


### PR DESCRIPTION
We are no longer maintaining CJS, since some of our deps are already ESM-only. And also since Node.js already support CJS-ESM interop, we don't need CJS anymore

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the repo to ESM-only. Removes CommonJS builds and require exports across all packages to match ESM-only dependencies and simplify builds.

- **Refactors**
  - Dropped CJS output and removed .cjs/.d.cts entries in package.json exports for better-auth, core, expo, sso, stripe, and telemetry.
  - Updated tsdown configs to build ESM only.

- **Migration**
  - Replace require('...') with ESM imports, or use dynamic import in CJS (await import('...')).
  - No .cjs files are published. Ensure TypeScript uses NodeNext/Bundler module resolution to consume .d.ts from ESM.

<sup>Written for commit 63bec1cd7606f9ba08e8281f73c4cd68ec90a003. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

