### PR TITLE
feat(rate-limit): add IPv6 address normalization and subnet support

### DIFF
--- a/docs/content/docs/concepts/rate-limit.mdx
+++ b/docs/content/docs/concepts/rate-limit.mdx
@@ -52,7 +52,7 @@ Rate limiting uses the connecting IP address to track the number of requests mad
 default header checked is `x-forwarded-for`, which is commonly used in production environments. If
 you are using a different header to track the user's IP address, you'll need to specify it.
 
-```ts title="auth.ts" 
+```ts title="auth.ts"
 export const auth = betterAuth({
     //...other options
     advanced: {
@@ -67,6 +67,40 @@ export const auth = betterAuth({
     },
 })
 ```
+
+#### IPv6 Address Support
+
+Better Auth automatically normalizes IPv6 addresses to prevent bypass attacks where attackers use different representations of the same IPv6 address (e.g., `2001:db8::1` vs `2001:0db8:0000:0000:0000:0000:0000:0001`). This ensures that all representations of the same IPv6 address are treated as the same for rate limiting purposes.
+
+Additionally, IPv4-mapped IPv6 addresses (e.g., `::ffff:192.0.2.1`) are automatically converted to their IPv4 form (`192.0.2.1`) to prevent attackers from bypassing rate limits by switching between IPv4 and IPv6 representations.
+
+#### IPv6 Subnet Rate Limiting
+
+By default, IPv6 addresses are rate limited individually (using the full /128 address). However, since IPv6 typically allocates large address blocks to single users, attackers could potentially bypass rate limits by rotating through multiple IPv6 addresses from their allocation.
+
+To prevent this, you can configure rate limiting to apply to IPv6 subnets instead of individual addresses:
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+    //...other options
+    rateLimit: {
+        enabled: true,
+        window: 60,
+        max: 100,
+        ipv6Subnet: 64, // Rate limit by /64 subnet instead of individual addresses
+    },
+})
+```
+
+Common IPv6 subnet prefix lengths:
+- `128` (default): Individual IPv6 address - most restrictive
+- `64`: /64 subnet - typical home/business allocation
+- `48`: /48 subnet - larger network allocation
+- `32`: /32 subnet - ISP-level allocation
+
+<Callout type="info">
+IPv6 subnet configuration only affects IPv6 addresses. IPv4 addresses are always rate limited individually.
+</Callout>
 
 ### Rate Limit Window
 
@@ -184,6 +218,10 @@ export const auth = betterAuth({
     },
 })
 ```
+
+<Callout type="warning">
+**Key Format Update**: Rate limit keys now use the format `{ip}|{path}` (with a pipe separator) instead of `{ip}{path}`. This prevents potential collision attacks where different IP/path combinations could create the same key. If you have custom storage with existing keys, they will be recreated with the new format automatically.
+</Callout>
 
 ## Handling Rate Limit Errors
 

--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -2,6 +2,7 @@ import type {
 	AuthContext,
 	BetterAuthRateLimitStorage,
 } from "@better-auth/core";
+import { createRateLimitKey } from "@better-auth/core/utils/ip";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { normalizePathname } from "@better-auth/core/utils/url";
 import type { RateLimit } from "../../types";
@@ -168,7 +169,7 @@ export async function onRequestRateLimit(req: Request, ctx: AuthContext) {
 	if (!ip) {
 		return;
 	}
-	const key = ip + path;
+	const key = createRateLimitKey(ip, path);
 	const specialRules = getDefaultSpecialRules();
 	const specialRule = specialRules.find((rule) => rule.pathMatcher(path));
 

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -1,110 +1,105 @@
+import { normalizeIP } from "@better-auth/core/utils/ip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import type { RateLimit } from "../../types";
 
-describe(
-	"rate-limiter",
-	{
-		timeout: 10000,
-	},
-	async () => {
-		const { client, testUser } = await getTestInstance({
-			rateLimit: {
-				enabled: true,
-				window: 10,
-				max: 20,
-			},
-		});
+describe("rate-limiter", async () => {
+	const { client, testUser } = await getTestInstance({
+		rateLimit: {
+			enabled: true,
+			window: 10,
+			max: 20,
+		},
+	});
 
-		it("should return 429 after 3 request for sign-in", async () => {
-			for (let i = 0; i < 5; i++) {
-				const response = await client.signIn.email({
-					email: testUser.email,
-					password: testUser.password,
-				});
-				if (i >= 3) {
-					expect(response.error?.status).toBe(429);
-				} else {
-					expect(response.error).toBeNull();
-				}
-			}
-		});
-
-		it("should reset the limit after the window period", async () => {
-			vi.useFakeTimers();
-			vi.advanceTimersByTime(11000);
-			for (let i = 0; i < 5; i++) {
-				const res = await client.signIn.email({
-					email: testUser.email,
-					password: testUser.password,
-				});
-				if (i >= 3) {
-					expect(res.error?.status).toBe(429);
-				} else {
-					expect(res.error).toBeNull();
-				}
-			}
-		});
-
-		it("should respond the correct retry-after header", async () => {
-			vi.useFakeTimers();
-			vi.advanceTimersByTime(3000);
-			let retryAfter = "";
-			await client.signIn.email(
-				{
-					email: testUser.email,
-					password: testUser.password,
-				},
-				{
-					onError(context) {
-						retryAfter = context.response.headers.get("X-Retry-After") ?? "";
-					},
-				},
-			);
-			expect(retryAfter).toBe("7");
-		});
-
-		it("should rate limit based on the path", async () => {
-			const signInRes = await client.signIn.email({
+	it("should return 429 after 3 request for sign-in", async () => {
+		for (let i = 0; i < 5; i++) {
+			const response = await client.signIn.email({
 				email: testUser.email,
 				password: testUser.password,
 			});
-			expect(signInRes.error?.status).toBe(429);
+			if (i >= 3) {
+				expect(response.error?.status).toBe(429);
+			} else {
+				expect(response.error).toBeNull();
+			}
+		}
+	});
 
-			const signUpRes = await client.signUp.email({
-				email: "new-test@email.com",
+	it("should reset the limit after the window period", async () => {
+		vi.useFakeTimers();
+		vi.advanceTimersByTime(11000);
+		for (let i = 0; i < 5; i++) {
+			const res = await client.signIn.email({
+				email: testUser.email,
 				password: testUser.password,
-				name: "test",
 			});
-			expect(signUpRes.error).toBeNull();
-		});
-
-		it("non-special-rules limits", async () => {
-			for (let i = 0; i < 25; i++) {
-				const response = await client.getSession();
-				expect(response.error?.status).toBe(i >= 20 ? 429 : undefined);
+			if (i >= 3) {
+				expect(res.error?.status).toBe(429);
+			} else {
+				expect(res.error).toBeNull();
 			}
-		});
+		}
+	});
 
-		it("query params should be ignored", async () => {
-			for (let i = 0; i < 25; i++) {
-				const response = await client.listSessions({
-					fetchOptions: {
-						query: {
-							"test-query": Math.random().toString(),
-						},
+	it("should respond the correct retry-after header", async () => {
+		vi.useFakeTimers();
+		vi.advanceTimersByTime(3000);
+		let retryAfter = "";
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onError(context) {
+					retryAfter = context.response.headers.get("X-Retry-After") ?? "";
+				},
+			},
+		);
+		expect(retryAfter).toBe("7");
+	});
+
+	it("should rate limit based on the path", async () => {
+		const signInRes = await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+		});
+		expect(signInRes.error?.status).toBe(429);
+
+		const signUpRes = await client.signUp.email({
+			email: "new-test@email.com",
+			password: testUser.password,
+			name: "test",
+		});
+		expect(signUpRes.error).toBeNull();
+	});
+
+	it("non-special-rules limits", async () => {
+		for (let i = 0; i < 25; i++) {
+			const response = await client.getSession();
+			expect(response.error?.status).toBe(i >= 20 ? 429 : undefined);
+		}
+	});
+
+	it("query params should be ignored", async () => {
+		for (let i = 0; i < 25; i++) {
+			const response = await client.listSessions({
+				fetchOptions: {
+					query: {
+						"test-query": Math.random().toString(),
 					},
-				});
+				},
+			});
 
-				if (i >= 20) {
-					expect(response.error?.status).toBe(429);
-				} else {
-					expect(response.error?.status).toBe(401);
-				}
+			if (i >= 20) {
+				expect(response.error?.status).toBe(429);
+			} else {
+				expect(response.error?.status).toBe(401);
 			}
-		});
-	},
-);
+		}
+	});
+});
 
 describe("custom rate limiting storage", async () => {
 	const store = new Map<string, string>();
@@ -138,7 +133,7 @@ describe("custom rate limiting storage", async () => {
 				password: testUser.password,
 			});
 			const rateLimitData: RateLimit = JSON.parse(
-				store.get("127.0.0.1/sign-in/email") ?? "{}",
+				store.get("127.0.0.1|/sign-in/email") ?? "{}",
 			);
 			expect(rateLimitData.lastRequest).toBeGreaterThanOrEqual(lastRequest);
 			lastRequest = rateLimitData.lastRequest;
@@ -149,7 +144,7 @@ describe("custom rate limiting storage", async () => {
 				expect(response.error).toBeNull();
 				expect(rateLimitData.count).toBe(i + 1);
 			}
-			const rateLimitExp = expirationMap.get("127.0.0.1/sign-in/email");
+			const rateLimitExp = expirationMap.get("127.0.0.1|/sign-in/email");
 			expect(rateLimitExp).toBe(10);
 		}
 	});
@@ -277,7 +272,7 @@ describe("should work in development/test environment", () => {
 		);
 
 		expect(signInKeys.length).toBeGreaterThan(0);
-		expect(signInKeys[0]).toBe(`${LOCALHOST_IP}${REQUEST_PATH}`);
+		expect(signInKeys[0]).toBe(`${LOCALHOST_IP}|${REQUEST_PATH}`);
 	});
 
 	it("should work in test environment", async () => {
@@ -321,6 +316,94 @@ describe("should work in development/test environment", () => {
 		);
 
 		expect(signInKeys.length).toBeGreaterThan(0);
-		expect(signInKeys[0]).toBe(`${LOCALHOST_IP}${REQUEST_PATH}`);
+		expect(signInKeys[0]).toBe(`${LOCALHOST_IP}|${REQUEST_PATH}`);
+	});
+});
+
+describe("IPv6 address normalization and rate limiting", () => {
+	it("should normalize IPv6 addresses to canonical form", () => {
+		// All these representations of the same IPv6 address should normalize to the same value
+		const representations = [
+			"2001:db8::1",
+			"2001:DB8::1",
+			"2001:0db8::1",
+			"2001:db8:0::1",
+			"2001:0db8:0:0:0:0:0:1",
+		];
+
+		const normalized = representations.map((ip) => normalizeIP(ip));
+		const uniqueValues = new Set(normalized);
+
+		// All should normalize to the same value
+		expect(uniqueValues.size).toBe(1);
+		expect(normalized[0]).toBe("2001:0db8:0000:0000:0000:0000:0000:0001");
+	});
+
+	it("should convert IPv4-mapped IPv6 to IPv4", () => {
+		const ipv4Mapped = [
+			"::ffff:192.0.2.1",
+			"::FFFF:192.0.2.1",
+			"::ffff:c000:0201", // hex-encoded
+		];
+
+		const normalized = ipv4Mapped.map((ip) => normalizeIP(ip));
+
+		// All should normalize to the same IPv4 address
+		normalized.forEach((ip) => {
+			expect(ip).toBe("192.0.2.1");
+		});
+	});
+
+	it("should support IPv6 subnet rate limiting", () => {
+		// Simulate attacker rotating through IPv6 addresses in their /64 allocation
+		const attackIPs = [
+			"2001:db8:abcd:1234:0000:0000:0000:0001",
+			"2001:db8:abcd:1234:1111:2222:3333:4444",
+			"2001:db8:abcd:1234:ffff:ffff:ffff:ffff",
+		];
+
+		const normalized = attackIPs.map((ip) =>
+			normalizeIP(ip, { ipv6Subnet: 64 }),
+		);
+
+		// All should map to same /64 subnet
+		const uniqueValues = new Set(normalized);
+		expect(uniqueValues.size).toBe(1);
+		expect(normalized[0]).toBe("2001:0db8:abcd:1234:0000:0000:0000:0000");
+	});
+
+	it("should rate limit different IPv6 subnets separately", () => {
+		// Different /64 subnets should have separate rate limits
+		const subnet1IPs = ["2001:db8:abcd:1111::1", "2001:db8:abcd:1111::2"];
+		const subnet2IPs = ["2001:db8:abcd:2222::1", "2001:db8:abcd:2222::2"];
+
+		const normalized1 = subnet1IPs.map((ip) =>
+			normalizeIP(ip, { ipv6Subnet: 64 }),
+		);
+		const normalized2 = subnet2IPs.map((ip) =>
+			normalizeIP(ip, { ipv6Subnet: 64 }),
+		);
+
+		// Same subnet should normalize to same value
+		expect(normalized1[0]).toBe(normalized1[1]);
+		expect(normalized2[0]).toBe(normalized2[1]);
+
+		// Different subnets should normalize to different values
+		expect(normalized1[0]).not.toBe(normalized2[0]);
+	});
+
+	it("should handle localhost IPv6 addresses", () => {
+		expect(normalizeIP("::1")).toBe("0000:0000:0000:0000:0000:0000:0000:0001");
+	});
+
+	it("should handle link-local IPv6 addresses", () => {
+		const linkLocal = normalizeIP("fe80::1");
+		expect(linkLocal).toBe("fe80:0000:0000:0000:0000:0000:0000:0001");
+	});
+
+	it("IPv6 subnet should not affect IPv4 addresses", () => {
+		const ipv4 = "192.168.1.1";
+		const normalized = normalizeIP(ipv4, { ipv6Subnet: 64 });
+		expect(normalized).toBe(ipv4);
 	});
 });

--- a/packages/better-auth/src/utils/get-request-ip.ts
+++ b/packages/better-auth/src/utils/get-request-ip.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 import { isDevelopment, isTest } from "@better-auth/core/env";
-import * as z from "zod";
+import { isValidIP, normalizeIP } from "@better-auth/core/utils/ip";
 
 // Localhost IP used for test and development environments
 const LOCALHOST_IP = "127.0.0.1";
@@ -25,7 +25,9 @@ export function getIp(
 		if (typeof value === "string") {
 			const ip = value.split(",")[0]!.trim();
 			if (isValidIP(ip)) {
-				return ip;
+				return normalizeIP(ip, {
+					ipv6Subnet: options.rateLimit?.ipv6Subnet,
+				});
 			}
 		}
 	}
@@ -36,19 +38,4 @@ export function getIp(
 	}
 
 	return null;
-}
-
-function isValidIP(ip: string): boolean {
-	const ipv4 = z.ipv4().safeParse(ip);
-
-	if (ipv4.success) {
-		return true;
-	}
-
-	const ipv6 = z.ipv6().safeParse(ip);
-	if (ipv6.success) {
-		return true;
-	}
-
-	return false;
 }

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -69,6 +69,25 @@ export type BetterAuthRateLimitOptions = Optional<BetterAuthRateLimitRule> & {
 	 */
 	enabled?: boolean | undefined;
 	/**
+	 * IPv6 subnet prefix length for rate limiting.
+	 *
+	 * IPv6 addresses can be grouped by subnet to prevent attackers from
+	 * bypassing rate limits by rotating through multiple addresses in
+	 * their allocation.
+	 *
+	 * Common values:
+	 * - 128 (default): Individual IPv6 address
+	 * - 64: /64 subnet (typical home/business allocation)
+	 * - 48: /48 subnet (larger network allocation)
+	 * - 32: /32 subnet (ISP allocation)
+	 *
+	 * Note: This only affects IPv6 addresses. IPv4 addresses are always
+	 * rate limited individually.
+	 *
+	 * @default 128 (individual address)
+	 */
+	ipv6Subnet?: 128 | 64 | 48 | 32 | undefined;
+	/**
 	 * Custom rate limit rules to apply to
 	 * specific paths.
 	 */

--- a/packages/core/src/utils/ip.test.ts
+++ b/packages/core/src/utils/ip.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import { createRateLimitKey, isValidIP, normalizeIP } from "./ip";
+
+describe("IP Normalization", () => {
+	describe("isValidIP", () => {
+		it("should validate IPv4 addresses", () => {
+			expect(isValidIP("192.168.1.1")).toBe(true);
+			expect(isValidIP("127.0.0.1")).toBe(true);
+			expect(isValidIP("0.0.0.0")).toBe(true);
+			expect(isValidIP("255.255.255.255")).toBe(true);
+		});
+
+		it("should validate IPv6 addresses", () => {
+			expect(isValidIP("2001:db8::1")).toBe(true);
+			expect(isValidIP("::1")).toBe(true);
+			expect(isValidIP("::")).toBe(true);
+			expect(isValidIP("2001:0db8:0000:0000:0000:0000:0000:0001")).toBe(true);
+		});
+
+		it("should reject invalid IPs", () => {
+			expect(isValidIP("not-an-ip")).toBe(false);
+			expect(isValidIP("999.999.999.999")).toBe(false);
+			expect(isValidIP("gggg::1")).toBe(false);
+		});
+	});
+
+	describe("IPv4 Normalization", () => {
+		it("should return IPv4 addresses unchanged", () => {
+			expect(normalizeIP("192.168.1.1")).toBe("192.168.1.1");
+			expect(normalizeIP("127.0.0.1")).toBe("127.0.0.1");
+			expect(normalizeIP("10.0.0.1")).toBe("10.0.0.1");
+		});
+	});
+
+	describe("IPv6 Normalization", () => {
+		it("should normalize compressed IPv6 to full form", () => {
+			expect(normalizeIP("2001:db8::1")).toBe(
+				"2001:0db8:0000:0000:0000:0000:0000:0001",
+			);
+			expect(normalizeIP("::1")).toBe(
+				"0000:0000:0000:0000:0000:0000:0000:0001",
+			);
+			expect(normalizeIP("::")).toBe("0000:0000:0000:0000:0000:0000:0000:0000");
+		});
+
+		it("should normalize uppercase to lowercase", () => {
+			expect(normalizeIP("2001:DB8::1")).toBe(
+				"2001:0db8:0000:0000:0000:0000:0000:0001",
+			);
+			expect(normalizeIP("2001:0DB8:ABCD:EF00::1")).toBe(
+				"2001:0db8:abcd:ef00:0000:0000:0000:0001",
+			);
+		});
+
+		it("should handle various IPv6 formats consistently", () => {
+			// All these represent the same address
+			const normalized = "2001:0db8:0000:0000:0000:0000:0000:0001";
+			expect(normalizeIP("2001:db8::1")).toBe(normalized);
+			expect(normalizeIP("2001:0db8:0:0:0:0:0:1")).toBe(normalized);
+			expect(normalizeIP("2001:db8:0::1")).toBe(normalized);
+			expect(normalizeIP("2001:0db8::0:0:0:1")).toBe(normalized);
+		});
+
+		it("should handle IPv6 with :: at different positions", () => {
+			expect(normalizeIP("2001:db8:85a3::8a2e:370:7334")).toBe(
+				"2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			);
+			expect(normalizeIP("::ffff:192.0.2.1")).not.toContain("::");
+		});
+	});
+
+	describe("IPv4-mapped IPv6 Conversion", () => {
+		it("should convert IPv4-mapped IPv6 to IPv4", () => {
+			expect(normalizeIP("::ffff:192.0.2.1")).toBe("192.0.2.1");
+			expect(normalizeIP("::ffff:127.0.0.1")).toBe("127.0.0.1");
+			expect(normalizeIP("::FFFF:10.0.0.1")).toBe("10.0.0.1");
+		});
+
+		it("should handle hex-encoded IPv4 in mapped addresses", () => {
+			// ::ffff:c000:0201 = ::ffff:192.0.2.1 = 192.0.2.1
+			expect(normalizeIP("::ffff:c000:0201")).toBe("192.0.2.1");
+			// ::ffff:7f00:0001 = ::ffff:127.0.0.1 = 127.0.0.1
+			expect(normalizeIP("::ffff:7f00:0001")).toBe("127.0.0.1");
+		});
+
+		it("should handle full form IPv4-mapped IPv6", () => {
+			expect(normalizeIP("0:0:0:0:0:ffff:192.0.2.1")).toBe("192.0.2.1");
+		});
+	});
+
+	describe("IPv6 Subnet Support", () => {
+		it("should extract /64 subnet", () => {
+			const ip1 = normalizeIP("2001:db8:0:0:1234:5678:90ab:cdef", {
+				ipv6Subnet: 64,
+			});
+			const ip2 = normalizeIP("2001:db8:0:0:ffff:ffff:ffff:ffff", {
+				ipv6Subnet: 64,
+			});
+			// Both should have same /64 prefix
+			expect(ip1).toBe("2001:0db8:0000:0000:0000:0000:0000:0000");
+			expect(ip2).toBe("2001:0db8:0000:0000:0000:0000:0000:0000");
+			expect(ip1).toBe(ip2);
+		});
+
+		it("should extract /48 subnet", () => {
+			const ip1 = normalizeIP("2001:db8:1234:5678:90ab:cdef:1234:5678", {
+				ipv6Subnet: 48,
+			});
+			const ip2 = normalizeIP("2001:db8:1234:ffff:ffff:ffff:ffff:ffff", {
+				ipv6Subnet: 48,
+			});
+			// Both should have same /48 prefix
+			expect(ip1).toBe("2001:0db8:1234:0000:0000:0000:0000:0000");
+			expect(ip2).toBe("2001:0db8:1234:0000:0000:0000:0000:0000");
+			expect(ip1).toBe(ip2);
+		});
+
+		it("should extract /32 subnet", () => {
+			const ip1 = normalizeIP("2001:db8:1234:5678:90ab:cdef:1234:5678", {
+				ipv6Subnet: 32,
+			});
+			const ip2 = normalizeIP("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff", {
+				ipv6Subnet: 32,
+			});
+			// Both should have same /32 prefix
+			expect(ip1).toBe("2001:0db8:0000:0000:0000:0000:0000:0000");
+			expect(ip2).toBe("2001:0db8:0000:0000:0000:0000:0000:0000");
+			expect(ip1).toBe(ip2);
+		});
+
+		it("should handle /128 (full address) by default", () => {
+			const ip1 = normalizeIP("2001:db8::1");
+			const ip2 = normalizeIP("2001:db8::1", { ipv6Subnet: 128 });
+			expect(ip1).toBe(ip2);
+			expect(ip1).toBe("2001:0db8:0000:0000:0000:0000:0000:0001");
+		});
+
+		it("should not affect IPv4 addresses when ipv6Subnet is set", () => {
+			expect(normalizeIP("192.168.1.1", { ipv6Subnet: 64 })).toBe(
+				"192.168.1.1",
+			);
+		});
+	});
+
+	describe("Rate Limit Key Creation", () => {
+		it("should create keys with separator", () => {
+			expect(createRateLimitKey("192.168.1.1", "/sign-in")).toBe(
+				"192.168.1.1|/sign-in",
+			);
+			expect(createRateLimitKey("2001:db8::1", "/api/auth")).toBe(
+				"2001:db8::1|/api/auth",
+			);
+		});
+
+		it("should prevent collision attacks", () => {
+			// Without separator: "192.0.2.1" + "/sign-in" = "192.0.2.1/sign-in"
+			//                    "192.0.2" + ".1/sign-in" = "192.0.2.1/sign-in"
+			// With separator: they're different
+			const key1 = createRateLimitKey("192.0.2.1", "/sign-in");
+			const key2 = createRateLimitKey("192.0.2", ".1/sign-in");
+			expect(key1).not.toBe(key2);
+			expect(key1).toBe("192.0.2.1|/sign-in");
+			expect(key2).toBe("192.0.2|.1/sign-in");
+		});
+	});
+
+	describe("Security: Bypass Prevention", () => {
+		it("should prevent IPv6 representation bypass", () => {
+			// Attacker tries different representations of same address
+			const representations = [
+				"2001:db8::1",
+				"2001:DB8::1",
+				"2001:0db8::1",
+				"2001:db8:0::1",
+				"2001:0db8:0:0:0:0:0:1",
+				"2001:db8::0:1",
+			];
+
+			const normalized = representations.map((ip) => normalizeIP(ip));
+			// All should normalize to the same value
+			const uniqueValues = new Set(normalized);
+			expect(uniqueValues.size).toBe(1);
+			expect(normalized[0]).toBe("2001:0db8:0000:0000:0000:0000:0000:0001");
+		});
+
+		it("should prevent IPv4-mapped bypass", () => {
+			// Attacker switches between IPv4 and IPv4-mapped IPv6
+			const ip1 = normalizeIP("192.0.2.1");
+			const ip2 = normalizeIP("::ffff:192.0.2.1");
+			const ip3 = normalizeIP("::FFFF:192.0.2.1");
+			const ip4 = normalizeIP("::ffff:c000:0201");
+
+			// All should normalize to the same IPv4
+			expect(ip1).toBe("192.0.2.1");
+			expect(ip2).toBe("192.0.2.1");
+			expect(ip3).toBe("192.0.2.1");
+			expect(ip4).toBe("192.0.2.1");
+		});
+
+		it("should group IPv6 subnet attacks", () => {
+			// Attacker rotates through addresses in their /64 allocation
+			const attackIPs = [
+				"2001:db8:abcd:1234:0000:0000:0000:0001",
+				"2001:db8:abcd:1234:1111:2222:3333:4444",
+				"2001:db8:abcd:1234:ffff:ffff:ffff:ffff",
+				"2001:db8:abcd:1234:aaaa:bbbb:cccc:dddd",
+			];
+
+			const normalized = attackIPs.map((ip) =>
+				normalizeIP(ip, { ipv6Subnet: 64 }),
+			);
+
+			// All should map to same /64 subnet
+			const uniqueValues = new Set(normalized);
+			expect(uniqueValues.size).toBe(1);
+			expect(normalized[0]).toBe("2001:0db8:abcd:1234:0000:0000:0000:0000");
+		});
+	});
+
+	describe("Edge Cases", () => {
+		it("should handle localhost addresses", () => {
+			expect(normalizeIP("127.0.0.1")).toBe("127.0.0.1");
+			expect(normalizeIP("::1")).toBe(
+				"0000:0000:0000:0000:0000:0000:0000:0001",
+			);
+		});
+
+		it("should handle all-zeros address", () => {
+			expect(normalizeIP("0.0.0.0")).toBe("0.0.0.0");
+			expect(normalizeIP("::")).toBe("0000:0000:0000:0000:0000:0000:0000:0000");
+		});
+
+		it("should handle link-local addresses", () => {
+			expect(normalizeIP("169.254.0.1")).toBe("169.254.0.1");
+			expect(normalizeIP("fe80::1")).toBe(
+				"fe80:0000:0000:0000:0000:0000:0000:0001",
+			);
+		});
+	});
+});

--- a/packages/core/src/utils/ip.ts
+++ b/packages/core/src/utils/ip.ts
@@ -1,0 +1,211 @@
+import * as z from "zod";
+
+/**
+ * Normalizes an IP address for consistent rate limiting.
+ *
+ * Features:
+ * - Normalizes IPv6 to canonical lowercase form
+ * - Converts IPv4-mapped IPv6 to IPv4
+ * - Supports IPv6 subnet extraction
+ * - Handles all edge cases (::1, ::, etc.)
+ */
+
+interface NormalizeIPOptions {
+	/**
+	 * For IPv6 addresses, extract the subnet prefix instead of full address.
+	 * Common values: 32, 48, 64, 128 (default: 128 = full address)
+	 *
+	 * @default 128
+	 */
+	ipv6Subnet?: 128 | 64 | 48 | 32;
+}
+
+/**
+ * Checks if an IP is valid IPv4 or IPv6
+ */
+export function isValidIP(ip: string): boolean {
+	return z.ipv4().safeParse(ip).success || z.ipv6().safeParse(ip).success;
+}
+
+/**
+ * Checks if an IP is IPv6
+ */
+function isIPv6(ip: string): boolean {
+	return z.ipv6().safeParse(ip).success;
+}
+
+/**
+ * Converts IPv4-mapped IPv6 address to IPv4
+ * e.g., "::ffff:192.0.2.1" -> "192.0.2.1"
+ */
+function extractIPv4FromMapped(ipv6: string): string | null {
+	const lower = ipv6.toLowerCase();
+
+	// Handle ::ffff:192.0.2.1 format
+	if (lower.startsWith("::ffff:")) {
+		const ipv4Part = lower.substring(7);
+		// Check if it's a valid IPv4
+		if (z.ipv4().safeParse(ipv4Part).success) {
+			return ipv4Part;
+		}
+	}
+
+	// Handle full form: 0:0:0:0:0:ffff:192.0.2.1
+	const parts = ipv6.split(":");
+	if (parts.length === 7 && parts[5]?.toLowerCase() === "ffff") {
+		const ipv4Part = parts[6];
+		if (ipv4Part && z.ipv4().safeParse(ipv4Part).success) {
+			return ipv4Part;
+		}
+	}
+
+	// Handle hex-encoded IPv4 in mapped address
+	// e.g., ::ffff:c000:0201 -> 192.0.2.1
+	if (lower.includes("::ffff:") || lower.includes(":ffff:")) {
+		const groups = expandIPv6(ipv6);
+		if (
+			groups.length === 8 &&
+			groups[0] === "0000" &&
+			groups[1] === "0000" &&
+			groups[2] === "0000" &&
+			groups[3] === "0000" &&
+			groups[4] === "0000" &&
+			groups[5] === "ffff" &&
+			groups[6] &&
+			groups[7]
+		) {
+			// Convert last two groups to IPv4
+			const byte1 = Number.parseInt(groups[6].substring(0, 2), 16);
+			const byte2 = Number.parseInt(groups[6].substring(2, 4), 16);
+			const byte3 = Number.parseInt(groups[7].substring(0, 2), 16);
+			const byte4 = Number.parseInt(groups[7].substring(2, 4), 16);
+			return `${byte1}.${byte2}.${byte3}.${byte4}`;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Expands a compressed IPv6 address to full form
+ * e.g., "2001:db8::1" -> ["2001", "0db8", "0000", "0000", "0000", "0000", "0000", "0001"]
+ */
+function expandIPv6(ipv6: string): string[] {
+	// Handle :: notation (zero compression)
+	if (ipv6.includes("::")) {
+		const sides = ipv6.split("::");
+		const left = sides[0] ? sides[0].split(":") : [];
+		const right = sides[1] ? sides[1].split(":") : [];
+
+		// Calculate missing groups
+		const totalGroups = 8;
+		const missingGroups = totalGroups - left.length - right.length;
+		const zeros = Array(missingGroups).fill("0000");
+
+		// Pad existing groups to 4 digits
+		const paddedLeft = left.map((g) => g.padStart(4, "0"));
+		const paddedRight = right.map((g) => g.padStart(4, "0"));
+
+		return [...paddedLeft, ...zeros, ...paddedRight];
+	}
+
+	// No compression, just pad each group
+	return ipv6.split(":").map((g) => g.padStart(4, "0"));
+}
+
+/**
+ * Normalizes an IPv6 address to canonical form
+ * e.g., "2001:DB8::1" -> "2001:0db8:0000:0000:0000:0000:0000:0001"
+ */
+function normalizeIPv6(
+	ipv6: string,
+	subnetPrefix?: 128 | 32 | 48 | 64,
+): string {
+	const groups = expandIPv6(ipv6);
+
+	if (subnetPrefix && subnetPrefix < 128) {
+		// Apply subnet mask
+		const prefix = subnetPrefix;
+		let bitsRemaining: 128 | 64 | 48 | 32 | 0 = prefix;
+
+		const maskedGroups = groups.map((group) => {
+			if (bitsRemaining <= 0) {
+				return "0000";
+			}
+			if (bitsRemaining >= 16) {
+				bitsRemaining -= 16;
+				return group;
+			}
+
+			// Partial mask for this group
+			const value = Number.parseInt(group, 16);
+			const mask = (0xffff << (16 - bitsRemaining)) & 0xffff;
+			const masked = value & mask;
+			bitsRemaining = 0;
+			return masked.toString(16).padStart(4, "0");
+		});
+
+		return maskedGroups.join(":").toLowerCase();
+	}
+
+	return groups.join(":").toLowerCase();
+}
+
+/**
+ * Normalizes an IP address (IPv4 or IPv6) for consistent rate limiting.
+ *
+ * @param ip - The IP address to normalize
+ * @param options - Normalization options
+ * @returns Normalized IP address
+ *
+ * @example
+ * normalizeIP("2001:DB8::1")
+ * // -> "2001:0db8:0000:0000:0000:0000:0000:0001"
+ *
+ * @example
+ * normalizeIP("::ffff:192.0.2.1")
+ * // -> "192.0.2.1" (converted to IPv4)
+ *
+ * @example
+ * normalizeIP("2001:db8::1", { ipv6Subnet: 64 })
+ * // -> "2001:0db8:0000:0000:0000:0000:0000:0000" (subnet /64)
+ */
+export function normalizeIP(
+	ip: string,
+	options: NormalizeIPOptions = {},
+): string {
+	// IPv4 addresses are already normalized
+	if (z.ipv4().safeParse(ip).success) {
+		return ip.toLowerCase();
+	}
+
+	// Check if it's IPv6
+	if (!isIPv6(ip)) {
+		// Return as-is if not valid (shouldn't happen due to prior validation)
+		return ip.toLowerCase();
+	}
+
+	// Check for IPv4-mapped IPv6
+	const ipv4 = extractIPv4FromMapped(ip);
+	if (ipv4) {
+		return ipv4.toLowerCase();
+	}
+
+	// Normalize IPv6
+	const subnetPrefix = options.ipv6Subnet || 128;
+	return normalizeIPv6(ip, subnetPrefix);
+}
+
+/**
+ * Creates a rate limit key from IP and path
+ * Uses a separator to prevent collision attacks
+ *
+ * @param ip - The IP address (should be normalized)
+ * @param path - The request path
+ * @returns Rate limit key
+ */
+export function createRateLimitKey(ip: string, path: string): string {
+	// Use | as separator to prevent collision attacks
+	// e.g., "192.0.2.1" + "/sign-in" vs "192.0.2" + ".1/sign-in"
+	return `${ip}|${path}`;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds IPv6-aware rate limiting with address normalization and optional subnet grouping to prevent bypass via alternate IPv6 forms or IPv4-mapped addresses. Also changes rate-limit keys to use a pipe separator to avoid collisions.

- **New Features**
  - Normalize IPv6 to a canonical form and convert IPv4‑mapped IPv6 (e.g., ::ffff:192.0.2.1) to IPv4 before rate limiting.
  - Add rateLimit.ipv6Subnet (32/48/64/128; default 128) to group IPv6 requests by subnet when desired.

- **Migration**
  - Rate-limit keys now use {ip}|{path} instead of {ip}{path}. Update any custom storage or tooling that reads/writes keys. Existing keys will be recreated automatically as requests arrive.

<sup>Written for commit cd9776780e27e35e6a8c578a145d246ad58c17b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

