### PR TITLE
chore: re-export helper types in client plugins

### DIFF
--- a/packages/better-auth/src/client/plugins/index.ts
+++ b/packages/better-auth/src/client/plugins/index.ts
@@ -1,3 +1,7 @@
+//#region Necessary re-exports
+export type * from "../../types/helper";
+//#endregion
+
 export * from "../../plugins/additional-fields/client";
 export * from "../../plugins/admin/client";
 export * from "../../plugins/anonymous/client";


### PR DESCRIPTION
`The inferred type of 'authClient' cannot be named without a reference to '../../node_modules/better-auth/dist/helper-BQDBO9v8' (src/types/helper.ts). This is likely not portable. A type annotation is necessary.`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exported helper types from the client plugins entry to fix the TypeScript error where authClient’s inferred type required a reference to dist/helper. This makes the types portable for consumers with no runtime changes.

<sup>Written for commit dc9495f7b7b38d458e20c18250e6cb1ea337fb91. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

