### PR TITLE
chore: fix siwe tests not matching error message

### DIFF
--- a/packages/better-auth/src/plugins/siwe/siwe.test.ts
+++ b/packages/better-auth/src/plugins/siwe/siwe.test.ts
@@ -129,7 +129,9 @@ describe("siwe", async (it) => {
 		const { error } = await client.siwe.nonce({ walletAddress: "invalid" });
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(400);
-		expect(error?.message).toBe("Invalid body parameters");
+		expect(error?.message).toBe(
+			"[body.walletAddress] Invalid string: must match pattern /^0[xX][a-fA-F0-9]{40}$/i; [body.walletAddress] Too small: expected string to have >=42 characters",
+		);
 	});
 
 	it("should reject verification with invalid signature", async () => {
@@ -259,7 +261,9 @@ describe("siwe", async (it) => {
 		});
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(400);
-		expect(error?.message).toBe("Invalid body parameters");
+		expect(error?.message).toBe(
+			"[body.email] Email is required when the anonymous plugin option is disabled.",
+		);
 	});
 
 	it("should accept verification with email when anonymous is false", async () => {
@@ -333,7 +337,7 @@ describe("siwe", async (it) => {
 		});
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(400);
-		expect(error?.message).toBe("Invalid body parameters");
+		expect(error?.message).toBe("[body.email] Invalid email address");
 	});
 
 	it("should allow verification without email when anonymous is true", async () => {
@@ -449,7 +453,9 @@ describe("siwe", async (it) => {
 		});
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(400);
-		expect(error?.message).toBe("Invalid body parameters");
+		expect(error?.message).toBe(
+			"[body.email] Invalid email address; [body.email] Email is required when the anonymous plugin option is disabled.",
+		);
 	});
 
 	it("should store and return the wallet address in checksum format", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated SIWE plugin tests to match the new, detailed validation error messages so assertions stop failing and reflect current API behavior.

- **Bug Fixes**
  - Assert walletAddress pattern and length errors for nonce requests.
  - Assert email required error when anonymous=false.
  - Assert invalid email error.
  - Assert combined email errors for invalid and required cases.

<sup>Written for commit 1feaff64d6225da555699a213988db14e8a92205. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

