### PR TITLE
feat(client): add type helper `AuthClient`

### DIFF
--- a/e2e/smoke/test/ssr.ts
+++ b/e2e/smoke/test/ssr.ts
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "node:test";
 import { betterAuth } from "better-auth";
-import { createAuthClient } from "better-auth/client";
-import { apiKeyClient } from "better-auth/client/plugins";
+import { type AuthClient, createAuthClient } from "better-auth/client";
+import {
+	type ApiKeyClientPlugin,
+	apiKeyClient,
+} from "better-auth/client/plugins";
 import { getMigrations } from "better-auth/db";
 import { apiKey } from "better-auth/plugins";
 
@@ -34,7 +37,9 @@ describe("server side client", () => {
 		const { runMigrations } = await getMigrations(auth.options);
 		await runMigrations();
 
-		const authClient: ReturnType<typeof createAuthClient> = createAuthClient({
+		const authClient: AuthClient<{
+			plugins: [ApiKeyClientPlugin];
+		}> = createAuthClient({
 			baseURL: "http://localhost:3000",
 			plugins: [apiKeyClient()],
 			fetchOptions: {

--- a/e2e/smoke/tsconfig.json
+++ b/e2e/smoke/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "customConditions": [],
     "target": "esnext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/better-auth/src/client/vanilla.ts
+++ b/packages/better-auth/src/client/vanilla.ts
@@ -95,3 +95,7 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 			>;
 		};
 }
+
+export type AuthClient<Option extends BetterAuthClientOptions> = ReturnType<
+	typeof createAuthClient<Option>
+>;

--- a/packages/better-auth/src/plugins/api-key/client.ts
+++ b/packages/better-auth/src/plugins/api-key/client.ts
@@ -12,3 +12,5 @@ export const apiKeyClient = () => {
 		},
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type ApiKeyClientPlugin = ReturnType<typeof apiKeyClient>;

--- a/packages/better-auth/src/plugins/oidc-provider/client.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/client.ts
@@ -7,3 +7,5 @@ export const oidcClient = () => {
 		$InferServerPlugin: {} as ReturnType<typeof oidcProvider>,
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type OidcClientPlugin = ReturnType<typeof oidcClient>;

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -9,22 +9,20 @@ import {
 	it,
 	test,
 } from "vitest";
-import { createAuthClient } from "../../client";
+import { type AuthClient, createAuthClient } from "../../client";
 import { toNodeHandler } from "../../integrations/node";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { genericOAuth } from "../generic-oauth";
 import { genericOAuthClient } from "../generic-oauth/client";
 import { jwt } from "../jwt";
 import { oidcProvider } from ".";
-import { oidcClient } from "./client";
+import { type OidcClientPlugin, oidcClient } from "./client";
 import type { Client } from "./types";
 
 // Type for the server client with OIDC plugin
-type ServerClient = ReturnType<
-	typeof createAuthClient<{
-		plugins: [ReturnType<typeof oidcClient>];
-	}>
->;
+type ServerClient = AuthClient<{
+	plugins: [OidcClientPlugin];
+}>;
 
 /**
  * Helper to handle OIDC consent flow when required per OIDC spec


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new AuthClient type helper and plugin type aliases to simplify and strengthen typing for createAuthClient and client plugins. Updates tests to use the new types for clearer, safer client declarations.

- **New Features**
  - Exported AuthClient<Option> as a typed alias for createAuthClient.
  - Exported ApiKeyClientPlugin and OidcClientPlugin type helpers.

- **Refactors**
  - Updated SSR and OIDC tests to use the new type helpers.
  - Added customConditions: [] in e2e tsconfig.
  - No runtime changes.

<sup>Written for commit def9fc54276e56eb505c7dbc43b2a9417cbc015a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

