### PR TITLE
chore: add stack-traces to node:async_hooks error

### DIFF
--- a/packages/core/src/async_hooks/index.ts
+++ b/packages/core/src/async_hooks/index.ts
@@ -16,6 +16,8 @@ const AsyncLocalStoragePromise: Promise<typeof AsyncLocalStorage> = import(
 		if ("AsyncLocalStorage" in globalThis) {
 			return (globalThis as any).AsyncLocalStorage;
 		}
+		const errorStack = err.stack;
+		console.warn(errorStack);
 		console.warn(
 			"[better-auth] Warning: AsyncLocalStorage is not available in this environment. Some features may not work as expected.",
 		);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Log the error stack when AsyncLocalStorage import fails, right before the existing warning. This makes it easier to debug environments where AsyncLocalStorage is missing.

<sup>Written for commit fa54732e59068d5a13d98ebd312102c96e35ec0c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

