### PR TITLE
fix(stripe): cancel subscription fails with Prisma

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -858,7 +858,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 							 * this is a rare case and should not happen
 							 */
 							if (!subscription.cancelAtPeriodEnd) {
-								await ctx.context.adapter.update({
+								await ctx.context.adapter.updateMany({
 									model: "subscription",
 									update: {
 										cancelAtPeriodEnd: true,


### PR DESCRIPTION
Caused by not using `updateMany` when using a where clause that doesn't include a `unique` identifier on any of the fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subscription cancellation in the Stripe flow when using Prisma by switching from update to updateMany for non-unique where clauses. Prevents runtime errors and correctly sets cancelAtPeriodEnd.

<sup>Written for commit c1d314751b42cc6524b60d8531a0d617479aba1c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

