### PR TITLE
fix(cli): prevent duplicate index creation in Prisma schema generation

### DIFF
--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -381,7 +381,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 							(v) =>
 								v.type === "attribute" &&
 								v.name === "index" &&
-								JSON.stringify(v).includes(fieldName),
+								JSON.stringify(v.args[0]?.value).includes(fieldName),
 						);
 						if (indexExist) {
 							continue;


### PR DESCRIPTION
solves **#6233** 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate index creation in Prisma schema generation by skipping indexes that already exist on the model. Fixes #6233 and avoids repeated index lines across subsequent CLI runs.

<sup>Written for commit a5e64688df15f6b0d34fc7b3f907a5d016049639. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



