### PR TITLE
feat(expo): support multiple cookie prefixes for better-auth detection

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -470,6 +470,44 @@ const authClient = createAuthClient({
 });
 ```
 
+**cookiePrefix**: Prefix(es) for server cookie names to identify which cookies belong to better-auth. This prevents infinite refetching when third-party cookies are set. Can be a single string or an array of strings to match multiple prefixes. Defaults to `"better-auth"`.
+
+```ts title="lib/auth-client.ts"
+import { createAuthClient } from "better-auth/react";
+import { expoClient } from "@better-auth/expo/client";
+import * as SecureStore from "expo-secure-store";
+
+const authClient = createAuthClient({
+    baseURL: "http://localhost:8081",
+    plugins: [
+        expoClient({
+            storage: SecureStore,
+            // Single prefix
+            cookiePrefix: "better-auth"
+        })
+    ]
+});
+```
+
+You can also provide multiple prefixes to match cookies from different authentication systems:
+
+```ts title="lib/auth-client.ts"
+const authClient = createAuthClient({
+    baseURL: "http://localhost:8081",
+    plugins: [
+        expoClient({
+            storage: SecureStore,
+            // Multiple prefixes
+            cookiePrefix: ["better-auth", "my-app", "custom-auth"]
+        })
+    ]
+});
+```
+
+<Callout type="info">
+  **Important:** If you're using plugins like passkey with a custom `webAuthnChallengeCookie` option, make sure to include the cookie prefix in the `cookiePrefix` array. For example, if you set `webAuthnChallengeCookie: "my-app-passkey"`, include `"my-app"` in your `cookiePrefix`. See the [Passkey plugin documentation](/docs/plugins/passkey#expo-integration) for more details.
+</Callout>
+
 
 ### Expo Servers
 

--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -341,3 +341,63 @@ until it hits an effective TLD. So `www.example.com` can use the RP IDs `www.exa
 **advanced**: Advanced options
 
 - `webAuthnChallengeCookie`: Cookie name for storing WebAuthn challenge ID during authentication flow (Default: `better-auth-passkey`)
+
+## Expo Integration
+
+When using the passkey plugin with Expo, you need to configure the `cookiePrefix` option in the Expo client to ensure passkey cookies are properly detected and stored.
+
+By default, the passkey plugin uses `"better-auth-passkey"` as the challenge cookie name. Since this starts with `"better-auth"`, it will work with the default Expo client configuration. However, if you customize the `webAuthnChallengeCookie` option, you must also update the `cookiePrefix` in your Expo client configuration.
+
+### Example Configuration
+
+If you're using a custom cookie name:
+
+```ts title="Server: auth.ts"
+import { betterAuth } from "better-auth";
+import { passkey } from "@better-auth/passkey";
+
+export const auth = betterAuth({
+    plugins: [
+        passkey({
+            advanced: {
+                webAuthnChallengeCookie: "my-app-passkey" // Custom cookie name
+            }
+        })
+    ]
+});
+```
+
+Make sure to configure your Expo client with the matching prefix:
+
+```ts title="Client: auth-client.ts"
+import { createAuthClient } from "better-auth/react";
+import { expoClient } from "@better-auth/expo/client";
+import { passkeyClient } from "@better-auth/passkey/client";
+import * as SecureStore from "expo-secure-store";
+
+export const authClient = createAuthClient({
+    baseURL: "http://localhost:8081",
+    plugins: [
+        expoClient({
+            storage: SecureStore,
+            cookiePrefix: "my-app" // Must match the prefix of your custom cookie name
+        }),
+        passkeyClient()
+    ]
+});
+```
+
+If you're using multiple authentication systems or custom cookie names, you can provide an array of prefixes:
+
+```ts title="Client: auth-client.ts"
+expoClient({
+    storage: SecureStore,
+    cookiePrefix: ["better-auth", "my-app", "custom-auth"]
+})
+```
+
+<Callout type="warn">
+  If the `cookiePrefix` doesn't match the prefix of your `webAuthnChallengeCookie`, the passkey authentication flow will fail because the challenge cookie won't be stored and sent back to the server during verification.
+</Callout>
+
+For more information on Expo integration, see the [Expo documentation](/docs/integrations/expo).

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -455,6 +455,48 @@ describe("expo with cookieCache", async () => {
 		expect(hasBetterAuthCookies(customCookieHeader, "better-auth")).toBe(false);
 	});
 
+	it("should support array of cookie prefixes", async () => {
+		const { hasBetterAuthCookies } = await import("../src/client");
+
+		// Test with multiple prefixes - should match any of them
+		const betterAuthHeader = "better-auth.session_token=abc; Path=/";
+		expect(
+			hasBetterAuthCookies(betterAuthHeader, ["better-auth", "my-app"]),
+		).toBe(true);
+
+		const myAppHeader = "my-app.session_data=xyz; Path=/";
+		expect(hasBetterAuthCookies(myAppHeader, ["better-auth", "my-app"])).toBe(
+			true,
+		);
+
+		const otherAppHeader = "other-app.session_token=def; Path=/";
+		expect(
+			hasBetterAuthCookies(otherAppHeader, ["better-auth", "my-app"]),
+		).toBe(false);
+
+		// Test with passkey cookies
+		const passkeyHeader1 = "better-auth-passkey=xyz; Path=/";
+		expect(
+			hasBetterAuthCookies(passkeyHeader1, ["better-auth", "my-app"]),
+		).toBe(true);
+
+		const passkeyHeader2 = "my-app-passkey=xyz; Path=/";
+		expect(
+			hasBetterAuthCookies(passkeyHeader2, ["better-auth", "my-app"]),
+		).toBe(true);
+
+		// Test with __Secure- prefix
+		const secureHeader = "__Secure-my-app.session_token=abc; Path=/";
+		expect(hasBetterAuthCookies(secureHeader, ["better-auth", "my-app"])).toBe(
+			true,
+		);
+
+		// Test with empty array (should check for suffixes)
+		const sessionTokenHeader = "session_token=abc; Path=/";
+		expect(hasBetterAuthCookies(sessionTokenHeader, [])).toBe(false);
+		expect(hasBetterAuthCookies(sessionTokenHeader, [""])).toBe(true);
+	});
+
 	it("should normalize colons in secure storage name via storage adapter", async () => {
 		const map = new Map<string, string>();
 		const storage = storageAdapter({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for multiple cookie prefixes in the Expo client to correctly detect better-auth cookies and prevent infinite refetching when third-party cookies are set. Documentation for Expo and Passkey is updated with examples for custom cookie names.

- **New Features**
  - cookiePrefix now accepts a string or an array of strings; detection checks all provided prefixes, including "__Secure-" variants.
  - hasBetterAuthCookies updated to match session and passkey cookies by prefix; default remains "better-auth".

- **Migration**
  - If you use a custom webAuthnChallengeCookie (e.g., "my-app-passkey"), include its prefix (e.g., "my-app") in cookiePrefix.
  - For multiple auth systems, pass an array: ["better-auth", "my-app"].
  - To match cookies without a prefix, set cookiePrefix to "" (empty string); passing [] will not match suffixes.

<sup>Written for commit dafc3c114edc4ea62c3e6a4ff88893a581f7663e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

