### PR TITLE
fix: override of cookiePrefix in getCookieCache function

### DIFF
--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1091,3 +1091,92 @@ describe("Cookie Chunking", () => {
 		expect(cache?.user?.email).toEqual(testUser.email);
 	});
 });
+
+describe("getCookieCache prefix handling", () => {
+	it("should use custom cookieName with no prefix when config has empty cookiePrefix", async () => {
+		const { client, testUser } = await getTestInstance({
+			secret: "better-auth.secret",
+			advanced: {
+				cookiePrefix: "some-prefix",
+				cookies: {
+					session_data: {
+						name: "my_session", // betterAuth server ignores prefix when custom name is provided
+					},
+				},
+			},
+			session: {
+				cookieCache: {
+					enabled: true,
+				},
+			},
+		});
+
+		const headers = new Headers();
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					if (setCookie) {
+						const parsed = parseSetCookieHeader(setCookie);
+						parsed.forEach((value, name) => {
+							headers.append("cookie", `${name}=${value.value}`);
+						});
+					}
+				},
+			},
+		);
+
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+
+		const cache = await getCookieCache(request, {
+			secret: "better-auth.secret",
+			cookieName: "my_session",
+			cookiePrefix: "",
+		});
+
+		expect(cache).not.toBeNull();
+		expect(cache?.user?.email).toEqual(testUser.email);
+	});
+
+	it("should return null when looking for wrong prefix", async () => {
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			secret: "better-auth.secret",
+			session: {
+				cookieCache: {
+					enabled: true,
+				},
+			},
+		});
+
+		const headers = new Headers();
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(headers),
+			},
+		);
+
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+
+		// Looking for wrong prefix - should return null
+		const cache = await getCookieCache(request, {
+			secret: "better-auth.secret",
+			cookiePrefix: "wrong-prefix",
+		});
+
+		expect(cache).toBeNull();
+	});
+});

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -394,7 +394,6 @@ export const getCookieCache = async <
 ) => {
 	const headers = request instanceof Headers ? request : request.headers;
 	const cookies = headers.get("cookie");
-	console.log("getCookieCache cookies:", cookies);
 	if (!cookies) {
 		return null;
 	}

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -394,19 +394,28 @@ export const getCookieCache = async <
 ) => {
 	const headers = request instanceof Headers ? request : request.headers;
 	const cookies = headers.get("cookie");
+	console.log("getCookieCache cookies:", cookies);
 	if (!cookies) {
 		return null;
 	}
-	const { cookieName = "session_data", cookiePrefix = "better-auth" } =
-		config || {};
+	const cookieName = config?.cookieName ?? "session_data";
+	const cookiePrefix =
+		config?.cookiePrefix === undefined
+			? "better-auth"
+			: config.cookiePrefix === ""
+				? undefined
+				: config.cookiePrefix;
+	const maybePrefixCookieName = cookiePrefix
+		? `${cookiePrefix}.${cookieName}`
+		: cookieName;
 	const name =
 		config?.isSecure !== undefined
 			? config.isSecure
-				? `__Secure-${cookiePrefix}.${cookieName}`
-				: `${cookiePrefix}.${cookieName}`
+				? `__Secure-${maybePrefixCookieName}`
+				: `${maybePrefixCookieName}`
 			: isProduction
-				? `__Secure-${cookiePrefix}.${cookieName}`
-				: `${cookiePrefix}.${cookieName}`;
+				? `__Secure-${maybePrefixCookieName}`
+				: `${maybePrefixCookieName}`;
 	const parsedCookie = parseCookies(cookies);
 
 	// Check for chunked cookies


### PR DESCRIPTION
**Problem**

Given a `betterAuth` config like so;
```
betterAuth({
  ... // other config options,
  advanced: {
    cookiePrefix: 'some_prefix',
    cookies: {
      session_data: {
        name: "custom_cookie_name"
      }
    }
  }
})
```
The cookie name will be created as `custom_cookie_name`, which is expected by design. 

When retrieving the cookie with `getCookieCache` like so;
```
getCookieCache(headers, {
  cookieName: "custom_cookie_name"
});
```
the cookie name gets prefixed with the default cookiePrefix, `better-auth.custom_cookie_name`, there by making the function return null, even if the cookie exists.
Also, passing an empty `cookiePrefix` value to the `getCookieCache` function doesn't help, as the function tries to find the cookie with `.custom_cookie_name`.

**Proposed solution**
Ensure the `getCookiecache` searches by only the cookieName if `cookiePrefix` is set as an empty string.


**Clarification needed**
I see the `getSessionCookie` function can have either `cookiePrefix-` or `cookiePrefix.`. I checked the `betterAuth` initialization code and couldn't find a place where the cookie name could be concatenated with a `-`. 
Is this different concatenator in `getSessionCookie` by design? Otherwise, the change done in the getCookieCache can be reused there as well.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix getCookieCache to respect custom cookie names without a prefix. When cookiePrefix is an empty string, it now searches using only cookieName, preventing null cache results.

- **Bug Fixes**
  - Skip applying the default prefix when cookiePrefix is "" and preserve __Secure cookie handling.
  - Added tests for custom cookie names without a prefix and for wrong-prefix lookups returning null.

<sup>Written for commit aa144b3aba222ca9027bd24372884712eddc3d92. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



