### PR TITLE
fix(one-tap): respect user dismiss actions in prompt retry logic

### DIFF
--- a/packages/better-auth/src/plugins/one-tap/client.ts
+++ b/packages/better-auth/src/plugins/one-tap/client.ts
@@ -105,6 +105,15 @@ function isFedCMSupported() {
 	return typeof window !== "undefined" && "IdentityCredential" in window;
 }
 
+/**
+ * Reasons that should NOT trigger a retry.
+ * @see https://developers.google.com/identity/gsi/web/reference/js-reference
+ */
+const noRetryReasons = {
+	dismissed: ["credential_returned", "cancel_called"],
+	skipped: ["user_cancel", "tap_outside"],
+} as const;
+
 export const oneTapClient = (options: GoogleOneTapOptions) => {
 	return {
 		id: "one-tap",
@@ -236,15 +245,6 @@ export const oneTapClient = (options: GoogleOneTapOptions) => {
 
 									window.google?.accounts.id.prompt((notification: any) => {
 										if (isResolved) return;
-
-										/**
-										 * Reasons that should NOT trigger a retry.
-										 * @see https://developers.google.com/identity/gsi/web/reference/js-reference
-										 */
-										const noRetryReasons = {
-											dismissed: ["credential_returned", "cancel_called"],
-											skipped: ["user_cancel", "tap_outside"],
-										};
 
 										if (
 											notification.isDismissedMoment &&


### PR DESCRIPTION
- Reference https://developers.google.com/identity/gsi/web/reference/js-reference

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-retrying the Google One Tap prompt when the user intentionally dismisses or skips it. Keeps exponential backoff retries for other cases and forwards the notification to onPromptNotification.

- **Bug Fixes**
  - No retry on dismissed: credential_returned, cancel_called; skipped: user_cancel, tap_outside.
  - Continue retries with exponential backoff for other reasons.
  - Always pass prompt notifications to onPromptNotification.

<sup>Written for commit 27a69ff56a296f6d300f2c79ab07ca7be7f7b4e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

