### PR TITLE
test: no hanging promise

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2234,7 +2234,7 @@ describe("Additional Fields", async () => {
 	});
 
 	it("get active member", async () => {
-		auth.api.setActiveOrganization({
+		await auth.api.setActiveOrganization({
 			body: { organizationId: org.id },
 			headers: addedMemberHeaders,
 		});


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/actions/runs/19255020378/job/55047819906?pr=5891

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added await to auth.api.setActiveOrganization in organization.test to prevent a hanging promise. Stabilizes the “get active member” test and fixes the failing CI run.

<sup>Written for commit 9a2bae590f30346e514981814da0a68b05c7d33f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

