### PR TITLE
fix(anonymous): define delete-anonymous-user path method

### DIFF
--- a/packages/better-auth/src/plugins/anonymous/client.ts
+++ b/packages/better-auth/src/plugins/anonymous/client.ts
@@ -8,6 +8,7 @@ export const anonymousClient = () => {
 		$InferServerPlugin: {} as ReturnType<typeof anonymous>,
 		pathMethods: {
 			"/sign-in/anonymous": "POST",
+			"/delete-anonymous-user": "POST",
 		},
 		atomListeners: [
 			{


### PR DESCRIPTION
We didn't define the path-method for the new delete-anonymous-user endpoint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defined the POST path for /delete-anonymous-user in the anonymous client. This enables calling the endpoint and prevents failures from the missing path method.

<sup>Written for commit 01bd8c9c1d358d7b8cf8981f84b2c7c4b66e0373. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

