### PR TITLE
docs: prevent sending empty message in AI chat

### DIFF
--- a/docs/components/floating-ai-search.tsx
+++ b/docs/components/floating-ai-search.tsx
@@ -79,6 +79,7 @@ function SearchAIInput(props: ComponentProps<"form"> & { isMobile?: boolean }) {
 
 	const onStart = (e?: SyntheticEvent) => {
 		e?.preventDefault();
+		if (!input.trim() || isLoading) return;
 		void sendMessage({ text: input });
 		setInput("");
 	};
@@ -121,6 +122,10 @@ function SearchAIInput(props: ComponentProps<"form"> & { isMobile?: boolean }) {
 					}}
 					onKeyDown={(event) => {
 						if (!event.shiftKey && event.key === "Enter") {
+							if (!input.trim() || isLoading) {
+								event.preventDefault();
+								return;
+							}
 							onStart(event);
 						}
 					}}
@@ -149,7 +154,7 @@ function SearchAIInput(props: ComponentProps<"form"> & { isMobile?: boolean }) {
 								className: "mt-2 rounded-full transition-all",
 							}),
 						)}
-						disabled={input.length === 0}
+						disabled={!input.trim() || isLoading}
 					>
 						<Send className="size-4" />
 					</button>


### PR DESCRIPTION
…ading state in input

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent empty message submissions and disable sending while a request is in progress in the floating search input. This avoids accidental sends and duplicate requests.

- **Bug Fixes**
  - Ignore Enter and programmatic sends when input is blank (after trim) or loading; disable the send button in the same state.

<sup>Written for commit 1309fdd48bd5ac7672fbc910cac849b7e2c76fbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

