### PR TITLE
fix(two-factor): remove incorrect blocking logic in OTP setup and verification

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/otp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/otp/index.ts
@@ -177,11 +177,6 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 				});
 			}
 			const { session, key } = await verifyTwoFactor(ctx);
-			if (!session.user.twoFactorEnabled) {
-				throw new APIError("BAD_REQUEST", {
-					message: TWO_FACTOR_ERROR_CODES.OTP_NOT_ENABLED,
-				});
-			}
 			const code = generateRandomString(opts.digits, "0-9");
 			const hashedCode = await storeOTP(ctx, code);
 			await ctx.context.internalAdapter.createVerificationValue({


### PR DESCRIPTION
This patch removes the conditional logic that blocked OTP setup and verification when
`twoFactorEnabled` was false. That behavior prevented `sendOTP` from running during initial
enrollment, which in turn broke the OTP verification flow entirely.

The updated implementation aligns with the expected behavior: OTP can be issued during setup,
and verification proceeds normally without requiring a pre-existing two-factor record.

This change directly addresses the problem described in #3561 by reverting #3302.

All changes are isolated to the two-factor OTP plugin. Code is formatted and linted per
project guidelines, and the patch is based on the current `canary` branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the check that blocked OTP issuance when twoFactorEnabled was false, restoring OTP setup and verification during initial 2FA enrollment. OTP codes now send and verify as expected, addressing #3561.

<sup>Written for commit 3fe0e9b5ae6143307d27f69ed9269fe3f419a7fc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

