### PR TITLE
chore: shouldn't show cli warning on uuid type for strings

### DIFF
--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -51,7 +51,7 @@ const sqliteMap = {
 };
 
 const mssqlMap = {
-	string: ["varchar", "nvarchar", "uuid"],
+	string: ["varchar", "nvarchar", "uniqueidentifier"],
 	number: ["int", "bigint", "smallint", "decimal", "float", "double"],
 	boolean: ["bit", "smallint"],
 	date: ["datetime2", "date", "datetime"],


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Recognize UUID columns as strings in migration type mapping to prevent Postgres warnings and keep behavior consistent across adapters.

- **Bug Fixes**
  - Add "uuid" to Postgres and MySQL string lists, and "uniqueidentifier" to MSSQL, in get-migration.ts to stop migration warnings and normalize types.

<sup>Written for commit 2f8d949e9107c3ac695045c2d2ba0d85f00b799c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



