### PR TITLE
fix(cognito): use %20 encoding for scopes instead of +

### DIFF
--- a/packages/core/src/social-providers/cognito.ts
+++ b/packages/core/src/social-providers/cognito.ts
@@ -92,6 +92,17 @@ export const cognito = (options: CognitoOptions) => {
 				redirectURI,
 				prompt: options.prompt,
 			});
+			// AWS Cognito requires scopes to be encoded with %20 instead of +
+			// URLSearchParams encodes spaces as + by default, so we need to fix this
+			const scopeValue = url.searchParams.get("scope");
+			if (scopeValue) {
+				url.searchParams.delete("scope");
+				const encodedScope = encodeURIComponent(scopeValue);
+				// Manually append the scope with proper encoding to the URL
+				const urlString = url.toString();
+				const separator = urlString.includes("?") ? "&" : "?";
+				return new URL(`${urlString}${separator}scope=${encodedScope}`);
+			}
 			return url;
 		},
 


### PR DESCRIPTION
## Summary
Fixes the Cognito OAuth scope encoding issue where spaces are encoded as `+` instead of `%20`.

## Problem
AWS Cognito requires scopes to be space-separated with `%20` encoding per [AWS documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html), but `URLSearchParams` encodes spaces as `+` by default.

## Solution
After constructing the authorization URL, manually re-encode the scope parameter using `encodeURIComponent()` which produces `%20` for spaces.

Fixes #6840

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cognito OAuth scope encoding to use %20 for spaces instead of +, matching AWS requirements and preventing auth failures with multiple scopes.

- **Bug Fixes**
  - Re-encodes the scope query param with encodeURIComponent and appends it to the auth URL so scopes are separated by %20.

<sup>Written for commit 9372cc188a8dfcc61b32724c50570c93c37bec2c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

