### PR TITLE
fix(expo): dismiss auth session on android to prevent invalid state error 

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -383,6 +383,13 @@ export const expoClient = (opts: ExpoClientOptions) => {
 									},
 								);
 							}
+
+							if (Platform.OS === "android") {
+								try {
+									Browser.dismissAuthSession();
+								} catch (e) {}
+							}
+
 							const proxyURL = `${context.request.baseURL}/expo-authorization-proxy?authorizationURL=${encodeURIComponent(signInURL)}`;
 							const result = await Browser.openAuthSessionAsync(proxyURL, to);
 							if (result.type !== "success") return;


### PR DESCRIPTION
Fixes #6368

### The Issue
On Android, `expo-web-browser` maintains a stale redirect handler state if the previous OAuth session isn't explicitly dismissed. This causes subsequent sign-in attempts (after a sign-out) to fail with the error:
`[Error: The WebBrowser's auth session is in an invalid state with a redirect handler set when it should not be]`

### The Fix
- Added a `Platform.OS === "android"` check in the `onSuccess` hook.
- Explicitly calls `Browser.dismissAuthSession()` before opening a new session to ensure the browser state is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dismiss the Android auth session before starting a new OAuth flow to prevent the “invalid state” error. This makes sign-in after sign-out work reliably on Android.

- **Bug Fixes**
  - On Android, call Browser.dismissAuthSession() before opening a new auth session.
  - Wrap dismiss call in try/catch to ignore cases with no existing session.
  - No changes for iOS or web.

<sup>Written for commit 6716b870507136fbdcb8dce7882d8ee1cb3fce0a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

