### PR TITLE
chore(docs): fix invalid 1.4 blog links

### DIFF
--- a/docs/content/blogs/1-4.mdx
+++ b/docs/content/blogs/1-4.mdx
@@ -63,7 +63,7 @@ const accountInfo = await authClient.accountInfo();
 
 SCIM makes managing identities in multi-domain scenarios easier to support via a standardized protocol.
 
-[👉 Read more about SCIM provisioning](/docs/concepts/scim)
+[👉 Read more about SCIM provisioning](/docs/plugins/scim)
 
 ```ts
 import { scim } from "@better-auth/scim";


### PR DESCRIPTION
* The api-key secondary storage link is wrong
* SCIM link is wrong

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the broken link in the 1.4 release notes for the API-Key plugin’s secondary storage, updating it to the correct “storage modes” section so readers don’t hit a 404.

<sup>Written for commit ef7522e0b4fd966f3ee17a8edfaf362e1018b6d2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

