### PR TITLE
fix(sso): remove direct `better-call` runtime dependency

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -90,8 +90,7 @@
 		"packages/sso": {
 			"ignoreDependencies": [
 				// type-only dependencies
-				"@better-auth/core",
-				"better-call"
+				"@better-auth/core"
 			]
 		},
 		"packages/test-utils": {

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -73,7 +73,6 @@
     "@types/body-parser": "^1.19.6",
     "@types/express": "^5.0.6",
     "better-auth": "workspace:*",
-    "better-call": "catalog:",
     "body-parser": "^2.2.2",
     "express": "^5.2.1",
     "oauth2-mock-server": "^8.2.1",

--- a/packages/sso/src/saml-state.ts
+++ b/packages/sso/src/saml-state.ts
@@ -1,7 +1,7 @@
 import type { GenericEndpointContext, StateData } from "better-auth";
 import { generateGenericState, parseGenericState } from "better-auth";
+import { APIError } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
-import { APIError } from "better-call";
 
 export async function generateRelayState(
 	c: GenericEndpointContext,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1811,9 +1811,6 @@ importers:
       better-auth:
         specifier: workspace:*
         version: link:../better-auth
-      better-call:
-        specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
       body-parser:
         specifier: ^2.2.2
         version: 2.2.2


### PR DESCRIPTION
- Closes https://github.com/better-auth/better-auth/issues/7219

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the direct better-call dependency from the SSO package and uses APIError from better-auth instead. This simplifies runtime dependencies and avoids shipping better-call.

- **Dependencies**
  - Removed better-call from packages/sso/package.json and pnpm-lock.
  - Switched APIError import in saml-state.ts to better-auth/api.
  - Updated knip.jsonc to stop ignoring better-call.

<sup>Written for commit d0b619e6c478341ba2433601fd28b83d5d4f234c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

