### PR TITLE
feat(prisma): Enhance JSON default value handling for arrays and objects in schema generation

### DIFF
--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -181,9 +181,70 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 				}
 
 				if (attr.defaultValue !== undefined) {
+					if (Array.isArray(attr.defaultValue)) {
+						// for json objects and array of object 
+
+						if (attr.type === "json") {
+							if (
+								Object.prototype.toString.call(attr.defaultValue[0]) ===
+								"[object Object]"
+							) {
+								fieldBuilder.attribute(
+									`default("${JSON.stringify(attr.defaultValue).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}")`,
+								);
+								continue;
+							}
+							let jsonArray = [];
+							for (const value of attr.defaultValue) jsonArray.push(`${value}`);
+							fieldBuilder.attribute(
+								`default("${JSON.stringify(jsonArray).replace(/"/g, '\\"')}")`,
+							);
+							continue;
+						}
+
+						if (!attr.defaultValue[0]) {
+							fieldBuilder.attribute(`default([])`);
+							continue;
+						} else if (
+							typeof attr.defaultValue[0] === "string" &&
+							attr.type === "string[]"
+						) {
+							let valueArray = [];
+							for (const value of attr.defaultValue)
+								valueArray.push(`"${value}"`);
+							fieldBuilder.attribute(`default([${valueArray}])`);
+						} else if (typeof attr.defaultValue[0] === "number") {
+							let valueArray = [];
+							for (const value of attr.defaultValue)
+								valueArray.push(`${value}`);
+							fieldBuilder.attribute(`default([${valueArray}])`);
+						}
+					}
+					// for json objects
+					else if (
+						typeof attr.defaultValue === "object" &&
+						!Array.isArray(attr.defaultValue) &&
+						attr.defaultValue !== null
+					) {
+						if (
+							Object.entries(attr.defaultValue as Record<string, any>)
+								.length === 0
+						) {
+							fieldBuilder.attribute(`default("{}")`);
+							continue;
+						}
+						fieldBuilder.attribute(
+							`default("${JSON.stringify(attr.defaultValue).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}")`,
+						);
+					}
 					if (field === "createdAt") {
 						fieldBuilder.attribute("default(now())");
-					} else if (typeof attr.defaultValue === "boolean") {
+					} else if (typeof attr.defaultValue === "string" && provider !=="mysql" ) {
+						fieldBuilder.attribute(`default("${attr.defaultValue}")`);
+					} else if (
+						typeof attr.defaultValue === "boolean" ||
+						typeof attr.defaultValue === "number"
+					) {
 						fieldBuilder.attribute(`default(${attr.defaultValue})`);
 					} else if (typeof attr.defaultValue === "function") {
 						// we are intentionally not adding the default value here

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -360,6 +360,45 @@ describe("JSON field support in CLI generators", () => {
 		});
 		expect(schema.code).toContain("preferences   Json?");
 	});
+
+	it("should generate Prisma schema with JSON default values of arrays and objects", async () => {
+		const schema = await generatePrismaSchema({
+			file: "test.prisma",
+			adapter: {
+				id: "prisma",
+				options: {},
+			} as any,
+			options: {
+				database: {} as any,
+				user: {
+					additionalFields: {
+						preferences: {
+							type: "json",
+							defaultValue: {
+								premiumuser: true,
+							},
+						},
+						metadata: {
+							type: "json",
+							defaultValue: [
+								{
+									name: "john",
+									subscribed: false,
+								},
+								{ name: "doe", subscribed: true },
+							],
+						},
+					},
+				},
+			} as BetterAuthOptions,
+		});
+		expect(schema.code).toContain("preferences   Json?");
+		// expect(schema.code).toContain(JSON.stringify(`@default("{\"premiumuser\":true}")`).slice(1,-1));
+		expect(schema.code).toContain('@default("{\\"premiumuser\\":true}")');
+		expect(schema.code).toContain(
+			'@default("[{\\"name\\":\\"john\\",\\"subscribed\\":false},{\\"name\\":\\"doe\\",\\"subscribed\\":true}]")',
+		);
+	});
 });
 
 describe("Enum field support in Drizzle schemas", () => {

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -31,7 +31,8 @@ export type DBPrimitive =
 	| null
 	| undefined
 	| string[]
-	| number[];
+	| number[]
+	| Object;
 
 export type DBFieldAttributeConfig = {
 	/**


### PR DESCRIPTION
**solves #5900** 

### Added objects and arrays compatibility for default JSON values  with test cases


The default string value is not sorted for mysql ,but will be soon be done with the #5866 PR



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for default JSON objects and arrays in Prisma schema generation, with proper escaping, plus defaults for string[] and number[]. Improves reliability of generated defaults and adds tests.

- **New Features**
  - Support default values for JSON objects and arrays (escaped and quoted).
  - Generate defaults for string[] and number[], including empty arrays.
  - Skip string defaults on MySQL for now.
  - Add tests for JSON defaults and expand DBPrimitive to include Object.

<sup>Written for commit 73465b72206c6a738984db16a14711acfa1a1af2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

