### PR TITLE
fix(anonymous): `isAnonymous` should default to false instead of null

### DIFF
--- a/packages/better-auth/src/plugins/anonymous/schema.ts
+++ b/packages/better-auth/src/plugins/anonymous/schema.ts
@@ -7,6 +7,7 @@ export const schema = {
 				type: "boolean",
 				required: false,
 				input: false,
+				defaultValue: false,
 			},
 		},
 	},


### PR DESCRIPTION
When creating a user outside of the anonymous plugin, such as email-otp, the default value for `isAnonymous` once the user is created is `null`. It should be set to `false` instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set isAnonymous to default to false in the anonymous plugin schema to avoid null values for users created via non-anonymous flows (e.g., email-otp).
This ensures consistent boolean behavior and removes the need for null checks.

<sup>Written for commit 7e5a9cd07a62c5b31d45b863f891551b013c751e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

