### PR TITLE
feat(cli): support forced schema file generation and migration

### DIFF
--- a/docs/content/docs/concepts/cli.mdx
+++ b/docs/content/docs/concepts/cli.mdx
@@ -18,6 +18,7 @@ npx @better-auth/cli@latest generate
 - `--output` - Where to save the generated schema. For Prisma, it will be saved in prisma/schema.prisma. For Drizzle, it goes to schema.ts in your project root. For Kysely, it's an SQL file saved as schema.sql in your project root.
 - `--config` - The path to your Better Auth config file. By default, the CLI will search for an auth.ts file in **./**, **./utils**, **./lib**, or any of these directories under the `src` directory.
 - `--yes` - Skip the confirmation prompt and generate the schema directly.
+- `--force` - Force schema generation, regenerating all tables regardless of existing database state. Useful when you need to recreate schema files from scratch.
 
 
 ## Migrate
@@ -32,6 +33,7 @@ npx @better-auth/cli@latest migrate
 
 - `--config` - The path to your Better Auth config file. By default, the CLI will search for an auth.ts file in **./**, **./utils**, **./lib**, or any of these directories under the `src` directory.
 - `--yes` - Skip the confirmation prompt and apply the schema directly.
+- `--force` - Force migration by dropping and recreating all relevant tables. **Warning**: This will delete all existing data in the affected tables.
 
 <Callout type="info">
 **Using PostgreSQL with a non-default schema?**

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -111,7 +111,7 @@ describe("oauth2", async () => {
 	}
 
 	it("should delete state cookie with path attribute", async () => {
-		let headers = new Headers();
+		const headers = new Headers();
 		const signInRes = await authClient.signIn.oauth2({
 			providerId: "test",
 			callbackURL: "http://localhost:3000/dashboard",

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -22,6 +22,7 @@ async function generateAction(opts: any) {
 			output: z.string().optional(),
 			y: z.boolean().optional(),
 			yes: z.boolean().optional(),
+			force: z.boolean().optional(),
 		})
 		.parse(opts);
 
@@ -52,6 +53,7 @@ async function generateAction(opts: any) {
 		adapter,
 		file: options.output,
 		options: config,
+		force: options.force,
 	});
 
 	spinner.stop();
@@ -202,5 +204,10 @@ export const generate = new Command("generate")
 	)
 	.option("--output <output>", "the file to output to the generated schema")
 	.option("-y, --yes", "automatically answer yes to all prompts", false)
+	.option(
+		"-f, --force",
+		"force schema generation, overriding any existing schema files",
+		false,
+	)
 	.option("--y", "(deprecated) same as --yes", false)
 	.action(generateAction);

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -20,6 +20,7 @@ export async function migrateAction(opts: any) {
 			config: z.string().optional(),
 			y: z.boolean().optional(),
 			yes: z.boolean().optional(),
+			force: z.boolean().optional(),
 		})
 		.parse(opts);
 
@@ -101,7 +102,10 @@ export async function migrateAction(opts: any) {
 
 	const spinner = yoctoSpinner({ text: "preparing migration..." }).start();
 
-	const { toBeAdded, toBeCreated, runMigrations } = await getMigrations(config);
+	const { toBeAdded, toBeCreated, runMigrations } = await getMigrations(
+		config,
+		{ force: options.force },
+	);
 
 	if (!toBeAdded.length && !toBeCreated.length) {
 		spinner.stop();
@@ -187,6 +191,11 @@ export const migrate = new Command("migrate")
 	.option(
 		"-y, --yes",
 		"automatically accept and run migrations without prompting",
+		false,
+	)
+	.option(
+		"-f, --force",
+		"force migration by dropping and recreating all relevant tables",
 		false,
 	)
 	.option("--y", "(deprecated) same as --yes", false)

--- a/packages/cli/src/generators/index.ts
+++ b/packages/cli/src/generators/index.ts
@@ -1,8 +1,7 @@
-import type { BetterAuthOptions } from "@better-auth/core";
-import type { DBAdapter } from "@better-auth/core/db/adapter";
 import { generateDrizzleSchema } from "./drizzle";
 import { generateKyselySchema } from "./kysely";
 import { generatePrismaSchema } from "./prisma";
+import type { SchemaGeneratorOptions } from "./types";
 
 export const adapters = {
 	prisma: generatePrismaSchema,
@@ -10,11 +9,7 @@ export const adapters = {
 	kysely: generateKyselySchema,
 };
 
-export const generateSchema = (opts: {
-	adapter: DBAdapter;
-	file?: string;
-	options: BetterAuthOptions;
-}) => {
+export const generateSchema = (opts: SchemaGeneratorOptions) => {
 	const adapter = opts.adapter;
 	const generator =
 		adapter.id in adapters

--- a/packages/cli/src/generators/kysely.ts
+++ b/packages/cli/src/generators/kysely.ts
@@ -1,16 +1,38 @@
 import { getMigrations } from "better-auth/db";
-import type { SchemaGenerator } from "./types";
+import type { SchemaGenerator, SchemaGeneratorOptions } from "./types";
 
 export const generateKyselySchema: SchemaGenerator = async ({
 	options,
 	file,
+	force,
 }) => {
-	const { compileMigrations } = await getMigrations(options);
+	const { compileMigrations } = await getMigrations(options, { force });
 	const migrations = await compileMigrations();
 	return {
 		code: migrations.trim() === ";" ? "" : migrations,
 		fileName:
 			file ||
+			`./better-auth_migrations/${new Date()
+				.toISOString()
+				.replace(/:/g, "-")}.sql`,
+	};
+};
+
+/**
+ * Generate migrations for Kysely adapter
+ * Exported for testing purposes
+ */
+export const generateMigrations = async (
+	opts: Omit<SchemaGeneratorOptions, "adapter">,
+) => {
+	const { compileMigrations } = await getMigrations(opts.options, {
+		force: opts.force,
+	});
+	const migrations = await compileMigrations();
+	return {
+		code: migrations.trim() === ";" ? "" : migrations,
+		fileName:
+			opts.file ||
 			`./better-auth_migrations/${new Date()
 				.toISOString()
 				.replace(/:/g, "-")}.sql`,

--- a/packages/cli/src/generators/types.ts
+++ b/packages/cli/src/generators/types.ts
@@ -8,10 +8,17 @@ export interface SchemaGeneratorResult {
 	append?: boolean;
 }
 
+export interface SchemaGeneratorOptions {
+	file?: string;
+	adapter: DBAdapter;
+	options: BetterAuthOptions;
+	/**
+	 * When true, forces regeneration of all migrations by treating
+	 * the database as if it were empty.
+	 */
+	force?: boolean;
+}
+
 export interface SchemaGenerator {
-	<Options extends BetterAuthOptions>(opts: {
-		file?: string;
-		adapter: DBAdapter;
-		options: Options;
-	}): Promise<SchemaGeneratorResult>;
+	(opts: SchemaGeneratorOptions): Promise<SchemaGeneratorResult>;
 }

--- a/packages/cli/test/migrate.test.ts
+++ b/packages/cli/test/migrate.test.ts
@@ -1,5 +1,6 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { betterAuth } from "better-auth";
+import { getMigrations } from "better-auth/db";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { migrateAction } from "../src/commands/migrate";
@@ -90,5 +91,202 @@ describe("migrate auth instance with plugins", () => {
 			.prepare("INSERT INTO plugin (id, test) VALUES (?, ?)")
 			.run("1", "test");
 		expect(res.changes).toBe(1);
+	});
+});
+
+describe("migrate command with force flag", () => {
+	beforeEach(() => {
+		vi.spyOn(process, "exit").mockImplementation((code) => {
+			return code as never;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("should pass force flag to config when --force is used", async () => {
+		const testDb = new Database(":memory:");
+		const testAuthConfig = {
+			baseURL: "http://localhost:3000",
+			database: testDb,
+			emailAndPassword: {
+				enabled: true,
+			},
+		};
+
+		vi.spyOn(config, "getConfig").mockImplementation(
+			async () => testAuthConfig,
+		);
+
+		await migrateAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			force: true,
+			yes: true,
+		});
+
+		// Verify that user table exists and we can insert
+		const currentTime = Math.floor(Date.now() / 1000);
+		const signUpRes = testDb
+			.prepare(
+				"INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?)",
+			)
+			.run(
+				"force-test-user",
+				"Force Test User",
+				"force-test@example.com",
+				0,
+				currentTime,
+				currentTime,
+			);
+
+		expect(signUpRes.changes).toBe(1);
+	});
+
+	it("should handle force flag with existing database tables", async () => {
+		const testDb = new Database(":memory:");
+		const testAuthConfig = {
+			baseURL: "http://localhost:3000",
+			database: testDb,
+			emailAndPassword: {
+				enabled: true,
+			},
+		};
+
+		vi.spyOn(config, "getConfig").mockImplementation(
+			async () => testAuthConfig,
+		);
+
+		// Create tables manually first
+		testDb.exec(`
+			CREATE TABLE IF NOT EXISTS user (
+				id TEXT PRIMARY KEY,
+				name TEXT,
+				email TEXT UNIQUE,
+				emailVerified INTEGER DEFAULT 0,
+				image TEXT,
+				createdAt INTEGER DEFAULT (unixepoch()),
+				updatedAt INTEGER DEFAULT (unixepoch())
+			);
+			INSERT INTO user (id, name, email) VALUES ('existing-user', 'Existing User', 'existing@example.com');
+		`);
+
+		// Run migration with force flag - should drop and recreate tables
+		await migrateAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			force: true,
+			yes: true,
+		});
+
+		// The old data should be gone after force migration
+		const userCount = testDb
+			.prepare("SELECT COUNT(*) as count FROM user")
+			.get() as { count: number };
+		expect(userCount.count).toBe(0);
+	});
+
+	it("should run multiple migrations with force flag", async () => {
+		const testDb = new Database(":memory:");
+		const testAuthConfig = {
+			baseURL: "http://localhost:3000",
+			database: testDb,
+			emailAndPassword: {
+				enabled: true,
+			},
+		};
+
+		vi.spyOn(config, "getConfig").mockImplementation(
+			async () => testAuthConfig,
+		);
+
+		// First migration
+		await migrateAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			force: true,
+			yes: true,
+		});
+
+		// Insert some data
+		const currentTime = Math.floor(Date.now() / 1000);
+		testDb
+			.prepare(
+				"INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?)",
+			)
+			.run(
+				"first-user",
+				"First User",
+				"first@example.com",
+				0,
+				currentTime,
+				currentTime,
+			);
+
+		// Second migration with force - should drop and recreate
+		await migrateAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			force: true,
+			yes: true,
+		});
+
+		// Old data should be gone
+		const userCount = testDb
+			.prepare("SELECT COUNT(*) as count FROM user")
+			.get() as { count: number };
+		expect(userCount.count).toBe(0);
+	});
+});
+
+describe("getMigrations with force option", () => {
+	it("should return toBeCreated for all tables when force is true", async () => {
+		const testDb = new Database(":memory:");
+		const testAuthConfig = {
+			baseURL: "http://localhost:3000",
+			database: testDb,
+			emailAndPassword: {
+				enabled: true,
+			},
+		};
+
+		// First create the tables
+		const { runMigrations: firstRun } = await getMigrations(testAuthConfig);
+		await firstRun();
+
+		// Without force, no migrations needed
+		const { toBeCreated: withoutForce } = await getMigrations(testAuthConfig);
+		expect(withoutForce.length).toBe(0);
+
+		// With force, all tables should be in toBeCreated
+		const { toBeCreated: withForce } = await getMigrations(testAuthConfig, {
+			force: true,
+		});
+		expect(withForce.length).toBeGreaterThan(0);
+	});
+
+	it("should include drop statements in compileMigrations when force is true", async () => {
+		const testDb = new Database(":memory:");
+		const testAuthConfig = {
+			baseURL: "http://localhost:3000",
+			database: testDb,
+			emailAndPassword: {
+				enabled: true,
+			},
+		};
+
+		// First create the tables
+		const { runMigrations: firstRun } = await getMigrations(testAuthConfig);
+		await firstRun();
+
+		// Compile migrations with force
+		const { compileMigrations } = await getMigrations(testAuthConfig, {
+			force: true,
+		});
+		const sql = await compileMigrations();
+
+		// Should contain DROP TABLE statements
+		expect(sql.toLowerCase()).toContain("drop table");
 	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a --force flag to CLI generate and migrate to rebuild schemas and run full destructive migrations by dropping and recreating Better Auth tables. Updates getMigrations, docs, and tests to support forced regeneration.

- **New Features**
  - CLI: -f/--force on generate and migrate. For Kysely, generate emits DROP + CREATE; migrate drops then recreates tables.
  - Core: getMigrations(config, { force }) treats the DB as empty, drops tables in reverse order, and includes DROP statements in compileMigrations.
  - Docs/Tests: Added flag docs and comprehensive tests for forced generate/migrate flows.

- **Migration**
  - Use with care. This deletes data in Better Auth tables.
  - Commands: npx @better-auth/cli migrate --force --yes and npx @better-auth/cli generate --force.

<sup>Written for commit 33456957a209c0583c059b1fac1949de50555e9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

