### PR TITLE
fix: genericOAuth and SSO ignore discoveryUrl for authorization

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -926,6 +926,22 @@ export const signInSSO = (options?: SSOOptions) => {
 			}
 
 			if (provider.oidcConfig && body.providerType !== "saml") {
+				let finalAuthUrl = provider.oidcConfig.authorizationEndpoint;
+				if (!finalAuthUrl && provider.oidcConfig.discoveryEndpoint) {
+					const discovery = await betterFetch<{
+						authorization_endpoint: string;
+					}>(provider.oidcConfig.discoveryEndpoint, {
+						method: "GET",
+					});
+					if (discovery.data) {
+						finalAuthUrl = discovery.data.authorization_endpoint;
+					}
+				}
+				if (!finalAuthUrl) {
+					throw new APIError("BAD_REQUEST", {
+						message: "Invalid OIDC configuration. Authorization URL not found.",
+					});
+				}
 				const state = await generateState(ctx, undefined, false);
 				const redirectURI = `${ctx.context.baseURL}/sso/callback/${provider.providerId}`;
 				const authorizationURL = await createAuthorizationURL({
@@ -947,7 +963,7 @@ export const signInSSO = (options?: SSOOptions) => {
 							"offline_access",
 						],
 					loginHint: ctx.body.loginHint || email,
-					authorizationEndpoint: provider.oidcConfig.authorizationEndpoint!,
+					authorizationEndpoint: finalAuthUrl,
 				});
 				return ctx.json({
 					url: authorizationURL.toString(),


### PR DESCRIPTION
## Description
This PR fixes an issue where `generic-oauth` and `SSO` providers would crash with a `TypeError: Invalid URL` if only a `discoveryUrl` was provided without an explicit `authorizationUrl`.

## Changes
- **generic-oauth:** Updated `createAuthorizationURL` to fetch the `authorization_endpoint` from the `discoveryUrl` if it is not explicitly defined.
- **SSO:** Updated `signInSSO` to perform the same discovery lookup, resolving the issue reported in the comments by @aheidelberg [here](https://github.com/better-auth/better-auth/issues/6042#issuecomment-3543396443).

## Related Issue
Fixes #6042

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash where generic OAuth and SSO failed with “TypeError: Invalid URL” when only a discoveryUrl was configured. Both flows now resolve the authorization endpoint via OIDC discovery and validate the config.

- **Bug Fixes**
  - generic-oauth: createAuthorizationURL fetches authorization_endpoint (and userinfo_endpoint) from discoveryUrl when authorizationUrl is missing, and throws a clear error if not found.
  - SSO: signInSSO looks up authorization_endpoint from discoveryEndpoint when absent and validates before building the redirect URL.

<sup>Written for commit c89873e546f2e34e9b4c2e35410df83f3afc84ac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

