### PR TITLE
docs: clearer verificationUri description

### DIFF
--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -39,14 +39,11 @@ This will demonstrate the complete device authorization flow by:
 
         export const auth = betterAuth({
           // ... other config
-          plugins: [ // [!code highlight]
+          plugins: [
             deviceAuthorization({ // [!code highlight]
-              // Optional configuration
-              verificationUri: "/device/verify", // Custom URL where users verify their device code (default: /device) // [!code highlight]
-              expiresIn: "30m", // Device code expiration time // [!code highlight]
-              interval: "5s",    // Minimum polling interval // [!code highlight]
+              verificationUri: "/device", // [!code highlight]
             }), // [!code highlight]
-          ], // [!code highlight]
+          ],
         });
         ```
     </Step>
@@ -81,9 +78,9 @@ This will demonstrate the complete device authorization flow by:
         import { deviceAuthorizationClient } from "better-auth/client/plugins"; // [!code highlight]
 
         export const authClient = createAuthClient({
-          plugins: [ // [!code highlight]
+          plugins: [
             deviceAuthorizationClient(), // [!code highlight]
-          ], // [!code highlight]
+          ],
         });
         ```
     </Step>
@@ -556,7 +553,7 @@ authenticateCLI().catch((err) => {
 
 ### Server
 
-**verificationUri**: The URL (absolute or relative) where users verify their device code. It is typically the page where users enter the code. Returned as `verification_uri` in the response. Default: `"/device"`.
+**verificationUri**: The URL of the verification page where users can enter their device code. Match this to the route of your verification page. Returned as `verification_uri` in the response. Can be an absolute URL (e.g., `https://example.com/device`) or relative path (e.g., `/device`). Default: `/device`.
 
 **expiresIn**: The expiration time for device codes. Default: `"30m"` (30 minutes).
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies how verificationUri works in the device authorization plugin. Updates examples to use the default /device route and explains that verificationUri can be an absolute URL or a relative path that matches your verification page.

<sup>Written for commit 8b4609cfa10c6a0db7029d41fae1ee0e63511824. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

