### PR TITLE
fix: consistent token endpoint for dropbox provider

### DIFF
--- a/packages/core/src/social-providers/dropbox.ts
+++ b/packages/core/src/social-providers/dropbox.ts
@@ -74,7 +74,7 @@ export const dropbox = (options: DropboxOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: "https://api.dropbox.com/oauth2/token",
+						tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {


### PR DESCRIPTION
> [!NOTE]
> https://www.dropbox.com/developers/documentation/http/documentation

Dropbox documentation points to https://api.dropboxapi.com/oauth2/token, but the examples use https://api.dropbox.com/oauth2/token.. interesting 🧐

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Dropbox OAuth uses the resolved tokenEndpoint instead of the hardcoded https://api.dropbox.com/oauth2/token. This keeps the token URL consistent with provider config and Dropbox’s documented endpoint.

<sup>Written for commit 7a9c64d0e953786a30b71649b1b14dda95091a67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

