### PR TITLE
feat(email-otp): username sign-in

### DIFF
--- a/docs/content/docs/plugins/email-otp.mdx
+++ b/docs/content/docs/plugins/email-otp.mdx
@@ -136,6 +136,42 @@ type signInEmailOTP = {
 If the user is not registered, they'll be automatically registered. If you want to prevent this, you can pass `disableSignUp` as `true` in the [options](#options).
 </Callout>
 
+### Sign In with Username OTP
+
+To sign in with username and OTP, use the `sendUsernameSignInOtp()` method to send a sign-in OTP to the email address associated with the user's username.
+
+<APIMethod path="/email-otp/send-username-sign-in-otp" method="POST">
+```ts
+type sendUsernameSignInOtp = {
+    /**
+     * Username of the account to send the OTP to.
+     */
+    username: string = "username"
+}
+```
+</APIMethod>
+
+Once the user provides the OTP, you can sign in the user using the `signIn.usernameOtp()` method.
+
+<APIMethod path="/sign-in/username-otp" method="POST">
+```ts
+type signInUsernameOTP = {
+    /**
+     * Username of the account to sign in.
+     */
+    username: string = "username"
+    /**
+     * OTP sent to the email associated with the username. 
+     */
+    otp: string = "123456"
+}
+```
+</APIMethod>
+
+<Callout>
+The username plugin must be enabled for these endpoints to work. The OTP will be sent to the email address associated with the username.
+</Callout>
+
 ### Verify Email with OTP
 
 To verify the user's email address with OTP, use the `sendVerificationOtp()` method to send an "email-verification" OTP to the user's email address.

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -5,6 +5,8 @@ import { bearer } from "../bearer";
 import { emailOTP } from ".";
 import { emailOTPClient } from "./client";
 import { splitAtLastColon } from "./utils";
+import { username } from "../username";
+import { usernameClient } from "../username/client";
 
 describe("email-otp", async () => {
 	const otpFn = vi.fn();
@@ -72,6 +74,100 @@ describe("email-otp", async () => {
 			},
 		);
 		expect(verifiedUser.data?.token).toBeDefined();
+	});
+
+	it("should sign-in with username otp", async () => {
+		const { client, sessionSetter } = await getTestInstance(
+			{
+				plugins: [
+					username({ minUsernameLength: 4 }),
+					emailOTP({
+						async sendVerificationOTP({ email, otp: _otp, type }) {
+							otp = _otp;
+							otpFn(email, _otp, type);
+						},
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [emailOTPClient(), usernameClient()],
+				},
+			},
+		);
+
+		const newUser = {
+			email: "new-email@gamil.com",
+			username: "new_username",
+			password: "new-password",
+			name: "new-name",
+		};
+
+		const headers = new Headers();
+		await client.signUp.email(newUser, {
+			onSuccess: sessionSetter(headers),
+		});
+
+		const { data, error } = await client.emailOtp.sendUsernameSignInOtp({
+			username: newUser.username,
+		});
+
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+		expect(data?.success).toBeTruthy();
+
+		const user = await client.signIn.usernameOtp(
+			{
+				username: newUser.username,
+				otp,
+			},
+			{
+				onSuccess: (ctx) => {
+					const header = ctx.response.headers.get("set-cookie");
+					expect(header).toContain("better-auth.session_token");
+				},
+			},
+		);
+		expect(user.data?.token).toBeDefined();
+	});
+
+	it("should return error when username plugin is not enabled", async () => {
+		const { client, sessionSetter, auth } = await getTestInstance(
+			{
+				plugins: [
+					emailOTP({
+						async sendVerificationOTP({ email, otp: _otp, type }) {
+							otp = _otp;
+							otpFn(email, _otp, type);
+						},
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [emailOTPClient(), usernameClient()],
+				},
+			},
+		);
+
+		const newUser = {
+			email: "new-email@gamil.com",
+			password: "new-password",
+			name: "new-name",
+		};
+
+		const headers = new Headers();
+		await client.signUp.email(newUser, {
+			onSuccess: sessionSetter(headers),
+		});
+
+		const { data, error } = await client.emailOtp.sendUsernameSignInOtp({
+			username: "new_username",
+		});
+
+		expect(data).toBeNull();
+		expect(error).not.toBeNull();
+		expect(error?.message).toBe("username plugin not enabled");
 	});
 
 	it("should sign-up with otp", async () => {

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import { createAuthClient } from "../../client";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { bearer } from "../bearer";
+import { username } from "../username";
+import { usernameClient } from "../username/client";
 import { emailOTP } from ".";
 import { emailOTPClient } from "./client";
 import { splitAtLastColon } from "./utils";
-import { username } from "../username";
-import { usernameClient } from "../username/client";
 
 describe("email-otp", async () => {
 	const otpFn = vi.fn();

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -6,6 +6,7 @@ import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
+import type { User } from "@better-auth/core/db";
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import { defineErrorCodes } from "@better-auth/core/utils";
 import * as z from "zod";
@@ -18,10 +19,9 @@ import {
 } from "../../crypto";
 import { getDate } from "../../utils/date";
 import { getEndpointResponse } from "../../utils/plugin-helper";
-import { defaultKeyHasher, splitAtLastColon } from "./utils";
-import { USERNAME_ERROR_CODES } from "../username";
 import type { UsernameOptions } from "../username";
-import type { User } from "@better-auth/core/db";
+import { USERNAME_ERROR_CODES } from "../username";
+import { defaultKeyHasher, splitAtLastColon } from "./utils";
 
 export interface EmailOTPOptions {
 	/**

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -519,11 +519,14 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							});
 						});
 
-					await options.sendVerificationOTP({
-						email: user.email,
-						otp,
-						type: "sign-in",
-					});
+					await options.sendVerificationOTP(
+						{
+							email: user.email,
+							otp,
+							type: "sign-in",
+						},
+						ctx,
+					);
 
 					return ctx.json({ success: true });
 				},

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -400,7 +400,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					method: "POST",
 					body: z.object({
 						username: z.string().meta({
-							description: "Username to send the OTP",
+							description: "Username of the account to send the OTP to",
 						}),
 					}),
 					metadata: {
@@ -1109,7 +1109,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 					method: "POST",
 					body: z.object({
 						username: z.string({}).meta({
-							description: "Username to sign in",
+							description: "Username of the account to sign in",
 						}),
 						otp: z.string().meta({
 							required: true,

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -19,6 +19,9 @@ import {
 import { getDate } from "../../utils/date";
 import { getEndpointResponse } from "../../utils/plugin-helper";
 import { defaultKeyHasher, splitAtLastColon } from "./utils";
+import { USERNAME_ERROR_CODES } from "../username";
+import type { UsernameOptions } from "../username";
+import type { User } from "@better-auth/core/db";
 
 export interface EmailOTPOptions {
 	/**
@@ -116,6 +119,20 @@ export const emailOTP = (options: EmailOTPOptions) => {
 		storeOTP: "plain",
 		...options,
 	} satisfies EmailOTPOptions;
+
+	function normalizer(username: string, options: UsernameOptions) {
+		if (options?.usernameNormalization === false) {
+			return username;
+		}
+		if (options?.usernameNormalization) {
+			return options.usernameNormalization(username);
+		}
+		return username.toLowerCase();
+	}
+
+	function defaultUsernameValidator(username: string) {
+		return /^[a-zA-Z0-9_.]+$/.test(username);
+	}
 
 	async function storeOTP(ctx: GenericEndpointContext, otp: string) {
 		if (opts.storeOTP === "encrypted") {
@@ -360,6 +377,155 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						expiresAt: getDate(opts.expiresIn, "sec"),
 					});
 					return otp;
+				},
+			),
+			/**
+			 * ### Endpoint
+			 *
+			 * POST `/email-otp/send-username-sign-in-otp`
+			 *
+			 * ### API Methods
+			 *
+			 * **server:**
+			 * `auth.api.sendUsernameSignInOtp`
+			 *
+			 * **client:**
+			 * `authClient.emailOtp.sendUsernameSignInOtp`
+			 *
+			 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/email-otp#api-method-email-otp-send-username-sign-in-otp)
+			 */
+			sendUsernameSignInOtp: createAuthEndpoint(
+				"/email-otp/send-username-sign-in-otp",
+				{
+					method: "POST",
+					body: z.object({
+						username: z.string().meta({
+							description: "Username to send the OTP",
+						}),
+					}),
+					metadata: {
+						openapi: {
+							operationId: "sendUsernameSignInOtp",
+							description:
+								"Send a sign-in OTP to the email of the account with the given username",
+							responses: {
+								200: {
+									description: "Success",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													success: {
+														type: "boolean",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					const usernameOptions = ctx.context.options.plugins?.find(
+						(plugin) => plugin.id === "username",
+					) as UsernameOptions | undefined;
+
+					if (!usernameOptions) {
+						ctx.context.logger.error("username plugin not enabled");
+						throw new APIError("BAD_REQUEST", {
+							message: "username plugin not enabled",
+						});
+					}
+
+					const username =
+						usernameOptions?.validationOrder?.username === "pre-normalization"
+							? normalizer(ctx.body.username, usernameOptions)
+							: ctx.body.username;
+
+					const minUsernameLength = usernameOptions?.minUsernameLength || 3;
+					const maxUsernameLength = usernameOptions?.maxUsernameLength || 30;
+
+					if (username.length < minUsernameLength) {
+						ctx.context.logger.error("Username too short", {
+							username,
+						});
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							code: "USERNAME_TOO_SHORT",
+							message: USERNAME_ERROR_CODES.USERNAME_TOO_SHORT,
+						});
+					}
+
+					if (username.length > maxUsernameLength) {
+						ctx.context.logger.error("Username too long", {
+							username,
+						});
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							message: USERNAME_ERROR_CODES.USERNAME_TOO_LONG,
+						});
+					}
+
+					const validator =
+						usernameOptions?.usernameValidator || defaultUsernameValidator;
+
+					if (!validator(username)) {
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							message: USERNAME_ERROR_CODES.INVALID_USERNAME,
+						});
+					}
+
+					const normalizedUsername = normalizer(username, usernameOptions);
+
+					const user = await ctx.context.adapter.findOne<
+						User & { username: string; displayUsername: string }
+					>({
+						model: "user",
+						where: [
+							{
+								field: "username",
+								value: normalizedUsername,
+							},
+						],
+					});
+					if (!user) {
+						return ctx.json({ success: true });
+					}
+
+					let otp =
+						opts.generateOTP({ email: user.email, type: "sign-in" }, ctx) ||
+						defaultOTPGenerator(opts);
+
+					let storedOTP = await storeOTP(ctx, otp);
+
+					// use different namespace identifier to avoid collision with email-based sign-in
+					await ctx.context.internalAdapter
+						.createVerificationValue({
+							value: `${storedOTP}:0`,
+							identifier: `sign-in-otp-username-${normalizedUsername}`,
+							expiresAt: getDate(opts.expiresIn, "sec"),
+						})
+						.catch(async (error) => {
+							// might be duplicate key error
+							await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+								`sign-in-otp-username-${normalizedUsername}`,
+							);
+							//try again
+							await ctx.context.internalAdapter.createVerificationValue({
+								value: `${storedOTP}:0`,
+								identifier: `sign-in-otp-username-${normalizedUsername}`,
+								expiresAt: getDate(opts.expiresIn, "sec"),
+							});
+						});
+
+					await options.sendVerificationOTP({
+						email: user.email,
+						otp,
+						type: "sign-in",
+					});
+
+					return ctx.json({ success: true });
 				},
 			),
 			/**
@@ -925,6 +1091,207 @@ export const emailOTP = (options: EmailOTPOptions) => {
 			/**
 			 * ### Endpoint
 			 *
+			 * POST `/sign-in/username-otp`
+			 *
+			 * ### API Methods
+			 *
+			 * **server:**
+			 * `auth.api.signInUsernameOtp`
+			 *
+			 * **client:**
+			 * `authClient.signIn.usernameOtp`
+			 *
+			 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/email-otp#api-method-sign-in-username-otp)
+			 */
+			signInUsernameOtp: createAuthEndpoint(
+				"/sign-in/username-otp",
+				{
+					method: "POST",
+					body: z.object({
+						username: z.string({}).meta({
+							description: "Username to sign in",
+						}),
+						otp: z.string().meta({
+							required: true,
+							description:
+								"OTP sent to the email associated with the given username",
+						}),
+					}),
+					metadata: {
+						openapi: {
+							operationId: "signInUsernameOtp",
+							description: "Sign in with username and OTP",
+							responses: {
+								200: {
+									description: "Success",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													token: {
+														type: "string",
+														description:
+															"Session token for the authenticated session",
+													},
+													user: {
+														$ref: "#/components/schemas/User",
+													},
+												},
+												required: ["token", "user"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					const usernameOptions = ctx.context.options.plugins?.find(
+						(plugin) => plugin.id === "username",
+					) as UsernameOptions | undefined;
+
+					if (!usernameOptions) {
+						ctx.context.logger.error("username plugin not enabled");
+						throw new APIError("BAD_REQUEST", {
+							message: "username plugin not enabled",
+						});
+					}
+
+					const username =
+						usernameOptions?.validationOrder?.username === "pre-normalization"
+							? normalizer(ctx.body.username, usernameOptions)
+							: ctx.body.username;
+
+					const minUsernameLength = usernameOptions?.minUsernameLength || 3;
+					const maxUsernameLength = usernameOptions?.maxUsernameLength || 30;
+
+					if (username.length < minUsernameLength) {
+						ctx.context.logger.error("Username too short", {
+							username,
+						});
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							code: "USERNAME_TOO_SHORT",
+							message: USERNAME_ERROR_CODES.USERNAME_TOO_SHORT,
+						});
+					}
+
+					if (username.length > maxUsernameLength) {
+						ctx.context.logger.error("Username too long", {
+							username,
+						});
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							message: USERNAME_ERROR_CODES.USERNAME_TOO_LONG,
+						});
+					}
+
+					const validator =
+						usernameOptions?.usernameValidator || defaultUsernameValidator;
+
+					if (!validator(username)) {
+						throw new APIError("UNPROCESSABLE_ENTITY", {
+							message: USERNAME_ERROR_CODES.INVALID_USERNAME,
+						});
+					}
+
+					const normalizedUsername = normalizer(username, usernameOptions);
+
+					const verificationValue =
+						await ctx.context.internalAdapter.findVerificationValue(
+							`sign-in-otp-username-${normalizedUsername}`,
+						);
+
+					if (!verificationValue) {
+						throw new APIError("BAD_REQUEST", {
+							message: ERROR_CODES.INVALID_OTP,
+						});
+					}
+
+					if (verificationValue.expiresAt < new Date()) {
+						throw new APIError("BAD_REQUEST", {
+							message: ERROR_CODES.OTP_EXPIRED,
+						});
+					}
+
+					const [otpValue, attempts] = splitAtLastColon(
+						verificationValue.value,
+					);
+
+					const allowedAttempts = options?.allowedAttempts || 3;
+
+					if (attempts && parseInt(attempts) >= allowedAttempts) {
+						await ctx.context.internalAdapter.deleteVerificationValue(
+							verificationValue.id,
+						);
+
+						throw new APIError("FORBIDDEN", {
+							message: ERROR_CODES.TOO_MANY_ATTEMPTS,
+						});
+					}
+
+					const verified = await verifyStoredOTP(ctx, otpValue, ctx.body.otp);
+					if (!verified) {
+						await ctx.context.internalAdapter.updateVerificationValue(
+							verificationValue.id,
+							{
+								value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
+							},
+						);
+						throw new APIError("BAD_REQUEST", {
+							message: ERROR_CODES.INVALID_OTP,
+						});
+					}
+
+					await ctx.context.internalAdapter.deleteVerificationValue(
+						verificationValue.id,
+					);
+
+					const user = await ctx.context.adapter.findOne<
+						User & { username: string; displayUsername: string }
+					>({
+						model: "user",
+						where: [
+							{
+								field: "username",
+								value: normalizedUsername,
+							},
+						],
+					});
+					if (!user) {
+						throw new APIError("UNAUTHORIZED", {
+							message: USERNAME_ERROR_CODES.INVALID_USERNAME,
+						});
+					}
+
+					if (!user.emailVerified) {
+						await ctx.context.internalAdapter.updateUser(user.id, {
+							emailVerified: true,
+						});
+					}
+
+					const session = await ctx.context.internalAdapter.createSession(
+						user.id,
+					);
+					await setSessionCookie(ctx, { session, user });
+
+					return ctx.json({
+						token: session.token,
+						user: {
+							id: user.id,
+							email: user.email,
+							emailVerified: user.emailVerified,
+							name: user.name,
+							image: user.image,
+							createdAt: user.createdAt,
+							updatedAt: user.updatedAt,
+						},
+					});
+				},
+			),
+			/**
+			 * ### Endpoint
+			 *
 			 * POST `/forget-password/email-otp`
 			 *
 			 * ### API Methods
@@ -1218,6 +1585,20 @@ export const emailOTP = (options: EmailOTPOptions) => {
 			{
 				pathMatcher(path) {
 					return path === "/sign-in/email-otp";
+				},
+				window: 60,
+				max: 3,
+			},
+			{
+				pathMatcher(path) {
+					return path === "/email-otp/send-username-sign-in-otp";
+				},
+				window: 60,
+				max: 3,
+			},
+			{
+				pathMatcher(path) {
+					return path === "/sign-in/username-otp";
 				},
 				window: 60,
 				max: 3,


### PR DESCRIPTION
add username sign-in with emailOTP plugin

closes #4712 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds username-based OTP sign-in to the email-otp plugin. Users can request an OTP by username and sign in with it, with validation and rate limits.

- **New Features**
  - Added POST /email-otp/send-username-sign-in-otp and POST /sign-in/username-otp endpoints.
  - Supports username normalization/validation (length, allowed characters, custom validator) and auto-verifies email on success.
  - Uses a separate OTP namespace for usernames, with attempt limits and rate limiting.

- **Migration**
  - Enable the username plugin.
  - If using the client, include emailOTPClient() and usernameClient().
  - No schema changes.

<sup>Written for commit c241aeeaf0c500215430322a280eaf7b300a7462. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



