### PR TITLE
chore(organization): re-export schema types in client

### DIFF
--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -319,3 +319,5 @@ export const inferOrgAdditionalFields = <
 		: undefined;
 	return {} as undefined extends S ? Schema : S;
 };
+
+export type * from "./schema";


### PR DESCRIPTION
closes #6565

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exported organization schema types from the client module so consumers can import them from a single entry point. This is type-only and has no runtime impact.

<sup>Written for commit 75e0bd8e8ad13d855ce9059efea6c65da901dbad. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

