### PR TITLE
fix(oauth-provider): honor prompt=none for OIDC

### DIFF
--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -341,6 +341,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						nonce: z.string().optional(),
 						prompt: z
 							.enum([
+								"none",
 								"consent",
 								"login",
 								"create",


### PR DESCRIPTION
The OIDC standard allows prompt=none to be a valid value. This commit fixes hte plugin to honor the standard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts prompt=none in OIDC requests to match the spec and support silent authentication flows. Prevents validation errors from clients using prompt=none.

<sup>Written for commit 6c4da7ef1b996aacd98fdf7f1212ff69618c3353. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

