### PR TITLE
chore: re-export helper types in client

### DIFF
--- a/packages/better-auth/src/client/index.ts
+++ b/packages/better-auth/src/client/index.ts
@@ -1,19 +1,19 @@
 import type {
-  BetterAuthClientPlugin,
-  BetterAuthOptions,
-  BetterAuthPlugin,
+	BetterAuthClientPlugin,
+	BetterAuthOptions,
+	BetterAuthPlugin,
 } from "@better-auth/core";
 
 export * from "./broadcast-channel";
 export {
-  type FocusListener,
-  type FocusManager,
-  kFocusManager,
+	type FocusListener,
+	type FocusManager,
+	kFocusManager,
 } from "./focus-manager";
 export {
-  kOnlineManager,
-  type OnlineListener,
-  type OnlineManager,
+	kOnlineManager,
+	type OnlineListener,
+	type OnlineManager,
 } from "./online-manager";
 export * from "./query";
 export * from "./session-refresh";
@@ -21,23 +21,23 @@ export * from "./types";
 export * from "./vanilla";
 
 export const InferPlugin = <T extends BetterAuthPlugin>() => {
-  return {
-    id: "infer-server-plugin",
-    $InferServerPlugin: {} as T,
-  } satisfies BetterAuthClientPlugin;
+	return {
+		id: "infer-server-plugin",
+		$InferServerPlugin: {} as T,
+	} satisfies BetterAuthClientPlugin;
 };
 
 export function InferAuth<O extends { options: BetterAuthOptions }>() {
-  return {} as O["options"];
+	return {} as O["options"];
 }
 
 //#region Necessary re-exports
 export type * from "@better-auth/core/db";
 export type { Primitive } from "@better-auth/core/db";
 export type * from "@better-fetch/fetch";
-export type * from "../types/helper";
-export type { UnionToIntersection } from "../types/helper";
 // @ts-expect-error
 export type * from "nanostores";
 export type * from "../plugins/access";
+export type * from "../types/helper";
+export type { UnionToIntersection } from "../types/helper";
 //#endregion

--- a/packages/better-auth/src/client/lynx/index.ts
+++ b/packages/better-auth/src/client/lynx/index.ts
@@ -1,110 +1,110 @@
 import type {
-  BetterAuthClientOptions,
-  BetterAuthClientPlugin,
+	BetterAuthClientOptions,
+	BetterAuthClientPlugin,
 } from "@better-auth/core";
 import type { BASE_ERROR_CODES } from "@better-auth/core/error";
 import type {
-  BetterFetchError,
-  BetterFetchResponse,
+	BetterFetchError,
+	BetterFetchResponse,
 } from "@better-fetch/fetch";
 import type { PrettifyDeep, UnionToIntersection } from "../../types/helper";
 import { getClientConfig } from "../config";
 import { createDynamicPathProxy } from "../proxy";
 import type {
-  InferActions,
-  InferClientAPI,
-  InferErrorCodes,
-  IsSignal,
-  SessionQueryParams,
+	InferActions,
+	InferClientAPI,
+	InferErrorCodes,
+	IsSignal,
+	SessionQueryParams,
 } from "../types";
 import { useStore } from "./lynx-store";
 
 function getAtomKey(str: string) {
-  return `use${capitalizeFirstLetter(str)}`;
+	return `use${capitalizeFirstLetter(str)}`;
 }
 
 export function capitalizeFirstLetter(str: string) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
+	return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 type InferResolvedHooks<O extends BetterAuthClientOptions> = O extends {
-  plugins: Array<infer Plugin>;
+	plugins: Array<infer Plugin>;
 }
