### PR TITLE
fix(admin): change list type from `never[]` to `UserWithRole[]`

### DIFF
--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -688,7 +688,7 @@ export const listUsers = (opts: AdminOptions) =>
 				});
 			} catch {
 				return ctx.json({
-					users: [],
+					users: [] as UserWithRole[],
 					total: 0,
 				});
 			}


### PR DESCRIPTION
Prevents type inference issues and ensures the list correctly represents users with roles instead of collapsing to never.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TypeScript typing in admin listUsers by returning an empty array as UserWithRole[] instead of never[]. This prevents inference issues and keeps the response type consistent for consumers.

<sup>Written for commit 881675901ad928384b3487daa48aaf7cc9114bd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

