### PR TITLE
chore: bump pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@better-auth/root",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.23.0",
+  "packageManager": "pnpm@10.26.2",
   "scripts": {
     "build": "turbo build --filter=./packages/*",
     "dev": "turbo dev --filter=./packages/* --filter=!./packages/cli",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped pnpm from 10.23.0 to 10.26.2 in package.json to keep the toolchain current and ensure consistent installs across environments.

<sup>Written for commit 99fbfc7222429f534f3bc7a81edb9723ea4865c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

