### PR TITLE
docs: correct codeblock title

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -936,7 +936,7 @@ When a provider's domain is verified, it is also trusted for **automatic account
 
 <Tabs items={["client", "server"]}>
     <Tab value="client">
-```ts title="auth.ts"
+```ts title="auth-client.ts"
 const authClient = createAuthClient({
     plugins: [
         ssoClient({ // [!code highlight]
@@ -950,7 +950,7 @@ const authClient = createAuthClient({
     </Tab>
 
     <Tab value="server">
-```ts title="auth-client.ts"
+```ts title="auth.ts"
 const auth = betterAuth({
     plugins: [
         sso({ // [!code highlight]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed code block titles in the SSO plugin docs to match the client and server examples. Client now uses auth-client.ts; server uses auth.ts.

<sup>Written for commit f4b272b46da3fdf058795b9381f2e252bddbd69a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

