### PR TITLE
chore(db): remove deprecated types

### DIFF
--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { capitalizeFirstLetter } from "@better-auth/core/utils";
 import { produceSchema } from "@mrleebo/prisma-ast";
 import { initGetFieldName, initGetModelName } from "better-auth/adapters";
-import type { FieldType } from "better-auth/db";
+import type { DBFieldType } from "better-auth/db";
 import { getAuthTables } from "better-auth/db";
 import { getPrismaVersion } from "../utils/get-package-info";
 import type { SchemaGenerator } from "./types";
@@ -114,7 +114,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 				isOptional,
 				type,
 			}: {
-				type: FieldType;
+				type: DBFieldType;
 				isOptional: boolean;
 				isBigint: boolean;
 			}) {

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -1,11 +1,4 @@
-import type { BetterAuthPluginDBSchema } from "./plugin";
-import type {
-	BetterAuthDBSchema,
-	DBFieldAttribute,
-	DBFieldAttributeConfig,
-	DBFieldType,
-} from "./type";
-
+export { getAuthTables } from "./get-tables";
 export type { BetterAuthPluginDBSchema } from "./plugin";
 export { type Account, accountSchema } from "./schema/account";
 export { type RateLimit, rateLimitSchema } from "./schema/rate-limit";
@@ -23,26 +16,3 @@ export type {
 	ModelNames,
 	SecondaryStorage,
 } from "./type";
-
-/**
- * @deprecated Backport for 1.3.x, we will remove this in 1.4.x
- */
-export type AuthPluginSchema = BetterAuthPluginDBSchema;
-/**
- * @deprecated Backport for 1.3.x, we will remove this in 1.4.x
- */
-export type FieldAttribute = DBFieldAttribute;
-/**
- * @deprecated Backport for 1.3.x, we will remove this in 1.4.x
- */
-export type FieldAttributeConfig = DBFieldAttributeConfig;
-/**
- * @deprecated Backport for 1.3.x, we will remove this in 1.4.x
- */
-export type FieldType = DBFieldType;
-/**
- * @deprecated Backport for 1.3.x, we will remove this in 1.4.x
- */
-export type BetterAuthDbSchema = BetterAuthDBSchema;
-
-export { getAuthTables } from "./get-tables";


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed deprecated DB type aliases and updated the Prisma schema generator to use DBFieldType. No runtime changes; cleans up the public API.

- **Migration**
  - FieldType → DBFieldType
  - FieldAttribute → DBFieldAttribute
  - FieldAttributeConfig → DBFieldAttributeConfig
  - BetterAuthDbSchema → BetterAuthDBSchema
  - AuthPluginSchema → BetterAuthPluginDBSchema

<sup>Written for commit 499cfbc16c37e4986ed29b41c52d28a9a2338816. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



