### PR TITLE
chore: use the Biome schema with a relative path from node_modules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "$schema": "https://biomejs.dev/schemas/2.3.5/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "tab"


### PR DESCRIPTION
Reference: https://biomejs.dev/reference/configuration/#schema

This helps prevent mistakes when updating versions later.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update biome.json to use the local Biome schema from node_modules instead of a versioned URL. This keeps the schema in sync with the installed Biome version and avoids upgrade mismatches.

<sup>Written for commit aebc55de3905a8b15603ae1be38ca2bf678dd81a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

