### PR TITLE
fix(adapters): respect default field names when serializing IDs for mongodb adapter

### DIFF
--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -50,17 +50,27 @@ export const mongodbAdapter = (
 			db: Db,
 			session?: ClientSession | undefined,
 		): AdapterFactoryCustomizeAdapterCreator =>
-		({ options, getFieldName, schema, getDefaultModelName }) => {
+		({
+			options,
+			getFieldName,
+			schema,
+			getDefaultModelName,
+			getDefaultFieldName,
+		}) => {
 			function serializeID({
-				field,
+				field: field_name,
 				value,
-				model,
+				model: model_name,
 			}: {
 				field: string;
 				value: any;
 				model: string;
 			}) {
-				model = getDefaultModelName(model);
+				const model = getDefaultModelName(model_name);
+				const field = getDefaultFieldName({
+					model: model_name,
+					field: field_name,
+				});
 				if (
 					field === "id" ||
 					field === "_id" ||


### PR DESCRIPTION
This pull request updates the MongoDB adapter in the authentication package to improve how model and field names are resolved during ID serialization. The main change is that the adapter now supports a `getDefaultFieldName` function, which allows for more flexible and consistent mapping of field names.

**Improvements to adapter customization:**

* The adapter factory now accepts a `getDefaultFieldName` parameter, enabling custom logic for resolving default field names.
* The `serializeID` function uses `getDefaultModelName` and `getDefaultFieldName` to resolve model and field names, improving consistency and flexibility in ID handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect default field names during ID serialization in the MongoDB adapter to prevent incorrect ID mapping when models use custom field naming. The adapter now uses getDefaultFieldName alongside getDefaultModelName for consistent name resolution.

- **Bug Fixes**
  - Adapter factory accepts getDefaultFieldName for default field resolution.
  - serializeID resolves model and field via getDefaultModelName and getDefaultFieldName before handling id/_id.

<sup>Written for commit 6689f9caba02656249dd7e00c893bc9347f1c56a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

