### PR TITLE
chore: remove unnecessary custom word

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -13,4 +13,3 @@ prefs
 uncompromised
 myapp
 Neue
-user_01KBT4BMFF7ASGRDD0WZ6W63FF

--- a/docs/content/docs/guides/workos-migration-guide.mdx
+++ b/docs/content/docs/guides/workos-migration-guide.mdx
@@ -123,6 +123,7 @@ export const auth = betterAuth({
 
 ### Additional Fields
 
+{/* cspell:disable-next-line */}
 You probably used metadata in WorkOS. To preserve that metadata and the user id from WorkOS (e.g., user_01KBT4BMFF7ASGRDD0WZ6W63FF), extend the `user` schema as shown below. Better Auth provides a more flexible way to store user data. For more information, see [here](/docs/concepts/database#extending-core-schema).
 
 ```ts title="auth.ts"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the hardcoded WorkOS user id from cspell custom words and added a local cspell ignore in the migration guide. This keeps the dictionary lean and prevents spellcheck noise around the example id.

<sup>Written for commit 79ce197ca553f3692aa03acab48c1f61077421c4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

