### PR TITLE
docs: correct Captcha plugin default option description

### DIFF
--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -84,7 +84,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 
 - **`provider` (required)**: your captcha provider.
 - **`secretKey` (required)**: your provider's secret key used for the server-side validation.
-- `endpoints` (optional): overrides the default array of paths where captcha validation is enforced. Default is: `["/sign-up/email", "/sign-in/email", "/forget-password",]`.
+- `endpoints` (optional): replaces the default array of paths where captcha verification is enforced. If set, only the specified paths will be protected. Default is `["/sign-up/email", "/sign-in/email", "/request-password-reset"]`.
 - `minScore` (optional - only *Google ReCAPTCHA v3*): minimum score threshold. Default is `0.5`.
 - `siteKey` (optional - only *hCaptcha* and *CaptchaFox*): prevents tokens issued on one sitekey from being redeemed elsewhere.
 - `siteVerifyURLOverride` (optional): overrides endpoint URL for the captcha verification request.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the Captcha plugin docs for the endpoints option to clarify it replaces the default protected paths and that only the specified paths are verified when set. Updated the default paths to /sign-up/email, /sign-in/email, and /request-password-reset to match current behavior.

<sup>Written for commit a9579f97b67202ddf09c135bbf69d423dcac32d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

