### PR TITLE
fix: fallback to isProduction when baseURL is empty string

### DIFF
--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -162,6 +162,52 @@ describe("cookie configuration", () => {
 		expect(cookies.sessionData.options.sameSite).toBe("lax");
 		expect(cookies.sessionData.options.domain).toBe("example.com");
 	});
+
+	it("should use secure cookies for https baseURL", () => {
+		const cookies = getCookies({
+			baseURL: "https://example.com",
+		});
+		expect(cookies.sessionToken.options.secure).toBe(true);
+		expect(cookies.sessionToken.name).toContain("__Secure-");
+	});
+
+	it("should not use secure cookies for http baseURL", () => {
+		const cookies = getCookies({
+			baseURL: "http://localhost:3000",
+		});
+		expect(cookies.sessionToken.options.secure).toBe(false);
+		expect(cookies.sessionToken.name).not.toContain("__Secure-");
+	});
+
+	it("should fallback to isProduction when baseURL is empty string", () => {
+		// When baseURL is empty string, it should fallback to isProduction (false in test env)
+		const cookies = getCookies({
+			baseURL: "",
+		});
+		// In test environment, isProduction is false, so secure should be false
+		expect(cookies.sessionToken.options.secure).toBe(false);
+		expect(cookies.sessionToken.name).not.toContain("__Secure-");
+	});
+
+	it("should fallback to isProduction when baseURL is undefined", () => {
+		// When baseURL is undefined, it should fallback to isProduction (false in test env)
+		const cookies = getCookies({
+			baseURL: undefined,
+		});
+		// In test environment, isProduction is false, so secure should be false
+		expect(cookies.sessionToken.options.secure).toBe(false);
+		expect(cookies.sessionToken.name).not.toContain("__Secure-");
+	});
+
+	it("should treat empty string baseURL the same as undefined baseURL", () => {
+		// Both empty string and undefined should fallback to isProduction
+		const cookiesWithEmpty = getCookies({ baseURL: "" });
+		const cookiesWithUndefined = getCookies({ baseURL: undefined });
+
+		expect(cookiesWithEmpty.sessionToken.options.secure).toBe(
+			cookiesWithUndefined.sessionToken.options.secure,
+		);
+	});
 });
 
 describe("cookie-utils parseSetCookieHeader", () => {

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -27,10 +27,8 @@ export function createCookieGetter(options: BetterAuthOptions) {
 	const secure =
 		options.advanced?.useSecureCookies !== undefined
 			? options.advanced?.useSecureCookies
-			: options.baseURL !== undefined
+			: options.baseURL
 				? options.baseURL.startsWith("https://")
-					? true
-					: false
 				: isProduction;
 	const secureCookiePrefix = secure ? SECURE_COOKIE_PREFIX : "";
 	const crossSubdomainEnabled =


### PR DESCRIPTION
## Summary

Fixes #7156

When `baseURL` is not configured, `create-context.ts` sets it to an empty string `""`. The previous condition `options.baseURL !== undefined` treated empty string as a valid value, causing the secure flag to be determined by `"".startsWith("https://")` which always returns `false`.

This bypasses the intended fallback to `isProduction`, potentially leaving cookies insecure in production environments where `baseURL` is not explicitly set.

## Changes

- Changed the condition from `options.baseURL !== undefined` to a truthy check (`options.baseURL`)
- Empty string now correctly falls back to `isProduction` like `undefined` does
- Added tests to verify the fix and prevent regression

## Test Plan

- [x] Added test: `should use secure cookies for https baseURL`
- [x] Added test: `should not use secure cookies for http baseURL`
- [x] Added test: `should fallback to isProduction when baseURL is empty string`
- [x] Added test: `should fallback to isProduction when baseURL is undefined`
- [x] Added test: `should treat empty string baseURL the same as undefined baseURL`
- [x] All existing tests pass
- [x] `pnpm lint` passes
- [x] `pnpm format` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes secure cookie detection when baseURL is empty, so production cookies default to secure even if baseURL isn’t set.

- **Bug Fixes**
  - Treat empty baseURL as unset; secure flag now falls back to isProduction (avoids false insecure cookies).
  - Added tests for https/http baseURL, empty string, and undefined cases.

<sup>Written for commit 3a86537249d8bcaa908bdf267f994407b1a9fd32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

