### PR TITLE
[backport] fix: preserve attributes when expiring cookies

### DIFF
--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -15,6 +15,7 @@ import { APIError } from "better-call";
 import * as z from "zod";
 import {
 	deleteSessionCookie,
+	expireCookie,
 	getChunkedCookie,
 	setCookieCache,
 	setSessionCookie,
@@ -119,10 +120,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 								expiresAt: payload.exp ? payload.exp * 1000 : Date.now(),
 							};
 						} else {
-							const dataCookie = ctx.context.authCookies.sessionData.name;
-							ctx.setCookie(dataCookie, "", {
-								maxAge: 0,
-							});
+							expireCookie(ctx, ctx.context.authCookies.sessionData);
 							return ctx.json(null);
 						}
 					} else if (strategy === "jwt") {
@@ -146,10 +144,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 								expiresAt: payload.exp ? payload.exp * 1000 : Date.now(),
 							};
 						} else {
-							const dataCookie = ctx.context.authCookies.sessionData.name;
-							ctx.setCookie(dataCookie, "", {
-								maxAge: 0,
-							});
+							expireCookie(ctx, ctx.context.authCookies.sessionData);
 							return ctx.json(null);
 						}
 					} else {
@@ -180,10 +175,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 							if (isValid) {
 								sessionDataPayload = parsed;
 							} else {
-								const dataCookie = ctx.context.authCookies.sessionData.name;
-								ctx.setCookie(dataCookie, "", {
-									maxAge: 0,
-								});
+								expireCookie(ctx, ctx.context.authCookies.sessionData);
 								return ctx.json(null);
 							}
 						}
