### PR TITLE
chore(sso): remove beta tag for stable release

### DIFF
--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@better-auth/sso",
   "author": "Bereket Engida",
-  "version": "1.5.0-beta.8",
+  "version": "1.5.0",
   "type": "module",
   "main": "dist/index.mjs",
   "types": "dist/index.d.mts",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release @better-auth/sso as stable by removing the beta tag and setting the version to 1.5.0. This marks the package as production-ready with no code changes.

<sup>Written for commit 1a0e8b26095ad8cea91174dbbbd4460d0f567311. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

