### PR TITLE
feat(core): add publicEndpoints plugin capability for well-known endpoints

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -63,6 +63,10 @@ export function checkEndpointConflicts(
 		string,
 		{ pluginId: string; endpointKey: string; methods: string[] }[]
 	>();
+	const publicEndpointRegistry = new Map<
+		string,
+		{ pluginId: string; endpointKey: string; methods: string[] }[]
+	>();
 
 	options.plugins?.forEach((plugin) => {
 		if (plugin.endpoints) {
@@ -96,8 +100,70 @@ export function checkEndpointConflicts(
 				}
 			}
 		}
+		if (plugin.publicEndpoints) {
+			for (const [key, endpoint] of Object.entries(plugin.publicEndpoints)) {
+				if (
+					endpoint &&
+					"path" in endpoint &&
+					typeof endpoint.path === "string"
+				) {
+					const path = endpoint.path;
+					let methods: string[] = [];
+					if (endpoint.options && "method" in endpoint.options) {
+						if (Array.isArray(endpoint.options.method)) {
+							methods = endpoint.options.method;
+						} else if (typeof endpoint.options.method === "string") {
+							methods = [endpoint.options.method];
+						}
+					}
+					if (methods.length === 0) {
+						methods = ["*"];
+					}
+
+					if (!publicEndpointRegistry.has(path)) {
+						publicEndpointRegistry.set(path, []);
+					}
+					publicEndpointRegistry.get(path)!.push({
+						pluginId: plugin.id,
+						endpointKey: key,
+						methods,
+					});
+				}
+			}
+		}
 	});
 
+	const conflicts = detectEndpointConflicts(endpointRegistry);
+	const publicConflicts = detectEndpointConflicts(publicEndpointRegistry);
+	if (conflicts.length > 0 || publicConflicts.length > 0) {
+		const messages = [
+			formatConflictMessages(conflicts, "Endpoint path conflicts:"),
+			formatConflictMessages(
+				publicConflicts,
+				"Public endpoint path conflicts:",
+			),
+		]
+			.filter(Boolean)
+			.join("\n\n");
+		logger.error(
+			`Endpoint path conflicts detected! Multiple plugins are trying to use the same endpoint paths with conflicting HTTP methods:
+${messages}
+
+To resolve this, you can:
+\t1. Use only one of the conflicting plugins
+\t2. Configure the plugins to use different paths (if supported)
+\t3. Ensure plugins use different HTTP methods for the same path
+`,
+		);
+	}
+}
+
+function detectEndpointConflicts(
+	endpointRegistry: Map<
+		string,
+		{ pluginId: string; endpointKey: string; methods: string[] }[]
+	>,
+) {
 	const conflicts: {
 		path: string;
 		plugins: string[];
@@ -149,25 +215,25 @@ export function checkEndpointConflicts(
 			}
 		}
 	}
+	return conflicts;
+}
 
-	if (conflicts.length > 0) {
-		const conflictMessages = conflicts
-			.map(
-				(conflict) =>
-					`  - "${conflict.path}" [${conflict.conflictingMethods.join(", ")}] used by plugins: ${conflict.plugins.join(", ")}`,
-			)
-			.join("\n");
-		logger.error(
-			`Endpoint path conflicts detected! Multiple plugins are trying to use the same endpoint paths with conflicting HTTP methods:
-${conflictMessages}
-
-To resolve this, you can:
-	1. Use only one of the conflicting plugins
-	2. Configure the plugins to use different paths (if supported)
-	3. Ensure plugins use different HTTP methods for the same path
-`,
-		);
-	}
+function formatConflictMessages(
+	items: {
+		path: string;
+		plugins: string[];
+		conflictingMethods: string[];
+	}[],
+	label: string,
+) {
+	if (items.length === 0) return "";
+	const conflictMessages = items
+		.map(
+			(conflict) =>
+				`  - "${conflict.path}" [${conflict.conflictingMethods.join(", ")}] used by plugins: ${conflict.plugins.join(", ")}`,
+		)
+		.join("\n");
+	return `${label}\n${conflictMessages}`;
 }
 
 export function getEndpoints<Option extends BetterAuthOptions>(
@@ -181,12 +247,30 @@ export function getEndpoints<Option extends BetterAuthOptions>(
 				...plugin.endpoints,
 			};
 		}, {}) ?? {};
