### PR TITLE
fix(haveibeenpwned): check for limited set of paths

### DIFF
--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -6,95 +6,95 @@ import { betterFetch } from "@better-fetch/fetch";
 import { APIError } from "../../api";
 
 const ERROR_CODES = defineErrorCodes({
-  PASSWORD_COMPROMISED:
-    "The password you entered has been compromised. Please choose a different password.",
+	PASSWORD_COMPROMISED:
+		"The password you entered has been compromised. Please choose a different password.",
 });
 
 async function checkPasswordCompromise(
-  password: string,
-  customMessage?: string | undefined,
+	password: string,
+	customMessage?: string | undefined,
 ) {
-  if (!password) return;
+	if (!password) return;
 
-  const sha1Hash = (
-    await createHash("SHA-1", "hex").digest(password)
-  ).toUpperCase();
-  const prefix = sha1Hash.substring(0, 5);
-  const suffix = sha1Hash.substring(5);
-  try {
-    const { data, error } = await betterFetch<string>(
-      `https://api.pwnedpasswords.com/range/${prefix}`,
-      {
-        headers: {
-          "Add-Padding": "true",
-          "User-Agent": "BetterAuth Password Checker",
-        },
-      },
-    );
+	const sha1Hash = (
+		await createHash("SHA-1", "hex").digest(password)
+	).toUpperCase();
+	const prefix = sha1Hash.substring(0, 5);
+	const suffix = sha1Hash.substring(5);
+	try {
+		const { data, error } = await betterFetch<string>(
+			`https://api.pwnedpasswords.com/range/${prefix}`,
+			{
+				headers: {
+					"Add-Padding": "true",
+					"User-Agent": "BetterAuth Password Checker",
+				},
+			},
+		);
 
-    if (error) {
-      throw new APIError("INTERNAL_SERVER_ERROR", {
-        message: `Failed to check password. Status: ${error.status}`,
-      });
-    }
-    const lines = data.split("\n");
-    const found = lines.some(
-      (line) => line.split(":")[0]!.toUpperCase() === suffix.toUpperCase(),
-    );
+		if (error) {
+			throw new APIError("INTERNAL_SERVER_ERROR", {
+				message: `Failed to check password. Status: ${error.status}`,
+			});
+		}
+		const lines = data.split("\n");
+		const found = lines.some(
+			(line) => line.split(":")[0]!.toUpperCase() === suffix.toUpperCase(),
+		);
 
-    if (found) {
-      throw new APIError("BAD_REQUEST", {
-        message: customMessage || ERROR_CODES.PASSWORD_COMPROMISED,
-        code: "PASSWORD_COMPROMISED",
-      });
-    }
-  } catch (error) {
-    if (error instanceof APIError) throw error;
-    throw new APIError("INTERNAL_SERVER_ERROR", {
-      message: "Failed to check password. Please try again later.",
-    });
-  }
+		if (found) {
+			throw new APIError("BAD_REQUEST", {
+				message: customMessage || ERROR_CODES.PASSWORD_COMPROMISED,
+				code: "PASSWORD_COMPROMISED",
+			});
+		}
+	} catch (error) {
+		if (error instanceof APIError) throw error;
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			message: "Failed to check password. Please try again later.",
+		});
+	}
 }
 
 export interface HaveIBeenPwnedOptions {
-  customPasswordCompromisedMessage?: string | undefined;
-  /**
-   * Paths to check for password
-   *
-   * @default ["/sign-up/email", "/change-password", "/reset-password"]
-   */
-  paths?: string[];
+	customPasswordCompromisedMessage?: string | undefined;
+	/**
+	 * Paths to check for password
+	 *
+	 * @default ["/sign-up/email", "/change-password", "/reset-password"]
+	 */
+	paths?: string[];
 }
 
 export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions | undefined) => {
-  const paths = options?.paths || [
-    "/sign-up/email",
-    "/change-password",
-    "/reset-password",
-  ];
+	const paths = options?.paths || [
+		"/sign-up/email",
+		"/change-password",
+		"/reset-password",
+	];
 
-  return {
-    id: "haveIBeenPwned",
-    init(ctx) {
-      return {
-        context: {
-          password: {
-            ...ctx.password,
-            async hash(password) {
-              const c = await getCurrentAuthContext();
-              if (!c.path || !paths.includes(c.path)) {
-                return ctx.password.hash(password);
-              }
-              await checkPasswordCompromise(
-                password,
-                options?.customPasswordCompromisedMessage,
-              );
-              return ctx.password.hash(password);
-            },
-          },
-        },
-      };
-    },
-    $ERROR_CODES: ERROR_CODES,
-  } satisfies BetterAuthPlugin;
+	return {
+		id: "haveIBeenPwned",
+		init(ctx) {
+			return {
+				context: {
+					password: {
+						...ctx.password,
+						async hash(password) {
+							const c = await getCurrentAuthContext();
+							if (!c.path || !paths.includes(c.path)) {
+								return ctx.password.hash(password);
+							}
+							await checkPasswordCompromise(
+								password,
+								options?.customPasswordCompromisedMessage,
+							);
+							return ctx.password.hash(password);
+						},
+					},
+				},
+			};
+		},
+		$ERROR_CODES: ERROR_CODES,
+	} satisfies BetterAuthPlugin;
 };


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit Have I Been Pwned checks to specific auth routes to avoid unnecessary lookups and improve performance. By default, checks run only on /sign-up/email, /change-password, and /reset-password.

- **New Features**
  - Added paths option to configure which routes trigger the password breach check.
  - Keeps customPasswordCompromisedMessage support.

- **Bug Fixes**
  - Run checks only when the current request path matches the whitelist (via getCurrentAuthContext).
  - Prevents unintended checks during unrelated hashing, reducing external calls and false positives.

<sup>Written for commit 0ccc4946c3e88fc4431f4f7fee78738055c4bf2e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









