### PR TITLE
feat(oauth-provider): add Client ID Metadata Document support for dynamic client discovery

### DIFF
--- a/.changeset/oauth-provider-client-id-metadata-document.md
+++ b/.changeset/oauth-provider-client-id-metadata-document.md
@@ -1,0 +1,40 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+feat(oauth-provider): add Client ID Metadata Document support
+
+Implements [draft-ietf-oauth-client-id-metadata-document](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) for verified dynamic client discovery, the mechanism used by [MCP](https://modelcontextprotocol.io/specification/draft/basic/authorization#client-id-metadata-documents-flow).
+
+### New option: `clientIdMetadataDocument`
+
+```ts
+oauthProvider({
+  clientIdMetadataDocument: {
+    refreshRate: "60m",
+    originBoundFields: ["redirect_uris", "post_logout_redirect_uris", "client_uri"],
+    onClientCreated({ client, metadata, ctx }) {
+      // called after first creation from a metadata document
+    },
+    onClientRefreshed({ client, metadata, ctx }) {
+      // called after re-fetch and update
+    },
+  },
+})
+```
+
+When enabled, clients can use an HTTPS URL as their `client_id`. The server fetches and validates the metadata document hosted at that URL, creating a client automatically on first authorization request. Documents are re-fetched on a configurable TTL (`refreshRate`).
+
+Supports `token_endpoint_auth_method: "none"` (public clients) and `"private_key_jwt"` (with `jwks` or `jwks_uri`).
+
+Lifecycle hooks (`onClientCreated`, `onClientRefreshed`) allow post-processing such as trust-level assignment, logo prefetching, or change-detection logging.
+
+### Security
+
+- SSRF protection via hostname validation (RFC 6890 private ranges, IPv4-mapped IPv6, cloud metadata endpoints); runtime-agnostic (no `node:dns` dependency).
+- Validates `client_id` URL per §3 (path required, no fragments, no credentials, no dot segments).
+- Validates document per §4.1 (`client_id` must equal fetch URL, no shared secrets, no symmetric auth methods).
+- Origin-bound field enforcement prevents cross-domain redirect URI injection; localhost redirect URIs are allowed for local/native app flows.
+- Admin-only fields (`skip_consent`, `enable_end_session`, `disabled`) are stripped from external metadata documents.
+- Only recognized RFC 7591 fields are persisted; arbitrary document fields are discarded.
+- 5 KB response size limit and 5-second fetch timeout.

--- a/.cspell/auth-terms.txt
+++ b/.cspell/auth-terms.txt
@@ -33,3 +33,4 @@ Vercel
 rgba
 idtoken
 HIBP
+cimd

--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -358,6 +358,7 @@ const authOptions = {
 			consentPage: "/oauth/consent",
 			allowDynamicClientRegistration: true,
 			allowUnauthenticatedClientRegistration: true,
+			clientIdMetadataDocument: {},
 			scopes: [
 				"openid",
 				"profile",

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1245,6 +1245,44 @@ PKCE prevents authorization code interception attacks. Even for confidential cli
 
 Only disable PKCE for confidential clients when absolutely necessary for legacy compatibility.
 
+### Client ID Metadata Documents
+
+[Client ID Metadata Documents](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) allow clients to identify themselves without prior registration by hosting a metadata document at an HTTPS URL. The URL itself becomes the `client_id`.
+
+This is the mechanism used by [MCP](https://modelcontextprotocol.io/specification/draft/basic/authorization#client-id-metadata-documents-flow) for dynamic client discovery.
+
+To enable Client ID Metadata Document support:
+
+```ts title="auth.ts"
+oauthProvider({
+  clientIdMetadataDocument: {},
+})
+```
+
+#### Configuration
+
+The `clientIdMetadataDocument` object accepts the following options:
+
+* `refreshRate` (default: `"60m"`): how frequently the server re-fetches metadata documents to pick up changes.
+* `originBoundFields` (default: `["redirect_uris", "post_logout_redirect_uris", "client_uri"]`): metadata fields whose URL values must share the same origin as the `client_id` URL. Localhost redirect URIs are always allowed for local/native app flows.
+* `onClientCreated({ client, metadata, ctx })`: called after a client is created from a metadata document for the first time.
+* `onClientRefreshed({ client, metadata, ctx })`: called after a client is refreshed from a re-fetched metadata document.
+
+```ts title="auth.ts"
+oauthProvider({
+  clientIdMetadataDocument: {
+    refreshRate: "10m",
+    originBoundFields: ["redirect_uris", "post_logout_redirect_uris"],
+    onClientCreated({ client, metadata, ctx }) {
+      // assign trust levels, prefetch logos, etc.
+    },
+    onClientRefreshed({ client, metadata, ctx }) {
+      // detect field changes, update derived data, etc.
+    },
+  },
+})
+```
+
 ### Organizations
 
 OAuth Clients are tied to either a user or `reference_id` at registration and is immutable. If you are utilizing the [organization plugin](/docs/plugins/organization), you must ensure that the [`activeOrganizationId`](/docs/plugins/organization#active-organization) is set on your active session when you create new clients.
@@ -1557,7 +1595,7 @@ You can easily make your APIs [MCP-compatible](https://modelcontextprotocol.io/s
   </Step>
 
   <Step>
-    If you use `allowUnauthenticatedClientRegistration`, you must ensure that your API Server is a confidential client itself:
+    If you use `clientIdMetadataDocument` or `allowUnauthenticatedClientRegistration`, you must ensure that your API Server is a confidential client itself:
 
     ```ts
     await auth.api.createOAuthClient({
@@ -1571,7 +1609,7 @@ You can easily make your APIs [MCP-compatible](https://modelcontextprotocol.io/s
     These values should be used in the verify options `remoteVerify.clientId` and `remoteVerify.clientSecret`. Additionally, `remoteVerify.introspectUrl` would be something like `${BASE_URL}/${AUTH_PATH}/oauth2/introspect`.
 
     <Callout type="info">
-      If you choose to not support `allowUnauthenticatedClientRegistration` (and only `allowDynamicClientRegistration`), the MCP client (ie. ChatGPT, Anthropic, Gemini) would need to allow you to put in a public client\_id in their UI or at runtime while chatting with the AI.
+      If you choose to not support `clientIdMetadataDocument` or `allowUnauthenticatedClientRegistration` (and only `allowDynamicClientRegistration`), the MCP client (ie. ChatGPT, Anthropic, Gemini) would need to allow you to put in a public client\_id in their UI or at runtime while chatting with the AI.
     </Callout>
   </Step>
 

--- a/packages/oauth-provider/src/cimd.test.ts
+++ b/packages/oauth-provider/src/cimd.test.ts
@@ -1,0 +1,276 @@
+import { createAuthClient } from "better-auth/client";
+import { toNodeHandler } from "better-auth/node";
+import { jwt } from "better-auth/plugins/jwt";
+import { getTestInstance } from "better-auth/test";
+import type { Listener } from "listhen";
+import { listen } from "listhen";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { oauthProviderClient } from "./client";
+import { oauthProvider } from "./oauth";
+
+describe("Client ID Metadata Document - integration", async () => {
+	const port = 3002;
+	const authServerBaseUrl = `http://localhost:${port}`;
+	const rpBaseUrl = "http://localhost:5002";
+	const providerId = "cimd-test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+
+	const clientMetadataUrl =
+		"https://mcp-client.example.com/client-metadata.json";
+	const metadataDocument = {
+		client_id: clientMetadataUrl,
+		client_name: "Test MCP Client",
+		redirect_uris: [redirectUri],
+		token_endpoint_auth_method: "none",
+		grant_types: ["authorization_code"],
+		response_types: ["code"],
+	};
+
+	const {
+		auth: authorizationServer,
+		signInWithTestUser,
+		customFetchImpl,
+	} = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				clientIdMetadataDocument: {},
+				scopes: ["openid", "profile", "email", "offline_access"],
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	let server: Listener;
+
+	beforeAll(async () => {
+		server = await listen(
+			async (req, res) => {
+				if (req.url === "/.well-known/openid-configuration") {
+					const config = await authorizationServer.api.getOpenIdConfig();
+					res.setHeader("Content-Type", "application/json");
+					res.end(JSON.stringify(config));
+				} else {
+					await toNodeHandler(authorizationServer.handler)(req, res);
+				}
+			},
+			{ port },
+		);
+	});
+
+	afterAll(async () => {
+		await server.close();
+	});
+
+	it("should auto-create a public client from a URL client_id on authorize", async ({
+		onTestFinished,
+	}) => {
+		// Stub fetch to serve the metadata document for the external URL
+		const originalFetch = globalThis.fetch.bind(globalThis);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.href
+							: input.url;
+				if (url === clientMetadataUrl) {
+					return Promise.resolve(
+						new Response(JSON.stringify(metadataDocument), {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						}),
+					);
+				}
+				return originalFetch(input, init);
+			}),
+		);
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const { headers } = await signInWithTestUser();
+		const authedClient = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: authServerBaseUrl,
+			fetchOptions: { customFetchImpl, headers },
+		});
+
+		// Hit /authorize with the URL as client_id
+		const authorizeUrl =
+			`${authServerBaseUrl}/api/auth/oauth2/authorize` +
+			`?client_id=${encodeURIComponent(clientMetadataUrl)}` +
+			`&response_type=code` +
+			`&redirect_uri=${encodeURIComponent(redirectUri)}` +
+			`&scope=openid` +
+			`&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM` +
+			`&code_challenge_method=S256`;
+
+		// The authorize endpoint should redirect to the consent page
+		// (not error), which proves the CIMD client was created
+		let loginRedirect = "";
+		await authedClient.$fetch(authorizeUrl, {
+			method: "GET",
+			onError(ctx) {
+				loginRedirect = ctx.response.headers.get("Location") || "";
+			},
+		});
+
+		// Should redirect to consent (not login, since we're signed in)
+		expect(loginRedirect).toContain("/consent");
+		expect(loginRedirect).toContain(
+			`client_id=${encodeURIComponent(clientMetadataUrl)}`,
+		);
+	});
+
+	it("should complete authorize and consent flow with a CIMD client", async ({
+		onTestFinished,
+	}) => {
+		const originalFetch = globalThis.fetch.bind(globalThis);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.href
+							: input.url;
+				if (url === clientMetadataUrl) {
+					return Promise.resolve(
+						new Response(JSON.stringify(metadataDocument), {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						}),
+					);
+				}
+				return originalFetch(input, init);
+			}),
+		);
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const { headers: userHeaders } = await signInWithTestUser();
+		const authedClient = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: authServerBaseUrl,
+			fetchOptions: { customFetchImpl, headers: userHeaders },
+		});
+
+		// Hit authorize with the URL client_id
+		const authorizeUrl =
+			`${authServerBaseUrl}/api/auth/oauth2/authorize` +
+			`?client_id=${encodeURIComponent(clientMetadataUrl)}` +
+			`&response_type=code` +
+			`&redirect_uri=${encodeURIComponent(redirectUri)}` +
+			`&scope=openid` +
+			`&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM` +
+			`&code_challenge_method=S256`;
+
+		let consentRedirect = "";
+		await authedClient.$fetch(authorizeUrl, {
+			method: "GET",
+			onError(ctx) {
+				consentRedirect = ctx.response.headers.get("Location") || "";
+			},
+		});
+		expect(consentRedirect).toContain("/consent");
+
+		// Accept consent
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(consentRedirect, authServerBaseUrl).search,
+			},
+		});
+
+		const consentResponse = await authedClient.oauth2.consent(
+			{ accept: true },
+			{ throw: true },
+		);
+		expect(consentResponse.redirect).toBe(true);
+		expect(consentResponse.url).toContain(redirectUri);
+		expect(consentResponse.url).toContain("code=");
+	});
+
+	it("should advertise client_id_metadata_document_supported in discovery", async () => {
+		const config =
+			(await authorizationServer.api.getOAuthServerConfig()) as Record<
+				string,
+				unknown
+			>;
+		expect(config.client_id_metadata_document_supported).toBe(true);
+	});
+
+	it("should reject metadata document where client_id does not match URL", async ({
+		onTestFinished,
+	}) => {
+		const originalFetch = globalThis.fetch.bind(globalThis);
+		const mismatchedUrl = "https://mismatch.example.com/client-metadata.json";
+		vi.stubGlobal(
+			"fetch",
+			vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.href
+							: input.url;
+				if (url === mismatchedUrl) {
+					return Promise.resolve(
+						new Response(
+							JSON.stringify({
+								client_id: "https://wrong.example.com/other.json",
+								redirect_uris: ["https://mismatch.example.com/callback"],
+								token_endpoint_auth_method: "none",
+							}),
+							{
+								status: 200,
+								headers: { "content-type": "application/json" },
+							},
+						),
+					);
+				}
+				return originalFetch(input, init);
+			}),
+		);
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const { headers } = await signInWithTestUser();
+		const authedClient = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: authServerBaseUrl,
+			fetchOptions: { customFetchImpl, headers },
+		});
+
+		const authorizeUrl =
+			`${authServerBaseUrl}/api/auth/oauth2/authorize` +
+			`?client_id=${encodeURIComponent(mismatchedUrl)}` +
+			`&response_type=code` +
+			`&redirect_uri=${encodeURIComponent("https://mismatch.example.com/callback")}` +
+			`&scope=openid` +
+			`&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM` +
+			`&code_challenge_method=S256`;
+
+		// Should get an error, not a consent redirect
+		let errorStatus = 0;
+		await authedClient.$fetch(authorizeUrl, {
+			method: "GET",
+			onError(ctx) {
+				errorStatus = ctx.response.status;
+			},
+		});
+		expect(errorStatus).toBeGreaterThanOrEqual(400);
+	});
+});

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -17,6 +17,7 @@ export function authServerMetadata(
 	overrides?: {
 		scopes_supported?: AuthServerMetadata["scopes_supported"];
 		public_client_supported?: boolean;
+		cimd_supported?: boolean;
 		grant_types_supported?: GrantType[];
 		jwt_disabled?: boolean;
 	},
@@ -74,6 +75,7 @@ export function authServerMetadata(
 		],
 		code_challenge_methods_supported: ["S256"],
 		authorization_response_iss_parameter_supported: true,
+		client_id_metadata_document_supported: overrides?.cimd_supported,
 	};
 	return metadata;
 }
