### PR TITLE
feat(oauth): PKCE support for Github

### DIFF
--- a/packages/core/src/social-providers/github.ts
+++ b/packages/core/src/social-providers/github.ts
@@ -61,7 +61,13 @@ export const github = (options: GithubOptions) => {
 	return {
 		id: "github",
 		name: "GitHub",
-		createAuthorizationURL({ state, scopes, loginHint, codeVerifier, redirectURI }) {
+		createAuthorizationURL({
+			state,
+			scopes,
+			loginHint,
+			codeVerifier,
+			redirectURI,
+		}) {
 			const _scopes = options.disableDefaultScope
 				? []
 				: ["read:user", "user:email"];


### PR DESCRIPTION
GitHub added support for [PKCE](https://github.blog/changelog/2025-07-14-pkce-support-for-oauth-and-github-app-authentication/) in July 2025 for OAuth authentication and it is recommended. 

The changes
- GitHub Authorization url includes `code_challenge_method` and `code_challenge` 
- GitHub code exchange includes `code_verifier`




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PKCE support to GitHub OAuth for improved security and to match GitHub’s latest recommendation. The authorization request now includes a code challenge, and the token exchange uses the code verifier.

<sup>Written for commit dc4a66bb1063aad6cfd6729a7356acfca21e8e53. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



