### PR TITLE
feat(oidc-provider): add support for JWT access tokens and update accessTokenFormat option

### DIFF
--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -20,6 +20,7 @@ The **OIDC Provider Plugin** enables you to build and manage your own OpenID Con
 - **Refresh Tokens**: Issue refresh tokens and handle access token renewal using the `refresh_token` grant.
 - **OAuth Consent**: Implement OAuth consent screens for user authorization, with an option to bypass consent for trusted applications.
 - **UserInfo Endpoint**: Provide a UserInfo endpoint for clients to retrieve user details.
+- **JWT Access Tokens (optional)**: Issue signed JWT access tokens using the JWT plugin.
 
 <Callout type="warn">
 This plugin is in active development and may not be suitable for production use. Please report any issues or bugs on [GitHub](https://github.com/better-auth/better-auth).
@@ -378,6 +379,7 @@ export const auth = betterAuth({
 ### JWKS Endpoint
 
 The OIDC Provider plugin can integrate with the JWT plugin to provide asymmetric key signing for ID tokens verifiable at a JWKS endpoint.
+JWT access tokens also require the JWT plugin, since they are signed with the JWKS key pair.
 
 To make your plugin OIDC compliant, you **MUST** disable the `/token` endpoint, the OAuth equivalent is located at `/oauth2/token` instead.
 
@@ -631,5 +633,7 @@ Table Name: `oauthConsent`
 **getAdditionalUserInfoClaim**: `(user: User, scopes: string[], client: Client) => Record<string, any>` - Function to get additional user info claims.
 
 **useJWTPlugin**: `boolean` - When `true`, ID tokens are signed using the JWT plugin's asymmetric keys. When `false` (default), ID tokens are signed with HMAC-SHA256 using the application secret.
+
+**accessTokenFormat**: `"opaque" | "jwt"` - Controls the access token format. `"jwt"` requires the JWT plugin and returns a signed JWT access token. Default is `"opaque"`.
 
 **schema**: `AuthPluginSchema` - Customize the OIDC provider schema.

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -3,6 +3,15 @@ import type { OAuthApplication, schema } from "./schema";
 
 export interface OIDCOptions {
 	/**
+	 * The format of the access token returned by the token endpoint.
+	 *
+	 * - "opaque": A random string stored in the database (default)
+	 * - "jwt": A signed JWT access token (requires the JWT plugin)
+	 *
+	 * @default "opaque"
+	 */
+	accessTokenFormat?: "opaque" | "jwt" | undefined;
+	/**
 	 * The amount of time in seconds that the access token is valid for.
 	 *
 	 * @default 3600 (1 hour) - Recommended by the OIDC spec


### PR DESCRIPTION
## Summary
Adds optional JWT access tokens for the OIDC Provider via a new `accessTokenFormat` option (default remains `"opaque"`).

## Changes
- Add `accessTokenFormat?: "opaque" | "jwt"` to OIDC provider options.
- When `accessTokenFormat: "jwt"`, sign access tokens using the JWT plugin (iss/aud from JWT plugin config or `baseURL`) and include `sub`, `azp`, `scope`, `iat`, `exp`, `jti`.
- Keep existing opaque access token behavior as the default.
- Update docs + add/extend tests for JWT access token issuance and verification.

## Testing
- Added/updated `packages/better-auth/src/plugins/oidc-provider/oidc.test.ts` coverage for JWT access tokens.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional JWT access tokens to the OIDC Provider via a new accessTokenFormat option. Default remains opaque; when set to jwt, access tokens are signed via the JWT plugin with standard claims.

- **New Features**
  - accessTokenFormat: "opaque" | "jwt" (default "opaque").
  - JWT access tokens use JWT plugin issuer/audience (or baseURL) and include sub, azp, scope, iat, exp, jti.
  - Supported in authorization_code and refresh_token flows.
  - Docs updated; tests added for issuance and JWKS verification.

- **Migration**
  - No action needed. To use JWT, enable the JWT plugin and set accessTokenFormat to "jwt".

<sup>Written for commit 816e68f37e4f21896fb0db8709d049cf8411e470. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

