### PR TITLE
feat: add `skipTrailingSlashes` option to advanced config

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -543,7 +543,8 @@ export const auth = betterAuth({
 			})) | false | "serial" | "uuid",
 			defaultFindManyLimit: 100,
 			experimentalJoins: false,
-		}
+		},
+		skipTrailingSlashes: true
 	},
 })
 ```
@@ -557,6 +558,7 @@ export const auth = betterAuth({
 - `defaultCookieAttributes`: Default attributes for all cookies
 - `cookiePrefix`: Prefix for cookies
 - `database`: Database configuration options
+- `skipTrailingSlashes`: Skip trailing slash validation in route matching. (default: `false`)
 - OAuth state configuration options (`storeStateStrategy`, `skipStateCookieCheck`) are now part of the `account` option
 
 ## `logger`

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -273,6 +273,7 @@ export const router = <Option extends BetterAuthOptions>(
 			...middlewares,
 		],
 		allowedMediaTypes: ["application/json"],
+		skipTrailingSlashes: options.advanced?.skipTrailingSlashes ?? false,
 		async onRequest(req) {
 			//handle disabled paths
 			const disabledPaths = ctx.options.disabledPaths || [];

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -305,6 +305,12 @@ export type BetterAuthAdvancedOptions = {
 	backgroundTasks?: {
 		handler: (promise: Promise<void>) => void;
 	};
+	/**
+	 * Skip trailing slash validation in route matching
+	 *
+	 * @default false
+	 */
+	skipTrailingSlashes?: boolean | undefined;
 };
 
 export type BetterAuthOptions = {


### PR DESCRIPTION
> [!NOTE]
> useful when your framework automatically adds a trailing slash 

- Closes #6671

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an advanced config option to handle trailing slashes in route matching. This helps frameworks that auto-append slashes; default behavior remains strict (404 on trailing slashes).

- **New Features**
  - Added advanced.skipTrailingSlashes to bypass trailing slash validation in the router.
  - Router respects the flag so trailing-slash requests reach endpoints.
  - Added tests for GET and POST with trailing slashes and updated the options reference docs.

<sup>Written for commit 6f417c706ea8478923bf054e10f539985c0191ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

