### PR TITLE
docs: fix session table info

### DIFF
--- a/docs/content/docs/concepts/session-management.mdx
+++ b/docs/content/docs/concepts/session-management.mdx
@@ -9,7 +9,8 @@ Better Auth manages session using a traditional cookie-based session management.
 
 The session table stores the session data. The session table has the following fields:
 
-- `id`: The session token. Which is also used as the session cookie.
+- `id`: Unique identifier for the session.
+- `token`: The session token. Which is also used as the session cookie.
 - `userId`: The user ID of the user.
 - `expiresAt`: The expiration date of the session.
 - `ipAddress`: The IP address of the user.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the session table docs to correctly list both id and token. id is the unique session identifier; token is the session cookie.

<sup>Written for commit 3aa2cfb7f8adf1d3d93a615dbeac271e2337df77. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

