### PR TITLE
docs: change role type from string to enum values

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -406,7 +406,7 @@ export const auth = betterAuth({
   user: {
     additionalFields: {
       role: {
-        type: "string",
+        type: ["user", "admin"],
         required: false,
         defaultValue: "user",
         input: false, // don't allow user to set role


### PR DESCRIPTION
The example for the additional "role" field now uses an array instead of a raw string. This comes very handy when one is already using an enum-like DB schema (like `pgEnum`) and Drizzle for better type inference.

By the way, I found out that this is allowed by accident from this test, so I am not even sure that this is the intended usage.
 
https://github.com/better-auth/better-auth/pull/5287/files#diff-b98623fbecefef5313e8c1fe082f4895ee707cea0183c5cf4f860942cf3d0e3e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update database docs to define the user role additional field as enum values (["user", "admin"]) instead of a generic "string". This clarifies supported types and aligns with enum-backed schemas (e.g., pgEnum) for better Drizzle type inference.

<sup>Written for commit 37ae4ea6596b003a577bbbc0c8ae3bfce2c2457c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