-  ? UnionToIntersection<
-      Plugin extends BetterAuthClientPlugin
-        ? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
-          ? Atoms extends Record<string, any>
-            ? {
-                [key in keyof Atoms as IsSignal<key> extends true
-                  ? never
-                  : key extends string
-                    ? `use${Capitalize<key>}`
-                    : never]: () => ReturnType<Atoms[key]["get"]>;
-              }
-            : {}
-          : {}
-        : {}
-    >
-  : {};
+	? UnionToIntersection<
+			Plugin extends BetterAuthClientPlugin
+				? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
+					? Atoms extends Record<string, any>
+						? {
+								[key in keyof Atoms as IsSignal<key> extends true
+									? never
+									: key extends string
+										? `use${Capitalize<key>}`
+										: never]: () => ReturnType<Atoms[key]["get"]>;
+							}
+						: {}
+					: {}
+				: {}
+		>
+	: {};
 
 export function createAuthClient<Option extends BetterAuthClientOptions>(
-  options?: Option | undefined,
+	options?: Option | undefined,
 ) {
-  const {
-    pluginPathMethods,
-    pluginsActions,
-    pluginsAtoms,
-    $fetch,
-    $store,
-    atomListeners,
-  } = getClientConfig(options);
-  let resolvedHooks: Record<string, any> = {};
-  for (const [key, value] of Object.entries(pluginsAtoms)) {
-    resolvedHooks[getAtomKey(key)] = () => useStore(value);
-  }
+	const {
+		pluginPathMethods,
+		pluginsActions,
+		pluginsAtoms,
+		$fetch,
+		$store,
+		atomListeners,
+	} = getClientConfig(options);
+	let resolvedHooks: Record<string, any> = {};
+	for (const [key, value] of Object.entries(pluginsAtoms)) {
+		resolvedHooks[getAtomKey(key)] = () => useStore(value);
+	}
 
-  const routes = {
-    ...pluginsActions,
-    ...resolvedHooks,
-    $fetch,
-    $store,
-  };
-  const proxy = createDynamicPathProxy(
-    routes,
-    $fetch,
-    pluginPathMethods,
-    pluginsAtoms,
-    atomListeners,
-  );
+	const routes = {
+		...pluginsActions,
+		...resolvedHooks,
+		$fetch,
+		$store,
+	};
+	const proxy = createDynamicPathProxy(
+		routes,
+		$fetch,
+		pluginPathMethods,
+		pluginsAtoms,
+		atomListeners,
+	);
 
-  type ClientAPI = InferClientAPI<Option>;
-  type Session = ClientAPI extends {
-    getSession: () => Promise<infer Res>;
-  }
-    ? Res extends BetterFetchResponse<infer S>
-      ? S
-      : Res
-    : never;
-  return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
-    ClientAPI &
-    InferActions<Option> & {
-      useSession: () => {
-        data: Session;
-        isPending: boolean;
-        error: BetterFetchError | null;
-        refetch: (
-          queryParams?: { query?: SessionQueryParams } | undefined,
-        ) => Promise<void>;
-      };
-      $Infer: {
-        Session: NonNullable<Session>;
-      };
-      $fetch: typeof $fetch;
-      $store: typeof $store;
-      $ERROR_CODES: PrettifyDeep<
-        InferErrorCodes<Option> & typeof BASE_ERROR_CODES
-      >;
-    };
+	type ClientAPI = InferClientAPI<Option>;
+	type Session = ClientAPI extends {
+		getSession: () => Promise<infer Res>;
+	}
+		? Res extends BetterFetchResponse<infer S>
+			? S
+			: Res
+		: never;
+	return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
+		ClientAPI &
+		InferActions<Option> & {
+			useSession: () => {
+				data: Session;
+				isPending: boolean;
+				error: BetterFetchError | null;
+				refetch: (
+					queryParams?: { query?: SessionQueryParams } | undefined,
+				) => Promise<void>;
+			};
+			$Infer: {
+				Session: NonNullable<Session>;
+			};
+			$fetch: typeof $fetch;
+			$store: typeof $store;
+			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+		};
 }
 
 export { useStore };

