### PR TITLE
fix:#5849 default value in  prisma schema

### DIFF
--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -163,19 +163,21 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 				if (attr.unique) {
 					builder.model(modelName).blockAttribute(`unique([${fieldName}])`);
 				}
-
+				
 				if (attr.defaultValue !== undefined) {
 					if (field === "createdAt") {
 						fieldBuilder.attribute("default(now())");
-					} else if (typeof attr.defaultValue === "boolean") {
+					}else if (typeof attr.defaultValue === "string"){
+							fieldBuilder.attribute(`default("${attr.defaultValue}")`);
+					} else if (typeof attr.defaultValue === "boolean" || typeof attr.defaultValue === "number"){
 						fieldBuilder.attribute(`default(${attr.defaultValue})`);
-					} else if (typeof attr.defaultValue === "function") {
+					}
+					else if (typeof attr.defaultValue === "function") {
 						// we are intentionally not adding the default value here
 						// this is because if the defaultValue is a function, it could have
 						// custom logic within that function that might not work in prisma's context.
 					}
 				}
-
 				// This is a special handling for updatedAt fields
 				if (field === "updatedAt" && attr.onUpdate) {
 					fieldBuilder.attribute("updatedAt");


### PR DESCRIPTION
as mentioned in #5849 the default value for Prisma schema where not generating properly, 
it was because it was only looking out for the types other  than number.

```
 additionalFields: {
      role: {
        type: "string",
        required: false,
        defaultValue: "user",
        input: false,
      },
    },
```

**before**

> **schema.prisma**

```
model User {
  id            String    @id @default(uuid())
  name          String
  email         String
  emailVerified Boolean   @default(false)
  role String?
  createdAt     DateTime  @default(now())
  updatedAt     DateTime  @default(now()) @updatedAt


  @@unique([email])
  @@map("user")
}
```

after

> **schema.prisma**
```
model User {
  id            String    @id @default(uuid())
  name          String
  email         String
  emailVerified Boolean   @default(false)
  role String? @default("user")
  createdAt     DateTime  @default(now())
  updatedAt     DateTime  @default(now()) @updatedAt
  

 

  @@unique([email])
  @@map("user")
}
```

now it adds the default value inPrisma schema
solves  #5849.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5849: Prisma schema generator now correctly emits default values for string, number, and boolean fields. Example: role String? becomes role String? @default("user").

- **Bug Fixes**
  - Add quoting for string defaults: default("value").
  - Support numeric and boolean defaults: default(123), default(false).
  - Preserve special cases: createdAt default(now()), updatedAt @updatedAt.
  - Skip function defaults to avoid invalid Prisma output.

<sup>Written for commit 7c54162238249c9cd29222a6c32aa9df0ad95a11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

