### PR TITLE
chore(sso): add support for custom field mapping

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -816,5 +816,47 @@ If you want to allow account linking for specific trusted providers, enable the 
             },
         },
     },
+    modelName: {
+        description: "The model name for the SSO provider table",
+        type: "string",
+        default: "ssoProvider"
+    },
+    fields: {
+        issuer: {
+            description: "Custom name for the issuer column",
+            type: "string",
+            default: "issuer",
+        },
+		oidcConfig: {
+            description: "Custom name for the oidcConfig column",
+            type: "string",
+            default: "oidcConfig",
+        },
+		samlConfig: {
+            description: "Custom name for the samlConfig column",
+            type: "string",
+            default: "samlConfig",
+        },
+		userId: {
+            description: "Custom name for the userId column",
+            type: "string",
+            default: "userId",
+        },
+		providerId: {
+            description: "Custom name for the providerId column",
+            type: "string",
+            default: "providerId",
+        },
+		organizationId: {
+            description: "Custom name for the organizationId column",
+            type: "string",
+            default: "organizationId",
+        },
+		domain: {
+            description: "Custom name for the domain column",
+            type: "string",
+            default: "domain",
+        }
+    }
   }}
 />

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -54,18 +54,22 @@ export function sso<O extends SSOOptions>(options?: O | undefined): any {
 		},
 		schema: {
 			ssoProvider: {
+				modelName: options?.modelName ?? "ssoProvider",
 				fields: {
 					issuer: {
 						type: "string",
 						required: true,
+						fieldName: options?.fields?.issuer ?? "issuer",
 					},
 					oidcConfig: {
 						type: "string",
 						required: false,
+						fieldName: options?.fields?.oidcConfig ?? "oidcConfig",
 					},
 					samlConfig: {
 						type: "string",
 						required: false,
+						fieldName: options?.fields?.samlConfig ?? "samlConfig",
 					},
 					userId: {
 						type: "string",
@@ -73,19 +77,23 @@ export function sso<O extends SSOOptions>(options?: O | undefined): any {
 							model: "user",
 							field: "id",
 						},
+						fieldName: options?.fields?.userId ?? "userId",
 					},
 					providerId: {
 						type: "string",
 						required: true,
 						unique: true,
+						fieldName: options?.fields?.providerId ?? "providerId",
 					},
 					organizationId: {
 						type: "string",
 						required: false,
+						fieldName: options?.fields?.organizationId ?? "organizationId",
 					},
 					domain: {
 						type: "string",
 						required: true,
+						fieldName: options?.fields?.domain ?? "domain",
 					},
 				},
 			},

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -178,6 +178,29 @@ export interface SSOOptions {
 	 */
 	disableImplicitSignUp?: boolean | undefined;
 	/**
+	 * The model name for the SSO provider table. Defaults to "ssoProvider".
+	 */
+	modelName?: string;
+	/**
+	 * Map fields
+	 *
+	 * @example
+	 * ```ts
+	 * {
+	 *  samlConfig: "saml_config"
+	 * }
+	 * ```
+	 */
+	fields?: {
+		issuer?: string | undefined;
+		oidcConfig?: string | undefined;
+		samlConfig?: string | undefined;
+		userId?: string | undefined;
+		providerId?: string | undefined;
+		organizationId?: string | undefined;
+		domain?: string | undefined;
+	};
+	/**
 	 * Configure the maximum number of SSO providers a user can register.
 	 * You can also pass a function that returns a number.
 	 * Set to 0 to disable SSO provider registration.


### PR DESCRIPTION
Closes #5649 
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for custom field mapping for SSO providers so teams can use existing table and column names without changing their schema. Defaults remain unchanged for backward compatibility.

- **New Features**
  - Added modelName and fields overrides in SSOOptions for issuer, oidcConfig, samlConfig, userId, providerId, organizationId, and domain.
  - Updated types and docs to document the new options.
  - Added SAML tests covering custom field mapping.

<sup>Written for commit fe2c99b4f4896258e93e8b3270c62a613e2b20be. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

