### PR TITLE
feat(adapters): add advanced.database.usePlural as fallback for adapter-specific option

### DIFF
--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -45,6 +45,9 @@ export interface DrizzleAdapterConfig {
 	 * If the table names in the schema are plural
 	 * set this to true. For example, if the schema
 	 * has an object with a key "users" instead of "user"
+	 *
+	 * @deprecated Use `advanced.database.usePlural` in the main config instead.
+	 * This option will be removed in a future release.
 	 */
 	usePlural?: boolean | undefined;
 	/**
@@ -75,6 +78,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	const createCustomAdapter =
 		(db: DB): AdapterFactoryCustomizeAdapterCreator =>
 		({ getFieldName, options }) => {
+			const usePlural =
+				config.usePlural ?? options.advanced?.database?.usePlural ?? false;
 			function getSchema(model: string) {
 				const schema = config.schema || db._.fullSchema;
 				if (!schema) {
@@ -384,7 +389,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 										options.advanced?.database?.defaultFindManyLimit ??
 										100;
 									const isUnique = joinAttr.relation === "one-to-one";
-									const pluralSuffix = isUnique || config.usePlural ? "" : "s";
+									const pluralSuffix = isUnique || usePlural ? "" : "s";
 									includes[`${model}${pluralSuffix}`] = isUnique
 										? true
 										: { limit };
@@ -401,7 +406,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 
 							if (res) {
 								for (const pluralJoinResult of pluralJoinResults) {
-									let singularKey = !config.usePlural
+									let singularKey = !usePlural
 										? pluralJoinResult.slice(0, -1)
 										: pluralJoinResult;
 									res[singularKey] = res[pluralJoinResult];
@@ -450,7 +455,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 										joinAttr.limit ??
 										options.advanced?.database?.defaultFindManyLimit ??
 										100;
-									let pluralSuffix = isUnique || config.usePlural ? "" : "s";
+									let pluralSuffix = isUnique || usePlural ? "" : "s";
 									includes[`${model}${pluralSuffix}`] = isUnique
 										? true
 										: { limit };
@@ -477,7 +482,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							if (res) {
 								for (const item of res) {
 									for (const pluralJoinResult of pluralJoinResults) {
-										const singularKey = !config.usePlural
+										const singularKey = !usePlural
 											? pluralJoinResult.slice(0, -1)
 											: pluralJoinResult;
 										if (singularKey === pluralJoinResult) continue;
@@ -576,7 +581,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 		config: {
 			adapterId: "drizzle",
 			adapterName: "Drizzle Adapter",
-			usePlural: config.usePlural ?? false,
+			usePlural: config.usePlural,
 			debugLogs: config.debugLogs ?? false,
 			supportsUUIDs: config.provider === "pg" ? true : false,
 			supportsJSON:

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -32,6 +32,9 @@ interface KyselyAdapterConfig {
 	 * Use plural for table names.
 	 *
 	 * @default false
+	 *
+	 * @deprecated Use `advanced.database.usePlural` in the main config instead.
+	 * This option will be removed in a future release.
 	 */
 	usePlural?: boolean | undefined;
 	/**

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -33,6 +33,9 @@ export interface PrismaConfig {
 	 * Use plural table names
 	 *
 	 * @default false
+	 *
+	 * @deprecated Use `advanced.database.usePlural` in the main config instead.
+	 * This option will be removed in a future release.
 	 */
 	usePlural?: boolean | undefined;
 
@@ -74,8 +77,11 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 			getFieldAttributes,
 			getDefaultModelName,
 			schema,
+			options,
 		}) => {
 			const db = prisma as PrismaClientInternal;
+			const usePlural =
+				config.usePlural ?? options.advanced?.database?.usePlural ?? false;
 
 			const convertSelect = (
 				select: string[] | undefined,
@@ -148,7 +154,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 						const [_foreignKey, foreignKeyAttributes] = foreignKeys[0] as any;
 						// Only check if field is explicitly marked as unique
 						const isUnique = foreignKeyAttributes?.unique === true;
-						return isUnique || config.usePlural === true ? key : `${key}s`;
+						return isUnique || usePlural ? key : `${key}s`;
 					}
 
 					// Check backwards: does the base model have FKs to the joined model?
@@ -529,7 +535,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 		config: {
 			adapterId: "prisma",
 			adapterName: "Prisma Adapter",
-			usePlural: config.usePlural ?? false,
+			usePlural: config.usePlural,
 			debugLogs: config.debugLogs ?? false,
 			supportsUUIDs: config.provider === "postgresql" ? true : false,
 			supportsArrays:

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -143,29 +143,31 @@ export const createAdapterFactory =
 
 		const logger = createLogger(options.logger);
 
+		const usePlural = config.usePlural ?? options.advanced?.database?.usePlural;
+
 		const getDefaultModelName = initGetDefaultModelName({
-			usePlural: config.usePlural,
+			usePlural,
 			schema,
 		});
 
 		const getDefaultFieldName = initGetDefaultFieldName({
-			usePlural: config.usePlural,
+			usePlural,
 			schema,
 		});
 
 		const getModelName = initGetModelName({
-			usePlural: config.usePlural,
+			usePlural,
 			schema,
 		});
 		const getFieldName = initGetFieldName({
 			schema,
-			usePlural: config.usePlural,
+			usePlural,
 		});
 
 		const idField = initGetIdField({
 			schema,
 			options,
-			usePlural: config.usePlural,
+			usePlural,
 			disableIdGeneration: config.disableIdGeneration,
 			customIdGenerator: config.customIdGenerator,
 			supportsUUIDs: config.supportsUUIDs,
@@ -174,7 +176,7 @@ export const createAdapterFactory =
 		const getFieldAttributes = initGetFieldAttributes({
 			schema,
 			options,
-			usePlural: config.usePlural,
+			usePlural,
 			disableIdGeneration: config.disableIdGeneration,
 			customIdGenerator: config.customIdGenerator,
 		});

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -270,6 +270,16 @@ export type BetterAuthAdvancedOptions = {
 				 * function.
 				 */
 				generateId?: GenerateIdFn | false | "serial" | "uuid";
+				/**
+				 * Use plural table names (e.g., "users" instead of "user").
+				 *
+				 * This option is used as a fallback for database adapters
+				 * that support plural table names. If set here, it will apply
+				 * to all adapters unless overridden in the adapter-specific config.
+				 *
+				 * @default false
+				 */
+				usePlural?: boolean;
 		  }
 		| undefined;
 	/**


### PR DESCRIPTION
- Add usePlural to advanced.database config in init-options.ts
- Update adapter factory to use config.usePlural ?? options.advanced?.database?.usePlural
- Update Drizzle adapter to use the fallback for internal usePlural usages
- Update Prisma adapter to use the fallback for internal usePlural usages
- Mark adapter-specific usePlural options as deprecated with guidance to use advanced.database.usePlural instead

This allows users to set usePlural once in advanced.database and have it apply to all adapters, while still allowing adapter-specific overrides if needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global advanced.database.usePlural option that acts as a fallback for adapter-specific usePlural. This unifies plural table handling across adapters while still allowing per-adapter overrides.

- **New Features**
  - Introduced advanced.database.usePlural (default false) to control plural table names across all adapters.
  - Adapter factory, Drizzle, and Prisma now resolve usePlural via adapterConfig.usePlural ?? advanced.database.usePlural.
  - Marked usePlural in Drizzle/Prisma/Kysely adapter configs as deprecated.

- **Migration**
  - Set advanced.database.usePlural in your main config.
  - Keep adapter-specific usePlural only if you need an override.
  - Plan to remove adapter-level usePlural in a future release.

<sup>Written for commit 0e80707ad855ac5435075824a093cd955977a3cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

