### PR TITLE
chore(demo): redirect to home when current session is removed

### DIFF
--- a/demo/nextjs/app/dashboard/_components/user-card.tsx
+++ b/demo/nextjs/app/dashboard/_components/user-card.tsx
@@ -175,6 +175,9 @@ const UserCard = (props: {
 													{
 														onSuccess: () => {
 															removeActiveSession(session.id);
+															if (isCurrentSession) {
+																router.push("/");
+															}
 														},
 													},
 												);


### PR DESCRIPTION
Fixed a UI bug when current session is removed from `deviceSession`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect to "/" when the current session is removed, preventing the dashboard user card from breaking. After successfully removing the active session, we immediately navigate home.

<sup>Written for commit 3a976968869ed2a5cc7f164aece4420632bb3c1c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



