### PR TITLE
fix: deeply merge client actions

### DIFF
--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -124,7 +124,7 @@ export const getClientConfig = (
 
 	const pluginsActions = defu(
 		{},
-		plugins.map((p) => p.getActions?.($fetch, $store, options)),
+		...plugins.map((p) => p.getActions?.($fetch, $store, options)),
 	) as Record<string, any>;
 
 	return {


### PR DESCRIPTION
Related: https://discord.com/channels/1288403910284935179/1461599895474409617/1461599895474409617

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use deep merge for client plugin actions to prevent nested actions from being overwritten. This ensures all plugin actions compose correctly in getClientConfig.

- **Bug Fixes**
  - Replaced shallow Object.assign with defu to deeply merge actions from all plugins.
  - Prevents collisions when multiple plugins define nested action keys, preserving all actions.

<sup>Written for commit 1b81e58331ad7a397fbefba6d9f43e6fbb7db610. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

