### PR TITLE
chore: clean up unused import

### DIFF
--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -11,7 +11,6 @@ import {
 	vi,
 } from "vitest";
 import * as apiModule from "../../api";
-import { createAuthClient } from "../../client";
 import { signJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../../utils/constants";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed an unused createAuthClient import from the anonymous plugin test to reduce dead code and prevent lint warnings.

<sup>Written for commit 57ecb7e8698af07a9a2c21e143300b77d0e57f79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

