### PR TITLE
chore(passkey): re-export necessary types in client

### DIFF
--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -264,5 +264,5 @@ export const passkeyClient = () => {
 	} satisfies BetterAuthClientPlugin;
 };
 
-export type * from "./types";
 export type * from "@simplewebauthn/server";
+export type * from "./types";


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Re-exported passkey types from the client to simplify TypeScript imports (from ./types and @simplewebauthn/server).

<sup>Written for commit 82c4b836af570b147595eecb71f4082e405f476a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





