### PR TITLE
fix(sso): use the internalAdapter for user queries to avoid skipping database hooks

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1584,15 +1584,10 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 			if (existingUser) {
 				user = existingUser;
 			} else {
-				user = await ctx.context.adapter.create({
-					model: "user",
-					data: {
-						email: userInfo.email,
-						name: userInfo.name,
-						emailVerified: userInfo.emailVerified,
-						createdAt: new Date(),
-						updatedAt: new Date(),
-					},
+				user = await ctx.context.internalAdapter.createUser({
+					email: userInfo.email,
+					name: userInfo.name,
+					emailVerified: userInfo.emailVerified,
 				});
 			}
 
@@ -1607,17 +1602,12 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 			});
 
 			if (!account) {
-				await ctx.context.adapter.create<Account>({
-					model: "account",
-					data: {
-						userId: user.id,
-						providerId: provider.providerId,
-						accountId: userInfo.id,
-						createdAt: new Date(),
-						updatedAt: new Date(),
-						accessToken: "",
-						refreshToken: "",
-					},
+				await ctx.context.internalAdapter.createAccount({
+					userId: user.id,
+					providerId: provider.providerId,
+					accountId: userInfo.id,
+					accessToken: "",
+					refreshToken: "",
 				});
 			}
 
@@ -1942,47 +1932,32 @@ export const acsEndpoint = (options?: SSOOptions) => {
 							`${parsedSamlConfig.callbackUrl}?error=account_not_found`,
 						);
 					}
-					await ctx.context.adapter.create<Account>({
-						model: "account",
-						data: {
-							userId: existingUser.id,
-							providerId: provider.providerId,
-							accountId: userInfo.id,
-							createdAt: new Date(),
-							updatedAt: new Date(),
-							accessToken: "",
-							refreshToken: "",
-						},
-					});
-				}
-				user = existingUser;
-			} else {
-				user = await ctx.context.adapter.create({
-					model: "user",
-					data: {
-						email: userInfo.email,
-						name: userInfo.name,
-						emailVerified: options?.trustEmailVerified
-							? userInfo.emailVerified || false
-							: false,
-						createdAt: new Date(),
-						updatedAt: new Date(),
-					},
-				});
-				await ctx.context.adapter.create<Account>({
-					model: "account",
-					data: {
-						userId: user.id,
+					await ctx.context.internalAdapter.createAccount({
+						userId: existingUser.id,
 						providerId: provider.providerId,
 						accountId: userInfo.id,
 						accessToken: "",
 						refreshToken: "",
-						accessTokenExpiresAt: new Date(),
-						refreshTokenExpiresAt: new Date(),
-						scope: "",
-						createdAt: new Date(),
-						updatedAt: new Date(),
-					},
+					});
+				}
+				user = existingUser;
+			} else {
+				user = await ctx.context.internalAdapter.createUser({
+					email: userInfo.email,
+					name: userInfo.name,
+					emailVerified: options?.trustEmailVerified
+						? userInfo.emailVerified || false
+						: false,
+				});
+				await ctx.context.internalAdapter.createAccount({
+					userId: user.id,
+					providerId: provider.providerId,
+					accountId: userInfo.id,
+					accessToken: "",
+					refreshToken: "",
+					accessTokenExpiresAt: new Date(),
+					refreshTokenExpiresAt: new Date(),
+					scope: "",
 				});
 			}
 


### PR DESCRIPTION
I noticed my user database hook wasn't being called when using the SSO plugin. I saw it came from the fact that it uses the adapter directly instead of the internal adapter when creating users and account. This fixes that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch SSO user/account creation to internalAdapter so user database hooks and side effects run during SAML logins. Aligns SSO behavior with standard auth with no API changes.

- **Bug Fixes**
  - Use internalAdapter.createUser/createAccount in callbackSSOSAML and acsEndpoint.
  - Keep existing fields and trustEmailVerified logic; timestamps handled by internal adapter.

<sup>Written for commit 2de4e0a8f2e552b2c99d38bca3da17f460ffaec2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

