### PR TITLE
fix: missing urlencoded media type

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -263,7 +263,10 @@ export const router = <Option extends BetterAuthOptions>(
 			},
 			...middlewares,
 		],
-		allowedMediaTypes: ["application/json"],
+		allowedMediaTypes: [
+			"application/json",
+			"application/x-www-form-urlencoded",
+		],
 		async onRequest(req) {
 			//handle disabled paths
 			const disabledPaths = ctx.options.disabledPaths || [];


### PR DESCRIPTION
Revert breaking. Add "application/x-www-form-urlencoded" for router oauth endpoints such as token.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add application/x-www-form-urlencoded to the router’s allowed media types so OAuth endpoints (e.g., /token) accept urlencoded requests. This fixes failed token exchanges from providers that post form data.

<sup>Written for commit f2840d6d675bd125bceb4e7b1ec4ec064286936b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

