### PR TITLE
fix(email-otp): prevent duplicate verification emails when override is enabled

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -1152,7 +1152,8 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					matcher(context) {
 						return !!(
 							context.path?.startsWith("/sign-up") &&
-							opts.sendVerificationOnSignUp
+							opts.sendVerificationOnSignUp &&
+							!opts.overrideDefaultEmailVerification
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents duplicate verification emails on sign-up when email OTP override is enabled. Users now receive a single verification email from the override, not both.

- **Bug Fixes**
  - Disable default send-on-sign-up when overrideDefaultEmailVerification is true.
  - Add test to confirm sendVerificationOTP is called once with the correct payload.

<sup>Written for commit 14de5a80dc949b08e7ecfedaa8d630bf836a4a71. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

