### PR TITLE
feat(two-factor): separte send otp to email and phone otp

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/otp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/otp/index.ts
@@ -14,6 +14,18 @@ import type { TwoFactorProvider, UserWithTwoFactor } from "../types";
 import { defaultKeyHasher } from "../utils";
 import { verifyTwoFactor } from "../verify-two-factor";
 
+export type OTPMethod = "email" | "phone";
+
+export type SendOTPData = {
+	user: UserWithTwoFactor;
+	otp: string;
+};
+
+export type SendOTPFn = (
+	data: SendOTPData,
+	ctx?: GenericEndpointContext,
+) => Awaitable<void>;
+
 export interface OTPOptions {
 	/**
 	 * How long the opt will be valid for in
@@ -29,30 +41,31 @@ export interface OTPOptions {
 	 */
 	digits?: number | undefined;
 	/**
-	 * Send the otp to the user
+	 * Send the otp to the user (used as fallback if sendEmailOTP/sendPhoneOTP are not provided)
 	 *
 	 * @param user - The user to send the otp to
 	 * @param otp - The otp to send
 	 * @param request - The request object
 	 * @returns void | Promise<void>
+	 * @deprecated Use `sendEmailOTP` or `sendPhoneOTP` instead for more explicit OTP delivery methods
 	 */
-	sendOTP?:
-		| ((
-				/**
-				 * The user to send the otp to
-				 * @type UserWithTwoFactor
-				 * @default UserWithTwoFactors
-				 */
-				data: {
-					user: UserWithTwoFactor;
-					otp: string;
-				},
-				/**
-				 * The request object
-				 */
-				ctx?: GenericEndpointContext,
-		  ) => Awaitable<void>)
-		| undefined;
+	sendOTP?: SendOTPFn | undefined;
+	/**
+	 * Send the otp to the user via email
+	 *
+	 * @param data - Object containing the user and the otp
+	 * @param ctx - The request context
+	 * @returns void | Promise<void>
+	 */
+	sendEmailOTP?: SendOTPFn | undefined;
+	/**
+	 * Send the otp to the user via phone (SMS)
+	 *
+	 * @param data - Object containing the user and the otp
+	 * @param ctx - The request context
+	 * @returns void | Promise<void>
+	 */
+	sendPhoneOTP?: SendOTPFn | undefined;
 	/**
 	 * The number of allowed attempts for the OTP
 	 *
@@ -88,19 +101,25 @@ const verifyOTPBodySchema = z.object({
 	}),
 });
 
-const send2FaOTPBodySchema = z
-	.object({
-		/**
-		 * if true, the device will be trusted
-		 * for 30 days. It'll be refreshed on
-		 * every sign in request within this time.
-		 */
-		trustDevice: z.boolean().optional().meta({
-			description:
-				"If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time. Eg: true",
-		}),
-	})
-	.optional();
+const send2FaOTPBodySchema = z.object({
+	/**
+	 * The method to send the OTP
+	 * @default "email"
+	 */
+	method: z.enum(["email", "phone"]).optional().default("email").meta({
+		description:
+			'The method to use for sending the OTP. Can be "email" or "phone". Defaults to "email".',
+	}),
+	/**
+	 * if true, the device will be trusted
+	 * for 30 days. It'll be refreshed on
+	 * every sign in request within this time.
+	 */
+	trustDevice: z.boolean().optional().meta({
+		description:
+			"If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time. Eg: true",
+	}),
+});
 
 /**
  * The otp adapter is created from the totp adapter.
@@ -152,6 +171,19 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 	}
 
 	/**
+	 * Get the appropriate send function based on the method
+	 */
+	function getSendOTPFunction(method: OTPMethod): SendOTPFn | undefined {
+		if (method === "email") {
+			return options?.sendEmailOTP ?? options?.sendOTP;
+		}
+		if (method === "phone") {
+			return options?.sendPhoneOTP ?? options?.sendOTP;
+		}
+		return options?.sendOTP;
+	}
+
+	/**
 	 * Generate OTP and send it to the user.
 	 */
 	const send2FaOTP = createAuthEndpoint(
@@ -162,7 +194,8 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 			metadata: {
 				openapi: {
 					summary: "Send two factor OTP",
-					description: "Send two factor OTP to the user",
+					description:
+						"Send two factor OTP to the user via email or phone based on the specified method",
 					responses: {
 						200: {
 							description: "Successful response",
@@ -184,15 +217,20 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 			},
 		},
 		async (ctx) => {
-			if (!options || !options.sendOTP) {
+			const method = ctx.body?.method ?? "email";
+			const sendOTPFn = getSendOTPFunction(method);
+
+			if (!sendOTPFn) {
+				const methodName = method === "email" ? "sendEmailOTP" : "sendPhoneOTP";
 				ctx.context.logger.error(
-					"send otp isn't configured. Please configure the send otp function on otp options.",
+					`send otp isn't configured for method "${method}". Please configure the ${methodName} function on otp options.`,
 				);
 				throw APIError.from("BAD_REQUEST", {
-					message: "otp isn't configured",
+					message: `otp isn't configured for method "${method}"`,
 					code: "OTP_NOT_CONFIGURED",
 				});
 			}
+
 			const { session, key } = await verifyTwoFactor(ctx);
 			const code = generateRandomString(opts.digits, "0-9");
 			const hashedCode = await storeOTP(ctx, code);
@@ -201,14 +239,17 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 				identifier: `2fa-otp-${key}`,
 				expiresAt: new Date(Date.now() + opts.period),
 			});
-			const sendOTPResult = options.sendOTP(
+			const sendOTPResult = sendOTPFn(
 				{ user: session.user as UserWithTwoFactor, otp: code },
 				ctx,
 			);
 			if (sendOTPResult instanceof Promise) {
 				await ctx.context.runInBackgroundOrAwait(
 					sendOTPResult.catch((e: unknown) => {
-						ctx.context.logger.error("Failed to send two-factor OTP", e);
+						ctx.context.logger.error(
+							`Failed to send two-factor OTP via ${method}`,
+							e,
+						);
 					}),
 				);
 			}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds explicit OTP delivery methods for two-factor auth: sendEmailOTP and sendPhoneOTP, with request-time method selection and a fallback to the existing sendOTP. This enables SMS support and returns a clear error if the chosen method isn’t configured.

- New Features
  - Added sendEmailOTP and sendPhoneOTP options; sendOTP is deprecated but used as fallback.
  - sendTwoFactorOTP now accepts body.method: "email" | "phone" (defaults to "email").
  - Clear 400 error and log when a requested method isn’t configured (code: OTP_NOT_CONFIGURED).
  - Tests cover email/phone flows, fallback behavior, and verification with either method.

- Migration
  - Existing sendOTP continues to work; prefer implementing sendEmailOTP/sendPhoneOTP.
  - Configure sendPhoneOTP to support method: "phone" requests; otherwise they will 400.
  - To use SMS, pass body: { method: "phone" } to sendTwoFactorOTP.

<sup>Written for commit ff956a87ddd57b2e712a3163271ba83447af414e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

