### PR TITLE
test: increase organization test timeout

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1,7 +1,7 @@
 import type { APIError } from "@better-auth/core/error";
 import { memoryAdapter } from "@better-auth/memory-adapter";
 import type { Prettify } from "better-call";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import type {
 	BetterFetchError,
 	PreinitializedWritableAtom,
@@ -26,6 +26,10 @@ import type {
 	InvitationStatus,
 } from "./schema";
 import type { OrganizationOptions } from "./types";
+
+vi.setConfig({
+	testTimeout: 10_000,
+});
 
 describe("organization type", () => {
 	it("empty org type should works", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increased the Vitest test timeout to 10s in organization.test.ts to prevent intermittent timeouts on slower CI runs.

<sup>Written for commit b230fbf419fc636d1fe8cd140dd783c104d8b693. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

