### PR TITLE
fix(passkey): change `generate-authenticate-options` from POST to GET

### DIFF
--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -41,7 +41,7 @@ export const getPasskeyActions = (
 		const response = await $fetch<PublicKeyCredentialRequestOptionsJSON>(
 			"/passkey/generate-authenticate-options",
 			{
-				method: "POST",
+				method: "GET",
 				throw: false,
 			},
 		);

--- a/packages/passkey/src/index.ts
+++ b/packages/passkey/src/index.ts
@@ -252,7 +252,7 @@ export const passkey = (options?: PasskeyOptions | undefined) => {
 			generatePasskeyAuthenticationOptions: createAuthEndpoint(
 				"/passkey/generate-authenticate-options",
 				{
-					method: "POST",
+					method: "GET",
 					metadata: {
 						openapi: {
 							operationId: "passkeyGenerateAuthenticateOptions",


### PR DESCRIPTION
Fixes #6197

## Changes
- Changed `/passkey/generate-authenticate-options` from POST to GET method
- Updated both server endpoint definition and client implementation

## Reason
The `better-call` upgrade (v1.0.19 → v1.1.0) introduced `Content-Type` validation for POST requests. Since this endpoint doesn't accept a body, using GET is semantically correct and matches the pattern used by `/passkey/generate-register-options`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch /passkey/generate-authenticate-options from POST to GET to fix Content-Type validation errors in better-call v1.1.0 when no body is sent. Updates both the server endpoint and client call, and matches /passkey/generate-register-options.

<sup>Written for commit 3acedfd316fd9cd015c6b6c7ed9297c64563e94d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

