### PR TITLE
docs: add `better-auth-nostr` community plugin

### DIFF
--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -265,14 +265,13 @@ export const communityPlugins: CommunityPlugin[] = [
 	{
 		name: "better-auth-nostr",
 		url: "https://github.com/leon-wbr/better-auth-nostr",
-		description:
-			"Nostr authentication plugin for Better Auth (NIP-98).",
+		description: "Nostr authentication plugin for Better Auth (NIP-98).",
 		author: {
 			name: "leon-wbr",
 			github: "leon-wbr",
 			avatar: "https://github.com/leon-wbr.png",
-		}
-	}
+		},
+	},
 ];
 export function CommunityPluginsTable() {
 	const [sorting, setSorting] = useState<SortingState>([]);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added “better-auth-nostr” to the community plugins table to list the Nostr authentication plugin (NIP-98) with its link, description, and author details.

<sup>Written for commit dce788987a67d6f97dd6d4b543d96f3c348d2f3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

