### PR TITLE
docs: remove `guest` doc mention

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -866,7 +866,7 @@ type createInvitation = {
      */
     email: string = "example@gmail.com"
     /**
-     * The role(s) to assign to the user. It can be `admin`, `member`, or `guest`.  
+     * The role(s) to assign to the user. It can be `admin`, `member`, `owner`
      */
     role: string | string[] = "member"
     /**

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -43,7 +43,7 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 			])
 			.meta({
 				description:
-					'The role(s) to assign to the user. It can be `admin`, `member`, or `guest`. Eg: "member"',
+					'The role(s) to assign to the user. It can be `admin`, `member`, owner. Eg: "member"',
 			}),
 		organizationId: z
 			.string()


### PR DESCRIPTION
closes #5757

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated organization invite docs to remove the deprecated “guest” role and clarify allowed roles: admin, member, owner.
Aligned the API route metadata description to match the docs.

<sup>Written for commit 0fe1056d75c3ff094ecfb814c661e06ca0ccdef8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

