### PR TITLE
docs: update endpoints docs that require session

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -612,7 +612,7 @@ You can set the active organization by calling the `organization.setActive` func
   set to `null`.
 </Callout>
 
-<APIMethod path="/organization/set-active" method="POST">
+<APIMethod path="/organization/set-active" method="POST" requireSession>
 ```ts
 type setActiveOrganization = {
     /**
@@ -858,7 +858,7 @@ export const auth = betterAuth({
 
 To invite users to an organization, you can use the `invite` function provided by the client. The `invite` function takes an object with the following properties:
 
-<APIMethod path="/organization/invite-member" method="POST">
+<APIMethod path="/organization/invite-member" method="POST" requireSession>
 ```ts
 type createInvitation = {
     /**
@@ -900,7 +900,7 @@ When a user receives an invitation email, they can click on the invitation link 
 
 Make sure to call the `acceptInvitation` function after the user is logged in.
 
-<APIMethod path="/organization/accept-invitation" method="POST">
+<APIMethod path="/organization/accept-invitation" method="POST" requireSession>
 ```ts
 type acceptInvitation = {
     /**
@@ -937,7 +937,7 @@ If a user has sent out an invitation, you can use this method to cancel it.
 
 If you're looking for how a user can reject an invitation, you can find that [here](#reject-invitation).
 
-<APIMethod path="/organization/cancel-invitation" method="POST" noResult>
+<APIMethod path="/organization/cancel-invitation" method="POST" noResult requireSession>
 ```ts
 type cancelInvitation = {
     /**
@@ -952,7 +952,7 @@ type cancelInvitation = {
 
 If this user has received an invitation, but wants to decline it, this method will allow you to do so by rejecting it.
 
-<APIMethod path="/organization/reject-invitation" method="POST" noResult>
+<APIMethod path="/organization/reject-invitation" method="POST" noResult requireSession>
 ```ts
 type rejectInvitation = {
     /**
@@ -993,7 +993,7 @@ type getInvitation = {
 
 To list all invitations for a given organization you can use the `listInvitations` function provided by the client.
 
-<APIMethod path="/organization/list-invitations" method="GET">
+<APIMethod path="/organization/list-invitations" method="GET" requireSession>
 ```ts
 type listInvitations = {
     /**
@@ -1033,7 +1033,7 @@ const invitations = await auth.api.listUserInvitations({
 
 To list all members of an organization you can use the `listMembers` function.
 
-<APIMethod path="/organization/list-members" method="GET">
+<APIMethod path="/organization/list-members" method="GET" requireSession>
 
 ```ts
 type listMembers = {
@@ -1077,7 +1077,7 @@ type listMembers = {
 
 To remove you can use `organization.removeMember`
 
-<APIMethod path="/organization/remove-member" method="POST">
+<APIMethod path="/organization/remove-member" method="POST" requireSession>
 ```ts
 type removeMember = {
     /**
@@ -1096,7 +1096,7 @@ type removeMember = {
 
 To update the role of a member in an organization, you can use the `organization.updateMemberRole`. If the user has the permission to update the role of the member, the role will be updated.
 
-<APIMethod path="/organization/update-member-role" method="POST" noResult>
+<APIMethod path="/organization/update-member-role" method="POST" noResult requireSession>
 ```ts
 type updateMemberRole = {
     /**
@@ -1911,7 +1911,7 @@ type removeTeam = {
 
 Sets the given team as the current active team. If `teamId` is `null` the current active team is unset.
 
-<APIMethod path="/organization/set-active-team" method="POST">
+<APIMethod path="/organization/set-active-team" method="POST" requireSession>
 ```ts
 type setActiveTeam = {
     /**
@@ -1926,7 +1926,7 @@ type setActiveTeam = {
 
 List all teams that the current user is a part of.
 
-<APIMethod path="/organization/list-user-teams" method="GET">
+<APIMethod path="/organization/list-user-teams" method="GET" requireSession>
   ```ts 
   type listUserTeams = {
   }
@@ -1937,7 +1937,7 @@ List all teams that the current user is a part of.
 
 List the members of the given team.
 
-<APIMethod path="/organization/list-team-members" method="POST" forceAsQuery>
+<APIMethod path="/organization/list-team-members" method="POST" forceAsQuery requireSession>
 ```ts
 type listTeamMembers = {
     /**
@@ -1952,7 +1952,7 @@ type listTeamMembers = {
 
 Add a member to a team.
 
-<APIMethod path="/organization/add-team-member" method="POST">
+<APIMethod path="/organization/add-team-member" method="POST" requireSession>
 ```ts
 type addTeamMember = {
     /**
@@ -1971,7 +1971,7 @@ type addTeamMember = {
 
 Remove a member from a team.
 
-<APIMethod path="/organization/remove-team-member" method="POST">
+<APIMethod path="/organization/remove-team-member" method="POST" requireSession>
 ```ts
 type removeTeamMember = {
     /**


### PR DESCRIPTION
Closes https://github.com/better-auth/better-auth/issues/6512
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Marked organization and team endpoints as session-required in the docs by adding requireSession to APIMethod blocks (set-active org, invitations, members, teams). This clarifies authentication requirements and aligns the docs with actual API behavior.

<sup>Written for commit 5fd8070f01826d881913f016ca480014992a4d0d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

