### PR TITLE
fix(phone-number): shouldn't allow updating phone number on `/update-user` endpoint

### DIFF
--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -76,6 +76,7 @@ const schema = {
 			isAnonymous: {
 				type: "boolean",
 				required: false,
+				input: false,
 			},
 		},
 	},

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -141,19 +141,14 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 	return {
 		id: "phone-number",
 		hooks: {
-			after: [
+			before: [
 				{
-					// if a request was made to update the user and the phone number is being updated
-					// make sure to set `phoneNumberVerified` to `false`
+					// Stop any requests attempting to update the user's phone number
 					matcher: (ctx) =>
-						ctx.path === "/update-user" &&
-						"phoneNumber" in ctx.body &&
-						ctx.body.phoneNumber,
+						ctx.path === "/update-user" && "phoneNumber" in ctx.body,
 					handler: createAuthMiddleware(async (ctx) => {
-						const session = ctx.context.session;
-						if (!session) return;
-						await ctx.context.internalAdapter.updateUser(session.user.id, {
-							phoneNumberVerified: false,
+						throw new APIError("BAD_REQUEST", {
+							message: "Phone number cannot be updated",
 						});
 					}),
 				},


### PR DESCRIPTION
Right now you can call `authClient.updateUser({phoneNumber: "123"})` and if the user previously had an older phone number verified, the `phoneNumberVerified` state stays `true`, despite updating to an unverified phone number.

This PR fixes this and introduces tests.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents updating a user's phone number via updateUser. Requests now return 400 and keep phoneNumber and phoneNumberVerified unchanged.

- **Bug Fixes**
  - Block phoneNumber updates on /update-user via a before hook; returns "Phone number cannot be updated".
  - Added tests to ensure the phone number can't be changed and verification state remains intact.

<sup>Written for commit 50a41e4309602d03bccdcb1de6e7785320245a01. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



