### PR TITLE
docs: update username docs to include enabling `emailAndPassword`

### DIFF
--- a/docs/content/docs/plugins/username.mdx
+++ b/docs/content/docs/plugins/username.mdx
@@ -11,11 +11,14 @@ The username plugin is a lightweight plugin that adds username support to the em
     <Step>
         ### Add Plugin to the server
 
-        ```ts title="auth.ts" 
+        ```ts title="auth.ts"
         import { betterAuth } from "better-auth"
         import { username } from "better-auth/plugins"
 
         export const auth = betterAuth({
+            emailAndPassword: { // [!code highlight]
+                enabled: true, // [!code highlight]
+            }, // [!code highlight]
             plugins: [ // [!code highlight]
                 username() // [!code highlight]
             ] // [!code highlight]
@@ -43,11 +46,11 @@ The username plugin is a lightweight plugin that adds username support to the em
     </Step>
     <Step>
         ### Add the client plugin
-        
+
         ```ts title="auth-client.ts"
         import { createAuthClient } from "better-auth/client"
         import { usernameClient } from "better-auth/client/plugins"
-        
+
         export const authClient = createAuthClient({
             plugins: [ // [!code highlight]
                 usernameClient() // [!code highlight]
@@ -162,6 +165,9 @@ import { betterAuth } from "better-auth"
 import { username } from "better-auth/plugins"
 
 const auth = betterAuth({
+    emailAndPassword: {
+        enabled: true,
+    },
     plugins: [
         username({
             minUsernameLength: 5
@@ -179,6 +185,9 @@ import { betterAuth } from "better-auth"
 import { username } from "better-auth/plugins"
 
 const auth = betterAuth({
+    emailAndPassword: {
+        enabled: true,
+    },
     plugins: [
         username({
             maxUsernameLength: 100
@@ -196,6 +205,9 @@ import { betterAuth } from "better-auth"
 import { username } from "better-auth/plugins"
 
 const auth = betterAuth({
+    emailAndPassword: {
+        enabled: true,
+    },
     plugins: [
         username({
             usernameValidator: (username) => {
@@ -218,6 +230,9 @@ import { betterAuth } from "better-auth"
 import { username } from "better-auth/plugins"
 
 const auth = betterAuth({
+    emailAndPassword: {
+        enabled: true,
+    },
     plugins: [
         username({
             displayUsernameValidator: (displayUsername) => {
@@ -240,6 +255,9 @@ import { betterAuth } from "better-auth"
 import { username } from "better-auth/plugins"
 
 const auth = betterAuth({
+    emailAndPassword: {
+        enabled: true,
+    },
     plugins: [
         username({
             usernameNormalization: (username) => {
@@ -264,11 +282,14 @@ import { betterAuth } from "better-auth"
 import { username } from "better-auth/plugins"
 
 const auth = betterAuth({
+    emailAndPassword: {
+        enabled: true,
+    },
     plugins: [
         username({
             displayUsernameNormalization: (displayUsername) => displayUsername.toLowerCase(),
         })
-    ]   
+    ]
 })
 ```
 
@@ -281,6 +302,9 @@ import { betterAuth } from "better-auth"
 import { username } from "better-auth/plugins"
 
 const auth = betterAuth({
+    emailAndPassword: {
+        enabled: true,
+    },
     plugins: [
         username({
             validationOrder: {
@@ -298,15 +322,15 @@ The plugin requires 2 fields to be added to the user table:
 
 <DatabaseTable
     fields={[
-        { 
-            name: "username", 
-            type: "string", 
+        {
+            name: "username",
+            type: "string",
             description: "The username of the user",
             isUnique: true
         },
-        { 
-            name: "displayUsername", 
-            type: "string", 
+        {
+            name: "displayUsername",
+            type: "string",
             description: "Non normalized username of the user",
             isUnique: true
         },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified username plugin setup by adding `emailAndPassword: { enabled: true }` to server config in all examples and highlighting plugin usage. This makes it clear that username support requires email/password auth to be enabled.

<sup>Written for commit d50f72202e5807b1b379a84141b42a862fba90ba. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

