### PR TITLE
fix(cli): use inkeep remote mcp url

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -15,8 +15,7 @@ interface MCPOptions {
 	remoteOnly?: boolean;
 }
 
-const REMOTE_MCP_URL =
-	"https://mcp.chonkie.ai/better-auth/better-auth-builder/mcp";
+const REMOTE_MCP_URL = "https://mcp.inkeep.com/better-auth/mcp";
 const LOCAL_MCP_COMMAND = "npx @better-auth/mcp";
 
 async function mcpAction(options: MCPOptions) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the CLI remote MCP URL to https://mcp.inkeep.com/better-auth/mcp. Fixes remote MCP runs by using the correct hosted endpoint.

<sup>Written for commit 85b5561b37cadb68e270df40f5f31c7afc7d148d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

