### PR TITLE
chore(fix): support native UUID generation

### DIFF
--- a/packages/better-auth/src/adapters/adapter-factory/index.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/index.ts
@@ -266,9 +266,9 @@ export const createAdapterFactory =
 				} else if (useNumberId && !forceAllowId) {
 					// if force allow is true, then we should be using their custom provided id.
 					return false;
-				} else if (useUUIDs && !config.supportsUUIDs) {
+				} else if (useUUIDs) {
 					// should only generate UUIDs via JS if the database doesn't support natively generating UUIDs.
-					return true;
+					return !config.supportsUUIDs;
 				} else {
 					return true;
 				}


### PR DESCRIPTION
follow up for #5823 - current logic was still relying on JS

can be easily tested with:
```sql
alter table "user" alter column id set default '00000000-0000-0000-0000-000000000000'::uuid;
```
```js
import { Pool } from 'pg';
import { betterAuth } from './index.mjs';
import { getMigrations } from './db/index.mjs';

export async function runMigrations(auth) {
  try {
    const migration = await getMigrations(auth.options);
    console.log(`Running migrations`);
    await migration.runMigrations();
    console.log('Migrations run successfully');
  } catch (error) {
    console.error(error);
    throw error;
  }
}

const connectionString = '...'; // put conn str here

export const a = betterAuth({
    database: new Pool({
      connectionString,
    }),
    emailAndPassword: {
        enabled: true,
    },
    advanced: {
      database: {
        generateId: "uuid",
      },
    }
});

await runMigrations(a);
await a.api.signUpEmail({ body: { email: "test2@test.com", password: "2test123456", name: "test user2" } });
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the UUID generation logic to defer to the database when native UUIDs are supported. We now only generate UUIDs in JS when the database does not support them (config.supportsUUIDs is false).

<sup>Written for commit df688f58d80f0a84dc0391eb4b87d3f1110e4774. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

