### PR TITLE
fix: export necessary adapter types

### DIFF
--- a/e2e/smoke/test/types.spec.ts
+++ b/e2e/smoke/test/types.spec.ts
@@ -1,0 +1,17 @@
+import type { JoinConfig, JoinOption } from "better-auth/adapters";
+import type { GoogleProfile } from "better-auth/social-providers";
+import { describe, expectTypeOf, it } from "vitest";
+
+describe("type exports", () => {
+	it("should export JoinOption", () => {
+		expectTypeOf<JoinOption>().not.toBeAny();
+	});
+
+	it("should export JoinConfig", () => {
+		expectTypeOf<JoinConfig>().not.toBeAny();
+	});
+
+	it("should export GoogleProfile", () => {
+		expectTypeOf<GoogleProfile>().not.toBeAny();
+	});
+});

--- a/packages/better-auth/src/types/adapter.ts
+++ b/packages/better-auth/src/types/adapter.ts
@@ -11,6 +11,8 @@ export type {
 	DBAdapterInstance,
 	DBAdapterSchemaCreation,
 	DBTransactionAdapter,
+	JoinConfig,
+	JoinOption,
 } from "@better-auth/core/db/adapter";
 
 export type { Where };

--- a/packages/better-auth/src/types/index.ts
+++ b/packages/better-auth/src/types/index.ts
@@ -5,6 +5,7 @@ export type {
 	BetterAuthPlugin,
 	BetterAuthRateLimitOptions,
 } from "@better-auth/core";
+export type * from "@better-auth/core/social-providers";
 export * from "../client/types";
 export type * from "./adapter";
 export * from "./api";


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/6876

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export missing adapter and social provider types so users can import JoinConfig, JoinOption, and profiles like GoogleProfile. Adds a smoke test to prevent regressions and fixes #6876.

- **Bug Fixes**
  - Export JoinConfig and JoinOption from better-auth/adapters.
  - Re-export social provider types from types/index.ts.
  - Add e2e test to verify JoinOption, JoinConfig, and GoogleProfile are exported.

<sup>Written for commit 69b61b3c2fabbad006c2ad7b1492bc1d24b91416. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

