### PR TITLE
fix(two-factor): add missing POST endpoints to client pathMethods

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/client.ts
+++ b/packages/better-auth/src/plugins/two-factor/client.ts
@@ -29,6 +29,10 @@ export const twoFactorClient = (
 			"/two-factor/enable": "POST",
 			"/two-factor/send-otp": "POST",
 			"/two-factor/generate-backup-codes": "POST",
+			"/two-factor/get-totp-uri": "POST",
+			"/two-factor/verify-totp": "POST",
+			"/two-factor/verify-otp": "POST",
+			"/two-factor/verify-backup-code": "POST",
 		},
 		fetchPlugins: [
 			{


### PR DESCRIPTION
Closes #7277

The two-factor client plugin was missing several POST endpoints in its `pathMethods` configuration, causing the client to default to GET requests and receive 404 errors.

Added the following endpoints:
- `/two-factor/get-totp-uri`
- `/two-factor/verify-totp`
- `/two-factor/verify-otp`
- `/two-factor/verify-backup-code`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the two-factor client so TOTP/OTP actions use POST instead of defaulting to GET, preventing 404s and aligning the client with the server API.

- **Bug Fixes**
  - Added POST mappings for: /two-factor/get-totp-uri, /two-factor/verify-totp, /two-factor/verify-otp, /two-factor/verify-backup-code.

<sup>Written for commit c3cd0f9e1280b8f60296328eb68abd60770ce479. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

