### PR TITLE
fix(admin): clear admin session cookie on `stopImpersonating`

### DIFF
--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1513,9 +1513,8 @@ const userHasPermissionBodySchema = z
  */
 export const userHasPermission = <O extends AdminOptions>(opts: O) => {
 	type DefaultStatements = typeof defaultStatements;
-	type Statements = O["ac"] extends AccessControl<infer S>
-		? S
-		: DefaultStatements;
+	type Statements =
+		O["ac"] extends AccessControl<infer S> ? S : DefaultStatements;
 
 	type PermissionType = {
 		[key in keyof Statements]?: Array<


### PR DESCRIPTION
closes #6567





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear the admin session cookie when an admin stops impersonating to fully end the session and prevent lingering auth state. The route now deletes the signed admin cookie by setting an empty value with immediate expiry.

<sup>Written for commit fa8ce158a538f9ebded41c242a77eaf117ea8e43. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





