### PR TITLE
docs(organization): add missing organizationRole schema

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -2291,6 +2291,46 @@ You need to add two more fields to the session table to store the active organiz
   ]}
 />
 
+### Organization Role (optional)
+
+Table Name: `organizationRole`
+
+<DatabaseTable
+  fields={[
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier for each organization role",
+    },
+    {
+      name: "organizationId",
+      type: "string",
+      description: "The ID of the organization",
+      isForeignKey: true,
+    },
+    {
+      name: "role",
+      type: "string",
+      description: "The name of the role",
+    },
+    {
+      name: "permission",
+      type: "string",
+      description: "The permission of the role",
+    },
+    {
+      name: "createdAt",
+      type: "Date",
+      description: "Timestamp of when the organization role was created",
+    },
+    {
+      name: "updatedAt",
+      type: "Date",
+      description: "Timestamp of when the organization role was updated",
+    },
+  ]}
+/>
+
 ### Teams (optional)
 
 Table Name: `team`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the missing organizationRole schema to the Organization plugin docs to document fields for role and permission management. This completes the database tables and helps teams implement consistent role storage.

<sup>Written for commit ceaab3b75afa7eb3d256aaf490b101c948863185. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

