### PR TITLE
chore(api-key): re-export types

### DIFF
--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -337,3 +337,5 @@ export const apiKey = (options?: ApiKeyOptions | undefined) => {
 		schema,
 	} satisfies BetterAuthPlugin;
 };
+
+export type * from "./types";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Re-exported api-key plugin types from the plugin index so consumers can import types from the entrypoint instead of deep paths. DX-only change with no runtime impact.

<sup>Written for commit a1842ef4bd855ef8b3506a9cbcc951bfacdb29cb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

