### PR TITLE
docs(org): remove reference to non-existent option

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1511,12 +1511,6 @@ Only users with roles which contain the `ac` resource with the `create` permissi
 By default, only the `admin` and `owner` roles have this permission. You also cannot add permissions that your
 current role in that organization can't already access.
 
-<Callout>
-  TIP: You can validate role names by using the `dynamicAccessControl.validateRoleName` option in the organization plugin config.
-  Learn more [here](#validaterolename).
-</Callout>
-
-
 <APIMethod
   path="/organization/create-role"
   method="POST"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed a callout in the Organization plugin docs that referenced the non-existent dynamicAccessControl.validateRoleName option. This prevents confusion and removes a broken anchor link, aligning the docs with supported configuration.

<sup>Written for commit 3e2d2d70d4b263242a72e8e990a6f96e26c544fc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

