### PR TITLE
Fix opencode tag and MCP command structure

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -37,7 +37,13 @@ async function mcpAction(options: MCPOptions) {
 }
 
 async function _installMcpServers(
-	client: "cursor" | "claude-code" | "open-code" | "opencode" | "manual" | string,
+	client:
+		| "cursor"
+		| "claude-code"
+		| "open-code"
+		| "opencode"
+		| "manual"
+		| string,
 	installLocal: boolean = true,
 	installRemote: boolean = true,
 ) {


### PR DESCRIPTION
opencode is the name of the product, not open-code. also the mcp config was incorrect based on the json schema provided by opencode.


before:
<img width="545" height="274" alt="image" src="https://github.com/user-attachments/assets/19287d71-2333-44a6-bea5-fd0d401ef560" />

after:
<img width="534" height="275" alt="image" src="https://github.com/user-attachments/assets/139a0f25-e804-4f88-9b78-dcf8526f5987" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect Opencode client name and align MCP config with the Opencode schema for reliable local server setup and CLI installation.

- **Bug Fixes**
  - Support "opencode" as the canonical client, with "open-code" kept as an alias.
  - Update local MCP config for better-auth to use type "local" and command as an array.

<sup>Written for commit c1f5374fb0b973f2d2a1f0e152a0316a05f2fe53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

