### PR TITLE
chore: clean up lint warning

### DIFF
--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -1259,7 +1259,7 @@ describe("base context creation", () => {
 			vi.stubEnv("AUTH_SECRET", "");
 			const originalNodeEnv = process.env.NODE_ENV;
 			const log = vi.fn();
-			const res = await initBase({
+			await initBase({
 				logger: {
 					level: "warn",
 					log,


### PR DESCRIPTION
<img width="903" height="486" alt="lint" src="https://github.com/user-attachments/assets/439fc2bc-0ee7-44c4-9483-e1a1e175de98" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved a lint warning in create-context.test.ts by removing an unused variable assignment from the initBase call. No functional changes; tests behave the same.

<sup>Written for commit df2fc9548037472cf3dc88c177a562d823b03e7d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

