### PR TITLE
fix(adapter): add logger creation in adapter factory

### DIFF
--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -139,6 +139,8 @@ export const createAdapterFactory =
 			}
 		};
 
+		const logger = createLogger(options.logger);
+
 		const getDefaultModelName = initGetDefaultModelName({
 			usePlural: config.usePlural,
 			schema,
@@ -220,7 +222,6 @@ export const createAdapterFactory =
 					try {
 						value = new Date(value);
 					} catch {
-						const logger = createLogger(options.logger);
 						logger.error("[Adapter Factory] Failed to convert string to date", {
 							value,
 							field,


### PR DESCRIPTION
Adapter debug logs don't work after previous changes to moving to createLogger. This PR ensures the adapter factory debug logs function again.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore adapter debug logs by creating a logger in the adapter factory. We now import createLogger and instantiate it inside debugLog and the date conversion error handler, so logs work again after the logger refactor.

<sup>Written for commit afc17e8921d7e0c781b0131c6e2846ef675a8e8c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





