### PR TITLE
fix(email-verification): sending email verification of another user fails with EMAIL_ALREADY_VERIFIED

### DIFF
--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -187,14 +187,14 @@ export const sendVerificationEmail = createAuthEndpoint(
 				status: true,
 			});
 		}
+		if (session?.user.email !== email) {
+			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.EMAIL_MISMATCH);
+		}
 		if (session?.user.emailVerified) {
 			throw APIError.from(
 				"BAD_REQUEST",
 				BASE_ERROR_CODES.EMAIL_ALREADY_VERIFIED,
 			);
-		}
-		if (session?.user.email !== email) {
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.EMAIL_MISMATCH);
 		}
 		await sendVerificationEmailFn(ctx, session.user);
 		return ctx.json({


### PR DESCRIPTION
Closes https://github.com/better-auth/better-auth/issues/5621

The `/send-verification-email` endpoint is meant to be called by the user who intends to verify the email, not someone else - such as an admin.

If you didn't know this and ran through this flow, you'll meet an unexpected error: "Email already verified" - even if the user was just created using the admin plugin.

This error stems from the admin user info being email verified, not the actual new user. Our if-statement logic to ensure that the session is equal to the email that is trying to be verified is performed later down the line from the email_already_verified error, and thus creates confusion.

This PR simply moves that if-statement earlier for devs to correctly understand the issue and that they can't call that endpoint for users.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered validation in the /send-verification-email endpoint to check for email mismatch before emailVerified. This fixes confusing EMAIL_ALREADY_VERIFIED errors when an admin tries to verify another user; the endpoint now returns EMAIL_MISMATCH and enforces that users can only verify their own email.

<sup>Written for commit f31d77ae2c74bd9480f3f111b0bfdb1bfef1b7c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

