### PR TITLE
fix(two-factor): more than 1 twoFactor rows per user breaks

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -289,7 +289,7 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 			// Delete the two factor record upon successful verification
 			// Otherwise if left there, and the user uses the TOTP flow again, it will have more than one two factor record
 			// Which leads to the findOne to catch only one of them, which leads to an `invalid code` error
-			
+
 			await ctx.context.adapter.deleteMany({
 				model: twoFactorTable,
 				where: [
@@ -298,7 +298,7 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 						value: user.id,
 					},
 				],
-			})
+			});
 			return valid(ctx);
 		},
 	);


### PR DESCRIPTION
Upon successful TOTP verification, we do not delete such row from DB. If the user were to do the same flow again, it would generate a new row in `twoFactor` table with that same `userId` field, then when using the verification endpoint, the `findOne` would only work sometimes as it may catch the old two-factor verification value and leads to a runtime `invalid code` error

### NOTE:

I made it delete all rows related to that userId, this is because in the same endpoint code, we find the `twoFactor` row based on `userId` this same way. It could be that we need more requirements in the where clause, if so please let me know.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete all twoFactor rows for a user after successful TOTP verification. This prevents duplicate records from causing intermittent "invalid code" errors when findOne hits a stale entry.

<sup>Written for commit 4cfb4f3f8eed8a69563b2b8e7598ae744ceca5ca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





