### PR TITLE
docs: drop halloween logo

### DIFF
--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -3,7 +3,7 @@ import { MobileSearchIcon } from "@/components/mobile-search-icon";
 import { ThemeToggle } from "@/components/theme-toggler";
 import DarkPng from "../public/branding/better-auth-logo-dark.png";
 import WhitePng from "../public/branding/better-auth-logo-light.png";
-import HalloweenLogo from "./halloween/logo";
+import { Logo } from "./logo";
 import LogoContextMenu from "./logo-context-menu";
 import { NavLink } from "./nav-link";
 import { NavbarMobile, NavbarMobileBtn } from "./nav-mobile";
@@ -90,13 +90,10 @@ export const Navbar = () => {
 					<div className="flex flex-col gap-2 w-full">
 						<LogoContextMenu
 							logo={
-								// TODO: Revert to original logo after Halloween
-								//
-								// <div className="flex items-center gap-2">
-								// 	<Logo />
-								// 	<p className="select-none">BETTER-AUTH.</p>
-								// </div>
-								<HalloweenLogo />
+								<div className="flex items-center gap-2">
+									<Logo />
+									<p className="select-none">BETTER-AUTH.</p>
+								</div>
 							}
 							logoAssets={logoAssets}
 						/>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore the standard Better Auth logo and wordmark in the docs navbar, replacing the seasonal Halloween logo.
Removes the HalloweenLogo component usage and reinstates Logo with the "BETTER-AUTH." label.

<sup>Written for commit 74b7ba01e9d2e35532673b4186cacf9f0a231703. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

