### PR TITLE
fix: clean up expired rate-limit entries on memory storage

### DIFF
--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -85,7 +85,12 @@ function createDBStorage(ctx: AuthContext) {
 	};
 }
 
-const memory = new Map<string, RateLimit>();
+interface MemoryRateLimitEntry {
+	data: RateLimit;
+	expiresAt: number;
+}
+
+const memory = new Map<string, MemoryRateLimitEntry>();
 function getRateLimitStorage(
 	ctx: AuthContext,
 	rateLimitSettings?:
@@ -121,10 +126,25 @@ function getRateLimitStorage(
 	} else if (storage === "memory") {
 		return {
 			async get(key: string) {
-				return memory.get(key);
+				const entry = memory.get(key);
+				if (!entry) {
+					return undefined;
+				}
+				// Check if entry has expired
+				if (Date.now() >= entry.expiresAt) {
+					memory.delete(key);
+					return undefined;
+				}
+				return entry.data;
 			},
 			async set(key: string, value: RateLimit, _update?: boolean | undefined) {
-				memory.set(key, value);
+				const ttl =
+					rateLimitSettings?.window ?? ctx.options.rateLimit?.window ?? 10;
+				const expiresAt = Date.now() + ttl * 1000;
+				memory.set(key, {
+					data: value,
+					expiresAt,
+				});
 			},
 		};
 	}


### PR DESCRIPTION
We don't clean up expired rate-limit entries on memory storage. This PR adds simple logic to remove those rate-limit entries upon expiration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory leak in the in-memory rate limiter by expiring and cleaning entries based on the configured rate-limit window.

- **Bug Fixes**
  - Store entries with an expiresAt derived from the rate-limit window (default 10s).
  - On get, remove expired entries and return undefined.

<sup>Written for commit 01b1506ca26d0ac481acc42cf44d4a542c8c6db6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

