### PR TITLE
chore: export SubscriptionOptions type

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1509,4 +1509,4 @@ export type StripePlugin<O extends StripeOptions> = ReturnType<
 	typeof stripe<O>
 >;
 
-export type { Subscription, StripePlan };
+export type { Subscription, SubscriptionOptions, StripePlan };


### PR DESCRIPTION
Exporting the `SubscriptionOptions` type makes it possible to reuse the `getCheckoutSessionParams` function in other files without manually extracting its type.
Otherwise, consumers need to derive the type through nested utility types like:

```ts
type SubscriptionConfig = Extract<
  NonNullable<Parameters<typeof stripe>[0]["subscription"]>,
  { enabled: true }
>;

type GetCheckoutSessionParamsFn = NonNullable<
  SubscriptionConfig["getCheckoutSessionParams"]
>;
```

By exporting the type directly, we avoid this boilerplate and keep the integration simpler.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported the SubscriptionOptions type from the Stripe package to make it easy to import and reuse in other files. This simplifies using getCheckoutSessionParams and removes nested utility type extraction.

<sup>Written for commit 5a932fe7f598e305191dd49329df89952a93ea71. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

