### PR TITLE
fix(phoneNumber): create/update account with reset-password

### DIFF
--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -848,6 +848,23 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 						user.id,
 						hashedPassword,
 					);
+					const accounts = await ctx.context.internalAdapter.findAccounts(
+						user.id,
+					);
+					const account = accounts.find((ac) => ac.providerId === "credential");
+					if (!account) {
+						await ctx.context.internalAdapter.linkAccount({
+							userId: user.id,
+							providerId: "credential",
+							accountId: user.id,
+							password: hashedPassword,
+						});
+					} else {
+						await ctx.context.internalAdapter.updatePassword(
+							user.id,
+							hashedPassword,
+						);
+					}
 					await ctx.context.internalAdapter.deleteVerificationValue(
 						verification.id,
 					);


### PR DESCRIPTION
**Problem:**
 When using the phoneNumber plugin for sign in with phoneNumber an appropriately linked 'credential' provider must exist in the account table. This is done under the email signup/reset flow but not within the phoneNumber plugin. Noticed this was missing after troubleshooting and finding #6401 

**Fix:**
This patch adds the create/update functionality to the phoneNumber plugin.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds credential account linking/update to the phoneNumber plugin during password reset to match the email flow and prevent phone sign-in failures.

- **Bug Fixes**
  - On reset-password, link a 'credential' account with the hashed password if missing; otherwise update the existing credential password.

<sup>Written for commit 9f9624947ace4a85f1234ec66142964c410ec7b7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



