### PR TITLE
feat(organization): export `./adapter.ts` for plugin extensibility

### DIFF
--- a/packages/better-auth/src/plugins/organization/index.ts
+++ b/packages/better-auth/src/plugins/organization/index.ts
@@ -1,5 +1,5 @@
 export type * from "./access";
-export * from "./adapter";
+export { getOrgAdapter } from "./adapter";
 export * from "./organization";
 export type * from "./schema";
 export type * from "./types";


### PR DESCRIPTION
This PR exports `./adapter.ts` (specifically for `getOrgAdapter`) from the "organization" plugin to enable building extensions on top of it

Right now, if you want to build a plugin that extends organization functionality, you need to either duplicate the adapter logic or access internal APIs. Exporting `getOrgAdapter` lets developers reuse the existing type-safe operations instead.







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported the organization plugin’s adapter (./adapter.ts) to expose getOrgAdapter so external plugins can reuse the type-safe organization operations instead of duplicating logic. This improves plugin extensibility without relying on internal APIs.

<sup>Written for commit 1d7ce78c8f2d8189976429173bbc4ac2c68e4581. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







