### PR TITLE
chore: add lint rule `useConst`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,7 @@
           }
         },
         "useNodejsImportProtocol": "error",
+        "useConst": "error",
         "noRestrictedTypes": "off",
         "noRestrictedGlobals": "off"
       },

--- a/demo/oidc-client/src/lib/auth/useAuth.ts
+++ b/demo/oidc-client/src/lib/auth/useAuth.ts
@@ -54,8 +54,6 @@ export const useAuth = () => {
 		const code_verifier = oauth.generateRandomCodeVerifier();
 		const code_challenge =
 			await oauth.calculatePKCECodeChallenge(code_verifier);
-		let state: string | undefined;
-		let nonce: string | undefined;
 
 		const authorizationUrl = new URL(as.authorization_endpoint!);
 		authorizationUrl.searchParams.set("client_id", client.client_id);
@@ -68,10 +66,10 @@ export const useAuth = () => {
 			code_challenge_method,
 		);
 
-		state = oauth.generateRandomState();
+		const state = oauth.generateRandomState();
 		authorizationUrl.searchParams.set("state", state);
 
-		nonce = oauth.generateRandomNonce();
+		const nonce = oauth.generateRandomNonce();
 		authorizationUrl.searchParams.set("nonce", nonce);
 
 		console.log("store code_verifier and nonce in the end-user session");
@@ -101,9 +99,6 @@ export const useAuth = () => {
 		}
 		sessionStorage.removeItem(webStorageKey);
 		const { code_verifier, state, nonce, redirectUri } = JSON.parse(storage);
-
-		let sub: string;
-		let accessToken: string;
 
 		// @ts-expect-error
 		const currentUrl: URL = new URL(window.location);
@@ -147,12 +142,12 @@ export const useAuth = () => {
 		}
 
 		console.log("Access Token Response", authorizationCodeResult);
-		accessToken = authorizationCodeResult.access_token;
+		const accessToken = authorizationCodeResult.access_token;
 		setAccessToken(accessToken);
 		setIdToken(authorizationCodeResult.id_token);
 		const claims = oauth.getValidatedIdTokenClaims(authorizationCodeResult);
 		console.log("ID Token Claims", claims);
-		sub = claims.sub;
+		const sub = claims.sub;
 
 		// UserInfo Request
 		const response = await oauth.userInfoRequest(as, client, accessToken);

--- a/docs/app/blog/_components/_layout.tsx
+++ b/docs/app/blog/_components/_layout.tsx
@@ -4,7 +4,7 @@ import { Intro, IntroFooter } from "./changelog-layout";
 import { StarField } from "./stat-field";
 
 function Timeline() {
-	let id = useId();
+	const id = useId();
 
 	return (
 		<div className="pointer-events-none absolute inset-0 z-50 overflow-hidden lg:right-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem] lg:overflow-visible">
@@ -29,7 +29,7 @@ function Timeline() {
 }
 
 function Glow() {
-	let id = useId();
+	const id = useId();
 
 	return (
 		<div className="absolute inset-0  overflow-hidden  lg:right-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem]">

--- a/docs/app/blog/_components/default-changelog.tsx
+++ b/docs/app/blog/_components/default-changelog.tsx
@@ -217,7 +217,7 @@ ${message.content}
 export default ChangelogPage;
 
 export function Glow() {
-	let id = useId();
+	const id = useId();
 
 	return (
 		<div className="absolute inset-0 -z-10 overflow-hidden bg-gradient-to-tr from-transparent dark:via-stone-950/5 via-stone-100/30 to-stone-200/20 dark:to-transparent/10">

--- a/docs/app/blog/_components/stat-field.tsx
+++ b/docs/app/blog/_components/stat-field.tsx
@@ -75,17 +75,17 @@ function Star({
 	blurId: string;
 	point: Star;
 }) {
-	let groupRef = useRef<React.ElementRef<"g">>(null);
-	let ref = useRef<React.ElementRef<"circle">>(null);
+	const groupRef = useRef<React.ElementRef<"g">>(null);
+	const ref = useRef<React.ElementRef<"circle">>(null);
 
 	useEffect(() => {
 		if (!groupRef.current || !ref.current) {
 			return;
 		}
 
-		let delay = Math.random() * 2;
+		const delay = Math.random() * 2;
 
-		let animations = [
+		const animations = [
 			animate(groupRef.current, { opacity: 1 }, { duration: 4, delay }),
 			animate(
 				ref.current,
@@ -101,7 +101,7 @@ function Star({
 		];
 
 		return () => {
-			for (let animation of animations) {
+			for (const animation of animations) {
 				animation.cancel();
 			}
 		};
@@ -132,19 +132,19 @@ function Constellation({
 	points: Array<Star>;
 	blurId: string;
 }) {
-	let ref = useRef<React.ElementRef<"path">>(null);
-	let uniquePoints = points.filter(
+	const ref = useRef<React.ElementRef<"path">>(null);
+	const uniquePoints = points.filter(
 		(point, pointIndex) =>
 			points.findIndex((p) => String(p) === String(point)) === pointIndex,
 	);
-	let isFilled = uniquePoints.length !== points.length;
+	const isFilled = uniquePoints.length !== points.length;
 
 	useEffect(() => {
 		if (!ref.current) {
 			return;
 		}
 
-		let sequence: Array<Segment> = [
+		const sequence: Array<Segment> = [
 			[
 				ref.current,
 				{ strokeDashoffset: 0, opacity: 1 },
@@ -160,7 +160,7 @@ function Constellation({
 			]);
 		}
 
-		let animation = animate(sequence);
+		const animation = animate(sequence);
 
 		return () => {
 			animation.cancel();
@@ -188,7 +188,7 @@ function Constellation({
 }
 
 export function StarField({ className }: { className?: string }) {
-	let blurId = useId();
+	const blurId = useId();
 
 	return (
 		<svg

--- a/docs/app/changelogs/_components/_layout.tsx
+++ b/docs/app/changelogs/_components/_layout.tsx
@@ -4,7 +4,7 @@ import { Intro, IntroFooter } from "./changelog-layout";
 import { StarField } from "./stat-field";
 
 function Timeline() {
-	let id = useId();
+	const id = useId();
 
 	return (
 		<div className="pointer-events-none absolute inset-0 z-50 overflow-hidden lg:right-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem] lg:overflow-visible">
@@ -29,7 +29,7 @@ function Timeline() {
 }
 
 function Glow() {
-	let id = useId();
+	const id = useId();
 
 	return (
 		<div className="absolute inset-0  overflow-hidden  lg:right-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem]">

--- a/docs/app/changelogs/_components/changelog-layout.tsx
+++ b/docs/app/changelogs/_components/changelog-layout.tsx
@@ -79,7 +79,7 @@ export function IntroFooter() {
 }
 
 export function SignUpForm() {
-	let id = useId();
+	const id = useId();
 
 	return (
 		<form className="relative isolate mt-8 flex items-center pr-1">

--- a/docs/app/changelogs/_components/default-changelog.tsx
+++ b/docs/app/changelogs/_components/default-changelog.tsx
@@ -218,7 +218,7 @@ ${message.content}
 export default ChangelogPage;
 
 export function Glow() {
-	let id = useId();
+	const id = useId();
 
 	return (
 		<div className="overflow-hidden absolute inset-0 bg-gradient-to-tr from-transparent -z-10 dark:via-stone-950/5 via-stone-100/30 to-stone-200/20 dark:to-transparent/10">

--- a/docs/app/changelogs/_components/stat-field.tsx
+++ b/docs/app/changelogs/_components/stat-field.tsx
@@ -75,17 +75,17 @@ function Star({
 	blurId: string;
 	point: Star;
 }) {
-	let groupRef = useRef<React.ElementRef<"g">>(null);
-	let ref = useRef<React.ElementRef<"circle">>(null);
+	const groupRef = useRef<React.ElementRef<"g">>(null);
+	const ref = useRef<React.ElementRef<"circle">>(null);
 
 	useEffect(() => {
 		if (!groupRef.current || !ref.current) {
 			return;
 		}
 
-		let delay = Math.random() * 2;
+		const delay = Math.random() * 2;
 
-		let animations = [
+		const animations = [
 			animate(groupRef.current, { opacity: 1 }, { duration: 4, delay }),
 			animate(
 				ref.current,
@@ -101,7 +101,7 @@ function Star({
 		];
 
 		return () => {
-			for (let animation of animations) {
+			for (const animation of animations) {
 				animation.cancel();
 			}
 		};
@@ -132,19 +132,19 @@ function Constellation({
 	points: Array<Star>;
 	blurId: string;
 }) {
-	let ref = useRef<React.ElementRef<"path">>(null);
-	let uniquePoints = points.filter(
+	const ref = useRef<React.ElementRef<"path">>(null);
+	const uniquePoints = points.filter(
 		(point, pointIndex) =>
 			points.findIndex((p) => String(p) === String(point)) === pointIndex,
 	);
-	let isFilled = uniquePoints.length !== points.length;
+	const isFilled = uniquePoints.length !== points.length;
 
 	useEffect(() => {
 		if (!ref.current) {
 			return;
 		}
 
-		let sequence: Array<Segment> = [
+		const sequence: Array<Segment> = [
 			[
 				ref.current,
 				{ strokeDashoffset: 0, opacity: 1 },
@@ -160,7 +160,7 @@ function Constellation({
 			]);
 		}
 
-		let animation = animate(sequence);
+		const animation = animate(sequence);
 
 		return () => {
 			animation.cancel();
@@ -188,7 +188,7 @@ function Constellation({
 }
 
 export function StarField({ className }: { className?: string }) {
-	let blurId = useId();
+	const blurId = useId();
 
 	return (
 		<svg

--- a/docs/components/api-method.tsx
+++ b/docs/components/api-method.tsx
@@ -144,7 +144,7 @@ export const APIMethod = ({
 	 */
 	forceAsParam?: boolean;
 }) => {
-	let { props, functionName, code_prefix, code_suffix } = parseCode(children);
+	const { props, functionName, code_prefix, code_suffix } = parseCode(children);
 
 	const authClientMethodPath = pathToDotNotation(path);
 
@@ -213,7 +213,7 @@ export const APIMethod = ({
 		return serverTabContent;
 	}
 
-	let pathId = path.replaceAll("/", "-");
+	const pathId = path.replaceAll("/", "-");
 
 	return (
 		<>
@@ -454,7 +454,7 @@ function parseCode(children: JSX.Element) {
 		.join("")
 		.split("\n");
 
-	let props: Property[] = [];
+	const props: Property[] = [];
 
 	let functionName: string = "";
 	let currentJSDocDescription: string = "";
@@ -463,9 +463,9 @@ function parseCode(children: JSX.Element) {
 	let hasAlreadyDefinedApiMethodType = false;
 	let isServerOnly_ = false;
 	let isClientOnly_ = false;
-	let nestPath: string[] = []; // str arr segmented-path, eg: ["data", "metadata", "something"]
-	let serverOnlyPaths: string[] = []; // str arr full-path, eg: ["data.metadata.something"]
-	let clientOnlyPaths: string[] = []; // str arr full-path, eg: ["data.metadata.something"]
+	const nestPath: string[] = []; // str arr segmented-path, eg: ["data", "metadata", "something"]
+	const serverOnlyPaths: string[] = []; // str arr full-path, eg: ["data.metadata.something"]
+	const clientOnlyPaths: string[] = []; // str arr full-path, eg: ["data.metadata.something"]
 	let isNullable = false;
 
 	let code_prefix = "";

--- a/docs/components/ui/background-boxes.tsx
+++ b/docs/components/ui/background-boxes.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 export const BoxesCore = ({ className, ...rest }: { className?: string }) => {
 	const rows = new Array(150).fill(1);
 	const cols = new Array(100).fill(1);
-	let colors = [
+	const colors = [
 		"--sky-300",
 		"--pink-300",
 		"--green-300",

--- a/docs/lib/blog.ts
+++ b/docs/lib/blog.ts
@@ -67,7 +67,7 @@ export const getAllBlogPosts = cache(async (): Promise<BlogPost[]> => {
 });
 
 export function formatBlogDate(date: Date) {
-	let d = new Date(date);
+	const d = new Date(date);
 	return d.toLocaleDateString("en-US", {
 		month: "short",
 		day: "numeric",

--- a/docs/lib/llm-text.ts
+++ b/docs/lib/llm-text.ts
@@ -95,7 +95,7 @@ function parseTypeBody(typeBody: string): PropertyDefinition[] {
 			const [, name, optional, type, , exampleValue, , description] = propMatch;
 
 			let cleanType = type.trim();
-			let cleanExampleValue = exampleValue || "";
+			const cleanExampleValue = exampleValue || "";
 
 			cleanType = cleanType.replace(/,$/, "");
 

--- a/docs/lib/utils.ts
+++ b/docs/lib/utils.ts
@@ -32,7 +32,7 @@ export const baseUrl =
 				`https://${process.env.VERCEL_PROJECT_PRODUCTION_URL || process.env.VERCEL_URL}`,
 			);
 export function formatDate(date: Date) {
-	let d = new Date(date);
+	const d = new Date(date);
 	return d
 		.toLocaleDateString("en-US", { month: "short", day: "numeric" })
 		.replace(",", "");

--- a/docs/scripts/endpoint-to-doc/index.ts
+++ b/docs/scripts/endpoint-to-doc/index.ts
@@ -69,14 +69,14 @@ async function generateMDX() {
 
 	console.log(`function name:`, functionName);
 
-	let jsdoc = generateJSDoc({
+	const jsdoc = generateJSDoc({
 		path,
 		functionName,
 		options,
 		isServerOnly: options.metadata?.SERVER_ONLY ?? false,
 	});
 
-	let mdx = `<APIMethod${parseParams(path, options)}>\n\`\`\`ts\n${parseType(
+	const mdx = `<APIMethod${parseParams(path, options)}>\n\`\`\`ts\n${parseType(
 		functionName,
 		options,
 	)}\n\`\`\`\n</APIMethod>`;
@@ -128,7 +128,7 @@ function parseType(functionName: string, options: Options) {
 
 	// console.log(parsedBody);
 
-	let strBody: string = convertBodyToString(parsedBody);
+	const strBody: string = convertBodyToString(parsedBody);
 
 	return `type ${functionName} = {\n${strBody}}`;
 }
@@ -168,7 +168,7 @@ function convertBodyToString(parsedBody: Body[]) {
 			!parsedBody[i + 1] ||
 			parsedBody[i + 1].path.length < body.path.length
 		) {
-			let diff = body.path.length - (parsedBody[i + 1]?.path?.length || 0);
+			const diff = body.path.length - (parsedBody[i + 1]?.path?.length || 0);
 			for (const index of Array(diff)
 				.fill(0)
 				.map((_, i) => i)
@@ -211,14 +211,14 @@ function parseZodShape(zod: z.ZodAny, path: string[]) {
 	for (const [key, value] of Object.entries(shape)) {
 		if (!value) continue;
 		let description = value.description;
-		let { type, isOptional, defaultValue } = getType(value as any, {
+		const { type, isOptional, defaultValue } = getType(value as any, {
 			forceOptional: isRootOptional,
 		});
 
-		let example = description ? description.split(" Eg: ")[1] : undefined;
+		const example = description ? description.split(" Eg: ")[1] : undefined;
 		if (example) description = description?.replace(" Eg: " + example, "");
 
-		let isServerOnly = description
+		const isServerOnly = description
 			? description.includes("server-only.")
 			: false;
 		if (isServerOnly) description = description?.replace(" server-only. ", "");
@@ -403,7 +403,7 @@ function getType(
 }
 
 function parseParams(path: string, options: Options): string {
-	let params: string[] = [];
+	const params: string[] = [];
 	params.push(`path="${path}"`);
 	params.push(`method="${options.method}"`);
 
@@ -444,7 +444,7 @@ function generateJSDoc({
 	 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/organization#api-method-organization-set-active)
 	 */
 
-	let jsdoc: string[] = [];
+	const jsdoc: string[] = [];
 	jsdoc.push(`### Endpoint`);
 	jsdoc.push(``);
 	jsdoc.push(`${options.method} \`${path}\``);

--- a/packages/better-auth/src/adapters/create-test-suite.ts
+++ b/packages/better-auth/src/adapters/create-test-suite.ts
@@ -428,7 +428,7 @@ export const createTestSuite = <
 			};
 
 			const transformGeneratedModel = (data: Record<string, any>) => {
-				let newData = { ...data };
+				const newData = { ...data };
 				if (helpers.transformIdOutput) {
 					newData.id = helpers.transformIdOutput(newData.id);
 				}
@@ -515,7 +515,7 @@ export const createTestSuite = <
 				model: M,
 				count: Count = 1 as Count,
 			) => {
-				let res: any[] = [];
+				const res: any[] = [];
 				const a = wrapperAdapter();
 
 				for (let i = 0; i < count; i++) {
@@ -819,7 +819,7 @@ export const createTestSuite = <
 				);
 				const isFirstInGroup = testGroup && testGroup.testIndices[0] === i;
 
-				let shouldSkip =
+				const shouldSkip =
 					(allDisabled && options?.disableTests?.[testName] !== false) ||
 					(options?.disableTests?.[testName] ?? false);
 

--- a/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -393,7 +393,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 									}
 								}
 							}
-							let query = db.query[model].findFirst({
+							const query = db.query[model].findFirst({
 								where: clause[0],
 								with: includes,
 							});
@@ -401,7 +401,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 
 							if (res) {
 								for (const pluralJoinResult of pluralJoinResults) {
-									let singularKey = !config.usePlural
+									const singularKey = !config.usePlural
 										? pluralJoinResult.slice(0, -1)
 										: pluralJoinResult;
 									res[singularKey] = res[pluralJoinResult];
@@ -414,7 +414,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						}
 					}
 
-					let query = db
+					const query = db
 						.select()
 						.from(schemaModel)
 						.where(...clause);
@@ -450,7 +450,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 										joinAttr.limit ??
 										options.advanced?.database?.defaultFindManyLimit ??
 										100;
-									let pluralSuffix = isUnique || config.usePlural ? "" : "s";
+									const pluralSuffix = isUnique || config.usePlural ? "" : "s";
 									includes[`${model}${pluralSuffix}`] = isUnique
 										? true
 										: { limit };
@@ -466,14 +466,14 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 									),
 								];
 							}
-							let query = db.query[model].findMany({
+							const query = db.query[model].findMany({
 								where: clause[0],
 								with: includes,
 								limit: limit ?? 100,
 								offset: offset ?? 0,
 								orderBy,
 							});
-							let res = await query;
+							const res = await query;
 							if (res) {
 								for (const item of res) {
 									for (const pluralJoinResult of pluralJoinResults) {

--- a/packages/better-auth/src/adapters/drizzle-adapter/test/generate-schema.ts
+++ b/packages/better-auth/src/adapters/drizzle-adapter/test/generate-schema.ts
@@ -27,7 +27,7 @@ export const generateDrizzleSchema = async (
 		};
 	}
 	generationCount++;
-	let thisCount = generationCount;
+	const thisCount = generationCount;
 	const i = async (x: string) => {
 		// Clear the Node.js module cache for the generated schema file to ensure fresh import
 		try {
@@ -63,9 +63,9 @@ export const generateDrizzleSchema = async (
 		await fs.mkdir(join(import.meta.dirname, `/.tmp`), { recursive: true });
 	}
 
-	let adapter = drizzleAdapter(db, { provider: dialect })(options);
+	const adapter = drizzleAdapter(db, { provider: dialect })(options);
 
-	let { code } = await generateSchema({
+	const { code } = await generateSchema({
 		adapter,
 		options,
 	});

--- a/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/dialect.ts
@@ -114,7 +114,7 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		let DatabaseSync: typeof import("node:sqlite").DatabaseSync | undefined =
 			undefined;
 		try {
-			let nodeSqlite: string = "node:sqlite";
+			const nodeSqlite: string = "node:sqlite";
 			// Ignore both Vite and Webpack for dynamic import as they both try to pre-bundle 'node:sqlite' which might fail
 			// It's okay because we are in a try-catch block
 			({ DatabaseSync } = await import(

--- a/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/kysely-adapter.ts
@@ -151,14 +151,14 @@ export const kyselyAdapter = (
 				};
 
 				w.forEach((condition) => {
-					let {
+					const {
 						field: _field,
 						value: _value,
 						operator = "=",
 						connector = "AND",
 					} = condition;
-					let value: any = _value;
-					let field: string | any = getFieldName({
+					const value: any = _value;
+					const field: string | any = getFieldName({
 						model,
 						field: _field,
 					});
@@ -348,7 +348,7 @@ export const kyselyAdapter = (
 					}
 				}
 
-				let result = Array.from(groupedByMainId.values());
+				const result = Array.from(groupedByMainId.values());
 
 				// Apply final limit to non-unique join arrays as a safety measure
 				for (const entry of result) {

--- a/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.custom-schema-pg.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.custom-schema-pg.test.ts
@@ -25,7 +25,7 @@ const pgDB = new Pool({
 	connectionString: `postgres://user:password@localhost:5435/better_auth?options=-c search_path=${CUSTOM_SCHEMA}`,
 });
 
-let kyselyDB = new Kysely({
+const kyselyDB = new Kysely({
 	dialect: new PostgresDialect({ pool: pgDB }),
 });
 

--- a/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.mysql.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.mysql.test.ts
@@ -18,7 +18,7 @@ const mysqlDB = createPool({
 	timezone: "Z",
 });
 
-let kyselyDB = new Kysely({
+const kyselyDB = new Kysely({
 	dialect: new MysqlDialect(mysqlDB),
 });
 

--- a/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.pg.test.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/test/adapter.kysely.pg.test.ts
@@ -22,7 +22,7 @@ const pgDB = new Pool({
 	connectionString: "postgres://user:password@localhost:5433/better_auth",
 });
 
-let kyselyDB = new Kysely({
+const kyselyDB = new Kysely({
 	dialect: new PostgresDialect({ pool: pgDB }),
 });
 

--- a/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/better-auth/src/adapters/memory-adapter/memory-adapter.ts
@@ -20,7 +20,7 @@ export const memoryAdapter = (
 	config?: MemoryAdapterConfig | undefined,
 ) => {
 	let lazyOptions: BetterAuthOptions | null = null;
-	let adapterCreator = createAdapterFactory({
+	const adapterCreator = createAdapterFactory({
 		config: {
 			adapterId: "memory",
 			adapterName: "Memory Adapter",
@@ -37,7 +37,7 @@ export const memoryAdapter = (
 				return props.data;
 			},
 			transaction: async (cb) => {
-				let clone = structuredClone(db);
+				const clone = structuredClone(db);
 				try {
 					const r = await cb(adapterCreator(lazyOptions!));
 					return r;
@@ -271,7 +271,7 @@ export const memoryAdapter = (
 					return record;
 				},
 				findMany: async ({ model, where, sortBy, limit, offset, join }) => {
-					let res = convertWhereClause(where || [], model, join);
+					const res = convertWhereClause(where || [], model, join);
 
 					if (join) {
 						// When join is present, res is an array of nested objects

--- a/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
+++ b/packages/better-auth/src/adapters/mongodb-adapter/mongodb-adapter.ts
@@ -315,7 +315,7 @@ export const mongodbAdapter = (
 							// For unique relationships, limit is ignored (as per JoinConfig type)
 							// For non-unique relationships, apply limit if specified
 							const shouldLimit = !isUnique && joinConfig.limit !== undefined;
-							let limit =
+							const limit =
 								joinConfig.limit ??
 								options.advanced?.database?.defaultFindManyLimit ??
 								100;
@@ -425,7 +425,7 @@ export const mongodbAdapter = (
 								joinConfig.relation !== "one-to-one" &&
 								joinConfig.limit !== undefined;
 
-							let limit =
+							const limit =
 								joinConfig.limit ??
 								options.advanced?.database?.defaultFindManyLimit ??
 								100;

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -84,7 +84,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 			) => {
 				if (!select && !join) return undefined;
 
-				let result: Record<string, Record<string, any> | boolean> = {};
+				const result: Record<string, Record<string, any> | boolean> = {};
 
 				if (select) {
 					for (const field of select) {
@@ -359,7 +359,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 					}
 
 					// transform join keys to use Prisma expected field names
-					let map = new Map<string, string>();
+					const map = new Map<string, string>();
 					for (const joinModel of Object.keys(join ?? {})) {
 						const key = getJoinKeyName(model, joinModel, schema);
 						map.set(key, getModelName(joinModel));
@@ -367,7 +367,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 
 					const selects = convertSelect(select, model, join);
 
-					let result = await db[model]!.findFirst({
+					const result = await db[model]!.findFirst({
 						where: whereClause,
 						select: selects,
 					});
@@ -397,7 +397,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 						);
 					}
 					// transform join keys to use Prisma expected field names
-					let map = new Map<string, string>();
+					const map = new Map<string, string>();
 					if (join) {
 						for (const [joinModel, _value] of Object.entries(join)) {
 							const key = getJoinKeyName(model, joinModel, schema);

--- a/packages/better-auth/src/adapters/prisma-adapter/test/generate-auth-config.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/test/generate-auth-config.ts
@@ -6,7 +6,7 @@ export const generateAuthConfigFile = async (_options: BetterAuthOptions) => {
 	const options = { ..._options };
 	// biome-ignore lint/performance/noDelete: perf doesn't matter here.
 	delete options.database;
-	let code = `import { betterAuth } from "../../../auth";
+	const code = `import { betterAuth } from "../../../auth";
 import { prismaAdapter } from "../prisma-adapter";		
 import { PrismaClient } from "@prisma/client";
 const db = new PrismaClient();

--- a/packages/better-auth/src/adapters/test.ts
+++ b/packages/better-auth/src/adapters/test.ts
@@ -98,7 +98,7 @@ function adapterTest(
 	const getUniqueEmail = (base: string) => `${testRunId}_${base}`;
 
 	//@ts-expect-error - intentionally omitting id
-	let user: {
+	const user: {
 		name: string;
 		email: string;
 		emailVerified: boolean;

--- a/packages/better-auth/src/adapters/tests/basic.ts
+++ b/packages/better-auth/src/adapters/tests/basic.ts
@@ -738,7 +738,7 @@ export const getNormalTestSuiteTests = (
 					},
 					forceAllowId: true,
 				});
-				let result = await adapter.findOne<
+				const result = await adapter.findOne<
 					User & { oneToOneTable: OneToOneTable; session: Session[] }
 				>({
 					model: "user",
@@ -890,7 +890,7 @@ export const getNormalTestSuiteTests = (
 					},
 					forceAllowId: true,
 				});
-				let sessions: Session[] = [];
+				const sessions: Session[] = [];
 				for (let index = 0; index < 3; index++) {
 					const session = await adapter.create<Session>({
 						model: "session",
@@ -899,7 +899,7 @@ export const getNormalTestSuiteTests = (
 					});
 					sessions.push(session);
 				}
-				let accounts: Account[] = [];
+				const accounts: Account[] = [];
 				for (let index = 0; index < 3; index++) {
 					const account = await adapter.create<Account>({
 						model: "account",
@@ -1386,7 +1386,7 @@ export const getNormalTestSuiteTests = (
 					update: { name: user.name.toLowerCase() }, // make name lowercase
 				});
 				if (!res) throw new Error("No result");
-				let u = users.find((u) => u.id === user.id)!;
+				const u = users.find((u) => u.id === user.id)!;
 				u.name = res.name;
 				u.updatedAt = res.updatedAt;
 			}
@@ -1836,7 +1836,7 @@ export const getNormalTestSuiteTests = (
 					},
 					true,
 				);
-				let users = (await insertRandom("user", 10)).map(
+				const users = (await insertRandom("user", 10)).map(
 					(x) => x[0],
 				) as (User & { numericField: number })[];
 

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -107,7 +107,7 @@ describe(
 );
 
 describe("custom rate limiting storage", async () => {
-	let store = new Map<string, string>();
+	const store = new Map<string, string>();
 	const expirationMap = new Map<string, number>();
 	const { client, testUser } = await getTestInstance({
 		rateLimit: {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -515,7 +515,7 @@ export const getAccessToken = createAuthEndpoint(
 		if (req && !session) {
 			throw ctx.error("UNAUTHORIZED");
 		}
-		let resolvedUserId = session?.user?.id || userId;
+		const resolvedUserId = session?.user?.id || userId;
 		if (!resolvedUserId) {
 			throw ctx.error("UNAUTHORIZED");
 		}
@@ -680,7 +680,7 @@ export const refreshToken = createAuthEndpoint(
 		if (req && !session) {
 			throw ctx.error("UNAUTHORIZED");
 		}
-		let resolvedUserId = session?.user?.id || userId;
+		const resolvedUserId = session?.user?.id || userId;
 		if (!resolvedUserId) {
 			throw APIError.from("BAD_REQUEST", {
 				message: `Either userId or session is required`,

--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -92,7 +92,7 @@ describe("Email Verification", async () => {
 		});
 
 		let sessionToken = "";
-		let verifyHeaders = new Headers();
+		const verifyHeaders = new Headers();
 		await client.verifyEmail({
 			query: {
 				token,
@@ -306,7 +306,7 @@ describe("Email Verification", async () => {
 });
 
 describe("Email Verification Secondary Storage", async () => {
-	let store = new Map<string, string>();
+	const store = new Map<string, string>();
 	let token: string;
 	const { client, signInWithTestUser, auth, testUser, cookieSetter } =
 		await getTestInstance({

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -60,7 +60,7 @@ describe("session", async () => {
 				expiresIn: 60 * 2,
 			},
 		});
-		let headers = new Headers();
+		const headers = new Headers();
 
 		await client.signIn.email(
 			{
@@ -141,7 +141,7 @@ describe("session", async () => {
 	});
 
 	it("should handle 'don't remember me' option", async () => {
-		let headers = new Headers();
+		const headers = new Headers();
 		await client.signIn.email(
 			{
 				email: testUser.email,
@@ -220,7 +220,7 @@ describe("session", async () => {
 	});
 
 	it("should clear session on sign out", async () => {
-		let headers = new Headers();
+		const headers = new Headers();
 		await client.signIn.email(
 			{
 				email: testUser.email,
@@ -372,7 +372,7 @@ describe("session", async () => {
 });
 
 describe("session storage", async () => {
-	let store = new Map<string, string>();
+	const store = new Map<string, string>();
 	const { client, signInWithTestUser } = await getTestInstance({
 		secondaryStorage: {
 			set(key, value, ttl) {

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -62,12 +62,12 @@ export const getClientConfig = (
 	});
 	const { $sessionSignal, session } = getSessionAtom($fetch, options);
 	const plugins = options?.plugins || [];
-	let pluginsActions = {} as Record<string, any>;
-	let pluginsAtoms = {
+	const pluginsActions = {} as Record<string, any>;
+	const pluginsAtoms = {
 		$sessionSignal,
 		session,
 	} as Record<string, WritableAtom<any>>;
-	let pluginPathMethods: Record<string, "POST" | "GET"> = {
+	const pluginPathMethods: Record<string, "POST" | "GET"> = {
 		"/sign-out": "POST",
 		"/revoke-sessions": "POST",
 		"/revoke-other-sessions": "POST",

--- a/packages/better-auth/src/client/lynx/index.ts
+++ b/packages/better-auth/src/client/lynx/index.ts
@@ -55,7 +55,7 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 		$store,
 		atomListeners,
 	} = getClientConfig(options);
-	let resolvedHooks: Record<string, any> = {};
+	const resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
 		resolvedHooks[getAtomKey(key)] = () => useStore(value);
 	}

--- a/packages/better-auth/src/client/lynx/lynx-store.ts
+++ b/packages/better-auth/src/client/lynx/lynx-store.ts
@@ -49,11 +49,11 @@ export function useStore<SomeStore extends Store>(
 	store: SomeStore,
 	options: UseStoreOptions<SomeStore> = {},
 ): StoreValue<SomeStore> {
-	let snapshotRef = useRef<StoreValue<SomeStore>>(store.get());
+	const snapshotRef = useRef<StoreValue<SomeStore>>(store.get());
 
 	const { keys, deps = [store, keys] } = options;
 
-	let subscribe = useCallback((onChange: () => void) => {
+	const subscribe = useCallback((onChange: () => void) => {
 		const emitChange = (value: StoreValue<SomeStore>) => {
 			if (snapshotRef.current === value) return;
 			snapshotRef.current = value;
@@ -67,7 +67,7 @@ export function useStore<SomeStore extends Store>(
 		return store.listen(emitChange);
 	}, deps);
 
-	let get = () => snapshotRef.current as StoreValue<SomeStore>;
+	const get = () => snapshotRef.current as StoreValue<SomeStore>;
 
 	return useSyncExternalStore(subscribe, get, get);
 }

--- a/packages/better-auth/src/client/parser.ts
+++ b/packages/better-auth/src/client/parser.ts
@@ -56,7 +56,7 @@ function parseISODate(value: string): Date | null {
 		offsetMinute,
 	] = match;
 
-	let date = new Date(
+	const date = new Date(
 		Date.UTC(
 			parseInt(year!, 10),
 			parseInt(month!, 10) - 1,

--- a/packages/better-auth/src/client/react/index.ts
+++ b/packages/better-auth/src/client/react/index.ts
@@ -55,7 +55,7 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 		$store,
 		atomListeners,
 	} = getClientConfig(options);
-	let resolvedHooks: Record<string, any> = {};
+	const resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
 		resolvedHooks[getAtomKey(key)] = () => useStore(value);
 	}

--- a/packages/better-auth/src/client/react/react-store.ts
+++ b/packages/better-auth/src/client/react/react-store.ts
@@ -49,11 +49,11 @@ export function useStore<SomeStore extends Store>(
 	store: SomeStore,
 	options: UseStoreOptions<SomeStore> = {},
 ): StoreValue<SomeStore> {
-	let snapshotRef = useRef<StoreValue<SomeStore>>(store.get());
+	const snapshotRef = useRef<StoreValue<SomeStore>>(store.get());
 
 	const { keys, deps = [store, keys] } = options;
 
-	let subscribe = useCallback((onChange: () => void) => {
+	const subscribe = useCallback((onChange: () => void) => {
 		const emitChange = (value: StoreValue<SomeStore>) => {
 			if (snapshotRef.current === value) return;
 			snapshotRef.current = value;
@@ -67,7 +67,7 @@ export function useStore<SomeStore extends Store>(
 		return store.listen(emitChange);
 	}, deps);
 
-	let get = () => snapshotRef.current as StoreValue<SomeStore>;
+	const get = () => snapshotRef.current as StoreValue<SomeStore>;
 
 	return useSyncExternalStore(subscribe, get, get);
 }

--- a/packages/better-auth/src/client/solid/index.ts
+++ b/packages/better-auth/src/client/solid/index.ts
@@ -55,7 +55,7 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 		$fetch,
 		atomListeners,
 	} = getClientConfig(options);
-	let resolvedHooks: Record<string, any> = {};
+	const resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
 		resolvedHooks[getAtomKey(key)] = () => useStore(value);
 	}

--- a/packages/better-auth/src/client/svelte/index.ts
+++ b/packages/better-auth/src/client/svelte/index.ts
@@ -51,7 +51,7 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 		atomListeners,
 		$store,
 	} = getClientConfig(options);
-	let resolvedHooks: Record<string, any> = {};
+	const resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
 		resolvedHooks[`use${capitalizeFirstLetter(key)}`] = () => value;
 	}

--- a/packages/better-auth/src/client/vanilla.ts
+++ b/packages/better-auth/src/client/vanilla.ts
@@ -51,7 +51,7 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 		atomListeners,
 		$store,
 	} = getClientConfig(options);
-	let resolvedHooks: Record<string, any> = {};
+	const resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
 		resolvedHooks[`use${capitalizeFirstLetter(key)}`] = value;
 	}

--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -59,7 +59,7 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 		$store,
 		atomListeners,
 	} = getClientConfig(options, false);
-	let resolvedHooks: Record<string, any> = {};
+	const resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
 		resolvedHooks[getAtomKey(key)] = () => useStore(value);
 	}

--- a/packages/better-auth/src/client/vue/vue-store.ts
+++ b/packages/better-auth/src/client/vue/vue-store.ts
@@ -9,10 +9,10 @@ import {
 } from "vue";
 
 function registerStore(store: Store) {
-	let instance = getCurrentInstance();
+	const instance = getCurrentInstance();
 	if (instance && instance.proxy) {
-		let vm = instance.proxy as any;
-		let cache = "_nanostores" in vm ? vm._nanostores : (vm._nanostores = []);
+		const vm = instance.proxy as any;
+		const cache = "_nanostores" in vm ? vm._nanostores : (vm._nanostores = []);
 		cache.push(store);
 	}
 }
@@ -21,9 +21,9 @@ export function useStore<
 	SomeStore extends Store,
 	Value extends StoreValue<SomeStore>,
 >(store: SomeStore): DeepReadonly<UnwrapNestedRefs<ShallowRef<Value>>> {
-	let state = shallowRef();
+	const state = shallowRef();
 
-	let unsubscribe = store.subscribe((value) => {
+	const unsubscribe = store.subscribe((value) => {
 		state.value = value;
 	});
 

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -16,7 +16,7 @@ export async function runPluginInit(ctx: AuthContext) {
 	const dbHooks: BetterAuthOptions["databaseHooks"][] = [];
 	for (const plugin of plugins) {
 		if (plugin.init) {
-			let initPromise = plugin.init(context);
+			const initPromise = plugin.init(context);
 			let result: ReturnType<Required<BetterAuthPlugin>["init"]>;
 			if (isPromise(initPromise)) {
 				result = await initPromise;

--- a/packages/better-auth/src/db/field-converter.ts
+++ b/packages/better-auth/src/db/field-converter.ts
@@ -4,7 +4,7 @@ export function convertToDB<T extends Record<string, any>>(
 	fields: Record<string, DBFieldAttribute>,
 	values: T,
 ) {
-	let result: Record<string, any> = values.id
+	const result: Record<string, any> = values.id
 		? {
 				id: values.id,
 			}
@@ -27,7 +27,7 @@ export function convertFromDB<T extends Record<string, any>>(
 	if (!values) {
 		return null;
 	}
-	let result: Record<string, any> = {
+	const result: Record<string, any> = {
 		id: values.id,
 	};
 	for (const [key, value] of Object.entries(fields)) {

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -241,7 +241,7 @@ export async function getMigrations(config: BetterAuthOptions) {
 			}
 			continue;
 		}
-		let toBeAddedFields: Record<string, DBFieldAttribute> = {};
+		const toBeAddedFields: Record<string, DBFieldAttribute> = {};
 		for (const [fieldName, field] of Object.entries(value.fields)) {
 			const column = table.columns.find((c) => c.name === fieldName);
 			if (!column) {
@@ -419,7 +419,7 @@ export async function getMigrations(config: BetterAuthOptions) {
 		for (const table of toBeAdded) {
 			for (const [fieldName, field] of Object.entries(table.fields)) {
 				const type = getType(field, fieldName);
-				let builder = db.schema.alterTable(table.table);
+				const builder = db.schema.alterTable(table.table);
 
 				if (field.index) {
 					const index = db.schema
@@ -428,7 +428,7 @@ export async function getMigrations(config: BetterAuthOptions) {
 					migrations.push(index);
 				}
 
-				let built = builder.addColumn(fieldName, type, (col) => {
+				const built = builder.addColumn(fieldName, type, (col) => {
 					col = field.required !== false ? col.notNull() : col;
 					if (field.references) {
 						col = col
@@ -461,7 +461,7 @@ export async function getMigrations(config: BetterAuthOptions) {
 		}
 	}
 
-	let toBeIndexed: CreateIndexBuilder[] = [];
+	const toBeIndexed: CreateIndexBuilder[] = [];
 
 	if (config.advanced?.database?.useNumberId) {
 		logger.warn(
@@ -531,7 +531,7 @@ export async function getMigrations(config: BetterAuthOptions) {
 				});
 
 				if (field.index) {
-					let builder = db.schema
+					const builder = db.schema
 						.createIndex(
 							`${table.table}_${fieldName}_${field.unique ? "uidx" : "idx"}`,
 						)

--- a/packages/better-auth/src/db/get-schema.ts
+++ b/packages/better-auth/src/db/get-schema.ts
@@ -4,7 +4,7 @@ import { getAuthTables } from ".";
 
 export function getSchema(config: BetterAuthOptions) {
 	const tables = getAuthTables(config);
-	let schema: Record<
+	const schema: Record<
 		string,
 		{
 			fields: Record<string, DBFieldAttribute>;
@@ -14,7 +14,7 @@ export function getSchema(config: BetterAuthOptions) {
 	for (const key in tables) {
 		const table = tables[key]!;
 		const fields = table.fields;
-		let actualFields: Record<string, DBFieldAttribute> = {};
+		const actualFields: Record<string, DBFieldAttribute> = {};
 		Object.entries(fields).forEach(([key, field]) => {
 			actualFields[field.fieldName || key] = field;
 			if (field.references) {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -609,7 +609,7 @@ export const createInternalAdapter = (
 						`active-sessions-${userId}`,
 					);
 					if (currentList) {
-						let list: { token: string; expiresAt: number }[] =
+						const list: { token: string; expiresAt: number }[] =
 							safeJSONParse(currentList) || [];
 						const now = Date.now();
 

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { getTestInstance } from "../test-utils/test-instance";
 
 describe("secondary storage - get returns JSON string", async () => {
-	let store = new Map<string, string>();
+	const store = new Map<string, string>();
 
 	const { client, signInWithTestUser } = await getTestInstance({
 		secondaryStorage: {
@@ -70,7 +70,7 @@ describe("secondary storage - get returns JSON string", async () => {
 });
 
 describe("secondary storage - get returns already-parsed object", async () => {
-	let store = new Map<string, any>();
+	const store = new Map<string, any>();
 
 	const { client, signInWithTestUser } = await getTestInstance({
 		secondaryStorage: {

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -35,7 +35,7 @@ export async function handleOAuthUserInfo(
 			throw c.redirect(`${errorURL}?error=internal_server_error`);
 		});
 	let user = dbUser?.user;
-	let isRegister = !user;
+	const isRegister = !user;
 
 	if (dbUser) {
 		const hasBeenLinked = dbUser.accounts.find(

--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -83,7 +83,7 @@ describe("api-key", async () => {
 	}
 
 	it("should fail to create API Keys from server without headers and userId", async () => {
-		let res: { data: ApiKey | null; error: Err | null } = {
+		const res: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -253,7 +253,7 @@ describe("api-key", async () => {
 	});
 
 	it("should create the API key with a name that's shorter than the allowed minimum", async () => {
-		let result: { data: ApiKey | null; error: Err | null } = {
+		const result: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -277,7 +277,7 @@ describe("api-key", async () => {
 	});
 
 	it("should create the API key with a name that's longer than the allowed maximum", async () => {
-		let result: { data: ApiKey | null; error: Err | null } = {
+		const result: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -315,7 +315,7 @@ describe("api-key", async () => {
 	});
 
 	it("should create the API key with a prefix that's shorter than the allowed minimum", async () => {
-		let result: { data: ApiKey | null; error: Err | null } = {
+		const result: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -339,7 +339,7 @@ describe("api-key", async () => {
 	});
 
 	it("should create the API key with a prefix that's longer than the allowed maximum", async () => {
-		let result: { data: ApiKey | null; error: Err | null } = {
+		const result: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -455,7 +455,7 @@ describe("api-key", async () => {
 		);
 
 		const { headers } = await signInWithTestUser();
-		let result: { data: ApiKey | null; error: Err | null } = {
+		const result: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -479,7 +479,7 @@ describe("api-key", async () => {
 	});
 
 	it("should create an API key with an expiresIn that's smaller than the allowed minimum", async () => {
-		let result: { data: ApiKey | null; error: Err | null } = {
+		const result: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -504,7 +504,7 @@ describe("api-key", async () => {
 	});
 
 	it("should fail to create an API key with an expiresIn that's larger than the allowed maximum", async () => {
-		let result: { data: ApiKey | null; error: Err | null } = {
+		const result: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -559,7 +559,7 @@ describe("api-key", async () => {
 	});
 
 	it("should fail to create API key when refill interval is provided, but no refill amount", async () => {
-		let res: { data: ApiKey | null; error: Err | null } = {
+		const res: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -584,7 +584,7 @@ describe("api-key", async () => {
 	});
 
 	it("should fail to create API key when refill amount is provided, but no refill interval", async () => {
-		let res: { data: ApiKey | null; error: Err | null } = {
+		const res: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -704,7 +704,7 @@ describe("api-key", async () => {
 	});
 
 	it("should create API key with invalid metadata", async () => {
-		let result: { data: ApiKey | null; error: Err | null } = {
+		const result: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1098,7 +1098,7 @@ describe("api-key", async () => {
 	}
 
 	it("should fail to update API key name without headers or userId", async () => {
-		let res: { data: ApiKey | null; error: Err | null } = {
+		const res: { data: ApiKey | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1239,7 +1239,7 @@ describe("api-key", async () => {
 
 		if (!firstApiKey) return;
 
-		let result: { data: Partial<ApiKey> | null; error: Err | null } = {
+		const result: { data: Partial<ApiKey> | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1286,7 +1286,7 @@ describe("api-key", async () => {
 
 		if (!firstApiKey) return;
 
-		let result: { data: Partial<ApiKey> | null; error: Err | null } = {
+		const result: { data: Partial<ApiKey> | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1333,7 +1333,7 @@ describe("api-key", async () => {
 
 		if (!firstApiKey) return;
 
-		let result: { data: Partial<ApiKey> | null; error: Err | null } = {
+		const result: { data: Partial<ApiKey> | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1372,7 +1372,7 @@ describe("api-key", async () => {
 	});
 
 	it("should fail update the refillInterval value since it requires refillAmount as well", async () => {
-		let result: { data: Partial<ApiKey> | null; error: Err | null } = {
+		const result: { data: Partial<ApiKey> | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1397,7 +1397,7 @@ describe("api-key", async () => {
 	});
 
 	it("should fail update the refillAmount value since it requires refillInterval as well", async () => {
-		let result: { data: Partial<ApiKey> | null; error: Err | null } = {
+		const result: { data: Partial<ApiKey> | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1453,7 +1453,7 @@ describe("api-key", async () => {
 	});
 
 	it("should fail to update metadata with invalid metadata type", async () => {
-		let result: { data: Partial<ApiKey> | null; error: Err | null } = {
+		const result: { data: Partial<ApiKey> | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1665,7 +1665,7 @@ describe("api-key", async () => {
 	// =========================================================================
 
 	it("should fail to list API keys without headers", async () => {
-		let result: { data: Partial<ApiKey>[] | null; error: Err | null } = {
+		const result: { data: Partial<ApiKey>[] | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1807,7 +1807,7 @@ describe("api-key", async () => {
 	// =========================================================================
 
 	it("should fail to delete an API key by ID without headers", async () => {
-		let result: { data: { success: boolean } | null; error: Err | null } = {
+		const result: { data: { success: boolean } | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -1859,7 +1859,7 @@ describe("api-key", async () => {
 	});
 
 	it("should fail to delete an API key by ID that doesn't exist", async () => {
-		let result: { data: { success: boolean } | null; error: Err | null } = {
+		const result: { data: { success: boolean } | null; error: Err | null } = {
 			data: null,
 			error: null,
 		};
@@ -2248,7 +2248,7 @@ describe("api-key", async () => {
 	});
 
 	describe("secondary storage", async () => {
-		let store = new Map<string, string>();
+		const store = new Map<string, string>();
 		const expirationMap = new Map<string, number>();
 
 		const { client, auth, signInWithTestUser } = await getTestInstance(
@@ -2600,7 +2600,7 @@ describe("api-key", async () => {
 	});
 
 	describe("secondary-storage-with-fallback", async () => {
-		let store = new Map<string, string>();
+		const store = new Map<string, string>();
 		const expirationMap = new Map<string, number>();
 
 		const { client, auth, signInWithTestUser } = await getTestInstance(
@@ -3103,7 +3103,7 @@ describe("api-key", async () => {
 	});
 
 	describe("custom storage methods", async () => {
-		let customStore = new Map<string, string>();
+		const customStore = new Map<string, string>();
 		let customGetCalled = false;
 		let customSetCalled = false;
 		let customDeleteCalled = false;

--- a/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/create-api-key.ts
@@ -397,7 +397,7 @@ export function createApiKey({
 					? JSON.stringify(defaultPermissions)
 					: undefined;
 
-			let data: Omit<ApiKey, "id"> = {
+			const data: Omit<ApiKey, "id"> = {
 				createdAt: new Date(),
 				updatedAt: new Date(),
 				name: name ?? null,

--- a/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/update-api-key.ts
@@ -309,7 +309,7 @@ export function updateApiKey({
 				throw APIError.from("NOT_FOUND", ERROR_CODES.KEY_NOT_FOUND);
 			}
 
-			let newValues: Partial<ApiKey> = {};
+			const newValues: Partial<ApiKey> = {};
 
 			if (name !== undefined) {
 				if (name.length < opts.minimumNameLength) {

--- a/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
+++ b/packages/better-auth/src/plugins/api-key/routes/verify-api-key.ts
@@ -126,10 +126,10 @@ export async function validateApiKey({
 
 		throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
 	} else if (remaining !== null) {
-		let now = Date.now();
+		const now = Date.now();
 		const refillInterval = apiKey.refillInterval;
 		const refillAmount = apiKey.refillAmount;
-		let lastTime = new Date(lastRefillAt ?? apiKey.createdAt).getTime();
+		const lastTime = new Date(lastRefillAt ?? apiKey.createdAt).getTime();
 
 		if (refillInterval && refillAmount) {
 			// if they provide refill info, then we should refill once the interval is reached.

--- a/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
+++ b/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
@@ -82,7 +82,7 @@ describe("Custom Session Plugin Tests", async () => {
 	});
 
 	it("should return the custom session for multi-session", async () => {
-		let headers = new Headers();
+		const headers = new Headers();
 		const testUser = {
 			email: "second-email@test.com",
 			password: "password",

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -856,7 +856,7 @@ describe("custom storeOTP", async () => {
 		const authCtx = await auth.$context;
 
 		let validOTP = "";
-		let userEmail1 = `${crypto.randomUUID()}@email.com`;
+		const userEmail1 = `${crypto.randomUUID()}@email.com`;
 
 		it("should create a custom encryptor otp", async () => {
 			const { get } = getTheSentOTP();
@@ -959,7 +959,7 @@ describe("custom storeOTP", async () => {
 		const authCtx = await auth.$context;
 
 		let validOTP = "";
-		let userEmail1 = `${crypto.randomUUID()}@email.com`;
+		const userEmail1 = `${crypto.randomUUID()}@email.com`;
 
 		it("should create a custom hasher otp", async () => {
 			const { get } = getTheSentOTP();

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -97,7 +97,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 							const otp =
 								opts.generateOTP({ email, type: ctx.body.type }, ctx) ||
 								defaultOTPGenerator(opts);
-							let storedOTP = await storeOTP(ctx, opts, otp);
+							const storedOTP = await storeOTP(ctx, opts, otp);
 							await ctx.context.internalAdapter.createVerificationValue({
 								value: `${storedOTP}:0`,
 								identifier: `email-verification-otp-${email}`,

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -86,11 +86,11 @@ export const sendVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 			if (!isValidEmail.success) {
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_EMAIL);
 			}
-			let otp =
+			const otp =
 				opts.generateOTP({ email, type: ctx.body.type }, ctx) ||
 				defaultOTPGenerator(opts);
 
-			let storedOTP = await storeOTP(ctx, opts, otp);
+			const storedOTP = await storeOTP(ctx, opts, otp);
 
 			await ctx.context.internalAdapter
 				.createVerificationValue({
@@ -179,7 +179,7 @@ export const createVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 			const otp =
 				opts.generateOTP({ email, type: ctx.body.type }, ctx) ||
 				defaultOTPGenerator(opts);
-			let storedOTP = await storeOTP(ctx, opts, otp);
+			const storedOTP = await storeOTP(ctx, opts, otp);
 			await ctx.context.internalAdapter.createVerificationValue({
 				value: `${storedOTP}:0`,
 				identifier: `${ctx.body.type}-otp-${email}`,
@@ -264,7 +264,7 @@ export const getVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 				});
 			}
 
-			let [storedOtp, _attempts] = splitAtLastColon(verificationValue.value);
+			const [storedOtp, _attempts] = splitAtLastColon(verificationValue.value);
 			let otp = storedOtp;
 			if (opts.storeOTP === "encrypted") {
 				otp = await symmetricDecrypt({
@@ -793,7 +793,7 @@ export const forgetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			const otp =
 				opts.generateOTP({ email, type: "forget-password" }, ctx) ||
 				defaultOTPGenerator(opts);
-			let storedOTP = await storeOTP(ctx, opts, otp);
+			const storedOTP = await storeOTP(ctx, opts, otp);
 			await ctx.context.internalAdapter.createVerificationValue({
 				value: `${storedOTP}:0`,
 				identifier: `forget-password-otp-${email}`,
@@ -932,7 +932,7 @@ export const resetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 			}
 			const passwordHash = await ctx.context.password.hash(ctx.body.password);
-			let account = user.accounts?.find(
+			const account = user.accounts?.find(
 				(account) => account.providerId === "credential",
 			);
 			if (!account) {

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -109,7 +109,7 @@ describe("oauth2", async () => {
 	}
 
 	it("should redirect to the provider and handle the response", async () => {
-		let headers = new Headers();
+		const headers = new Headers();
 		const signInRes = await authClient.signIn.oauth2({
 			providerId: "test",
 			callbackURL: "http://localhost:3000/dashboard",
@@ -141,7 +141,7 @@ describe("oauth2", async () => {
 			userInfoResponse.statusCode = 200;
 		});
 
-		let headers = new Headers();
+		const headers = new Headers();
 		const signInRes = await authClient.signIn.oauth2({
 			providerId: "test",
 			callbackURL: "http://localhost:3000/dashboard",
@@ -183,7 +183,7 @@ describe("oauth2", async () => {
 	});
 
 	it("should redirect to the provider and handle the response after linked", async () => {
-		let headers = new Headers();
+		const headers = new Headers();
 		const res = await authClient.signIn.oauth2({
 			providerId: "test",
 			callbackURL: "http://localhost:3000/dashboard",
@@ -220,7 +220,7 @@ describe("oauth2", async () => {
 			userInfoResponse.statusCode = 500;
 		});
 
-		let headers = new Headers();
+		const headers = new Headers();
 		const res = await authClient.signIn.oauth2(
 			{
 				providerId: "test",

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -166,7 +166,7 @@ describe("jwt", async () => {
 
 	for (const algorithm of algorithmsToTest) {
 		const expectedOutcome = algorithm.expectedOutcome;
-		for (let disablePrivateKeyEncryption of [false, true]) {
+		for (const disablePrivateKeyEncryption of [false, true]) {
 			const jwtOptions: JwtOptions = {
 				jwks: {
 					keyPairConfig: {

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -115,7 +115,7 @@ export async function signJWT(
 	const privateKeyEncryptionEnabled =
 		!options?.jwks?.disablePrivateKeyEncryption;
 
-	let privateWebKey = privateKeyEncryptionEnabled
+	const privateWebKey = privateKeyEncryptionEnabled
 		? await symmetricDecrypt({
 				key: ctx.context.secret,
 				data: JSON.parse(key.privateKey),

--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -63,7 +63,7 @@ export async function createJwk(
 	const stringifiedPrivateWebKey = JSON.stringify(privateWebKey);
 	const privateKeyEncryptionEnabled =
 		!options?.jwks?.disablePrivateKeyEncryption;
-	let jwk: Omit<Jwk, "id"> = {
+	const jwk: Omit<Jwk, "id"> = {
 		alg,
 		...(cfg && "crv" in cfg
 			? {

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -302,7 +302,7 @@ describe("lastLoginMethod", async () => {
 			{ throw: true },
 		);
 
-		let session = await auth.api.getSession({
+		const session = await auth.api.getSession({
 			headers: new Headers({
 				authorization: `Bearer ${emailSignInData.token}`,
 			}),

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -639,7 +639,7 @@ export const mcp = (options: MCPOptions) => {
 							error: "invalid_grant",
 						});
 					}
-					let secretKey = {
+					const secretKey = {
 						alg: "HS256",
 						key: await getWebcryptoSubtle().generateKey(
 							{

--- a/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
+++ b/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
@@ -20,7 +20,7 @@ describe("multi-session", async () => {
 		},
 	);
 
-	let headers = new Headers();
+	const headers = new Headers();
 	const testUser2 = {
 		email: "second-email@test.com",
 		password: "password",

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2472,7 +2472,7 @@ describe("Additional Fields", async () => {
 		}>();
 	});
 
-	let addedMemberHeaders = new Headers();
+	const addedMemberHeaders = new Headers();
 
 	const { data: addedMember, error } = await client.signUp.email({
 		email: "new-member-for-org@email.com",
@@ -2647,7 +2647,7 @@ describe("Additional Fields", async () => {
 			updatedAt: new Date(),
 			password: "password",
 		} satisfies Omit<User, "id"> & { password: string };
-		let headers = new Headers();
+		const headers = new Headers();
 		const setCookie = (name: string, value: string) => {
 			const current = headers.get("cookie");
 			headers.set("cookie", `${current || ""}; ${name}=${value}`);

--- a/packages/better-auth/src/plugins/organization/permission.ts
+++ b/packages/better-auth/src/plugins/organization/permission.ts
@@ -39,7 +39,7 @@ export type PermissionExclusive =
 			permission?: never | undefined;
 	  };
 
-export let cacheAllRoles = new Map<
+export const cacheAllRoles = new Map<
 	string,
 	{
 		[x: string]: Role<any> | undefined;

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
@@ -113,7 +113,7 @@ describe("dynamic access control", async (it) => {
 			headers,
 		});
 		if (!member) throw new Error("Member not found");
-		let userHeaders = new Headers();
+		const userHeaders = new Headers();
 		await authClient.signIn.email({
 			email: normalUserDetails.email,
 			password: normalUserDetails.password,

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -31,7 +31,7 @@ const getAdditionalFields = <
 	options: O,
 	shouldBePartial: AllPartial = false as AllPartial,
 ) => {
-	let additionalFields =
+	const additionalFields =
 		options?.schema?.organizationRole?.additionalFields || {};
 	if (shouldBePartial) {
 		for (const key in additionalFields) {
@@ -750,7 +750,7 @@ export const getOrgRole = <O extends OrganizationOptions>(options: O) => {
 					ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
 				);
 			}
-			let role = await ctx.context.adapter.findOne<OrganizationRole>({
+			const role = await ctx.context.adapter.findOne<OrganizationRole>({
 				model: "organizationRole",
 				where: [
 					{
@@ -949,7 +949,7 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 					ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
 				);
 			}
-			let role = await ctx.context.adapter.findOne<OrganizationRole>({
+			const role = await ctx.context.adapter.findOne<OrganizationRole>({
 				model: "organizationRole",
 				where: [
 					{
@@ -986,12 +986,12 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 				...additionalFields
 			} = ctx.body.data;
 
-			let updateData: Partial<OrganizationRole> = {
+			const updateData: Partial<OrganizationRole> = {
 				...additionalFields,
 			};
 
 			if (ctx.body.data.permission) {
-				let newPermission = ctx.body.data.permission;
+				const newPermission = ctx.body.data.permission;
 
 				await checkForInvalidResources({ ac, ctx, permission: newPermission });
 

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -823,7 +823,7 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 			const adapter = getOrgAdapter<O>(ctx.context, options);
 			const session = ctx.context.session;
 			let organizationId = ctx.body.organizationId;
-			let organizationSlug = ctx.body.organizationSlug;
+			const organizationSlug = ctx.body.organizationSlug;
 
 			if (organizationId === null) {
 				const sessionOrgId = session.session.activeOrganizationId;
@@ -881,7 +881,7 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 				);
 			}
 
-			let organization = await adapter.findOrganizationById(organizationId);
+			const organization = await adapter.findOrganizationById(organizationId);
 			if (!organization) {
 				throw APIError.from(
 					"BAD_REQUEST",

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -878,7 +878,7 @@ export const listTeamMembers = <O extends OrganizationOptions>(options: O) =>
 		async (ctx) => {
 			const session = ctx.context.session;
 			const adapter = getOrgAdapter(ctx.context, ctx.context.orgOptions);
-			let teamId = ctx.query?.teamId || session?.session.activeTeamId;
+			const teamId = ctx.query?.teamId || session?.session.activeTeamId;
 			if (!teamId) {
 				throw APIError.from(
 					"BAD_REQUEST",

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -159,7 +159,7 @@ describe("phone auth flow", async () => {
 		expect(session?.session.token).toBeDefined();
 	});
 
-	let headers = new Headers();
+	const headers = new Headers();
 	it("should go through send-verify and sign-in the user", async () => {
 		await client.phoneNumber.sendOtp({
 			phoneNumber: "+251911121314",

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -542,7 +542,7 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 						PHONE_NUMBER_ERROR_CODES.PHONE_NUMBER_EXIST,
 					);
 				}
-				let user =
+				const user =
 					await ctx.context.internalAdapter.updateUser<UserWithPhoneNumber>(
 						session.user.id,
 						{

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -668,7 +668,7 @@ describe("view backup codes", async () => {
 		});
 	let { headers } = await signInWithTestUser();
 
-	let session = await auth.api.getSession({ headers });
+	const session = await auth.api.getSession({ headers });
 	const userId = session?.user.id!;
 
 	const client = createAuthClient({

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -18,8 +18,8 @@ import { getMigrations } from "./db";
 import { getTestInstance } from "./test-utils/test-instance";
 import { DEFAULT_SECRET } from "./utils/constants";
 
-let server = new OAuth2Server();
-let port = 8005;
+const server = new OAuth2Server();
+const port = 8005;
 
 const mswServer = setupServer();
 let shouldUseUpdatedProfile = false;

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -235,7 +235,7 @@ export async function getTestInstance<
 		if (config?.disableTestUser) {
 			throw new Error("Test user is disabled");
 		}
-		let headers = new Headers();
+		const headers = new Headers();
 		const setCookie = (name: string, value: string) => {
 			const current = headers.get("cookie");
 			headers.set("cookie", `${current || ""}; ${name}=${value}`);

--- a/packages/better-auth/src/utils/wildcard.ts
+++ b/packages/better-auth/src/utils/wildcard.ts
@@ -47,7 +47,7 @@ function transform(
 	separator: string | boolean = true,
 ): string {
 	if (Array.isArray(pattern)) {
-		let regExpPatterns = pattern.map((p) => `^${transform(p, separator)}$`);
+		const regExpPatterns = pattern.map((p) => `^${transform(p, separator)}$`);
 		return `(?:${regExpPatterns.join("|")})`;
 	}
 
@@ -88,15 +88,15 @@ function transform(
 	// `foo/bar` will match `foo/bar//`
 	//
 	// So we use different quantifiers depending on the index of a segment.
-	let requiredSeparator = separator ? `${separatorMatcher}+?` : "";
-	let optionalSeparator = separator ? `${separatorMatcher}*?` : "";
+	const requiredSeparator = separator ? `${separatorMatcher}+?` : "";
+	const optionalSeparator = separator ? `${separatorMatcher}*?` : "";
 
-	let segments = separator ? pattern.split(separatorSplitter) : [pattern];
+	const segments = separator ? pattern.split(separatorSplitter) : [pattern];
 	let result = "";
 
 	for (let s = 0; s < segments.length; s++) {
-		let segment = segments[s]!;
-		let nextSegment = segments[s + 1]!;
+		const segment = segments[s]!;
+		const nextSegment = segments[s + 1]!;
 		let currentSeparator = "";
 
 		if (!segment && s > 0) {
@@ -122,7 +122,7 @@ function transform(
 		}
 
 		for (let c = 0; c < segment.length; c++) {
-			let char = segment[c]!;
+			const char = segment[c]!;
 
 			if (char === "\\") {
 				if (c < segment.length - 1) {
@@ -233,10 +233,10 @@ function wildcardMatch(
 		);
 	}
 
-	let regexpPattern = transform(pattern, options.separator);
-	let regexp = new RegExp(`^${regexpPattern}$`, options.flags);
+	const regexpPattern = transform(pattern, options.separator);
+	const regexp = new RegExp(`^${regexpPattern}$`, options.flags);
 
-	let fn = isMatch.bind(null, regexp) as isMatch;
+	const fn = isMatch.bind(null, regexp) as isMatch;
 	fn.options = options;
 	fn.pattern = pattern;
 	fn.regexp = regexp;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -310,7 +310,7 @@ const getDefaultAuthClientConfig = async ({
 		}
 		return result;
 	}
-	let imports = groupImportVariables();
+	const imports = groupImportVariables();
 	let importString = "";
 	for (const import_ of imports) {
 		if (Array.isArray(import_.variables)) {
@@ -882,7 +882,7 @@ async function initAction(opts: any) {
 			authClientConfigPath = path.join(cwd, "auth-client.ts");
 			log.info(`Creating auth client config file: ${authClientConfigPath}`);
 			try {
-				let contents = await getDefaultAuthClientConfig({
+				const contents = await getDefaultAuthClientConfig({
 					auth_config_path: (
 						"./" + path.join(config_path.replace(cwd, ""))
 					).replace(".//", "./"),
@@ -963,7 +963,7 @@ async function initAction(opts: any) {
 					cancel(`✋ Operation cancelled.`);
 					process.exit(0);
 				}
-				let envs: string[] = [];
+				const envs: string[] = [];
 				if (isMissingSecret) {
 					envs.push("BETTER_AUTH_SECRET");
 				}
@@ -1095,7 +1095,7 @@ async function getPackageManager() {
 		hint: "not recommended",
 	});
 
-	let packageManager = await select({
+	const packageManager = await select({
 		message: "Choose a package manager",
 		options: packageManagerOptions,
 	});

--- a/packages/cli/src/generators/auth-config.ts
+++ b/packages/cli/src/generators/auth-config.ts
@@ -48,7 +48,7 @@ export async function generateAuthConfig({
 	dependencies: string[];
 	envs: string[];
 }> {
-	let _start_of_plugins_common_index = {
+	const _start_of_plugins_common_index = {
 		START_OF_PLUGINS: {
 			type: "regex",
 			regex: /betterAuth\([\w\W]*plugins:[\W]*\[()/m,
@@ -88,7 +88,7 @@ export async function generateAuthConfig({
 			pluginContents: string;
 			config: string;
 		}): Promise<{ code: string; dependencies: string[]; envs: string[] }> => {
-			let start_of_plugins = getGroupInfo(
+			const start_of_plugins = getGroupInfo(
 				opts.config,
 				common_indexes.START_OF_PLUGINS,
 				{},
@@ -101,7 +101,7 @@ export async function generateAuthConfig({
 					"Couldn't find start of your plugins array in your auth config file.",
 				);
 			}
-			let end_of_plugins = getGroupInfo(
+			const end_of_plugins = getGroupInfo(
 				opts.config,
 				common_indexes.END_OF_PLUGINS,
 				{ start_of_plugins: start_of_plugins.index },
@@ -180,7 +180,7 @@ export async function generateAuthConfig({
 				}
 			}
 			try {
-				let new_content = format(importString + opts.config);
+				const new_content = format(importString + opts.config);
 				return { code: await new_content, dependencies: [], envs: [] };
 			} catch (error) {
 				console.error(error);
@@ -214,7 +214,7 @@ export async function generateAuthConfig({
 				code_before_betterAuth?: string;
 			}) {
 				if (code_before_betterAuth) {
-					let start_of_betterauth = getGroupInfo(
+					const start_of_betterauth = getGroupInfo(
 						opts.config,
 						common_indexes.START_OF_BETTERAUTH,
 						{},
@@ -440,7 +440,7 @@ export async function generateAuthConfig({
 				});
 			}
 
-			let start_of_betterauth = getGroupInfo(
+			const start_of_betterauth = getGroupInfo(
 				opts.config,
 				common_indexes.START_OF_BETTERAUTH,
 				{},
@@ -473,8 +473,8 @@ export async function generateAuthConfig({
 	};
 
 	let new_user_config: string = await format(current_user_config);
-	let total_dependencies: string[] = [];
-	let total_envs: string[] = [];
+	const total_dependencies: string[] = [];
+	const total_envs: string[] = [];
 
 	if (plugins.length !== 0) {
 		const imports: {

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -196,12 +196,12 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 
 		type Index = { type: "uniqueIndex" | "index"; name: string; on: string };
 
-		let indexes: Index[] = [];
+		const indexes: Index[] = [];
 
 		const assignIndexes = (indexes: Index[]): string => {
 			if (!indexes.length) return "";
 
-			let code: string[] = [`, (table) => [`];
+			const code: string[] = [`, (table) => [`];
 
 			for (const index of indexes) {
 				code.push(`  ${index.type}("${index.name}").on(table.${index.on}),`);

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -254,7 +254,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 								);
 								continue;
 							}
-							let jsonArray = [];
+							const jsonArray = [];
 							for (const value of attr.defaultValue) jsonArray.push(value);
 							fieldBuilder.attribute(
 								`default("${JSON.stringify(jsonArray).replace(/"/g, '\\"')}")`,
@@ -269,12 +269,12 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 							typeof attr.defaultValue[0] === "string" &&
 							attr.type === "string[]"
 						) {
-							let valueArray = [];
+							const valueArray = [];
 							for (const value of attr.defaultValue)
 								valueArray.push(JSON.stringify(value));
 							fieldBuilder.attribute(`default([${valueArray}])`);
 						} else if (typeof attr.defaultValue[0] === "number") {
-							let valueArray = [];
+							const valueArray = [];
 							for (const value of attr.defaultValue)
 								valueArray.push(`${value}`);
 							fieldBuilder.attribute(`default([${valueArray}])`);

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -200,7 +200,7 @@ export const createAdapterFactory =
 				let value = data[field];
 				const fieldAttributes = fields[field];
 
-				let newFieldName: string =
+				const newFieldName: string =
 					newMappedKeys[field] || fields[field]!.fieldName || field;
 				if (
 					value === undefined &&
@@ -335,7 +335,7 @@ export const createAdapterFactory =
 							newValue = await field.transform.output(newValue);
 						}
 
-						let newFieldName: string = newMappedKeys[key] || key;
+						const newFieldName: string = newMappedKeys[key] || key;
 
 						if (originalKey === "id" || field.references?.field === "id") {
 							// Even if `useNumberId` is true, we must always return a string `id` output.
@@ -392,7 +392,7 @@ export const createAdapterFactory =
 			unsafe_model = getDefaultModelName(unsafe_model);
 			// for now we just transform the base model
 			// later we append the joined models to this object.
-			let transformedData: Record<string, any> = await transformSingleOutput(
+			const transformedData: Record<string, any> = await transformSingleOutput(
 				data,
 				unsafe_model,
 				select,
@@ -443,7 +443,7 @@ export const createAdapterFactory =
 					joinedData = [joinedData];
 				}
 
-				let transformed = [];
+				const transformed = [];
 
 				if (Array.isArray(joinedData)) {
 					for (const item of joinedData) {
@@ -822,7 +822,7 @@ export const createAdapterFactory =
 				forceAllowId?: boolean;
 			}): Promise<R> => {
 				transactionId++;
-				let thisTransactionId = transactionId;
+				const thisTransactionId = transactionId;
 				const model = getModelName(unsafeModel);
 				unsafeModel = getDefaultModelName(unsafeModel);
 				if (
@@ -903,7 +903,7 @@ export const createAdapterFactory =
 				update: Record<string, any>;
 			}): Promise<T | null> => {
 				transactionId++;
-				let thisTransactionId = transactionId;
+				const thisTransactionId = transactionId;
 				unsafeModel = getDefaultModelName(unsafeModel);
 				const model = getModelName(unsafeModel);
 				const where = transformWhereClause({
@@ -965,7 +965,7 @@ export const createAdapterFactory =
 				update: Record<string, any>;
 			}) => {
 				transactionId++;
-				let thisTransactionId = transactionId;
+				const thisTransactionId = transactionId;
 				const model = getModelName(unsafeModel);
 				const where = transformWhereClause({
 					model: unsafeModel,
@@ -1021,7 +1021,7 @@ export const createAdapterFactory =
 				join?: JoinOption;
 			}) => {
 				transactionId++;
-				let thisTransactionId = transactionId;
+				const thisTransactionId = transactionId;
 				const model = getModelName(unsafeModel);
 				const where = transformWhereClause({
 					model: unsafeModel,
@@ -1095,7 +1095,7 @@ export const createAdapterFactory =
 				join?: JoinOption;
 			}) => {
 				transactionId++;
-				let thisTransactionId = transactionId;
+				const thisTransactionId = transactionId;
 				const limit =
 					unsafeLimit ??
 					options.advanced?.database?.defaultFindManyLimit ??
@@ -1173,7 +1173,7 @@ export const createAdapterFactory =
 				where: Where[];
 			}) => {
 				transactionId++;
-				let thisTransactionId = transactionId;
+				const thisTransactionId = transactionId;
 				const model = getModelName(unsafeModel);
 				const where = transformWhereClause({
 					model: unsafeModel,
@@ -1206,7 +1206,7 @@ export const createAdapterFactory =
 				where: Where[];
 			}) => {
 				transactionId++;
-				let thisTransactionId = transactionId;
+				const thisTransactionId = transactionId;
 				const model = getModelName(unsafeModel);
 				const where = transformWhereClause({
 					model: unsafeModel,
@@ -1240,7 +1240,7 @@ export const createAdapterFactory =
 				where?: Where[];
 			}) => {
 				transactionId++;
-				let thisTransactionId = transactionId;
+				const thisTransactionId = transactionId;
 				const model = getModelName(unsafeModel);
 				const where = transformWhereClause({
 					model: unsafeModel,
@@ -1350,7 +1350,7 @@ export const createAdapterFactory =
 								}
 
 								//`${colors.fg.blue}|${colors.reset} `,
-								let log: any[] = logs
+								const log: any[] = logs
 									.reverse()
 									.map((log) => {
 										log.args[0] = `\n${log.args[0]}`;

--- a/packages/core/src/db/adapter/get-default-model-name.ts
+++ b/packages/core/src/db/adapter/get-default-model-name.ts
@@ -23,7 +23,7 @@ export const initGetDefaultModelName = ({
 		// It's possible this `model` could had applied `usePlural`.
 		// Thus we'll try the search but without the trailing `s`.
 		if (usePlural && model.charAt(model.length - 1) === "s") {
-			let pluralessModel = model.slice(0, -1);
+			const pluralessModel = model.slice(0, -1);
 			let m = schema[pluralessModel] ? pluralessModel : undefined;
 			if (!m) {
 				m = Object.entries(schema).find(

--- a/packages/core/src/db/adapter/get-id-field.ts
+++ b/packages/core/src/db/adapter/get-id-field.ts
@@ -36,7 +36,7 @@ export const initGetIdField = ({
 			options.advanced?.database?.generateId === "serial";
 		const useUUIDs = options.advanced?.database?.generateId === "uuid";
 
-		let shouldGenerateId: boolean = (() => {
+		const shouldGenerateId: boolean = (() => {
 			if (disableIdGeneration) {
 				return false;
 			} else if (useNumberId && !forceAllowId) {
@@ -58,7 +58,7 @@ export const initGetIdField = ({
 				? {
 						defaultValue() {
 							if (disableIdGeneration) return undefined;
-							let generateId = options.advanced?.database?.generateId;
+							const generateId = options.advanced?.database?.generateId;
 							if (generateId === false || useNumberId) return undefined;
 							if (typeof generateId === "function") {
 								return generateId({

--- a/packages/core/src/social-providers/gitlab.ts
+++ b/packages/core/src/social-providers/gitlab.ts
@@ -65,7 +65,7 @@ const cleanDoubleSlashes = (input: string = "") => {
 };
 
 const issuerToEndpoints = (issuer?: string | undefined) => {
-	let baseUrl = issuer || "https://gitlab.com";
+	const baseUrl = issuer || "https://gitlab.com";
 	return {
 		authorizationEndpoint: cleanDoubleSlashes(`${baseUrl}/oauth/authorize`),
 		tokenEndpoint: cleanDoubleSlashes(`${baseUrl}/oauth/token`),

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -347,7 +347,7 @@ describe("expo", async () => {
 	});
 
 	it("should not modify origin header if origin is set", async () => {
-		let originalOrigin = "test.com";
+		const originalOrigin = "test.com";
 		let origin = null;
 		const { client, testUser } = await getTestInstance({
 			hooks: {

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -102,7 +102,7 @@ async function validateJwtAccessToken(
 	}
 
 	// Validate JWT against its session if it exists
-	let sessionId = jwtPayload.sid;
+	const sessionId = jwtPayload.sid;
 	if (sessionId) {
 		const session = await ctx.context.adapter.findOne<Session>({
 			model: "session",

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -165,7 +165,7 @@ export async function createOAuthClientEndpoint(
 				session: session?.session,
 			})
 		: undefined;
-	let schema = oauthToSchema({
+	const schema = oauthToSchema({
 		...((body ?? {}) as OAuthClient),
 		// Dynamic registration should not have disabled defined
 		disabled: undefined,

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -323,7 +323,7 @@ async function checkResource(
 	opts: OAuthOptions<Scope[]>,
 	scopes: string[],
 ) {
-	let resource: string | string[] | undefined = ctx.body.resource;
+	const resource: string | string[] | undefined = ctx.body.resource;
 	const audience =
 		typeof resource === "string"
 			? [resource]

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -415,7 +415,7 @@ export function parsePrompt(prompt: string) {
  * @param prompt - the prompt value to delete
  */
 export function deleteFromPrompt(query: URLSearchParams, prompt: Prompt) {
-	let prompts = query.get("prompt")?.split(" ");
+	const prompts = query.get("prompt")?.split(" ");
 	const foundPrompt = prompts?.findIndex((v) => v === prompt) ?? -1;
 	if (foundPrompt >= 0) {
 		prompts?.splice(foundPrompt, 1);

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -4,7 +4,6 @@ import { base64 } from "@better-auth/utils/base64";
 import type {
 	AuthenticationResponseJSON,
 	AuthenticatorTransportFuture,
-	PublicKeyCredentialCreationOptionsJSON,
 } from "@simplewebauthn/server";
 import {
 	generateAuthenticationOptions,
@@ -186,8 +185,7 @@ export const generatePasskeyRegistrationOptions = (
 			const userID = new TextEncoder().encode(
 				generateRandomString(32, "a-z", "0-9"),
 			);
-			let options: PublicKeyCredentialCreationOptionsJSON;
-			options = await generateRegistrationOptions({
+			const options = await generateRegistrationOptions({
 				rpName: opts.rpName || ctx.context.appName,
 				rpID: getRpID(opts, ctx.context.options.baseURL),
 				userID,

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -430,7 +430,7 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 			use: [authMiddleware],
 		},
 		async (ctx) => {
-			let apiFilters: DBFilter[] = parseSCIMAPIUserFilter(ctx.query?.filter);
+			const apiFilters: DBFilter[] = parseSCIMAPIUserFilter(ctx.query?.filter);
 
 			ctx.context.logger.info("Querying result with filters: ", apiFilters);
 

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { sso } from ".";
 import { ssoClient } from "./client";
 
-let server = new OAuth2Server();
+const server = new OAuth2Server();
 
 describe("SSO", async () => {
 	const { auth, signInWithTestUser, customFetchImpl, cookieSetter } =

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -1152,7 +1152,7 @@ describe("SAML SSO", async () => {
 			},
 		});
 
-		let samlRedirectUrl = new URL(signInResponse?.url);
+		const samlRedirectUrl = new URL(signInResponse?.url);
 		const callbackResponse = await auth.api.callbackSSOSAML({
 			method: "POST",
 			body: {
@@ -1297,7 +1297,7 @@ describe("SAML SSO", async () => {
 			},
 		});
 
-		let samlRedirectUrl = new URL(signInResponse?.url);
+		const samlRedirectUrl = new URL(signInResponse?.url);
 		const callbackResponse = await auth.api.callbackSSOSAML({
 			method: "POST",
 			body: {

--- a/test/unit/types/index.test.ts
+++ b/test/unit/types/index.test.ts
@@ -29,7 +29,7 @@ test("infer user type correctly", async () => {
 		onboardingCompleted: boolean | null | undefined;
 	};
 	expectTypeOf<User>().toEqualTypeOf<Res>();
-	let { api } = {
+	const { api } = {
 		api:
 			// use proxy to avoid runtime error
 			new Proxy(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the Biome lint rule “useConst” and refactored the codebase to prefer const for variables that aren’t reassigned. This enforces immutability and consistent style, with no runtime behavior changes.

- **Refactors**
  - Enabled useConst as an error in biome.json.
  - Replaced let with const across core, adapters, clients, plugins, tests, docs, and CLI wherever variables aren’t reassigned.

<sup>Written for commit d02deaeb4460bd1352ff02b230050f0e75495e10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

