### PR TITLE
chore(extend): cli utils get-config possible paths

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -19,6 +19,12 @@ let possiblePaths = [
 	"auth.jsx",
 	"auth.server.js",
 	"auth.server.ts",
+	"auth/index.ts",
+	"auth/index.tsx",
+	"auth/index.js",
+	"auth/index.jsx",
+	"auth/index.server.js",
+	"auth/index.server.ts",
 ];
 
 possiblePaths = [


### PR DESCRIPTION
In all my projects, I want to keep better auth logic tied together in an auth folder, but still want main addressing at `@/lib/auth`, now if a user wants client, it's `@/lib/auth/client`, otherwise `@/lib/auth`.

```
.
└── lib
    ├── auth
    │   ├── client.ts
    │   └── index.ts
    └── utils.ts
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extended the CLI get-config to resolve auth/index.* and auth/index.server.* files. This supports projects that organize auth code in lib/auth while still resolving @/lib/auth (and @/lib/auth/client) without extra setup.

- **New Features**
  - Added support for: auth/index.ts, .tsx, .js, .jsx and auth/index.server.ts, .js.

<sup>Written for commit 149083266b2510a6f2923cfe3fb84a80dad46a55. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

