### PR TITLE
docs: update Clerk migration guide to include bcrypt configuration

### DIFF
--- a/docs/content/docs/guides/clerk-migration-guide.mdx
+++ b/docs/content/docs/guides/clerk-migration-guide.mdx
@@ -40,21 +40,35 @@ export const auth = betterAuth({
 
 Enable the email and password in your auth config and implement your own logic for sending verification emails, reset password emails, etc.
 
+<Callout type="info">
+**Important for Clerk Migrations**: Clerk uses bcrypt to hash passwords, while Better Auth uses `scrypt` by default. To ensure migrated users can sign in with their existing passwords, you'll need to configure Better Auth to use bcrypt for password verification.
+</Callout>
+
+First, install bcrypt:
+
+```package-install
+pnpm add bcrypt
+pnpm add -D @types/bcrypt
+```
+
+Then configure Better Auth to use bcrypt:
+
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
+import bcrypt from "bcrypt";
 
 export const auth = betterAuth({
-    database: new Pool({ 
-        connectionString: process.env.DATABASE_URL 
-    }),
-    emailAndPassword: { // [!code highlight]
-        enabled: true, // [!code highlight]
+    emailAndPassword: { 
+        enabled: true,
+        password: { // [!code highlight]
+            hash: async (password) => { // [!code highlight]
+                return await bcrypt.hash(password, 10); // [!code highlight]
+            }, // [!code highlight]
+            verify: async ({ hash, password }) => { // [!code highlight]
+                return await bcrypt.compare(password, hash); // [!code highlight]
+            }, // [!code highlight]
+        }, // [!code highlight]
     }, // [!code highlight]
-    emailVerification: {
-      sendVerificationEmail: async({ user, url })=>{
-        // implement your logic here to send email verification
-      }
-	},
 })
 ```
 
@@ -101,6 +115,7 @@ You can add the following plugins to your auth config based on your needs.
 import { Pool } from "pg";
 import { betterAuth } from "better-auth";
 import { admin, twoFactor, phoneNumber, username } from "better-auth/plugins";
+import bcrypt from "bcrypt";
 
 export const auth = betterAuth({
     database: new Pool({ 
@@ -108,6 +123,14 @@ export const auth = betterAuth({
     }),
     emailAndPassword: { 
         enabled: true,
+        password: {
+            hash: async (password) => {
+                return await bcrypt.hash(password, 10);
+            },
+            verify: async ({ hash, password }) => {
+                return await bcrypt.compare(password, hash);
+            },
+        },
     },
     socialProviders: {
         github: {


### PR DESCRIPTION
**Problem:**

The guide didn't mention that Clerk uses bcrypt for password hashing, while Better Auth uses `scrypt` by default. Without configuring bcrypt, migrated users can't sign in with their existing passwords.

**Solution:**

- Added a callout explaining the bcrypt requirement for Clerk migrations
- Added installation instructions for `bcrypt` and `@types/bcrypt`
- Added bcrypt configuration examples in the `emailAndPassword.password` section with `hash` and `verify` functions
- Updated all relevant code examples to include the bcrypt configuration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Clerk migration guide to document bcrypt configuration in Better Auth so migrated users can sign in with existing passwords. Fixes sign-in failures caused by the default scrypt hash.

- **Migration**
  - Added a callout explaining bcrypt vs scrypt for Clerk migrations.
  - Added install steps for bcrypt and @types/bcrypt.
  - Added a bcrypt hash/verify example in emailAndPassword.password and updated related code samples.

<sup>Written for commit 7f4ba32866e6708061dfa7d5437d0b4aef7520b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

