### PR TITLE
fix(organization): incorrect status

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -275,7 +275,7 @@ const createHasPermission = <O extends OrganizationOptions>(options: O) => {
 			});
 			if (!member) {
 				throw APIError.from(
-					"FORBIDDEN",
+					"UNAUTHORIZED",
 					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
 				);
 			}


### PR DESCRIPTION
Regression from: https://github.com/better-auth/better-auth/commit/7d8786cd879023f87839095ece5cd69a82196c16#diff-6b35b5a9ecf1a18a045c3d1931abd54a11b6301c210b53df02c2c8b8680e0ba6L236-R240

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect API status when checking organization membership. Non-members now return UNAUTHORIZED instead of FORBIDDEN, restoring expected behavior and avoiding misclassified permission errors.

<sup>Written for commit 40b426b65878f56cd2567871c80495be470bc2ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

