### PR TITLE
fix(client): prevent duplicate signal processing in atom listeners

### DIFF
--- a/packages/better-auth/src/client/proxy.test.ts
+++ b/packages/better-auth/src/client/proxy.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDynamicPathProxy } from "./proxy";
+
+describe("createDynamicPathProxy", () => {
+	it("should avoid duplicate signal processing", async () => {
+		const client = vi.fn(async (path, options) => {
+			if (options?.onSuccess) {
+				await options.onSuccess({} as any);
+			}
+			return {
+				data: {},
+				error: null,
+			};
+		});
+		const knownPathMethods = {
+			"/test": "POST",
+		} as const;
+
+		const signalSet = vi.fn();
+		const signalGet = vi.fn(() => false);
+
+		const atoms = {
+			testSignal: {
+				get: signalGet,
+				set: signalSet,
+				subscribe: () => () => {},
+				listen: () => () => {},
+				off: () => {},
+				value: false,
+			} as any,
+		};
+		const atomListeners = [
+			{
+				matcher: (path: string) => path === "/test",
+				signal: "testSignal",
+			},
+			{
+				matcher: (path: string) => path === "/test",
+				signal: "testSignal",
+			},
+		];
+
+		const proxy = createDynamicPathProxy(
+			{
+				test: {},
+			},
+			client as any,
+			knownPathMethods,
+			atoms,
+			atomListeners,
+		);
+
+		vi.useFakeTimers();
+
+		await (proxy.test as any)();
+
+		expect(client).toHaveBeenCalled();
+
+		vi.runAllTimers();
+
+		expect(signalSet).toHaveBeenCalledTimes(1);
+
+		vi.useRealTimers();
+	});
+});

--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -101,6 +101,7 @@ export function createDynamicPathProxy<T extends Record<string, any>>(
 						 */
 						const matches = atomListeners.filter((s) => s.matcher(routePath));
 						if (!matches.length) return;
+
 						const visited = new Set<ClientAtomListener["signal"]>();
 						for (const match of matches) {
 							const signal = atoms[match.signal as any];


### PR DESCRIPTION
Upstream: https://github.com/better-auth/better-auth/pull/7013

Avoid duplicate value set







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate signal updates in client atom listeners when multiple match a route. We track visited signals to set each value once, reducing redundant updates and avoiding race conditions.

<sup>Written for commit 771bfa0d9bf005e5e50eb7e46d6b04dfdcfe1d99. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







