### PR TITLE
feat: add support for a custom betterAuth initializer that support intercepting and modifying the context

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -51,6 +51,11 @@
       "types": "./dist/auth/minimal.d.mts",
       "default": "./dist/auth/minimal.mjs"
     },
+    "./custom": {
+      "dev-source": "./src/auth/custom.ts",
+      "types": "./dist/auth/custom.d.mts",
+      "default": "./dist/auth/custom.mjs"
+    },
     "./social-providers": {
       "dev-source": "./src/social-providers/index.ts",
       "types": "./dist/social-providers/index.d.mts",

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -335,6 +335,9 @@
       "minimal": [
         "./dist/auth/minimal.d.mts"
       ],
+      "custom": [
+        "./dist/auth/custom.d.mts"
+      ],
       "node": [
         "./dist/integrations/node.d.mts"
       ],

--- a/packages/better-auth/src/auth/custom.test.ts
+++ b/packages/better-auth/src/auth/custom.test.ts
@@ -3,25 +3,25 @@ import type { Auth } from "../types";
 import { betterAuth } from "./custom";
 
 describe("auth-custom", () => {
-  test("default auth type should be okay (no interceptor)", () => {
-    const auth = betterAuth({});
-    type T = typeof auth;
-    expectTypeOf<T>().toEqualTypeOf<Auth>();
-  });
-  test("default auth type should be okay (with interceptor)", () => {
-    const auth = betterAuth({}, (ctx) => ctx);
-    type T = typeof auth;
-    expectTypeOf<T>().toEqualTypeOf<Auth>();
-  });
-  test("an invalid interceptor type should throw", () => {
-    expect(() => betterAuth({}, "not an interceptor" as any)).toThrow();
-  });
-  test("context should be modified all the way down", async () => {
-    const auth = betterAuth({}, (ctx) => {
-      ctx.appName = "My Different App Name";
-      return ctx;
-    });
-    const newContext = await auth.$context;
-    expect(newContext.appName).toBe("My Different App Name");
-  });
+	test("default auth type should be okay (no interceptor)", () => {
+		const auth = betterAuth({});
+		type T = typeof auth;
+		expectTypeOf<T>().toEqualTypeOf<Auth>();
+	});
+	test("default auth type should be okay (with interceptor)", () => {
+		const auth = betterAuth({}, (ctx) => ctx);
+		type T = typeof auth;
+		expectTypeOf<T>().toEqualTypeOf<Auth>();
+	});
+	test("an invalid interceptor type should throw", () => {
+		expect(() => betterAuth({}, "not an interceptor" as any)).toThrow();
+	});
+	test("context should be modified all the way down", async () => {
+		const auth = betterAuth({}, (ctx) => {
+			ctx.appName = "My Different App Name";
+			return ctx;
+		});
+		const newContext = await auth.$context;
+		expect(newContext.appName).toBe("My Different App Name");
+	});
 });

--- a/packages/better-auth/src/auth/custom.test.ts
+++ b/packages/better-auth/src/auth/custom.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, expectTypeOf, test } from "vitest";
+import type { Auth } from "../types";
+import { betterAuth } from "./custom";
+
+describe("auth-custom", () => {
+  test("default auth type should be okay (no interceptor)", () => {
+    const auth = betterAuth({});
+    type T = typeof auth;
+    expectTypeOf<T>().toEqualTypeOf<Auth>();
+  });
+  test("default auth type should be okay (with interceptor)", () => {
+    const auth = betterAuth({}, (ctx) => ctx);
+    type T = typeof auth;
+    expectTypeOf<T>().toEqualTypeOf<Auth>();
+  });
+  test("an invalid interceptor type should throw", () => {
+    expect(() => betterAuth({}, "not an interceptor" as any)).toThrow();
+  });
+  test("context should be modified all the way down", async () => {
+    const auth = betterAuth({}, (ctx) => {
+      ctx.appName = "My Different App Name";
+      return ctx;
+    });
+    const newContext = await auth.$context;
+    expect(newContext.appName).toBe("My Different App Name");
+  });
+});

