### PR TITLE
fix: revert token masking in listSessions route

### DIFF
--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -600,16 +600,9 @@ export const listSessions = <Option extends BetterAuthOptions>() =>
 				const sessions = await ctx.context.internalAdapter.listSessions(
 					ctx.context.session.user.id,
 				);
-				const activeSessions = sessions
-					.filter((session) => {
-						return session.expiresAt > new Date();
-					})
-					.map((session) => {
-						return {
-							...session,
-							token: "", // we don't need to return the token to the client
-						};
-					});
+				const activeSessions = sessions.filter((session) => {
+					return session.expiresAt > new Date();
+				});
 				return ctx.json(
 					activeSessions as unknown as Prettify<InferSession<Option>>[],
 				);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverted token masking in the listSessions route, returning active sessions with their original token field to restore expected behavior for clients. Expired sessions are still filtered out.

<sup>Written for commit d09ec35fecb335d6193569116415ddc419d57d65. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

