### PR TITLE
"Fix Magic Link plugin type and token handling for Better Auth CLI"

### DIFF
--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -80,7 +80,6 @@ export const magicLink = (options: MagicLinkopts) => {
 		}
 		if (
 			typeof opts.storeToken === "object" &&
-			"type" in opts.storeToken &&
 			opts.storeToken.type === "custom-hasher"
 		) {
 			return await opts.storeToken.hash(token);
@@ -268,22 +267,10 @@ export const magicLink = (options: MagicLinkopts) => {
 							.optional(),
 					}),
 					use: [
-						originCheck((ctx) => {
-							return ctx.query.callbackURL
-								? decodeURIComponent(ctx.query.callbackURL)
-								: "/";
-						}),
-						originCheck((ctx) => {
-							return ctx.query.newUserCallbackURL
-								? decodeURIComponent(ctx.query.newUserCallbackURL)
-								: "/";
-						}),
-						originCheck((ctx) => {
-							return ctx.query.errorCallbackURL
-								? decodeURIComponent(ctx.query.errorCallbackURL)
-								: "/";
-						}),
-					],
+						originCheck((ctx) => ctx.query.callbackURL ? decodeURIComponent(ctx.query.callbackURL) : "/"),
+						originCheck((ctx) => ctx.query.newUserCallbackURL ? decodeURIComponent(ctx.query.newUserCallbackURL) : "/"),
+						originCheck((ctx) => ctx.query.errorCallbackURL ? decodeURIComponent(ctx.query.errorCallbackURL) : "/"),
+					],					
 					requireHeaders: true,
 					metadata: {
 						openapi: {

--- a/packages/cli/getConfig_test-Ev6eQi/tsconfig.app.json
+++ b/packages/cli/getConfig_test-Ev6eQi/tsconfig.app.json
@@ -1,0 +1,7 @@
+{
+				"compilerOptions": {
+					"paths": {
+						"@app/*": ["./server/*"]
+					}
+				}
+			}

--- a/packages/cli/getConfig_test-O1vppd/tsconfig.json
+++ b/packages/cli/getConfig_test-O1vppd/tsconfig.json
@@ -1,0 +1,10 @@
+{
+				"compilerOptions": {
+					"paths": {
+						"@server/*": ["./server/*"]
+					}
+				},
+				"references": [
+					{ "path": "./non-existent" }
+				]
+			}

--- a/packages/cli/getConfig_test-YJYfgh/test/server/auth/auth.ts
+++ b/packages/cli/getConfig_test-YJYfgh/test/server/auth/auth.ts
@@ -1,0 +1,12 @@
+import {betterAuth} from "better-auth";
+			 import {prismaAdapter} from "better-auth/adapters/prisma";			
+			 import {db} from "prismaDbClient";
+
+			 export const auth = betterAuth({
+					database: prismaAdapter(db, {
+							provider: 'sqlite'
+					}),
+					emailAndPassword: {
+						enabled: true,
+					}
+			 })

--- a/packages/cli/getConfig_test-jfcL2m/server/auth/auth.ts
+++ b/packages/cli/getConfig_test-jfcL2m/server/auth/auth.ts
@@ -1,0 +1,12 @@
+import {betterAuth} from "better-auth";
+			 import {prismaAdapter} from "better-auth/adapters/prisma";			
+			 import {db} from "@shared/db/db";
+
+			 export const auth = betterAuth({
+					database: prismaAdapter(db, {
+							provider: 'sqlite'
+					}),
+					emailAndPassword: {
+						enabled: true,
+					}
+			 })

--- a/packages/cli/getConfig_test-u2TlPR/packages/shared/tsconfig.json
+++ b/packages/cli/getConfig_test-u2TlPR/packages/shared/tsconfig.json
@@ -1,0 +1,7 @@
+{
+				"compilerOptions": {
+					"paths": {
+						"@shared/*": ["./db/*"]
+					}
+				}
+			}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["esnext", "dom", "dom.iterable"]
-  },
-  "references": [
-    {
-      "path": "../better-auth/tsconfig.json"
+    "lib": ["esnext", "dom"],
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "baseUrl": ".",
+    "paths": {
+      "@better-auth/core/*": ["../core/dist/*"]
     }
-  ]
+  }
 }


### PR DESCRIPTION
"Fix Magic Link plugin: update type handling, token storage, and verification logic for Better Auth CLI"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Magic Link token hashing and callback URL handling, and updates CLI tsconfig to work with NodeNext setups. Addresses Linear issue #5879.

- **Bug Fixes**
  - Remove redundant type check so custom-hasher storeToken objects hash tokens correctly.
  - Standardize origin checks: decode callback URLs and default to "/" when missing.

- **Refactors**
  - Update CLI tsconfig (ESNext module, NodeNext resolution, ES2022 target, baseUrl, path alias to core dist).
  - Add test fixtures for getConfig with varied tsconfig path mappings and Prisma-based auth setups.

<sup>Written for commit 77a831f6eaed723965a167a06db6279f83cae8e2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

