### PR TITLE
fix: fields type for rate limit options

### DIFF
--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -106,7 +106,7 @@ export type BetterAuthRateLimitOptions = {
 	/**
 	 * Custom field names for the rate limit table
 	 */
-	fields?: Record<keyof RateLimit, string> | undefined;
+	fields?: Partial<Record<keyof RateLimit, string>> | undefined;
 	/**
 	 * custom storage configuration.
 	 *


### PR DESCRIPTION
There's a bug where we can't change a single field's name for `rateLimit` because it only accepts a full record, not partial ones. So, this fails right now:

```ts
fields: {
  lastRequest: "last_request",
},
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rateLimit options to accept partial field overrides, so you can rename a single field without providing all fields. Updated fields type to Partial<Record<keyof RateLimit, string>>.

<sup>Written for commit 275bbd54bc2d115105b5f858f89c1a1c4720e45e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

