### PR TITLE
docs: add "no email" warning for twitch

### DIFF
--- a/docs/content/docs/authentication/twitch.mdx
+++ b/docs/content/docs/authentication/twitch.mdx
@@ -30,7 +30,9 @@ description: Twitch provider setup and usage.
     </Step>
        <Step>
         ### Sign In with Twitch 
-        To sign in with Twitch, you can use the `signIn.social` function provided by the client. The `signIn` function takes an object with the following properties:
+        To sign in with Twitch, you can use the `signIn.social` function provided by the client.
+        The `signIn` function takes an object with the following properties:
+
         - `provider`: The provider to use. It should be set to `twitch`.
 
         ```ts title="auth-client.ts"  
@@ -43,5 +45,9 @@ description: Twitch provider setup and usage.
             })
         }
         ```
+
+        <Callout type="warn">
+            Twitch users who do not have an email address will not be able to sign in.
+        </Callout>
     </Step>
 </Steps>


### PR DESCRIPTION
Twitch does not require users to have an email on their account, causing users to not be able to sign up. This PR adds a warning to our docs regarding such.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a warning callout in the Twitch authentication docs explaining that accounts without an email cannot sign in. Also split a long sentence in the sign-in instructions for clarity.

<sup>Written for commit 5bfa0d736fbc2d2582c19f23f443ff8574dbd970. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

