### PR TITLE
docs(oauth-provider): remove production warning

### DIFF
--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -36,10 +36,6 @@ The plugin has a secured configuration by default providing ease to users unfami
 - **refresh_token**: Issue refresh tokens and handle access token renewal using `offline_access` scope.
 - **client_credentials**: Machine to Machine tokens for API communication.
 
-<Callout type="warn">
-This plugin is in active development and may not be suitable for production use. Please report any issues or bugs on [GitHub](https://github.com/better-auth/better-auth).
-</Callout>
-
 ## Installation
 
 <Steps>


### PR DESCRIPTION
The OAuth 2.1 provider plugin is now stable and ready for production use.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the production warning from the OAuth 2.1 provider plugin documentation to reflect its stable, production-ready status.

<sup>Written for commit ae14db09a8de2ae84a1501fdc251341fca7572f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

