### PR TITLE
fix: trigger use session on revoke sessions

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -79,7 +79,9 @@ export const getClientConfig = (
 					path.startsWith("/sign-in") ||
 					path.startsWith("/sign-up") ||
 					path === "/delete-user" ||
-					path === "/verify-email"
+					path === "/verify-email" ||
+					path === "/revoke-sessions" ||
+					path === "/revoke-session"
 				);
 			},
 		},


### PR DESCRIPTION
closes #5741 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added /revoke-sessions and /revoke-session to the paths that trigger useSession in the client config. This refreshes the session after revocation so the UI updates immediately and avoids stale auth state.

<sup>Written for commit 15575d4eae5ab891357fd9dc4390db33269b768b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

