### PR TITLE
fix(email-otp): throw USER_NOT_FOUND when email records do not exist (#7696)

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -115,7 +115,12 @@ export const sendVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 			const user = await ctx.context.internalAdapter.findUserByEmail(email);
 			if (!user) {
 				if (ctx.body.type === "sign-in" && !opts.disableSignUp) {
-					// allow
+					// allow sign-up flow to continue
+				} else if (ctx.body.type === "sign-in" && opts.disableSignUp) {
+					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+						`${ctx.body.type}-otp-${email}`,
+					);
+					throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.USER_NOT_FOUND);
 				} else {
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 						`${ctx.body.type}-otp-${email}`,


### PR DESCRIPTION
**PR description:**

1. **What & why**  
   - When the Email OTP plugin was used with disableSignUp: true, calling sendVerificationOTP with type: "sign-in" for an unregistered email returned 200 with { success: true } instead of an error. That made it impossible for clients to tell “user not found” from “OTP sent,” and broke flows that rely on showing a “no account” message or redirecting to sign-up.

2. **Link to the issue**  
   - Fixes #7696

3. **What changed**  
   - File(s) and behavior: e.g. `sendVerificationOTP` in `email-otp/routes.ts` now throws `USER_NOT_FOUND` for sign-in when `disableSignUp` is true and the user doesn’t exist; test updated/added in `email-otp.test.ts`.

4. **Testing**  
   - ran `pnpm -F better-auth test -- email-otp --run`  and it passes.

5. **Breaking / behavior change**  
   - Note that clients using `disableSignUp: true` with sign-in OTP will now get a 400 + `USER_NOT_FOUND` for non-existent emails instead of 200. No config or migration change.

6. **Target branch**  
   - Open the PR against **canary**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 USER_NOT_FOUND for Email OTP sign-in when disableSignUp is enabled and the email has no account. This removes the ambiguous success response so apps can show “no account” messages and meets the needs of #7696.

- **Bug Fixes**
  - Updated sendVerificationOTP to throw BAD_REQUEST with USER_NOT_FOUND for non-existent emails in sign-in when disableSignUp is true, and clear any pending verification for that identifier.
  - Updated tests to expect the error and verify no OTP is sent to unknown emails.

<sup>Written for commit 05e658e83db38d23fb7b015fc3c0853cf74fe576. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

