### PR TITLE
feat: option to redirect after `/sign-up/email` finished

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.test.ts
+++ b/packages/better-auth/src/api/routes/sign-up.test.ts
@@ -144,4 +144,20 @@ describe("sign-up with custom fields", async (it) => {
 			}),
 		).rejects.toThrow("role is not allowed to be set");
 	});
+
+	it("should return redirect object when redirectTo is defined", async () => {
+		await expect(
+			auth.api.signUpEmail({
+				body: {
+					email: "email3@test.com",
+					password: "password",
+					name: "Test Name",
+					redirectTo: "https://example.com",
+				},
+			}),
+		).resolves.toMatchObject({
+			redirect: true,
+			url: "https://example.com",
+		});
+	});
 });

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -25,6 +25,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 						password: string;
 						image?: string | undefined;
 						callbackURL?: string | undefined;
+						redirectTo?: string | undefined;
 						rememberMe?: boolean | undefined;
 					} & AdditionalUserFieldsInput<O>,
 				},
@@ -58,6 +59,11 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 											description:
 												"The URL to use for email verification callback",
 										},
+										redirectTo: {
+											type: "string",
+											description:
+												"The URL to redirect to after successful sign-up",
+										},
 										rememberMe: {
 											type: "boolean",
 											description:
@@ -77,6 +83,14 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 									schema: {
 										type: "object",
 										properties: {
+											redirect: {
+												type: "boolean",
+												enum: [false],
+											},
+											url: {
+												type: "null",
+												nullable: true,
+											},
 											token: {
 												type: "string",
 												nullable: true,
@@ -177,6 +191,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					password,
 					image,
 					callbackURL,
+					redirectTo,
 					rememberMe,
 					...rest
 				} = body;
@@ -306,6 +321,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					ctx.context.options.emailAndPassword.requireEmailVerification
 				) {
 					return ctx.json({
+						redirect: false,
 						token: null,
 						user: {
 							id: createdUser.id,
@@ -337,6 +353,8 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					rememberMe === false,
 				);
 				return ctx.json({
+					redirect: !!redirectTo,
+					url: redirectTo,
 					token: session.token,
 					user: {
 						id: createdUser.id,

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -88,7 +88,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 												enum: [false],
 											},
 											url: {
-												type: "null",
+												type: "string",
 												nullable: true,
 											},
 											token: {

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -143,7 +143,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 												],
 											},
 										},
-										required: ["user"], // token is optional
+										required: ["redirect", "user"], // token is optional
 									},
 								},
 							},
@@ -181,6 +181,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 				const body = ctx.body as any as User & {
 					password: string;
 					callbackURL?: string | undefined;
+					redirectTo?: string | undefined;
 					rememberMe?: boolean | undefined;
 				} & {
 					[key: string]: any;


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional redirectTo parameter to the sign-up API to enable redirect after a successful sign-up. The response now returns redirect and url to guide client-side navigation; no redirect when email verification is required.

- **New Features**
  - Request: accepts redirectTo in the body.
  - Response: adds redirect (boolean) and url (nullable).
  - Behavior: if email verification is required, returns redirect: false and token: null; otherwise sets redirect/url based on redirectTo.

<sup>Written for commit 14e097e53df3b3cddcc78736798e9ed5f1875e56. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





