### PR TITLE
docs(convex): fix import statement for `authConfig`

### DIFF
--- a/docs/content/docs/integrations/convex.mdx
+++ b/docs/content/docs/integrations/convex.mdx
@@ -147,7 +147,7 @@ If you're not using Next.js, support for other frameworks is documented in the [
         import { DataModel } from "./_generated/dataModel";
         import { query } from "./_generated/server";
         import { betterAuth } from "better-auth";
-        import { authConfig } from "./auth.config";
+        import authConfig from "./auth.config";
 
         const siteUrl = process.env.SITE_URL!;
 


### PR DESCRIPTION
This pull request makes a minor update to the import statement for `authConfig` in the documentation example. The change switches from a named import to a default import for improved accuracy and consistency.

* Changed the import of `authConfig` from a named import to a default import in the code sample in `docs/content/docs/integrations/convex.mdx`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix docs example to use a default import for authConfig in convex.mdx. This matches the actual export and prevents copy-paste errors.

<sup>Written for commit 8a21ea23a68c7cf68e1c2c2e36b0ed94039d72ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

