### PR TITLE
fix(oauth-proxy): return multiple Set-Cookie headers instead of a single comma-separated header

### DIFF
--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -4,7 +4,7 @@ import {
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import { env } from "@better-auth/core/env";
-import type { EndpointContext } from "better-call";
+import type { CookieOptions, EndpointContext } from "better-call";
 import * as z from "zod";
 import { originCheck } from "../../api";
 import { parseJSON } from "../../client/parser";
@@ -186,12 +186,53 @@ export const oAuthProxy = (opts?: OAuthProxyOptions | undefined) => {
 								filteredAttrs.push("Secure");
 							}
 
-							return filteredAttrs.length > 0
-								? `${name}=${value}; ${filteredAttrs.join("; ")}`
-								: `${name}=${value}`;
+							// Build options
+							const options: CookieOptions = {};
+							for (const attr of filteredAttrs) {
+								const [attrName, attrValue] = attr.split("=");
+								if (!attrName) continue;
+								switch (attrName.toLowerCase()) {
+									case "path":
+										options.path = attrValue;
+										break;
+									case "expires":
+										if (!attrValue) break;
+										options.expires = new Date(attrValue);
+										break;
+									case "samesite":
+										options.sameSite = attrValue as "lax" | "strict" | "none";
+										break;
+									case "httponly":
+										options.httpOnly = true;
+										break;
+									case "max-age":
+										if (!attrValue) break;
+										options.maxAge = parseInt(attrValue, 10);
+										break;
+									case "prefix":
+										if (!attrValue) break;
+										options.prefix = attrValue as "host" | "secure";
+										break;
+									case "partitioned": {
+										options.partitioned = true;
+										break;
+									}
+								}
+							}
+
+							return {
+								name,
+								value,
+								options,
+							};
 						});
 
-					ctx.setHeader("set-cookie", processedCookies.join(", "));
+					for (const cookie of processedCookies) {
+						// using `ctx.setHeader` overrides previous Set-Cookie headers
+						// so use ctx.setCookie helper instead
+						// https://github.com/Bekacru/better-call/blob/d27ac20e64b329a4851e97adf864098a9bc2a260/src/context.ts#L217
+						ctx.setCookie(cookie.name, cookie.value, cookie.options);
+					}
 					throw ctx.redirect(ctx.query.callbackURL);
 				},
 			),


### PR DESCRIPTION
According to [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2), multiple Set-Cookie requests must be sent to create multiple cookies. In the current implementation, oAuthProxy uses comma-separated cookies. This doesn't work well.
<img width="285" height="130" alt="image" src="https://github.com/user-attachments/assets/5bbfa3eb-1c40-4d01-8503-88db12f7210f" />

I have fixed this in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OAuth proxy cookie handling to send separate Set-Cookie headers per cookie per RFC 6265, so multi-cookie flows work reliably across browsers.

- **Bug Fixes**
  - Use ctx.setCookie for each cookie instead of a single comma-separated Set-Cookie header.
  - Parse cookie attributes into CookieOptions (path, expires, samesite, httponly, max-age, prefix, partitioned).
  - Added a test to verify multiple cookies are set and redirect behavior works.

<sup>Written for commit 75236cf10f62198c442a36efc5b5b60a75c01c00. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

