### PR TITLE
Add auth handler for latest version

### DIFF
--- a/docs/content/docs/integrations/hono.mdx
+++ b/docs/content/docs/integrations/hono.mdx
@@ -51,6 +51,12 @@ app.on(["POST", "GET"], "/api/auth/*", (c) => {
 	return auth.handler(c.req.raw);
 });
 
+// On better-auth 1.4.18
+// app.on(["GET", "POST"], "/auth/*", (c) => {
+//  const req = new Request(c.req.raw.url, c.req.raw);
+//  return auth(c.env).handler(req);
+// });
+
 serve(app);
 ```
 


### PR DESCRIPTION
The latest version treats the request as immutable so we need to create a copy of the request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Hono integration docs for better-auth 1.4.18 to handle immutable Request objects. Adds an example that copies the Request before calling the auth handler to prevent runtime errors.

<sup>Written for commit 4b39cba797386ce07bb85fe792598db7a1aab73b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

