### PR TITLE
fix(cli): move type dependencies to devDependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,8 @@
   "bin": "./dist/index.js",
   "devDependencies": {
     "@types/semver": "^7.7.1",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/prompts": "^2.4.9",
     "tsdown": "catalog:",
     "tsx": "^4.20.6",
     "typescript": "catalog:"
@@ -47,8 +49,6 @@
     "@clack/prompts": "^0.11.0",
     "@mrleebo/prisma-ast": "^0.13.0",
     "@prisma/client": "^5.22.0",
-    "@types/better-sqlite3": "^7.6.13",
-    "@types/prompts": "^2.4.9",
     "better-auth": "workspace:*",
     "better-sqlite3": "^12.2.0",
     "c12": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1106,12 +1106,6 @@ importers:
       '@prisma/client':
         specifier: ^5.22.0
         version: 5.22.0(prisma@5.22.0)
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
-      '@types/prompts':
-        specifier: ^2.4.9
-        version: 2.4.9
       better-auth:
         specifier: workspace:*
         version: link:../better-auth
@@ -1164,6 +1158,12 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/prompts':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1


### PR DESCRIPTION
Moves `@types/better-sqlite3` and `@types/prompts` into devDependencies since they are only needed for development.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved @types/better-sqlite3 and @types/prompts to devDependencies in the CLI so type-only packages aren’t shipped to users. This reduces install size and avoids unnecessary dependencies, with no behavior change.

<sup>Written for commit 00473097cb851804b4073559931d45252bd26f75. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

