### PR TITLE
chore: remove unused `server-only` package

### DIFF
--- a/demo/nextjs/package.json
+++ b/demo/nextjs/package.json
@@ -75,7 +75,6 @@
     "react-resizable-panels": "^3.0.5",
     "recharts": "^3.1.2",
     "resend": "^6.0.2",
-    "server-only": "^0.0.1",
     "sonner": "^2.0.7",
     "stripe": "^20.0.0",
     "tailwind-merge": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,9 +435,6 @@ importers:
       resend:
         specifier: ^6.0.2
         version: 6.0.2(@react-email/render@1.2.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      server-only:
-        specifier: ^0.0.1
-        version: 0.0.1
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused server-only package from demo/nextjs and updated pnpm-lock.yaml to reduce dependency bloat and install size.

<sup>Written for commit aa6f01925d927eb818f2a4bb093cfb83bc2ac55b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

