### PR TITLE
ci: improve db adapter tests

### DIFF
--- a/.github/workflows/adapter-tests.yml
+++ b/.github/workflows/adapter-tests.yml
@@ -11,7 +11,7 @@ on:
       - canary
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}-${{ matrix.adapter || 'all' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -21,6 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x]
+        adapter: [drizzle, kysely, prisma, mongodb, memory]
+    name: Test ${{ matrix.adapter }} adapter (Node ${{ matrix.node-version }})
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -30,8 +32,9 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ matrix.adapter }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ matrix.adapter }}-
             ${{ runner.os }}-turbo-
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -53,18 +56,20 @@ jobs:
         run: pnpm build
 
       - name: Start Docker Containers
+        if: matrix.adapter != 'memory'
         run: |
           docker compose up -d
           # Wait for services to be ready
           sleep 10
 
-      - name: Test Adapters
-        working-directory: e2e/adapter
+      - name: Test ${{ matrix.adapter }} Adapter
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
-        run: pnpm test
+          TURBO_CACHE: remote:rw
+        run: pnpm turbo test:${{ matrix.adapter }} --filter=adapter
 
       - name: Stop Docker Containers
+        if: matrix.adapter != 'memory'
         run: docker compose down
 

--- a/e2e/adapter/package.json
+++ b/e2e/adapter/package.json
@@ -2,6 +2,11 @@
   "name": "adapter",
   "scripts": {
     "test": "vitest",
+    "test:drizzle": "vitest run test/drizzle-adapter/**/*.test.ts",
+    "test:kysely": "vitest run test/kysely-adapter/**/*.test.ts",
+    "test:prisma": "vitest run test/prisma-adapter/**/*.test.ts",
+    "test:mongodb": "vitest run test/mongodb-adapter/**/*.test.ts",
+    "test:memory": "vitest run test/adapter.memory.test.ts",
     "prepare": "prisma generate --schema ./test/prisma-adapter/base.prisma"
   },
   "private": true,

--- a/turbo.json
+++ b/turbo.json
@@ -29,17 +29,131 @@
       "dependsOn": ["build"]
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "src/**",
+        "test/**",
+        "tests/**",
+        "*.test.*",
+        "*.spec.*",
+        "package.json"
+      ],
+      "outputs": [".vitest/**", "coverage/**", "test-results/**"],
+      "cache": true
+    },
+    "test:drizzle": {
+      "dependsOn": ["@better-auth/drizzle-adapter#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "test/drizzle-adapter/**",
+        "test/test-adapter.ts",
+        "test/tests/**",
+        "package.json"
+      ],
+      "outputs": [".vitest/**", "test-results/**"],
+      "cache": true
+    },
+    "test:kysely": {
+      "dependsOn": ["@better-auth/kysely-adapter#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "test/kysely-adapter/**",
+        "test/test-adapter.ts",
+        "test/tests/**",
+        "package.json"
+      ],
+      "outputs": [".vitest/**", "test-results/**"],
+      "cache": true
+    },
+    "test:prisma": {
+      "dependsOn": ["@better-auth/prisma-adapter#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "test/prisma-adapter/**",
+        "test/test-adapter.ts",
+        "test/tests/**",
+        "package.json"
+      ],
+      "outputs": [".vitest/**", "test-results/**"],
+      "cache": true
+    },
+    "test:mongodb": {
+      "dependsOn": ["@better-auth/mongo-adapter#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "test/mongodb-adapter/**",
+        "test/test-adapter.ts",
+        "test/tests/**",
+        "package.json"
+      ],
+      "outputs": [".vitest/**", "test-results/**"],
+      "cache": true
+    },
+    "test:memory": {
+      "dependsOn": ["@better-auth/memory-adapter#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "test/adapter.memory.test.ts",
+        "test/test-adapter.ts",
+        "test/tests/**",
+        "package.json"
+      ],
+      "outputs": [".vitest/**", "test-results/**"],
+      "cache": true
     },
     "coverage": {
       "dependsOn": ["build"],
-      "outputs": ["coverage"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "src/**",
+        "test/**",
+        "tests/**",
+        "*.test.*",
+        "*.spec.*",
+        "package.json"
+      ],
+      "outputs": ["coverage/**", "coverage-final.json", ".nyc_output/**"],
+      "cache": true
     },
     "e2e:smoke": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "playwright.config.*",
+        "test/**",
+        "tests/**",
+        "e2e/**",
+        "*.test.*",
+        "*.spec.*",
+        "package.json"
+      ],
+      "outputs": ["test-results/**", "playwright-report/**"],
+      "cache": true
     },
     "e2e:integration": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "playwright.config.*",
+        "test/**",
+        "tests/**",
+        "e2e/**",
+        "*.test.*",
+        "*.spec.*",
+        "package.json"
+      ],
+      "outputs": ["test-results/**", "playwright-report/**"],
+      "cache": true
     },
     "deploy": {
       "cache": false


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve CI for database adapter tests by running each adapter in its own matrix job with adapter-scoped turbo caching. This speeds up runs, avoids cache collisions, and only starts Docker when a DB is required.

- **New Features**
  - CI matrix for adapters: drizzle, kysely, prisma, mongodb, memory.
  - Adapter-specific Vitest scripts and turbo tasks (test:drizzle/kysely/prisma/mongodb/memory) with defined inputs/outputs for better caching.
  - Adapter-scoped turbo cache keys and concurrency groups; remote cache enabled.
  - Conditional Docker start/stop for non-memory adapters.

<sup>Written for commit fc25bb17c3360cadfeeb1723fb38af9c8cbef54c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

