### PR TITLE
perf: add index on organizations slug field

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -1042,6 +1042,7 @@ export function organization<O extends OrganizationOptions>(
 						unique: true,
 						sortable: true,
 						fieldName: options?.schema?.organization?.fields?.slug,
+						index: true,
 					},
 					logo: {
 						type: "string",


### PR DESCRIPTION
Closes #6295 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an index to organizations.slug in the Better Auth organization schema to speed up slug-based queries. Improves lookup performance with no API or behavior changes.

<sup>Written for commit 23a2c88b69616272cd920772efed444b49e04a4c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

