### PR TITLE
fix: prevent return type breakage

### DIFF
--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -607,16 +607,11 @@ export const listSessions = <Option extends BetterAuthOptions>() =>
 					.map((session) => {
 						return {
 							...session,
-							token: undefined, // we don't need to return the token to the client
-							expiresAt: session.expiresAt.toISOString(),
-							createdAt: session.createdAt.toISOString(),
-							updatedAt: session.updatedAt.toISOString(),
+							token: "", // we don't need to return the token to the client
 						};
 					});
 				return ctx.json(
-					activeSessions as unknown as Prettify<
-						InferSession<Option> & { token: undefined }
-					>[],
+					activeSessions as unknown as Prettify<InferSession<Option>>[],
 				);
 			} catch (e: any) {
 				ctx.context.logger.error(e);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes listSessions response to match InferSession types and avoid breaking client code. Token is now blank and date fields are no longer forced to strings.

- **Bug Fixes**
  - Set token to "" instead of undefined to keep the field shape without exposing secrets.
  - Removed manual toISOString conversions and simplified the cast to Prettify<InferSession<Option>>[] to align payload types.

<sup>Written for commit 4a0740aedb747c9a7e5e6e22c7c69bdbee5cf567. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

