### PR TITLE
docs: mark permission as server-only param

### DIFF
--- a/docs/content/docs/plugins/api-key.mdx
+++ b/docs/content/docs/plugins/api-key.mdx
@@ -135,6 +135,7 @@ type createApiKey = {
     rateLimitEnabled?: boolean = true
     /**
      * Permissions of the Api Key.
+     * @serverOnly
      */
     permissions?: Record<string, string[]>
 }


### PR DESCRIPTION
Closes #6217

Fix docs to describe `permissions` options in the `createApiKey` method as `server-only`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated API Key plugin docs to mark createApiKey permissions as server-only. Adds @serverOnly to clarify it should not be used on the client.

<sup>Written for commit 33f5649ca48051aee5ef0d84ff63666ec0c25d4f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

