### PR TITLE
chore: enable color for cspell

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "biome check .",
     "lint:dependencies": "knip --strict",
     "lint:fix": "biome check . --fix --unsafe",
-    "lint:spell": "cspell check . --color",
+    "lint:spell": "cspell . --color",
     "lint:types": "turbo lint:types --filter=./packages/*",
     "lint:packages": "turbo lint:package --filter=./packages/*",
     "release": "turbo build --filter=./packages/* && bumpp && pnpm -r publish --access public --no-git-checks",


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable colored output for cspell in the lint:spell script by using "cspell . --color" to make spelling diagnostics easier to read.

<sup>Written for commit 6f5b35ecac572dd6f4af3ba968ad4da65d135d77. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





