### PR TITLE
fix(sso): use default import for zod/v4

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -22,7 +22,7 @@ import * as saml from "samlify";
 import type { BindingContext } from "samlify/types/src/entity";
 import type { IdentityProvider } from "samlify/types/src/entity-idp";
 import type { FlowResult } from "samlify/types/src/flow";
-import * as z from "zod/v4";
+import z from "zod/v4";
 
 interface AuthnRequestRecord {
 	id: string;
@@ -830,7 +830,7 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 							: `better-auth-token-${provider.providerId}`,
 						createdAt: new Date(),
 						updatedAt: new Date(),
-						value: domainVerificationToken,
+						value: domainVerificationToken as string,
 						expiresAt: new Date(Date.now() + 3600 * 24 * 7 * 1000), // 1 week
 					},
 				});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use default import for zod/v4 and fix token type in SSO provider to resolve build-time type errors and ensure domain verification tokens are stored correctly.

- **Bug Fixes**
  - Switched zod/v4 to default import.
  - Cast domainVerificationToken to string when saving the provider token.

<sup>Written for commit dffd4ff630e3515886991a570f56b716e5b5199d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

