### PR TITLE
Fix: string[] additionalFields inferred as number[]

### DIFF
--- a/packages/better-auth/src/db/field.ts
+++ b/packages/better-auth/src/db/field.ts
@@ -18,21 +18,27 @@ export const createFieldAttribute = <
 	} satisfies DBFieldAttribute<T>;
 };
 
-export type InferValueType<T extends DBFieldType> = T extends "string"
-	? string
-	: T extends "number"
-		? number
-		: T extends "boolean"
-			? boolean
-			: T extends "date"
-				? Date
-				: T extends `${infer T}[]`
-					? T extends "string"
-						? string[]
-						: number[]
-					: T extends Array<any>
-						? T[number]
-						: never;
+export type InferValueType<T extends DBFieldType> =
+  T extends `${infer U}[]`
+    ? U extends "string"
+      ? string[]
+      : U extends "number"
+      ? number[]
+      : U extends "boolean"
+      ? boolean[]
+      : U extends "date"
+      ? Date[]
+      : unknown[]
+    : T extends "string"
+    ? string
+    : T extends "number"
+    ? number
+    : T extends "boolean"
+    ? boolean
+    : T extends "date"
+    ? Date
+    : never;
+
 
 export type InferFieldsOutput<Field> = Field extends Record<
 	infer Key,


### PR DESCRIPTION
### Summary
This PR fixes an issue where additional fields defined with the type `string[]`
were being incorrectly inferred as `number[]` during schema inference.

### Root Cause
The type inference logic in `InferValueType` did not properly handle
`string[]` cases due to incorrect conditional type resolution.

### Changes
- Updated `InferValueType` in `packages/better-auth/src/db/field.ts` to correctly infer `string[]` fields.
- Added support for distinguishing array types of `string`, `number`, `boolean`, and `date`.
- Ensured type inference returns the correct array element type for all supported DB field types.

### Impact
This resolves incorrect type mapping for array fields and prevents runtime type mismatches when dealing with additional schema fields.

### Testing
- Verified type inference manually for:
  - `string[]`
  - `number[]`
  - `boolean[]`
  - `date[]`
- All types are now correctly resolved by TypeScript.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect type inference where additionalFields declared as string[] were inferred as number[]. Array field types are now correctly resolved for string, number, boolean, and date.

- **Bug Fixes**
  - Updated InferValueType in packages/better-auth/src/db/field.ts to correctly handle `${infer U}[]`.
  - Maps "string[]", "number[]", "boolean[]", and "date[]" to the right TypeScript types.
  - Prevents runtime type mismatches and incorrect schema typing for additional fields.

<sup>Written for commit 5f4e208306a90c1f90588c16a4f1174b56b797e2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

