### PR TITLE
test: add missing organizationId in `addMember`

### DIFF
--- a/packages/sso/src/domain-verification.test.ts
+++ b/packages/sso/src/domain-verification.test.ts
@@ -92,6 +92,7 @@ describe("Domain verification", async () => {
 					body: {
 						userId: response.data.user.id,
 						role: "member",
+						organizationId,
 					},
 					headers,
 				});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the missing organizationId to the addMember request in the domain-verification test so the payload matches the API contract and the test passes reliably. Prevents failures caused by an incomplete request body.

<sup>Written for commit 9169f9d1630820119d9a32ddcb3bb1baf8238d4e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

