### PR TITLE
fix: updateUser `image` type should allow null

### DIFF
--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -51,6 +51,7 @@ export const updateUser = <O extends BetterAuthOptions>() =>
 										image: {
 											type: "string",
 											description: "The image of the user",
+											nullable: true,
 										},
 									},
 								},


### PR DESCRIPTION
Currently you get a type error saying `image` can't be `null` on the updateUser endpoint, this is incorrect. Currently, this issue does not affect authClient, only auth.api.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the updateUser API typing to allow image: null and updates the OpenAPI schema to mark the field as nullable, so clearing a user’s image no longer throws a type error. This affects auth.api only; authClient already handles null.

<sup>Written for commit 8957ee17db1d3d988e91b13febf53774ef283e1f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



