### PR TITLE
feat: make username optional

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.test.ts
+++ b/packages/better-auth/src/api/routes/sign-up.test.ts
@@ -1,6 +1,49 @@
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
-import { afterEach, describe, expect, vi } from "vitest";
-import { getTestInstance } from "../../test-utils/test-instance";
+import { afterEach, describe, expect, expectTypeOf, vi } from "vitest";
+import { getTestInstance } from "../../test-utils";
+
+describe("sign-up with username field", async (it) => {
+	it("disable `requireUsername` should make username type happy", async () => {
+		const { auth } = await getTestInstance({
+			user: {
+				requireUsername: false,
+			},
+		});
+
+		type NoUndefined<T> = T extends undefined ? never : T;
+		type SignUpEmail = NoUndefined<Parameters<typeof auth.api.signUpEmail>[0]>;
+		type Body = SignUpEmail["body"];
+		expectTypeOf<Body>().toMatchObjectType<{
+			name?: string | undefined;
+		}>();
+	});
+
+	it("default options should make username type happy", async () => {
+		const { auth } = await getTestInstance();
+
+		type NoUndefined<T> = T extends undefined ? never : T;
+		type SignUpEmail = NoUndefined<Parameters<typeof auth.api.signUpEmail>[0]>;
+		type Body = SignUpEmail["body"];
+		expectTypeOf<Body>().toMatchObjectType<{
+			name: string;
+		}>();
+	});
+
+	it("enable `requireUsername` options should make username type happy", async () => {
+		const { auth } = await getTestInstance({
+			user: {
+				requireUsername: true,
+			},
+		});
+
+		type NoUndefined<T> = T extends undefined ? never : T;
+		type SignUpEmail = NoUndefined<Parameters<typeof auth.api.signUpEmail>[0]>;
+		type Body = SignUpEmail["body"];
+		expectTypeOf<Body>().toMatchObjectType<{
+			name: string;
+		}>();
+	});
+});
 
 describe("sign-up with custom fields", async (it) => {
 	const mockFn = vi.fn();

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -622,6 +622,10 @@ export type BetterAuthOptions = {
 					[key: string]: DBFieldAttribute;
 				};
 				/**
+				 * Whether username is required
+				 */
+				requireUsername?: boolean;
+				/**
 				 * Changing email configuration
 				 */
 				changeEmail?: {


### PR DESCRIPTION
- Closes https://github.com/better-auth/better-auth/issues/424

> - Related to https://github.com/better-auth/better-auth/issues/5139

---

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make username optional during email sign-up, controlled by a new user.requireUsername option. Default behavior keeps username required; set requireUsername to false to make it optional.

- **New Features**
  - Added user.requireUsername?: boolean to BetterAuthOptions.
  - Updated signUpEmail to accept optional name and infer body types based on config.
  - Added tests to validate type behavior for default, true, and false configurations.

<sup>Written for commit e4bd02153c54030ff9e53d91853e1bd254d38437. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

