### PR TITLE
fix(sso): prevent server instance from leaking to client

### DIFF
--- a/packages/sso/src/client.ts
+++ b/packages/sso/src/client.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthClientPlugin } from "better-auth";
-import { sso } from "./index";
+import type { sso } from "./index";
 export const ssoClient = () => {
 	return {
 		id: "sso-client",


### PR DESCRIPTION
When importing the SSO client from the latest beta release, it crashed my app due to missing node dependencies in the browser. I realized that the SSO client is importing the server plugin without a type-only import. This aligns the SSO client plugin with the other client plugins.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented server libraries from leaking into the SSO client build by switching the sso import to a type-only import. This avoids browser crashes caused by Node-only dependencies and aligns the SSO client with other client plugins.

<sup>Written for commit 74c75f50c102570a974b7a540895ec673086ef21. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

