### PR TITLE
fix: remove duplicate `refreshUserSessions` calls

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -804,7 +804,6 @@ export const createInternalAdapter = (
 				undefined,
 			);
 			await refreshUserSessions(user);
-			await refreshUserSessions(user);
 			return user;
 		},
 		updateUserByEmail: async (
@@ -822,7 +821,6 @@ export const createInternalAdapter = (
 				"user",
 				undefined,
 			);
-			await refreshUserSessions(user);
 			await refreshUserSessions(user);
 			return user;
 		},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed duplicate refreshUserSessions calls in the internal adapter when updating a user and when updating by email. This avoids double session refreshes and reduces unnecessary work.

<sup>Written for commit 24566c8fd2258aed7fbdc0dbde5c274ee201091d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

