### PR TITLE
fix(jwt): retrieve latest keys from storage properly

### DIFF
--- a/packages/better-auth/src/plugins/jwt/adapter.ts
+++ b/packages/better-auth/src/plugins/jwt/adapter.ts
@@ -25,6 +25,12 @@ export const getJwksAdapter = (
 					(a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
 				)[0];
 			}
+			const keys = await adapter.findMany<Jwk>({
+				model: "jwks",
+			});
+			return keys?.sort(
+				(a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+			)[0];
 		},
 		createJwk: async (ctx: GenericEndpointContext, webKey: Omit<Jwk, "id">) => {
 			if (options?.adapter?.createJwk) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed JWT JWK retrieval to fetch keys from storage and return the newest by createdAt, preventing stale keys during token signing/verification.

- **Bug Fixes**
  - getLatestJwk now uses adapter.findMany("jwks") and sorts by createdAt to return the most recent key.

<sup>Written for commit 8eadb2759b5b6a8eed4d3da8433a54a392a46356. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

