### PR TITLE
docs: fix incorrect unique constraint on subscription.referenceId

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -622,8 +622,8 @@ Table Name: `subscription`
     { 
       name: "referenceId", 
       type: "string", 
-      description: "The ID this subscription is associated with (user ID by default)",
-      isUnique: true
+      description: "The ID this subscription is associated with (user ID by default). This should NOT be a unique field in your database, as it must allow users to resubscribe after a cancellation.",
+      isUnique: false
     },
     { 
       name: "stripeCustomerId", 


### PR DESCRIPTION
## Summary

This PR fixes a documentation error that causes users to create a buggy database schema, leading to the "duplicate key error" reported in #5781.

**The issue is not in the plugin's code** (which works correctly), but in the **documentation** that misleads users into adding an incorrect unique constraint.

## The Problem

1. **User's Bug:** Issue #5781 reports a "duplicate key error" when users try to resubscribe after cancellation. This only happens if their database has a `UNIQUE` constraint on `referenceId`.

2. **Documentation Error:** Our docs (`docs/content/docs/plugins/stripe.mdx`, line 617) incorrectly state:
   ```markdown
   { 
     name: "referenceId", 
     isUnique: true  // ❌ WRONG - causes users to add unique constraint
   }
   

Actual Code: The plugin's schema (packages/stripe/src/schema.ts) correctly does NOT specify unique: true.

Result: Users (especially those using Mongoose or manual schema creation) follow the documentation and add a unique constraint, which breaks the resubscription flow.

**The Fix**
Update documentation to match the actual implementation:

Change isUnique: true → isUnique: false
Add clear warning: "This should NOT be a unique field in your database, as it must allow users to resubscribe after a cancellation."

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected Stripe plugin docs: subscription.referenceId is not unique. This prevents users from adding a bad unique constraint that causes duplicate key errors on resubscribe.

<sup>Written for commit f0bd57a0cc4ee47af7fb752c18039f34a83dc935. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

