### PR TITLE
feat(scim): add support to parse custom scim+json media type

### DIFF
--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -29,6 +29,7 @@ import { getResourceURL } from "./utils";
 
 const supportedSCIMSchemas = [SCIMUserResourceSchema];
 const supportedSCIMResourceTypes = [SCIMUserResourceType];
+const supportedMediaTypes = ["application/json", "application/scim+json"];
 
 const findUserById = async (
 	adapter: DBAdapter,
@@ -241,6 +242,7 @@ export const scim = (options?: SCIMOptions) => {
 					body: APIUserSchema,
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "Create SCIM user.",
 							description:
@@ -370,6 +372,7 @@ export const scim = (options?: SCIMOptions) => {
 					body: APIUserSchema,
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "Update SCIM user.",
 							description:
@@ -452,6 +455,7 @@ export const scim = (options?: SCIMOptions) => {
 						.optional(),
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "List SCIM users",
 							description:
@@ -539,6 +543,7 @@ export const scim = (options?: SCIMOptions) => {
 					method: "GET",
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "Get SCIM user details",
 							description:
@@ -604,6 +609,7 @@ export const scim = (options?: SCIMOptions) => {
 					}),
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "Patch SCIM user",
 							description: "Updates fields on a SCIM user record",
@@ -673,6 +679,7 @@ export const scim = (options?: SCIMOptions) => {
 					method: "DELETE",
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "Delete SCIM user",
 							description:
@@ -716,6 +723,7 @@ export const scim = (options?: SCIMOptions) => {
 					method: "GET",
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "SCIM Service Provider Configuration",
 							description:
@@ -767,6 +775,7 @@ export const scim = (options?: SCIMOptions) => {
 					method: "GET",
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "SCIM Service Provider Configuration Schemas",
 							description:
@@ -815,6 +824,7 @@ export const scim = (options?: SCIMOptions) => {
 					method: "GET",
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "SCIM a Service Provider Configuration Schema",
 							description:
@@ -862,6 +872,7 @@ export const scim = (options?: SCIMOptions) => {
 					method: "GET",
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "SCIM Service Provider Supported Resource Types",
 							description:
@@ -918,6 +929,7 @@ export const scim = (options?: SCIMOptions) => {
 					method: "GET",
 					metadata: {
 						isAction: false,
+						allowedMediaTypes: supportedMediaTypes,
 						openapi: {
 							summary: "SCIM Service Provider Supported Resource Type",
 							description:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 1.1.18
       version: 1.1.18
     better-call:
-      specifier: 1.1.2
-      version: 1.1.2
+      specifier: 1.1.3
+      version: 1.1.3
     tsdown:
       specifier: ^0.16.0
       version: 0.16.6
@@ -1024,7 +1024,7 @@ importers:
         version: 1.0.0
       better-call:
         specifier: 'catalog:'
-        version: 1.1.2(zod@4.1.12)
+        version: 1.1.3(zod@4.1.12)
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -1279,7 +1279,7 @@ importers:
         version: 7.6.13
       better-call:
         specifier: 'catalog:'
-        version: 1.1.2(zod@4.1.12)
+        version: 1.1.3(zod@4.1.12)
       better-sqlite3:
         specifier: ^12.4.1
         version: 12.4.1
@@ -1303,7 +1303,7 @@ importers:
         version: 1.1.18
       better-call:
         specifier: 'catalog:'
-        version: 1.1.2(zod@4.1.12)
+        version: 1.1.3(zod@4.1.12)
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -1355,7 +1355,7 @@ importers:
         version: 13.1.2
       better-call:
         specifier: 'catalog:'
-        version: 1.1.2(zod@4.1.12)
+        version: 1.1.3(zod@4.1.12)
       nanostores:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1383,7 +1383,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.1.2(zod@4.1.12)
+        version: 1.1.3(zod@4.1.12)
       zod:
         specifier: ^4.1.5
         version: 4.1.12
@@ -1424,7 +1424,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.1.2(zod@4.1.12)
+        version: 1.1.3(zod@4.1.12)
       body-parser:
         specifier: ^2.2.1
         version: 2.2.1
@@ -1455,7 +1455,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.1.2(zod@4.1.12)
+        version: 1.1.3(zod@4.1.12)
       stripe:
         specifier: ^20.0.0
         version: 20.0.0(@types/node@24.10.1)
@@ -7221,8 +7221,8 @@ packages:
     peerDependencies:
       better-auth: ^1.0.3
 
-  better-call@1.1.2:
-    resolution: {integrity: sha512-7TOAl541WiXxNdMcmb/iAT26QVUkbCOWIRMemUN4EBlkfMw19E4LIPRUtQis2paKjrQ5pfqd6NLoHVk8Qn+THg==}
+  better-call@1.1.3:
+    resolution: {integrity: sha512-zN4sgcl5sI4MZDx0l3HpJkhKbidPGWyR/9TjCUmNFWl2la5z7Mk7xT5TxqGdN33OaU7fzHj/kzDYz7ck3IXvsQ==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -20419,7 +20419,7 @@ snapshots:
       mailchecker: 6.0.18
       validator: 13.15.15
 
-  better-call@1.1.2(zod@4.1.12):
+  better-call@1.1.3(zod@4.1.12):
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 
 catalog:
   '@better-fetch/fetch': 1.1.18
-  better-call: 1.1.2
+  better-call: 1.1.3
   tsdown: ^0.16.0
   typescript: ^5.9.3
   vitest: 4.0.13


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for the application/scim+json media type across all SCIM routes, so providers that send SCIM+JSON work without extra config. Also updates better-call to a build that parses custom media types.

- **New Features**
  - SCIM routes now accept application/json and application/scim+json via metadata.allowedMediaTypes (create, update, list, get, patch, delete, and config endpoints).

- **Dependencies**
  - Upgrade better-call to 1.1.3 to enable custom media type parsing.
  - No migration required.

<sup>Written for commit bafee216f114e9ba6cec5598e75e7a933fd44312. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





