### PR TITLE
fix: additional fields default values should apply when creating session

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -20,7 +20,11 @@ import { generateId } from "../utils";
 import { getDate } from "../utils/date";
 import { getIp } from "../utils/get-request-ip";
 import { safeJSONParse } from "../utils/json";
-import { parseSessionOutput, parseUserOutput } from "./schema";
+import {
+	parseSessionInput,
+	parseSessionOutput,
+	parseUserOutput,
+} from "./schema";
 import { getWithHooks } from "./with-hooks";
 
 export const createInternalAdapter = (
@@ -272,6 +276,11 @@ export const createInternalAdapter = (
 			const ctx = await getCurrentAuthContext();
 			const headers = ctx.headers || ctx.request?.headers;
 			const { id: _, ...rest } = override || {};
+			//we're parsing default values for session additional fields
+			const defaultAdditionalFields = parseSessionInput(
+				ctx.context.options,
+				{},
+			);
 			const data: Omit<Session, "id"> = {
 				ipAddress:
 					ctx.request || ctx.headers
@@ -292,6 +301,7 @@ export const createInternalAdapter = (
 				// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
 				createdAt: new Date(),
 				updatedAt: new Date(),
+				...defaultAdditionalFields,
 				...(overrideAll ? rest : {}),
 			};
 			const res = await createWithHooks(

--- a/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
+++ b/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
@@ -219,4 +219,85 @@ describe("additionalFields", async () => {
 			session: Session;
 		} | null>;
 	});
+
+	it("should apply default values", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			databaseHooks: {
+				session: {
+					create: {
+						before: async (session) => {
+							return {
+								data: {
+									newField2: "new-field-2",
+								},
+							};
+						},
+					},
+				},
+			},
+			session: {
+				additionalFields: {
+					newField: {
+						type: "string",
+						defaultValue: "default-value",
+					},
+					newField2: {
+						type: "string",
+					},
+				},
+			},
+		});
+
+		const { headers } = await signInWithTestUser();
+		const res = await auth.api.getSession({
+			headers,
+		});
+		expect(res?.session.newField).toBe("default-value");
+	});
+	it("should apply default values with secondary storage", async () => {
+		const store = new Map<string, string>();
+		const { client, auth, signInWithTestUser } = await getTestInstance({
+			secondaryStorage: {
+				set(key, value) {
+					store.set(key, value);
+				},
+				get(key) {
+					return store.get(key) || null;
+				},
+				delete(key) {
+					store.delete(key);
+				},
+			},
+			databaseHooks: {
+				session: {
+					create: {
+						before: async (session) => {
+							return {
+								data: {
+									newField2: "new-field-2",
+								},
+							};
+						},
+					},
+				},
+			},
+			session: {
+				additionalFields: {
+					newField: {
+						type: "string",
+						defaultValue: "default-value",
+					},
+					newField2: {
+						type: "string",
+					},
+				},
+			},
+		});
+
+		const { headers } = await signInWithTestUser();
+		const res = await auth.api.getSession({
+			headers,
+		});
+		expect(res?.session.newField).toBe("default-value");
+	});
 });


### PR DESCRIPTION
closes #5687 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5687 by applying default values for session additionalFields during session creation. Ensures defaults are saved and returned by getSession, including with secondary storage.

- **Bug Fixes**
  - Use parseSessionInput to merge default additionalFields into new sessions.
  - Add tests verifying defaults with database hooks and with secondary storage.

<sup>Written for commit 726a5b90b5c41bcddfdf8d9465a8f7e36fab2d85. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

