### PR TITLE
set default to cookie to match JSDoc

### DIFF
--- a/packages/better-auth/src/index.ts
+++ b/packages/better-auth/src/index.ts
@@ -9,6 +9,7 @@ export * from "@better-auth/core/oauth2";
 export * from "@better-auth/core/utils";
 //#endregion
 export * from "./auth";
+// @ts-expect-error
 export * from "./types";
 export * from "./utils";
 // export this as we are referencing OAuth2Tokens in the `refresh-token` api as return type
@@ -20,6 +21,7 @@ export {
 	type TelemetryEvent,
 } from "@better-auth/telemetry";
 // re-export third party types
+// @ts-expect-error
 export type * from "better-call";
 export type { JSONWebKeySet, JWTPayload } from "jose";
 export type * from "zod";

--- a/packages/better-auth/src/types/index.ts
+++ b/packages/better-auth/src/types/index.ts
@@ -9,5 +9,6 @@ export * from "../client/types";
 export type * from "./adapter";
 export * from "./api";
 export type * from "./auth";
+export type * from "./helper";
 export type * from "./models";
 export type * from "./plugins";


### PR DESCRIPTION
Would fix https://github.com/better-auth/better-auth/issues/5034 since after "1.3.13" this was broken for people (see my last comment)

Pre "1.3.13" it was essentially cookie-based, so this would be similar. Users who want the added security of database storage can still explicitly set storeStateStrategy: "database" and use skipStateCookieCheck: true if cookies are unreliable in their environment.


I'm not sure what the team thinks so let me know if this is desired or not









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore oauthConfig.storeStateStrategy default to "cookie" to match the JSDoc and previous behavior. This fixes a regression after 1.3.13 that broke OAuth state handling for apps not setting this option.

- **Bug Fixes**
  - Default storeStateStrategy is now "cookie" when not provided.
  - Aligns runtime with docs and prevents state mismatches during sign-in.

<sup>Written for commit 5390502fe1b0a2e19a15ef79d55c26fdff71b028. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









