### PR TITLE
fix(stripe): restore `better-call` peerDeps

### DIFF
--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -60,11 +60,13 @@
   "peerDependencies": {
     "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
+    "better-call": "catalog:",
     "stripe": "^18 || ^19 || ^20"
   },
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
+    "better-call": "catalog:",
     "stripe": "^20.2.0",
     "tsdown": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1842,6 +1842,9 @@ importers:
       better-auth:
         specifier: workspace:*
         version: link:../better-auth
+      better-call:
+        specifier: 'catalog:'
+        version: 1.2.0(zod@4.3.6)
       stripe:
         specifier: ^20.2.0
         version: 20.2.0(@types/node@25.0.10)


### PR DESCRIPTION
This caused a type issue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored better-call in the stripe package by adding it to peerDependencies and devDependencies to resolve type issues and ensure proper integration with better-auth. Updated pnpm-lock.yaml to include better-call 1.2.0.

<sup>Written for commit d3d838b46b17eb56f5465251a1b000e75da12363. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