--- a/packages/better-auth/src/client/react/index.ts
+++ b/packages/better-auth/src/client/react/index.ts
@@ -1,111 +1,111 @@
 import type {
-  BetterAuthClientOptions,
-  BetterAuthClientPlugin,
+	BetterAuthClientOptions,
+	BetterAuthClientPlugin,
 } from "@better-auth/core";
 import type { BASE_ERROR_CODES } from "@better-auth/core/error";
 import type {
-  BetterFetchError,
-  BetterFetchResponse,
+	BetterFetchError,
+	BetterFetchResponse,
 } from "@better-fetch/fetch";
 import type { PrettifyDeep, UnionToIntersection } from "../../types/helper";
 import { getClientConfig } from "../config";
 import { createDynamicPathProxy } from "../proxy";
 import type {
-  InferActions,
-  InferClientAPI,
-  InferErrorCodes,
-  IsSignal,
-  SessionQueryParams,
+	InferActions,
+	InferClientAPI,
+	InferErrorCodes,
+	IsSignal,
+	SessionQueryParams,
 } from "../types";
 import { useStore } from "./react-store";
 
 function getAtomKey(str: string) {
-  return `use${capitalizeFirstLetter(str)}`;
+	return `use${capitalizeFirstLetter(str)}`;
 }
 
 export function capitalizeFirstLetter(str: string) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
+	return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 type InferResolvedHooks<O extends BetterAuthClientOptions> = O extends {
-  plugins: Array<infer Plugin>;
+	plugins: Array<infer Plugin>;
 }
-  ? UnionToIntersection<
-      Plugin extends BetterAuthClientPlugin
-        ? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
-          ? Atoms extends Record<string, any>
-            ? {
-                [key in keyof Atoms as IsSignal<key> extends true
-                  ? never
-                  : key extends string
-                    ? `use${Capitalize<key>}`
-                    : never]: () => ReturnType<Atoms[key]["get"]>;
-              }
-            : {}
-          : {}
-        : {}
-    >
-  : {};
+	? UnionToIntersection<
+			Plugin extends BetterAuthClientPlugin
+				? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
+					? Atoms extends Record<string, any>
+						? {
+								[key in keyof Atoms as IsSignal<key> extends true
+									? never
+									: key extends string
+										? `use${Capitalize<key>}`
+										: never]: () => ReturnType<Atoms[key]["get"]>;
+							}
+						: {}
+					: {}
+				: {}
+		>
+	: {};
 
 export function createAuthClient<Option extends BetterAuthClientOptions>(
-  options?: Option | undefined,
+	options?: Option | undefined,
 ) {
-  const {
-    pluginPathMethods,
-    pluginsActions,
-    pluginsAtoms,
-    $fetch,
-    $store,
-    atomListeners,
-  } = getClientConfig(options);
-  let resolvedHooks: Record<string, any> = {};
-  for (const [key, value] of Object.entries(pluginsAtoms)) {
-    resolvedHooks[getAtomKey(key)] = () => useStore(value);
-  }
+	const {
+		pluginPathMethods,
+		pluginsActions,
+		pluginsAtoms,
+		$fetch,
+		$store,
+		atomListeners,
+	} = getClientConfig(options);
+	let resolvedHooks: Record<string, any> = {};
+	for (const [key, value] of Object.entries(pluginsAtoms)) {
+		resolvedHooks[getAtomKey(key)] = () => useStore(value);
+	}
 
-  const routes = {
-    ...pluginsActions,
-    ...resolvedHooks,
-    $fetch,
-    $store,
-  };
-  const proxy = createDynamicPathProxy(
-    routes,
-    $fetch,
-    pluginPathMethods,
-    pluginsAtoms,
-    atomListeners,
-  );
+	const routes = {
+		...pluginsActions,
+		...resolvedHooks,
+		$fetch,
+		$store,
+	};
+	const proxy = createDynamicPathProxy(
+		routes,
+		$fetch,
+		pluginPathMethods,
+		pluginsAtoms,
+		atomListeners,
+	);
 
-  type ClientAPI = InferClientAPI<Option>;
-  type Session = ClientAPI extends {
-    getSession: () => Promise<infer Res>;
-  }
-    ? Res extends BetterFetchResponse<infer S>
-      ? S
-      : Res
-    : never;
-  return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
-    ClientAPI &
-    InferActions<Option> & {
-      useSession: () => {
-        data: Session;
-        isPending: boolean;
-        isRefetching: boolean;
-        error: BetterFetchError | null;
-        refetch: (
-          queryParams?: { query?: SessionQueryParams } | undefined,
-        ) => Promise<void>;
-      };
-      $Infer: {
-        Session: NonNullable<Session>;
-      };
-      $fetch: typeof $fetch;
-      $store: typeof $store;
-      $ERROR_CODES: PrettifyDeep<
-        InferErrorCodes<Option> & typeof BASE_ERROR_CODES
-      >;
-    };
+	type ClientAPI = InferClientAPI<Option>;
+	type Session = ClientAPI extends {
+		getSession: () => Promise<infer Res>;
+	}
+		? Res extends BetterFetchResponse<infer S>
+			? S
+			: Res
+		: never;
+	return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
+		ClientAPI &
+		InferActions<Option> & {
+			useSession: () => {
+				data: Session;
+				isPending: boolean;
+				isRefetching: boolean;
+				error: BetterFetchError | null;
+				refetch: (
+					queryParams?: { query?: SessionQueryParams } | undefined,
+				) => Promise<void>;
+			};
+			$Infer: {
+				Session: NonNullable<Session>;
+			};
+			$fetch: typeof $fetch;
+			$store: typeof $store;
+			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+		};
 }
 
 export { useStore };

