### PR TITLE
chore: fix type when `declaration: true`

### DIFF
--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -9,7 +9,7 @@ import { setSessionCookie } from "../../cookies";
 import { generateRandomString } from "../../crypto";
 import { defaultKeyHasher } from "./utils";
 
-interface MagicLinkopts {
+export interface MagicLinkOptions {
 	/**
 	 * Time in seconds until the magic link expires.
 	 * @default (60 * 5) // 5 minutes
@@ -66,11 +66,11 @@ interface MagicLinkopts {
 		| undefined;
 }
 
-export const magicLink = (options: MagicLinkopts) => {
+export const magicLink = (options: MagicLinkOptions) => {
 	const opts = {
 		storeToken: "plain",
 		...options,
-	} satisfies MagicLinkopts;
+	} satisfies MagicLinkOptions;
 
 	async function storeToken(ctx: GenericEndpointContext, token: string) {
 		if (opts.storeToken === "hashed") {

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -16,6 +16,8 @@ import { PHONE_NUMBER_ERROR_CODES } from "./error-codes";
 import { schema } from "./schema";
 import type { PhoneNumberOptions, UserWithPhoneNumber } from "./types";
 
+export type { PhoneNumberOptions, UserWithPhoneNumber };
+
 function generateOTP(size: number) {
 	return generateRandomString(size, "0-9");
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix TypeScript declaration output when declaration: true by exporting the right types. No runtime changes; resolves type access errors for consumers.

- **Bug Fixes**
  - Export MagicLinkOptions and update magicLink signature and satisfies in magic-link plugin.
  - Re-export PhoneNumberOptions and UserWithPhoneNumber from the phone-number plugin for proper .d.ts generation.

<sup>Written for commit d8577b7ff59fc9b6138acb9982351d4a20bdb12e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

