### PR TITLE
fix(captcha-plugin): export types from the captcha module

### DIFF
--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -6,6 +6,8 @@ import { EXTERNAL_ERROR_CODES, INTERNAL_ERROR_CODES } from "./error-codes";
 import type { CaptchaOptions } from "./types";
 import * as verifyHandlers from "./verify-handlers";
 
+export type * from "./types";
+
 export const captcha = (options: CaptchaOptions) =>
 	({
 		id: "captcha",


### PR DESCRIPTION
### Problem
When using the captcha plugin, TypeScript produces the following error:
```
The inferred type of 'auth' cannot be named without a reference to '@/node_modules/better-auth/dist/plugins/captcha/types.mjs'. This is likely not portable. A type annotation is necessary.
```
This happens because the `CaptchaOptions` and related types are used in the public API of the captcha function but aren't exported from the plugin's entry point. TypeScript's declaration emit cannot generate portable `.d.ts` files when it needs to reference unexported internal types.

### Solution
Re-export all types from `types.ts` in the plugin's `index.ts`:
```js
export type * from "./types";
```
This follows the same pattern used by other plugins like `two-factor` and `phone-number`.

### Testing
Verified the generated `dist/plugins/captcha/index.d.mts` now exports all types
Confirmed the TypeScript error is resolved when using the captcha plugin in consuming projects

### Screenshots
#### Before
<img width="1018" height="218" alt="image" src="https://github.com/user-attachments/assets/6bdf7096-a8bb-467d-842f-d18435ca1442" />

#### After
<img width="660" height="214" alt="image" src="https://github.com/user-attachments/assets/affea2ad-3fd9-4e5e-ae9c-9442b06533e0" />

Fixes #7119 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exported all captcha plugin types from the module entry point to fix TypeScript “inferred type cannot be named” errors and produce portable .d.ts files. Aligns the captcha plugin’s exports with other plugins (two-factor, phone-number).

<sup>Written for commit 6d06e2bb1d2b2d02cf36762045604cfddfd1b7d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

