### PR TITLE
fix(api-key): check metadata is enabled for api key update endpoint

### DIFF
--- a/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
@@ -353,7 +353,8 @@ export function updateApiKey({
 				}
 				newValues.expiresAt = expiresIn ? getDate(expiresIn, "sec") : null;
 			}
-			if (metadata !== undefined) {
+
+			if (metadata !== undefined && opts.enableMetadata === true) {
 				if (typeof metadata !== "object") {
 					throw new APIError("BAD_REQUEST", {
 						message: ERROR_CODES.INVALID_METADATA_TYPE,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Only process metadata in the API key update endpoint when metadata is enabled. Prevents validation errors and accidental updates if clients send metadata while the feature is off.

<sup>Written for commit 080d9b763d1e8611460a45429bf977f5342f5eb2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

