### PR TITLE
fix: storeStateStrategy default to database if provided

### DIFF
--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -170,7 +170,9 @@ export async function createAuthContext(
 		socialProviders: providers,
 		options,
 		oauthConfig: {
-			storeStateStrategy: options.account?.storeStateStrategy || "database",
+			storeStateStrategy:
+				options.account?.storeStateStrategy ||
+				(options.database ? "database" : "cookie"),
 			skipStateCookieCheck: !!options.account?.skipStateCookieCheck,
 		},
 		tables,

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -27,8 +27,7 @@ export async function generateState(
 
 	const codeVerifier = generateRandomString(128);
 	const state = generateRandomString(32);
-	const storeStateStrategy =
-		c.context.oauthConfig?.storeStateStrategy || "cookie";
+	const storeStateStrategy = c.context.oauthConfig.storeStateStrategy;
 
 	const stateData = {
 		...(additionalData ? additionalData : {}),
@@ -99,8 +98,7 @@ export async function generateState(
 
 export async function parseState(c: GenericEndpointContext) {
 	const state = c.query.state || c.body.state;
-	const storeStateStrategy =
-		c.context.oauthConfig.storeStateStrategy || "cookie";
+	const storeStateStrategy = c.context.oauthConfig.storeStateStrategy;
 
 	const stateDataSchema = z.looseObject({
 		callbackURL: z.string(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes inconsistent OAuth2 state storage defaults. If a database is configured, we now default to database storage; otherwise we use cookies, and both state generation and parsing use the same config.

- **Bug Fixes**
  - Set oauthConfig.storeStateStrategy in createAuthContext to: explicit option > database (if configured) > cookie.
  - Removed internal fallbacks in generateState/parseState; both read the strategy from context to avoid mismatches.

<sup>Written for commit 7aba98a6949ac22726b699e89f9544d231097e9f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

