### PR TITLE
feat: list accounts should include `idToken`

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -55,6 +55,7 @@ export const listUserAccounts = createAuthEndpoint(
 											},
 											idToken: {
 												type: "string",
+												nullable: true,
 											},
 											scopes: {
 												type: "array",

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -53,6 +53,9 @@ export const listUserAccounts = createAuthEndpoint(
 											userId: {
 												type: "string",
 											},
+											idToken: {
+												type: "string",
+											},
 											scopes: {
 												type: "array",
 												items: {
@@ -91,6 +94,7 @@ export const listUserAccounts = createAuthEndpoint(
 				updatedAt: a.updatedAt,
 				accountId: a.accountId,
 				userId: a.userId,
+				idToken: a.idToken,
 				scopes: a.scope?.split(",") || [],
 			})),
 		);


### PR DESCRIPTION
Similar to https://github.com/better-auth/better-auth/pull/1081



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated /list-accounts to include a nullable idToken for each account in the response. This lets clients access the provider token directly without an extra request.

<sup>Written for commit fa74054b2c565c6ba45b8e7fd8151b3b8716e379. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



