### PR TITLE
doc(auth): clarify trustedOrigins callback request parameter

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -250,7 +250,12 @@ trustedOrigins: [
 2. Or dynamically compute the `trustedOrigins` by specifying a callback function:
 
 ```ts
-trustedOrigins: async (request: Request) => {
+trustedOrigins: async (request) => {
+    // request is undefined during initialization and auth.api calls
+    if (!request) {
+        return ["https://my-frontend.com"];
+    }
+
     // SSO trusted origin list
     if (request.url.endsWith("/sso/register")) {
         const trustedOrigins = await fetchOriginList();

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -67,12 +67,20 @@ You can provide a function that returns origins dynamically:
 
 ```ts
 export const auth = betterAuth({
-	trustedOrigins: async (request: Request) => {
-		// Return an array of trusted origins based on the request
+	trustedOrigins: async (request) => {
+		// request is undefined during initialization and auth.api calls
+		if (!request) {
+			return ["https://my-frontend.com"];
+		}
+		// Dynamic logic based on the request
 		return ["https://dynamic-origin.com"];
 	}
 })
 ```
+
+<Callout type="info">
+  The `request` parameter is `undefined` during initialization and when calling `auth.api` directly. Make sure to handle this case by returning default trusted origins.
+</Callout>
 
 ### Wildcard Support
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified trustedOrigins callback docs: the request parameter can be undefined during initialization and direct auth.api calls, and the examples now include a guard with default origins. Added an info callout and updated SSO and options samples to help avoid runtime errors.

<sup>Written for commit a30dbf9e96e3ddfc40bef21823d2c9c38d4aea5b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

