### PR TITLE
fix:#5849 default value in prisma schema #5858

### DIFF
--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -163,7 +163,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 				if (attr.unique) {
 					builder.model(modelName).blockAttribute(`unique([${fieldName}])`);
 				}
-				
+
 				if (attr.defaultValue !== undefined) {
 					if (field === "createdAt") {
 						fieldBuilder.attribute("default(now())");
@@ -176,8 +176,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 						typeof attr.defaultValue === "number"
 					) {
 						fieldBuilder.attribute(`default(${attr.defaultValue})`);
-					}
-					else if (typeof attr.defaultValue === "function") {
+					} else if (typeof attr.defaultValue === "function") {
 						// we are intentionally not adding the default value here
 						// this is because if the defaultValue is a function, it could have
 						// custom logic within that function that might not work in prisma's context.

--- a/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
+++ b/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
@@ -106,7 +106,7 @@ model Member {
   workspace      Workspace @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   userId         String
   user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  role           String    @db.Text
+  role           String    @default("member") @db.Text
   createdAt      DateTime
 
   @@map("member")
@@ -118,7 +118,7 @@ model WorkspaceInvitation {
   workspace      Workspace @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   email          String    @db.Text
   role           String?   @db.Text
-  status         String    @db.Text
+  status         String    @default("pending") @db.Text
   expiresAt      DateTime
   createdAt      DateTime  @default(now())
   inviterId      String


### PR DESCRIPTION
as mentioned in #5849 the default value for Prisma schema where not generating properly, 
it was because it was only looking out for the types other  than number.

```
 additionalFields: {
      role: {
        type: "string",
        required: false,
        defaultValue: "user",
        input: false,
      },
    },
```

**before**

> **schema.prisma**

```
model User {
  id            String    @id @default(uuid())
  name          String
  email         String
  emailVerified Boolean   @default(false)
  role String?
  createdAt     DateTime  @default(now())
  updatedAt     DateTime  @default(now()) @updatedAt


  @@unique([email])
  @@map("user")
}
```

after

> **schema.prisma**
```
model User {
  id            String    @id @default(uuid())
  name          String
  email         String
  emailVerified Boolean   @default(false)
  role String? @default("user")
  createdAt     DateTime  @default(now())
  updatedAt     DateTime  @default(now()) @updatedAt
  

 

  @@unique([email])
  @@map("user")
}
```

now it adds the default value inPrisma schema
solves  #5849.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5849: Prisma schema generator now correctly emits default values for string, number, and boolean fields. Example: role String? becomes role String? @default("user").

- **Bug Fixes**
  - Add quoting for string defaults: default("value").
  - Support numeric and boolean defaults: default(123), default(false).
  - Preserve special cases: createdAt default(now()), updatedAt @updatedAt.
  - Skip function defaults to avoid invalid Prisma output.

<sup>Written for commit 7375631b406207f230b2a5f8b7c3ad28e42e5335. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



