### PR TITLE
docs: replace `pnpm` with `npx` in ai tooling commands

### DIFF
--- a/docs/content/docs/introduction.mdx
+++ b/docs/content/docs/introduction.mdx
@@ -34,22 +34,22 @@ Use the Better Auth CLI to easily add the MCP server to your preferred client:
 <Tabs items={["Cursor", "Claude Code", "Open Code", "Manual"]}>
     <Tab value="Cursor">
       ```bash title="terminal"
-      pnpx @better-auth/cli mcp --cursor
+      npx @better-auth/cli mcp --cursor
       ```
     </Tab>
     <Tab value="Claude Code">
       ```bash title="terminal"
-      pnpx @better-auth/cli mcp --claude-code
+      npx @better-auth/cli mcp --claude-code
       ```
     </Tab>
     <Tab value="Open Code">
       ```bash title="terminal"
-      pnpx @better-auth/cli mcp --open-code
+      npx @better-auth/cli mcp --open-code
       ```
     </Tab>
     <Tab value="Manual">
       ```bash title="terminal"
-      pnpx @better-auth/cli mcp --manual
+      npx @better-auth/cli mcp --manual
       ```
     </Tab>
 </Tabs>


### PR DESCRIPTION
This pull request makes a minor update to the documentation to improve the command examples for adding the MCP server to your preferred client.

* Updated all CLI command examples in the `docs/content/docs/introduction.mdx` file to use `pnpx` instead of `pnpm`, ensuring the Better Auth CLI runs correctly even if it is not installed yet.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the introduction docs to use npx in MCP server commands, so the Better Auth CLI runs even if it isn’t installed locally. Replaced pnpm with npx across all client tabs (Cursor, Claude Code, Open Code, Manual).

<sup>Written for commit d6bb88ea0e3ef25ebb0551195ca451db6bc0ba62. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



