### PR TITLE
fix(oauth-provider): support jwksPath

### DIFF
--- a/packages/oauth-provider/src/client-resource.ts
+++ b/packages/oauth-provider/src/client-resource.ts
@@ -62,7 +62,7 @@ export const oauthProviderResourceClient = <T extends Auth | undefined>(
 						opts?.jwksUrl ??
 						jwtPluginOptions?.jwks?.remoteUrl ??
 						(authServerBaseUrl
-							? `${authServerBaseUrl + (authServerBasePath ?? "")}/${jwtPluginOptions?.jwks?.jwksPath ?? "jwks"}`
+							? `${authServerBaseUrl + (authServerBasePath ?? "")}${jwtPluginOptions?.jwks?.jwksPath ?? "/jwks"}`
 							: undefined);
 					const introspectUrl =
 						opts?.remoteVerify?.introspectUrl ??

--- a/packages/oauth-provider/src/logout.ts
+++ b/packages/oauth-provider/src/logout.ts
@@ -38,7 +38,7 @@ export async function rpInitiatedLogoutEndpoint(
 	const jwtPluginOptions = jwtPlugin?.options;
 	const jwksUrl =
 		jwtPluginOptions?.jwks?.remoteUrl ??
-		`${baseURL}/${jwtPluginOptions?.jwks?.jwksPath ?? "jwks"}`;
+		`${baseURL}${jwtPluginOptions?.jwks?.jwksPath ?? "/jwks"}`;
 
 	let clientId = client_id;
 	if (!clientId) {

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -28,7 +28,7 @@ export function authServerMetadata(
 		jwks_uri: overrides?.jwt_disabled
 			? undefined
 			: (opts?.jwks?.remoteUrl ??
-				`${baseURL}/${opts?.jwks?.jwksPath ?? "jwks"}`),
+				`${baseURL}${opts?.jwks?.jwksPath ?? "/jwks"}`),
 		registration_endpoint: `${baseURL}/oauth2/register`,
 		introspection_endpoint: `${baseURL}/oauth2/introspect`,
 		revocation_endpoint: `${baseURL}/oauth2/revoke`,


### PR DESCRIPTION
Supports `jwksPath` when set by the `jwks` plugin.

Closes: #6972



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for jwksPath from the jwks plugin so JWKS URLs use the configured custom path.

- **Bug Fixes**
  - Use jwksPath when building JWKS URLs; default to "/jwks" if not set.
  - Preserve jwks.remoteUrl override when provided.
  - Apply to client resource, logout endpoint, and metadata jwks_uri.

<sup>Written for commit 4eaa1a2f2eceb0be43c82efa7dfadb1b424471fe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



