### PR TITLE
chore: use more `APIError.from`

### DIFF
--- a/packages/better-auth/src/api/middlewares/origin-check.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.ts
@@ -245,7 +245,7 @@ async function validateOrigin(
 			`If it's a valid URL, please add ${originHeader} to trustedOrigins in your auth config\n`,
 			`Current list of trustedOrigins: ${trustedOrigins}`,
 		);
-		throw new APIError("FORBIDDEN", { message: "Invalid origin" });
+		throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.INVALID_ORIGIN);
 	}
 }
 

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -378,7 +378,7 @@ export const verifyPassword = createAuthEndpoint(
 		});
 
 		if (!isValid) {
-			throw new APIError("BAD_REQUEST", BASE_ERROR_CODES.INVALID_PASSWORD);
+			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_PASSWORD);
 		}
 
 		return ctx.json({

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -88,9 +88,10 @@ export const updateUser = <O extends BetterAuthOptions>() =>
 			};
 
 			if (typeof body !== "object" || Array.isArray(body)) {
-				throw new APIError("BAD_REQUEST", {
-					message: "Body must be an object",
-				});
+				throw APIError.from(
+					"BAD_REQUEST",
+					BASE_ERROR_CODES.BODY_MUST_BE_AN_OBJECT,
+				);
 			}
 
 			if (body.email) {
@@ -359,10 +360,7 @@ export const setPassword = createAuthEndpoint(
 				status: true,
 			});
 		}
-		throw APIError.from("BAD_REQUEST", {
-			message: "user already has a password",
-			code: "USER_ALREADY_HAS_PASSWORD",
-		});
+		throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_ALREADY_SET);
 	},
 );
 

--- a/packages/core/src/error/codes.ts
+++ b/packages/core/src/error/codes.ts
@@ -51,6 +51,8 @@ export const BASE_ERROR_CODES = defineErrorCodes({
 	MISSING_FIELD: "Field is required",
 	METHOD_NOT_ALLOWED_DEFER_SESSION_REQUIRED:
 		"POST method requires deferSessionRefresh to be enabled in session config",
+	BODY_MUST_BE_AN_OBJECT: "Body must be an object",
+	PASSWORD_ALREADY_SET: "User already has a password set",
 });
 
 export type APIErrorCode = keyof typeof BASE_ERROR_CODES;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized error handling by switching to APIError.from and BASE_ERROR_CODES in origin checks, password verification, and user update routes. This makes error responses consistent and easier to consume.

- **Refactors**
  - Origin check: FORBIDDEN with INVALID_ORIGIN.
  - verifyPassword: BAD_REQUEST with INVALID_PASSWORD.
  - updateUser body validation: BAD_REQUEST with BODY_MUST_BE_AN_OBJECT.
  - setPassword: BAD_REQUEST with PASSWORD_ALREADY_SET.

<sup>Written for commit 5f1d776b8b648cdafb7671ca27dd2183f1f3c879. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

