### PR TITLE
fix(organization) implement parseOutputData for removing non returnab…

### DIFF
--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -38,9 +38,6 @@ export function toZodSchema<
 		if (field?.required === false) {
 			schema = schema.optional();
 		}
-		if (!isClientSide && field?.returned === false) {
-			return acc;
-		}
 		return {
 			...acc,
 			[key]: schema,

--- a/packages/better-auth/src/plugins/organization/parse-output-data.ts
+++ b/packages/better-auth/src/plugins/organization/parse-output-data.ts
@@ -1,0 +1,81 @@
+import type { SchemaTable } from "./schema";
+import { schemaTables } from "./schema";
+import type { OrganizationOptions } from "./types";
+
+export const parseOutputData = <
+	S extends SchemaTable,
+	T extends Record<string, any>,
+>(
+	data: T | T[],
+	orgOptions: OrganizationOptions,
+	schemaTableName: S = "organization" as S,
+): T | T[] => {
+	if (!orgOptions.schema) {
+		return data;
+	}
+
+	const hasAnyAdditionalFields = Object.values(orgOptions.schema).some(
+		(table) => "additionalFields" in table,
+	);
+
+	if (!hasAnyAdditionalFields) {
+		return data;
+	}
+
+	if (Array.isArray(data)) {
+		return data.map((item) =>
+			parseOutputData(item, orgOptions, schemaTableName),
+		) as T[];
+	}
+
+	const schemaTable = orgOptions.schema[schemaTableName];
+	const additionalFields =
+		schemaTable && "additionalFields" in schemaTable
+			? schemaTable.additionalFields
+			: undefined;
+
+	if (!additionalFields) {
+		let parsedData: Record<string, any> | null = null;
+
+		for (const key in data) {
+			if (schemaTables.includes(key as SchemaTable)) {
+				if (!parsedData) {
+					parsedData = { ...(data as Record<string, any>) };
+				}
+				parsedData[key] = parseOutputData(
+					(data as Record<string, any>)[key],
+					orgOptions,
+					key as SchemaTable,
+				);
+			}
+		}
+
+		return (parsedData ?? data) as T;
+	}
+
+	const parsedData: Record<string, any> = {};
+	for (const key in data) {
+		if (schemaTables.includes(key as SchemaTable)) {
+			parsedData[key] = parseOutputData(
+				data[key],
+				orgOptions,
+				key as SchemaTable,
+			);
+			continue;
+		}
+
+		const field = additionalFields[key];
+		if (!field) {
+			parsedData[key] = data[key];
+			continue;
+		}
+
+		if (field.returned === false && key !== "id") {
+			continue;
+		}
+
+		parsedData[key] = data[key];
+	}
+
+	return parsedData as T;
+};

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -12,6 +12,7 @@ import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { hasPermission } from "../has-permission";
 import { parseRoles } from "../organization";
+import { parseOutputData } from "../parse-output-data";
 import type {
 	InferInvitation,
 	InferOrganizationRolesFromOption,
@@ -349,7 +350,12 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 					);
 				}
 
-				return ctx.json(updatedInvitation as InferInvitation<O, false>);
+				const parsedUpdatedInvitation = parseOutputData(
+					updatedInvitation,
+					ctx.context.orgOptions,
+					"invitation",
+				);
+				return ctx.json(parsedUpdatedInvitation as InferInvitation<O, false>);
 			}
 
 			if (
@@ -506,8 +512,12 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 					organization,
 				});
 			}
-
-			return ctx.json(invitation);
+			const parsedInvitation = parseOutputData(
+				invitation,
+				ctx.context.orgOptions,
+				"invitation",
+			);
+			return ctx.json(parsedInvitation);
 		},
 	);
 };
@@ -716,8 +726,13 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 					organization,
 				});
 			}
+			const parsedAcceptedInvitation = parseOutputData(
+				acceptedI,
+				ctx.context.orgOptions,
+				"invitation",
+			);
 			return ctx.json({
-				invitation: acceptedI,
+				invitation: parsedAcceptedInvitation,
 				member,
 			});
 		},
