### PR TITLE
chore: lint fix

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthOptions } from "@better-auth/core";
-import type { Dialect, SqliteDatabase } from "kysely";
+import type { Dialect } from "kysely";
 import {
 	Kysely,
 	MssqlDialect,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed an unused SqliteDatabase type import in the Kysely adapter dialect to resolve a lint warning. No runtime changes.

<sup>Written for commit e20c806c088c04d821cb342c77a77c03eb3d2872. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

