### PR TITLE
chore(sso): move utils to peer deps

### DIFF
--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -68,7 +68,6 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@better-auth/utils": "catalog:",
     "@types/body-parser": "^1.19.6",
     "@types/express": "^5.0.5",
     "better-auth": "workspace:*",
@@ -79,6 +78,7 @@
     "tsdown": "catalog:"
   },
   "peerDependencies": {
+    "@better-auth/utils": "catalog:",
     "better-auth": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1462,6 +1462,9 @@ importers:
 
   packages/sso:
     dependencies:
+      '@better-auth/utils':
+        specifier: 'catalog:'
+        version: 0.3.0
       '@better-fetch/fetch':
         specifier: 'catalog:'
         version: 1.1.21
@@ -1478,9 +1481,6 @@ importers:
         specifier: ^4.1.12
         version: 4.3.4
     devDependencies:
-      '@better-auth/utils':
-        specifier: 'catalog:'
-        version: 0.3.0
       '@types/body-parser':
         specifier: ^1.19.6
         version: 1.19.6
@@ -20384,7 +20384,9 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89': {}


### PR DESCRIPTION
Upstream: https://github.com/better-auth/better-auth/pull/6836/changes#r2663944999

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved @better-auth/utils from devDependencies to peerDependencies in the SSO package to ensure consumers provide a compatible version and avoid duplicate installs. Updated pnpm-lock to reflect the change.

- **Migration**
  - Add @better-auth/utils to your app’s dependencies (catalog: or 0.3.x).
  - Ensure the version matches the SSO package’s expected range.

<sup>Written for commit 2b349dbfced322a0040367cb29b60f8cada16f4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

