### PR TITLE
fix(device-anthorization): authentication requirement in deny endpoint

### DIFF
--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -688,13 +688,14 @@ export const deviceDeny = createAuthEndpoint(
 			}),
 		}),
 		error: z.object({
-			error: z.enum(["invalid_request", "expired_token"]).meta({
+			error: z.enum(["invalid_request", "expired_token", "unauthorized"]).meta({
 				description: "Error code",
 			}),
 			error_description: z.string().meta({
 				description: "Detailed error description",
 			}),
 		}),
+		requireHeaders: true,
 		metadata: {
 			openapi: {
 				description: "Deny device authorization",
@@ -719,6 +720,15 @@ export const deviceDeny = createAuthEndpoint(
 		},
 	},
 	async (ctx) => {
+		const session = await getSessionFromCtx(ctx);
+		if (!session) {
+			throw new APIError("UNAUTHORIZED", {
+				error: "unauthorized",
+				error_description:
+					DEVICE_AUTHORIZATION_ERROR_CODES.AUTHENTICATION_REQUIRED.message,
+			});
+		}
+
 		const { userCode } = ctx.body;
 		const cleanUserCode = userCode.replace(/-/g, "");
 


### PR DESCRIPTION
Add session requirement to the `/device/deny` endpoint to prevent denial-of-service attacks.

The `/device/deny` endpoint previously lacked authentication, allowing anyone with a valid `userCode` to deny pending device authorization requests. This fix aligns its security requirements with the `/device/approve` endpoint, requiring an authenticated user session to perform the denial.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1769481117322019?thread_ts=1769481117.322019&cid=C0A8B5BARUK)

<a href="https://cursor.com/background-agent?bcId=bc-d32f6c0c-3bb2-4bb3-b83b-2b66e354617f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d32f6c0c-3bb2-4bb3-b83b-2b66e354617f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require authentication for the /device/deny endpoint to block denial-of-service via public userCode. Aligns security with /device/approve.

- **Bug Fixes**
  - Enforce auth on /device/deny using requireHeaders and getSessionFromCtx.
  - Add "unauthorized" error type; return "Authentication required" when no session.
  - Update tests to use authenticated headers and verify the new requirement.

- **Migration**
  - Call /device/deny with an authenticated user session and include auth headers.

<sup>Written for commit 654545a4ed6f06f2da28b1528bbfe34bfe6b7aef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

