### PR TITLE
feat(plugin-openapi): Allow passing nonce for CSP

### DIFF
--- a/docs/content/docs/plugins/open-api.mdx
+++ b/docs/content/docs/plugins/open-api.mdx
@@ -83,3 +83,5 @@ app.get("/docs", Scalar({
 This allows you to display both your application's API and Better Auth's authentication endpoints in a unified documentation interface.
 
 `theme` - Allows you to change the theme of the OpenAPI reference page. Default is `default`.
+
+`nonce` - Allows you to pass a nonce string to the inline scripts for Content Security Policy (CSP) compliance. Default is `undefined`.

--- a/packages/better-auth/src/plugins/open-api/index.ts
+++ b/packages/better-auth/src/plugins/open-api/index.ts
@@ -24,7 +24,10 @@ type ScalarTheme =
 const getHTML = (
 	apiReference: Record<string, any>,
 	theme?: ScalarTheme | undefined,
-) => `<!doctype html>
+	nonce?: string | undefined,
+) => {
+	const nonceAttr = nonce ? `nonce="${nonce}"` : "";
+	return `<!doctype html>
 <html>
   <head>
     <title>Scalar API Reference</title>
@@ -39,7 +42,7 @@ const getHTML = (
       type="application/json">
     ${JSON.stringify(apiReference)}
     </script>
-	 <script>
+	 <script ${nonceAttr}>
       var configuration = {
 	  	favicon: "data:image/svg+xml;utf8,${encodeURIComponent(logo)}",
 	   	theme: "${theme || "default"}",
@@ -52,9 +55,10 @@ const getHTML = (
       document.getElementById('api-reference').dataset.configuration =
         JSON.stringify(configuration)
     </script>
-	  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+	  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" ${nonceAttr}></script>
   </body>
 </html>`;
+};
 
 export interface OpenAPIOptions {
 	/**
@@ -78,6 +82,12 @@ export interface OpenAPIOptions {
 	 * @default "default"
 	 */
 	theme?: ScalarTheme | undefined;
+	/**
+	 * A 'nonce' string to be attached to inline scripts
+	 * for Content Security Policy (CSP) compliance.
+	 * @default undefined
+	 */
+	nonce?: string | undefined;
 }
 
 export const openAPI = <O extends OpenAPIOptions>(options?: O | undefined) => {
@@ -108,7 +118,7 @@ export const openAPI = <O extends OpenAPIOptions>(options?: O | undefined) => {
 						throw new APIError("NOT_FOUND");
 					}
 					const schema = await generator(ctx.context, ctx.context.options);
-					return new Response(getHTML(schema, options?.theme), {
+					return new Response(getHTML(schema, options?.theme, options?.nonce), {
 						headers: {
 							"Content-Type": "text/html",
 						},


### PR DESCRIPTION
This PR introduces a new `nonce` option to the `openAPI` plugin configuration.

When a `nonce` is provided, it is automatically added as an attribute to the two executable script tags (the inline configuration and the external `@scalar/api-reference` script) on the API reference page.

This allows the plugin to function correctly under a strict Content Security Policy (CSP) that requires nonces for all scripts.

**Changes:**
* Added `nonce?: string` to `OpenAPIOptions` in `index.ts`.
* Applied the `nonce` attribute to the two executable `<script>` tags in `getHTML`.
* Updated `docs/plugins/open-api.mdx` to include the new `nonce` option.

Fixes #5744

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a nonce option to the openAPI plugin to support strict CSP by attaching the nonce to executable scripts on the API reference page. This ensures both the inline config and the external @scalar/api-reference script run under CSP.

- **New Features**
  - Added `nonce?: string` to `OpenAPIOptions`.
  - Injected `nonce` into the inline config script and the external `@scalar/api-reference` script via `getHTML`.
  - Updated plugin docs to document the new `nonce` option.

<sup>Written for commit 4a6027fd6beeddaeea54cbc1e169767caddfa49a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