+	const pluginPublicEndpoints =
+		options.plugins?.reduce<Record<string, Endpoint>>((acc, plugin) => {
+			return {
+				...acc,
+				...plugin.publicEndpoints,
+			};
+		}, {}) ?? {};
 
 	type PluginEndpoint = UnionToIntersection<
 		Option["plugins"] extends Array<infer T>
 			? T extends BetterAuthPlugin
 				? T extends {
 						endpoints: infer E;
+					}
+					? E
+					: {}
+				: {}
+			: {}
+	>;
+	type PluginPublicEndpoint = UnionToIntersection<
+		Option["plugins"] extends Array<infer T>
+			? T extends BetterAuthPlugin
+				? T extends {
+						publicEndpoints: infer E;
 					}
 					? E
 					: {}
@@ -264,10 +348,19 @@ export function getEndpoints<Option extends BetterAuthOptions>(
 		ok,
 		error,
 	} as const;
+	const publicEndpoints = {
+		...pluginPublicEndpoints,
+	} as const;
 	const api = toAuthEndpoints(endpoints, ctx);
+	const publicApi = toAuthEndpoints(publicEndpoints, ctx);
 	return {
 		api: api as unknown as Omit<typeof endpoints, keyof PluginEndpoint> &
 			PluginEndpoint,
+		publicApi: publicApi as unknown as Omit<
+			typeof publicEndpoints,
+			keyof PluginPublicEndpoint
+		> &
+			PluginPublicEndpoint,
 		middlewares,
 	};
 }
@@ -277,7 +370,24 @@ export const router = <Option extends BetterAuthOptions>(
 ) => {
 	const { api, middlewares } = getEndpoints(ctx, options);
 	const basePath = new URL(ctx.baseURL).pathname;
+	return createAuthRouter(ctx, options, api, middlewares, basePath);
+};
 
