### PR TITLE
fix(postgres): allow updating string[] (text[]) fields without errors

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -44,8 +44,12 @@ interface KyselyAdapterConfig {
 	transaction?: boolean | undefined;
 }
 
+function escapePostgresArrayValue(value: string) {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 function toPostgresArray(value: string[]) {
-	return `{${value.map((v) => `"${v}"`).join(",")}}`;
+	return `{${value.map((v) => `"${escapePostgresArrayValue(v)}"`).join(",")}}`;
 }
 
 export const kyselyAdapter = (

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -614,7 +614,7 @@ export const kyselyAdapter = (
 				config?.type === "postgres"
 					? true // even if there is JSON support, only pg supports passing direct json, all others must stringify
 					: false,
-			supportsArrays: false, // Even if field supports JSON, we must pass stringified arrays to the database.
+			supportsArrays: config?.type === "postgres",
 			supportsUUIDs: config?.type === "postgres" ? true : false,
 			transaction: config?.transaction
 				? (cb) =>

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -45,7 +45,7 @@ interface KyselyAdapterConfig {
 }
 
 function toPostgresArray(value: string[]) {
-	return `{${value.map(v => `"${v}"`).join(",")}}`;
+	return `{${value.map((v) => `"${v}"`).join(",")}}`;
 }
 
 export const kyselyAdapter = (

--- a/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.pg.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.pg.test.ts
@@ -1,9 +1,10 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 import { Kysely, PostgresDialect } from "kysely";
 import { Pool } from "pg";
+import { expect, it } from "vitest";
+
 import { getMigrations } from "../../../db";
 import { testAdapter } from "../../test-adapter";
-import { it, expect } from "vitest";
 import {
 	authFlowTestSuite,
 	joinsTestSuite,
@@ -23,7 +24,7 @@ const pgDB = new Pool({
 	connectionString: "postgres://user:password@localhost:5433/better_auth",
 });
 
-let kyselyDB = new Kysely({
+const kyselyDB = new Kysely({
 	dialect: new PostgresDialect({ pool: pgDB }),
 });
 
@@ -34,12 +35,9 @@ const cleanupDatabase = async () => {
 	);
 };
 
-const postgresArrayRegressionTestSuite = () =>
-	async ({
-		adapter,
-	}: {
-		adapter: () => Promise<any>;
-	}) => {
+const postgresArrayRegressionTestSuite =
+	() =>
+	async ({ adapter }: { adapter: () => Promise<any> }) => {
 		it("updates postgres string[] (text[]) without error", async () => {
 			const db = await adapter();
 
@@ -96,4 +94,5 @@ const { execute } = await testAdapter({
 		await pgDB.end();
 	},
 });
+
 execute();


### PR DESCRIPTION
### Summary
Fixes an issue where updating Postgres `string[]` / `text[]` fields would fail.

### Changes
- Corrected update handling for Postgres array fields
- Added a regression test to ensure updates work as expected

### Tests
- Added `should update postgres string[] (text[]) fields without error`

fixes #7155 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Postgres string[] (text[]) handling in the Kysely adapter for create and update, so writing array fields no longer throws errors.

- **Bug Fixes**
  - Convert string[] values to Postgres array literals during create/update.
  - Added a regression test to verify updating user.organizationType (string[]) succeeds.

<sup>Written for commit 42bee1d1d22d3ce21baa3bdba13736db6dc9c98b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

