### PR TITLE
fix(docs): correct typo in backup code recovery method description

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -436,7 +436,7 @@ twoFactor({
 
 ## Schema
 
-The plugin requires 1 additional fields in the `user` table and 1 additional table to store the two factor authentication data.
+The plugin requires 1 additional field in the `user` table and 1 additional table to store the two factor authentication data.
 
 Table: `user`
 


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed typos in the 2FA docs to clarify backup code usage, viewing instructions, and schema wording. Updated to “provide a backup code as an account recovery method”, “only do this if the user has a fresh session”, and “1 additional field”.

<sup>Written for commit dcdd3b9bbd531ed2483fea522df760dcea9dc162. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





