### PR TITLE
fix(stripe): add 'subscription/restore' to pathMethods

### DIFF
--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -29,8 +29,8 @@ export const stripeClient = <
 			>
 		>,
 		pathMethods: {
-			"/subscription/restore": "POST",
 			"/subscription/billing-portal": "POST",
+			"/subscription/restore": "POST",
 		},
 		$ERROR_CODES: STRIPE_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added POST mapping for "/subscription/restore" in the Stripe client so restore subscription requests work correctly.

<sup>Written for commit da0e2a9c6d742d3551be4f93e53ae750a73564a4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



