### PR TITLE
chore(demo): correct trustedProviders option

### DIFF
--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -78,7 +78,18 @@ const authOptions = {
 	},
 	account: {
 		accountLinking: {
-			trustedProviders: ["google", "github", "demo-app", "sso"],
+			trustedProviders: [
+				"email-password",
+				"facebook",
+				"github",
+				"google",
+				"discord",
+				"microsoft",
+				"twitch",
+				"twitter",
+				"paypal",
+				"vercel",
+			],
 		},
 	},
 	emailAndPassword: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the trustedProviders list in the demo Next.js auth config to match the supported providers. This prevents account linking errors and enables linking for email-password, Facebook, GitHub, Google, Discord, Microsoft, Twitch, Twitter, PayPal, and Vercel.

<sup>Written for commit c8066fdd448470e0bd1f9412f8d25dda03f7893c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

