### PR TITLE
test: fix case attempting signin before signup

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1054,16 +1054,7 @@ describe("organization", async (it) => {
 			},
 		});
 		if (!invite.data) throw new Error("Invitation not created");
-		await client.signUp.email({
-			email: userOverLimit.email,
-			password: userOverLimit.password,
-			name: userOverLimit.name,
-		});
-		const { headers: headers2 } = await signInWithUser(
-			userOverLimit2.email,
-			userOverLimit2.password,
-		);
-
+		const headers2 = new Headers();
 		await client.signUp.email(
 			{
 				email: userOverLimit2.email,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix organization test setup by removing a sign-in attempt before user signup and initializing headers with new Headers(). Prevents failures when trying to sign in a user who doesn’t exist yet.

<sup>Written for commit 50d72bc7e079fa5ffaf89cb609e2f6dd1d75a6b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

