### PR TITLE
fix(prisma-adapter): do not throw when deleting no records

### DIFF
--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -504,6 +504,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 					} catch (e: any) {
 						// If the record doesn't exist, we don't want to throw an error
 						if (e?.meta?.cause === "Record to delete does not exist.") return;
+						if (e?.code === "P2025") return; // Prisma 7+
 						// otherwise if it's an unknown error, we want to just log it for debugging.
 						console.log(e);
 					}


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/7129

The error messages differ in prisma 7 so our old if-statement logic is out of date. This PR adds an additional if-statement to ensure the Prisma 7 error can be caught

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent errors when deleting a non-existent record in the Prisma adapter. We now catch Prisma 7’s P2025 code so “no record” deletions return silently.

<sup>Written for commit 656c721cf64ab92293922820d93825b17501f9f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

