### PR TITLE
docs: add corporate proxy configuration instructions in `faq.mdx`

### DIFF
--- a/docs/content/docs/reference/faq.mdx
+++ b/docs/content/docs/reference/faq.mdx
@@ -69,10 +69,6 @@ Since Better Auth runs on the server side, you have full control over Node.js's 
 <Callout type="info">
   Learn more about undici ProxyAgent in the [undici documentation](https://github.com/nodejs/undici/blob/main/docs/docs/api/ProxyAgent.md).
 </Callout>
-
-<Callout type="info">
-  Related issue: [#7396](https://github.com/better-auth/better-auth/issues/7396)
-</Callout>
 </Accordion>
 
 <Accordion id="adding-custom-fields-to-the-users-table" title="Adding custom fields to the users table">


### PR DESCRIPTION
Related: https://github.com/better-auth/better-auth/issues/7396

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new FAQ entry that shows how to route Better Auth’s server-side outbound requests through a corporate proxy using undici’s ProxyAgent and setGlobalDispatcher. Helps deployments behind proxies handle OAuth and other calls; addresses issue #7396.

<sup>Written for commit 8d15f687da359516b8f5501a96242001835936fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

