### PR TITLE
feat(stripe): add disableRedirect option for subscription and billing

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -249,7 +249,7 @@ type upgradeSubscription = {
     /**
      * Disable redirect after successful subscription. 
      */
-    disableRedirect: boolean = true
+    disableRedirect: boolean = false
 }
 ```
 </APIMethod>
@@ -457,6 +457,11 @@ type createBillingPortal = {
      * Return URL to redirect back after successful subscription. 
      */
     returnUrl?: string
+    /**
+     * Disable the automatic redirect to the billing page.
+     * @default false
+     */
+    disableRedirect?: boolean = false
 }
 ```
 </APIMethod>

--- a/packages/stripe/src/routes.ts
+++ b/packages/stripe/src/routes.ts
@@ -403,7 +403,7 @@ export const upgradeSubscription = (options: StripeOptions) => {
 					});
 				return ctx.json({
 					url,
-					redirect: true,
+					redirect: !ctx.body.disableRedirect,
 				});
 			}
 
@@ -676,6 +676,16 @@ const cancelSubscriptionBodySchema = z.object({
 		description:
 			'URL to take customers to when they click on the billing portal\'s link to return to your website. Eg: "/account"',
 	}),
+	/**
+	 * Disable Redirect
+	 */
+	disableRedirect: z
+		.boolean()
+		.meta({
+			description:
+				"Disable redirect after successful subscription cancellation. Eg: true",
+		})
+		.default(false),
 });
 
 /**
@@ -830,10 +840,10 @@ export const cancelSubscription = (options: StripeOptions) => {
 						code: e.code,
 					});
 				});
-			return {
+			return ctx.json({
 				url,
-				redirect: true,
-			};
+				redirect: !ctx.body.disableRedirect,
+			});
 		},
 	);
 };
@@ -1178,6 +1188,16 @@ const createBillingPortalBodySchema = z.object({
 		.optional(),
 	referenceId: z.string().optional(),
 	returnUrl: z.string().default("/"),
+	/**
+	 * Disable Redirect
+	 */
+	disableRedirect: z
+		.boolean()
+		.meta({
+			description:
+				"Disable redirect after creating billing portal session. Eg: true",
+		})
+		.default(false),
 });
 
 export const createBillingPortal = (options: StripeOptions) => {
@@ -1236,7 +1256,7 @@ export const createBillingPortal = (options: StripeOptions) => {
 
 				return ctx.json({
 					url,
-					redirect: true,
+					redirect: !ctx.body.disableRedirect,
 				});
 			} catch (error: any) {
 				ctx.context.logger.error(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a disableRedirect option to Stripe subscription upgrade, cancellation, and billing portal endpoints. This lets apps opt out of automatic redirects and handle navigation manually while keeping default behavior unchanged.

- **New Features**
  - Add disableRedirect (default false) to upgradeSubscription, cancelSubscription, and createBillingPortal.
  - Responses now set redirect to !disableRedirect and include url for manual navigation.
  - Update validation for cancelSubscription and createBillingPortal; improve docs and examples for all affected endpoints.

<sup>Written for commit d9036b2930902efb86e4864ba01d994c304fce31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

