### PR TITLE
docs: minor improvements to `state_mismatch` docs

### DIFF
--- a/docs/content/docs/errors/state_mismatch.mdx
+++ b/docs/content/docs/errors/state_mismatch.mdx
@@ -16,7 +16,7 @@ same browser session that started it.
 
 ## Common Causes
 
-* The cookie wasn't set or readable during callback (common with .vercel.app preview domains or cross-domain issues).
+* The cookie wasn't set or readable during callback (common with `.vercel.app` preview domains or cross-domain issues).
 * The cookie domain/path doesn't match between your app and callback route.
 * The browser blocked third-party cookies (especially on Safari / iOS).
 * You started the OAuth flow in one tab but finished it in another (different cookie context).
@@ -34,9 +34,9 @@ same browser session that started it.
 * Check that cookies are not blocked by browser settings or privacy modes.
 * Ensure you're starting and ending the OAuth flow in the same browser session.
 
-### Debug locally
+### Production Debug
 
-Use your browser's DevTools → Application → Cookies to confirm:
+Head to your production site, and use your browser's DevTools → Application → Cookies to confirm:
 
 * The state cookie is being set before redirect.
 * It still exists when the OAuth provider redirects back.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the state_mismatch error docs to reduce confusion. Properly formats `.vercel.app` and updates the debug steps to focus on checking cookies on the production site via DevTools.

<sup>Written for commit 3b72a2c50015a7dd2e2a96d303690a1a0a2cb87c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

