### PR TITLE
docs: remove extra spaces to make copying and searching easier.

### DIFF
--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -52,7 +52,7 @@ The phone number plugin extends the authentication system by allowing users to s
         import { createAuthClient } from "better-auth/client"
         import { phoneNumberClient } from "better-auth/client/plugins"
 
-        const authClient =  createAuthClient({
+        const authClient = createAuthClient({
             plugins: [ // [!code highlight]
                 phoneNumberClient() // [!code highlight]
             ] // [!code highlight]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up spacing in the phone-number plugin docs example to make copying and text search more reliable. Replaced the double space in the authClient initialization with a single space.

<sup>Written for commit 857aa37314cdc8ff1227082c8ed803e04ce81426. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

