### PR TITLE
docs: correct set password code example

### DIFF
--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -134,8 +134,10 @@ If a user was registered using OAuth or other providers, they won't have a passw
 
 ```ts
 await auth.api.setPassword({
-    body: { newPassword: "password" },
-    headers: // headers containing the user's session token
+    body: {
+        newPassword: "new-password",
+    },
+    headers: await headers() // headers containing the user's session token
 });
 ```
 


### PR DESCRIPTION
Cherry pick from https://github.com/better-auth/better-auth/pull/6934

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the setPassword code example in the Users & Accounts docs to show a working request. Updated the body to use newPassword: "new-password" and added headers: await headers() so the user's session token is sent.

<sup>Written for commit 28842d57a76b1c1fab12c321bbe26c32bb7c3083. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

