### PR TITLE
test(passkey): enhance passkey deletion tests

### DIFF
--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -192,6 +192,7 @@ describe("passkey", async () => {
 		const setCookie = signInResponse.headers.get("set-cookie");
 		const cookies = parseSetCookieHeader(setCookie || "");
 		const sessionToken = cookies.get("better-auth.session_token")?.value;
+		expect(sessionToken).toBeDefined();
 
 		const headers2 = new Headers();
 		headers2.set("cookie", `better-auth.session_token=${sessionToken}`);


### PR DESCRIPTION
…existence





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened passkey deletion tests to cover real deletion for the signed-in user, non-existent IDs, and attempts to delete another user’s passkey. Added cookie parsing to create a second user session and verified the endpoint returns null without leaking ownership or deleting the other user’s passkey.

<sup>Written for commit ca4e58e66761e597c375f3631cb5fe54f6f101c1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





