### PR TITLE
docs(dodopayments-plugin): add docs for new checkout sessions and usage plugin

### DIFF
--- a/docs/content/docs/plugins/dodopayments.mdx
+++ b/docs/content/docs/plugins/dodopayments.mdx
@@ -18,6 +18,7 @@ description: Better Auth Plugin for Dodo Payments
 - Automatic customer creation on sign-up
 - Type-safe checkout flows with product slug mapping
 - Self-service customer portal
+- Metered usage ingestion and recent usage reporting
 - Real-time webhook event processing with signature verification
 
 <Card href="https://app.dodopayments.com" title="Get started with Dodo Payments">
@@ -51,6 +52,7 @@ import {
   checkout,
   portal,
   webhooks,
+  usage,
 } from "@dodopayments/better-auth";
 import DodoPayments from "dodopayments";
 
@@ -82,6 +84,7 @@ export const auth = betterAuth({
             console.log("Received webhook:", payload.event_type);
           },
         }),
+        usage(),
       ],
     }),
   ],
@@ -107,7 +110,64 @@ export const authClient = createAuthClient({
 
 ## Usage
 
-### Creating a Checkout Session
+### Creating a Checkout Session (preferred)
+
+<Callout type="info">
+  Use <code>authClient.dodopayments.checkoutSession</code> for new integrations.
+  It maps one-to-one with Dodo Payments' Create Checkout Session API and honors
+  the product slugs you configured on the server.
+</Callout>
+
+#### Using a configured slug
+
+```typescript
+const { data: session, error } = await authClient.dodopayments.checkoutSession({
+  slug: "premium-plan",
+  referenceId: "order_123",
+});
+
+if (session) {
+  window.location.href = session.url;
+}
+```
+
+#### Using a product cart
+
+```typescript
+const { data: session, error } = await authClient.dodopayments.checkoutSession({
+  product_cart: [
+    {
+      product_id: "pdt_xxxxxxxxxxxxxxxxxxxxx",
+      quantity: 1,
+    },
+  ],
+  referenceId: "order_123",
+});
+
+if (session) {
+  window.location.href = session.url;
+}
+```
+
+<Callout type="info">
+  Checkout Sessions automatically pull the customer's email and name from their
+  Better Auth session. Override them (or supply billing details upfront) by
+  passing <code>customer</code> or <code>billing</code> in the request body when
+  necessary.
+</Callout>
+
+<Callout>
+  The redirect URL comes from the <code>successUrl</code> configured in the
+  server-side checkout plugin, so you do not need to send a <code>return_url</code>
+  from the client.
+</Callout>
+
+### Legacy Checkout (deprecated)
+
+<Callout type="warn">
+  The <code>authClient.dodopayments.checkout</code> helper remains for backward
+  compatibility only. Prefer <code>checkoutSession</code> for new builds.
+</Callout>
 
 ```typescript
 const { data: checkout, error } = await authClient.dodopayments.checkout({
@@ -163,6 +223,52 @@ const { data: payments, error } = await authClient.dodopayments.customer.payment
 });
 ```
 
+### Tracking Metered Usage
+
+Enable the <code>usage()</code> plugin (shown in the server setup) to ingest
+metered events for the signed-in, email-verified customer and expose recent
+usage history.
+
+```typescript
+const { error: ingestError } = await authClient.dodopayments.usage.ingest({
+  event_id: crypto.randomUUID(),
+  event_name: "api_request",
+  metadata: {
+    route: "/reports",
+    method: "GET",
+  },
+  timestamp: new Date(),
+});
+
+if (ingestError) {
+  console.error("Failed to record usage", ingestError);
+}
+
+const { data: usage, error: usageError } =
+  await authClient.dodopayments.usage.meters.list({
+    query: {
+      page_size: 20,
+      meter_id: "mtr_yourMeterId",
+    },
+  });
+
+if (usage?.items) {
+  usage.items.forEach((event) => {
+    console.log(event.event_name, event.timestamp, event.metadata);
+  });
+}
+```
+
+<Callout type="info">
+  Usage timestamps older than one hour or more than five minutes in the future
+  are rejected.
+</Callout>
+
+<Callout type="info">
+  Omit <code>meter_id</code> to return all meters tied to the customer's active
+  subscriptions.
+</Callout>
+
 ### Webhooks
 
 <Card>
@@ -196,7 +302,7 @@ webhooks({
 
 - **client** (required): DodoPayments client instance
 - **createCustomerOnSignUp** (optional): Auto-create customers on user signup  
-- **use** (required): Array of plugins to enable (checkout, portal, webhooks)
+- **use** (required): Array of plugins to enable (checkout, portal, usage, webhooks)
 
 ### Checkout Plugin Options
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Dodo Payments plugin docs to cover the new checkoutSession API and the metered usage plugin. Adds client/server examples, clarifies defaults, and deprecates the legacy checkout helper.

- **New Features**
  - Client examples for checkoutSession using slugs or product_cart; note auto-filled customer data and server-configured successUrl.
  - Usage plugin: enable usage(), ingest events, list recent usage; timestamp limits; meter_id optional to fetch all meters.
  - Updated imports and plugin options to include usage in the use array.

<sup>Written for commit 216e44145c86c56a79b7cbd59d0e11620208ecab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

