### PR TITLE
docs: add Argon2 password hashing example

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -327,21 +327,47 @@ Better Auth stores passwords inside the `account` table with `providerId` set to
 
 **Password Hashing**: Better Auth uses `scrypt` to hash passwords. The `scrypt` algorithm is designed to be slow and memory-intensive to make it difficult for attackers to brute force passwords. OWASP recommends using `scrypt` if `argon2id` is not available. We decided to use `scrypt` because it's natively supported by Node.js.
 
-You can pass custom password hashing algorithm by setting `passwordHasher` option in the `auth` configuration.
+You can pass custom password hashing algorithm by setting `password` option in the `emailAndPassword` configuration.
 
+**Example**
+
+Here's an example of customizing the password hashing to use Argon2:
+```ts title="password.ts"
+import { hash, type Options, verify } from "@node-rs/argon2";
+
+const opts: Options = {
+  memoryCost: 65536, // 64 MiB
+  timeCost: 3, // 3 iterations
+  parallelism: 4, // 4 lanes
+  outputLen: 32, // 32 bytes
+  algorithm: 2, // Argon2id
+};
+
+export async function hashPassword(password: string) {
+  const result = await hash(password, opts);
+  return result;
+}
+
+export async function verifyPassword(data: { password: string; hash: string }) {
+  const { password, hash } = data;
+  const result = await verify(hash, password, opts);
+  return result;
+}
+```
 ```ts title="auth.ts"
-import { betterAuth } from "better-auth"
-import { scrypt } from "scrypt"
+import { betterAuth } from "better-auth";
+import { hashPassword, verifyPassword } from "./password";
 
 export const auth = betterAuth({
+  emailAndPassword: {
     //...rest of the options
-    emailAndPassword: {
-        password: {
-            hash: // your custom password hashing function
-            verify: // your custom password verification function
-        }
-    }
-})
+    enabled: true,
+    password: {
+      hash: hashPassword,
+      verify: verifyPassword,
+    },
+  },
+});
 ```
 
 <TypeTable


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an Argon2 password hashing example to help users replace the default scrypt with Argon2id. Updated docs to use the emailAndPassword.password config with hash/verify functions based on @node-rs/argon2.

<sup>Written for commit bd74fa0d89d8330677e29342d26af4dd75992815. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

