### PR TITLE
chore: delete session with hooks

### DIFF
--- a/packages/better-auth/src/api/routes/sign-out.test.ts
+++ b/packages/better-auth/src/api/routes/sign-out.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect } from "vitest";
+import { describe, expect, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 
 describe("sign-out", async (it) => {
-	const { signInWithTestUser, client } = await getTestInstance();
+	const afterSessionDeleted = vi.fn();
+	const { signInWithTestUser, client } = await getTestInstance({
+		databaseHooks: {
+			session: {
+				delete: {
+					after: afterSessionDeleted,
+				},
+			},
+		},
+	});
 
 	it("should sign out", async () => {
 		const { runWithUser } = await signInWithTestUser();
@@ -11,6 +20,8 @@ describe("sign-out", async (it) => {
 			expect(res.data).toMatchObject({
 				success: true,
 			});
+
+			expect(afterSessionDeleted).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -586,15 +586,12 @@ export const createInternalAdapter = (
 					return;
 				}
 			}
-			await (await getCurrentAdapter(adapter)).delete<Session>({
-				model: "session",
-				where: [
-					{
-						field: "token",
-						value: token,
-					},
-				],
-			});
+
+			await deleteWithHooks(
+				[{ field: "token", value: token }],
+				"session",
+				undefined,
+			);
 		},
 		deleteAccounts: async (userId: string) => {
 			await deleteManyWithHooks(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sign-out now deletes the session using database hooks so after-delete handlers run. Added a test to confirm the hook is called.

- **Bug Fixes**
  - Replaced direct session delete with deleteWithHooks in the internal adapter.
  - Added sign-out test that verifies the after session delete hook is invoked.

<sup>Written for commit 1999bd282dd5f49992da14462e9bcd0e2bb4d35c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

