### PR TITLE
fix: clean up incorrect null type in OpenAPI

### DIFF
--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -380,7 +380,7 @@ export const signInEmail = createAuthEndpoint(
 											description: "Session token",
 										},
 										url: {
-											type: "null",
+											type: "string",
 											nullable: true,
 										},
 										user: {

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -689,7 +689,8 @@ export const rejectInvitation = <O extends OrganizationOptions>(options: O) =>
 												type: "object",
 											},
 											member: {
-												type: "null",
+												type: "object",
+												nullable: true,
 											},
 										},
 									},


### PR DESCRIPTION
Closes https://github.com/better-auth/better-auth/issues/6250

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect OpenAPI schema types by replacing “null” with proper types and marking them as nullable. This resolves spec validation issues and prevents broken SDK/codegen.

- **Bug Fixes**
  - sign-in email: url is now type "string" with nullable: true.
  - organization rejectInvitation: member is now type "object" with nullable: true.

<sup>Written for commit 4db1da6d643ee68b53a9fe6173b8b9b586c422f6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

