### PR TITLE
chore: remove deprecated zod API

### DIFF
--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -102,22 +102,20 @@ export async function parseState(c: GenericEndpointContext) {
 	const storeStateStrategy =
 		c.context.oauthConfig.storeStateStrategy || "cookie";
 
-	const stateDataSchema = z
-		.object({
-			callbackURL: z.string(),
-			codeVerifier: z.string(),
-			errorURL: z.string().optional(),
-			newUserURL: z.string().optional(),
-			expiresAt: z.number(),
-			link: z
-				.object({
-					email: z.string(),
-					userId: z.coerce.string(),
-				})
-				.optional(),
-			requestSignUp: z.boolean().optional(),
-		})
-		.passthrough();
+	const stateDataSchema = z.looseObject({
+		callbackURL: z.string(),
+		codeVerifier: z.string(),
+		errorURL: z.string().optional(),
+		newUserURL: z.string().optional(),
+		expiresAt: z.number(),
+		link: z
+			.object({
+				email: z.string(),
+				userId: z.coerce.string(),
+			})
+			.optional(),
+		requestSignUp: z.boolean().optional(),
+	});
 
 	let parsedData: z.infer<typeof stateDataSchema>;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the OAuth state schema from z.object(...).passthrough() to z.looseObject(...) to remove use of a deprecated Zod API. Behavior stays the same—unknown keys are still allowed; no functional changes to parseState.

<sup>Written for commit fc69ad4e87d035794ea7831d212133d58f98caef. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

