### PR TITLE
fix(fastify): Change request body handling from undefined to null

### DIFF
--- a/docs/content/docs/integrations/fastify.mdx
+++ b/docs/content/docs/integrations/fastify.mdx
@@ -53,7 +53,7 @@ fastify.route({
       const req = new Request(url.toString(), {
         method: request.method,
         headers,
-        body: request.body ? JSON.stringify(request.body) : undefined,
+        body: request.body ? JSON.stringify(request.body) : null,
       });
 
       // Process authentication request


### PR DESCRIPTION
Fix TS error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Fastify integration example to pass null for Request body when no payload is present, instead of undefined. This resolves the TypeScript error by matching RequestInit’s expected type and keeps the example consistent.

<sup>Written for commit b69bf65d82cbcf3904e74c0292106d35b1a6cd1c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

