### PR TITLE
docs(stripe): clarify createCustomerOnSignUp configuration requirement

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -131,7 +131,7 @@ The Stripe plugin integrates Stripe's payment and subscription functionality wit
 
 You can use this plugin solely for customer management without enabling subscriptions. This is useful if you just want to link Stripe customers to your users.
 
-By default, when a user signs up, a Stripe customer is automatically created if you set `createCustomerOnSignUp: true`. This customer is linked to the user in your database.
+When you set `createCustomerOnSignUp: true`, a Stripe customer is automatically created on signup and linked to the user in your database.
 You can customize the customer creation process:
 
 ```ts title="auth.ts"


### PR DESCRIPTION
Reworded misleading sentence that implied Stripe customers are created by default. The original phrasing suggested automatic customer creation without the required configuration setting.

Changed from stating "By default, when a user signs up..." to explicitly lead with the configuration requirement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified that Stripe customers are created on signup only when createCustomerOnSignUp: true is set. Fixes misleading wording that implied customers are created by default.

<sup>Written for commit bf0ce50d8a4cc47fc289b51aab93f0b4eec44b84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

