### PR TITLE
docs(one-tap): add note for Authorised JavaScript origins

### DIFF
--- a/docs/content/docs/plugins/one-tap.mdx
+++ b/docs/content/docs/plugins/one-tap.mdx
@@ -121,3 +121,6 @@ await authClient.oneTap({
 - **disableSignUp**:  Disable the sign-up option, allowing only existing users to sign in. Default is `false`.
 - **ClientId**: Optionally, pass a client ID here if it is not provided in your social provider configuration.
 
+### Authorised JavaScript origins
+Ensure you have configured the Authorised JavaScript origins (e.g., http://localhost:3000, https://example.com) for your Client ID in the Google Cloud Console. This is a required step for the Google One Tap API, and it will not function correctly unless your origins are correctly set.
+


### PR DESCRIPTION
Added information about configuring Authorised JavaScript origins for Google One Tap API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a note to the One Tap docs to configure Authorised JavaScript origins for your Google Client ID. This ensures One Tap initializes correctly in local and production environments.

<sup>Written for commit 50b8bdd2fdb41819a6166811ef0b0b7fbe698d14. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

