### PR TITLE
docs: update `auth.api.signUpEmail` to use body object

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -431,12 +431,12 @@ Now you can access the additional fields in your application logic.
 ```ts
 //on signup
 const res = await auth.api.signUpEmail({
-  body: {
-    email: "test@example.com",
-    password: "password",
-    name: "John Doe",
-    lang: "fr",
-  }
+	body: {
+		email: 'test@example.com',
+		password: 'password',
+		name: 'John Doe',
+		lang: 'fr',
+	},
 });
 
 //user object


### PR DESCRIPTION
Updated the signUpEmail API call to use a body object for parameters.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to show auth.api.signUpEmail expects parameters inside a body object. Aligns the example with the current API and prevents integration errors.

<sup>Written for commit df2c9c5745a582cad399ea01cf7a3126278ee30a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

