### PR TITLE
Added Two-Factor option to skip TOTP code creation

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -92,7 +92,11 @@ type enableTwoFactor = {
     /**
      * The user's password
      */
-    password: string = "secure-password"
+    password: string = "secure-password",
+    /**
+     * Whether to enable the OTP method or TOTP method (uses the TOTP method by default)
+     */
+    twoFactorMethod?: "otp" | "totp" = "totp",
     /**
      * An optional custom issuer for the TOTP URI. Defaults to app-name defined in your auth config.
      */

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -69,6 +69,7 @@ export const twoFactor = (options?: TwoFactorOptions | undefined) => {
 						password: z.string().meta({
 							description: "User password",
 						}),
+						twoFactorMethod: z.enum(["otp", "totp"]).default("totp"), // Default means it doesn't break any exsisting implementations
 						issuer: z
 							.string()
 							.meta({
@@ -90,18 +91,37 @@ export const twoFactor = (options?: TwoFactorOptions | undefined) => {
 											schema: {
 												type: "object",
 												properties: {
-													totpURI: {
-														type: "string",
-														description: "TOTP URI",
-													},
-													backupCodes: {
-														type: "array",
-														items: {
-															type: "string",
+													result: {
+														oneOf: [
+														{
+															type: "object",
+															properties: {
+															totpURI: {
+																type: "string",
+																description: "TOTP URI used to generate a QR code for authenticator apps (only returned when 'totp' is set as the twoFactorMethod)",
+															},
+															backupCodes: {
+																type: "array",
+																items: { type: "string" },
+																description: "List of single-use backup codes (only returned when 'totp' is set as the twoFactorMethod)",
+															},
+															},
+															required: ["totpURI", "backupCodes"],
 														},
-														description: "Backup codes",
+														{
+															type: "object",
+															properties: {
+															twoFactor: {
+																type: "boolean",
+																enum: [true],
+																description: "Indicates that 2FA was already enabled, so no setup data is returned (only returned when 'otp' is set as the twoFactorMethod)",
+															},
+															},
+															required: ["twoFactor"],
+														},
+														],
 													},
-												},
+													}
 											},
 										},
 									},
@@ -112,7 +132,7 @@ export const twoFactor = (options?: TwoFactorOptions | undefined) => {
 				},
 				async (ctx) => {
 					const user = ctx.context.session.user as UserWithTwoFactor;
-					const { password, issuer } = ctx.body;
+					const { password, issuer, twoFactorMethod } = ctx.body;
 					const isPasswordValid = await validatePassword(ctx, {
 						password,
 						userId: user.id,
@@ -131,7 +151,7 @@ export const twoFactor = (options?: TwoFactorOptions | undefined) => {
 						ctx.context.secret,
 						backupCodeOptions,
 					);
-					if (options?.skipVerificationOnEnable) {
+					if (options?.skipVerificationOnEnable || twoFactorMethod === "otp") {
 						const updatedUser = await ctx.context.internalAdapter.updateUser(
 							user.id,
 							{
@@ -155,6 +175,11 @@ export const twoFactor = (options?: TwoFactorOptions | undefined) => {
 						await ctx.context.internalAdapter.deleteSession(
 							ctx.context.session.session.token,
 						);
+
+						// there is no point creating totp stuff if we don't need to
+						if (twoFactorMethod === "otp") {
+							return ctx.json({ twoFactor: true });
+						}
 					}
 					//delete existing two factor
 					await ctx.context.adapter.deleteMany({
@@ -179,7 +204,7 @@ export const twoFactor = (options?: TwoFactorOptions | undefined) => {
 						digits: options?.totpOptions?.digits || 6,
 						period: options?.totpOptions?.period,
 					}).url(issuer || options?.issuer || ctx.context.appName, user.email);
-					return ctx.json({ totpURI, backupCodes: backupCodes.backupCodes });
+					return ctx.json({ totpURI, backupCodes: backupCodes.backupCodes });			
 				},
 			),
 			/**

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -422,6 +422,29 @@ describe("two factor", async () => {
 		});
 		expect(signInRes.data?.user).toBeDefined();
 	});
+
+
+	it("should enable 2fa for the otp method", async () => {
+		const res = await client.twoFactor.enable({
+			password: testUser.password,
+			twoFactorMethod: "otp",
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(res.data?.twoFactor).toBeDefined();
+		const dbUser = await db.findOne<UserWithTwoFactor>({
+			model: "user",
+			where: [
+				{
+					field: "id",
+					value: session.data?.user.id as string,
+				},
+			],
+		});
+	
+		expect(dbUser?.twoFactorEnabled).toBe(true);
+	});
 });
 
 describe("two factor auth API", async () => {


### PR DESCRIPTION
I added an option to the API to skip TOTP creation so that you can enable two factor auth for the OTP method.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new twoFactorMethod option to enable 2FA using OTP without generating TOTP codes or QR data. Default remains TOTP, so existing integrations keep working.

- **New Features**
  - API: twoFactor.enable accepts twoFactorMethod: "otp" | "totp" (default "totp").
  - "otp" skips TOTP setup and verification-on-enable, marks the user 2FA-enabled, and returns { twoFactor: true }.
  - "totp" continues to return totpURI and backupCodes as before.
  - Docs updated to show the new parameter.
  - Test added for the OTP path to ensure no TOTP artifacts are created.

<sup>Written for commit a5601c39d583b366bc3cd90cd1e64c995fc2d160. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

