### PR TITLE
fix(oauth-proxy): add secure attribute and prevent double URL encoding

### DIFF
--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -217,12 +217,16 @@ export const oAuthProxy = (opts?: OAuthProxyOptions | undefined) => {
 										options.partitioned = true;
 										break;
 									}
+									case "secure": {
+										options.secure = true;
+										break;
+									}
 								}
 							}
 
 							return {
 								name,
-								value,
+								value: decodeURIComponent(value),
 								options,
 							};
 						});


### PR DESCRIPTION
Refers #6039 

In #6039, cookies were prevented from being double URL-encoded, and the secure attribute was planned to be removed. This PR fixes these issues.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cookie handling in the OAuth proxy by respecting the Secure attribute and decoding cookie values to avoid double-encoded cookies. This improves session reliability in secure environments.

- **Bug Fixes**
  - Set options.secure when the Secure flag is present.
  - Decode cookie values with decodeURIComponent to prevent double URL encoding.

<sup>Written for commit 4137fa552728aa235e6aefa6593421f28e01c8ca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

