### PR TITLE
fix(multi-session): Endpoints breaks with invalid signatures

### DIFF
--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -62,7 +62,6 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 					if (!cookieHeader) return ctx.json([]);
 
 					const cookies = Object.fromEntries(parseCookies(cookieHeader));
-
 					const sessionTokens = (
 						await Promise.all(
 							Object.entries(cookies)
@@ -72,7 +71,7 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 										await ctx.getSignedCookie(key, ctx.context.secret),
 								),
 						)
-					).filter((v) => v !== null);
+					).filter((v) => typeof v === "string");
 
 					if (!sessionTokens.length) return ctx.json([]);
 					const sessions =
@@ -255,7 +254,7 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 											await ctx.getSignedCookie(key, ctx.context.secret),
 									),
 							)
-						).filter((v): v is string => v !== undefined);
+						).filter((v) => typeof v === "string");
 						const internalAdapter = ctx.context.internalAdapter;
 
 						if (sessionTokens.length > 0) {
@@ -349,7 +348,7 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 									return null;
 								}),
 							)
-						).filter((v): v is string => v !== null);
+						).filter((v) => typeof v === "string");
 						if (verifiedTokens.length > 0) {
 							await ctx.context.internalAdapter.deleteSessions(verifiedTokens);
 						}


### PR DESCRIPTION
Say you use a BETTER_AUTH_SECRET of `1` and signed in, then the next day you changed it to `2`, this would cause the multi-session plugin to crash in various places.

This is because `ctx.getSignedCookie` returns `false` when a cookie has an invalid signature, however due to Better-Call having the incorrect types it caused us to develop Multi-Session incorrectly without considering the possibility that `getSignedCookie` can return false, thus breaking the plugin.

Better-Call fix to the type issue:
https://github.com/Bekacru/better-call/pull/81

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented multi-session endpoints from crashing when cookie signatures are invalid (e.g., after rotating BETTER_AUTH_SECRET). We now handle getSignedCookie returning non-string values safely.

- **Bug Fixes**
  - Filtered cookie results to only keep string tokens across list and delete session paths.
  - Added safe early returns when no valid session tokens are found.

<sup>Written for commit 9a73552783da1e01363730f281f4483c62b3c0d9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

