### PR TITLE
fix(api-key): exclude userId from update data in validateApiKey function

### DIFF
--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -169,12 +169,14 @@ export async function validateApiKey({
 		updatedAt: new Date(),
 	};
 
+	const { id: _id, userId: _userId, ...updateData } = updated;
+
 	const performUpdate = async (): Promise<ApiKey | null> => {
 		if (opts.storage === "database") {
 			return ctx.context.adapter.update<ApiKey>({
 				model: API_KEY_TABLE_NAME,
 				where: [{ field: "id", value: apiKey.id }],
-				update: { ...updated, id: undefined, userId: undefined },
+				update: updateData,
 			});
 		} else if (
 			opts.storage === "secondary-storage" &&
@@ -183,7 +185,7 @@ export async function validateApiKey({
 			const dbUpdated = await ctx.context.adapter.update<ApiKey>({
 				model: API_KEY_TABLE_NAME,
 				where: [{ field: "id", value: apiKey.id }],
-				update: { ...updated, id: undefined, userId: undefined },
+				update: updateData,
 			});
 			if (dbUpdated) {
 				await setApiKey(ctx, dbUpdated, opts);

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -3,10 +3,11 @@ import { createAuthEndpoint } from "@better-auth/core/api";
 import { APIError } from "@better-auth/core/error";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import * as z from "zod";
-import { isAPIError } from "../../../utils/is-api-error";
-import { role } from "../../access";
+import type { PredefinedApiKeyOptions } from ".";
 import { API_KEY_TABLE_NAME, API_KEY_ERROR_CODES as ERROR_CODES } from "..";
 import { defaultKeyHasher } from "../";
+import { isAPIError } from "../../../utils/is-api-error";
+import { role } from "../../access";
 import {
 	deleteApiKey,
 	getApiKey,
@@ -16,7 +17,6 @@ import {
 import { isRateLimited } from "../rate-limit";
 import type { apiKeySchema } from "../schema";
 import type { ApiKey } from "../types";
-import type { PredefinedApiKeyOptions } from ".";
 
 export async function validateApiKey({
 	hashedKey,
@@ -174,7 +174,7 @@ export async function validateApiKey({
 			return ctx.context.adapter.update<ApiKey>({
 				model: API_KEY_TABLE_NAME,
 				where: [{ field: "id", value: apiKey.id }],
-				update: { ...updated, id: undefined },
+				update: { ...updated, id: undefined, userId: undefined },
 			});
 		} else if (
 			opts.storage === "secondary-storage" &&
@@ -183,7 +183,7 @@ export async function validateApiKey({
 			const dbUpdated = await ctx.context.adapter.update<ApiKey>({
 				model: API_KEY_TABLE_NAME,
 				where: [{ field: "id", value: apiKey.id }],
-				update: { ...updated, id: undefined },
+				update: { ...updated, id: undefined, userId: undefined },
 			});
 			if (dbUpdated) {
 				await setApiKey(ctx, dbUpdated, opts);

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -169,6 +169,7 @@ export async function validateApiKey({
 		updatedAt: new Date(),
 	};
 
+	// Intentionally exclude immutable identifiers from updateData so they are not persisted/updated.
 	const { id: _id, userId: _userId, ...updateData } = updated;
 
 	const performUpdate = async (): Promise<ApiKey | null> => {


### PR DESCRIPTION
## Background / Problem

When using Better Auth’s API Key plugin with the MongoDB adapter, we observed a data type corruption issue on the `apikey.userId` field:

- API keys created through the official server API were stored with `userId` as a MongoDB `ObjectId` in our collection.
- After calling `auth.api.verifyApiKey` (`POST /api-key/verify`) once, the same record’s `userId` was persisted back as a **string**.
- This breaks downstream queries/aggregations that rely on `ObjectId` matching (e.g. listing/filtering by user via `new ObjectId(userId)`), causing “not found” results even though the data exists.

Root cause: `verifyApiKey` updates API key usage/rate-limit fields by writing back an object derived from the previously fetched API key record. The MongoDB adapter converts referenced IDs to strings on output, and during **update** it does not coerce those strings back to `ObjectId`. As a result, the update operation accidentally overwrites `userId` with its string representation.

## Fix / Approach

This PR applies a minimal, targeted fix in the API key verification flow:

- Keep `verifyApiKey` behavior the same (still updates usage/rate-limit fields like `lastRequest`, `requestCount`, `remaining`, `updatedAt`, etc.).
- Explicitly **exclude `userId`** from the database update payload used during `validateApiKey`/`verifyApiKey` so the verification write-back cannot overwrite the existing `userId` type in MongoDB.
- The change is applied to both write paths:
  - `storage === "database"`
  - `storage === "secondary-storage" && fallbackToDatabase`

## Scope / Impact

- Only affects the database update payload during API key verification.
- Does not change validation results or rate limiting semantics.
- Does not automatically migrate/repair existing records that were already converted to strings (those require a separate data fix).

## Reproduction (before fix)

1. Create an API key and confirm `apikey.userId` is stored as `ObjectId`.
2. Call `POST /api-key/verify` with that key.
3. Observe the API key record: `userId` becomes a string after verification, and subsequent queries expecting `ObjectId` may fail.

After this fix, verification updates occur without mutating `userId` in the database.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented userId from being overwritten during API key verification to avoid ObjectId → string corruption in MongoDB. This keeps verification updates while preserving identifier types.

- **Bug Fixes**
  - Exclude userId (and id) from update payload in validateApiKey.
  - Applied to both database and secondary-storage fallback paths.
  - No change to validation/rate limiting; existing stringified records are not auto-fixed.

<sup>Written for commit 3e7d1165438fd85e0a3b4e5d603817940ebb29e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

