### PR TITLE
fix(oauth-provider): only session db store currently supported

### DIFF
--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1591,7 +1591,7 @@ Table Name: `oauthRefreshToken`
     {
       name: "sessionId",
       type: "string",
-      description: "ID of the user associated with the token",
+      description: "ID of the session used at issuance of the token (and still active)",
       isForeignKey: true,
       isRequired: false,
       references: { model: "session", field: "id" },
@@ -1665,7 +1665,7 @@ Table Name: `oauthAccessToken`
     {
       name: "sessionId",
       type: "string",
-      description: "ID of the user associated with the token",
+      description: "ID of the session used at issuance of the token (and still active)",
       isForeignKey: true,
       isOptional: true,
       references: { model: "session", field: "id" },
@@ -1683,7 +1683,7 @@ Table Name: `oauthAccessToken`
       type: "string",
       description: "ID of the user associated with the token",
       isForeignKey: true,
-      isRequired: true,
+      isOptional: true,
       references: { model: "user", field: "id" },
     },
     {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -147,6 +147,11 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		id: "oauthProvider",
 		options: opts,
 		init: (ctx) => {
+			// Require session id storage on database (secondary-storage only solution not yet supported)
+			if (ctx.options.session && !ctx.options.session.storeSessionInDatabase) {
+				throw new BetterAuthError("sessions must be stored on database");
+			}
+
 			// Check for jwt plugin registration
 			if (!opts.disableJwtPlugin) {
 				const jwtPlugin = getJwtPlugin(ctx);


### PR DESCRIPTION
OAuth Provider Plugin only supports db session secondary-storage due to use of session id.

Closes: #6995

Fail fast in oauthProvider when sessions aren’t stored in the database, since only DB-backed sessionId is supported. Docs now clarify sessionId refers to the issuing, still-active session, and oauthAccessToken.userId is optional.

<sub>Written for commit b843b05957be2090abb7aed864bff3512e8a7b4b. Summary will update automatically on new commits.</sub>