### PR TITLE
fix(api-key): prevent id update error with MongoDB adapter

### DIFF
--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -192,7 +192,7 @@ export async function validateApiKey({
 					value: apiKey.id,
 				},
 			],
-			update: updated,
+			update: { ...updated, id: undefined },
 		});
 	} else if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
 		// Secondary storage with fallback: update database and then update storage
@@ -204,7 +204,7 @@ export async function validateApiKey({
 					value: apiKey.id,
 				},
 			],
-			update: updated,
+			update: { ...updated, id: undefined },
 		});
 		if (dbUpdated) {
 			await setApiKey(ctx, dbUpdated, opts);


### PR DESCRIPTION
## Description

Fixes MongoDB adapter compatibility with the API Key plugin by preventing attempts to update the immutable `_id` field.

Closes #6711

## Problem

The API Key plugin tests are currently failing when run with MongoDB adapter (`testWith: "mongodb"`).

**Test Results:**
- ❌ **Before fix:** `Tests  10 failed | 106 passed (116)` with MongoDB
- ✅ **After fix:** `Tests  116 passed (116)` with MongoDB

MongoDB throws an error when attempting to update the `_id` field:
```
codeName: "ImmutableField"
[...]
Plan executor error during findAndModify :: caused by :: Performing an update on the path '_id' would modify the immutable field '_id'
```

The `_id` field is immutable in MongoDB, but the update operation was including it in the update payload.

## Solution

Explicitly exclude the `id` field from the update object by setting it to `undefined` before passing it to the adapter update method.

## Changes

- Modified the `update` call in API Key plugin to exclude `id` from the update payload: `update: { ...updated, id: undefined }`
- Ensures MongoDB adapter compatibility without affecting other adapters

## Testing

- ✅ All API Key plugin tests now pass with MongoDB adapter (116/116)
- ✅ No regression with other adapters expected (id: undefined is safely ignored)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents MongoDB _id update errors in the API Key plugin by excluding the id field from update payloads. Restores MongoDB adapter compatibility; all API Key tests pass.

- **Bug Fixes**
  - Update calls now set id: undefined to avoid modifying the immutable _id on MongoDB.

<sup>Written for commit a05ac3a363ef7c569796c2f9a70bab54cc4acbce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

