### PR TITLE
feat(admin): make password field optional on create user

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -173,6 +173,39 @@ describe("Admin plugin", async () => {
 		expect(newUser?.role).toBe("user");
 	});
 
+	it("should allow admin to create users without password", async () => {
+		const res = await client.admin.createUser(
+			{
+				name: "Passwordless User",
+				email: "passwordless@email.com",
+				role: "user",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.user?.email).toBe("passwordless@email.com");
+		expect(res.data?.user?.name).toBe("Passwordless User");
+		expect(res.data?.user?.role).toBe("user");
+
+		// User should not be able to sign in with password since no credential account exists
+		const signInRes = await client.signIn.email({
+			email: "passwordless@email.com",
+			password: "anypassword",
+		});
+		expect(signInRes.error).toBeDefined();
+
+		// Clean up
+		await client.admin.removeUser(
+			{
+				userId: res.data?.user?.id || "",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+	});
+
 	it("should allow admin to create user with multiple roles", async () => {
 		const res = await client.admin.createUser(
 			{


### PR DESCRIPTION
Make the password field optional in the admin plugin's `createUser` endpoint to support users logging in via magic link or social login.

closes #4226

## Summary by cubic
Make the password field optional in the admin plugin’s createUser endpoint so admins can create passwordless users for magic link or social login. Addresses Linear #4226.

- **New Features**
  - Password is optional; credential account is linked only when a password is provided.
  - Added tests to confirm passwordless users can’t sign in with a password until credentials exist.

<sup>Written for commit e0a6f338069be2bb70644172bf821081f517c483. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

