### PR TITLE
refactor: avoid spread operator for data access

### DIFF
--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -37,6 +37,8 @@ export * from "./types";
 let debugLogs: { instance: string; args: any[] }[] = [];
 let transactionId = -1;
 
+const kAvoidSpreadSymbol = Symbol("kAvoidSpread");
+
 const createAsIsTransaction =
 	(adapter: DBAdapter<BetterAuthOptions>) =>
 	<R>(fn: (trx: DBTransactionAdapter<BetterAuthOptions>) => Promise<R>) =>
@@ -382,6 +384,14 @@ export const createAdapterFactory =
 						transformedData[newFieldName] = newValue;
 					}
 				}
+
+				Object.defineProperty(transformedData, kAvoidSpreadSymbol, {
+					get: () => {
+						throw new Error("You are not allowed to spread this object");
+					},
+					enumerable: true,
+				});
+
 				return transformedData as any;
 			};
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent spreading of transformed adapter data by adding a guard that throws on object spread to avoid accidental data leakage. Values and APIs remain the same.

- **Refactors**
  - Attach an enumerable Symbol with a throwing getter to transformedData to fail fast on object spread.

- **Migration**
  - Spreading transformedData (e.g., {...data}) now throws. Access fields directly or via adapter methods; for copies, select fields explicitly.

<sup>Written for commit 2cc4a2b276ae0557bbba325060518a945c865835. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

