### PR TITLE
feat: add support for `create` and `update` input types

### DIFF
--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { memoryAdapter } from "../../adapters/memory-adapter";
 import { createAuthClient } from "../../client";
 import { inferAdditionalFields } from "../../client/plugins";
 import { getTestInstance } from "../../test-utils/test-instance";
@@ -382,6 +383,26 @@ describe("updateUser", async () => {
 		);
 		expect(res.error).toBeDefined();
 		expect(res.error?.message).toBe("newField is not allowed to be set");
+	});
+
+	it("should not allow update fields that aren't defined in the user schema", async () => {
+		const { client, signInWithTestUser } = await getTestInstance({
+			database: memoryAdapter({
+				user: [],
+				session: [],
+				account: [],
+				verification: [],
+			}),
+		});
+		const { headers } = await signInWithTestUser();
+		const res = await client.updateUser(
+			{
+				//@ts-expect-error
+				newField: "new",
+			},
+			{ headers },
+		);
+		expect(res.error?.code).toBe("NO_FIELDS_TO_UPDATE");
 	});
 });
 

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -94,7 +94,7 @@ export function parseInputData<T extends Record<string, any>>(
 	);
 	for (const key in fields) {
 		if (key in data) {
-			if (fields[key]!.input === false) {
+			if (fields[key]!.input === false || fields[key]!.input !== action) {
 				if (fields[key]!.defaultValue !== undefined) {
 					if (action !== "update") {
 						parsedData[key] = fields[key]!.defaultValue;

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -76,6 +76,7 @@ const schema = {
 			isAnonymous: {
 				type: "boolean",
 				required: false,
+				input: false,
 			},
 		},
 	},

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -931,6 +931,8 @@ const schema = {
 				unique: true,
 				sortable: true,
 				returned: true,
+				//only allow to set phone number when creating a new user
+				input: "create",
 			},
 			phoneNumberVerified: {
 				type: "boolean",

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -46,9 +46,17 @@ export type DBFieldAttributeConfig = {
 	returned?: boolean | undefined;
 	/**
 	 * If a value should be provided when creating a new record.
+	 *
+	 * - `true` - The field will be included in the user input.
+	 * - `false` - The field will be excluded from the user input.
+	 * - `"update"` - The field will be included in the user input when updating a record but not when
+	 * creating a new record.
+	 * - `"create"` - The field will be included in the user input when creating a new record but not
+	 * when updating a record.
+	 *
 	 * @default true
 	 */
-	input?: boolean | undefined;
+	input?: boolean | undefined | "update" | "create";
 	/**
 	 * Default value for the field
 	 *


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds action-based field input control to the DB schema. Fields can now be create-only or update-only, and the server enforces this for user updates.

- **New Features**
  - DBFieldAttributeConfig.input now supports true | false | "create" | "update".
  - parseInputData enforces allowed fields based on the current action.
  - Applied to built-in plugins: phoneNumber is create-only; isAnonymous is not user-settable.
  - updateUser now rejects disallowed or unknown fields with clear errors (e.g., NO_FIELDS_TO_UPDATE, PHONENUMBER_IS_NOT_ALLOWED_TO_BE_SET).

<sup>Written for commit 49653031b483a03a5d09fd83d8fb074b4c068947. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

