### PR TITLE
docs: use `dotenv` instead of `env`

### DIFF
--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -52,7 +52,7 @@ description: Google provider setup and usage.
         **Option 1: Environment Variable (Recommended)**
 
         Add to your `.env` file:
-        ```env
+        ```dotenv
         BETTER_AUTH_URL=https://your-domain.com
         ```
 


### PR DESCRIPTION
<img width="926" height="152" alt="build-error" src="https://github.com/user-attachments/assets/959a6180-bf3e-4cd9-b2ee-51feabf8fb82" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the code fence language from env to dotenv in the Google auth docs to match .env files, fix syntax highlighting, and resolve the docs build error.

<sup>Written for commit 26e88d6e6a25659004f8a3dc0b72394aeac20431. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

