### PR TITLE
chore: fix prisma peer dependency version

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -492,7 +492,7 @@
   },
   "peerDependencies": {
     "@lynx-js/react": "*",
-    "@prisma/client": "^5.22.0",
+    "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "@sveltejs/kit": "^2.0.0",
     "@tanstack/react-start": "^1.0.0",
     "better-sqlite3": "^12.4.1",
@@ -502,7 +502,7 @@
     "mysql2": "^3.14.4",
     "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "pg": "^8.16.3",
-    "prisma": "^5.22.0",
+    "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "solid-js": "^1.0.0",


### PR DESCRIPTION
closes #6746

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded Prisma peer dependency support in Better Auth to include v5, v6, and v7. This removes install warnings and ensures compatibility for projects on Prisma 6/7.

- **Dependencies**
  - Updated peerDependencies for prisma and @prisma/client to "^5.0.0 || ^6.0.0 || ^7.0.0".

<sup>Written for commit 4d4c979b5eb2da25f82032f2ec7681345ab90ca1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

