### PR TITLE
chore(ci): remove turbo remote cache  (testing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - canary
+      - chore/actions-cache-fix
   merge_group:
 
 concurrency:
@@ -43,37 +44,18 @@ jobs:
         run: pnpm install
 
       - name: Build
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-          TURBO_CACHE: remote:rw
         run: pnpm build
 
       - name: Lint
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-          TURBO_CACHE: remote:rw
         run: pnpm lint
 
       - name: Lint Dependencies
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-          TURBO_CACHE: remote:rw
         run: pnpm lint:dependencies
+
       - name: Lint Packages
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-          TURBO_CACHE: remote:rw
         run: pnpm lint:packages
 
       - name: Lint Spell
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-          TURBO_CACHE: remote:rw
         run: pnpm lint:spell
 
   typecheck:
@@ -103,17 +85,9 @@ jobs:
         run: pnpm install
 
       - name: Build
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-          TURBO_CACHE: remote:rw
         run: pnpm build
 
       - name: Typecheck
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-          TURBO_CACHE: remote:rw
         run: pnpm typecheck
 
   test:
@@ -147,10 +121,6 @@ jobs:
         run: pnpm install
 
       - name: Build
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-          TURBO_CACHE: remote:rw
         run: pnpm build
 
       - name: Start Docker Containers
@@ -160,11 +130,7 @@ jobs:
           sleep 10
 
       - name: Test
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
         run: pnpm test
 
       - name: Stop Docker Containers
         run: docker compose down
-             


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed Turbo remote cache from GitHub Actions to stabilize CI and remove dependency on secrets. Build, lint, typecheck, and test now run without Turbo remote caching.

- **Refactors**
  - Deleted TURBO_TOKEN, TURBO_TEAM, and TURBO_CACHE envs from build, lint, typecheck, and test steps in .github/workflows/ci.yml.
  - Added chore/actions-cache-fix to workflow branches so CI runs on this testing branch.

<sup>Written for commit a85b56ce7db67a2c85a996842f3d8385f98cbeb2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



