### PR TITLE
feat: Add support for "jsonb" type in additional fields

### DIFF
--- a/packages/better-auth/src/db/field.ts
+++ b/packages/better-auth/src/db/field.ts
@@ -28,13 +28,15 @@ export type InferValueType<T extends DBFieldType> = T extends "string"
 				? Date
 				: T extends "json"
 					? Record<string, any>
-					: T extends `${infer U}[]`
-						? U extends "string"
-							? string[]
-							: number[]
-						: T extends Array<any>
-							? T[number]
-							: never;
+					: T extends "jsonb"
+						? Record<string, any>
+						: T extends `${infer U}[]`
+							? U extends "string"
+								? string[]
+								: number[]
+							: T extends Array<any>
+								? T[number]
+								: never;
 
 export type InferFieldsOutput<Field> = Field extends Record<
 	infer Key,

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -29,6 +29,7 @@ const postgresMap = {
 	boolean: ["bool", "boolean"],
 	date: ["timestamptz", "timestamp", "date"],
 	json: ["json", "jsonb"],
+	jsonb: ["jsonb", "json"],
 };
 const mysqlMap = {
 	string: ["varchar", "text", "uuid"],
@@ -44,6 +45,7 @@ const mysqlMap = {
 	boolean: ["boolean", "tinyint"],
 	date: ["timestamp", "datetime", "date"],
 	json: ["json"],
+	jsonb: ["json"],
 };
 
 const sqliteMap = {
@@ -52,6 +54,7 @@ const sqliteMap = {
 	boolean: ["INTEGER", "BOOLEAN"], // 0 or 1
 	date: ["DATE", "INTEGER"],
 	json: ["TEXT"],
+	jsonb: ["TEXT"],
 };
 
 const mssqlMap = {
@@ -60,6 +63,7 @@ const mssqlMap = {
 	boolean: ["bit", "smallint"],
 	date: ["datetime2", "date", "datetime"],
 	json: ["varchar", "nvarchar"],
+	jsonb: ["varchar", "nvarchar"],
 };
 
 const map = {
@@ -316,6 +320,12 @@ export async function getMigrations(config: BetterAuthOptions) {
 				mssql: sql`datetime2(3)`,
 			},
 			json: {
+				sqlite: "text",
+				postgres: "jsonb",
+				mysql: "json",
+				mssql: "varchar(8000)",
+			},
+			jsonb: {
 				sqlite: "text",
 				postgres: "jsonb",
 				mysql: "json",

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -25,7 +25,7 @@ export function toZodSchema<
 		}
 
 		let schema: ZodType;
-		if (field.type === "json") {
+		if (field.type === "json" || field.type === "jsonb") {
 			schema = (z as any).json ? (z as any).json() : z.any();
 		} else if (field.type === "string[]" || field.type === "number[]") {
 			schema = z.array(field.type === "string[]" ? z.string() : z.number());

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -157,6 +157,11 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 					pg: `jsonb('${name}')`,
 					mysql: `json('${name}')`,
 				},
+				jsonb: {
+					sqlite: `text('${name}')`,
+					pg: `jsonb('${name}')`,
+					mysql: `json('${name}')`,
+				},
 			} as const;
 			return typeMap[type][databaseType];
 		}
@@ -409,7 +414,7 @@ function generateImport({
 	for (const table of Object.values(tables)) {
 		for (const field of Object.values(table.fields)) {
 			if (field.bigint) hasBigint = true;
-			if (field.type === "json") hasJson = true;
+			if (field.type === "json" || field.type === "jsonb") hasJson = true;
 		}
 		if (hasJson && hasBigint) break;
 	}

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -102,7 +102,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 				if (type === "date") {
 					return isOptional ? "DateTime?" : "DateTime";
 				}
-				if (type === "json") {
+				if (type === "json" || type === "jsonb") {
 					return isOptional ? "Json?" : "Json";
 				}
 				if (type === "string[]") {
@@ -208,7 +208,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 					if (Array.isArray(attr.defaultValue)) {
 						// for json objects and array of object
 
-						if (attr.type === "json") {
+						if (attr.type === "json" || attr.type === "jsonb") {
 							if (
 								Object.prototype.toString.call(attr.defaultValue[0]) ===
 								"[object Object]"

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -20,6 +20,7 @@ export type DBFieldType =
 	| "boolean"
 	| "date"
 	| "json"
+	| "jsonb"
 	| `${"string" | "number"}[]`
 	| Array<LiteralString>;
 


### PR DESCRIPTION
### Description
This PR adds explicit support for the `jsonb` field type in `additionalFields`. While `json` currently maps to `jsonb` in Postgres, adding this explicit type improves clarity and allows for specific Postgres optimizations while maintaining backward compatibility.
<img width="969" height="472" alt="image" src="https://github.com/user-attachments/assets/83e2538f-1e04-4bcd-93f4-abb380f62464" />


### Changes
- **Core:** Added `jsonb` to `DBFieldType`.
- **Runtime:** Updated field inference to treat `jsonb` as an object (`Record<string, any>`).
- **Migrations:** Mapped `jsonb` to the `JSONB` SQL type for Postgres (with fallbacks to `JSON` or `TEXT` for MySQL/SQLite/MSSQL).
- **Validation:** Updated `to-zod.ts` to generate `z.any()` for `jsonb` fields to prevent runtime validation errors.
- **CLI:** Updated Drizzle and Prisma generators to correctly map and import the `jsonb` type.

### Impact
This is a purely additive, opt-in change. Existing `json` fields are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit support for the jsonb type in additionalFields. Improves clarity and enables Postgres-specific optimizations while keeping existing json fields unchanged.

- **New Features**
  - Added jsonb to DBFieldType with runtime inference as Record<string, any>.
  - Mapped jsonb to Postgres JSONB with fallbacks: MySQL JSON, SQLite TEXT, MSSQL VARCHAR.
  - Updated Zod schema generation to handle jsonb via z.json() or z.any().
  - Updated Drizzle and Prisma generators to output jsonb correctly and adjust imports.

<sup>Written for commit 2a73d6e494fcc66873b9951df41c83a46fefa365. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

