### PR TITLE
docs: update MCP guide to reflect remote-only migration

### DIFF
--- a/docs/content/docs/introduction.mdx
+++ b/docs/content/docs/introduction.mdx
@@ -69,7 +69,7 @@ Alternatively, you can manually configure the MCP server for each client:
 <Tabs items={["Claude Code", "Open Code", "Manual"]}>
     <Tab value="Claude Code">
       ```bash title="terminal"
-      claude mcp add --transport http better-auth https://mcp.chonkie.ai/better-auth/better-auth-builder/mcp
+      claude mcp add --transport http better-auth-docs https://mcp.inkeep.com/better-auth/mcp
       ```
     </Tab>
     <Tab value="Open Code">
@@ -77,9 +77,9 @@ Alternatively, you can manually configure the MCP server for each client:
         {
             "$schema": "https://opencode.ai/config.json",
             "mcp": {
-                "better-auth": {
+                "better-auth-docs": {
                     "type": "remote",
-                    "url": "https://mcp.chonkie.ai/better-auth/better-auth-builder/mcp",
+                    "url": "https://mcp.inkeep.com/better-auth/mcp",
                     "enabled": true,
                 }
             }
@@ -89,8 +89,8 @@ Alternatively, you can manually configure the MCP server for each client:
     <Tab value="Manual">
      ```json title="mcp.json"
     {
-        "better-auth": {
-            "url": "https://mcp.chonkie.ai/better-auth/better-auth-builder/mcp"
+        "better-auth-docs": {
+            "url": "https://mcp.inkeep.com/better-auth/mcp"
         }
     }
     ```
@@ -98,6 +98,6 @@ Alternatively, you can manually configure the MCP server for each client:
 </Tabs>
 
 <Callout>
-We provide a first‑party MCP, powered by [Chonkie](https://chonkie.ai). You can alternatively use [`context7`](https://context7.com/) and other MCP providers.
+We provide a first‑party MCP, powered by [Inkeep](https://inkeep.com).
 </Callout>
 


### PR DESCRIPTION
Docs were lagging behind the recent removal of the local MCP server in #7574. Users were hitting Unauthorized errors because the guide still pointed to the legacy Chonkie endpoint and referenced CLI flags that were removed.

### Changes
- Updated Manual Configuration URLs to the new `mcp.inkeep.com` endpoint.
- Removed deprecated `--local-only` and `--remote-only` flags from the CLI options.
- Updated the provider credit from Chonkie/Context7 to Inkeep to match the current implementation.

Fixes #7614

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the MCP guide to reflect the remote-only migration and prevent Unauthorized errors from the legacy endpoint.

- **Bug Fixes**
  - Switched manual configuration URLs to https://mcp.inkeep.com/better-auth/mcp.
  - Removed deprecated --local-only and --remote-only flags.
  - Updated provider credit to Inkeep and example keys to better-auth-docs.

<sup>Written for commit 1dc4a014b75d63d2621d3936ae1ab1764de0c102. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

