### PR TITLE
feat(stripe): add support for multiple product subscriptions per user

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -16,6 +16,7 @@ The Stripe plugin integrates Stripe's payment and subscription functionality wit
 - **Automatic trial abuse prevention** - Users can only get one trial per account across all plans
 - Flexible reference system to associate subscriptions with users or organizations
 - Team subscription support with seats management
+- **Multiple product subscriptions** - Users can subscribe to multiple products simultaneously (e.g., "Pro Plan" + "AI Addon")
 
 ## Installation
 
@@ -287,8 +288,8 @@ if(error) {
 }
 ```
 
-<Callout type="warn">
-For each reference ID (user or organization), only one active or trialing subscription is supported at a time. The plugin doesn't currently support multiple concurrent active subscriptions for the same reference ID.
+<Callout type="info">
+By default, each reference ID (user or organization) can only have one active subscription at a time. To support multiple concurrent subscriptions (e.g., a main plan plus add-ons), use the `group` property on your plans. See [Multiple Product Subscriptions](#multiple-product-subscriptions) for details.
 </Callout>
 
 #### Switching Plans
@@ -317,18 +318,22 @@ To get the user's active subscriptions:
 ```ts
 type listActiveSubscriptions = {
     /**
-     * Reference id of the subscription to list. 
+     * Reference id of the subscription to list.
      */
     referenceId?: string = '123'
+    /**
+     * Filter subscriptions by group ID. If not provided, returns all active subscriptions.
+     */
+    groupId?: string = 'ai-features'
 }
 
