### PR TITLE
docs: update client to authClient in Svelte and Solid examples for consistency 

### DIFF
--- a/docs/content/docs/concepts/client.mdx
+++ b/docs/content/docs/concepts/client.mdx
@@ -137,8 +137,8 @@ In addition to the standard methods, the client provides hooks to easily access 
         <Tab value="Svelte">
             ```svelte title="user.svelte"
             <script lang="ts">
-            import { client } from "$lib/client";
-            const session = client.useSession();
+            import { authClient } from "$lib/auth-client";
+            const session = authClient.useSession();
             </script>
 
             <div
@@ -179,11 +179,11 @@ In addition to the standard methods, the client provides hooks to easily access 
 
         <Tab value="Solid">
             ```tsx title="user.tsx"
-            import { client } from "~/lib/client";
+            import { authClient } from "~/lib/auth-client";
             import { Show } from 'solid-js';
 
             export default function Home() {
-                const session = client.useSession()
+                const session = authClient.useSession()
                 return (
                     <Show
                         when={session()}


### PR DESCRIPTION
Updated the Svelte and Solid useSession hook examples in client.mdx to use authClient naming convention instead of client, matching the pattern used in other framework examples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Svelte and Solid docs examples to use authClient.useSession instead of client.useSession for consistency across frameworks. This aligns naming with the authClient convention and avoids confusion when copying code.

<sup>Written for commit fa6b56514e087697895d7cd932a7592831fdbea1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

