### PR TITLE
fix(logger): log level priority

### DIFF
--- a/packages/core/src/env/logger.test.ts
+++ b/packages/core/src/env/logger.test.ts
@@ -8,22 +8,22 @@ describe("shouldPublishLog", () => {
 		logLevel: LogLevel;
 		expected: boolean;
 	}[] = [
-		{ currentLogLevel: "info", logLevel: "info", expected: true },
-		{ currentLogLevel: "info", logLevel: "warn", expected: false },
-		{ currentLogLevel: "info", logLevel: "error", expected: false },
-		{ currentLogLevel: "info", logLevel: "debug", expected: false },
-		{ currentLogLevel: "warn", logLevel: "info", expected: true },
-		{ currentLogLevel: "warn", logLevel: "warn", expected: true },
-		{ currentLogLevel: "warn", logLevel: "error", expected: false },
-		{ currentLogLevel: "warn", logLevel: "debug", expected: false },
-		{ currentLogLevel: "error", logLevel: "info", expected: true },
-		{ currentLogLevel: "error", logLevel: "warn", expected: true },
-		{ currentLogLevel: "error", logLevel: "error", expected: true },
-		{ currentLogLevel: "error", logLevel: "debug", expected: false },
+		{ currentLogLevel: "debug", logLevel: "debug", expected: true },
 		{ currentLogLevel: "debug", logLevel: "info", expected: true },
 		{ currentLogLevel: "debug", logLevel: "warn", expected: true },
 		{ currentLogLevel: "debug", logLevel: "error", expected: true },
-		{ currentLogLevel: "debug", logLevel: "debug", expected: true },
+		{ currentLogLevel: "info", logLevel: "debug", expected: false },
+		{ currentLogLevel: "info", logLevel: "info", expected: true },
+		{ currentLogLevel: "info", logLevel: "warn", expected: true },
+		{ currentLogLevel: "info", logLevel: "error", expected: true },
+		{ currentLogLevel: "warn", logLevel: "debug", expected: false },
+		{ currentLogLevel: "warn", logLevel: "info", expected: false },
+		{ currentLogLevel: "warn", logLevel: "warn", expected: true },
+		{ currentLogLevel: "warn", logLevel: "error", expected: true },
+		{ currentLogLevel: "error", logLevel: "debug", expected: false },
+		{ currentLogLevel: "error", logLevel: "info", expected: false },
+		{ currentLogLevel: "error", logLevel: "warn", expected: false },
+		{ currentLogLevel: "error", logLevel: "error", expected: true },
 	];
 
 	testCases.forEach(({ currentLogLevel, logLevel, expected }) => {

--- a/packages/core/src/env/logger.ts
+++ b/packages/core/src/env/logger.ts
@@ -31,15 +31,15 @@ export const TTY_COLORS = {
 	},
 } as const;
 
-export type LogLevel = "info" | "success" | "warn" | "error" | "debug";
+export type LogLevel = "debug" | "info" | "success" | "warn" | "error";
 
-export const levels = ["info", "success", "warn", "error", "debug"] as const;
+export const levels = ["debug", "info", "success", "warn", "error"] as const;
 
 export function shouldPublishLog(
 	currentLogLevel: LogLevel,
 	logLevel: LogLevel,
 ): boolean {
-	return levels.indexOf(logLevel) <= levels.indexOf(currentLogLevel);
+	return levels.indexOf(logLevel) >= levels.indexOf(currentLogLevel);
 }
 
 export interface Logger {


### PR DESCRIPTION
Ensure higher severity logs are published when the configured log level is lower (as it should be the "minimum" level to publish).

e.g., `'error'` level messages should be published when BA is configured with log level `'info'`

Unfortunately, this could be considered to be a breaking change. Although it may be what users were expecting all along and could be considered a bug just as much.

Fixes #6408

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated logger level priority so the configured level is a minimum threshold; higher-severity messages are now published. Aligns logging behavior with common expectations and fixes #6408.

- **Bug Fixes**
  - Reordered levels to: debug < info < success < warn < error.
  - Changed shouldPublishLog to publish when logLevel >= current level.
  - Updated tests to reflect the new priority.

- **Migration**
  - If you want only errors: set level to "error". For warnings + errors: "warn". For info/success/warn/error: "info". For all logs: "debug".

<sup>Written for commit a81fc8e9b45b45d7d1bd66c1d9271e05220b91ac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

