### PR TITLE
fix(org): update client schema types to allow all server schema options

### DIFF
--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -1,5 +1,4 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
-import type { DBFieldAttribute } from "@better-auth/core/db";
 import { atom } from "nanostores";
 import { useAuthQuery } from "../../client";
 import type {
@@ -42,35 +41,7 @@ interface OrganizationClientOptions {
 				enabled: boolean;
 		  }
 		| undefined;
-	schema?:
-		| {
-				organization?: {
-					additionalFields?: {
-						[key: string]: DBFieldAttribute;
-					};
-				};
-				member?: {
-					additionalFields?: {
-						[key: string]: DBFieldAttribute;
-					};
-				};
-				invitation?: {
-					additionalFields?: {
-						[key: string]: DBFieldAttribute;
-					};
-				};
-				team?: {
-					additionalFields?: {
-						[key: string]: DBFieldAttribute;
-					};
-				};
-				organizationRole?: {
-					additionalFields?: {
-						[key: string]: DBFieldAttribute;
-					};
-				};
-		  }
-		| undefined;
+	schema?: OrganizationOptions["schema"];
 	dynamicAccessControl?:
 		| {
 				enabled: boolean;

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
@@ -60,6 +60,7 @@ describe("dynamic access control", async (it) => {
 					},
 					schema: {
 						organizationRole: {
+							modelName: "organizationRole",
 							additionalFields,
 						},
 					},


### PR DESCRIPTION
**What is changing?**
Updating organization client to support al server schema options. Otherwise, inference breaks as soon as you use an option that is only available to the server.

See [related issue](https://discord.com/channels/1288403910284935179/1443985134452998239).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the organization client schema types with the server schema so type inference doesn’t break when using server-only options. The client now accepts all server schema options.

- **Bug Fixes**
  - Use OrganizationOptions["schema"] for OrganizationClientOptions.schema to match server types.
  - Update test to include organizationRole.modelName to reflect the expanded schema.

<sup>Written for commit da9784fd353af230f0887e5779f6befbbcfc6f96. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