--- a/packages/better-auth/src/client/solid/index.ts
+++ b/packages/better-auth/src/client/solid/index.ts
@@ -1,11 +1,11 @@
 import type {
-  BetterAuthClientOptions,
-  BetterAuthClientPlugin,
+	BetterAuthClientOptions,
+	BetterAuthClientPlugin,
 } from "@better-auth/core";
 import type { BASE_ERROR_CODES } from "@better-auth/core/error";
 import type {
-  BetterFetchError,
-  BetterFetchResponse,
+	BetterFetchError,
+	BetterFetchResponse,
 } from "@better-fetch/fetch";
 import type { Accessor } from "solid-js";
 import type { PrettifyDeep, UnionToIntersection } from "../../types/helper";
@@ -13,89 +13,89 @@ import { capitalizeFirstLetter } from "../../utils/misc";
 import { getClientConfig } from "../config";
 import { createDynamicPathProxy } from "../proxy";
 import type {
-  InferActions,
-  InferClientAPI,
-  InferErrorCodes,
-  IsSignal,
+	InferActions,
+	InferClientAPI,
+	InferErrorCodes,
+	IsSignal,
 } from "../types";
 import { useStore } from "./solid-store";
 
 function getAtomKey(str: string) {
-  return `use${capitalizeFirstLetter(str)}`;
+	return `use${capitalizeFirstLetter(str)}`;
 }
 
 type InferResolvedHooks<O extends BetterAuthClientOptions> = O extends {
-  plugins: Array<infer Plugin>;
+	plugins: Array<infer Plugin>;
 }
