### PR TITLE
refactor: rename test packages

### DIFF
--- a/e2e/adapter/package.json
+++ b/e2e/adapter/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "adapter",
+  "name": "@better-auth-test/adapter",
+  "type": "module",
   "scripts": {
     "test": "vitest",
     "prepare": "prisma generate --schema ./test/prisma-adapter/base.prisma"

--- a/e2e/integration/package.json
+++ b/e2e/integration/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "integration",
+  "name": "@better-auth-test/integration",
   "scripts": {
     "e2e:integration": "playwright test"
   },

--- a/e2e/integration/solid-vinxi/e2e/utils.ts
+++ b/e2e/integration/solid-vinxi/e2e/utils.ts
@@ -1,7 +1,7 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { terminate } from "@better-auth/test-utils/playwright";
+import { terminate } from "@better-auth-test/test-utils/playwright";
 import type { Page } from "@playwright/test";
 
 const root = fileURLToPath(new URL("../", import.meta.url));

--- a/e2e/integration/solid-vinxi/package.json
+++ b/e2e/integration/solid-vinxi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "better-auth-solid-vinxi-e2e",
+  "name": "@better-auth-test/fixtures-solid-vinxi",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,6 +16,6 @@
     "vinxi": "^0.5.8"
   },
   "devDependencies": {
-    "@better-auth/test-utils": "workspace:*"
+    "@better-auth-test/test-utils": "workspace:*"
   }
 }

--- a/e2e/integration/test-utils/package.json
+++ b/e2e/integration/test-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@better-auth/test-utils",
+  "name": "@better-auth-test/test-utils",
   "type": "module",
   "exports": {
     "./playwright": "./src/playwright.ts"

--- a/e2e/integration/vanilla-node/e2e/utils.ts
+++ b/e2e/integration/vanilla-node/e2e/utils.ts
@@ -1,7 +1,7 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { terminate } from "@better-auth/test-utils/playwright";
+import { terminate } from "@better-auth-test/test-utils/playwright";
 import type { Page } from "@playwright/test";
 import { createAuthServer } from "./app";
 

--- a/e2e/integration/vanilla-node/package.json
+++ b/e2e/integration/vanilla-node/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "vanilla-node-e2e",
+  "name": "@better-auth-test/fixtures-vanilla-node",
   "private": true,
   "type": "module",
   "scripts": {
     "start:client": "vite"
   },
   "devDependencies": {
-    "@better-auth/test-utils": "workspace:*",
+    "@better-auth-test/test-utils": "workspace:*",
     "vite": "^7.3.1"
   },
   "dependencies": {

--- a/e2e/smoke/package.json
+++ b/e2e/smoke/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "smoke",
+  "name": "@better-auth-test/smoke",
   "type": "module",
   "dependencies": {
     "better-auth": "workspace:*"

--- a/e2e/smoke/test/fixtures/cloudflare/package.json
+++ b/e2e/smoke/test/fixtures/cloudflare/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloudflare",
+  "name": "@better-auth-test/fixtures-cloudflare",
   "private": true,
   "dependencies": {
     "@better-auth/sso": "workspace:*",

--- a/e2e/smoke/test/fixtures/esbuild/package.json
+++ b/e2e/smoke/test/fixtures/esbuild/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixture-esbuild",
+  "name": "@better-auth-test/fixtures-esbuild",
   "private": true,
   "dependencies": {
     "better-auth": "workspace:*"

--- a/e2e/smoke/test/fixtures/ipv6/package.json
+++ b/e2e/smoke/test/fixtures/ipv6/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixtures-ipv6",
+  "name": "@better-auth-test/fixtures-ipv6",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/e2e/smoke/test/fixtures/tsconfig-declaration/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsconfig-declaration",
+  "name": "@better-auth-test/fixtures-tsconfig-declaration",
   "private": true,
   "type": "module",
   "scripts": {

--- a/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsconfig-exact-optional-property-types",
+  "name": "@better-auth-test/fixtures-tsconfig-exact-optional-property-types",
   "private": true,
   "type": "module",
   "scripts": {

--- a/e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsconfig-isolated-module-bundler",
+  "name": "@better-auth-test/fixtures-tsconfig-isolated-module-bundler",
   "private": true,
   "type": "module",
   "scripts": {

--- a/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-verbatim-module-syntax-node10/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsconfig-verbatim-module-syntax-node10",
+  "name": "@better-auth-test/fixtures-tsconfig-verbatim-module-syntax-node10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/e2e/smoke/test/fixtures/vite/package.json
+++ b/e2e/smoke/test/fixtures/vite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixture-vite",
+  "name": "@better-auth-test/fixtures-vite",
   "private": true,
   "scripts": {
     "build": "vite build"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1021,7 +1021,7 @@ importers:
         specifier: ^0.5.8
         version: 0.5.8(5cf6d5d1c3dfc70a051a8471a64ca767)
     devDependencies:
-      '@better-auth/test-utils':
+      '@better-auth-test/test-utils':
         specifier: workspace:*
         version: link:../test-utils
 
@@ -1049,7 +1049,7 @@ importers:
         specifier: ^3.4.7
         version: 3.4.7
     devDependencies:
-      '@better-auth/test-utils':
+      '@better-auth-test/test-utils':
         specifier: workspace:*
         version: link:../test-utils
       vite:
@@ -19457,7 +19457,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.30(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.21)(graphql@16.12.0)(react-native@0.80.2(@babel/core@7.28.6)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+      expo: 54.0.30(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.21)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -19544,7 +19544,7 @@ snapshots:
       '@expo/json-file': 10.0.8
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3
-      expo: 54.0.30(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.21)(graphql@16.12.0)(react-native@0.80.2(@babel/core@7.28.6)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+      expo: 54.0.30(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.21)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
       resolve-from: 5.0.0
       semver: 7.7.3
       xml2js: 0.6.0
@@ -26518,7 +26518,7 @@ snapshots:
 
   expo-keep-awake@15.0.8(expo@54.0.30)(react@19.2.3):
     dependencies:
-      expo: 54.0.30(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.21)(graphql@16.12.0)(react-native@0.80.2(@babel/core@7.28.6)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+      expo: 54.0.30(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.21)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.28.5))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   expo-linking@7.1.7(expo@54.0.30)(react-native@0.80.2(@babel/core@7.28.6)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):

--- a/test/package.json
+++ b/test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@better-auth/test",
+  "name": "@better-auth-test/test",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed all test packages to the @better-auth-test scope for consistent naming and isolation. Updated imports and fixtures; set adapter to ESM. No runtime changes.

- **Refactors**
  - Renamed adapter, integration, smoke, fixtures, and test-utils to @better-auth-test/*.
  - Updated imports to use @better-auth-test/test-utils in e2e utils.
  - Added "type": "module" to e2e/adapter.
  - Regenerated pnpm-lock.yaml to reflect workspace changes.

<sup>Written for commit 7283f09803cc434d701b70b7e8a73a18c5df4062. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

