### PR TITLE
docs: update usage in Next.js integration

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -13,7 +13,7 @@ We need to mount the handler to an API route. Create a route file inside `/api/a
 import { auth } from "@/lib/auth";
 import { toNextJsHandler } from "better-auth/next-js";
 
-export const { GET, POST } = toNextJsHandler(auth.handler);
+export const { GET, POST } = toNextJsHandler(auth);
 ```
 
 <Callout type="info">


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/6474

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Next.js integration docs to pass auth directly to toNextJsHandler, replacing toNextJsHandler(auth.handler). Fixes the incorrect example from #6474 and aligns with the current API.

<sup>Written for commit 801b6a17fb5f68637888f05e71e947437e134324. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

