### PR TITLE
chore: enable `useDateNow` lint rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,6 +20,7 @@
         "noDelete": "error"
       },
       "complexity": {
+        "useDateNow": "error",
         "noUselessSwitchCase": "warn",
         "noUselessTypeConstraint": "warn"
       },

--- a/demo/nextjs/app/admin/page.tsx
+++ b/demo/nextjs/app/admin/page.tsx
@@ -166,7 +166,7 @@ export default function AdminDashboard() {
 			await client.admin.banUser({
 				userId: banForm.userId,
 				banReason: banForm.reason,
-				banExpiresIn: banForm.expirationDate.getTime() - new Date().getTime(),
+				banExpiresIn: banForm.expirationDate.getTime() - Date.now(),
 			});
 			toast.success("User banned successfully");
 			setIsBanDialogOpen(false);

--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -355,7 +355,7 @@ describe("api-key", async () => {
 
 	it("should create an API key with a custom expiresIn", async () => {
 		const expiresIn = 60 * 60 * 24 * 7; // 7 days
-		const expectedResult = new Date().getTime() + expiresIn;
+		const expectedResult = Date.now() + expiresIn;
 		const apiKey = await auth.api.createApiKey({
 			body: {
 				expiresIn: expiresIn,
@@ -1176,7 +1176,7 @@ describe("api-key", async () => {
 
 	it("should update API key expiresIn value", async () => {
 		const expiresIn = 60 * 60 * 24 * 7; // 7 days
-		const expectedResult = new Date().getTime() + expiresIn;
+		const expectedResult = Date.now() + expiresIn;
 		const apiKey = await auth.api.updateApiKey({
 			body: {
 				keyId: firstApiKey.id,

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -48,7 +48,7 @@ export async function validateApiKey({
 	}
 
 	if (apiKey.expiresAt) {
-		const now = new Date().getTime();
+		const now = Date.now();
 		const expiresAt = new Date(apiKey.expiresAt).getTime();
 		if (now > expiresAt) {
 			try {
@@ -119,7 +119,7 @@ export async function validateApiKey({
 			code: "USAGE_EXCEEDED" as const,
 		});
 	} else if (remaining !== null) {
-		let now = new Date().getTime();
+		let now = Date.now();
 		const refillInterval = apiKey.refillInterval;
 		const refillAmount = apiKey.refillAmount;
 		let lastTime = new Date(lastRefillAt ?? apiKey.createdAt).getTime();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enabled the useDateNow lint rule and refactored time calculations to use Date.now() instead of new Date().getTime(). This standardizes epoch time usage and slightly improves performance in the admin UI and API key logic/tests.

- **Refactors**
  - Config: added "useDateNow": "error" to biome.json.
  - Admin: banExpiresIn now uses Date.now().
  - API key plugin: expiration and refill checks updated to Date.now(); tests adjusted accordingly.

<sup>Written for commit 328c467d381e588315e3a6e159c626aadbdf4ef8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

