### PR TITLE
chore: use generate random string helper

### DIFF
--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -4,6 +4,7 @@ import { defineErrorCodes } from "@better-auth/core/utils";
 import { base64Url } from "@better-auth/utils/base64";
 import { createHash } from "@better-auth/utils/hash";
 import { APIError } from "../../api";
+import { generateRandomString } from "../../crypto/random";
 import { mergeSchema } from "../../db";
 import { getDate } from "../../utils/date";
 import { getIp } from "../../utils/get-request-ip";
@@ -119,14 +120,8 @@ export const apiKey = (options?: ApiKeyOptions | undefined) => {
 	const keyGenerator =
 		opts.customKeyGenerator ||
 		(async (options: { length: number; prefix: string | undefined }) => {
-			const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-			let apiKey = `${options.prefix || ""}`;
-			for (let i = 0; i < options.length; i++) {
-				const randomIndex = Math.floor(Math.random() * characters.length);
-				apiKey += characters[randomIndex];
-			}
-
-			return apiKey;
+			const key = generateRandomString(options.length, "a-z", "A-Z");
+			return `${options.prefix || ""}${key}`;
 		});
 
 	const routes = createApiKeyRoutes({ keyGenerator, opts, schema });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched API key generation to use the shared generateRandomString helper. This improves consistency and randomness while keeping prefix behavior unchanged.

- **Refactors**
  - Replaced the custom character loop with generateRandomString ("a-z", "A-Z") in the default key generator.

<sup>Written for commit f6122429b5fc7edcb8cc1b58387f5ee972b3a527. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

