### PR TITLE
docs: add a callout about the Kakao Biz App requirement for the `account_email` scope

### DIFF
--- a/docs/content/docs/authentication/kakao.mdx
+++ b/docs/content/docs/authentication/kakao.mdx
@@ -15,12 +15,8 @@ description: Kakao provider setup and usage.
         To configure the provider, you need to import the provider and pass it to the `socialProviders` option of the auth instance.
 
         <Callout type="info">
-            The default scopes are `account_email`, `profile_image`, and `profile_nickname`. 
-            
-            Please note that retrieving `account_email` requires the app to be a **Biz App** (an app that has completed business verification). 
-            If you are not using a Biz App, you must disable the default scope.
-            
-            For more details, refer to the [Kakao Login scopes documentation](https://developers.kakao.com/docs/latest/kakaologin/utilize#scope-user).
+            - The default scopes are `account_email`, `profile_image`, and `profile_nickname`. 
+            - Note that retrieving `account_email` requires the app to be a **Biz App** (an app that has completed business verification). For more details, refer to the [Kakao Login scopes documentation](https://developers.kakao.com/docs/latest/kakaologin/utilize#scope-user).
         </Callout>
 
         ```ts title="auth.ts"
@@ -31,9 +27,6 @@ description: Kakao provider setup and usage.
                 kakao: { // [!code highlight]
                     clientId: process.env.KAKAO_CLIENT_ID as string, // [!code highlight]
                     clientSecret: process.env.KAKAO_CLIENT_SECRET as string, // [!code highlight]
-                    // If your app is not a Biz App, you must disable the default scope
-                    // disableDefaultScope: true,
-                    // scope: ["profile_nickname", "profile_image"]
                 }, // [!code highlight]
             }
         })
@@ -55,5 +48,4 @@ description: Kakao provider setup and usage.
         }
         ```
     </Step>
-
 </Steps>


### PR DESCRIPTION
## Description
This PR adds a warning callout to the Kakao authentication documentation.

Kakao Login requests the `account_email` scope by default. However, this scope is only available for apps that have switched to **Biz App** status. Users testing with a regular app (non-Biz) encounter an "Invalid Scope" error with the default configuration. 

I have added a `Callout` to warn users about this requirement and provided instructions on how to `disableDefaultScope` if they are not using a Biz App.

## Changes
- Updated `docs/content/docs/authentication/kakao.mdx` to include a warning about the `account_email` scope.

## Related Issues
- None

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/better-auth/better-auth/blob/canary/CONTRIBUTING.md) guide
- [x] Documentation has been updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a warning in the Kakao authentication docs that the default account_email scope only works for Biz Apps, which causes "Invalid Scope" errors on regular or test apps. The docs now show how to set disableDefaultScope: true and specify supported scopes (e.g., profile_nickname, profile_image) to avoid the error.

<sup>Written for commit 2a3ff27b1ead6735508ba2e0b7e068478365ddb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

