### PR TITLE
docs(tanstack): update cookie plugin name

### DIFF
--- a/docs/content/docs/integrations/tanstack.mdx
+++ b/docs/content/docs/integrations/tanstack.mdx
@@ -33,7 +33,7 @@ export const Route = createFileRoute('/api/auth/$')({
 ### Usage tips
 
 - We recommend using the client SDK or `authClient` to handle authentication, rather than server actions with `auth.api`.
-- When you call functions that need to set cookies (like `signInEmail` or `signUpEmail`), you'll need to handle cookie setting for TanStack Start. Better Auth provides a `reactStartCookies` plugin to automatically handle this for you.
+- When you call functions that need to set cookies (like `signInEmail` or `signUpEmail`), you'll need to handle cookie setting for TanStack Start. Better Auth provides a `tanstackStartCookies` plugin to automatically handle this for you.
 
 ```ts title="src/lib/auth.ts"
 import { betterAuth } from "better-auth";


### PR DESCRIPTION
I noticed that the `tanstackStartCookies` plugin name was not updated in the docs description after the 1.4 update so I quickly updated it :). 

Thanks for this awesome library, I am looking forward to use it for my next project

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update TanStack Start integration docs to reference the correct Better Auth plugin for cookie handling. Replaces reactStartCookies with tanstackStartCookies to match the 1.4 release and prevent setup confusion.

<sup>Written for commit a30cae11e84c469d862d90347221fcb87ddfe3ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

