### PR TITLE
docs: remove callbackURL from trusted device verification example

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -410,8 +410,7 @@ You can mark a device as trusted by passing `trustDevice` to `verifyTotp` or `ve
 const verify2FA = async (code: string) => {
     const { data, error } = await authClient.twoFactor.verifyTotp({
         code,
-        callbackURL: "/dashboard",
-        trustDevice: true // Mark this device as trusted
+        trustDevice: true, // Mark this device as trusted
     })
     if (data) {
         // 2FA verified and device trusted


### PR DESCRIPTION
Fixes #6355 - Remove incorrect callbackURL parameter from 2FA docs

As confirmed by @better-auth-agent, the documentation mistakenly shows a callbackURL parameter for authClient.twoFactor.verifyTotp() that isn't actually supported. This PR removes the incorrect parameter from the documentation examples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the incorrect callbackURL parameter from the 2FA trusted device example to match the verifyTotp API and prevent confusion. The docs now show only trustDevice for marking a device as trusted.

<sup>Written for commit 171b921286c274150b86f8e72c34ab2fe5a11a23. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

