### PR TITLE
sso(fix): generate metadata on saml sign on 

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1043,28 +1043,33 @@ export const signInSSO = (options?: SSOOptions) => {
 				let metadata = parsedSamlConfig.spMetadata.metadata;
 
 				if (!metadata) {
-					metadata = saml.SPMetadata({
-						entityID:
-							parsedSamlConfig.spMetadata?.entityID || parsedSamlConfig.issuer,
-						assertionConsumerService: [
-							{
-								Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-								Location:
-									parsedSamlConfig.callbackUrl ||
-									`${ctx.context.baseURL}/sso/saml2/sp/acs/${provider.providerId}`,
-							},
-						],
-						wantMessageSigned: parsedSamlConfig.wantAssertionsSigned || false,
-						nameIDFormat: parsedSamlConfig.identifierFormat
-							? [parsedSamlConfig.identifierFormat]
-							: undefined,
-					}).getMetadata() || "";
+					metadata =
+						saml
+							.SPMetadata({
+								entityID:
+									parsedSamlConfig.spMetadata?.entityID ||
+									parsedSamlConfig.issuer,
+								assertionConsumerService: [
+									{
+										Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+										Location:
+											parsedSamlConfig.callbackUrl ||
+											`${ctx.context.baseURL}/sso/saml2/sp/acs/${provider.providerId}`,
+									},
+								],
+								wantMessageSigned:
+									parsedSamlConfig.wantAssertionsSigned || false,
+								nameIDFormat: parsedSamlConfig.identifierFormat
+									? [parsedSamlConfig.identifierFormat]
+									: undefined,
+							})
+							.getMetadata() || "";
 				}
-	
+
 				const sp = saml.ServiceProvider({
 					metadata: metadata,
 					allowCreate: true,
-				});	
+				});
 
 				const idp = saml.IdentityProvider({
 					metadata: parsedSamlConfig.idpMetadata?.metadata,


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-generate a minimal SAML Service Provider config when SP metadata is missing, preventing SSO sign-in failures. ACS endpoint now accepts form-encoded and JSON payloads.

- **Bug Fixes**
  - Auto-build SP metadata when missing: entityID (spMetadata.entityID or issuer), HTTP-POST ACS at callbackUrl or default /sso/saml2/sp/acs/{providerId}, with wantMessageSigned and nameIDFormat support.
  - Add allowedMediaTypes to ACS endpoint: application/x-www-form-urlencoded and application/json.

<sup>Written for commit 4c1ba4ea014db2449d593649623af063966ddb5f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









