### PR TITLE
fix: include `Set-Cookie` when APIError thrown in hooks

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -301,6 +301,10 @@ describe("after hook", async () => {
 						};
 					}
 					if (c.query?.throwHook) {
+						c.setHeader(
+							"Set-Cookie",
+							"auth=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+						);
 						throw c.error("BAD_REQUEST", {
 							message: "from after hook",
 						});
@@ -341,6 +345,16 @@ describe("after hook", async () => {
 					expect(isAPIError(e)).toBeTruthy();
 					expect(e?.message).toBe("from after hook");
 				});
+
+			const response = await api.throwError({
+				query: {
+					throwHook: true,
+				},
+				asResponse: true,
+			});
+			expect(response.headers.get("Set-Cookie")).toBe(
+				"auth=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+			);
 		});
 	});
 

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -12,7 +12,7 @@ import type {
 	EndpointOptions,
 	InputContext,
 } from "better-call";
-import { toResponse } from "better-call";
+import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
 import { createDefu } from "defu";
 import { isAPIError } from "../utils/is-api-error";
 
@@ -276,13 +276,20 @@ async function runAfterHooks(
 		if (hook.matcher(context)) {
 			const result = (await hook.handler(context).catch((e) => {
 				if (isAPIError(e)) {
+					const headers = (e as any)[kAPIErrorHeaderSymbol] as
+						| Headers
+						| undefined;
 					if (shouldPublishLog(context.context.logger.level, "debug")) {
 						// inherit stack from errorStack if debug mode is enabled
 						e.stack = e.errorStack;
 					}
 					return {
 						response: e,
-						headers: e.headers ? new Headers(e.headers) : null,
+						headers: headers
+							? headers
+							: e.headers
+								? new Headers(e.headers)
+								: null,
 					};
 				}
 				throw e;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 1.1.21
       version: 1.1.21
     better-call:
-      specifier: 1.1.8
-      version: 1.1.8
+      specifier: 1.2.0
+      version: 1.2.0
     tsdown:
       specifier: ^0.19.0
       version: 0.19.0
@@ -1119,7 +1119,7 @@ importers:
         version: 2.0.0
       better-call:
         specifier: 'catalog:'
-        version: 1.1.8(zod@4.3.4)
+        version: 1.2.0(zod@4.3.4)
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -1356,7 +1356,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 1.1.8(zod@4.3.4)
+        version: 1.2.0(zod@4.3.4)
       jose:
         specifier: ^6.1.0
         version: 6.1.3
@@ -1377,7 +1377,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 1.1.8(zod@4.3.4)
+        version: 1.2.0(zod@4.3.4)
       zod:
         specifier: ^4.1.12
         version: 4.3.4
@@ -1501,7 +1501,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.1.8(zod@4.3.4)
+        version: 1.2.0(zod@4.3.4)
       zod:
         specifier: ^4.1.5
         version: 4.3.4
@@ -1551,7 +1551,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.1.8(zod@4.3.4)
+        version: 1.2.0(zod@4.3.4)
       body-parser:
         specifier: ^2.2.1
         version: 2.2.1
@@ -1582,7 +1582,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.1.8(zod@4.3.4)
+        version: 1.2.0(zod@4.3.4)
       stripe:
         specifier: ^20.0.0
         version: 20.0.0(@types/node@25.0.9)
@@ -8265,6 +8265,14 @@ packages:
 
   better-call@1.1.8:
     resolution: {integrity: sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  better-call@1.2.0:
+    resolution: {integrity: sha512-7msprrikJah2Pq+OPJOUkqqlDOpVQysBPfxLfXQZr1XeIPqUD3O5z6qxh0vsAU8m/GDFbJD0n1a4vvTnekM7Kw==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -23544,7 +23552,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.26':
     dependencies:
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.28.5
       '@vue/shared': 3.5.26
       entities: 7.0.0
       estree-walker: 2.0.2
@@ -23842,7 +23850,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.28.5
       pathe: 2.0.3
 
   ast-module-types@6.0.1: {}
@@ -24184,10 +24192,19 @@ snapshots:
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.10
+      rou3: 0.7.12
       set-cookie-parser: 2.7.2
     optionalDependencies:
       zod: 4.3.5
+
+  better-call@1.2.0(zod@4.3.4):
+    dependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      zod: 4.3.4
 
   better-opn@3.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ packages:
 catalog:
   '@better-auth/utils': 0.3.0
   '@better-fetch/fetch': 1.1.21
-  better-call: 1.1.8
+  better-call: 1.2.0
   tsdown: ^0.19.0
   typescript: ^5.9.3
 


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/7473
Fixes: https://github.com/better-auth/better-auth/issues/4983

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Set-Cookie headers when after hooks throw APIError, so clients still receive cookie updates on error responses. Adds a test to ensure the header is included.

- **Bug Fixes**
  - Propagate Set-Cookie from APIError via better-call’s header symbol.
  - Add test verifying Set-Cookie is returned when an after hook throws.

- **Dependencies**
  - Upgrade better-call to 1.2.0 to support header propagation.

<sup>Written for commit f5682929b0ad38306e78f5b16783eaebbf062ee2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

