### PR TITLE
fix: preserve provided string IDs in the MongoDB adapter when they are not valid ObjectId

### DIFF
--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -625,7 +625,7 @@ export const mongodbAdapter = (
 							const oid = new ObjectId(data);
 							return oid;
 						} catch (error) {
-							return new ObjectId();
+							return data;
 						}
 					}
 					if (


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve provided string IDs in the MongoDB adapter when they are not valid ObjectId, instead of generating a new ObjectId. This allows custom non-ObjectId identifiers to be stored and retrieved consistently.

<sup>Written for commit 9d069b66cd8e55456214b7ab912ef042e1ce8473. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

