### PR TITLE
chore: rename tsconfig customCondition to `dev-source`

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -33,252 +33,252 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "better-auth-dev-source": "./src/index.ts",
+      "dev-source": "./src/index.ts",
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "./social-providers": {
-      "better-auth-dev-source": "./src/social-providers/index.ts",
+      "dev-source": "./src/social-providers/index.ts",
       "types": "./dist/social-providers/index.d.mts",
       "default": "./dist/social-providers/index.mjs"
     },
     "./client": {
-      "better-auth-dev-source": "./src/client/index.ts",
+      "dev-source": "./src/client/index.ts",
       "types": "./dist/client/index.d.mts",
       "default": "./dist/client/index.mjs"
     },
     "./client/plugins": {
-      "better-auth-dev-source": "./src/client/plugins/index.ts",
+      "dev-source": "./src/client/plugins/index.ts",
       "types": "./dist/client/plugins/index.d.mts",
       "default": "./dist/client/plugins/index.mjs"
     },
     "./types": {
-      "better-auth-dev-source": "./src/types/index.ts",
+      "dev-source": "./src/types/index.ts",
       "types": "./dist/types/index.d.mts",
       "default": "./dist/types/index.mjs"
     },
     "./crypto": {
-      "better-auth-dev-source": "./src/crypto/index.ts",
+      "dev-source": "./src/crypto/index.ts",
       "types": "./dist/crypto/index.d.mts",
       "default": "./dist/crypto/index.mjs"
     },
     "./cookies": {
-      "better-auth-dev-source": "./src/cookies/index.ts",
+      "dev-source": "./src/cookies/index.ts",
       "types": "./dist/cookies/index.d.mts",
       "default": "./dist/cookies/index.mjs"
     },
     "./oauth2": {
-      "better-auth-dev-source": "./src/oauth2/index.ts",
+      "dev-source": "./src/oauth2/index.ts",
       "types": "./dist/oauth2/index.d.mts",
       "default": "./dist/oauth2/index.mjs"
     },
     "./react": {
-      "better-auth-dev-source": "./src/client/react/index.ts",
+      "dev-source": "./src/client/react/index.ts",
       "types": "./dist/client/react/index.d.mts",
       "default": "./dist/client/react/index.mjs"
     },
     "./solid": {
-      "better-auth-dev-source": "./src/client/solid/index.ts",
+      "dev-source": "./src/client/solid/index.ts",
       "types": "./dist/client/solid/index.d.mts",
       "default": "./dist/client/solid/index.mjs"
     },
     "./lynx": {
-      "better-auth-dev-source": "./src/client/lynx/index.ts",
+      "dev-source": "./src/client/lynx/index.ts",
       "types": "./dist/client/lynx/index.d.mts",
       "default": "./dist/client/lynx/index.mjs"
     },
     "./test": {
-      "better-auth-dev-source": "./src/test-utils/index.ts",
+      "dev-source": "./src/test-utils/index.ts",
       "types": "./dist/test-utils/index.d.mts",
       "default": "./dist/test-utils/index.mjs"
     },
     "./api": {
-      "better-auth-dev-source": "./src/api/index.ts",
+      "dev-source": "./src/api/index.ts",
       "types": "./dist/api/index.d.mts",
       "default": "./dist/api/index.mjs"
     },
     "./db": {
-      "better-auth-dev-source": "./src/db/index.ts",
+      "dev-source": "./src/db/index.ts",
       "types": "./dist/db/index.d.mts",
       "default": "./dist/db/index.mjs"
     },
     "./vue": {
-      "better-auth-dev-source": "./src/client/vue/index.ts",
+      "dev-source": "./src/client/vue/index.ts",
       "types": "./dist/client/vue/index.d.mts",
       "default": "./dist/client/vue/index.mjs"
     },
     "./plugins": {
-      "better-auth-dev-source": "./src/plugins/index.ts",
+      "dev-source": "./src/plugins/index.ts",
       "types": "./dist/plugins/index.d.mts",
       "default": "./dist/plugins/index.mjs"
     },
     "./svelte-kit": {
-      "better-auth-dev-source": "./src/integrations/svelte-kit.ts",
+      "dev-source": "./src/integrations/svelte-kit.ts",
       "types": "./dist/integrations/svelte-kit.d.mts",
       "default": "./dist/integrations/svelte-kit.mjs"
     },
     "./solid-start": {
-      "better-auth-dev-source": "./src/integrations/solid-start.ts",
+      "dev-source": "./src/integrations/solid-start.ts",
       "types": "./dist/integrations/solid-start.d.mts",
       "default": "./dist/integrations/solid-start.mjs"
     },
     "./svelte": {
-      "better-auth-dev-source": "./src/client/svelte/index.ts",
+      "dev-source": "./src/client/svelte/index.ts",
       "types": "./dist/client/svelte/index.d.mts",
       "default": "./dist/client/svelte/index.mjs"
     },
     "./next-js": {
-      "better-auth-dev-source": "./src/integrations/next-js.ts",
+      "dev-source": "./src/integrations/next-js.ts",
       "types": "./dist/integrations/next-js.d.mts",
       "default": "./dist/integrations/next-js.mjs"
     },
     "./react-start": {
-      "better-auth-dev-source": "./src/integrations/react-start.ts",
+      "dev-source": "./src/integrations/react-start.ts",
       "types": "./dist/integrations/react-start.d.mts",
       "default": "./dist/integrations/react-start.mjs"
     },
     "./node": {
-      "better-auth-dev-source": "./src/integrations/node.ts",
+      "dev-source": "./src/integrations/node.ts",
       "types": "./dist/integrations/node.d.mts",
       "default": "./dist/integrations/node.mjs"
     },
     "./adapters/prisma": {
-      "better-auth-dev-source": "./src/adapters/prisma-adapter/index.ts",
+      "dev-source": "./src/adapters/prisma-adapter/index.ts",
       "types": "./dist/adapters/prisma-adapter/index.d.mts",
       "default": "./dist/adapters/prisma-adapter/index.mjs"
     },
     "./adapters/drizzle": {
-      "better-auth-dev-source": "./src/adapters/drizzle-adapter/index.ts",
+      "dev-source": "./src/adapters/drizzle-adapter/index.ts",
       "types": "./dist/adapters/drizzle-adapter/index.d.mts",
       "default": "./dist/adapters/drizzle-adapter/index.mjs"
     },
     "./adapters/mongodb": {
-      "better-auth-dev-source": "./src/adapters/mongodb-adapter/index.ts",
+      "dev-source": "./src/adapters/mongodb-adapter/index.ts",
       "types": "./dist/adapters/mongodb-adapter/index.d.mts",
       "default": "./dist/adapters/mongodb-adapter/index.mjs"
     },
     "./adapters/memory": {
-      "better-auth-dev-source": "./src/adapters/memory-adapter/index.ts",
+      "dev-source": "./src/adapters/memory-adapter/index.ts",
       "types": "./dist/adapters/memory-adapter/index.d.mts",
       "default": "./dist/adapters/memory-adapter/index.mjs"
     },
     "./adapters/test": {
-      "better-auth-dev-source": "./src/adapters/test.ts",
+      "dev-source": "./src/adapters/test.ts",
       "types": "./dist/adapters/test.d.mts",
       "default": "./dist/adapters/test.mjs"
     },
     "./adapters": {
-      "better-auth-dev-source": "./src/adapters/index.ts",
+      "dev-source": "./src/adapters/index.ts",
       "types": "./dist/adapters/index.d.mts",
       "default": "./dist/adapters/index.mjs"
     },
     "./plugins/access": {
-      "better-auth-dev-source": "./src/plugins/access/index.ts",
+      "dev-source": "./src/plugins/access/index.ts",
       "types": "./dist/plugins/access/index.d.mts",
       "default": "./dist/plugins/access/index.mjs"
     },
     "./plugins/admin": {
-      "better-auth-dev-source": "./src/plugins/admin/index.ts",
+      "dev-source": "./src/plugins/admin/index.ts",
       "types": "./dist/plugins/admin/index.d.mts",
       "default": "./dist/plugins/admin/index.mjs"
     },
     "./plugins/admin/access": {
-      "better-auth-dev-source": "./src/plugins/admin/access/index.ts",
+      "dev-source": "./src/plugins/admin/access/index.ts",
       "types": "./dist/plugins/admin/access/index.d.mts",
       "default": "./dist/plugins/admin/access/index.mjs"
     },
     "./plugins/anonymous": {
-      "better-auth-dev-source": "./src/plugins/anonymous/index.ts",
+      "dev-source": "./src/plugins/anonymous/index.ts",
       "types": "./dist/plugins/anonymous/index.d.mts",
       "default": "./dist/plugins/anonymous/index.mjs"
     },
     "./plugins/bearer": {
-      "better-auth-dev-source": "./src/plugins/bearer/index.ts",
+      "dev-source": "./src/plugins/bearer/index.ts",
       "types": "./dist/plugins/bearer/index.d.mts",
       "default": "./dist/plugins/bearer/index.mjs"
     },
     "./plugins/custom-session": {
-      "better-auth-dev-source": "./src/plugins/custom-session/index.ts",
+      "dev-source": "./src/plugins/custom-session/index.ts",
       "types": "./dist/plugins/custom-session/index.d.mts",
       "default": "./dist/plugins/custom-session/index.mjs"
     },
     "./plugins/email-otp": {
-      "better-auth-dev-source": "./src/plugins/email-otp/index.ts",
+      "dev-source": "./src/plugins/email-otp/index.ts",
       "types": "./dist/plugins/email-otp/index.d.mts",
       "default": "./dist/plugins/email-otp/index.mjs"
     },
     "./plugins/generic-oauth": {
-      "better-auth-dev-source": "./src/plugins/generic-oauth/index.ts",
+      "dev-source": "./src/plugins/generic-oauth/index.ts",
       "types": "./dist/plugins/generic-oauth/index.d.mts",
       "default": "./dist/plugins/generic-oauth/index.mjs"
     },
     "./plugins/jwt": {
-      "better-auth-dev-source": "./src/plugins/jwt/index.ts",
+      "dev-source": "./src/plugins/jwt/index.ts",
       "types": "./dist/plugins/jwt/index.d.mts",
       "default": "./dist/plugins/jwt/index.mjs"
     },
     "./plugins/haveibeenpwned": {
-      "better-auth-dev-source": "./src/plugins/haveibeenpwned/index.ts",
+      "dev-source": "./src/plugins/haveibeenpwned/index.ts",
       "types": "./dist/plugins/haveibeenpwned/index.d.mts",
       "default": "./dist/plugins/haveibeenpwned/index.mjs"
     },
     "./plugins/oidc-provider": {
-      "better-auth-dev-source": "./src/plugins/oidc-provider/index.ts",
+      "dev-source": "./src/plugins/oidc-provider/index.ts",
       "types": "./dist/plugins/oidc-provider/index.d.mts",
       "default": "./dist/plugins/oidc-provider/index.mjs"
     },
     "./plugins/magic-link": {
-      "better-auth-dev-source": "./src/plugins/magic-link/index.ts",
+      "dev-source": "./src/plugins/magic-link/index.ts",
       "types": "./dist/plugins/magic-link/index.d.mts",
       "default": "./dist/plugins/magic-link/index.mjs"
     },
     "./plugins/multi-session": {
-      "better-auth-dev-source": "./src/plugins/multi-session/index.ts",
+      "dev-source": "./src/plugins/multi-session/index.ts",
       "types": "./dist/plugins/multi-session/index.d.mts",
       "default": "./dist/plugins/multi-session/index.mjs"
     },
     "./plugins/oauth-proxy": {
-      "better-auth-dev-source": "./src/plugins/oauth-proxy/index.ts",
+      "dev-source": "./src/plugins/oauth-proxy/index.ts",
       "types": "./dist/plugins/oauth-proxy/index.d.mts",
       "default": "./dist/plugins/oauth-proxy/index.mjs"
     },
     "./plugins/organization": {
-      "better-auth-dev-source": "./src/plugins/organization/index.ts",
+      "dev-source": "./src/plugins/organization/index.ts",
       "types": "./dist/plugins/organization/index.d.mts",
       "default": "./dist/plugins/organization/index.mjs"
     },
     "./plugins/organization/access": {
-      "better-auth-dev-source": "./src/plugins/organization/access/index.ts",
+      "dev-source": "./src/plugins/organization/access/index.ts",
       "types": "./dist/plugins/organization/access/index.d.mts",
       "default": "./dist/plugins/organization/access/index.mjs"
     },
     "./plugins/one-time-token": {
-      "better-auth-dev-source": "./src/plugins/one-time-token/index.ts",
+      "dev-source": "./src/plugins/one-time-token/index.ts",
       "types": "./dist/plugins/one-time-token/index.d.mts",
       "default": "./dist/plugins/one-time-token/index.mjs"
     },
     "./plugins/phone-number": {
-      "better-auth-dev-source": "./src/plugins/phone-number/index.ts",
+      "dev-source": "./src/plugins/phone-number/index.ts",
       "types": "./dist/plugins/phone-number/index.d.mts",
       "default": "./dist/plugins/phone-number/index.mjs"
     },
     "./plugins/two-factor": {
-      "better-auth-dev-source": "./src/plugins/two-factor/index.ts",
+      "dev-source": "./src/plugins/two-factor/index.ts",
       "types": "./dist/plugins/two-factor/index.d.mts",
       "default": "./dist/plugins/two-factor/index.mjs"
     },
     "./plugins/username": {
-      "better-auth-dev-source": "./src/plugins/username/index.ts",
+      "dev-source": "./src/plugins/username/index.ts",
       "types": "./dist/plugins/username/index.d.mts",
       "default": "./dist/plugins/username/index.mjs"
     },
     "./plugins/siwe": {
-      "better-auth-dev-source": "./src/plugins/siwe/index.ts",
+      "dev-source": "./src/plugins/siwe/index.ts",
       "types": "./dist/plugins/siwe/index.d.mts",
       "default": "./dist/plugins/siwe/index.mjs"
     },
     "./plugins/device-authorization": {
-      "better-auth-dev-source": "./src/plugins/device-authorization/index.ts",
+      "dev-source": "./src/plugins/device-authorization/index.ts",
       "types": "./dist/plugins/device-authorization/index.d.mts",
       "default": "./dist/plugins/device-authorization/index.mjs"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,57 +7,57 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "better-auth-dev-source": "./src/index.ts",
+      "dev-source": "./src/index.ts",
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "./api": {
-      "better-auth-dev-source": "./src/api/index.ts",
+      "dev-source": "./src/api/index.ts",
       "types": "./dist/api/index.d.mts",
       "default": "./dist/api/index.mjs"
     },
     "./async_hooks": {
-      "better-auth-dev-source": "./src/async_hooks/index.ts",
+      "dev-source": "./src/async_hooks/index.ts",
       "types": "./dist/async_hooks/index.d.mts",
       "default": "./dist/async_hooks/index.mjs"
     },
     "./context": {
-      "better-auth-dev-source": "./src/context/index.ts",
+      "dev-source": "./src/context/index.ts",
       "types": "./dist/context/index.d.mts",
       "default": "./dist/context/index.mjs"
     },
     "./env": {
-      "better-auth-dev-source": "./src/env/index.ts",
+      "dev-source": "./src/env/index.ts",
       "types": "./dist/env/index.d.mts",
       "default": "./dist/env/index.mjs"
     },
     "./error": {
-      "better-auth-dev-source": "./src/error/index.ts",
+      "dev-source": "./src/error/index.ts",
       "types": "./dist/error/index.d.mts",
       "default": "./dist/error/index.mjs"
     },
     "./utils": {
-      "better-auth-dev-source": "./src/utils/index.ts",
+      "dev-source": "./src/utils/index.ts",
       "types": "./dist/utils/index.d.mts",
       "default": "./dist/utils/index.mjs"
     },
     "./social-providers": {
-      "better-auth-dev-source": "./src/social-providers/index.ts",
+      "dev-source": "./src/social-providers/index.ts",
       "types": "./dist/social-providers/index.d.mts",
       "default": "./dist/social-providers/index.mjs"
     },
     "./db": {
-      "better-auth-dev-source": "./src/db/index.ts",
+      "dev-source": "./src/db/index.ts",
       "types": "./dist/db/index.d.mts",
       "default": "./dist/db/index.mjs"
     },
     "./db/adapter": {
-      "better-auth-dev-source": "./src/db/adapter/index.ts",
+      "dev-source": "./src/db/adapter/index.ts",
       "types": "./dist/db/adapter/index.d.mts",
       "default": "./dist/db/adapter/index.mjs"
     },
     "./oauth2": {
-      "better-auth-dev-source": "./src/oauth2/index.ts",
+      "dev-source": "./src/oauth2/index.ts",
       "types": "./dist/oauth2/index.d.mts",
       "default": "./dist/oauth2/index.mjs"
     }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -19,12 +19,12 @@
   },
   "exports": {
     ".": {
-      "better-auth-dev-source": "./src/index.ts",
+      "dev-source": "./src/index.ts",
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "./client": {
-      "better-auth-dev-source": "./src/client.ts",
+      "dev-source": "./src/client.ts",
       "types": "./dist/client.d.mts",
       "default": "./dist/client.mjs"
     }

--- a/packages/passkey/package.json
+++ b/packages/passkey/package.json
@@ -16,12 +16,12 @@
   },
   "exports": {
     ".": {
-      "better-auth-dev-source": "./src/index.ts",
+      "dev-source": "./src/index.ts",
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "./client": {
-      "better-auth-dev-source": "./src/client.ts",
+      "dev-source": "./src/client.ts",
       "types": "./dist/client.d.mts",
       "default": "./dist/client.mjs"
     }

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -36,12 +36,12 @@
   },
   "exports": {
     ".": {
-      "better-auth-dev-source": "./src/index.ts",
+      "dev-source": "./src/index.ts",
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "./client": {
-      "better-auth-dev-source": "./src/client.ts",
+      "dev-source": "./src/client.ts",
       "types": "./dist/client.d.mts",
       "default": "./dist/client.mjs"
     }

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -29,12 +29,12 @@
   },
   "exports": {
     ".": {
-      "better-auth-dev-source": "./src/index.ts",
+      "dev-source": "./src/index.ts",
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "./client": {
-      "better-auth-dev-source": "./src/client.ts",
+      "dev-source": "./src/client.ts",
       "types": "./dist/client.d.mts",
       "default": "./dist/client.mjs"
     }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -7,7 +7,7 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "better-auth-dev-source": "./src/index.ts",
+      "dev-source": "./src/index.ts",
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,7 +23,7 @@
     // A custom condition that can be set to the "exports" filed in package.json
     // and it should directs to the source .ts files. This enables the
     // jump-to-definition feature in IDEs to function properly.
-    "customConditions": ["better-auth-dev-source"]
+    "customConditions": ["dev-source"]
   },
   "exclude": ["**/dist/**", "**/node_modules/**"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the custom exports condition from better-auth-dev-source to dev-source across all packages and updated tsconfig.base.json. This preserves IDE jump-to-definition and has no runtime impact.

- **Migration**
  - If any external tooling referenced better-auth-dev-source, update it to dev-source.

<sup>Written for commit d28b3f9c8d0a4c498c5235065e8cc53bcee35b61. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

