### PR TITLE
feat(stripe): add customerLookupFilter option for multi-app support

### DIFF
--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -13,6 +13,7 @@ import {
 	upgradeSubscription,
 } from "./routes";
 import { getSchema } from "./schema";
+import { findExistingStripeCustomer } from "./utils";
 import type {
 	StripeOptions,
 	StripePlan,
@@ -76,12 +77,13 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 										if (userWithStripe.stripeCustomerId) return;
 
 										// Check if customer already exists in Stripe by email
-										const existingCustomers = await client.customers.list({
-											email: user.email,
-											limit: 1,
-										});
-
-										let stripeCustomer = existingCustomers.data[0];
+										// Uses customerLookupFilter if provided for multi-app scenarios
+										let stripeCustomer = await findExistingStripeCustomer(
+											client,
+											user,
+											options,
+											ctx,
+										);
 
 										// If customer exists, link it to prevent duplicate creation
 										if (stripeCustomer) {

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -337,6 +337,39 @@ export interface StripeOptions {
 		  ) => Promise<Partial<Stripe.CustomerCreateParams>>)
 		| undefined;
 	/**
+	 * Filter function to select the appropriate existing Stripe customer
+	 * when multiple customers may exist with the same email.
+	 *
+	 * This is useful for multi-app Stripe accounts where each app stamps
+	 * customers with metadata (e.g., app_id).
+	 *
+	 * @param data - Contains the list of customers and the user being processed
+	 * @param ctx - The endpoint context
+	 * @returns The customer to use, or undefined to create a new one
+	 *
+	 * @example
+	 * ```ts
+	 * customerLookupFilter: async ({ customers, user }, ctx) => {
+	 *   return customers.find(c => c.metadata?.app_id === 'my-app');
+	 * }
+	 * ```
+	 */
+	customerLookupFilter?:
+		| ((
+				data: {
+					/**
+					 * List of Stripe customers matching the user's email
+					 */
+					customers: Stripe.Customer[];
+					/**
+					 * The user being processed (signup or upgrade)
+					 */
+					user: User & Record<string, any>;
+				},
+				ctx: GenericEndpointContext,
+		  ) => Promise<Stripe.Customer | undefined> | Stripe.Customer | undefined)
+		| undefined;
+	/**
 	 * Subscriptions
 	 */
 	subscription?:

--- a/packages/stripe/src/utils.ts
+++ b/packages/stripe/src/utils.ts
@@ -1,4 +1,48 @@
+import type { GenericEndpointContext, User } from "better-auth";
+import type Stripe from "stripe";
 import type { StripeOptions } from "./types";
+
+/**
+ * Finds an existing Stripe customer for a user, applying optional filtering.
+ *
+ * @param client - Stripe client instance
+ * @param user - The user to find a customer for
+ * @param options - Stripe plugin options
+ * @param ctx - Endpoint context
+ * @returns The matching Stripe customer, or undefined if none found
+ */
+export async function findExistingStripeCustomer(
+	client: Stripe,
+	user: User & Record<string, any>,
+	options: StripeOptions,
+	ctx: GenericEndpointContext,
+): Promise<Stripe.Customer | undefined> {
+	// Fetch more customers when filter is provided to allow filtering
+	const limit = options.customerLookupFilter ? 25 : 1;
+
+	const existingCustomers = await client.customers.list({
+		email: user.email,
+		limit,
+	});
+
+	if (existingCustomers.data.length === 0) {
+		return undefined;
+	}
+
+	// If no filter is provided, use default behavior (first customer)
+	if (!options.customerLookupFilter) {
+		return existingCustomers.data[0];
+	}
+
+	// Apply the custom filter
+	return await options.customerLookupFilter(
+		{
+			customers: existingCustomers.data,
+			user,
+		},
+		ctx,
+	);
+}
 
 export async function getPlans(
 	subscriptionOptions: StripeOptions["subscription"],


### PR DESCRIPTION
## Summary

Adds a new `customerLookupFilter` option to the Stripe plugin that allows filtering existing customers by metadata when multiple apps share the same Stripe account.

This is useful when:
- Multiple applications share the same Stripe account
- Each app stamps customers with metadata (e.g., `app_id`)
- You want to prevent cross-app customer conflicts

## Changes

- Add `customerLookupFilter` option to `StripeOptions` interface
- Add shared `findExistingStripeCustomer()` utility function
- Update signup hook to use shared utility
- Update upgrade flow to use shared utility + add `getCustomerCreateParams` support for consistency
- Add tests for filter scenarios

## Usage Example

```typescript
stripe({
  createCustomerOnSignUp: true,
  
  // Filter customers by app-specific metadata
  customerLookupFilter: async ({ customers, user }, ctx) => {
    return customers.find(c => c.metadata?.app_id === "my-app");
  },
  
  // Ensure new customers get the app_id metadata
  getCustomerCreateParams: async (user, ctx) => ({
    metadata: {
      app_id: "my-app",
    },
  }),
})
```

## Test plan

- [x] Filter selects correct customer by metadata
- [x] Filter returns undefined → creates new customer
- [x] Backward compatible without filter (limit: 1, first match)
- [x] All existing tests pass (37/37)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds customerLookupFilter to the Stripe plugin to safely find app-specific customers when multiple apps share a Stripe account. Sign-up and upgrade flows now use a shared customer lookup and consistently apply metadata.

- **New Features**
  - Stripe: Added customerLookupFilter to StripeOptions to select the correct customer (e.g., by metadata like app_id).
  - Introduced findExistingStripeCustomer and wired it into sign-up and upgrade paths.
  - Upgrade flow now respects getCustomerCreateParams for consistent customer metadata.
  - Added tests covering filter selection, undefined → create behavior, and backward compatibility.

- **Migration**
  - For multi-app setups, set customerLookupFilter to pick the right customer and use getCustomerCreateParams to stamp app-specific metadata.
  - Single-app setups require no changes; default behavior remains first match.
  - Make your filter return undefined when no match exists to create a new customer.

<sup>Written for commit 281f32116d236682dfab4adfb1e4541ba53a7962. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



