### PR TITLE
Fix: Docs uses latest `getRequestHeaders()` to grab headers from request in Auth Middleware in Tanstack Start

### DIFF
--- a/docs/content/docs/integrations/tanstack.mdx
+++ b/docs/content/docs/integrations/tanstack.mdx
@@ -67,11 +67,13 @@ You can use TanStack Start's middleware to protect routes that require authentic
 ```ts title="src/middleware/auth.ts"
 import { redirect } from "@tanstack/react-router";
 import { createMiddleware } from "@tanstack/react-start";
+import { getRequestHeaders } from "@tanstack/react-start/server";
 import { auth } from "./auth";
 
 export const authMiddleware = createMiddleware().server(
     async ({ next, request }) => {
-        const session = await auth.api.getSession({ headers: request.headers })
+        const headers = getRequestHeaders();
+        const session = await auth.api.getSession({ headers })
 
         if (!session) {
             throw redirect({ to: "/login" })


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/6818

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated TanStack Start auth middleware docs to use getRequestHeaders() for server-side header access. Ensures sessions resolve correctly with the latest TanStack Start.

- **Bug Fixes**
  - Replaced request.headers with getRequestHeaders() in the example to match current server API and fix the broken auth example (better-auth/better-auth#6818).

<sup>Written for commit fbe189b12d746a34bf6e41685aac9970867228c4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

