### PR TITLE
Fix JSON key casing in introduction.mdx

### DIFF
--- a/docs/content/docs/introduction.mdx
+++ b/docs/content/docs/introduction.mdx
@@ -81,8 +81,8 @@ Alternatively, you can manually configure the MCP server for each client:
     <Tab value="Manual">
      ```json title="mcp.json"
     {
-        "Better Auth": {
-            "url": "https://mcp.chonkie.ai/better-auth/better-auth-builder/mcp"
+        "better-auth": {
+            "serverUrl": "https://mcp.chonkie.ai/better-auth/better-auth-builder/mcp"
         }
     }
     ```


### PR DESCRIPTION
chore: update MCP config to new format and fix invalid server name

- Replace deprecated `url` with `serverUrl`
- Rename server key from "Better Auth" to "better-auth" to satisfy MCP naming regex

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the MCP config example in introduction.mdx to the new format and fixed the server name to meet MCP naming rules. Replaces "url" with "serverUrl" and renames "Better Auth" to "better-auth" to prevent invalid configs.

<sup>Written for commit f482d52062a22ef6bb7b81b9bdf8af8d17022fb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

