### PR TITLE
fix issue: after oidc client successfully signin use better-auth oaut…

### DIFF
--- a/packages/oauth-provider/src/client.ts
+++ b/packages/oauth-provider/src/client.ts
@@ -45,13 +45,20 @@ export const oauthProviderClient = () => {
 							pathname.endsWith("/oauth2/consent") ||
 							pathname.endsWith("/oauth2/continue")
 						) {
+							const oauthQuery =
+								typeof window !== "undefined"
+									? parseSignedQuery(window?.location?.search)
+									: undefined;
 							ctx.body = JSON.stringify({
 								...body,
-								oauth_query:
-									typeof window !== "undefined"
-										? parseSignedQuery(window?.location?.search)
-										: undefined,
+								oauth_query: oauthQuery,
 							});
+							// Set accept header to application/json when in OAuth flow
+							// This ensures the server returns JSON redirect instead of throwing a redirect
+							// which would cause CORS errors when fetch tries to follow cross-origin redirects
+							if (oauthQuery) {
+								ctx.headers.set("accept", "application/json");
+							}
 						}
 					},
 				},


### PR DESCRIPTION
fix issue: after oidc client successfully signin use better-auth oauth provider authorization server, user cant be redirected back to oidc client page due to error: xxx been blocked by CORS policy: The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'.

[may related issue link](https://github.com/better-auth/better-auth/issues/7041)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix redirect after OIDC sign-in with the better-auth OAuth provider by forcing JSON responses during the OAuth flow. This prevents CORS credential errors and lets the client handle redirects safely.

- **Bug Fixes**
  - Send Accept: application/json when oauth_query is present on /oauth2/consent and /oauth2/continue.
  - Pass parsed oauth_query in the response body for the client to process signed query params.

<sup>Written for commit 0867f4bb09278ff75c187c61a5a2a1072a63499a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

