### PR TITLE
docs: switch to default logo

### DIFF
--- a/docs/components/nav-bar.tsx
+++ b/docs/components/nav-bar.tsx
@@ -3,7 +3,7 @@ import { MobileSearchIcon } from "@/components/mobile-search-icon";
 import { ThemeToggle } from "@/components/theme-toggle";
 import DarkPng from "../public/branding/better-auth-logo-dark.png";
 import WhitePng from "../public/branding/better-auth-logo-light.png";
-import ChristmasLogo from "./christmas/logo";
+import { Logo } from "./logo";
 import LogoContextMenu from "./logo-context-menu";
 import { NavLink } from "./nav-link";
 import { NavbarMobile, NavbarMobileBtn } from "./nav-mobile";
@@ -90,13 +90,9 @@ export const Navbar = () => {
 					<div className="flex flex-col gap-2 w-full">
 						<LogoContextMenu
 							logo={
-								// <div className="flex items-center gap-2">
-								// 	<Logo />
-								// 	<p className="select-none">BETTER-AUTH.</p>
-								// </div>
-
-								<div className="flex items-center h-6">
-									<ChristmasLogo />
+								<div className="flex items-center gap-2">
+									<Logo />
+									<p className="select-none">BETTER-AUTH.</p>
 								</div>
 							}
 							logoAssets={logoAssets}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the docs navbar from the Christmas logo to the default brand logo and restored the "BETTER-AUTH." label for consistent branding.

<sup>Written for commit 1905c4753241883f2e64cc37456ff3a3fad8a7a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

