### PR TITLE
fix(api): return Response for HTTP request contexts

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -433,6 +433,19 @@ describe("after hook", async () => {
 			expect(result2.headers.get("set-cookie")).toContain("session=value");
 			expect(result2.headers.get("set-cookie")).toContain("data=2");
 		});
+
+		it("should return a Response when invoked with a request context", async () => {
+			const response = await authEndpoints.cookies({
+				request: new Request("http://localhost:3000/cookies", {
+					method: "POST",
+				}),
+			} as any);
+			expect(response).toBeInstanceOf(Response);
+			const body = await response.json();
+			expect(body).toMatchObject({ hello: "world" });
+			expect(response.headers.get("set-cookie")).toContain("session=value");
+			expect(response.headers.get("set-cookie")).toContain("data=2");
+		});
 	});
 });
 

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -120,6 +120,8 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 					path: endpoint.path,
 					headers: context?.headers ? new Headers(context?.headers) : undefined,
 				};
+				const hasRequest = context?.request instanceof Request;
+				const shouldReturnResponse = context?.asResponse ?? hasRequest;
 				return withSpan(
 					`${methodName} ${pathName}`,
 					{
@@ -160,7 +162,7 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 								internalContext = defuReplaceArrays(rest, internalContext);
 							} else if (before) {
 								/* Return before hook response if it's anything other than a context return */
-								return context?.asResponse
+								return shouldReturnResponse
 									? toResponse(before, {
 											headers: context?.headers,
 										})
@@ -232,11 +234,11 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 								result.response.stack = result.response.errorStack;
 							}
 
-							if (isAPIError(result.response) && !context?.asResponse) {
+							if (isAPIError(result.response) && !shouldReturnResponse) {
 								throw result.response;
 							}
 
-							const response = context?.asResponse
+							const response = shouldReturnResponse
 								? toResponse(result.response, {
 										headers: result.headers,
 										status: result.status,


### PR DESCRIPTION
## Summary
Fixes OAuth/OIDC endpoints returning wrapped JSON responses for HTTP requests.

## Problem
When endpoints receive an HTTP request context (with `request` object), they should return a proper `Response` object. Previously, if `asResponse` wasn't explicitly set, endpoints returned `{ response: {...} }` which broke OAuth/OIDC spec compliance.

## Solution
Detect HTTP request context by checking for `context.request.url` and automatically return a `Response` object, same as when `asResponse: true` is set.

```typescript
const hasRequest = typeof context?.request?.url === "string";
const shouldReturnResponse = Boolean(context?.asResponse) || hasRequest;
```

## Why this approach?
- **Generic**: Works for ALL endpoints with HTTP request context, not just specific paths
- **Future-proof**: No maintenance needed when adding new OAuth/OIDC/OpenID4VC endpoints
- **Complete**: Handles both before hook early returns and final response construction
- **Tested**: Includes regression test coverage

Fixes #7355

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return proper Response objects for OAuth/OIDC endpoints when called with an HTTP request context. This restores spec-compliant JSON bodies and Set-Cookie headers, and removes the wrapped { response: ... } output.

- **Bug Fixes**
  - Detect HTTP request contexts via context.request instanceof Request and set shouldReturnResponse = context.asResponse ?? hasRequest.
  - Apply shouldReturnResponse across before-hook early returns, API error handling, and final response creation; add a regression test asserting Response type, JSON body, and Set-Cookie headers.

<sup>Written for commit db4168d236ad54c8a48c4ab1a134d2f59ae619e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

