### PR TITLE
chore: expose BetterAuthOptions type from `/minimal`

### DIFF
--- a/packages/better-auth/src/auth/minimal.ts
+++ b/packages/better-auth/src/auth/minimal.ts
@@ -3,6 +3,8 @@ import { initMinimal } from "../context/init-minimal";
 import type { Auth } from "../types";
 import { createBetterAuth } from "./base";
 
+export type { BetterAuthOptions };
+
 /**
  * Better Auth initializer for minimal mode (without Kysely)
  */


### PR DESCRIPTION
Fixes #5971 

This PR exports the `BetterAuthOptions` type from the `better-auth/minimal` package.

This improves the developer experience (DX) for TypeScript users, allowing them to import the type directly alongside the `betterAuth` function, rather than needing to import it from `@better-auth/core`.

**Example:**
```typescript
import { betterAuth, type BetterAuthOptions } from "better-auth/minimal";

const config: BetterAuthOptions = { ... };

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported BetterAuthOptions from better-auth/minimal so TypeScript users can import the type alongside betterAuth in minimal mode. This improves DX and removes the need to import the type from @better-auth/core.

<sup>Written for commit 2cf53f148cd9fe1c4affcefdd5ebf51c336c88fa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

