### PR TITLE
chore(deps): bump stripe v20

### DIFF
--- a/demo/nextjs/package.json
+++ b/demo/nextjs/package.json
@@ -79,7 +79,7 @@
     "resend": "^6.0.2",
     "server-only": "^0.0.1",
     "sonner": "^2.0.7",
-    "stripe": "^19.1.0",
+    "stripe": "^20.0.0",
     "tailwind-merge": "^3.3.1",
     "ua-parser-js": "^2.0.4",
     "vaul": "^1.1.2",

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -38,7 +38,7 @@ The Stripe plugin integrates Stripe's payment and subscription functionality wit
         Next, install the Stripe SDK on your server:
 
         ```package-install
-        stripe@^19.1.0
+        stripe@^20.0.0
         ```
     </Step>
     <Step>
@@ -50,7 +50,7 @@ The Stripe plugin integrates Stripe's payment and subscription functionality wit
         import Stripe from "stripe"
 
         const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-            apiVersion: "2025-09-30.clover", // Latest API version as of Stripe SDK v19
+            apiVersion: "2025-11-17.clover", // Latest API version as of Stripe SDK v20.0.0
         })
 
         export const auth = betterAuth({

--- a/e2e/smoke/test/fixtures/tsconfig-declaration/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/package.json
@@ -10,6 +10,6 @@
     "@better-auth/stripe": "workspace:*",
     "@better-auth/passkey": "workspace:*",
     "better-auth": "workspace:*",
-    "stripe": "^18.5.0"
+    "stripe": "^20.0.0"
   }
 }

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -56,13 +56,13 @@
   "peerDependencies": {
     "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
-    "stripe": "^18 || ^19"
+    "stripe": "^18 || ^19 || ^20"
   },
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
     "better-call": "catalog:",
-    "stripe": "^19.1.0",
+    "stripe": "^20.0.0",
     "tsdown": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,8 +408,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       stripe:
-        specifier: ^19.1.0
-        version: 19.1.0(@types/node@24.9.2)
+        specifier: ^20.0.0
+        version: 20.0.0(@types/node@24.9.2)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -889,8 +889,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../../packages/better-auth
       stripe:
-        specifier: ^18.5.0
-        version: 18.5.0(@types/node@24.9.2)
+        specifier: ^20.0.0
+        version: 20.0.0(@types/node@24.9.2)
 
   e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types:
     dependencies:
@@ -1365,8 +1365,8 @@ importers:
         specifier: 'catalog:'
         version: 1.0.28
       stripe:
-        specifier: ^19.1.0
-        version: 19.1.0(@types/node@24.9.2)
+        specifier: ^20.0.0
+        version: 20.0.0(@types/node@24.9.2)
       tsdown:
         specifier: 'catalog:'
         version: 0.16.5(ms@2.1.3)(synckit@0.11.11)(typescript@5.9.3)
@@ -12201,17 +12201,8 @@ packages:
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
-  stripe@18.5.0:
-    resolution: {integrity: sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==}
-    engines: {node: '>=12.*'}
-    peerDependencies:
-      '@types/node': '>=12.x.x'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  stripe@19.1.0:
-    resolution: {integrity: sha512-FjgIiE98dMMTNssfdjMvFdD4eZyEzdWAOwPYqzhPRNZeg9ggFWlPXmX1iJKD5pPIwZBaPlC3SayQQkwsPo6/YQ==}
+  stripe@20.0.0:
+    resolution: {integrity: sha512-EaZeWpbJOCcDytdjKSwdrL5BxzbDGNueiCfHjHXlPdBQvLqoxl6AAivC35SPzTmVXJb5duXQlXFGS45H0+e6Gg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@types/node': '>=16'
@@ -26869,13 +26860,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stripe@18.5.0(@types/node@24.9.2):
-    dependencies:
-      qs: 6.14.0
-    optionalDependencies:
-      '@types/node': 24.9.2
-
-  stripe@19.1.0(@types/node@24.9.2):
+  stripe@20.0.0(@types/node@24.9.2):
     dependencies:
       qs: 6.14.0
     optionalDependencies:


### PR DESCRIPTION
This PR upgrade Stripe to [v20.0.0](https://github.com/stripe/stripe-node/blob/d70b2f78b836d59b4056d3a922439c74207719a4/CHANGELOG.md).
Looks like there aren't any issues from the breaking changes in this version.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Stripe SDK to v20 across the repo to stay current and aligned with our docs. No app code changes required.

- **Dependencies**
  - Bump stripe to ^20.0.0 in demo, packages/stripe (dev), and e2e fixture.
  - Expand @better-auth/stripe peerDependency to include ^20.
  - Update docs to recommend stripe@^20 and apiVersion "2025-11-17.clover".
  - Refresh pnpm-lock.yaml.

<sup>Written for commit 82e99c68f027c44d8a11d7a0bef00684f9a1436e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

