### PR TITLE
docs: fix incorrect oidc provider schema link

### DIFF
--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -49,7 +49,7 @@ The **MCP** plugin lets your app act as an OAuth provider for MCP clients. It ha
             ```
             </Tab>
         </Tabs>
-        The MCP plugin uses the same schema as the OIDC Provider plugin. See the [OIDC Provider Schema](#schema) section for details.
+        The MCP plugin uses the same schema as the OIDC Provider plugin. See the [OIDC Provider Schema](/docs/plugins/oidc-provider#schema) section for details.
     </Step>
 </Steps>
 
@@ -236,4 +236,4 @@ The plugin supports additional OIDC configuration options through the `oidcConfi
 
 ## Schema
 
-The MCP plugin uses the same schema as the OIDC Provider plugin. See the [OIDC Provider Schema](#schema) section for details.
+The MCP plugin uses the same schema as the OIDC Provider plugin. See the [OIDC Provider Schema](/docs/plugins/oidc-provider#schema) section for details.


### PR DESCRIPTION
This PR fixes incorrect link in MCP doc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect OIDC Provider Schema links in the MCP plugin docs so they point to the correct page. Updated both references to use /docs/plugins/oidc-provider#schema to restore navigation.

<sup>Written for commit d201b76e3672dac823207f4df0e8d990bb22c4e3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

