### PR TITLE
chore(knip): use relative $schema path

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
+	"$schema": "./node_modules/knip/schema-jsonc.json",
 	"ignoreExportsUsedInFile": {
 		"interface": true,
 		"type": true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use a relative $schema path in knip.jsonc to reference the local Knip schema instead of unpkg. This removes the external dependency, works offline, and prevents schema resolution issues in restricted networks.

<sup>Written for commit e0223c7fb7a3f2e524c1d71308ce2099d34ee616. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

