### PR TITLE
feat(api-key): add referenceId support and authorization hook

### DIFF
--- a/packages/better-auth/src/plugins/api-key/error-codes.ts
+++ b/packages/better-auth/src/plugins/api-key/error-codes.ts
@@ -32,4 +32,7 @@ export const API_KEY_ERROR_CODES = defineErrorCodes({
 		"The property you're trying to set can only be set from the server auth instance only.",
 	FAILED_TO_UPDATE_API_KEY: "Failed to update API key",
 	NAME_REQUIRED: "API Key name is required.",
+	REFERENCE_ID_REQUIRED: "Reference ID is required",
+	UNAUTHORIZED_REFERENCE:
+		"You are not authorized to create a key for this referenceId",
 });

--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -159,6 +159,13 @@ export const apiKey = (options?: ApiKeyOptions | undefined) => {
 							ctx.context.runInBackground(cleanupTask);
 						}
 
+						if (!apiKey.userId) {
+							throw APIError.from(
+								"UNAUTHORIZED",
+								API_KEY_ERROR_CODES.INVALID_USER_ID_FROM_API_KEY,
+							);
+						}
+
 						const user = await ctx.context.internalAdapter.findUserById(
 							apiKey.userId,
 						);

--- a/packages/better-auth/src/plugins/api-key/schema.ts
+++ b/packages/better-auth/src/plugins/api-key/schema.ts
@@ -51,7 +51,16 @@ export const apiKeySchema = ({
 				userId: {
 					type: "string",
 					references: { model: "user", field: "id", onDelete: "cascade" },
-					required: true,
+					required: false,
+					input: false,
+					index: true,
+				},
+				/**
+				 * The reference id of the key.
+				 */
+				referenceId: {
+					type: "string",
+					required: false,
 					input: false,
 					index: true,
 				},

--- a/packages/better-auth/src/plugins/api-key/types.ts
+++ b/packages/better-auth/src/plugins/api-key/types.ts
@@ -3,6 +3,7 @@ import type {
 	GenericEndpointContext,
 	HookEndpointContext,
 } from "@better-auth/core";
+import type { Session, User } from "@better-auth/core/db";
 
 import type { InferOptionSchema } from "../../types";
 import type { Statements } from "../access";
@@ -272,6 +273,17 @@ export interface ApiKeyOptions {
 	 * @default false
 	 */
 	deferUpdates?: boolean | undefined;
+	/**
+	 * A custom function to authorize the reference id
+	 */
+	authorizeReference?: (
+		data: {
+			user: User;
+			session: Session;
+			referenceId: string;
+		},
+		ctx: GenericEndpointContext,
+	) => Awaitable<boolean>;
 }
 
 export type ApiKey = {
@@ -299,7 +311,11 @@ export type ApiKey = {
 	/**
 	 * The owner of the user id
 	 */
-	userId: string;
+	userId?: string;
+	/**
+	 * The reference id of the key.
+	 */
+	referenceId?: string;
 	/**
 	 * The interval in milliseconds between refills of the `remaining` count
 	 *


### PR DESCRIPTION
## What this PR does
Fixes #4746 

Adds `referenceId` support to the API Key plugin, allowing keys to be associated with external entities (such as organizations or projects) and enabling custom authorization logic for managing these keys.

## Key Changes
- **Schema Update**: Added `referenceId` field to the `apiKey` table schema.
- **New Hook**: Introduced `authorizeReference` hook in plugin options to control access to keys based on their `referenceId`.
- **Authorization Logic**: Updated `get`, `list`, `update`, and `delete` operations to check `authorizeReference`. This allows authorized users (e.g., organization admins) to manage keys they don't own.
- **Creation Flow**: Updated `create` endpoint to accept and store `referenceId`.

## Configuration
```typescript
apiKey({
  authorizeReference: async ({ referenceId, user }, ctx) => {
    // Example: Allow if user is an admin of the organization (referenceId)
    const membership = await db.findMembership(user.id, referenceId);
    return membership?.role === "admin";
  }
})
```

## Usage
```typescript
// Client: Create a key for a specific organization
await authClient.apiKey.create({
    name: "Production Key",
    referenceId: "org_123"
});

// Client: List keys for an organization
await authClient.apiKey.list({
    query: {
        referenceId: "org_123"
    }
});

// Client: Admin updates a key they don't own (authorized via hook)
await authClient.apiKey.update({
    keyId: "key_abc",
    name: "Updated Name"
});
```

## Testing
✅ **Creation**: Verified keys are created with the correct `referenceId`.
✅ **Authorization**: Verified `authorizeReference` hook is called with correct parameters.
✅ **Cross-User Access**: Verified that a user (e.g., admin) can manage keys created by another user if authorized by the hook.
✅ **Security**: Verified that operations fail with `UNAUTHORIZED_REFERENCE` when the hook returns `false`.

## Breaking Changes
None - The `referenceId` field is optional, and the `authorizeReference` hook defaults to standard ownership checks if not provided. Existing functionality remains unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds referenceId support to API keys and a new authorization hook so org/project-scoped keys can be created and managed by authorized users (e.g., admins). Endpoints now enforce access by referenceId and support filtering by it.

- **New Features**
  - Added referenceId to API keys; create/list/get/update/delete now handle it, with list supporting query.referenceId.
  - Introduced authorizeReference hook to gate access when the requester isn’t the owner; returns UNAUTHORIZED_REFERENCE on denial and REFERENCE_ID_REQUIRED on create when the hook is enabled.
  - Updated storage and DB queries to index and list keys by userId and referenceId for secondary storage and fallback paths.

- **Migration**
  - No breaking changes. If you enable authorizeReference, send referenceId on create and implement the hook to define who can manage keys for that reference.

<sup>Written for commit fc4c45a22bcd6314ff08b72a01c8365966ce89d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

