### PR TITLE
feat(magic-link): add support for JSON response

### DIFF
--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -116,16 +116,83 @@ If you want to handle the verification manually, (e.g, if you send the user a di
 ```ts
 type magicLinkVerify = {
     /**
-     * Verification token. 
+     * Verification token.
      */
     token: string = "123456"
     /**
-     * URL to redirect after magic link verification, if not provided will return the session. 
+     * URL to redirect after magic link verification, if not provided will return the session.
      */
     callbackURL?: string = "/dashboard"
+    /**
+     * If set to true, returns JSON response instead of redirecting. Useful for programmatic verification.
+     */
+    disableRedirect?: boolean = false
 }
 ```
 </APIMethod>
+
+#### Programmatic Verification with JSON Response
+
+By default, the verification endpoint redirects the user to the specified callback URLs. However, you can use JSON-based responses for programmatic verification by setting `disableRedirect` to `true`:
+
+```tsx title="components/verify-code.tsx"
+const handleVerifyCode = async (code: string) => {
+  await authClient.magicLink.verify(
+    {
+      query: {
+        token: code,
+        disableRedirect: true  // Enable JSON response mode
+      },
+    },
+    {
+      onSuccess: async (context) => {
+        console.log("Code verified successfully");
+
+        // Access session data
+        const { session, user, isNewUser } = context.data;
+        console.log("Session token:", session.token);
+        console.log("User email:", user.email);
+
+        if (isNewUser) {
+          // Handle new user flow
+          router.push("/welcome");
+        } else {
+          // Handle existing user flow
+          router.push("/dashboard");
+        }
+      },
+      onError: (context) => {
+        // Handle errors with proper messages
+        console.error("Verification failed:", context.error);
+        toast.error(context.error.message);
+      },
+    },
+  );
+};
+```
+
+**Response Format:**
+
+When `disableRedirect` is `true`, successful verification returns:
+
+```ts
+{
+  session: {
+    token: string;
+    expiresAt: Date;
+  };
+  user: {
+    id: string;
+    email: string;
+    emailVerified: boolean;
+    name: string;
+    image: string;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  isNewUser: boolean;
+}
+```
 
 ## Configuration Options
 

--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -171,29 +171,6 @@ const handleVerifyCode = async (code: string) => {
 };
 ```
 
-**Response Format:**
-
-When `disableRedirect` is `true`, successful verification returns:
-
-```ts
-{
-  session: {
-    token: string;
-    expiresAt: Date;
-  };
-  user: {
-    id: string;
-    email: string;
-    emailVerified: boolean;
-    name: string;
-    image: string;
-    createdAt: Date;
-    updatedAt: Date;
-  };
-  isNewUser: boolean;
-}
-```
-
 ## Configuration Options
 
 **sendMagicLink**: The `sendMagicLink` function is called when a user requests a magic link. It takes an object with the following properties:

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -4,6 +4,7 @@ import type {
 	GenericEndpointContext,
 } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
+import { APIError } from "@better-auth/core/error";
 import * as z from "zod";
 import { originCheck } from "../../api";
 import { setSessionCookie } from "../../cookies";
@@ -145,6 +146,10 @@ const magicLinkVerifyQuerySchema = z.object({
 				"URL to redirect after new user signup. Only used if the user is registering for the first time.",
 		})
 		.optional(),
+	disableRedirect: z.boolean().meta({
+		description:
+			"If set to true, the endpoint will return JSON response instead of redirecting.",
+	}),
 });
 export const magicLink = (options: MagicLinkOptions) => {
 	const opts = {
@@ -328,6 +333,8 @@ export const magicLink = (options: MagicLinkOptions) => {
 				},
 				async (ctx) => {
 					const token = ctx.query.token;
+					const disableRedirect = ctx.query.disableRedirect === true;
+
 					// If the first argument provides the origin, it will ignore the second argument of `new URL`.
 					// new URL("http://localhost:3001/hello", "http://localhost:3000").toString()
 					// Returns http://localhost:3001/hello
@@ -344,7 +351,12 @@ export const magicLink = (options: MagicLinkOptions) => {
 						ctx.context.baseURL,
 					);
 
-					function redirectWithError(error: string): never {
+					function handleError(error: string, message?: string): never {
+						if (disableRedirect) {
+							throw new APIError("BAD_REQUEST", {
+								message: message || error,
+							});
+						}
 						errorCallbackURL.searchParams.set("error", error);
 						throw ctx.redirect(errorCallbackURL.toString());
 					}
@@ -361,13 +373,13 @@ export const magicLink = (options: MagicLinkOptions) => {
 							storedToken,
 						);
 					if (!tokenValue) {
-						redirectWithError("INVALID_TOKEN");
+						handleError("INVALID_TOKEN", "Invalid or expired token");
 					}
 					if (tokenValue.expiresAt < new Date()) {
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 							storedToken,
 						);
-						redirectWithError("EXPIRED_TOKEN");
+						handleError("EXPIRED_TOKEN", "Token has expired");
 					}
 					const {
 						email,
@@ -410,10 +422,13 @@ export const magicLink = (options: MagicLinkOptions) => {
 							isNewUser = true;
 							user = newUser;
 							if (!user) {
-								redirectWithError("failed_to_create_user");
+								handleError("failed_to_create_user", "Failed to create user");
 							}
 						} else {
-							redirectWithError("new_user_signup_disabled");
+							handleError(
+								"new_user_signup_disabled",
+								"New user signup is disabled",
+							);
 						}
 					}
 
@@ -428,13 +443,33 @@ export const magicLink = (options: MagicLinkOptions) => {
 					);
 
 					if (!session) {
-						redirectWithError("failed_to_create_session");
+						handleError("failed_to_create_session", "Failed to create session");
 					}
 
 					await setSessionCookie(ctx, {
 						session,
 						user,
 					});
+
+					if (disableRedirect) {
+						return ctx.json({
+							session: {
+								token: session.token,
+								expiresAt: session.expiresAt,
+							},
+							user: {
+								id: user.id,
+								email: user.email,
+								emailVerified: user.emailVerified,
+								name: user.name,
+								image: user.image,
+								createdAt: user.createdAt,
+								updatedAt: user.updatedAt,
+							},
+							isNewUser,
+						});
+					}
+
 					if (!ctx.query.callbackURL) {
 						return ctx.json({
 							token: session.token,
@@ -442,6 +477,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 							session: parseSessionOutput(ctx.context.options, session),
 						});
 					}
+
 					if (isNewUser) {
 						throw ctx.redirect(newUserCallbackURL);
 					}

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -146,7 +146,7 @@ const magicLinkVerifyQuerySchema = z.object({
 				"URL to redirect after new user signup. Only used if the user is registering for the first time.",
 		})
 		.optional(),
-	disableRedirect: z.boolean().meta({
+	disableRedirect: z.coerce.boolean().optional().meta({
 		description:
 			"If set to true, the endpoint will return JSON response instead of redirecting.",
 	}),

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -468,6 +468,106 @@ describe("magic link verify origin validation", async () => {
 	});
 });
 
+describe("magic link JSON response mode", async () => {
+	let verificationEmail: VerificationEmail = {
+		email: "",
+		token: "",
+		url: "",
+	};
+	const { customFetchImpl, testUser, sessionSetter } = await getTestInstance({
+		plugins: [
+			magicLink({
+				async sendMagicLink(data) {
+					verificationEmail = data;
+				},
+			}),
+		],
+	});
+
+	const client = createAuthClient({
+		plugins: [magicLinkClient()],
+		fetchOptions: {
+			customFetchImpl,
+		},
+		baseURL: "http://localhost:3000",
+		basePath: "/api/auth",
+	});
+
+	it("should verify magic link with JSON response when disableRedirect is true", async () => {
+		await client.signIn.magicLink({
+			email: testUser.email,
+		});
+
+		const headers = new Headers();
+		const response = await client.magicLink.verify({
+			query: {
+				token: new URL(verificationEmail.url).searchParams.get("token") || "",
+				disableRedirect: "true",
+			},
+			fetchOptions: {
+				onSuccess: sessionSetter(headers),
+			},
+		});
+
+		expect(response.data).toBeDefined();
+		expect(response.data?.session).toBeDefined();
+		expect(response.data?.session.token).toBeDefined();
+		expect(response.data?.user).toBeDefined();
+		expect(response.data?.user.email).toBe(testUser.email);
+		expect(response.data?.isNewUser).toBeDefined();
+		const betterAuthCookie = headers.get("set-cookie");
+		expect(betterAuthCookie).toBeDefined();
+	});
+
+	it("should return JSON error when disableRedirect is true and token is invalid", async () => {
+		const response = await client.magicLink.verify(
+			{
+				query: {
+					token: "invalid-token-12345",
+					disableRedirect: "true",
+				},
+			},
+			{
+				onError(context) {
+					expect(context.response.status).toBe(400);
+					expect(context.error).toBeDefined();
+					expect(context.error?.message).toContain("Invalid or expired token");
+				},
+			},
+		);
+
+		expect(response.error).toBeDefined();
+	});
+
+	it("should return JSON error when disableRedirect is true and token is expired", async () => {
+		await client.signIn.magicLink({
+			email: testUser.email,
+		});
+		const token = verificationEmail.token;
+
+		vi.useFakeTimers();
+		await vi.advanceTimersByTimeAsync(1000 * 60 * 5 + 1);
+
+		await client.magicLink.verify(
+			{
+				query: {
+					token,
+					disableRedirect: "true",
+				},
+			},
+			{
+				onError(context) {
+					expect(context.response.status).toBe(400);
+					expect(context.error).toBeDefined();
+					expect(context.error?.message).toContain("Token has expired");
+				},
+			},
+		);
+
+		vi.useRealTimers();
+	});
+});
+
 describe("magic link storeToken", async () => {
 	it("should store token in hashed", async () => {
 		let verificationEmail: VerificationEmail = {

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -80,9 +80,10 @@ describe("magic link", async () => {
 			},
 		});
 		expect(response.data).toBeDefined();
-		// Legacy format returns { token, user }
 		if (response.data && "token" in response.data) {
 			expect(response.data.token).toBeDefined();
+		} else {
+			throw new Error("Unexpected response format");
 		}
 		const betterAuthCookie = headers.get("set-cookie");
 		expect(betterAuthCookie).toBeDefined();
@@ -418,9 +419,10 @@ describe("magic link verify", async () => {
 			},
 		});
 		expect(response.data).toBeDefined();
-		// Legacy format returns { token, user }
 		if (response.data && "token" in response.data) {
 			expect(response.data.token).toBeDefined();
+		} else {
+			throw new Error("Unexpected response format");
 		}
 		const betterAuthCookie = headers.get("set-cookie");
 		expect(betterAuthCookie).toBeDefined();
@@ -518,13 +520,14 @@ describe("magic link JSON response mode", async () => {
 		});
 
 		expect(response.data).toBeDefined();
-		// New format with disableRedirect returns { session, user, isNewUser }
 		if (response.data && "session" in response.data) {
 			expect(response.data.session).toBeDefined();
 			expect(response.data.session.token).toBeDefined();
 			expect(response.data.user).toBeDefined();
 			expect(response.data.user.email).toBe(testUser.email);
 			expect(response.data.isNewUser).toBeDefined();
+		} else {
+			throw new Error("Unexpected response format");
 		}
 		const betterAuthCookie = headers.get("set-cookie");
 		expect(betterAuthCookie).toBeDefined();

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -79,7 +79,11 @@ describe("magic link", async () => {
 				onSuccess: sessionSetter(headers),
 			},
 		});
-		expect(response.data?.token).toBeDefined();
+		expect(response.data).toBeDefined();
+		// Legacy format returns { token, user }
+		if (response.data && "token" in response.data) {
+			expect(response.data.token).toBeDefined();
+		}
 		const betterAuthCookie = headers.get("set-cookie");
 		expect(betterAuthCookie).toBeDefined();
 	});
@@ -413,7 +417,11 @@ describe("magic link verify", async () => {
 				onSuccess: sessionSetter(headers),
 			},
 		});
-		expect(response.data?.token).toBeDefined();
+		expect(response.data).toBeDefined();
+		// Legacy format returns { token, user }
+		if (response.data && "token" in response.data) {
+			expect(response.data.token).toBeDefined();
+		}
 		const betterAuthCookie = headers.get("set-cookie");
 		expect(betterAuthCookie).toBeDefined();
 	});
@@ -502,7 +510,7 @@ describe("magic link JSON response mode", async () => {
 		const response = await client.magicLink.verify({
 			query: {
 				token: new URL(verificationEmail.url).searchParams.get("token") || "",
-				disableRedirect: "true",
+				disableRedirect: true,
 			},
 			fetchOptions: {
 				onSuccess: sessionSetter(headers),
@@ -510,11 +518,14 @@ describe("magic link JSON response mode", async () => {
 		});
 
 		expect(response.data).toBeDefined();
-		expect(response.data?.session).toBeDefined();
-		expect(response.data?.session.token).toBeDefined();
-		expect(response.data?.user).toBeDefined();
-		expect(response.data?.user.email).toBe(testUser.email);
-		expect(response.data?.isNewUser).toBeDefined();
+		// New format with disableRedirect returns { session, user, isNewUser }
+		if (response.data && "session" in response.data) {
+			expect(response.data.session).toBeDefined();
+			expect(response.data.session.token).toBeDefined();
+			expect(response.data.user).toBeDefined();
+			expect(response.data.user.email).toBe(testUser.email);
+			expect(response.data.isNewUser).toBeDefined();
+		}
 		const betterAuthCookie = headers.get("set-cookie");
 		expect(betterAuthCookie).toBeDefined();
 	});
@@ -524,7 +535,7 @@ describe("magic link JSON response mode", async () => {
 			{
 				query: {
 					token: "invalid-token-12345",
-					disableRedirect: "true",
+					disableRedirect: true,
 				},
 			},
 			{
@@ -552,7 +563,7 @@ describe("magic link JSON response mode", async () => {
 			{
 				query: {
 					token,
-					disableRedirect: "true",
+					disableRedirect: true,
 				},
 			},
 			{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add JSON response mode to magic link verification to support programmatic flows without redirects. Default redirect behavior remains unchanged.

- **New Features**
  - Added `disableRedirect` query param to `magicLink.verify`; when true, returns JSON instead of redirecting.
  - Success JSON includes `session` (token, expiresAt), `user` fields, and `isNewUser`; session cookie is still set.
  - Errors return 400 JSON with clear messages (invalid/expired token, signup disabled, failed to create user/session).

<sup>Written for commit 14deccaadea00edec053b69edcf94fb16f794c1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

