### PR TITLE
fix: warn when baseURL is not explicitly provided

### DIFF
--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -104,6 +104,12 @@ export async function createAuthContext(
 	const logger = createLogger(options.logger);
 	const baseURL = getBaseURL(options.baseURL, options.basePath);
 
+	if (!options.baseURL) {
+		logger.warn(
+			"[better-auth] Warning: No baseURL was provided. Falling back to inferred values may cause incorrect redirect URIs, especially in production or multi-domain environments. Set baseURL explicitly for reliable behavior.",
+		);
+	}
+
 	const secret =
 		options.secret ||
 		env.BETTER_AUTH_SECRET ||


### PR DESCRIPTION
## Summary

- Add a warning log when `baseURL` is not provided in options
- Helps developers debug redirect URI issues in production or multi-domain environments

## Context

When `baseURL` is not explicitly set, Better Auth falls back to inferred values from environment variables or request headers. This can cause incorrect redirect URIs, especially in:
- Production environments
- Multi-domain setups
- Proxy configurations

This change adds a clear warning message to help developers identify the issue quickly.

## Test plan

- [x] Verified the warning is logged when `baseURL` is not provided
- [x] Verified existing tests pass
- [x] Verified lint passes

Closes #6780

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log a clear warning when baseURL is not provided, instead of silently relying on inferred values. This helps developers diagnose incorrect redirect URIs in production, multi-domain, and proxy setups and encourages setting baseURL explicitly.

<sup>Written for commit 96e9f2c4ade674cef3f357519f16fa9c6b0ce91d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

