### PR TITLE
Issue 7607 investigation

### DIFF
--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -354,6 +354,8 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 				 * or if the session refresh is disabled
 				 */
 				if (dontRememberMe || ctx.query?.disableRefresh) {
+					// Still set the cookie cache if enabled - this is about caching, not session lifetime
+					await setCookieCache(ctx, session, !!dontRememberMe);
 					// Parse session and user to ensure additionalFields are included
 					const parsedSession = parseSessionOutput(
 						ctx.context.options,

--- a/packages/better-auth/src/api/routes/session_data_regeneration.test.ts
+++ b/packages/better-auth/src/api/routes/session_data_regeneration.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { parseSetCookieHeader } from "../../cookies";
+import { getTestInstance } from "../../test-utils/test-instance";
+
+describe("session_data regeneration after expiry", async () => {
+	it("should regenerate session_data cookie when it expires but session_token is still valid", async () => {
+		const { client, testUser } = await getTestInstance({
+			session: {
+				expiresIn: 60 * 60 * 24 * 7, // 7 days
+				updateAge: 60 * 60 * 24, // 1 day
+				cookieCache: {
+					enabled: true,
+					maxAge: 5, // 5 seconds for testing (simulating a short expiry)
+				},
+			},
+		});
+
+		const headers = new Headers();
+
+		// Sign in - this should set both session_token and session_data
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					console.log("Sign-in cookies:", setCookie);
+					const parsed = parseSetCookieHeader(setCookie!);
+					expect(parsed.get("better-auth.session_data")).toBeDefined();
+					expect(parsed.get("better-auth.session_token")).toBeDefined();
+
+					// Store only session_token (simulating session_data expiry)
+					const sessionToken = parsed.get("better-auth.session_token");
+					headers.set(
+						"cookie",
+						`better-auth.session_token=${sessionToken?.value}`,
+					);
+				},
+			},
+		);
+
+		// Now make a getSession call WITHOUT session_data cookie
+		// This simulates the case where session_data has expired but session_token is still valid
+		let sessionDataRegenerated = false;
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+				onSuccess(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					console.log("GetSession cookies:", setCookie);
+					if (setCookie) {
+						const parsed = parseSetCookieHeader(setCookie);
+						if (parsed.get("better-auth.session_data")?.value) {
+							sessionDataRegenerated = true;
+						}
+					}
+				},
+			},
+		});
+
+		expect(session.data).not.toBeNull();
+		expect(session.data?.user.email).toBe(testUser.email);
+		expect(sessionDataRegenerated).toBe(true); // This is the key assertion
+	});
+
+	it("should regenerate session_data when dontRememberMe is true", async () => {
+		const { client, testUser } = await getTestInstance({
+			session: {
+				expiresIn: 60 * 60 * 24 * 7, // 7 days
+				updateAge: 60 * 60 * 24, // 1 day
+				cookieCache: {
+					enabled: true,
+					maxAge: 60 * 5, // 5 minutes
+				},
+			},
+		});
+
+		const headers = new Headers();
+
+		// Sign in with rememberMe: false
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+				rememberMe: false,
+			},
+			{
+				onSuccess(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					const parsed = parseSetCookieHeader(setCookie!);
+
+					// With rememberMe: false, max-age should be undefined (session cookie)
+					expect(
+						parsed.get("better-auth.session_token")?.["max-age"],
+					).toBeUndefined();
+					expect(
+						parsed.get("better-auth.session_data")?.["max-age"],
+					).toBeUndefined();
+
+					// Store only session_token and dont_remember cookie (simulating session_data expiry)
+					const sessionToken = parsed.get("better-auth.session_token");
+					const dontRemember = parsed.get("better-auth.dont_remember");
+					headers.set(
+						"cookie",
+						`better-auth.session_token=${sessionToken?.value}; better-auth.dont_remember=${dontRemember?.value}`,
+					);
+				},
+			},
+		);
+
+		// Now make a getSession call WITHOUT session_data cookie
+		let sessionDataRegenerated = false;
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+				onSuccess(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					console.log("GetSession (dontRememberMe) cookies:", setCookie);
+					if (setCookie) {
+						const parsed = parseSetCookieHeader(setCookie);
+						if (parsed.get("better-auth.session_data")?.value) {
+							sessionDataRegenerated = true;
+						}
+					}
+				},
+			},
+		});
+
+		expect(session.data).not.toBeNull();
+		expect(session.data?.user.email).toBe(testUser.email);
+		// BUG: session_data is NOT regenerated when dontRememberMe is true!
+		// This assertion will fail if there's a bug
+		expect(sessionDataRegenerated).toBe(true);
+	});
+});


### PR DESCRIPTION
Fix `session_data` cookie regeneration when `dontRememberMe` or `disableRefresh` is true.

Previously, `setCookieCache` was skipped when `dontRememberMe` or `disableRefresh` was true, preventing the `session_data` cookie from being re-sent after expiry. This was incorrect as `setCookieCache` is for caching session data to avoid DB lookups, not for controlling session lifetime, and should always be called when enabled.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1769370518124229?thread_ts=1769370518.124229&cid=C0A8B5BARUK)

<a href="https://cursor.com/background-agent?bcId=bc-7591e3af-ead6-4a02-a8b6-56982536e44d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7591e3af-ead6-4a02-a8b6-56982536e44d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates the session_data cookie after it expires even when remember-me is off or refresh is disabled, so sessions keep working and DB lookups are avoided. Addresses #7607.

- **Bug Fixes**
  - Always call setCookieCache in getSession when dontRememberMe or disableRefresh are set, refreshing the cookie cache (caching only, not session lifetime).
  - Tests: reissue session_data when missing but session_token is valid (incl. dontRememberMe), and confirm twoFactor TOTP works with cookieCache disabled.

<sup>Written for commit bc91f3972e4d9437923fb869b90567baf7ca615b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

