### PR TITLE
fix(sso): export SSOProvider type

### DIFF
--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -9,9 +9,9 @@ import {
 	signInSSO,
 	spMetadata,
 } from "./routes/sso";
-import type { OIDCConfig, SAMLConfig, SSOOptions } from "./types";
+import type { OIDCConfig, SAMLConfig, SSOOptions, SSOProvider } from "./types";
 
-export type { SAMLConfig, OIDCConfig, SSOOptions };
+export type { SAMLConfig, OIDCConfig, SSOOptions, SSOProvider };
 
 const fastValidator = {
 	async validate(xml: string) {


### PR DESCRIPTION
This type is no longer exported by the SSO after a recent refactor - it's useful to have the type when using the adapter to fetch data. eg:

```
const existingProvider = await adapter.findOne<SSOProvider>({
  model: "ssoProvider",
  where: [{ field: "providerId", operator: "eq", value: providerId }],
});
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export SSOProvider type from the sso package index to restore the missing export after the recent refactor. This fixes type errors and lets consumers use it in typed adapter queries (e.g., findOne<SSOProvider>).

<sup>Written for commit 76ed85197e367e8f1ebe5c11f8aa981504f8cc1f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

