### PR TITLE
docs: update `getMigrations` path imports

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -57,10 +57,10 @@ Better Auth provides a `getMigrations` function that you can use to generate and
 
 #### Using `getMigrations`
 
-The `getMigrations` function is available from `better-auth/db` and works with the built-in Kysely adapter (SQLite, PostgreSQL, MySQL, MSSQL).
+The `getMigrations` function is available from `better-auth/db/migration` and works with the built-in Kysely adapter (SQLite, PostgreSQL, MySQL, MSSQL).
 
 ```typescript
-import { getMigrations } from "better-auth/db";
+import { getMigrations } from "better-auth/db/migration";
 
 const { toBeCreated, toBeAdded, runMigrations, compileMigrations } = await getMigrations(authConfig);
 
@@ -83,7 +83,7 @@ For Cloudflare Workers using D1 (SQLite), you can create a migration endpoint th
 ```typescript title="src/index.ts"
 import { Hono } from "hono";
 import { auth } from "./auth"; // your auth instance
-import { getMigrations } from "better-auth/db";
+import { getMigrations } from "better-auth/db/migration";
 
 const app = new Hono<{ Bindings: Env }>();
 

--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -207,7 +207,7 @@ If you're using the built-in Kysely adapter (SQLite/D1, PostgreSQL, MySQL), you 
 
 ```typescript title="src/index.ts"
 import { Hono } from "hono";
-import { getMigrations } from "better-auth/db";
+import { getMigrations } from "better-auth/db/migration";
 import { betterAuth } from "better-auth";
 
 type Env = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated docs to use the correct import path for getMigrations: better-auth/db/migration. Fixes examples in Database concepts and Hono integration guides to avoid import errors when running migrations.

<sup>Written for commit a09d59c5ad898e49455ae52472dc391f04874ecc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

