### PR TITLE
Fix typo in Organization plugin docs

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1616,7 +1616,7 @@ type getOrgRole = {
      */
     roleId?: string = "role-id"
     /**
-     * The organization ID which the role will be deleted in. Defaults to the active organization.
+     * The organization ID from which the role will be retrieved. Defaults to the active organization.
      */
     organizationId?: string = "organization-id"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed a typo in the Organization plugin docs for getOrgRole: updated the organizationId description to say the role is retrieved (not deleted) and defaults to the active organization.

<sup>Written for commit f32a5cc94abba94caca359c8b7603631b4d89d73. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

