### PR TITLE
feat(oauth-provider): database hooks

### DIFF
--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -452,7 +452,7 @@ oauthProvider({
 
     // Before an existing consent is updated
     beforeUpdateConsent: async ({ consent }) => {
-      if (consent.scopes.length > 5) {
+      if (consent.scopes.split(' ').length > 5) {
         throw new Error("Too many scopes requested")
       }
     },

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -364,6 +364,118 @@ type deleteOAuthConsent = {
 </APIMethod>
 
 
+### Database Hooks
+
+The `databaseHooks` configuration option lets you tap into the lifecycle of OAuth-related database operations.
+Hooks can be used to validate input, enrich data, enforce security rules, or trigger side effects such as logging or notifications.
+
+#### OAuth Client Hooks
+
+Lifecycle hooks for the [OAuthClient](#oauth-client-1) table.
+
+Common use cases include:
+- Enforcing business rules (e.g. protecting system clients)
+- Automatically update the `metadata` or admin fields
+- Auditing client creation, updates, and deletions
+
+```ts title="auth.ts"
+oauthProvider({
+  databaseHooks: {
+    // Runs before a client is persisted
+    beforeCreateClient: async ({ schema }) => {
+      return {
+        data: {
+          ...schema,
+          metadata: {
+            ...schema.metadata,
+            createdBy: "system",
+          },
+        },
+      }
+    },
+
+    // Runs after a client has been created
+    afterCreateClient: async ({ schema }) => {
+      console.log("OAuth client created:", schema.clientId)
+    },
+
+    // Runs before an existing client is updated
+    beforeUpdateClient: async ({ schema }) => {
+      if (schema.isSystemClient) {
+        throw new Error("System clients cannot be modified")
+      }
+    },
+
+    // Runs after a client update completes
+    afterUpdateClient: async ({ schema }) => {
+      console.log("OAuth client updated:", schema.clientId)
+    },
+
+    // Runs before a client is deleted
+    beforeDeleteClient: async ({ schema }) => {
+      if (schema.isProtected) {
+        throw new Error("Protected clients cannot be deleted")
+      }
+    },
+
+    // Runs after a client has been deleted
+    afterDeleteClient: async ({ schema }) => {
+      console.log("OAuth client deleted:", schema.clientId)
+    },
+  },
+})
+```
+
+#### OAuth Consent Hooks
+
+Lifecycle hooks for the [OAuthConsent](#oauth-consent-1) table.
+
+These hooks are useful for:
+- Validating requested scopes
+- Limiting permissions
+- Tracking when users connect or disconnect third-party applications
+
+```ts title="auth.ts"
+oauthProvider({
+  databaseHooks: {
+    // Before a new consent record is created
+    beforeCreateConsent: async ({ consent }) => {
+      if (!consent.scopes.includes("profile")) {
+        throw new Error("The `profile` scope is required")
+      }
+    },
+
+    // After consent has been granted
+    afterCreateConsent: async ({ consent }) => {
+      console.log("Consent granted:", consent.id)
+    },
+
+    // Before an existing consent is updated
+    beforeUpdateConsent: async ({ consent }) => {
+      if (consent.scopes.length > 5) {
+        throw new Error("Too many scopes requested")
+      }
+    },
+
+    // After consent has been updated
+    afterUpdateConsent: async ({ consent }) => {
+      console.log("Consent updated:", consent.id)
+    },
+
+    // Before consent is revoked
+    beforeDeleteConsent: async ({ consent }) => {
+      console.log("Revoking consent:", consent.id)
+    },
+
+    // After consent has been revoked
+    afterDeleteConsent: async ({ consent }) => {
+      console.log("Consent revoked:", consent.id)
+    },
+  },
+})
+```
+
+
 ### Dynamic Registration Endpoint
 
 <Callout type="info">

--- a/packages/oauth-provider/src/oauthClient/endpoints.ts
+++ b/packages/oauth-provider/src/oauthClient/endpoints.ts
@@ -367,9 +367,12 @@ export async function rotateClientSecretEndpoint(
 			],
 			update: {
 				...(typeof additionalData === "object" && "data" in additionalData
-					? additionalData.data
+					? (additionalData.data ?? {})
 					: {}),
 				...client,
+				...(typeof additionalData === "object" && "overrides" in additionalData
+					? (additionalData.overrides ?? {})
+					: {}),
 				clientSecret: storedClientSecret,
 			},
 		},

--- a/packages/oauth-provider/src/oauthClient/endpoints.ts
+++ b/packages/oauth-provider/src/oauthClient/endpoints.ts
@@ -366,7 +366,9 @@ export async function rotateClientSecretEndpoint(
 				},
 			],
 			update: {
-				...additionalData,
+				...(typeof additionalData === "object" && "data" in additionalData
+					? additionalData.data
+					: {}),
 				...client,
 				clientSecret: storedClientSecret,
 			},

--- a/packages/oauth-provider/src/oauthConsent/endpoints.ts
+++ b/packages/oauth-provider/src/oauthConsent/endpoints.ts
@@ -162,6 +162,7 @@ export async function updateConsentEndpoint(
 			updatedAt: new Date(iat * 1000),
 		},
 	});
-	await opts.databaseHooks?.afterUpdateConsent?.({ consent });
+	if (update)
+		await opts.databaseHooks?.afterUpdateConsent?.({ consent: update });
 	return update;
 }

--- a/packages/oauth-provider/src/oauthConsent/endpoints.ts
+++ b/packages/oauth-provider/src/oauthConsent/endpoints.ts
@@ -89,6 +89,7 @@ export async function deleteConsentEndpoint(
 	}
 	if (consent.userId !== session.user.id) throw new APIError("UNAUTHORIZED");
 
+	await opts.databaseHooks?.beforeDeleteConsent?.({ consent });
 	await ctx.context.adapter.delete({
 		model: "oauthConsent",
 		where: [
@@ -98,6 +99,7 @@ export async function deleteConsentEndpoint(
 			},
 		],
 	});
+	await opts.databaseHooks?.afterDeleteConsent?.({ consent });
 }
 
 export async function updateConsentEndpoint(
@@ -146,7 +148,8 @@ export async function updateConsentEndpoint(
 	}
 
 	const iat = Math.floor(Date.now() / 1000);
-	return await ctx.context.adapter.update<OAuthConsent<Scope[]>>({
+	await opts.databaseHooks?.beforeUpdateConsent?.({ consent });
+	const update = await ctx.context.adapter.update<OAuthConsent<Scope[]>>({
 		model: "oauthConsent",
 		where: [
 			{
@@ -159,4 +162,6 @@ export async function updateConsentEndpoint(
 			updatedAt: new Date(iat * 1000),
 		},
 	});
+	await opts.databaseHooks?.afterUpdateConsent?.({ consent });
+	return update;
 }

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -193,9 +193,12 @@ export async function createOAuthClientEndpoint(
 		model: "oauthClient",
 		data: {
 			...(typeof additionalData === "object" && "data" in additionalData
-				? additionalData.data
+				? (additionalData.data ?? {})
 				: {}),
 			...schema,
+			...(typeof additionalData === "object" && "overrides" in additionalData
+				? (additionalData.overrides ?? {})
+				: {}),
 			createdAt: new Date(iat * 1000),
 			updatedAt: new Date(iat * 1000),
 		},

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -132,11 +132,15 @@ export interface OAuthOptions<
 		 * - Notify a user/org that a client was created
 		 * - Add other metadata to the client
 		 *
-		 * Returning `{ data }` will replace the schema used for creation.
+		 * Returning `{ data }` will safely add to the schema used for creation.
+		 * Returning `{ overrides }` will replace the schema values used for creation.
 		 */
 		beforeCreateClient?: (data?: {
 			schema: SchemaClient<Scope[]>;
-		}) => Promise<void | { data: SchemaClient }>;
+		}) => Promise<void | {
+			data?: Partial<SchemaClient>;
+			overrides?: Partial<SchemaClient>;
+		}>;
 		/**
 		 * Runs after an OAuth client has been created successfully
 		 * such as for auditing/logging.
@@ -151,11 +155,15 @@ export interface OAuthOptions<
 		 * - Notify a user/org that a client was updated
 		 * - Add other metadata to the client
 		 *
-		 * Returning `{ data }` will replace the schema used for the update.
+		 * Returning `{ data }` will safely add to the schema used for the update.
+		 * Returning `{ overrides }` will replace the schema values used for the update.
 		 */
 		beforeUpdateClient?: (data?: {
 			schema: SchemaClient<Scope[]>;
-		}) => Promise<void | { data: SchemaClient }>;
+		}) => Promise<void | {
+			data?: Partial<SchemaClient>;
+			overrides?: Partial<SchemaClient>;
+		}>;
 		/**
 		 * Runs after an OAuth client has been updated
 		 * such as for auditing/logging.

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -116,42 +116,105 @@ export interface OAuthOptions<
 		[K in Scopes[number]]?: number | string | Date;
 	};
 	/**
-	 * Database hooks
+	 * Database lifecycle hooks for the OAuth provider.
+	 *
+	 * These hooks allow you to run custom logic before or after
+	 * OAuth-related entities are created, updated, or deleted.
+	 *
+	 * All hooks are optional. If provided, they are executed in sequence
+	 * with the core database operation.
 	 */
 	databaseHooks?: {
+		/**
+		 * Runs before an OAuth client is created.
+		 *
+		 * Use this hook to:
+		 * - Notify a user/org that a client was created
+		 * - Add other metadata to the client
+		 *
+		 * Returning `{ data }` will replace the schema used for creation.
+		 */
 		beforeCreateClient?: (data?: {
 			schema: SchemaClient<Scope[]>;
 		}) => Promise<void | { data: SchemaClient }>;
+		/**
+		 * Runs after an OAuth client has been created successfully
+		 * such as for auditing/logging.
+		 */
 		afterCreateClient?: (data?: {
 			schema: SchemaClient<Scope[]>;
 		}) => Promise<void>;
+		/**
+		 * Runs before an OAuth client is updated.
+		 *
+		 * Use this hook to:
+		 * - Notify a user/org that a client was created
+		 * - Add other metadata to the client
+		 *
+		 * Returning `{ data }` will replace the schema used for the update.
+		 */
 		beforeUpdateClient?: (data?: {
 			schema: SchemaClient<Scope[]>;
 		}) => Promise<void | { data: SchemaClient }>;
+		/**
+		 * Runs after an OAuth client has been updated
+		 * such as for auditing/logging.
+		 */
 		afterUpdateClient?: (data?: {
 			schema: SchemaClient<Scope[]>;
 		}) => Promise<void>;
+		/**
+		 * Runs before an OAuth client is deleted
+		 * such as for auditing/logging.
+		 */
 		beforeDeleteClient?: (data?: {
 			schema: SchemaClient<Scope[]>;
 		}) => Promise<void>;
+		/**
+		 * Runs after an OAuth client has been deleted
+		 * such as for auditing/logging.
+		 */
 		afterDeleteClient?: (data?: {
 			schema: SchemaClient<Scope[]>;
 		}) => Promise<void>;
+		/**
+		 * Runs before a consent record is created.
+		 *
+		 * Use this hook to validate scopes or user permissions.
+		 */
 		beforeCreateConsent?: (data?: {
 			consent: Omit<OAuthConsent<Scope[]>, "id">;
 		}) => Promise<void>;
+		/**
+		 * Runs after a consent record has been created.
+		 */
 		afterCreateConsent?: (data?: {
 			consent: OAuthConsent<Scope[]>;
 		}) => Promise<void>;
+		/**
+		 * Runs before a consent record is updated.
+		 *
+		 * Use this hook to restrict changes to scopes
+		 * or enforce re-authorization rules.
+		 */
 		beforeUpdateConsent?: (data?: {
 			consent: OAuthConsent<Scope[]>;
 		}) => Promise<void>;
+		/**
+		 * Runs after a consent record has been updated.
+		 */
 		afterUpdateConsent?: (data?: {
 			consent: OAuthConsent<Scope[]>;
 		}) => Promise<void>;
+		/**
+		 * Runs before a consent record is deleted.
+		 */
 		beforeDeleteConsent?: (data?: {
 			consent: OAuthConsent<Scope[]>;
 		}) => Promise<void>;
+		/**
+		 * Runs after a consent record has been deleted.
+		 */
 		afterDeleteConsent?: (data?: {
 			consent: OAuthConsent<Scope[]>;
 		}) => Promise<void>;

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -116,6 +116,47 @@ export interface OAuthOptions<
 		[K in Scopes[number]]?: number | string | Date;
 	};
 	/**
+	 * Database hooks
+	 */
+	databaseHooks?: {
+		beforeCreateClient?: (data?: {
+			schema: SchemaClient<Scope[]>;
+		}) => Promise<void | { data: SchemaClient }>;
+		afterCreateClient?: (data?: {
+			schema: SchemaClient<Scope[]>;
+		}) => Promise<void>;
+		beforeUpdateClient?: (data?: {
+			schema: SchemaClient<Scope[]>;
+		}) => Promise<void | { data: SchemaClient }>;
+		afterUpdateClient?: (data?: {
+			schema: SchemaClient<Scope[]>;
+		}) => Promise<void>;
+		beforeDeleteClient?: (data?: {
+			schema: SchemaClient<Scope[]>;
+		}) => Promise<void>;
+		afterDeleteClient?: (data?: {
+			schema: SchemaClient<Scope[]>;
+		}) => Promise<void>;
+		beforeCreateConsent?: (data?: {
+			consent: Omit<OAuthConsent<Scope[]>, "id">;
+		}) => Promise<void>;
+		afterCreateConsent?: (data?: {
+			consent: OAuthConsent<Scope[]>;
+		}) => Promise<void>;
+		beforeUpdateConsent?: (data?: {
+			consent: OAuthConsent<Scope[]>;
+		}) => Promise<void>;
+		afterUpdateConsent?: (data?: {
+			consent: OAuthConsent<Scope[]>;
+		}) => Promise<void>;
+		beforeDeleteConsent?: (data?: {
+			consent: OAuthConsent<Scope[]>;
+		}) => Promise<void>;
+		afterDeleteConsent?: (data?: {
+			consent: OAuthConsent<Scope[]>;
+		}) => Promise<void>;
+	};
+	/**
 	 * Allow unauthenticated dynamic client registration.
 	 *
 	 * Support for `allowUnauthenticatedClientRegistration` **will be deprecated**

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -148,7 +148,7 @@ export interface OAuthOptions<
 		 * Runs before an OAuth client is updated.
 		 *
 		 * Use this hook to:
-		 * - Notify a user/org that a client was created
+		 * - Notify a user/org that a client was updated
 		 * - Add other metadata to the client
 		 *
 		 * Returning `{ data }` will replace the schema used for the update.


### PR DESCRIPTION
Add lifecycle hooks for `OAuthClient` and `OAuthConsent` tables similar to the structure of the [organization plugin](https://www.better-auth.com/docs/plugins/organization#organization-hooks).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds database lifecycle hooks to the OAuth provider for OAuthClient and OAuthConsent operations. This enables validation, auditing, and metadata changes around create, update, and delete.

- **New Features**
  - New databaseHooks option with before/after hooks for client and consent create/update/delete.
  - Client create/update hooks can return { data } to add fields or { overrides } to replace persisted values.
  - Endpoints call hooks around adapter operations to enforce rules or log events.
  - Docs updated with usage examples.

<sup>Written for commit 6bf0e1b0e9b048e142d2a9fc0b3decfe2adb6a62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

