### PR TITLE
docs: hide method/url from server-only API documentation

### DIFF
--- a/docs/components/api-method.tsx
+++ b/docs/components/api-method.tsx
@@ -178,7 +178,7 @@ export const APIMethod = ({
 
 	const serverTabContent = (
 		<>
-			{isClientOnly ? null : (
+			{isClientOnly || isServerOnly ? null : (
 				<Endpoint
 					method={method || "GET"}
 					path={path}


### PR DESCRIPTION
Server-only APIs are not accessible over HTTP, but the documentation was showing method and URL which confused users into thinking they could call these endpoints directly. This hides the endpoint display for server-only APIs.

Closes #7315

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide HTTP method and URL in docs for server-only APIs so users don’t think they can call them over HTTP. APIMethod now skips Endpoint rendering when isServerOnly, addressing #7315.

<sup>Written for commit 57ba9fc30ed24a6be7bf55e4db089b1dc664949b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

