### PR TITLE
perf: fix infinite typecheck

### DIFF
--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -101,7 +101,7 @@ type SSOEndpoints<O extends SSOOptions> = {
 	acsEndpoint: ReturnType<typeof acsEndpoint>;
 	listSSOProviders: ReturnType<typeof listSSOProviders>;
 	getSSOProvider: ReturnType<typeof getSSOProvider>;
-	updateSSOProvider: ReturnType<typeof updateSSOProvider<O>>;
+	updateSSOProvider: ReturnType<typeof updateSSOProvider>;
 	deleteSSOProvider: ReturnType<typeof deleteSSOProvider>;
 };
 

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -382,7 +382,7 @@ function mergeOIDCConfig(
 	};
 }
 
-export const updateSSOProvider = <O extends SSOOptions>(options: O) => {
+export const updateSSOProvider = (options: SSOOptions) => {
 	return createAuthEndpoint(
 		"/sso/providers/:providerId",
 		{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified updateSSOProvider typings to stop infinite TypeScript type checking loops. This improves build and editor performance in the SSO package.

- **Bug Fixes**
  - Removed the generic from updateSSOProvider and updated SSOEndpoints ReturnType to avoid recursive types.
  - No runtime behavior changes; types only.

<sup>Written for commit 11804f29bb32a3ba9025754bf9cb28d273498453. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

