### PR TITLE
feat: Vercel BotID support on captcha plugin

### DIFF
--- a/.cspell/third-party.txt
+++ b/.cspell/third-party.txt
@@ -38,3 +38,4 @@ WorkOS
 authjs
 vite
 electronjs
+botid

--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -8,6 +8,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 - [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/)
 - [hCaptcha](https://www.hcaptcha.com/)
 - [CaptchaFox](https://captchafox.com/)
+- [Vercel BotID](https://vercel.com/docs/botid)
 
 <Callout type="info">
   This plugin works out of the box with <Link href="/docs/authentication/email-password">Email & Password</Link> authentication. To use it with other authentication methods, you will need to configure the <Link href="/docs/plugins/captcha#plugin-options">endpoints</Link> array in the plugin options.
@@ -17,7 +18,20 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 
 <Steps>
   <Step>
+    ### Install dependencies (Optional)
+
+    If you are using **Vercel BotID** as your provider, you need to install the `botid` library:
+
+    ```package-install
+    npm install botid
+    ```
+  </Step>
+  <Step>
     ### Add the plugin to your **auth** config
+
+    <Callout type="info">
+      **Vercel BotID** doesn't require a `secretKey`. You can omit it from the plugin options.
+    </Callout>
 
     ```ts title="auth.ts"
     import { betterAuth } from "better-auth";
@@ -26,7 +40,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     export const auth = betterAuth({
         plugins: [
             captcha({ // [!code highlight]
-                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha, captchafox // [!code highlight]
+                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha, captchafox, vercel-botid // [!code highlight]
                 secretKey: process.env.TURNSTILE_SECRET_KEY!, // [!code highlight]
             }), // [!code highlight]
         ],
@@ -39,6 +53,10 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 
     <Callout type="warning">
       The `x-captcha-user-remote-ip` header is no longer required—IP is now auto-detected server-side.
+    </Callout>
+
+    <Callout type="info">
+      Using **Vercel BotID**? You don't need a captcha token header or a `secretKey`. Install the BotID library (`npm install botid`) and set `provider: "vercel-botid"` in the plugin options.
     </Callout>
 
     Add the captcha token to your request headers for all protected endpoints. This example shows how to include it in a `signIn` request:
@@ -61,6 +79,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     - To implement Google reCAPTCHA on the client side, follow the official [Google reCAPTCHA documentation](https://developers.google.com/recaptcha/intro) or use libraries like [react-google-recaptcha](https://www.npmjs.com/package/react-google-recaptcha) (v2) and [react-google-recaptcha-v3](https://www.npmjs.com/package/react-google-recaptcha-v3) (v3).
     - To implement hCaptcha on the client side, follow the official [hCaptcha documentation](https://docs.hcaptcha.com/#add-the-hcaptcha-widget-to-your-webpage) or use libraries like [@hcaptcha/react-hcaptcha](https://www.npmjs.com/package/@hcaptcha/react-hcaptcha)
     - To implement CaptchaFox on the client side, follow the official [CaptchaFox documentation](https://docs.captchafox.com/getting-started) or use libraries like [@captchafox/react](https://www.npmjs.com/package/@captchafox/react)
+    - To implement Vercel BotID, follow the official [Vercel BotID documentation](https://vercel.com/docs/botid/get-started)
   </Step>
 </Steps>
 
@@ -85,8 +104,10 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 ## Plugin Options
 
 - **`provider` (required)**: your captcha provider.
-- **`secretKey` (required)**: your provider's secret key used for the server-side validation.
+- **`secretKey` (required for all providers except `vercel-botid`)**: your provider's secret key used for the server-side validation.
 - `endpoints` (optional): replaces the default array of paths where captcha verification is enforced. If set, only the specified paths will be protected. Default is `["/sign-up/email", "/sign-in/email", "/request-password-reset"]`.
 - `minScore` (optional - only *Google ReCAPTCHA v3*): minimum score threshold. Default is `0.5`.
 - `siteKey` (optional - only *hCaptcha* and *CaptchaFox*): prevents tokens issued on one sitekey from being redeemed elsewhere.
 - `siteVerifyURLOverride` (optional): overrides endpoint URL for the captcha verification request.
+- `validateRequest` (optional - only *Vercel BotID*): custom validation logic. Return `true` to allow the request, `false` to reject it.
+- `checkBotIdOptions` (optional - only *Vercel BotID*): options passed to `checkBotId` from the BotID library.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -45,7 +45,10 @@
 				"react-dom",
 				"solid-js",
 				"svelte",
-				"vue"
+				"vue",
+
+				// implicit plugins dependencies
+				"botid"
 			]
 		},
 		"packages/core": {

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -517,6 +517,7 @@
     "@types/pg": "^8.16.0",
     "@types/react": "catalog:react19",
     "better-sqlite3": "^12.6.2",
+    "botid": "^1.5.10",
     "deepmerge": "^4.3.1",
     "happy-dom": "^20.7.0",
     "listhen": "^1.9.0",
@@ -541,6 +542,7 @@
     "@tanstack/react-start": "^1.0.0",
     "@tanstack/solid-start": "^1.0.0",
     "better-sqlite3": "^12.0.0",
+    "botid": "^1.0.0",
     "drizzle-kit": ">=0.31.4",
     "drizzle-orm": ">=0.41.0",
     "mongodb": "^6.0.0 || ^7.0.0",
@@ -569,6 +571,9 @@
       "optional": true
     },
     "@tanstack/solid-start": {
+      "optional": true
+    },
+    "botid": {
       "optional": true
     },
     "next": {

--- a/packages/better-auth/src/plugins/captcha/captcha.test.ts
+++ b/packages/better-auth/src/plugins/captcha/captcha.test.ts
@@ -439,4 +439,48 @@ describe("captcha", async () => {
 			expect(res.error?.status).toBe(403);
 		});
 	});
+
+	describe("botid", async (it) => {
+		const { client: badBotClient } = await getTestInstance({
+			plugins: [
+				captcha({
+					provider: "vercel-botid",
+					validateRequest({ request, verification }) {
+						return !verification.isBot;
+					},
+					checkBotIdOptions: { developmentOptions: { bypass: "BAD-BOT" } },
+				}),
+			],
+		});
+
+		const { client: humanClient } = await getTestInstance({
+			plugins: [
+				captcha({
+					provider: "vercel-botid",
+					validateRequest({ request, verification }) {
+						return !verification.isBot;
+					},
+					checkBotIdOptions: { developmentOptions: { bypass: "HUMAN" } },
+				}),
+			],
+		});
+
+		it("should have expected error details when request is a bot", async () => {
+			const response = await badBotClient.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+			});
+
+			expect(response.error?.status).toBe(403);
+		});
+
+		it("should successfully sign in a human user", async () => {
+			const response = await humanClient.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+			});
+
+			expect(response.data?.user).toBeDefined();
+		});
+	});
 });

--- a/packages/better-auth/src/plugins/captcha/constants.ts
+++ b/packages/better-auth/src/plugins/captcha/constants.ts
@@ -11,6 +11,7 @@ export const Providers = {
 	GOOGLE_RECAPTCHA: "google-recaptcha",
 	HCAPTCHA: "hcaptcha",
 	CAPTCHAFOX: "captchafox",
+	VERCEL_BOTID: "vercel-botid",
 } as const;
 
 export const siteVerifyMap: Record<Provider, string> = {
@@ -20,4 +21,5 @@ export const siteVerifyMap: Record<Provider, string> = {
 		"https://www.google.com/recaptcha/api/siteverify",
 	[Providers.HCAPTCHA]: "https://api.hcaptcha.com/siteverify",
 	[Providers.CAPTCHAFOX]: "https://api.captchafox.com/siteverify",
+	[Providers.VERCEL_BOTID]: "",
 };

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -30,6 +30,16 @@ export const captcha = (options: CaptchaOptions) =>
 				if (!endpoints.some((endpoint) => request.url.includes(endpoint)))
 					return undefined;
 
+				// BotId does not require a secret key to be provided, nor a captcha response header
+				// as it uses its own internal verification method, so we handle it first
+				if (options.provider === Providers.VERCEL_BOTID) {
+					return await verifyHandlers.vercelBotId({
+						request,
+						checkBotIdOptions: options.checkBotIdOptions,
+						validateRequest: options.validateRequest,
+					});
+				}
+
 				if (!options.secretKey) {
 					throw new Error(INTERNAL_ERROR_CODES.MISSING_SECRET_KEY.message);
 				}

--- a/packages/better-auth/src/plugins/captcha/types.ts
+++ b/packages/better-auth/src/plugins/captcha/types.ts
@@ -1,4 +1,8 @@
 import type { Providers } from "./constants";
+import type {
+	CheckBotIdOptions,
+	ValidateRequestContext,
+} from "./verify-handlers/vercel-botid";
 
 export type Provider = (typeof Providers)[keyof typeof Providers];
 
@@ -27,8 +31,29 @@ export interface CaptchaFoxOptions extends BaseCaptchaOptions {
 	siteKey?: string | undefined;
 }
 
+export interface VercelBotIdOptions
+	extends Pick<BaseCaptchaOptions, "endpoints"> {
+	provider: typeof Providers.VERCEL_BOTID;
+
+	/**
+	 * If you want custom logic to validate the request, you can use this function.
+	 * Return `false` to invalidate the request, and `true` to allow the request to proceed.
+	 *
+	 * Note: Any requests which are invalidated by the `endpoints` will not be checked by this function.
+	 *
+	 * @example
+	 * ```ts
+	 * ({ request, verification }) => {
+	 * 	return verification.isBot === false;
+	 * }
+	 */
+	validateRequest?: (ctx: ValidateRequestContext) => boolean | Promise<boolean>;
+	checkBotIdOptions?: CheckBotIdOptions;
+}
+
 export type CaptchaOptions =
 	| GoogleRecaptchaOptions
 	| CloudflareTurnstileOptions
 	| HCaptchaOptions
-	| CaptchaFoxOptions;
+	| CaptchaFoxOptions
+	| VercelBotIdOptions;

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
@@ -2,3 +2,4 @@ export { captchaFox } from "./captchafox";
 export { cloudflareTurnstile } from "./cloudflare-turnstile";
 export { googleRecaptcha } from "./google-recaptcha";
 export { hCaptcha } from "./h-captcha";
+export { vercelBotId } from "./vercel-botid";

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/vercel-botid.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/vercel-botid.ts
@@ -1,0 +1,59 @@
+import type * as BotIdServer from "botid/server";
+import { middlewareResponse } from "../../../utils/middleware-response";
+import { EXTERNAL_ERROR_CODES, INTERNAL_ERROR_CODES } from "../error-codes";
+
+export type BotIdVerification = Awaited<
+	ReturnType<typeof BotIdServer.checkBotId>
+>;
+export type CheckBotIdOptions = Parameters<typeof BotIdServer.checkBotId>[0];
+
+export type ValidateRequestContext = {
+	request: Request;
+	verification: BotIdVerification;
+};
+
+type Params = {
+	request: Request;
+	/**
+	 * If you want custom logic to validate the request, you can use this function.
+	 * Return `false` to invalidate the request, and `true` to allow the request to proceed.
+	 *
+	 * Note: Any requests which are invalidated by the `endpoints` will not be checked by this function.
+	 *
+	 * @example
+	 * ```ts
+	 * ({ request, verification }) => {
+	 * 	return verification.isBot === false;
+	 * }
+	 */
+	validateRequest?: (ctx: ValidateRequestContext) => boolean | Promise<boolean>;
+	checkBotIdOptions?: CheckBotIdOptions;
+};
+
+function defaultValidateRequest({ verification }: ValidateRequestContext) {
+	return !verification.isBot;
+}
+
+export const vercelBotId = async ({
+	request,
+	checkBotIdOptions,
+	validateRequest = defaultValidateRequest,
+}: Params) => {
+	let verification: BotIdVerification;
+	try {
+		const { checkBotId } = await import("botid/server"); // botid is an optional dependency
+		verification = await checkBotId(checkBotIdOptions);
+	} catch (error) {
+		throw new Error(INTERNAL_ERROR_CODES.SERVICE_UNAVAILABLE.message, {
+			cause: error,
+		});
+	}
+	const isValid = await validateRequest({ request, verification });
+
+	if (isValid) return undefined;
+
+	return middlewareResponse({
+		message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.message,
+		status: 403,
+	});
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,6 +1454,9 @@ importers:
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
+      botid:
+        specifier: ^1.5.10
+        version: 1.5.10(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1))(react@19.2.4)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -8687,6 +8690,17 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  botid@1.5.10:
+    resolution: {integrity: sha512-hhgty1u0CxozqTqLbTQMtYBwmWdzWZTAsBCvN7/qhkN3fM7MlXacmmcMoyc0f+vV+U6RRoLYdlo32td+PhJyew==}
+    peerDependencies:
+      next: '*'
+      react: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+      react:
+        optional: true
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -23814,6 +23828,11 @@ snapshots:
 
   boolean@3.2.0:
     optional: true
+
+  botid@1.5.10(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1))(react@19.2.4):
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1)
+      react: 19.2.4
 
   boxen@8.0.1:
     dependencies:


