### PR TITLE
fix: correct verification deletion when using useNumberId

### DIFF
--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -583,7 +583,9 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 			}
 
 			const data =
-				await ctx.context.internalAdapter.findVerificationValue(challengeId);
+				await ctx.context.internalAdapter.findVerificationValue(
+          challengeId,
+        );
 			if (!data) {
 				throw new APIError("BAD_REQUEST", {
 					message: PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
@@ -660,7 +662,9 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 					session: s,
 					user,
 				});
-				await ctx.context.internalAdapter.deleteVerificationByIdentifier(challengeId);
+				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+          challengeId,
+        );
 
 				return ctx.json(
 					{


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix verification cleanup in passkey registration and authentication by deleting by identifier (challengeId) instead of value. Ensures verifications are removed correctly when useNumberId is enabled, preventing stale challenge records.

<sup>Written for commit 89a49892698c2fa69d905eb2e6abcd9b75b93f5b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



