### PR TITLE
docs(JWT): moved incorrect documentation

### DIFF
--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -143,20 +143,6 @@ In case a JWT with a different `kid` is received, it is recommended to fetch the
   }
 ```
 
-### OAuth Provider Mode
-
-If you are making your system oAuth compliant (such as when utilizing the OIDC or MCP plugins), you **MUST** disable the `/token` endpoint (oAuth equivalent `/oauth2/token`) and disable setting the jwt header (oAuth equivalent `/oauth2/userinfo`).
-
-```ts title="auth.ts"
-betterAuth({
-  disabledPaths: [
-    "/token",
-  ],
-  plugins: [jwt({
-    disableSettingJwtHeader: true,
-  })]
-})
-```
 
 #### Example using jose with remote JWKS
 
@@ -219,6 +205,22 @@ async function validateToken(token: string) {
 const token = 'your.jwt.token' // this is the token you get from the /api/auth/token endpoint
 const payload = await validateToken(token)
 ```
+
+### OAuth Provider Mode
+
+If you are making your system oAuth compliant (such as when utilizing the OIDC or MCP plugins), you **MUST** disable the `/token` endpoint (oAuth equivalent `/oauth2/token`) and disable setting the jwt header (oAuth equivalent `/oauth2/userinfo`).
+
+```ts title="auth.ts"
+betterAuth({
+  disabledPaths: [
+    "/token",
+  ],
+  plugins: [jwt({
+    disableSettingJwtHeader: true,
+  })]
+})
+```
+
 
 ### Remote JWKS Url
 


### PR DESCRIPTION
In simple terms, this PR fixes the following (img). Those sub-categories are placed under the wrong parent category.


<img width="594" height="352" alt="CleanShot 2026-01-19 at 04 49 28@2x" src="https://github.com/user-attachments/assets/ddbacf7f-8f4c-438f-a7fa-a71c49bf3721" />
