### PR TITLE
build: fix package depends on itself

### DIFF
--- a/e2e/smoke/test/fixtures/vite/package.json
+++ b/e2e/smoke/test/fixtures/vite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite",
+  "name": "fixture-vite",
   "private": true,
   "scripts": {
     "build": "vite build"


### PR DESCRIPTION
I tried running `pnpm build` locally.

```
> @better-auth/root@ build /Users/hyoban/f/better-auth
> turbo --filter "./packages/*" build

turbo 2.4.4

  × Invalid package dependency graph:
  ╰─▶ vite depends on itself
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed pnpm build by renaming the e2e Vite fixture package from "vite" to "fixture-vite". This removes Turbo’s "Invalid package dependency graph: vite depends on itself" error.

<sup>Written for commit c19bee8cabe36b0893a0539b314d164c1224a110. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

