### PR TITLE
feat(jwt): add HS256 symmetric key algorithm support

### DIFF
--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -165,6 +165,11 @@ export const jwt = <O extends JwtOptions>(options?: O) => {
 						throw new APIError("NOT_FOUND");
 					}
 
+					// Disables endpoint for HS256 (symmetric keys should not be exposed)
+					if (options?.jwks?.keyPairConfig?.alg === "HS256") {
+						throw new APIError("NOT_FOUND");
+					}
+
 					const adapter = getJwksAdapter(ctx.context.adapter, options);
 
 					let keySets = await adapter.getAllKeys(ctx);

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -833,3 +833,168 @@ describe("toExpJWT", () => {
 		});
 	});
 });
+
+describe("jwt - HS256 symmetric algorithm", async () => {
+	const jwtOptions: JwtOptions = {
+		jwks: {
+			keyPairConfig: {
+				alg: "HS256",
+			},
+		},
+	};
+
+	const { auth, signInWithTestUser } = await getTestInstance({
+		plugins: [jwt(jwtOptions)],
+		logger: {
+			level: "error",
+		},
+	});
+
+	const client = createAuthClient({
+		plugins: [jwtClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	const { headers } = await signInWithTestUser();
+
+	it("should generate a symmetric key", async () => {
+		const { publicWebKey, privateWebKey, alg } =
+			await generateExportedKeyPair(jwtOptions);
+
+		expect(alg).toBe("HS256");
+		// For HS256, publicWebKey is a marker object
+		expect(publicWebKey.kty).toBe("oct");
+		expect((publicWebKey as any).symmetric).toBe(true);
+		// privateWebKey is the actual secret
+		expect(privateWebKey.kty).toBe("oct");
+		expect(privateWebKey.k).toBeDefined();
+	});
+
+	it("should sign a JWT with HS256", async () => {
+		const token = await auth.api.signJWT({
+			body: {
+				payload: {
+					sub: "123",
+					exp: Math.floor(Date.now() / 1000) + 600,
+					iat: Math.floor(Date.now() / 1000),
+					iss: "https://example.com",
+					aud: "https://example.com",
+					custom: "custom",
+				},
+			},
+		});
+		expect(token?.token).toBeDefined();
+
+		// Verify the token has HS256 in the header
+		const parts = token?.token!.split(".");
+		const header = JSON.parse(
+			Buffer.from(parts[0]!, "base64url").toString("utf8"),
+		);
+		expect(header.alg).toBe("HS256");
+	});
+
+	it("should get a token from session with HS256", async () => {
+		let token = "";
+		await client.getSession({
+			fetchOptions: {
+				headers,
+				onSuccess(context) {
+					token = context.response.headers.get("set-auth-jwt") || "";
+				},
+			},
+		});
+
+		expect(token.length).toBeGreaterThan(10);
+
+		// Verify the token has HS256 in the header
+		const parts = token.split(".");
+		const header = JSON.parse(
+			Buffer.from(parts[0]!, "base64url").toString("utf8"),
+		);
+		expect(header.alg).toBe("HS256");
+	});
+
+	it("should disable /jwks endpoint for HS256", async () => {
+		const response = await client.$fetch<JSONWebKeySet>("/jwks");
+		expect(response.error?.status).toBe(404);
+	});
+
+	it("should verify a JWT signed with HS256", async () => {
+		const signedToken = await auth.api.signJWT({
+			body: {
+				payload: {
+					sub: "test-user",
+					exp: Math.floor(Date.now() / 1000) + 600,
+					iat: Math.floor(Date.now() / 1000),
+					iss: "http://localhost:3000/api/auth",
+					aud: "http://localhost:3000/api/auth",
+				},
+			},
+		});
+
+		const result = await auth.api.verifyJWT({
+			body: {
+				token: signedToken?.token!,
+			},
+		});
+
+		expect(result.payload).toBeDefined();
+		expect(result.payload?.sub).toBe("test-user");
+	});
+
+	it("should work with private key encryption disabled", async () => {
+		const optionsNoEncryption: JwtOptions = {
+			jwks: {
+				keyPairConfig: {
+					alg: "HS256",
+				},
+				disablePrivateKeyEncryption: true,
+			},
+		};
+
+		const { auth: authNoEnc, signInWithTestUser: signInNoEnc } =
+			await getTestInstance({
+				plugins: [jwt(optionsNoEncryption)],
+				logger: {
+					level: "error",
+				},
+			});
+
+		const { headers: headersNoEnc } = await signInNoEnc();
+
+		const clientNoEnc = createAuthClient({
+			plugins: [jwtClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					return authNoEnc.handler(new Request(url, init));
+				},
+			},
+		});
+
+		let token = "";
+		await clientNoEnc.getSession({
+			fetchOptions: {
+				headers: headersNoEnc,
+				onSuccess(context) {
+					token = context.response.headers.get("set-auth-jwt") || "";
+				},
+			},
+		});
+
+		expect(token.length).toBeGreaterThan(10);
+
+		// Verify token and check it works
+		const result = await authNoEnc.api.verifyJWT({
+			body: {
+				token,
+			},
+		});
+		expect(result.payload).toBeDefined();
+	});
+});

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -931,8 +931,6 @@ describe("jwt - HS256 symmetric algorithm", async () => {
 					sub: "test-user",
 					exp: Math.floor(Date.now() / 1000) + 600,
 					iat: Math.floor(Date.now() / 1000),
-					iss: "http://localhost:3000/api/auth",
-					aud: "http://localhost:3000/api/auth",
 				},
 			},
 		});
