### PR TITLE
chore: bump better-call

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 1.1.18
       version: 1.1.18
     better-call:
-      specifier: 1.1.0
-      version: 1.1.0
+      specifier: 1.1.1
+      version: 1.1.1
     tsdown:
       specifier: ^0.16.6
       version: 0.16.6
@@ -1024,7 +1024,7 @@ importers:
         version: 1.0.0
       better-call:
         specifier: 'catalog:'
-        version: 1.1.0
+        version: 1.1.1(zod@4.1.12)
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -1279,7 +1279,7 @@ importers:
         version: 7.6.13
       better-call:
         specifier: 'catalog:'
-        version: 1.1.0
+        version: 1.1.1(zod@4.1.12)
       better-sqlite3:
         specifier: ^12.4.1
         version: 12.4.1
@@ -1303,7 +1303,7 @@ importers:
         version: 1.1.18
       better-call:
         specifier: 'catalog:'
-        version: 1.1.0
+        version: 1.1.1(zod@4.1.12)
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -1355,7 +1355,7 @@ importers:
         version: 13.1.2
       better-call:
         specifier: 'catalog:'
-        version: 1.1.0
+        version: 1.1.1(zod@4.1.12)
       nanostores:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1383,7 +1383,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.1.0
+        version: 1.1.1(zod@4.1.12)
       zod:
         specifier: ^4.1.5
         version: 4.1.12
@@ -1424,7 +1424,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.1.0
+        version: 1.1.1(zod@4.1.12)
       body-parser:
         specifier: ^2.2.1
         version: 2.2.1
@@ -1455,7 +1455,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.1.0
+        version: 1.1.1(zod@4.1.12)
       stripe:
         specifier: ^20.0.0
         version: 20.0.0(@types/node@24.10.1)
@@ -7221,8 +7221,13 @@ packages:
     peerDependencies:
       better-auth: ^1.0.3
 
-  better-call@1.1.0:
-    resolution: {integrity: sha512-7CecYG+yN8J1uBJni/Mpjryp8bW/YySYsrGEWgFe048ORASjq17keGjbKI2kHEOSc6u8pi11UxzkJ7jIovQw6w==}
+  better-call@1.1.1:
+    resolution: {integrity: sha512-fx6fAJuUrBPnXbEsqvyvP95z8QLAEy+xLJFpRRH9CqdrtHC06qqqLGeray/Cs+gp8JPeULdVsu+YXJLiOzliBA==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -20414,12 +20419,14 @@ snapshots:
       mailchecker: 6.0.18
       validator: 13.15.15
 
-  better-call@1.1.0:
+  better-call@1.1.1(zod@4.1.12):
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
       rou3: 0.5.1
       set-cookie-parser: 2.7.2
+    optionalDependencies:
+      zod: 4.1.12
 
   better-opn@3.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 
 catalog:
   '@better-fetch/fetch': 1.1.18
-  better-call: 1.1.0
+  better-call: 1.1.1
   tsdown: ^0.16.6
   typescript: ^5.9.3
   vitest: 4.0.13


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump better-call to 1.1.1 across the workspace to pick up the latest patch. This aligns packages and adds optional zod support where available.

- **Dependencies**
  - Updated pnpm-workspace catalog and pnpm-lock to better-call 1.1.1.
  - better-call now declares zod as an optional peer; resolves to zod 4.1.12 where present.

<sup>Written for commit c4541308d43550c7a821cdf5b9bc7167407f9cc4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

