### PR TITLE
feat(admin): implement multi-field search with customizable search mode

### DIFF
--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -131,6 +131,17 @@ type listUsers = {
    */
   searchOperator?: "contains" | "starts_with" | "ends_with" = "contains"
   /**
+   * The fields to search in when `searchField` is not provided.  
+   * Example: ["email", "name"]
+   */
+  searchInFields?: string[] = ["email"]
+  /**
+   * How to combine multiple fields from `searchInFields`.  
+   * - OR: match any field (default)  
+   * - AND: match all fields  
+   */
+  searchMode?: "OR" | "AND" = "OR"
+  /**
    * The number of users to return. Defaults to 100.
    */
   limit?: string | number = 100


### PR DESCRIPTION
https://github.com/better-auth/better-auth/issues/5990
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Implemented multi-field search in admin.listUsers with a configurable OR/AND mode to improve user discovery across multiple fields.

- **New Features**
  - Added searchInFields to search across multiple fields when searchField is not provided; accepts an array or a comma-separated string.
  - Added searchMode with "OR" (default) or "AND" to combine matches across fields.
  - Defaults: fields ["email"] and operator "contains".
  - Updated docs and added tests covering OR default and AND behavior.

<sup>Written for commit 07ad83fa1f4510f920f515c237ce78a68ec6beec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

