### PR TITLE
chore(organization): error handling test for missing headers in listOrganizations

### DIFF
--- a/.changeset/deep-lights-fix.md
+++ b/.changeset/deep-lights-fix.md
@@ -1,5 +1,5 @@
 ---
-"@better-auth/core": major
+"@better-auth/core": minor
 ---
 
 Add error handling test for missing headers in listOrganizations

--- a/.changeset/deep-lights-fix.md
+++ b/.changeset/deep-lights-fix.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": major
+---
+
+Add error handling test for missing headers in listOrganizations

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2461,6 +2461,12 @@ describe("Additional Fields", async () => {
 		expect(db.organization[0]?.someRequiredField).toBe("hey2");
 	});
 
+	it("should throw error if no header is present", async () => {
+		await expect(auth.api.listOrganizations()).rejects.toThrowError(
+			"Headers is required",
+		);
+	});
+
 	it("list user organizations", async () => {
 		const orgs = await auth.api.listOrganizations({
 			headers,


### PR DESCRIPTION
solves **#6157** 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require headers for `listOrganizations` and throw "Headers is required" when missing, with a new test and a changeset marking a minor in `@better-auth/core`. Also scope `organization.setActiveTeam` to the active org and honor custom IDs from `beforeCreateTeam` and `beforeCreateInvitation` (addresses #6157).

- **Migration**
  - Pass `headers` to all `auth.api.listOrganizations` calls.

<sup>Written for commit ce323efc5efdf220a090727de38c3a98cc141481. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

