### PR TITLE
chore(docs): fix ask ai query param

### DIFF
--- a/docs/components/floating-ai-search.tsx
+++ b/docs/components/floating-ai-search.tsx
@@ -540,6 +540,25 @@ export function AISearchTrigger() {
 		}
 	}, [open]);
 
+	useEffect(() => {
+		const params = new URLSearchParams(window.location.search);
+		const aiQuery = params.get("askai");
+
+		if (aiQuery) {
+			setOpen(true);
+			// Send the message to AI
+			void chat.sendMessage({ text: decodeURIComponent(aiQuery) });
+
+			// Clean up the URL by removing the askai parameter
+			const newParams = new URLSearchParams(window.location.search);
+			newParams.delete("askai");
+			const newUrl = newParams.toString()
+				? `${window.location.pathname}?${newParams.toString()}`
+				: window.location.pathname;
+			window.history.replaceState({}, "", newUrl);
+		}
+	}, []);
+
 	return (
 		<Context value={useMemo(() => ({ chat, open, setOpen }), [chat, open])}>
 			<RemoveScroll enabled={open}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes handling of the askai URL parameter in docs. When ?askai= is present, the floating search opens, submits the query, and the parameter is removed from the URL to prevent re-triggering.

<sup>Written for commit cf426cdfa977349c9577d91158bad95010a0c159. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

