### PR TITLE
test: remove `runWithUser` API

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -4,7 +4,7 @@ import { getTestInstance } from "../../test-utils/test-instance";
 describe("Email Verification", async () => {
 	const mockSendEmail = vi.fn();
 	let token: string;
-	const { auth, testUser, client, signInWithUser } = await getTestInstance({
+	const { auth, testUser, client, runWithUser } = await getTestInstance({
 		emailAndPassword: {
 			enabled: true,
 			requireEmailVerification: true,
@@ -30,7 +30,9 @@ describe("Email Verification", async () => {
 	});
 
 	it("should send a verification email if verification is required and user is not verified", async () => {
-		await signInWithUser(testUser.email, testUser.password);
+		await runWithUser(testUser.email, testUser.password, async () => {
+			// Sign in triggers verification email
+		});
 
 		expect(mockSendEmail).toHaveBeenCalledWith(
 			testUser.email,

--- a/packages/better-auth/src/test-utils/index.ts
+++ b/packages/better-auth/src/test-utils/index.ts
@@ -248,10 +248,17 @@ export async function getTestInstanceMemory<
 		client,
 		testUser,
 		signInWithTestUser,
-		signInWithUser,
 		cookieSetter: setCookieToHeader,
 		customFetchImpl,
 		sessionSetter,
 		db: await getAdapter(auth.options),
+		runWithUser: async (
+			email: string,
+			password: string,
+			fn: (headers: Headers) => Promise<void> | void,
+		) => {
+			const { headers } = await signInWithUser(email, password);
+			await fn(headers);
+		},
 	};
 }

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -293,7 +293,6 @@ export async function getTestInstance<
 		client,
 		testUser,
 		signInWithTestUser,
-		signInWithUser,
 		cookieSetter: setCookieToHeader,
 		customFetchImpl,
 		sessionSetter,


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored test helpers to use runWithUser() instead of signInWithUser() for scoped auth, and updated admin, organization, and email verification tests accordingly. This simplifies header handling and makes permission checks clearer in tests.

- **Refactors**
  - Added runWithUser(email, password, fn) in test utils to sign in and pass headers to a callback.
  - Removed signInWithUser from getTestInstance exports.
  - Updated admin and organization tests to wrap calls in runWithUser for non-admin scenarios and invitations.
  - Adjusted email verification test to trigger verification via runWithUser.
  - Minor cleanups around header management and session retrieval.

<sup>Written for commit 13a010b79c4b326de013266de6b80bc9d5075e62. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









