### PR TITLE
feat(device-authorization): add user id checks

### DIFF
--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -577,6 +577,8 @@ export const deviceApprove = createAuthEndpoint(
 					"invalid_request",
 					"expired_token",
 					"device_code_already_processed",
+					"unauthorized",
+					"access_denied",
 				])
 				.meta({
 					description: "Error code",
@@ -657,6 +659,18 @@ export const deviceApprove = createAuthEndpoint(
 			});
 		}
 
+		// Check if userId is set and matches the current user
+		if (
+			deviceCodeRecord.userId &&
+			deviceCodeRecord.userId !== session.user.id
+		) {
+			throw new APIError("FORBIDDEN", {
+				error: "access_denied",
+				error_description:
+					"You are not authorized to approve this device authorization",
+			});
+		}
+
 		// Update device code with approved status and user ID
 		await ctx.context.adapter.update({
 			model: "deviceCode",
@@ -688,13 +702,21 @@ export const deviceDeny = createAuthEndpoint(
 			}),
 		}),
 		error: z.object({
-			error: z.enum(["invalid_request", "expired_token"]).meta({
-				description: "Error code",
-			}),
+			error: z
+				.enum([
+					"invalid_request",
+					"expired_token",
+					"unauthorized",
+					"access_denied",
+				])
+				.meta({
+					description: "Error code",
+				}),
 			error_description: z.string().meta({
 				description: "Detailed error description",
 			}),
 		}),
+		requireHeaders: true,
 		metadata: {
 			openapi: {
 				description: "Deny device authorization",
@@ -719,6 +741,15 @@ export const deviceDeny = createAuthEndpoint(
 		},
 	},
 	async (ctx) => {
+		const session = await getSessionFromCtx(ctx);
+		if (!session) {
+			throw new APIError("UNAUTHORIZED", {
+				error: "unauthorized",
+				error_description:
+					DEVICE_AUTHORIZATION_ERROR_CODES.AUTHENTICATION_REQUIRED.message,
+			});
+		}
+
 		const { userCode } = ctx.body;
 		const cleanUserCode = userCode.replace(/-/g, "");
 
@@ -757,7 +788,19 @@ export const deviceDeny = createAuthEndpoint(
 			});
 		}
 
-		// Update device code with denied status
+		// Check if userId is set and matches the current user
+		if (
+			deviceCodeRecord.userId &&
+			deviceCodeRecord.userId !== session.user.id
+		) {
+			throw new APIError("FORBIDDEN", {
+				error: "access_denied",
+				error_description:
+					"You are not authorized to deny this device authorization",
+			});
+		}
+
+		// Update device code with denied status and userId if not already set
 		await ctx.context.adapter.update({
 			model: "deviceCode",
 			where: [
@@ -768,6 +811,7 @@ export const deviceDeny = createAuthEndpoint(
 			],
 			update: {
 				status: "denied",
+				userId: deviceCodeRecord.userId || session.user.id,
 			},
 		});
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces user-bound checks in device authorization so only the signed-in user can approve or deny a device code. Adds authentication to deny, tracks userId, prevents re-approval, and expands error responses.

- **New Features**
  - Require authentication for deviceDeny; request headers are now mandatory.
  - Validate userId on approve/deny; block actions by a different user.
  - Store userId when approving/denying; prevent re-approval of processed codes.
  - Add error codes: unauthorized and access_denied (approve/deny), device_code_already_processed (approve).
  - Add tests covering auth requirements, userId checks, and re-approval prevention.

- **Migration**
  - Clients must send authenticated headers to deviceDeny.
  - Handle new error responses: unauthorized, access_denied, and device_code_already_processed.

<sup>Written for commit 76c6a7f036ea801401a1318fc84f882910aa3460. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

