### PR TITLE
docs: clarify wording in Admin Roles plugin section

### DIFF
--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -754,12 +754,11 @@ admin({
 ```
 ### Admin Roles
 
-Specifies which of the built-in roles (`admin` and `user`) are considered admin roles. Defaults to `["admin"]`.
-
-**Note**: Custom roles require using custom access control with the `ac` and `roles` options. Without custom access control, you can only use the built-in `admin` and `user` roles.
+Specifies which roles are considered admin roles. Defaults to `["admin"]`. Custom roles (for example, `superadmin`) must be defined in custom access control.
 
 ```ts title="auth.ts"
 admin({
+  // Requires custom access control with `superadmin` defined in `roles`
   adminRoles: ["admin", "superadmin"],
 });
 ```
@@ -767,8 +766,9 @@ admin({
 <Callout type="warning">
   **Note:** The `adminRoles` option is **not required** when using custom access control (via `ac` and `roles`). When you define custom roles with specific permissions, those roles will have exactly the permissions you grant them through the access control system.  
   
-  **Warning:** When **not** using custom access control, any role that isn't in the `adminRoles` list will **not** be able to perform admin operations.
   
+  **Warning:** When **not** using custom access control, only `admin` and `user` exist as valid roles. Any role that isn't in the `adminRoles` list will **not** be able to perform admin operations.
+
 </Callout>
 
 ### Admin userIds


### PR DESCRIPTION
This PR closes #7520.

### Context
A new validation introduced in #6590 caused a breaking change in my project now that roles defined in `adminRoles` must also be defined in custom access control. The docs page for the Admin plugin (specifically Admin Roles) is now potentially misleading, and this PR adds a clarification reflecting the new requirement.

### Changes
Reworded the text in `admin.mdx` that previously implied the possibility of defining custom roles in `adminRoles` without using custom access control.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the Admin Roles section in the Admin plugin docs. Added an inline snippet comment and updated the warning to make it clear that custom roles require custom access control (ac/roles), and that without it only admin and user exist.

<sup>Written for commit d3fd7123d85fb2cafb5691ca9ab0e752cea30d82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

