### PR TITLE
chore: fix typecheck

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -273,7 +273,7 @@ export const createInternalAdapter = (
 			const { id: _, ...rest } = override || {};
 			//we're parsing default values for session additional fields
 			const defaultAdditionalFields = parseSessionInput(
-				ctx?.context.options ?? {},
+				ctx?.context.options ?? options,
 				{},
 			);
 			const data: Omit<Session, "id"> = {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Safely handle missing ctx.context.options in createInternalAdapter by using optional chaining and falling back to the function’s options when calling parseSessionInput. Fixes typecheck and prevents runtime errors when ctx or options are undefined.

<sup>Written for commit d90716bbb6aa962e3fd2e61f2a987ecd784f61ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



