### PR TITLE
docs: fix overflowing code elements

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -357,6 +357,6 @@ html:not([data-anchor-scrolling]) {
 	animation: stream-pulse 1s ease-in-out infinite;
 }
 
-code {
-    @apply text-pretty break-words;
+code:not(pre code) {
+	@apply break-words;
 }


### PR DESCRIPTION
Before:
<img width="375" height="253" alt="image" src="https://github.com/user-attachments/assets/dfb376f7-b599-4e0f-9548-be6cf1539c2a" />

After:
<img width="372" height="303" alt="image" src="https://github.com/user-attachments/assets/3cf836c4-033b-4b2b-985f-15d291d64ff6" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed overflowing inline code in the docs by adding word wrapping and improved text flow to code elements. Long tokens now wrap instead of spilling outside containers, improving readability on small screens.

<sup>Written for commit 14da384ff9f8c11508f916c6c26489b64a70e48b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



