### PR TITLE
fix(types): replace unsafe any in adapter factory types

### DIFF
--- a/packages/better-auth/src/adapters/adapter-factory/types.ts
+++ b/packages/better-auth/src/adapters/adapter-factory/types.ts
@@ -50,7 +50,7 @@ export type AdapterFactoryCustomizeAdapterCreator = (config: {
 	 *
 	 * If the config has defined `debugLogs` as `false`, no logs will be shown.
 	 */
-	debugLog: (...args: any[]) => void;
+	debugLog: (...args: unknown[]) => void;
 	/**
 	 * Get the model name which is expected to be saved in the database based on the user's schema.
 	 */
@@ -104,16 +104,16 @@ export type AdapterFactoryCustomizeAdapterCreator = (config: {
 	}) => DBFieldAttribute;
 	// The following functions are exposed primarily for the purpose of having wrapper adapters.
 	transformInput: (
-		data: Record<string, any>,
+		data: Record<string, unknown>,
 		defaultModelName: string,
 		action: "create" | "update",
 		forceAllowId?: boolean | undefined,
-	) => Promise<Record<string, any>>;
+	) => Promise<Record<string, unknown>>;
 	transformOutput: (
-		data: Record<string, any>,
+		data: Record<string, unknown>,
 		defaultModelName: string,
 		select?: string[] | undefined,
-	) => Promise<Record<string, any>>;
+	) => Promise<Record<string, unknown>>;
 	transformWhereClause: <W extends Where[] | undefined>({
 		model,
 		where,


### PR DESCRIPTION
Replaces unsafe `any` usage in adapter factory public types with `unknown`.

This is a type-only change and does not affect runtime behavior.








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unsafe any with unknown in adapter factory public types to improve type safety and prevent misuse. Type-only change; no runtime behavior changes.

<sup>Written for commit e5bebfa198e840a6362a32ef8bd1f54fcbf84889. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







