### PR TITLE
fix: call hooks on `change-email-verification` flow

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -501,4 +501,69 @@ describe("Email Verification Secondary Storage", async () => {
 		expect(secondSignInSession.data?.user.email).toBe(sampleUser.email);
 		expect(secondSignInSession.data?.user.emailVerified).toBe(true);
 	});
+
+	it("should call hooks when verifying email change (change-email-verification)", async () => {
+		const onEmailVerificationMock = vi.fn();
+		const afterEmailVerificationMock = vi.fn();
+		let capturedToken: string;
+
+		const { client, auth, signInWithTestUser, cookieSetter, testUser } =
+			await getTestInstance({
+				emailAndPassword: {
+					enabled: true,
+				},
+				emailVerification: {
+					async sendVerificationEmail({ token: _token }) {
+						capturedToken = _token;
+					},
+					onEmailVerification: onEmailVerificationMock,
+					afterEmailVerification: afterEmailVerificationMock,
+				},
+				user: {
+					changeEmail: {
+						enabled: true,
+						async sendChangeEmailVerification(data) {
+							capturedToken = data.token;
+						},
+					},
+				},
+			});
+
+		const { runWithUser } = await signInWithTestUser();
+
+		await runWithUser(async (headers) => {
+			// Request email change
+			await auth.api.changeEmail({
+				body: {
+					newEmail: "newemail@example.com",
+				},
+				headers,
+			});
+
+			// Verify new email (change-email-verification flow)
+			const verificationHeaders = new Headers();
+			await client.verifyEmail({
+				query: {
+					token: capturedToken,
+				},
+				fetchOptions: {
+					onSuccess: cookieSetter(verificationHeaders),
+					headers,
+				},
+			});
+
+			// Hooks should be called when email is verified
+			expect(onEmailVerificationMock).toHaveBeenCalledWith(
+				expect.objectContaining({ email: testUser.email }),
+				expect.any(Object),
+			);
+			expect(afterEmailVerificationMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					email: "newemail@example.com",
+					emailVerified: true,
+				}),
+				expect.any(Object),
+			);
+		});
+	});
 });

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -365,6 +365,12 @@ export const verifyEmail = createAuthEndpoint(
 				};
 			}
 			if (parsed.requestType === "change-email-verification") {
+				if (ctx.context.options.emailVerification?.onEmailVerification) {
+					await ctx.context.options.emailVerification.onEmailVerification(
+						user.user,
+						ctx.request,
+					);
+				}
 				const updatedUser = await ctx.context.internalAdapter.updateUserByEmail(
 					parsed.email,
 					{
@@ -372,6 +378,12 @@ export const verifyEmail = createAuthEndpoint(
 						emailVerified: true,
 					},
 				);
+				if (ctx.context.options.emailVerification?.afterEmailVerification) {
+					await ctx.context.options.emailVerification.afterEmailVerification(
+						updatedUser,
+						ctx.request,
+					);
+				}
 				await setSessionCookie(ctx, {
 					session: session.session,
 					user: {


### PR DESCRIPTION
- Closes https://github.com/better-auth/better-auth/issues/7057

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure hooks run during the change-email-verification flow so integrators can perform pre/post verification actions. This aligns email change verification with the standard verification behavior.

- **Bug Fixes**
  - Call onEmailVerification before updating the email, and afterEmailVerification after the update is saved.
  - Add tests verifying hooks receive the original email on pre-verification and the new, verified email on post-verification.

<sup>Written for commit 74b6bb537c1e677c43d9770281d0a98089d57f01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

