### PR TITLE
feat(cli): enable direct package installation with explicit bin command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,9 @@
     "better-auth"
   ],
   "exports": "./dist/index.mjs",
-  "bin": "./dist/index.mjs",
+  "bin": {
+    "better-auth": "./dist/index.mjs"
+  },
   "devDependencies": {
     "@better-auth/passkey": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -8,7 +8,11 @@ const getCliPath = async () => {
 	const pkgJson: PackageJson = JSON.parse(
 		await fs.readFile(path.join(rootDir, "package.json"), "utf-8"),
 	);
-	return path.join(rootDir, pkgJson.bin as string);
+	const binPath =
+		typeof pkgJson.bin === "string"
+			? pkgJson.bin
+			: pkgJson.bin?.["better-auth"];
+	return path.join(rootDir, binPath as string);
 };
 
 export const cliPath = await getCliPath();


### PR DESCRIPTION
## Changes

- Updated `bin` field in `packages/cli/package.json` from a string to an object with explicit command name mapping: `{ "better-auth": "./dist/index.mjs" }`

## Motivation

The current CLI setup works well with `npx @better-auth/cli@latest`, but this approach has some limitations:
- Shadow installs the package every time (or uses cache)
- Cannot lock CLI version alongside other better-auth packages
- Difficult to ensure all team members use the same CLI version

With this change, projects can now:
- Install CLI as a dev dependency: `pnpm install -D @better-auth/cli`
- Execute with locked version: `pnpm exec better-auth <command>`
- Manage CLI updates together with other better-auth package updates
- Avoid repeated installations

## Usage Examples

**After this change:**

```bash
# Install as dev dependency
pnpm install -D @better-auth/cli

# Run commands using project's installed version
pnpm exec better-auth init
pnpm exec better-auth generate
pnpm exec better-auth migrate

# Or install globally
pnpm install -g @better-auth/cli
better-auth init
```

**Existing npx usage still works:**
```bash
npx @better-auth/cli@latest init
```







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the better-auth CLI as a direct command via an explicit bin mapping. Allows installing and running a pinned CLI version without relying on repeated npx installs.

- New Features
  - Install as a dev dependency and run with: pnpm exec better-auth <command>.
  - Global install supported: better-auth <command>.
  - Lock CLI version with the project; npx usage still works.

<sup>Written for commit 5266ff14e63ba66147f9c15dae0da81b12e9102e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







