### PR TITLE
feat(client): add fallback support for VERCEL_URL and NEXTAUTH_URL

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -11,7 +11,7 @@ import { getSessionAtom } from "./session-atom";
 
 const resolvePublicAuthUrl = (basePath?: string) => {
 	if (typeof process === "undefined") return undefined;
-	const path = basePath || "/api/auth";
+	const path = basePath ?? "/api/auth";
 
 	if (process.env.NEXT_PUBLIC_AUTH_URL) return process.env.NEXT_PUBLIC_AUTH_URL;
 


### PR DESCRIPTION
## Description
This PR adds automatic `baseURL` resolution for Vercel deployments and improves compatibility with NextAuth.js environment variables.

Currently, users deploying to Vercel often need to manually configure `NEXT_PUBLIC_AUTH_URL`. This change allows the client configuration to automatically fall back to `VERCEL_URL` or `NEXTAUTH_URL` if the explicit `baseURL` or `NEXT_PUBLIC_AUTH_URL` are missing.

## Related Issue
Closes #6406





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically resolves the client baseURL for Vercel deployments by falling back to VERCEL_URL or NEXTAUTH_URL when baseURL or NEXT_PUBLIC_AUTH_URL are not set. This reduces manual config and improves NextAuth compatibility.

- **New Features**
  - Adds resolvePublicAuthUrl to infer the public auth URL from env vars.
  - Order: NEXT_PUBLIC_AUTH_URL → (server-side) NEXTAUTH_URL → VERCEL_URL (defaults to https), with the auth base path appended for VERCEL_URL.
  - If none are set, falls back to /api/auth.

<sup>Written for commit 8a3b34594bc3f7dd655a78c10f86a2fe325311d0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





