### PR TITLE
chore: dont show conflict error for virtual endpoints

### DIFF
--- a/demo/nextjs/tsconfig.json
+++ b/demo/nextjs/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "declarationMap": true,
     "noEmit": true,
     "declaration": true,
     "esModuleInterop": true,

--- a/packages/better-auth/src/api/check-endpoint-conflicts.test.ts
+++ b/packages/better-auth/src/api/check-endpoint-conflicts.test.ts
@@ -2,7 +2,7 @@ import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
 import type { InternalLogger, LogLevel } from "@better-auth/core/env";
 import { createEndpoint } from "better-call";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { checkEndpointConflicts } from "./index";
+import { checkEndpointConflicts, createAuthEndpoint } from "./index";
 
 let mockLoggerLevel: LogLevel = "debug";
 const mockLogger = {
@@ -439,6 +439,27 @@ describe("checkEndpointConflicts", () => {
 	it("should handle options with empty plugins array", () => {
 		const options: BetterAuthOptions = {
 			plugins: [],
+		};
+
+		checkEndpointConflicts(options, mockLogger);
+
+		expect(mockLogger.error).not.toHaveBeenCalled();
+	});
+
+	it("should handle plugins with endpoints that don't have a path", () => {
+		const plugin1: BetterAuthPlugin = {
+			id: "plugin1",
+			endpoints: {
+				endpoint1: createAuthEndpoint({ method: "GET" }, async () => ({
+					ok: true,
+				})),
+				endpoint2: createAuthEndpoint({ method: "GET" }, async () => ({
+					ok: true,
+				})),
+			},
+		};
+		const options: BetterAuthOptions = {
+			plugins: [plugin1],
 		};
 
 		checkEndpointConflicts(options, mockLogger);

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -55,7 +55,11 @@ export function checkEndpointConflicts(
 	options.plugins?.forEach((plugin) => {
 		if (plugin.endpoints) {
 			for (const [key, endpoint] of Object.entries(plugin.endpoints)) {
-				if (endpoint && "path" in endpoint) {
+				if (
+					endpoint &&
+					"path" in endpoint &&
+					typeof endpoint.path === "string"
+				) {
 					const path = endpoint.path;
 					let methods: string[] = [];
 					if (endpoint.options && "method" in endpoint.options) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent false conflict errors by ignoring virtual plugin endpoints that don’t define a path. This removes noisy error logs during startup.

- **Bug Fixes**
  - Validate endpoint.path is a string before checking conflicts.
  - Add tests for plugins with path-less endpoints to ensure no error is logged.
  - Enable declarationMap in the demo tsconfig for better type debugging.

<sup>Written for commit a9b5e82badebe34d43e9932583b8f411e4855037. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

