### PR TITLE
fix(oidc-provider): enforce JWT plugin for public clients to prevent zero-length key crash

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -1038,10 +1038,13 @@ export const oidcProvider = (options: OIDCOptions) => {
 						// If the JWT token is not enabled, create a key and use it to sign
 					} else {
 						if (client.type === "public") {
+							ctx.context.logger.error(
+								"OIDC: Public client (PKCE) detected but JWT plugin is disabled. Public clients require Asymmetric (RS256/EdDSA) signing via the 'jwt' plugin.",
+							);
 							throw new APIError("INTERNAL_SERVER_ERROR", {
 								error_description:
 									"Public clients (PKCE) require the 'jwt' plugin to be enabled. They must use RS256 (Asymmetric) signing because they cannot hold a clientSecret.",
-								error: "server_error",
+								error: "internal_server_error",
 							});
 						}
 						if (!client.clientSecret) {


### PR DESCRIPTION
## Description
Fixes #6651

This PR addresses a runtime crash ("Zero-length key is not supported") that occurs when a **Public Client** (e.g., mobile app, SPA) attempts to obtain an ID Token using the OIDC provider.

### The Issue
Currently, the OIDC provider defaults to symmetric signing (`HS256`) using the `clientSecret` if the `jwt` plugin is not explicitly enabled. Public clients (using PKCE) correctly have `clientSecret: undefined`. When the signer receives this undefined secret, it throws a crypto error.

### The Fix
This patch strictly enforces the OAuth 2.0 / OIDC security model for public clients:
1.  **Prevents HS256 Signing:** Explicitly blocks the code from attempting to sign with `client.clientSecret` when `client.type === "public"`.
2.  **Enforces Asymmetric Signing:** Throws a clear, actionable error if a public client is configured without the `jwt` plugin enabled. Public clients *must* use RS256 (provided by the JWT plugin) since they cannot securely hold a symmetric secret.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes when public OIDC clients request ID tokens. Enforces RS256 via the JWT plugin for public clients and validates clientSecret for HS256.

- **Bug Fixes**
  - Block HS256 signing for public clients; require the jwt plugin (RS256).
  - Add clear errors: public clients need jwt; HS256 requires a client_secret.

<sup>Written for commit 6bc17dd68a9233d93c5569264b506caa0b1ce28d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



