### PR TITLE
fix: remove applying user-agent by default

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -5,7 +5,7 @@ import type {
 import { createFetch } from "@better-fetch/fetch";
 import type { WritableAtom } from "nanostores";
 import { getBaseURL } from "../utils/url";
-import { redirectPlugin, userAgentPlugin } from "./fetch-plugins";
+import { redirectPlugin } from "./fetch-plugins";
 import { parseJSON } from "./parser";
 import { getSessionAtom } from "./session-atom";
 
@@ -51,9 +51,7 @@ export const getClientConfig = (
 		plugins: [
 			lifeCyclePlugin,
 			...(restOfFetchOptions.plugins || []),
-			...(options?.disableDefaultFetchPlugins
-				? []
-				: [userAgentPlugin, redirectPlugin]),
+			...(options?.disableDefaultFetchPlugins ? [] : [redirectPlugin]),
 			...pluginsFetchPlugins,
 		],
 	});

--- a/packages/better-auth/src/client/fetch-plugins.ts
+++ b/packages/better-auth/src/client/fetch-plugins.ts
@@ -17,13 +17,3 @@ export const redirectPlugin = {
 		},
 	},
 } satisfies BetterFetchPlugin;
-
-export const userAgentPlugin = {
-	id: "user-agent",
-	name: "UserAgent",
-	hooks: {
-		onRequest(context) {
-			context.headers.append("user-agent", "better-auth");
-		},
-	},
-} satisfies BetterFetchPlugin;


### PR DESCRIPTION
closes #6358 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the automatic "user-agent: better-auth" header from client requests by removing the userAgentPlugin and excluding it from default plugins. This prevents overriding runtime user agents and avoids header issues.

- **Migration**
  - If you relied on this header, add it manually via a custom BetterFetch plugin or set the header on your requests.

<sup>Written for commit 57ca7b720d6254b5f99fe99f4174fa855df66fb0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

