### PR TITLE
chore: fix missing AnonymousSession import

### DIFF
--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -18,7 +18,11 @@ import {
 import { mergeSchema } from "../../db/schema";
 import { ANONYMOUS_ERROR_CODES } from "./error-codes";
 import { schema } from "./schema";
-import type { AnonymousOptions, AnonymousSession } from "./types";
+import type {
+	AnonymousOptions,
+	AnonymousSession,
+	UserWithAnonymous,
+} from "./types";
 
 declare module "@better-auth/core" {
 	// biome-ignore lint/correctness/noUnusedVariables: Auth and Context need to be same as declared in the module


### PR DESCRIPTION
Fixes CI failure in canary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TypeScript imports in the anonymous plugin to resolve the canary CI build failure. Adds AnonymousSession and UserWithAnonymous to the types import to restore correct module augmentation typings.

<sup>Written for commit b7e8c43582111d7a852420a0bc21271e3aa439dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

