### PR TITLE
fix(organization): remove unnecessary type re-export

### DIFF
--- a/packages/better-auth/src/plugins/organization/index.ts
+++ b/packages/better-auth/src/plugins/organization/index.ts
@@ -1,4 +1,3 @@
-export type * from "./access";
 export { getOrgAdapter } from "./adapter";
 export * from "./organization";
 export type * from "./schema";


### PR DESCRIPTION
The type doesn't actually exist, and that method is meant to be accessed through a different entry path.

- Closes https://github.com/better-auth/better-auth/issues/7004

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed re-export of a non-existent access type from the organization plugin index to prevent TypeScript import errors. Use the intended access entry path; closes #7004.

<sup>Written for commit 43961b34fec4adaed7148afd3eacd45557178360. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

