### PR TITLE
chore(api-key): pass options to plugin config

### DIFF
--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -335,6 +335,7 @@ export const apiKey = (options?: ApiKeyOptions | undefined) => {
 			deleteAllExpiredApiKeys: routes.deleteAllExpiredApiKeys,
 		},
 		schema,
+		options,
 	} satisfies BetterAuthPlugin;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose apiKey plugin options on the plugin config so apps and other plugins can read them at runtime. This keeps the apiKey plugin consistent with other plugins and enables easier debugging and composition.

<sup>Written for commit 4b81add005f359aa3f8910af628a21c8ee59e928. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

