### PR TITLE
chore: use relative schema path for turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turborepo.org/schema.json",
+  "$schema": "./node_modules/turbo/schema.json",
   "globalDependencies": [
     "package.json",
     "tsconfig.json",


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch turbo.json $schema to a local path (./node_modules/turbo/schema.json). This removes the external URL dependency and keeps schema validation working offline and in CI.

<sup>Written for commit 628e0545f12e1c68b3970c52847340b01db8d52d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



