### PR TITLE
chore: improve drizzle-adapter errors

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -341,13 +341,13 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 			) {
 				if (!schema) {
 					throw new BetterAuthError(
-						"Drizzle adapter failed to initialize. Schema not found. Please provide a schema object in the adapter options object.",
+						"Drizzle adapter failed to initialize. Drizzle Schema not found. Please provide a schema object in the adapter options object.",
 					);
 				}
 				for (const key in values) {
 					if (!schema[key]) {
 						throw new BetterAuthError(
-							`The field "${key}" does not exist in the "${model}" schema. Please update your drizzle schema or re-generate using "npx @better-auth/cli generate".`,
+							`The field "${key}" does not exist in the "${model}" Drizzle schema. Please update your drizzle schema or re-generate using "npx @better-auth/cli generate".`,
 						);
 					}
 				}
@@ -368,7 +368,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					if (options.experimental?.joins) {
 						if (!db.query || !db.query[model]) {
 							logger.error(
-								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your schema to include relations or re-generate using "npx auth generate".`,
+								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx auth generate".`,
 							);
 							logger.info("Falling back to regular query");
 						} else {
@@ -434,7 +434,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					if (options.experimental?.joins) {
 						if (!db.query[model]) {
 							logger.error(
-								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your schema to include relations or re-generate using "npx auth generate".`,
+								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx auth generate".`,
 							);
 							logger.info("Falling back to regular query");
 						} else {


### PR DESCRIPTION
Far too often Drizzle schema errors confuse our users into thinking that they have a faulty schema with their database, when in reality it was their Drizzle schema which was wrong.

This PR makes those errors more specifically refer to their Drizzle schema.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified Drizzle adapter errors to explicitly reference the Drizzle schema, reducing confusion with the database schema. Updated messages for missing schema, unknown fields, and missing query models when joins are enabled.

<sup>Written for commit 660d90543082094840e9325408c16dce6f58d5cc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