-  ? UnionToIntersection<
-      Plugin extends BetterAuthClientPlugin
-        ? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
-          ? Atoms extends Record<string, any>
-            ? {
-                [key in keyof Atoms as IsSignal<key> extends true
-                  ? never
-                  : key extends string
-                    ? `use${Capitalize<key>}`
-                    : never]: () => Accessor<ReturnType<Atoms[key]["get"]>>;
-              }
-            : {}
-          : {}
-        : {}
-    >
-  : {};
+	? UnionToIntersection<
+			Plugin extends BetterAuthClientPlugin
+				? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
+					? Atoms extends Record<string, any>
+						? {
+								[key in keyof Atoms as IsSignal<key> extends true
+									? never
+									: key extends string
+										? `use${Capitalize<key>}`
+										: never]: () => Accessor<ReturnType<Atoms[key]["get"]>>;
+							}
+						: {}
+					: {}
+				: {}
+		>
+	: {};
 
 export function createAuthClient<Option extends BetterAuthClientOptions>(
-  options?: Option | undefined,
+	options?: Option | undefined,
 ) {
-  const {
-    pluginPathMethods,
-    pluginsActions,
-    pluginsAtoms,
-    $fetch,
-    atomListeners,
-  } = getClientConfig(options);
-  let resolvedHooks: Record<string, any> = {};
-  for (const [key, value] of Object.entries(pluginsAtoms)) {
-    resolvedHooks[getAtomKey(key)] = () => useStore(value);
-  }
-  const routes = {
-    ...pluginsActions,
-    ...resolvedHooks,
-  };
-  const proxy = createDynamicPathProxy(
-    routes,
-    $fetch,
-    pluginPathMethods,
-    pluginsAtoms,
-    atomListeners,
-  );
-  type ClientAPI = InferClientAPI<Option>;
-  type Session = ClientAPI extends {
-    getSession: () => Promise<infer Res>;
-  }
-    ? Res extends BetterFetchResponse<infer S>
-      ? S
-      : Res extends Record<string, any>
-        ? Res
-        : never
-    : never;
-  return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
-    InferClientAPI<Option> &
-    InferActions<Option> & {
-      useSession: () => Accessor<{
-        data: Session;
-        isPending: boolean;
-        isRefetching: boolean;
-        error: BetterFetchError | null;
-      }>;
-      $Infer: {
-        Session: NonNullable<Session>;
-      };
-      $fetch: typeof $fetch;
-      $ERROR_CODES: PrettifyDeep<
-        InferErrorCodes<Option> & typeof BASE_ERROR_CODES
-      >;
-    };
+	const {
+		pluginPathMethods,
+		pluginsActions,
+		pluginsAtoms,
+		$fetch,
+		atomListeners,
+	} = getClientConfig(options);
+	let resolvedHooks: Record<string, any> = {};
+	for (const [key, value] of Object.entries(pluginsAtoms)) {
+		resolvedHooks[getAtomKey(key)] = () => useStore(value);
+	}
+	const routes = {
+		...pluginsActions,
+		...resolvedHooks,
+	};
+	const proxy = createDynamicPathProxy(
+		routes,
+		$fetch,
+		pluginPathMethods,
+		pluginsAtoms,
+		atomListeners,
+	);
+	type ClientAPI = InferClientAPI<Option>;
+	type Session = ClientAPI extends {
+		getSession: () => Promise<infer Res>;
+	}
+		? Res extends BetterFetchResponse<infer S>
+			? S
+			: Res extends Record<string, any>
+				? Res
+				: never
+		: never;
+	return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
+		InferClientAPI<Option> &
+		InferActions<Option> & {
+			useSession: () => Accessor<{
+				data: Session;
+				isPending: boolean;
+				isRefetching: boolean;
+				error: BetterFetchError | null;
+			}>;
+			$Infer: {
+				Session: NonNullable<Session>;
+			};
+			$fetch: typeof $fetch;
+			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+		};
 }
 
 export type * from "@better-fetch/fetch";

--- a/packages/better-auth/src/client/svelte/index.ts
+++ b/packages/better-auth/src/client/svelte/index.ts
@@ -1,11 +1,11 @@
 import type {
-  BetterAuthClientOptions,
-  BetterAuthClientPlugin,
+	BetterAuthClientOptions,
+	BetterAuthClientPlugin,
 } from "@better-auth/core";
 import type { BASE_ERROR_CODES } from "@better-auth/core/error";
 import type {
-  BetterFetchError,
-  BetterFetchResponse,
+	BetterFetchError,
+	BetterFetchResponse,
 } from "@better-fetch/fetch";
 import type { Atom } from "nanostores";
 import type { PrettifyDeep, UnionToIntersection } from "../../types/helper";
@@ -13,88 +13,88 @@ import { capitalizeFirstLetter } from "../../utils/misc";
 import { getClientConfig } from "../config";
 import { createDynamicPathProxy } from "../proxy";
 import type {
-  InferActions,
-  InferClientAPI,
-  InferErrorCodes,
-  IsSignal,
+	InferActions,
+	InferClientAPI,
+	InferErrorCodes,
+	IsSignal,
 } from "../types";
 
 type InferResolvedHooks<O extends BetterAuthClientOptions> = O extends {
-  plugins: Array<infer Plugin>;
+	plugins: Array<infer Plugin>;
 }
