### PR TITLE
chore: fix filter server api type

### DIFF
--- a/packages/better-auth/src/types/api.ts
+++ b/packages/better-auth/src/types/api.ts
@@ -6,21 +6,12 @@ export type FilteredAPI<API> = Omit<
 	API extends { [key in infer K]: Endpoint }
 		? K extends string
 			? K extends "getSession"
-				? K
-				: API[K]["options"]["metadata"] extends { isAction: false }
+				? never
+				: API[K]["options"]["metadata"] extends
+							| { isAction: false }
+							| { scope: "http" }
 					? K
 					: never
-			: never
-		: never
->;
-
-export type FilterActions<API> = Omit<
-	API,
-	API extends { [key in infer K]: Endpoint }
-		? K extends string
-			? API[K]["options"]["metadata"] extends { isAction: false }
-				? K
-				: never
 			: never
 		: never
 >;
@@ -59,4 +50,4 @@ export type InferSessionAPI<API> = API extends {
 		>
 	: never;
 
-export type InferAPI<API> = InferSessionAPI<API> & API;
+export type InferAPI<API> = InferSessionAPI<API> & FilteredAPI<API>;

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -76,14 +76,24 @@ describe("general types", async (it) => {
 							},
 							async () => "ok",
 						),
+						testNonAction: createAuthEndpoint(
+							"/test-non-action",
+							{
+								method: "GET",
+								metadata: {
+									isAction: false,
+								},
+							},
+							async () => "ok",
+						),
 					},
 				},
 			],
 		});
-
 		expectTypeOf<typeof auth.api>().toHaveProperty("testServerScoped");
 		expectTypeOf<typeof auth.api>().toHaveProperty("testVirtual");
-		expectTypeOf<typeof auth.api>().not.toHaveProperty("testHttpScoped");
+		expectTypeOf<typeof auth.api>().not.toHaveProperty("testHTTPScoped");
+		expectTypeOf<typeof auth.api>().not.toHaveProperty("testNonAction");
 	});
 
 	it("should infer additional fields from plugins", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes server API type filtering so only server-safe endpoints are exposed, hiding HTTP-scoped and non-action routes. Also updates type inference to prevent leaking filtered endpoints.

- **Bug Fixes**
  - Filtered out endpoints with metadata.isAction: false and metadata.scope: "http".
  - InferAPI now composes InferSessionAPI with FilteredAPI to restrict the surface.
  - Removed unused FilterActions type and added tests to assert exclusions.

<sup>Written for commit a0a1bf26247af8032f279e5688892120619a9318. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

