### PR TITLE
chore: update zod email chaining

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -285,7 +285,7 @@ export const verifyEmail = createAuthEndpoint(
 			return redirectOnError("invalid_token");
 		}
 		const schema = z.object({
-			email: z.string().email(),
+			email: z.email(),
 			updateTo: z.string().optional(),
 		});
 		const parsed = schema.parse(jwt.payload);

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -407,7 +407,7 @@ export const signInEmail = createAuthEndpoint(
 			});
 		}
 		const { email, password } = ctx.body;
-		const isValidEmail = z.string().email().safeParse(email);
+		const isValidEmail = z.email().safeParse(email);
 		if (!isValidEmail.success) {
 			throw new APIError("BAD_REQUEST", {
 				message: BASE_ERROR_CODES.INVALID_EMAIL,

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -466,7 +466,7 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 					}
 
 					const email = ctx.body.email.toLowerCase();
-					const isValidEmail = z.string().email().safeParse(email);
+					const isValidEmail = z.email().safeParse(email);
 					if (!isValidEmail.success) {
 						throw new APIError("BAD_REQUEST", {
 							message: BASE_ERROR_CODES.INVALID_EMAIL,

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -227,7 +227,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					});
 				}
 				const email = ctx.body.email.toLowerCase();
-				const isValidEmail = z.string().email().safeParse(email);
+				const isValidEmail = z.email().safeParse(email);
 				if (!isValidEmail.success) {
 					throw ctx.error("BAD_REQUEST", {
 						message: BASE_ERROR_CODES.INVALID_EMAIL,
@@ -511,7 +511,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 				},
 				async (ctx) => {
 					const email = ctx.body.email.toLowerCase();
-					const isValidEmail = z.string().email().safeParse(email);
+					const isValidEmail = z.email().safeParse(email);
 					if (!isValidEmail.success) {
 						throw new APIError("BAD_REQUEST", {
 							message: BASE_ERROR_CODES.INVALID_EMAIL,
@@ -636,7 +636,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 				},
 				async (ctx) => {
 					const email = ctx.body.email.toLowerCase();
-					const isValidEmail = z.string().email().safeParse(email);
+					const isValidEmail = z.email().safeParse(email);
 					if (!isValidEmail.success) {
 						throw new APIError("BAD_REQUEST", {
 							message: BASE_ERROR_CODES.INVALID_EMAIL,

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -112,12 +112,9 @@ export const magicLink = (options: MagicLinkopts) => {
 					method: "POST",
 					requireHeaders: true,
 					body: z.object({
-						email: z
-							.string()
-							.meta({
-								description: "Email address to send the magic link",
-							})
-							.email(),
+						email: z.email().meta({
+							description: "Email address to send the magic link",
+						}),
 						name: z
 							.string()
 							.meta({

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -185,7 +185,7 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 			}
 
 			const email = ctx.body.email.toLowerCase();
-			const isValidEmail = z.string().email().safeParse(email);
+			const isValidEmail = z.email().safeParse(email);
 			if (!isValidEmail.success) {
 				throw new APIError("BAD_REQUEST", {
 					message: BASE_ERROR_CODES.INVALID_EMAIL,

--- a/packages/better-auth/src/plugins/siwe/index.ts
+++ b/packages/better-auth/src/plugins/siwe/index.ts
@@ -82,7 +82,7 @@ export const siwe = (options: SIWEPluginOptions) =>
 								.max(2147483647)
 								.optional()
 								.default(1),
-							email: z.string().email().optional(),
+							email: z.email().optional(),
 						})
 						.refine((data) => options.anonymous !== false || !!data.email, {
 							message:


### PR DESCRIPTION
Reference: https://zod.dev/v4?id=top-level-string-formats

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched email validation to Zod v4’s top-level z.email() across auth routes and plugins. Keeps behavior the same, improves clarity, and aligns with Zod v4.

- **Refactors**
  - Replaced z.string().email() with z.email() in email-verification, sign-in, admin, email-otp, magic-link, organization invites, and SIWE.
  - Kept magic-link email field metadata while moving to z.email().

<sup>Written for commit fc50c73907394d3d7325074520616a558a6b0d3d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

