### PR TITLE
fix: check jsconfig.json in getPathAliases

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -120,7 +120,10 @@ function getPathAliasesRecursive(
 }
 
 function getPathAliases(cwd: string): Record<string, string> | null {
-	const tsConfigPath = path.join(cwd, "tsconfig.json");
+	let tsConfigPath = path.join(cwd, "tsconfig.json");
+	if (!fs.existsSync(tsConfigPath)) {
+		tsConfigPath = path.join(cwd, "jsconfig.json");
+	}
 	if (!fs.existsSync(tsConfigPath)) {
 		return null;
 	}


### PR DESCRIPTION
## Summary

- Fall back to `jsconfig.json` when `tsconfig.json` is not found in `getPathAliases`
- Fixes JSDoc-based SvelteKit projects where `@better-auth/cli generate` fails because aliases (`$env/*`, `$app/*`, `$lib/*`) are never registered

Fixes #7649

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
getPathAliases now falls back to jsconfig.json when tsconfig.json is missing. This fixes @better-auth/cli generate for JSDoc-based SvelteKit projects by correctly registering $env/*, $app/*, and $lib/* aliases.

<sup>Written for commit ff5d5e1ea96fbd7e3e928dc59df976ccfb60619a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

