### PR TITLE
fix: export organization plugin types

### DIFF
--- a/packages/better-auth/src/client/index.ts
+++ b/packages/better-auth/src/client/index.ts
@@ -38,6 +38,7 @@ export type * from "@better-fetch/fetch";
 // @ts-expect-error
 export type * from "nanostores";
 export type * from "../plugins/access";
+export type * from "../plugins/organization";
 export type * from "../types/helper";
 export type { UnionToIntersection } from "../types/helper";
 //#endregion


### PR DESCRIPTION
## Problem

TypeScript requires complex Zod inference types to be exported, so that we can get type inference in the `createAuthClient` when used with plugins. However, the `organization` zod inferred types  weren't being properly exported, thus, TS couldn't automatically infer them.

E.g.

```.ts
// this would throw a TS error we tried to generate the declaration types
export const supportedBetterAuthClientPlugins = [
  organizationClient(),
] satisfies BetterAuthClientOptions['plugins'];
```

**ERROR**
```
The inferred type of 'supportedBetterAuthClientPlugins' cannot be named without a reference to '../../../../node_modules/better-auth/dist/index-Bl9JYXWC.mjs'. This is likely not portable. A type annotation is necessary.
```

## Fix

The fix seems to be, simply re-exporting the types, making them available to TS in the consumer application.


## Test Plan

I couldn't build a proper test for this, since it would have to happen in a isolated env that didn't have access to the codebase types. However, I did build this locally and used the local version to make sure that there were no errors when exporting the organization's plugin types.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported organization plugin types from the client index to restore TypeScript inference for plugins in createAuthClient. Fixes the non-portable “inferred type cannot be named” error in consumer builds.

<sup>Written for commit 6468ff9a3c83f85ebda8a7e462cdf54167b333bf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



