### PR TITLE
docs: document `disableOriginCheck` in options.mdx

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -491,6 +491,7 @@ export const auth = betterAuth({
 		},
 		useSecureCookies: true,
 		disableCSRFCheck: false,
+		disableOriginCheck: false,
 		crossSubDomainCookies: {
 			enabled: true,
 			additionalCookies: ["custom_cookie"],
@@ -532,6 +533,7 @@ export const auth = betterAuth({
 - `ipAddress`: IP address configuration for rate limiting and session tracking
 - `useSecureCookies`: Use secure cookies (default: `false`)
 - `disableCSRFCheck`: Disable trusted origins check (⚠️ security risk)
+- `disableOriginCheck`: Disable origin check (⚠️ security risk)
 - `crossSubDomainCookies`: Configure cookies to be shared across subdomains
 - `cookies`: Customize cookie names and attributes
 - `defaultCookieAttributes`: Default attributes for all cookies

--- a/packages/better-auth/src/api/middlewares/origin-check.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.ts
@@ -165,7 +165,7 @@ async function validateOrigin(
 	}
 
 	if (!originHeader || originHeader === "null") {
-		throw new APIError("FORBIDDEN", { message: "Missing or null Origin" });
+		throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN);
 	}
 
 	const trustedOrigins: string[] = Array.isArray(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added disableOriginCheck to the options docs and updated the origin-check middleware to use a consistent error code for missing/null Origin. This clarifies configuration and makes error handling consistent.

- **Refactors**
  - Switched to APIError.from('FORBIDDEN', BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN) in origin-check middleware.

<sup>Written for commit 603ff838b173ef546dbd40a676593621f69cb0d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

