### PR TITLE
fix: zoom refresh token

### DIFF
--- a/packages/core/src/social-providers/zoom.ts
+++ b/packages/core/src/social-providers/zoom.ts
@@ -1,6 +1,10 @@
 import { betterFetch } from "@better-fetch/fetch";
 import type { OAuthProvider, ProviderOptions } from "../oauth2";
-import { generateCodeChallenge, validateAuthorizationCode } from "../oauth2";
+import {
+	generateCodeChallenge,
+	refreshAccessToken,
+	validateAuthorizationCode,
+} from "../oauth2";
 
 export type LoginType =
 	| 0 /** Facebook OAuth */
@@ -180,6 +184,18 @@ export const zoom = (userOptions: ZoomOptions) => {
 				authentication: "post",
 			});
 		},
+		refreshAccessToken: options.refreshAccessToken
+			? options.refreshAccessToken
+			: async (refreshToken) =>
+					refreshAccessToken({
+						refreshToken,
+						options: {
+							clientId: options.clientId,
+							clientKey: options.clientKey,
+							clientSecret: options.clientSecret,
+						},
+						tokenEndpoint: "https://zoom.us/oauth/token",
+					}),
 		async getUserInfo(token) {
 			if (options.getUserInfo) {
 				return options.getUserInfo(token);


### PR DESCRIPTION
Ensures the zoom provider will refresh the access token when needed. I tested it locally with an app that uses it, not sure if there's a better option?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic access token refresh to the Zoom OAuth provider to prevent failures when tokens expire. Tokens now refresh via Zoom’s token endpoint using client credentials.

- **Bug Fixes**
  - Implemented a default refreshAccessToken handler (overridable) using the shared OAuth2 refresh utility and https://zoom.us/oauth/token.

<sup>Written for commit 31df040631f20b406a0ac5f700b6ff544f75a57d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

