### PR TITLE
fix: preserve user ID in cookie cache during stateless sessions

### DIFF
--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -135,10 +135,7 @@ export async function setCookieCache(
 		);
 
 		// Apply field filtering to user data
-		const filteredUser = {
-			...parseUserOutput(ctx.context.options, session.user),
-			id: session.user.id,
-		};
+		const filteredUser = parseUserOutput(ctx.context.options, session.user);
 
 		// Compute version
 		const versionConfig = ctx.context.options.session?.cookieCache?.version;

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -60,7 +60,10 @@ function getAllFields(options: BetterAuthOptions, table: string) {
 
 export function parseUserOutput(options: BetterAuthOptions, user: User) {
 	const schema = getAllFields(options, "user");
-	return parseOutputData(user, { fields: schema });
+	return {
+		...parseOutputData(user, { fields: schema }),
+		id: user.id,
+	};
 }
 
 export function parseAccountOutput(


### PR DESCRIPTION
Fixes #6447

This PR fixes a bug where the user.id was being stripped from the session cookie (JWT) when running in stateless mode with generateId: false.

**The Issue:** In setCookieCache, the parseUserOutput helper filters the user object based on the configuration. When generateId is set to false (e.g., using an external provider's ID like Entra ID), the internal schema definition does not recognize id as a generated field, causing it to be filtered out. This resulted in 401 Unauthorized errors on API endpoints because the session was restored without a User ID.

**The Fix:** Modified setCookieCache in packages/better-auth/src/cookies/index.ts to explicitly merge session.user.id back into the filtered user object before tokenization.

**Changes:**
- packages/better-auth/src/cookies/index.ts: Explicitly preserve id during cookie creation.
- packages/better-auth/src/cookies/cookies.test.ts: Added a regression test to ensure user.id is always present in the cookie cache.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where user.id was stripped from the session cookie in stateless mode (generateId: false), causing 401 errors when restoring sessions. The cookie cache now always preserves user.id.

- **Bug Fixes**
  - Always preserve user.id in parseUserOutput so it isn't filtered out before cookie creation.
  - Add a regression test to ensure user.id is present in the cookie cache.

<sup>Written for commit 7062dcfcead746e96565f31017d8ead03e80c1bf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



