### PR TITLE
fix(two-factor): use parseUserOutput for consistent user response

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -2,8 +2,8 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError } from "@better-auth/core/error";
 import { createHMAC } from "@better-auth/utils/hmac";
 import { getSessionFromCtx } from "../../api";
-import { parseUserOutput } from "../../db/schema";
 import { expireCookie, setSessionCookie } from "../../cookies";
+import { parseUserOutput } from "../../db/schema";
 import {
 	TRUST_DEVICE_COOKIE_MAX_AGE,
 	TRUST_DEVICE_COOKIE_NAME,


### PR DESCRIPTION
The two-factor verification endpoints (/two-factor/verify-totp, /two-factor/verify-otp) return a hardcoded user object with only basic fields, which excludes additional user fields configured through plugins like the admin plugin's role field.

This PR updates the two-factor verification response to use parseUserOutput(), ensuring consistency with other authentication endpoints

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use parseUserOutput for two-factor verification responses so user data matches other auth endpoints. This returns all configured fields (including plugin fields like role) instead of a hardcoded subset.

<sup>Written for commit 9d04d28f4910c8a0b3872a3e7d17f2ba5d8bbc99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

