### PR TITLE
docs: add missing `customizeDefaultErrorPage` docs

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -604,7 +604,39 @@ export const auth = betterAuth({
 			// Custom error handling
 			console.error("Auth error:", error);
 		},
-		errorURL: "/auth/error"
+		errorURL: "/auth/error",
+		customizeDefaultErrorPage: {
+			colors: {
+				background: "#ffffff",
+				foreground: "#000000",
+				primary: "#0070f3",
+				primaryForeground: "#ffffff",
+				mutedForeground: "#666666",
+				border: "#e0e0e0",
+				destructive: "#ef4444",
+				titleBorder: "#0070f3",
+				titleColor: "#000000",
+				gridColor: "#f0f0f0",
+				cardBackground: "#ffffff",
+				cornerBorder: "#0070f3"
+			},
+			size: {
+				radiusSm: "0.25rem",
+				radiusMd: "0.5rem",
+				radiusLg: "1rem",
+				textSm: "0.875rem",
+				text2xl: "1.5rem",
+				text4xl: "2.25rem",
+				text6xl: "3.75rem"
+			},
+			font: {
+				defaultFamily: "system-ui, sans-serif",
+				monoFamily: "monospace"
+			},
+			disableTitleBorder: false,
+			disableCornerDecorations: false,
+			disableBackgroundGrid: false
+		}
 	},
 })
 ```
@@ -612,6 +644,34 @@ export const auth = betterAuth({
 - `throw`: Throw an error on API error (default: `false`)
 - `onError`: Custom error handler
 - `errorURL`: URL to redirect to on error (default: `/api/auth/error`)
+- `customizeDefaultErrorPage`: Configure the default error page provided by Better Auth. Start your dev server and go to `/api/auth/error` to see the error page.
+  - `colors`: Customize color scheme for the error page
+    - `background`: Background color
+    - `foreground`: Foreground/text color
+    - `primary`: Primary accent color
+    - `primaryForeground`: Text color on primary background
+    - `mutedForeground`: Muted text color
+    - `border`: Border color
+    - `destructive`: Error/destructive color
+    - `titleBorder`: Border color for the title
+    - `titleColor`: Title text color
+    - `gridColor`: Background grid color
+    - `cardBackground`: Card background color
+    - `cornerBorder`: Corner decoration border color
+  - `size`: Customize sizing and spacing
+    - `radiusSm`: Small border radius
+    - `radiusMd`: Medium border radius
+    - `radiusLg`: Large border radius
+    - `textSm`: Small text size
+    - `text2xl`: 2xl text size
+    - `text4xl`: 4xl text size
+    - `text6xl`: 6xl text size
+  - `font`: Customize font families
+    - `defaultFamily`: Default font family
+    - `monoFamily`: Monospace font family
+  - `disableTitleBorder`: Disable the border around the title (default: `false`)
+  - `disableCornerDecorations`: Disable corner decorations (default: `false`)
+  - `disableBackgroundGrid`: Disable the background grid pattern (default: `false`)
 
 ## `hooks`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added missing documentation for the customizeDefaultErrorPage option in auth settings, including an example config and field descriptions. Helps users style the default error page at /api/auth/error (colors, size, font, and disable flags).

<sup>Written for commit d529de3b48aa4f645655cb8d42208b881bdb2337. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