@@ -88,7 +90,10 @@ export function oidcServerMetadata(
 		: getJwtPlugin(ctx.context).options;
 	const authMetadata = authServerMetadata(ctx, jwtPluginOptions, {
 		scopes_supported: opts.advertisedMetadata?.scopes_supported ?? opts.scopes,
-		public_client_supported: opts.allowUnauthenticatedClientRegistration,
+		public_client_supported:
+			!!opts.clientIdMetadataDocument ||
+			opts.allowUnauthenticatedClientRegistration,
+		cimd_supported: !!opts.clientIdMetadataDocument,
 		grant_types_supported: opts.grantTypes,
 		jwt_disabled: opts.disableJwtPlugin,
 	});

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -336,7 +336,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							scopes_supported:
 								opts.advertisedMetadata?.scopes_supported ?? opts.scopes,
 							public_client_supported:
+								!!opts.clientIdMetadataDocument ||
 								opts.allowUnauthenticatedClientRegistration,
+							cimd_supported: !!opts.clientIdMetadataDocument,
 							grant_types_supported: opts.grantTypes,
 							jwt_disabled: opts.disableJwtPlugin,
 						});

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -130,10 +130,13 @@ export interface OAuthOptions<
 	/**
 	 * Allow unauthenticated dynamic client registration.
 	 *
-	 * Support for `allowUnauthenticatedClientRegistration` **will be deprecated**
-	 * when the MCP protocol standardizes unauthenticated dynamic client registration.
-	 * As of writing, both [Client ID Metadata Documents](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/991)
-	 * and [`software_statement` and `jwks_uri`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1032) are under debate.
+	 * When enabled, the `/oauth2/register` endpoint accepts requests
+	 * without a session, but only for public clients
+	 * (`token_endpoint_auth_method: "none"`).
+	 *
+	 * For verified client discovery (MCP), consider using
+	 * {@link clientIdMetadataDocument} instead, which verifies client
+	 * identity through domain ownership.
 	 *
 	 * @default false
 	 */
