### PR TITLE
docs: clarify MongoDB adapter transaction default behavior

### DIFF
--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -31,9 +31,11 @@ export interface MongoDBAdapterConfig {
 	/**
 	 * Whether to execute multiple operations in a transaction.
 	 *
-	 * If the database doesn't support transactions,
-	 * set this to `false` and operations will be executed sequentially.
-	 * @default false
+	 * ⚠️ Important:
+	 * - Defaults to `true` when a MongoDB client is provided.
+	 * - If your MongoDB instance does not support transactions
+	 *   (e.g. standalone server without a replica set),
+	 *   you must explicitly set `transaction: false`.
 	 */
 	transaction?: boolean | undefined;
 }


### PR DESCRIPTION
### What changed
- Updated MongoDB adapter JSDoc to reflect the actual default behavior
- Clarified that transactions default to `true` when a MongoDB client is provided
- Added guidance for disabling transactions on MongoDB instances that do not support them

### Why
The documentation stated that transactions default to `false`, but the code enables
transactions when a MongoDB client is provided. This mismatch caused unexpected
failures in production for databases without transaction support.

### Related issue
Closes #7213 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified MongoDB adapter docs: transactions default to true when a MongoDB client is provided, not false. Added guidance to set transaction: false for instances without transaction support (e.g., standalone servers) to prevent failures.

<sup>Written for commit a30a083d04d854bae7a91847e3c98ee31a4ec5f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

