### PR TITLE
feat: drizzle pg supports JSON

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -579,6 +579,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 			usePlural: config.usePlural ?? false,
 			debugLogs: config.debugLogs ?? false,
 			supportsUUIDs: config.provider === "pg" ? true : false,
+			supportsJSON: config.provider === "pg" ? true : false,
 			transaction:
 				(config.transaction ?? false)
 					? (cb) =>


### PR DESCRIPTION
Required for recently added JSON, string[], and number[] type support



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled JSON support in the Drizzle adapter for Postgres by setting supportsJSON when the provider is pg. This enables JSON, string[], and number[] column types.

<sup>Written for commit 956a93f0bf2aa4543f973e3bd7f61f2d50ba7530. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



