### PR TITLE
docs: improve community plugins page

### DIFF
--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -274,7 +274,13 @@ export function CommunityPluginsTable() {
 	});
 
 	return (
-		<div className="w-full space-y-4">
+		<div className="w-full">
+			<div className="flex items-center justify-between text-xs text-muted-foreground">
+				<p>
+					Showing {table.getRowModel().rows.length} of {communityPlugins.length}{" "}
+					plugins
+				</p>
+			</div>
 			<div className="relative">
 				<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 				<input
@@ -285,8 +291,7 @@ export function CommunityPluginsTable() {
 					className="w-full rounded-lg border bg-background pl-10 pr-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
 				/>
 			</div>
-
-			<div className="rounded-lg border">
+			<div className="rounded-lg">
 				<div className="overflow-x-auto">
 					<table className="w-full">
 						<thead>
@@ -337,13 +342,6 @@ export function CommunityPluginsTable() {
 							)}
 						</tbody>
 					</table>
-				</div>
-			</div>
-
-			<div className="flex items-center justify-between text-sm text-muted-foreground">
-				<div>
-					Showing {table.getRowModel().rows.length} of {communityPlugins.length}{" "}
-					plugins
 				</div>
 			</div>
 		</div>

--- a/docs/content/docs/plugins/community-plugins.mdx
+++ b/docs/content/docs/plugins/community-plugins.mdx
@@ -5,10 +5,12 @@ description: A list of recommended community plugins.
 
 import { CommunityPluginsTable } from "@/components/community-plugins-table";
 
-This page showcases a list of recommended community made plugins.
+This page showcases a list of recommended community made plugins. We encourage you to create custom plugins and maybe get added to the list!
 
-We encourage you to create custom plugins and maybe get added to the list!
+## Create Your Own Plugin
 
 To create your own custom plugin, get started by reading our [plugins documentation](/docs/concepts/plugins). And if you want to share your plugin with the community, please open a pull request to add it to this list.
+
+## Browse Community Plugins
 
 <CommunityPluginsTable />


### PR DESCRIPTION
## Before

<img width="1215" height="734" alt="before" src="https://github.com/user-attachments/assets/097793e2-f2d1-4f9f-bf42-d17ca2218c3f" />

## After

<img width="1216" height="733" alt="after" src="https://github.com/user-attachments/assets/e2bbbfe1-c575-4fb5-aa88-792dd4bc6ef3" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the Community Plugins docs page with clearer headings and a streamlined table UI. The plugin count now appears above the search, the extra footer and table border are removed, and the intro copy encourages creating and sharing plugins.

<sup>Written for commit 972a9345cda3de2a80f3b11f3e69abdf3ce9edd9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

