### PR TITLE
fix(oauth2): add missing logger.error calls in state.ts

### DIFF
--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -184,6 +184,9 @@ export async function parseState(c: GenericEndpointContext) {
 			!skipStateCookieCheck &&
 			(!stateCookieValue || stateCookieValue !== state)
 		) {
+			c.context.logger.error("State Mismatch. Cookie value mismatch", {
+				state,
+			});
 			const errorURL =
 				c.context.options.onAPIError?.errorURL || `${c.context.baseURL}/error`;
 			throw c.redirect(`${errorURL}?error=state_mismatch`);
@@ -203,6 +206,9 @@ export async function parseState(c: GenericEndpointContext) {
 
 	// Check expiration
 	if (parsedData.expiresAt < Date.now()) {
+		c.context.logger.error("OAuth state expired", {
+			expiresAt: parsedData.expiresAt,
+		});
 		const errorURL =
 			c.context.options.onAPIError?.errorURL || `${c.context.baseURL}/error`;
 		throw c.redirect(`${errorURL}?error=please_restart_the_process`);


### PR DESCRIPTION
## Summary
Added missing `logger.error` calls in `oauth2/state.ts` to ensure consistent error logging whenever redirecting to `errorURL`.

## Changes
- Added `logger.error` for state mismatch when cookie value doesn't match (line 187-189)
- Added `logger.error` for expired OAuth state (line 206-208)

Previously, some error redirects had logging while others didn't. This PR makes the logging consistent across all error cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing logger.error calls in oauth2/state.ts so all OAuth error redirects are logged. Improves visibility and debugging for state-related failures.

- **Bug Fixes**
  - Log state mismatch when the cookie value differs before redirecting to errorURL.
  - Log expired OAuth state before redirecting to errorURL.

<sup>Written for commit f436b5458e07748859903c0a92c8073dcf17fbd5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

