### PR TITLE
docs(api-key): correct table name in schema section

### DIFF
--- a/docs/content/docs/plugins/api-key.mdx
+++ b/docs/content/docs/plugins/api-key.mdx
@@ -1085,7 +1085,7 @@ When verifying an API key, all required permissions must be present in the API k
 
 ## Schema
 
-Table: `apiKey`
+Table: `apikey`
 
 <DatabaseTable
   fields={[


### PR DESCRIPTION
closes #6835

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the API Key plugin docs to show the correct schema table name, apikey, instead of apiKey. This aligns the docs with the actual database table and avoids confusion.

<sup>Written for commit 05da70612fc5d7c449c47e0330e22f223706eed3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

