### PR TITLE
chore: add packages linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ jobs:
           TURBO_CACHE: remote:rw
         run: pnpm lint
 
+      - name: Lint Packages
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+          TURBO_CACHE: remote:rw
+        run: pnpm lint:packages
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "biome format . --write",
     "lint": "biome check .",
     "lint:fix": "biome check . --fix --unsafe",
+    "lint:packages": "turbo --filter \"./packages/*\" lint:package",
     "release": "turbo --filter \"./packages/*\" build && bumpp && pnpm -r publish --access public --no-git-checks",
     "release:no-build": "bumpp && pnpm -r publish --access public --no-git-checks --tag next",
     "release:canary": "turbo --filter \"./packages/*\" build && bumpp && pnpm -r publish --access public --tag canary --no-git-checks",
@@ -20,6 +21,7 @@
     "typecheck": "tsc --build"
   },
   "devDependencies": {
+    "publint": "^0.3.15",
     "@biomejs/biome": "2.3.7",
     "@types/bun": "^1.3.3",
     "@types/node": "^24.10.1",

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsdown",
     "test": "vitest",
+    "lint:package": "publint run --strict",
     "test:adapters": "vitest run --config vitest.config.adapters.ts",
     "prepare": "prisma generate --schema ./src/adapters/prisma-adapter/test/base.prisma",
     "typecheck": "tsc --project tsconfig.json"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsdown",
     "start": "node ./dist/index.mjs",
+    "lint:package": "publint run --strict",
     "dev": "tsx ./src/index.ts",
     "test": "vitest",
     "typecheck": "tsc --project tsconfig.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -107,6 +107,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest"
   },

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://www.better-auth.com/docs/integrations/expo",
   "scripts": {
     "test": "vitest",
+    "lint:package": "publint run --strict",
     "build": "tsdown",
     "dev": "tsdown --watch",
     "typecheck": "tsc --project tsconfig.json"

--- a/packages/passkey/package.json
+++ b/packages/passkey/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "test": "vitest",
+    "lint:package": "publint run --strict",
     "build": "tsdown",
     "dev": "tsdown --watch",
     "typecheck": "tsc --project tsconfig.json"

--- a/packages/scim/package.json
+++ b/packages/scim/package.json
@@ -3,7 +3,7 @@
   "author": "Jonathan Samines",
   "version": "1.4.2-beta.5",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -21,6 +21,7 @@
   "description": "SCIM plugin for Better Auth",
   "scripts": {
     "test": "vitest",
+    "lint:package": "publint run --strict",
     "build": "tsdown",
     "dev": "tsdown --watch",
     "typecheck": "tsc --project tsconfig.json"

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -30,6 +30,7 @@
   "description": "SSO plugin for Better Auth",
   "scripts": {
     "test": "vitest",
+    "lint:package": "publint run --strict",
     "build": "tsdown",
     "dev": "tsdown --watch",
     "typecheck": "tsc --project tsconfig.json"

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -20,6 +20,7 @@
   "description": "Stripe plugin for Better Auth",
   "scripts": {
     "test": "vitest",
+    "lint:package": "publint run --strict",
     "build": "tsdown",
     "dev": "tsdown --watch",
     "typecheck": "tsc --project tsconfig.json"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       bumpp:
         specifier: ^10.3.1
         version: 10.3.1(magicast@0.3.5)
+      publint:
+        specifier: ^0.3.15
+        version: 0.3.15
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
@@ -1139,7 +1142,7 @@ importers:
         version: 18.6.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.6(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3)
       type-fest:
         specifier: ^5.2.0
         version: 5.2.0
@@ -1248,7 +1251,7 @@ importers:
         version: 7.7.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.6(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3)
       tsx:
         specifier: ^4.20.6
         version: 4.20.6
@@ -1294,7 +1297,7 @@ importers:
         version: 1.0.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.6(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3)
 
   packages/expo:
     dependencies:
@@ -1337,7 +1340,7 @@ importers:
         version: 0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.3))(@types/react@19.2.2)(react@19.2.0)
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.6(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3)
 
   packages/passkey:
     dependencies:
@@ -1371,7 +1374,7 @@ importers:
         version: link:../better-auth
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.6(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3)
 
   packages/scim:
     dependencies:
@@ -1393,7 +1396,7 @@ importers:
         version: link:../sso
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.6(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3)
 
   packages/sso:
     dependencies:
@@ -1436,7 +1439,7 @@ importers:
         version: 8.2.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.6(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3)
 
   packages/stripe:
     dependencies:
@@ -1461,7 +1464,7 @@ importers:
         version: 20.0.0(@types/node@24.10.1)
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.6(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3)
 
   packages/telemetry:
     dependencies:
@@ -1477,7 +1480,7 @@ importers:
         version: link:../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.6(synckit@0.11.11)(typescript@5.9.3)
+        version: 0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3)
       type-fest:
         specifier: ^5.2.0
         version: 5.2.0
@@ -4424,6 +4427,10 @@ packages:
 
   '@prisma/get-platform@5.22.0':
     resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
+
+  '@publint/pack@0.1.2':
+    resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
+    engines: {node: '>=18'}
 
   '@quansync/fs@0.1.5':
     resolution: {integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==}
@@ -11702,6 +11709,11 @@ packages:
     engines: {node: '>= 0.10'}
     hasBin: true
 
+  publint@0.3.15:
+    resolution: {integrity: sha512-xPbRAPW+vqdiaKy5sVVY0uFAu3LaviaPO3pZ9FaRx59l9+U/RKR1OEbLhkug87cwiVKxPXyB4txsv5cad67u+A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -17105,6 +17117,8 @@ snapshots:
     dependencies:
       '@prisma/debug': 5.22.0
 
+  '@publint/pack@0.1.2': {}
+
   '@quansync/fs@0.1.5':
     dependencies:
       quansync: 0.2.11
@@ -18305,9 +18319,7 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89': {}
@@ -25747,6 +25759,13 @@ snapshots:
     dependencies:
       event-stream: 3.3.4
 
+  publint@0.3.15:
+    dependencies:
+      '@publint/pack': 0.1.2
+      package-manager-detector: 1.5.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -27473,7 +27492,7 @@ snapshots:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
 
-  tsdown@0.16.6(synckit@0.11.11)(typescript@5.9.3):
+  tsdown@0.16.6(publint@0.3.15)(synckit@0.11.11)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -27491,6 +27510,7 @@ snapshots:
       unconfig-core: 7.4.1
       unrun: 0.2.11(synckit@0.11.11)
     optionalDependencies:
+      publint: 0.3.15
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'

--- a/test/package.json
+++ b/test/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "lint:package": "publint run --strict"
   },
   "devDependencies": {
     "@better-auth/core": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,9 @@
     },
     "//#format": {},
     "lint": {},
+    "lint:package": {
+      "dependsOn": ["build"]
+    },
     "test": {
       "dependsOn": ["build"]
     },


### PR DESCRIPTION
**What is changing?**
Adding a package linter ([publint](https://publint.dev/)) as a way to detect common [publishing configuration issues](https://publint.dev/rules).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a package linter (publint) across all packages and runs it in CI to catch publishing config issues early. Also fixes the SCIM package entry to ESM.

- **New Features**
  - Added publint (--strict) and lint:package scripts to all packages; added root lint:packages to run them via Turbo.
  - CI runs package linting to block invalid publish configs.
  - Turbo config makes lint:package depend on build.

- **Bug Fixes**
  - SCIM: set "main" to dist/index.mjs to match ESM output.

<sup>Written for commit 82f1aed16f9bca5f723d39c461280a78ed75156c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

