### PR TITLE
chore: remove unused variables

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -50,7 +50,8 @@
         "noUselessTypeConstraint": "warn"
       },
       "correctness": {
-        "noUnusedImports": "warn"
+        "noUnusedImports": "warn",
+        "noUnusedVariables": "warn"
       },
       "nursery": {
         "noMisusedPromises": "error",

--- a/demo/expo/metro.config.js
+++ b/demo/expo/metro.config.js
@@ -1,6 +1,5 @@
 // Learn more: https://docs.expo.dev/guides/monorepos/
 const { getDefaultConfig } = require("expo/metro-config");
-const { FileStore } = require("metro-cache");
 const { withNativeWind } = require("nativewind/metro");
 const path = require("node:path");
 

--- a/demo/nextjs/app/(auth)/forget-password/page.tsx
+++ b/demo/nextjs/app/(auth)/forget-password/page.tsx
@@ -34,7 +34,7 @@ export default function Component() {
 				redirectTo: "/reset-password",
 			});
 			setIsSubmitted(true);
-		} catch (err) {
+		} catch {
 			setError("An error occurred. Please try again.");
 		} finally {
 			setIsSubmitting(false);

--- a/demo/nextjs/app/(auth)/two-factor/otp/page.tsx
+++ b/demo/nextjs/app/(auth)/two-factor/otp/page.tsx
@@ -26,7 +26,7 @@ export default function Component() {
 	const userEmail = "user@example.com";
 
 	const requestOTP = async () => {
-		const res = await client.twoFactor.sendOtp();
+		await client.twoFactor.sendOtp();
 		// In a real app, this would call your backend API to send the OTP
 		setMessage("OTP sent to your email");
 		setIsError(false);

--- a/demo/nextjs/app/admin/page.tsx
+++ b/demo/nextjs/app/admin/page.tsx
@@ -49,13 +49,6 @@ import {
 import { client } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
-type User = {
-	id: string;
-	email: string;
-	name: string;
-	role: "admin" | "user";
-};
-
 export default function AdminDashboard() {
 	const queryClient = useQueryClient();
 	const router = useRouter();

--- a/demo/nextjs/app/apps/register/page.tsx
+++ b/demo/nextjs/app/apps/register/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { AlertCircle, Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -22,7 +21,6 @@ export default function RegisterOAuthClient() {
 	const [redirectUri, setRedirectUri] = useState("");
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const router = useRouter();
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
@@ -34,7 +32,7 @@ export default function RegisterOAuthClient() {
 			setIsSubmitting(false);
 			return;
 		}
-		const res = await client.oauth2.register({
+		await client.oauth2.register({
 			client_name: name,
 			redirect_uris: [redirectUri],
 		});
@@ -101,13 +99,4 @@ export default function RegisterOAuthClient() {
 			</Card>
 		</div>
 	);
-}
-
-async function convertImageToBase64(file: File): Promise<string> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onloadend = () => resolve(reader.result as string);
-		reader.onerror = reject;
-		reader.readAsDataURL(file);
-	});
 }

--- a/demo/nextjs/app/dashboard/organization-card.tsx
+++ b/demo/nextjs/app/dashboard/organization-card.tsx
@@ -451,10 +451,8 @@ function InviteMemberDialog({
 	setOptimisticOrg: (org: ActiveOrganization | null) => void;
 	optimisticOrg: ActiveOrganization | null;
 }) {
-	const [open, setOpen] = useState(false);
 	const [email, setEmail] = useState("");
 	const [role, setRole] = useState("member");
-	const [loading, setLoading] = useState(false);
 	return (
 		<Dialog>
 			<DialogTrigger asChild>
@@ -491,7 +489,6 @@ function InviteMemberDialog({
 				<DialogFooter>
 					<DialogClose>
 						<Button
-							disabled={loading}
 							onClick={async () => {
 								const invite = organization.inviteMember({
 									email: email,

--- a/demo/nextjs/app/dashboard/user-card.tsx
+++ b/demo/nextjs/app/dashboard/user-card.tsx
@@ -67,7 +67,7 @@ export default function UserCard(props: {
 	subscription?: Subscription;
 }) {
 	const router = useRouter();
-	const { data, isPending } = useSession();
+	const { data } = useSession();
 	const session = data || props.session;
 	const [isTerminating, setIsTerminating] = useState<string>();
 	const [isPendingTwoFa, setIsPendingTwoFa] = useState<boolean>(false);
@@ -392,7 +392,7 @@ export default function UserCard(props: {
 												}
 												setIsPendingTwoFa(true);
 												if (session?.user.twoFactorEnabled) {
-													const res = await client.twoFactor.disable({
+													await client.twoFactor.disable({
 														password: twoFaPassword,
 														fetchOptions: {
 															onError(context) {
@@ -425,7 +425,7 @@ export default function UserCard(props: {
 														});
 														return;
 													}
-													const res = await client.twoFactor.enable({
+													await client.twoFactor.enable({
 														password: twoFaPassword,
 														fetchOptions: {
 															onError(context) {
@@ -640,7 +640,7 @@ function ChangePassword() {
 }
 
 function EditUserDialog() {
-	const { data, isPending, error } = useSession();
+	const { data } = useSession();
 	const [name, setName] = useState<string>();
 	const router = useRouter();
 	const [image, setImage] = useState<File | null>(null);
@@ -878,7 +878,7 @@ function ListPasskeys() {
 									<TableCell className="text-right">
 										<button
 											onClick={async () => {
-												const res = await client.passkey.deletePasskey({
+												await client.passkey.deletePasskey({
 													id: passkey.id,
 													fetchOptions: {
 														onRequest: () => {

--- a/demo/nextjs/app/oauth/authorize/page.tsx
+++ b/demo/nextjs/app/oauth/authorize/page.tsx
@@ -25,7 +25,7 @@ interface AuthorizePageProps {
 export default async function AuthorizePage({
 	searchParams,
 }: AuthorizePageProps) {
-	const { redirect_uri, scope, client_id, cancel_uri } = await searchParams;
+	const { scope, client_id } = await searchParams;
 	const session = await auth.api.getSession({
 		headers: await headers(),
 	});

--- a/demo/nextjs/tailwind.config.ts
+++ b/demo/nextjs/tailwind.config.ts
@@ -2,7 +2,6 @@ import type { Config } from "tailwindcss";
 
 const svgToDataUri = require("mini-svg-data-uri");
 
-const colors = require("tailwindcss/colors");
 const {
 	default: flattenColorPalette,
 } = require("tailwindcss/lib/util/flattenColorPalette");

--- a/demo/stateless/src/app/dashboard/page.tsx
+++ b/demo/stateless/src/app/dashboard/page.tsx
@@ -31,7 +31,7 @@ export default function Dashboard() {
 				const response = await fetch("/api/user");
 				const data = await response.json();
 				setServerData(data);
-			} catch (error) {
+			} catch {
 				setServerData("Failed to fetch server data");
 			}
 		});

--- a/docs/app/api/analytics/conversation/route.ts
+++ b/docs/app/api/analytics/conversation/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
 		});
 
 		return NextResponse.json(result);
-	} catch (error) {
+	} catch {
 		return NextResponse.json(
 			{ error: "Failed to log conversation" },
 			{ status: 500 },

--- a/docs/app/api/analytics/event/route.ts
+++ b/docs/app/api/analytics/event/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
 		});
 
 		return NextResponse.json(result);
-	} catch (error) {
+	} catch {
 		return NextResponse.json({ error: "Failed to log event" }, { status: 500 });
 	}
 }

--- a/docs/app/api/analytics/feedback/route.ts
+++ b/docs/app/api/analytics/feedback/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
 		});
 
 		return NextResponse.json(result);
-	} catch (error) {
+	} catch {
 		return NextResponse.json(
 			{ error: "Failed to submit feedback" },
 			{ status: 500 },

--- a/docs/app/api/chat/route.ts
+++ b/docs/app/api/chat/route.ts
@@ -77,7 +77,7 @@ export async function POST(req: Request) {
 						model: "inkeep-qa-sonnet-4",
 					},
 				});
-			} catch (error) {
+			} catch {
 				// Don't fail the request if analytics logging fails
 			}
 		},

--- a/docs/app/blog/_components/changelog-layout.tsx
+++ b/docs/app/blog/_components/changelog-layout.tsx
@@ -19,18 +19,6 @@ function GitHubIcon(props: React.ComponentPropsWithoutRef<"svg">) {
 	);
 }
 
-function FeedIcon(props: React.ComponentPropsWithoutRef<"svg">) {
-	return (
-		<svg viewBox="0 0 16 16" aria-hidden="true" fill="currentColor" {...props}>
-			<path
-				fillRule="evenodd"
-				clipRule="evenodd"
-				d="M2.5 3a.5.5 0 0 1 .5-.5h.5c5.523 0 10 4.477 10 10v.5a.5.5 0 0 1-.5.5h-.5a.5.5 0 0 1-.5-.5v-.5A8.5 8.5 0 0 0 3.5 4H3a.5.5 0 0 1-.5-.5V3Zm0 4.5A.5.5 0 0 1 3 7h.5A5.5 5.5 0 0 1 9 12.5v.5a.5.5 0 0 1-.5.5H8a.5.5 0 0 1-.5-.5v-.5a4 4 0 0 0-4-4H3a.5.5 0 0 1-.5-.5v-.5Zm0 5a1 1 0 1 1 2 0 1 1 0 0 1-2 0Z"
-			/>
-		</svg>
-	);
-}
-
 function XIcon(props: React.ComponentPropsWithoutRef<"svg">) {
 	return (
 		<svg viewBox="0 0 16 16" aria-hidden="true" fill="currentColor" {...props}>

--- a/docs/app/changelogs/[[...slug]]/page.tsx
+++ b/docs/app/changelogs/[[...slug]]/page.tsx
@@ -38,7 +38,6 @@ export default async function Page({
 		notFound();
 	}
 	const MDX = page.data?.body;
-	const toc = page.data?.toc;
 	const { title, description, date } = page.data;
 	return (
 		<div className="md:grid md:grid-cols-2 items-start">

--- a/docs/app/changelogs/_components/changelog-layout.tsx
+++ b/docs/app/changelogs/_components/changelog-layout.tsx
@@ -19,18 +19,6 @@ function GitHubIcon(props: React.ComponentPropsWithoutRef<"svg">) {
 	);
 }
 
-function FeedIcon(props: React.ComponentPropsWithoutRef<"svg">) {
-	return (
-		<svg viewBox="0 0 16 16" aria-hidden="true" fill="currentColor" {...props}>
-			<path
-				fillRule="evenodd"
-				clipRule="evenodd"
-				d="M2.5 3a.5.5 0 0 1 .5-.5h.5c5.523 0 10 4.477 10 10v.5a.5.5 0 0 1-.5.5h-.5a.5.5 0 0 1-.5-.5v-.5A8.5 8.5 0 0 0 3.5 4H3a.5.5 0 0 1-.5-.5V3Zm0 4.5A.5.5 0 0 1 3 7h.5A5.5 5.5 0 0 1 9 12.5v.5a.5.5 0 0 1-.5.5H8a.5.5 0 0 1-.5-.5v-.5a4 4 0 0 0-4-4H3a.5.5 0 0 1-.5-.5v-.5Zm0 5a1 1 0 1 1 2 0 1 1 0 0 1-2 0Z"
-			/>
-		</svg>
-	);
-}
-
 function XIcon(props: React.ComponentPropsWithoutRef<"svg">) {
 	return (
 		<svg viewBox="0 0 16 16" aria-hidden="true" fill="currentColor" {...props}>

--- a/docs/app/enterprise/_components/enterprise-form.tsx
+++ b/docs/app/enterprise/_components/enterprise-form.tsx
@@ -43,7 +43,7 @@ export function EnterpriseForm() {
 			} else {
 				setSubmitStatus("error");
 			}
-		} catch (error) {
+		} catch {
 			setSubmitStatus("error");
 		} finally {
 			setIsSubmitting(false);

--- a/docs/components/builder/sign-up.tsx
+++ b/docs/components/builder/sign-up.tsx
@@ -3,7 +3,6 @@
 import { useAtom } from "jotai";
 import { Loader2, X } from "lucide-react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { optionsAtom } from "@/components/builder/store";
 import { Button } from "@/components/ui/button";
@@ -24,10 +23,9 @@ export function SignUp() {
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const [passwordConfirmation, setPasswordConfirmation] = useState("");
-	const [image, setImage] = useState<File | null>(null);
+	const [_image, setImage] = useState<File | null>(null);
 	const [imagePreview, setImagePreview] = useState<string | null>(null);
 	const [options] = useAtom(optionsAtom);
-	const router = useRouter();
 
 	const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const file = e.target.files?.[0];
@@ -40,7 +38,7 @@ export function SignUp() {
 			reader.readAsDataURL(file);
 		}
 	};
-	const [loading, setLoading] = useState(false);
+	const [loading] = useState(false);
 
 	return (
 		<Card className="z-50 rounded-md rounded-t-none max-w-md">
@@ -171,15 +169,6 @@ export function SignUp() {
 			)}
 		</Card>
 	);
-}
-
-async function convertImageToBase64(file: File): Promise<string> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onloadend = () => resolve(reader.result as string);
-		reader.onerror = reject;
-		reader.readAsDataURL(file);
-	});
 }
 
 export const signUpString = (options: any) => `"use client";

--- a/docs/components/endpoint.tsx
+++ b/docs/components/endpoint.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useState } from "react";
 import { cn } from "@/lib/utils";
 
 function Method({ method }: { method: "POST" | "GET" | "DELETE" | "PUT" }) {
@@ -21,7 +20,6 @@ export function Endpoint({
 	isServerOnly?: boolean;
 	className?: string;
 }) {
-	const [copying, setCopying] = useState(false);
 	return (
 		<div
 			className={cn(

--- a/docs/components/floating-ai-search.tsx
+++ b/docs/components/floating-ai-search.tsx
@@ -96,7 +96,7 @@ function SearchAIInput(props: ComponentProps<"form"> & { isMobile?: boolean }) {
 		if (isLoading) document.getElementById("nd-ai-input")?.focus();
 	}, [isLoading]);
 
-	const { isMobile, ...formProps } = props;
+	const { isMobile: _isMobile, ...formProps } = props;
 
 	return (
 		<div
@@ -305,7 +305,7 @@ function List(
 		return () => container.removeEventListener("scroll", handleScroll);
 	}, []);
 
-	const { messageCount, ...divProps } = props;
+	const { messageCount: _messageCount, ...divProps } = props;
 
 	return (
 		<div
@@ -504,9 +504,6 @@ export function AISearchTrigger() {
 			api: "/api/chat",
 		}),
 	});
-
-	const showSuggestions =
-		chat.messages.length === 0 && chat.status !== "streaming";
 
 	const onKeyPress = (e: KeyboardEvent) => {
 		if (e.key === "Escape" && open) {

--- a/docs/components/message-feedback.tsx
+++ b/docs/components/message-feedback.tsx
@@ -56,7 +56,7 @@ export function MessageFeedback({
 			setTimeout(() => {
 				setShowSuccessCheckmark(null);
 			}, 1000);
-		} catch (error) {
+		} catch {
 		} finally {
 			setIsSubmittingFeedback(false);
 		}
@@ -74,7 +74,7 @@ export function MessageFeedback({
 			await logEventToInkeep("message:copied", "message", eventMessageId);
 
 			setTimeout(() => setCopied(false), 2000);
-		} catch (error) {
+		} catch {
 			// Silently handle error
 		}
 	};

--- a/docs/components/search-dialog.tsx
+++ b/docs/components/search-dialog.tsx
@@ -15,8 +15,6 @@ import {
 	SearchDialogOverlay,
 } from "fumadocs-ui/components/dialog/search";
 import { useI18n } from "fumadocs-ui/contexts/i18n";
-import { useAtom } from "jotai";
-import { aiChatModalAtom } from "./ai-chat-modal";
 
 const client = new OramaClient({
 	endpoint: process.env.NEXT_PUBLIC_ORAMA_ENDPOINT!,
@@ -25,22 +23,11 @@ const client = new OramaClient({
 
 export function CustomSearchDialog(props: SharedProps) {
 	const { locale } = useI18n();
-	const [isAIModalOpen, setIsAIModalOpen] = useAtom(aiChatModalAtom);
-
 	const { search, setSearch, query } = useDocsSearch({
 		type: "orama-cloud",
 		client,
 		locale,
 	});
-
-	const handleAskAIClick = () => {
-		props.onOpenChange?.(false);
-		setIsAIModalOpen(true);
-	};
-
-	const handleAIModalClose = () => {
-		setIsAIModalOpen(false);
-	};
 
 	return (
 		<>

--- a/docs/components/ui/code-block.tsx
+++ b/docs/components/ui/code-block.tsx
@@ -235,8 +235,6 @@ export function CodeBlockTabs({ ref, ...props }: ComponentProps<typeof Tabs>) {
 	);
 }
 export function CodeBlockTabsList(props: ComponentProps<typeof TabsList>) {
-	const { containerRef, nested } = useContext(TabsContext)!;
-
 	return (
 		<TabsList
 			{...props}

--- a/docs/lib/blog.ts
+++ b/docs/lib/blog.ts
@@ -39,7 +39,7 @@ export const getBlogPost = cache(
 				author: data.author,
 				tags: data.tags,
 			};
-		} catch (error) {
+		} catch {
 			return null;
 		}
 	},
@@ -61,7 +61,7 @@ export const getAllBlogPosts = cache(async (): Promise<BlogPost[]> => {
 		return posts
 			.filter((post): post is BlogPost => post !== null)
 			.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-	} catch (error) {
+	} catch {
 		return [];
 	}
 });

--- a/docs/lib/inkeep-analytics.ts
+++ b/docs/lib/inkeep-analytics.ts
@@ -98,7 +98,7 @@ export async function logConversationToInkeep(messages: InkeepMessage[]) {
 		}
 
 		return data;
-	} catch (error) {
+	} catch {
 		return null;
 	}
 }
@@ -152,7 +152,7 @@ export async function logEventToInkeep(
 		}
 
 		return data;
-	} catch (error) {
+	} catch {
 		return null;
 	}
 }

--- a/packages/better-auth/src/adapters/create-test-suite.ts
+++ b/packages/better-auth/src/adapters/create-test-suite.ts
@@ -364,7 +364,7 @@ export const createTestSuite = <
 								model,
 								where: [{ field: "id", value: row.id }],
 							});
-						} catch (error) {
+						} catch {
 							// We ignore any failed attempts to delete the created rows.
 						}
 						if (createdRows[model]!.length === 1) {

--- a/packages/better-auth/src/adapters/drizzle-adapter/test/generate-schema.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/test/generate-schema.ts
@@ -37,7 +37,7 @@ export const generateDrizzleSchema = async (
 			if (resolvedPath && typeof resolvedPath === "string" && require?.cache) {
 				delete require.cache[resolvedPath];
 			}
-		} catch (error) {}
+		} catch {}
 		return await import(x);
 	};
 

--- a/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.pg.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.pg.test.ts
@@ -45,7 +45,7 @@ const { execute } = await testAdapter({
 		const opts = Object.assign(betterAuthOptions, {
 			database: pgDB,
 		} satisfies BetterAuthOptions);
-		const { runMigrations, compileMigrations } = await getMigrations(opts);
+		const { runMigrations } = await getMigrations(opts);
 		await runMigrations();
 	},
 	tests: [

--- a/packages/better-auth/src/adapters/kysely-adapter/test/node-sqlite-dialect.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/node-sqlite-dialect.test.ts
@@ -136,7 +136,7 @@ describe.runIf(nodeSqliteSupported)("node-sqlite-dialect", async () => {
 					// Force an error
 					throw new Error("Test error");
 				});
-			} catch (error) {
+			} catch {
 				// Expected error
 			}
 

--- a/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/adapter.mongo-db.test.ts
@@ -15,10 +15,7 @@ const dbClient = async (connectionString: string, dbName: string) => {
 	return { db, client };
 };
 
-const { db, client } = await dbClient(
-	"mongodb://127.0.0.1:27017",
-	"better-auth",
-);
+const { db } = await dbClient("mongodb://127.0.0.1:27017", "better-auth");
 
 const { execute } = await testAdapter({
 	adapter: (options) => {

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -99,7 +99,7 @@ export const mongodbAdapter = (
 								if (typeof v === "string") {
 									try {
 										return new ObjectId(v);
-									} catch (e) {
+									} catch {
 										return v;
 									}
 								}
@@ -117,7 +117,7 @@ export const mongodbAdapter = (
 					}
 					try {
 						return new ObjectId(value);
-					} catch (e) {
+					} catch {
 						return value;
 					}
 				}
@@ -613,7 +613,7 @@ export const mongodbAdapter = (
 								try {
 									const oid = new ObjectId(v);
 									return oid;
-								} catch (error) {
+								} catch {
 									return v;
 								}
 							}
@@ -624,7 +624,7 @@ export const mongodbAdapter = (
 						try {
 							const oid = new ObjectId(data);
 							return oid;
-						} catch (error) {
+						} catch {
 							return data;
 						}
 					}

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -300,7 +300,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 					// transform join keys to use Prisma expected field names
 					let map = new Map<string, string>();
 					if (join) {
-						for (const [joinModel, value] of Object.entries(join)) {
+						for (const [joinModel, _value] of Object.entries(join)) {
 							const key = getJoinKeyName(model, joinModel, schema);
 							map.set(key, getModelName(joinModel));
 						}

--- a/packages/better-auth/src/adapters/tests/basic.ts
+++ b/packages/better-auth/src/adapters/tests/basic.ts
@@ -331,9 +331,7 @@ export const getNormalTestSuiteTests = (
 			const users: User[] = [];
 			const sessions: Session[] = [];
 			const accounts: Account[] = [];
-			let i = -1;
 			for (const _ of Array.from({ length: 3 })) {
-				i++;
 				const user = await adapter.create<User>({
 					model: "user",
 					data: {
@@ -2401,7 +2399,7 @@ export const getNormalTestSuiteTests = (
 				});
 
 				// Add a member to the organization
-				const member = await adapter.create<Member>({
+				await adapter.create<Member>({
 					model: "member",
 					data: {
 						organizationId: organizationData.id,
@@ -2413,7 +2411,7 @@ export const getNormalTestSuiteTests = (
 				});
 
 				// Create a team for the organization
-				const team = await adapter.create<Team>({
+				await adapter.create<Team>({
 					model: "team",
 					data: {
 						name: "Test Team",

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -328,7 +328,7 @@ export const linkSocialAccount = createAuthEndpoint(
 					refreshToken: c.body.idToken.refreshToken,
 					scope: c.body.idToken.scopes?.join(","),
 				});
-			} catch (e: any) {
+			} catch {
 				throw new APIError("EXPECTATION_FAILED", {
 					message: "Account not linked - unable to create account",
 				});

--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -93,7 +93,7 @@ describe("Email Verification", async () => {
 
 		let sessionToken = "";
 		let verifyHeaders = new Headers();
-		const res = await client.verifyEmail({
+		await client.verifyEmail({
 			query: {
 				token,
 			},
@@ -273,7 +273,7 @@ describe("Email Verification", async () => {
 describe("Email Verification Secondary Storage", async () => {
 	let store = new Map<string, string>();
 	let token: string;
-	const { client, signInWithTestUser, db, auth, testUser, cookieSetter } =
+	const { client, signInWithTestUser, auth, testUser, cookieSetter } =
 		await getTestInstance({
 			secondaryStorage: {
 				set(key, value, ttl) {

--- a/packages/better-auth/src/api/routes/reset-password.test.ts
+++ b/packages/better-auth/src/api/routes/reset-password.test.ts
@@ -201,7 +201,7 @@ describe("forget password", async (it) => {
 		});
 		vi.useFakeTimers();
 		await vi.advanceTimersByTimeAsync(1000 * 9);
-		const callbackRes = await client.$fetch("/reset-password/:token", {
+		await client.$fetch("/reset-password/:token", {
 			params: {
 				token,
 			},

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -142,7 +142,7 @@ describe("session", async () => {
 
 	it("should handle 'don't remember me' option", async () => {
 		let headers = new Headers();
-		const res = await client.signIn.email(
+		await client.signIn.email(
 			{
 				email: testUser.email,
 				password: testUser.password,
@@ -221,7 +221,7 @@ describe("session", async () => {
 
 	it("should clear session on sign out", async () => {
 		let headers = new Headers();
-		const res = await client.signIn.email(
+		await client.signIn.email(
 			{
 				email: testUser.email,
 				password: testUser.password,
@@ -275,7 +275,7 @@ describe("session", async () => {
 	it("should revoke session", async () => {
 		const headers = new Headers();
 		const headers2 = new Headers();
-		const res = await client.signIn.email({
+		await client.signIn.email({
 			email: testUser.email,
 			password: testUser.password,
 			fetchOptions: {
@@ -373,7 +373,7 @@ describe("session", async () => {
 
 describe("session storage", async () => {
 	let store = new Map<string, string>();
-	const { client, signInWithTestUser, db } = await getTestInstance({
+	const { client, signInWithTestUser } = await getTestInstance({
 		secondaryStorage: {
 			set(key, value, ttl) {
 				store.set(key, value);
@@ -454,7 +454,7 @@ describe("session storage", async () => {
 		await runWithUser(async () => {
 			const session = await client.getSession();
 			expect(session.data).not.toBeNull();
-			const res = await client.revokeSession({
+			await client.revokeSession({
 				token: session.data?.session?.token || "",
 			});
 			const revokedSession = await client.getSession();
@@ -1121,7 +1121,6 @@ describe("cookie cache versioning", async () => {
 			client: client1,
 			testUser: testUser1,
 			cookieSetter: cookieSetter1,
-			auth: auth1,
 		} = await getTestInstance({
 			session: {
 				cookieCache: {
@@ -1153,16 +1152,15 @@ describe("cookie cache versioning", async () => {
 		expect(session1.data?.user.email).toBe(testUser1.email);
 
 		// Create new instance with version "2" using same cookies
-		const { client: client2, cookieSetter: cookieSetter2 } =
-			await getTestInstance({
-				session: {
-					cookieCache: {
-						enabled: true,
-						strategy: "jwe",
-						version: "2",
-					},
+		const { client: client2 } = await getTestInstance({
+			session: {
+				cookieCache: {
+					enabled: true,
+					strategy: "jwe",
+					version: "2",
 				},
-			});
+			},
+		});
 
 		// Try to get session with old cookies but new version - should invalidate cache
 		const session2 = await client2.getSession({

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -183,7 +183,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					email,
 					password,
 					image,
-					callbackURL,
+					callbackURL: _callbackURL,
 					rememberMe,
 					...rest
 				} = body;

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -7,28 +7,27 @@ import type { Account, Session } from "../../types";
 describe("updateUser", async () => {
 	const sendChangeEmail = vi.fn();
 	let emailVerificationToken = "";
-	const {
-		client,
-		testUser,
-		sessionSetter,
-		db,
-		customFetchImpl,
-		signInWithTestUser,
-	} = await getTestInstance({
-		emailVerification: {
-			async sendVerificationEmail({ user, url, token }) {
-				emailVerificationToken = token;
-			},
-		},
-		user: {
-			changeEmail: {
-				enabled: true,
-				sendChangeEmailVerification: async ({ user, newEmail, url, token }) => {
-					sendChangeEmail(user, newEmail, url, token);
+	const { client, testUser, sessionSetter, db, signInWithTestUser } =
+		await getTestInstance({
+			emailVerification: {
+				async sendVerificationEmail({ user, url, token }) {
+					emailVerificationToken = token;
 				},
 			},
-		},
-	});
+			user: {
+				changeEmail: {
+					enabled: true,
+					sendChangeEmailVerification: async ({
+						user,
+						newEmail,
+						url,
+						token,
+					}) => {
+						sendChangeEmail(user, newEmail, url, token);
+					},
+				},
+			},
+		});
 	// Sign in once for all tests in this describe block
 	const { runWithUser: globalRunWithClient } = await signInWithTestUser();
 
@@ -46,7 +45,7 @@ describe("updateUser", async () => {
 
 	it("should unset image", async () => {
 		await globalRunWithClient(async () => {
-			const updated = await client.updateUser({
+			await client.updateUser({
 				image: null,
 			});
 			const sessionRes = await client.getSession();
@@ -71,7 +70,7 @@ describe("updateUser", async () => {
 
 		const newEmail = "new-email@email.com";
 		await globalRunWithClient(async () => {
-			const res = await client.changeEmail({
+			await client.changeEmail({
 				newEmail,
 			});
 			const sessionRes = await client.getSession();
@@ -306,7 +305,7 @@ describe("updateUser", async () => {
 		});
 		expect(res?.newField).toBe("new");
 
-		const updated = await client.updateUser({
+		await client.updateUser({
 			name: "newName",
 			fetchOptions: {
 				headers,

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -423,7 +423,7 @@ describe("after hook", async () => {
 
 describe("disabled paths", async () => {
 	it("should return 404 for disabled paths", async () => {
-		const { client, auth } = await getTestInstance({
+		const { client } = await getTestInstance({
 			disabledPaths: ["/sign-in/email"],
 		});
 

--- a/packages/better-auth/src/auth/auth.test.ts
+++ b/packages/better-auth/src/auth/auth.test.ts
@@ -71,7 +71,7 @@ describe("auth type", () => {
 describe("auth with trusted proxy headers", () => {
 	test("shouldn't infer base url from proxy headers if trusted", async () => {
 		let baseURL: string | undefined;
-		const { auth, customFetchImpl } = await getTestInstance({
+		const { customFetchImpl } = await getTestInstance({
 			baseURL: undefined,
 			advanced: {
 				trustedProxyHeaders: true,
@@ -88,7 +88,7 @@ describe("auth with trusted proxy headers", () => {
 			},
 			baseURL: "http://localhost:3000",
 		});
-		const res = await client.$fetch("/ok", {
+		await client.$fetch("/ok", {
 			headers: {
 				"x-forwarded-host": "localhost:3001",
 				"x-forwarded-proto": "http",
@@ -115,7 +115,7 @@ describe("auth with trusted proxy headers", () => {
 			},
 			baseURL: "http://localhost:3000",
 		});
-		const res = await client.$fetch("/ok", {
+		await client.$fetch("/ok", {
 			headers: {
 				"x-forwarded-host": "localhost:3001",
 				"x-forwarded-proto": "http",

--- a/packages/better-auth/src/call.test.ts
+++ b/packages/better-auth/src/call.test.ts
@@ -179,7 +179,6 @@ describe("call", async () => {
 			],
 		},
 	} satisfies BetterAuthPlugin;
-	let latestOauthStore: Record<string, any> | undefined = {};
 	const options = {
 		baseURL: "http://localhost:3000",
 		plugins: [testPlugin, testPlugin2, bearer()],

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -32,8 +32,13 @@ export const getClientConfig = (
 			onResponse: options?.fetchOptions?.onResponse,
 		},
 	};
-	const { onSuccess, onError, onRequest, onResponse, ...restOfFetchOptions } =
-		options?.fetchOptions || {};
+	const {
+		onSuccess: _onSuccess,
+		onError: _onError,
+		onRequest: _onRequest,
+		onResponse: _onResponse,
+		...restOfFetchOptions
+	} = options?.fetchOptions || {};
 	const $fetch = createFetch({
 		baseURL,
 		...(isCredentialsSupported ? { credentials: "include" } : {}),

--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -18,7 +18,7 @@ function getMethod(
 		| undefined,
 ) {
 	const method = knownPathMethods[path];
-	const { fetchOptions, query, ...body } = args || {};
+	const { fetchOptions, query: _query, ...body } = args || {};
 	if (method) {
 		return method;
 	}

--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -93,7 +93,7 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 			statusText: string;
 		}>;
 	}>;
-	function useSession<UseFetch extends <T>(...args: any) => any>(
+	function useSession<UseFetch extends <_T>(...args: any) => any>(
 		useFetch?: UseFetch | undefined,
 	) {
 		if (useFetch) {

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -45,7 +45,7 @@ describe("cookies", async () => {
 		const { client, testUser } = await getTestInstance({
 			advanced: { useSecureCookies: true },
 		});
-		const res = await client.signIn.email(
+		await client.signIn.email(
 			{
 				email: testUser.email,
 				password: testUser.password,
@@ -166,7 +166,7 @@ describe("cookie-utils parseSetCookieHeader", () => {
 
 describe("getSessionCookie", async () => {
 	it("should return the correct session cookie", async () => {
-		const { client, testUser, signInWithTestUser } = await getTestInstance();
+		const { signInWithTestUser } = await getTestInstance();
 		const { headers } = await signInWithTestUser();
 		const request = new Request("http://localhost:3000/api/auth/session", {
 			headers,
@@ -325,7 +325,7 @@ describe("getSessionCookie", async () => {
 	});
 
 	it("should return null if the cookie is invalid", async () => {
-		const { client, testUser, cookieSetter } = await getTestInstance({
+		const { client, testUser } = await getTestInstance({
 			session: {
 				cookieCache: {
 					enabled: true,
@@ -371,7 +371,7 @@ describe("getSessionCookie", async () => {
 	});
 
 	it("should chunk large cookies instead of logging error", async () => {
-		const { client, testUser } = await getTestInstance({
+		const { client } = await getTestInstance({
 			secret: "better-auth.secret",
 			user: {
 				additionalFields: {
@@ -789,16 +789,6 @@ describe("Cookie Cache Field Filtering", () => {
 	});
 
 	it("should return null for invalid JWT token", async () => {
-		const { cookieSetter } = await getTestInstance({
-			secret: "better-auth.secret",
-			session: {
-				cookieCache: {
-					enabled: true,
-					strategy: "jwt",
-				},
-			},
-		});
-
 		const headers = new Headers();
 		// Set an invalid JWT token manually
 		headers.set("cookie", "better-auth.session_data=invalid.jwt.token");
@@ -856,7 +846,7 @@ describe("Cookie Chunking", () => {
 		// Create a large string that will exceed the cookie size limit
 		const largeString = "x".repeat(2000);
 
-		const { client, cookieSetter } = await getTestInstance({
+		const { client } = await getTestInstance({
 			secret: "better-auth.secret",
 			user: {
 				additionalFields: {
@@ -1052,7 +1042,7 @@ describe("Cookie Chunking", () => {
 	});
 
 	it("should NOT chunk cookies when they are under 4KB", async () => {
-		const { client, testUser, cookieSetter } = await getTestInstance({
+		const { client, testUser } = await getTestInstance({
 			secret: "better-auth.secret",
 			session: {
 				cookieCache: {

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -20,7 +20,6 @@ import {
 import { parseUserOutput } from "../db/schema";
 import type { Session, User } from "../types";
 import { getDate } from "../utils/date";
-import { getBaseURL } from "../utils/url";
 import { createAccountStore, createSessionStore } from "./session-store";
 
 export function createCookieGetter(options: BetterAuthOptions) {
@@ -379,8 +378,6 @@ export const getSessionCookie = (
 		}
 	}
 	const headers = "headers" in request ? request.headers : request;
-	const req = request instanceof Request ? request : undefined;
-	const url = getBaseURL(req?.url, config?.path, req);
 	const cookies = headers.get("cookie");
 	if (!cookies) {
 		return null;

--- a/packages/better-auth/src/crypto/jwt.ts
+++ b/packages/better-auth/src/crypto/jwt.ts
@@ -30,7 +30,7 @@ export async function verifyJWT<T = any>(
 	try {
 		const verified = await jwtVerify(token, new TextEncoder().encode(secret));
 		return verified.payload as T;
-	} catch (error) {
+	} catch {
 		return null;
 	}
 }
@@ -108,7 +108,7 @@ export async function symmetricDecodeJWT<T = any>(
 			},
 		);
 		return payload as T;
-	} catch (error) {
+	} catch {
 		return null;
 	}
 }

--- a/packages/better-auth/src/db/db.test.ts
+++ b/packages/better-auth/src/db/db.test.ts
@@ -37,7 +37,7 @@ describe("db", async () => {
 
 	it("db hooks", async () => {
 		let callback = false;
-		const { client, db } = await getTestInstance({
+		const { client } = await getTestInstance({
 			databaseHooks: {
 				user: {
 					create: {
@@ -223,7 +223,7 @@ describe("db", async () => {
 					throw: true,
 				},
 			});
-		} catch (error) {
+		} catch {
 			// Expected to fail due to hook returning false
 		}
 

--- a/packages/better-auth/src/db/get-migration-schema.test.ts
+++ b/packages/better-auth/src/db/get-migration-schema.test.ts
@@ -217,7 +217,7 @@ describe.runIf(isPostgresAvailable)(
 			};
 			const { runMigrations, compileMigrations } = await getMigrations(config);
 			await runMigrations();
-			const migrations = await compileMigrations();
+			await compileMigrations();
 			const auth = betterAuth(config);
 
 			const user = await auth.api.signUpEmail({

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -112,7 +112,7 @@ async function getPostgresSchema(db: Kysely<unknown>): Promise<string> {
 				.filter((s) => !s.startsWith("$"));
 			return schemas[0] || "public";
 		}
-	} catch (error) {
+	} catch {
 		// If query fails, fall back to public schema
 	}
 	return "public";

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -115,9 +115,6 @@ describe("internal adapter test", async () => {
 		map.clear();
 	});
 	const authContext = await init(opts);
-	const ctx = {
-		context: authContext,
-	} as GenericEndpointContext;
 	const internalAdapter = authContext.internalAdapter;
 
 	it("should create oauth user with custom generate id", async () => {

--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -122,7 +122,7 @@ export function getWithHooks(
 		return updated;
 	}
 
-	async function updateManyWithHooks<T extends Record<string, any>>(
+	async function updateManyWithHooks<_T extends Record<string, any>>(
 		data: any,
 		where: Where[],
 		model: BaseModelNames,
@@ -198,7 +198,7 @@ export function getWithHooks(
 				limit: 1,
 			});
 			entityToDelete = entities[0] || null;
-		} catch (error) {
+		} catch {
 			// If we can't find the entity, we'll still proceed with deletion
 		}
 
@@ -258,7 +258,7 @@ export function getWithHooks(
 				model,
 				where,
 			});
-		} catch (error) {
+		} catch {
 			// If we can't find the entities, we'll still proceed with deletion
 		}
 

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -71,7 +71,7 @@ export const nextCookies = () => {
 								} as const;
 								try {
 									cookieHelper.set(key, decodeURIComponent(value.value), opts);
-								} catch (e) {
+								} catch {
 									// this will fail if the cookie is being set on server component
 								}
 							});

--- a/packages/better-auth/src/integrations/svelte-kit.ts
+++ b/packages/better-auth/src/integrations/svelte-kit.ts
@@ -85,7 +85,7 @@ export const sveltekitCookies = (
 										domain: ops.domain,
 										maxAge: ops["max-age"],
 									});
-								} catch (e) {
+								} catch {
 									// this will avoid any issue related to already streamed response
 								}
 							}

--- a/packages/better-auth/src/integrations/tanstack-start.ts
+++ b/packages/better-auth/src/integrations/tanstack-start.ts
@@ -35,7 +35,7 @@ export const tanstackStartCookies = () => {
 								} as const;
 								try {
 									setCookie(key, decodeURIComponent(value.value), opts);
-								} catch (e) {
+								} catch {
 									// this will fail if the cookie is being set on server component
 								}
 							});

--- a/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
+++ b/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
@@ -112,7 +112,7 @@ describe("additionalFields", async () => {
 				onSuccess: sessionSetter(headers),
 			},
 		);
-		const res = await client.updateUser({
+		await client.updateUser({
 			name: "test",
 			newField: "updated-field",
 			fetchOptions: {
@@ -160,7 +160,7 @@ describe("additionalFields", async () => {
 				onSuccess: sessionSetter(headers),
 			},
 		);
-		const res = await client.updateUser(
+		await client.updateUser(
 			{
 				name: "test",
 				newField: "updated-field",
@@ -256,7 +256,7 @@ describe("additionalFields", async () => {
 	});
 	it("should apply default values with secondary storage", async () => {
 		const store = new Map<string, string>();
-		const { client, auth, signInWithTestUser } = await getTestInstance({
+		const { auth, signInWithTestUser } = await getTestInstance({
 			secondaryStorage: {
 				set(key, value) {
 					store.set(key, value);

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -326,7 +326,7 @@ describe("Admin plugin", async () => {
 	});
 
 	it("should allow to filter users by role", async () => {
-		const res = await client.admin.listUsers({
+		await client.admin.listUsers({
 			query: {
 				filterValue: "admin",
 				filterField: "role",
@@ -958,46 +958,41 @@ describe("access control", async (it) => {
 		order: ["read"],
 	});
 
-	const {
-		signInWithTestUser,
-		signInWithUser,
-		cookieSetter,
-		auth,
-		customFetchImpl,
-	} = await getTestInstance(
-		{
-			plugins: [
-				admin({
-					ac,
-					roles: {
-						admin: adminAc,
-						user: userAc,
-					},
-				}),
-			],
-			databaseHooks: {
-				user: {
-					create: {
-						before: async (user) => {
-							if (user.name === "Admin") {
-								return {
-									data: {
-										...user,
-										role: "admin",
-									},
-								};
-							}
+	const { signInWithTestUser, cookieSetter, auth, customFetchImpl } =
+		await getTestInstance(
+			{
+				plugins: [
+					admin({
+						ac,
+						roles: {
+							admin: adminAc,
+							user: userAc,
+						},
+					}),
+				],
+				databaseHooks: {
+					user: {
+						create: {
+							before: async (user) => {
+								if (user.name === "Admin") {
+									return {
+										data: {
+											...user,
+											role: "admin",
+										},
+									};
+								}
+							},
 						},
 					},
 				},
 			},
-		},
-		{
-			testUser: {
-				name: "Admin",
+			{
+				testUser: {
+					name: "Admin",
+				},
 			},
-		},
-	);
+		);
 
 	const client = createAuthClient({
 		plugins: [

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -638,7 +638,7 @@ export const listUsers = (opts: AdminOptions) =>
 					limit: Number(ctx.query?.limit) || undefined,
 					offset: Number(ctx.query?.offset) || undefined,
 				});
-			} catch (e) {
+			} catch {
 				return ctx.json({
 					users: [],
 					total: 0,

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -113,7 +113,7 @@ describe("anonymous", async () => {
 
 	it("link anonymous user account", async () => {
 		expect(linkAccountFn).toHaveBeenCalledTimes(0);
-		const res = await client.signIn.email(testUser, {
+		await client.signIn.email(testUser, {
 			headers,
 		});
 		expect(linkAccountFn).toHaveBeenCalledWith(expect.any(Object));

--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -427,7 +427,7 @@ describe("api-key", async () => {
 	});
 
 	it("should fail to create a key with a custom expiresIn value when customExpiresTime is disabled", async () => {
-		const { client, auth, signInWithTestUser } = await getTestInstance(
+		const { auth, signInWithTestUser } = await getTestInstance(
 			{
 				plugins: [
 					apiKey({
@@ -445,7 +445,7 @@ describe("api-key", async () => {
 			},
 		);
 
-		const { headers, user } = await signInWithTestUser();
+		const { headers } = await signInWithTestUser();
 		let result: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
@@ -758,7 +758,7 @@ describe("api-key", async () => {
 	});
 
 	it("create API key with with metadata when metadata is disabled (should fail)", async () => {
-		const { client, auth, signInWithTestUser } = await getTestInstance(
+		const { auth, signInWithTestUser } = await getTestInstance(
 			{
 				plugins: [
 					apiKey({
@@ -811,7 +811,7 @@ describe("api-key", async () => {
 	});
 
 	it("should have the start property as null if shouldStore is false", async () => {
-		const { client, auth, signInWithTestUser } = await getTestInstance(
+		const { client, signInWithTestUser } = await getTestInstance(
 			{
 				plugins: [
 					apiKey({
@@ -839,7 +839,7 @@ describe("api-key", async () => {
 
 	it("should use the defined charactersLength if provided", async () => {
 		const customLength = 3;
-		const { client, auth, signInWithTestUser } = await getTestInstance(
+		const { client, signInWithTestUser } = await getTestInstance(
 			{
 				plugins: [
 					apiKey({
@@ -2300,7 +2300,7 @@ describe("api-key", async () => {
 		});
 
 		it("should list API keys from secondary storage", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 
 			// Create multiple API keys
 			const { data: key1 } = await client.apiKey.create(
@@ -2323,7 +2323,7 @@ describe("api-key", async () => {
 		});
 
 		it("should update API key in secondary storage", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{ name: "Original Name" },
 				{ headers: headers },
@@ -2372,7 +2372,7 @@ describe("api-key", async () => {
 		});
 
 		it("should verify API key from secondary storage", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{},
 				{ headers: headers },
@@ -2392,7 +2392,7 @@ describe("api-key", async () => {
 		});
 
 		it("should set TTL when API key has expiration", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const expiresIn = 60 * 60 * 24; // 1 day in seconds
 
 			const { data: createdKey } = await client.apiKey.create(
@@ -2413,7 +2413,7 @@ describe("api-key", async () => {
 		});
 
 		it("should handle metadata in secondary storage", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const metadata = { plan: "premium", environment: "production" };
 
 			const { data: createdKey } = await client.apiKey.create(
@@ -2433,7 +2433,7 @@ describe("api-key", async () => {
 		});
 
 		it("should handle rate limiting with secondary storage", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { user } = await signInWithTestUser();
 			const createdKey = await auth.api.createApiKey({
 				body: {
 					rateLimitEnabled: true,
@@ -2471,7 +2471,7 @@ describe("api-key", async () => {
 		});
 
 		it("should handle remaining count with secondary storage", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { user } = await signInWithTestUser();
 			const remaining = 5;
 
 			const createdKey = await auth.api.createApiKey({
@@ -2503,7 +2503,7 @@ describe("api-key", async () => {
 
 		it("should handle expired keys with TTL in secondary storage", async () => {
 			vi.useFakeTimers();
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			// Use 1 day in seconds (minimum allowed) + 1 second for testing expiration
 			const expiresIn = 60 * 60 * 24 + 1; // 86401 seconds = 1 day + 1 second
 
@@ -2531,7 +2531,7 @@ describe("api-key", async () => {
 		});
 
 		it("should maintain user's API key list in secondary storage", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 
 			// Create multiple API keys for the same user
 			const { data: key1 } = await client.apiKey.create(
@@ -2610,7 +2610,7 @@ describe("api-key", async () => {
 		});
 
 		it("should read from secondary storage first", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{},
 				{ headers: headers },
@@ -2766,7 +2766,7 @@ describe("api-key", async () => {
 		});
 
 		it("should write to secondary storage only", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{ name: "Test Key" },
 				{ headers: headers },
@@ -2777,7 +2777,7 @@ describe("api-key", async () => {
 		});
 
 		it("should create in both database and secondary storage when fallbackToDatabase is true", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{ name: "Fallback Test Key" },
 				{ headers: headers },
@@ -2799,7 +2799,7 @@ describe("api-key", async () => {
 		});
 
 		it("should update both database and secondary storage when fallbackToDatabase is true", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{ name: "Original Name" },
 				{ headers: headers },
@@ -2834,7 +2834,7 @@ describe("api-key", async () => {
 		});
 
 		it("should delete from both database and secondary storage when fallbackToDatabase is true", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{},
 				{ headers: headers },
@@ -2882,7 +2882,7 @@ describe("api-key", async () => {
 		let customSetCalled = false;
 		let customDeleteCalled = false;
 
-		const { client, auth, signInWithTestUser } = await getTestInstance(
+		const { client, signInWithTestUser } = await getTestInstance(
 			{
 				// Don't provide global secondaryStorage
 				plugins: [
@@ -2921,7 +2921,7 @@ describe("api-key", async () => {
 		});
 
 		it("should use custom storage methods instead of global secondaryStorage", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{},
 				{ headers: headers },
@@ -2933,7 +2933,7 @@ describe("api-key", async () => {
 		});
 
 		it("should use custom get method", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{},
 				{ headers: headers },
@@ -2952,7 +2952,7 @@ describe("api-key", async () => {
 		});
 
 		it("should use custom delete method", async () => {
-			const { headers, user } = await signInWithTestUser();
+			const { headers } = await signInWithTestUser();
 			const { data: createdKey } = await client.apiKey.create(
 				{},
 				{ headers: headers },

--- a/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/get-api-key.ts
@@ -197,7 +197,7 @@ export function getApiKey({
 				apiKey.metadata as never as string,
 			);
 
-			const { key, ...returningApiKey } = apiKey;
+			const { key: _key, ...returningApiKey } = apiKey;
 
 			return ctx.json({
 				...returningApiKey,

--- a/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/list-api-keys.ts
@@ -180,7 +180,7 @@ export function listApiKeys({
 			});
 
 			let returningApiKey = apiKeys.map((x) => {
-				const { key, ...returningApiKey } = x;
+				const { key: _key, ...returningApiKey } = x;
 				return {
 					...returningApiKey,
 					permissions: returningApiKey.permissions

--- a/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
@@ -452,7 +452,7 @@ export function updateApiKey({
 				newApiKey.metadata as never as string,
 			);
 
-			const { key, ...returningApiKey } = newApiKey;
+			const { key: _key, ...returningApiKey } = newApiKey;
 
 			return ctx.json({
 				...returningApiKey,

--- a/packages/better-auth/src/plugins/bearer/index.ts
+++ b/packages/better-auth/src/plugins/bearer/index.ts
@@ -62,7 +62,7 @@ export const bearer = (options?: BearerOptions | undefined) => {
 							if (!isValid) {
 								return;
 							}
-						} catch (e) {
+						} catch {
 							return;
 						}
 						const existingHeaders = (c.request?.headers ||

--- a/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
+++ b/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
@@ -14,7 +14,7 @@ describe("Custom Session Plugin Tests", async () => {
 	const options = {
 		plugins: [admin(), multiSession()],
 	} satisfies BetterAuthOptions;
-	const { auth, signInWithTestUser, testUser, customFetchImpl, cookieSetter } =
+	const { auth, signInWithTestUser, customFetchImpl, cookieSetter } =
 		await getTestInstance({
 			session: {
 				maxAge: 10,
@@ -66,7 +66,7 @@ describe("Custom Session Plugin Tests", async () => {
 
 	it("should return set cookie headers", async () => {
 		const { headers } = await signInWithTestUser();
-		const s = await client.getSession({
+		await client.getSession({
 			fetchOptions: {
 				headers,
 				onResponse(context) {

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -475,7 +475,7 @@ describe("device authorization flow", async () => {
 
 describe("device authorization with custom options", async () => {
 	it("should correctly store interval as milliseconds in database", async () => {
-		const { auth, client, db } = await getTestInstance({
+		const { auth, db } = await getTestInstance({
 			plugins: [
 				deviceAuthorization({
 					interval: "5s",

--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -18,7 +18,7 @@ const msStringValueSchema = z.custom<MSStringValue>(
 	(val) => {
 		try {
 			ms(val as MSStringValue);
-		} catch (e) {
+		} catch {
 			return false;
 		}
 		return true;

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -148,13 +148,13 @@ describe("email-otp", async () => {
 			email: testUser.email,
 			type: "forget-password",
 		});
-		const res = await client.emailOtp.resetPassword({
+		await client.emailOtp.resetPassword({
 			email: testUser.email,
 			otp,
 			password: "changed-password",
 		});
 
-		const { data, error } = await client.signIn.email({
+		const { data } = await client.signIn.email({
 			email: testUser.email,
 			password: "changed-password",
 		});
@@ -303,7 +303,7 @@ describe("email-otp", async () => {
 	});
 
 	it("should get verification otp on server", async () => {
-		const res = await auth.api.getVerificationOTP({
+		await auth.api.getVerificationOTP({
 			query: {
 				email: "test@email.com",
 				type: "sign-in",
@@ -312,7 +312,7 @@ describe("email-otp", async () => {
 	});
 
 	it("should work with custom options", async () => {
-		const { client, testUser, auth } = await getTestInstance(
+		const { client, testUser } = await getTestInstance(
 			{
 				plugins: [
 					bearer(),
@@ -354,7 +354,7 @@ describe("email-otp", async () => {
 describe("email-otp-verify", async () => {
 	const otpFn = vi.fn();
 	const otp = [""];
-	const { client, testUser, auth } = await getTestInstance(
+	const { client, testUser } = await getTestInstance(
 		{
 			plugins: [
 				emailOTP({
@@ -509,7 +509,7 @@ describe("email-otp-verify", async () => {
 });
 
 describe("custom rate limiting storage", async () => {
-	const { client, testUser } = await getTestInstance({
+	const { client } = await getTestInstance({
 		rateLimit: {
 			enabled: true,
 		},
@@ -629,7 +629,7 @@ describe("custom storeOTP", async () => {
 			};
 		}
 
-		const { client, testUser, auth } = await getTestInstance(
+		const { client, auth } = await getTestInstance(
 			{
 				plugins: [
 					emailOTP({
@@ -730,7 +730,7 @@ describe("custom storeOTP", async () => {
 			};
 		}
 
-		const { client, testUser, auth } = await getTestInstance(
+		const { client, auth } = await getTestInstance(
 			{
 				plugins: [
 					emailOTP({
@@ -750,7 +750,6 @@ describe("custom storeOTP", async () => {
 		const authCtx = await auth.$context;
 		const userEmail1 = `${crypto.randomUUID()}@email.com`;
 
-		let encryptedOtp = "";
 		let validOTP = "";
 
 		it("should create an encrypted otp", async () => {
@@ -769,7 +768,6 @@ describe("custom storeOTP", async () => {
 			expect(storedOtp.length !== 0).toBe(true);
 			expect(splitAtLastColon(storedOtp)[0]).not.toBe(otp);
 			expect(storedOtp.endsWith(":0")).toBe(true);
-			encryptedOtp = storedOtp;
 			validOTP = otp;
 		});
 
@@ -831,7 +829,7 @@ describe("custom storeOTP", async () => {
 			};
 		}
 
-		const { client, testUser, auth } = await getTestInstance(
+		const { client, auth } = await getTestInstance(
 			{
 				plugins: [
 					emailOTP({
@@ -937,7 +935,7 @@ describe("custom storeOTP", async () => {
 			};
 		}
 
-		const { client, testUser, auth } = await getTestInstance(
+		const { client, auth } = await getTestInstance(
 			{
 				plugins: [
 					emailOTP({
@@ -983,7 +981,7 @@ describe("custom storeOTP", async () => {
 
 		it("should be allowed to get otp if storeOTP is custom hasher", async () => {
 			try {
-				const result = await auth.api.getVerificationOTP({
+				await auth.api.getVerificationOTP({
 					query: {
 						email: userEmail1,
 						type: "sign-in",
@@ -1128,6 +1126,7 @@ describe("override default email verification", async () => {
 			name: "Test User",
 		});
 
+		expect(callCountForTestEmail).toBe(1);
 		expect(sendVerificationOTPFn).toHaveBeenCalledTimes(1);
 		expect(sendVerificationOTPFn).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -252,7 +252,7 @@ describe("oauth2", async () => {
 	});
 
 	it("should work with custom redirect uri", async () => {
-		const { customFetchImpl, auth } = await getTestInstance({
+		const { customFetchImpl } = await getTestInstance({
 			plugins: [
 				genericOAuth({
 					config: [
@@ -908,7 +908,7 @@ describe("oauth2", async () => {
 			userInfoResponse.statusCode = 200;
 		});
 
-		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+		const { customFetchImpl, cookieSetter } = await getTestInstance({
 			plugins: [
 				genericOAuth({
 					config: [

--- a/packages/better-auth/src/plugins/generic-oauth/providers/line.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/line.ts
@@ -76,7 +76,6 @@ export function line(options: LineOptions): GenericOAuthConfig {
 	const authorizationUrl = "https://access.line.me/oauth2/v2.1/authorize";
 	const tokenUrl = "https://api.line.me/oauth2/v2.1/token";
 	const userInfoUrl = "https://api.line.me/oauth2/v2.1/userinfo";
-	const verifyIdTokenUrl = "https://api.line.me/oauth2/v2.1/verify";
 
 	const getUserInfo = async (
 		tokens: OAuth2Tokens,

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -136,7 +136,6 @@ export const signInWithOAuth2 = (options: GenericOAuthOptions) =>
 				accessType,
 				authorizationUrlParams,
 				responseMode,
-				authentication,
 			} = config;
 			let finalAuthUrl = authorizationUrl;
 			let finalTokenUrl = tokenUrl;

--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -1,5 +1,4 @@
 import type { GenericEndpointContext } from "@better-auth/core";
-import { getWebcryptoSubtle } from "@better-auth/utils";
 import { exportJWK, generateKeyPair } from "jose";
 import { symmetricEncrypt } from "../../crypto";
 import { joseSecs } from "../../utils/time";
@@ -26,31 +25,6 @@ export function toExpJWT(
 	} else {
 		return iat + joseSecs(expirationTime);
 	}
-}
-
-async function deriveKey(secretKey: string): Promise<CryptoKey> {
-	const enc = new TextEncoder();
-	const subtle = getWebcryptoSubtle();
-	const keyMaterial = await subtle.importKey(
-		"raw",
-		enc.encode(secretKey),
-		{ name: "PBKDF2" },
-		false,
-		["deriveKey"],
-	);
-
-	return subtle.deriveKey(
-		{
-			name: "PBKDF2",
-			salt: enc.encode("encryption_salt"),
-			iterations: 100000,
-			hash: "SHA-256",
-		},
-		keyMaterial,
-		{ name: "AES-GCM", length: 256 },
-		false,
-		["encrypt", "decrypt"],
-	);
 }
 
 export async function generateExportedKeyPair(

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -146,7 +146,7 @@ describe("magic link", async () => {
 			),
 		});
 		const headers = new Headers();
-		const response = await client.magicLink.verify({
+		await client.magicLink.verify({
 			query: {
 				token: new URL(verificationEmail.url).searchParams.get("token") || "",
 			},
@@ -333,21 +333,20 @@ describe("magic link storeToken", async () => {
 			token: "",
 			url: "",
 		};
-		const { auth, signInWithTestUser, client, testUser } =
-			await getTestInstance({
-				plugins: [
-					magicLink({
-						storeToken: "hashed",
-						sendMagicLink(data, request) {
-							verificationEmail = data;
-						},
-					}),
-				],
-			});
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			plugins: [
+				magicLink({
+					storeToken: "hashed",
+					sendMagicLink(data, request) {
+						verificationEmail = data;
+					},
+				}),
+			],
+		});
 
 		const internalAdapter = (await auth.$context).internalAdapter;
 		const { headers } = await signInWithTestUser();
-		const response = await auth.api.signInMagicLink({
+		await auth.api.signInMagicLink({
 			body: {
 				email: testUser.email,
 			},
@@ -372,22 +371,21 @@ describe("magic link storeToken", async () => {
 			token: "",
 			url: "",
 		};
-		const { auth, signInWithTestUser, client, testUser } =
-			await getTestInstance({
-				plugins: [
-					magicLink({
-						storeToken: {
-							type: "custom-hasher",
-							async hash(token) {
-								return token + "hashed";
-							},
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			plugins: [
+				magicLink({
+					storeToken: {
+						type: "custom-hasher",
+						async hash(token) {
+							return token + "hashed";
 						},
-						sendMagicLink(data, request) {
-							verificationEmail = data;
-						},
-					}),
-				],
-			});
+					},
+					sendMagicLink(data, request) {
+						verificationEmail = data;
+					},
+				}),
+			],
+		});
 
 		const internalAdapter = (await auth.$context).internalAdapter;
 		const { headers } = await signInWithTestUser();

--- a/packages/better-auth/src/plugins/mcp/authorize.ts
+++ b/packages/better-auth/src/plugins/mcp/authorize.ts
@@ -203,7 +203,7 @@ export async function authorizeMCPOAuth(
 			identifier: code,
 			expiresAt,
 		});
-	} catch (e) {
+	} catch {
 		throw ctx.redirect(
 			redirectErrorURL(
 				query.redirect_uri,

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -356,7 +356,7 @@ export const mcp = (options: MCPOptions) => {
 							}
 							client_id = id;
 							client_secret = secret;
-						} catch (error) {
+						} catch {
 							throw new APIError("UNAUTHORIZED", {
 								error_description: "invalid authorization header format",
 								error: "invalid_client",

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -21,28 +21,27 @@ describe("mcp", async () => {
 	const baseURL = `http://localhost:${port}`;
 	await tempServer.close();
 
-	const { auth, signInWithTestUser, customFetchImpl, testUser, cookieSetter } =
-		await getTestInstance({
-			baseURL,
-			plugins: [
-				mcp({
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL,
+		plugins: [
+			mcp({
+				loginPage: "/login",
+				oidcConfig: {
 					loginPage: "/login",
-					oidcConfig: {
-						loginPage: "/login",
-						consentPage: "/oauth/consent",
-						requirePKCE: true,
+					consentPage: "/oauth/consent",
+					requirePKCE: true,
 
-						getAdditionalUserInfoClaim(user, scopes, client) {
-							return {
-								custom: "custom value",
-								userId: user.id,
-							};
-						},
+					getAdditionalUserInfoClaim(user, scopes, client) {
+						return {
+							custom: "custom value",
+							userId: user.id,
+						};
 					},
-				}),
-				jwt(),
-			],
-		});
+				},
+			}),
+			jwt(),
+		],
+	});
 
 	const signInResult = await signInWithTestUser();
 	const headers = signInResult.headers;
@@ -472,7 +471,7 @@ describe("mcp", async () => {
 		});
 
 		// Perform OAuth flow
-		const data = await client.signIn.oauth2(
+		await client.signIn.oauth2(
 			{
 				providerId: "test-userinfo",
 				callbackURL: "/dashboard",

--- a/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
+++ b/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
@@ -97,7 +97,7 @@ describe("multi-session", async () => {
 			name: "Name",
 		};
 		let token = "";
-		const signUpRes = await client.signUp.email(testUser3, {
+		await client.signUp.email(testUser3, {
 			onSuccess: (ctx) => {
 				const header = ctx.response.headers.get("set-cookie");
 				expect(header).toContain("better-auth.session_token");
@@ -162,15 +162,8 @@ describe("multi-session", async () => {
 		};
 
 		const attackerHeaders = new Headers();
-		let attackerSessionToken = "";
 		await client.signUp.email(attackerUser, {
 			onSuccess: cookieSetter(attackerHeaders),
-			onResponse(context) {
-				const header = context.response.headers.get("set-cookie");
-				const cookies = parseSetCookieHeader(header || "");
-				attackerSessionToken =
-					cookies.get("better-auth.session_token")?.value.split(".")[0] || "";
-			},
 		});
 
 		const victimHeaders = new Headers();

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -278,7 +278,7 @@ export const oAuthProxy = (opts?: OAuthProxyOptions | undefined) => {
 							});
 							statePackage =
 								parseJSON<OAuthProxyStatePackage>(decryptedPackage);
-						} catch (e) {
+						} catch {
 							// Not an OAuth proxy state, continue normally
 							return;
 						}

--- a/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
@@ -55,7 +55,7 @@ afterAll(() => server.close());
 
 describe("oauth-proxy", async () => {
 	it("should redirect to proxy url", async () => {
-		const { client, cookieSetter } = await getTestInstance({
+		const { client } = await getTestInstance({
 			plugins: [
 				oAuthProxy({
 					currentURL: "http://preview-localhost:3000",

--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -297,7 +297,7 @@ export async function authorize(
 			identifier: code,
 			expiresAt,
 		});
-	} catch (e) {
+	} catch {
 		return handleRedirect(
 			formatErrorURL(
 				query.redirect_uri,

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -691,7 +691,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 							}
 							client_id = id;
 							client_secret = secret;
-						} catch (error) {
+						} catch {
 							throw new APIError("UNAUTHORIZED", {
 								error_description: "invalid authorization header format",
 								error: "invalid_client",
@@ -1607,14 +1607,8 @@ export const oidcProvider = (options: OIDCOptions) => {
 					},
 				},
 				async (ctx) => {
-					const {
-						id_token_hint,
-						logout_hint,
-						client_id,
-						post_logout_redirect_uri,
-						state,
-						ui_locales,
-					} = ctx.query || {};
+					const { id_token_hint, client_id, post_logout_redirect_uri, state } =
+						ctx.query || {};
 
 					let validatedClientId: string | null = null;
 					let validatedUserId: string | null = null;
@@ -1649,13 +1643,13 @@ export const oidcProvider = (options: OIDCOptions) => {
 											);
 											validatedUserId = payload.sub as string;
 											validatedClientId = payload.aud as string;
-										} catch (error) {
+										} catch {
 											// Invalid token, continue with logout but no validation
 										}
 									}
 								}
 							}
-						} catch (error) {
+						} catch {
 							// Invalid id_token_hint, but we continue with logout anyway
 							ctx.context.logger.debug(
 								"Invalid id_token_hint provided to end_session endpoint",
@@ -1747,7 +1741,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 								redirectUrl.searchParams.set("state", state);
 							}
 							return ctx.redirect(redirectUrl.toString());
-						} catch (error) {
+						} catch {
 							throw new APIError("BAD_REQUEST", {
 								error: "invalid_request",
 								error_description: "Invalid post_logout_redirect_uri format",

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -87,7 +87,7 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 							},
 						);
 						payload = verifiedPayload;
-					} catch (error) {
+					} catch {
 						throw new APIError("BAD_REQUEST", {
 							message: "invalid id token",
 						});

--- a/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
+++ b/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
@@ -73,7 +73,7 @@ describe("One-time token", async () => {
 
 	describe("should work with different storeToken options", () => {
 		describe("hashed", async () => {
-			const { auth, signInWithTestUser, client } = await getTestInstance(
+			const { auth, signInWithTestUser } = await getTestInstance(
 				{
 					plugins: [
 						oneTimeToken({
@@ -117,7 +117,7 @@ describe("One-time token", async () => {
 		});
 
 		describe("custom hasher", async () => {
-			const { auth, signInWithTestUser, client } = await getTestInstance({
+			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					oneTimeToken({
 						storeToken: {

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -303,7 +303,7 @@ export const inferOrgAdditionalFields = <
 	// if we don't remove all other properties we may see assignability issues
 
 	type ExtractClientOnlyFields<T> = {
-		[K in keyof T]: T[K] extends { additionalFields: infer AF }
+		[K in keyof T]: T[K] extends { additionalFields: infer _AF }
 			? T[K]
 			: undefined;
 	};

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -299,7 +299,7 @@ describe("organization", async (it) => {
 	});
 	it("should allow activating organization by slug", async () => {
 		const { headers } = await signInWithTestUser();
-		const organization = await client.organization.setActive({
+		await client.organization.setActive({
 			organizationSlug: "test2",
 			fetchOptions: {
 				headers,
@@ -531,7 +531,7 @@ describe("organization", async (it) => {
 	});
 
 	it("should allow updating member", async () => {
-		const { headers, user } = await signInWithTestUser();
+		const { headers } = await signInWithTestUser();
 		const org = await client.organization.getFullOrganization({
 			query: {
 				organizationId,
@@ -656,7 +656,7 @@ describe("organization", async (it) => {
 		const res = await client.signUp.email(newUser, {
 			onSuccess: cookieSetter(headers),
 		});
-		const member = await auth.api.addMember({
+		await auth.api.addMember({
 			body: {
 				organizationId,
 				userId: res.data?.user.id!,
@@ -756,7 +756,7 @@ describe("organization", async (it) => {
 
 		expect(removedOwner.error?.status).toBe(400);
 
-		const res = await client.organization.updateMemberRole({
+		await client.organization.updateMemberRole({
 			organizationId: organizationId,
 			role: ["owner", "admin"],
 			memberId: org.data?.members.find((m) => m.role === "owner")?.id!,
@@ -847,7 +847,7 @@ describe("organization", async (it) => {
 			adminUser.password,
 		);
 
-		const r = await client.organization.delete({
+		await client.organization.delete({
 			organizationId,
 			fetchOptions: {
 				headers: adminHeaders,
@@ -1088,11 +1088,11 @@ describe("organization", async (it) => {
 		await auth.api.signUpEmail({
 			body: orgAdminUser,
 		});
-		const { headers: headers2, res: session } = await signInWithUser(
+		const { headers: headers2 } = await signInWithUser(
 			user.email,
 			user.password,
 		);
-		const { headers: adminHeaders, res: adminSession } = await signInWithUser(
+		const { headers: adminHeaders } = await signInWithUser(
 			orgAdminUser.email,
 			orgAdminUser.password,
 		);
@@ -1178,7 +1178,7 @@ describe("access control", async (it) => {
 		sales: ["read"],
 		...memberAc.statements,
 	});
-	const { auth, customFetchImpl, sessionSetter, signInWithTestUser } =
+	const { customFetchImpl, sessionSetter, signInWithTestUser } =
 		await getTestInstance({
 			plugins: [
 				organization({
@@ -1218,7 +1218,7 @@ describe("access control", async (it) => {
 		organization: { checkRolePermission, hasPermission, create },
 	} = authClient;
 
-	const { headers, user, session } = await signInWithTestUser();
+	const { headers } = await signInWithTestUser();
 
 	const org = await create(
 		{
@@ -2344,7 +2344,7 @@ describe("Additional Fields", async () => {
 			headers.set("cookie", `${current || ""}; ${name}=${value}`);
 		};
 
-		const { data, error } = await client.signUp.email({
+		const { data } = await client.signUp.email({
 			email: testUser.email,
 			password: testUser.password,
 			name: testUser.name,

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
@@ -92,10 +92,10 @@ describe("dynamic access control", async (it) => {
 		},
 	});
 	const {
-		organization: { checkRolePermission, hasPermission, create },
+		organization: { create },
 	} = authClient;
 
-	const { headers, user, session } = await signInWithTestUser();
+	const { headers } = await signInWithTestUser();
 
 	async function createUser({ role }: { role: "admin" | "member" | "owner" }) {
 		const normalUserDetails = {
@@ -157,20 +157,12 @@ describe("dynamic access control", async (it) => {
 	if (!memberInfo) throw new Error("Member info not found");
 
 	// Create an admin user in the org.
-	const {
-		headers: adminHeaders,
-		user: adminUser,
-		member: adminMember,
-	} = await createUser({
+	const { headers: adminHeaders } = await createUser({
 		role: "admin",
 	});
 
 	// Create normal users in the org.
-	const {
-		headers: normalHeaders,
-		user: normalUser,
-		member: normalMember,
-	} = await createUser({
+	const { headers: normalHeaders, member: normalMember } = await createUser({
 		role: "member",
 	});
 
@@ -658,11 +650,7 @@ describe("dynamic access control", async (it) => {
 	 */
 	it("should not allow member to list roles using another member's permissions", async () => {
 		// Create a fresh member for this test to avoid role contamination
-		const {
-			headers: freshMemberHeaders,
-			user: freshMemberUser,
-			member: freshMember,
-		} = await createUser({
+		const { headers: freshMemberHeaders } = await createUser({
 			role: "member",
 		});
 
@@ -696,11 +684,7 @@ describe("dynamic access control", async (it) => {
 
 	it("should not allow member to get role details using another member's permissions", async () => {
 		// Create a fresh member for this test to avoid role contamination
-		const {
-			headers: freshMemberHeaders,
-			user: freshMemberUser,
-			member: freshMember,
-		} = await createUser({
+		const { headers: freshMemberHeaders } = await createUser({
 			role: "member",
 		});
 
@@ -737,11 +721,7 @@ describe("dynamic access control", async (it) => {
 
 	it("should not allow member to update roles without proper permissions (privilege escalation test)", async () => {
 		// Create a fresh member for this test to avoid role contamination
-		const {
-			headers: freshMemberHeaders,
-			user: freshMemberUser,
-			member: freshMember,
-		} = await createUser({
+		const { headers: freshMemberHeaders } = await createUser({
 			role: "member",
 		});
 
@@ -795,11 +775,7 @@ describe("dynamic access control", async (it) => {
 
 	it("should properly identify the correct member when checking permissions", async () => {
 		// Create a fresh member for this test to avoid role contamination
-		const {
-			headers: freshMemberHeaders,
-			user: freshMemberUser,
-			member: freshMember,
-		} = await createUser({
+		const { headers: freshMemberHeaders } = await createUser({
 			role: "member",
 		});
 
@@ -852,11 +828,7 @@ describe("dynamic access control", async (it) => {
 
 	it("should not allow cross-organization privilege escalation", async () => {
 		// Create a fresh member for this test to avoid role contamination
-		const {
-			headers: freshMemberHeaders,
-			user: freshMemberUser,
-			member: freshMember,
-		} = await createUser({
+		const { headers: freshMemberHeaders } = await createUser({
 			role: "member",
 		});
 

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
@@ -227,13 +227,12 @@ describe("listMembers", async () => {
 });
 
 describe("updateMemberRole", async () => {
-	const { auth, signInWithTestUser, cookieSetter, customFetchImpl } =
-		await getTestInstance({
-			plugins: [organization()],
-		});
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		plugins: [organization()],
+	});
 
 	it("should update the member role", async () => {
-		const { headers, user } = await signInWithTestUser();
+		const { headers } = await signInWithTestUser();
 		const client = createAuthClient({
 			plugins: [organizationClient()],
 			baseURL: "http://localhost:3000/api/auth",
@@ -291,7 +290,7 @@ describe("updateMemberRole", async () => {
 			},
 		});
 
-		const org = await client.organization.create({
+		await client.organization.create({
 			name: "test",
 			slug: "test",
 			metadata: {
@@ -348,7 +347,7 @@ describe("updateMemberRole", async () => {
 });
 
 describe("activeMemberRole", async () => {
-	const { auth, signInWithTestUser, cookieSetter } = await getTestInstance({
+	const { auth, signInWithTestUser } = await getTestInstance({
 		plugins: [organization()],
 	});
 	const ctx = await auth.$context;
@@ -372,7 +371,7 @@ describe("activeMemberRole", async () => {
 			headers,
 		},
 	});
-	const secondOrg = await client.organization.create({
+	await client.organization.create({
 		name: "test-second",
 		slug: "test-second",
 		metadata: {

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
@@ -312,7 +312,7 @@ describe("organization hooks", async () => {
 			],
 		});
 		const { headers } = await signInWithTestUser();
-		const result = await auth.api.createOrganization({
+		await auth.api.createOrganization({
 			body: {
 				name: "test",
 				slug: "test",

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -349,7 +349,7 @@ describe("team", async (it) => {
 });
 
 describe("multi team support", async (it) => {
-	const { auth, signInWithTestUser, cookieSetter } = await getTestInstance(
+	const { auth, signInWithTestUser } = await getTestInstance(
 		{
 			plugins: [
 				organization({
@@ -655,7 +655,7 @@ describe("multi team support", async (it) => {
 		const newUser = await response.json();
 
 		// Add the user as a member to the organization
-		const member = await auth.api.addMember({
+		await auth.api.addMember({
 			headers: admin.headers,
 			body: {
 				organizationId: organizationId!,
@@ -751,7 +751,7 @@ describe("multi team support", async (it) => {
 		const newUser = await response.json();
 
 		// Add the user as a member to the organization
-		const member = await auth.api.addMember({
+		await auth.api.addMember({
 			headers: admin.headers,
 			body: {
 				organizationId: organizationId!,

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -70,7 +70,7 @@ describe("phone-number", async (it) => {
 				headers,
 			},
 		});
-		const res = await client.phoneNumber.verify({
+		await client.phoneNumber.verify({
 			phoneNumber: newPhoneNumber,
 			updatePhoneNumber: true,
 			code: otp,
@@ -178,7 +178,7 @@ describe("phone auth flow", async () => {
 
 	const newEmail = "new-email@email.com";
 	it("should set password and update user", async () => {
-		const res = await auth.api.setPassword({
+		await auth.api.setPassword({
 			body: {
 				newPassword: "password",
 			},
@@ -296,7 +296,7 @@ describe("reset password flow attempts", async (it) => {
 	let otp = "";
 	let resetOtp = "";
 
-	const { client, sessionSetter } = await getTestInstance(
+	const { client } = await getTestInstance(
 		{
 			plugins: [
 				phoneNumber({
@@ -513,15 +513,12 @@ describe("updateUser phone number update prevention", async () => {
 
 describe("custom verifyOTP", async () => {
 	const mockVerifyOTP = vi.fn();
-	let sentCode = "";
 
 	const { client, sessionSetter } = await getTestInstance(
 		{
 			plugins: [
 				phoneNumber({
-					async sendOTP({ code }) {
-						sentCode = code;
-					},
+					async sendOTP() {},
 					verifyOTP: mockVerifyOTP,
 					signUpOnVerification: {
 						getTempEmail(phoneNumber) {

--- a/packages/better-auth/src/plugins/siwe/siwe.test.ts
+++ b/packages/better-auth/src/plugins/siwe/siwe.test.ts
@@ -508,7 +508,7 @@ describe("siwe", async (it) => {
 			walletAddress: walletAddress.toUpperCase(),
 			chainId,
 		});
-		const { data: data2, error: error2 } = await client.siwe.verify({
+		const { data: data2 } = await client.siwe.verify({
 			message: "valid_message",
 			signature: "valid_signature",
 			walletAddress: walletAddress.toUpperCase(),

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -378,7 +378,7 @@ describe("two factor", async () => {
 			},
 		});
 		expect((res.data as any)?.twoFactorRedirect).toBe(true);
-		const otpRes = await client.twoFactor.sendOtp({
+		await client.twoFactor.sendOtp({
 			fetchOptions: {
 				headers,
 				onSuccess(context) {
@@ -650,7 +650,7 @@ describe("two factor auth API", async () => {
 
 describe("view backup codes", async () => {
 	const sendOTP = vi.fn();
-	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+	const { auth, signInWithTestUser, testUser } = await getTestInstance({
 		secret: DEFAULT_SECRET,
 		plugins: [
 			twoFactor({

--- a/packages/better-auth/src/plugins/username/username.test.ts
+++ b/packages/better-auth/src/plugins/username/username.test.ts
@@ -54,7 +54,7 @@ describe("username", async (it) => {
 		expect(res.data?.token).toBeDefined();
 	});
 	it("should update username", async () => {
-		const res = await client.updateUser({
+		await client.updateUser({
 			username: "new_username_2.1",
 			fetchOptions: {
 				headers,
@@ -468,7 +468,7 @@ describe("username with displayUsername validation", async (it) => {
 });
 
 describe("isUsernameAvailable with custom validator", async (it) => {
-	const { client, cookieSetter } = await getTestInstance(
+	const { client } = await getTestInstance(
 		{
 			plugins: [
 				username({

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -382,7 +382,7 @@ describe("Social Providers", async (c) => {
 				expect(cookies.get("better-auth.session_token")?.value).toBeDefined();
 			},
 		});
-		const accounts = await client.listAccounts({
+		await client.listAccounts({
 			fetchOptions: { headers },
 		});
 		await client.$fetch("/refresh-token", {

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -240,7 +240,7 @@ export async function getTestInstance<
 			headers.set("cookie", `${current || ""}; ${name}=${value}`);
 		};
 		//@ts-expect-error
-		const { data, error } = await client.signIn.email({
+		const { data } = await client.signIn.email({
 			email: testUser.email,
 			password: testUser.password,
 			fetchOptions: {

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -6,7 +6,7 @@ function checkHasPath(url: string): boolean {
 		const parsedUrl = new URL(url);
 		const pathname = parsedUrl.pathname.replace(/\/+$/, "") || "/";
 		return pathname !== "/";
-	} catch (error) {
+	} catch {
 		throw new BetterAuthError(
 			`Invalid base URL: ${url}. Please provide a valid base URL.`,
 		);
@@ -103,7 +103,7 @@ export function getOrigin(url: string) {
 		// For custom URL schemes (like exp://), the origin property returns the string "null"
 		// instead of null. We need to handle this case and return null so the fallback logic works.
 		return parsedUrl.origin === "null" ? null : parsedUrl.origin;
-	} catch (error) {
+	} catch {
 		return null;
 	}
 }
@@ -112,7 +112,7 @@ export function getProtocol(url: string) {
 	try {
 		const parsedUrl = new URL(url);
 		return parsedUrl.protocol;
-	} catch (error) {
+	} catch {
 		return null;
 	}
 }
@@ -121,7 +121,7 @@ export function getHost(url: string) {
 	try {
 		const parsedUrl = new URL(url);
 		return parsedUrl.host;
-	} catch (error) {
+	} catch {
 		return null;
 	}
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1011,7 +1011,7 @@ async function initAction(opts: any) {
 					}
 				}
 			}
-		} catch (error) {
+		} catch {
 			// if fails, ignore, and do not proceed with ENV operations.
 		}
 	}

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -252,7 +252,7 @@ async function storeToken(token: any): Promise<void> {
 		};
 
 		await fs.writeFile(TOKEN_FILE, JSON.stringify(tokenData, null, 2), "utf-8");
-	} catch (error) {
+	} catch {
 		console.warn("Failed to store authentication token locally");
 	}
 }

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -62,7 +62,7 @@ async function handleCursorAction(mcpUrl: string, mcpName: string) {
 
 		execSync(command, { stdio: "inherit" });
 		console.log(chalk.green("\n✓ Cursor MCP installed successfully!"));
-	} catch (error) {
+	} catch {
 		console.log(
 			chalk.yellow(
 				"\n⚠ Could not automatically open Cursor. Please copy the deeplink URL above and open it manually.",
@@ -93,7 +93,7 @@ function handleClaudeCodeAction(mcpUrl: string) {
 	try {
 		execSync(command, { stdio: "inherit" });
 		console.log(chalk.green("\n✓ Claude Code MCP installed successfully!"));
-	} catch (error) {
+	} catch {
 		console.log(
 			chalk.yellow(
 				"\n⚠ Could not automatically add to Claude Code. Please run this command manually:",
@@ -155,7 +155,7 @@ function handleOpenCodeAction(mcpUrl: string) {
 			chalk.green(`\n✓ Open Code configuration written to ${configPath}`),
 		);
 		console.log(chalk.green("✓ Better Auth MCP added successfully!"));
-	} catch (error) {
+	} catch {
 		console.log(
 			chalk.yellow(
 				"\n⚠ Could not automatically write opencode.json. Please add this configuration manually:",
@@ -197,7 +197,7 @@ function handleManualAction(mcpUrl: string, mcpName: string) {
 		fs.writeFileSync(configPath, JSON.stringify(mergedConfig, null, 2));
 		console.log(chalk.green(`\n✓ MCP configuration written to ${configPath}`));
 		console.log(chalk.green("✓ Better Auth MCP added successfully!"));
-	} catch (error) {
+	} catch {
 		console.log(
 			chalk.yellow(
 				"\n⚠ Could not automatically write mcp.json. Please add this configuration manually:",

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -385,11 +385,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 		}
 
 		// Add relations, deduplicating by relationKey
-		for (const {
-			modelName,
-			hasUnique,
-			hasMany,
-		} of modelRelationsMap.values()) {
+		for (const { modelName, hasMany } of modelRelationsMap.values()) {
 			// Determine relation type: if all are unique, it's "one", otherwise "many"
 			const relationType = hasMany ? "many" : "one";
 			let relationKey = getModelName(modelName);
@@ -431,7 +427,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 		const duplicateRelations: Relation[] = [];
 		const singleRelations: Relation[] = [];
 
-		for (const [modelKey, relations] of relationsByModel.entries()) {
+		for (const [_modelKey, relations] of relationsByModel.entries()) {
 			if (relations.length > 1) {
 				// Multiple relations to the same model - these need field-specific naming
 				duplicateRelations.push(...relations);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,7 +22,7 @@ async function main() {
 	let packageInfo: Record<string, any> = {};
 	try {
 		packageInfo = await getPackageInfo();
-	} catch (error) {
+	} catch {
 		// it doesn't matter if we can't read the package.json file, we'll just use an empty object
 	}
 	program

--- a/packages/cli/src/utils/get-package-info.ts
+++ b/packages/cli/src/utils/get-package-info.ts
@@ -25,7 +25,7 @@ export function getPrismaVersion(cwd?: string): number | null {
 		// Handles versions like "^5.0.0", "~7.1.0", "7.0.0", etc.
 		const match = prismaVersion.match(/(\d+)/);
 		return match ? parseInt(match[1], 10) : null;
-	} catch (error) {
+	} catch {
 		// If package.json doesn't exist or can't be read, return null
 		return null;
 	}

--- a/packages/core/src/db/adapter/index.ts
+++ b/packages/core/src/db/adapter/index.ts
@@ -424,7 +424,7 @@ export type DBAdapter<Options extends BetterAuthOptions = BetterAuthOptions> = {
 		where: Where[];
 		update: Record<string, any>;
 	}) => Promise<number>;
-	delete: <T>(data: { model: string; where: Where[] }) => Promise<void>;
+	delete: <_T>(data: { model: string; where: Where[] }) => Promise<void>;
 	deleteMany: (data: { model: string; where: Where[] }) => Promise<number>;
 	/**
 	 * Execute multiple operations in a transaction.

--- a/packages/core/src/social-providers/facebook.ts
+++ b/packages/core/src/social-providers/facebook.ts
@@ -102,7 +102,7 @@ export const facebook = (options: FacebookOptions) => {
 					}
 
 					return !!jwtClaims;
-				} catch (error) {
+				} catch {
 					return false;
 				}
 			}

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -24,7 +24,7 @@ export type GenericEndpointContext<
 };
 
 export interface InternalAdapter<
-	Options extends BetterAuthOptions = BetterAuthOptions,
+	_Options extends BetterAuthOptions = BetterAuthOptions,
 > {
 	createOAuthUser(
 		user: Omit<User, "id" | "createdAt" | "updatedAt">,

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -141,7 +141,7 @@ export function getCookie(cookie: string) {
 	let parsed = {} as Record<string, StoredCookie>;
 	try {
 		parsed = JSON.parse(cookie) as Record<string, StoredCookie>;
-	} catch (e) {}
+	} catch {}
 	const toSend = Object.entries(parsed).reduce((acc, [key, value]) => {
 		if (value.expires && new Date(value.expires) < new Date()) {
 			return acc;
@@ -387,7 +387,7 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							if (Platform.OS === "android") {
 								try {
 									Browser.dismissAuthSession();
-								} catch (e) {}
+								} catch {}
 							}
 
 							const proxyURL = `${context.request.baseURL}/expo-authorization-proxy?authorizationURL=${encodeURIComponent(signInURL)}`;

--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -69,7 +69,7 @@ export const getPasskeyActions = (
 			$store.notify("$sessionSignal");
 
 			return verified;
-		} catch (e) {
+		} catch {
 			return {
 				data: null,
 				error: {

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -484,16 +484,8 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 						status: 400,
 					});
 				}
-				const {
-					aaguid,
-					// credentialID,
-					// credentialPublicKey,
-					// counter,
-					credentialDeviceType,
-					credentialBackedUp,
-					credential,
-					credentialType,
-				} = registrationInfo;
+				const { aaguid, credentialDeviceType, credentialBackedUp, credential } =
+					registrationInfo;
 				const pubKey = base64.encode(credential.publicKey);
 				const newPasskey: Omit<Passkey, "id"> = {
 					name: ctx.body.name,

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1107,7 +1107,7 @@ export const callbackSSO = (options?: SSOOptions) => {
 			},
 		},
 		async (ctx) => {
-			const { code, state, error, error_description } = ctx.query;
+			const { code, error, error_description } = ctx.query;
 			const stateData = await parseState(ctx);
 			if (!stateData) {
 				const errorURL =

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -448,13 +448,9 @@ const createMockSAMLIdP = (port: number) => {
 		async (req: ExpressRequest, res: ExpressResponse) => {
 			const { SAMLResponse, RelayState } = req.body;
 			try {
-				const parseResult = await sp.parseLoginResponse(
-					idp,
-					saml.Constants.wording.binding.post,
-					{ body: { SAMLResponse } },
-				);
-
-				const { attributes, nameID } = parseResult.extract;
+				await sp.parseLoginResponse(idp, saml.Constants.wording.binding.post, {
+					body: { SAMLResponse },
+				});
 
 				res.redirect(302, RelayState || "http://localhost:3000/dashboard");
 			} catch (error) {
@@ -550,18 +546,6 @@ describe("SAML SSO with defaultSSO array", async () => {
 		plugins: [sso(ssoOptions)],
 	});
 
-	const ctx = await auth.$context;
-
-	const authClient = createAuthClient({
-		baseURL: "http://localhost:3000",
-		plugins: [bearer(), ssoClient()],
-		fetchOptions: {
-			customFetchImpl: async (url, init) => {
-				return auth.handler(new Request(url, init));
-			},
-		},
-	});
-
 	beforeAll(async () => {
 		await mockIdP.start();
 	});
@@ -619,8 +603,6 @@ describe("SAML SSO", async () => {
 		plugins: [sso(ssoOptions)],
 	});
 
-	const ctx = await auth.$context;
-
 	const authClient = createAuthClient({
 		baseURL: "http://localhost:3000",
 		plugins: [bearer(), ssoClient()],
@@ -639,7 +621,7 @@ describe("SAML SSO", async () => {
 
 	beforeAll(async () => {
 		await mockIdP.start();
-		const res = await authClient.signUp.email({
+		await authClient.signUp.email({
 			email: testUser.email,
 			password: testUser.password,
 			name: testUser.name,
@@ -667,7 +649,7 @@ describe("SAML SSO", async () => {
 			password: testUser.password,
 			name: testUser.name,
 		});
-		const res = await authClient.signIn.email(testUser, {
+		await authClient.signIn.email(testUser, {
 			throw: true,
 			onSuccess: setCookieToHeader(headers),
 		});
@@ -676,7 +658,7 @@ describe("SAML SSO", async () => {
 
 	it("should register a new SAML provider", async () => {
 		const headers = await getAuthHeaders();
-		const res = await authClient.signIn.email(testUser, {
+		await authClient.signIn.email(testUser, {
 			throw: true,
 			onSuccess: setCookieToHeader(headers),
 		});
@@ -847,11 +829,11 @@ describe("SAML SSO", async () => {
 	});
 	it("should initiate SAML login and handle response", async () => {
 		const headers = await getAuthHeaders();
-		const res = await authClient.signIn.email(testUser, {
+		await authClient.signIn.email(testUser, {
 			throw: true,
 			onSuccess: setCookieToHeader(headers),
 		});
-		const provider = await auth.api.registerSSOProvider({
+		await auth.api.registerSSOProvider({
 			body: {
 				providerId: "saml-provider-1",
 				issuer: "http://localhost:8081",
@@ -1184,11 +1166,7 @@ describe("SAML SSO", async () => {
 	});
 
 	it("should deny account linking when provider is not trusted and domain is not verified", async () => {
-		const {
-			auth: authUntrusted,
-			signInWithTestUser,
-			client,
-		} = await getTestInstance({
+		const { auth: authUntrusted, signInWithTestUser } = await getTestInstance({
 			account: {
 				accountLinking: {
 					enabled: true,
@@ -1401,7 +1379,7 @@ describe("SAML SSO with custom fields", () => {
 
 	beforeAll(async () => {
 		await mockIdP.start();
-		const res = await authClient.signUp.email({
+		await authClient.signUp.email({
 			email: testUser.email,
 			password: testUser.password,
 			name: testUser.name,

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -84,7 +84,7 @@ export const getSchema = (options: StripeOptions) => {
 		!options.subscription?.enabled &&
 		"subscription" in options.schema
 	) {
-		const { subscription, ...restSchema } = options.schema;
+		const { subscription: _subscription, ...restSchema } = options.schema;
 		return mergeSchema(baseSchema, restSchema);
 	}
 

--- a/packages/stripe/src/stripe.test.ts
+++ b/packages/stripe/src/stripe.test.ts
@@ -168,18 +168,6 @@ describe("stripe", async () => {
 		vi.clearAllMocks();
 	});
 
-	async function getHeader() {
-		const headers = new Headers();
-		const userRes = await authClient.signIn.email(testUser, {
-			throw: true,
-			onSuccess: setCookieToHeader(headers),
-		});
-		return {
-			headers,
-			response: userRes,
-		};
-	}
-
 	it("should create a customer on sign up", async () => {
 		const userRes = await authClient.signUp.email(testUser, {
 			throw: true,
@@ -642,15 +630,6 @@ describe("stripe", async () => {
 			stripeWebhookSecret: "test_secret",
 		} as unknown as StripeOptions;
 
-		const testAuth = betterAuth({
-			baseURL: "http://localhost:3000",
-			database: memory,
-			emailAndPassword: {
-				enabled: true,
-			},
-			plugins: [stripe(testOptions)],
-		});
-
 		// Test subscription complete handler
 		const completeEvent = {
 			type: "checkout.session.completed",
@@ -1097,7 +1076,7 @@ describe("stripe", async () => {
 	});
 
 	it("should only call Stripe customers.create once for signup and upgrade", async () => {
-		const userRes = await authClient.signUp.email(
+		await authClient.signUp.email(
 			{ ...testUser, email: "single-create@email.com" },
 			{ throw: true },
 		);
@@ -2107,7 +2086,7 @@ describe("stripe", async () => {
 				plugins: [stripe(testOptions)],
 			});
 
-			const { id: subId } = await ctx.adapter.create({
+			await ctx.adapter.create({
 				model: "subscription",
 				data: {
 					referenceId: userId,
@@ -2249,7 +2228,7 @@ describe("stripe", async () => {
 				plugins: [stripe(testOptions)],
 			});
 
-			const { id: subId } = await ctx.adapter.create({
+			await ctx.adapter.create({
 				model: "subscription",
 				data: {
 					referenceId: userId,

--- a/packages/telemetry/src/detectors/detect-system-info.ts
+++ b/packages/telemetry/src/detectors/detect-system-info.ts
@@ -95,7 +95,7 @@ export async function detectSystemInfo() {
 					? (process as any).stdout.isTTY
 					: null,
 		};
-	} catch (e) {
+	} catch {
 		return {
 			systemPlatform: null,
 			systemRelease: null,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unused imports, variables, and parameters across demos, docs, packages, and tests, and enabled Biome’s noUnusedVariables rule. This reduces lint noise and keeps the codebase lean with no behavior changes.

- **Refactors**
  - Enabled noUnusedVariables in biome.json.
  - Removed unused imports and state; prefixed unused params with underscores.
  - Simplified try/catch blocks by dropping unused error variables.
  - Cleaned test code to remove unused assignments and redundant variables.

<sup>Written for commit 1cbe1982e01c52cb871cd386d42f59953345b313. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

