### PR TITLE
docs: update import path for auth in tanstack integration

### DIFF
--- a/docs/content/docs/integrations/tanstack.mdx
+++ b/docs/content/docs/integrations/tanstack.mdx
@@ -68,7 +68,7 @@ You can use TanStack Start's middleware to protect routes that require authentic
 import { redirect } from "@tanstack/react-router";
 import { createMiddleware } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
-import { auth } from "./auth";
+import { auth } from "@/lib/auth";
 
 export const authMiddleware = createMiddleware().server(
     async ({ next, request }) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update TanStack integration docs to import auth from "@/lib/auth" instead of "./auth". This matches the recommended project structure and prevents import errors in the middleware example.

<sup>Written for commit e48e1918a591c34a9a3f45756e56bda04093abcc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