-// get the active subscription
-const activeSubscription = subscriptions.find(
+// get all active subscriptions
+const activeSubscriptions = subscriptions.filter(
     sub => sub.status === "active" || sub.status === "trialing"
 );
 
-// Check subscription limits
-const projectLimit = subscriptions?.limits?.projects || 0;
+// Check subscription limits for a specific subscription
+const projectLimit = activeSubscriptions[0]?.limits?.projects || 0;
 ```
 </APIMethod>
 
@@ -371,11 +376,15 @@ type cancelSubscription = {
      */
     referenceId?: string = 'org_123'
     /**
-     * The id of the subscription to cancel. 
+     * The id of the subscription to cancel.
      */
     subscriptionId?: string = 'sub_123'
     /**
-     * URL to take customers to when they click on the billing portal’s link to return to your website.
+     * Group ID to identify which subscription to cancel when user has multiple subscriptions.
+     */
+    groupId?: string = 'ai-features'
+    /**
+     * URL to take customers to when they click on the billing portal's link to return to your website.
      */
     returnUrl: string = '/account'
 }
@@ -383,6 +392,10 @@ type cancelSubscription = {
 </APIMethod>
 
 This will redirect the user to the Stripe Billing Portal where they can cancel their subscription.
+
+<Callout type="info">
+If the user has multiple active subscriptions (from different plan groups), you must specify either `subscriptionId` or `groupId` to identify which subscription to cancel. If neither is provided and multiple subscriptions exist, an error will be returned.
+</Callout>
 
 <Callout type="info">
 **Understanding Cancellation States**
@@ -417,9 +430,13 @@ type restoreSubscription = {
      */
     referenceId?: string = '123'
     /**
-     * The id of the subscription to restore. 
+     * The id of the subscription to restore.
      */
     subscriptionId?: string = 'sub_123'
+    /**
+     * Group ID to identify which subscription to restore when user has multiple subscriptions.
+     */
+    groupId?: string = 'ai-features'
 }
 ```
 </APIMethod>
@@ -509,6 +526,92 @@ await client.subscription.upgrade({
 ```
 
 The `seats` parameter is passed to Stripe as the quantity for the subscription item. You can use this value in your application logic to limit the number of members in a team or organization.
+
+### Multiple Product Subscriptions
+
+By default, each reference ID (user or organization) can only have one active subscription at a time. If you need users to subscribe to multiple products simultaneously (e.g., a main plan plus add-ons), you can use the `group` property on your plans.
+
+#### How Groups Work
+
+- Plans with the same `group` value will upgrade/replace each other
+- Plans with different `group` values create separate, concurrent subscriptions
+- Plans without a `group` value belong to a default group
+
+```ts title="auth.ts"
+subscription: {
+    enabled: true,
+    plans: [
+        // Main subscription group - these plans upgrade each other
+        { name: "starter", priceId: "price_starter", group: "main" },
+        { name: "pro", priceId: "price_pro", group: "main" },
+        { name: "enterprise", priceId: "price_enterprise", group: "main" },
+
+        // AI add-on group - separate subscription
+        { name: "ai-basic", priceId: "price_ai_basic", group: "ai" },
+        { name: "ai-pro", priceId: "price_ai_pro", group: "ai" },
+
+        // Storage add-on group - another separate subscription
+        { name: "storage-100gb", priceId: "price_storage_100", group: "storage" },
+        { name: "storage-1tb", priceId: "price_storage_1tb", group: "storage" },
+    ]
+}
+```
+
+#### Subscribing to Multiple Products
+
+```ts title="client.ts"
+// Subscribe to the main plan
+await client.subscription.upgrade({
+    plan: "pro",
+    successUrl: "/dashboard",
+    cancelUrl: "/pricing"
+});
+
+// Subscribe to AI add-on (creates a separate subscription)
+await client.subscription.upgrade({
+    plan: "ai-basic",
+    successUrl: "/dashboard",
+    cancelUrl: "/pricing"
+});
+
+// Upgrade within the same group (upgrades existing AI subscription)
+await client.subscription.upgrade({
+    plan: "ai-pro",
+    successUrl: "/dashboard",
+    cancelUrl: "/pricing"
+});
+```
+
+#### Managing Multiple Subscriptions
+
+When a user has multiple subscriptions, you need to specify which one you're managing:
+
+```ts title="client.ts"
+// List all subscriptions
+const { data: subscriptions } = await client.subscription.list();
+// Returns: [{ plan: "pro", groupId: "main", ... }, { plan: "ai-pro", groupId: "ai", ... }]
+
+// Cancel a specific subscription by group
+await client.subscription.cancel({
+    groupId: "ai",
+    returnUrl: "/billing"
+});
+
+// Or cancel by subscription ID
+await client.subscription.cancel({
+    subscriptionId: "sub_123",
+    returnUrl: "/billing"
+});
+
+// Restore a specific subscription
+await client.subscription.restore({
+    groupId: "ai"
+});
+```
+
+<Callout type="warn">
+If you don't specify `groupId` or `subscriptionId` when canceling/restoring and the user has multiple active subscriptions, an error will be returned asking you to specify which subscription to manage.
+</Callout>
 
 To authorize reference IDs, implement the `authorizeReference` function:
 
@@ -713,22 +816,28 @@ Table Name: `subscription`
       description: "If the subscription has ended, this is the date the subscription ended",
       isOptional: true
     },
-    { 
-      name: "seats", 
-      type: "number", 
+    {
+      name: "seats",
+      type: "number",
       description: "Number of seats for team plans",
       isOptional: true
     },
-    { 
-      name: "trialStart", 
-      type: "Date", 
+    {
+      name: "trialStart",
+      type: "Date",
       description: "Start date of the trial period",
       isOptional: true
     },
-    { 
-      name: "trialEnd", 
-      type: "Date", 
+    {
+      name: "trialEnd",
+      type: "Date",
       description: "End date of the trial period",
+      isOptional: true
+    },
+    {
+      name: "groupId",
+      type: "string",
+      description: "Group identifier for multi-product subscriptions. Derived from the plan's group property.",
       isOptional: true
     }
   ]}
@@ -793,7 +902,7 @@ stripe({
 | `annualDiscountPriceId`   | `string`   | A price ID for annual billing.                               |
 | `annualDiscountLookupKey` | `string`   | The Stripe price lookup key for annual billing.              |
 | `limits`                  | `object`   | Limits for plan (e.g. `{ projects: 10, storage: 5 }`).       |
-| `group`                   | `string`   | A group name for categorizing plans.                         |
+| `group`                   | `string`   | A group name for multi-product subscriptions. Plans in the same group upgrade each other; plans in different groups create separate subscriptions. See [Multiple Product Subscriptions](#multiple-product-subscriptions). |
 | `freeTrial`               | `object`   | Trial configuration. See [below](#free-trial-configuration). |
 
 #### Free Trial Configuration

--- a/packages/stripe/CHANGELOG.md
+++ b/packages/stripe/CHANGELOG.md
@@ -1,5 +1,38 @@
 # [**@better-auth/stripe**](https://github.com/better-auth/stripe)
 
+## Unreleased
+
+### Minor Changes
+
+* Added support for multiple product subscriptions per user/reference. Users can now subscribe to multiple products simultaneously (e.g., "Pro Plan" + "AI Addon" + "Storage Addon").
+
+  **New Features:**
+
+  * Added `groupId` field to subscription schema for grouping subscriptions by product line
+  * Plans in the same `group` upgrade each other, plans in different groups create separate subscriptions
+  * Added `groupId` parameter to cancel and restore endpoints for disambiguation
+  * Added `groupId` filter to list subscriptions endpoint
+  * Improved webhook handling for multi-subscription scenarios
+
+  **Usage:**
+
+  ```ts
+  // Define plans with groups
+  plans: [
+    { name: "pro", priceId: "price_xxx", group: "main" },
+    { name: "ai-addon", priceId: "price_yyy", group: "ai" },
+  ]
+
+  // Subscribe to multiple products
+  await client.subscription.upgrade({ plan: "pro" });      // main group
+  await client.subscription.upgrade({ plan: "ai-addon" }); // ai group (separate subscription)
+
+  // Cancel specific subscription
+  await client.subscription.cancel({ groupId: "ai", returnUrl: "/" });
+  ```
+
+  **Breaking Changes:** None. Fully backwards compatible - existing subscriptions without `groupId` continue to work as before.
+
 ## 1.3.4
 
 ### Patch Changes

--- a/packages/stripe/src/error-codes.ts
+++ b/packages/stripe/src/error-codes.ts
@@ -20,4 +20,8 @@ export const STRIPE_ERROR_CODES = defineErrorCodes({
 	SUBSCRIPTION_NOT_ACTIVE: "Subscription is not active",
 	SUBSCRIPTION_NOT_SCHEDULED_FOR_CANCELLATION:
 		"Subscription is not scheduled for cancellation",
+	SUBSCRIPTION_GROUP_REQUIRED:
+		"Multiple subscriptions found. Please specify a groupId to identify which subscription.",
+	SUBSCRIPTION_EXISTS_IN_GROUP:
+		"An active subscription already exists in this group",
 });

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -62,6 +62,10 @@ export const subscriptions = {
 				type: "number",
 				required: false,
 			},
+			groupId: {
+				type: "string",
+				required: false,
+			},
 		},
 	},
 } satisfies BetterAuthPluginDBSchema;

--- a/packages/stripe/src/utils.ts
+++ b/packages/stripe/src/utils.ts
@@ -57,3 +57,17 @@ export function isPendingCancel(sub: Subscription): boolean {
 export function isStripePendingCancel(stripeSub: Stripe.Subscription): boolean {
 	return !!(stripeSub.cancel_at_period_end || stripeSub.cancel_at);
 }
+
+/**
+ * Check if two group IDs match. Treats undefined/null as the same "default" group.
+ * This allows backwards compatibility where existing subscriptions without groupId
+ * are treated as belonging to the same default group.
+ */
+export function groupsMatch(
+	groupA: string | undefined | null,
+	groupB: string | undefined | null,
+): boolean {
+	// Both undefined/null means same "default" group
+	if (!groupA && !groupB) return true;
+	return groupA === groupB;
+}


### PR DESCRIPTION
## Summary

- Added support for multiple product subscriptions per user/reference
- Users can now subscribe to multiple products simultaneously (e.g., "Pro Plan" + "AI Addon" + "Storage Addon")
- Plans in the same `group` upgrade each other, plans in different groups create separate subscriptions

## New Features

- Added `groupId` field to subscription schema for grouping subscriptions by product line
- Added `groupId` parameter to cancel and restore endpoints for disambiguation
- Added `groupId` filter to list subscriptions endpoint
- Improved webhook handling for multi-subscription scenarios
- Added `groupsMatch` utility for null-safe group comparison

## Usage

```ts
// Define plans with groups
plans: [
  { name: "pro", priceId: "price_xxx", group: "main" },
  { name: "ai-addon", priceId: "price_yyy", group: "ai" },
]

// Subscribe to multiple products
await client.subscription.upgrade({ plan: "pro" });      // main group
await client.subscription.upgrade({ plan: "ai-addon" }); // ai group (separate subscription)

// Cancel specific subscription
await client.subscription.cancel({ groupId: "ai", returnUrl: "/" });
```

## Breaking Changes

None. Fully backwards compatible - existing subscriptions without `groupId` continue to work as before.

## Test plan

- [x] Added 16 comprehensive tests for group subscriptions
- [x] All 64 tests in stripe.test.ts pass
- [x] Tested basic group subscription creation
- [x] Tested multi-product subscriptions in different groups
- [x] Tested upgrade within same group
- [x] Tested cancel/restore with multiple subscriptions
- [x] Tested webhook handling with groups
- [x] Tested edge cases and backwards compatibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-product subscriptions to the Stripe plugin using plan groups, so users can subscribe to a main plan plus add-ons at the same time. Updates APIs, webhooks, and docs, and remains fully backward compatible.

- **New Features**
  - Added groupId to the subscription schema; plans in the same group upgrade each other, different groups create separate subscriptions.
  - Added groupId to cancel and restore endpoints; required when a user has multiple active subscriptions.
  - Added groupId filter to list subscriptions.
  - Webhooks now persist groupId from metadata and match the correct subscription in multi-sub scenarios.
  - New utility groupsMatch for null-safe group comparison and new error codes for disambiguation.
  - Documentation updated for multi-product setup and management.

- **Migration**
  - No breaking changes; existing subscriptions without groupId continue to work.
  - To enable multiple products, add group to plans.
  - When multiple subscriptions exist, pass groupId or subscriptionId to cancel/restore.

<sup>Written for commit 7f2b862afafb4c89be3f7c89569ad3829b624b37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

