### PR TITLE
docs(jwt): remove JWT adapter `getLatestKey`

### DIFF
--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -526,11 +526,6 @@ jwt({
       // This overrides the default database query
       return await yourCustomStorage.getAllKeys()
     },
-    getLatestKey: async (ctx) => {
-      // Custom implementation to get the latest key
-      // This overrides the default database query
-      return await yourCustomStorage.getLatestKey()
-    },
     createJwk: async (ctx, webKey) => {
       // Custom implementation to create a new key
       // This overrides the default database insert


### PR DESCRIPTION
according to the changes in #6147

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated JWT plugin docs to remove the adapter’s getLatestKey example, since the API no longer supports this hook. Keeps the docs aligned with the current adapter API and avoids confusion.

<sup>Written for commit 646ca4c8b9267e62cad0e2c650bc31ee8a465446. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

