### PR TITLE
fix(prisma): user findFirst instead of findMany for findOne

### DIFF
--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -274,13 +274,10 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 
 					const selects = convertSelect(select, model, join);
 
-					let result = (
-						await db[model]!.findMany({
-							where: whereClause,
-							select: selects,
-							take: 1,
-						})
-					)[0];
+					let result = await db[model]!.findFirst({
+						where: whereClause,
+						select: selects,
+					});
 
 					// transform the resulting `include` items to use better-auth expected field names
 					if (join && result) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch findOne in the Prisma adapter to use findFirst instead of findMany + take: 1. This returns a single record directly, avoids array indexing edge cases, and slightly improves performance.

<sup>Written for commit 1ce52998836a4003e45b7cac36b5c9d4287ed94f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

