### PR TITLE
fix(mongodb-adapter): use duck-typing for ObjectId validation

### DIFF
--- a/e2e/adapter/test/mongo-adapter/adapter.mongo-db.test.ts
+++ b/e2e/adapter/test/mongo-adapter/adapter.mongo-db.test.ts
@@ -1,6 +1,7 @@
-import { mongodbAdapter } from "@better-auth/mongo-adapter";
+import { isObjectIdLike, mongodbAdapter } from "@better-auth/mongo-adapter";
 import { testAdapter } from "@better-auth/test-utils/adapter";
 import { MongoClient, ObjectId } from "mongodb";
+import { describe, expect, it } from "vitest";
 import {
 	authFlowTestSuite,
 	joinsTestSuite,
@@ -36,3 +37,84 @@ const { execute } = await testAdapter({
 });
 
 execute();
+
+/**
+ * Test suite for isObjectIdLike duck-typing validation.
+ *
+ * This tests the fix for the instanceof ObjectId check which fails
+ * when different instances of the mongodb package are loaded
+ * (e.g., different versions or bundled copies).
+ *
+ * @see https://github.com/jdesboeufs/connect-mongo/issues/172
+ * @see https://github.com/mongodb/js-bson/blob/main/src/objectid.ts
+ */
+describe("isObjectIdLike", () => {
+	it("should return true for real ObjectId instances", () => {
+		const objectId = new ObjectId();
+		expect(isObjectIdLike(objectId)).toBe(true);
+	});
+
+	it("should return true for ObjectId created from hex string", () => {
+		const objectId = new ObjectId("507f1f77bcf86cd799439011");
+		expect(isObjectIdLike(objectId)).toBe(true);
+	});
+
+	it("should return true for ObjectId-like objects with toHexString method", () => {
+		// Simulates an ObjectId from a different mongodb package instance
+		const objectIdLike = {
+			toHexString: () => "507f1f77bcf86cd799439011",
+		};
+		expect(isObjectIdLike(objectIdLike)).toBe(true);
+	});
+
+	it("should return true for objects that duck-type as ObjectId", () => {
+		// This simulates the case when a user passes an ObjectId created
+		// from a different version of the mongodb package
+		class CustomObjectId {
+			private id: string;
+			constructor(id?: string) {
+				this.id = id || "507f1f77bcf86cd799439011";
+			}
+			toHexString(): string {
+				return this.id;
+			}
+		}
+		const customId = new CustomObjectId();
+		expect(isObjectIdLike(customId)).toBe(true);
+	});
+
+	it("should return false for null", () => {
+		expect(isObjectIdLike(null)).toBe(false);
+	});
+
+	it("should return false for undefined", () => {
+		expect(isObjectIdLike(undefined)).toBe(false);
+	});
+
+	it("should return false for plain strings", () => {
+		expect(isObjectIdLike("507f1f77bcf86cd799439011")).toBe(false);
+	});
+
+	it("should return false for numbers", () => {
+		expect(isObjectIdLike(123)).toBe(false);
+	});
+
+	it("should return false for plain objects without toHexString", () => {
+		expect(isObjectIdLike({ id: "507f1f77bcf86cd799439011" })).toBe(false);
+	});
+
+	it("should return false for objects with non-function toHexString", () => {
+		const invalidObj = {
+			toHexString: "not-a-function",
+		};
+		expect(isObjectIdLike(invalidObj)).toBe(false);
+	});
+
+	it("should return false for arrays", () => {
+		expect(isObjectIdLike(["507f1f77bcf86cd799439011"])).toBe(false);
+	});
+
+	it("should return false for Date objects", () => {
+		expect(isObjectIdLike(new Date())).toBe(false);
+	});
+});

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -14,8 +14,12 @@ import { ObjectId } from "mongodb";
  * Check if a value is ObjectId-like using duck-typing.
  * This avoids instanceof checks which fail across module boundaries
  * when different instances of the mongodb package are loaded.
+ *
+ * @see https://github.com/jdesboeufs/connect-mongo/issues/172
+ * @see https://github.com/mongodb/js-bson/blob/main/src/objectid.ts
+ * @see https://github.com/Automattic/mongoose/pull/11841
  */
-const isObjectIdLike = (value: unknown): value is ObjectId =>
+export const isObjectIdLike = (value: unknown): value is ObjectId =>
 	value !== null &&
 	typeof value === "object" &&
 	typeof (value as ObjectId).toHexString === "function";


### PR DESCRIPTION
The MongoDB adapter uses instanceof ObjectId to validate ObjectId values. This fails when the ObjectId originates from a different instance of the mongodb package (e.g., when mongoose bundles its own mongodb).

This PR replaces instanceof ObjectId checks with duck-typing by checking for the presence of the toHexString method.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch ObjectId validation in the MongoDB adapter to duck-typing to avoid instanceof failures across different mongodb package instances. This improves compatibility with Mongoose and prevents invalid ID errors.

- **Bug Fixes**
  - Added isObjectIdLike helper that checks for toHexString.
  - Replaced instanceof ObjectId checks in input/output transforms and array handling.
  - Accepts ObjectId-like values directly to avoid "INVALID_ID" errors.

<sup>Written for commit b07db1cb2f468dd17b86479711eec51c931d6acb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

