### PR TITLE
docs: fix `safeDateConversion` to use milliseconds directly

### DIFF
--- a/docs/content/docs/guides/clerk-migration-guide.mdx
+++ b/docs/content/docs/guides/clerk-migration-guide.mdx
@@ -244,8 +244,7 @@ export async function generateBackupCodes(
 function safeDateConversion(timestamp?: number): Date {
     if (!timestamp) return new Date();
 
-    // Convert seconds to milliseconds
-    const date = new Date(timestamp * 1000);
+    const date = new Date(timestamp);
 
     // Check if the date is valid
     if (isNaN(date.getTime())) {


### PR DESCRIPTION
Closes: https://github.com/better-auth/better-auth/pull/5743

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Clerk migration guide’s safeDateConversion example to use millisecond timestamps directly, removing the seconds-to-milliseconds conversion. This matches Clerk’s API and prevents invalid date calculations.

- **Bug Fixes**
  - Use new Date(timestamp) to handle millisecond input from Clerk.

<sup>Written for commit 0cc1fd7f9cf3349b61052e3ac4272e68604868d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

