### PR TITLE
debug state mismatch

### DIFF
--- a/packages/core/src/env/logger.ts
+++ b/packages/core/src/env/logger.ts
@@ -112,6 +112,13 @@ export const createLogger = (options?: Logger | undefined): InternalLogger => {
 
 		const formattedMessage = formatMessage(level, message, colorsEnabled);
 
+		// FIXME: workaround for APIError
+		args.forEach((arg) => {
+			if (typeof arg === "object" && arg !== null && "errorStack" in arg) {
+				arg.stack = arg.errorStack;
+			}
+		});
+
 		if (!options || typeof options.log !== "function") {
 			if (level === "error") {
 				console.error(formattedMessage, ...args);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing stack traces when logging APIError objects. The logger now copies errorStack to stack in args so error logs show the correct trace for easier debugging.

<sup>Written for commit c61da9f451f463e446085601306fcc71cee7553a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

