### PR TITLE
fix: passkey - correct verification deletion when using useNumberId

### DIFF
--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -506,7 +506,9 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 					model: "passkey",
 					data: newPasskey,
 				});
-				await ctx.context.internalAdapter.deleteVerificationValue(challengeId);
+				await·ctx.context.internalAdapter.deleteVerificationByIdentifier(
+					challengeId,
+				);
 				return ctx.json(newPasskeyRes, {
 					status: 200,
 				});
@@ -660,7 +662,9 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 					session: s,
 					user,
 				});
-				await ctx.context.internalAdapter.deleteVerificationValue(challengeId);
+				await·ctx.context.internalAdapter.deleteVerificationByIdentifier(
+					challengeId,
+				);
 
 				return ctx.json(
 					{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes passkey verification cleanup by deleting challenges by identifier, ensuring correct behavior when useNumberId is enabled. Prevents stale verification records after registration and authentication by using internalAdapter.deleteVerificationByIdentifier in both flows.

<sup>Written for commit 4bf9960d8648e9a8366a93ab24b4e1412fd306aa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

