### PR TITLE
fix(client): deep merge plugin actions to preserve all methods

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -3,6 +3,7 @@ import type {
 	ClientAtomListener,
 } from "@better-auth/core";
 import { createFetch } from "@better-fetch/fetch";
+import { defu } from "defu";
 import type { WritableAtom } from "nanostores";
 import { getBaseURL } from "../utils/url";
 import { redirectPlugin } from "./fetch-plugins";
@@ -62,7 +63,7 @@ export const getClientConfig = (
 	});
 	const { $sessionSignal, session } = getSessionAtom($fetch, options);
 	const plugins = options?.plugins || [];
-	const pluginsActions = {} as Record<string, any>;
+	let pluginsActions = {} as Record<string, any>;
 	const pluginsAtoms = {
 		$sessionSignal,
 		session,
@@ -124,9 +125,9 @@ export const getClientConfig = (
 
 	for (const plugin of plugins) {
 		if (plugin.getActions) {
-			Object.assign(
+			pluginsActions = defu(
+				plugin.getActions?.($fetch, $store, options) ?? {},
 				pluginsActions,
-				plugin.getActions?.($fetch, $store, options),
 			);
 		}
 	}

--- a/packages/better-auth/src/client/test-plugin.ts
+++ b/packages/better-auth/src/client/test-plugin.ts
@@ -181,3 +181,34 @@ export const testClientPlugin2 = () => {
 		],
 	} satisfies BetterAuthClientPlugin;
 };
+
+/**
+ * Test plugins for verifying deep merge of plugin actions.
+ * When multiple plugins return the same top-level action key (e.g., `signIn`),
+ * all methods should be merged together instead of the last one overwriting.
+ */
+export const testDeepMergePluginA = () => {
+	return {
+		id: "test-deep-merge-a",
+		getActions() {
+			return {
+				signIn: {
+					methodA: async () => ({ success: true, method: "A" }),
+				},
+			};
+		},
+	} satisfies BetterAuthClientPlugin;
+};
+
+export const testDeepMergePluginB = () => {
+	return {
+		id: "test-deep-merge-b",
+		getActions() {
+			return {
+				signIn: {
+					methodB: async () => ({ success: true, method: "B" }),
+				},
+			};
+		},
+	} satisfies BetterAuthClientPlugin;
+};


### PR DESCRIPTION
## Summary

Fixes a bug where client plugin actions with the same top-level key would overwrite each other instead of merging.

When multiple plugins return actions under the same namespace (e.g., `signIn`), only the last plugin's methods were accessible due to `Object.assign` performing a shallow merge.

**Before:**
```ts
// Plugin A: { signIn: { methodA: fn } }
// Plugin B: { signIn: { methodB: fn } }
// Result: { signIn: { methodB: fn } }  methodA is lost
```

**After:**
```ts
// Plugin A: { signIn: { methodA: fn } }
// Plugin B: { signIn: { methodB: fn } }
// Result: { signIn: { methodA: fn, methodB: fn } }  both preserved
```

This aligns the runtime behavior with the TypeScript types, which already use `UnionToIntersection` to merge plugin action types; implying deep merge semantics.

## Solution

This PR switches to `defu` for deep merging, to preserve all methods from all plugins.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deep-merge client plugin actions so methods aren’t lost when multiple plugins share the same namespace (e.g., signIn). Uses defu for deep merge and adds tests to confirm methods from all plugins remain available.

- **Bug Fixes**
  - Replace Object.assign with defu to deep-merge plugin actions.
  - Preserve all methods under the same top-level key, regardless of plugin order.
  - Add tests covering merge behavior and order independence.

<sup>Written for commit 98450509c160d9f2e7574053ea3872ed4be34f40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

