### PR TITLE
fix(core): consolidate rateLimit table schema definition

### DIFF
--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -1284,42 +1284,6 @@ export const createAdapterFactory =
 							delete tables.session;
 						}
 
-						if (
-							options.rateLimit &&
-							options.rateLimit.storage === "database" &&
-							// rate-limit will default to enabled in production,
-							// and given storage is database, it will try to use the rate-limit table,
-							// so we should make sure to generate rate-limit table schema
-							(typeof options.rateLimit.enabled === "undefined" ||
-								// and of course if they forcefully set to true, then they want rate-limit,
-								// thus we should also generate rate-limit table schema
-								options.rateLimit.enabled === true)
-						) {
-							tables.ratelimit = {
-								modelName: options.rateLimit.modelName ?? "ratelimit",
-								fields: {
-									key: {
-										type: "string",
-										unique: true,
-										required: true,
-										fieldName: options.rateLimit.fields?.key ?? "key",
-									},
-									count: {
-										type: "number",
-										required: true,
-										fieldName: options.rateLimit.fields?.count ?? "count",
-									},
-									lastRequest: {
-										type: "number",
-										required: true,
-										bigint: true,
-										defaultValue: () => Date.now(),
-										fieldName:
-											options.rateLimit.fields?.lastRequest ?? "lastRequest",
-									},
-								},
-							};
-						}
 						return adapterInstance.createSchema!({ file, tables });
 					}
 				: undefined,

--- a/packages/core/src/db/get-tables.ts
+++ b/packages/core/src/db/get-tables.ts
@@ -32,16 +32,21 @@ export const getAuthTables = (
 			fields: {
 				key: {
 					type: "string",
+					unique: true,
+					required: true,
 					fieldName: options.rateLimit?.fields?.key || "key",
 				},
 				count: {
 					type: "number",
+					required: true,
 					fieldName: options.rateLimit?.fields?.count || "count",
 				},
 				lastRequest: {
 					type: "number",
 					bigint: true,
+					required: true,
 					fieldName: options.rateLimit?.fields?.lastRequest || "lastRequest",
+					defaultValue: () => Date.now(),
 				},
 			},
 		},


### PR DESCRIPTION
- Closes https://github.com/better-auth/better-auth/issues/7518

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated the rateLimit table schema into getAuthTables and removed the duplicate definition from the adapter factory. This ensures consistent constraints and avoids schema drift across adapters.

- **Bug Fixes**
  - Single source of truth for the rateLimit table schema in getAuthTables.
  - Enforced constraints: key is unique and required; count and lastRequest are required; lastRequest defaults to Date.now().
  - Preserves configurable field names via options.rateLimit.fields.

<sup>Written for commit e1bab2807f47698db6fd214570bccd5b449327c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

