### PR TITLE
feat: implement user-defined hook positions

### DIFF
--- a/docs/content/docs/concepts/hooks.mdx
+++ b/docs/content/docs/concepts/hooks.mdx
@@ -240,6 +240,82 @@ This may be useful to use instead of using your db directly to get access to `da
 
 You can use `ctx.context.generateId` to generate Id for various reasons.
 
+## Hook Position
+
+By default, user-defined hooks run **before** plugin hooks. This is useful for pre-processing requests before plugins see them. However, sometimes you want your hooks to run **after** all plugin hooks, giving you the final say on the response.
+
+You can control when your hook runs relative to plugin hooks using the `position` option:
+
+- `"pre"` (default): Your hook runs **before** all plugin hooks
+- `"post"`: Your hook runs **after** all plugin hooks
+
+### Example: Final Response Adjustment
+
+This example shows how to use `position: "post"` to make final adjustments after all plugins have processed the request:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { createAuthMiddleware } from "better-auth/api";
+
+export const auth = betterAuth({
+    plugins: [
+        // ... your plugins
+    ],
+    hooks: {
+        // Run after all plugin hooks for final adjustments
+        after: {
+            handler: createAuthMiddleware(async (ctx) => {
+                // Access the response after plugins have modified it
+                const returned = ctx.context.returned;
+                
+                // Make final modifications
+                if (ctx.path === "/sign-up/email") {
+                    // Add custom data to response
+                    return {
+                        ...returned,
+                        customField: "added after plugins",
+                    };
+                }
+            }),
+            position: "post",
+        },
+    },
+});
+```
+
+### Example: Pre-processing Before Plugins
+
+Using the default `"pre"` position (or omitting position entirely), your hook runs before plugins:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { createAuthMiddleware, APIError } from "better-auth/api";
+
+export const auth = betterAuth({
+    hooks: {
+        // Runs before plugin hooks (default behavior)
+        before: createAuthMiddleware(async (ctx) => {
+            // Validate or modify request before plugins see it
+            if (ctx.path === "/sign-up/email") {
+                // Plugins will see this modified body
+                return {
+                    context: {
+                        body: {
+                            ...ctx.body,
+                            source: "pre-processed",
+                        },
+                    },
+                };
+            }
+        }),
+    },
+});
+```
+
+<Callout>
+The `position` option is available for both `before` and `after` hooks. Use `"post"` when you need to override or adjust what plugins have done.
+</Callout>
+
 ## Reusable Hooks
 
 If you need to reuse a hook across multiple endpoints, consider creating a plugin. Learn more in the [Plugins Documentation](/docs/concepts/plugins).

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1398,13 +1398,59 @@ export type BetterAuthOptions = {
 	hooks?:
 		| {
 				/**
-				 * Before a request is processed
+				 * Before a request is processed.
+				 *
+				 * Can be either a middleware function directly (runs before plugin hooks - "pre"),
+				 * or an object with `handler` and `position` to control execution order.
+				 *
+				 * @example
+				 * ```ts
+				 * // Simple usage (runs before plugins - "pre")
+				 * hooks: { before: (ctx) => { ... } }
+				 *
+				 * // With position control (runs after plugins - "post")
+				 * hooks: { before: { handler: (ctx) => { ... }, position: "post" } }
+				 * ```
 				 */
-				before?: AuthMiddleware;
+				before?:
+					| AuthMiddleware
+					| {
+							handler: AuthMiddleware;
+							/**
+							 * When to run the hook relative to plugin hooks.
+							 * - "pre": Run before plugin hooks (default)
+							 * - "post": Run after plugin hooks
+							 * @default "pre"
+							 */
+							position?: "pre" | "post";
+					  };
 				/**
-				 * After a request is processed
+				 * After a request is processed.
+				 *
+				 * Can be either a middleware function directly (runs before plugin hooks - "pre"),
+				 * or an object with `handler` and `position` to control execution order.
+				 *
+				 * @example
+				 * ```ts
+				 * // Simple usage (runs before plugins - "pre")
+				 * hooks: { after: (ctx) => { ... } }
+				 *
+				 * // With position control (runs after plugins - "post")
+				 * hooks: { after: { handler: (ctx) => { ... }, position: "post" } }
+				 * ```
 				 */
-				after?: AuthMiddleware;
+				after?:
+					| AuthMiddleware
+					| {
+							handler: AuthMiddleware;
+							/**
+							 * When to run the hook relative to plugin hooks.
+							 * - "pre": Run before plugin hooks (default)
+							 * - "post": Run after plugin hooks
+							 * @default "pre"
+							 */
+							position?: "pre" | "post";
+					  };
 		  }
 		| undefined;
 	/**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds hook position control so user-defined hooks can run before or after plugin hooks. Also improves multi-session cookie handling for more reliable session switching and cleanup.

- **New Features**
  - Support "pre" (default) and "post" positions for `before` and `after` hooks.
  - Hooks can be defined as a function or `{ handler, position }`.
  - Updated execution order to respect positions; added tests and docs.

- **Bug Fixes**
  - Include the active session token when listing sessions.
  - Correctly set/retain multi-session cookies when switching sessions.
  - Clean up expired/invalid multi-session cookies and avoid duplicates for the same user.
  - Enforce maximum sessions using accurate multi-session counting.

<sup>Written for commit 80f4b8e88f0095d2851b2b6c856e16729af4bc75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

