### PR TITLE
fix(core): detect dual module error

### DIFF
--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -37,8 +37,6 @@ if (glo[importIdentifier] === true) {
 	 *
 	 * If you see this message, make sure that you only import one version of Better Auth. In many cases,
 	 * your package manager installs two versions of Better Auth that are used by different packages within your project.
-	 * Another reason for this message is that some parts of your project use the commonjs version of Better Auth
-	 * and others use the EcmaScript version of Better Auth.
 	 *
 	 * This often leads to issues that are hard to debug. We often need to ensure async local storage instance,
 	 * If you imported different versions of Better Auth, it is impossible for us to


### PR DESCRIPTION
Related to https://github.com/better-auth/better-auth/issues/6613


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a global import guard to prevent loading multiple versions of Better Auth. This avoids broken AsyncLocalStorage and request state sync issues.

- **Bug Fixes**
  - Detects duplicate imports across Node and browser via globalThis/window/global.
  - Logs a clear console error if Better Auth is imported more than once.
  - Ensures a single AsyncLocalStorage instance per request.

<sup>Written for commit 83b3607106ad912588ace88d47cd9b87cc3d2dcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



