### PR TITLE
fix: support `WantAuthnRequestsSigned="true"` for sso SAML SPs

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -984,6 +984,9 @@ export const signInSSO = (options?: SSOOptions) => {
 				}
 				const sp = saml.ServiceProvider({
 					metadata: parsedSamlConfig.spMetadata.metadata,
+					privateKey: parsedSamlConfig.spMetadata.privateKey,
+					privateKeyPass: parsedSamlConfig.spMetadata.privateKeyPass,
+					relayState: body.callbackURL,
 					allowCreate: true,
 				});
 
@@ -1004,9 +1007,7 @@ export const signInSSO = (options?: SSOOptions) => {
 					});
 				}
 				return ctx.json({
-					url: `${loginRequest.context}&RelayState=${encodeURIComponent(
-						body.callbackURL,
-					)}`,
+					url: loginRequest.context,
 					redirect: true,
 				});
 			}

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -984,16 +984,16 @@ export const signInSSO = (options?: SSOOptions) => {
 				}
 				const sp = parsedSamlConfig.spMetadata.metadata
 					? saml.ServiceProvider({
-						metadata: parsedSamlConfig.spMetadata.metadata,
-						privateKey: parsedSamlConfig.spMetadata.privateKey,
-						privateKeyPass: parsedSamlConfig.spMetadata.privateKeyPass,
-						relayState: body.callbackURL,
-						allowCreate: true,
-					})
+							metadata: parsedSamlConfig.spMetadata.metadata,
+							privateKey: parsedSamlConfig.spMetadata.privateKey,
+							privateKeyPass: parsedSamlConfig.spMetadata.privateKeyPass,
+							relayState: body.callbackURL,
+							allowCreate: true,
+						})
 					: saml.ServiceProvider({
-						relayState: body.callbackURL,
-						allowCreate: true,
-					});
+							relayState: body.callbackURL,
+							allowCreate: true,
+						});
 
 				const idp = saml.IdentityProvider({
 					metadata: parsedSamlConfig.idpMetadata?.metadata,

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -982,13 +982,18 @@ export const signInSSO = (options?: SSOOptions) => {
 						message: "Invalid SAML configuration",
 					});
 				}
