### PR TITLE
chore: re-export zod types in plugins

### DIFF
--- a/packages/better-auth/src/plugins/index.ts
+++ b/packages/better-auth/src/plugins/index.ts
@@ -8,6 +8,7 @@ export {
 	createAuthMiddleware,
 	optionsMiddleware,
 } from "@better-auth/core/api";
+export type * as z from "zod";
 export * from "../types/plugins";
 export * from "../utils/hide-metadata";
 export * from "./access";


### PR DESCRIPTION
Related: #6230

`The inferred type of 'auth' cannot be named without a reference to '.pnpm/zod@4.1.13/node_modules/zod'. This is likely not portable. A type annotation is necessary. (ts 2742)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-export Zod types from the plugins entry to prevent non-portable type errors (TS2742) in consumers. Consumers can access z via @better-auth/plugins without importing zod directly. Related to #6230.

- **Bug Fixes**
  - Added export type * as z from "zod" in plugins index to avoid .pnpm path references when inferring types like auth (TS2742).

<sup>Written for commit d262f1b3a943b85cd5cd77fa88d89ac39d62ae46. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

