### PR TITLE
chore(organization): remove `any` return type

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -443,7 +443,7 @@ export function organization<
 export function organization<O extends OrganizationOptions>(
 	options?: O | undefined,
 ): DefaultOrganizationPlugin<O>;
-export function organization<O extends OrganizationOptions>(options?: O): any {
+export function organization<O extends OrganizationOptions>(options?: O) {
 	const opts = (options || {}) as O;
 	let endpoints = {
 		/**


### PR DESCRIPTION
Fixes #7359

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the any return type from organization() so TypeScript infers the correct type from the existing overloads. Improves type safety and editor autocompletion with no runtime changes.

<sup>Written for commit 839c873dc71b7aa8df886b3f89c11ea12a99ac93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

