### PR TITLE
docs: add IdP-initiated SAML SSO workaround for Next.js

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -430,23 +430,29 @@ await auth.api.registerSSOProvider({
     </Tab>
 </Tabs>
 
-### IdP-Initiated SSO (Next.js)
+### IdP-Initiated SSO
 
-For IdP-initiated flows (e.g., via Okta dashboard), Next.js requires an explicit route handler to manage the redirect. Create this file to prevent 404 errors:
+ For IdP-initiated flows (e.g., via Okta dashboard), your framework may require an explicit route handler to manage the redirect if the default handler doesn't support the `GET` request following the SAML POST.
 
-```ts title="app/api/auth/sso/saml2/callback/[providerId]/route.ts"
-import { auth } from "@/lib/auth";
-import { NextResponse } from "next/server";
+ <Tabs items={["next-js-app-router"]}>
+   <Tab value="next-js-app-router">
+     Create this file to prevent 404 errors:
 
-export async function POST(req: Request) {
-    return auth.handler(req);
-}
+     ```ts title="app/api/auth/sso/saml2/callback/[providerId]/route.ts"
+     import { auth } from "@/lib/auth";
+     import { NextResponse } from "next/server";
 
-export async function GET(req: Request) {
-    // Required: IdP-initiated flows redirect to this URL after POST
-    return NextResponse.redirect(new URL("/", req.url));
-}
-```
+     export async function POST(req: Request) {
+         return auth.handler(req);
+     }
+
+     export async function GET(req: Request) {
+         // Required: IdP-initiated flows redirect to this URL after POST
+         return NextResponse.redirect(new URL("/", req.url));
+     }
+     ```
+   </Tab>
+</Tabs>
 
 ### Get Service Provider Metadata
 


### PR DESCRIPTION
### Description
This PR addresses the issue where IdP-initiated SAML SSO flows (e.g., clicking the app icon from an Okta dashboard) fail with a 404  error in Next.js App Router.

### The Issue
As discussed in #6615, when the IdP POSTs to the callback URL, Better Auth redirects (302). The browser follows this with a `GET` request to the same URL. Since the default setup relies on a catch-all route that may not handle this specific `GET` context, the flow breaks.

### The Fix
I have added a new documentation section **"IdP-Initiated SSO (Next.js)"** to `docs/content/docs/plugins/sso.mdx`. It provides the code snippet for creating an explicit route handler (`route.ts`) that manages both the `POST` (handshake) and the `GET` (redirect) methods.

### Related Issue
Fixes #6615

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for a Next.js workaround to support IdP-initiated SAML SSO and prevent 404s after the IdP redirect. Includes a route handler snippet that handles both POST (handshake) and GET (redirect) on the callback URL.

<sup>Written for commit 30cc9d558c2b3e96ff8c848962f747979b2d7623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

