### PR TITLE
chore: fix lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "biome format . --write",
     "format:md": "remark . --output --quiet",
     "format:check": "remark . --quiet --frail",
-    "lint": "biome check .",
+    "lint": "biome check . --error-on-warnings",
     "lint:dependencies": "knip --strict",
     "lint:fix": "biome check . --fix --unsafe",
     "lint:spell": "cspell . --color",

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -36,7 +36,7 @@ async function mcpAction(options: MCPOptions) {
 	}
 }
 
-async function installMcpServers(
+async function _installMcpServers(
 	client: "cursor" | "claude-code" | "open-code" | "manual" | string,
 	installLocal: boolean = true,
 	installRemote: boolean = true,

--- a/packages/mcp/src/lib/templates/features.ts
+++ b/packages/mcp/src/lib/templates/features.ts
@@ -28,7 +28,7 @@ export function getSocialProviderEnvVars(provider: string): EnvVar[] {
 	];
 }
 
-const KNOWN_SOCIAL_PROVIDERS = [
+const _KNOWN_SOCIAL_PROVIDERS = [
 	"google",
 	"github",
 	"apple",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces Biome lint warnings as errors and clears existing warnings. CI will now fail on any new warnings.

- **Refactors**
  - Update lint script to use: biome check . --error-on-warnings
  - Prefix unused internals to satisfy lint: installMcpServers → _installMcpServers; KNOWN_SOCIAL_PROVIDERS → _KNOWN_SOCIAL_PROVIDERS

<sup>Written for commit 87048a143b9e4aeaed97f62df81eb673ef062cb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

