### PR TITLE
fix: `string[]` inference for additionalFields 

### DIFF
--- a/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
+++ b/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
@@ -192,34 +192,6 @@ describe("additionalFields", async () => {
 		} | null>;
 	});
 
-	it("should correctly infer string[] types with input: false (issue #5774)", async () => {
-		const { auth } = await getTestInstance({
-			user: {
-				additionalFields: {
-					roles: {
-						type: "string[]",
-						input: false,
-					},
-				},
-			},
-		});
-
-		const client = createAuthClient({
-			plugins: [inferAdditionalFields<typeof auth>()],
-		});
-
-		type SessionData = Awaited<ReturnType<typeof client.getSession>>["data"];
-
-		expectTypeOf<SessionData>()
-			.toHaveProperty("user")
-			.toHaveProperty("roles")
-			.toEqualTypeOf<string[]>();
-
-		type UserRoles = NonNullable<SessionData>["user"]["roles"];
-		type IncludesParam = Parameters<UserRoles["includes"]>[0];
-		expectTypeOf<IncludesParam>().toEqualTypeOf<string>();
-	});
-
 	it("should infer it on the client without direct import", async () => {
 		const client = createAuthClient({
 			plugins: [


### PR DESCRIPTION
Closes #5774

## Description

This PR fixes a bug where `additionalFields` with `type: 'string[]'` were incorrectly inferred as `number[]` on the client. This caused TypeScript errors when using array methods like `.includes()`.

The root cause was a **variable shadowing** bug in the `InferValueType` generic.

## Changes

1.  **`packages/better-auth/src/db/field.ts`**:
    * Renamed the inner inferred type in `InferValueType` from `T` to `U` to resolve the shadowing.
    * Added a more precise `Record<string, any>` type for the `json` type.
2.  **`packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts`**:
    * Added a new test case that specifically replicates the bug from #5774 (using `input: false`).
    * The test asserts that the inferred type is `string[]` and, more importantly, that the `.includes()` method correctly accepts a `string` parameter.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect type inference for additionalFields with type "string[]" that returned number[] on the client, causing TypeScript errors (e.g., .includes). Updates InferValueType to correctly handle "string[]" and "json".

- **Bug Fixes**
  - Prevented generic shadowing in InferValueType by renaming the inferred type (T → U) for `${infer U}[]`.
  - Correctly infers string[] for "string[]" and number[] for other arrays; adds Record<string, any> for "json".

<sup>Written for commit 2f0d36310d3cdbd23b911f591f79a56ee6cd32c0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



