### PR TITLE
fix(two-factor): updated backup codes respect `storeBackupCodes` option

### DIFF
--- a/.changeset/fix-backup-codes-storage.md
+++ b/.changeset/fix-backup-codes-storage.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+fix(two-factor): preserve backup codes storage format after verification
+
+After using a backup code, remaining codes are now re-saved using the same `storeBackupCodes` strategy (plain, encrypted, or custom) configured by the user. Previously, codes were always re-encrypted with the built-in symmetric encryption, breaking subsequent verifications for plain or custom storage modes.

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -63,6 +63,24 @@ function generateBackupCodesFn(options?: BackupCodeOptions | undefined) {
 		.map((code) => `${code.slice(0, 5)}-${code.slice(5)}`);
 }
 
+export async function encodeBackupCodes(
+	codes: string[],
+	secret: string | SecretConfig,
+	options?: BackupCodeOptions | undefined,
+): Promise<string> {
+	const json = JSON.stringify(codes);
+	if (options?.storeBackupCodes === "encrypted") {
+		return symmetricEncrypt({ data: json, key: secret });
+	}
+	if (
+		typeof options?.storeBackupCodes === "object" &&
+		"encrypt" in options.storeBackupCodes
+	) {
+		return options.storeBackupCodes.encrypt(json);
+	}
+	return json;
+}
+
 export async function generateBackupCodes(
 	secret: string | SecretConfig,
 	options?: BackupCodeOptions | undefined,
@@ -70,30 +88,9 @@ export async function generateBackupCodes(
 	const backupCodes = options?.customBackupCodesGenerate
 		? options.customBackupCodesGenerate()
 		: generateBackupCodesFn(options);
-	if (options?.storeBackupCodes === "encrypted") {
-		const encCodes = await symmetricEncrypt({
-			data: JSON.stringify(backupCodes),
-			key: secret,
-		});
-		return {
-			backupCodes,
-			encryptedBackupCodes: encCodes,
-		};
-	}
-	if (
-		typeof options?.storeBackupCodes === "object" &&
-		"encrypt" in options?.storeBackupCodes
-	) {
-		return {
-			backupCodes,
-			encryptedBackupCodes: await options?.storeBackupCodes.encrypt(
-				JSON.stringify(backupCodes),
-			),
-		};
-	}
 	return {
 		backupCodes,
-		encryptedBackupCodes: JSON.stringify(backupCodes),
+		encryptedBackupCodes: await encodeBackupCodes(backupCodes, secret, options),
 	};
 }
 
@@ -346,16 +343,17 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 						ctx.context.secretConfig,
 						opts,
 					);
