### PR TITLE
feat: refactor fetch plugins config disableDefaultFetchPlugins to include userAgentPlugin

### DIFF
--- a/packages/better-auth/src/client/config.test.ts
+++ b/packages/better-auth/src/client/config.test.ts
@@ -1,0 +1,52 @@
+import { createServer } from "node:http";
+import { describe, expect, it } from "vitest";
+import { getClientConfig } from "./config";
+
+describe("client config", () => {
+	it("enable default plugins should include user agent", async ({
+		onTestFinished,
+	}) => {
+		const server = createServer((_, res) => res.end());
+		await new Promise<void>((resolve) =>
+			server.listen(0, () => {
+				resolve();
+			}),
+		);
+		onTestFinished(() => {
+			server.close();
+		});
+		const url = `http://localhost:${(server.address() as any).port}`;
+		const { $fetch } = getClientConfig({
+			baseURL: "http://localhost:3000",
+		});
+		await $fetch(url, {
+			onResponse: ({ request }) => {
+				expect(request.headers.has("User-Agent")).toBe(true);
+			},
+		});
+	});
+
+	it("disable default plugins should not include user agent", async ({
+		onTestFinished,
+	}) => {
+		const server = createServer((_, res) => res.end());
+		await new Promise<void>((resolve) =>
+			server.listen(0, () => {
+				resolve();
+			}),
+		);
+		onTestFinished(() => {
+			server.close();
+		});
+		const url = `http://localhost:${(server.address() as any).port}`;
+		const { $fetch } = getClientConfig({
+			disableDefaultFetchPlugins: true,
+			baseURL: "http://localhost:3000",
+		});
+		await $fetch(url, {
+			onResponse: ({ request }) => {
+				expect(request.headers.has("User-Agent")).toBe(false);
+			},
+		});
+	});
+});

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -51,7 +51,9 @@ export const getClientConfig = (
 		plugins: [
 			lifeCyclePlugin,
 			...(restOfFetchOptions.plugins || []),
-			...(options?.disableDefaultFetchPlugins ? [] : [userAgentPlugin, redirectPlugin]),
+			...(options?.disableDefaultFetchPlugins
+				? []
+				: [userAgentPlugin, redirectPlugin]),
 			...pluginsFetchPlugins,
 		],
 	});


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated fetch client config so disableDefaultFetchPlugins now disables both userAgentPlugin and redirectPlugin. If you still need a user agent when defaults are off, add userAgentPlugin to plugins manually.

<sup>Written for commit 57b0c36cb4995b74c537524ddbde9564a4ec588f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



