### PR TITLE
fix(email-otp): add stricter default rate limits for password reset endpoints

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -149,6 +149,27 @@ export const emailOTP = (options: EmailOTPOptions) => {
 				window: 60,
 				max: 3,
 			},
+			{
+				pathMatcher(path) {
+					return path === "/email-otp/request-password-reset";
+				},
+				window: 60,
+				max: 3,
+			},
+			{
+				pathMatcher(path) {
+					return path === "/email-otp/reset-password";
+				},
+				window: 60,
+				max: 3,
+			},
+			{
+				pathMatcher(path) {
+					return path === "/forget-password/email-otp";
+				},
+				window: 60,
+				max: 3,
+			},
 		],
 		options,
 		$ERROR_CODES: EMAIL_OTP_ERROR_CODES,


### PR DESCRIPTION
Seeing the others applied, these were probably missed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds default rate limits to email OTP password reset endpoints to reduce abuse. Applies a 60s window with a max of 3 requests per endpoint.

- **Bug Fixes**
  - Added rate limit for /email-otp/request-password-reset: 60s window, max 3.
  - Added rate limit for /email-otp/reset-password: 60s window, max 3.
  - Added rate limit for /forget-password/email-otp: 60s window, max 3.

<sup>Written for commit 04ee3a8eee3feed240af3881b17b3e7b601f9415. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

