### PR TITLE
feat(drizzle): Add Row Level Security (RLS) support for PSQL when using drizzle

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -70,6 +70,13 @@ export interface DrizzleAdapterConfig {
 	 * @default false
 	 */
 	transaction?: boolean | undefined;
+	/**
+	 * Whether to enable Row Level Security (RLS) for the database.
+	 *
+	 * This is only supported for PostgreSQL.
+	 * @default false
+	 */
+	enableRLS?: boolean;
 }
 
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -28,8 +28,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	const filePath = file || "./auth-schema.ts";
 	const databaseType: "sqlite" | "mysql" | "pg" | undefined =
 		adapter.options?.provider;
-
-	const isRlsEnabled =
+	const isRLSEnabled =
 		databaseType === "pg" && options.advanced?.database?.enableRLS;
 
 	if (!databaseType) {
@@ -271,7 +270,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 							}`;
 						})
 						.join(",\n ")}
-					}${assignIndexes(indexes)})${isRlsEnabled ? ".enableRLS()" : ""};`;
+					}${assignIndexes(indexes)})${isRLSEnabled ? ".enableRLS()" : ""};`;
 		code += `\n${schema}\n`;
 	}
 	const formattedCode = await prettier.format(code, {

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -29,11 +29,15 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	const databaseType: "sqlite" | "mysql" | "pg" | undefined =
 		adapter.options?.provider;
 
+	const isRlsEnabled =
+		databaseType === "pg" && options.advanced?.database?.enableRLS;
+
 	if (!databaseType) {
 		throw new Error(
 			`Database provider type is undefined during Drizzle schema generation. Please define a \`provider\` in the Drizzle adapter config. Read more at https://better-auth.com/docs/adapters/drizzle`,
 		);
 	}
+
 	const fileExist = existsSync(filePath);
 
 	let code: string = generateImport({ databaseType, tables, options });
