### PR TITLE
fix(oauth-provider): honor prompt=none for OIDC

### DIFF
--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -333,6 +333,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						nonce: z.string().optional(),
 						prompt: z
 							.enum([
+								"none",
 								"consent",
 								"login",
 								"create",


### PR DESCRIPTION
The OIDC standard allows prompt=none to be a valid value. This commit fixes hte plugin to honor the standard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the OAuth provider to accept prompt=none per the OIDC spec. This enables silent login flows and prevents validation errors with compliant clients.

<sup>Written for commit 60c7a7b3e410eb6141b1b387a61adc34a88f724b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

