### PR TITLE
Fix userinfo route to match Okta specs.

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/providers/okta.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/okta.ts
@@ -53,7 +53,7 @@ export function okta(options: OktaOptions): GenericOAuthConfig {
 	const getUserInfo = async (
 		tokens: OAuth2Tokens,
 	): Promise<OAuth2UserInfo | null> => {
-		const userInfoUrl = `${issuer}/v1/userinfo`;
+		const userInfoUrl = `${issuer}/oauth2/v1/userinfo`;
 
 		const { data: profile, error } = await betterFetch<OktaProfile>(
 			userInfoUrl,


### PR DESCRIPTION
Append an `oauth2` segment to the Okta userinfo path as per the documentation.

`/v1/userinfo`  -> `/oauth2/v1/userinfo`

Previously, the path did not match the documentation, meaning that the provider [threw the following exception on signin](https://github.com/better-auth/better-auth/blob/762a11f97162dbc1f807457b2e3e0b8d1619f633/packages/better-auth/src/plugins/generic-oauth/routes.ts#L397):
```
user_info_is_missing
```

See: [Okta API for UserInfo](https://developer.okta.com/docs/api/openapi/okta-oauth/oauth/tag/OrgAS/#tag/OrgAS/operation/userinfo)

