### PR TITLE
Fix: hex string expected, got unpadded hex of length 253

### DIFF
--- a/packages/better-auth/src/oauth2/utils.ts
+++ b/packages/better-auth/src/oauth2/utils.ts
@@ -3,24 +3,25 @@ import { symmetricDecrypt, symmetricEncrypt } from "../crypto";
 
 export function decryptOAuthToken(token: string, ctx: AuthContext) {
 	if (!token) return token;
-	if (ctx.options.account?.encryptOAuthTokens) {
+	if (ctx.options.account?.encryptOAuthTokens && token.startsWith('enc:')) {
 		return symmetricDecrypt({
 			key: ctx.secret,
-			data: token,
+			data: token.slice(4),
 		});
 	}
 	return token;
 }
 
-export function setTokenUtil(
+export async function setTokenUtil(
 	token: string | null | undefined,
 	ctx: AuthContext,
 ) {
 	if (ctx.options.account?.encryptOAuthTokens && token) {
-		return symmetricEncrypt({
+		const encryptedToken = await symmetricEncrypt({
 			key: ctx.secret,
 			data: token,
 		});
+		return 'enc:' + encryptedToken
 	}
 	return token;
 }


### PR DESCRIPTION
Propose solution to bug reported in [#6018](https://github.com/better-auth/better-auth/issues/6018)

This PR fixes a bug where toggling `encryptOAuthTokens` from `false` to `true` causes a `"hex string expected, got unpadded hex of length 253"` error when refreshing expired tokens. The issue occurred because `decryptOAuthToken` attempted to decrypt plain text tokens that were stored before encryption was enabled. The fix adds a prefix-based check (`enc:`) to distinguish encrypted tokens from plain text ones. Encrypted tokens are now prefixed with `enc:` when stored with setTokenUtil, and `decryptOAuthToken` only attempts decryption if the prefix is present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefix encrypted OAuth tokens with 'enc:' and decrypt only when the prefix is present. Prevents errors when handling plaintext or mixed tokens.

- **Bug Fixes**
  - Stops decryption attempts on plaintext tokens, avoiding failures when encryption is disabled or tokens vary.

- **Migration**
  - setTokenUtil is now async; update callers to await its result.

<sup>Written for commit e293957d651494ad554bd79fab7d735b1accbd14. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

