### PR TITLE
docs: update the sidebar content order

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1918,24 +1918,6 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				),
 			},
 			{
-				title: "Creem",
-				href: "/docs/plugins/creem",
-				icon: () => (
-					<svg
-						width="1.2em"
-						height="1.2em"
-						viewBox="0 0 54 47"
-						xmlns="http://www.w3.org/2000/svg"
-						preserveAspectRatio="xMidYMid meet"
-					>
-						<path
-							d="M7.44678 1H1L26.9696 46L53 1H9.39298L26.9696 31.4858L30.193 26.0202L19.0632 6.7085H43.3298L26.9696 34.8866L7.44678 1Z"
-							fill="currentColor"
-						/>
-					</svg>
-				),
-			},
-			{
 				title: "Polar",
 				href: "/docs/plugins/polar",
 				icon: () => (
@@ -2025,6 +2007,24 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 								fill="#0D0D0D"
 							/>
 						</g>
+					</svg>
+				),
+			},
+			{
+				title: "Creem",
+				href: "/docs/plugins/creem",
+				icon: () => (
+					<svg
+						width="1.2em"
+						height="1.2em"
+						viewBox="0 0 54 47"
+						xmlns="http://www.w3.org/2000/svg"
+						preserveAspectRatio="xMidYMid meet"
+					>
+						<path
+							d="M7.44678 1H1L26.9696 46L53 1H9.39298L26.9696 31.4858L30.193 26.0202L19.0632 6.7085H43.3298L26.9696 34.8866L7.44678 1Z"
+							fill="currentColor"
+						/>
 					</svg>
 				),
 			},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reordered the docs sidebar Plugins list to improve navigation consistency. Moved “Creem” below “Polar” and above “Dub”; no content changes.

<sup>Written for commit 7b5b0d5b1fe64073165d6a5782aaf5dc7c026e78. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

