### PR TITLE
fix(cookies): update domain extraction logic for cross-subdomain cookies

### DIFF
--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -128,6 +128,30 @@ describe("crossSubdomainCookies", () => {
 			},
 		);
 	});
+
+	it("should use default top level domain from subdomain baseURL if domain is not provided", async () => {
+		const { testUser, client } = await getTestInstance({
+			baseURL: "https://api.example.com",
+			advanced: {
+				crossSubDomainCookies: {
+					enabled: true,
+				},
+			},
+		});
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onResponse(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					expect(setCookie).toContain("Domain=example.com");
+				},
+			},
+		);
+	});
 });
 
 describe("cookie configuration", () => {

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -36,7 +36,9 @@ export function createCookieGetter(options: BetterAuthOptions) {
 		!!options.advanced?.crossSubDomainCookies?.enabled;
 	const domain = crossSubdomainEnabled
 		? options.advanced?.crossSubDomainCookies?.domain ||
-			(options.baseURL ? new URL(options.baseURL).hostname : undefined)
+			(options.baseURL
+				? new URL(options.baseURL).hostname.split(".").slice(-2).join(".")
+				: undefined)
 		: undefined;
 	if (crossSubdomainEnabled && !domain) {
 		throw new BetterAuthError(


### PR DESCRIPTION
This PR extends the fallback domain for crossSubdomain cookies logic to use TLD instead of baseURL hostname;


### Issue
Currently when serving better-auth on a subdomain like `api.example.com` (think of setup like HonoJS/Express API) and client is also on `example.com`, with crossSubdomain enabled,  better-auth redirect to client successfully but client does not have access to cookies because it has `.api.example.com` as domain.

### Fix
This change uses the TLD of the baseURL hostname, in this case `example.com` so that auth cookies is truly available across all subdomains



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-subdomain cookies by using the top-level domain from baseURL as the fallback cookie domain, so cookies set on a subdomain are readable on the root domain (e.g., api.example.com -> example.com).

- **Bug Fixes**
  - Use baseURL’s top-level domain when crossSubDomainCookies is enabled and no domain is provided.
  - Added a test to assert cookies default to Domain=example.com when baseURL is a subdomain.

<sup>Written for commit 4392b6265774547268172886bca34ab40e6bdd0a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



