### PR TITLE
docs: correct API component usage

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -102,6 +102,8 @@ type createOrganization = {
 }
 ```
 
+</APIMethod>
+
 <Callout type="warn">
 **Mutually Exclusive Parameters**
 
@@ -111,8 +113,6 @@ The `userId` and session headers cannot be used together:
 
 **For Admins:** To create an organization on behalf of another user, you must make the API call server-side **without** passing session headers.
 </Callout>
-
-</APIMethod>
 
 #### Restrict who can create an organization
 


### PR DESCRIPTION
fixes build error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected MDX component structure in plugins/organization.mdx to fix a docs build error. Moved the closing </APIMethod> tag before the warn Callout to ensure proper nesting.

<sup>Written for commit f8950c5a4e4a7f12cad4ac0d1ee4cefae07a0e20. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

