### PR TITLE
docs: correct spelling of 'Tiktok' to 'TikTok'

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -999,7 +999,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				),
 			},
 			{
-				title: "Tiktok",
+				title: "TikTok",
 				href: "/docs/authentication/tiktok",
 				icon: () => (
 					<svg


### PR DESCRIPTION
the dev's on this project clearly aren't doing enough doomscrolling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the docs sidebar label from "Tiktok" to "TikTok" to match official branding and improve consistency.

<sup>Written for commit 28e63769a4a926cf050c2c906cc2d2812a40ba81. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

