### PR TITLE
fix: resolve SESSION_IS_NOT_FRESH error with cookieCache

### DIFF
--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -544,8 +544,9 @@ export const freshSessionMiddleware = createAuthMiddleware(async (ctx) => {
 		};
 	}
 	const freshAge = ctx.context.sessionConfig.freshAge;
-	const lastUpdated =
-		session.session.updatedAt?.valueOf() || session.session.createdAt.valueOf();
+	const lastUpdated = new Date(
+		session.session.updatedAt || session.session.createdAt,
+	).getTime();
 	const now = Date.now();
 	const isFresh = now - lastUpdated < freshAge * 1000;
 	if (!isFresh) {


### PR DESCRIPTION
Closes #6028

### Description
Fixes a bug where `freshSessionMiddleware` incorrectly threw `SESSION_IS_NOT_FRESH` when `cookieCache` was enabled. 

The issue was caused by the `updatedAt` field being retrieved from the cookie as an ISO string, while the freshness logic used `.valueOf()` directly, which failed to perform the correct math against `Date.now()`.

### The Fix
Updated `freshSessionMiddleware` in `session.ts` to explicitly wrap `updatedAt` (or `createdAt`) in `new Date(...).getTime()`. This ensures a numeric timestamp is always used for comparison, regardless of whether the input is a Date object or an ISO string.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the session freshness check to stop false SESSION_IS_NOT_FRESH errors when cookieCache is enabled. Normalizes cookie dates to numeric timestamps before comparison.

- **Bug Fixes**
  - In freshSessionMiddleware, compute lastUpdated with new Date(updatedAt || createdAt).getTime() so ISO strings from cookies compare correctly against Date.now().

<sup>Written for commit e3498d79bb4920e43788107c62e0507cda16c799. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

