### PR TITLE
fix(expo): Due to an incorrect type of the copied request object, the…

### DIFF
--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -39,7 +39,7 @@ export const expo = (options?: ExpoOptions | undefined) => {
 			if (!expoOrigin) {
 				return;
 			}
-			const req = request.clone();
+			const req = new Request(request);
 			req.headers.set("origin", expoOrigin);
 			return {
 				request: req,


### PR DESCRIPTION
Due to an incorrect type of the copied request object, the subsequent logic did not use this duplicated object which had the origin field added. This resulted in the MISSING_OR_NULL_ORIGIN error.

Based on my investigation so far, the affected logic is within the handler method returned by the createRouter function in the better-call package [source code at line 248](https://github.com/Bekacru/better-call/blob/main/src/router.ts#L248). Here is the relevant source code:
```ts
return {
    handler: async (request: Request) => {
        const onReq = await config?.onRequest?.(request);
        if (onReq instanceof Response) {
            return onReq;
        }
        // onReq instanceof Request = false, so req = request
        const req = onReq instanceof Request ? onReq : request;
        const res = await processRequest(req);
        const onRes = await config?.onResponse?.(res);
        if (onRes instanceof Response) {
            return onRes;
        }
        return res;
    },
    endpoints,
};
```

Please note this line of code: `const req = onReq instanceof Request ? onReq : request;`

The root cause is that the req object, which was previously created using `const req = request.clone();`, was not of the Request type. Consequently, the type check onReq instanceof Request in better-call evaluated to false. This forced the handler to fall back to using the original request object instead of the onReq object that contained the added origin field.

As a result, the originCheckMiddleware could not detect the origin field in the request, ultimately throwing the "Missing or null Origin" error.

link issue: #5536 #6257



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix origin header handling in Expo by creating a real Request (new Request(request)) instead of using request.clone(). This ensures the better-call router uses the modified request and resolves MISSING_OR_NULL_ORIGIN errors.

<sup>Written for commit fe6553e2c7a40b6e69995ffce5ff9a80291bc054. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



