### PR TITLE
docs(drizzle): cleanup code highlights

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -17,8 +17,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "./database.ts";
 
 export const auth = betterAuth({
-  database: drizzleAdapter(db, {
-    // [!code highlight]
+  database: drizzleAdapter(db, { // [!code highlight]
     provider: "sqlite", // or "pg" or "mysql" // [!code highlight]
   }), // [!code highlight]
   //... the rest of your config
@@ -79,10 +78,10 @@ import { schema } from "./schema";
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "sqlite", // or "pg" or "mysql"
-    schema: {
-      ...schema,
-      user: schema.users,
-    },
+    schema: { // [!code highlight]
+      ...schema, // [!code highlight]
+      user: schema.users, // [!code highlight]
+    }, // [!code highlight]
   }),
 });
 ```


### PR DESCRIPTION
small docs cleanup

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up code highlight tags in the Drizzle adapter docs so the right lines are emphasized in examples. Inline-highlighted the database config and added highlights for the schema block for clearer guidance.

<sup>Written for commit 95055c1cc0c01e8fd9e0cd2f3b68f119569a407f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

