### PR TITLE
fix: preserve `=` padding in parsed cookies

### DIFF
--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1,6 +1,11 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 import { describe, expect, it } from "vitest";
-import { getCookieCache, getCookies, getSessionCookie } from "../cookies";
+import {
+	getCookieCache,
+	getCookies,
+	getSessionCookie,
+	parseCookies,
+} from "../cookies";
 import { parseUserOutput } from "../db/schema";
 import { getTestInstance } from "../test-utils/test-instance";
 import { parseSetCookieHeader } from "./cookie-utils";
@@ -1100,5 +1105,35 @@ describe("Cookie Chunking", () => {
 
 		expect(cache).not.toBeNull();
 		expect(cache?.user?.email).toEqual(testUser.email);
+	});
+});
+
+describe("parse cookies", () => {
+	it("should parse cookies into key-value map", () => {
+		const cookieHeader =
+			"better-auth.session_token=session-token.signature; better-auth.session_data=session-data.signature";
+
+		const parsedCookies = parseCookies(cookieHeader);
+
+		expect(parsedCookies.get("better-auth.session_token")).toBe(
+			"session-token.signature",
+		);
+		expect(parsedCookies.get("better-auth.session_data")).toBe(
+			"session-data.signature",
+		);
+	});
+
+	it("should securely parse the signed cookies with padding", () => {
+		const cookieHeader =
+			"better-auth.session_token=session-token.signature=; better-auth.session_data=session-data.signature=";
+
+		const parsedCookies = parseCookies(cookieHeader);
+
+		expect(parsedCookies.get("better-auth.session_token")).toBe(
+			"session-token.signature=",
+		);
+		expect(parsedCookies.get("better-auth.session_data")).toBe(
+			"session-data.signature=",
+		);
 	});
 });

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -352,7 +352,7 @@ export function parseCookies(cookieHeader: string) {
 	const cookieMap = new Map<string, string>();
 
 	cookies.forEach((cookie) => {
-		const [name, value] = cookie.split("=");
+		const [name, value] = cookie.split(/=(.*)/s);
 		cookieMap.set(name!, value!);
 	});
 	return cookieMap;


### PR DESCRIPTION

Sometimes the signed cookies end with signature padding `=`, which causes issue with `parseCookies` to exclude them while parsing request cookies. 

The current implementation splits each cookie with `=` to format into key-value pair, however, if cookie value contains `=` it is split into into three parts, ignoring the last part.  Example breaking tests:

```sh
better-auth:test:  FAIL  src/cookies/cookies.test.ts > parse cookies > should securely parse the signed cookies with padding
better-auth:test: AssertionError: expected 'session-token.signature' to be 'session-token.signature=' // Object.is equality
better-auth:test:
better-auth:test: Expected: "session-token.signature="
better-auth:test: Received: "session-token.signature"
better-auth:test:
better-auth:test:  ❯ src/cookies/cookies.test.ts:1121:58
better-auth:test:     1119|   const parsedCookies = parseCookies(cookieHeader);
better-auth:test:     1120|
better-auth:test:     1121|   expect(parsedCookies.get("better-auth.session_token")).toBe("session-token.signature=");
better-auth:test:        |                                                          ^
better-auth:test:     1122|   expect(parsedCookies.get("better-auth.session_data")).toBe("session-data.signature=");
better-auth:test:     1123|  })
```


This change splits the individual cookie by first `=` ensure only two parts. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cookie parsing to preserve "=" padding in signed cookies by splitting on the first "=". This prevents truncation and ensures session cookies are read correctly from request headers.

- **Bug Fixes**
  - Updated parseCookies to split on the first "=" (using /(=(.*)/s)) so values with padding are preserved.
  - Added tests for signed cookies with "=" padding to prevent regressions.

<sup>Written for commit f238277de147a81d19a570d92391e8e3cc8b937d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

