### PR TITLE
docs: add bottom margin to TOC

### DIFF
--- a/docs/components/docs/layout/toc.tsx
+++ b/docs/components/docs/layout/toc.tsx
@@ -57,7 +57,7 @@ export function Toc(props: HTMLAttributes<HTMLDivElement>) {
 				{
 					...props.style,
 					"--fd-toc-height":
-						"calc(100dvh - var(--fd-banner-height) - var(--fd-nav-height))",
+						"calc(100dvh - var(--fd-banner-height) - var(--fd-nav-height) - 4rem)",
 				} as object
 			}
 		>


### PR DESCRIPTION
### Before

https://github.com/user-attachments/assets/24bd1d19-350b-4c20-a042-b7666106706b


### After

https://github.com/user-attachments/assets/3a0e869d-2fab-436c-aafc-054eaecadaac



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 4rem bottom margin to the docs TOC by subtracting it from --fd-toc-height. Prevents the TOC from touching the bottom of the viewport and keeps the last items visible.

<sup>Written for commit 6f8a77885eba22c4b7981a898613e162c3aee3f3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

