### PR TITLE
fix(prisma-adapter): enhance null condition handling

### DIFF
--- a/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/better-auth/src/adapters/prisma-adapter/prisma-adapter.ts
@@ -207,7 +207,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 					if (w.operator === "ne" && w.value === null) {
 						const fieldAttributes = getFieldAttributes({
 							model,
-							field: w.field
+							field: w.field,
 						});
 						const isNullable = fieldAttributes?.required !== true;
 						return isNullable ? { [fieldName]: { not: null } } : {};


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/pull/7464

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes handling of "not equals null" filters in the Prisma adapter: now applies {not: null} for nullable fields and skips the condition for non-nullable fields. This prevents dropped filters and returns correct query results.

- **Bug Fixes**
  - Detect field nullability with getFieldAttributes and conditionally apply { [fieldName]: { not: null } }.

<sup>Written for commit af5bc11e7eb604149ca32812592e794509b2a42d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

