### PR TITLE
docs: update apple.mdx

### DIFF
--- a/docs/content/docs/authentication/apple.mdx
+++ b/docs/content/docs/authentication/apple.mdx
@@ -93,8 +93,6 @@ description: Apple provider setup and usage.
 Apple Sign In does **not** support `localhost` or non-HTTPS URLs. During development:
 - You cannot use `http://localhost` as a return URL
 - You must use a domain with valid HTTPS/TLS certificate
-- Consider using a tunneling service to expose your local development server with HTTPS
-- Alternatively, use a staging/development environment with a proper domain and SSL certificate
 
 This limitation is enforced by Apple's security requirements and cannot be bypassed.
 </Callout>


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a warning callout to the Apple authentication docs explaining that Sign in with Apple does not support localhost or non-HTTPS and requires a valid HTTPS domain. This clarifies Apple's security restrictions and helps avoid setup errors.

<sup>Written for commit e3b8277483fe628c38716fecda843ff6c0a1eceb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