--- a/packages/better-auth/src/auth/custom.ts
+++ b/packages/better-auth/src/auth/custom.ts
@@ -14,22 +14,22 @@ import { createBetterAuth } from "./base";
  */
 
 export const betterAuth = <Options extends BetterAuthOptions>(
-  options: Options &
-    // fixme(alex): do we need Record<never, never> here?
-    Record<never, never>,
-  contextInterceptor?: (ctx: AuthContext) => AuthContext,
+	options: Options &
+		// fixme(alex): do we need Record<never, never> here?
+		Record<never, never>,
+	contextInterceptor?: (ctx: AuthContext) => AuthContext,
 ): Auth<Options> => {
-  const isValidInterceptor = typeof contextInterceptor === "function";
-  const interceptor = isValidInterceptor
-    ? contextInterceptor
-    : (ctx: AuthContext) => ctx;
+	const isValidInterceptor = typeof contextInterceptor === "function";
+	const interceptor = isValidInterceptor
+		? contextInterceptor
+		: (ctx: AuthContext) => ctx;
 
-  if (!isValidInterceptor && contextInterceptor !== undefined) {
-    throw new BetterAuthError(
-      "Provided contextInterceptor is not a valid function",
-    );
-  }
+	if (!isValidInterceptor && contextInterceptor !== undefined) {
+		throw new BetterAuthError(
+			"Provided contextInterceptor is not a valid function",
+		);
+	}
 
-  const initFn = (options: Options) => init(options).then(interceptor);
-  return createBetterAuth(options, initFn);
+	const initFn = (options: Options) => init(options).then(interceptor);
+	return createBetterAuth(options, initFn);
 };

--- a/packages/better-auth/src/auth/custom.ts
+++ b/packages/better-auth/src/auth/custom.ts
@@ -1,0 +1,35 @@
+import type { AuthContext, BetterAuthOptions } from "@better-auth/core";
+import { BetterAuthError } from "@better-auth/core/error";
+import { init } from "../context/init";
+import type { Auth } from "../types";
+import { createBetterAuth } from "./base";
+
+/**
+ * Better Auth initializer that allows for a modified context (Advanced)
+ *
+ * Lets you intercept + modify the AuthContext right after init() runs.
+ * Only use this if you genuinely need to patch or extend the context.
+ *
+ * Check `auth.ts` for standard initialization
+ */
+
+export const betterAuth = <Options extends BetterAuthOptions>(
+  options: Options &
+    // fixme(alex): do we need Record<never, never> here?
+    Record<never, never>,
+  contextInterceptor?: (ctx: AuthContext) => AuthContext,
+): Auth<Options> => {
+  const isValidInterceptor = typeof contextInterceptor === "function";
+  const interceptor = isValidInterceptor
+    ? contextInterceptor
+    : (ctx: AuthContext) => ctx;
+
+  if (!isValidInterceptor && contextInterceptor !== undefined) {
+    throw new BetterAuthError(
+      "Provided contextInterceptor is not a valid function",
+    );
+  }
+
+  const initFn = (options: Options) => init(options).then(interceptor);
+  return createBetterAuth(options, initFn);
+};


### PR DESCRIPTION
Summary
- add a `betterAuth` initializer variant that allows intercepting and mutating the resolved auth context
- expose the custom initializer through the package export map and cover the behavior with vitest

```ts
export const auth = betterAuth(
  {
    appName: "My App",
  },
  (ctx) => {
    ctx.appName = "My Better App";
    return ctx;
  },
);
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a custom `betterAuth` initializer to intercept and mutate the `AuthContext` after init. Covered by tests.

- **New Features**
  - New `./custom` entry: `betterAuth(options, interceptor?)` applies a context interceptor after `init()`.
  - Validates interceptor and throws `BetterAuthError` if not a function.
  - Adds `typesVersions` for `./custom`; preserves `Auth` types and reflects mutations in `auth.$context`.

<sup>Written for commit 862bba4c652e11e3ca8cfebcb40da8dd4fb4b756. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