@@ -825,9 +840,11 @@ export const rejectInvitation = <O extends OrganizationOptions>(options: O) =>
 					organization,
 				});
 			}
-
+			const parsedRejectedInvitation = rejectedI
+				? parseOutputData(rejectedI, ctx.context.orgOptions, "invitation")
+				: null;
 			return ctx.json({
-				invitation: rejectedI,
+				invitation: parsedRejectedInvitation,
 				member: null,
 			});
 		},
@@ -942,8 +959,10 @@ export const cancelInvitation = <O extends OrganizationOptions>(options: O) =>
 					organization,
 				});
 			}
-
-			return ctx.json(canceledI);
+			const parsedCanceledInvitation = canceledI
+				? parseOutputData(canceledI, ctx.context.orgOptions, "invitation")
+				: null;
+			return ctx.json(parsedCanceledInvitation);
 		},
 	);
 
@@ -1066,9 +1085,13 @@ export const getInvitation = <O extends OrganizationOptions>(options: O) =>
 					ORGANIZATION_ERROR_CODES.INVITER_IS_NO_LONGER_A_MEMBER_OF_THE_ORGANIZATION,
 				);
 			}
-
+			const parsedInvitation = parseOutputData(
+				invitation,
+				ctx.context.orgOptions,
+				"invitation",
+			);
 			return ctx.json({
-				...invitation,
+				...parsedInvitation,
 				organizationName: organization.name,
 				organizationSlug: organization.slug,
 				inviterEmail: member.user.email,
@@ -1123,7 +1146,12 @@ export const listInvitations = <O extends OrganizationOptions>(options: O) =>
 			const invitations = await adapter.listInvitations({
 				organizationId: orgId,
 			});
-			return ctx.json(invitations);
+			const parsedInvitations = parseOutputData(
+				invitations,
+				ctx.context.orgOptions,
+				"invitation",
+			);
+			return ctx.json(parsedInvitations);
 		},
 	);
 
@@ -1239,6 +1267,11 @@ export const listUserInvitations = <O extends OrganizationOptions>(
 			const pendingInvitations = invitations.filter(
 				(inv) => inv.status === "pending",
 			);
-			return ctx.json(pendingInvitations);
+			const parsedInvitations = parseOutputData(
+				pendingInvitations,
+				ctx.context.orgOptions,
+				"invitation",
+			);
+			return ctx.json(parsedInvitations);
 		},
 	);

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -10,6 +10,7 @@ import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { hasPermission } from "../has-permission";
 import { parseRoles } from "../organization";
+import { parseOutputData } from "../parse-output-data";
 import type {
 	InferMember,
 	InferOrganizationRolesFromOption,
@@ -210,7 +211,13 @@ export const addMember = <O extends OrganizationOptions>(option: O) => {
 				});
 			}
 
-			return ctx.json(createdMember);
+			const parsedMember = parseOutputData(
+				createdMember,
+				ctx.context.orgOptions,
+				"member",
+			);
+
+			return ctx.json(parsedMember);
 		},
 	);
 };
@@ -416,8 +423,14 @@ export const removeMember = <O extends OrganizationOptions>(options: O) =>
 				});
 			}
 
+			const parsedMember = parseOutputData(
+				toBeRemovedMember,
+				ctx.context.orgOptions,
+				"member",
+			);
+
 			return ctx.json({
-				member: toBeRemovedMember,
+				member: parsedMember,
 			});
 		},
 	);
@@ -701,7 +714,13 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 				});
 			}
 
-			return ctx.json(updatedMember);
+			const parsedMember = parseOutputData(
+				updatedMember,
+				ctx.context.orgOptions,
+				"member",
+			);
+
+			return ctx.json(parsedMember);
 		},
 	);
 
@@ -765,7 +784,13 @@ export const getActiveMember = <O extends OrganizationOptions>(options: O) =>
 					ORGANIZATION_ERROR_CODES.MEMBER_NOT_FOUND,
 				);
 			}
