### PR TITLE
feat :add afterCommit hook for user creation to prevent foreign key violations

### DIFF
--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -177,8 +177,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 			},
 		},
 		async (ctx) => {
-			ctx.context.internalAdapter.clearAfterCommitCallbacks();
-			const result = await runWithTransaction(ctx.context.adapter, async () => {
+			return runWithTransaction(ctx.context.adapter, async () => {
 				if (
 					!ctx.context.options.emailAndPassword?.enabled ||
 					ctx.context.options.emailAndPassword?.disableSignUp
@@ -359,7 +358,5 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					) as InferUser<O>,
 				});
 			});
-			await ctx.context.internalAdapter.runAfterCommitCallbacks();
-			return result;
 		},
 	);

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -167,17 +167,6 @@ export interface InternalAdapter<
 		id: string,
 		data: Partial<Verification>,
 	): Promise<Verification>;
-
-	/**
-	 * Executes all pending afterCommit callbacks.
-	 * Should be called after a transaction is committed.
-	 */
-	runAfterCommitCallbacks(): Promise<void>;
-
-	/**
-	 * Clears all pending afterCommit callbacks without executing them.
-	 */
-	clearAfterCommitCallbacks(): void;
 }
 
 type CreateCookieGetterFn = (


### PR DESCRIPTION
fixes #7260

adds a new `databaseHooks.user.create.afterCommit` hook that runs after the transaction commits, not inside it like the existing `after` hook.

### problem
when using `databaseHooks.user.create.after` during oauth login, any code that tries to reference the newly created user (like creating related records) fails with foreign key constraint violations because the hook runs inside the transaction before it commits.

### solution
- added `afterCommit` hook type to `user.create` in init-options.ts
- modified with-hooks.ts to collect afterCommit callbacks during transaction execution
- added `runAfterCommitCallbacks()` and `clearAfterCommitCallbacks()` methods to internal adapter
- updated `createOAuthUser` and sign-up route to execute afterCommit callbacks after transaction commits

### usage
```typescript
databaseHooks: {
  user: {
    create: {
      afterCommit: async (user, context) => {
        // this runs AFTER the transaction commits
        // safe to create records with foreign keys to user.id
        await db.insert(profiles).values({ userId: user.id, ... });
      }
    }
  }
}

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user.create.afterCommit hook that runs after the transaction commits. Prevents foreign key violations during OAuth login and sign-up when creating related records. Fixes #7260.

- **New Features**
  - Adds databaseHooks.user.create.afterCommit for post-commit actions.
  - createWithHooks now returns { data, afterCommitCallbacks }; callbacks are request-scoped and executed after commit via executeAfterCommitCallbacks with per-callback error handling.
  - Internal adapter collects callbacks during OAuth user creation and runs them after commit; createUser and createAccount also run afterCommit callbacks outside the transaction.

- **Migration**
  - Move related-record creation from user.create.after to user.create.afterCommit.
  - No breaking changes; existing after still runs inside the transaction.

<sup>Written for commit 010947dfa49228fab133812c12190d59d35c69bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

