### PR TITLE
chore: update repository URLs in package.json

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://better-auth.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/better-auth"
   },
   "keywords": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.mjs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/cli"
   },
   "homepage": "https://www.better-auth.com/docs/concepts/cli",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/core"
   },
   "main": "./dist/index.mjs",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/expo"
   },
   "homepage": "https://www.better-auth.com/docs/integrations/expo",

--- a/packages/passkey/package.json
+++ b/packages/passkey/package.json
@@ -60,7 +60,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/passkey"
   },
   "homepage": "https://www.better-auth.com/docs/plugins/passkey",

--- a/packages/scim/package.json
+++ b/packages/scim/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/scim"
   },
   "keywords": [

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://www.better-auth.com/docs/plugins/sso",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/sso"
   },
   "license": "MIT",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://www.better-auth.com/docs/plugins/stripe",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/stripe"
   },
   "keywords": [

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/telemetry"
   },
   "main": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated repository URLs in package.json across all packages to use the git+https format with .git, so npm and tooling correctly resolve repository links.
No functional changes.

<sup>Written for commit 889ab19c841ae32b5c97a5b74fa04eb5cd6d1e2b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

