### PR TITLE
fix(access): allow passing statements directly into `newRole`

### DIFF
--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from "vitest";
 import { createAccessControl } from "./access";
 
 describe("access", () => {
-  const statements = {
+	const statements = {
 		project: ["create", "update", "delete", "delete-many"],
 		ui: ["view", "edit", "comment", "hide"],
-  } as const;
+	} as const;
 	const ac = createAccessControl(statements);
 
 	const role1 = ac.newRole({
 		project: ["create", "update", "delete"],
 		ui: ["view", "edit", "comment"],
 	});
-	
+
 	it("should allow passing defined statements directly into newRole", () => {
-	  const role2 = ac.newRole(statements);
-    const response = role2.authorize({
-      project: ["create"],
-    });
-    expect(response.success).toBe(true);
+		const role2 = ac.newRole(statements);
+		const response = role2.authorize({
+			project: ["create"],
+		});
+		expect(response.success).toBe(true);
 	});
 
 	it("should validate permissions", async () => {

--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -80,8 +80,8 @@ export function createAccessControl<const TStatements extends Statements>(
 	s: TStatements,
 ) {
 	return {
-		newRole<K extends keyof TStatements>(statements: Subset<K, TStatements> | TStatements) {
-			return role<Subset<K, TStatements> | TStatements>(statements);
+		newRole<K extends keyof TStatements>(statements: Subset<K, TStatements>) {
+			return role<Subset<K, TStatements>>(statements);
 		},
 		statements: s,
 	};

--- a/packages/better-auth/src/plugins/access/types.ts
+++ b/packages/better-auth/src/plugins/access/types.ts
@@ -2,7 +2,8 @@ import type { LiteralString } from "@better-auth/core";
 import type { AuthorizeResponse, createAccessControl } from "./access";
 
 export type SubArray<T extends unknown[] | readonly unknown[] | any[]> =
-	T[number][];
+	| T[number][]
+	| ReadonlyArray<T[number]>;
 
 export type Subset<
 	K extends keyof R,


### PR DESCRIPTION
closes #7681

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow passing the full statements object directly into newRole in the access control plugin. Fixes the type restriction and satisfies Linear #7681.

- **Bug Fixes**
  - Updated newRole to accept either a subset of statements or the full TStatements.
  - Added a test to verify authorization works when passing the defined statements object.

<sup>Written for commit e66c8e542c150c76832e79f4bd74bb23b64475df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

