### PR TITLE
docs: clarify username sign-in functionality in documentation

### DIFF
--- a/docs/content/docs/plugins/username.mdx
+++ b/docs/content/docs/plugins/username.mdx
@@ -3,7 +3,7 @@ title: Username
 description: Username plugin
 ---
 
-The username plugin is a lightweight plugin that adds username support to the email and password authenticator. This allows users to sign in and sign up with their username instead of their email.
+The username plugin is a lightweight plugin that adds username support to the email and password authenticator. This allows users to sign in with their username instead of their email.
 
 ## Installation
 


### PR DESCRIPTION
Closes: https://github.com/better-auth/better-auth/pull/6889

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the Username plugin docs: users can sign in with a username, but sign-up still requires an email. Removed the incorrect claim that you can sign up with a username.

<sup>Written for commit e78f0a36961b913b0e5333036f99e081eaa7e93a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

