### PR TITLE
fix: add missing userId in listAccounts response

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -47,6 +47,9 @@ export const listUserAccounts = createAuthEndpoint(
 											accountId: {
 												type: "string",
 											},
+											userId: {
+												type: "string",
+											},
 											scopes: {
 												type: "array",
 												items: {
@@ -60,6 +63,7 @@ export const listUserAccounts = createAuthEndpoint(
 											"createdAt",
 											"updatedAt",
 											"accountId",
+											"userId",
 											"scopes",
 										],
 									},
@@ -83,6 +87,7 @@ export const listUserAccounts = createAuthEndpoint(
 				createdAt: a.createdAt,
 				updatedAt: a.updatedAt,
 				accountId: a.accountId,
+				userId: a.userId,
 				scopes: a.scope?.split(",") || [],
 			})),
 		);


### PR DESCRIPTION
Closes https://github.com/better-auth/better-auth/issues/5620

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing userId field to the listUserAccounts API response and schema so clients can identify the user for each account. Fixes schema mismatch and prevents client errors when reading account data.

- **Bug Fixes**
  - Added userId to the response schema (properties and required).
  - Included userId in the response payload mapping.

<sup>Written for commit 8ae3a1fafcfb2bcf832bde03f01ba62794e02155. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

