### PR TITLE
refactor(haveibeenpwned): add try catch and timeout

### DIFF
--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -29,6 +29,7 @@ async function checkPasswordCompromise(
 					"Add-Padding": "true",
 					"User-Agent": "BetterAuth Password Checker",
 				},
+				timeout: 5000, // 5s timeout
 			},
 		);
 
@@ -81,15 +82,19 @@ export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions | undefined) => {
 					password: {
 						...ctx.password,
 						async hash(password) {
-							const c = await getCurrentAuthContext();
-							if (!c.path || !paths.includes(c.path)) {
+							try {
+								const c = await getCurrentAuthContext();
+								if (!c.path || !paths.includes(c.path)) {
+									return ctx.password.hash(password);
+								}
+								await checkPasswordCompromise(
+									password,
+									options?.customPasswordCompromisedMessage,
+								);
+								return ctx.password.hash(password);
+							} catch (e) {
 								return ctx.password.hash(password);
 							}
-							await checkPasswordCompromise(
-								password,
-								options?.customPasswordCompromisedMessage,
-							);
-							return ctx.password.hash(password);
 						},
 					},
 				},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a 5s timeout to the Have I Been Pwned API call and wrap the password compromise check in try/catch so hashing always proceeds if the request fails. This prevents auth flows from hanging or breaking when the HIBP service is slow or unreachable, while still checking on allowed paths.

<sup>Written for commit 2c2b990aa20154b121f413009f4359199c4e825d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

