### PR TITLE
chore: sort out exports

### DIFF
--- a/packages/better-auth/src/index.ts
+++ b/packages/better-auth/src/index.ts
@@ -8,9 +8,7 @@ export * from "@better-auth/core/error";
 export * from "@better-auth/core/oauth2";
 export * from "@better-auth/core/utils";
 //#endregion
-export type * from "better-call";
 export * from "./auth";
-export type * from "./plugins/access";
 export * from "./types";
 export * from "./utils";
 // export this as we are referencing OAuth2Tokens in the `refresh-token` api as return type
@@ -22,6 +20,7 @@ export {
 	type TelemetryEvent,
 } from "@better-auth/telemetry";
 // re-export third party types
+export type * from "better-call";
 export type { JSONWebKeySet, JWTPayload } from "jose";
 export type * from "zod";
 export type * from "zod/v4";

--- a/packages/better-auth/src/plugins/index.ts
+++ b/packages/better-auth/src/plugins/index.ts
@@ -10,6 +10,7 @@ export {
 } from "@better-auth/core/api";
 export * from "../types/plugins";
 export * from "../utils/hide-metadata";
+export * from "./access";
 export * from "./admin";
 export * from "./anonymous";
 export * from "./api-key";

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -272,7 +272,7 @@ export type OrganizationSchema<O extends OrganizationOptions> =
 					};
 				};
 
-export const role = z.string();
+export const roleSchema = z.string();
 export const invitationStatus = z
 	.enum(["pending", "accepted", "rejected", "canceled"])
 	.default("pending");
@@ -293,7 +293,7 @@ export const memberSchema = z.object({
 	id: z.string().default(generateId),
 	organizationId: z.string(),
 	userId: z.coerce.string(),
-	role,
+	role: roleSchema,
 	createdAt: z.date().default(() => new Date()),
 });
 
@@ -301,7 +301,7 @@ export const invitationSchema = z.object({
 	id: z.string().default(generateId),
 	organizationId: z.string(),
 	email: z.string(),
-	role,
+	role: roleSchema,
 	status: invitationStatus,
 	teamId: z.string().nullish(),
 	inviterId: z.string(),


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamlined exports and clarified organization schema naming to make imports consistent and easier to use. Access plugin is now exported from the plugins entrypoint, and better-call types are re-exported with third-party types.

- **Refactors**
  - Moved access plugin export to the plugins index; removed its type export from the root.
  - Re-exported better-call types from the root alongside third-party types.
  - Renamed organization role to roleSchema and updated references.

- **Migration**
  - Import the access plugin from the plugins entrypoint instead of the root.
  - Replace any imports of role with roleSchema.

<sup>Written for commit f7c04a15f41f7307bd0f3b5adc1dcc07ab21734c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



