### PR TITLE
fix(email-otp): allow OTP to persist on validation errors

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -506,6 +506,119 @@ describe("email-otp-verify", async () => {
 		expect(res.error?.status).toBe(403);
 		expect(res.error?.message).toBe("Too many attempts");
 	});
+
+	it("should keep OTP valid when password validation fails", async () => {
+		// Send OTP for password reset
+		await client.emailOtp.sendVerificationOtp({
+			email: testUser.email,
+			type: "forget-password",
+		});
+
+		const currentOtp = otp[otp.length - 1] || "";
+		expect(currentOtp).toBeTruthy();
+
+		// First attempt with a password that is too short
+		// - should fail validation
+		const firstAttempt = await client.emailOtp.resetPassword({
+			email: testUser.email,
+			otp: currentOtp,
+			password: "123",
+		});
+		expect(firstAttempt.error?.status).toBe(400);
+		expect(firstAttempt.error?.message).toBe("Password too short");
+
+		// Second attempt with the same OTP but valid password
+		// - should succeed
+		const secondAttempt = await client.emailOtp.resetPassword({
+			email: testUser.email,
+			otp: currentOtp,
+			password: "new-valid-password",
+		});
+		expect(secondAttempt.data).toBeDefined();
+		expect(secondAttempt.error).toBe(null);
+
+		// Verify the password was actually changed
+		const signIn = await client.signIn.email({
+			email: testUser.email,
+			password: "new-valid-password",
+		});
+		expect(signIn.data?.user).toBeDefined();
+	});
+
+	it("should keep OTP valid when verifyEmail fails due to user not found", async () => {
+		// Create a test instance and send OTP, then delete the user before verification
+		let testOtp = "";
+		const { client: testClient, sessionSetter } = await getTestInstance(
+			{
+				user: {
+					deleteUser: {
+						enabled: true,
+					},
+				},
+				plugins: [
+					emailOTP({
+						async sendVerificationOTP({ otp: _otp }) {
+							testOtp = _otp;
+						},
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [emailOTPClient()],
+				},
+			},
+		);
+
+		// Create a new user to delete
+		const headers = new Headers();
+		const signUpRes = await testClient.signUp.email({
+			email: `delete-test-${Date.now()}@email.com`,
+			password: "password123",
+			name: "Test User",
+			fetchOptions: {
+				onSuccess: sessionSetter(headers),
+			},
+		});
+		expect(signUpRes.data?.user).toBeDefined();
+		const userToDelete = signUpRes.data!.user;
+
+		// Send OTP for email verification while user exists
+		await testClient.emailOtp.sendVerificationOtp({
+			email: userToDelete.email,
+			type: "email-verification",
+		});
+
+		expect(testOtp).toBeTruthy();
+
+		// Delete the user after OTP is sent
+		// - simulates edge case
+		const deleteRes = await testClient.deleteUser({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(deleteRes.error).toBeFalsy();
+		expect(deleteRes.data?.success).toBe(true);
+
+		// First attempt
+		// - should fail because user no longer exists
+		const firstAttempt = await testClient.emailOtp.verifyEmail({
+			email: userToDelete.email,
+			otp: testOtp,
+		});
+		expect(firstAttempt.error?.status).toBe(400);
+		expect(firstAttempt.error?.message).toBe("User not found");
+
+		// Second attempt with the same OTP should still return "User not found" not "Invalid OTP"
+		// - OTP should not be consumed on business logic failure
+		const secondAttempt = await testClient.emailOtp.verifyEmail({
+			email: userToDelete.email,
+			otp: testOtp,
+		});
+		expect(secondAttempt.error?.status).toBe(400);
+		expect(secondAttempt.error?.message).toBe("User not found");
+	});
 });
 
 describe("custom rate limiting storage", async () => {

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -51,6 +51,31 @@ describe("email-otp", async () => {
 		expect(verifiedUser.data?.status).toBe(true);
 	});
 
+	it("should delete OTP after successful verification with autoSignInAfterVerification", async () => {
+		await client.emailOtp.sendVerificationOtp({
+			email: testUser.email,
+			type: "email-verification",
+		});
+
+		const currentOtp = otp;
+		expect(currentOtp).toBeTruthy();
+
+		// First attempt - should succeed with auto sign-in
+		const firstAttempt = await client.emailOtp.verifyEmail({
+			email: testUser.email,
+			otp: currentOtp,
+		});
+		expect(firstAttempt.data?.status).toBe(true);
+		expect(firstAttempt.data?.token).toBeDefined();
+
+		// Second attempt with same OTP - should fail (OTP should be deleted)
+		const secondAttempt = await client.emailOtp.verifyEmail({
+			email: testUser.email,
+			otp: currentOtp,
+		});
+		expect(secondAttempt.error?.message).toBe("Invalid OTP");
+	});
+
 	it("should sign-in with otp", async () => {
 		const res = await client.emailOtp.sendVerificationOtp({
 			email: testUser.email,

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -716,6 +716,9 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							session,
 							user: updatedUser,
 						});
+						await ctx.context.internalAdapter.deleteVerificationValue(
+							verificationValue.id,
+						);
 						return ctx.json({
 							status: true,
 							token: session.token,

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -684,9 +684,6 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							message: ERROR_CODES.INVALID_OTP,
 						});
 					}
-					await ctx.context.internalAdapter.deleteVerificationValue(
-						verificationValue.id,
-					);
 					const user = await ctx.context.internalAdapter.findUserByEmail(email);
 					if (!user) {
 						/**
@@ -733,6 +730,9 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							},
 						});
 					}
+					await ctx.context.internalAdapter.deleteVerificationValue(
+						verificationValue.id,
+					);
 					const currentSession = await getSessionFromCtx(ctx);
 					if (currentSession && updatedUser.emailVerified) {
 						const dontRememberMeCookie = await ctx.getSignedCookie(
@@ -864,9 +864,6 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							message: ERROR_CODES.INVALID_OTP,
 						});
 					}
-					await ctx.context.internalAdapter.deleteVerificationValue(
-						verificationValue.id,
-					);
 					const user = await ctx.context.internalAdapter.findUserByEmail(email);
 					if (!user) {
 						if (opts.disableSignUp) {
@@ -886,6 +883,9 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							session,
 							user: newUser,
 						});
+						await ctx.context.internalAdapter.deleteVerificationValue(
+							verificationValue.id,
+						);
 						return ctx.json({
 							token: session.token,
 							user: {
@@ -913,6 +913,9 @@ export const emailOTP = (options: EmailOTPOptions) => {
 						session,
 						user: user.user,
 					});
+					await ctx.context.internalAdapter.deleteVerificationValue(
+						verificationValue.id,
+					);
 					return ctx.json({
 						token: session.token,
 						user: {
@@ -1111,9 +1114,6 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							message: ERROR_CODES.INVALID_OTP,
 						});
 					}
-					await ctx.context.internalAdapter.deleteVerificationValue(
-						verificationValue.id,
-					);
 					const user = await ctx.context.internalAdapter.findUserByEmail(
 						email,
 						{
@@ -1158,7 +1158,9 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							passwordHash,
 						);
 					}
-
+					await ctx.context.internalAdapter.deleteVerificationValue(
+						verificationValue.id,
+					);
 					if (ctx.context.options.emailAndPassword?.onPasswordReset) {
 						await ctx.context.options.emailAndPassword.onPasswordReset(
 							{


### PR DESCRIPTION
This PR addresses a [Discord issue](https://discord.com/channels/1288403910284935179/1288403910284935182/1445592492496916500) where the verificationValue is deleted immediately after validation, forcing users to restart the OTP flow if they fail to enter the correct value on the first try. OTP reuse can be controlled with `allowedAttempts`.







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows email OTP to persist on validation errors so users can retry without restarting the flow. OTP is only consumed after a successful verification, sign-in, or password reset, with attempts still limited by allowedAttempts.

- **Bug Fixes**
  - Move deletion of verificationValue to occur only after successful email verify, sign-in, or password reset.
  - Enforce allowedAttempts; return 403 “Too many attempts” after the limit.
  - Add tests for OTP reuse on validation failures and blocking sign-in after exceeding attempts.

<sup>Written for commit d530803f7aa60756131cf0b143e9c1bf5bf926aa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





