### PR TITLE
docs: fix trusted by section layout in enterprise page

### DIFF
--- a/docs/app/enterprise/_components/enterprise-hero.tsx
+++ b/docs/app/enterprise/_components/enterprise-hero.tsx
@@ -25,8 +25,8 @@ export function EnterpriseHero() {
 				</p>
 
 				{/* Trusted By Section */}
-				<div className="pt-6 border-t border-zinc-200 dark:border-zinc-800">
-					<p className="text-xs text-zinc-600 dark:text-zinc-400 mb-1 text-center xl:text-left">
+				<div className="py-8 space-y-4 border-t border-zinc-200 dark:border-zinc-800">
+					<p className="text-xs text-zinc-600 dark:text-zinc-400 text-center xl:text-left">
 						Trusted by teams at
 					</p>
 					<div className="flex flex-wrap items-center justify-center xl:justify-start gap-6 md:gap-4 opacity-60 text-zinc-900 dark:text-white">
@@ -148,7 +148,7 @@ export function EnterpriseHero() {
 									<svg
 										xmlns="http://www.w3.org/2000/svg"
 										width="3em"
-										height="3em"
+										height="1.3em"
 										viewBox="0 0 78 27"
 										fill="currentColor"
 									>


### PR DESCRIPTION
I missed this in the previous update.

### Before -> After
https://github.com/user-attachments/assets/d970b65c-b2ce-4f43-88a8-bf21cddf9918




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed spacing and logo sizing in the Enterprise hero “Trusted by” section to improve alignment and avoid oversized logos. Updated container padding/vertical spacing and reduced SVG logo height from 3em to 1.3em.

<sup>Written for commit 4e8ed14678d8718b42dc3d0a8dd018a03594ee89. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

