### PR TITLE
test(auth): handle undefined request in trustedOrigins test

### DIFF
--- a/packages/better-auth/src/auth/trusted-origins.test.ts
+++ b/packages/better-auth/src/auth/trusted-origins.test.ts
@@ -262,6 +262,7 @@ describe("trusted origins", () => {
 		it("should allow dynamically computed trusted origins", async () => {
 			const { isTrustedOrigin } = await createAuthTestInstance({
 				trustedOrigins: async (request) => {
+					if (!request) return [];
 					const url = new URL(
 						new URL(request.url).searchParams.get("url") ?? "unknown",
 					);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Handle undefined request in trustedOrigins test by returning an empty array. This prevents URL parsing errors and stabilizes the dynamic trustedOrigins logic.

<sup>Written for commit ec2e8b61234cdbc587723b098e613cc9bf71de8f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

