### PR TITLE
fix(last-login-method): LastLoginMethod cookie is not set when using a generic oauth provider

### DIFF
--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -52,14 +52,16 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 ) => {
 	const paths = [
 		"/callback/:id",
-		"/oauth2/callback/:id",
+		"/oauth2/callback/:providerId",
 		"/sign-in/email",
 		"/sign-up/email",
 	];
 
 	const defaultResolveMethod = (ctx: GenericEndpointContext) => {
 		if (paths.includes(ctx.path)) {
-			return ctx.params?.id ? ctx.params.id : ctx.path.split("/").pop();
+			return (
+				ctx.params?.id || ctx.params?.providerId || ctx.path.split("/").pop()
+			);
 		}
 		return null;
 	};


### PR DESCRIPTION
Fixes https://github.com/better-auth/better-auth/issues/5970



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes last login method resolution for generic OAuth by correctly handling /oauth2/callback/:providerId so the cookie and user.lastLoginMethod are set.

- **Bug Fixes**
  - Added support for providerId in /oauth2/callback paths and resolver fallback.
  - Added tests covering generic OAuth flow to verify cookie and session values.

<sup>Written for commit 985453176e346ef569829b3286ec015b9360d498. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



