### PR TITLE
fix(stripe): add generic return type to `getSchema` for proper field inference

### DIFF
--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -88,8 +88,14 @@ export const organization = {
 	},
 } satisfies BetterAuthPluginDBSchema;
 
-export const getSchema = (options: StripeOptions) => {
-	let baseSchema = {};
+type GetSchemaResult<O extends StripeOptions> = typeof user &
+	(O["subscription"] extends { enabled: true } ? typeof subscriptions : {}) &
+	(O["organization"] extends { enabled: true } ? typeof organization : {});
+
+export const getSchema = <O extends StripeOptions>(
+	options: O,
+): GetSchemaResult<O> => {
+	let baseSchema: BetterAuthPluginDBSchema = {};
 
 	if (options.subscription?.enabled) {
 		baseSchema = {
@@ -115,8 +121,8 @@ export const getSchema = (options: StripeOptions) => {
 		"subscription" in options.schema
 	) {
 		const { subscription: _subscription, ...restSchema } = options.schema;
-		return mergeSchema(baseSchema, restSchema);
+		return mergeSchema(baseSchema, restSchema) as GetSchemaResult<O>;
 	}
 
-	return mergeSchema(baseSchema, options.schema);
+	return mergeSchema(baseSchema, options.schema) as GetSchemaResult<O>;
 };

--- a/packages/stripe/test/stripe.test.ts
+++ b/packages/stripe/test/stripe.test.ts
@@ -58,6 +58,45 @@ describe("stripe type", () => {
 		expectTypeOf<MyAuth["api"]["upgradeSubscription"]>().toBeFunction();
 		expectTypeOf<MyAuth["api"]["createBillingPortal"]>().toBeFunction();
 	});
+
+	it("should infer plugin schema fields on user type", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [
+				stripe({
+					stripeClient: {} as Stripe,
+					stripeWebhookSecret: "test",
+				}),
+			],
+		});
+		expectTypeOf<
+			(typeof auth)["$Infer"]["Session"]["user"]["stripeCustomerId"]
+		>().toEqualTypeOf<string | null | undefined>();
+	});
+
+	it("should infer plugin schema fields alongside additional user fields", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [
+				stripe({
+					stripeClient: {} as Stripe,
+					stripeWebhookSecret: "test",
+				}),
+			],
+			user: {
+				additionalFields: {
+					customField: {
+						type: "string",
+						required: false,
+					},
+				},
+			},
+		});
+		expectTypeOf<
+			(typeof auth)["$Infer"]["Session"]["user"]["stripeCustomerId"]
+		>().toEqualTypeOf<string | null | undefined>();
+		expectTypeOf<
+			(typeof auth)["$Infer"]["Session"]["user"]["customField"]
+		>().toEqualTypeOf<string | null | undefined>();
+	});
 });
 
 describe("stripe", () => {


### PR DESCRIPTION
> [!NOTE]
> At the moment, `stripeCustomerId` isn't accessible on organization, but since it's not directly needed in typical use cases, this is acceptable for now, though there's room for improvement. 

- Closes https://github.com/better-auth/better-auth/issues/6440

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Stripe schema type inference by making getSchema generic, so plugin fields (like user.stripeCustomerId) are correctly inferred, even with additional user fields. Added type tests to validate inference. Closes #6440.

- **Bug Fixes**
  - getSchema now returns a conditional type based on StripeOptions for subscription and organization schemas.
  - Correctly infers user.stripeCustomerId in $Infer types alongside user.additionalFields.
  - stripeCustomerId remains unavailable on organization for now.

<sup>Written for commit 34eb73c4f67a69ea69344b85cee3db5a7970a165. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

