### PR TITLE
docs(convex): clean up documentation

### DIFF
--- a/docs/content/docs/integrations/convex.mdx
+++ b/docs/content/docs/integrations/convex.mdx
@@ -53,7 +53,7 @@ If you're not using Next.js, support for other frameworks is documented in the [
     <Step>
         #### Install packages
 
-        Install the component, Better Auth and ensure you use version `1.25.0` or later of Convex.
+        Install the component and Better Auth. Ensure you use version `1.25.0` or later of Convex.
 
         ```package-install
         npm install better-auth


### PR DESCRIPTION
In #6811 convex was upgraded to latest so we no longer need to pin it to latest. Cleans that part up and removes some whitespace!



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the Convex integration docs: removed the Better Auth version pin, clarified the Convex 1.25.0+ requirement, and simplified the install steps. Also removed extra whitespace.

<sup>Written for commit 310af27d61d0caca368ba37be687f08d519cacf3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



