### PR TITLE
feat(social-provider): support custom URL options to `github`

### DIFF
--- a/packages/core/src/social-providers/github.ts
+++ b/packages/core/src/social-providers/github.ts
@@ -55,9 +55,16 @@ export interface GithubProfile {
 
 export interface GithubOptions extends ProviderOptions<GithubProfile> {
 	clientId: string;
+	tokenEndpointUrl?: string;
+	refreshTokenUrl?: string;
+	userInfoUrl?: string;
 }
 export const github = (options: GithubOptions) => {
-	const tokenEndpoint = "https://github.com/login/oauth/access_token";
+	const tokenEndpoint =
+		options.tokenEndpointUrl ?? "https://github.com/login/oauth/access_token";
+	const userInfoUrl = options.userInfoUrl ?? "https://api.github.com/user";
+	const refreshTokenUrl =
+		options.refreshTokenUrl ?? "https://github.com/login/oauth/token";
 	return {
 		id: "github",
 		name: "GitHub",
@@ -104,7 +111,7 @@ export const github = (options: GithubOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: "https://github.com/login/oauth/access_token",
+						tokenEndpoint: refreshTokenUrl,
 					});
 				},
 		async getUserInfo(token) {
@@ -112,7 +119,7 @@ export const github = (options: GithubOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<GithubProfile>(
-				"https://api.github.com/user",
+				userInfoUrl,
 				{
 					headers: {
 						"User-Agent": "better-auth",


### PR DESCRIPTION
Closes: https://github.com/better-auth/better-auth/pull/2049

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional URL overrides to the GitHub provider for token, refresh, and user info endpoints. This enables GitHub Enterprise and proxy setups while keeping defaults unchanged.

- **New Features**
  - GithubOptions: tokenEndpointUrl, refreshTokenUrl, userInfoUrl.
  - Overrides are used for token exchange, refresh, and user info requests.
  - Defaults: access_token https://github.com/login/oauth/access_token, refresh https://github.com/login/oauth/token, user info https://api.github.com/user.

<sup>Written for commit a0f26e7aceecfa6c786f8751908d1c91d760115c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

