### PR TITLE
test(oauth-provider): correct failing test

### DIFF
--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -120,7 +120,7 @@ describe("oauth metadata", async () => {
 				scopes,
 			},
 		});
-		await expect(auth.api.getOpenIdConfig()).rejects.toThrow(APIError);
+		await expect(auth.api.getOpenIdConfig()).rejects.toThrowError(APIError);
 		const oauthMetadata = await auth.api.getOAuthServerConfig();
 		expect(oauthMetadata).toMatchObject({
 			scopes_supported: scopes,


### PR DESCRIPTION
<img width="992" height="433" alt="test" src="https://github.com/user-attachments/assets/4e9e32eb-2be6-4272-a8d4-324533316fb7" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix oauth-provider metadata test by asserting that getOpenIdConfig rejects with APIError (class) instead of a specific NOT_FOUND instance. This matches current error handling and prevents false failures when OpenID config is missing.

<sup>Written for commit 590be88e12f6fcbda8b1853b47e5949d9c80cc6a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



