### PR TITLE
docs: OAuth Migration improvements

### DIFF
--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1780,6 +1780,7 @@ Previously `oauthApplication`
 The following function will convert a `plain` representation into the default hash:
 ```ts
 import { createHash } from "@better-auth/utils/hash";
+import { base64Url } from "@better-auth/utils/base64";
 
 const defaultHasher = async (value: string) => {
 	const hash = await createHash("SHA-256").digest(


### PR DESCRIPTION
Minor improvements to the documentation, specifically the migration plan





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the OAuth Provider migration guide with a ready-to-use hashing function, clearer token migration steps, and a corrected jwt import path.

- **Migration**
  - Added a `defaultHasher` TypeScript snippet to convert plain client secrets to SHA-256 base64Url.
  - Updated token migration examples to use `defaultHasher` for access and refresh tokens.
  - Fixed the example to import `jwt` from `better-auth/plugins`.
  - Clarified that database changes match the “From OIDC Provider Plugin” section.

<sup>Written for commit 366c757173b9b78c0b0fb25aecb812be49c2bfad. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





