### PR TITLE
fix(prisma-adapter): ignores ne null on nullable fields

### DIFF
--- a/packages/better-auth/src/adapters/kysely-adapter/bun-sqlite-dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/bun-sqlite-dialect.ts
@@ -147,7 +147,7 @@ class ConnectionMutex {
 	#resolve?: () => void;
 
 	async lock(): Promise<void> {
-		while (this.#promise) {
+		while (await this.#promise) {
 			await this.#promise;
 		}
 

--- a/packages/better-auth/src/adapters/kysely-adapter/node-sqlite-dialect.ts
+++ b/packages/better-auth/src/adapters/kysely-adapter/node-sqlite-dialect.ts
@@ -149,7 +149,7 @@ class ConnectionMutex {
 	#resolve?: () => void;
 
 	async lock(): Promise<void> {
-		while (this.#promise) {
+		while (await this.#promise) {
 			await this.#promise;
 		}
 

--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -207,7 +207,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 					if (w.operator === "ne" && w.value === null) {
 						const fieldAttributes = getFieldAttributes({
 							model,
-							field: w.field
+							field: w.field,
 						});
 						const isNullable = fieldAttributes?.required !== true;
 						return isNullable ? { [fieldName]: { not: null } } : {};


### PR DESCRIPTION
## Problem

The Prisma adapter ignores `ne: null` by returning `{}`.  
For nullable fields (e.g. `expiresAt`), this effectively **drops the filter**.  
As a result, the cleanup logic runs only with `expiresAt < now` and deletes API keys that have `expiresAt: null`.

## Impact

Non-expiring API keys are unexpectedly deleted after calling `/api-key/list` when using **Prisma + MongoDB**.

## Fix

If a field is **nullable**, map:

- `ne: null` → `{ not: null }`

Keep it as a no-op (`{}`) **only** for non-nullable fields.

## Regression

PR https://github.com/better-auth/better-auth/pull/3413 reintroduces this issue.

The Prisma adapter again drops `ne: null` by returning `{}`, which removes the filter for nullable fields such as `expiresAt`. This causes the cleanup process to delete non-expiring API keys.

This appears to be an oversight in **@okisdev**’s change https://github.com/better-auth/better-auth/pull/5686.  
**@ping-maxwell**, could you please take a look?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Prisma adapter handling of ne: null on nullable fields so filters are preserved and non-expiring API keys aren’t deleted during cleanup in Prisma + MongoDB.

- **Bug Fixes**
  - Map ne: null to { not: null } when a field is nullable; keep it a no-op for non-nullable fields.
  - Use getFieldAttributes to detect nullability and apply the correct where condition for fields like expiresAt.

<sup>Written for commit a79d865330315251a2af7bfec6c8fd38dd2fb2fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

