### PR TITLE
fix: remove duplicate secondary storage writes from setSessionCookie

### DIFF
--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -276,23 +276,6 @@ export async function setSessionCookie(
 	}
 	await setCookieCache(ctx, session, dontRememberMe);
 	ctx.context.setNewSession(session);
-	/**
-	 * If secondary storage is enabled, store the session data in the secondary storage
-	 * This is useful if the session got updated and we want to update the session data in the
-	 * secondary storage
-	 */
-	if (ctx.context.options.secondaryStorage) {
-		await ctx.context.secondaryStorage?.set(
-			session.session.token,
-			JSON.stringify({
-				user: session.user,
-				session: session.session,
-			}),
-			Math.floor(
-				(new Date(session.session.expiresAt).getTime() - Date.now()) / 1000,
-			),
-		);
-	}
 }
 
 /**


### PR DESCRIPTION
> [!NOTE]
> It appears to already be handled within the internal adapter, and having the cookie helper function also handle secondary storage goes beyond its responsibility.

- Closes https://github.com/better-auth/better-auth/issues/7586

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate secondary storage writes by stopping setSessionCookie from writing. Secondary storage updates now happen only in the internal adapter, so updateUser writes once per session token.

- **Bug Fixes**
  - Removed secondaryStorage write from setSessionCookie.
  - Added test to ensure updateUser writes a session token only once.

<sup>Written for commit 9b2cd66bb5307d49d206ee420f95f57556a64ff8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

