### PR TITLE
docs: update prisma adapter guide for v7 patterns

### DIFF
--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -14,9 +14,13 @@ Then, you can use the Prisma adapter to connect to your database.
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@/generated/prisma/client";
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 
-const prisma = new PrismaClient();
+const adapter = new PrismaBetterSqlite3({
+  url: process.env.DATABASE_URL ?? "file:./dev.db",
+});
+const prisma = new PrismaClient({ adapter });
 
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
@@ -24,10 +28,6 @@ export const auth = betterAuth({
   }),
 });
 ```
-
-<Callout type="warning">
-  If you have configured a custom output directory in your `schema.prisma` file (e.g., `output = "../src/generated/prisma"`), make sure to import the Prisma client from that location instead of `@prisma/client`. Learn more about custom output directories in the [Prisma documentation](https://www.prisma.io/docs/guides/nextjs#21-install-prisma-orm-and-create-your-first-models).
-</Callout>
 
 ## Schema generation & migration
 


### PR DESCRIPTION
### Description
This PR updates the Prisma adapter documentation to align with [Prisma v7 breaking changes](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-7).

**Changes:**
- Updated the import path to `@/generated/prisma/client`.
- Updated the code snippet to demonstrate the required **Driver Adapter** pattern (using `PrismaBetterSqlite3` as the example to match the existing SQLite context).
- Removed the warning about custom output directories as it is no longer the primary concern in v7 migrations compared to adapter initialization.

### Related Issue
Closes #6112

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Prisma adapter guide to match Prisma v7 patterns. Switch imports to "@/generated/prisma/client", show driver adapter setup using PrismaBetterSqlite3 for SQLite, and remove the outdated custom output directory warning.

<sup>Written for commit 2b7dba590a5b964ebcf4ed47573c4afd96182f67. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

