### PR TITLE
docs: updated the accountInfo server side example

### DIFF
--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -108,7 +108,7 @@ server-side usage:
 
 ```ts
 await auth.api.accountInfo({
-  body: { accountId: "accountId" },
+  query: { accountId: "accountId" },
   headers: // pass headers with authenticated token
 });
 ```


### PR DESCRIPTION
The documentation was listing the usage example prior to better-auth version 1.4 which introduced some breaking changes as stated in: https://www.better-auth.com/blog/1-4#existing-auth-flows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the server-side accountInfo example to match better-auth v1.4’s breaking change: pass accountId in query instead of body. This aligns the docs with the current API and prevents incorrect usage.

<sup>Written for commit 6d3dda03f509511a605e43840708369b7b84299a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

