### PR TITLE
fix(client): get-session gets triggered twice on foucs

### DIFF
--- a/packages/better-auth/src/client/focus-manager.ts
+++ b/packages/better-auth/src/client/focus-manager.ts
@@ -31,19 +31,15 @@ class WindowFocusManager implements FocusManager {
 			return () => {};
 		}
 
-		const onFocus = () => this.setFocused(true);
-
 		const visibilityHandler = () => {
 			if (document.visibilityState === "visible") {
 				this.setFocused(true);
 			}
 		};
 
-		window.addEventListener("focus", onFocus, false);
 		document.addEventListener("visibilitychange", visibilityHandler, false);
 
 		return () => {
-			window.removeEventListener("focus", onFocus, false);
 			document.removeEventListener(
 				"visibilitychange",
 				visibilityHandler,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop double getSession calls when returning to the tab. Removed the window focus listener and now rely on document visibilitychange to set focus only when the page becomes visible.

<sup>Written for commit 978cf9858fa73ac8ec935ef3fed4171c526cedaf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

