### PR TITLE
[typo]: mongodb page join link

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -804,4 +804,4 @@ It's very important to read the documentation regarding experimental joins for y
 - [MySQL](/docs/adapters/mysql#joins-experimental)
 - [PostgreSQL](/docs/adapters/postgresql#joins-experimental)
 - [MSSQL](/docs/adapters/mssql#joins-experimental)
-- [MongoDB](/docs/adapters/mongodb#joins-experimental)
+- [MongoDB](/docs/adapters/mongo#joins-experimental)


### PR DESCRIPTION
On the page - https://www.better-auth.com/docs/concepts/database#experimental-joins the MongoDB link goes to https://www.better-auth.com/docs/adapters/mongodb#joins-experimental which is invalid.
This PR fixes the link and points the link to the correct page - https://www.better-auth.com/docs/adapters/mongo#joins-experimental

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the broken MongoDB “joins (experimental)” link on the database concepts page to point to /docs/adapters/mongo#joins-experimental, preventing 404s and directing readers to the correct adapter docs.

<sup>Written for commit 828fdc4bee93d831cdca7a82b04b196ed2b28a75. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

