### PR TITLE
fix(docs): correct banExpires field and time unit in Clerk migration guide

### DIFF
--- a/docs/content/docs/guides/clerk-migration-guide.mdx
+++ b/docs/content/docs/guides/clerk-migration-guide.mdx
@@ -294,7 +294,9 @@ async function migrateFromClerk() {
                 // # Admin (if you enabled admin plugin)
                 ...(isAdminEnabled ? {
                     banned: clerkUser?.banned,
-                    banExpiresAt: clerkUser?.lockout_expires_in_seconds,
+                    banExpires: clerkUser?.lockout_expires_in_seconds
+                       ? new Date(Date.now() + clerkUser.lockout_expires_in_seconds * 1000)
+                       : undefined,
                     role: "user"
                 } : {}),
                 // # Username (if you enabled username plugin)


### PR DESCRIPTION
## Description
Fixes #6442

Updates the Clerk migration guide script to correctly map user ban data to the Admin plugin schema.

## Changes
- Renamed `banExpiresAt` to `banExpires` to match the correct Admin plugin schema.
- Added logic to convert Clerk's `lockout_expires_in_seconds` (which is a duration in seconds) into a JavaScript `Date` object (timestamp), as the database adapter expects a Date.

## Checklist
- [x] Documentation updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the Clerk migration guide to use banExpires (not banExpiresAt) and to convert Clerk’s lockout_expires_in_seconds into a Date timestamp. Prevents incorrect admin ban data when migrating from Clerk.

<sup>Written for commit 6d99bb4a138dd7a07ad396689615d68c152fca06. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