@@ -144,6 +147,59 @@ export interface OAuthOptions<
 	 * @default false
 	 */
 	allowDynamicClientRegistration?: boolean;
+	/**
+	 * Enable [Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/)
+	 * support for unauthenticated dynamic client registration.
+	 *
+	 * When present, clients can identify themselves by providing an HTTPS URL as
+	 * their `client_id`. The authorization server fetches and validates the metadata
+	 * document hosted at that URL, creating a public client automatically.
+	 *
+	 * This is the mechanism used by [MCP](https://modelcontextprotocol.io/specification/draft/basic/authorization#client-id-metadata-documents-flow)
+	 * for dynamic client discovery.
+	 *
+	 * @see https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/
+	 */
+	clientIdMetadataDocument?: {
+		/**
+		 * How frequently the server should re-fetch metadata documents to
+		 * pick up changes from the client.
+		 *
+		 * @default "60m"
+		 */
+		refreshRate?: number | string;
+		/**
+		 * Metadata fields whose URL values must share the same origin as
+		 * the `client_id` URL. This prevents a client from claiming
+		 * redirect URIs on a different domain.
+		 *
+		 * Set to an empty array to disable origin restrictions
+		 * (not recommended for production).
+		 *
+		 * @default ["redirect_uris", "post_logout_redirect_uris", "client_uri"]
+		 */
+		originBoundFields?: string[];
+		/**
+		 * Called after a client is created from a metadata document
+		 * for the first time. Use this to assign trust levels, prefetch
+		 * logos, or perform other post-creation processing.
+		 */
+		onClientCreated?: (data: {
+			client: SchemaClient<Scope[]>;
+			metadata: Record<string, unknown>;
+			ctx: GenericEndpointContext;
+		}) => Awaitable<void>;
+		/**
+		 * Called after a client is refreshed from a re-fetched metadata
+		 * document. Use this for change-detection logging or updating
+		 * derived fields.
+		 */
+		onClientRefreshed?: (data: {
+			client: SchemaClient<Scope[]>;
+			metadata: Record<string, unknown>;
+			ctx: GenericEndpointContext;
+		}) => Awaitable<void>;
+	};
 	/**
 	 * List of scopes for newly registered clients
 	 * if not requested.

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -179,6 +179,13 @@ export interface AuthServerMetadata {
 	 * @default true
 	 */
 	authorization_response_iss_parameter_supported?: boolean;
