### PR TITLE
docs: add middleware section for TanStack Start

### DIFF
--- a/docs/content/docs/integrations/tanstack.mdx
+++ b/docs/content/docs/integrations/tanstack.mdx
@@ -59,3 +59,44 @@ const signIn = async () => {
     })
 }
 ```
+
+### Middleware
+
+You can use TanStack Start's middleware to protect routes that require authentication. Create a middleware that checks for a valid session and redirects unauthenticated users to the login page.
+
+```ts title="src/middleware/auth.ts"
+import { redirect } from "@tanstack/react-router";
+import { createMiddleware } from "@tanstack/react-start";
+import { auth } from "./auth";
+
+export const authMiddleware = createMiddleware().server(
+    async ({ next, request }) => {
+        const session = await auth.api.getSession({ headers: request.headers })
+
+        if (!session) {
+            throw redirect({ to: "/login" })
+        }
+
+        return await next()
+    }
+);
+```
+
+You can then use this middleware in your route definitions to protect specific routes:
+
+```tsx title="src/routes/dashboard.tsx"
+import { createFileRoute } from '@tanstack/react-router'
+import { authMiddleware } from '@/lib/middleware'
+
+export const Route = createFileRoute('/dashboard')({
+  component: RouteComponent,
+  server: {
+    middleware: [authMiddleware],
+  },
+})
+
+function RouteComponent() {
+  return <div>Hello "/dashboard"!</div>
+}
+```
+


### PR DESCRIPTION
## Middleware Integration with Better Auth

This PR adds documentation for using **TanStack Start's middleware** feature together with **Better Auth** to protect routes that require authentication.

---

## 🔧 Changes

### ➕ Added
- A new **Middleware** section in the TanStack Start integration docs.
- A complete example demonstrating how to create an authentication middleware that:
  - Checks for a valid session using `auth.api.getSession()`
  - Redirects unauthenticated users to the login page
  - Applies the middleware to route definitions via the `server.middleware` array

---

## 🧠 Why This Is Needed

The existing TanStack Start integration docs only covered:
- Mounting the auth handler  
- Managing cookies

However, they didn’t explain how to **protect routes from unauthenticated users** a very common requirement.

This PR fills that gap by documenting how to leverage TanStack Start’s built-in middleware system to guard pages using Better Auth, making it easier for developers to build secure applications.

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds middleware docs to the TanStack Start + Better Auth integration to show how to protect routes by checking the session and redirecting to /login when not authenticated. This fills the gap in the guide so developers can guard pages easily.

- **New Features**
  - New Middleware section with an auth middleware example using auth.api.getSession and redirect.
  - Route usage example showing server.middleware to protect specific pages.

<sup>Written for commit d4a6e3be693df775572e6d2d97f04776b92f53f5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

