### PR TITLE
fix(oidc-provider): resolve getSignedCookie return type

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -408,10 +408,13 @@ export const oidcProvider = (options: OIDCOptions) => {
 
 					if (!consentCode) {
 						// Check for cookie-based consent flow
-						consentCode = await ctx.getSignedCookie(
+						const cookieValue = await ctx.getSignedCookie(
 							"oidc_consent_prompt",
 							ctx.context.secret,
 						);
+						if (cookieValue) {
+							consentCode = cookieValue;
+						}
 					}
 
 					if (!consentCode) {


### PR DESCRIPTION
Return type updated -> https://github.com/Bekacru/better-call/pull/81


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Handled nullable return from getSignedCookie in the OIDC consent flow. We now set consentCode only when the "oidc_consent_prompt" cookie exists, resolving type errors and preventing undefined assignments.

<sup>Written for commit 4d5853c890332a8cd96136794622b41ec08cd002. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

