### PR TITLE
docs: add warning on `trustEmailVerified` config 

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -744,7 +744,9 @@ For a detailed guide on setting up SAML SSO with examples for Okta and testing w
 
 **disableImplicitSignUp**: Disable implicit sign up for new users.
 
-**trustEmailVerified**: Trust the email verified flag from the provider.
+**trustEmailVerified** — Trusts the `email_verified` flag from the provider. ⚠️ Use this with caution — it can lead to account takeover if misused. Only enable it if users **cannot freely register new providers**. You can prevent that by using `disabledPaths` or other safeguards to block provider registration from the client.
+
+If you want to allow account linking for specific trusted providers, enable the `accountLinking` option in your auth config and specify those providers in the `trustedProviders` list.
 
 <TypeTable
   type={{

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -260,6 +260,12 @@ export interface SSOOptions {
 		| undefined;
 	/**
 	 * Trust the email verified flag from the provider.
+	 *
+	 * ⚠️ Use this with caution — it can lead to account takeover if misused. Only enable it if users **cannot freely register new providers**. You can
+	 * prevent that by using `disabledPaths` or other safeguards to block provider registration from the client.
+	 *
+	 * If you want to allow account linking for specific trusted providers, enable the `accountLinking` option in your auth config and specify those
+	 * providers in the `trustedProviders` list.
 	 * @default false
 	 */
 	trustEmailVerified?: boolean | undefined;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a security warning and clear guidance for the trustEmailVerified option in SSO docs and JSDoc. Explains takeover risk, when to enable, how to block new provider registration (e.g., disabledPaths), and how to allow safe account linking via accountLinking + trustedProviders.

<sup>Written for commit f8edab22e1b658d3cb9fdac2bac9693dfe660bff. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

