### PR TITLE
chore: remove convex callouts

### DIFF
--- a/docs/content/docs/integrations/convex.mdx
+++ b/docs/content/docs/integrations/convex.mdx
@@ -3,11 +3,6 @@ title: Convex Integration
 description: Integrate Better Auth with Convex.
 ---
 
-<Callout>
-  This documentation comes from the [Convex documentation](https://convex-better-auth.netlify.app/),
-  for more information, please refer to their documentation.
-</Callout>
-
 ## Prerequisites
 
 <Steps>
@@ -340,8 +335,3 @@ export async function updatePassword({
   );
 }
 ```
-
-<Callout>
-  This documentation comes from the [Convex documentation](https://convex-better-auth.netlify.app/),
-  for more information, please refer to their documentation.
-</Callout>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed external callouts in the Convex integration guide to streamline the page and avoid repeated messaging. No content or instructions changed—only the duplicated notices were removed.

<sup>Written for commit 9b9f4eacc3193318932de8c65e48a1dd4cd5abdc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

