### PR TITLE
docs: restrict SIWE example nonce generation characters

### DIFF
--- a/docs/content/docs/plugins/siwe.mdx
+++ b/docs/content/docs/plugins/siwe.mdx
@@ -228,7 +228,7 @@ export const auth = betterAuth({
       anonymous: false,
       getNonce: async () => {
         // Generate a cryptographically secure random nonce
-        return generateRandomString(32);
+        return generateRandomString(32, "a-z", "A-Z", "0-9");
       },
       verifyMessage: async ({ message, signature, address }) => {
         try {


### PR DESCRIPTION
[EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) indicates that generated nonces should be "at least 8 alphanumeric characters". The current BA docs use the BA `generateRandomString` utility to generate nonces, however this currently implements a mix of alphanumeric and non-alphanumeric characters. I updated the docs example to only pull alphanumeric characters for nonce generation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update SIWE docs to generate alphanumeric-only nonces, matching EIP-4361. Example now uses generateRandomString(32, "a-z", "A-Z", "0-9") instead of generateRandomString(32).

<sup>Written for commit ac24134dbd50c596c6c3dec2ea5ccd89fa0f8178. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

