### PR TITLE
docs(builder): fix layout overflow on smaller screens

### DIFF
--- a/docs/components/builder/index.tsx
+++ b/docs/components/builder/index.tsx
@@ -268,7 +268,7 @@ export function Builder() {
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="flex gap-4 md:gap-12 flex-col md:flex-row items-center md:items-start">
+				<div className="overflow-y-scroll no-scrollbar flex gap-4 md:gap-12 flex-col md:flex-row items-center md:items-start">
 					<div className={cn("w-4/12")}>
 						<div className="overflow-scroll h-[580px] relative no-scrollbar">
 							{options.signUp ? (


### PR DESCRIPTION
Fixing layout on smaller screens to be able to see the continue button

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix layout overflow in the Builder dialog on small screens by making the content container vertically scrollable. Added overflow-y-scroll with no-scrollbar so the Continue button stays visible without showing scrollbars.

<sup>Written for commit 3af5a64d24efd4683885abcf77098a1d4f4df26e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

