### PR TITLE
fix(stripe): prevent duplicate subscription creation when a subscription already exists

### DIFF
--- a/packages/stripe/src/hooks.ts
+++ b/packages/stripe/src/hooks.ts
@@ -138,19 +138,17 @@ export async function onSubscriptionCreated(
 		}
 
 		// Check if subscription already exists in database
+		const subscriptionId = subscriptionCreated.metadata?.subscriptionId;
 		const existingSubscription =
 			await ctx.context.adapter.findOne<Subscription>({
 				model: "subscription",
-				where: [
-					{
-						field: "stripeSubscriptionId",
-						value: subscriptionCreated.id,
-					},
-				],
+				where: subscriptionId
+					? [{ field: "id", value: subscriptionId }]
+					: [{ field: "stripeSubscriptionId", value: subscriptionCreated.id }], // Probably won't match since it's not set yet
 			});
 		if (existingSubscription) {
 			ctx.context.logger.info(
-				`Stripe webhook: Subscription ${subscriptionCreated.id} already exists in database, skipping creation`,
+				`Stripe webhook: Subscription already exists in database (id: ${existingSubscription.id}), skipping creation`,
 			);
 			return;
 		}


### PR DESCRIPTION
Recently, `customer.subscription.created` event handler was added to handle subscription assignments from the Stripe dashboard, but the existing subscription check logic in that handler was weak. This PR fixes this issue.

- Closes https://github.com/better-auth/better-auth/issues/7099

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate subscription creation in the Stripe customer.subscription.created webhook by checking metadata.subscriptionId before creating a new record. Ensures a single subscription per user and closes #7099.

- **Bug Fixes**
  - Update onSubscriptionCreated to look up by metadata.subscriptionId first, fallback to stripeSubscriptionId.
  - Add test verifying the webhook skips creating a duplicate when metadata.subscriptionId is present.

<sup>Written for commit c607d5ef6bee6f3bd18942fd5c0ea5728aed4f2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

