### PR TITLE
temp-test

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -339,6 +339,7 @@ export const router = <Option extends BetterAuthOptions>(
 						return;
 					}
 				}
+				console.log("hi");
 
 				if (e instanceof APIError) {
 					if (e.status === "INTERNAL_SERVER_ERROR") {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a temporary console.log('hi') in the API router error handling to help debug unexpected failures during testing.
This prints right before APIError handling for quick traceability.

<sup>Written for commit dc7f6567bd352e17a904cc8eabce2a6b890550fc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

