### PR TITLE
chore: enable sourcemap for packages

### DIFF
--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -5,4 +5,5 @@ export default defineConfig({
 	format: ["esm"],
 	entry: ["./src/index.ts", "./src/api.ts"],
 	external: ["better-auth", "better-call"],
+	sourcemap: true,
 });

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
 		BETTER_AUTH_TELEMETRY_ENDPOINT:
 			process.env.BETTER_AUTH_TELEMETRY_ENDPOINT ?? "",
 	},
+	sourcemap: true,
 	unbundle: true,
 	clean: true,
 });

--- a/packages/drizzle-adapter/tsdown.config.ts
+++ b/packages/drizzle-adapter/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
 	dts: { build: true, incremental: true },
 	format: ["esm"],
 	entry: ["./src/index.ts"],
+	sourcemap: true,
 });

--- a/packages/expo/tsdown.config.ts
+++ b/packages/expo/tsdown.config.ts
@@ -13,5 +13,6 @@ export default defineConfig({
 		"expo-linking",
 		"expo-constants",
 	],
+	sourcemap: true,
 	treeshake: true,
 });

--- a/packages/i18n/tsdown.config.ts
+++ b/packages/i18n/tsdown.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
 	format: ["esm"],
 	entry: ["./src/index.ts", "./src/client.ts"],
 	external: ["@better-auth/core", "better-auth"],
+	sourcemap: true,
 	treeshake: true,
 });

--- a/packages/kysely-adapter/tsdown.config.ts
+++ b/packages/kysely-adapter/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
 	dts: { build: true, incremental: true },
 	format: ["esm"],
 	entry: ["./src/index.ts", "./src/node-sqlite-dialect.ts"],
+	sourcemap: true,
 });

--- a/packages/memory-adapter/tsdown.config.ts
+++ b/packages/memory-adapter/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
 	dts: { build: true, incremental: true },
 	format: ["esm"],
 	entry: ["./src/index.ts"],
+	sourcemap: true,
 });

--- a/packages/mongo-adapter/tsdown.config.ts
+++ b/packages/mongo-adapter/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
 	dts: { build: true, incremental: true },
 	format: ["esm"],
 	entry: ["./src/index.ts"],
+	sourcemap: true,
 });

--- a/packages/oauth-provider/tsdown.config.ts
+++ b/packages/oauth-provider/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 		"better-auth",
 		"better-call",
 	],
+	sourcemap: true,
 	treeshake: true,
 	clean: true,
 });

--- a/packages/passkey/tsdown.config.ts
+++ b/packages/passkey/tsdown.config.ts
@@ -12,5 +12,6 @@ export default defineConfig({
 		"@better-auth/core",
 		"better-auth",
 	],
+	sourcemap: true,
 	treeshake: true,
 });

--- a/packages/prisma-adapter/tsdown.config.ts
+++ b/packages/prisma-adapter/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
 	dts: { build: true, incremental: true },
 	format: ["esm"],
 	entry: ["./src/index.ts"],
+	sourcemap: true,
 });

--- a/packages/scim/tsdown.config.ts
+++ b/packages/scim/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
 	dts: { build: true, incremental: true },
 	format: ["esm"],
 	entry: ["./src/index.ts", "./src/client.ts"],
+	sourcemap: true,
 });

--- a/packages/sso/tsdown.config.ts
+++ b/packages/sso/tsdown.config.ts
@@ -5,4 +5,5 @@ export default defineConfig({
 	format: ["esm"],
 	entry: ["./src/index.ts", "./src/client.ts"],
 	external: ["better-auth", "better-call", "@better-fetch/fetch", "stripe"],
+	sourcemap: true,
 });

--- a/packages/stripe/tsdown.config.ts
+++ b/packages/stripe/tsdown.config.ts
@@ -5,4 +5,5 @@ export default defineConfig({
 	format: ["esm"],
 	entry: ["./src/index.ts", "./src/client.ts"],
 	external: ["better-auth", "better-call", "@better-fetch/fetch", "stripe"],
+	sourcemap: true,
 });

--- a/packages/telemetry/tsdown.config.ts
+++ b/packages/telemetry/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
 	dts: { build: true, incremental: true },
 	format: ["esm"],
 	entry: ["./src/index.ts"],
+	sourcemap: true,
 });

--- a/packages/test-utils/tsdown.config.ts
+++ b/packages/test-utils/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
 	entry: {
 		adapter: "./src/adapter/index.ts",
 	},
+	sourcemap: true,
 	unbundle: true,
 	outDir: "./dist",
 	clean: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enabled source maps across all packages to improve debugging and provide clearer stack traces in ESM builds. Set sourcemap: true in each tsdown.config.ts with no API or runtime changes.

<sup>Written for commit cdcfbda633210f0af1a98ac9d2be7ca33ffff0b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

