### PR TITLE
fix: consistent prefix delimiter for session_token cookie

### DIFF
--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -20,7 +20,6 @@ import { parseUserOutput } from "../db/schema";
 import type { Session, User } from "../types";
 import { getDate } from "../utils/date";
 import { safeJSONParse } from "../utils/json";
-import { getBaseURL } from "../utils/url";
 import { createSessionStore } from "./session-store";
 
 export function createCookieGetter(options: BetterAuthOptions) {
@@ -342,23 +341,14 @@ export const getSessionCookie = (
 		  }
 		| undefined,
 ) => {
-	if (config?.cookiePrefix) {
-		if (config.cookieName) {
-			config.cookiePrefix = `${config.cookiePrefix}-`;
-		} else {
-			config.cookiePrefix = `${config.cookiePrefix}.`;
-		}
-	}
 	const headers = "headers" in request ? request.headers : request;
-	const req = request instanceof Request ? request : undefined;
-	const url = getBaseURL(req?.url, config?.path, req);
 	const cookies = headers.get("cookie");
 	if (!cookies) {
 		return null;
 	}
-	const { cookieName = "session_token", cookiePrefix = "better-auth." } =
+	const { cookieName = "session_token", cookiePrefix = "better-auth" } =
 		config || {};
-	const name = `${cookiePrefix}${cookieName}`;
+	const name = `${cookiePrefix}.${cookieName}`;
 	const secureCookieName = `__Secure-${name}`;
 	const parsedCookie = parseCookies(cookies);
 	const sessionToken =


### PR DESCRIPTION
closes #6435

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the session token cookie name to always use a dot delimiter between prefix and name, ensuring consistent parsing and secure cookie lookup across environments.

- **Bug Fixes**
  - Default prefix is "better-auth" and the cookie name is built as "better-auth.session_token".
  - Removed conditional delimiter logic so the prefix format is consistent.

<sup>Written for commit f6170d983243815a65a0fc841ea9f76b39ea8f9a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

