### PR TITLE
ci: cherry-pick to main by default

### DIFF
--- a/.github/workflows/cherry-pick-to-main.yml
+++ b/.github/workflows/cherry-pick-to-main.yml
@@ -5,7 +5,7 @@ on:
     # Run every 5 minutes
     - cron: '*/5 * * * *'
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
     branches:
       - canary
@@ -23,7 +23,6 @@ jobs:
       - name: Add merge-to-main label
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             await github.rest.issues.addLabels({
               owner: context.repo.owner,


### PR DESCRIPTION












<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-labels new PRs targeting canary with “merge-to-main” so cherry-pick to main runs by default and no manual labeling is needed. Uses a pull_request_target trigger on canary to apply the label when a PR is opened or reopened, and prevents the cherry-pick job from running on pull_request events.

<sup>Written for commit db69759d84c5bccbc2589fc0f4a753461ef40eb0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











