### PR TITLE
docs: remove/rephrase wrong statement about permissions and projects

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1219,7 +1219,7 @@ By default, there are three roles in the organization:
 
 `admin`: Users with the admin role have full control over the organization except for deleting the organization or changing the owner.
 
-`member`: Users with the member role have limited control over the organization. They can create projects, invite users, and manage projects they have created.
+`member`: Users with the member role have limited control over the organization. They can only read organization data and have no permissions to create, update, or delete resources.
 
 <Callout>
   A user can have multiple roles. Multiple roles are stored as string separated


### PR DESCRIPTION
While implementing custom roles, our team at Chatbyte noticed, the description of default privileges of the `member` roles was ambiguous. In one place they pretty much can't do anything, in another it's stated they can invite others. We were pretty sure that members can't create invitations. This was confirmed after reviewing the actual code in `packages/better-auth/src/plugins/organization/access/statement.ts:32`.

We updated the docs to better represent the actual logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the member role description in the organization plugin docs. Members can only read organization data and cannot create, update, delete, invite, or manage projects.

<sup>Written for commit 62f5a1ef56da1c73c7768848bbfa49a9ccfea18f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

