### PR TITLE
chore(e2e): type fix

### DIFF
--- a/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/package.json
@@ -6,7 +6,6 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
-    "better-auth": "workspace:*",
-    "better-sqlite3": "^12.4.1"
+    "better-auth": "workspace:*"
   }
 }

--- a/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/index.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/index.ts
@@ -6,10 +6,8 @@ import {
 import { nextCookies } from "better-auth/next-js";
 import { organization } from "better-auth/plugins";
 import { createAuthClient } from "better-auth/react";
-import Database from "better-sqlite3";
 
 const auth = betterAuth({
-	database: new Database("./sqlite.db"),
 	trustedOrigins: [],
 	emailAndPassword: {
 		enabled: true,

--- a/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/user-additional-fields.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/user-additional-fields.ts
@@ -1,8 +1,6 @@
 import { betterAuth } from "better-auth";
-import Database from "better-sqlite3";
 
 const auth = betterAuth({
-	database: new Database("./sqlite.db"),
 	trustedOrigins: [],
 	emailAndPassword: {
 		enabled: true,

--- a/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/package.json
@@ -6,8 +6,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
-    "@better-auth/expo": "workspace:^",
-    "better-auth": "workspace:^",
-    "better-sqlite3": "^12.4.1"
+    "@better-auth/expo": "workspace:*",
+    "better-auth": "workspace:*"
   }
 }

--- a/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/src/index.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/src/index.ts
@@ -1,9 +1,7 @@
 import { expo } from "@better-auth/expo";
 import { betterAuth } from "better-auth";
-import Database from "better-sqlite3";
 
 const auth = betterAuth({
-	database: new Database("./sqlite.db"),
 	plugins: [expo()],
 });
 

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/body-parser": "^1.19.6",
     "@types/express": "^5.0.5",
-    "better-auth": "workspace:^",
+    "better-auth": "workspace:*",
     "better-call": "catalog:",
     "body-parser": "^2.2.0",
     "express": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,9 +897,6 @@ importers:
       better-auth:
         specifier: workspace:*
         version: link:../../../../../packages/better-auth
-      better-sqlite3:
-        specifier: ^12.4.1
-        version: 12.4.1
 
   e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler:
     dependencies:
@@ -913,14 +910,11 @@ importers:
   e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10:
     dependencies:
       '@better-auth/expo':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../../../../packages/expo
       better-auth:
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../../../../packages/better-auth
-      better-sqlite3:
-        specifier: ^12.4.1
-        version: 12.4.1
 
   e2e/smoke/test/fixtures/vite:
     dependencies:
@@ -1334,7 +1328,7 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5
       better-auth:
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix TS type checks in e2e fixtures by removing better-sqlite3 and its Database usage. Standardize workspace ranges to workspace:* and update the lockfile.

- **Bug Fixes**
  - Removed Database usage in fixture code so typecheck passes under exactOptionalPropertyTypes and verbatimModuleSyntax.

- **Dependencies**
  - Dropped better-sqlite3 from fixtures and pruned from pnpm-lock.yaml.
  - Switched workspace ranges to workspace:* for better-auth and @better-auth/expo (including packages/sso).

<sup>Written for commit 5131c3783dbf0528aabc89e53fb5715e98b57938. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

