### PR TITLE
docs: add warnings about awaiting emails

### DIFF
--- a/docs/content/blogs/1-4.mdx
+++ b/docs/content/blogs/1-4.mdx
@@ -338,7 +338,7 @@ export const auth = betterAuth({
         changeEmail: {
             enabled: true,
             sendChangeEmailConfirmation: async ({ user, newEmail, url, token }, request) => {
-                await sendEmail({
+                sendEmail({
                     to: user.email, // Sent to the CURRENT email
                     subject: 'Approve email change',
                     text: `Click the link to approve the change to ${newEmail}: ${url}`

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -140,7 +140,7 @@ import { sendEmail } from "./email"; // your email sending function
 export const auth = betterAuth({
   emailVerification: {
     sendVerificationEmail: async ( { user, url, token }, request) => {
-      await sendEmail({
+      void sendEmail({
         to: user.email,
         subject: "Verify your email address",
         text: `Click the link to verify your email: ${url}`,
@@ -149,6 +149,11 @@ export const auth = betterAuth({
   },
 });
 ```
+
+<Callout type="warn">
+  Avoid awaiting the email sending to prevent 
+  timing attacks.  On serverless platforms, use `waitUntil` or similar to ensure the email is sent.
+</Callout>
 
 On the client side you can use `sendVerificationEmail` function to send verification link to user. This will trigger the `sendVerificationEmail` function you provided in the `auth` configuration.
 
@@ -221,7 +226,7 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     sendResetPassword: async ({user, url, token}, request) => {
-      await sendEmail({
+      void sendEmail({
         to: user.email,
         subject: "Reset your password",
         text: `Click the link to reset your password: ${url}`,
@@ -234,6 +239,11 @@ export const auth = betterAuth({
   },
 });
 ```
+
+<Callout type="warn">
+  Avoid awaiting the email sending to prevent 
+  timing attacks.  On serverless platforms, use `waitUntil` or similar to ensure the email is sent.
+</Callout>
 
 Additionally, you can provide an `onPasswordReset` callback to execute logic after a password has been successfully reset.
 

--- a/docs/content/docs/concepts/email.mdx
+++ b/docs/content/docs/concepts/email.mdx
@@ -29,7 +29,7 @@ import { sendEmail } from './email'; // your email sending function
 export const auth = betterAuth({
     emailVerification: {
         sendVerificationEmail: async ({ user, url, token }, request) => {
-            await sendEmail({
+            void sendEmail({
                 to: user.email,
                 subject: 'Verify your email address',
                 text: `Click the link to verify your email: ${url}`
@@ -38,6 +38,11 @@ export const auth = betterAuth({
     }
 })
 ```
+
+<Callout type="warn">
+  Avoid awaiting the email sending to prevent 
+  timing attacks.  On serverless platforms, use `waitUntil` or similar to ensure the email is sent.
+</Callout>
 
 ### Triggering Email Verification
 
@@ -75,7 +80,7 @@ If you enable require email verification, users must verify their email before t
 export const auth = betterAuth({
   emailVerification: {
     sendVerificationEmail: async ({ user, url }) => {
-      await sendEmail({
+      void sendEmail({
         to: user.email,
         subject: "Verify your email address",
         text: `Click the link to verify your email: ${url}`,
@@ -180,7 +185,7 @@ export const auth = betterAuth({
     emailAndPassword: {
         enabled: true,
         sendResetPassword: async ({ user, url, token }, request) => {
-            await sendEmail({
+            void sendEmail({
                 to: user.email,
                 subject: 'Reset your password',
                 text: `Click the link to reset your password: ${url}`
@@ -189,6 +194,11 @@ export const auth = betterAuth({
     }
 })
 ```
+
+<Callout type="warn">
+  Avoid awaiting the email sending to prevent 
+  timing attacks.  On serverless platforms, use `waitUntil` or similar to ensure the email is sent.
+</Callout>
 
 Check out the [Email and Password](/docs/authentication/email-password#forget-password) guide for more details on how to implement password reset in your app.
 Also you can check out the [Otp verification](/docs/plugins/email-otp#reset-password) guide for how to implement password reset with OTP in your app.

--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -35,13 +35,18 @@ export const auth = betterAuth({
     emailVerification: {
         // Required to send the verification email
         sendVerificationEmail: async ({ user, url, token }) => {
-            await sendEmail({
+            void sendEmail({
                 to: user.email,
             })
         }
     }
 })
 ```
+
+<Callout type="warn">
+  Avoid awaiting the email sending to prevent 
+  timing attacks.  On serverless platforms, use `waitUntil` or similar to ensure the email is sent.
+</Callout>
 
 By default, when a user requests to change their email, a verification email is sent to the **new** email address.
 The email is only updated after the user verifies the new email.
@@ -58,7 +63,7 @@ export const auth = betterAuth({
         changeEmail: {
             enabled: true,
             sendChangeEmailConfirmation: async ({ user, newEmail, url, token }, request) => {
-                await sendEmail({
+                sendEmail({
                     to: user.email, // Sent to the CURRENT email
                     subject: 'Approve email change',
                     text: `Click the link to approve the change to ${newEmail}: ${url}`

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -212,7 +212,7 @@ export interface OrganizationOptions {
 	 * sendInvitationEmail: async (data) => {
 	 * 	const url = `https://yourapp.com/organization/
 	 * accept-invitation?id=${data.id}`;
-	 * 	await sendEmail(data.email, "Invitation to join
+	 * 	 sendEmail(data.email, "Invitation to join
 	 * organization", `Click the link to join the
 	 * organization: ${url}`);
 	 * }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add warnings and update docs to avoid awaiting email sends in verification, reset-password, and change-email flows. This reduces timing attack risk and keeps requests fast; examples now use void sendEmail and recommend waitUntil on serverless, and the organization invitation sample no longer awaits the email send.

<sup>Written for commit cde4873223d87e69ba2ef201a7649b3da4dd2c6e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

