### PR TITLE
docs: await promise function `convertToModelMessages`

### DIFF
--- a/docs/app/api/chat/route.ts
+++ b/docs/app/api/chat/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: Request) {
 				inputSchema: ProvideLinksToolSchema,
 			},
 		},
-		messages: convertToModelMessages(reqJson.messages, {
+		messages: await convertToModelMessages(reqJson.messages, {
 			ignoreIncompleteToolCalls: true,
 		}),
 		toolChoice: "auto",


### PR DESCRIPTION
- Closes https://github.com/better-auth/better-auth/issues/7088

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Await convertToModelMessages in the chat API route so messages are resolved before sending to the model. This prevents passing a Promise and ensures tool call handling works as expected.

<sup>Written for commit 45791078471e0bdea725b6944d805f666ef1d341. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

