### PR TITLE
chore: explicit export `auth.ts`

### DIFF
--- a/packages/better-auth/src/auth/index.ts
+++ b/packages/better-auth/src/auth/index.ts
@@ -1,1 +1,1 @@
-export * from "./auth";
+export { betterAuth } from "./auth";

--- a/packages/better-auth/src/index.ts
+++ b/packages/better-auth/src/index.ts
@@ -8,7 +8,7 @@ export * from "@better-auth/core/error";
 export * from "@better-auth/core/oauth2";
 export * from "@better-auth/core/utils";
 //#endregion
-export * from "./auth";
+export { betterAuth } from "./auth";
 // @ts-expect-error
 export * from "./types";
 export * from "./utils";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Export only betterAuth from auth.ts instead of exporting everything. This tightens the public API and prevents unintended exports.

<sup>Written for commit 26cd48b04616922d7ba21061277752cc1d81b6d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

