### PR TITLE
fix(email-verification): set emailVerified to true upon email verification

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -357,7 +357,7 @@ describe("Email Verification Secondary Storage", async () => {
 				},
 			});
 			expect(session.data?.user.email).toBe("new@email.com");
-			expect(session.data?.user.emailVerified).toBe(false);
+			expect(session.data?.user.emailVerified).toBe(true);
 		});
 	});
 

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -354,30 +354,12 @@ export const verifyEmail = createAuthEndpoint(
 				},
 			);
 
-			const newToken = await createEmailVerificationToken(
-				ctx.context.secret,
-				parsed.updateTo,
-			);
-
-			//send verification email to the new email
-			const updateCallbackURL = ctx.query.callbackURL
-				? encodeURIComponent(ctx.query.callbackURL)
-				: encodeURIComponent("/");
-			await ctx.context.options.emailVerification?.sendVerificationEmail?.(
-				{
-					user: updatedUser,
-					url: `${ctx.context.baseURL}/verify-email?token=${newToken}&callbackURL=${updateCallbackURL}`,
-					token: newToken,
-				},
-				ctx.request,
-			);
-
 			await setSessionCookie(ctx, {
 				session: session.session,
 				user: {
 					...session.user,
 					email: parsed.updateTo,
-					emailVerified: false,
+					emailVerified: true,
 				},
 			});
 

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -350,7 +350,7 @@ export const verifyEmail = createAuthEndpoint(
 				parsed.email,
 				{
 					email: parsed.updateTo,
-					emailVerified: false,
+					emailVerified: true,
 				},
 			);
 


### PR DESCRIPTION
# Fix: Remove redundant email verification when changing email

## Problem

When a user with a verified email changes their email address, the system was sending **two verification emails**:

1. **First email** (from `changeEmail` endpoint): Sent via `sendChangeEmailVerification` callback to the **new email address** to confirm the email change request
2. **Second email** (from `verifyEmail` endpoint): After clicking the first verification link, a second verification email was automatically sent to the **new email address** again

This created an unnecessary extra step in the email change flow - the user had to verify their new email twice.

## Solution

When a user verifies an email change request (by clicking the link sent to their new email), we now:

- ✅ Update the email address to the new email
- ✅ Set `emailVerified: true` immediately
- ❌ **Remove** the redundant second verification email

## Why This Makes Sense

The verification flow already ensures the user owns the new email:

1. The user must be **logged in** (session required) to change their email
2. The verification email is sent to the **new email address** via `sendChangeEmailVerification` (lines 793-801 in `update-user.ts`)
3. Clicking the verification link sent to the new email confirms the user has access to that email address

Since the user has already verified their ownership of the new email by clicking the verification link sent to it, there's no need for an additional verification email. The act of verifying the change request **is** sufficient verification of the new email. This matches the pattern used for unverified email changes (lines 744-767 in `update-user.ts`), where a single verification email to the new address is sufficient.

## Changes

- Updated `verifyEmail` endpoint to set `emailVerified: true` when processing email changes (when `updateTo` is present in the token)
- Removed the redundant token creation and second verification email sending logic

## Related Code

- `packages/better-auth/src/api/routes/email-verification.ts` - Removed redundant verification email logic
- `packages/better-auth/src/api/routes/update-user.ts` - Already sends the initial change email verification (lines 751-760)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending a second verification email after users confirm an email change. When the user clicks the change-email verification link, we update their email and mark it verified immediately.

- **Bug Fixes**
  - Set emailVerified: true in verifyEmail when processing email changes.
  - Removed token generation and follow-up verification email to the new address.
  - Updated session cookie to reflect the new email with emailVerified: true.

<sup>Written for commit ddfe08660efed9767700bf87df415c2da6e1a1ed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