@@ -267,7 +271,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 							}`;
 						})
 						.join(",\n ")}
-					}${assignIndexes(indexes)});`;
+					}${assignIndexes(indexes)})${isRlsEnabled ? ".enableRLS()" : ""};`;
 		code += `\n${schema}\n`;
 	}
 	const formattedCode = await prettier.format(code, {

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -28,8 +28,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	const filePath = file || "./auth-schema.ts";
 	const databaseType: "sqlite" | "mysql" | "pg" | undefined =
 		adapter.options?.provider;
-	const isRLSEnabled =
-		databaseType === "pg" && options.advanced?.database?.enableRLS;
+	const isRLSEnabled = databaseType === "pg" && adapter.options?.enableRLS;
 
 	if (!databaseType) {
 		throw new Error(

--- a/packages/cli/test/__snapshots__/auth-schema-pg-passkey-rls-enabled.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-passkey-rls-enabled.txt
@@ -1,0 +1,103 @@
+import {
+  pgTable,
+  text,
+  timestamp,
+  boolean,
+  integer,
+  index,
+} from "drizzle-orm/pg-core";
+
+export const custom_user = pgTable("custom_user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: boolean("email_verified").default(false).notNull(),
+  image: text("image"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+}).enableRLS();
+
+export const custom_session = pgTable(
+  "custom_session",
+  {
+    id: text("id").primaryKey(),
+    expiresAt: timestamp("expires_at").notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    userId: text("user_id")
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+  },
+  (table) => [index("custom_session_userId_idx").on(table.userId)],
+).enableRLS();
+
+export const custom_account = pgTable(
+  "custom_account",
+  {
+    id: text("id").primaryKey(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at"),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("custom_account_userId_idx").on(table.userId)],
+).enableRLS();
+
+export const custom_verification = pgTable(
+  "custom_verification",
+  {
+    id: text("id").primaryKey(),
+    identifier: text("identifier").notNull(),
+    value: text("value").notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("custom_verification_identifier_idx").on(table.identifier)],
+).enableRLS();
+
+export const passkey = pgTable(
+  "passkey",
+  {
+    id: text("id").primaryKey(),
+    name: text("name"),
+    publicKey: text("public_key").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+    credentialID: text("credential_id").notNull(),
+    counter: integer("counter").notNull(),
+    deviceType: text("device_type").notNull(),
+    backedUp: boolean("backed_up").notNull(),
+    transports: text("transports"),
+    createdAt: timestamp("created_at"),
+    aaguid: text("aaguid"),
+  },
+  (table) => [
+    index("passkey_userId_idx").on(table.userId),
+    index("passkey_credentialID_idx").on(table.credentialID),
+  ],
+).enableRLS();

--- a/packages/cli/test/__snapshots__/auth-schema-pg-rls-enabled.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-rls-enabled.txt
@@ -1,0 +1,110 @@
+import { sql } from "drizzle-orm";
+import {
+  pgTable,
+  text,
+  timestamp,
+  boolean,
+  uuid,
+  index,
+} from "drizzle-orm/pg-core";
+
+export const custom_user = pgTable("custom_user", {
+  id: uuid("id")
+    .default(sql`pg_catalog.gen_random_uuid()`)
+    .primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: boolean("email_verified").default(false).notNull(),
+  image: text("image"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  twoFactorEnabled: boolean("two_factor_enabled").default(false),
+  username: text("username").unique(),
+  displayUsername: text("display_username"),
+}).enableRLS();
+
+export const custom_session = pgTable(
+  "custom_session",
+  {
+    id: uuid("id")
+      .default(sql`pg_catalog.gen_random_uuid()`)
+      .primaryKey(),
+    expiresAt: timestamp("expires_at").notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+  },
+  (table) => [index("custom_session_userId_idx").on(table.userId)],
+).enableRLS();
+
+export const custom_account = pgTable(
+  "custom_account",
+  {
+    id: uuid("id")
+      .default(sql`pg_catalog.gen_random_uuid()`)
+      .primaryKey(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at"),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("custom_account_userId_idx").on(table.userId)],
+).enableRLS();
+
+export const custom_verification = pgTable(
+  "custom_verification",
+  {
+    id: uuid("id")
+      .default(sql`pg_catalog.gen_random_uuid()`)
+      .primaryKey(),
+    identifier: text("identifier").notNull(),
+    value: text("value").notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("custom_verification_identifier_idx").on(table.identifier)],
+).enableRLS();
+
+export const twoFactor = pgTable(
+  "two_factor",
+  {
+    id: uuid("id")
+      .default(sql`pg_catalog.gen_random_uuid()`)
+      .primaryKey(),
+    secret: text("secret").notNull(),
+    backupCodes: text("backup_codes").notNull(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+  },
+  (table) => [
+    index("twoFactor_secret_idx").on(table.secret),
+    index("twoFactor_userId_idx").on(table.userId),
+  ],
+).enableRLS();

--- a/packages/cli/test/generate-all-db.test.ts
+++ b/packages/cli/test/generate-all-db.test.ts
@@ -209,6 +209,51 @@ describe("generate drizzle schema for all databases", async () => {
 			"./__snapshots__/auth-schema-pg-uuid.txt",
 		);
 	});
+
+	it("should generate drizzle schema for PostgreSQL with RLS enabled", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "pg",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "pg",
+						schema: {},
+					},
+				),
+				plugins: [twoFactor(), username()],
+				advanced: {
+					database: {
+						generateId: "uuid",
+						enableRLS: true,
+					},
+				},
+				user: {
+					modelName: "custom_user",
+				},
+				account: {
+					modelName: "custom_account",
+				},
+				session: {
+					modelName: "custom_session",
+				},
+				verification: {
+					modelName: "custom_verification",
+				},
+			},
+		});
+		expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-pg-rls-enabled.txt",
+		);
+	});
+
 	it("should generate drizzle schema for SQLite with uuid id", async () => {
 		const schema = await generateDrizzleSchema({
 			file: "test.drizzle",
@@ -408,6 +453,49 @@ describe("generate drizzle schema for all databases with passkey plugin", async 
 		});
 		expect(schema.code).toMatchFileSnapshot(
 			"./__snapshots__/auth-schema-pg-passkey.txt",
+		);
+	});
+
+	it("should generate drizzle schema for PostgreSQL with passkey plugin and RLS enabled", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "pg",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "pg",
+						schema: {},
+					},
+				),
+				plugins: [passkey()],
+				user: {
+					modelName: "custom_user",
+				},
+				account: {
+					modelName: "custom_account",
+				},
+				session: {
+					modelName: "custom_session",
+				},
+				verification: {
+					modelName: "custom_verification",
+				},
+				advanced: {
+					database: {
+						enableRLS: true,
+					},
+				},
+			},
+		});
+		expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-pg-passkey-rls-enabled.txt",
 		);
 	});
 

--- a/packages/cli/test/generate-all-db.test.ts
+++ b/packages/cli/test/generate-all-db.test.ts
@@ -218,6 +218,7 @@ describe("generate drizzle schema for all databases", async () => {
 				{
 					provider: "pg",
 					schema: {},
+					enableRLS: true,
 				},
 			)({} as BetterAuthOptions),
 			options: {
@@ -226,13 +227,13 @@ describe("generate drizzle schema for all databases", async () => {
 					{
 						provider: "pg",
 						schema: {},
+						enableRLS: true,
 					},
 				),
 				plugins: [twoFactor(), username()],
 				advanced: {
 					database: {
 						generateId: "uuid",
-						enableRLS: true,
 					},
 				},
 				user: {
@@ -464,6 +465,7 @@ describe("generate drizzle schema for all databases with passkey plugin", async 
 				{
 					provider: "pg",
 					schema: {},
+					enableRLS: true,
 				},
 			)({} as BetterAuthOptions),
 			options: {
@@ -472,6 +474,7 @@ describe("generate drizzle schema for all databases with passkey plugin", async 
 					{
 						provider: "pg",
 						schema: {},
+						enableRLS: true,
 					},
 				),
 				plugins: [passkey()],
@@ -486,11 +489,6 @@ describe("generate drizzle schema for all databases with passkey plugin", async 
 				},
 				verification: {
 					modelName: "custom_verification",
-				},
-				advanced: {
-					database: {
-						enableRLS: true,
-					},
 				},
 			},
 		});

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -254,6 +254,13 @@ export type BetterAuthAdvancedOptions = {
 				 * function.
 				 */
 				generateId?: GenerateIdFn | false | "serial" | "uuid";
+				/**
+				 * Whether to enable Row Level Security (RLS) for the database.
+				 *
+				 * This is only supported for PostgreSQL.
+				 * @default false
+				 */
+				enableRLS?: boolean;
 		  }
 		| undefined;
 	/**

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -254,13 +254,6 @@ export type BetterAuthAdvancedOptions = {
 				 * function.
 				 */
 				generateId?: GenerateIdFn | false | "serial" | "uuid";
-				/**
-				 * Whether to enable Row Level Security (RLS) for the database.
-				 *
-				 * This is only supported for PostgreSQL.
-				 * @default false
-				 */
-				enableRLS?: boolean;
 		  }
 		| undefined;
 	/**


### PR DESCRIPTION
## Add PostgreSQL Row Level Security (RLS) to Drizzle Schema Generator

### Summary

Adds optional Row Level Security (RLS) support when generating Drizzle schemas for PostgreSQL. When enabled, generated tables automatically include `.enableRLS()`.

---

### Changes

#### Core

* Added `enableRLS` option to `DrizzleAdapterConfig` (PostgreSQL only).
* Schema generator now checks `adapter.options?.enableRLS` and appends `.enableRLS()` to each table definition.
* RLS is only applied when the provider is PostgreSQL and the flag is enabled ( all other providers will simply ignore this flag )

#### Testing

* Added tests for PostgreSQL with RLS enabled.
* Added tests for PostgreSQL + passkey plugin with RLS.
* Added snapshots for RLS-enabled schema generation.

---

### Usage

```ts
const adapter = drizzleAdapter(db, {
  provider: "pg",
  schema: {},
  enableRLS: true, // Enable RLS
});
```

---

### Technical Details

* RLS applies only when:

  * `databaseType === "pg"`
  * `adapter.options?.enableRLS === true`
* `.enableRLS()` is appended to every `pgTable()` call.

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional PostgreSQL Row Level Security to Drizzle schema generation. When enableRLS is true in the adapter config, generated pgTable() definitions include .enableRLS().

- New Features
  - Added enableRLS?: boolean to DrizzleAdapterConfig (PostgreSQL only).
  - Generator appends .enableRLS() to tables when provider === "pg" and enableRLS is true.
  - Other providers ignore this flag.
  - Added tests and snapshots for RLS (including passkey plugin).

<sup>Written for commit 5600ca1725833c66f3b281d085151103aabe90f3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

