### PR TITLE
docs(fastify): add session retrieval section

### DIFF
--- a/docs/content/docs/integrations/fastify.mdx
+++ b/docs/content/docs/integrations/fastify.mdx
@@ -122,52 +122,15 @@ fastify.register(fastifyCors, {
 
 ### Getting the User Session
 
-To retrieve the user's session in your Fastify routes, use the `auth.api.getSession` method. You need to convert Fastify's request headers to the standard `Headers` object format:
+To retrieve the user's session in your Fastify routes, use the `auth.api.getSession` method. Better Auth provides a `fromNodeHeaders` helper function that converts Node.js request headers to the format expected by Better Auth.
 
 ```ts title="server.ts"
+import { fromNodeHeaders } from "better-auth/node";
 import { auth } from "./auth"; // Your Better Auth instance
 
 fastify.get("/api/me", async (request, reply) => {
-  // Convert Fastify headers to standard Headers object
-  const headers = new Headers();
-  Object.entries(request.headers).forEach(([key, value]) => {
-    if (value) headers.append(key, value.toString());
-  });
-
   const session = await auth.api.getSession({
-    headers,
-  });
-
-  if (!session) {
-    return reply.status(401).send({ error: "Unauthorized" });
-  }
-
-  return reply.send(session);
-});
-```
-
-You can also create a reusable helper function to simplify header conversion:
-
-```ts title="utils.ts"
-import type { IncomingHttpHeaders } from "http";
-
-export function toHeaders(headers: IncomingHttpHeaders): Headers {
-  const result = new Headers();
-  Object.entries(headers).forEach(([key, value]) => {
-    if (value) result.append(key, value.toString());
-  });
-  return result;
-}
-```
-
-Then use it in your routes:
-
-```ts title="server.ts"
-import { toHeaders } from "./utils";
-
-fastify.get("/api/me", async (request, reply) => {
-  const session = await auth.api.getSession({
-    headers: toHeaders(request.headers),
+    headers: fromNodeHeaders(request.headers),
   });
 
   if (!session) {


### PR DESCRIPTION
## Summary

- Add "Getting the User Session" section to Fastify integration docs
- Show how to use `auth.api.getSession()` with proper header conversion
- Include reusable helper function example for header conversion

Closes #7107

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Getting the User Session" section to the Fastify integration docs with examples for using auth.api.getSession and converting Fastify request headers to a standard Headers object. Addresses Linear #7107 by clarifying session retrieval in Fastify routes.

<sup>Written for commit c947ed94f0db3ede94af67d4aed0f5c6a20c16fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

