### PR TITLE
chore: fix tsdown config

### DIFF
--- a/packages/expo/tsdown.config.ts
+++ b/packages/expo/tsdown.config.ts
@@ -3,12 +3,6 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
 	dts: { build: true, incremental: true },
 	format: ["esm"],
-	outExtension({ format }) {
-		if (format === "esm") {
-			return { js: ".mjs", dts: ".d.mts" };
-		}
-		return { js: ".js", dts: ".d.ts" };
-	},
 	entry: ["./src/index.ts", "./src/client.ts"],
 	external: [
 		"better-auth",

--- a/packages/passkey/tsdown.config.ts
+++ b/packages/passkey/tsdown.config.ts
@@ -3,12 +3,6 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
 	dts: { build: true, incremental: true },
 	format: ["esm"],
-	outExtension({ format }) {
-		if (format === "esm") {
-			return { js: ".mjs", dts: ".d.mts" };
-		}
-		return { js: ".js", dts: ".d.ts" };
-	},
 	entry: ["./src/index.ts", "./src/client.ts"],
 	external: [
 		"nanostores",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed tsdown configs for expo and passkey by removing the custom outExtension override. Builds now use tsdown’s default ESM/DTS extensions, resolving issues caused by .d.mts outputs.

<sup>Written for commit e937aae1f7e41d154d4b5125c6558f273bb0f706. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

