### PR TITLE
docs: remove `3rd Party Payment` section

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1989,12 +1989,6 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				),
 			},
 			{
-				title: "3rd Party Payment",
-				separator: true,
-				href: "",
-				icon: () => null,
-			},
-			{
 				title: "Polar",
 				href: "/docs/plugins/polar",
 				icon: () => (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the "3rd Party Payment" section from the docs sidebar to eliminate an empty placeholder link. This cleans up navigation and prevents clicks to a non-existent page.

<sup>Written for commit 6e6a6b02eb0308ab4bcba46ce82ad530ac74554b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

