### PR TITLE
chore(demo): remove cookie and baseURL

### DIFF
--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -50,23 +50,8 @@ if (!dialect) {
 	throw new Error("No dialect found");
 }
 
-const baseURL: string | undefined =
-	process.env.VERCEL === "1"
-		? process.env.BETTER_AUTH_URL
-			? process.env.BETTER_AUTH_URL
-			: `https://${process.env.VERCEL_URL}`
-		: undefined;
-
-const cookieDomain: string | undefined =
-	process.env.VERCEL === "1"
-		? process.env.BETTER_AUTH_URL
-			? new URL(process.env.BETTER_AUTH_URL).hostname
-			: `.${process.env.VERCEL_URL}`
-		: undefined;
-
 export const auth = betterAuth({
 	appName: "Better Auth Demo",
-	baseURL,
 	database: {
 		dialect,
 		type: "sqlite",
@@ -351,10 +336,4 @@ export const auth = betterAuth({
 		lastLoginMethod(),
 	],
 	trustedOrigins: ["exp://", "https://appleid.apple.com"],
-	advanced: {
-		crossSubDomainCookies: {
-			enabled: process.env.NODE_ENV === "production",
-			domain: cookieDomain,
-		},
-	},
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified the Next.js demo auth config by removing the custom baseURL and cross-subdomain cookie setup. The demo now relies on Better Auth defaults, reducing environment-specific configuration.

<sup>Written for commit 14f77722441dc0f26bcb2ead97d400cbb10f909a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