@@ -221,10 +213,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 					const cookieVersion = session.version || "1";
 					if (cookieVersion !== expectedVersion) {
 						// Version mismatch - invalidate the cookie cache
-						const dataCookie = ctx.context.authCookies.sessionData.name;
-						ctx.setCookie(dataCookie, "", {
-							maxAge: 0,
-						});
+						expireCookie(ctx, ctx.context.authCookies.sessionData);
 					} else {
 						const cachedSessionExpiresAt = new Date(
 							session.session.expiresAt as unknown as string | number | Date,
@@ -236,10 +225,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 						if (hasExpired) {
 							// When the session data cookie has expired, delete it;
 							//  then we try to fetch from DB
-							const dataCookie = ctx.context.authCookies.sessionData.name;
-							ctx.setCookie(dataCookie, "", {
-								maxAge: 0,
-							});
+							expireCookie(ctx, ctx.context.authCookies.sessionData);
 						} else {
 							// Check if the cookie cache needs to be refreshed based on refreshCache
 							const cookieRefreshCache =

--- a/packages/better-auth/src/context/__snapshots__/create-context.test.ts.snap
+++ b/packages/better-auth/src/context/__snapshots__/create-context.test.ts.snap
@@ -37,43 +37,43 @@ exports[`base context creation > should match config 1`] = `
   "appName": "Better Auth",
   "authCookies": {
     "accountData": {
-      "name": "better-auth.account_data",
-      "options": {
+      "attributes": {
         "httpOnly": true,
         "maxAge": 300,
         "path": "/",
         "sameSite": "lax",
         "secure": false,
       },
+      "name": "better-auth.account_data",
     },
     "dontRememberToken": {
-      "name": "better-auth.dont_remember",
-      "options": {
+      "attributes": {
         "httpOnly": true,
         "path": "/",
         "sameSite": "lax",
         "secure": false,
       },
+      "name": "better-auth.dont_remember",
     },
     "sessionData": {
-      "name": "better-auth.session_data",
-      "options": {
+      "attributes": {
         "httpOnly": true,
         "maxAge": 300,
         "path": "/",
         "sameSite": "lax",
         "secure": false,
       },
+      "name": "better-auth.session_data",
     },
     "sessionToken": {
-      "name": "better-auth.session_token",
-      "options": {
+      "attributes": {
         "httpOnly": true,
         "maxAge": 604800,
         "path": "/",
         "sameSite": "lax",
         "secure": false,
       },
+      "name": "better-auth.session_token",
     },
   },
   "baseURL": "http://localhost:3000/api/auth",

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1,6 +1,7 @@
 import type { BetterAuthOptions } from "@better-auth/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+	expireCookie,
 	getCookieCache,
 	getCookies,
 	getSessionCookie,
@@ -167,10 +168,10 @@ describe("cookie configuration", () => {
 
 		const cookies = getCookies(options);
 
-		expect(cookies.sessionToken.options.secure).toBe(true);
+		expect(cookies.sessionToken.attributes.secure).toBe(true);
 		expect(cookies.sessionToken.name).toContain("test-prefix.session_token");
-		expect(cookies.sessionData.options.sameSite).toBe("lax");
-		expect(cookies.sessionData.options.domain).toBe("example.com");
+		expect(cookies.sessionData.attributes.sameSite).toBe("lax");
+		expect(cookies.sessionData.attributes.domain).toBe("example.com");
 	});
 });
 
@@ -1202,5 +1203,23 @@ describe("parse cookies", () => {
 		expect(parsedCookies.get("better-auth.session_data")).toBe(
 			"session-data.signature=",
 		);
+	});
+});
+
+describe("expireCookie", () => {
+	it("preserves attributes", () => {
+		const setCookie = vi.fn();
+		expireCookie({ setCookie } as any, {
+			name: "test",
+			attributes: {
+				path: "/custom",
+				httpOnly: true,
+			},
+		});
+		expect(setCookie).toHaveBeenCalledWith("test", "", {
+			path: "/custom",
+			httpOnly: true,
+			maxAge: 0,
+		});
 	});
 });

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -1,4 +1,5 @@
 import type {
+	BetterAuthCookie,
 	BetterAuthCookies,
 	BetterAuthOptions,
 	GenericEndpointContext,
@@ -67,8 +68,8 @@ export function createCookieGetter(options: BetterAuthOptions) {
 				...options.advanced?.defaultCookieAttributes,
 				...overrideAttributes,
 				...attributes,
-			} as CookieOptions,
-		};
+			},
+		} satisfies BetterAuthCookie;
 	}
 	return createCookie;
 }
@@ -89,7 +90,7 @@ export function getCookies(options: BetterAuthOptions) {
 	return {
 		sessionToken: {
 			name: sessionToken.name,
-			options: sessionToken.attributes,
+			attributes: sessionToken.attributes,
 		},
 		/**
 		 * This cookie is used to store the session data in the cookie
@@ -97,15 +98,15 @@ export function getCookies(options: BetterAuthOptions) {
 		 */
 		sessionData: {
 			name: sessionData.name,
-			options: sessionData.attributes,
+			attributes: sessionData.attributes,
 		},
 		dontRememberToken: {
 			name: dontRememberToken.name,
-			options: dontRememberToken.attributes,
+			attributes: dontRememberToken.attributes,
 		},
 		accountData: {
 			name: accountData.name,
-			options: accountData.attributes,
+			attributes: accountData.attributes,
 		},
 	};
 }
@@ -157,10 +158,10 @@ export async function setCookieCache(
 		};
 
 		const options = {
-			...ctx.context.authCookies.sessionData.options,
+			...ctx.context.authCookies.sessionData.attributes,
 			maxAge: dontRememberMe
 				? undefined
-				: ctx.context.authCookies.sessionData.options.maxAge,
+				: ctx.context.authCookies.sessionData.attributes.maxAge,
 		};
 
 		const expiresAtDate = getDate(options.maxAge || 60, "sec").getTime();
@@ -249,7 +250,7 @@ export async function setSessionCookie(
 	dontRememberMe =
 		dontRememberMe !== undefined ? dontRememberMe : !!dontRememberMeCookie;
 
-	const options = ctx.context.authCookies.sessionToken.options;
+	const options = ctx.context.authCookies.sessionToken.attributes;
 	const maxAge = dontRememberMe
 		? undefined
 		: ctx.context.sessionConfig.expiresIn;
@@ -269,7 +270,7 @@ export async function setSessionCookie(
 			ctx.context.authCookies.dontRememberToken.name,
 			"true",
 			ctx.context.secret,
-			ctx.context.authCookies.dontRememberToken.options,
+			ctx.context.authCookies.dontRememberToken.attributes,
 		);
 	}
 	await setCookieCache(ctx, session, dontRememberMe);
@@ -293,30 +294,33 @@ export async function setSessionCookie(
 	}
 }
 
+/**
+ * Expires a cookie by setting `maxAge: 0` while preserving its attributes
+ */
+export function expireCookie(
+	ctx: GenericEndpointContext,
+	cookie: BetterAuthCookie,
+) {
+	ctx.setCookie(cookie.name, "", {
+		...cookie.attributes,
+		maxAge: 0,
+	});
+}
+
 export function deleteSessionCookie(
 	ctx: GenericEndpointContext,
 	skipDontRememberMe?: boolean | undefined,
 ) {
-	ctx.setCookie(ctx.context.authCookies.sessionToken.name, "", {
-		...ctx.context.authCookies.sessionToken.options,
-		maxAge: 0,
-	});
-
-	ctx.setCookie(ctx.context.authCookies.sessionData.name, "", {
-		...ctx.context.authCookies.sessionData.options,
-		maxAge: 0,
-	});
+	expireCookie(ctx, ctx.context.authCookies.sessionToken);
+	expireCookie(ctx, ctx.context.authCookies.sessionData);
 
 	if (ctx.context.options.account?.storeAccountCookie) {
-		ctx.setCookie(ctx.context.authCookies.accountData.name, "", {
-			...ctx.context.authCookies.accountData.options,
-			maxAge: 0,
-		});
+		expireCookie(ctx, ctx.context.authCookies.accountData);
 
 		//clean up the account data chunks
 		const accountStore = createAccountStore(
 			ctx.context.authCookies.accountData.name,
-			ctx.context.authCookies.accountData.options,
+			ctx.context.authCookies.accountData.attributes,
 			ctx,
 		);
 		const cleanCookies = accountStore.clean();
@@ -325,26 +329,20 @@ export function deleteSessionCookie(
 
 	if (ctx.context.oauthConfig.storeStateStrategy === "cookie") {
 		const stateCookie = ctx.context.createAuthCookie("oauth_state");
-		ctx.setCookie(stateCookie.name, "", {
-			...stateCookie.attributes,
-			maxAge: 0,
-		});
+		expireCookie(ctx, stateCookie);
 	}
 
 	// Use createSessionStore to clean up all session data chunks
 	const sessionStore = createSessionStore(
 		ctx.context.authCookies.sessionData.name,
-		ctx.context.authCookies.sessionData.options,
+		ctx.context.authCookies.sessionData.attributes,
 		ctx,
 	);
 	const cleanCookies = sessionStore.clean();
 	sessionStore.setCookies(cleanCookies);
 
 	if (!skipDontRememberMe) {
-		ctx.setCookie(ctx.context.authCookies.dontRememberToken.name, "", {
-			...ctx.context.authCookies.dontRememberToken.options,
-			maxAge: 0,
-		});
+		expireCookie(ctx, ctx.context.authCookies.dontRememberToken);
 	}
 }
 

--- a/packages/better-auth/src/cookies/session-store.ts
+++ b/packages/better-auth/src/cookies/session-store.ts
@@ -16,7 +16,7 @@ const CHUNK_SIZE = ALLOWED_COOKIE_SIZE - ESTIMATED_EMPTY_COOKIE_SIZE;
 interface Cookie {
 	name: string;
 	value: string;
-	options: CookieOptions;
+	attributes: CookieOptions;
 }
 
 type Chunks = Record<string, string>;
@@ -135,7 +135,7 @@ function getCleanCookies(
 		cleanedChunks[name] = {
 			name,
 			value: "",
-			options: { ...cookieOptions, maxAge: 0 },
+			attributes: { ...cookieOptions, maxAge: 0 },
 		};
 	}
 	return cleanedChunks;
@@ -191,7 +191,7 @@ const storeFactory =
 					{
 						name: cookieName,
 						value,
-						options: { ...cookieOptions, ...options },
+						attributes: { ...cookieOptions, ...options },
 					},
 					chunks,
 					logger,
@@ -222,7 +222,7 @@ const storeFactory =
 			 */
 			setCookies(cookies: Cookie[]): void {
 				for (const cookie of cookies) {
-					ctx.setCookie(cookie.name, cookie.value, cookie.options);
+					ctx.setCookie(cookie.name, cookie.value, cookie.attributes);
 				}
 			},
 		};
@@ -282,7 +282,7 @@ export async function setAccountCookie(
 	const accountDataCookie = c.context.authCookies.accountData;
 	const options = {
 		maxAge: 60 * 5,
-		...accountDataCookie.options,
+		...accountDataCookie.attributes,
 	};
 	const data = await symmetricEncodeJWT(
 		accountData,

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -2,6 +2,7 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError } from "better-call";
 import * as z from "zod";
 import { setOAuthState } from "../api/middlewares/oauth";
+import { expireCookie } from "../cookies";
 import {
 	generateRandomString,
 	symmetricDecrypt,
@@ -170,9 +171,7 @@ export async function parseState(c: GenericEndpointContext) {
 		}
 
 		// Clear the cookie after successful parsing
-		c.setCookie(stateCookie.name, "", {
-			maxAge: 0,
-		});
+		expireCookie(c, stateCookie);
 	} else {
 		// Default: database strategy
 		const data = await c.context.internalAdapter.findVerificationValue(state);
@@ -201,9 +200,7 @@ export async function parseState(c: GenericEndpointContext) {
 				c.context.options.onAPIError?.errorURL || `${c.context.baseURL}/error`;
 			throw c.redirect(`${errorURL}?error=state_mismatch`);
 		}
-		c.setCookie(stateCookie.name, "", {
-			maxAge: 0,
-		});
+		expireCookie(c, stateCookie);
 
 		// Delete verification value after retrieval
 		await c.context.internalAdapter.deleteVerificationValue(data.id);

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -94,6 +94,7 @@ describe("oauth2", async () => {
 		if (!location) throw new Error("No redirect location found");
 
 		let callbackURL = "";
+		let setCookieHeader = "";
 		const newHeaders = new Headers();
 		await betterFetch(location, {
 			method: "GET",
@@ -101,12 +102,35 @@ describe("oauth2", async () => {
 			headers,
 			onError(context) {
 				callbackURL = context.response.headers.get("location") || "";
+				setCookieHeader = context.response.headers.get("set-cookie") || "";
 				cookieSetter(newHeaders)(context);
 			},
 		});
 
-		return { callbackURL, headers: newHeaders };
+		return { callbackURL, headers: newHeaders, setCookieHeader };
 	}
+
+	it("should delete state cookie with path attribute", async () => {
+		const headers = new Headers();
+		const signInRes = await authClient.signIn.oauth2({
+			providerId: "test",
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const { setCookieHeader } = await simulateOAuthFlow(
+			signInRes.data?.url || "",
+			headers,
+		);
+
+		const cookies = parseSetCookieHeader(setCookieHeader);
+		const stateCookie = cookies.get("better-auth.state");
+
+		expect(stateCookie?.["max-age"]).toBe(0);
+		expect(stateCookie?.path).toBe("/");
+	});
 
 	it("should redirect to the provider and handle the response", async () => {
 		const headers = new Headers();

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -145,7 +145,7 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 								// Inherit cookie attributes from Better Auth's centralized cookie system
 								// This ensures consistency with cross-origin, cross-subdomain, and security settings
 								const cookieAttributes = {
-									...ctx.context.authCookies.sessionToken.options,
+									...ctx.context.authCookies.sessionToken.attributes,
 									maxAge: config.maxAge,
 									httpOnly: false, // Override: plugin cookies are not httpOnly
 								};

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -15,7 +15,7 @@ import { createHash } from "@better-auth/utils/hash";
 import { SignJWT } from "jose";
 import * as z from "zod";
 import { APIError, getSessionFromCtx } from "../../api";
-import { parseSetCookieHeader } from "../../cookies";
+import { expireCookie, parseSetCookieHeader } from "../../cookies";
 import { generateRandomString } from "../../crypto";
 import { HIDE_METADATA } from "../../utils";
 import { getBaseURL } from "../../utils/url";
@@ -196,8 +196,9 @@ export const mcp = (options: MCPOptions) => {
 						if (!cookie || !hasSessionToken) {
 							return;
 						}
-						ctx.setCookie("oidc_login_prompt", "", {
-							maxAge: 0,
+						expireCookie(ctx, {
+							name: "oidc_login_prompt",
+							attributes: { path: "/" },
 						});
 						const sessionCookie = parsedSetCookieHeader.get(cookieName)?.value;
 						const sessionToken = sessionCookie?.split(".")[0]!;

--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -8,8 +8,10 @@ import * as z from "zod";
 import { APIError, sessionMiddleware } from "../../api";
 import {
 	deleteSessionCookie,
+	expireCookie,
 	parseCookies,
 	parseSetCookieHeader,
+	SECURE_COOKIE_PREFIX,
 	setSessionCookie,
 } from "../../cookies";
 
@@ -166,9 +168,9 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 					const session =
 						await ctx.context.internalAdapter.findSession(sessionToken);
 					if (!session || session.session.expiresAt < new Date()) {
-						ctx.setCookie(multiSessionCookieName, "", {
-							...ctx.context.authCookies.sessionToken.options,
-							maxAge: 0,
+						expireCookie(ctx, {
+							name: multiSessionCookieName,
+							attributes: ctx.context.authCookies.sessionToken.attributes,
 						});
 						throw new APIError("UNAUTHORIZED", {
 							message: ERROR_CODES.INVALID_SESSION_TOKEN,
@@ -239,9 +241,9 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 					}
 
 					await ctx.context.internalAdapter.deleteSession(sessionToken);
-					ctx.setCookie(multiSessionCookieName, "", {
-						...ctx.context.authCookies.sessionToken.options,
-						maxAge: 0,
+					expireCookie(ctx, {
+						name: multiSessionCookieName,
+						attributes: ctx.context.authCookies.sessionToken.attributes,
 					});
 					const isActive = ctx.context.session?.session.token === sessionToken;
 					if (!isActive) return ctx.json({ status: true });
@@ -319,7 +321,7 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 							cookieName,
 							sessionToken,
 							ctx.context.secret,
-							sessionCookieConfig.options,
+							sessionCookieConfig.attributes,
 						);
 					}),
 				},
@@ -340,14 +342,16 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 										ctx.context.secret,
 									);
 									if (verifiedToken) {
-										ctx.setCookie(
-											key.toLowerCase().replace("__secure-", "__Secure-"),
-											"",
-											{
-												...ctx.context.authCookies.sessionToken.options,
-												maxAge: 0,
-											},
-										);
+										expireCookie(ctx, {
+											name: key
+												.toLowerCase()
+												.replace(
+													SECURE_COOKIE_PREFIX.toLowerCase(),
+													SECURE_COOKIE_PREFIX,
+												),
+											attributes:
+												ctx.context.authCookies.sessionToken.attributes,
+										});
 										return verifiedToken;
 									}
 									return null;

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -13,7 +13,7 @@ import type { OpenAPIParameter } from "better-call";
 import { jwtVerify, SignJWT } from "jose";
 import * as z from "zod";
 import { APIError, getSessionFromCtx, sessionMiddleware } from "../../api";
-import { parseSetCookieHeader } from "../../cookies";
+import { expireCookie, parseSetCookieHeader } from "../../cookies";
 import {
 	generateRandomString,
 	symmetricDecrypt,
@@ -397,8 +397,9 @@ export const oidcProvider = (options: OIDCOptions) => {
 						if (!loginPromptCookie || !hasSessionToken) {
 							return;
 						}
-						ctx.setCookie("oidc_login_prompt", "", {
-							maxAge: 0,
+						expireCookie(ctx, {
+							name: "oidc_login_prompt",
+							attributes: { path: "/" },
 						});
 						const sessionCookie = parsedSetCookieHeader.get(cookieName)?.value;
 						const sessionToken = sessionCookie?.split(".")[0]!;
@@ -576,8 +577,9 @@ export const oidcProvider = (options: OIDCOptions) => {
 					}
 
 					// Clear the cookie
-					ctx.setCookie("oidc_consent_prompt", "", {
-						maxAge: 0,
+					expireCookie(ctx, {
+						name: "oidc_consent_prompt",
+						attributes: { path: "/" },
 					});
 
 					const value = JSON.parse(verification.value) as CodeVerificationValue;
@@ -1721,14 +1723,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 						await ctx.context.internalAdapter.deleteSession(
 							session.session.token,
 						);
-						ctx.setSignedCookie(
-							ctx.context.authCookies.sessionToken.name,
-							"",
-							ctx.context.secret,
-							{
-								maxAge: 0,
-							},
-						);
+						expireCookie(ctx, ctx.context.authCookies.sessionToken);
 					}
 
 					if (post_logout_redirect_uri) {

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -11,7 +11,7 @@ import type {
 import type { DBAdapter, Where } from "../db/adapter";
 import type { createLogger } from "../env";
 import type { OAuthProvider } from "../oauth2";
-import type { BetterAuthCookies } from "./cookie";
+import type { BetterAuthCookie, BetterAuthCookies } from "./cookie";
 import type {
 	BetterAuthOptions,
 	BetterAuthRateLimitOptions,
@@ -150,10 +150,7 @@ export interface InternalAdapter<
 type CreateCookieGetterFn = (
 	cookieName: string,
 	overrideAttributes?: Partial<CookieOptions> | undefined,
-) => {
-	name: string;
-	attributes: CookieOptions;
-};
+) => BetterAuthCookie;
 
 type CheckPasswordFn<Options extends BetterAuthOptions = BetterAuthOptions> = (
 	userId: string,

--- a/packages/core/src/types/cookie.ts
+++ b/packages/core/src/types/cookie.ts
@@ -1,8 +1,10 @@
 import type { CookieOptions } from "better-call";
 
+export type BetterAuthCookie = { name: string; attributes: CookieOptions };
+
 export type BetterAuthCookies = {
-	sessionToken: { name: string; options: CookieOptions };
-	sessionData: { name: string; options: CookieOptions };
-	accountData: { name: string; options: CookieOptions };
-	dontRememberToken: { name: string; options: CookieOptions };
+	sessionToken: BetterAuthCookie;
+	sessionData: BetterAuthCookie;
+	accountData: BetterAuthCookie;
+	dontRememberToken: BetterAuthCookie;
 };

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -5,7 +5,7 @@ export type {
 	InternalAdapter,
 	PluginContext,
 } from "./context";
-export type { BetterAuthCookies } from "./cookie";
+export type { BetterAuthCookie, BetterAuthCookies } from "./cookie";
 export type * from "./helper";
 export type {
 	BetterAuthAdvancedOptions,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Backport: ensure cookies expire without losing their attributes (path, domain, sameSite, secure) by introducing a centralized expireCookie helper and applying it across auth flows.

- **Bug Fixes**
  - Use expireCookie when clearing session, state, admin, OIDC, MCP, multi-session, two-factor, and account cookies to preserve attributes.
  - OAuth state cookie now expires with correct path and max-age; added tests for this and expireCookie behavior.
  - Preserve __Secure- prefix casing when expiring multi-session cookies.

- **Refactors**
  - Standardized cookie shape to BetterAuthCookie and renamed options to attributes.
  - Centralized cookie cleanup in deleteSessionCookie and session-store; updated related tests and helpers.

<sup>Written for commit d8d17739141fce1eb99df5c76401de6e1c43dde7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

