### PR TITLE
feat(phone-number): include verification code in phone number processing and tests

### DIFF
--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -629,6 +629,7 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 						{
 							phoneNumber: ctx.body.phoneNumber,
 							user,
+							code: ctx.body.code,
 						},
 						ctx,
 					);

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -6,6 +6,11 @@ import { phoneNumberClient } from "./client";
 
 describe("phone-number", async (it) => {
 	let otp = "";
+	let verificationData: {
+		phoneNumber: string;
+		code: string;
+		user: any;
+	} | null = null;
 
 	const { client, sessionSetter } = await getTestInstance(
 		{
@@ -18,6 +23,9 @@ describe("phone-number", async (it) => {
 						getTempEmail(phoneNumber) {
 							return `temp-${phoneNumber}`;
 						},
+					},
+					callbackOnVerification: async ({ phoneNumber, code, user }) => {
+						verificationData = { phoneNumber, code, user };
 					},
 				}),
 			],
@@ -52,6 +60,10 @@ describe("phone-number", async (it) => {
 		);
 		expect(res.error).toBe(null);
 		expect(res.data?.status).toBe(true);
+		expect(verificationData).not.toBeNull();
+		expect(verificationData?.phoneNumber).toBe(testPhoneNumber);
+		expect(verificationData?.code).toBe(otp);
+		expect(verificationData?.user).toBeDefined();
 	});
 
 	it("shouldn't verify again with the same code", async () => {

--- a/packages/better-auth/src/plugins/phone-number/types.ts
+++ b/packages/better-auth/src/plugins/phone-number/types.ts
@@ -85,6 +85,7 @@ export interface PhoneNumberOptions {
 				data: {
 					phoneNumber: string;
 					user: UserWithPhoneNumber;
+					code: string;
 				},
 				ctx?: GenericEndpointContext,
 		  ) => Awaitable<void>)


### PR DESCRIPTION

closes https://github.com/better-auth/better-auth/issues/2811

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the verification code to the phone number verification callback so apps can use the OTP during verification. Updated types and tests to support this.

- **New Features**
  - Send code to callbackOnVerification: { phoneNumber, user, code }.
  - Extend PhoneNumberOptions types to include code.
  - Add tests verifying the callback receives phoneNumber, code, and user.

<sup>Written for commit 77d8795e8079f293cac73980fa96d829a492a3e3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

