### PR TITLE
feat: support custom id field names

### DIFF
--- a/packages/better-auth/src/adapters/adapter-factory/adapter-factory.id-field.test.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/adapter-factory.id-field.test.ts
@@ -1,86 +1,93 @@
 // packages/better-auth/src/adapters/adapter-factory/adapter-factory.id-field.test.ts
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getAuthTables } from "../../db/get-tables";
+import { createAdapterFactory } from ".";
+import { initGetDefaultFieldName } from "./get-default-field-name";
 import { initGetDefaultModelName } from "./get-default-model-name";
 import { initGetFieldName } from "./get-field-name";
-import { initGetDefaultFieldName } from "./get-default-field-name";
-import { createAdapterFactory } from ".";
 
 describe("custom id field mapping", () => {
-  it("getAuthTables should include fields.id.fieldName from options", () => {
-    const options = {
-      user: { fields: { id: "userId" } },
-      session: { fields: { id: "sessionId" } },
-      account: { fields: { id: "accountId" } },
-    } as any;
-    const schema = getAuthTables(options);
-    expect(schema?.user?.fields.id?.fieldName).toBe("userId");
-    expect(schema?.session?.fields.id?.fieldName).toBe("sessionId");
-    expect(schema?.account?.fields.id?.fieldName).toBe("accountId");
-  });
+	it("getAuthTables should include fields.id.fieldName from options", () => {
+		const options = {
+			user: { fields: { id: "userId" } },
+			session: { fields: { id: "sessionId" } },
+			account: { fields: { id: "accountId" } },
+		} as any;
+		const schema = getAuthTables(options);
+		expect(schema?.user?.fields.id?.fieldName).toBe("userId");
+		expect(schema?.session?.fields.id?.fieldName).toBe("sessionId");
+		expect(schema?.account?.fields.id?.fieldName).toBe("accountId");
+	});
 
-  it("adapter should store under DB column `user_id` and return logical `id`", async () => {
-    const options = { user: { fields: { id: "user_id" } } } as any;
+	it("adapter should store under DB column `user_id` and return logical `id`", async () => {
+		const options = { user: { fields: { id: "user_id" } } } as any;
 
-    const factory = createAdapterFactory({
-      config: {
-        adapterId: "test-adapter",
-        adapterName: "Test Adapter",
-        usePlural: false,
-        debugLogs: false,
-        supportsJSON: true,
-        supportsDates: true,
-        supportsBooleans: true,
-      },
-      adapter: () => {
-        // Simple in-memory backing store for this test
-        let stored: any = null;
-        return {
-          async create(data: { data: any; }) {
-            // underlying adapter receives DB-shaped payload in data.data
-            stored = data.data;
-            return stored;
-          },
-          async findOne(data: {data: any; where: any;}) {
-            // where clause should use DB column names (user_id)
-            const where = data.where;
-            if (!stored) return null;
-            if (where?.user_id && where.user_id === stored.user_id) return stored;
-            return null;
-          },
-        } as any;
-      },
-    });
+		const factory = createAdapterFactory({
+			config: {
+				adapterId: "test-adapter",
+				adapterName: "Test Adapter",
+				usePlural: false,
+				debugLogs: false,
+				supportsJSON: true,
+				supportsDates: true,
+				supportsBooleans: true,
+			},
+			adapter: () => {
+				// Simple in-memory backing store for this test
+				let stored: any = null;
+				return {
+					async create(data: { data: any }) {
+						// underlying adapter receives DB-shaped payload in data.data
+						stored = data.data;
+						return stored;
+					},
+					async findOne(data: { data: any; where: any }) {
+						// where clause should use DB column names (user_id)
+						const where = data.where;
+						if (!stored) return null;
+						if (where?.user_id && where.user_id === stored.user_id)
+							return stored;
+						return null;
+					},
+				} as any;
+			},
+		});
 
-    const adapter = factory(options);
+		const adapter = factory(options);
 
-    // create a user (logical payload)
-    const created = await adapter.create({ model: "user", data: { name: "Alice" } });
+		// create a user (logical payload)
+		const created = await adapter.create({
+			model: "user",
+			data: { name: "Alice" },
+		});
 
-    // Underlying store must have used DB column `user_id` (not logical `id`)
-    // We verify this by calling findOne using logical id and expecting a result.
-    expect(created).toHaveProperty("id");
-    const found = await adapter.findOne({ model: "user", where: [{ field: "id", value: created.id }] }) as any;
-    expect(found).not.toBeNull();
-    expect(found.id).toBe(created.id);
-  });
+		// Underlying store must have used DB column `user_id` (not logical `id`)
+		// We verify this by calling findOne using logical id and expecting a result.
+		expect(created).toHaveProperty("id");
+		const found = (await adapter.findOne({
+			model: "user",
+			where: [{ field: "id", value: created.id }],
+		})) as any;
+		expect(found).not.toBeNull();
+		expect(found.id).toBe(created.id);
+	});
 
-  it("getFieldName should resolve to DB column name for id", () => {
-    const options = { user: { fields: { id: "userId" } } } as any;
-    const schema = getAuthTables(options);
-    const getDefaultModelName = initGetDefaultModelName({
-      usePlural: false,
-      schema,
-    });
-    const getFieldName = initGetFieldName({ schema, usePlural: false });
+	it("getFieldName should resolve to DB column name for id", () => {
+		const options = { user: { fields: { id: "userId" } } } as any;
+		const schema = getAuthTables(options);
+		const getDefaultModelName = initGetDefaultModelName({
+			usePlural: false,
+			schema,
+		});
+		const getFieldName = initGetFieldName({ schema, usePlural: false });
 
-    const modelKey = getDefaultModelName("user"); // should be "user"
-    const defaultField = initGetDefaultFieldName({ schema, usePlural: false })({
-      model: "user",
-      field: "id",
-    });
-    // DB column name:
-    const dbCol = getFieldName({ model: modelKey, field: defaultField });
-    expect(dbCol).toBe("userId");
-  });
+		const modelKey = getDefaultModelName("user"); // should be "user"
+		const defaultField = initGetDefaultFieldName({ schema, usePlural: false })({
+			model: "user",
+			field: "id",
+		});
+		// DB column name:
+		const dbCol = getFieldName({ model: modelKey, field: defaultField });
+		expect(dbCol).toBe("userId");
+	});
 });

