### PR TITLE
docs: fix typo "Crate" -> "Create"

### DIFF
--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -224,7 +224,7 @@ const myPlugin = ()=>{
 This will add an `age` field to the `user` table and all `user` returning endpoints will include the `age` field and it'll be inferred properly by typescript.
 
 <Callout type="warn">
-Don't store sensitive information in `user` or `session` table. Crate a new table if you need to store sensitive information.
+Don't store sensitive information in `user` or `session` table. Create a new table if you need to store sensitive information.
 </Callout>
 
 ### Hooks


### PR DESCRIPTION
see title

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a typo in the plugins docs: "Crate" -> "Create" in the sensitive data callout to improve clarity.

<sup>Written for commit b64c4e98de4d1783e03ce7f0a4fcba18af494dc2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

