### PR TITLE
fix(cli): cmd `info --json` unexpected exit with 1

### DIFF
--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -328,7 +328,7 @@ async function getBetterAuthInfo(
 			const config = await getConfig({
 				cwd: projectRoot,
 				configPath,
-				shouldThrowOnError: false,
+				shouldThrowOnError: true,
 			});
 			const packageInfo = await getPackageInfo();
 			const betterAuthVersion =

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -197,6 +197,7 @@ export async function getConfig({
 				configFile: resolvedPath,
 				dotenv: true,
 				jitiOptions: jitiOptions(cwd),
+				cwd,
 			});
 			if (!("auth" in config) && !isDefaultExport(config)) {
 				if (shouldThrowOnError) {
@@ -225,6 +226,7 @@ export async function getConfig({
 					}>({
 						configFile: possiblePath,
 						jitiOptions: jitiOptions(cwd),
+						cwd,
 					});
 					const hasConfig = Object.keys(config).length > 0;
 					if (hasConfig) {


### PR DESCRIPTION
reported from https://github.com/better-auth/better-auth/issues/6944

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI command `info --json` unexpectedly exiting with code 1 by loading the config with the correct cwd and failing fast on invalid configs. The command now returns reliable JSON output.

- **Bug Fixes**
  - Pass `cwd` to `loadConfig` for correct config resolution.
  - Set `shouldThrowOnError: true` in `info` to surface config errors early.

<sup>Written for commit b503a9aecbc8e13045d80d0eb4b0da48e40e1d1b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

