### PR TITLE
fix(multi-session): maximumSessions comparison

### DIFF
--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -306,7 +306,7 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 								isMultiSessionCookie,
 							).length + (cookieString.includes("session_token") ? 1 : 0);
 
-						if (currentMultiSessions >= opts.maximumSessions) {
+						if (currentMultiSessions > opts.maximumSessions) {
 							return;
 						}
 


### PR DESCRIPTION
closes #4490

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the multi-session limit check to allow up to the configured maximum sessions. We now block only when current sessions exceed the limit, addressing Linear #4490.

<sup>Written for commit a589662bbd0c15c333c032f2e1094dd0e3f33dc8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

