### PR TITLE
refactor: replace DBPreservedModels with BaseModelNames

### DIFF
--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -3,7 +3,7 @@ import {
 	getCurrentAdapter,
 	getCurrentAuthContext,
 } from "@better-auth/core/context";
-import type { DBPreservedModels } from "@better-auth/core/db";
+import type { BaseModelNames } from "@better-auth/core/db";
 import type { DBAdapter, Where } from "@better-auth/core/db/adapter";
 
 export function getWithHooks(
@@ -14,13 +14,9 @@ export function getWithHooks(
 	},
 ) {
 	const hooks = ctx.hooks;
-	type BaseModels = Extract<
-		DBPreservedModels,
-		"user" | "account" | "session" | "verification"
-	>;
 	async function createWithHooks<T extends Record<string, any>>(
 		data: T,
-		model: BaseModels,
+		model: BaseModelNames,
 		customCreateFn?:
 			| {
 					fn: (data: Record<string, any>) => void | Promise<any>;
@@ -74,7 +70,7 @@ export function getWithHooks(
 	async function updateWithHooks<T extends Record<string, any>>(
 		data: any,
 		where: Where[],
-		model: BaseModels,
+		model: BaseModelNames,
 		customUpdateFn?:
 			| {
 					fn: (data: Record<string, any>) => void | Promise<any>;
@@ -129,7 +125,7 @@ export function getWithHooks(
 	async function updateManyWithHooks<T extends Record<string, any>>(
 		data: any,
 		where: Where[],
-		model: BaseModels,
+		model: BaseModelNames,
 		customUpdateFn?:
 			| {
 					fn: (data: Record<string, any>) => void | Promise<any>;
@@ -184,7 +180,7 @@ export function getWithHooks(
 
 	async function deleteWithHooks<T extends Record<string, any>>(
 		where: Where[],
-		model: BaseModels,
+		model: BaseModelNames,
 		customDeleteFn?:
 			| {
 					fn: (where: Where[]) => void | Promise<any>;
@@ -246,7 +242,7 @@ export function getWithHooks(
 
 	async function deleteManyWithHooks<T extends Record<string, any>>(
 		where: Where[],
-		model: BaseModels,
+		model: BaseModelNames,
 		customDeleteFn?:
 			| {
 					fn: (where: Where[]) => void | Promise<any>;

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -15,12 +15,13 @@ export { coreSchema } from "./schema/shared";
 export { type User, userSchema } from "./schema/user";
 export { type Verification, verificationSchema } from "./schema/verification";
 export type {
+	BaseModelNames,
 	BetterAuthDBSchema,
 	DBFieldAttribute,
 	DBFieldAttributeConfig,
 	DBFieldType,
-	DBPreservedModels,
 	DBPrimitive,
+	ModelNames,
 	SecondaryStorage,
 } from "./type";
 

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -1,18 +1,12 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { LiteralString } from "../types";
 
-export type DBPreservedModels =
-	| "user"
-	| "account"
-	| "session"
-	| "verification"
-	| "rate-limit"
-	| "organization"
-	| "member"
-	| "invitation"
-	| "jwks"
-	| "passkey"
-	| "two-factor";
+export type BaseModelNames = "user" | "account" | "session" | "verification";
+
+export type ModelNames<T extends string = LiteralString> =
+	| BaseModelNames
+	| T
+	| "rate-limit";
 
 export type DBFieldType =
 	| "string"

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -2,7 +2,7 @@ import type { CookieOptions, EndpointContext } from "better-call";
 import type {
 	Account,
 	BetterAuthDBSchema,
-	DBPreservedModels,
+	ModelNames,
 	SecondaryStorage,
 	Session,
 	User,
@@ -12,7 +12,6 @@ import type { DBAdapter, Where } from "../db/adapter";
 import type { createLogger } from "../env";
 import type { OAuthProvider } from "../oauth2";
 import type { BetterAuthCookies } from "./cookie";
-import type { LiteralUnion } from "./helper";
 import type {
 	BetterAuthOptions,
 	BetterAuthRateLimitOptions,
@@ -226,7 +225,7 @@ export type AuthContext<Options extends BetterAuthOptions = BetterAuthOptions> =
 				  };
 		};
 		generateId: (options: {
-			model: LiteralUnion<DBPreservedModels, string>;
+			model: ModelNames;
 			size?: number | undefined;
 		}) => string | false;
 		secondaryStorage: SecondaryStorage | undefined;

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -12,7 +12,7 @@ import type { AuthMiddleware } from "../api";
 import type {
 	Account,
 	DBFieldAttribute,
-	DBPreservedModels,
+	ModelNames,
 	RateLimit,
 	SecondaryStorage,
 	Session,
@@ -33,7 +33,7 @@ type Optional<T> = {
 };
 
 export type GenerateIdFn = (options: {
-	model: LiteralUnion<DBPreservedModels, string>;
+	model: ModelNames;
 	size?: number | undefined;
 }) => string | false;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored model typing by replacing DBPreservedModels with BaseModelNames and introducing ModelNames for extensible model names. This clarifies the core model set and standardizes types across DB, hooks, and init options.

- **Refactors**
  - Replace DBPreservedModels with BaseModelNames ("user" | "account" | "session" | "verification").
  - Add ModelNames<T> = BaseModelNames | T | "rate-limit".
  - Update with-hooks, AuthContext, and GenerateIdFn to use the new types.
  - Export BaseModelNames and ModelNames from @better-auth/core/db.

- **Migration**
  - Replace imports of DBPreservedModels with BaseModelNames or ModelNames.
  - Update generateId to accept model: ModelNames.
  - If you used additional model names, supply them via ModelNames<"your" | "names">.

<sup>Written for commit 0ddfe1a64deb8fa4e3ac747b67bb7ef1fb50cd25. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