-			return ctx.json(member);
+			const parsedMember = parseOutputData(
+				member,
+				ctx.context.orgOptions,
+				"member",
+			);
+
+			return ctx.json(parsedMember);
 		},
 	);
 
@@ -829,7 +854,12 @@ export const leaveOrganization = <O extends OrganizationOptions>(options: O) =>
 			if (session.session.activeOrganizationId === ctx.body.organizationId) {
 				await adapter.setActiveOrganization(session.session.token, null, ctx);
 			}
-			return ctx.json(member);
+			const parsedMember = parseOutputData(
+				member,
+				ctx.context.orgOptions,
+				"member",
+			);
+			return ctx.json(parsedMember);
 		},
 	);
 
@@ -953,8 +983,13 @@ export const listMembers = <O extends OrganizationOptions>(options: O) =>
 						}
 					: undefined,
 			});
-			return ctx.json({
+			const parsedMembers = parseOutputData(
 				members,
+				ctx.context.orgOptions,
+				"member",
+			);
+			return ctx.json({
+				members: parsedMembers,
 				total,
 			});
 		},

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -9,6 +9,7 @@ import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { hasPermission } from "../has-permission";
+import { parseOutputData } from "../parse-output-data";
 import type {
 	InferInvitation,
 	InferMember,
@@ -322,8 +323,13 @@ export const createOrganization = <O extends OrganizationOptions>(
 				);
 			}
 
+			const parsedOrganization = parseOutputData(
+				organization,
+				ctx.context.orgOptions,
+			);
+
 			return ctx.json({
-				...organization,
+				...parsedOrganization,
 				metadata:
 					organization.metadata && typeof organization.metadata === "string"
 						? JSON.parse(organization.metadata)
@@ -536,7 +542,12 @@ export const updateOrganization = <O extends OrganizationOptions>(
 					member,
 				});
 			}
-			return ctx.json(updatedOrg);
+
+			const parsedOrg = updatedOrg
+				? parseOutputData(updatedOrg, ctx.context.orgOptions)
+				: null;
+
+			return ctx.json(parsedOrg);
 		},
 	);
 };
@@ -657,7 +668,8 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 					user: session.user,
 				});
 			}
-			return ctx.json(org);
+			const parsedOrg = parseOutputData(org, ctx.context.orgOptions);
+			return ctx.json(parsedOrg);
 		},
 	);
 };
@@ -766,7 +778,11 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 						members: InferMember<O, false>[];
 						invitations: InferInvitation<O, false>[];
 					} & InferOrganization<O, false>;
-			return ctx.json(organization as unknown as OrganizationReturn);
+			const parsedOrganization = parseOutputData(
+				organization,
+				ctx.context.orgOptions,
+			);
+			return ctx.json(parsedOrganization as unknown as OrganizationReturn);
 		},
 	);
 
@@ -907,7 +923,11 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 						members: InferMember<O, false>[];
 						invitations: InferInvitation<O, false>[];
 					} & InferOrganization<O, false>;
-			return ctx.json(organization as unknown as OrganizationReturn);
+			const parsedOrganization = parseOutputData(
+				organization,
+				ctx.context.orgOptions,
+			);
+			return ctx.json(parsedOrganization as unknown as OrganizationReturn);
 		},
 	);
 };
@@ -945,6 +965,10 @@ export const listOrganizations = <O extends OrganizationOptions>(options: O) =>
 			const organizations = await adapter.listOrganizations(
 				ctx.context.session.user.id,
 			);
-			return ctx.json(organizations);
+			const parsedOrganizations = parseOutputData(
+				organizations,
+				ctx.context.orgOptions,
+			);
+			return ctx.json(parsedOrganizations);
 		},
 	);

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -10,6 +10,7 @@ import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { hasPermission } from "../has-permission";
+import { parseOutputData } from "../parse-output-data";
 import { teamSchema } from "../schema";
 import type { OrganizationOptions } from "../types";
 
