### PR TITLE
docs: update file naming example in Next.js integration guide

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -35,7 +35,7 @@ export default toNodeHandler(auth.handler)
 
 ## Create a client
 
-Create a client instance. You can name the file anything you want. Here we are creating `client.ts` file inside the `lib/` directory.
+Create a client instance. You can name the file anything you want. Here we are creating `auth-client.ts` file inside the `lib/` directory.
 
 ```ts title="auth-client.ts"
 import { createAuthClient } from "better-auth/react" // make sure to import from better-auth/react


### PR DESCRIPTION
Fixes #6946 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Next.js integration guide to use auth-client.ts as the example file name for the client in lib/.
This clarifies naming and matches the code snippet title to prevent confusion.

<sup>Written for commit b08ef5c0896a1eb8ee0dd374d2fb872a67a39e3d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

