### PR TITLE
fix(mcp): pass oidc config to oauth-authorization-server route

### DIFF
--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -123,7 +123,7 @@ export const mcp = (options: MCPOptions) => {
 			"offline_access",
 			...(options.oidcConfig?.scopes || []),
 		],
-	};
+	} satisfies OIDCOptions;
 	const modelName = {
 		oauthClient: "oauthApplication",
 		oauthAccessToken: "oauthAccessToken",
@@ -185,7 +185,7 @@ export const mcp = (options: MCPOptions) => {
 				},
 				async (c) => {
 					try {
-						const metadata = getMCPProviderMetadata(c, options);
+						const metadata = getMCPProviderMetadata(c, opts);
 						return c.json(metadata);
 					} catch (e) {
 						console.log(e);


### PR DESCRIPTION
Fixes bug where `oidcConfig` options were not correctly passed to `getMCPProviderMetadata` utility, resulting in `/.well-known/oauth-authorization-server` not reflecting custom metadata options.

---

Addresses
- #5782 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed OIDC config passthrough in the MCP plugin so /.well-known/oauth-authorization-server returns custom provider metadata as expected.

- **Bug Fixes**
  - Pass opts (with oidcConfig) to getMCPProviderMetadata.
  - Assert OIDC options with satisfies OIDCOptions for type safety and correct scopes.

<sup>Written for commit 961b9b4741ea2634f631e097917663d173e87ae0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

