### PR TITLE
feat(oidc-provider): support prompt=create

### DIFF
--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -349,6 +349,10 @@ export const auth = betterAuth({
 
 You don't need to handle anything from your side; when a new session is created, the plugin will handle continuing the authorization flow.
 
+### Initiating Registration (`prompt=create`)
+
+Better Auth supports the OpenID Connect Prompt Create extension. When an authorization request includes `prompt=create` and the user is not authenticated, Better Auth will redirect the user to `createAccountPage` (if provided) instead of `loginPage`. If `createAccountPage` is not set, the user will be redirected to `loginPage` and you can render a sign-up experience based on the `prompt` query parameter.
+
 ## Configuration
 
 ### OIDC Metadata
@@ -619,6 +623,8 @@ Table Name: `oauthConsent`
 **metadata**: `OIDCMetadata` - Customize the OIDC provider metadata.
 
 **loginPage**: `string` - Path to the custom login page.
+
+**createAccountPage**: `string` - Path to the custom create account (sign-up) page. When an authorization request includes `prompt=create`, unauthenticated users will be redirected here instead of `loginPage`.
 
 **consentPage**: `string` - Path to the custom consent page.
 

--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -12,6 +12,11 @@ function formatErrorURL(url: string, error: string, description: string) {
 	}error=${error}&error_description=${description}`;
 }
 
+function appendQuery(url: string, query: string) {
+	if (!query) return url;
+	return `${url}${url.includes("?") ? "&" : "?"}${query}`;
+}
+
 function getErrorURL(
 	ctx: GenericEndpointContext,
 	error: string,
@@ -86,8 +91,12 @@ export async function authorize(
 				sameSite: "lax",
 			},
 		);
-		const queryFromURL = ctx.request.url?.split("?")[1]!;
-		return handleRedirect(`${options.loginPage}?${queryFromURL}`);
+		const queryFromURL = ctx.request.url?.split("?")[1] || "";
+		const targetPage =
+			promptSet.has("create") && options.createAccountPage
+				? options.createAccountPage
+				: options.loginPage;
+		return handleRedirect(appendQuery(targetPage, queryFromURL));
 	}
 
 	const query = ctx.query as AuthorizationQuery;

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -102,6 +102,13 @@ export const getMetadata = (
 		jwks_uri: `${baseURL}/jwks`,
 		registration_endpoint: `${baseURL}/oauth2/register`,
 		end_session_endpoint: `${baseURL}/oauth2/endsession`,
+		prompt_values_supported: [
+			"none",
+			"login",
+			"consent",
+			"select_account",
+			"create",
+		],
 		scopes_supported: ["openid", "profile", "email", "offline_access"],
 		response_types_supported: ["code"],
 		response_modes_supported: ["query"],

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -89,6 +89,13 @@ export interface OIDCOptions {
 	 */
 	loginPage: string;
 	/**
+	 * The URL to the account creation page. This is used if the client requests
+	 * the `create` prompt.
+	 *
+	 * If not provided, the `loginPage` will be used.
+	 */
+	createAccountPage?: string | undefined;
+	/**
 	 * Whether to require PKCE (proof key code exchange) or not
 	 *
 	 * According to OAuth2.1 spec this should be required. But in any
@@ -206,7 +213,7 @@ export interface AuthorizationQuery {
 	 */
 	prompt?:
 		| (string & {})
-		| ("none" | "consent" | "login" | "select_account")
+		| ("none" | "consent" | "login" | "select_account" | "create")
 		| undefined;
 	/**
 	 * The display parameter is used to specify how the authorization server displays the
@@ -452,6 +459,12 @@ export interface OIDCMetadata {
 	 * @default `/oauth2/register`
 	 */
 	registration_endpoint: string;
+	/**
+	 * Supported prompt values.
+	 *
+	 * When defined, it MUST include all prompt values supported by this OP.
+	 */
+	prompt_values_supported?: string[] | undefined;
 	/**
 	 * Supported scopes.
 	 */

--- a/packages/better-auth/src/plugins/oidc-provider/utils/prompt.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/utils/prompt.test.ts
@@ -60,10 +60,11 @@ describe("parsePrompt", () => {
 	});
 
 	it("should handle all valid prompt types", () => {
-		const result = parsePrompt("login consent select_account");
+		const result = parsePrompt("login consent select_account create");
 		expect(result.has("login")).toBe(true);
 		expect(result.has("consent")).toBe(true);
 		expect(result.has("select_account")).toBe(true);
-		expect(result.size).toBe(3);
+		expect(result.has("create")).toBe(true);
+		expect(result.size).toBe(4);
 	});
 });

--- a/packages/better-auth/src/plugins/oidc-provider/utils/prompt.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/utils/prompt.ts
@@ -1,6 +1,11 @@
 import { InvalidRequest } from "../error";
 
-export type AuthorizePrompt = "login" | "consent" | "select_account" | "none";
+export type AuthorizePrompt =
+	| "login"
+	| "consent"
+	| "select_account"
+	| "create"
+	| "none";
 export type AuthorizePromptSet = ReadonlySet<AuthorizePrompt>;
 
 /**
@@ -16,6 +21,7 @@ export function parsePrompt(prompt: string) {
 			p === "login" ||
 			p === "consent" ||
 			p === "select_account" ||
+			p === "create" ||
 			p === "none"
 		) {
 			set.add(p);


### PR DESCRIPTION
## Summary

Implements OpenID Connect Prompt Create (`prompt=create`) support in the Better Auth OIDC Provider plugin to enable a sign-up-first onboarding experience via the standard `/oauth2/authorize` flow.

Closes #6737

## Solution

This supports an "OIDC-first" onboarding UX where the relying party (an external app) never handles the user's password:

1. The relying party initiates authorization with `prompt=create` (optionally `login_hint`):
   - `/oauth2/authorize?...&prompt=create&login_hint=user@example.com`
2. If the user is not authenticated, Better Auth redirects to `createAccountPage` (or `loginPage` if not configured), preserving the query string so the UI can render sign-up-first.
3. The user completes sign-up in the Better Auth-hosted UI.
4. Once a session is created, Better Auth resumes the OIDC authorization flow and completes the redirect back to the relying party.

Note: `prompt=create` is treated as a UX routing hint in the OP. It does not create users "through OIDC parameters"; the actual user creation is performed by Better Auth's sign-up endpoint as part of the OP's UI flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for OIDC prompt=create to enable a sign-up-first flow via /oauth2/authorize. Unauthenticated requests with prompt=create now redirect to a dedicated sign-up page, improving onboarding.

- New Features
  - Handle prompt=create by redirecting unauthenticated users to createAccountPage (falls back to loginPage). Preserves the original query string.
  - Added createAccountPage option to the OIDC provider config.
  - Updated metadata (prompt_values_supported) and prompt parsing to include create.
  - Docs and tests added for prompt=create behavior.

- Migration
  - No breaking changes. Optionally set createAccountPage to use a dedicated sign-up route.

<sup>Written for commit d13cdd034ee4f3200abbfdd5ffb72ff703b5d432. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

