### PR TITLE
chore(sso): support `form-urlencoded` for acs endpoint

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1798,6 +1798,10 @@ export const acsEndpoint = (options?: SSOOptions) => {
 			}),
 			metadata: {
 				isAction: false,
+				allowedMediaTypes: [
+					"application/x-www-form-urlencoded",
+					"application/json",
+				],
 				openapi: {
 					operationId: "handleSAMLAssertionConsumerService",
 					summary: "SAML Assertion Consumer Service",


### PR DESCRIPTION
SSO's asc saml endpoint needs to accept `x-www-form-urlencoded` mime type.