### PR TITLE
docs(fix): update saml sso guide example to refelect types properly

### DIFF
--- a/docs/content/docs/guides/saml-sso-with-okta.mdx
+++ b/docs/content/docs/guides/saml-sso-with-okta.mdx
@@ -50,13 +50,13 @@ const ssoConfig = {
           Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
           Location: "https://trial-1076874.okta.com/app/trial-1076874_samltest_1/exktofb0a62hqLAUL697/sso/saml"
         }],
-        cert: `-----BEGIN CERTIFICATE-----
+      },
+      cert: `-----BEGIN CERTIFICATE-----
 MIIDqjCCApKgAwIBAgIGAZhVGMeUMA0GCSqGSIb3DQEBCwUAMIGVMQswCQYDVQQGEwJVUzETMBEG
 ...
 [Your Okta Certificate]
 ...
------END CERTIFICATE-----`
-      },
+-----END CERTIFICATE-----`,
       
       // SP Metadata
       spMetadata: {


### PR DESCRIPTION
`SSOOptions.cert` is required but the example only defines `SSOOptions.idpMetadata.cert` (Internally the same but breaks type safety)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the SAML SSO with Okta guide example to use SSOOptions.cert instead of idpMetadata.cert, matching the required types. This prevents TypeScript errors and clarifies where to place the Okta certificate.

<sup>Written for commit 6e7580034a7d79eb4d45f69c728addcbe05b10bd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

