### PR TITLE
docs: add baseURL configuration warning to Google provider

### DIFF
--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -35,6 +35,7 @@ description: Google provider setup and usage.
         import { betterAuth } from "better-auth"
 
         export const auth = betterAuth({
+            baseURL: process.env.BETTER_AUTH_URL, // [!code highlight]
             socialProviders: {
                 google: { // [!code highlight]
                     clientId: process.env.GOOGLE_CLIENT_ID as string, // [!code highlight]
@@ -43,6 +44,23 @@ description: Google provider setup and usage.
             },
         })
         ```
+        <Callout type="warn">
+        **Important: Set Your Base URL**
+
+        You must configure the `baseURL` to avoid `redirect_uri_mismatch` errors. Better Auth uses this to construct the OAuth callback URL sent to Google.
+
+        **Option 1: Environment Variable (Recommended)**
+
+        Add to your `.env` file:
+        ```env
+        BETTER_AUTH_URL=https://your-domain.com
+        ```
+
+        **Option 2: Explicit Configuration**
+
+        Pass `baseURL` directly in the auth config as shown above.
+        Without this, the callback URL may default to `localhost`, causing Google OAuth to fail in production.
+        </Callout>
     </Step>
 
 </Steps>


### PR DESCRIPTION
Fixes #6775

### Description
Added a warning and configuration example to the Google provider documentation.

This addresses the common `redirect_uri_mismatch` error users encounter in production when the `baseURL` is not explicitly set. The documentation now clarifies that Better Auth requires the `baseURL` (or `BETTER_AUTH_URL` env var) to construct the correct callback URL sent to Google.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a baseURL configuration warning and example to the Google provider docs to prevent redirect_uri_mismatch errors in production. Shows how to set BETTER_AUTH_URL or pass baseURL directly so the correct OAuth callback is sent to Google.

<sup>Written for commit 61efc2f7fd02ffac9488c2c4bd390c9a29027608. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

