### PR TITLE
docs: update plugin schema definition

### DIFF
--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -176,10 +176,10 @@ The key is the column name and the value is the column definition. The column de
 
 `unique`: if the field should be unique. (default: `false`)
 
-`reference`: if the field is a reference to another table. (default: `null`) It takes an object with the following properties:
+`references`: if the field is a reference to another table. (optional) It takes an object with the following properties:
     - `model`: The table name to reference.
     - `field`: The field name to reference.
-    - `onDelete`: The action to take when the referenced record is deleted. (default: `null`)
+    - `onDelete`: The action to take when the referenced record is deleted. (default: `cascade`)
 
 **Other Schema Properties**
 

--- a/docs/content/docs/guides/your-first-plugin.mdx
+++ b/docs/content/docs/guides/your-first-plugin.mdx
@@ -74,7 +74,6 @@ export const birthdayPlugin = () =>
             type: "date", // string, number, boolean, date // [!code highlight]
             required: true, // if the field should be required on a new record. (default: false) // [!code highlight]
             unique: false, // if the field should be unique. (default: false) // [!code highlight]
-            references: null // if the field is a reference to another table. (default: null) // [!code highlight]
           },// [!code highlight]
         },// [!code highlight]
       },// [!code highlight]


### PR DESCRIPTION
Closes: https://github.com/better-auth/better-auth/pull/2637

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin schema docs to use the correct references property and clarify defaults. The field is optional, and onDelete now documents a default of cascade; removed an outdated example line.

- **Bug Fixes**
  - Renamed reference to references in concepts doc.
  - Documented onDelete default as cascade.
  - Removed references: null from the “Your first plugin” guide example.

<sup>Written for commit 03169edd8924b8c3109615518f37c1cc82c6ec45. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

