### PR TITLE
fix(docs): grammar and linting issues in plugins documentation

### DIFF
--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -23,13 +23,13 @@ export const auth = betterAuth({
 });
 ```
 
-Client plugins are added when creating the client. Most plugin require both server and client plugins to work correctly.
+Client plugins are added when creating the client. Most plugins require both server and client plugins to work correctly.
 The Better Auth auth client on the frontend uses the `createAuthClient` function provided by `better-auth/client`.
 
 ```ts title="auth-client.ts"
 import { createAuthClient } from "better-auth/client";
 
-const authClient =  createAuthClient({
+const authClient = createAuthClient({
     plugins: [
         // Add your client plugins here
     ]
@@ -50,21 +50,21 @@ To get started, you'll need a server plugin.
 Server plugins are the backbone of all plugins, and client plugins are there to provide an interface with frontend APIs to easily work with your server plugins.
 
 <Callout type="info">
-    If your server plugins has endpoints that needs to be called from the client, you'll also need to create a client plugin.
+    If your server plugins have endpoints that need to be called from the client, you'll also need to create a client plugin.
 </Callout>
 
 ### What can a plugin do?
 
 * Create custom `endpoint`s to perform any action you want.
 * Extend database tables with custom `schemas`.
-* Use a `middleware` to target a group of routes using it's route matcher, and run only when those routes are called through a request.
+* Use a `middleware` to target a group of routes using its route matcher, and run only when those routes are called through a request.
 * Use `hooks` to target a specific route or request. And if you want to run the hook even if the endpoint is called directly.
 * Use `onRequest` or `onResponse` if you want to do something that affects all requests or responses.
-* Create custom `rate-limit` rule.
+* Create a custom `rate-limit` rule.
 
 ## Create a Server plugin
 
-To create a server plugin you need to pass an object that satisfies the `BetterAuthPlugin` interface.
+To create a server plugin, you need to pass an object that satisfies the `BetterAuthPlugin` interface.
 
 The only required property is `id`, which is a unique identifier for the plugin.
 Both server and client plugins can use the same `id`.
@@ -72,14 +72,14 @@ Both server and client plugins can use the same `id`.
 ```ts title="plugin.ts"
 import type { BetterAuthPlugin } from "better-auth";
 
-export const myPlugin = ()=>{
+export const myPlugin = () => {
     return {
         id: "my-plugin",
     } satisfies BetterAuthPlugin
 }
 ```
 <Callout>
-    You don't have to make the plugin a function, but it's recommended to do so. This way you can pass options to the plugin and it's consistent with the built-in plugins.
+    You don't have to make the plugin a function, but it's recommended to do so. This way, you can pass options to the plugi,n and it's consistent with the built-in plugins.
 </Callout>
 
 ### Endpoints
@@ -93,7 +93,7 @@ Better Auth uses wraps around another library called <Link href="https://github.
 ```ts title="plugin.ts"
 import { createAuthEndpoint } from "better-auth/api";
 
-const myPlugin = ()=> {
+const myPlugin = () => {
     return {
         id: "my-plugin",
         endpoints: {
@@ -145,7 +145,7 @@ You can define a database schema for your plugin by passing a `schema` object. T
 ```ts title="plugin.ts"
 import { BetterAuthPlugin } from "better-auth/plugins";
 
-const myPlugin = ()=> {
+const myPlugin = () => {
     return {
         id: "my-plugin",
         schema: {
@@ -184,7 +184,7 @@ The key is the column name and the value is the column definition. The column de
 `disableMigration`: if the table should not be migrated. (default: `false`)
 
 ```ts title="plugin.ts"
-const myPlugin = (opts: PluginOptions)=>{
+const myPlugin = (opts: PluginOptions) => {
     return {
         id: "my-plugin",
         schema: {
@@ -205,7 +205,7 @@ if you add additional fields to a `user` or `session` table, the types will be i
 
 ```ts title="plugin.ts"
 
-const myPlugin = ()=>{
+const myPlugin = () => {
     return {
         id: "my-plugin",
         schema: {
@@ -224,7 +224,7 @@ const myPlugin = ()=>{
 This will add an `age` field to the `user` table and all `user` returning endpoints will include the `age` field and it'll be inferred properly by typescript.
 
 <Callout type="warn">
-Don't store sensitive information in `user` or `session` table. Create a new table if you need to store sensitive information.
+Don't store sensitive information in the `user` or `session` table. Create a new table if you need to store sensitive information.
 </Callout>
 
 ### Hooks
@@ -232,28 +232,28 @@ Don't store sensitive information in `user` or `session` table. Create a new tab
 Hooks are used to run code before or after an action is performed, either from a client or directly on the server. You can add hooks to the server by passing a `hooks` object, which should contain `before` and `after` properties.
 
 ```ts title="plugin.ts"
-import {  createAuthMiddleware } from "better-auth/plugins";
+import { createAuthMiddleware } from "better-auth/plugins";
 
-const myPlugin = ()=>{
+const myPlugin = () => {
     return {
         id: "my-plugin",
         hooks: {
             before: [{
-                    matcher: (context)=>{
+                    matcher: (context) => {
                         return context.headers.get("x-my-header") === "my-value"
                     },
-                    handler: createAuthMiddleware(async (ctx)=>{
-                        //do something before the request
+                    handler: createAuthMiddleware(async (ctx) => {
+                        // do something before the request
                         return  {
                             context: ctx // if you want to modify the context
                         }
                     })
                 }],
             after: [{
-                matcher: (context)=>{
+                matcher: (context) => {
                     return context.path === "/sign-up/email"
                 },
-                handler: createAuthMiddleware(async (ctx)=>{
+                handler: createAuthMiddleware(async (ctx) => {
                     return ctx.json({
                         message: "Hello World"
                     }) // if you want to modify the response
@@ -270,17 +270,17 @@ You can add middleware to the server by passing a `middlewares` array. This arra
 
 The `path` can be either a string or a path matcher, using the same path-matching system as `better-call`.
 
-If you throw an `APIError` from the middleware or returned a `Response` object, the request will be stopped and the response will be sent to the client.
+If you throw an `APIError` from the middleware or return a `Response` object, the request will be stopped, and the response will be sent to the client.
 
 ```ts title="plugin.ts"
-const myPlugin = ()=>{
+const myPlugin = () => {
     return {
         id: "my-plugin",
         middlewares: [
             {
                 path: "/my-plugin/hello-world",
-                middleware: createAuthMiddleware(async(ctx)=>{
-                    //do something
+                middleware: createAuthMiddleware(async(ctx) => {
+                    // do something
                 })
             }
         ]
@@ -304,11 +304,11 @@ Here’s how it works:
 - **Modify the Request**: You can also return a modified `request` object to change the request before it's sent.
 
 ```ts title="plugin.ts"
-const myPlugin = ()=> {
+const myPlugin = () => {
     return  {
         id: "my-plugin",
         onRequest: async (request, context) => {
-            //do something
+            // do something
         },
     } satisfies BetterAuthPlugin
 }
@@ -324,11 +324,11 @@ Here’s how to use it:
 - **Continue Normally**: If you don't return anything, the response will be sent as is.
 
 ```ts title="plugin.ts"
-const myPlugin = ()=>{
+const myPlugin = () => {
     return {
         id: "my-plugin",
         onResponse: async (response, context) => {
-            //do something
+            // do something
         },
     } satisfies BetterAuthPlugin
 }
@@ -339,12 +339,12 @@ const myPlugin = ()=>{
 You can define custom rate limit rules for your plugin by passing a `rateLimit` array. The rate limit array should contain an array of rate limit objects.
 
 ```ts title="plugin.ts"
-const myPlugin = ()=>{
+const myPlugin = () => {
     return {
         id: "my-plugin",
         rateLimit: [
             {
-                pathMatcher: (path)=>{
+                pathMatcher: (path) => {
                     return path === "/my-plugin/hello-world"
                 },
                 limit: 10,
@@ -364,19 +364,19 @@ Some additional helper functions for creating server plugins.
 Allows you to get the client's session data by passing the auth middleware's `context`.
 
 ```ts title="plugin.ts"
-import {  createAuthMiddleware } from "better-auth/plugins";
+import { createAuthMiddleware } from "better-auth/plugins";
 import { getSessionFromCtx } from "better-auth/api";
 
 const myPlugin = {
     id: "my-plugin",
     hooks: {
         before: [{
-                matcher: (context)=>{
+                matcher: (context) => {
                     return context.headers.get("x-my-header") === "my-value"
                 },
                 handler: createAuthMiddleware(async (ctx) => {
                     const session = await getSessionFromCtx(ctx);
-                    //do something with the client's session.
+                    // do something with the client's session.
 
                     return  {
                         context: ctx
@@ -395,14 +395,14 @@ A middleware that checks if the client has a valid session. If the client has a 
 import { createAuthMiddleware } from "better-auth/plugins";
 import { sessionMiddleware } from "better-auth/api";
 
-const myPlugin = ()=>{
+const myPlugin = () => {
     return {
         id: "my-plugin",
         endpoints: {
             getHelloWorld: createAuthEndpoint("/my-plugin/hello-world", {
                 method: "GET",
                 use: [sessionMiddleware], // [!code highlight]
-            }, async(ctx) => {
+            }, async (ctx) => {
                 const session = ctx.context.session;
                 return ctx.json({
                     message: "Hello World"
@@ -416,12 +416,12 @@ const myPlugin = ()=>{
 
 ## Creating a client plugin
 
-If your endpoints needs to be called from the client, you'll need to also create a client plugin. Better Auth clients can infer the endpoints from the server plugins. You can also add additional client side logic.
+If your endpoints need to be called from the client, you'll also need to create a client plugin. Better Auth clients can infer the endpoints from the server plugins. You can also add additional client-side logic.
 
 ```ts title="client-plugin.ts"
 import type { BetterAuthClientPlugin } from "better-auth";
 
-export const myPluginClient = ()=>{
+export const myPluginClient = () => {
     return {
         id: "my-plugin",
     } satisfies BetterAuthClientPlugin
@@ -438,7 +438,7 @@ The client infers the `path` as an object and converts kebab-case to camelCase. 
 import type { BetterAuthClientPlugin } from "better-auth/client";
 import type { myPlugin } from "./plugin";
 
-const myPluginClient = ()=> {
+const myPluginClient = () => {
     return  {
         id: "my-plugin",
         $InferServerPlugin: {} as ReturnType<typeof myPlugin>,
@@ -448,9 +448,9 @@ const myPluginClient = ()=> {
 
 ### Get actions
 
-If you need to add additional methods or what not to the client you can use the `getActions` function. This function is called with the `fetch` function from the client.
+If you need to add additional methods or whatnot to the client, you can use the `getActions` function. This function is called with the `fetch` function from the client.
 
-Better Auth uses <Link href="https://better-fetch.vercel.app"> Better fetch </Link> to make requests. Better fetch is a simple fetch wrapper made by the same author of Better Auth.
+Better Auth uses <Link href="https://better-fetch.vercel.app"> Better fetch </Link> to make requests. Better Fetch is a simple fetch wrapper made by the same author of Better Auth.
 
 ```ts title="client-plugin.ts"
 import type { BetterAuthClientPlugin } from "better-auth/client";
@@ -460,11 +460,11 @@ import type { BetterFetchOption } from "@better-fetch/fetch";
 const myPluginClient = {
     id: "my-plugin",
     $InferServerPlugin: {} as ReturnType<typeof myPlugin>,
-    getActions: ($fetch)=>{
+    getActions: ($fetch) => {
         return {
             myCustomAction: async (data: {
                 foo: string,
-            }, fetchOptions?: BetterFetchOption)=>{
+            }, fetchOptions?: BetterFetchOption) => {
                 const res = $fetch("/custom/action", {
                     method: "POST",
                     body: {
@@ -489,7 +489,7 @@ If your use case involves actions beyond API calls, feel free to deviate from th
 
 This is only useful if you want to provide `hooks` like `useSession`.
 
-Get atoms is called with the `fetch` function from better fetch and it should return an object with the atoms. The atoms should be created using <Link href="https://github.com/nanostores/nanostores">nanostores</Link>. The atoms will be resolved by each framework `useStore` hook provided by nanostores.
+Get atoms is called with the `fetch` function from better fetch, and it should return an object with the atoms. The atoms should be created using <Link href="https://github.com/nanostores/nanostores">nanostores</Link>. The atoms will be resolved by each framework's `useStore` hook provided by nanostores.
 
 ```ts title="client-plugin.ts"
 import { atom } from "nanostores";
@@ -498,7 +498,7 @@ import type { BetterAuthClientPlugin } from "better-auth/client";
 const myPluginClient = {
     id: "my-plugin",
     $InferServerPlugin: {} as ReturnType<typeof myPlugin>,
-    getAtoms: ($fetch)=>{
+    getAtoms: ($fetch) => {
         const myAtom = atom<null>()
         return {
             myAtom
@@ -511,7 +511,7 @@ See built-in plugins for examples of how to use atoms properly.
 
 ### Path methods
 
-By default, inferred paths use `GET` method if they don't require a body and `POST` if they do. You can override this by passing a `pathMethods` object. The key should be the path and the value should be the method ("POST" | "GET").
+By default, inferred paths use the `GET` method if they don't require a body and `POST` if they do. You can override this by passing a `pathMethods` object. The key should be the path, and the value should be the method ("POST" | "GET").
 
 ```ts title="client-plugin.ts"
 import type { BetterAuthClientPlugin } from "better-auth/client";
@@ -528,7 +528,7 @@ const myPluginClient = {
 
 ### Fetch plugins
 
-If you need to use better fetch plugins you can pass them to the `fetchPlugins` array. You can read more about better fetch plugins in the <Link href="https://better-fetch.vercel.app/docs/plugins">better fetch documentation</Link>.
+If you need to use better fetch plugins, you can pass them to the `fetchPlugins` array. You can read more about better fetch plugins in the <Link href="https://better-fetch.vercel.app/docs/plugins">better fetch documentation</Link>.
 
 ### Atom Listeners
 


### PR DESCRIPTION
Corrected grammatical errors and improved code snippets' clarity throughout the document.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the plugins documentation: fixed grammar, applied lint rules, and made code snippets easier to read.

- **Bug Fixes**
  - Corrected pluralization, punctuation, and phrasing across the page, including callouts.
  - Standardized TypeScript examples (spacing, arrow functions, async handlers, comments) and clarified endpoint, middleware, hooks, and rate-limit sections.

<sup>Written for commit 1b4aa585e554c14db5729cb49f2250a6fba69d25. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

