### PR TITLE
fix(api): chain plugin `onRequest` hooks properly

### DIFF
--- a/packages/better-auth/src/api/index.test.ts
+++ b/packages/better-auth/src/api/index.test.ts
@@ -5,6 +5,7 @@ import type {
 } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
 import { describe, expect, it, vi } from "vitest";
+import { getTestInstance } from "../test-utils/test-instance";
 import { getEndpoints } from "./index";
 
 describe("getEndpoints", () => {
@@ -53,5 +54,132 @@ describe("getEndpoints", () => {
 			options: {},
 			customProp: "value",
 		});
+	});
+});
+
+describe("onRequest chain", () => {
+	it("should execute all plugins onRequest handlers in chain", async () => {
+		const onRequestOrder: string[] = [];
+
+		const pluginA: BetterAuthPlugin = {
+			id: "plugin-a",
+			async onRequest(request, _ctx) {
+				onRequestOrder.push("plugin-a");
+				// Return a modified request - this should NOT stop the chain
+				const newHeaders = new Headers(request.headers);
+				newHeaders.set("x-plugin-a", "true");
+				return {
+					request: new Request(request, { headers: newHeaders }),
+				};
+			},
+		};
+
+		const pluginB: BetterAuthPlugin = {
+			id: "plugin-b",
+			async onRequest(request, _ctx) {
+				onRequestOrder.push("plugin-b");
+				// This should also execute and see the modified request from plugin-a
+				const newHeaders = new Headers(request.headers);
+				newHeaders.set("x-plugin-b", "true");
+				return {
+					request: new Request(request, { headers: newHeaders }),
+				};
+			},
+		};
+
+		const pluginC: BetterAuthPlugin = {
+			id: "plugin-c",
+			async onRequest(_request, _ctx) {
+				onRequestOrder.push("plugin-c");
+				// Just observe, don't modify
+				return;
+			},
+		};
+
+		const { client, testUser } = await getTestInstance({
+			plugins: [pluginA, pluginB, pluginC],
+		});
+
+		await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+		});
+
+		// All three plugins should have their onRequest called
+		expect(onRequestOrder).toEqual(["plugin-a", "plugin-b", "plugin-c"]);
+	});
+
+	it("should pass modified request from previous plugin to next plugin", async () => {
+		let pluginBReceivedHeader: string | null = null;
+
+		const pluginA: BetterAuthPlugin = {
+			id: "plugin-a",
+			async onRequest(request, _ctx) {
+				const newHeaders = new Headers(request.headers);
+				newHeaders.set("x-from-plugin-a", "hello");
+				return {
+					request: new Request(request, { headers: newHeaders }),
+				};
+			},
+		};
+
+		const pluginB: BetterAuthPlugin = {
+			id: "plugin-b",
+			async onRequest(request, _ctx) {
+				// Should receive the header set by plugin-a
+				pluginBReceivedHeader = request.headers.get("x-from-plugin-a");
+				return;
+			},
+		};
+
+		const { client, testUser } = await getTestInstance({
+			plugins: [pluginA, pluginB],
+		});
+
+		await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+		});
+
+		expect(pluginBReceivedHeader).toBe("hello");
+	});
+
+	it("should stop chain when response is returned", async () => {
+		const onRequestOrder: string[] = [];
+
+		const pluginA: BetterAuthPlugin = {
+			id: "plugin-a",
+			async onRequest(_request, _ctx) {
+				onRequestOrder.push("plugin-a");
+				// Return a response - this SHOULD stop the chain
+				return {
+					response: new Response("Blocked by plugin-a", { status: 403 }),
+				};
+			},
+		};
+
+		const pluginB: BetterAuthPlugin = {
+			id: "plugin-b",
+			async onRequest(_request, _ctx) {
+				onRequestOrder.push("plugin-b");
+				return {
+					response: new Response("ok", { status: 200 }),
+				};
+			},
+		};
+
+		const { client, testUser } = await getTestInstance({
+			plugins: [pluginA, pluginB],
+		});
+
+		const result = await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+		});
+
+		// Only plugin-a should execute, plugin-b should NOT execute
+		expect(onRequestOrder).toEqual(["plugin-a"]);
+		// Response should be from plugin-a
+		expect(result.error?.status).toBe(403);
 	});
 });


### PR DESCRIPTION
Currently, only the first plugin that returned a modified request would execute, preventing subsequent plugins from processing the request.

- All plugins now execute sequentially, passing the modified request
along the chain, unless a response is returned (which stops the chain)
- Rate limiting is now applied after all plugin hooks execute, ensuring
it checks the final modified request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Chained plugin onRequest hooks so all plugins run in order and can modify the request. Rate limiting now checks the final request after all hooks.

- **Bug Fixes**
  - Run all onRequest hooks sequentially, passing the modified request.
  - Stop the chain when a plugin returns a response.
  - Apply rate limiting after hooks, using the final request.

<sup>Written for commit 04d64822b317a30c50d7cbf00a8e695ee68e58af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

