### PR TITLE
ci: only run node.js 22

### DIFF
--- a/.github/workflows/adapter-tests.yml
+++ b/.github/workflows/adapter-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 24.x, 25.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit adapter-tests CI to Node.js 22. This matches the supported runtime, reduces CI time, and avoids flaky failures on newer Node versions.

<sup>Written for commit 251aa7ca1fac68226485bc6ff205eea2c55fceb7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

