### PR TITLE
fix(core): allow returning null in getUserInfo in provider options

### DIFF
--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -150,7 +150,7 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 					[key: string]: any;
 				};
 				data: any;
-		  }>)
+		  } | null>)
 		| undefined;
 	/**
 	 * Custom function to refresh a token


### PR DESCRIPTION
This PR allows users that want to customize the `getUserInfo` function for a social provider to return null when something goes wrong. Especially, this means that it becomes possible to copy the default implementation from the better auth source code (which often does return null) and tweak something minor with it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow custom social provider getUserInfo to return null, matching the default behavior and enabling safer error handling. Updated ProviderOptions type to accept null for getUserInfo results; no runtime changes.

<sup>Written for commit d7f2a78784dec25238aff1ec39021060aecc8eed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

