### PR TITLE
chore(sso): support form-urlencoded for callback endpoint

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1452,6 +1452,10 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 			}),
 			metadata: {
 				isAction: false,
+				allowedMediaTypes: [
+					"application/x-www-form-urlencoded",
+					"application/json",
+				],
 				openapi: {
 					operationId: "handleSAMLCallback",
 					summary: "Callback URL for SAML provider",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for application/x-www-form-urlencoded on the SAML callback endpoint, alongside application/json. Improves compatibility with IdPs that send form-encoded payloads.

<sup>Written for commit f14fb4bbd46e89445b0b7857542d8afd275c56d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

