### PR TITLE
feat(admin): add `/admin/has-role` endpoint

### DIFF
--- a/demo/nextjs/app/admin/page.tsx
+++ b/demo/nextjs/app/admin/page.tsx
@@ -93,6 +93,8 @@ export default function AdminDashboard() {
 		},
 	});
 
+	
+
 	const handleCreateUser = async (e: React.FormEvent) => {
 		e.preventDefault();
 		setIsLoading("create");

--- a/demo/nextjs/app/admin/page.tsx
+++ b/demo/nextjs/app/admin/page.tsx
@@ -93,8 +93,6 @@ export default function AdminDashboard() {
 		},
 	});
 
-	
-
 	const handleCreateUser = async (e: React.FormEvent) => {
 		e.preventDefault();
 		setIsLoading("create");

--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -694,6 +694,25 @@ const canDeleteUserAndRevokeSession = authClient.admin.checkRolePermission({
 });
 ```
 
+**Has Role:**
+
+To check if a user has a specific role, you can use the `hasRole` function provided by the client.
+
+<APIMethod path="/admin/has-role" method="POST">
+```ts
+type userHasRole = {
+    /**
+     * The user id which you want to check the role for. 
+     */
+    userId: string = "user-id"
+    /**
+     * The role to check for. This can be a string or an array of strings. Eg: `admin` or `[admin, user]`.
+     */
+    role: string | string[] = "admin"
+}
+```
+</APIMethod>
+
 ## Schema
 
 This plugin adds the following fields to the `user` table:

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -1337,4 +1337,67 @@ describe("access control", async (it) => {
 			}),
 		).toThrowError(BetterAuthError);
 	});
+
+	it("should check user has role", async () => {
+		const res = await client.admin.hasRole(
+			{
+				role: "admin",
+				userId: user.id,
+			},
+			{
+				headers: headers,
+			},
+		);
+		expect(res.data?.success).toBe(true);
+	});
+
+	it("should return false if user doesn't have role", async () => {
+		const createdUser = await client.admin.createUser(
+			{
+				name: "Test User mr",
+				email: "testmr@test.com",
+				password: "test",
+				role: ["user"],
+			},
+			{
+				headers: headers,
+			},
+		);
+		expect(createdUser.data?.user.role).toBe("user");
+		const res = await client.admin.hasRole(
+			{
+				role: "admin",
+				userId: createdUser.data?.user.id || "",
+			},
+			{
+				headers: headers,
+			},
+		);
+		expect(res.data?.success).toBe(false);
+	});
+
+	it("should return true if user has multiple roles", async () => {
+		const createdUser = await client.admin.createUser(
+			{
+				name: "Test User mr",
+				email: "testmrsdf@test.com",
+				password: "test",
+				role: ["user", "admin"],
+			},
+			{
+				headers: headers,
+			},
+		);
+		expect(createdUser.data?.user.role).toBe("user,admin");
+		const res = await client.admin.hasRole(
+			{
+				role: ["admin", "user"],
+				userId: createdUser.data?.user.id || "",
+			},
+			{
+				headers: headers,
+			},
+		);
+		expect(res.data?.success).toBe(true);
+	});
 });

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -22,6 +22,7 @@ import {
 	stopImpersonating,
 	unbanUser,
 	userHasPermission,
+	userHasRole,
 } from "./routes";
 import { schema } from "./schema";
 import type {
@@ -164,6 +165,7 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 			removeUser: removeUser(opts),
 			setUserPassword: setUserPassword(opts),
 			userHasPermission: userHasPermission(opts as O),
+			userHasRole: userHasRole(opts as O),
 		},
 		$ERROR_CODES: ADMIN_ERROR_CODES,
 		schema: mergeSchema(schema, opts.schema),

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1715,7 +1715,10 @@ export const userHasRole = <O extends AdminOptions>(opts: O) => {
 											description: "The id of the user",
 										},
 										role: {
-											type: "string",
+											oneOf: [
+												{ type: "string" },
+												{ type: "array", items: { type: "string" } },
+											],
 											description: "The role to check for",
 										},
 									},

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1781,7 +1781,7 @@ export const userHasRole = <O extends AdminOptions>(opts: O) => {
 				});
 			}
 
-			const userRoles = user.role.split(",");
+			const userRoles = user.role.split(",").map((role) => role.trim());
 			const roles = Array.isArray(ctx.body.role)
 				? ctx.body.role
 				: [ctx.body.role];


### PR DESCRIPTION
Closes #6625 







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin hasRole endpoint to check if a user has one or more roles. Exposes server and client APIs so admin flows can gate actions by role.

- **New Features**
  - POST /admin/has-role with admin middleware.
  - Accepts userId and role(s) (string or array); validates input.
  - Requires an authenticated session; handles not-found users and missing roles.
  - Checks comma-separated user.role; returns success only if all requested roles are present.
  - Exposes auth.api.userHasRole and authClient.admin.hasRole with OpenAPI metadata.

<sup>Written for commit ef71e571af16b7c7ac32f9b24c88e55437d6b534. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







