### PR TITLE
chore: remove incorrect auth cli

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -61,7 +61,7 @@ export const auth = betterAuth({
 <Callout type="warn">
   Please make sure that your Drizzle schema has the necessary relations defined.
   If you do not see any relations in your Drizzle schema, you can manually add them using the [`relation`](https://orm.drizzle.team/docs/relations) drizzle-orm function
-  or run our latest CLI version `npx auth@latest generate` to generate a new Drizzle schema with the relations.
+  or run our latest CLI version `npx @better-auth/cli@latest generate` to generate a new Drizzle schema with the relations.
 
   Additionally, you're required to pass each [relation](https://orm.drizzle.team/docs/relations) through the drizzle adapter schema object.
 </Callout>

--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -75,7 +75,7 @@ export const auth = betterAuth({
 <Callout type="warn">
   Please make sure that your Prisma schema has the necessary relations defined.
   If you do not see any relations in your Prisma schema, you can manually add them using the `@relation` directive
-  or run our latest CLI version `npx auth@latest generate` to generate a new Prisma schema with the relations.
+  or run our latest CLI version `npx @better-auth/cli@latest generate` to generate a new Prisma schema with the relations.
 </Callout>
 
 ## Additional Information

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -347,7 +347,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				for (const key in values) {
 					if (!schema[key]) {
 						throw new BetterAuthError(
-							`The field "${key}" does not exist in the "${model}" Drizzle schema. Please update your drizzle schema or re-generate using "npx @better-auth/cli generate".`,
+							`The field "${key}" does not exist in the "${model}" Drizzle schema. Please update your drizzle schema or re-generate using "npx @better-auth/cli@latest generate".`,
 						);
 					}
 				}
@@ -368,7 +368,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					if (options.experimental?.joins) {
 						if (!db.query || !db.query[model]) {
 							logger.error(
-								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx auth generate".`,
+								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx @better-auth/cli@latest generate".`,
 							);
 							logger.info("Falling back to regular query");
 						} else {
@@ -434,7 +434,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					if (options.experimental?.joins) {
 						if (!db.query[model]) {
 							logger.error(
-								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx auth generate".`,
+								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx @better-auth/cli@latest generate".`,
 							);
 							logger.info("Falling back to regular query");
 						} else {


### PR DESCRIPTION
Previously I thought we were going to include auth cli in the 1.4 release so some parts I started to mention `auth` instead of `@better-auth/cli` - this needs to be removed until it's actually released

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect CLI references by switching all mentions of `auth` to `npx @better-auth/cli@latest generate` in docs and Drizzle adapter messages to prevent confusion until the auth CLI is released.

- **Bug Fixes**
  - Updated Drizzle and Prisma adapter docs to show the correct CLI command.
  - Updated Drizzle adapter error and log messages to reference `@better-auth/cli@latest`.

<sup>Written for commit 49869c0e3248b6ac5dafbd4d2a2126ce83496372. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

