### PR TITLE
chore: ignore cursor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,5 @@ playwright-report/
 test-results/
 
 state.txt
+
+.cursor/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add .cursor/ to .gitignore to prevent committing Cursor editor workspace files. This keeps local state out of the repo and reduces diff noise.

<sup>Written for commit fc3abd6ee83e5825d274fabac44f7477d563d07d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

