### PR TITLE
fix: array inserts breaking with neon pg + kysely

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -614,7 +614,7 @@ export const kyselyAdapter = (
 				config?.type === "postgres"
 					? true // even if there is JSON support, only pg supports passing direct json, all others must stringify
 					: false,
-			supportsArrays: false, // Even if field supports JSON, we must pass stringified arrays to the database.
+			supportsArrays: true, // Even if field supports JSON, we must pass stringified arrays to the database.
 			supportsUUIDs: config?.type === "postgres" ? true : false,
 			transaction: config?.transaction
 				? (cb) =>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes array insert errors with Neon Postgres + Kysely by enabling array support in the Kysely adapter. Arrays are now passed as JSON to prevent broken inserts.

<sup>Written for commit 5a08278451b291d0e0fa5b1e3b28c0cf898452ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

