### PR TITLE
chore: re-export better-call types

### DIFF
--- a/packages/better-auth/src/index.ts
+++ b/packages/better-auth/src/index.ts
@@ -1,14 +1,14 @@
 //#region Re-exports necessaries from core module
 
-export * from "@better-auth/core";
-//#endregion
-export type * from "better-call";
 export type { StandardSchemaV1 } from "@better-auth/core";
+export * from "@better-auth/core";
 export { getCurrentAdapter } from "@better-auth/core/context";
 export * from "@better-auth/core/env";
 export * from "@better-auth/core/error";
 export * from "@better-auth/core/oauth2";
 export * from "@better-auth/core/utils";
+//#endregion
+export type * from "better-call";
 export * from "./auth";
 export * from "./types";
 export * from "./utils";


### PR DESCRIPTION
`The inferred type of 'auth' cannot be named without a reference to '.pnpm/better-call@1.0.24/node_modules/better-call'. This is likely not portable. A type annotation is necessary.`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exported better-call types and StandardSchemaV1 from better-auth to fix non-portable type references. TypeScript can now name the auth type without referencing the better-call package path, avoiding pnpm node_modules leaks.

<sup>Written for commit 326765cdd32ba4dc8000f7a3b94055cbf5fb3fd9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



