### PR TITLE
chore: fix type inference for future TS compatibility

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -167,6 +167,6 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 		},
 		$ERROR_CODES: ADMIN_ERROR_CODES,
 		schema: mergeSchema(schema, opts.schema),
-		options: options as any,
+		options: options as NoInfer<O>,
 	} satisfies BetterAuthPlugin;
 };

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -29,7 +29,7 @@ const verifyJWTBodySchema = z.object({
 	issuer: z.string().optional(),
 });
 
-export const jwt = (options?: JwtOptions | undefined) => {
+export const jwt = <O extends JwtOptions>(options?: O) => {
 	// Remote url must be set when using signing function
 	if (options?.jwt?.sign && !options.jwks?.remoteUrl) {
 		throw new BetterAuthError(
@@ -61,7 +61,7 @@ export const jwt = (options?: JwtOptions | undefined) => {
 
 	return {
 		id: "jwt",
-		options,
+		options: options as NoInfer<O>,
 		endpoints: {
 			getJwks: createAuthEndpoint(
 				jwksPath,

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -55,12 +55,12 @@ const oAuthProxyQuerySchema = z.object({
 	}),
 });
 
-export const oAuthProxy = (opts?: OAuthProxyOptions | undefined) => {
+export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 	const maxAge = opts?.maxAge ?? 60; // Default 60 seconds
 
 	return {
 		id: "oauth-proxy",
-		options: opts,
+		options: opts as NoInfer<O>,
 		endpoints: {
 			oAuthProxy: createAuthEndpoint(
 				"/oauth-proxy-callback",

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -47,7 +47,7 @@ const disableTwoFactorBodySchema = z.object({
 	}),
 });
 
-export const twoFactor = (options?: TwoFactorOptions | undefined) => {
+export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 	const opts = {
 		twoFactorTable: "twoFactor",
 	};
@@ -284,7 +284,7 @@ export const twoFactor = (options?: TwoFactorOptions | undefined) => {
 				},
 			),
 		},
-		options: options,
+		options: options as NoInfer<O>,
 		hooks: {
 			after: [
 				{


### PR DESCRIPTION
Similar to #6643

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved TypeScript type inference for plugin options using NoInfer to prevent unintended widening and ensure future TS compatibility. No runtime behavior changes.

- **Refactors**
  - Updated admin, jwt, oauth-proxy, and two-factor plugins to use generic O extends Options and cast options as NoInfer<O>.
  - Preserves exact option types in returned plugin objects for safer inference across TS versions.
  - API surface unchanged; type-only adjustments.

<sup>Written for commit d0aa895fe19278841480afeca97a716cb78932dc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

