### PR TITLE
docs(oidc-provider): add some clear instructions to OIDC provider

### DIFF
--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -85,7 +85,7 @@ Once installed, you can utilize the OIDC Provider to manage authentication flows
 
 ### Register a New Client
 
-To register a new OIDC client, you can use the `oauth2.register` method on either the client or server.
+To register a new OIDC client, use the `oauth2.register` method on the client or `auth.api.registerOAuthApplication` on the server.
 
 <APIMethod 
   path="/oauth2/register" 


### PR DESCRIPTION
This PR adds some clear instructions to OIDC provider doc.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved OIDC Provider docs with clearer client registration guidance and practical UserInfo examples to make setup and integrations easier. Clarifies auth requirements for registration (and how to enable dynamic public registration), maps claims by scope, and adds server/external client snippets plus a full custom-claims example using getAdditionalUserInfoClaim.

<sup>Written for commit eae577dd8e50705a2ca46e68fdd3ad1d5a84dbcb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



