### PR TITLE
Update next-auth-migration-guide.mdx

### DIFF
--- a/docs/content/docs/guides/next-auth-migration-guide.mdx
+++ b/docs/content/docs/guides/next-auth-migration-guide.mdx
@@ -48,6 +48,12 @@ export const auth = betterAuth({
 
 Make sure to have `createdAt` and `updatedAt` fields on your session schema.
 
+
+#### Verification Schema
+
+- Rename the schema name from `VerificationToken` to `Verification`.
+
+
 #### Account Schema
 
 Map these fields in the account schema:
@@ -78,6 +84,9 @@ export const auth = betterAuth({
     },
 });
 ```
+
+
+
 
 **Note:** If you use ORM adapters, you can map these fields in your schema file.
 

--- a/docs/content/docs/guides/next-auth-migration-guide.mdx
+++ b/docs/content/docs/guides/next-auth-migration-guide.mdx
@@ -85,9 +85,6 @@ export const auth = betterAuth({
 });
 ```
 
-
-
-
 **Note:** If you use ORM adapters, you can map these fields in your schema file.
 
 **Example with Prisma:**

--- a/docs/content/docs/guides/next-auth-migration-guide.mdx
+++ b/docs/content/docs/guides/next-auth-migration-guide.mdx
@@ -51,7 +51,7 @@ Make sure to have `createdAt` and `updatedAt` fields on your session schema.
 
 #### Verification Schema
 
-- Rename the schema name from `VerificationToken` to `Verification`. Depending on your ORM, the table/model name may need to be lowercase (`verification`) or PascalCase (`Verification`).
+- Rename the schema name from `VerificationToken` to `Verification`. Depending on your ORM, the name may need to be lowercase (`verification`) or PascalCase (`Verification`).
 
 
 #### Account Schema

--- a/docs/content/docs/guides/next-auth-migration-guide.mdx
+++ b/docs/content/docs/guides/next-auth-migration-guide.mdx
@@ -51,7 +51,7 @@ Make sure to have `createdAt` and `updatedAt` fields on your session schema.
 
 #### Verification Schema
 
-- Rename the schema name from `VerificationToken` to `Verification`.
+- Rename the schema name from `VerificationToken` to `Verification`. Depending on your ORM, the table/model name may need to be lowercase (`verification`) or PascalCase (`Verification`).
 
 
 #### Account Schema


### PR DESCRIPTION
The migration docs from Next-auth / Auth.js is missing a step: renaming a table. Without this, the following error shows in the console:

```bash
2025-11-01T01:41:38.007Z ERROR [Better Auth]: Model verification does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'
# SERVER_ERROR:  [Error [BetterAuthError]: Model verification does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'] {
  cause: undefined
}
```







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the missing migration step to rename the verification table from VerificationToken to Verification so Better Auth recognizes the model and avoids the “Model verification does not exist” error.

- **Migration**
  - Rename the verification schema/table from VerificationToken to Verification and match ORM casing (verification or Verification).

<sup>Written for commit 178e630bc04442eb8050487d9c4e7714f65e7cf8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







