### PR TITLE
chore: make `expo-network` optional peerDeps

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -88,6 +88,9 @@
     "expo-linking": {
       "optional": true
     },
+    "expo-network": {
+      "optional": true
+    },
     "expo-web-browser": {
       "optional": true
     }


### PR DESCRIPTION
This has always been required on the expoClient. I had removed it along with updating the docs. I’m reverting it.

- Closes https://github.com/better-auth/better-auth/issues/7603

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make expo-network an optional peer dependency in the expo package so apps that don’t use it aren’t forced to install it. Closes #7603.

- **Migration**
  - If your app uses expo-network, add it to your project dependencies.

<sup>Written for commit 7162e6c8c50a74e15e4efc1957c320930dcd4592. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

