### PR TITLE
fix(cli): support drizzle json type defaults

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -252,6 +252,12 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 										// this is because if the defaultValue is a function, it could have
 										// custom logic within that function that might not work in drizzle's context.
 									}
+								} else if (
+									databaseType === "pg" &&
+									attr.type === "json" &&
+									typeof attr.defaultValue === "object"
+								) {
+									type += `.default(${JSON.stringify(attr.defaultValue)})`;
 								} else if (typeof attr.defaultValue === "string") {
 									type += `.default("${attr.defaultValue}")`;
 								} else {

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -544,6 +544,37 @@ describe("JSON field support in CLI generators", () => {
 		expect(schema.code).toContain("preferences: jsonb(");
 	});
 
+	it("should generate Drizzle schema with JSON Default for Postgres", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: {
+					provider: "pg",
+					schema: {},
+				},
+			} as any,
+			options: {
+				database: {} as any,
+				user: {
+					additionalFields: {
+						preferences: {
+							type: "json",
+							defaultValue: {
+								theme: "dark",
+							},
+						},
+					},
+				},
+			} as BetterAuthOptions,
+		});
+
+		expect(schema.code).toContain("preferences: jsonb(");
+		expect(schema.code).toContain(
+			'jsonb("preferences").default({ theme: "dark" })',
+		);
+	});
+
 	it("should generate Drizzle schema with JSON fields for MySQL", async () => {
 		const schema = await generateDrizzleSchema({
 			file: "test.drizzle",


### PR DESCRIPTION
- Adds support for JSON defaultValue in CLI generator
- Adds test for new functionality

Fixes #7275

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSON default handling in the CLI Drizzle schema generator for Postgres. JSON defaults are now emitted as .default({ ... }) on jsonb columns (not stringified), with tests added.

<sup>Written for commit 69e82e5b005eedb8e31c5a8ff4c0b7e9fdd602f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

