### PR TITLE
docs: add callout for access control bundle size

### DIFF
--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -485,7 +485,7 @@ The plugin provides an easy way to define your own set of permissions for each r
     ```
     
     <Callout type="warning">
-      Make sure to import from `better-auth/plugins/access`, rather than from `better-auth/plugins`, to avoid unnecessary large bundle sizes.
+      To keep bundle sizes small, make sure to import from `better-auth/plugins/access` instead of `better-auth/plugins`.
     </Callout>
     </Step>
 

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1268,7 +1268,7 @@ The plugin provides an easy way to define your own set of permissions for each r
     ```
     
     <Callout type="warning">
-      Make sure to import from `better-auth/plugins/access`, rather than from `better-auth/plugins`, to avoid unnecessary large bundle sizes.
+      To keep bundle sizes small, make sure to import from `better-auth/plugins/access` instead of `better-auth/plugins`.
     </Callout>
     </Step>
 


### PR DESCRIPTION
closes #7637

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a warning callout in the admin and organization plugin docs to import access control from `better-auth/plugins/access` instead of `better-auth/plugins` to keep bundle sizes small. Connects to Linear #7637 by clarifying the correct import path to avoid bundle bloat.

<sup>Written for commit 8a2b1dc3002c62a12680948d51c2cd86041fa611. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

