### PR TITLE
fix(organization): use opts pattern to enable hook injection

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -741,7 +741,7 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 		 */
 		getActiveMemberRole: getActiveMemberRole(opts),
 	};
-	const teamSupport = options?.teams?.enabled;
+	const teamSupport = opts.teams?.enabled;
 	const teamEndpoints = {
 		/**
 		 * ### Endpoint
@@ -902,7 +902,7 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 		getOrgRole: getOrgRole(opts),
 		updateOrgRole: updateOrgRole(opts),
 	};
-	if (options?.dynamicAccessControl?.enabled) {
+	if (opts.dynamicAccessControl?.enabled) {
 		endpoints = {
 			...endpoints,
 			...dynamicAccessControlEndpoints,
@@ -910,19 +910,19 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 	}
 	const roles = {
 		...defaultRoles,
-		...options?.roles,
+		...opts.roles,
 	};
 
 	// Build team schema in a way that never introduces undefined values when spreading
 	const teamSchema = teamSupport
 		? ({
 				team: {
-					modelName: options?.schema?.team?.modelName,
+					modelName: opts.schema?.team?.modelName,
 					fields: {
 						name: {
 							type: "string",
 							required: true,
-							fieldName: options?.schema?.team?.fields?.name,
+							fieldName: opts.schema?.team?.fields?.name,
 						},
 						organizationId: {
 							type: "string",
@@ -931,25 +931,25 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 								model: "organization",
 								field: "id",
 							},
-							fieldName: options?.schema?.team?.fields?.organizationId,
+							fieldName: opts.schema?.team?.fields?.organizationId,
 							index: true,
 						},
 						createdAt: {
 							type: "date",
 							required: true,
-							fieldName: options?.schema?.team?.fields?.createdAt,
+							fieldName: opts.schema?.team?.fields?.createdAt,
 						},
 						updatedAt: {
 							type: "date",
 							required: false,
-							fieldName: options?.schema?.team?.fields?.updatedAt,
+							fieldName: opts.schema?.team?.fields?.updatedAt,
 							onUpdate: () => new Date(),
 						},
-						...(options?.schema?.team?.additionalFields || {}),
+						...(opts.schema?.team?.additionalFields || {}),
 					},
 				},
 				teamMember: {
-					modelName: options?.schema?.teamMember?.modelName,
+					modelName: opts.schema?.teamMember?.modelName,
 					fields: {
 						teamId: {
 							type: "string",
@@ -958,7 +958,7 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 								model: "team",
 								field: "id",
 							},
-							fieldName: options?.schema?.teamMember?.fields?.teamId,
+							fieldName: opts.schema?.teamMember?.fields?.teamId,
 							index: true,
 						},
 						userId: {
@@ -968,20 +968,20 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 								model: "user",
 								field: "id",
 							},
-							fieldName: options?.schema?.teamMember?.fields?.userId,
+							fieldName: opts.schema?.teamMember?.fields?.userId,
 							index: true,
 						},
 						createdAt: {
 							type: "date",
 							required: false,
-							fieldName: options?.schema?.teamMember?.fields?.createdAt,
+							fieldName: opts.schema?.teamMember?.fields?.createdAt,
 						},
 					},
 				},
 			} satisfies BetterAuthPluginDBSchema)
 		: {};
 
-	const organizationRoleSchema = options?.dynamicAccessControl?.enabled
+	const organizationRoleSchema = opts.dynamicAccessControl?.enabled
 		? ({
 				organizationRole: {
 					fields: {
@@ -992,36 +992,35 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 								model: "organization",
 								field: "id",
 							},
-							fieldName:
-								options?.schema?.organizationRole?.fields?.organizationId,
+							fieldName: opts.schema?.organizationRole?.fields?.organizationId,
 							index: true,
 						},
 						role: {
 							type: "string",
 							required: true,
-							fieldName: options?.schema?.organizationRole?.fields?.role,
+							fieldName: opts.schema?.organizationRole?.fields?.role,
 							index: true,
 						},
 						permission: {
 							type: "string",
 							required: true,
-							fieldName: options?.schema?.organizationRole?.fields?.permission,
+							fieldName: opts.schema?.organizationRole?.fields?.permission,
 						},
 						createdAt: {
 							type: "date",
 							required: true,
 							defaultValue: () => new Date(),
-							fieldName: options?.schema?.organizationRole?.fields?.createdAt,
+							fieldName: opts.schema?.organizationRole?.fields?.createdAt,
 						},
 						updatedAt: {
 							type: "date",
 							required: false,
-							fieldName: options?.schema?.organizationRole?.fields?.updatedAt,
+							fieldName: opts.schema?.organizationRole?.fields?.updatedAt,
 							onUpdate: () => new Date(),
 						},
-						...(options?.schema?.organizationRole?.additionalFields || {}),
+						...(opts.schema?.organizationRole?.additionalFields || {}),
 					},
-					modelName: options?.schema?.organizationRole?.modelName,
+					modelName: opts.schema?.organizationRole?.modelName,
 				},
 			} satisfies BetterAuthPluginDBSchema)
 		: {};
@@ -1029,38 +1028,38 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 	const schema = {
 		...({
 			organization: {
-				modelName: options?.schema?.organization?.modelName,
+				modelName: opts.schema?.organization?.modelName,
 				fields: {
 					name: {
 						type: "string",
 						required: true,
 						sortable: true,
-						fieldName: options?.schema?.organization?.fields?.name,
+						fieldName: opts.schema?.organization?.fields?.name,
 					},
 					slug: {
 						type: "string",
 						required: true,
 						unique: true,
 						sortable: true,
-						fieldName: options?.schema?.organization?.fields?.slug,
+						fieldName: opts.schema?.organization?.fields?.slug,
 						index: true,
 					},
 					logo: {
 						type: "string",
 						required: false,
-						fieldName: options?.schema?.organization?.fields?.logo,
+						fieldName: opts.schema?.organization?.fields?.logo,
 					},
 					createdAt: {
 						type: "date",
 						required: true,
-						fieldName: options?.schema?.organization?.fields?.createdAt,
+						fieldName: opts.schema?.organization?.fields?.createdAt,
 					},
 					metadata: {
 						type: "string",
 						required: false,
-						fieldName: options?.schema?.organization?.fields?.metadata,
+						fieldName: opts.schema?.organization?.fields?.metadata,
 					},
-					...(options?.schema?.organization?.additionalFields || {}),
+					...(opts.schema?.organization?.additionalFields || {}),
 				},
 			},
 		} satisfies BetterAuthPluginDBSchema),
@@ -1068,7 +1067,7 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 		...teamSchema,
 		...({
 			member: {
-				modelName: options?.schema?.member?.modelName,
+				modelName: opts.schema?.member?.modelName,
 				fields: {
 					organizationId: {
 						type: "string",
@@ -1077,13 +1076,13 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 							model: "organization",
 							field: "id",
 						},
-						fieldName: options?.schema?.member?.fields?.organizationId,
+						fieldName: opts.schema?.member?.fields?.organizationId,
 						index: true,
 					},
 					userId: {
 						type: "string",
 						required: true,
-						fieldName: options?.schema?.member?.fields?.userId,
+						fieldName: opts.schema?.member?.fields?.userId,
 						references: {
 							model: "user",
 							field: "id",
@@ -1095,18 +1094,18 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 						required: true,
 						sortable: true,
 						defaultValue: "member",
-						fieldName: options?.schema?.member?.fields?.role,
+						fieldName: opts.schema?.member?.fields?.role,
 					},
 					createdAt: {
 						type: "date",
 						required: true,
-						fieldName: options?.schema?.member?.fields?.createdAt,
+						fieldName: opts.schema?.member?.fields?.createdAt,
 					},
-					...(options?.schema?.member?.additionalFields || {}),
+					...(opts.schema?.member?.additionalFields || {}),
 				},
 			},
 			invitation: {
-				modelName: options?.schema?.invitation?.modelName,
+				modelName: opts.schema?.invitation?.modelName,
 				fields: {
 					organizationId: {
 						type: "string",
@@ -1115,21 +1114,21 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 							model: "organization",
 							field: "id",
 						},
-						fieldName: options?.schema?.invitation?.fields?.organizationId,
+						fieldName: opts.schema?.invitation?.fields?.organizationId,
 						index: true,
 					},
 					email: {
 						type: "string",
 						required: true,
 						sortable: true,
-						fieldName: options?.schema?.invitation?.fields?.email,
+						fieldName: opts.schema?.invitation?.fields?.email,
 						index: true,
 					},
 					role: {
 						type: "string",
 						required: false,
 						sortable: true,
-						fieldName: options?.schema?.invitation?.fields?.role,
+						fieldName: opts.schema?.invitation?.fields?.role,
 					},
 					...(teamSupport
 						? {
@@ -1137,7 +1136,7 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 									type: "string",
 									required: false,
 									sortable: true,
-									fieldName: options?.schema?.invitation?.fields?.teamId,
+									fieldName: opts.schema?.invitation?.fields?.teamId,
 								},
 							}
 						: {}),
@@ -1146,17 +1145,17 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 						required: true,
 						sortable: true,
 						defaultValue: "pending",
-						fieldName: options?.schema?.invitation?.fields?.status,
+						fieldName: opts.schema?.invitation?.fields?.status,
 					},
 					expiresAt: {
 						type: "date",
 						required: true,
-						fieldName: options?.schema?.invitation?.fields?.expiresAt,
+						fieldName: opts.schema?.invitation?.fields?.expiresAt,
 					},
 					createdAt: {
 						type: "date",
 						required: true,
-						fieldName: options?.schema?.invitation?.fields?.createdAt,
+						fieldName: opts.schema?.invitation?.fields?.createdAt,
 						defaultValue: () => new Date(),
 					},
 					inviterId: {
@@ -1165,10 +1164,10 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 							model: "user",
 							field: "id",
 						},
-						fieldName: options?.schema?.invitation?.fields?.inviterId,
+						fieldName: opts.schema?.invitation?.fields?.inviterId,
 						required: true,
 					},
-					...(options?.schema?.invitation?.additionalFields || {}),
+					...(opts.schema?.invitation?.additionalFields || {}),
 				},
 			},
 		} satisfies BetterAuthPluginDBSchema),
@@ -1200,14 +1199,14 @@ export function organization<O extends OrganizationOptions>(options?: O): any {
 					activeOrganizationId: {
 						type: "string",
 						required: false,
-						fieldName: options?.schema?.session?.fields?.activeOrganizationId,
+						fieldName: opts.schema?.session?.fields?.activeOrganizationId,
 					},
 					...(teamSupport
 						? {
 								activeTeamId: {
 									type: "string",
 									required: false,
-									fieldName: options?.schema?.session?.fields?.activeTeamId,
+									fieldName: opts.schema?.session?.fields?.activeTeamId,
 								},
 							}
 						: {}),


### PR DESCRIPTION
When the org plugin is used as `organization()` instead of `organization({})`, the organizationHooks are not injected properly. Although this usage is unlikely, aligning the pattern with other plugins (e.g. the admin plugin) improves extensibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensured the organization plugin injects hooks when called as organization() by normalizing options with the opts pattern. This fixes missing options in context and aligns behavior with other plugins.

- **Bug Fixes**
  - Hooks now inject correctly when the plugin is invoked without arguments.
  - Resolved missing options in endpoints, schema builders, and hasPermission.

- **Refactors**
  - Normalized options to opts and passed it consistently to all endpoint creators.
  - Unified gating for teams and dynamicAccessControl using opts to avoid undefined spreads.

<sup>Written for commit d32d9cfde90223432b4c603ee09e5387539cdabe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

