### PR TITLE
chore: fix lint warning

### DIFF
--- a/test/unit/oidc/scope-consent.spec.ts
+++ b/test/unit/oidc/scope-consent.spec.ts
@@ -93,7 +93,9 @@ describe("oidc scope consent", async () => {
 		const cookie = signInRes.headers.get("set-cookie");
 
 		// 2. Register a client
-		let clientReg;
+		let clientReg: Awaited<
+			ReturnType<typeof auth.api.registerOAuthApplication>
+		>;
 		try {
 			clientReg = await auth.api.registerOAuthApplication({
 				body: {


### PR DESCRIPTION
<img width="893" height="300" alt="lint-warning" src="https://github.com/user-attachments/assets/1e34d7db-8a09-4a9a-aa5e-6aa6e84a96a0" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved a lint warning in the OIDC scope consent unit test by adding an explicit type to clientReg. Uses Awaited<ReturnType<typeof auth.api.registerOAuthApplication>> to improve type safety.

<sup>Written for commit 5ca9102264dc0abf4fba201872012edcd781a0f4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

