### PR TITLE
fix: postgres escaped search_path

### DIFF
--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -107,9 +107,9 @@ async function getPostgresSchema(db: Kysely<unknown>): Promise<string> {
 			const schemas = result.rows[0].search_path
 				.split(",")
 				.map((s) => s.trim())
-				// Remove quotes and filter out variables like $user
+				// Remove quotes and filter out variables like $user or \$user (escaped)
 				.map((s) => s.replace(/^["']|["']$/g, ""))
-				.filter((s) => !s.startsWith("$"));
+				.filter((s) => !/^\\?\$/.test(s));
 			return schemas[0] || "public";
 		}
 	} catch {


### PR DESCRIPTION
### Problem

When running migrations on PostgreSQL, users could see the following warning:

```
Schema '\$user' does not exist. Tables will be inspected from available schemas.
```
Even tho I am sure the schema exists for `$user`

### Cause

PostgreSQL's `search_path` can return the `$user` variable in different formats:
- `$user` (unescaped) - standard PostgreSQL default
- `\$user` (escaped) - used by some providers like Supabase

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed PostgreSQL schema detection when providers escape $user in search_path, preventing false warnings and correctly choosing the next valid schema (e.g., public).

- **Bug Fixes**
  - Filter both $user and \$user with a regex that matches an optional backslash before $.
  - Removes the "Schema '\$user' does not exist" warning in migrations; compatible with Supabase’s escaped search_path (https://github.com/supabase/supabase/issues/20842).

<sup>Written for commit ac0cb53ec02c9802ceb674f64821662656287f35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

