### PR TITLE
fix(docs): fix Next.js 16 proxy build error issue

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -154,7 +154,6 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  runtime: "nodejs", // Required for auth.api calls
   matcher: ["/dashboard"], // Specify the routes the middleware applies to
 };
 ```


### PR DESCRIPTION
<img width="1142" height="640" alt="image" src="https://github.com/user-attachments/assets/d2dee112-a4fd-430a-bf4a-6dc68d140a46" />

When config.runtime = 'nodejs' is configured in the proxy file, the build fails。

The official documentation mentions that there is no runtime configuration in proxy：
https://nextjs.org/docs/app/api-reference/file-conventions/proxy#runtime

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed runtime: "nodejs" from the Next.js proxy example to prevent build failures in Next.js 16. This aligns the docs with Next.js guidance that proxy files do not support a runtime config.

<sup>Written for commit ebdc6032d3f3e4afcc9c5cd29f849ca01b04a31f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

