### PR TITLE
fix(adapter): allow run internal adapter outside context

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1,5 +1,4 @@
 import type { GenericEndpointContext } from "@better-auth/core";
-import { runWithEndpointContext } from "@better-auth/core/context";
 import { safeJSONParse } from "@better-auth/core/utils";
 import Database from "better-sqlite3";
 import { Kysely, SqliteDialect } from "kysely";
@@ -122,22 +121,20 @@ describe("internal adapter test", async () => {
 	const internalAdapter = authContext.internalAdapter;
 
 	it("should create oauth user with custom generate id", async () => {
-		const user = await runWithEndpointContext(ctx, () =>
-			internalAdapter.createOAuthUser(
-				{
-					email: "email@email.com",
-					name: "name",
-					emailVerified: false,
-				},
-				{
-					providerId: "provider",
-					accountId: "account",
-					accessTokenExpiresAt: new Date(),
-					refreshTokenExpiresAt: new Date(),
-					createdAt: new Date(),
-					updatedAt: new Date(),
-				},
-			),
+		const user = await internalAdapter.createOAuthUser(
+			{
+				email: "email@email.com",
+				name: "name",
+				emailVerified: false,
+			},
+			{
+				providerId: "provider",
+				accountId: "account",
+				accessTokenExpiresAt: new Date(),
+				refreshTokenExpiresAt: new Date(),
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
 		);
 		expect(user).toMatchObject({
 			user: {
@@ -443,9 +440,7 @@ describe("internal adapter test", async () => {
 			name: "test-user",
 			email: "test@email.com",
 		});
-		const session = await runWithEndpointContext(ctx, () =>
-			internalAdapter.createSession(user.id),
-		);
+		const session = await internalAdapter.createSession(user.id);
 		const storedSessions: { token: string; expiresAt: number }[] = JSON.parse(
 			map.get(`active-sessions-${user.id}`),
 		);

--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -26,22 +26,20 @@ export function getWithHooks(
 	) {
 		const context = await getCurrentAuthContext().catch(() => null);
 		let actualData = data;
-		if (context !== null) {
-			for (const hook of hooks || []) {
-				const toRun = hook[model]?.create?.before;
-				if (toRun) {
-					// @ts-expect-error context type mismatch
-					const result = await toRun(actualData as any, context);
-					if (result === false) {
-						return null;
-					}
-					const isObject = typeof result === "object" && "data" in result;
-					if (isObject) {
-						actualData = {
-							...actualData,
-							...result.data,
-						};
-					}
+		for (const hook of hooks || []) {
+			const toRun = hook[model]?.create?.before;
+			if (toRun) {
+				// @ts-expect-error context type mismatch
+				const result = await toRun(actualData as any, context);
+				if (result === false) {
+					return null;
+				}
+				const isObject = typeof result === "object" && "data" in result;
+				if (isObject) {
+					actualData = {
+						...actualData,
+						...result.data,
+					};
 				}
 			}
 		}
@@ -83,22 +81,20 @@ export function getWithHooks(
 		const context = await getCurrentAuthContext().catch(() => null);
 		let actualData = data;
 
-		if (context !== null) {
-			for (const hook of hooks || []) {
-				const toRun = hook[model]?.update?.before;
-				if (toRun) {
-					// @ts-expect-error context type mismatch
-					const result = await toRun(data as any, context);
-					if (result === false) {
-						return null;
-					}
-					const isObject = typeof result === "object" && "data" in result;
-					if (isObject) {
-						actualData = {
-							...actualData,
-							...result.data,
-						};
-					}
+		for (const hook of hooks || []) {
+			const toRun = hook[model]?.update?.before;
+			if (toRun) {
+				// @ts-expect-error context type mismatch
+				const result = await toRun(data as any, context);
+				if (result === false) {
+					return null;
+				}
+				const isObject = typeof result === "object" && "data" in result;
+				if (isObject) {
+					actualData = {
+						...actualData,
+						...result.data,
+					};
 				}
 			}
 		}
@@ -140,22 +136,20 @@ export function getWithHooks(
 		const context = await getCurrentAuthContext().catch(() => null);
 		let actualData = data;
 
-		if (context !== null) {
-			for (const hook of hooks || []) {
-				const toRun = hook[model]?.update?.before;
-				if (toRun) {
-					// @ts-expect-error context type mismatch
-					const result = await toRun(data as any, context);
-					if (result === false) {
-						return null;
-					}
-					const isObject = typeof result === "object" && "data" in result;
-					if (isObject) {
-						actualData = {
-							...actualData,
-							...result.data,
-						};
-					}
+		for (const hook of hooks || []) {
+			const toRun = hook[model]?.update?.before;
+			if (toRun) {
+				// @ts-expect-error context type mismatch
+				const result = await toRun(data as any, context);
+				if (result === false) {
+					return null;
+				}
+				const isObject = typeof result === "object" && "data" in result;
+				if (isObject) {
+					actualData = {
+						...actualData,
+						...result.data,
+					};
 				}
 			}
 		}
@@ -208,7 +202,7 @@ export function getWithHooks(
 			// If we can't find the entity, we'll still proceed with deletion
 		}
 
-		if (entityToDelete && context !== null) {
+		if (entityToDelete) {
 			for (const hook of hooks || []) {
 				const toRun = hook[model]?.delete?.before;
 				if (toRun) {
@@ -268,16 +262,14 @@ export function getWithHooks(
 			// If we can't find the entities, we'll still proceed with deletion
 		}
 
-		if (context !== null) {
-			for (const entity of entitiesToDelete) {
-				for (const hook of hooks || []) {
-					const toRun = hook[model]?.delete?.before;
-					if (toRun) {
-						// @ts-expect-error context type mismatch
-						const result = await toRun(entity as any, context);
-						if (result === false) {
-							return null;
-						}
+		for (const entity of entitiesToDelete) {
+			for (const hook of hooks || []) {
+				const toRun = hook[model]?.delete?.before;
+				if (toRun) {
+					// @ts-expect-error context type mismatch
+					const result = await toRun(entity as any, context);
+					if (result === false) {
+						return null;
 					}
 				}
 			}

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -995,7 +995,7 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							user: User & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<
 							| boolean
 							| void
@@ -1008,7 +1008,7 @@ export type BetterAuthOptions = {
 						 */
 						after?: (
 							user: User & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 					update?: {
@@ -1019,7 +1019,7 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							user: Partial<User> & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<
 							| boolean
 							| void
@@ -1032,7 +1032,7 @@ export type BetterAuthOptions = {
 						 */
 						after?: (
 							user: User & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 					delete?: {
@@ -1042,14 +1042,14 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							user: User & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<boolean | void>;
 						/**
 						 * Hook that is called after a user is deleted.
 						 */
 						after?: (
 							user: User & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 				};
@@ -1065,7 +1065,7 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							session: Session & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<
 							| boolean
 							| void
@@ -1078,7 +1078,7 @@ export type BetterAuthOptions = {
 						 */
 						after?: (
 							session: Session & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 					/**
@@ -1092,7 +1092,7 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							session: Partial<Session> & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<
 							| boolean
 							| void
@@ -1105,7 +1105,7 @@ export type BetterAuthOptions = {
 						 */
 						after?: (
 							session: Session & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 					delete?: {
@@ -1115,14 +1115,14 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							session: Session & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<boolean | void>;
 						/**
 						 * Hook that is called after a session is deleted.
 						 */
 						after?: (
 							session: Session & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 				};
@@ -1138,7 +1138,7 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							account: Account,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<
 							| boolean
 							| void
@@ -1151,7 +1151,7 @@ export type BetterAuthOptions = {
 						 */
 						after?: (
 							account: Account,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 					/**
@@ -1165,7 +1165,7 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							account: Partial<Account> & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<
 							| boolean
 							| void
@@ -1178,7 +1178,7 @@ export type BetterAuthOptions = {
 						 */
 						after?: (
 							account: Account & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 					delete?: {
@@ -1188,14 +1188,14 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							account: Account & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<boolean | void>;
 						/**
 						 * Hook that is called after an account is deleted.
 						 */
 						after?: (
 							account: Account & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 				};
@@ -1211,7 +1211,7 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							verification: Verification & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<
 							| boolean
 							| void
@@ -1224,7 +1224,7 @@ export type BetterAuthOptions = {
 						 */
 						after?: (
 							verification: Verification & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 					update?: {
@@ -1235,7 +1235,7 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							verification: Partial<Verification> & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<
 							| boolean
 							| void
@@ -1248,7 +1248,7 @@ export type BetterAuthOptions = {
 						 */
 						after?: (
 							verification: Verification & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 					delete?: {
@@ -1258,14 +1258,14 @@ export type BetterAuthOptions = {
 						 */
 						before?: (
 							verification: Verification & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<boolean | void>;
 						/**
 						 * Hook that is called after a verification is deleted.
 						 */
 						after?: (
 							verification: Verification & Record<string, unknown>,
-							context?: GenericEndpointContext,
+							context: GenericEndpointContext | null,
 						) => Promise<void>;
 					};
 				};


### PR DESCRIPTION








<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allows the internal DB adapter to run when no auth context is available. Hooks now receive a null context instead of throwing, preventing crashes in background jobs and tests.

- **Bug Fixes**
  - Treat missing auth context as null and pass it to hooks; update hook types accordingly.
  - Keep existing behavior and data merging when context is present.

<sup>Written for commit 4c3ac9c7743ccab02fed9b411b2797c210546823. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