@@ -943,7 +941,7 @@ describe("jwt - HS256 symmetric algorithm", async () => {
 			},
 		});
 
-		expect(result.payload).toBeDefined();
+		expect(result.payload).not.toBeNull();
 		expect(result.payload?.sub).toBe("test-user");
 	});
 
@@ -995,6 +993,6 @@ describe("jwt - HS256 symmetric algorithm", async () => {
 				token,
 			},
 		});
-		expect(result.payload).toBeDefined();
+		expect(result.payload).not.toBeNull();
 	});
 });

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -941,6 +941,7 @@ describe("jwt - HS256 symmetric algorithm", async () => {
 			},
 		});
 
+		expect(result.payload).toBeDefined();
 		expect(result.payload).not.toBeNull();
 		expect(result.payload?.sub).toBe("test-user");
 	});
@@ -993,6 +994,7 @@ describe("jwt - HS256 symmetric algorithm", async () => {
 				token,
 			},
 		});
+		expect(result.payload).toBeDefined();
 		expect(result.payload).not.toBeNull();
 	});
 });

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -167,11 +167,18 @@ export interface JwtOptions {
 }
 
 /**
- * Asymmetric (JWS) Supported.
+ * JWS Algorithms Supported.
  *
  * @see https://github.com/panva/jose/issues/210
+ *
+ * Asymmetric algorithms (EdDSA, ES256, ES512, PS256, RS256) use public/private key pairs
+ * and support JWKS endpoints for public key distribution.
+ *
+ * Symmetric algorithm (HS256) uses a shared secret key. When using HS256:
+ * - The JWKS endpoint will be disabled (no public key to share)
+ * - The secret is derived from the auth secret
+ * - Suitable for internal service-to-service communication
  */
