### PR TITLE
fix: trusted origins resolving

### DIFF
--- a/packages/better-auth/src/auth/base.ts
+++ b/packages/better-auth/src/auth/base.ts
@@ -38,19 +38,13 @@ export const createBetterAuth = <Options extends BetterAuthOptions>(
 				if (baseURL) {
 					ctx.baseURL = baseURL;
 					ctx.options.baseURL = getOrigin(ctx.baseURL) || undefined;
-					ctx.trustedOrigins = getTrustedOrigins(ctx.options);
 				} else {
 					throw new BetterAuthError(
 						"Could not get base URL from request. Please provide a valid base URL.",
 					);
 				}
 			}
-			if (typeof options.trustedOrigins === "function") {
-				ctx.trustedOrigins = [
-					...ctx.trustedOrigins,
-					...(await options.trustedOrigins(request)),
-				];
-			}
+			ctx.trustedOrigins = await getTrustedOrigins(ctx.options, request);
 			const { handler } = router(ctx, options);
 			return runWithAdapter(ctx.adapter, () => handler(request));
 		},

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -104,16 +104,10 @@ export async function createAuthContext(
 	const logger = createLogger(options.logger);
 	const baseURL = getBaseURL(options.baseURL, options.basePath);
 
-	let showBaseURLWarning = false;
-	if (
-		!baseURL &&
-		!options.advanced?.trustedProxyHeaders &&
-		!showBaseURLWarning
-	) {
-		logger.error(
+	if (!baseURL) {
+		logger.warn(
 			`[better-auth] Base URL could not be determined. Please set a valid base URL using the baseURL config option or the BETTER_AUTH_BASE_URL environment variable. Without this, callbacks and redirects may not work correctly.`,
 		);
-		showBaseURLWarning = true;
 	}
 
 	const secret =
@@ -188,8 +182,13 @@ export async function createAuthContext(
 			skipStateCookieCheck: !!options.account?.skipStateCookieCheck,
 		},
 		tables,
-		trustedOrigins: getTrustedOrigins(options),
-		isTrustedOrigin(url: string, settings?: { allowRelativePaths: boolean }) {
+		trustedOrigins: await getTrustedOrigins(options),
+		isTrustedOrigin(
+			url: string,
+			settings?: {
+				allowRelativePaths: boolean;
+			},
+		) {
 			return ctx.trustedOrigins.some((origin) =>
 				matchesOriginPattern(url, origin, settings),
 			);

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -61,14 +61,19 @@ export function getInternalPlugins(options: BetterAuthOptions) {
 	return plugins;
 }
 
-export function getTrustedOrigins(options: BetterAuthOptions) {
+export async function getTrustedOrigins(
+	options: BetterAuthOptions,
+	request?: Request,
+) {
 	const baseURL = getBaseURL(options.baseURL, options.basePath);
-	if (!baseURL) {
-		return [];
-	}
-	const trustedOrigins = [new URL(baseURL).origin];
-	if (options.trustedOrigins && Array.isArray(options.trustedOrigins)) {
-		trustedOrigins.push(...options.trustedOrigins);
+	const trustedOrigins = baseURL ? [new URL(baseURL).origin] : [];
+	if (options.trustedOrigins) {
+		if (Array.isArray(options.trustedOrigins)) {
+			trustedOrigins.push(...options.trustedOrigins);
+		}
+		if (typeof options.trustedOrigins === "function" && request) {
+			trustedOrigins.push(...(await options.trustedOrigins(request)));
+		}
 	}
 	const envTrustedOrigins = env.BETTER_AUTH_TRUSTED_ORIGINS;
 	if (envTrustedOrigins) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes trusted origin resolution so redirect and origin checks use the correct list on every request. Origins from baseURL, env, and per-request functions are now merged in one place.

- **Bug Fixes**
  - Centralized origin resolution in async getTrustedOrigins(options, request) and use it in context and request handler.
  - Support options.trustedOrigins as an array or per-request function; merge with BETTER_AUTH_TRUSTED_ORIGINS.
  - Handle missing baseURL gracefully; still resolve other origins and log a warning instead of an error.

<sup>Written for commit cdebe4207440b2e36429b1c019892fc8acd08842. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

