### PR TITLE
docs: update Spotify provider guide to use 127.0.0.1

### DIFF
--- a/docs/content/docs/authentication/spotify.mdx
+++ b/docs/content/docs/authentication/spotify.mdx
@@ -24,7 +24,7 @@ description: Spotify provider setup and usage.
         You must also ensure your environment variables use the correct loopback IP to match the redirect URI. Update your `.env` file:
         
         ```bash title=".env"
-        BETTER_AUTH_URL=[http://127.0.0.1:3000](http://127.0.0.1:3000)
+        BETTER_AUTH_URL=http://127.0.0.1:3000
         ```
 
         ```ts title="auth.ts"  


### PR DESCRIPTION
## Description
Updates the Spotify provider documentation to strictly use `127.0.0.1` instead of `localhost`.

**Changes include:**
1. Updating the **Spotify Dashboard** setup instructions to use `http://127.0.0.1:3000/...`.
2. Adding a required step to set `BETTER_AUTH_URL=http://127.0.0.1:3000` in the `.env` file.
3. Adding a warning to access the local app via the loopback IP address.

## Why this is needed
Spotify has updated their developer policy and now strictly enforces the use of `127.0.0.1` for local development redirect URIs. `localhost` is no longer permitted as a valid Redirect URI in the Spotify Developer Dashboard.

Without these changes (specifically the matching `BETTER_AUTH_URL` and Dashboard URI), users following the current documentation will encounter an `INVALID_REDIRECT_URI` error during authentication.

## References
- **Spotify Developer Documentation (App Settings):** https://developer.spotify.com/documentation/web-api/concepts/apps
  *(See section: "Redirect URIs" -> "Requirements")*
<img width="1071" height="685" alt="Screenshot 2025-12-31 at 11 43 15 PM" src="https://github.com/user-attachments/assets/2beca990-938b-463e-b99d-4b5cb074420f" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Spotify provider guide to require 127.0.0.1 instead of localhost for local redirect URIs. Adds an .env step (BETTER_AUTH_URL=http://127.0.0.1:3000) and a note to open the app at http://127.0.0.1:3000 to avoid INVALID_REDIRECT_URI.

<sup>Written for commit 345581dd70156a806a86f27358363b3d49d7f936. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

