### PR TITLE
Fix typo in navMenu name from 'helo_' to 'hello_'

### DIFF
--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -10,7 +10,7 @@ import { NavbarMobile, NavbarMobileBtn } from "./nav-mobile";
 
 export const navMenu = [
 	{
-		name: "helo_",
+		name: "hello_",
 		path: "/",
 	},
 	{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the nav menu item label from "helo_" to "hello_" so the navbar displays the proper text.

<sup>Written for commit 4fe9651f96e34ec36df49fcc0646e3a6cb2b480d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