### PR DESCRIPTION
This pull request adds support for Vercel BotID as a new captcha provider in the Better Auth captcha plugin. It updates the documentation, types, and implementation to allow BotID to be used seamlessly alongside existing providers, and includes tests and dependency updates for the new provider.

**Vercel BotID Integration:**

- Added Vercel BotID as a supported captcha provider in the plugin, including new provider constants and provider-specific options (`validateRequest`, `checkBotIdOptions`).
- Implemented the BotID verification handler (`vercelBotId`) that uses the `botid` library for server-side bot detection, with customizable validation logic.
- Updated tests to cover BotID scenarios, verifying both bot and human request handling.

**Documentation Updates:**

- Extended the captcha plugin documentation to include setup and usage instructions for Vercel BotID, including installation steps, configuration notes, and client-side integration.

**Dependency Management:**

- Added `botid` as an optional dependency in `package.json` and updated `pnpm-lock.yaml` accordingly.

Based on the work of @ping-maxwell at https://github.com/better-auth/better-auth/pull/3214

Resolves #7535, Closes #3214

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Vercel BotID as a captcha provider with server-side bot detection. No secret key or captcha token header needed; includes a new verify handler with customizable validation.

- **New Features**
  - Added provider "vercel-botid" with a verify handler that runs before secret-key checks; default validation rejects requests when verification.isBot is true.
  - New options: validateRequest(ctx) and checkBotIdOptions; added VercelBotIdOptions and related types.
  - Updated docs with install/setup notes and examples; added tests for bot (403) vs human flows; added botid as an optional dependency/peer, plus knip and dictionary updates.

<sup>Written for commit db949a3081cd9d9cf1f3019b08349d44791b0790. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

