### PR TITLE
chore: fix validation errors in unit tests

### DIFF
--- a/packages/better-auth/src/plugins/siwe/siwe.test.ts
+++ b/packages/better-auth/src/plugins/siwe/siwe.test.ts
@@ -129,7 +129,9 @@ describe("siwe", async (it) => {
 		const { error } = await client.siwe.nonce({ walletAddress: "invalid" });
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(400);
-		expect(error?.message).toBe("[body.walletAddress] Invalid string: must match pattern /^0[xX][a-fA-F0-9]{40}$/i; [body.walletAddress] Too small: expected string to have >=42 characters");
+		expect(error?.message).toBe(
+			"[body.walletAddress] Invalid string: must match pattern /^0[xX][a-fA-F0-9]{40}$/i; [body.walletAddress] Too small: expected string to have >=42 characters",
+		);
 	});
 
 	it("should reject verification with invalid signature", async () => {
@@ -259,7 +261,9 @@ describe("siwe", async (it) => {
 		});
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(400);
-		expect(error?.message).toBe("[body.email] Email is required when the anonymous plugin option is disabled.");
+		expect(error?.message).toBe(
+			"[body.email] Email is required when the anonymous plugin option is disabled.",
+		);
 	});
 
 	it("should accept verification with email when anonymous is false", async () => {
@@ -449,7 +453,9 @@ describe("siwe", async (it) => {
 		});
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(400);
-		expect(error?.message).toBe("[body.email] Invalid email address; [body.email] Email is required when the anonymous plugin option is disabled.");
+		expect(error?.message).toBe(
+			"[body.email] Invalid email address; [body.email] Email is required when the anonymous plugin option is disabled.",
+		);
 	});
 
 	it("should store and return the wallet address in checksum format", async () => {


### PR DESCRIPTION
Validation errors were recently changed in the new Better-Call version, this PR fixes unit tests in better-auth which were accounting for the old validation errors



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated SIWE unit tests to match Better-Call’s new validation error format, fixing failing tests in better-auth. Tests now assert specific field-level messages instead of the old generic "Invalid body parameters".

- **Bug Fixes**
  - Adjusted nonce invalid walletAddress to expect pattern and length errors.
  - Verification when anonymous=false now requires email and asserts the specific message.
  - Invalid email now asserts "Invalid email address".
  - Combined email errors covered when anonymous=false with an invalid email.

<sup>Written for commit 2e53aa8f7f1ccfd422ca248f60c5c83ae6fec9a3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



