### PR TITLE
fix: handle potential null values in `getCurrentAuthContext`

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -264,13 +264,13 @@ export const createInternalAdapter = (
 			override?: (Partial<Session> & Record<string, any>) | undefined,
 			overrideAll?: boolean | undefined,
 		) => {
-			const ctx = await getCurrentAuthContext();
-			const headers = ctx.headers || ctx.request?.headers;
+			const ctx = await getCurrentAuthContext().catch(() => null);
+			const headers = ctx?.headers || ctx?.request?.headers;
 			const { id: _, ...rest } = override || {};
 			const data: Omit<Session, "id"> = {
 				ipAddress:
-					ctx.request || ctx.headers
-						? getIp(ctx.request || ctx.headers!, ctx.context.options) || ""
+					ctx?.request || ctx?.headers
+						? getIp(ctx?.request || ctx?.headers!, ctx?.context.options) || ""
 						: "",
 				userAgent: headers?.get("user-agent") || "",
 				...rest,


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/6315



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully handle missing or failing auth context in createInternalAdapter to prevent session creation crashes.

- **Bug Fixes**
  - Wrap getCurrentAuthContext with catch(() => null).
  - Use optional chaining for ctx.request, ctx.headers, and ctx.context.options.
  - Add safe fallbacks for ipAddress and userAgent when headers are unavailable.

<sup>Written for commit 0bc9258ab0d0d083a8cbb0836059e1bd49d1c1bf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



