### PR TITLE
fix(last-login-method): detect passkey login to set last used method

### DIFF
--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -64,6 +64,7 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 			);
 		}
 		if (ctx.path.includes("siwe")) return "siwe";
+		if (ctx.path.includes("/passkey/verify-authentication")) return "passkey";
 		return null;
 	};
 


### PR DESCRIPTION
## Description
This PR fixes an issue where logging in with a Passkey resulted in the `better-auth.last_used_login_method` cookie being empty (or null).

The `last-login-method` plugin's default resolver was missing the check for the specific Passkey verification endpoint.

## Changes
- Added a check for `/passkey/verify-authentication` in the `defaultResolveMethod` function within `last-login-method/index.ts`.

Closes #6128

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes last-login-method so passkey logins are detected and the better-auth.last_used_login_method cookie is set to "passkey". Adds a check for /passkey/verify-authentication in the plugin’s defaultResolveMethod.

<sup>Written for commit f7ac6b511a28fcea57edd4b454dabf103af9ddc1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

