### PR TITLE
docs(bearer): explain bearer requests requirements better

### DIFF
--- a/docs/content/docs/plugins/bearer.mdx
+++ b/docs/content/docs/plugins/bearer.mdx
@@ -114,12 +114,15 @@ const response = await fetch("https://api.example.com/data", {
 const data = await response.json();
 ```
 
-And in the server, you can use the `auth.api.getSession` function to authenticate requests:
+On the server, you can authenticate requests using the `auth.api.getSession` function,
+as long as the Authorization Bearer token header is present in the request:
+
 
 ```ts title="server.ts"
 import { auth } from "@/auth";
 
 export async function handler(req, res) {
+  // Make sure `req.headers` contains the Authorization Bearer token header!
   const session = await auth.api.getSession({
     headers: req.headers
   });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified Bearer plugin docs to state that server-side authentication with auth.api.getSession requires the Authorization: Bearer token header. Updated the server example to highlight passing req.headers and the header requirement.

<sup>Written for commit 22adecee0defb04f1701791d474ed08c976e1d4a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

