### PR TITLE
fix(kysely): wrong affected row count in updateMany & deleteMany

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -536,8 +536,10 @@ export const kyselyAdapter = (
 					if (or) {
 						query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
 					}
-					const res = await query.execute();
-					return res.length;
+					const res = (await query.executeTakeFirst()).numUpdatedRows;
+					return res > Number.MAX_SAFE_INTEGER
+						? Number.MAX_SAFE_INTEGER
+						: Number(res);
 				},
 				async count({ model, where }) {
 					const { and, or } = convertWhereClause(model, where);
@@ -581,7 +583,10 @@ export const kyselyAdapter = (
 					if (or) {
 						query = query.where((eb) => eb.or(or.map((expr) => expr(eb))));
 					}
-					return (await query.execute()).length;
+					const res = (await query.executeTakeFirst()).numDeletedRows;
+					return res > Number.MAX_SAFE_INTEGER
+						? Number.MAX_SAFE_INTEGER
+						: Number(res);
 				},
 				options: config,
 			};


### PR DESCRIPTION
Related: https://discord.com/channels/1288403910284935179/1446936682401235074

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect affected row counts in the Kysely adapter for updateMany and deleteMany. Counts now reflect actual rows updated/deleted across dialects.

- **Bug Fixes**
  - Use executeTakeFirst() with numUpdatedRows/numDeletedRows instead of result length.
  - Convert to number and cap at Number.MAX_SAFE_INTEGER to handle BigInt results.

<sup>Written for commit f8a642a809359150c7243a9434ece1491737fad6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

