### PR TITLE
chore: bump better-fetch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@better-fetch/fetch':
-      specifier: 1.1.18
-      version: 1.1.18
+      specifier: 1.1.21
+      version: 1.1.21
     better-call:
       specifier: 1.1.5
       version: 1.1.5
@@ -586,7 +586,7 @@ importers:
         version: 0.3.0
       '@better-fetch/fetch':
         specifier: 'catalog:'
-        version: 1.1.18
+        version: 1.1.21
       '@hookform/resolvers':
         specifier: ^5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.2.1))
@@ -1033,7 +1033,7 @@ importers:
         version: 0.3.0
       '@better-fetch/fetch':
         specifier: 'catalog:'
-        version: 1.1.18
+        version: 1.1.21
       '@noble/ciphers':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1276,7 +1276,7 @@ importers:
         version: 0.3.0
       '@better-fetch/fetch':
         specifier: 'catalog:'
-        version: 1.1.18
+        version: 1.1.21
       better-call:
         specifier: 'catalog:'
         version: 1.1.5(zod@4.1.13)
@@ -1297,7 +1297,7 @@ importers:
     dependencies:
       '@better-fetch/fetch':
         specifier: 'catalog:'
-        version: 1.1.18
+        version: 1.1.21
       better-call:
         specifier: 'catalog:'
         version: 1.1.5(zod@4.1.13)
@@ -1343,7 +1343,7 @@ importers:
         version: 0.3.0
       '@better-fetch/fetch':
         specifier: 'catalog:'
-        version: 1.1.18
+        version: 1.1.21
       '@simplewebauthn/browser':
         specifier: ^13.1.2
         version: 13.1.2
@@ -1396,7 +1396,7 @@ importers:
     dependencies:
       '@better-fetch/fetch':
         specifier: 'catalog:'
-        version: 1.1.18
+        version: 1.1.21
       fast-xml-parser:
         specifier: ^5.2.5
         version: 5.2.5
@@ -1467,7 +1467,7 @@ importers:
         version: 0.3.0
       '@better-fetch/fetch':
         specifier: 'catalog:'
-        version: 1.1.18
+        version: 1.1.21
     devDependencies:
       '@better-auth/core':
         specifier: workspace:*
@@ -1486,7 +1486,7 @@ importers:
         version: link:../packages/core
       '@better-fetch/fetch':
         specifier: 'catalog:'
-        version: 1.1.18
+        version: 1.1.21
       better-auth:
         specifier: workspace:*
         version: link:../packages/better-auth
@@ -2385,8 +2385,8 @@ packages:
   '@better-auth/utils@0.3.0':
     resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
 
-  '@better-fetch/fetch@1.1.18':
-    resolution: {integrity: sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA==}
+  '@better-fetch/fetch@1.1.21':
+    resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
   '@biomejs/biome@2.3.8':
     resolution: {integrity: sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA==}
@@ -15558,7 +15558,7 @@ snapshots:
 
   '@better-auth/utils@0.3.0': {}
 
-  '@better-fetch/fetch@1.1.18': {}
+  '@better-fetch/fetch@1.1.21': {}
 
   '@biomejs/biome@2.3.8':
     optionalDependencies:
@@ -18991,9 +18991,7 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89': {}
@@ -21019,7 +21017,7 @@ snapshots:
   better-call@1.1.5(zod@4.1.13):
     dependencies:
       '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.18
+      '@better-fetch/fetch': 1.1.21
       rou3: 0.7.10
       set-cookie-parser: 2.7.2
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
   - test
 
 catalog:
-  '@better-fetch/fetch': 1.1.18
+  '@better-fetch/fetch': 1.1.21
   better-call: 1.1.5
   tsdown: ^0.17.2
   typescript: ^5.9.3


### PR DESCRIPTION
Properly encodes JSON body as a `application/x-www-form-urlencoded` when sent from a client. For example, when `allowedMediaTypes: ["application/x-www-form-urlencoded"]` (meaning json is not accepted), this requires the client to send the `application/x-www-form-urlencoded` header.

Example use case:
```ts
const tokens = await client.oauth2.token({
	grant_type: "client_credentials",
	client_id
	client_secret,
	scope,
	redirect_uri,
}, {
	headers: {
		accept: "application/json",
		'content-type': "application/x-www-form-urlencoded"
	},
});
```











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send client request bodies as application/x-www-form-urlencoded when the content-type header is set. This fixes requests to endpoints that require form-encoded payloads (e.g., OAuth2 token).

- **Bug Fixes**
  - Serialize the body with URLSearchParams when content-type is application/x-www-form-urlencoded; otherwise send the original body.

<sup>Written for commit cba5010d09ce675574fb9306b66ac594215dcbc4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











