### PR TITLE
docs: add a badge for auto-refresh on deepwiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 [![npm](https://img.shields.io/npm/dm/better-auth?style=flat&colorA=000000&colorB=000000)](https://npm.chart.dev/better-auth?primary=neutral&gray=neutral&theme=dark)
 [![npm version](https://img.shields.io/npm/v/better-auth.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/better-auth)
 [![GitHub stars](https://img.shields.io/github/stars/better-auth/better-auth?style=flat&colorA=000000&colorB=000000)](https://github.com/better-auth/better-auth/stargazers)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/better-auth/better-auth)
 </p>
 
 ## About the Project


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an Ask DeepWiki badge to the README that links to our DeepWiki page and auto-refreshed content. This makes live docs and Q&A easier to discover from the repo.

<sup>Written for commit 6f564223403b865191795f7460203d6c8784f6e1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

<img width="1440" height="900" alt="スクリーンショット 2025-11-25 21 07 33" src="https://github.com/user-attachments/assets/f877ba46-9c2a-4408-bbae-6892fd615e72" />

https://deepwiki.com/badge-maker?url=https%3A%2F%2Fdeepwiki.com%2Fbetter-auth%2Fbetter-auth
