### PR TITLE
chore: update import paths

### DIFF
--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -1,5 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
-import type { JWSAlgorithms, JwtOptions } from "better-auth/plugins/jwt";
+import type { JWSAlgorithms, JwtOptions } from "better-auth/plugins";
 import type { OAuthOptions, Scope } from "./types";
 import type {
 	AuthServerMetadata,

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -149,7 +149,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		init: (ctx) => {
 			// Require session id storage on database (secondary-storage only solution not yet supported)
 			if (ctx.options.session && !ctx.options.session.storeSessionInDatabase) {
-				throw new BetterAuthError("sessions must be stored on database");
+				throw new BetterAuthError(
+					"OAuth Provider requires `session.storeSessionInDatabase: true` when using secondaryStorage",
+				);
 			}
 
 			// Check for jwt plugin registration

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -1,7 +1,7 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError, getSessionFromCtx } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
-import { toExpJWT } from "../../better-auth/src/plugins/jwt/utils";
+import { toExpJWT } from "better-auth/plugins";
 import type { OAuthOptions, SchemaClient, Scope } from "./types";
 import type { OAuthClient } from "./types/oauth";
 import { storeClientSecret } from "./utils";

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -2,7 +2,7 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
 import { generateCodeChallenge } from "better-auth/oauth2";
-import { signJWT, toExpJWT } from "better-auth/plugins/jwt";
+import { signJWT, toExpJWT } from "better-auth/plugins";
 import type { Session, User } from "better-auth/types";
 import type { JWTPayload } from "jose";
 import { SignJWT } from "jose";

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -1,4 +1,4 @@
-import type { JWSAlgorithms } from "better-auth/plugins/jwt";
+import type { JWSAlgorithms } from "better-auth/plugins";
 import type { Prompt } from ".";
 
 /**

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -7,7 +7,7 @@ import {
 	symmetricDecrypt,
 	symmetricEncrypt,
 } from "better-auth/crypto";
-import type { jwt } from "better-auth/plugins/jwt";
+import type { jwt } from "better-auth/plugins";
 import type { Auth } from "better-auth/types";
 import { APIError } from "better-call";
 import type { oauthProvider } from "..";


### PR DESCRIPTION
Update OAuth Provider Import paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update OAuth Provider imports to use the consolidated better-auth/plugins entrypoint and clarify the session storage requirement error message. Keeps the provider compatible with the latest Better Auth plugin structure.

- **Refactors**
  - Switched imports from better-auth/plugins/jwt and a local path to better-auth/plugins for JWSAlgorithms, JwtOptions, signJWT, toExpJWT, and jwt type.
  - Updated error text to clearly require session.storeSessionInDatabase: true when using secondaryStorage.

<sup>Written for commit 393d32958186b72a0f727f7fa2e74b8aed9ceff0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

