### PR TITLE
fix(organization): infer endpoints when dynamic ac and teams enabled

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -344,9 +344,11 @@ export type OrganizationPlugin<O extends OrganizationOptions> = {
 export function organization<
 	O extends OrganizationOptions & {
 		teams: { enabled: true };
-		dynamicAccessControl?: {
-  		enabled?: false | undefined;
-		} | undefined;
+		dynamicAccessControl?:
+			| {
+					enabled?: false | undefined;
+			  }
+			| undefined;
 	},
 >(
 	options?: O | undefined,


### PR DESCRIPTION
closes #7356

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes endpoint inference in the organization plugin when dynamicAccessControl and teams are used together, so endpoints are generated correctly for both configurations. Addresses issue #7356.

- **Bug Fixes**
  - Added type overloads to accept teams.enabled with optional dynamicAccessControl, and dynamicAccessControl.enabled with optional teams.
  - Prevents missing or mis-inferred endpoints when both features are toggled.

<sup>Written for commit a224bbeea3d0a302828ff0a8783591d9342686b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