-				const sp = saml.ServiceProvider({
-					metadata: parsedSamlConfig.spMetadata.metadata,
-					privateKey: parsedSamlConfig.spMetadata.privateKey,
-					privateKeyPass: parsedSamlConfig.spMetadata.privateKeyPass,
-					relayState: body.callbackURL,
-					allowCreate: true,
-				});
+				const sp = parsedSamlConfig.spMetadata.metadata
+					? saml.ServiceProvider({
+						metadata: parsedSamlConfig.spMetadata.metadata,
+						privateKey: parsedSamlConfig.spMetadata.privateKey,
+						privateKeyPass: parsedSamlConfig.spMetadata.privateKeyPass,
+						relayState: body.callbackURL,
+						allowCreate: true,
+					})
+					: saml.ServiceProvider({
+						relayState: body.callbackURL,
+						allowCreate: true,
+					});
 
 				const idp = saml.IdentityProvider({
 					metadata: parsedSamlConfig.idpMetadata?.metadata,

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -101,6 +101,80 @@ const idpMetadata = `
     </md:ContactPerson>
     </md:EntityDescriptor>
     `;
+const spMetadataWantsAuthnSigned = `
+    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://localhost:3001/api/sso/saml2/sp/metadata">
+    <md:SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+            <ds:X509Certificate>MIIE3jCCAsYCCQDE5FzoAkixzzANBgkqhkiG9w0BAQsFADAxMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHRmxvcmlkYTEQMA4GA1UEBwwHT3JsYW5kbzAeFw0yMzExMTkxMjUyMTVaFw0zMzExMTYxMjUyMTVaMDExCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdGbG9yaWRhMRAwDgYDVQQHDAdPcmxhbmRvMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2ELJsLZs4yBH7a2U5pA7xw+Oiut7b/ROKh2BqSTKRbEG4xy7WwljT02Mh7GTjLvswtZSUObWFO5v14HNORa3+J9JT2DH+9F+FJ770HX8a3cKYBNQt3xP4IeUyjI3QWzrGtkYPwSZ74tDpAUtuqPAxtoCaZXFDtX6lvCJDqiPnfxRZrKkepYWINSwu4DRpg6KoiPWRCYTsEcCzImInzlACdM97jpG1gLGA6a4dmjalQbRtvC56N0Z56gIhYq2F5JdzB2a10pqoIY8ggXZGIJS9I++8mmdTj6So5pPxLwnCYUhwDew1/DMbi9xIwYozs9pEtHCTn1l34jldDwTziVAxGQZO7QUuoMl997zqcPS7pVWRnfz5odKuytLvQDA0lRVfzOxtqbM3qVhoLT2iDmnuEtlZzgfbt4WEuT2538qxZJkFRpZQIrTj3ybqmWAv36Cp49dfeMwaqjhfX7/mVfbsPMSC653DSZBB+n+Uz0FC3QhH+vIdNhXNAQ5tBseHUR6pXiMnLtI/WVbMvpvFwK2faFTcx1oaP/Qk6yCq66tJvPbnatT9qGF8rdBJmAk9aBdQTI+hAh5mDtDweCrgVL+Tm/+Q85hSl4HGzH/LhLVS478tZVX+o+0yorZ35LCW3e4v8iX+1VEGSdg2ooOWtbSSXK2cYZr8ilyUQp0KueenR0CAwEAATANBgkqhkiG9w0BAQsFAAOCAgEAsonAahruWuHlYbDNQVD0ryhL/b+ttKKqVeT87XYDkvVhlSSSVAKcCwK/UU6z8Ty9dODUkd93Qsbof8fGMlXeYCtDHMRanvWLtk4wVkAMyNkDYHzJ1FbO7v44ZBbqNzSLy2kosbRELlcz+P3/42xumlDqAw/k13tWUdlLDxb0pd8R5yBev6HkIdJBIWtKmUuI+e8F/yTNf5kY7HO1p0NeKdVeZw4Ydw33+BwVxVNmhIxzdP5ZFQv0XRFWhCMo/6RLEepCvWUp/T1WRFqgwAdURaQrvvfpjO/Ls+neht1SWDeP8RRgsDrXIc3gZfaD8q4liIDTZ6HsFi7FmLbZatU8jJ4pCstxQLCvmix+1zF6Fwa9V5OApSTbVqBOsDZbJxeAoSzy5Wx28wufAZT4Kc/OaViXPV5o/ordPs4EYKgd/eNFCgIsZYXe75rYXqnieAIfJEGddsLBpqlgLkwvf5KVS4QNqqX+2YubP63y+3sICq2ScdhO3LZs3nlqQ/SgMiJnCBbDUDZ9GGgJNJVVytcSz5IDQHeflrq/zTt1c4q1DO3CS7mimAnTCjetERRQ3mgY/2hRiuCDFj3Cy7QMjFs3vBsbWrjNWlqyveFmHDRkq34Om7eA2jl3LZ5u7vSm0/ylp/vtoysMjwEmw/0NA3hZPTG3OJxcvFcXBsz0SiFcd1U=</ds:X509Certificate>
+            </ds:X509Data>
+        </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:KeyDescriptor use="encryption">
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+            <ds:X509Certificate>MIIE3jCCAsYCCQDE5FzoAkixzzANBgkqhkiG9w0BAQsFADAxMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHRmxvcmlkYTEQMA4GA1UEBwwHT3JsYW5kbzAeFw0yMzExMTkxMjUyMTVaFw0zMzExMTYxMjUyMTVaMDExCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdGbG9yaWRhMRAwDgYDVQQHDAdPcmxhbmRvMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2ELJsLZs4yBH7a2U5pA7xw+Oiut7b/ROKh2BqSTKRbEG4xy7WwljT02Mh7GTjLvswtZSUObWFO5v14HNORa3+J9JT2DH+9F+FJ770HX8a3cKYBNQt3xP4IeUyjI3QWzrGtkYPwSZ74tDpAUtuqPAxtoCaZXFDtX6lvCJDqiPnfxRZrKkepYWINSwu4DRpg6KoiPWRCYTsEcCzImInzlACdM97jpG1gLGA6a4dmjalQbRtvC56N0Z56gIhYq2F5JdzB2a10pqoIY8ggXZGIJS9I++8mmdTj6So5pPxLwnCYUhwDew1/DMbi9xIwYozs9pEtHCTn1l34jldDwTziVAxGQZO7QUuoMl997zqcPS7pVWRnfz5odKuytLvQDA0lRVfzOxtqbM3qVhoLT2iDmnuEtlZzgfbt4WEuT2538qxZJkFRpZQIrTj3ybqmWAv36Cp49dfeMwaqjhfX7/mVfbsPMSC653DSZBB+n+Uz0FC3QhH+vIdNhXNAQ5tBseHUR6pXiMnLtI/WVbMvpvFwK2faFTcx1oaP/Qk6yCq66tJvPbnatT9qGF8rdBJmAk9aBdQTI+hAh5mDtDweCrgVL+Tm/+Q85hSl4HGzH/LhLVS478tZVX+o+0yorZ35LCW3e4v8iX+1VEGSdg2ooOWtbSSXK2cYZr8ilyUQp0KueenR0CAwEAATANBgkqhkiG9w0BAQsFAAOCAgEAsonAahruWuHlYbDNQVD0ryhL/b+ttKKqVeT87XYDkvVhlSSSVAKcCwK/UU6z8Ty9dODUkd93Qsbof8fGMlXeYCtDHMRanvWLtk4wVkAMyNkDYHzJ1FbO7v44ZBbqNzSLy2kosbRELlcz+P3/42xumlDqAw/k13tWUdlLDxb0pd8R5yBev6HkIdJBIWtKmUuI+e8F/yTNf5kY7HO1p0NeKdVeZw4Ydw33+BwVxVNmhIxzdP5ZFQv0XRFWhCMo/6RLEepCvWUp/T1WRFqgwAdURaQrvvfpjO/Ls+neht1SWDeP8RRgsDrXIc3gZfaD8q4liIDTZ6HsFi7FmLbZatU8jJ4pCstxQLCvmix+1zF6Fwa9V5OApSTbVqBOsDZbJxeAoSzy5Wx28wufAZT4Kc/OaViXPV5o/ordPs4EYKgd/eNFCgIsZYXe75rYXqnieAIfJEGddsLBpqlgLkwvf5KVS4QNqqX+2YubP63y+3sICq2ScdhO3LZs3nlqQ/SgMiJnCBbDUDZ9GGgJNJVVytcSz5IDQHeflrq/zTt1c4q1DO3CS7mimAnTCjetERRQ3mgY/2hRiuCDFj3Cy7QMjFs3vBsbWrjNWlqyveFmHDRkq34Om7eA2jl3LZ5u7vSm0/ylp/vtoysMjwEmw/0NA3hZPTG3OJxcvFcXBsz0SiFcd1U=</ds:X509Certificate>
+            </ds:X509Data>
+        </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:3001/api/sso/saml2/sp/sls"/>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:3001/api/sso/saml2/sp/acs" index="1"/>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:3001/api/sso/saml2/sp/acs" index="1"/>
+        </md:SPSSODescriptor>
+    <md:Organization>
+        <md:OrganizationName xml:lang="en-US">Organization Name</md:OrganizationName>
+        <md:OrganizationDisplayName xml:lang="en-US">Organization DisplayName</md:OrganizationDisplayName>
+        <md:OrganizationURL xml:lang="en-US">http://localhost:3001/</md:OrganizationURL>
+    </md:Organization>
+    <md:ContactPerson contactType="technical">
+        <md:GivenName>Technical Contact Name</md:GivenName>
+        <md:EmailAddress>technical_contact@gmail.com</md:EmailAddress>
+    </md:ContactPerson>
+    <md:ContactPerson contactType="support">
+        <md:GivenName>Support Contact Name</md:GivenName>
+        <md:EmailAddress>support_contact@gmail.com</md:EmailAddress>
+    </md:ContactPerson>
+    </md:EntityDescriptor>
+    `;
+const idpMetadataWantsAuthnSigned = `
+    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://localhost:8081/api/sso/saml2/idp/metadata">
+    <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+            <ds:X509Certificate>MIIFOjCCAyICCQCqP5DN+xQZDjANBgkqhkiG9w0BAQsFADBfMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHRmxvcmlkYTEQMA4GA1UEBwwHT3JsYW5kbzENMAsGA1UECgwEVGVzdDEdMBsGCSqGSIb3DQEJARYOdGVzdEBnbWFpbC5jb20wHhcNMjMxMTE5MTIzNzE3WhcNMzMxMTE2MTIzNzE3WjBfMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHRmxvcmlkYTEQMA4GA1UEBwwHT3JsYW5kbzENMAsGA1UECgwEVGVzdDEdMBsGCSqGSIb3DQEJARYOdGVzdEBnbWFpbC5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQD5giLoLyED41IHt0RxB/k6x4K0vzAKiGecPyedRNR1oyiv3OYkuG5jgTE2wcPZc7kD1Eg5d6th0BWHy/ovaNS5mkgnOV6jKkMaWW4sCMSnLnaWy0seftPK3O4mNeZpM5e9amj2gXnZvKrK8cqnJ/bsUUQvXxttXNVVmOHWg/t3c2vJ4XuUfph6wIKbrj297ILzuAFRNvAVxeS0tElwepvZ5Wbf7Hc1MORAqTpw/mp8cRjHRzYCA9y6OM4hgVs1gvTJS8WGoMmsdAZHaOnv9vLJvW3jDLQQecOheYIJncWgcESzJFIkmXadorYCEfWhwwBdVphknmeLr4BMpJBclAYaFjYDLIKpMcXYO5k/2r3BgSPlw4oqbxbR5geD05myKYtZ/wNUtku118NjhIfJFulU/kfDcp1rYYkvzgBfqr80wgNps4oQzVr1mnpgHsSTAhXMuZbaTByJRmPqecyvyQqRQcRIN0oTLJNGyzoUf0RkH6DKJ4+7qDhlq4Zhlfso9OFMv9xeONfIrJo5HtTfFZfidkXZqir2ZqwqNlNOMfK5DsYq37x2Gkgqig4nqLpITXyxfnQpL2HsaoFrlctt/OL+Zqba7NT4heYk9GX8qlAS+Ipsv6T2HSANbah55oSS3uvcrDOug2Zq7+GYMLKS1IKUKhwX+wLMxmMwSJQ9ZgFwfQIDAQABMA0GCSqGSIb3DQEBCwUAA4ICAQCkGPZdflocTSXIe5bbehsBn/IPdyb38eH2HaAvWqO2XNcDcq+6/uLc8BVK4JMa3AFS9xtBza7MOXN/lw/Ccb8uJGVNUE31+rTvsJaDtMCQkp+9aG04I1BonEHfSB0ANcTy/Gp+4hKyFCd6x35uyPO7CWX5Z8I87q9LF6Dte3/v1j7VZgDjAi9yHpBJv9Xje33AK1vF+WmEfDUOi8y2B8htVeoyS3owln3ZUbnmJdCmMp2BMRq63ymINwklEaYaNrp1L201bSqNdKZF2sNwROWyDX+WFYgufrnzPYb6HS8gYb4oEZmaG5cBM7Hs730/3BlbHKhxNTy1Io2TVCYcMQD+ieiVg5e5eGTwaPYGuVvY3NVhO8FaYBG7K2NT2hqutdCMaQpGyHEzbbbTY1afhbeMmWWqivRnVJNDv4kgBc2SE8JO82qHikIW9Om0cghC5xwTT+1JTtxxD1KeC1M1IwLzzuuMmwJSKAsv4duDqN+YRIP78J2SlrssqlsmoF8+48e7Vzr7JRT/Ya274P8RpUPNtxTR7WDmZ4tunqXjiBpz6l0uTtVXnj5UBo4HCyRjWJOGf15OCuQX03qz8tKn1IbZUf723qrmSF+cxBwHqpAywqhTSsaLjIXKnQ0UlMov7QWb0a5N07JZMdMSerbHvbXd/z9S1Ssea2+EGuTYuQur3A==</ds:X509Certificate>
+            </ds:X509Data>
+        </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:KeyDescriptor use="encryption">
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+            <ds:X509Certificate>MIIFOjCCAyICCQCqP5DN+xQZDjANBgkqhkiG9w0BAQsFADBfMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHRmxvcmlkYTEQMA4GA1UEBwwHT3JsYW5kbzENMAsGA1UECgwEVGVzdDEdMBsGCSqGSIb3DQEJARYOdGVzdEBnbWFpbC5jb20wHhcNMjMxMTE5MTIzNzE3WhcNMzMxMTE2MTIzNzE3WjBfMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHRmxvcmlkYTEQMA4GA1UEBwwHT3JsYW5kbzENMAsGA1UECgwEVGVzdDEdMBsGCSqGSIb3DQEJARYOdGVzdEBnbWFpbC5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQD5giLoLyED41IHt0RxB/k6x4K0vzAKiGecPyedRNR1oyiv3OYkuG5jgTE2wcPZc7kD1Eg5d6th0BWHy/ovaNS5mkgnOV6jKkMaWW4sCMSnLnaWy0seftPK3O4mNeZpM5e9amj2gXnZvKrK8cqnJ/bsUUQvXxttXNVVmOHWg/t3c2vJ4XuUfph6wIKbrj297ILzuAFRNvAVxeS0tElwepvZ5Wbf7Hc1MORAqTpw/mp8cRjHRzYCA9y6OM4hgVs1gvTJS8WGoMmsdAZHaOnv9vLJvW3jDLQQecOheYIJncWgcESzJFIkmXadorYCEfWhwwBdVphknmeLr4BMpJBclAYaFjYDLIKpMcXYO5k/2r3BgSPlw4oqbxbR5geD05myKYtZ/wNUtku118NjhIfJFulU/kfDcp1rYYkvzgBfqr80wgNps4oQzVr1mnpgHsSTAhXMuZbaTByJRmPqecyvyQqRQcRIN0oTLJNGyzoUf0RkH6DKJ4+7qDhlq4Zhlfso9OFMv9xeONfIrJo5HtTfFZfidkXZqir2ZqwqNlNOMfK5DsYq37x2Gkgqig4nqLpITXyxfnQpL2HsaoFrlctt/OL+Zqba7NT4heYk9GX8qlAS+Ipsv6T2HSANbah55oSS3uvcrDOug2Zq7+GYMLKS1IKUKhwX+wLMxmMwSJQ9ZgFwfQIDAQABMA0GCSqGSIb3DQEBCwUAA4ICAQCkGPZdflocTSXIe5bbehsBn/IPdyb38eH2HaAvWqO2XNcDcq+6/uLc8BVK4JMa3AFS9xtBza7MOXN/lw/Ccb8uJGVNUE31+rTvsJaDtMCQkp+9aG04I1BonEHfSB0ANcTy/Gp+4hKyFCd6x35uyPO7CWX5Z8I87q9LF6Dte3/v1j7VZgDjAi9yHpBJv9Xje33AK1vF+WmEfDUOi8y2B8htVeoyS3owln3ZUbnmJdCmMp2BMRq63ymINwklEaYaNrp1L201bSqNdKZF2sNwROWyDX+WFYgufrnzPYb6HS8gYb4oEZmaG5cBM7Hs730/3BlbHKhxNTy1Io2TVCYcMQD+ieiVg5e5eGTwaPYGuVvY3NVhO8FaYBG7K2NT2hqutdCMaQpGyHEzbbbTY1afhbeMmWWqivRnVJNDv4kgBc2SE8JO82qHikIW9Om0cghC5xwTT+1JTtxxD1KeC1M1IwLzzuuMmwJSKAsv4duDqN+YRIP78J2SlrssqlsmoF8+48e7Vzr7JRT/Ya274P8RpUPNtxTR7WDmZ4tunqXjiBpz6l0uTtVXnj5UBo4HCyRjWJOGf15OCuQX03qz8tKn1IbZUf723qrmSF+cxBwHqpAywqhTSsaLjIXKnQ0UlMov7QWb0a5N07JZMdMSerbHvbXd/z9S1Ssea2+EGuTYuQur3A==</ds:X509Certificate>
+            </ds:X509Data>
+        </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:8081/api/sso/saml2/idp/slo"/>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:8081/api/sso/saml2/idp/redirect"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8081/api/sso/saml2/idp/post"/>
+        </md:IDPSSODescriptor>
+    <md:Organization>
+        <md:OrganizationName xml:lang="en-US">Your Organization Name</md:OrganizationName>
+        <md:OrganizationDisplayName xml:lang="en-US">Your Organization DisplayName</md:OrganizationDisplayName>
+        <md:OrganizationURL xml:lang="en-US">http://localhost:8081</md:OrganizationURL>
+    </md:Organization>
+    <md:ContactPerson contactType="technical">
+        <md:GivenName>Technical Contact Name</md:GivenName>
+        <md:EmailAddress>technical_contact@gmail.com</md:EmailAddress>
+    </md:ContactPerson>
+    <md:ContactPerson contactType="support">
+        <md:GivenName>Support Contact Name</md:GivenName>
+        <md:EmailAddress>support_contact@gmail.com</md:EmailAddress>
+    </md:ContactPerson>
+    </md:EntityDescriptor>
+    `;
 const idPk = `
     -----BEGIN RSA PRIVATE KEY-----
     MIIJKgIBAAKCAgEA+YIi6C8hA+NSB7dEcQf5OseCtL8wCohnnD8nnUTUdaMor9zm
@@ -187,6 +261,38 @@ const spPrivateKey = `
     jnnjCjsK5YzTa4hmbHhPZIW262KoFV9TqxYKkhP5ab7AXRSakrdrY2cwACWN4AMT
     -----END RSA PRIVATE KEY-----
     `;
+const spSigningPrivateKey = `
+    -----BEGIN ENCRYPTED PRIVATE KEY-----
+    MIIFNTBfBgkqhkiG9w0BBQ0wUjAxBgkqhkiG9w0BBQwwJAQQYMClIo0EPp7638o7
+    S3aTagICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEOuofdEnzS+mcUar
+    hFXZ8RsEggTQWgS4IbsslJtmrn3P3Fxo/E1BRMfUTWXmXMn0y1wgmQiSxjCn12fm
+    1Q4M+sMhOb0hFdc0jgQzgl7W96YerZ2TOE2OF2BjJ7udjV2WbAOz+VMlrnM6jMtA
+    fL7LgikbzCZ+sk1rfaQBXaqTDGHVDce/GV3pUOQ42cLn7qcCVzkA03HEj7Qh33Dq
+    QRaDQDhmLsYqzhQWLyHoZXpXlLggxooTzRI2nLOA0VTo/MDY8sKI/eC0nu5bg4fT
+    zB16UpZdRfCMJmsvb7F5jHAb3qcuAeqlpPAqKj+xZ8uY4SFxluOHLJKoVEBA4HM/
+    AekgcRj16mBrFf+AEgyGeQjQtXymLjnfvS7bA1p6Ri1DKv3wgiNnFgTYhEd5unnA
+    kuSz8cpbydurUDDtX+ZpQZNvwCyDEx00p0sHFQKBr/BLJLOopKo5fCc2GpB4QLo6
+    VFDtMC+g7JuaGNJHBoS/Sjy7hefNmxy44xd1LWaDXKe4cLbXchjwgGa4DyK59DJO
+    rjBfiPeCPn1CN+r5Y9IermOMKmFn9Pae7VPF+PLGkm4cAf4kn9loXW7NWQEzpFqU
+    EKVeoY67l64sAck9uJgaKvY/lUB7IF1KVH4+geOa1gNDyK4i4e74kj9rhF7HQkah
+    QzXmb4BHmA9jYKnO/mMDAbQrgzZ6HAufps0QX7LsW/vFssD5Q6BB47/ureaR02bu
+    YX2V7xW60j/7nrmrkUWlKWAdW9w20YeRDSMkj5dZXlx6zLzqzkwX8by4buYPAOI6
+    4PJhlfW2RnHx/E9L2uwi9DI9lpXd8eajNdy/TCWGcgXhExn2leOiuJLmc0o7Ti3b
+    E0KRslNHmSxCGgMh9kWXmdHsxGMPbg2oVmPRZnfOu0NQDn/bKY2egVpx7qopdZrX
+    8i0R+Bl1R3WueZjaGA43jNyhzA8l8nW9SYK/COou+AHjuO02i8NSUQNA5RFiorMi
+    7Nh3gKfbPYFvEs85siEytHDaF/rrsLByhBDtnwFLuMYhGogah4yrlXTJRr2W7YeH
+    4vzWVFA3LU2OyQAlxEtNbaD8YYM0Vyz6egzq8VWcAfO4oBaH4xA1TxGAwNS0CV03
+    HLDfTvzmuxFrYCaqw41tqBgdwUruuZS4F5i49Oq2JxfGESiKYLGpkI73X5VXfTmy
+    bAq2MvfUAQEAQ7TARd7Sn4XlmK1nVxxAS7xEOzdM5VnFDExRaU1wq1pz/9rW06kF
+    NAoe96Nlxlm1Sq/Q2yZQ+A+/rEX73vN2jTtRFh9rPu4noVtWKjSckhJHux9LqYpU
+    P1fsF6wJjrVQBlIm+qknmUCEusfN9BvoXxnvlt3BsQaPOm37MfvwIU+kewNQuy8U
+    KIyHYaXFgzek7U4BvXv6c7czv2/XVHXCKpy8h+lBf0+MqFnpao2267amkq9/N0Jb
+    A4jjjIF6Emkj+ZCBsbB8L1BLiG/z5HylFUaar0MSzMHueTdTw+1bEGW3S+Yy2J6O
+    C30/D9mw9gWevoPNf+vcNoI4VIk++9xX/LgUpbYjUDp0YoknSetbDICdzjG1uIAG
+    JWw0uNXy/LURkeUyS5Fk5ve1vMyTslw0tFZ/P1Gr3zGxXdMcdUyodX4CiLPJuDJx
+    ZKQxCrJ6KIpbEnflZuqs/0qXBQrE6leKmrKLN/8uXb6tOkvMr6IqR3o=
+    -----END ENCRYPTED PRIVATE KEY-----
+`;
 const idpPrivateKey = `
     -----BEGIN RSA PRIVATE KEY-----
     Proc-Type: 4,ENCRYPTED
@@ -523,6 +629,100 @@ describe("SAML SSO with defaultSSO array", async () => {
 					},
 					spMetadata: {
 						metadata: spMetadata,
+					},
+					identifierFormat:
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+				},
+			},
+		],
+		provisionUser: vi
+			.fn()
+			.mockImplementation(async ({ user, userInfo, token, provider }) => {
+				return {
+					id: "provisioned-user-id",
+					email: userInfo.email,
+					name: userInfo.name,
+					attributes: userInfo.attributes,
+				};
+			}),
+	};
+
+	const auth = betterAuth({
+		database: memory,
+		baseURL: "http://localhost:3000",
+		emailAndPassword: {
+			enabled: true,
+		},
+		plugins: [sso(ssoOptions)],
+	});
+
+	const ctx = await auth.$context;
+
+	const authClient = createAuthClient({
+		baseURL: "http://localhost:3000",
+		plugins: [bearer(), ssoClient()],
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	beforeAll(async () => {
+		await mockIdP.start();
+	});
+
+	afterAll(async () => {
+		await mockIdP.stop();
+	});
+
+	it("should use default SAML SSO provider from array when no provider found in database", async () => {
+		const signInResponse = await auth.api.signInSSO({
+			body: {
+				providerId: "default-saml",
+				callbackURL: "http://localhost:3000/dashboard",
+			},
+		});
+
+		expect(signInResponse).toEqual({
+			url: expect.stringContaining("http://localhost:8081"),
+			redirect: true,
+		});
+	});
+});
+
+describe("SAML SSO with defaultSSO array and IDP requires signed Authn requests", async () => {
+	const data = {
+		user: [],
+		session: [],
+		verification: [],
+		account: [],
+		ssoProvider: [],
+	};
+
+	const memory = memoryAdapter(data);
+	const mockIdP = createMockSAMLIdP(8081); // Different port from your main app
+
+	const ssoOptions = {
+		defaultSSO: [
+			{
+				domain: "localhost:8081",
+				providerId: "default-saml",
+				samlConfig: {
+					issuer: "http://localhost:8081",
+					entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+					cert: certificate,
+					callbackUrl: "http://localhost:8081/dashboard",
+					wantAssertionsSigned: false,
+					signatureAlgorithm: "sha256",
+					digestAlgorithm: "sha256",
+					idpMetadata: {
+						metadata: idpMetadataWantsAuthnSigned,
+					},
+					spMetadata: {
+						metadata: spMetadataWantsAuthnSigned,
+						privateKey: spSigningPrivateKey,
+						privateKeyPass: "VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px",
 					},
 					identifierFormat:
 						"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -750,7 +750,6 @@ describe("SAML SSO with defaultSSO array and IDP requires signed Authn requests"
 		plugins: [sso(ssoOptions)],
 	});
 
-
 	beforeAll(async () => {
 		await mockIdP.start();
 	});

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -750,7 +750,6 @@ describe("SAML SSO with defaultSSO array and IDP requires signed Authn requests"
 		plugins: [sso(ssoOptions)],
 	});
 
-	const ctx = await auth.$context;
 
 	beforeAll(async () => {
 		await mockIdP.start();

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -752,16 +752,6 @@ describe("SAML SSO with defaultSSO array and IDP requires signed Authn requests"
 
 	const ctx = await auth.$context;
 
-	const authClient = createAuthClient({
-		baseURL: "http://localhost:3000",
-		plugins: [bearer(), ssoClient()],
-		fetchOptions: {
-			customFetchImpl: async (url, init) => {
-				return auth.handler(new Request(url, init));
-			},
-		},
-	});
-
 	beforeAll(async () => {
 		await mockIdP.start();
 	});


### PR DESCRIPTION
The `sso` package cannot currently authenticate with a SAML IDP that requires signed authentication requests. There are a couple problems:

- If the SP metadata includes `AuthnRequestsSigned="true"`, samlify will throw an error when constructing the ServiceProvider object because the private key (and optional private key password) are not included in the samlConfig object. Only the metadata and `allowCreate` are currently set.
- After adding the private key for signing, the request to the IDP cannot be validated because the `RelayState` is added to the URL after the request has been signed.

This adds the private key and private key password to the constructor for the samlify ServiceProvider object so that it is able to sign the request, and moves the relayState to that same constructor so that it is included in the signature.











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for SAML IDPs that require signed Authn requests (WantAuthnRequestsSigned="true"). Authn requests are now signed by the SP and include RelayState in the signature so IDP validation succeeds.

- **Bug Fixes**
  - Pass privateKey and privateKeyPass from spMetadata to the samlify ServiceProvider.
  - Set relayState in the ServiceProvider constructor and stop appending RelayState after signing.
  - Added tests covering IDPs that require signed Authn requests.

<sup>Written for commit 735f5fd7009da949689fd19c929a2f9cf9bb7bf6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











