### PR TITLE
docs: clarify username sign-in functionality

### DIFF
--- a/docs/content/docs/plugins/username.mdx
+++ b/docs/content/docs/plugins/username.mdx
@@ -3,7 +3,7 @@ title: Username
 description: Username plugin
 ---
 
-The username plugin is a lightweight plugin that adds username support to the email and password authenticator. This allows users to sign in and sign up with their username instead of their email.
+The username plugin is a lightweight plugin that adds username support to the email and password authenticator. This allows users to sign in with their username instead of their email.
 
 ## Installation
 


### PR DESCRIPTION
Updated description to clarify username sign-in functionality. You can not sign-up without an email address, so the docs are currently wrong.







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the Username plugin docs: users can sign in with a username, but sign-up still requires an email address.

<sup>Written for commit 509b457e272b608f65be487ff4410117f89e0ad1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







