### PR TITLE
chore(demo): add loading component for `reset-password`

### DIFF
--- a/demo/nextjs/app/(auth)/reset-password/loading.tsx
+++ b/demo/nextjs/app/(auth)/reset-password/loading.tsx
@@ -2,7 +2,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function Loading() {
 	return (
-		<div className="flex flex-col items-center justify-center min-h-[calc(100vh-10rem)]">
+		<div
+			className="flex flex-col items-center justify-center min-h-[calc(100vh-10rem)]"
+			aria-busy="true"
+			aria-label="Loading reset password form"
+		>
 			<Skeleton className="w-87.5 h-50" />
 		</div>
 	);


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a loading skeleton for the reset-password page in the demo. Shows a centered pulse placeholder while the route loads to avoid flicker.

<sup>Written for commit 1c8684f450ed346f2cf770785c17c1c84421223f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





