### PR TITLE
docs: creem subscription database schema changes

### DIFF
--- a/docs/content/docs/plugins/creem.mdx
+++ b/docs/content/docs/plugins/creem.mdx
@@ -186,7 +186,9 @@ npx @better-auth/cli migrate
 
 When `persistSubscriptions: true`, the plugin creates the following schema:
 
-### Creem_Subscription Table
+### Creem Subscription Table
+
+Table Name: `creem_subscription`
 
 | Field                 | Type    | Description                      |
 | --------------------- | ------- | -------------------------------- |


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Creem plugin docs to correctly name the subscription table as creem_subscription, matching the schema when persistSubscriptions: true. Also set the section title to "Creem Subscription Table" for clarity.

<sup>Written for commit 344878378363b2771d392427f1bbc6be797d1392. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



