### PR TITLE
Use "user id" as _id in mongo adapter if defined when creating user

### DIFF
--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -264,7 +264,7 @@ export const mongodbAdapter = (
 			return {
 				async create({ model, data: values }) {
 					const res = await db.collection(model).insertOne(values, { session });
-					const insertedData = { _id: res.insertedId.toString(), ...values };
+					const insertedData = { _id: values.id ?? res.insertedId.toString(), ...values };
 					return insertedData as any;
 				},
 				async findOne({ model, where, select }) {


### PR DESCRIPTION
IMO when you define a user id when using the MongoAdapter, then the id of user user should be the same on the user object that is created. To achieve this the _id field has to be the same, see https://www.mongodb.com/docs/drivers/node/current/crud/insert/#a-note-about-_id

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the provided user id as the MongoDB _id when creating a user. Falls back to the insertedId if no id is provided, keeping user ids consistent across the app and database.

<sup>Written for commit bbc37f14442eb8387f4a1fb772f3cd4c24f4d84d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