@@ -207,7 +208,12 @@ export const createTeam = <O extends OrganizationOptions>(options: O) => {
 				});
 			}
 
-			return ctx.json(createdTeam);
+			const parsedTeam = parseOutputData(
+				createdTeam,
+				ctx.context.orgOptions,
+				"team",
+			);
+			return ctx.json(parsedTeam);
 		},
 	);
 };
@@ -549,8 +555,10 @@ export const updateTeam = <O extends OrganizationOptions>(options: O) => {
 					organization,
 				});
 			}
-
-			return ctx.json(updatedTeam);
+			const parsedTeam = updatedTeam
+				? parseOutputData(updatedTeam, ctx.context.orgOptions, "team")
+				: null;
+			return ctx.json(parsedTeam);
 		},
 	);
 };
@@ -654,7 +662,12 @@ export const listOrganizationTeams = <O extends OrganizationOptions>(
 				);
 			}
 			const teams = await adapter.listTeams(organizationId);
-			return ctx.json(teams);
+			const parsedTeams = parseOutputData(
+				teams,
+				ctx.context.orgOptions,
+				"team",
+			);
+			return ctx.json(parsedTeams);
 		},
 	);
 
@@ -766,7 +779,8 @@ export const setActiveTeam = <O extends OrganizationOptions>(options: O) =>
 				user: session.user,
 			});
 
-			return ctx.json(team);
+			const parsedTeam = parseOutputData(team, ctx.context.orgOptions, "team");
+			return ctx.json(parsedTeam);
 		},
 	);
 
@@ -809,7 +823,12 @@ export const listUserTeams = <O extends OrganizationOptions>(options: O) =>
 				userId: session.user.id,
 			});
 
-			return ctx.json(teams);
+			const parsedTeams = parseOutputData(
+				teams,
+				ctx.context.orgOptions,
+				"team",
+			);
+			return ctx.json(parsedTeams);
 		},
 	);
 
@@ -899,7 +918,12 @@ export const listTeamMembers = <O extends OrganizationOptions>(options: O) =>
 			const members = await adapter.listTeamMembers({
 				teamId,
 			});
-			return ctx.json(members);
+			const parsedMembers = parseOutputData(
+				members,
+				ctx.context.orgOptions,
+				"teamMember",
+			);
+			return ctx.json(parsedMembers);
 		},
 	);
 
@@ -1078,8 +1102,12 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 					organization,
 				});
 			}
-
-			return ctx.json(teamMember);
+			const parsedTeamMember = parseOutputData(
+				teamMember,
+				ctx.context.orgOptions,
+				"teamMember",
+			);
+			return ctx.json(parsedTeamMember);
 		},
 	);
 

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -460,3 +460,14 @@ export type InferInvitation<
 			}) &
 		InferAdditionalFieldsFromPluginOptions<"invitation", O, isClientSide>
 >;
+
+export const schemaTables = [
+	"organization",
+	"member",
+	"invitation",
+	"team",
+	"teamMember",
+	"organizationRole",
+] as const;
+
+export type SchemaTable = (typeof schemaTables)[number];


### PR DESCRIPTION
…le additionalFields

#7489 fix

I will add unit testing once this approach is approved. 
I based my solution on what it was already developed for "user", "session" and "account" in [to-zod](https://github.dev/better-auth/better-auth/blob/b286da60db49695a251d9afa98148ce764f353cf/packages/better-auth/src/db/to-zod.ts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements parseOutputData to strip non-returnable additionalFields from organization-related API responses. Ensures consistent, safe output across org, member, invitation, team, and team member endpoints. Addresses #7489.

- **Bug Fixes**
  - Added parseOutputData with recursive handling for objects and arrays; omits fields with returned=false (except id) based on schema.additionalFields.
  - Applied parsing across create/update/get/list routes for organizations, members, invitations, teams, and team members.
  - Exported schemaTables/SchemaTable and removed server-side filtering from toZod to keep response shaping separate from schema generation.

<sup>Written for commit f55ef71bf7a33b5e62f95798954b43c279d0faaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

