### PR TITLE
fix(api-key): log key verification errors

### DIFF
--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -285,7 +285,6 @@ export function verifyApiKey({
 				}
 			} catch (error) {
 				ctx.context.logger.error("Failed to validate API key:", error);
-
 				if (isAPIError(error)) {
 					return ctx.json({
 						valid: false,


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/6258

We don't log the errors when an api-key verification errors occur, this PR adds those logs to help debug issues.

This should help with any users facing this issue too:
https://github.com/better-auth/better-auth/issues/6258


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add error logging when API key verification fails. This records the error to help debug validation issues without changing the response behavior.

<sup>Written for commit 1903b0bc4935d3c5090ad57c3db891c568372b35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



