### PR TITLE
docs: add bearer plugin requirement note to device auth docs

### DIFF
--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -416,8 +416,8 @@ The device flow defines specific error codes:
 
 Here's a complete example for a CLI application based on the actual demo:
 
-<Callout type="warn">
-  To use the access token for authenticated API calls (like `getSession`), ensure you have added the **bearer** plugin to your server configuration.
+<Callout type="info">
+  To use the access token for API requests, ensure you have added the [Bearer plugin](/docs/plugins/bearer) to your auth instance.
 </Callout>
 
 ```ts title="cli-auth.ts"


### PR DESCRIPTION
### Description
This PR addresses a documentation gap identified in #6348. The Device Authorization documentation provides an example using `Authorization: Bearer ${data.access_token}`, but previously failed to mention that the **Bearer** plugin must be enabled in the server configuration for this header to be processed correctly.

I have added a `Callout` warning in `docs/content/docs/plugins/device-authorization.mdx` to clarify this prerequisite.

### Fixes
Closes #6348

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a warning in the Device Authorization docs that the bearer plugin must be enabled for Authorization: Bearer access tokens (e.g., getSession) to work. Fixes #6348.

<sup>Written for commit 7d0b66474f1bcdf31f69778fe6d03c00fa3cc4a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

