### PR TITLE
feat(passkey): add pre-auth registration and extensions

### DIFF
--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -68,6 +68,56 @@ The passkey plugin implementation is powered by [SimpleWebAuthn](https://simplew
 
 </Steps>
 
+## Configuration (Optional)
+
+You can customize the passkey plugin to support passkey-first onboarding or WebAuthn extensions.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+import { passkey } from "@better-auth/passkey"
+
+export const auth = betterAuth({
+  plugins: [
+    passkey({
+      registration: {
+        // Default: true. Set false for passkey-first onboarding.
+        requireSession: false,
+        // Required if requireSession is false and no session exists.
+        resolveUser: async ({ ctx, context }) => {
+          // Validate context (e.g., a signed token), then create or load a user.
+          return { id: "user-id", name: "user@example.com" }
+        },
+        // Optional server-defined extensions
+        extensions: { credProps: true },
+      },
+      authentication: {
+        // Optional server-defined extensions
+        extensions: { credProps: true },
+      },
+    }),
+  ],
+})
+```
+
+### Passkey-first registration (pre-auth)
+
+When `registration.requireSession` is `false`, passkey registration can be initiated without a session. You can pass an opaque `context` to the registration options endpoint; it will be forwarded to `resolveUser`.
+
+```ts
+await auth.api.generatePasskeyRegistrationOptions({
+  context: "signed-registration-token",
+})
+```
+
+When using passkey-first flows (`registration.requireSession: false`), pass the same `context` from the client when registering the passkey so the server can resolve the user during verification:
+
+```ts
+await authClient.passkey.addPasskey({
+  name: "Primary passkey",
+  context: "signed-registration-token",
+})
+```
+
 ## Usage
 
 ### Add/Register a passkey
@@ -85,6 +135,18 @@ type addPasskey = {
      * You can also specify the type of authenticator you want to register. Default behavior allows both platform and cross-platform passkeys
     */
     authenticatorAttachment?: "platform" | "cross-platform" = "cross-platform"
+    /**
+     * Optional WebAuthn extensions (e.g., PRF, credProps, largeBlob)
+     */
+    extensions?: AuthenticationExtensionsClientInputs
+    /**
+     * Return WebAuthn response and extension results
+     */
+    returnWebAuthnResponse?: boolean
+    /**
+     * Optional context for passkey-first registration flows. Forwarded to `registration.resolveUser`.
+     */
+    context?: string
 }
 ```
 </APIMethod>
@@ -106,6 +168,14 @@ type signInPasskey = {
      * Browser autofill, a.k.a. Conditional UI. Read more: https://simplewebauthn.dev/docs/packages/browser#browser-autofill-aka-conditional-ui
     */
     autoFill?: boolean = true
+    /**
+     * Optional WebAuthn extensions (e.g., PRF, credProps, largeBlob)
+     */
+    extensions?: AuthenticationExtensionsClientInputs
+    /**
+     * Return WebAuthn response and extension results
+     */
+    returnWebAuthnResponse?: boolean
 }
 ```
 </APIMethod>
@@ -117,6 +187,8 @@ import { authClient } from "@/lib/auth-client";
 // With post authentication redirect
 await authClient.signIn.passkey({
     autoFill: true,
+    // Optional extensions
+    extensions: { credProps: true },
     fetchOptions: {
         onSuccess(context) {
             // Redirect to dashboard after successful authentication
@@ -128,6 +200,23 @@ await authClient.signIn.passkey({
         }
     }
 });
+```
+
+### Extensions
+
+You can use WebAuthn extensions through the client API by passing `extensions`. When `returnWebAuthnResponse` is true, the client returns `webauthn.clientExtensionResults`.
+
+```ts
+const result = await authClient.passkey.addPasskey({
+  name: "My Passkey",
+  extensions: {
+    // Example extension input (generic)
+    credProps: true,
+  },
+  returnWebAuthnResponse: true,
+});
+
+console.log(result.webauthn?.clientExtensionResults);
 ```
 
 ### List passkeys

--- a/e2e/smoke/package.json
+++ b/e2e/smoke/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@better-auth-test/smoke",
   "type": "module",
+  "dependencies": {
+    "@better-auth/passkey": "workspace:*",
+    "better-auth": "workspace:*"
+  },
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "@better-auth/redis-storage": "workspace:*",

--- a/e2e/smoke/test/passkey-preauth.spec.ts
+++ b/e2e/smoke/test/passkey-preauth.spec.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { describe, it } from "node:test";
+import { passkey } from "@better-auth/passkey";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { toNodeHandler } from "better-auth/node";
+
+type PasskeyRegistrationOptionsPayload = {
+	user?: { name?: string; displayName?: string };
+	challenge?: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+const isPasskeyRegistrationOptionsPayload = (
+	value: unknown,
+): value is PasskeyRegistrationOptionsPayload => {
+	if (!isRecord(value)) {
+		return false;
+	}
+	if ("challenge" in value && typeof value.challenge !== "string") {
+		return false;
+	}
+	if ("user" in value) {
+		const user = value.user;
+		if (user !== undefined) {
+			if (!isRecord(user)) {
+				return false;
+			}
+			if ("name" in user && typeof user.name !== "string") {
+				return false;
+			}
+			if ("displayName" in user && typeof user.displayName !== "string") {
+				return false;
+			}
+		}
+	}
+	return true;
+};
+
+describe("(node) passkey pre-auth", () => {
+	it("generates registration options without session", async (t) => {
+		const db: Record<string, any[]> = {
+			passkey: [],
+		};
+		const auth = betterAuth({
+			baseURL: "http://localhost",
+			database: memoryAdapter(db),
+			trustedOrigins: ["http://localhost:*"],
+			plugins: [
+				passkey({
+					registration: {
+						requireSession: false,
+						resolveUser: ({ context }) => {
+							const value = typeof context === "string" ? context : "unknown";
+							return {
+								id: `user-${value}`,
+								name: value,
+								displayName: `Pre-auth ${value}`,
+							};
+						},
+					},
+				}),
+			],
+		});
+		const authHandler = toNodeHandler(auth);
+		const server = createServer((req, res) => {
+			res.setHeader("Access-Control-Allow-Origin", req.headers.origin || "*");
+			res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+			res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+			res.setHeader("Access-Control-Allow-Credentials", "true");
+
+			if (req.method === "OPTIONS") {
+				res.statusCode = 200;
+				res.end();
+				return;
+			}
+
+			if (req.url?.startsWith("/api/auth")) {
+				return authHandler(req, res);
+			}
+
+			res.statusCode = 404;
+			res.end();
+		});
+
+		server.listen(0);
+		t.after(() => {
+			server.close();
+		});
+
+		await once(server, "listening");
+		const address = server.address();
+		if (!address || typeof address === "string") {
+			throw new Error("Expected server address to be available");
+		}
+		const port = address.port;
+		const context = "preauth@example.com";
+
+		const response = await fetch(
+			`http://localhost:${port}/api/auth/passkey/generate-register-options?context=${encodeURIComponent(context)}`,
+			{
+				headers: {
+					origin: `http://localhost:${port}`,
+				},
+			},
+		);
+
+		assert.strictEqual(response.ok, true);
+		const payload = await response.json();
+		if (!isPasskeyRegistrationOptionsPayload(payload)) {
+			throw new Error("Unexpected payload shape");
+		}
+		assert.equal(payload.user?.name, context);
+		assert.equal(payload.user?.displayName, `Pre-auth ${context}`);
+		assert.equal(typeof payload.challenge, "string");
+
+		const setCookie = response.headers.get("set-cookie") || "";
+		assert.strictEqual(setCookie.includes("better-auth-passkey"), true);
+	});
+});

--- a/packages/passkey/src/client.test.ts
+++ b/packages/passkey/src/client.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import { getPasskeyActions } from "./client";
+
+const mocks = vi.hoisted(() => ({
+	startRegistration: vi.fn(),
+	startAuthentication: vi.fn(),
+}));
+
+vi.mock("@simplewebauthn/browser", () => ({
+	startRegistration: mocks.startRegistration,
+	startAuthentication: mocks.startAuthentication,
+	WebAuthnError: class WebAuthnError extends Error {
+		code: string;
+		constructor(code: string, message?: string) {
+			super(message ?? code);
+			this.code = code;
+		}
+	},
+}));
+
+describe("passkey client", () => {
+	it("merges registration extensions and returns WebAuthn response", async () => {
+		const fetchMock = vi.fn(async (path: string, options?: any) => {
+			if (path === "/passkey/generate-register-options") {
+				return {
+					data: {
+						challenge: "challenge",
+						rp: { name: "Test", id: "example.com" },
+						user: { id: "user", name: "user" },
+						pubKeyCredParams: [],
+						extensions: { credProps: true },
+					},
+				};
+			}
+			if (path === "/passkey/verify-registration") {
+				return {
+					data: {
+						id: "passkey-id",
+						userId: "user",
+					},
+				};
+			}
+			return { data: null };
+		});
+		const listPasskeys = { set: vi.fn() };
+		const store = { notify: vi.fn() };
+		const actions = getPasskeyActions(fetchMock as any, {
+			$listPasskeys: listPasskeys as any,
+			$store: store as any,
+		});
+
+		mocks.startRegistration.mockResolvedValue({
+			clientExtensionResults: { credProps: true },
+			response: {
+				transports: ["internal"],
+			},
+		});
+
+		const result = await actions.passkey.addPasskey({
+			extensions: { hmacCreateSecret: true },
+			returnWebAuthnResponse: true,
+			context: "onboarding-context",
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/passkey/generate-register-options",
+			expect.objectContaining({
+				query: expect.objectContaining({
+					context: "onboarding-context",
+				}),
+			}),
+		);
+
+		expect(mocks.startRegistration).toHaveBeenCalledWith(
+			expect.objectContaining({
+				optionsJSON: expect.objectContaining({
+					extensions: {
+						credProps: true,
+						hmacCreateSecret: true,
+					},
+				}),
+			}),
+		);
+		expect(
+			"webauthn" in result && result.webauthn?.clientExtensionResults,
+		).toEqual({
+			credProps: true,
+		});
+	});
+
+	it("merges authentication extensions and returns WebAuthn response", async () => {
+		const fetchMock = vi.fn(async (path: string) => {
+			if (path === "/passkey/generate-authenticate-options") {
+				return {
+					data: {
+						challenge: "challenge",
+						rpId: "example.com",
+						allowCredentials: [],
+						userVerification: "preferred",
+						extensions: { credProps: true },
+					},
+				};
+			}
+			if (path === "/passkey/verify-authentication") {
+				return {
+					data: {
+						session: { id: "session" },
+						user: { id: "user" },
+					},
+				};
+			}
+			return { data: null };
+		});
+		const listPasskeys = { set: vi.fn() };
+		const store = { notify: vi.fn() };
+		const actions = getPasskeyActions(fetchMock as any, {
+			$listPasskeys: listPasskeys as any,
+			$store: store as any,
+		});
+
+		mocks.startAuthentication.mockResolvedValue({
+			clientExtensionResults: { credProps: true },
+		});
+
+		const result = await actions.signIn.passkey({
+			// hmacGetSecret is a valid WebAuthn extension but not in standard type definitions
+			extensions: { hmacGetSecret: true } as Record<string, unknown>,
+			returnWebAuthnResponse: true,
+		});
+
+		expect(mocks.startAuthentication).toHaveBeenCalledWith(
+			expect.objectContaining({
+				optionsJSON: expect.objectContaining({
+					extensions: {
+						credProps: true,
+						hmacGetSecret: true,
+					},
+				}),
+			}),
+		);
+		expect(
+			"webauthn" in result && result.webauthn?.clientExtensionResults,
+		).toEqual({
+			credProps: true,
+		});
+	});
+});

--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -13,6 +13,12 @@ import {
 	startRegistration,
 	WebAuthnError,
 } from "@simplewebauthn/browser";
+import type {
+	AuthenticationExtensionsClientInputs,
+	AuthenticationExtensionsClientOutputs,
+	AuthenticationResponseJSON,
+	RegistrationResponseJSON,
+} from "@simplewebauthn/server";
 import { useAuthQuery } from "better-auth/client";
 import type { Session, User } from "better-auth/types";
 import { atom } from "nanostores";
@@ -34,6 +40,8 @@ export const getPasskeyActions = (
 		opts?:
 			| {
 					autoFill?: boolean;
+					extensions?: AuthenticationExtensionsClientInputs;
+					returnWebAuthnResponse?: boolean;
 					fetchOptions?: ClientFetchOption;
 			  }
 			| undefined,
@@ -50,16 +58,27 @@ export const getPasskeyActions = (
 			return response;
 		}
 		try {
+			const mergedExtensions =
+				response.data.extensions || opts?.extensions
+					? {
+							...(response.data.extensions || {}),
+							...(opts?.extensions || {}),
+						}
+					: undefined;
 			const res = await startAuthentication({
-				optionsJSON: response.data,
+				optionsJSON: {
+					...response.data,
+					extensions: mergedExtensions,
+				},
 				useBrowserAutofill: opts?.autoFill,
 			});
+			const { clientExtensionResults, ...responseBody } = res;
 			const verified = await $fetch<{
 				session: Session;
 				user: User;
 			}>("/passkey/verify-authentication", {
 				body: {
-					response: res,
+					response: responseBody,
 				},
 				...opts?.fetchOptions,
 				...options,
@@ -68,6 +87,17 @@ export const getPasskeyActions = (
 			});
 			$listPasskeys.set(Math.random());
 			$store.notify("$sessionSignal");
+
+			if (opts?.returnWebAuthnResponse) {
+				return {
+					...verified,
+					webauthn: {
+						response: res as AuthenticationResponseJSON,
+						clientExtensionResults:
+							clientExtensionResults as AuthenticationExtensionsClientOutputs,
+					},
+				};
+			}
 
 			return verified;
 		} catch (err) {
@@ -100,6 +130,14 @@ export const getPasskeyActions = (
 					 * platform and cross-platform allowed, with platform preferred.
 					 */
 					authenticatorAttachment?: "platform" | "cross-platform";
+					/**
+					 * Optional context for passkey-first registration flows.
+					 */
+					context?: string | null;
+					/**
+					 * Optional WebAuthn extensions to include during registration.
+					 */
+					extensions?: AuthenticationExtensionsClientInputs;
 
 					/**
 					 * Try to silently create a passkey with the password manager that the user just signed
@@ -107,6 +145,10 @@ export const getPasskeyActions = (
 					 * @default false
 					 */
 					useAutoRegister?: boolean;
+					/**
+					 * Return WebAuthn response and extension results.
+					 */
+					returnWebAuthnResponse?: boolean;
 			  }
 			| undefined,
 		fetchOpts?: ClientFetchOption | undefined,
@@ -122,6 +164,9 @@ export const getPasskeyActions = (
 					...(opts?.name && {
 						name: opts.name,
 					}),
+					...(opts?.context && {
+						context: opts.context,
+					}),
 				},
 				throw: false,
 			},
@@ -131,15 +176,26 @@ export const getPasskeyActions = (
 			return options;
 		}
 		try {
+			const mergedExtensions =
+				options.data.extensions || opts?.extensions
+					? {
+							...(options.data.extensions || {}),
+							...(opts?.extensions || {}),
+						}
+					: undefined;
 			const res = await startRegistration({
-				optionsJSON: options.data,
+				optionsJSON: {
+					...options.data,
+					extensions: mergedExtensions,
+				},
 				useAutoRegister: opts?.useAutoRegister,
 			});
+			const { clientExtensionResults, ...responseBody } = res;
 			const verified = await $fetch<Passkey>("/passkey/verify-registration", {
 				...opts?.fetchOptions,
 				...fetchOpts,
 				body: {
-					response: res,
+					response: responseBody,
 					name: opts?.name,
 				},
 				method: "POST",
@@ -150,6 +206,16 @@ export const getPasskeyActions = (
 				return verified;
 			}
 			$listPasskeys.set(Math.random());
+			if (opts?.returnWebAuthnResponse) {
+				return {
+					...verified,
+					webauthn: {
+						response: res as RegistrationResponseJSON,
+						clientExtensionResults:
+							clientExtensionResults as AuthenticationExtensionsClientOutputs,
+					},
+				};
+			}
 			return verified;
 		} catch (e) {
 			if (e instanceof WebAuthnError) {

--- a/packages/passkey/src/error-codes.ts
+++ b/packages/passkey/src/error-codes.ts
@@ -13,4 +13,8 @@ export const PASSKEY_ERROR_CODES = defineErrorCodes({
 	REGISTRATION_CANCELLED: "Registration cancelled",
 	AUTH_CANCELLED: "Auth cancelled",
 	UNKNOWN_ERROR: "Unknown error",
+	SESSION_REQUIRED: "Passkey registration requires an authenticated session",
+	RESOLVE_USER_REQUIRED:
+		"Passkey registration requires either an authenticated session or a resolveUser callback when requireSession is false",
+	RESOLVED_USER_INVALID: "Resolved user is invalid",
 });

--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -15,17 +15,48 @@ import type { Passkey } from ".";
 import { passkey } from ".";
 import { passkeyClient } from "./client";
 
-vi.mock("@simplewebauthn/server", async (importOriginal) => {
-	const mod = await importOriginal<typeof import("@simplewebauthn/server")>();
+const serverMocks = vi.hoisted(() => ({
+	verifyRegistrationResponse: vi.fn(),
+}));
+
+vi.mock("@simplewebauthn/server", async () => {
+	const actual = await vi.importActual<typeof import("@simplewebauthn/server")>(
+		"@simplewebauthn/server",
+	);
 	return {
-		...mod,
-		verifyAuthenticationResponse: vi.fn(mod.verifyAuthenticationResponse),
+		...actual,
+		verifyRegistrationResponse: serverMocks.verifyRegistrationResponse,
 	};
 });
+
+const mockRegistrationResponse = {
+	id: "credential-id",
+	response: {
+		transports: ["internal"],
+	},
+};
+
+const mockRegistrationVerification = {
+	verified: true,
+	registrationInfo: {
+		aaguid: "test-aaguid",
+		credentialDeviceType: "singleDevice",
+		credentialBackedUp: false,
+		credential: {
+			id: "credential-id",
+			publicKey: new Uint8Array([1, 2, 3]),
+			counter: 0,
+		},
+	},
+};
 
 describe("passkey", async () => {
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		plugins: [passkey()],
+	});
+
+	afterEach(() => {
+		serverMocks.verifyRegistrationResponse.mockReset();
 	});
 
 	it("should generate register options", async () => {
@@ -52,12 +83,215 @@ describe("passkey", async () => {
 		await client.$fetch("/passkey/generate-register-options", {
 			headers: headers,
 			method: "GET",
-			onResponse(context) {
+			onResponse(context: { response: Response }) {
 				const setCookie = context.response.headers.get("Set-Cookie");
 				expect(setCookie).toBeDefined();
 				expect(setCookie).toContain("better-auth-passkey");
 			},
 		});
+	});
+
+	it("should generate register options without session when resolveUser is provided", async () => {
+		const { auth: preAuth } = await getTestInstance({
+			plugins: [
+				passkey({
+					registration: {
+						requireSession: false,
+						resolveUser: async () => ({
+							id: "pre-auth-user",
+							name: "pre-auth@example.com",
+						}),
+					},
+				}),
+			],
+		});
+
+		const options = await preAuth.api.generatePasskeyRegistrationOptions({});
+
+		expect(options).toBeDefined();
+		expect(options).toHaveProperty("challenge");
+		expect(options).toHaveProperty("rp");
+		expect(options).toHaveProperty("user");
+		expect(options).toHaveProperty("pubKeyCredParams");
+	});
+
+	it("should require resolveUser when session is not available", async () => {
+		const { auth: preAuth } = await getTestInstance({
+			plugins: [
+				passkey({
+					registration: {
+						requireSession: false,
+					},
+				}),
+			],
+		});
+
+		await expect(
+			preAuth.api.generatePasskeyRegistrationOptions({}),
+		).rejects.toThrowError(APIError);
+	});
+
+	it("should call afterVerification and allow userId override", async () => {
+		let linkedUserId = "";
+		const afterVerification = vi.fn(async () => ({
+			userId: linkedUserId,
+		}));
+		const {
+			auth: preAuth,
+			client,
+			cookieSetter,
+		} = await getTestInstance({
+			plugins: [
+				passkey({
+					registration: {
+						requireSession: false,
+						resolveUser: async () => ({
+							id: "pre-auth-user-id",
+							name: "pre-auth@example.com",
+							displayName: "Pre-auth user",
+						}),
+						afterVerification,
+					},
+				}),
+			],
+		});
+		const signUp = await preAuth.api.signUpEmail({
+			body: {
+				email: "linked-user@example.com",
+				password: "test123456",
+				name: "Linked User",
+			},
+		});
+		linkedUserId = signUp.user.id;
+		serverMocks.verifyRegistrationResponse.mockResolvedValue(
+			mockRegistrationVerification,
+		);
+		const headers = new Headers();
+		headers.set("origin", "http://localhost:3000");
+		const setCookie = cookieSetter(headers);
+
+		await client.$fetch("/passkey/generate-register-options", {
+			method: "GET",
+			query: {
+				context: "link-token",
+			},
+			onResponse: setCookie,
+		});
+
+		const passkeyRecord = await preAuth.api.verifyPasskeyRegistration({
+			headers,
+			body: {
+				response: mockRegistrationResponse,
+			},
+		});
+
+		expect(serverMocks.verifyRegistrationResponse).toHaveBeenCalled();
+		expect(afterVerification).toHaveBeenCalledWith(
+			expect.objectContaining({
+				context: "link-token",
+			}),
+		);
+		expect(passkeyRecord).not.toBeNull();
+		expect(passkeyRecord!.userId).toBe(linkedUserId);
+	});
+
+	it("should reject invalid userId returned from afterVerification", async () => {
+		let resolvedUserId = "";
+		const afterVerification = vi.fn(async () => ({
+			userId: 123 as unknown as string,
+		}));
+		const {
+			auth: preAuth,
+			client,
+			cookieSetter,
+		} = await getTestInstance({
+			plugins: [
+				passkey({
+					registration: {
+						requireSession: false,
+						resolveUser: async () => ({
+							id: resolvedUserId,
+							name: "pre-auth@example.com",
+						}),
+						afterVerification,
+					},
+				}),
+			],
+		});
+		const signUp = await preAuth.api.signUpEmail({
+			body: {
+				email: "invalid-user-id@example.com",
+				password: "test123456",
+				name: "Invalid User Id Test",
+			},
+		});
+		resolvedUserId = signUp.user.id;
+		serverMocks.verifyRegistrationResponse.mockResolvedValue(
+			mockRegistrationVerification,
+		);
+		const headers = new Headers();
+		headers.set("origin", "http://localhost:3000");
+		const setCookie = cookieSetter(headers);
+
+		await client.$fetch("/passkey/generate-register-options", {
+			method: "GET",
+			query: {
+				context: "link-token",
+			},
+			onResponse: setCookie,
+		});
+
+		await expect(
+			preAuth.api.verifyPasskeyRegistration({
+				headers,
+				body: {
+					response: mockRegistrationResponse,
+				},
+			}),
+		).rejects.toThrowError(APIError);
+		expect(afterVerification).toHaveBeenCalled();
+	});
+
+	it("should reject afterVerification override that mismatches session user", async () => {
+		const afterVerification = vi.fn(async () => ({
+			userId: "different-user-id",
+		}));
+		const {
+			auth: sessionAuth,
+			client,
+			cookieSetter,
+			signInWithTestUser,
+		} = await getTestInstance({
+			plugins: [
+				passkey({
+					registration: {
+						afterVerification,
+					},
+				}),
+			],
+		});
+		serverMocks.verifyRegistrationResponse.mockResolvedValue(
+			mockRegistrationVerification,
+		);
+		const { headers } = await signInWithTestUser();
+		headers.set("origin", "http://localhost:3000");
+		const setCookie = cookieSetter(headers);
+
+		await client.$fetch("/passkey/generate-register-options", {
+			method: "GET",
+			headers,
+			onResponse: setCookie,
+		});
+
+		await expect(
+			sessionAuth.api.verifyPasskeyRegistration({
+				headers,
+				body: {
+					response: mockRegistrationResponse,
+				},
+			}),
+		).rejects.toThrowError(APIError);
+		expect(afterVerification).toHaveBeenCalled();
 	});
 
 	it("should generate authenticate options", async () => {

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -1,7 +1,9 @@
+import type { GenericEndpointContext } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import { APIError } from "@better-auth/core/error";
 import { base64 } from "@better-auth/utils/base64";
 import type {
+	AuthenticationExtensionsClientInputs,
 	AuthenticationResponseJSON,
 	AuthenticatorTransportFuture,
 } from "@simplewebauthn/server";
@@ -20,7 +22,13 @@ import { setSessionCookie } from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
 import * as z from "zod";
 import { PASSKEY_ERROR_CODES } from "./error-codes";
-import type { Passkey, PasskeyOptions, WebAuthnChallengeValue } from "./types";
+import type {
+	Passkey,
+	PasskeyExtensionsResolver,
+	PasskeyOptions,
+	PasskeyRegistrationUser,
+	WebAuthnChallengeValue,
+} from "./types";
 import { getRpID } from "./utils";
 
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
@@ -29,22 +37,87 @@ type RequiredPassKeyOptions = WithRequired<PasskeyOptions, "advanced"> & {
 	advanced: Required<PasskeyOptions["advanced"]>;
 };
 
+const resolveExtensions = async (
+	extensions: PasskeyExtensionsResolver | undefined,
+	ctx: GenericEndpointContext,
+): Promise<AuthenticationExtensionsClientInputs | undefined> => {
+	if (!extensions) {
+		return undefined;
+	}
+	if (typeof extensions === "function") {
+		return await extensions({ ctx });
+	}
+	return extensions;
+};
+
+const resolveRegistrationUser = async (
+	opts: RequiredPassKeyOptions,
+	ctx: GenericEndpointContext,
+): Promise<PasskeyRegistrationUser> => {
+	const requireSession = opts.registration?.requireSession ?? true;
+	if (requireSession) {
+		const session = ctx.context?.session;
+		if (!session?.user?.id) {
+			throw APIError.from("UNAUTHORIZED", PASSKEY_ERROR_CODES.SESSION_REQUIRED);
+		}
+		const sessionName = session.user.email || session.user.id;
+		return {
+			id: session.user.id,
+			name: sessionName,
+			displayName: sessionName,
+		};
+	}
+
+	const session = await getSessionFromCtx(ctx);
+	if (session?.user?.id) {
+		const sessionName = session.user.email || session.user.id;
+		return {
+			id: session.user.id,
+			name: sessionName,
+			displayName: sessionName,
+		};
+	}
+
+	if (!opts.registration?.resolveUser) {
+		throw APIError.from(
+			"BAD_REQUEST",
+			PASSKEY_ERROR_CODES.RESOLVE_USER_REQUIRED,
+		);
+	}
+
+	const resolvedUser = await opts.registration.resolveUser({
+		ctx,
+		context: ctx.query?.context ?? null,
+	});
+
+	if (!resolvedUser?.id || !resolvedUser?.name) {
+		throw APIError.from(
+			"BAD_REQUEST",
+			PASSKEY_ERROR_CODES.RESOLVED_USER_INVALID,
+		);
+	}
+
+	return resolvedUser;
+};
+
 const generatePasskeyQuerySchema = z
 	.object({
 		authenticatorAttachment: z.enum(["platform", "cross-platform"]).optional(),
 		name: z.string().optional(),
+		context: z.string().optional(),
 	})
 	.optional();
 
 export const generatePasskeyRegistrationOptions = (
 	opts: RequiredPassKeyOptions,
 	{ maxAgeInSeconds }: { maxAgeInSeconds: number },
-) =>
-	createAuthEndpoint(
+) => {
+	const requireSession = opts.registration?.requireSession ?? true;
+	return createAuthEndpoint(
 		"/passkey/generate-register-options",
 		{
 			method: "GET",
-			use: [freshSessionMiddleware],
+			use: requireSession ? [freshSessionMiddleware] : undefined,
 			query: generatePasskeyQuerySchema,
 			metadata: {
 				openapi: {
@@ -64,6 +137,11 @@ export const generatePasskeyRegistrationOptions = (
 									name: {
 										description: `Optional custom name for the passkey.
                           This can help identify the passkey when managing multiple credentials.`,
+										required: false,
+									},
+									context: {
+										description:
+											"Optional context for passkey-first registration flows.",
 										required: false,
 									},
 								},
@@ -169,16 +247,20 @@ export const generatePasskeyRegistrationOptions = (
 			},
 		},
 		async (ctx) => {
-			const { session } = ctx.context;
+			const user = await resolveRegistrationUser(opts, ctx);
 			const userPasskeys = await ctx.context.adapter.findMany<Passkey>({
 				model: "passkey",
 				where: [
 					{
 						field: "userId",
-						value: session.user.id,
+						value: user.id,
 					},
 				],
 			});
+			const registrationExtensions = await resolveExtensions(
+				opts.registration?.extensions,
+				ctx,
+			);
 			const userID = new TextEncoder().encode(
 				generateRandomString(32, "a-z", "0-9"),
 			);
@@ -190,8 +272,8 @@ export const generatePasskeyRegistrationOptions = (
 				rpName: opts.rpName || ctx.context.appName,
 				rpID: getRpID(opts, baseURLString),
 				userID,
-				userName: ctx.query?.name || session.user.email || session.user.id,
-				userDisplayName: session.user.email || session.user.id,
+				userName: ctx.query?.name || user.name || user.id,
+				userDisplayName: user.displayName || user.name || user.id,
 				attestationType: "none",
 				excludeCredentials: userPasskeys.map((passkey) => ({
 					id: passkey.credentialID,
@@ -209,6 +291,7 @@ export const generatePasskeyRegistrationOptions = (
 							}
 						: {}),
 				},
+				extensions: registrationExtensions,
 			});
 			const verificationToken = generateRandomString(32);
 			const webAuthnCookie = ctx.context.createAuthCookie(
@@ -229,8 +312,11 @@ export const generatePasskeyRegistrationOptions = (
 				value: JSON.stringify({
 					expectedChallenge: options.challenge,
 					userData: {
-						id: session.user.id,
+						id: user.id,
+						name: user.name,
+						displayName: user.displayName,
 					},
+					context: ctx.query?.context ?? null,
 				}),
 				expiresAt: expirationTime,
 			});
@@ -239,6 +325,7 @@ export const generatePasskeyRegistrationOptions = (
 			});
 		},
 	);
+};
 
 export const generatePasskeyAuthenticationOptions = (
 	opts: RequiredPassKeyOptions,
@@ -358,9 +445,14 @@ export const generatePasskeyAuthenticationOptions = (
 				typeof ctx.context.options.baseURL === "string"
 					? ctx.context.options.baseURL
 					: undefined;
+			const authenticationExtensions = await resolveExtensions(
+				opts.authentication?.extensions,
+				ctx,
+			);
 			const options = await generateAuthenticationOptions({
 				rpID: getRpID(opts, baseURLString),
 				userVerification: "preferred",
+				extensions: authenticationExtensions,
 				...(userPasskeys.length
 					? {
 							allowCredentials: userPasskeys.map((passkey) => ({
@@ -413,13 +505,14 @@ const verifyPasskeyRegistrationBodySchema = z.object({
 		.optional(),
 });
 
-export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
-	createAuthEndpoint(
+export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) => {
+	const requireSession = options.registration?.requireSession ?? true;
+	return createAuthEndpoint(
 		"/passkey/verify-registration",
 		{
 			method: "POST",
 			body: verifyPasskeyRegistrationBodySchema,
-			use: [freshSessionMiddleware],
+			use: requireSession ? [freshSessionMiddleware] : undefined,
 			metadata: {
 				openapi: {
 					operationId: "passkeyVerifyRegistration",
@@ -475,11 +568,14 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 					PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
 				);
 			}
-			const { expectedChallenge, userData } = JSON.parse(
+			const { expectedChallenge, userData, context } = JSON.parse(
 				data.value,
 			) as WebAuthnChallengeValue;
 
-			if (userData.id !== ctx.context.session.user.id) {
+			const session = requireSession
+				? ctx.context.session
+				: await getSessionFromCtx(ctx);
+			if (session?.user?.id && userData.id !== session.user.id) {
 				throw APIError.from(
 					"UNAUTHORIZED",
 					PASSKEY_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY,
@@ -507,10 +603,40 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 				}
 				const { aaguid, credentialDeviceType, credentialBackedUp, credential } =
 					registrationInfo;
+				const resolvedUser: PasskeyRegistrationUser = {
+					id: userData.id,
+					name: userData.name || userData.id,
+					displayName: userData.displayName,
+				};
+				let targetUserId = resolvedUser.id;
+				if (options.registration?.afterVerification) {
+					const result = await options.registration.afterVerification({
+						ctx,
+						verification,
+						user: resolvedUser,
+						clientData: resp,
+						context,
+					});
+					if (result?.userId) {
+						if (typeof result.userId !== "string" || !result.userId) {
+							throw APIError.from(
+								"BAD_REQUEST",
+								PASSKEY_ERROR_CODES.RESOLVED_USER_INVALID,
+							);
+						}
+						if (session?.user?.id && result.userId !== session.user.id) {
+							throw APIError.from(
+								"UNAUTHORIZED",
+								PASSKEY_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY,
+							);
+						}
+						targetUserId = result.userId;
+					}
+				}
 				const pubKey = base64.encode(credential.publicKey);
 				const newPasskey: Omit<Passkey, "id"> = {
 					name: ctx.body.name,
-					userId: userData.id,
+					userId: targetUserId,
 					credentialID: credential.id,
 					publicKey: pubKey,
 					counter: credential.counter,
@@ -542,6 +668,7 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 			}
 		},
 	);
+};
 
 const verifyPasskeyAuthenticationBodySchema = z.object({
 	response: z.record(z.any(), z.any()),
@@ -661,6 +788,14 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 						"UNAUTHORIZED",
 						PASSKEY_ERROR_CODES.AUTHENTICATION_FAILED,
 					);
+
+				if (options.authentication?.afterVerification) {
+					await options.authentication.afterVerification({
+						ctx,
+						verification,
+						clientData: resp as AuthenticationResponseJSON,
+					});
+				}
 
 				await ctx.context.adapter.update<Passkey>({
 					model: "passkey",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,6 +624,13 @@ importers:
         version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
   e2e/smoke:
+    dependencies:
+      '@better-auth/passkey':
+        specifier: workspace:*
+        version: link:../../packages/passkey
+      better-auth:
+        specifier: workspace:*
+        version: link:../../packages/better-auth
     devDependencies:
       '@better-auth/core':
         specifier: workspace:*
@@ -634,9 +641,6 @@ importers:
       '@better-auth/sso':
         specifier: workspace:*
         version: link:../../packages/sso
-      better-auth:
-        specifier: workspace:*
-        version: link:../../packages/better-auth
       ioredis:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Motivation
We need a middle ground where Better Auth remains generic, while allowing apps to plug in advanced passkey flows (PRF-based identity derivation) without custom forks. This change enables pre-auth passkey registration with extension data and keeps Better Auth’s auth flow intact.

Closes #7151 

## Summary
- Adds a pre-auth registration flow for passkeys so servers can derive user identity from client extensions (e.g., PRF) before user creation.
- Allows passing WebAuthn extensions into registration and authentication option generation.
- Adds optional hooks to post-process verification and surface the WebAuthn response.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in pre-auth passkey registration with context forwarding, server/client WebAuthn extensions, and verification hooks. Enables passkey-first onboarding and PRF-based identity derivation without changing defaults. Addresses #7151.

- **New Features**
  - Pre-auth registration: set `registration.requireSession=false`; when no session, require `registration.resolveUser({ ctx, context })`; client can pass `context` to options and registration; forwarded into `resolveUser` and `registration.afterVerification`.
  - User linking: `registration.afterVerification` may return `{ userId }`; validated and must match session user if present; new error codes: `SESSION_REQUIRED`, `RESOLVE_USER_REQUIRED`, `RESOLVED_USER_INVALID`.
  - Extensions: server-defined `extensions` for registration/auth (object or `(ctx) => inputs`); client can pass `extensions`; SDK merges client+server.
  - WebAuthn response: set `returnWebAuthnResponse` to get raw response and `clientExtensionResults` for registration and authentication; client omits `clientExtensionResults` when posting to server.
  - Hooks: added `authentication.afterVerification`.
  - Docs and tests updated, including client merge tests and e2e pre-auth smoke.

- **Migration**
  - No changes unless you opt in.
  - To use pre-auth: set `requireSession=false`, implement `resolveUser`, and pass `context` from the client on options and registration.
  - To use extensions/results: configure plugin `registration.extensions`/`authentication.extensions` or pass client `extensions`, and set `returnWebAuthnResponse` on the client.

<sup>Written for commit ad3060138961af9b9b8f73a39bc995daa66cd8b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

