### PR TITLE
docs: use `package-install` instead of `bash` for cli commands

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -32,13 +32,13 @@ your database schema based on your Better Auth configuration and plugins.
 
 To generate the schema required by Better Auth, run the following command:
 
-```bash title="Schema Generation"
+```package-install title="Schema Generation"
 npx @better-auth/cli@latest generate
 ```
 
 To generate and apply the migration, run the following commands:
 
-```bash title="Schema Migration"
+```package-install title="Schema Migration"
 npx drizzle-kit generate # generate the migration file
 npx drizzle-kit migrate # apply the migration
 ```

--- a/docs/content/docs/adapters/mssql.mdx
+++ b/docs/content/docs/adapters/mssql.mdx
@@ -86,11 +86,11 @@ your database schema based on your Better Auth configuration and plugins.
   </tbody>
 </table>
 
-```bash title="Schema Generation"
+```package-install title="Schema Generation"
 npx @better-auth/cli@latest generate
 ```
 
-```bash title="Schema Migration"
+```package-install title="Schema Migration"
 npx @better-auth/cli@latest migrate
 ```
 

--- a/docs/content/docs/adapters/mysql.mdx
+++ b/docs/content/docs/adapters/mysql.mdx
@@ -55,11 +55,11 @@ your database schema based on your Better Auth configuration and plugins.
   </tbody>
 </table>
 
-```bash title="Schema Generation"
+```package-install title="Schema Generation"
 npx @better-auth/cli@latest generate
 ```
 
-```bash title="Schema Migration"
+```package-install title="Schema Migration"
 npx @better-auth/cli@latest migrate
 ```
 

--- a/docs/content/docs/adapters/postgresql.mdx
+++ b/docs/content/docs/adapters/postgresql.mdx
@@ -51,11 +51,11 @@ your database schema based on your Better Auth configuration and plugins.
   </tbody>
 </table>
 
-```bash title="Schema Generation"
+```package-install title="Schema Generation"
 npx @better-auth/cli@latest generate
 ```
 
-```bash title="Schema Migration"
+```package-install title="Schema Migration"
 npx @better-auth/cli@latest migrate
 ```
 
@@ -176,4 +176,3 @@ This should return your custom schema (e.g., `auth`) as the first value.
 PostgreSQL is supported under the hood via the [Kysely](https://kysely.dev/) adapter, any database supported by Kysely would also be supported. (<Link href="/docs/adapters/other-relational-databases">Read more here</Link>)
 
 If you're looking for performance improvements or tips, take a look at our guide to <Link href="/docs/guides/optimizing-for-performance">performance optimizations</Link>.
-

--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -53,7 +53,7 @@ your database schema based on your Better Auth configuration and plugins.
   </tbody>
 </table>
 
-```bash title="Schema Generation"
+```package-install title="Schema Generation"
 npx @better-auth/cli@latest generate
 ```
 

--- a/docs/content/docs/adapters/sqlite.mdx
+++ b/docs/content/docs/adapters/sqlite.mdx
@@ -86,11 +86,11 @@ your database schema based on your Better Auth configuration and plugins.
   </tbody>
 </table>
 
-```bash title="Schema Generation"
+```package-install title="Schema Generation"
 npx @better-auth/cli@latest generate
 ```
 
-```bash title="Schema Migration"
+```package-install title="Schema Migration"
 npx @better-auth/cli@latest migrate
 ```
 

--- a/docs/content/docs/concepts/cli.mdx
+++ b/docs/content/docs/concepts/cli.mdx
@@ -9,7 +9,7 @@ Better Auth comes with a built-in CLI to help you manage the database schemas, i
 
 The `generate` command creates the schema required by Better Auth. If you're using a database adapter like Prisma or Drizzle, this command will generate the right schema for your ORM. If you're using the built-in Kysely adapter, it will generate an SQL file you can run directly on your database.
 
-```bash title="Terminal"
+```package-install title="Terminal"
 npx @better-auth/cli@latest generate
 ```
 
@@ -24,7 +24,7 @@ npx @better-auth/cli@latest generate
 
 The migrate command applies the Better Auth schema directly to your database. This is available if you're using the built-in Kysely adapter. For other adapters, you'll need to apply the schema using your ORM's migration tool.
 
-```bash title="Terminal"
+```package-install title="Terminal"
 npx @better-auth/cli@latest migrate
 ```
 
@@ -43,7 +43,7 @@ The migrate command automatically detects your configured `search_path` and crea
 
 The `init` command allows you to initialize Better Auth in your project.
 
-```bash title="Terminal"
+```package-install title="Terminal"
 npx @better-auth/cli@latest init
 ```
 
@@ -59,7 +59,7 @@ npx @better-auth/cli@latest init
 
 The `info` command provides diagnostic information about your Better Auth setup and environment. Useful for debugging and sharing when seeking support.
 
-```bash title="Terminal"
+```package-install title="Terminal"
 npx @better-auth/cli@latest info
 ```
 
@@ -96,7 +96,7 @@ Sensitive data like secrets, API keys, and database URLs are automatically repla
 
 The CLI also provides a way to generate a secret key for your Better Auth instance.
 
-```bash title="Terminal"
+```package-install title="Terminal"
 npx @better-auth/cli@latest secret
 ```
 

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -38,19 +38,19 @@ This plugin offers two main methods to do a second factor verification:
         })
         ```
     </Step>
-      <Step>
+    <Step>
         ### Migrate the database
 
         Run the migration or generate the schema to add the necessary fields and tables to the database.
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -34,12 +34,12 @@ The Admin plugin provides a set of administrative functions for user management 
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/anonymous.mdx
+++ b/docs/content/docs/plugins/anonymous.mdx
@@ -33,12 +33,12 @@ The Anonymous plugin allows users to have an authenticated experience without re
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/api-key.mdx
+++ b/docs/content/docs/plugins/api-key.mdx
@@ -39,12 +39,12 @@ The API Key plugin allows you to create and manage API keys for your application
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/creem.mdx
+++ b/docs/content/docs/plugins/creem.mdx
@@ -121,10 +121,18 @@ export const authClient = createCreemAuthClient({
 
 If you're using database persistence (`persistSubscriptions: true`), generate and run the database schema:
 
-```bash
-npx @better-auth/cli generate
-npx @better-auth/cli migrate
-```
+<Tabs items={["migrate", "generate"]}>
+    <Tab value="migrate">
+    ```package-install
+    npx @better-auth/cli migrate
+    ```
+    </Tab>
+    <Tab value="generate">
+    ```package-install
+    npx @better-auth/cli generate
+    ```
+    </Tab>
+</Tabs>
 
 <Callout type="info">
   Depending on your database adapter, additional setup steps may be required. Refer to the [Better Auth adapter documentation](https://www.better-auth.com/docs/adapters/mysql) for details.
@@ -837,4 +845,3 @@ For issues or questions:
 - Contact Creem support at [support@creem.io](mailto:support@creem.io)
 - Join our [Discord community](https://discord.gg/q3GKZs92Av) for real-time support and discussion.
 - Chat with us directly using the in-app live chat on the [Creem dashboard](https://creem.io/dashboard).
-

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -55,12 +55,12 @@ This will demonstrate the complete device authorization flow by:
         
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -33,12 +33,12 @@ export const auth = betterAuth({
 
     <Tabs items={["migrate", "generate"]}>
         <Tab value="migrate">
-        ```bash
+        ```package-install
         npx @better-auth/cli migrate
         ```
         </Tab>
         <Tab value="generate">
