### PR TITLE
ci: remove `NODE_AUTH_TOKEN` during publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,4 @@ jobs:
       - name: Publish to npm
         run: pnpm -r publish --access public --no-git-checks --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove NODE_AUTH_TOKEN from the npm publish step to avoid passing the token via env. Publishing now uses the existing npm auth configuration (e.g., setup-node/.npmrc) with provenance still enabled.

<sup>Written for commit 15348959e78af8ad874e7713569de29a6c17757a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

