### PR TITLE
docs(sso): fix default sso docs

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -642,6 +642,7 @@ const auth = betterAuth({
             defaultSSO: [
                 {
                     providerId: "default-saml", // Provider ID for the default provider
+                    domain: "http://your-app.com",
                     samlConfig: {
                         issuer: "https://your-app.com",
                         entryPoint: "https://idp.example.com/sso",


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated SSO plugin docs to correctly show defaultSSO as an array of provider configs instead of a single object. The example and schema reference now reflect multiple default providers with per-provider SAML/OIDC settings and include the domain field.

<sup>Written for commit e4900e5d827b6bf6d7783e49324f7b92c437f907. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