-  ? UnionToIntersection<
-      Plugin extends BetterAuthClientPlugin
-        ? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
-          ? Atoms extends Record<string, any>
-            ? {
-                [key in keyof Atoms as IsSignal<key> extends true
-                  ? never
-                  : key extends string
-                    ? `use${Capitalize<key>}`
-                    : never]: () => Atoms[key];
-              }
-            : {}
-          : {}
-        : {}
-    >
-  : {};
+	? UnionToIntersection<
+			Plugin extends BetterAuthClientPlugin
+				? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
+					? Atoms extends Record<string, any>
+						? {
+								[key in keyof Atoms as IsSignal<key> extends true
+									? never
+									: key extends string
+										? `use${Capitalize<key>}`
+										: never]: () => Atoms[key];
+							}
+						: {}
+					: {}
+				: {}
+		>
+	: {};
 
 export function createAuthClient<Option extends BetterAuthClientOptions>(
-  options?: Option | undefined,
+	options?: Option | undefined,
 ) {
-  const {
-    pluginPathMethods,
-    pluginsActions,
-    pluginsAtoms,
-    $fetch,
-    atomListeners,
-    $store,
-  } = getClientConfig(options);
-  let resolvedHooks: Record<string, any> = {};
-  for (const [key, value] of Object.entries(pluginsAtoms)) {
-    resolvedHooks[`use${capitalizeFirstLetter(key)}`] = () => value;
-  }
-  const routes = {
-    ...pluginsActions,
-    ...resolvedHooks,
-    $fetch,
-    $store,
-  };
-  const proxy = createDynamicPathProxy(
-    routes,
-    $fetch,
-    pluginPathMethods,
-    pluginsAtoms,
-    atomListeners,
-  );
-  type ClientAPI = InferClientAPI<Option>;
-  type Session = ClientAPI extends {
-    getSession: () => Promise<infer Res>;
-  }
-    ? Res extends BetterFetchResponse<infer S>
-      ? S
-      : Res extends Record<string, any>
-        ? Res
-        : never
-    : never;
-  return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
-    InferClientAPI<Option> &
-    InferActions<Option> & {
-      useSession: () => Atom<{
-        data: Session;
-        error: BetterFetchError | null;
-        isPending: boolean;
-        isRefetching: boolean;
-      }>;
-      $fetch: typeof $fetch;
-      $store: typeof $store;
-      $Infer: {
-        Session: NonNullable<Session>;
-      };
-      $ERROR_CODES: PrettifyDeep<
-        InferErrorCodes<Option> & typeof BASE_ERROR_CODES
-      >;
-    };
+	const {
+		pluginPathMethods,
+		pluginsActions,
+		pluginsAtoms,
+		$fetch,
+		atomListeners,
+		$store,
+	} = getClientConfig(options);
+	let resolvedHooks: Record<string, any> = {};
+	for (const [key, value] of Object.entries(pluginsAtoms)) {
+		resolvedHooks[`use${capitalizeFirstLetter(key)}`] = () => value;
+	}
+	const routes = {
+		...pluginsActions,
+		...resolvedHooks,
+		$fetch,
+		$store,
+	};
+	const proxy = createDynamicPathProxy(
+		routes,
+		$fetch,
+		pluginPathMethods,
+		pluginsAtoms,
+		atomListeners,
+	);
+	type ClientAPI = InferClientAPI<Option>;
+	type Session = ClientAPI extends {
+		getSession: () => Promise<infer Res>;
+	}
+		? Res extends BetterFetchResponse<infer S>
+			? S
+			: Res extends Record<string, any>
+				? Res
+				: never
+		: never;
+	return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
+		InferClientAPI<Option> &
+		InferActions<Option> & {
+			useSession: () => Atom<{
+				data: Session;
+				error: BetterFetchError | null;
+				isPending: boolean;
+				isRefetching: boolean;
+			}>;
+			$fetch: typeof $fetch;
+			$store: typeof $store;
+			$Infer: {
+				Session: NonNullable<Session>;
+			};
+			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+		};
 }
 
 export type * from "@better-fetch/fetch";

