### PR TITLE
docs: use tabs on drizzle-kit scripts

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -37,10 +37,18 @@ npx @better-auth/cli@latest generate
 
 To generate and apply the migration, run the following commands:
 
-```package-install title="Schema Migration"
-npx drizzle-kit generate # generate the migration file
-npx drizzle-kit migrate # apply the migration
-```
+   <Tabs items={["generate", "migrate"]}>
+      <Tab value="generate">
+      ```package-install
+      npx drizzle-kit generate # generate the migration file
+      ```
+      </Tab>
+      <Tab value="migrate">
+      ```package-install
+      npx drizzle-kit migrate # apply the migration
+      ```
+      </Tab>
+    </Tabs>
 
 
 ## Joins (Experimental)


### PR DESCRIPTION
Convert Drizzle migration commands in `drizzle.mdx` to a tabbed interface for better clarity.

This change was cherry-picked from PR #7457 to improve the presentation of the schema migration commands, making it easier for users to follow the "generate" and "migrate" steps.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1768846752699759?thread_ts=1768846752.699759&cid=C0A8B5BARUK)

<a href="https://cursor.com/background-agent?bcId=bc-7c31d37f-b5ac-4bb9-94af-c0a54ba0e74c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c31d37f-b5ac-4bb9-94af-c0a54ba0e74c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted the Drizzle migration commands in docs/adapters/drizzle.mdx to a tabbed interface that separates “generate” and “migrate” steps. This improves readability and makes copy/paste of each step clearer.

<sup>Written for commit fb6fa1d8bce398b7b1a0a8649e552c05a8898d2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

