### PR TITLE
feat(stripe): allow any scheme

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -46,7 +46,7 @@ const STRIPE_ERROR_CODES = defineErrorCodes({
 });
 
 const getUrl = (ctx: GenericEndpointContext, url: string) => {
-	if (url.match(/^[a-zA-Z][a-zA-Z0-9+\-.]*:/)) {
+	if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(url)) {
 		return url;
 	}
 	return `${ctx.context.options.baseURL}${


### PR DESCRIPTION
This allows user to return from the stripe to the Electron app.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support custom URL schemes in Stripe redirects so users can return to the Electron app after checkout. getUrl now treats any scheme (e.g., myapp://) as absolute and no longer prefixes baseURL when a scheme is present.

<sup>Written for commit 4551df4ff0a000fbc68ace4dbcfabb681bd3ebd6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



