### PR TITLE
chore(sso): remove unused ascEndpoint params schema

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -2254,10 +2254,6 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 	);
 };
 
-const acsEndpointParamsSchema = z.object({
-	providerId: z.string().optional(),
-});
-
 const acsEndpointBodySchema = z.object({
 	SAMLResponse: z.string(),
 	RelayState: z.string().optional(),
@@ -2268,7 +2264,6 @@ export const acsEndpoint = (options?: SSOOptions) => {
 		"/sso/saml2/sp/acs/:providerId",
 		{
 			method: "POST",
-			params: acsEndpointParamsSchema,
 			body: acsEndpointBodySchema,
 			metadata: {
 				...HIDE_METADATA,
@@ -2332,7 +2327,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 						where: [
 							{
 								field: "providerId",
-								value: providerId ?? "sso",
+								value: providerId,
 							},
 						],
 					})


### PR DESCRIPTION
If it's optional, it won't match the router in the first place and becomes dead code, so it's not a breaking change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up SAML ACS routing by removing the optional params schema and the 'sso' providerId fallback. The route now relies only on the path param, with no functional change.

<sup>Written for commit d471baf4de57750d78cbc850412a28db691ea8f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

