### PR TITLE
Fix/test rotating keys

### DIFF
--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -363,6 +363,12 @@ describe.each([
 		const jwks = await auth.api.getJwks();
 		const localJwks = createLocalJWKSet(jwks);
 		const decoded = await jwtVerify(jwt?.token!, localJwks);
+		
+		// Verify the kid from the JWT exists in the JWKS
+		const kidFromJwt = decoded.protectedHeader.kid;
+		const keyExists = jwks.keys.some((key) => key.kid === kidFromJwt);
+		expect(keyExists).toBe(true);
+		
 		expect(decoded).toMatchObject({
 			payload: {
 				iss: "https://example.com",
@@ -374,7 +380,7 @@ describe.each([
 			},
 			protectedHeader: {
 				alg: keyPairConfig.alg,
-				kid: jwks.keys[0]!.kid,
+				kid: expect.any(String),
 			},
 		});
 	});


### PR DESCRIPTION
from feat(jwt): add key rotation PR [key rotations](https://github.com/better-auth/better-auth/pull/6147)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add configurable JWT key rotation with rotationInterval and gracePeriod to keep tokens verifiable while rotating keys. JWKS now only returns keys that are still valid within the grace window, and signing auto-rotates when the latest key is expired.

- **New Features**
  - Enable key rotation via rotationInterval (seconds) and gracePeriod (seconds; default 30 days).
  - Store expiresAt on keys; JWKS filters out keys beyond gracePeriod.
  - Auto-create a new key on sign when the latest key has expired.

- **Refactors**
  - Removed adapter.getLatestKey override; latest key is derived from getJwks sorted by createdAt.
  - Updated docs and schema to include expiresAt and rotation options.
  - Added rotation tests; JWT test now checks the kid exists in JWKS without assuming order.

<sup>Written for commit b5738eb2a361a9d56ed2b902e17ed258e99a5682. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

