### PR TITLE
docs: improve set active organization guide

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -646,7 +646,7 @@ export const auth = betterAuth({
       create: {
         before: async (session) => {
           // Implement your custom logic to set initial active organization
-          const organization = await getOrganizationByUserId(session.userId);
+          const organization = await getInitialOrganization(session.userId);
           return {
             data: {
               ...session,


### PR DESCRIPTION
- Closes https://github.com/better-auth/better-auth/issues/7005



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the organization plugin docs to show how to set the initial active organization on session creation using database hooks. The example uses clearer naming, optional chaining to handle missing orgs, and reminds you to implement custom logic to choose the user's organization.

<sup>Written for commit f22e277f9e07df2410524ee3bd737e615897fe97. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



