### PR TITLE
chore(oauth-provider): add `NoInfer`

### DIFF
--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -145,7 +145,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 
 	return {
 		id: "oauthProvider",
-		options: opts,
+		options: opts as NoInfer<O>,
 		init: (ctx) => {
 			// Require session id storage on database (secondary-storage only solution not yet supported)
 			if (ctx.options.session && !ctx.options.session.storeSessionInDatabase) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use NoInfer on oauthProvider options to preserve the input type and stop unwanted TypeScript inference. This improves type safety and avoids accidental type widening.

<sup>Written for commit f7d57cbea231312b48da7b4f45f04e50cd0df345. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

