### PR TITLE
fix: use `ctx` over `request` in plugin options

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -30,7 +30,7 @@ export interface EmailOTPOptions {
 			otp: string;
 			type: "sign-in" | "email-verification" | "forget-password";
 		},
-		request?: Request | undefined,
+		ctx?: GenericEndpointContext | undefined,
 	) => Promise<void>;
 	/**
 	 * Length of the OTP
@@ -52,7 +52,7 @@ export interface EmailOTPOptions {
 			email: string;
 			type: "sign-in" | "email-verification" | "forget-password";
 		},
-		request?: Request,
+		ctx?: GenericEndpointContext,
 	) => string | undefined;
 	/**
 	 * Send email verification on sign-up
@@ -248,7 +248,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					}
 				}
 				let otp =
-					opts.generateOTP({ email, type: ctx.body.type }, ctx.request) ||
+					opts.generateOTP({ email, type: ctx.body.type }, ctx) ||
 					defaultOTPGenerator(opts);
 
 				let storedOTP = await storeOTP(ctx, otp);
@@ -277,7 +277,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						otp,
 						type: ctx.body.type,
 					},
-					ctx.request,
+					ctx,
 				);
 				return ctx.json({
 					success: true,
@@ -348,7 +348,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 				async (ctx) => {
 					const email = ctx.body.email;
 					const otp =
-						opts.generateOTP({ email, type: ctx.body.type }, ctx.request) ||
+						opts.generateOTP({ email, type: ctx.body.type }, ctx) ||
 						defaultOTPGenerator(opts);
 					let storedOTP = await storeOTP(ctx, otp);
 					await ctx.context.internalAdapter.createVerificationValue({
@@ -974,7 +974,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						});
 					}
 					const otp =
-						opts.generateOTP({ email, type: "forget-password" }, ctx.request) ||
+						opts.generateOTP({ email, type: "forget-password" }, ctx) ||
 						defaultOTPGenerator(opts);
 					let storedOTP = await storeOTP(ctx, otp);
 					await ctx.context.internalAdapter.createVerificationValue({
@@ -988,7 +988,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							otp,
 							type: "forget-password",
 						},
-						ctx.request,
+						ctx,
 					);
 					return ctx.json({
 						success: true,
@@ -1163,7 +1163,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						const email = response?.user.email;
 						if (email) {
 							const otp =
-								opts.generateOTP({ email, type: ctx.body.type }, ctx.request) ||
+								opts.generateOTP({ email, type: ctx.body.type }, ctx) ||
 								defaultOTPGenerator(opts);
 							let storedOTP = await storeOTP(ctx, otp);
 							await ctx.context.internalAdapter.createVerificationValue({
@@ -1177,7 +1177,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 									otp,
 									type: "email-verification",
 								},
-								ctx.request,
+								ctx,
 							);
 						}
 					}),

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -26,7 +26,7 @@ interface MagicLinkopts {
 			url: string;
 			token: string;
 		},
-		request?: Request | undefined,
+		ctx?: GenericEndpointContext | undefined,
 	) => Promise<void> | void;
 	/**
 	 * Disable sign up if user is not found.
@@ -216,7 +216,7 @@ export const magicLink = (options: MagicLinkopts) => {
 							url: url.toString(),
 							token: verificationToken,
 						},
-						ctx.request,
+						ctx,
 					);
 					return ctx.json({
 						status: true,

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -264,7 +264,7 @@ export const createOrganization = <O extends OrganizationOptions>(
 				const defaultTeam =
 					(await options.teams.defaultTeam?.customCreateDefaultTeam?.(
 						organization,
-						ctx.request,
+						ctx,
 					)) || (await adapter.createTeam(teamData));
 
 				teamMember = await adapter.findOrCreateTeamMember({

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -148,7 +148,7 @@ export const createTeam = <O extends OrganizationOptions>(options: O) => {
 								organizationId,
 								session,
 							},
-							ctx.request,
+							ctx,
 						)
 					: ctx.context.orgOptions.teams?.maximumTeams;
 

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -1,4 +1,4 @@
-import type { AuthContext } from "@better-auth/core";
+import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
 import type { DBFieldAttribute } from "@better-auth/core/db";
 import type { Session, User } from "../../types";
 import type { AccessControl, Role } from "../access";
@@ -109,7 +109,7 @@ export interface OrganizationOptions {
 			 */
 			customCreateDefaultTeam?: (
 				organization: Organization & Record<string, any>,
-				request?: Request,
+				ctx?: GenericEndpointContext,
 			) => Promise<Team & Record<string, any>>;
 		};
 		/**
@@ -132,7 +132,7 @@ export interface OrganizationOptions {
 							session: Session;
 						} | null;
 					},
-					request?: Request,
+					ctx?: GenericEndpointContext,
 			  ) => number | Promise<number>)
 			| number;
 

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -1,4 +1,7 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
+import type {
+	BetterAuthPlugin,
+	GenericEndpointContext,
+} from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
@@ -40,7 +43,7 @@ export interface PhoneNumberOptions {
 	 */
 	sendOTP: (
 		data: { phoneNumber: string; code: string },
-		request?: Request | undefined,
+		ctx?: GenericEndpointContext | undefined,
 	) => Promise<void> | void;
 	/**
 	 * a callback to send otp on user requesting to reset their password
@@ -52,7 +55,7 @@ export interface PhoneNumberOptions {
 	sendPasswordResetOTP?:
 		| ((
 				data: { phoneNumber: string; code: string },
-				request?: Request,
+				ctx?: GenericEndpointContext,
 		  ) => Promise<void> | void)
 		| undefined;
 	/**
@@ -83,7 +86,7 @@ export interface PhoneNumberOptions {
 					phoneNumber: string;
 					user: UserWithPhoneNumber;
 				},
-				request?: Request,
+				ctx?: GenericEndpointContext,
 		  ) => void | Promise<void>)
 		| undefined;
 	/**
@@ -259,7 +262,7 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 									phoneNumber,
 									code: otp,
 								},
-								ctx.request,
+								ctx,
 							);
 							throw new APIError("UNAUTHORIZED", {
 								message: ERROR_CODES.PHONE_NUMBER_NOT_VERIFIED,
@@ -409,7 +412,7 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 							phoneNumber: ctx.body.phoneNumber,
 							code,
 						},
-						ctx.request,
+						ctx,
 					);
 					return ctx.json({ message: "code sent" });
 				},
@@ -698,7 +701,7 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 							phoneNumber: ctx.body.phoneNumber,
 							user,
 						},
-						ctx.request,
+						ctx,
 					);
 
 					if (!ctx.body.disableSession) {
@@ -808,7 +811,7 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 							phoneNumber: ctx.body.phoneNumber,
 							code,
 						},
-						ctx.request,
+						ctx,
 					);
 					return ctx.json({
 						status: true,

--- a/packages/better-auth/src/plugins/two-factor/otp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/otp/index.ts
@@ -50,7 +50,7 @@ export interface OTPOptions {
 				/**
 				 * The request object
 				 */
-				request?: Request,
+				ctx?: GenericEndpointContext,
 		  ) => Promise<void> | void)
 		| undefined;
 	/**
@@ -190,7 +190,7 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 			});
 			await options.sendOTP(
 				{ user: session.user as UserWithTwoFactor, otp: code },
-				ctx.request,
+				ctx,
 			);
 			return ctx.json({ status: true });
 		},


### PR DESCRIPTION
linear: https://linear.app/better-auth/issue/ENG-457/change-all-request-callback-params-on-better-auth-options-to-be
closes: https://github.com/better-auth/better-auth/issues/5300

## Breaking Change

Many plugin options which allow `request` have now been convert to `ctx`. You can still access request, it's under `ctx.request`.

Endpoints changed: email-otp, magic-link, organization, phone-number, two-factor