--- a/packages/better-auth/src/adapters/adapter-factory/adapter-factory.id-field.test.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/adapter-factory.id-field.test.ts
@@ -1,0 +1,86 @@
+// packages/better-auth/src/adapters/adapter-factory/adapter-factory.id-field.test.ts
+import { describe, it, expect } from "vitest";
+import { getAuthTables } from "../../db/get-tables";
+import { initGetDefaultModelName } from "./get-default-model-name";
+import { initGetFieldName } from "./get-field-name";
+import { initGetDefaultFieldName } from "./get-default-field-name";
+import { createAdapterFactory } from ".";
+
+describe("custom id field mapping", () => {
+  it("getAuthTables should include fields.id.fieldName from options", () => {
+    const options = {
+      user: { fields: { id: "userId" } },
+      session: { fields: { id: "sessionId" } },
+      account: { fields: { id: "accountId" } },
+    } as any;
+    const schema = getAuthTables(options);
+    expect(schema?.user?.fields.id?.fieldName).toBe("userId");
+    expect(schema?.session?.fields.id?.fieldName).toBe("sessionId");
+    expect(schema?.account?.fields.id?.fieldName).toBe("accountId");
+  });
+
+  it("adapter should store under DB column `user_id` and return logical `id`", async () => {
+    const options = { user: { fields: { id: "user_id" } } } as any;
+
+    const factory = createAdapterFactory({
+      config: {
+        adapterId: "test-adapter",
+        adapterName: "Test Adapter",
+        usePlural: false,
+        debugLogs: false,
+        supportsJSON: true,
+        supportsDates: true,
+        supportsBooleans: true,
+      },
+      adapter: () => {
+        // Simple in-memory backing store for this test
+        let stored: any = null;
+        return {
+          async create(data: { data: any; }) {
+            // underlying adapter receives DB-shaped payload in data.data
+            stored = data.data;
+            return stored;
+          },
+          async findOne(data: {data: any; where: any;}) {
+            // where clause should use DB column names (user_id)
+            const where = data.where;
+            if (!stored) return null;
+            if (where?.user_id && where.user_id === stored.user_id) return stored;
+            return null;
+          },
+        } as any;
+      },
+    });
+
+    const adapter = factory(options);
+
+    // create a user (logical payload)
+    const created = await adapter.create({ model: "user", data: { name: "Alice" } });
+
+    // Underlying store must have used DB column `user_id` (not logical `id`)
+    // We verify this by calling findOne using logical id and expecting a result.
+    expect(created).toHaveProperty("id");
+    const found = await adapter.findOne({ model: "user", where: [{ field: "id", value: created.id }] }) as any;
+    expect(found).not.toBeNull();
+    expect(found.id).toBe(created.id);
+  });
+
+  it("getFieldName should resolve to DB column name for id", () => {
+    const options = { user: { fields: { id: "userId" } } } as any;
+    const schema = getAuthTables(options);
+    const getDefaultModelName = initGetDefaultModelName({
+      usePlural: false,
+      schema,
+    });
+    const getFieldName = initGetFieldName({ schema, usePlural: false });
+
+    const modelKey = getDefaultModelName("user"); // should be "user"
+    const defaultField = initGetDefaultFieldName({ schema, usePlural: false })({
+      model: "user",
+      field: "id",
+    });
+    // DB column name:
+    const dbCol = getFieldName({ model: modelKey, field: defaultField });
+    expect(dbCol).toBe("userId");
+  });
+});

