### PR TITLE
chore: op plugin test fail

### DIFF
--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -52,7 +52,11 @@ export const getOAuthProviderPlugin = (ctx: AuthContext) => {
  * @internal
  */
 export const getJwtPlugin = (ctx: AuthContext) => {
-	return ctx.getPlugin("jwt") satisfies ReturnType<typeof jwt> | null;
+	const plugin = ctx.getPlugin("jwt") satisfies ReturnType<typeof jwt> | null;
+	if (!plugin) {
+		throw new BetterAuthError("jwt_config", "jwt plugin not found");
+	}
+	return plugin;
 };
 
 const cachedTrustedClients = new TTLCache<string, SchemaClient<Scope[]>>();


### PR DESCRIPTION
Revert breaking change preventing failure when plugin is undefined when it should be.

Fixes the failing test in `oauth.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make getJwtPlugin throw a BetterAuthError when the jwt plugin is missing, restoring fail-fast behavior. This surfaces misconfiguration early and fixes tests that expect failure.

<sup>Written for commit 7c4083542d95c62de98979ddf834eeb38f6fb497. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

