### PR TITLE
fix: finalize email changes only after successful verification

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -361,6 +361,7 @@ describe("Email Verification Secondary Storage", async () => {
 				},
 			});
 			expect(sessionAfterConfirmation.data?.user.email).toBe(testUser.email);
+			expect(sessionAfterConfirmation.data?.user.emailVerified).toBe(true);
 
 			// 2. Verify new email token (token variable was updated by sendVerificationEmail mock)
 			const verificationHeaders = new Headers();


### PR DESCRIPTION
This change ensures that a user’s email address is only updated after the new email has been successfully verified.

The new email is stored temporarily in a pending state until verification completes, and session mutation during email verification has been removed. All related email verification tests pass and existing behavior remains unchanged.

fixed #7196 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalize a user's email only after successful verification to avoid unverified emails showing up in the session. This aligns the change-email flow with requirements and fixes Linear #7196.

- **Bug Fixes**
  - Store new email in pendingEmail with a 30-minute expiry; apply on verification.
  - Remove setSessionCookie updates from updateUser, changePassword, and changeEmail.
  - Send change-email verification tokens with requestType and the unmodified user.
  - Update tests to assert emailVerified is true after confirmation.

<sup>Written for commit 24d5daa380c84daa5c315eb2c93f9ec6aab66071. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

