### PR TITLE
chore: fix operationId for requestPasswordReset endpoint

### DIFF
--- a/packages/better-auth/src/api/routes/reset-password.ts
+++ b/packages/better-auth/src/api/routes/reset-password.ts
@@ -35,7 +35,6 @@ export const requestPasswordReset = createAuthEndpoint(
 	"/request-password-reset",
 	{
 		method: "POST",
-		operationId: "forgetPassword",
 		body: z.object({
 			/**
 			 * The email address of the user to send a password reset email to.
@@ -60,7 +59,7 @@ export const requestPasswordReset = createAuthEndpoint(
 		}),
 		metadata: {
 			openapi: {
-				operationId: "forgetPassword",
+				operationId: "requestPasswordReset",
 				description: "Send a password reset email to the user",
 				responses: {
 					"200": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the OpenAPI operationId for the /request-password-reset endpoint to "requestPasswordReset" (was "forgetPassword") so generated clients and docs use the correct name. Also removed the incorrect operationId from the endpoint config.

<sup>Written for commit 6d1a0900f2bf6ce446736fc7f0d40ca2909477d7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