+	/**
+	 * Whether the server supports Client ID Metadata Documents
+	 * for unauthenticated dynamic client registration.
+	 *
+	 * @see https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/
+	 */
+	client_id_metadata_document_supported?: boolean;
 }
 
 /**

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -2,7 +2,7 @@ import * as z from "zod";
 
 const DANGEROUS_SCHEMES = ["javascript:", "data:", "vbscript:"];
 
-function isLocalhost(hostname: string): boolean {
+export function isLocalhost(hostname: string): boolean {
 	return (
 		hostname === "localhost" ||
 		hostname === "127.0.0.1" ||

--- a/packages/oauth-provider/src/utils/cimd.test.ts
+++ b/packages/oauth-provider/src/utils/cimd.test.ts
@@ -1,0 +1,459 @@
+import { describe, expect, it } from "vitest";
+import {
+	isUrlClientId,
+	validateCimdMetadata,
+	validateClientIdUrl,
+} from "./validate-metadata-document";
+
+function validMetadata(
+	fetchUrl: string,
+	overrides: Record<string, unknown> = {},
+) {
+	const origin = new URL(fetchUrl).origin;
+	return {
+		client_id: fetchUrl,
+		redirect_uris: [`${origin}/callback`],
+		...overrides,
+	};
+}
+
+describe("isUrlClientId", () => {
+	it("accepts https:// URLs", () => {
+		expect(isUrlClientId("https://example.com/meta")).toBe(true);
+	});
+
+	it("accepts http://localhost URLs (dev mode)", () => {
+		expect(isUrlClientId("http://localhost/meta")).toBe(true);
+		expect(isUrlClientId("http://localhost:3000/meta")).toBe(true);
+	});
+
+	it("accepts http://127.0.0.1 (dev mode)", () => {
+		expect(isUrlClientId("http://127.0.0.1/meta")).toBe(true);
+		expect(isUrlClientId("http://127.0.0.1:8080/meta")).toBe(true);
+	});
+
+	it("accepts http://[::1] (dev mode)", () => {
+		expect(isUrlClientId("http://[::1]/meta")).toBe(true);
+	});
+
+	it("accepts localhost subdomains (dev mode)", () => {
+		expect(isUrlClientId("http://app.localhost/meta")).toBe(true);
+		expect(isUrlClientId("http://app.localhost:3000/meta")).toBe(true);
+	});
+
+	it("rejects http:// non-localhost URLs", () => {
+		expect(isUrlClientId("http://example.com/meta")).toBe(false);
+	});
+
+	it("rejects non-URL strings", () => {
+		expect(isUrlClientId("my-client-id")).toBe(false);
+		expect(isUrlClientId("ftp://example.com/meta")).toBe(false);
+	});
+
+	it("rejects empty string", () => {
+		expect(isUrlClientId("")).toBe(false);
+	});
+});
+
+describe("validateClientIdUrl", () => {
+	it("accepts valid https URL with path", () => {
+		expect(
+			validateClientIdUrl("https://example.com/client-metadata.json"),
+		).toBeNull();
+	});
+
+	it("rejects URL without path", () => {
+		expect(validateClientIdUrl("https://example.com")).not.toBeNull();
+		expect(validateClientIdUrl("https://example.com/")).not.toBeNull();
+	});
+
+	it("rejects URL with fragment", () => {
+		const result = validateClientIdUrl("https://example.com/meta#frag");
+		expect(result).toContain("fragment");
+	});
+
+	it("rejects URL with dot segments", () => {
+		expect(validateClientIdUrl("https://example.com/../meta.json")).toContain(
+			"dot segments",
+		);
+		expect(validateClientIdUrl("https://example.com/./meta.json")).toContain(
+			"dot segments",
+		);
+	});
+
+	it("rejects URL with credentials", () => {
+		expect(validateClientIdUrl("https://user:pass@example.com/meta")).toContain(
+			"credentials",
+		);
+	});
+
+	it("rejects non-https non-localhost", () => {
+		const result = validateClientIdUrl("http://example.com/meta");
+		expect(result).toContain("HTTPS");
+	});
+
+	it("accepts http://localhost/meta (dev)", () => {
+		expect(validateClientIdUrl("http://localhost/meta")).toBeNull();
+		expect(validateClientIdUrl("http://localhost:8080/meta")).toBeNull();
+	});
+
+	it("rejects private IP 10.0.0.1", () => {
+		expect(validateClientIdUrl("https://10.0.0.1/meta")).toContain("private");
+	});
+
+	it("rejects private IP 172.16.0.1", () => {
+		expect(validateClientIdUrl("https://172.16.0.1/meta")).toContain("private");
+	});
+
+	it("rejects private IP 192.168.1.1", () => {
+		expect(validateClientIdUrl("https://192.168.1.1/meta")).toContain(
+			"private",
+		);
+	});
+
+	it("rejects link-local 169.254.169.254 (AWS metadata)", () => {
+		expect(validateClientIdUrl("https://169.254.169.254/meta")).toContain(
+			"private",
+		);
+	});
+
+	it("rejects loopback IP 127.0.0.1 via https", () => {
+		// 127.0.0.1 is localhost, so it should be allowed (localhost is exempt)
+		// but only over http; https://127.0.0.1 is treated as localhost
+		expect(validateClientIdUrl("https://127.0.0.1/meta")).toBeNull();
+	});
+
+	it("accepts public IP like 8.8.8.8", () => {
+		expect(validateClientIdUrl("https://8.8.8.8/meta")).toBeNull();
+	});
+
+	it("rejects IPv4-mapped IPv6 targeting private IPs", () => {
+		expect(
+			validateClientIdUrl("https://[::ffff:169.254.169.254]/meta"),
+		).toContain("private");
+		expect(validateClientIdUrl("https://[::ffff:127.0.0.1]/meta")).toContain(
+			"private",
+		);
+		expect(validateClientIdUrl("https://[::ffff:10.0.0.1]/meta")).toContain(
+			"private",
+		);
+	});
+
+	it("rejects cloud metadata hostname", () => {
+		expect(
+			validateClientIdUrl("https://metadata.google.internal/meta"),
+		).toContain("private");
+	});
+
+	it("accepts subdomain of localhost", () => {
+		expect(validateClientIdUrl("http://app.localhost/meta")).toBeNull();
+	});
+});
+
+describe("validateCimdMetadata", () => {
+	const fetchUrl = "https://example.com/client-metadata.json";
+
+	it("accepts valid metadata where client_id == fetchUrl", () => {
+		const result = validateCimdMetadata(fetchUrl, validMetadata(fetchUrl));
+		expect(result.valid).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	it("rejects when client_id != fetchUrl", () => {
+		const result = validateCimdMetadata(fetchUrl, {
+			...validMetadata(fetchUrl),
+			client_id: "https://evil.com/client-metadata.json",
+		});
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("does not match");
+	});
+
+	it("rejects when client_secret is present", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, { client_secret: "test-secret" }),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("client_secret");
+	});
+
+	it("rejects when client_secret_expires_at is present", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, { client_secret_expires_at: 0 }),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("client_secret_expires_at");
+	});
+
+	it("rejects symmetric auth method client_secret_post", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				token_endpoint_auth_method: "client_secret_post",
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("symmetric");
+	});
+
+	it("rejects symmetric auth method client_secret_basic", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				token_endpoint_auth_method: "client_secret_basic",
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("symmetric");
+	});
+
+	it("rejects symmetric auth method client_secret_jwt", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				token_endpoint_auth_method: "client_secret_jwt",
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("symmetric");
+	});
+
+	it('accepts token_endpoint_auth_method: "none"', () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, { token_endpoint_auth_method: "none" }),
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	it('accepts token_endpoint_auth_method: "private_key_jwt" with jwks', () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				token_endpoint_auth_method: "private_key_jwt",
+				jwks: { keys: [{ kty: "EC" }] },
+			}),
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	it('accepts token_endpoint_auth_method: "private_key_jwt" with jwks_uri', () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				token_endpoint_auth_method: "private_key_jwt",
+				jwks_uri: "https://example.com/.well-known/jwks.json",
+			}),
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	it("rejects private_key_jwt without jwks or jwks_uri", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				token_endpoint_auth_method: "private_key_jwt",
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("jwks");
+	});
+
+	it("rejects unknown auth method", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				token_endpoint_auth_method: "custom_method",
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("private_key_jwt");
+	});
+
+	it("rejects missing redirect_uris", () => {
+		const result = validateCimdMetadata(fetchUrl, {
+			client_id: fetchUrl,
+		});
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("redirect_uris");
+	});
+
+	it("rejects empty redirect_uris", () => {
+		const result = validateCimdMetadata(fetchUrl, {
+			client_id: fetchUrl,
+			redirect_uris: [],
+		});
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("redirect_uris");
+	});
+
+	it("rejects non-HTTP redirect_uris", () => {
+		const result = validateCimdMetadata(fetchUrl, {
+			client_id: fetchUrl,
+			redirect_uris: ["ftp://example.com/callback"],
+		});
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("redirect_uris");
+	});
+
+	it("rejects disallowed grant_types", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				grant_types: ["client_credentials"],
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("grant_types");
+	});
+
+	it("accepts allowed grant_types", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				grant_types: ["authorization_code", "refresh_token"],
+			}),
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	it("accepts authorization_code alone", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				grant_types: ["authorization_code"],
+			}),
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	it("rejects disallowed response_types", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				response_types: ["token"],
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("response_types");
+	});
+
+	it('accepts response_types: ["code"]', () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				response_types: ["code"],
+			}),
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	it("allows localhost redirect_uris for local/native app flows", () => {
+		const result = validateCimdMetadata(fetchUrl, {
+			client_id: fetchUrl,
+			redirect_uris: [
+				"http://localhost:3000/callback",
+				"http://127.0.0.1:3000/callback",
+			],
+		});
+		expect(result.valid).toBe(true);
+	});
+
+	it("validates origin-bound fields (redirect_uris origin must match client_id)", () => {
+		const result = validateCimdMetadata(fetchUrl, {
+			client_id: fetchUrl,
+			redirect_uris: ["https://other-domain.com/callback"],
+		});
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("same origin");
+	});
+
+	it("respects custom originBoundFields parameter", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			{
+				client_id: fetchUrl,
+				redirect_uris: ["https://example.com/callback"],
+				custom_field: "https://evil.com/hook",
+			},
+			["custom_field"],
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("same origin");
+	});
+
+	it("does not enforce origin on fields outside originBoundFields", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			{
+				client_id: fetchUrl,
+				redirect_uris: ["https://example.com/callback"],
+				client_uri: "https://other.com/about",
+			},
+			["redirect_uris"],
+		);
+		// client_uri is NOT in the custom originBoundFields, so origin mismatch is not checked.
+		// However, client_uri still gets SSRF validation.
+		expect(result.valid).toBe(true);
+	});
+
+	it("validates client_uri for SSRF (private address)", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				client_uri: "http://169.254.169.254/latest/meta-data/",
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("private");
+	});
+
+	it("validates logo_uri for SSRF (private address)", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				logo_uri: "http://10.0.0.1/internal-logo.png",
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("private");
+	});
+
+	it("returns warning for query string in fetchUrl", () => {
+		const urlWithQuery = "https://example.com/client-metadata.json?v=1";
+		const result = validateCimdMetadata(
+			urlWithQuery,
+			validMetadata(urlWithQuery),
+		);
+		expect(result.valid).toBe(true);
+		expect(result.warnings).toBeDefined();
+		expect(result.warnings![0]).toContain("query string");
+	});
+
+	it("rejects non-object metadata", () => {
+		expect(validateCimdMetadata(fetchUrl, null).valid).toBe(false);
+		expect(validateCimdMetadata(fetchUrl, "string").valid).toBe(false);
+		expect(validateCimdMetadata(fetchUrl, 42).valid).toBe(false);
+	});
+
+	it("rejects client_uri with non-HTTP scheme", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				client_uri: "ftp://example.com/about",
+			}),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("client_uri");
+	});
+
+	it("rejects logo_uri that is not a valid URL", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, { logo_uri: "not a url" }),
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("logo_uri");
+	});
+});

--- a/packages/oauth-provider/src/utils/cimd.ts
+++ b/packages/oauth-provider/src/utils/cimd.ts
@@ -1,0 +1,250 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import { betterFetch } from "@better-fetch/fetch";
+import { APIError } from "better-auth/api";
+import { checkOAuthClient, oauthToSchema } from "../register";
+import type { OAuthClient, OAuthOptions, SchemaClient, Scope } from "../types";
+import {
+	validateCimdMetadata,
+	validateClientIdUrl,
+} from "./validate-metadata-document";
+
+export { isUrlClientId } from "./validate-metadata-document";
+
+const FETCH_TIMEOUT_MS = 5_000;
+const MAX_RESPONSE_BYTES = 5 * 1024; // 5 KB per spec recommendation (§6.6)
+
+/** RFC 7591 / CIMD fields accepted from external metadata documents. */
+const ALLOWED_METADATA_FIELDS = new Set([
+	"client_id",
+	"redirect_uris",
+	"token_endpoint_auth_method",
+	"grant_types",
+	"response_types",
+	"client_name",
+	"client_uri",
+	"logo_uri",
+	"scope",
+	"contacts",
+	"tos_uri",
+	"policy_uri",
+	"software_id",
+	"software_version",
+	"software_statement",
+	"post_logout_redirect_uris",
+	"subject_type",
+	"jwks",
+	"jwks_uri",
+]);
+
+/**
+ * Extract only recognized RFC 7591 / CIMD fields from the metadata document.
+ * Prevents arbitrary attacker-controlled fields from leaking into the DB.
+ */
+function toOAuthClientBody(metadata: Record<string, unknown>): OAuthClient {
+	const filtered: Record<string, unknown> = {};
+	for (const key of ALLOWED_METADATA_FIELDS) {
+		if (key in metadata) {
+			filtered[key] = metadata[key];
+		}
+	}
+	return {
+		...(filtered as OAuthClient),
+		token_endpoint_auth_method:
+			(filtered.token_endpoint_auth_method as OAuthClient["token_endpoint_auth_method"]) ??
+			"none",
+	};
+}
+
+/**
+ * Create a new client from a Client ID Metadata Document.
+ * Called when a URL-format client_id is encountered for the first time.
+ *
+ * Writes the DB record directly rather than routing through
+ * `createOAuthClientEndpoint`, because CIMD clients must use the URL
+ * as their `clientId` (not a generated random ID).
+ */
+export async function createMetadataDocumentClient(
+	ctx: GenericEndpointContext,
+	clientIdUrl: string,
+	opts: OAuthOptions<Scope[]>,
+): Promise<SchemaClient<Scope[]>> {
+	const metadata = await fetchAndValidateMetadataDocument(clientIdUrl, opts);
+	const oauthClient = toOAuthClientBody(metadata);
+
+	await checkOAuthClient(oauthClient, opts, { isRegister: true });
+
+	const isPrivateKeyJwt =
+		oauthClient.token_endpoint_auth_method === "private_key_jwt";
+	const iat = Math.floor(Date.now() / 1000);
+	const schema = oauthToSchema({
+		...oauthClient,
+		// Admin-only fields: never trust from external metadata
+		disabled: undefined,
+		skip_consent: undefined,
+		enable_end_session: undefined,
+		// Preserve jwks/jwks_uri only for private_key_jwt clients
+		jwks: isPrivateKeyJwt ? oauthClient.jwks : undefined,
+		jwks_uri: isPrivateKeyJwt ? oauthClient.jwks_uri : undefined,
+		client_id: clientIdUrl,
+		client_secret: undefined,
+		client_secret_expires_at: undefined,
+		client_id_issued_at: iat,
+		public: !isPrivateKeyJwt,
+	});
+
+	const model = opts.schema?.oauthClient?.modelName ?? "oauthClient";
+	let client: SchemaClient<Scope[]>;
+	try {
+		client = await ctx.context.adapter.create<SchemaClient<Scope[]>>({
+			model,
+			data: {
+				...schema,
+				createdAt: new Date(iat * 1000),
+				updatedAt: new Date(iat * 1000),
+			},
+		});
+	} catch (err) {
+		// A concurrent request may have created this client first.
+		// If the record exists, return it; otherwise re-throw the original error.
+		const existing = await ctx.context.adapter.findOne<SchemaClient<Scope[]>>({
+			model,
+			where: [{ field: "clientId", value: clientIdUrl }],
+		});
+		if (existing) {
+			return existing;
+		}
+		throw err;
+	}
+
+	await opts.clientIdMetadataDocument?.onClientCreated?.({
+		client,
+		metadata,
+		ctx,
+	});
+
+	return client;
+}
+
+/**
+ * Refresh an existing client by re-fetching its metadata document.
+ */
+export async function refreshMetadataDocumentClient(
+	ctx: GenericEndpointContext,
+	clientIdUrl: string,
+	opts: OAuthOptions<Scope[]>,
+): Promise<SchemaClient<Scope[]>> {
+	const metadata = await fetchAndValidateMetadataDocument(clientIdUrl, opts);
+	const oauthClient = toOAuthClientBody(metadata);
+
+	await checkOAuthClient(oauthClient, opts, { isRegister: true });
+
+	const isPrivateKeyJwt =
+		oauthClient.token_endpoint_auth_method === "private_key_jwt";
+	const schema = oauthToSchema({
+		...oauthClient,
+		disabled: undefined,
+		skip_consent: undefined,
+		enable_end_session: undefined,
+		jwks: isPrivateKeyJwt ? oauthClient.jwks : undefined,
+		jwks_uri: isPrivateKeyJwt ? oauthClient.jwks_uri : undefined,
+		client_id: clientIdUrl,
+		client_secret: undefined,
+		client_secret_expires_at: undefined,
+		public: !isPrivateKeyJwt,
+	});
+
+	const model = opts.schema?.oauthClient?.modelName ?? "oauthClient";
+	const client = await ctx.context.adapter.update<SchemaClient<Scope[]>>({
+		model,
+		where: [{ field: "clientId", value: clientIdUrl }],
+		update: {
+			...schema,
+			updatedAt: new Date(Math.floor(Date.now() / 1000) * 1000),
+		},
+	});
+
+	if (!client) {
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description:
+				"Failed to update client from metadata document (client may have been deleted)",
+		});
+	}
+
+	await opts.clientIdMetadataDocument?.onClientRefreshed?.({
+		client,
+		metadata,
+		ctx,
+	});
+
+	return client;
+}
+
+/**
+ * Fetch a Client ID Metadata Document, validate it against the spec,
+ * and return the parsed metadata.
+ */
+async function fetchAndValidateMetadataDocument(
+	clientIdUrl: string,
+	opts: OAuthOptions<Scope[]>,
+): Promise<Record<string, unknown>> {
+	// §3: validate the URL structure before fetching
+	const urlError = validateClientIdUrl(clientIdUrl);
+	if (urlError) {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_client",
+			error_description: urlError,
+		});
+	}
+
+	let result: { data: Record<string, unknown> | null; error: unknown };
+	try {
+		result = await betterFetch<Record<string, unknown>>(clientIdUrl, {
+			headers: { Accept: "application/json" },
+			redirect: "error",
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		});
+	} catch (err) {
+		const isTimeout =
+			err instanceof DOMException && err.name === "TimeoutError";
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_client",
+			error_description: isTimeout
+				? `Metadata document fetch timed out after ${FETCH_TIMEOUT_MS}ms`
+				: "Failed to fetch metadata document (network error or redirect blocked)",
+		});
+	}
+
+	if (result.error || !result.data) {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_client",
+			error_description: "Metadata document returned a non-success response",
+		});
+	}
+
+	// §6.6: enforce response size limit
+	const serialized = JSON.stringify(result.data);
+	if (serialized.length > MAX_RESPONSE_BYTES) {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_client",
+			error_description: `Metadata document exceeds ${MAX_RESPONSE_BYTES / 1024}KB size limit`,
+		});
+	}
+
+	// §4.1: validate the document contents
+	const originBoundFields = opts.clientIdMetadataDocument?.originBoundFields;
+	const validation = validateCimdMetadata(
+		clientIdUrl,
+		result.data,
+		originBoundFields,
+	);
+
+	if (!validation.valid) {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_client",
+			error_description: validation.error ?? "Invalid metadata document",
+		});
+	}
+
+	return result.data;
+}

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -9,6 +9,7 @@ import {
 	symmetricEncrypt,
 } from "better-auth/crypto";
 import type { jwt } from "better-auth/plugins";
