### PR TITLE
docs: use type-only import for `BetterAuthClientPlugin`

### DIFF
--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -461,7 +461,7 @@ const myPlugin = () => {
 If your endpoints need to be called from the client, you'll also need to create a client plugin. Better Auth clients can infer the endpoints from the server plugins. You can also add additional client-side logic.
 
 ```ts title="client-plugin.ts"
-import type { BetterAuthClientPlugin } from "better-auth";
+import type { BetterAuthClientPlugin } from "better-auth/client";
 
 export const myPluginClient = () => {
     return {

--- a/docs/content/docs/guides/your-first-plugin.mdx
+++ b/docs/content/docs/guides/your-first-plugin.mdx
@@ -164,7 +164,7 @@ First, let’s create our `client.ts` file first:
 </Files>
 Then, add the following code:
 ```ts title="client.ts"
-import type { BetterAuthClientPlugin } from "better-auth";
+import type { BetterAuthClientPlugin } from "better-auth/client";
 import type { birthdayPlugin } from "./index"; // make sure to import the server plugin as a type // [!code highlight]
 
 type BirthdayPlugin = typeof birthdayPlugin;

--- a/packages/scim/src/client.ts
+++ b/packages/scim/src/client.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthClientPlugin } from "better-auth";
+import type { BetterAuthClientPlugin } from "better-auth/client";
 import type { scim } from "./index";
 
 export const scimClient = () => {

--- a/packages/sso/src/client.ts
+++ b/packages/sso/src/client.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthClientPlugin } from "better-auth";
+import type { BetterAuthClientPlugin } from "better-auth/client";
 import type { SSOPlugin } from "./index";
 
 interface SSOClientOptions {

--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthClientPlugin } from "better-auth";
+import type { BetterAuthClientPlugin } from "better-auth/client";
 import { STRIPE_ERROR_CODES } from "./error-codes";
 import type { stripe } from "./index";
 

--- a/test/unit/types/index.test.ts
+++ b/test/unit/types/index.test.ts
@@ -1,6 +1,11 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 import type { Auth, InferUser } from "better-auth";
+import type { AuthClient } from "better-auth/client";
 import { expectTypeOf, test } from "vitest";
+
+test("expect imports", async () => {
+	expectTypeOf<AuthClient<{}>>().not.toBeUndefined();
+});
 
 test("infer user type correctly", async () => {
 	const config = {


### PR DESCRIPTION
This snippet causes an error, tries to import a type as an object. Thanks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch BetterAuthClientPlugin to a type-only import from better-auth/client across docs and client packages to prevent importing a type as a value.

- **Bug Fixes**
  - Updated imports in scim, sso, and stripe client files to use better-auth/client with import type.
  - Fixed docs examples to use import type from better-auth/client.
  - Added a unit test to verify AuthClient type import.

<sup>Written for commit 0c9146e924a86e6aef14cc15eb7e12ebb62902ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

