### PR TITLE
docs: correct `sequenzy-better-auth` community plugin link

### DIFF
--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -252,8 +252,8 @@ export const communityPlugins: CommunityPlugin[] = [
 		},
 	},
 	{
-		name: "better-auth-sequenzy",
-		url: "https://www.npmjs.com/package/better-auth-sequenzy",
+		name: "@sequenzy/better-auth",
+		url: "https://github.com/Sequenzy/sequenzy-better-auth",
 		description:
 			"Automatically add users to Sequenzy mailing lists on signup for seamless email marketing integration.",
 		author: {


### PR DESCRIPTION
- Related to https://github.com/better-auth/better-auth/pull/7266

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Sequenzy community plugin entry to use the correct package name (@sequenzy/better-auth) and GitHub URL (https://github.com/Sequenzy/sequenzy-better-auth). Ensures users reach the maintained repository.

<sup>Written for commit f8543b01f23341fc6d93308991cfdeb0b1bfa635. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

