### PR TITLE
fix: add 'sso' to trustedProviders type

### DIFF
--- a/docs/content/docs/guides/workos-migration-guide.mdx
+++ b/docs/content/docs/guides/workos-migration-guide.mdx
@@ -115,7 +115,7 @@ export const auth = betterAuth({
   account: { // [!code highlight]
     accountLinking: { // [!code highlight]
       enabled: true, // [!code highlight]
-      trustedProviders: ["email-password", "github"], // [!code highlight]
+      trustedProviders: ["credential", "github"], // [!code highlight]
     }, // [!code highlight]
   }, // [!code highlight]
 });

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -408,7 +408,7 @@ export const auth = betterAuth({
 		storeAccountCookie: true, // Store account data after OAuth flow in a cookie (useful for database-less flows)
 		accountLinking: {
 			enabled: true,
-			trustedProviders: ["google", "github", "email-password"],
+			trustedProviders: ["google", "github", "credential"],
 			allowDifferentEmails: false
 		}
 	},

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -927,7 +927,7 @@ export type BetterAuthOptions = {
 					 */
 					trustedProviders?: Array<
 						LiteralUnion<
-							SocialProviderList[number] | "email-password" | "sso",
+							SocialProviderList[number] | "credential" | "sso" | "siwe",
 							string
 						>
 					>;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds "sso", "credential", and "siwe" to the trustedProviders type, replacing "email-password". Matches plugin IDs (SSO uses "sso") and improves autocomplete and SAML ACS fallback when no providerId is provided.

<sup>Written for commit ac6426a59c0da64bb601d52fdfee45dba80d95c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

