### PR TITLE
docs: add explanation of stateless mode to database concept

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -5,9 +5,13 @@ description: Learn how to use a database with Better Auth.
 
 ## Adapters
 
-Better Auth requires a database connection to store data. The database will be used to store data such as users, sessions, and more. Plugins can also define their own database tables to store data.
+Better Auth connects to a database to store data. The database will be used to store data such as users, sessions, and more. Plugins can also define their own database tables to store data.
 
 You can pass a database connection to Better Auth by passing a supported database instance in the database options. You can learn more about supported database adapters in the [Other relational databases](/docs/adapters/other-relational-databases) documentation.
+
+<Callout type="info">
+Better Auth also works without any database. For more details, see [Stateless Session Management](/docs/concepts/session-management#stateless-session-management).
+</Callout>
 
 ## CLI
 


### PR DESCRIPTION
-> canary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Database concept page to explain that Better Auth can run without a database and link to Stateless Session Management. Added an info callout to highlight this option.

<sup>Written for commit 42e81100f65511e5650ebbf9727ce69bb7f8b70f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

