### PR TITLE
fix(db): postgres - explicitly define pg_catalog for gen_random_uuid()

### DIFF
--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -416,7 +416,7 @@ export async function getMigrations(config: BetterAuthOptions) {
 						if (dbType === "postgres") {
 							return col
 								.primaryKey()
-								.defaultTo(sql`gen_random_uuid()`)
+								.defaultTo(sql`pg_catalog.gen_random_uuid()`)
 								.notNull();
 						} else if (dbType === "mysql" || dbType === "mssql") {
 							return col.primaryKey().defaultTo(sql`uuid()`).notNull();


### PR DESCRIPTION
when #5809 was merged as 4ac3476642efbd40a10536d3f36adb1fb6795e52 it introduced a vulnerability marked as CVE-2018-1058. It's described in https://wiki.postgresql.org/wiki/A_Guide_to_CVE-2018-1058%3A_Protect_Your_Search_Path

> The problem described in CVE-2018-1058 centers around the default
> "public" schema and how PostgreSQL uses the search_path setting. The
> ability to create objects with the same names in different schemas,
> combined with how PostgreSQL searches for objects within schemas,
> presents an opportunity for a user to modify the behavior of a query for
> other users.

This vulnerability is not so much severe since Postgres 15 (https://www.postgresql.org/docs/release/15.0/ and https://pganalyze.com/blog/5mins-postgres-security-patch-releases-pgspot-pghostile#postgres-15-default-revoke-public-create-from-public-schema) due to:
> The new default is one of the secure schema usage patterns that
> Section 5.9.6 has recommended since the security release for
> CVE-2018-1058. The change applies to new database clusters and to
> newly-created databases in existing clusters. Upgrading a cluster or
> restoring a database dump will preserve public's existing permissions.

That being said, it's a good thing to define `pg_catalog` schema explicity (even for postgres versions >=15) to have a additional security layer.

This vulnerability should be fixed before a release containing 4ac3476642efbd40a10536d3f36adb1fb6795e52 is created so that it couldn't be exploited "in the wild"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use pg_catalog.gen_random_uuid() in Postgres migrations to prevent search_path hijacking (CVE-2018-1058) and ensure safe UUID defaults. Only affects Postgres; MySQL/MSSQL unchanged.

<sup>Written for commit 7e649eba5dc091e43d489e0496c4fcf603a1dcba. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

