### PR TITLE
feat(cli): check `/auth` for `auth.ts`

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -24,10 +24,11 @@ let possiblePaths = [
 possiblePaths = [
 	...possiblePaths,
 	...possiblePaths.map((it) => `lib/server/${it}`),
+	...possiblePaths.map((it) => `server/auth/${it}`),
 	...possiblePaths.map((it) => `server/${it}`),
+	...possiblePaths.map((it) => `auth/${it}`),
 	...possiblePaths.map((it) => `lib/${it}`),
 	...possiblePaths.map((it) => `utils/${it}`),
-	...possiblePaths.map((it) => `auth/${it}`),
 ];
 possiblePaths = [
 	...possiblePaths,


### PR DESCRIPTION
Allows users to add their `auth.ts` under `@/auth` if desired.

https://discord.com/channels/1288403910284935179/1288403910284935182/1442600288182599751



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The CLI now searches /auth and /server/auth for auth.ts when resolving config. This lets you place auth.ts under @/auth or @/server/auth without extra setup.

<sup>Written for commit f19ae021b3a6c0b917b776a7323b039ae52888d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