-					if (!validate.status) {
+					if (!validate.status || !validate.updated) {
 						throw APIError.from(
 							"UNAUTHORIZED",
 							TWO_FACTOR_ERROR_CODES.INVALID_BACKUP_CODE,
 						);
 					}
-					const updatedBackupCodes = await symmetricEncrypt({
-						key: ctx.context.secretConfig,
-						data: JSON.stringify(validate.updated),
-					});
+					const updatedBackupCodes = await encodeBackupCodes(
+						validate.updated,
+						ctx.context.secretConfig,
+						opts,
+					);
 
 					const updated = await ctx.context.adapter.update({
 						model: twoFactorTable,

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -74,7 +74,7 @@ export async function encodeBackupCodes(
 	}
 	if (
 		typeof options?.storeBackupCodes === "object" &&
-		"encrypt" in options.storeBackupCodes
+		"encrypt" in options?.storeBackupCodes
 	) {
 		return options.storeBackupCodes.encrypt(json);
 	}

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -2433,3 +2433,124 @@ describe("2FA enforcement on non-credential sign-in paths", async () => {
 		expect(json.twoFactorRedirect).toBeUndefined();
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/pull/7231
+ */
+describe("backup codes storage configurations", () => {
+	const customEncrypt = async (data: string) =>
+		Buffer.from(data).toString("base64") + ":custom";
+	const customDecrypt = async (data: string) => {
+		const [encoded] = data.split(":custom");
+		return Buffer.from(encoded!, "base64").toString("utf-8");
+	};
+
+	const modes = [
+		{
+			name: "plain",
+			config: "plain" as const,
+			decodeStored: (raw: string) => JSON.parse(raw) as string[],
+			verifyFormat: (_raw: string) => {},
+		},
+		{
+			name: "encrypted",
+			config: "encrypted" as const,
+			decodeStored: async (raw: string) =>
+				JSON.parse(
+					await symmetricDecrypt({ key: DEFAULT_SECRET, data: raw }),
+				) as string[],
+			verifyFormat: (raw: string) => {
+				expect(() => JSON.parse(raw)).toThrow();
+			},
+		},
+		{
+			name: "custom",
+			config: { encrypt: customEncrypt, decrypt: customDecrypt },
+			decodeStored: async (raw: string) =>
+				JSON.parse(await customDecrypt(raw)) as string[],
+			verifyFormat: (raw: string) => {
+				expect(raw).toContain(":custom");
+			},
+		},
+	];
+
+	for (const mode of modes) {
+		it(`should preserve ${mode.name} storage format after backup code verification`, async () => {
+			const { client, testUser, sessionSetter, db } = await getTestInstance(
+				{
+					secret: DEFAULT_SECRET,
+					plugins: [
+						twoFactor({
+							backupCodeOptions: { storeBackupCodes: mode.config },
+							skipVerificationOnEnable: true,
+						}),
+					],
+				},
+				{ clientOptions: { plugins: [twoFactorClient()] } },
+			);
+
+			const headers = new Headers();
+			const session = await client.signIn.email({
+				email: testUser.email,
+				password: testUser.password,
+				fetchOptions: { onSuccess: sessionSetter(headers) },
+			});
+
+			const enableRes = await client.twoFactor.enable({
+				password: testUser.password,
+				fetchOptions: { headers },
+			});
+
+			const initialCodes = enableRes.data?.backupCodes!;
+			expect(initialCodes).toHaveLength(10);
+
+			// Verify initial storage format
+			const twoFactorBefore = await db.findOne<TwoFactorTable>({
+				model: "twoFactor",
+				where: [{ field: "userId", value: session.data?.user.id as string }],
+			});
+			mode.verifyFormat(twoFactorBefore!.backupCodes);
+			const storedCodes = await mode.decodeStored(twoFactorBefore!.backupCodes);
+			expect(storedCodes).toEqual(initialCodes);
+
+			// Use a backup code
+			const signInHeaders = new Headers();
+			await client.signIn.email({
+				email: testUser.email,
+				password: testUser.password,
+				fetchOptions: {
+					onSuccess(context) {
+						const parsed = parseSetCookieHeader(
+							context.response.headers.get("Set-Cookie") || "",
+						);
+						signInHeaders.append(
+							"cookie",
+							`better-auth.two_factor=${parsed.get("better-auth.two_factor")?.value}`,
+						);
+					},
+				},
+			});
+
+			const usedCode = initialCodes[0]!;
+			await client.twoFactor.verifyBackupCode({
+				code: usedCode,
+				fetchOptions: { headers: signInHeaders },
+			});
+
+			// Verify storage format is preserved and used code is removed
+			const twoFactorAfter = await db.findOne<TwoFactorTable>({
+				model: "twoFactor",
+				where: [{ field: "userId", value: session.data?.user.id as string }],
+			});
+			mode.verifyFormat(twoFactorAfter!.backupCodes);
+			const remainingCodes = await mode.decodeStored(
+				twoFactorAfter!.backupCodes,
+			);
+			expect(remainingCodes).toHaveLength(9);
+			expect(remainingCodes).not.toContain(usedCode);
+			expect(remainingCodes).toEqual(
+				initialCodes.filter((code) => code !== usedCode),
+			);
+		});
+	}
+});


### PR DESCRIPTION
## Summary

After using a backup code, the remaining codes were always re-saved with the built-in `symmetricEncrypt`, ignoring the `storeBackupCodes` configuration. If a developer configured `"plain"` or a custom `{ encrypt, decrypt }` pair, the first successful verification would silently corrupt the storage format, making all remaining codes unusable.

## Fix

Extracted a new `encodeBackupCodes` helper that handles the 3-way storage branch (plain, encrypted, custom) in one place. Both `generateBackupCodes` and the verify endpoint now call it, so the encode logic can't drift out of sync.

Parameterized integration tests cover all three storage modes through a full generate/verify/re-verify cycle.