### PR TITLE
chore(stripe): remove unused `better-call` devDependency

### DIFF
--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -65,7 +65,6 @@
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
-    "better-call": "catalog:",
     "stripe": "^20.2.0",
     "tsdown": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1842,9 +1842,6 @@ importers:
       better-auth:
         specifier: workspace:*
         version: link:../better-auth
-      better-call:
-        specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
       stripe:
         specifier: ^20.2.0
         version: 20.2.0(@types/node@25.0.10)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused better-call devDependency from the Stripe package and cleaned up pnpm-lock to reflect the change. This reduces dependency bloat and avoids unnecessary installs.

<sup>Written for commit f337c1c0e33824dff6a6673346ffab88eb0a0fc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

