### PR TITLE
fix(open-api): clean up incorrect null type in OpenAPI

### DIFF
--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -408,7 +408,7 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 												description: "Session token",
 											},
 											url: {
-												type: "null",
+												type: "string",
 												nullable: true,
 											},
 											user: {

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -689,7 +689,8 @@ export const rejectInvitation = <O extends OrganizationOptions>(options: O) =>
 												type: "object",
 											},
 											member: {
-												type: "null",
+												type: "object",
+												nullable: true,
 											},
 										},
 									},


### PR DESCRIPTION
Closes https://github.com/better-auth/better-auth/issues/6250

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed invalid OpenAPI schemas by replacing "type: null" with the correct types and nullable flags. This resolves schema validation issues and prevents broken client codegen.

- **Bug Fixes**
  - sign-in email: response.url is now type string, nullable: true.
  - organization.rejectInvitation: response.member is now type object, nullable: true.

<sup>Written for commit 2e2f24cea04a87f9bfe977f551454506ebb78d03. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

