### PR TITLE
fix(mcp): correct version

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,6 +39,9 @@
   "bin": {
     "better-auth-mcp": "./dist/index.mjs"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "tsdown": "catalog:",
     "typescript": "catalog:"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,7 +7,7 @@ const server = new McpServer({
 	name: "better-auth",
 	description:
 		"Better Auth MCP server for AI-powered auth setup and diagnostics",
-	version: "0.0.1",
+	version: process.env.BETTER_AUTH_VERSION!,
 });
 
 registerSetupAuth(server);

--- a/packages/mcp/tsdown.config.ts
+++ b/packages/mcp/tsdown.config.ts
@@ -1,7 +1,16 @@
+import { readFile } from "node:fs/promises";
 import { defineConfig } from "tsdown";
+
+const packageJson = JSON.parse(
+	await readFile(new URL("./package.json", import.meta.url), "utf-8"),
+);
 
 export default defineConfig({
 	dts: { build: true },
 	format: ["esm"],
 	entry: ["./src/index.ts"],
+	sourcemap: "inline",
+	env: {
+		BETTER_AUTH_VERSION: packageJson.version,
+	},
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed MCP server version reporting by injecting the package.json version at build time. Also requires Node.js 20+.

- **Bug Fixes**
  - Injects package.json version into BETTER_AUTH_VERSION during build.
  - Reads version from process.env.BETTER_AUTH_VERSION instead of a hard-coded string.

- **Migration**
  - Node.js >= 20 is now required.

<sup>Written for commit df23b5f36c747e4fc61f13db07c6f18d55928b0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

