### PR TITLE
fix(build): externalize @better-auth/core to fix Expo/Metro resolution

### DIFF
--- a/packages/better-auth/tsdown.config.ts
+++ b/packages/better-auth/tsdown.config.ts
@@ -64,4 +64,5 @@ export default defineConfig({
 	treeshake: true,
 	clean: true,
 	unbundle: true,
+	external: ["@better-auth/core"],
 });


### PR DESCRIPTION
When using Expo/Metro, the bundler was incorrect rewriting @better-auth/core imports to relative paths causing module resolution errors. This PR adds @better-auth/core to external in tsdown config to preserve correct import paths.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Externalizes @better-auth/core in tsdown config so bundlers keep the package import and don’t rewrite it to relative paths. Fixes Expo/Metro module resolution errors.

<sup>Written for commit 30a862bc5b7b14da27f96db66b22acd5b2bed179. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

