### PR TITLE
chore: fix plugin import

### DIFF
--- a/packages/better-auth/src/plugins/additional-fields/client.ts
+++ b/packages/better-auth/src/plugins/additional-fields/client.ts
@@ -1,6 +1,9 @@
-import type { BetterAuthClientPlugin } from "@better-auth/core";
+import type {
+	BetterAuthClientPlugin,
+	BetterAuthOptions,
+	BetterAuthPlugin,
+} from "@better-auth/core";
 import type { DBFieldAttribute } from "@better-auth/core/db";
-import type { BetterAuthOptions, BetterAuthPlugin } from "../../types";
 
 export const inferAdditionalFields = <
 	T,

--- a/packages/better-auth/src/plugins/two-factor/client.ts
+++ b/packages/better-auth/src/plugins/two-factor/client.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
-import type { twoFactor as twoFa } from "../../plugins/two-factor";
+import type { twoFactor as twoFa } from ".";
 
 export const twoFactorClient = (
 	options?:


### PR DESCRIPTION
```
The inferred type of 'baseAuthPlugins' cannot be named without a reference to '../../../../node_modules/better-auth/dist/index-SBjk_96V.mjs'. This is likely not portable. A type annotation is necessary.ts(2742)
```






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the two-factor client to import the plugin type from "." instead of "../../plugins/two-factor", resolving the ts(2742) portability error. Also switched additional-fields client type imports to "@better-auth/core" to avoid non-portable inferred types.

<sup>Written for commit 4b0021b0ceb18c6eba15283fbd0ac3c45a58c639. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





