### PR TITLE
fix(organization): have deleteOrganization use adapter.deleteMany instead of delete

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -377,7 +377,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 		deleteOrganization: async (organizationId: string) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
-			await adapter.delete({
+			await adapter.deleteMany({
 				model: "member",
 				where: [
 					{
@@ -386,7 +386,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					},
 				],
 			});
-			await adapter.delete({
+			await adapter.deleteMany({
 				model: "invitation",
 				where: [
 					{


### PR DESCRIPTION
Prisma's delete requires a unique ID to be passed. This makes it so deleteOrganization uses the deleteMany function instead. This is the same issue as commented in the removeTeamMember function.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use deleteMany in deleteOrganization to remove members and invitations without requiring unique IDs. Fixes deletion failures caused by Prisma’s delete needing a unique ID.

<sup>Written for commit 9ab3960dcca29142238cc41457d6445c07efc37e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

