### PR TITLE
chore: fix lint warnings

### DIFF
--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -98,12 +98,12 @@ export function parseAccountOutput<T extends Account>(
 	// destructuring for type inference
 	// runtime filtering is already done by `parseOutputData`
 	const {
-		accessToken,
-		refreshToken,
-		idToken,
-		accessTokenExpiresAt,
-		refreshTokenExpiresAt,
-		password,
+		accessToken: _accessToken,
+		refreshToken: _refreshToken,
+		idToken: _idToken,
+		accessTokenExpiresAt: _accessTokenExpiresAt,
+		refreshTokenExpiresAt: _refreshTokenExpiresAt,
+		password: _password,
 		...rest
 	} = parsed;
 	return rest;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed lint warnings in parseAccountOutput by aliasing unused destructured fields to underscore-prefixed variables. No runtime changes; just code cleanup.

<sup>Written for commit 1bd2ed9fd66cee04cfc1f437e3de8e5bad2507cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

