### PR TITLE
chore: fix jsdoc depercated comment

### DIFF
--- a/packages/better-auth/src/client/types.ts
+++ b/packages/better-auth/src/client/types.ts
@@ -16,7 +16,7 @@ export type {
 };
 
 /**
- * @deprecated use type `BetterAuthClientOptions` instead.
+ * @deprecated use type `ClientStore` instead.
  */
 export type Store = ClientStore;
 /**
@@ -24,7 +24,7 @@ export type Store = ClientStore;
  */
 export type AtomListener = ClientAtomListener;
 /**
- * @deprecated use type `BetterAuthClientPlugin` instead.
+ * @deprecated use type `BetterAuthClientOptions` instead.
  */
 export type ClientOptions = BetterAuthClientOptions;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed incorrect JSDoc @deprecated guidance in client type aliases to improve IDE hints and docs accuracy.
Deprecation notes now correctly suggest ClientStore for Store and BetterAuthClientOptions for ClientOptions.

<sup>Written for commit e8e89bf8b3354ffa54771a54426cf5ec700b56ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

