### PR TITLE
fix(oidc-provider): session shouldn't be required

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -931,7 +931,6 @@ export const oidcProvider = (options: OIDCOptions) => {
 				{
 					method: "GET",
 					operationId: "oauth2Userinfo",
-					use: [sessionMiddleware],
 					metadata: {
 						isAction: false,
 						openapi: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop requiring a session for the OIDC /userinfo endpoint by removing sessionMiddleware. This aligns with the OIDC spec and fixes 401s for clients using only an access token.

<sup>Written for commit 87eb2dc2d17916626c440a017a686a3497d2bea7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

