### PR TITLE
docs(oidc-provider): fix incorrect redirectURLs property name

### DIFF
--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -190,7 +190,7 @@ const auth = betterAuth({
                 clientSecret: "secure-secret-here",
                 name: "Internal Dashboard",
                 type: "web",
-                redirectURLs: ["https://dashboard.company.com/auth/callback"],
+                redirectUrls: ["https://dashboard.company.com/auth/callback"],
                 disabled: false,
                 skipConsent: true, // Skip consent for this trusted client
                 metadata: { internal: true }
@@ -200,7 +200,7 @@ const auth = betterAuth({
                 clientSecret: "mobile-secret", 
                 name: "Company Mobile App",
                 type: "native",
-                redirectURLs: ["com.company.app://auth"],
+                redirectUrls: ["com.company.app://auth"],
                 disabled: false,
                 skipConsent: false, // Still require consent if needed
                 metadata: {}
@@ -450,7 +450,7 @@ Table Name: `oauthApplication`
       isRequired: true
     },
     { 
-      name: "redirectURLs", 
+      name: "redirectUrls",
       type: "string", 
       description: "Comma-separated list of redirect URLs",
       isRequired: true


### PR DESCRIPTION
## Description
This PR fixes a documentation error in the **OIDC Provider** plugin where the `redirectUrls` property was incorrectly referenced as `redirectURLs` (uppercase "URLs").

The internal code and TypeScript definitions expect `redirectUrls` (camelCase). Using the configuration currently shown in the docs causes `client.redirectUrls` to be undefined during runtime, leading to crashes in the authorize flow.

## Changes
- Updated `trustedClients` configuration examples to use `redirectUrls`.
- Updated the **Schema** section (OAuth Application table) to show the correct column name `redirectUrls`.

## Related Issue
Fixes #6724

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the OIDC Provider docs to use redirectUrls (not redirectURLs) in trustedClients examples and the OAuth Application schema. This matches the code and prevents authorize flow crashes caused by undefined client.redirectUrls.

<sup>Written for commit f2188d4b7430962a4ccac00683f623566696ab4d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

