### PR TITLE
fix(vk): check for empty email after user profile mapping

### DIFF
--- a/packages/core/src/social-providers/vk.ts
+++ b/packages/core/src/social-providers/vk.ts
@@ -98,11 +98,11 @@ export const vk = (options: VkOption) => {
 			if (error) {
 				return null;
 			}
-			if (!profile.user.email) {
-				return null;
-			}
 
 			const userMap = await options.mapProfileToUser?.(profile);
+			if (!profile.user.email && !userMap?.email) {
+				return null;
+			}
 
 			return {
 				user: {


### PR DESCRIPTION
Changes:

- Moves the email validation check to after the `mapProfileToUser` function call (instead of before)
- Updates the validation to accept an email from either `profile.user.email` or `userMap.email`

Impact:

This allows the `mapProfileToUser` callback to provide an email address even when the VK profile doesn't include one.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate email after mapProfileToUser in the VK provider so we can use an email from either the VK profile or the mapping. Prevents returning null when VK doesn’t include an email but the mapping provides one.

<sup>Written for commit 2065693286039ac1cc323d9defbd8fed4abb4ebe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



