### PR TITLE
docs: clarify `updatePhoneNumber` option usage

### DIFF
--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -7,7 +7,7 @@ import { APIError } from "../../api";
 import { isAPIError } from "../../utils/is-api-error";
 
 declare module "@better-auth/core" {
-	interface BetterAuthPluginRegistry<_AuthOptions, _Options> {
+	interface BetterAuthPluginRegistry<AuthOptions, Options> {
 		"have-i-been-pwned": {
 			creator: typeof haveIBeenPwned;
 		};


### PR DESCRIPTION
> [!NOTE]
> We don't need that callout since each option already has its own section.

- Closes https://github.com/better-auth/better-auth/issues/7694

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how to update a logged-in user's phone number in the phone-number plugin docs: updatePhoneNumber is now shown as opt-in (default false) with a clear send OTP → verify example. Removes a redundant callout and simplifies wording to avoid confusion.

<sup>Written for commit 00bd05ca8ad53cab7f2e5267aade169497a65afc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

