### PR TITLE
chore: update `.postmortem`

### DIFF
--- a/.postmortem/client-side-import-server.md
+++ b/.postmortem/client-side-import-server.md
@@ -2,7 +2,7 @@
 
 ## Issue Reference
 
-* [PR #7532](https://github.com/better-auth/better-auth/pull/7532)
+* [PR #7532][pr-7532]
 * [Issue #7529](https://github.com/better-auth/better-auth/issues/7529)
 * [Incorrectly blamed PR #4360](https://github.com/better-auth/better-auth/pull/4360)
 
@@ -86,7 +86,7 @@ import type { Session, User } from "better-auth/types"
    incorrect imports
 3. **Documentation** - Make the distinction crystal clear
 
-## Changes in PR [#7532](https://github.com/better-auth/better-auth/pull/7532)
+## Changes in PR [#7532][pr-7532]
 
 While fixing test infrastructure, the real issue was revealed:
 
@@ -137,3 +137,5 @@ If you are seeing build errors with `node:*` modules:
 3. **Never import server packages in client code**
 
 This is not a bug in Better Auth - it is incorrect usage.
+
+[pr-7532]: https://github.com/better-auth/better-auth/pull/7532


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a postmortem documenting the recurring issue of importing the server-only better-auth package in client code and the resulting build/runtime failures. It clarifies the correct client import (better-auth/client), outlines root causes, and lists prevention steps and user guidance to avoid future mistakes.

<sup>Written for commit a2f59dbfb8bb1ee2200274cea469568844bf40db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

