### PR TITLE
fix(org): return empty array instead of throwing in listOrganizations

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -917,7 +917,7 @@ export const listOrganizations = <O extends OrganizationOptions>(options: O) =>
 		"/organization/list",
 		{
 			method: "GET",
-			use: [orgMiddleware, orgSessionMiddleware],
+			use: [orgMiddleware],
 			requireHeaders: true,
 			metadata: {
 				openapi: {
@@ -941,10 +941,12 @@ export const listOrganizations = <O extends OrganizationOptions>(options: O) =>
 			},
 		},
 		async (ctx) => {
+			const session = await getSessionFromCtx(ctx);
+			if (!session) {
+				return ctx.json([]);
+			}
 			const adapter = getOrgAdapter<O>(ctx.context, options);
-			const organizations = await adapter.listOrganizations(
-				ctx.context.session.user.id,
-			);
+			const organizations = await adapter.listOrganizations(session.user.id);
 			return ctx.json(organizations);
 		},
 	);


### PR DESCRIPTION
Modifies `listOrganizations` to return an empty array `[]` instead of throwing a `401 APIError` when the user is unauthenticated.

**Changes:**
- Removed strict `orgSessionMiddleware` from the route.
- Added manual session check in the handler to return `[]` if no session exists.

**Reasoning:**
Fixes DX issues in Server Components (like RootLayout) where an unauthenticated state caused crashes instead of graceful empty states.

Closes #7178

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return an empty array from listOrganizations when unauthenticated instead of throwing 401, so server components render a graceful empty state and don’t crash. Addresses Linear #7178.

- **Bug Fixes**
  - Removed orgSessionMiddleware from /organization/list.
  - Added a manual session check with getSessionFromCtx; return [] if no session, otherwise fetch using session.user.id.

<sup>Written for commit 66f48e03ad7a733a67668b899702291d4d98319c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

