### PR TITLE
fix(passkey): ensure addPasskey returns passkey data instead of undefined

### DIFF
--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -128,9 +128,7 @@ export const getPasskeyActions = (
 				optionsJSON: options.data,
 				useAutoRegister: opts?.useAutoRegister,
 			});
-			const verified = await $fetch<{
-				passkey: Passkey;
-			}>("/passkey/verify-registration", {
+			const verified = await $fetch<Passkey>("/passkey/verify-registration", {
 				...opts?.fetchOptions,
 				...fetchOpts,
 				body: {
@@ -145,6 +143,7 @@ export const getPasskeyActions = (
 				return verified;
 			}
 			$listPasskeys.set(Math.random());
+			return verified;
 		} catch (e) {
 			if (e instanceof WebAuthnError) {
 				if (e.code === "ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED") {


### PR DESCRIPTION
## Description

Fixes an issue where `client.passkey.addPasskey()` was returning `undefined` instead of the passkey data when registration succeeded.

## Changes

- Added missing `return verified;` statement in the `registerPasskey` function's success path
- The function now correctly returns the passkey data from the server response
- No breaking changes to the API contract

## Problem

The `addPasskey` client method was missing a return statement after successful passkey registration. This caused the function to return `undefined` instead of the expected passkey data, making it impossible for consumers to access information about the newly created passkey.








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures client.passkey.addPasskey returns the passkey data on successful registration instead of undefined.

- **Bug Fixes**
  - Added missing return after list refresh so the verified passkey is returned.
  - Updated verify-registration fetch to use Passkey as the response type.
  - No breaking changes to the API.

<sup>Written for commit 8ccfc36cca05ee3e61183ed0cb64863c65b6f91b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







