### PR TITLE
fix(cli): `secret` generates empty 

### DIFF
--- a/packages/cli/src/commands/secret.ts
+++ b/packages/cli/src/commands/secret.ts
@@ -1,11 +1,10 @@
 import Crypto from "node:crypto";
-import { logger } from "better-auth";
 import chalk from "chalk";
 import { Command } from "commander";
 
 export const generateSecret = new Command("secret").action(() => {
 	const secret = generateSecretHash();
-	logger.info(`\nAdd the following to your .env file: 
+	console.log(`\nAdd the following to your .env file: 
 ${
 	chalk.gray("# Auth Secret") + chalk.green(`\nBETTER_AUTH_SECRET=${secret}`)
 }`);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the CLI `secret` command so it runs without errors and prints the .env instructions. Replaced the `better-auth` logger with `console.log` and removed the unused import.

<sup>Written for commit 7d485f31fad7e41b1f46ad85e6efd1e27feb234c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

