### PR TITLE
fix(email-otp): call afterEmailVerification hook on verification

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -513,6 +513,11 @@ export const verifyEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				ctx.request,
 			);
 
+			await ctx.context.options.emailVerification?.afterEmailVerification?.(
+				updatedUser,
+				ctx.request,
+			);
+
 			if (ctx.context.options.emailVerification?.autoSignInAfterVerification) {
 				const session = await ctx.context.internalAdapter.createSession(
 					updatedUser.id,


### PR DESCRIPTION
## Description
This PR fixes issue #7117 where the `afterEmailVerification` hook was not being called when using the `email-otp` plugin with `overrideDefaultEmailVerification: true`. 

Previously, only `onEmailVerification` was executed. This change adds the missing call to `afterEmailVerification` immediately after the user is verified, ensuring both hooks run as expected in the configuration.

## Fixes
Fixes #7117


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calls afterEmailVerification during email-otp verification when overrideDefaultEmailVerification is true. Ensures both hooks run right after the user is verified.

- **Bug Fixes**
  - Invoke afterEmailVerification with the updated user in verifyEmailOTP.
  - Add test to assert the hook fires once with the expected payload.

Fixes #7117

<sup>Written for commit 84afbd9480a90f2e2268ae8d4d7e1b2412339c18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

