### PR TITLE
chore: simplify type

### DIFF
--- a/packages/better-auth/src/types/helper.ts
+++ b/packages/better-auth/src/types/helper.ts
@@ -1,13 +1,5 @@
-import type { Primitive } from "@better-auth/core";
-
-export type LiteralNumber = 0 | (number & Record<never, never>);
-
-export type OmitId<T extends { id: unknown }> = Omit<T, "id">;
-
 export type Prettify<T> = Omit<T, never>;
-export type PreserveJSDoc<T> = {
-	[K in keyof T]: T[K];
-} & {};
+
 export type PrettifyDeep<T> = {
 	[K in keyof T]: T[K] extends (...args: any[]) => any
 		? T[K]
@@ -19,9 +11,6 @@ export type PrettifyDeep<T> = {
 					: PrettifyDeep<T[K]>
 			: T[K];
 } & {};
-export type LiteralUnion<LiteralType, BaseType extends Primitive> =
-	| LiteralType
-	| (BaseType & Record<never, never>);
 
 export type UnionToIntersection<U> = (
 	U extends any
@@ -42,16 +31,5 @@ export type RequiredKeysOf<BaseType extends object> = Exclude<
 
 export type HasRequiredKeys<BaseType extends object> =
 	RequiredKeysOf<BaseType> extends never ? false : true;
-export type WithoutEmpty<T> = T extends T ? ({} extends T ? never : T) : never;
 
-export type StripEmptyObjects<T> = T extends { [K in keyof T]: never }
-	? never
-	: T extends object
-		? { [K in keyof T as T[K] extends never ? never : K]: T[K] }
-		: T;
-export type DeepPartial<T> = T extends Function
-	? T
-	: T extends object
-		? { [K in keyof T]?: DeepPartial<T[K]> }
-		: T;
-export type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+export type StripEmptyObjects<T extends object> = { [K in keyof T]: T[K] };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified and tightened type definitions across client and DB helpers to reduce complexity and improve type safety.

- **Refactors**
  - Standardized field inference to use Fields extends Record<string, DBFieldAttribute>, returning never on invalid schemas.
  - Switched client plugin schema inference to BetterAuthPluginDBSchema and removed InferPluginsFromClient.
  - Simplified StripEmptyObjects and removed unused helpers (LiteralNumber, LiteralUnion, DeepPartial, Expand, PreserveJSDoc, OmitId).
  - Added guards in InferFieldsFromPlugins and options; additionalFields now explicitly typed as a DBFieldAttribute map.

- **Migration**
  - If you relied on {} fallbacks in field inference, update code to handle never types.
  - If you used removed helpers or expected StripEmptyObjects to drop empty keys, replace with local utilities or adjust usage.

<sup>Written for commit 740bb8daed676a440b39a82bd60bfb050a8290f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

