### PR TITLE
chore(two-factor): code reference

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -317,6 +317,21 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 			 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/2fa#getting-totp-uri)
 			 */
 			getTOTPURI: getTOTPURI,
+			/**
+			 * ### Endpoint
+			 *
+			 * POST `/two-factor/verify-totp`
+			 *
+			 * ### API Methods
+			 *
+			 * **server:**
+			 * `auth.api.verifyTOTP`
+			 *
+			 * **client:**
+			 * `authClient.twoFactor.verifyTotp`
+			 *
+			 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/2fa#verifying-totp)
+			 */
 			verifyTOTP,
 		},
 	} satisfies TwoFactorProvider;


### PR DESCRIPTION
This PR fixes the incorrect two factor doc link and adding new reference to `verifyTOTP`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed outdated two-factor doc links and added references for verifyTOTP in the TOTP provider. Developers now have accurate links and API method docs for generateTOTP, getTOTPURI, and verifyTOTP under the new /plugins/2fa pages.

<sup>Written for commit 8d805e6ebcae3c35d24d2f17d60ead00b3d2977f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

