### PR TITLE
feat: add i18n plugin

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -5,7 +5,7 @@ import type {
 import { createFetch } from "@better-fetch/fetch";
 import type { WritableAtom } from "nanostores";
 import { getBaseURL } from "../utils/url";
-import { redirectPlugin } from "./fetch-plugins";
+import { translationClientPlugin, redirectPlugin } from "./fetch-plugins";
 import { parseJSON } from "./parser";
 import { getSessionAtom } from "./session-atom";
 
@@ -57,6 +57,7 @@ export const getClientConfig = (
 			lifeCyclePlugin,
 			...(restOfFetchOptions.plugins || []),
 			...(options?.disableDefaultFetchPlugins ? [] : [redirectPlugin]),
+			translationClientPlugin(options?.translations as Record<string, string>),
 			...pluginsFetchPlugins,
 		],
 	});

--- a/packages/better-auth/src/client/fetch-plugins.ts
+++ b/packages/better-auth/src/client/fetch-plugins.ts
@@ -17,3 +17,42 @@ export const redirectPlugin = {
 		},
 	},
 } satisfies BetterFetchPlugin;
+
+
+export const translationClientPlugin = (
+	translations?: Record<string, string>,
+): BetterFetchPlugin => {
+	return {
+		id: "translation",
+		name: "Translation",
+		hooks: {
+			async onResponse(context) {
+				if (!translations) {
+					return;
+				}
+				const response = context.response;
+				if (!response.ok) {
+					try {
+						const data = await context.response.clone().json();
+						const code = data?.code || data?.error?.code;
+						if (code && translations[code]) {
+							const message = translations[code];
+							if (data.message) {
+								data.message = message;
+							}
+							if (data.error?.message) {
+								data.error.message = message;
+							}
+							return Response.json(data, {
+								status: response.status,
+								statusText: response.statusText === "OK" ? "OK" : message,
+								headers: response.headers,
+							});
+						}
+					} catch {}
+				}
+				return response;
+			},
+		},
+	};
+};

--- a/packages/better-auth/src/client/translation.test.ts
+++ b/packages/better-auth/src/client/translation.test.ts
@@ -1,0 +1,33 @@
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createAuthClient } from "./vanilla";
+
+describe("client translation", () => {
+    it("should translate error messages", async () => {
+        const client = createAuthClient({
+            baseURL: "http://localhost:3000",
+            translations: {
+                USER_NOT_FOUND: "用户找不到",
+                INVALID_PASSWORD: "密码不正确",
+            },
+            fetchOptions: {
+                customFetchImpl: async () => {
+                    return Response.json({
+                        code: "USER_NOT_FOUND",
+                        message: "User not found"
+                    }, {
+                        status: 400,
+                        headers: { "Content-Type": "application/json" }
+                    })
+                },
+            }
+        });
+
+        const { error } = await client.signIn.email({
+            email: "test@example.com",
+            password: "password"
+        });
+
+        expect(error?.message).toBe("用户找不到");
+    });
+});

--- a/packages/core/src/types/plugin-client.ts
+++ b/packages/core/src/types/plugin-client.ts
@@ -66,6 +66,8 @@ export interface RevalidateOptions {
 	refetchWhenOffline?: boolean | undefined;
 }
 
+import type { BASE_ERROR_CODES } from '../error';
+
 export interface BetterAuthClientOptions {
 	fetchOptions?: ClientFetchOption | undefined;
 	plugins?: BetterAuthClientPlugin[] | undefined;
@@ -74,6 +76,7 @@ export interface BetterAuthClientOptions {
 	disableDefaultFetchPlugins?: boolean | undefined;
 	$InferAuth?: BetterAuthOptions | undefined;
 	sessionOptions?: RevalidateOptions | undefined;
+	translations?: Partial<Record<keyof typeof BASE_ERROR_CODES, string>> & Record<string, string> | undefined;
 }
 
 export interface BetterAuthClientPlugin {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a client-side i18n plugin that translates API error codes into localized messages, configurable via a translations map. Improves user-facing error text without server changes.

- New Features
  - Introduced translationClientPlugin that intercepts non-OK responses and maps error code -> localized message (updates data.message, data.error.message, and statusText).
  - getClientConfig registers the plugin; it activates only if translations are provided.
  - Added translations option to BetterAuthClientOptions (typed against BASE_ERROR_CODES with support for custom codes).
  - Added unit test covering code-to-message translation (e.g., USER_NOT_FOUND -> 用户找不到).

<sup>Written for commit e721907ecfe2b06510d716bb520a540c35074e4c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

