### PR TITLE
chore: replace body schema with `signUpEmailBodySchema`

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -30,7 +30,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 			method: "POST",
 			operationId: "signUpWithEmailAndPassword",
 			use: [formCsrfMiddleware],
-			body: z.record(z.string(), z.any()),
+			body: signUpEmailBodySchema,
 			metadata: {
 				allowedMediaTypes: [
 					"application/x-www-form-urlencoded",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use signUpEmailBodySchema for the sign-up email route instead of a generic record. This enforces a typed payload and provides clearer validation errors.

<sup>Written for commit a59266d67339a54a1930dec62da810bfa6fd7983. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

