### PR TITLE
docs: simplify hono cors documentation to only the configuration required

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -39,10 +39,7 @@ app.use(
 	"/api/auth/*", // or replace with "*" to enable cors for all routes
 	cors({
 		origin: "http://localhost:3001", // replace with your origin
-		allowHeaders: ["Content-Type", "Authorization"],
 		allowMethods: ["POST", "GET", "OPTIONS"],
-		exposeHeaders: ["Content-Length"],
-		maxAge: 600,
 		credentials: true,
 	}),
 );


### PR DESCRIPTION
This reduces the Hono CORS documentation to only what is required to get it working and aligns the docs more closely with the Express integration docs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified Hono CORS docs to only the required config, aligned with the Express integration. Removed allowHeaders, exposeHeaders, and maxAge; kept origin, allowMethods, and credentials.

<sup>Written for commit 57f8578d44dfc8e88b38e0063ec9299a91585ef0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



