### PR TITLE
fix(twofactor): overwrite existing session cookies instead of deleting them (#6077)

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -272,10 +272,6 @@ export const twoFactor = (options?: TwoFactorOptions | undefined) => {
 						session: newSession,
 						user: updatedUser,
 					});
-					//remove current session
-					await ctx.context.internalAdapter.deleteSession(
-						ctx.context.session.session.token,
-					);
 					return ctx.json({ status: true });
 				},
 			),

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -275,7 +275,6 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 						throw e;
 					});
 
-				await ctx.context.internalAdapter.deleteSession(session.session.token);
 				await setSessionCookie(ctx, {
 					session: newSession,
 					user: updatedUser,


### PR DESCRIPTION
Potential fix for [#6077](https://github.com/better-auth/better-auth/issues/6077).

We now overwrite the session cookie in `disableTwoFactor` and `verifyTotp` in the twofactor plugin instead of deleting the session cookie and afterwards setting a new one.
This is potential fix for how Next.js handles cookies. Now the page will refresh only once instead of twice when changing the cookies and `getSession` will not return `null` for the short period where there is no cookie set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overwrite the session cookie when disabling two-factor and verifying TOTP. This aligns with Next.js cookie handling and prevents double page refreshes and transient null sessions.

- **Bug Fixes**
  - Removed internalAdapter.deleteSession calls; setSessionCookie now updates the existing cookie in place.
  - Applied in twoFactor and TOTP flows; fixes #6077.

<sup>Written for commit 7c82c603a8f84ddf9f749e0fe846eab46f8f9680. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

