### PR TITLE
chore: docs for `sendVerificationEmail` in change-email flow

### DIFF
--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -31,15 +31,26 @@ export const auth = betterAuth({
         changeEmail: {
             enabled: true,
         }
+    },
+    emailVerification: {
+        // Required to send the verification email
+        sendVerificationEmail: async ({ user, url, token }) => {
+            await sendEmail({
+                to: user.email,
+            })
+        }
     }
 })
 ```
 
-By default, when a user requests to change their email, a verification email is sent to the **new** email address. The email is only updated after the user verifies the new email.
+By default, when a user requests to change their email, a verification email is sent to the **new** email address.
+The email is only updated after the user verifies the new email.
+
 
 #### Confirming with Current Email
 
-For added security, you can require users to confirm the change via their **current** email before the verification email is sent to the new address. To do this, provide the `sendChangeEmailConfirmation` function.
+For added security, you can require users to confirm the change via their **current** email before
+the verification email is sent to the new address. To do this, provide the `sendChangeEmailConfirmation` function.
 
 ```ts
 export const auth = betterAuth({
@@ -54,7 +65,8 @@ export const auth = betterAuth({
                 })
             }
         }
-    }
+    },
+    // ...
 })
 ```
 


### PR DESCRIPTION
We forgot to include this in the docs that is required for the change email flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing docs for the change-email flow, showing how to implement emailVerification.sendVerificationEmail to send the verification to the new address. Clarifies default behavior and the optional current-email confirmation using sendChangeEmailConfirmation.

<sup>Written for commit b9ad6a222a1aeed190e59b554e07096876a15f1c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