+export const publicRouter = <Option extends BetterAuthOptions>(
+	ctx: AuthContext,
+	options: Option,
+) => {
+	const { publicApi, middlewares } = getEndpoints(ctx, options);
+	return createAuthRouter(ctx, options, publicApi, middlewares, "/");
+};
+
+function createAuthRouter<API extends Record<string, Endpoint>>(
+	ctx: AuthContext,
+	options: BetterAuthOptions,
+	api: API,
+	middlewares: { path: string; middleware: Middleware }[],
+	basePath: string,
+) {
 	return createRouter(api, {
 		routerContext: ctx,
 		openapi: {
@@ -403,7 +513,7 @@ export const router = <Option extends BetterAuthOptions>(
 			}
 		},
 	});
-};
+}
 
 export {
 	type AuthEndpoint,

--- a/packages/better-auth/src/api/public-endpoints.test.ts
+++ b/packages/better-auth/src/api/public-endpoints.test.ts
@@ -1,0 +1,270 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { describe, expect, it } from "vitest";
+import { getTestInstance } from "../test-utils/test-instance";
+import { createAuthEndpoint } from "./index";
+
+describe("publicEndpoints", () => {
+	const createTestPlugin = (config?: {
+		publicPath?: string;
+		regularPath?: string;
+	}): BetterAuthPlugin => ({
+		id: "test-public-endpoints",
+		publicEndpoints: {
+			wellKnownTest: createAuthEndpoint(
+				config?.publicPath ?? "/.well-known/test-config",
+				{
+					method: "GET",
+				},
+				async () => ({
+					issuer: "https://example.com",
+					test: true,
+				}),
+			),
+		},
+		endpoints: {
+			testRegular: createAuthEndpoint(
+				config?.regularPath ?? "/test-regular",
+				{
+					method: "GET",
+				},
+				async () => ({
+					regular: true,
+				}),
+			),
+		},
+	});
+
+	it("should serve public endpoints at root path", async () => {
+		const plugin = createTestPlugin();
+		const { auth } = await getTestInstance({
+			plugins: [plugin],
+		});
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/.well-known/test-config", {
+				method: "GET",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({
+			issuer: "https://example.com",
+			test: true,
+		});
+	});
+
+	it("should serve regular endpoints at basePath", async () => {
+		const plugin = createTestPlugin();
+		const { auth } = await getTestInstance({
+			plugins: [plugin],
+		});
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/test-regular", {
+				method: "GET",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({
+			regular: true,
+		});
+	});
+
+	it("should auto-route /.well-known/* paths in main handler", async () => {
+		const plugin = createTestPlugin();
+		const { auth } = await getTestInstance({
+			plugins: [plugin],
+		});
+
+		// Both routes should work through the main handler
+		const wellKnownResponse = await auth.handler(
+			new Request("http://localhost:3000/.well-known/test-config", {
+				method: "GET",
+			}),
+		);
+		expect(wellKnownResponse.status).toBe(200);
+
+		const regularResponse = await auth.handler(
+			new Request("http://localhost:3000/api/auth/test-regular", {
+				method: "GET",
+			}),
+		);
+		expect(regularResponse.status).toBe(200);
+	});
+
+	it("should expose publicHandler when plugins have publicEndpoints", async () => {
+		const plugin = createTestPlugin();
+		const { auth } = await getTestInstance({
+			plugins: [plugin],
+		});
+
+		expect(auth.publicHandler).toBeDefined();
+
+		const response = await auth.publicHandler!(
+			new Request("http://localhost:3000/.well-known/test-config", {
+				method: "GET",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({
+			issuer: "https://example.com",
+			test: true,
+		});
+	});
+
+	it("should expose publicApi when plugins have publicEndpoints", async () => {
+		const plugin = createTestPlugin();
+		const { auth } = await getTestInstance({
+			plugins: [plugin],
+		});
+
+		expect(auth.publicApi).toBeDefined();
+		expect(auth.publicApi?.wellKnownTest).toBeDefined();
+	});
+
+	it("should not have publicHandler when no plugins use publicEndpoints", async () => {
+		const regularPlugin: BetterAuthPlugin = {
+			id: "regular-plugin",
+			endpoints: {
+				regular: createAuthEndpoint(
+					"/regular",
+					{ method: "GET" },
+					async () => ({ regular: true }),
+				),
+			},
+		};
+
+		const { auth } = await getTestInstance({
+			plugins: [regularPlugin],
+		});
+
+		expect(auth.publicHandler).toBeUndefined();
+		expect(auth.publicApi).toBeUndefined();
+	});
+
+	it("should not have publicHandler with empty publicEndpoints object", async () => {
+		const pluginWithEmptyPublic: BetterAuthPlugin = {
+			id: "empty-public",
+			publicEndpoints: {},
+			endpoints: {
+				regular: createAuthEndpoint(
+					"/regular",
+					{ method: "GET" },
+					async () => ({ regular: true }),
+				),
+			},
+		};
+
+		const { auth } = await getTestInstance({
+			plugins: [pluginWithEmptyPublic],
+		});
+
+		expect(auth.publicHandler).toBeUndefined();
+		expect(auth.publicApi).toBeUndefined();
+	});
+
+	it("should work with custom basePath", async () => {
+		const plugin = createTestPlugin();
+		const { auth } = await getTestInstance({
+			basePath: "/auth",
+			plugins: [plugin],
+		});
+
+		// Public endpoint should still be at root
+		const wellKnownResponse = await auth.handler(
+			new Request("http://localhost:3000/.well-known/test-config", {
+				method: "GET",
+			}),
+		);
+		expect(wellKnownResponse.status).toBe(200);
+
+		// Regular endpoint should be at custom basePath
+		const regularResponse = await auth.handler(
+			new Request("http://localhost:3000/auth/test-regular", {
+				method: "GET",
+			}),
+		);
+		expect(regularResponse.status).toBe(200);
+	});
+
+	it("should return 404 for non-existent public endpoints", async () => {
+		const plugin = createTestPlugin();
+		const { auth } = await getTestInstance({
+			plugins: [plugin],
+		});
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/.well-known/non-existent", {
+				method: "GET",
+			}),
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("should handle multiple plugins with publicEndpoints", async () => {
+		const plugin1: BetterAuthPlugin = {
+			id: "plugin1",
+			publicEndpoints: {
+				config1: createAuthEndpoint(
+					"/.well-known/config-one",
+					{ method: "GET" },
+					async () => ({ plugin: 1 }),
+				),
+			},
+		};
+		const plugin2: BetterAuthPlugin = {
+			id: "plugin2",
+			publicEndpoints: {
+				config2: createAuthEndpoint(
+					"/.well-known/config-two",
+					{ method: "GET" },
+					async () => ({ plugin: 2 }),
+				),
+			},
+		};
+
+		const { auth } = await getTestInstance({
+			plugins: [plugin1, plugin2],
+		});
+
+		const response1 = await auth.handler(
+			new Request("http://localhost:3000/.well-known/config-one", {
+				method: "GET",
+			}),
+		);
+		expect(response1.status).toBe(200);
+		const body1 = await response1.json();
+		expect(body1).toEqual({ plugin: 1 });
+
+		const response2 = await auth.handler(
+			new Request("http://localhost:3000/.well-known/config-two", {
+				method: "GET",
+			}),
+		);
+		expect(response2.status).toBe(200);
+		const body2 = await response2.json();
+		expect(body2).toEqual({ plugin: 2 });
+	});
+
+	it("should call publicEndpoints via api object", async () => {
+		const plugin = createTestPlugin();
+		const { auth } = await getTestInstance({
+			plugins: [plugin],
+		});
+
+		expect(auth.publicApi).toBeDefined();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const publicApi = auth.publicApi as any;
+		const result = await publicApi.wellKnownTest({});
+		expect(result).toEqual({
+			issuer: "https://example.com",
+			test: true,
+		});
+	});
+});

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -390,6 +390,9 @@ async function runAfterHooks(
 				response: any;
 				headers: Headers;
 			};
+			if (!result) {
+				continue;
+			}
 			if (result.headers) {
 				result.headers.forEach((value, key) => {
 					if (!context.context.responseHeaders) {

--- a/packages/better-auth/src/auth/base.ts
+++ b/packages/better-auth/src/auth/base.ts
@@ -1,7 +1,7 @@
 import type { AuthContext, BetterAuthOptions } from "@better-auth/core";
 import { runWithAdapter } from "@better-auth/core/context";
 import { BASE_ERROR_CODES, BetterAuthError } from "@better-auth/core/error";
-import { getEndpoints, router } from "../api";
+import { getEndpoints, publicRouter, router } from "../api";
 import { getTrustedOrigins, getTrustedProviders } from "../context/helpers";
 import { createCookieGetter, getCookies } from "../cookies";
 import type { Auth } from "../types";
@@ -17,7 +17,13 @@ export const createBetterAuth = <Options extends BetterAuthOptions>(
 	initFn: (options: Options) => Promise<AuthContext>,
 ): Auth<Options> => {
 	const authContext = initFn(options);
-	const { api } = getEndpoints(authContext, options);
+	const { api, publicApi } = getEndpoints(authContext, options);
+	const hasPublicEndpoints =
+		options.plugins?.some(
+			(plugin) =>
+				plugin.publicEndpoints &&
+				Object.keys(plugin.publicEndpoints).length > 0,
+		) ?? false;
 	const errorCodes = options.plugins?.reduce((acc, plugin) => {
 		if (plugin.$ERROR_CODES) {
 			return {
@@ -27,89 +33,105 @@ export const createBetterAuth = <Options extends BetterAuthOptions>(
 		}
 		return acc;
 	}, {});
-	return {
-		handler: async (request: Request) => {
-			const ctx = await authContext;
-			const basePath = ctx.options.basePath || "/api/auth";
 
-			let handlerCtx: AuthContext;
+	const resolveHandlerContext = async (
+		request: Request,
+	): Promise<AuthContext> => {
+		const ctx = await authContext;
+		const basePath = ctx.options.basePath || "/api/auth";
 
-			if (isDynamicBaseURLConfig(options.baseURL)) {
-				// Create per-request context to avoid concurrent request race conditions.
-				// Each request may resolve to a different host, so we must not mutate the shared ctx.
-				handlerCtx = Object.create(
-					Object.getPrototypeOf(ctx),
-					Object.getOwnPropertyDescriptors(ctx),
-				) as AuthContext;
-				const baseURL = resolveBaseURL(options.baseURL, basePath, request);
-				if (baseURL) {
-					handlerCtx.baseURL = baseURL;
-					handlerCtx.options = {
-						...ctx.options,
-						baseURL: getOrigin(baseURL) || undefined,
-					};
-				} else {
-					throw new BetterAuthError(
-						"Could not resolve base URL from request. Check your allowedHosts config.",
-					);
-				}
-				// Use a typed variable so the baseURL override doesn't need
-				// an unsafe cast — the spread is structurally BetterAuthOptions.
-				const trustedOriginOptions: BetterAuthOptions = {
-					...handlerCtx.options,
-					baseURL: options.baseURL,
+		let handlerCtx: AuthContext;
+
+		if (isDynamicBaseURLConfig(options.baseURL)) {
+			// Create per-request context to avoid concurrent request race conditions.
+			// Each request may resolve to a different host, so we must not mutate the shared ctx.
+			handlerCtx = Object.create(
+				Object.getPrototypeOf(ctx),
+				Object.getOwnPropertyDescriptors(ctx),
+			) as AuthContext;
+			const baseURL = resolveBaseURL(options.baseURL, basePath, request);
+			if (baseURL) {
+				handlerCtx.baseURL = baseURL;
+				handlerCtx.options = {
+					...ctx.options,
+					baseURL: getOrigin(baseURL) || undefined,
 				};
-				handlerCtx.trustedOrigins = await getTrustedOrigins(
-					trustedOriginOptions,
-					request,
-				);
-				// When crossSubDomainCookies is enabled, recompute cookies
-				// per-request so the domain matches the resolved host.
-				if (options.advanced?.crossSubDomainCookies?.enabled) {
-					handlerCtx.authCookies = getCookies(handlerCtx.options);
-					handlerCtx.createAuthCookie = createCookieGetter(handlerCtx.options);
-				}
 			} else {
-				handlerCtx = ctx;
-				// Static config: resolve once from the first request when no
-				// baseURL was provided. Mutates the shared ctx intentionally so
-				// subsequent requests reuse the cached value.
-				// NOTE: narrow race if the very first requests arrive concurrently —
-				// both will enter this block and write to ctx. This is harmless
-				// because they resolve the same value, and matches pre-existing
-				// behavior. Using Object.create(ctx) here would break downstream
-				// references that depend on ctx.options being mutated in-place.
-				if (!ctx.options.baseURL) {
-					const baseURL = getBaseURL(
-						undefined,
-						basePath,
-						request,
-						undefined,
-						ctx.options.advanced?.trustedProxyHeaders,
-					);
-					if (baseURL) {
-						ctx.baseURL = baseURL;
-						ctx.options.baseURL = getOrigin(ctx.baseURL) || undefined;
-					} else {
-						throw new BetterAuthError(
-							"Could not get base URL from request. Please provide a valid base URL.",
-						);
-					}
-				}
-				handlerCtx.trustedOrigins = await getTrustedOrigins(
-					ctx.options,
-					request,
+				throw new BetterAuthError(
+					"Could not resolve base URL from request. Check your allowedHosts config.",
 				);
 			}
-			handlerCtx.trustedProviders = await getTrustedProviders(
-				handlerCtx.options,
+			// Use a typed variable so the baseURL override doesn't need
+			// an unsafe cast — the spread is structurally BetterAuthOptions.
+			const trustedOriginOptions: BetterAuthOptions = {
+				...handlerCtx.options,
+				baseURL: options.baseURL,
+			};
+			handlerCtx.trustedOrigins = await getTrustedOrigins(
+				trustedOriginOptions,
 				request,
 			);
+			// When crossSubDomainCookies is enabled, recompute cookies
+			// per-request so the domain matches the resolved host.
+			if (options.advanced?.crossSubDomainCookies?.enabled) {
+				handlerCtx.authCookies = getCookies(handlerCtx.options);
+				handlerCtx.createAuthCookie = createCookieGetter(handlerCtx.options);
+			}
+		} else {
+			handlerCtx = ctx;
+			// Static config: resolve once from the first request when no
+			// baseURL was provided. Mutates the shared ctx intentionally so
+			// subsequent requests reuse the cached value.
+			if (!ctx.options.baseURL) {
+				const baseURL = getBaseURL(
+					undefined,
+					basePath,
+					request,
+					undefined,
+					ctx.options.advanced?.trustedProxyHeaders,
+				);
+				if (baseURL) {
+					ctx.baseURL = baseURL;
+					ctx.options.baseURL = getOrigin(ctx.baseURL) || undefined;
+				} else {
+					throw new BetterAuthError(
+						"Could not get base URL from request. Please provide a valid base URL.",
+					);
+				}
+			}
+			handlerCtx.trustedOrigins = await getTrustedOrigins(ctx.options, request);
+		}
+		handlerCtx.trustedProviders = await getTrustedProviders(
+			handlerCtx.options,
+			request,
+		);
+		return handlerCtx;
+	};
+
+	return {
+		handler: async (request: Request) => {
+			const handlerCtx = await resolveHandlerContext(request);
+
+			if (hasPublicEndpoints) {
+				const pathname = new URL(request.url).pathname;
+				if (pathname.startsWith("/.well-known/")) {
+					const { handler } = publicRouter(handlerCtx, options);
+					return runWithAdapter(handlerCtx.adapter, () => handler(request));
+				}
+			}
 
 			const { handler } = router(handlerCtx, options);
 			return runWithAdapter(handlerCtx.adapter, () => handler(request));
 		},
+		publicHandler: hasPublicEndpoints
+			? async (request: Request) => {
+					const handlerCtx = await resolveHandlerContext(request);
+					const { handler } = publicRouter(handlerCtx, options);
+					return runWithAdapter(handlerCtx.adapter, () => handler(request));
+				}
+			: undefined,
 		api,
+		publicApi: hasPublicEndpoints ? publicApi : undefined,
 		options: options,
 		$context: authContext,
 		$ERROR_CODES: {

--- a/packages/better-auth/src/types/auth.ts
+++ b/packages/better-auth/src/types/auth.ts
@@ -1,13 +1,15 @@
 import type { AuthContext, BetterAuthOptions } from "@better-auth/core";
 import type { BASE_ERROR_CODES } from "@better-auth/core/error";
-import type { router } from "../api";
+import type { publicRouter, router } from "../api";
 import type { InferAPI } from "./api";
 import type { InferPluginTypes, Session, User } from "./models";
 import type { InferPluginContext, InferPluginErrorCodes } from "./plugins";
 
 export type Auth<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	handler: (request: Request) => Promise<Response>;
+	publicHandler?: (request: Request) => Promise<Response>;
 	api: InferAPI<ReturnType<typeof router<Options>>["endpoints"]>;
+	publicApi?: InferAPI<ReturnType<typeof publicRouter<Options>>["endpoints"]>;
 	options: Options;
 	$ERROR_CODES: InferPluginErrorCodes<Options> & typeof BASE_ERROR_CODES;
 	$context: Promise<AuthContext<Options> & InferPluginContext<Options>>;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -70,6 +70,15 @@ export type BetterAuthPlugin = BetterAuthPluginErrorCodePart & {
 				[key: string]: Endpoint;
 		  }
 		| undefined;
+	/**
+	 * Public endpoints that should be mounted at the root base path.
+	 * Useful for well-known endpoints that must live at `/.well-known/...`.
+	 */
+	publicEndpoints?:
+		| {
+				[key: string]: Endpoint;
+		  }
+		| undefined;
 	middlewares?:
 		| {
 				path: string;


### PR DESCRIPTION
## Summary

Adds `publicEndpoints` plugin capability for RFC 8414 / OIDC Discovery compliance.

This allows plugins to register endpoints at the origin root (e.g., `/.well-known/openid-configuration`) instead of under the `basePath` (e.g., `/api/auth/.well-known/...`).

**Important clarification**: This does NOT mount Better Auth at root. Only `/.well-known/*` paths are intercepted by the main handler and routed to the public router. All other endpoints remain at the configured `basePath`.

Closes #7453

## Changes

- Add `publicEndpoints` field to `BetterAuthPlugin` type
- Add `publicRouter` that mounts at `/` instead of basePath  
- Auto-route `/.well-known/*` in main handler to publicRouter
- Export optional `publicHandler` and `publicApi` on auth object
- Add conflict detection for public endpoints

## How It Works

1. Plugins can define `publicEndpoints` alongside regular `endpoints`
2. The main `handler` automatically routes `/.well-known/*` requests to the public router
3. `publicHandler` and `publicApi` are only defined when plugins actually use `publicEndpoints`
4. Existing behavior is completely unchanged - no breaking changes

## Example Usage

```typescript
const myPlugin = {
  id: "my-plugin",
  // Regular endpoints at basePath (e.g., /api/auth/my-endpoint)
  endpoints: {
    myEndpoint: createAuthEndpoint("/my-endpoint", ...)
  },
  // Public endpoints at root (e.g., /.well-known/my-config)  
  publicEndpoints: {
    wellKnownConfig: createAuthEndpoint("/.well-known/my-config", ...)
  }
};
```

## Test Plan

- [x] New tests for publicEndpoints functionality (11 tests)
- [x] Existing to-auth-endpoints tests pass (34 tests)
- [x] Existing check-endpoint-conflicts tests pass (13 tests)
- [x] TypeScript types check
- [x] Lint passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `publicEndpoints` so plugins can serve well-known routes at the origin root (`/.well-known/*`) while keeping all other endpoints under `basePath`. When used, the auth instance exposes a dedicated public router and API.

- New Features
  - `publicEndpoints` on `BetterAuthPlugin`; new `publicRouter` mounts at `/`, and the main handler auto-routes `/.well-known/*`.
  - `publicHandler` and `publicApi` are exposed only when at least one plugin defines `publicEndpoints`.
  - Detects and logs conflicts for public paths and HTTP methods; types updated to include `publicEndpoints`, `publicHandler`, and `publicApi`.

- Bug Fixes
  - After hooks can return void/null/undefined without modifying the response.
  - Safer per-request context for dynamic `baseURL` (recomputes trusted origins/providers and cookies; resolves base URL on first request for static configs).

<sup>Written for commit 8f0116d29c3847c2cb6f7bb81b9096d507eecde9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

