### PR TITLE
fix: include refreshToken in getAccessToken response

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -603,6 +603,15 @@ export const getAccessToken = createAuthEndpoint(
 					newTokens?.accessTokenExpiresAt ??
 					account.accessTokenExpiresAt ??
 					undefined,
+				refreshToken:
+					newTokens?.refreshToken ??
+					(account.refreshToken
+						? await decryptOAuthToken(account.refreshToken, ctx.context)
+						: undefined),
+				refreshTokenExpiresAt:
+					newTokens?.refreshTokenExpiresAt ??
+					account.refreshTokenExpiresAt ??
+					undefined,
 				scopes: account.scope?.split(",") ?? [],
 				idToken: newTokens?.idToken ?? account.idToken ?? undefined,
 			};


### PR DESCRIPTION
## Description
This PR addresses Issue #6301 where the `getAccessToken` endpoint was missing `refreshToken` and `refreshTokenExpiresAt` in the response body, specifically when running in stateless mode (though this logic applies generally).

## The Fix
I located the return statement in `packages/better-auth/src/api/routes/account.ts` and noticed these fields were explicitly missing from the constructed response object, despite being defined in the Zod/OpenAPI schema for this endpoint.

I have updated the response to:
1. Include `refreshToken` (decrypted using `decryptOAuthToken`, mirroring the `accessToken` logic).
2. Include `refreshTokenExpiresAt`.

## Related Issue
Fixes #6301

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return refreshToken and refreshTokenExpiresAt in getAccessToken responses to fix missing fields (notably in stateless mode) and align with the endpoint schema. refreshToken is decrypted like accessToken, and both fields fall back to newTokens or account values as available.

<sup>Written for commit f560d05f792aae031790270305be46781554a15a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

