### PR TITLE
fix(oidc-provider): fix opts order

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -146,19 +146,16 @@ export const oidcProvider = (options: OIDCOptions) => {
 		oauthConsent: "oauthConsent",
 	};
 
-	const opts = defu(
-		{
-			codeExpiresIn: 600,
-			defaultScope: "openid",
-			accessTokenExpiresIn: 3600,
-			refreshTokenExpiresIn: 604800,
-			allowPlainCodeChallengeMethod: true,
-			allowDynamicClientRegistration: true,
-			storeClientSecret: "plain" as const,
-			scopes: ["openid", "profile", "email", "offline_access"],
-		},
-		options,
-	);
+	const opts = defu(options, {
+		codeExpiresIn: 600,
+		defaultScope: "openid",
+		accessTokenExpiresIn: 3600,
+		refreshTokenExpiresIn: 604800,
+		allowPlainCodeChallengeMethod: true,
+		allowDynamicClientRegistration: true,
+		storeClientSecret: "plain" as const,
+		scopes: ["openid", "profile", "email", "offline_access"],
+	});
 
 	const trustedClients = opts.trustedClients || [];
 


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/pull/5945

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the OIDC provider options merge order so user-provided settings correctly override defaults. This prevents defaults from overwriting custom configuration.

<sup>Written for commit ad4050d3c333590717ff2e1560ebe15932324a37. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

