### PR TITLE
chore: simplify type

### DIFF
--- a/packages/better-auth/src/types/models.ts
+++ b/packages/better-auth/src/types/models.ts
@@ -1,7 +1,6 @@
 import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
 import type { Session, User } from "@better-auth/core/db";
 import type { InferFieldsFromOptions, InferFieldsFromPlugins } from "../db";
-import type { Auth } from "./auth";
 import type { StripEmptyObjects, UnionToIntersection } from "./helper";
 
 export type AdditionalUserFieldsInput<Options extends BetterAuthOptions> =
@@ -20,28 +19,13 @@ export type AdditionalSessionFieldsOutput<Options extends BetterAuthOptions> =
 	InferFieldsFromPlugins<Options, "session", "output"> &
 		InferFieldsFromOptions<Options, "session", "output">;
 
-export type InferUser<O extends BetterAuthOptions | Auth> = UnionToIntersection<
-	StripEmptyObjects<
-		User &
-			(O extends BetterAuthOptions
-				? AdditionalUserFieldsOutput<O>
-				: O extends Auth
-					? AdditionalUserFieldsOutput<O["options"]>
-					: {})
-	>
+export type InferUser<O extends BetterAuthOptions> = UnionToIntersection<
+	StripEmptyObjects<User & AdditionalUserFieldsOutput<O>>
 >;
 
-export type InferSession<O extends BetterAuthOptions | Auth> =
-	UnionToIntersection<
-		StripEmptyObjects<
-			Session &
-				(O extends BetterAuthOptions
-					? AdditionalSessionFieldsOutput<O>
-					: O extends Auth
-						? AdditionalSessionFieldsOutput<O["options"]>
-						: {})
-		>
-	>;
+export type InferSession<O extends BetterAuthOptions> = UnionToIntersection<
+	StripEmptyObjects<Session & AdditionalSessionFieldsOutput<O>>
+>;
 
 export type InferPluginTypes<O extends BetterAuthOptions> =
 	O["plugins"] extends Array<infer P>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified type helpers by making InferUser and InferSession accept only BetterAuthOptions, removing conditional handling for Auth. This reduces type complexity and makes inference more predictable.

- **Refactors**
  - Removed Auth import and union generics in InferUser/InferSession.
  - Types now compose User/Session with Additional*FieldsOutput based solely on options.

- **Migration**
  - If you passed Auth to InferUser/InferSession, use auth.options instead.

<sup>Written for commit 32163e7dfa6d9d81286b7d64b96a3d153eff9a6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