+import { toExpJWT } from "better-auth/plugins";
 import { APIError } from "better-call";
 import type { oauthProvider } from "../oauth";
 import type {
@@ -18,6 +19,11 @@ import type {
 	Scope,
 	StoreTokenType,
 } from "../types";
+import {
+	createMetadataDocumentClient,
+	isUrlClientId,
+	refreshMetadataDocumentClient,
+} from "./cimd";
 
 class TTLCache<K, V extends { expiresAt?: Date }> {
 	private cache = new Map<K, V>();
@@ -165,10 +171,27 @@ export async function getClient(
 		return Object.assign({}, trustedClient);
 	}
 
-	const dbClient = await ctx.context.adapter.findOne<SchemaClient<Scope[]>>({
+	let dbClient = await ctx.context.adapter.findOne<SchemaClient<Scope[]>>({
 		model: options.schema?.oauthClient?.modelName ?? "oauthClient",
 		where: [{ field: "clientId", value: clientId }],
 	});
+
+	if (options.clientIdMetadataDocument && isUrlClientId(clientId)) {
+		const updatedAt =
+			dbClient?.updatedAt ??
+			dbClient?.createdAt ??
+			new Date(Math.floor(Date.now() / 1000) * 1000);
+		const iat = Math.floor(updatedAt.getTime() / 1000);
+		const rate = options.clientIdMetadataDocument.refreshRate ?? "60m";
+		// toExpJWT treats numbers as absolute timestamps, so convert
+		// numeric seconds to a relative offset for correct TTL behavior
+		const exp = typeof rate === "number" ? iat + rate : toExpJWT(rate, iat);
+		if (!dbClient) {
+			dbClient = await createMetadataDocumentClient(ctx, clientId, options);
+		} else if (exp < Date.now() / 1000) {
+			dbClient = await refreshMetadataDocumentClient(ctx, clientId, options);
+		}
+	}
 
 	if (dbClient && options.cachedTrustedClients?.has(clientId)) {
 		cachedTrustedClients.set(clientId, Object.assign({}, dbClient));

--- a/packages/oauth-provider/src/utils/validate-metadata-document.ts
+++ b/packages/oauth-provider/src/utils/validate-metadata-document.ts
@@ -1,0 +1,440 @@
+// Pure validation for Client ID Metadata Documents.
+// Implements draft-ietf-oauth-client-id-metadata-document §3 and §4.1.
+// Zero side-effect imports: testable without building the monorepo.
+
+import { isLocalhost } from "../types/zod";
+
+// TODO: extract into a shared utils/ssrf.ts and unify with
+// isPrivateHostname in utils/client-assertion.ts.
+
+const DOT_SEGMENT_RE = /\/\.\.?(?:\/|$|#|\?)/;
+
+const PROHIBITED_FIELDS = new Set([
+	"client_secret",
+	"client_secret_expires_at",
+]);
+
+const SYMMETRIC_AUTH_METHODS = new Set([
+	"client_secret_post",
+	"client_secret_basic",
+	"client_secret_jwt",
+]);
+
+const ALLOWED_GRANT_TYPES = new Set(["authorization_code", "refresh_token"]);
+
+const ALLOWED_RESPONSE_TYPES = new Set(["code"]);
+
+export interface ClientIdMetadataDocumentResult {
+	valid: boolean;
+	error?: string;
+	warnings?: string[];
+}
+
+/** Check whether a dotted-decimal IPv4 address is private/reserved. */
+function isPrivateIpv4(host: string): boolean {
+	const parts = host.split(".");
+	if (parts.length !== 4 || parts.some((p) => !/^\d{1,3}$/.test(p))) {
+		return false;
+	}
+	const a = Number(parts[0]);
+	const b = Number(parts[1]);
+	return (
+		a === 127 ||
+		a === 10 ||
+		a === 0 ||
+		(a === 172 && b >= 16 && b <= 31) ||
+		(a === 192 && b === 168) ||
+		(a === 169 && b === 254) ||
+		(a === 100 && b >= 64 && b <= 127) ||
+		(a === 198 && (b === 18 || b === 19)) ||
+		(a === 192 && b === 0 && Number(parts[2]) === 2) ||
+		(a === 198 && b === 51 && Number(parts[2]) === 100) ||
+		(a === 203 && b === 0 && Number(parts[2]) === 113)
+	);
+}
+
+// Matches ::ffff:a.b.c.d (dotted-decimal, as written by humans)
+const V4_MAPPED_DOTTED_RE =
+	/^(?:0{0,4}:){0,4}:?(?:0{0,4}:)?ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/;
+
+// Matches hex-pair form (e.g. ::ffff:a9fe:a9fe), as normalized by the URL parser
+const V4_MAPPED_HEX_RE =
+	/^(?:0{0,4}:){0,4}:?(?:0{0,4}:)?ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
+
+/**
+ * Convert two hex groups from an IPv4-mapped IPv6 address to dotted-decimal IPv4.
+ * e.g. "a9fe" "a9fe" -> "169.254.169.254"
+ */
+function hexGroupsToIpv4(hi: string, lo: string): string {
+	const h = Number.parseInt(hi, 16);
+	const l = Number.parseInt(lo, 16);
+	return `${(h >> 8) & 0xff}.${h & 0xff}.${(l >> 8) & 0xff}.${l & 0xff}`;
+}
+
+/**
+ * Check whether a hostname is private/reserved per RFC 6890.
+ * Handles bracketed IPv6 (as returned by URL.hostname), IPv4-mapped
+ * IPv6 in both dotted-decimal and hex-normalized forms, and cloud
+ * metadata hostnames.
+ * No DNS resolution: runtime-compatible across all platforms.
+ */
+function isPrivateHost(hostname: string): boolean {
+	const lower = hostname.toLowerCase();
+	// Strip IPv6 brackets (URL.hostname returns "[::1]" for IPv6)
+	const host =
+		lower.startsWith("[") && lower.endsWith("]") ? lower.slice(1, -1) : lower;
+
+	if (host === "::1") {
+		return true;
+	}
+	if (isPrivateIpv4(host)) {
+		return true;
+	}
+	// IPv6 checks only when the host contains ":" (prevents false positives
+	// on DNS names starting with "fc" or "fd")
+	if (host.includes(":")) {
+		// IPv4-mapped IPv6 in dotted-decimal form (::ffff:a.b.c.d)
+		const dottedMatch = V4_MAPPED_DOTTED_RE.exec(host);
+		if (dottedMatch && isPrivateIpv4(dottedMatch[1]!)) {
+			return true;
+		}
+		// IPv4-mapped IPv6 in hex form (e.g. ::ffff:a9fe:a9fe, as normalized by URL parser)
+		const hexMatch = V4_MAPPED_HEX_RE.exec(host);
+		if (hexMatch) {
+			const ipv4 = hexGroupsToIpv4(hexMatch[1]!, hexMatch[2]!);
+			if (isPrivateIpv4(ipv4)) {
+				return true;
+			}
+		}
+		// Link-local (fe80::/10)
+		if (/^fe[89ab]/.test(host)) {
+			return true;
+		}
+		// Unique-local (fc00::/7)
+		if (host.startsWith("fc") || host.startsWith("fd")) {
+			return true;
+		}
+	}
+	if (host === "metadata.google.internal") {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Detect URL-formatted client_id (Client ID Metadata Document pattern).
+ * HTTPS always accepted; HTTP accepted for localhost variants
+ * (localhost, 127.0.0.1, [::1], *.localhost) for development.
+ */
+export function isUrlClientId(clientId: string): boolean {
+	if (clientId.startsWith("https://")) {
+		return true;
+	}
+	if (!clientId.startsWith("http://")) {
+		return false;
+	}
+	try {
+		return isLocalhost(new URL(clientId).hostname);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Validate a client_id URL per IETF draft §3.
+ * Returns null on success, error string on failure.
+ */
+export function validateClientIdUrl(url: string): string | null {
+	// §3: check raw URL for dot segments before URL class normalizes them
+	if (DOT_SEGMENT_RE.test(url)) {
+		return "client_id URL MUST NOT contain dot segments";
+	}
+
+	// §3: MUST NOT contain fragments
+	if (url.includes("#")) {
+		return "client_id URL MUST NOT contain a fragment";
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return "client_id is not a valid URL";
+	}
+
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+		return "client_id URL must use HTTPS";
+	}
+
+	if (parsed.protocol === "http:" && !isLocalhost(parsed.hostname)) {
+		return "client_id URL must use HTTPS (HTTP allowed only for localhost)";
+	}
+
+	// §3: MUST NOT contain credentials
+	if (parsed.username || parsed.password) {
+		return "client_id URL MUST NOT contain credentials";
+	}
+
+	// §3: MUST contain a path (not just scheme + authority)
+	if (parsed.pathname === "/" || parsed.pathname === "") {
+		return "client_id URL MUST contain a path component";
+	}
+
+	// SSRF: block private/reserved hosts
+	if (!isLocalhost(parsed.hostname) && isPrivateHost(parsed.hostname)) {
+		return "client_id URL must not resolve to a private or reserved address";
+	}
+
+	return null;
+}
+
+/**
+ * Check if a URL has a query string (§3 SHOULD NOT).
+ * Returns a warning string if present, null otherwise.
+ */
+function checkUrlQueryWarning(url: string): string | null {
+	try {
+		const parsed = new URL(url);
+		if (parsed.search) {
+			return "client_id URL SHOULD NOT contain a query string (§3)";
+		}
+	} catch {
+		// URL validation handled by validateClientIdUrl
+	}
+	return null;
+}
+
+function isAbsoluteHttpUri(uri: string): boolean {
+	try {
+		const parsed = new URL(uri);
+		return parsed.protocol === "http:" || parsed.protocol === "https:";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Validate a fetched Client ID Metadata Document per §4.1.
+ *
+ * @param fetchUrl - The URL the document was fetched from
+ * @param raw - The parsed JSON body of the response
+ * @param originBoundFields - Fields whose values must share the same origin as the client_id URL
+ */
+export function validateCimdMetadata(
+	fetchUrl: string,
+	raw: unknown,
+	originBoundFields?: string[],
+): ClientIdMetadataDocumentResult {
+	if (!raw || typeof raw !== "object") {
+		return { valid: false, error: "metadata document is not a JSON object" };
+	}
+
+	const doc = raw as Record<string, unknown>;
+	const warnings: string[] = [];
+
+	// §4.1: client_id MUST equal the fetch URL (simple string comparison)
+	if (doc.client_id !== fetchUrl) {
+		return {
+			valid: false,
+			error: `client_id "${String(doc.client_id)}" does not match the metadata document URL`,
+		};
+	}
+
+	// §4.1: prohibited fields MUST NOT be present
+	for (const field of PROHIBITED_FIELDS) {
+		if (field in doc) {
+			return {
+				valid: false,
+				error: `metadata document MUST NOT contain "${field}"`,
+			};
+		}
+	}
+
+	// §4.1: only non-secret auth methods are allowed
+	const ALLOWED_AUTH_METHODS = new Set(["none", "private_key_jwt"]);
+	if (
+		doc.token_endpoint_auth_method !== undefined &&
+		typeof doc.token_endpoint_auth_method !== "string"
+	) {
+		return {
+			valid: false,
+			error: "token_endpoint_auth_method must be a string",
+		};
+	}
+	if (typeof doc.token_endpoint_auth_method === "string") {
+		if (SYMMETRIC_AUTH_METHODS.has(doc.token_endpoint_auth_method)) {
+			return {
+				valid: false,
+				error: `symmetric auth method "${doc.token_endpoint_auth_method}" is prohibited for Client ID Metadata Document clients`,
+			};
+		}
+		if (!ALLOWED_AUTH_METHODS.has(doc.token_endpoint_auth_method)) {
+			return {
+				valid: false,
+				error:
+					'token_endpoint_auth_method must be "none" or "private_key_jwt" for Client ID Metadata Document clients',
+			};
+		}
+		if (
+			doc.token_endpoint_auth_method === "private_key_jwt" &&
+			!doc.jwks &&
+			!doc.jwks_uri
+		) {
+			return {
+				valid: false,
+				error:
+					"private_key_jwt requires either jwks or jwks_uri in the metadata document",
+			};
+		}
+	}
+
+	// redirect_uris: required, non-empty array of absolute HTTP(S) URIs
+	if (
+		!Array.isArray(doc.redirect_uris) ||
+		doc.redirect_uris.length === 0 ||
+		!doc.redirect_uris.every(
+			(uri: unknown) => typeof uri === "string" && isAbsoluteHttpUri(uri),
+		)
+	) {
+		return {
+			valid: false,
+			error: "redirect_uris must be a non-empty array of absolute HTTP(S) URIs",
+		};
+	}
+
+	// grant_types: must be a subset of allowed types
+	if (
+		doc.grant_types !== undefined &&
+		!(
+			Array.isArray(doc.grant_types) &&
+			doc.grant_types.every(
+				(g: unknown) => typeof g === "string" && ALLOWED_GRANT_TYPES.has(g),
+			)
+		)
+	) {
+		return {
+			valid: false,
+			error: `grant_types must be a subset of [${[...ALLOWED_GRANT_TYPES].map((g) => `"${g}"`).join(", ")}]`,
+		};
+	}
+
+	// response_types: must be a subset of allowed types
+	if (
+		doc.response_types !== undefined &&
+		!(
+			Array.isArray(doc.response_types) &&
+			doc.response_types.every(
+				(r: unknown) => typeof r === "string" && ALLOWED_RESPONSE_TYPES.has(r),
+			)
+		)
+	) {
+		return {
+			valid: false,
+			error: 'response_types must be a subset of ["code"]',
+		};
+	}
+
+	// Validate client_uri and logo_uri for SSRF if present
+	for (const field of ["client_uri", "logo_uri"] as const) {
+		if (doc[field] !== undefined && typeof doc[field] !== "string") {
+			return { valid: false, error: `${field} must be a string` };
+		}
+		if (typeof doc[field] === "string") {
+			try {
+				const parsed = new URL(doc[field]);
+				if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+					return { valid: false, error: `${field} must use HTTP(S)` };
+				}
+				if (!isLocalhost(parsed.hostname) && isPrivateHost(parsed.hostname)) {
+					return {
+						valid: false,
+						error: `${field} must not point to a private or reserved address`,
+					};
+				}
+			} catch {
+				return { valid: false, error: `${field} is not a valid URL` };
+			}
+		}
+	}
+
+	// Origin-bound fields: values must share the same origin as the client_id URL
+	const fieldsToCheck = originBoundFields ?? [
+		"redirect_uris",
+		"post_logout_redirect_uris",
+		"client_uri",
+	];
+
+	let clientIdOrigin: string;
+	try {
+		clientIdOrigin = new URL(fetchUrl).origin;
+	} catch {
+		return { valid: false, error: "client_id is not a valid URL" };
+	}
+
+	for (const key of fieldsToCheck) {
+		const value = doc[key];
+		if (value === undefined) {
+			continue;
+		}
+		let values: string[];
+		if (typeof value === "string") {
+			values = [value];
+		} else if (Array.isArray(value)) {
+			if (!value.every((v): v is string => typeof v === "string")) {
+				return {
+					valid: false,
+					error: `${key} must be a string or an array of strings`,
+				};
+			}
+			values = value;
+		} else {
+			return {
+				valid: false,
+				error: `${key} must be a string or an array of strings`,
+			};
+		}
+
+		for (const val of values) {
+			let uri: URL;
+			try {
+				uri = new URL(val);
+			} catch {
+				return {
+					valid: false,
+					error: `${key} contains an invalid URL: "${val}"`,
+				};
+			}
+
+			if (uri.protocol !== "https:" && uri.protocol !== "http:") {
+				return {
+					valid: false,
+					error: `all values for ${key} must use HTTP(S)`,
+				};
+			}
+
+			// Allow localhost redirect URIs for native/local app flows (MCP spec
+			// examples include http://127.0.0.1:3000/callback). The localhost
+			// exception only applies to redirect_uris, not to client_uri or
+			// other origin-bound fields.
+			const localhostAllowed =
+				key === "redirect_uris" && isLocalhost(uri.hostname);
+			if (uri.origin !== clientIdOrigin && !localhostAllowed) {
+				return {
+					valid: false,
+					error: `${key} value "${val}" must have the same origin as client_id (${clientIdOrigin})`,
+				};
+			}
+		}
+	}
+
+	// §3: SHOULD NOT have a query string
+	const queryWarning = checkUrlQueryWarning(fetchUrl);
+	if (queryWarning) {
+		warnings.push(queryWarning);
+	}
+
+	return {
+		valid: true,
+		...(warnings.length > 0 ? { warnings } : {}),
+	};
+}


### PR DESCRIPTION
Implements [Client ID Metadata Documents](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) (draft-ietf-oauth-client-id-metadata-document) for verified dynamic client discovery. This is the mechanism [MCP](https://modelcontextprotocol.io/specification/draft/basic/authorization#client-id-metadata-documents-flow) uses for authorization servers to discover clients without prior registration.

## New option: `clientIdMetadataDocument`

When enabled, clients can use an HTTPS URL as their `client_id`. The server fetches and validates the metadata document at that URL, creating a client automatically on first authorization request.

```ts
oauthProvider({
  clientIdMetadataDocument: {
    refreshRate: "60m",
    originBoundFields: ["redirect_uris", "post_logout_redirect_uris", "client_uri"],
    onClientCreated({ client, metadata, ctx }) { },
    onClientRefreshed({ client, metadata, ctx }) { },
  },
})
```

Configuration:
- `refreshRate`: TTL before re-fetching (default `"60m"`, accepts seconds or duration strings)
- `originBoundFields`: fields whose URLs must share the client_id origin (localhost always allowed for native app flows)
- `onClientCreated` / `onClientRefreshed`: lifecycle hooks for post-processing (trust levels, logo prefetching, change detection)

Supports `token_endpoint_auth_method: "none"` and `"private_key_jwt"` (with `jwks` or `jwks_uri`).

## Security

- SSRF protection: private/reserved IP ranges (RFC 6890), IPv4-mapped IPv6, cloud metadata endpoints; runtime-agnostic (no `node:dns`)
- Spec compliance: `client_id` must equal fetch URL, no shared secrets, no symmetric auth methods, path required, no fragments/credentials/dot-segments
- Origin-bound fields prevent cross-domain redirect URI injection
- Admin-only fields (`skip_consent`, `enable_end_session`, `disabled`) stripped from external documents
- Only recognized RFC 7591 fields persisted; arbitrary fields discarded
- 5 KB response size limit, 5-second fetch timeout, no redirect following

## Demo

https://github.com/user-attachments/assets/abee40ad-04a6-4ca4-915b-f3511b3fb73d

Closes #7184