### PR TITLE
chore: fix type inference for future TS compatibility

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -282,7 +282,7 @@ export type OrganizationPlugin<O extends OrganizationOptions> = {
 				} & InferOrganization<O, false>;
 	};
 	$ERROR_CODES: typeof ORGANIZATION_ERROR_CODES;
-	options: O;
+	options: NoInfer<O>;
 };
 
 /**
@@ -328,7 +328,7 @@ export function organization<
 				} & InferOrganization<O, false>;
 	};
 	$ERROR_CODES: typeof ORGANIZATION_ERROR_CODES;
-	options: O;
+	options: NoInfer<O>;
 };
 export function organization<
 	O extends OrganizationOptions & {
@@ -361,7 +361,7 @@ export function organization<
 				} & InferOrganization<O, false>;
 	};
 	$ERROR_CODES: typeof ORGANIZATION_ERROR_CODES;
-	options: O;
+	options: NoInfer<O>;
 };
 export function organization<
 	O extends OrganizationOptions & {
@@ -391,7 +391,7 @@ export function organization<
 				} & InferOrganization<O, false>;
 	};
 	$ERROR_CODES: typeof ORGANIZATION_ERROR_CODES;
-	options: O;
+	options: NoInfer<O>;
 };
 export function organization<O extends OrganizationOptions>(
 	options?: O | undefined,
@@ -417,7 +417,7 @@ export function organization<O extends OrganizationOptions>(
 				} & InferOrganization<O, false>;
 	};
 	$ERROR_CODES: typeof ORGANIZATION_ERROR_CODES;
-	options: O;
+	options: NoInfer<O>;
 };
 export function organization<O extends OrganizationOptions>(
 	options?: O | undefined,


### PR DESCRIPTION
Fixes return type inference issue (in organization plugin) with TS 6.x — for future compatibility.

Ref: https://github.com/microsoft/typescript-go/issues/2162

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix return type inference in the organization plugin by wrapping the options generic with NoInfer, ensuring compatibility with upcoming TypeScript 6.x.

- **Bug Fixes**
  - Replaced options: O with options: NoInfer<O> across all overloads in organization.ts to stabilize inference.
  - Type-only change; no runtime impact.

<sup>Written for commit 060f687fbaf235869e8ae40ed95cc89b3aaa13e0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

