### PR TITLE
docs(expo): fix code examples

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -440,6 +440,7 @@ export function TRPCProvider(props: { children: React.ReactNode }) {
 
 ```ts title="lib/auth-client.ts"
 import { createAuthClient } from "better-auth/react";
+import { expoClient } from "@better-auth/expo/client";
 import SecureStorage from "expo-secure-store";
 
 const authClient = createAuthClient({
@@ -457,6 +458,7 @@ const authClient = createAuthClient({
 
 ```ts title="lib/auth-client.ts"
 import { createAuthClient } from "better-auth/react";
+import { expoClient } from "@better-auth/expo/client";
 
 const authClient = createAuthClient({
     baseURL: "http://localhost:8081",
@@ -473,6 +475,7 @@ const authClient = createAuthClient({
 
 ```ts title="lib/auth-client.ts"
 import { createAuthClient } from "better-auth/react";
+import { expoClient } from "@better-auth/expo/client";
 
 const authClient = createAuthClient({
     baseURL: "http://localhost:8081",


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Expo integration code blocks to pass options through the expoClient plugin (plugins: [expoClient({...})]) rather than top-level createAuthClient keys. This prevents misconfiguration for storage, scheme, and disableCache in the examples.

<sup>Written for commit 99369e4674d269814d61dec1b83877bbfad1dcef. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



