### PR TITLE
fix: passkey - correct verification deletion when using useNumberId

### DIFF
--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -506,7 +506,9 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 					model: "passkey",
 					data: newPasskey,
 				});
-				await ctx.context.internalAdapter.deleteVerificationValue(challengeId);
+				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+					challengeId,
+				);
 				return ctx.json(newPasskeyRes, {
 					status: 200,
 				});
@@ -660,7 +662,9 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 					session: s,
 					user,
 				});
-				await ctx.context.internalAdapter.deleteVerificationValue(challengeId);
+				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+					challengeId,
+				);
 
 				return ctx.json(
 					{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect cleanup of passkey verification challenges by deleting records by identifier, ensuring proper removal when useNumberId is enabled in both registration and authentication flows.

- **Bug Fixes**
  - Replace internalAdapter.deleteVerificationValue with deleteVerificationByIdentifier(challengeId) in verifyPasskeyRegistration and verifyPasskeyAuthentication to prevent stale verification entries.

<sup>Written for commit 95cc3065d314037e4220f9572cf5f3651087f919. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

