### PR TITLE
docs: update Spotify provider guide to use 127.0.0.1

### DIFF
--- a/docs/content/docs/authentication/spotify.mdx
+++ b/docs/content/docs/authentication/spotify.mdx
@@ -24,7 +24,7 @@ description: Spotify provider setup and usage.
         You must also ensure your environment variables use the correct loopback IP to match the redirect URI. Update your `.env` file:
         
         ```bash title=".env"
-        BETTER_AUTH_URL=[http://127.0.0.1:3000](http://127.0.0.1:3000)
+        BETTER_AUTH_URL=http://127.0.0.1:3000
         ```
 
         ```ts title="auth.ts"  


### PR DESCRIPTION
## Description
Updates the Spotify provider documentation to strictly use `127.0.0.1` instead of `localhost`.

**Changes include:**
1. Updating the **Spotify Dashboard** setup instructions to use `http://127.0.0.1:3000/...`.
2. Adding a required step to set `BETTER_AUTH_URL=http://127.0.0.1:3000` in the `.env` file.
3. Adding a warning to access the local app via the loopback IP address.

## Why this is needed
Spotify has updated their developer policy and now strictly enforces the use of `127.0.0.1` for local development redirect URIs. `localhost` is no longer permitted as a valid Redirect URI in the Spotify Developer Dashboard.

Without these changes (specifically the matching `BETTER_AUTH_URL` and Dashboard URI), users following the current documentation will encounter an `INVALID_REDIRECT_URI` error during authentication.

## References
- **Spotify Developer Documentation (App Settings):** https://developer.spotify.com/documentation/web-api/concepts/apps
  *(See section: "Redirect URIs" -> "Requirements")*

<img width="1071" height="685" alt="Screenshot 2025-12-31 at 11 43 15 PM" src="https://github.com/user-attachments/assets/59db3b1b-38ae-4180-9a6a-cf0dea0bb153" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Spotify provider guide to require 127.0.0.1 instead of localhost for local redirect URIs. This follows Spotify’s policy and prevents INVALID_REDIRECT_URI errors.

- **Migration**
  - Set redirect URI to http://127.0.0.1:3000/api/auth/callback/spotify in the Spotify Dashboard.
  - Set BETTER_AUTH_URL=http://127.0.0.1:3000 in your .env.
  - Access the app at http://127.0.0.1:3000 (not localhost).

<sup>Written for commit 345581dd70156a806a86f27358363b3d49d7f936. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

