### PR TITLE
docs(fix): username is optional during sign-up

### DIFF
--- a/docs/content/docs/plugins/username.mdx
+++ b/docs/content/docs/plugins/username.mdx
@@ -85,7 +85,7 @@ type signUpEmail = {
     /**
      * The username of the user.
     */
-    username: string = "test"
+    username?: string = "test"
     /**
      * An optional display username of the user.
     */


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated plugin docs to mark username as optional during sign-up, aligning the signUpEmail type with current API behavior.
Changed username: string to username?: string in username.mdx to avoid confusion for integrators.

<sup>Written for commit 65dd824400e38086919e65e893182ef5d035ba3a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

