### PR TITLE
fix(expo): enhance cookie detection for better-auth cookies

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -198,44 +198,42 @@ function hasSessionCookieChanged(
 }
 
 /**
- * Check if the Set-Cookie header contains session-related better-auth cookies.
- * Only triggers session updates when session_token or session_data cookies are present.
- * This prevents infinite refetching when non-session cookies (like third-party cookies) change.
+ * Check if the Set-Cookie header contains better-auth cookies.
+ * This prevents infinite refetching when non-better-auth cookies (like third-party cookies) change.
  *
  * Supports multiple cookie naming patterns:
- * - Default: "better-auth.session_token", "__Secure-better-auth.session_token"
- * - Custom prefix: "myapp.session_token", "__Secure-myapp.session_token"
+ * - Default: "better-auth.session_token", "better-auth-passkey", "__Secure-better-auth.session_token"
+ * - Custom prefix: "myapp.session_token", "myapp-passkey", "__Secure-myapp.session_token"
  * - Custom full names: "my_custom_session_token", "custom_session_data"
- * - No prefix (cookiePrefix=""): "session_token", "my_session_token", etc.
+ * - No prefix (cookiePrefix=""): matches any cookie with known suffixes
  *
  * @param setCookieHeader - The Set-Cookie header value
  * @param cookiePrefix - The cookie prefix to check for. Can be empty string for custom cookie names.
- * @returns true if the header contains session-related cookies, false otherwise
+ * @returns true if the header contains better-auth cookies, false otherwise
  */
 export function hasBetterAuthCookies(
 	setCookieHeader: string,
 	cookiePrefix: string,
 ): boolean {
 	const cookies = parseSetCookieHeader(setCookieHeader);
-	const sessionCookieSuffixes = ["session_token", "session_data"];
+	const cookieSuffixes = ["session_token", "session_data"];
 
-	// Check if any cookie is a session-related cookie
+	// Check if any cookie is a better-auth cookie
 	for (const name of cookies.keys()) {
 		// Remove __Secure- prefix if present for comparison
 		const nameWithoutSecure = name.startsWith("__Secure-")
 			? name.slice(9)
 			: name;
 
-		for (const suffix of sessionCookieSuffixes) {
-			if (cookiePrefix) {
-				// When prefix is provided, only match exact pattern: "prefix.suffix"
-				if (nameWithoutSecure === `${cookiePrefix}.${suffix}`) {
-					return true;
-				}
-			} else {
-				// When prefix is empty, check for:
-				// 1. Exact match: "session_token"
-				// 2. Custom names ending with suffix: "my_custom_session_token"
+		if (cookiePrefix) {
+			// When prefix is provided, check if cookie starts with the prefix
+			// This matches all better-auth cookies including session cookies, passkey cookies, etc.
+			if (nameWithoutSecure.startsWith(cookiePrefix)) {
+				return true;
+			}
+		} else {
+			// When prefix is empty, check for common better-auth cookie patterns
+			for (const suffix of cookieSuffixes) {
 				if (nameWithoutSecure.endsWith(suffix)) {
 					return true;
 				}

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -214,10 +214,23 @@ describe("expo", async () => {
 			hasBetterAuthCookies(multipleNonBetterAuthHeader, "better-auth"),
 		).toBe(false);
 
+		// Non-session better-auth cookies should still be detected (e.g., passkey cookies)
 		const nonSessionBetterAuthHeader = "better-auth.other_cookie=abc; Path=/";
 		expect(
 			hasBetterAuthCookies(nonSessionBetterAuthHeader, "better-auth"),
-		).toBe(false);
+		).toBe(true);
+
+		// Passkey cookie should be detected
+		const passkeyHeader = "better-auth-passkey=xyz; Path=/";
+		expect(hasBetterAuthCookies(passkeyHeader, "better-auth")).toBe(true);
+
+		// Secure passkey cookie should be detected
+		const securePasskeyHeader = "__Secure-better-auth-passkey=xyz; Path=/";
+		expect(hasBetterAuthCookies(securePasskeyHeader, "better-auth")).toBe(true);
+
+		// Custom passkey cookie name should be detected
+		const customPasskeyHeader = "better-auth-custom-challenge=xyz; Path=/";
+		expect(hasBetterAuthCookies(customPasskeyHeader, "better-auth")).toBe(true);
 	});
 
 	it("should preserve unchanged client store session properties on signout", async () => {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded better-auth cookie detection to include non-session cookies (e.g., passkey) so auth changes are caught reliably while still ignoring third‑party cookies.

- **Bug Fixes**
  - Detect any cookie starting with the configured prefix (handles "__Secure-" variants).
  - Keep suffix matching when prefix is empty (session_token, session_data).
  - Add tests for passkey cookies, secure passkey, and custom prefixed names.

<sup>Written for commit ab44dae245e60b03a4b98104e8e9b165d26c2c9b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