--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -1,11 +1,11 @@
 import type {
-  BetterAuthClientOptions,
-  BetterAuthClientPlugin,
+	BetterAuthClientOptions,
+	BetterAuthClientPlugin,
 } from "@better-auth/core";
 import type { BASE_ERROR_CODES } from "@better-auth/core/error";
 import type {
-  BetterFetchError,
-  BetterFetchResponse,
+	BetterFetchError,
+	BetterFetchResponse,
 } from "@better-fetch/fetch";
 import type { DeepReadonly, Ref } from "vue";
 import type { PrettifyDeep, UnionToIntersection } from "../../types/helper";
@@ -13,133 +13,133 @@ import { capitalizeFirstLetter } from "../../utils/misc";
 import { getClientConfig } from "../config";
 import { createDynamicPathProxy } from "../proxy";
 import type {
-  InferActions,
-  InferClientAPI,
-  InferErrorCodes,
-  IsSignal,
+	InferActions,
+	InferClientAPI,
+	InferErrorCodes,
+	IsSignal,
 } from "../types";
 import { useStore } from "./vue-store";
 
 function getAtomKey(str: string) {
-  return `use${capitalizeFirstLetter(str)}`;
+	return `use${capitalizeFirstLetter(str)}`;
 }
 
 type InferResolvedHooks<O extends BetterAuthClientOptions> = O extends {
-  plugins: Array<infer Plugin>;
+	plugins: Array<infer Plugin>;
 }
