### PR TITLE
fix(oauth2): add missing `providerId` from `updateAccountOnSignIn`

### DIFF
--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -103,6 +103,7 @@ export async function handleOAuthUserInfo(
 						accessTokenExpiresAt: account.accessTokenExpiresAt,
 						refreshTokenExpiresAt: account.refreshTokenExpiresAt,
 						scope: account.scope,
+						providerId: account.providerId,
 					}).filter(([_, value]) => value !== undefined),
 				);
 				if (c.context.options.account?.storeAccountCookie) {


### PR DESCRIPTION
Fixes #6252 and #6188