### PR TITLE
fix(docs): Refactor safeDateConversion in Clerk migration guide

### DIFF
--- a/docs/content/docs/guides/clerk-migration-guide.mdx
+++ b/docs/content/docs/guides/clerk-migration-guide.mdx
@@ -244,8 +244,7 @@ export async function generateBackupCodes(
 function safeDateConversion(timestamp?: number): Date {
     if (!timestamp) return new Date();
 
-    // Convert seconds to milliseconds
-    const date = new Date(timestamp * 1000);
+    const date = new Date(timestamp);
 
     // Check if the date is valid
     if (isNaN(date.getTime())) {


### PR DESCRIPTION
Updated safeDateConversion function in the migration guide to use the timestamp returned by Clerk directly.
Clerk returns milliseconds now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the safeDateConversion example in the Clerk migration guide to use Clerk’s millisecond timestamp directly instead of multiplying by 1000. This aligns the docs with Clerk’s API and prevents invalid dates in the example.

<sup>Written for commit 006cf6e1a03da01c364d94ad2969462c788da370. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

