### PR TITLE
docs: use proper base url for rss feed

### DIFF
--- a/docs/lib/utils.ts
+++ b/docs/lib/utils.ts
@@ -25,9 +25,12 @@ export function kFormatter(num: number) {
 }
 
 export const baseUrl =
-	process.env.NODE_ENV === "development" || (!process.env.VERCEL_PROJECT_PRODUCTION_URL && !process.env.VERCEL_URL)
+	process.env.NODE_ENV === "development" ||
+	(!process.env.VERCEL_PROJECT_PRODUCTION_URL && !process.env.VERCEL_URL)
 		? new URL("http://localhost:3000")
-		: new URL(`https://${process.env.VERCEL_PROJECT_PRODUCTION_URL || process.env.VERCEL_URL}`);
+		: new URL(
+				`https://${process.env.VERCEL_PROJECT_PRODUCTION_URL || process.env.VERCEL_URL}`,
+			);
 export function formatDate(date: Date) {
 	let d = new Date(date);
 	return d


### PR DESCRIPTION
uses `better-auth.com` instead of vercel url

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix RSS feed to use the production base URL, not the Vercel preview domain. Prefer VERCEL_PROJECT_PRODUCTION_URL (fallback VERCEL_URL) so links resolve to https://better-auth.com/.

<sup>Written for commit 57f0fe198861aa54b94289a64c4a3d30137ad9a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

