### PR TITLE
fix(sso): respect disableImplicitSignUp in SAML callback

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1584,6 +1584,14 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 			if (existingUser) {
 				user = existingUser;
 			} else {
+				// if implicit sign up is disabled, we should not create a new user nor a new account.
+				if (options?.disableImplicitSignUp) {
+					throw new APIError("UNAUTHORIZED", {
+						message:
+							"User not found and implicit sign up is disabled for this provider",
+					});
+				}
+
 				user = await ctx.context.internalAdapter.createUser({
 					email: userInfo.email,
 					name: userInfo.name,


### PR DESCRIPTION
Addresses and closes the following issue: https://github.com/better-auth/better-auth/issues/5958



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect disableImplicitSignUp in SAML SSO callbacks to prevent auto-creating users when they don’t exist. Returns UNAUTHORIZED with a clear message and adds test coverage.

- **Bug Fixes**
  - Block user/account creation in SAML callback when disableImplicitSignUp is true and no existing user is found.
  - Added test asserting UNAUTHORIZED with “User not found and implicit sign up is disabled for this provider”.

<sup>Written for commit 9ed95e8981d685b0cf649085760c957b3f49c0b5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

