### PR TITLE
fix: passkey - correct verification deletion when using useNumberId

### DIFF
--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -506,7 +506,9 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 					model: "passkey",
 					data: newPasskey,
 				});
-				await ctx.context.internalAdapter.deleteVerificationValue(challengeId);
+        await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+          challengeId,
+        );
 				return ctx.json(newPasskeyRes, {
 					status: 200,
 				});
@@ -582,8 +584,9 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 				});
 			}
 
-			const data =
-				await ctx.context.internalAdapter.findVerificationValue(challengeId);
+			const data = await ctx.context.internalAdapter.findVerificationValue(
+        challengeId,
+      );
 			if (!data) {
 				throw new APIError("BAD_REQUEST", {
 					message: PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
@@ -660,7 +663,9 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 					session: s,
 					user,
 				});
-				await ctx.context.internalAdapter.deleteVerificationValue(challengeId);
+        await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+          challengeId,
+        );
 
 				return ctx.json(
 					{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes passkey verification cleanup to support useNumberId by deleting challenges by identifier instead of value. Prevents leftover verification records after successful registration or authentication.

- **Bug Fixes**
  - Replace deleteVerificationValue with deleteVerificationByIdentifier in both registration and authentication flows.

<sup>Written for commit 48745e985a54c75ef5d91c8c11889c5ce3d19136. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

