### PR TITLE
OAuth proxy early redirect

### DIFF
--- a/docs/content/docs/plugins/oauth-proxy.mdx
+++ b/docs/content/docs/plugins/oauth-proxy.mdx
@@ -73,3 +73,40 @@ This plugin requires skipping the state cookie check. This has security implicat
 **productionURL**: If this value matches the `baseURL` in your auth config, requests will not be proxied. Defaults to the `BETTER_AUTH_URL` environment variable.
 
 **maxAge**: Maximum age in seconds for encrypted cookie payloads. Payloads older than this will be rejected to prevent replay attacks. Keep this value short (e.g., 30-60 seconds) to minimize the window for potential replay attacks while still allowing normal OAuth flows. Defaults to `60` seconds.
+
+**earlyRedirect**: When enabled, the production server will redirect to the preview/current server BEFORE processing the OAuth callback. This allows the preview server to run the full callback logic against its own database. This is useful when the production server and preview server have different databases, as the session and user data need to be created in the preview server's database. Defaults to `false`.
+
+## Early Redirect Mode
+
+By default, the OAuth proxy processes the callback on the production server and then redirects to the preview server to set cookies. This works well when both servers share the same database.
+
+However, if your preview deployments have separate databases from production, you need the preview server to process the entire callback so that user and session data are created in the correct database.
+
+Enable `earlyRedirect` to handle this scenario:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+import { oAuthProxy } from "better-auth/plugins"
+
+export const auth = betterAuth({
+    plugins: [
+        oAuthProxy({
+            productionURL: "https://my-main-app.com",
+            earlyRedirect: true, // [!code highlight]
+        }),
+    ]
+})
+```
+
+### How Early Redirect Works
+
+1. User initiates OAuth sign-in on the preview server
+2. Preview server redirects to OAuth provider (with callback URL pointing to production)
+3. OAuth provider redirects to production server with the authorization code
+4. Production server immediately redirects to preview server with the code (without processing)
+5. Preview server processes the callback, creating user and session in its own database
+6. User is redirected to the final callback URL with cookies set
+
+<Callout type="info">
+Both the production and preview servers must use the same `secret` in their Better Auth configuration for the encrypted state to be decrypted correctly.
+</Callout>

--- a/packages/better-auth/src/plugins/oauth-proxy/types.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/types.ts
@@ -11,6 +11,11 @@ type OAuthConfigSnapshot = {
 
 export type AuthContextWithSnapshot = AuthContext & {
 	_oauthProxySnapshot?: OAuthConfigSnapshot;
+	/**
+	 * Flag indicating this callback is being processed on the preview server
+	 * after an early redirect from the production server.
+	 */
+	_oauthProxyEarlyRedirect?: boolean;
 };
 
 /**
@@ -20,4 +25,15 @@ export type OAuthProxyStatePackage = {
 	state: string;
 	stateCookie: string;
 	isOAuthProxy: boolean;
+	/**
+	 * If true, the production server will redirect to the preview server
+	 * BEFORE processing the callback, allowing the preview server to run
+	 * the full callback logic against its own database.
+	 */
+	earlyRedirect?: boolean;
+	/**
+	 * The preview server's base URL to redirect to for early redirect flow.
+	 * Required when earlyRedirect is true.
+	 */
+	previewBaseURL?: string;
 };


### PR DESCRIPTION
Add `earlyRedirect` option to OAuth proxy to enable full callback processing on preview servers with separate databases.

The previous OAuth proxy flow processed the callback on the production server and then redirected to the preview server to set cookies. This caused issues when preview deployments used separate databases, as user and session data would be created in the production database, making the preview session invalid. The `earlyRedirect` option ensures the preview server handles the entire callback, creating data in its own database.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1769820693965299?thread_ts=1769820693.965299&cid=C0A8B5BARUK)

<a href="https://cursor.com/background-agent?bcId=bc-746ce3d0-6073-576f-b535-4dbab88c6940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-746ce3d0-6073-576f-b535-4dbab88c6940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add earlyRedirect to the OAuth proxy so preview servers process the full OAuth callback against their own database. This fixes invalid preview sessions when production and preview use different databases.

- **New Features**
  - earlyRedirect option redirects the provider callback from production to the preview server before processing.
  - State package now includes earlyRedirect and previewBaseURL; preview runs the full callback and sets cookies.
  - After-hook skips proxy redirect when processing on preview (prevents double redirects).
  - Added tests and docs for “Early Redirect Mode”.

- **Migration**
  - Enable earlyRedirect: true in the OAuth proxy config on both production and preview.
  - Use the same Better Auth secret on both servers.

<sup>Written for commit f07c87dfb52049c83d60d4787cec61890c96a0af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

