### PR TITLE
docs: prevent content overflow

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -357,6 +357,7 @@ html:not([data-anchor-scrolling]) {
 	animation: stream-pulse 1s ease-in-out infinite;
 }
 
-code:not(pre code) {
-	@apply break-words;
+.prose code:not(pre code),
+.prose a {
+	overflow-wrap: anywhere;
 }

--- a/docs/components/docs/page.tsx
+++ b/docs/components/docs/page.tsx
@@ -272,7 +272,7 @@ export const DocsTitle = forwardRef<
 		<h1
 			ref={ref}
 			{...props}
-			className={cn("text-3xl font-semibold", props.className)}
+			className={cn("text-3xl font-semibold wrap-break-word", props.className)}
 		>
 			{props.children}
 		</h1>


### PR DESCRIPTION
### Before
<img height="400" alt="before" src="https://github.com/user-attachments/assets/a49a7906-5320-4b2b-98c6-f0aff32748d6" />

### After
<img height="400" alt="after" src="https://github.com/user-attachments/assets/f6ced0d5-cb69-4131-8c33-cf423e1d9e80" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent content overflow in docs by wrapping long inline code, links, and titles to avoid layout breakage on smaller screens.

- **Bug Fixes**
  - Apply overflow-wrap: anywhere to .prose code:not(pre code) and .prose a.
  - Add wrap-break-word to DocsTitle (H1) to break long words.

<sup>Written for commit 35797be1d7639902b52dbd56ed15baa272fb63ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

