### PR TITLE
fix(update-user): breaks during stateless auth

### DIFF
--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -125,8 +125,8 @@ export const updateUser = <O extends BetterAuthOptions>() =>
 			);
 			const updatedUser = user ?? {
 				...session.user,
-				name,
-				image,
+				...(name !== undefined && { name }),
+				...(image !== undefined && { image }),
 				...additionalFields,
 			};
 			/**


### PR DESCRIPTION
It's possible that the `internalAdapter.updateUser` to return null during stateless auth, which can break things unexpectedly.

This PR is just a patch for this specific issue where if `updateUser` does return null, we manually assemble the correctly updated user object to send to `setSessionCookie`

Also added a check at the start to ensure users can't pass an array as the body.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the update-user route so it no longer breaks in stateless auth when internalAdapter.updateUser returns null. We now build the updated user from the session + submitted fields and set it in the session cookie.

- **Bug Fixes**
  - Validate request body: must be an object, not an array.
  - Construct updatedUser from session.user when updateUser returns null.
  - Use updatedUser when calling setSessionCookie.

<sup>Written for commit b27838c819b66343d890e191d729df1a7b6ca727. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





