### PR TITLE
fix: normalize email to lowercase in handleOAuthUserInfo

### DIFF
--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -17,14 +17,13 @@ export async function handleOAuthUserInfo(
 		isTrustedProvider?: boolean | undefined;
 	},
 ) {
-	const { userInfo, account, callbackURL, disableSignUp, overrideUserInfo } =
-		opts;
+	const { account, callbackURL, disableSignUp, overrideUserInfo } = opts;
+	const userInfo = {
+		...opts.userInfo,
+		email: opts.userInfo.email.toLowerCase(),
+	};
 	const dbUser = await c.context.internalAdapter
-		.findOAuthUser(
-			userInfo.email.toLowerCase(),
-			account.accountId,
-			account.providerId,
-		)
+		.findOAuthUser(userInfo.email, account.accountId, account.providerId)
 		.catch((e) => {
 			logger.error(
 				"Better auth was unable to query your database.\nError: ",
@@ -86,7 +85,7 @@ export async function handleOAuthUserInfo(
 			if (
 				userInfo.emailVerified &&
 				!dbUser.user.emailVerified &&
-				userInfo.email.toLowerCase() === dbUser.user.email
+				userInfo.email === dbUser.user.email
 			) {
 				await c.context.internalAdapter.updateUser(dbUser.user.id, {
 					emailVerified: true,
@@ -122,7 +121,7 @@ export async function handleOAuthUserInfo(
 			if (
 				userInfo.emailVerified &&
 				!dbUser.user.emailVerified &&
-				userInfo.email.toLowerCase() === dbUser.user.email
+				userInfo.email === dbUser.user.email
 			) {
 				await c.context.internalAdapter.updateUser(dbUser.user.id, {
 					emailVerified: true,
@@ -134,9 +133,9 @@ export async function handleOAuthUserInfo(
 			// update user info from the provider if overrideUserInfo is true
 			user = await c.context.internalAdapter.updateUser(dbUser.user.id, {
 				...restUserInfo,
-				email: userInfo.email.toLowerCase(),
+				email: userInfo.email,
 				emailVerified:
-					userInfo.email.toLowerCase() === dbUser.user.email
+					userInfo.email === dbUser.user.email
 						? dbUser.user.emailVerified || userInfo.emailVerified
 						: userInfo.emailVerified,
 			});
@@ -165,7 +164,7 @@ export async function handleOAuthUserInfo(
 				await c.context.internalAdapter.createOAuthUser(
 					{
 						...restUserInfo,
-						email: userInfo.email.toLowerCase(),
+						email: userInfo.email,
 					},
 					accountData,
 				);


### PR DESCRIPTION
Closes [issue:7052](https://github.com/better-auth/better-auth/issues/7052)

Fixes case-sensitivity issue where SAML/OAuth SSO logins failed when IdPs (like Okta) sent mixed-case emails after user was created with lowercase email.

Key Changes:
- Normalize `userInfo.email` to lowercase at entry point of `handleOAuthUserInfo`
- Remove redundant `.toLowerCase()` calls throughout the function

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize incoming SSO email to lowercase at the start of handleOAuthUserInfo to make email matching case-insensitive and prevent login failures with mixed-case emails. Consolidates lowercasing to one place and uses the normalized email for lookups and updates.

- **Bug Fixes**
  - Lowercase userInfo.email once at the entry point.
  - Use the normalized email in findOAuthUser and emailVerified checks.
  - Pass the normalized email to update/create user calls.
  - Remove redundant .toLowerCase() calls throughout the function.

<sup>Written for commit f8d7cfcaa22d9d8773a1a85582893b25809034c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