-// JWE is symmetric (ie sharing a secret) thus a jwks is not applicable since there is no public key to share.
 // All new JWK "alg" and/or "crv" MUST have an associated test in jwt.test.ts
 export type JWKOptions =
 	| {
@@ -193,6 +200,9 @@ export type JWKOptions =
 	| {
 			alg: "RS256"; // RSA with SHA-256
 			modulusLength?: number | undefined; // Default to 2048 or higher
+	  }
+	| {
+			alg: "HS256"; // HMAC with SHA-256 (symmetric)
 	  };
 
 export type JWSAlgorithms = JWKOptions["alg"];

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -176,7 +176,7 @@ export interface JwtOptions {
  *
  * Symmetric algorithm (HS256) uses a shared secret key. When using HS256:
  * - The JWKS endpoint will be disabled (no public key to share)
- * - The secret is derived from the auth secret
+ * - The secret is randomly generated and encrypted using the auth secret for secure storage
  * - Suitable for internal service-to-service communication
  */
 // All new JWK "alg" and/or "crv" MUST have an associated test in jwt.test.ts

--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -40,8 +40,8 @@ export async function generateExportedKeyPair(
 	if (alg === "HS256") {
 		const secretKey = await generateSecret(alg, { extractable: true });
 		const secretWebKey = await exportJWK(secretKey);
-		// For symmetric keys, both public and private keys are the same (the secret)
-		// The public key is set to an empty object marker to indicate it's symmetric
+		// For symmetric keys, the privateWebKey contains the secret
+		// and the publicWebKey is a marker object to indicate it's symmetric
 		return {
 			publicWebKey: { kty: "oct", symmetric: true } as Record<string, unknown>,
 			privateWebKey: secretWebKey,

--- a/packages/better-auth/src/plugins/jwt/verify.ts
+++ b/packages/better-auth/src/plugins/jwt/verify.ts
@@ -3,6 +3,7 @@ import { getCurrentAuthContext } from "@better-auth/core/context";
 import { base64 } from "@better-auth/utils/base64";
 import type { JWTPayload } from "jose";
 import { importJWK, jwtVerify } from "jose";
+import { symmetricDecrypt } from "../../crypto";
 import { getJwksAdapter } from "./adapter";
 import type { JwtOptions } from "./types";
 
@@ -45,9 +46,29 @@ export async function verifyJWT<T extends JWTPayload = JWTPayload>(
 			return null;
 		}
 
-		const publicKey = JSON.parse(key.publicKey);
 		const alg = key.alg ?? options?.jwks?.keyPairConfig?.alg ?? "EdDSA";
-		const cryptoKey = await importJWK(publicKey, alg);
+
+		let cryptoKey;
+		if (alg === "HS256") {
+			// For HS256, we need to use the secret key (stored as privateKey)
+			const privateKeyEncryptionEnabled =
+				!options?.jwks?.disablePrivateKeyEncryption;
+			let secretWebKey = privateKeyEncryptionEnabled
+				? await symmetricDecrypt({
+						key: ctx.context.secret,
+						data: JSON.parse(key.privateKey),
+					}).catch(() => null)
+				: key.privateKey;
+
+			if (!secretWebKey) {
+				ctx.context.logger.debug("Failed to decrypt HS256 secret key");
+				return null;
+			}
+			cryptoKey = await importJWK(JSON.parse(secretWebKey), alg);
+		} else {
+			const publicKey = JSON.parse(key.publicKey);
+			cryptoKey = await importJWK(publicKey, alg);
+		}
 
 		const baseURLOrigin =
 			typeof ctx.context.options.baseURL === "string"

--- a/packages/better-auth/src/plugins/jwt/verify.ts
+++ b/packages/better-auth/src/plugins/jwt/verify.ts
@@ -48,26 +48,30 @@ export async function verifyJWT<T extends JWTPayload = JWTPayload>(
 
 		const alg = key.alg ?? options?.jwks?.keyPairConfig?.alg ?? "EdDSA";
 
-		let cryptoKey;
-		if (alg === "HS256") {
-			// For HS256, we need to use the secret key (stored as privateKey)
-			const privateKeyEncryptionEnabled =
-				!options?.jwks?.disablePrivateKeyEncryption;
-			let secretWebKey = privateKeyEncryptionEnabled
-				? await symmetricDecrypt({
-						key: ctx.context.secret,
-						data: JSON.parse(key.privateKey),
-					}).catch(() => null)
-				: key.privateKey;
+		const cryptoKey =
+			alg === "HS256"
+				? await (async () => {
+						// For HS256, we need to use the secret key (stored as privateKey)
+						const privateKeyEncryptionEnabled =
+							!options?.jwks?.disablePrivateKeyEncryption;
+						const secretWebKey = privateKeyEncryptionEnabled
+							? await symmetricDecrypt({
+									key: ctx.context.secretConfig,
+									data: JSON.parse(key.privateKey),
+								}).catch(() => null)
+							: key.privateKey;
 
-			if (!secretWebKey) {
-				ctx.context.logger.debug("Failed to decrypt HS256 secret key");
-				return null;
-			}
-			cryptoKey = await importJWK(JSON.parse(secretWebKey), alg);
-		} else {
-			const publicKey = JSON.parse(key.publicKey);
-			cryptoKey = await importJWK(publicKey, alg);
+						if (!secretWebKey) {
+							ctx.context.logger.debug("Failed to decrypt HS256 secret key");
+							return null;
+						}
+
+						return importJWK(JSON.parse(secretWebKey), alg);
+					})()
+				: await importJWK(JSON.parse(key.publicKey), alg);
+
+		if (!cryptoKey) {
+			return null;
 		}
 
 		const baseURLOrigin =


### PR DESCRIPTION
Adds support for HS256 (HMAC with SHA-256) symmetric key signing to the JWT plugin. This enables users to use symmetric key JWTs for internal service-to-service communication.

Changes:
- Add HS256 to JWKOptions type
- Generate symmetric secret keys for HS256 using jose's generateSecret
- Handle HS256 signing with the secret key
- Handle HS256 verification using the secret key (with decryption)
- Disable JWKS endpoint for HS256 (symmetric keys should not be exposed)
- Add comprehensive tests for HS256 functionality

Closes #7245

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added HS256 (HMAC-SHA256) support to the JWT plugin for symmetric key signing and verification. Meets #7245 by enabling symmetric service-to-service JWTs and disabling the JWKS endpoint for HS256.

- **New Features**
  - HS256 added to JWKOptions; symmetric secret generated via jose.generateSecret.
  - Sign and verify with the shared secret; works with or without private key encryption.
  - JWKS endpoint returns 404 for HS256 to avoid exposing symmetric keys.
  - Comprehensive tests cover key generation, signing, session tokens, and verification.

<sup>Written for commit c813a69cbfb974c03f74c9a0fac9ee1e407c15a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