--- a/packages/better-auth/src/adapters/adapter-factory/index.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/index.ts
@@ -187,10 +187,19 @@ export const createAdapterFactory =
 			const useNumberId =
 				options.advanced?.database?.useNumberId ||
 				options.advanced?.database?.generateId === "serial";
-			fields.id = idField({
+			// fields.id = idField({
+			// 	customModelName: defaultModelName,
+			// 	forceAllowId: forceAllowId && "id" in data,
+			// });
+			const generatedIdField = idField({
 				customModelName: defaultModelName,
 				forceAllowId: forceAllowId && "id" in data,
-			});
+			})as any;
+			if(fields.id && (fields.id as any).fieldName){
+				generatedIdField.fieldName = (fields.id as any).fieldName;
+			}
+			fields.id = generatedIdField;
+
 			for (const field in fields) {
 				let value = data[field];
 				const fieldAttributes = fields[field];

--- a/packages/better-auth/src/adapters/adapter-factory/index.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/index.ts
@@ -194,8 +194,8 @@ export const createAdapterFactory =
 			const generatedIdField = idField({
 				customModelName: defaultModelName,
 				forceAllowId: forceAllowId && "id" in data,
-			})as any;
-			if(fields.id && (fields.id as any).fieldName){
+			}) as any;
+			if (fields.id && (fields.id as any).fieldName) {
 				generatedIdField.fieldName = (fields.id as any).fieldName;
 			}
 			fields.id = generatedIdField;