-        ```bash
+        ```package-install
         npx @better-auth/cli generate
         ```
         </Tab>

--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -39,12 +39,12 @@ The **MCP** plugin lets your app act as an OAuth provider for MCP clients. It ha
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -49,12 +49,12 @@ This plugin is in active development and may not be suitable for production use.
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -29,12 +29,12 @@ export const auth = betterAuth({
 
     <Tabs items={["migrate", "generate"]}>
         <Tab value="migrate">
-        ```bash
+        ```package-install
         npx @better-auth/cli migrate
         ```
         </Tab>
         <Tab value="generate">
-        ```bash
+        ```package-install
         npx @better-auth/cli generate
         ```
         </Tab>

--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -39,12 +39,12 @@ The passkey plugin implementation is powered by [SimpleWebAuthn](https://simplew
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -33,12 +33,12 @@ The phone number plugin extends the authentication system by allowing users to s
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/scim.mdx
+++ b/docs/content/docs/plugins/scim.mdx
@@ -62,12 +62,12 @@ This plugin exposes a [SCIM](https://simplecloud.info/#Specification) server tha
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/siwe.mdx
+++ b/docs/content/docs/plugins/siwe.mdx
@@ -52,12 +52,12 @@ The Sign in with Ethereum (SIWE) plugin allows users to authenticate using their
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -38,12 +38,12 @@ Single Sign-On (SSO) allows users to authenticate with multiple applications usi
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -93,12 +93,12 @@ The Stripe plugin integrates Stripe's payment and subscription functionality wit
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>

--- a/docs/content/docs/plugins/username.mdx
+++ b/docs/content/docs/plugins/username.mdx
@@ -32,12 +32,12 @@ The username plugin is a lightweight plugin that adds username support to the em
 
         <Tabs items={["migrate", "generate"]}>
             <Tab value="migrate">
-            ```bash
+            ```package-install
             npx @better-auth/cli migrate
             ```
             </Tab>
             <Tab value="generate">
-            ```bash
+            ```package-install
             npx @better-auth/cli generate
             ```
             </Tab>


### PR DESCRIPTION
Before:
<img width="576" height="98" alt="Screenshot 2025-11-29 173532" src="https://github.com/user-attachments/assets/79c825db-6bc2-4c11-8ede-de3291ff4e00" />
<img width="626" height="98" alt="Screenshot 2025-11-29 174518" src="https://github.com/user-attachments/assets/035b8818-9962-4f53-b51d-376eca6bbde0" />

After:
<img width="580" height="164" alt="image" src="https://github.com/user-attachments/assets/a4be8614-c827-4013-ae06-3ec8eaf89491" />
<img width="622" height="134" alt="Screenshot 2025-11-29 174551" src="https://github.com/user-attachments/assets/5c23f21a-5646-4b71-beca-f8ae5a2ac0f8" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated docs to use the package-install code block for CLI commands, so install instructions render with npm/pnpm/yarn tabs and consistent styling across pages. Improves readability in adapters, plugins, and CLI docs.

- **Refactors**
  - Replaced bash code fences with package-install in adapter, plugin, and CLI pages.
  - Converted plugin examples to use Tabs with package-install; added migrate/generate tabs in Creem docs.
  - Small formatting cleanups (closing tags, newlines) to keep MDX consistent.

<sup>Written for commit 12e795451b6011d12d064271915979b4f1825de2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