-  ? UnionToIntersection<
-      Plugin extends BetterAuthClientPlugin
-        ? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
-          ? Atoms extends Record<string, any>
-            ? {
-                [key in keyof Atoms as IsSignal<key> extends true
-                  ? never
-                  : key extends string
-                    ? `use${Capitalize<key>}`
-                    : never]: () => DeepReadonly<
-                  Ref<ReturnType<Atoms[key]["get"]>>
-                >;
-              }
-            : {}
-          : {}
-        : {}
-    >
-  : {};
+	? UnionToIntersection<
+			Plugin extends BetterAuthClientPlugin
+				? Plugin["getAtoms"] extends (fetch: any) => infer Atoms
+					? Atoms extends Record<string, any>
+						? {
+								[key in keyof Atoms as IsSignal<key> extends true
+									? never
+									: key extends string
+										? `use${Capitalize<key>}`
+										: never]: () => DeepReadonly<
+									Ref<ReturnType<Atoms[key]["get"]>>
+								>;
+							}
+						: {}
+					: {}
+				: {}
+		>
+	: {};
 
 export function createAuthClient<Option extends BetterAuthClientOptions>(
-  options?: Option | undefined,
+	options?: Option | undefined,
 ) {
-  const {
-    baseURL,
-    pluginPathMethods,
-    pluginsActions,
-    pluginsAtoms,
-    $fetch,
-    $store,
-    atomListeners,
-  } = getClientConfig(options, false);
-  let resolvedHooks: Record<string, any> = {};
-  for (const [key, value] of Object.entries(pluginsAtoms)) {
-    resolvedHooks[getAtomKey(key)] = () => useStore(value);
-  }
+	const {
+		baseURL,
+		pluginPathMethods,
+		pluginsActions,
+		pluginsAtoms,
+		$fetch,
+		$store,
+		atomListeners,
+	} = getClientConfig(options, false);
+	let resolvedHooks: Record<string, any> = {};
+	for (const [key, value] of Object.entries(pluginsAtoms)) {
+		resolvedHooks[getAtomKey(key)] = () => useStore(value);
+	}
 
-  type ClientAPI = InferClientAPI<Option>;
-  type Session = ClientAPI extends {
-    getSession: () => Promise<infer Res>;
-  }
-    ? Res extends BetterFetchResponse<infer S>
-      ? S
-      : Res extends Record<string, any>
-        ? Res
-        : never
-    : never;
+	type ClientAPI = InferClientAPI<Option>;
+	type Session = ClientAPI extends {
+		getSession: () => Promise<infer Res>;
+	}
+		? Res extends BetterFetchResponse<infer S>
+			? S
+			: Res extends Record<string, any>
+				? Res
+				: never
+		: never;
 
-  function useSession(): DeepReadonly<
-    Ref<{
-      data: Session;
-      isPending: boolean;
-      isRefetching: boolean;
-      error: BetterFetchError | null;
-    }>
-  >;
-  function useSession<F extends (...args: any) => any>(
-    useFetch: F,
-  ): Promise<{
-    data: Ref<Session>;
-    isPending: false; //this is just to be consistent with the default hook
-    error: Ref<{
-      message?: string | undefined;
-      status: number;
-      statusText: string;
-    }>;
-  }>;
-  function useSession<UseFetch extends <T>(...args: any) => any>(
-    useFetch?: UseFetch | undefined,
-  ) {
-    if (useFetch) {
-      const ref = useStore(pluginsAtoms.$sessionSignal!);
-      return useFetch(`${baseURL}/get-session`, {
-        ref,
-      }).then((res: any) => {
-        return {
-          data: res.data,
-          isPending: false,
-          error: res.error,
-        };
-      });
-    }
-    return resolvedHooks.useSession();
-  }
+	function useSession(): DeepReadonly<
+		Ref<{
+			data: Session;
+			isPending: boolean;
+			isRefetching: boolean;
+			error: BetterFetchError | null;
+		}>
+	>;
+	function useSession<F extends (...args: any) => any>(
+		useFetch: F,
+	): Promise<{
+		data: Ref<Session>;
+		isPending: false; //this is just to be consistent with the default hook
+		error: Ref<{
+			message?: string | undefined;
+			status: number;
+			statusText: string;
+		}>;
+	}>;
+	function useSession<UseFetch extends <T>(...args: any) => any>(
+		useFetch?: UseFetch | undefined,
+	) {
+		if (useFetch) {
+			const ref = useStore(pluginsAtoms.$sessionSignal!);
+			return useFetch(`${baseURL}/get-session`, {
+				ref,
+			}).then((res: any) => {
+				return {
+					data: res.data,
+					isPending: false,
+					error: res.error,
+				};
+			});
+		}
+		return resolvedHooks.useSession();
+	}
 
-  const routes = {
-    ...pluginsActions,
-    ...resolvedHooks,
-    useSession,
-    $fetch,
-    $store,
-  };
+	const routes = {
+		...pluginsActions,
+		...resolvedHooks,
+		useSession,
+		$fetch,
+		$store,
+	};
 
-  const proxy = createDynamicPathProxy(
-    routes,
-    $fetch,
-    pluginPathMethods,
-    pluginsAtoms,
-    atomListeners,
-  );
+	const proxy = createDynamicPathProxy(
+		routes,
+		$fetch,
+		pluginPathMethods,
+		pluginsAtoms,
+		atomListeners,
+	);
 
-  return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
-    InferClientAPI<Option> &
-    InferActions<Option> & {
-      useSession: typeof useSession;
-      $Infer: {
-        Session: NonNullable<Session>;
-      };
-      $fetch: typeof $fetch;
-      $store: typeof $store;
-      $ERROR_CODES: PrettifyDeep<
-        InferErrorCodes<Option> & typeof BASE_ERROR_CODES
-      >;
-    };
+	return proxy as UnionToIntersection<InferResolvedHooks<Option>> &
+		InferClientAPI<Option> &
+		InferActions<Option> & {
+			useSession: typeof useSession;
+			$Infer: {
+				Session: NonNullable<Session>;
+			};
+			$fetch: typeof $fetch;
+			$store: typeof $store;
+			$ERROR_CODES: PrettifyDeep<
+				InferErrorCodes<Option> & typeof BASE_ERROR_CODES
+			>;
+		};
 }
 
 export type * from "@better-fetch/fetch";


### PR DESCRIPTION
`The inferred type of 'authClient' cannot be named without a reference to '../../node_modules/better-auth/dist/helper-DU33OcfW.mjs'. This is likely not portable. A type annotation is necessary. (ts 2742)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exported helper types from client packages to make authClient’s inferred type portable and fix TS2742 “non-portable type” errors. Applies to core client and all framework clients (Lynx, React, Solid, Svelte, Vue).

- **Bug Fixes**
  - Re-exported types from ../types/helper, including UnionToIntersection.
  - Explicitly exported Primitive from @better-auth/core/db.
  - Ensured public type references instead of internal build paths.

<sup>Written for commit b1288966ff24fa11628a3211e39cfc3d428c9e1b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