--- a/packages/better-auth/src/db/get-tables.ts
+++ b/packages/better-auth/src/db/get-tables.ts
@@ -56,6 +56,10 @@ export const getAuthTables = (
 		session: {
 			modelName: options.session?.modelName || "session",
 			fields: {
+				id:{
+					type: "string",
+					fieldName: options.session?.fields?.id || "id",
+				},
 				expiresAt: {
 					type: "date",
 					required: true,
@@ -111,6 +115,10 @@ export const getAuthTables = (
 		user: {
 			modelName: options.user?.modelName || "user",
 			fields: {
+				id:{
+					type: "string",
+					fieldName: options.user?.fields?.id || "id",
+				},
 				name: {
 					type: "string",
 					required: true,
@@ -161,6 +169,10 @@ export const getAuthTables = (
 		account: {
 			modelName: options.account?.modelName || "account",
 			fields: {
+					id:{
+					type: "string",
+					fieldName: options.account?.fields?.id || "id",
+				},
 				accountId: {
 					type: "string",
 					required: true,

--- a/packages/better-auth/src/db/get-tables.ts
+++ b/packages/better-auth/src/db/get-tables.ts
@@ -56,7 +56,7 @@ export const getAuthTables = (
 		session: {
 			modelName: options.session?.modelName || "session",
 			fields: {
-				id:{
+				id: {
 					type: "string",
 					fieldName: options.session?.fields?.id || "id",
 				},
@@ -115,7 +115,7 @@ export const getAuthTables = (
 		user: {
 			modelName: options.user?.modelName || "user",
 			fields: {
-				id:{
+				id: {
 					type: "string",
 					fieldName: options.user?.fields?.id || "id",
 				},
@@ -169,7 +169,7 @@ export const getAuthTables = (
 		account: {
 			modelName: options.account?.modelName || "account",
 			fields: {
-					id:{
+				id: {
 					type: "string",
 					fieldName: options.account?.fields?.id || "id",
 				},

--- a/packages/core/src/db/schema/account.ts
+++ b/packages/core/src/db/schema/account.ts
@@ -2,6 +2,7 @@ import * as z from "zod";
 import { coreSchema } from "./shared";
 
 export const accountSchema = coreSchema.extend({
+	id: z.string(),
 	providerId: z.string(),
 	accountId: z.string(),
 	userId: z.coerce.string(),

--- a/packages/core/src/db/schema/session.ts
+++ b/packages/core/src/db/schema/session.ts
@@ -2,6 +2,7 @@ import * as z from "zod";
 import { coreSchema } from "./shared";
 
 export const sessionSchema = coreSchema.extend({
+	id: z.string(),
 	userId: z.coerce.string(),
 	expiresAt: z.date(),
 	token: z.string(),

--- a/packages/core/src/db/schema/user.ts
+++ b/packages/core/src/db/schema/user.ts
@@ -2,6 +2,7 @@ import * as z from "zod";
 import { coreSchema } from "./shared";
 
 export const userSchema = coreSchema.extend({
+	id: z.string(),
 	email: z.string().transform((val) => val.toLowerCase()),
 	emailVerified: z.boolean().default(false),
 	name: z.string(),

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -597,7 +597,8 @@ export type BetterAuthOptions = {
 				 * }
 				 * ```
 				 */
-				fields?: Partial<Record<keyof OmitId<User>, string>>;
+				// fields?: Partial<Record<keyof OmitId<User>, string>>;
+				fields?: Partial<Record<keyof User, string>>;
 				/**
 				 * Additional fields for the user
 				 */
@@ -689,7 +690,9 @@ export type BetterAuthOptions = {
 				 *  userId: "user_id"
 				 * }
 				 */
-				fields?: Partial<Record<keyof OmitId<Session>, string>>;
+				// fields?: Partial<Record<keyof OmitId<Session>, string>>;
+				fields?: Partial<Record<keyof Session, string>>;
+
 				/**
 				 * Expiration time for the session token. The value
 				 * should be in seconds.
@@ -836,7 +839,8 @@ export type BetterAuthOptions = {
 				/**
 				 * Map fields
 				 */
-				fields?: Partial<Record<keyof OmitId<Account>, string>>;
+				// fields?: Partial<Record<keyof OmitId<Account>, string>>;
+				fields?: Partial<Record<keyof Account, string>>;
 				/**
 				 * Additional fields for the account
 				 */


### PR DESCRIPTION
Closes #5807
### Summary
Adds support for configuring custom database column names for primary ID fields (e.g., user_id) while preserving that mapping at runtime. This ensures that generated IDs are correctly inserted into the configured columns, while callers still use the canonical id field.

### Changes

- Updated types and options in init-options.ts to support custom ID field names.
- Added ID entries to the runtime schema generated by getAuthTables for user, session, and account schemas.
- Modified Adapter Factory to preserve fieldName when injecting generated ID attributes, ensuring transformInput inserts generated IDs into the configured DB column.
- Extended Zod schemas to include ID fields in userSchema, accountSchema, and sessionSchema.

**Note**:  Support for custom Id columns is currently implemented only  for the user, session and account tables.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for custom database column names for primary ID fields on user, session, and account tables. Generated IDs are written to the mapped columns, while callers continue to use the canonical id field.

- **New Features**
  - Configure custom ID columns via options.user/session/account.fields.id.
  - Runtime schema includes id.fieldName and the adapter writes generated IDs to that column.
  - Added id to user, session, and account Zod schemas; tests verify mapping and adapter behavior.

- **Migration**
  - If you use non-standard ID columns, set fields.id in your user/session/account options. No changes needed otherwise.

<sup>Written for commit 12b720acb5a5faf052b8fde8428dbf5d112851d1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



