### PR TITLE
feat: add magic-link prefix to token storage

### DIFF
--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -209,7 +209,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 						: generateRandomString(32, "a-z", "A-Z");
 					const storedToken = await storeToken(ctx, verificationToken);
 					await ctx.context.internalAdapter.createVerificationValue({
-						identifier: storedToken,
+						identifier: `magic-link:${storedToken}`,
 						value: JSON.stringify({ email, name: ctx.body.name }),
 						expiresAt: new Date(Date.now() + (opts.expiresIn || 60 * 5) * 1000),
 					});
@@ -342,7 +342,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					const storedToken = await storeToken(ctx, token);
 					const tokenValue =
 						await ctx.context.internalAdapter.findVerificationValue(
-							storedToken,
+							`magic-link:${storedToken}`,
 						);
 					if (!tokenValue) {
 						redirectWithError("INVALID_TOKEN");

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -340,10 +340,18 @@ export const magicLink = (options: MagicLinkOptions) => {
 						ctx.context.baseURL,
 					).toString();
 					const storedToken = await storeToken(ctx, token);
-					const tokenValue =
+					// Try prefixed identifier first (new format), then fallback to non-prefixed (backward compatibility)
+					let tokenValue =
 						await ctx.context.internalAdapter.findVerificationValue(
 							`magic-link:${storedToken}`,
 						);
+					if (!tokenValue) {
+						// Fallback to non-prefixed identifier for backward compatibility
+						tokenValue =
+							await ctx.context.internalAdapter.findVerificationValue(
+								storedToken,
+							);
+					}
 					if (!tokenValue) {
 						redirectWithError("INVALID_TOKEN");
 					}

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -403,7 +403,7 @@ describe("magic link storeToken", async () => {
 		});
 		const hashedToken = await defaultKeyHasher(verificationEmail.token);
 		const storedToken =
-			await internalAdapter.findVerificationValue(hashedToken);
+			await internalAdapter.findVerificationValue(`magic-link:${hashedToken}`);
 		expect(storedToken).toBeDefined();
 		const response2 = await auth.api.signInMagicLink({
 			body: {
@@ -446,7 +446,7 @@ describe("magic link storeToken", async () => {
 		});
 		const hashedToken = `${verificationEmail.token}hashed`;
 		const storedToken =
-			await internalAdapter.findVerificationValue(hashedToken);
+			await internalAdapter.findVerificationValue(`magic-link:${hashedToken}`);
 		expect(storedToken).toBeDefined();
 		const response2 = await auth.api.signInMagicLink({
 			body: {


### PR DESCRIPTION
Add 'magic-link:' prefix to token identifiers when storing verification values, matching the pattern used in one-time-token plugin. This helps distinguish token types in the database.

## Changes
- Add prefix when creating verification value
- Add prefix when finding verification value  
- Update tests to use prefix when looking up stored tokens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "magic-link:" prefix to verification token identifiers in the magic link plugin to prevent collisions and match one-time-token storage. Verification also supports old tokens without the prefix for backward compatibility.

- **Refactors**
  - Apply prefix when creating verification values.
  - Check prefixed identifier first when verifying, then fallback to non-prefixed tokens.
  - Update tests to use the prefixed identifier and cover backward compatibility.

<sup>Written for commit ffe47e9d12738db820179de6bd71ca8129d26e90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

