### PR TITLE
chore(demo): update auth instance to work with oauth-proxy

### DIFF
--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -52,7 +52,7 @@ if (!dialect) {
 
 export const auth = betterAuth({
 	appName: "Better Auth Demo",
-	// If not explicitly set, the system will check for the environment variable process.env.BETTER_AUTH_URL
+	// If not explicitly set, the system will check the environment variable process.env.BETTER_AUTH_URL
 	// baseURL: process.env.BETTER_AUTH_URL,
 	database: {
 		dialect,


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the demo auth config to work with oauth-proxy in production. Simplifies URL/cookie handling and expands trusted origins.

- **Refactors**
  - Configure oAuthProxy with productionURL set to https://demo.better-auth.com.
  - Remove Vercel-specific baseURL/cookieDomain logic; rely on BETTER_AUTH_URL env.
  - Drop crossSubDomainCookies settings and expand trustedOrigins to *.better-auth.com and Vercel preview URLs.

<sup>Written for commit 8bd8dfe25c116cc9dd813e4b0bb81dbe312fa0ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



