### PR TITLE
feat: async import in `getAdapter`

### DIFF
--- a/packages/better-auth/src/db/utils.ts
+++ b/packages/better-auth/src/db/utils.ts
@@ -3,9 +3,7 @@ import type { DBFieldAttribute } from "@better-auth/core/db";
 import type { DBAdapter } from "@better-auth/core/db/adapter";
 import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
-import { kyselyAdapter } from "../adapters/kysely-adapter";
-import { createKyselyAdapter } from "../adapters/kysely-adapter/dialect";
-import { type MemoryDB, memoryAdapter } from "../adapters/memory-adapter";
+import type { MemoryDB } from "../adapters/memory-adapter";
 import { getAuthTables } from ".";
 
 export async function getAdapter(
@@ -21,15 +19,18 @@ export async function getAdapter(
 		logger.warn(
 			"No database configuration provided. Using memory adapter in development",
 		);
+		const { memoryAdapter } = await import("../adapters/memory-adapter");
 		adapter = memoryAdapter(memoryDB)(options);
 	} else if (typeof options.database === "function") {
 		adapter = options.database(options);
 	} else {
+		const { createKyselyAdapter } = await import("../adapters/kysely-adapter");
 		const { kysely, databaseType, transaction } =
 			await createKyselyAdapter(options);
 		if (!kysely) {
 			throw new BetterAuthError("Failed to initialize database adapter");
 		}
+		const { kyselyAdapter } = await import("../adapters/kysely-adapter");
 		adapter = kyselyAdapter(kysely, {
 			type: databaseType || "sqlite",
 			debugLogs:


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lazy-load database adapters and drivers to avoid loading unused DB code and optional peer errors. This reduces bundle size and prevents runtime issues when pg/mysql/mongodb are not installed.

- **Refactors**
  - getAdapter now dynamically imports memoryAdapter, createKyselyAdapter, and kyselyAdapter.
  - Test utils lazily import Kysely, dialects, sql, MongoClient, and connection pools only when needed.
  - Consolidated DB imports via ../db and switched client import to ../client.
  - Postgres/MySQL teardown now uses lazy sql and per-DB instance creation.

<sup>Written for commit 7ad12063bd4b178f2bc5b83e179b33e028dbef9c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



