### PR TITLE
fix(sso): allow custom organization roles in provisioning types

### DIFF
--- a/packages/sso/src/linking/org-assignment.ts
+++ b/packages/sso/src/linking/org-assignment.ts
@@ -4,13 +4,13 @@ import type { NormalizedSSOProfile } from "./types";
 
 export interface OrganizationProvisioningOptions {
 	disabled?: boolean;
-	defaultRole?: "member" | "admin";
+	defaultRole?: string;
 	getRole?: (data: {
 		user: User & Record<string, any>;
 		userInfo: Record<string, any>;
 		token?: OAuth2Tokens;
 		provider: SSOProvider<SSOOptions>;
-	}) => Promise<"member" | "admin">;
+	}) => Promise<string>;
 }
 
 export interface AssignOrganizationFromProviderOptions {


### PR DESCRIPTION
### Problem
The SSO plugin currently restricts organization role assignment to `"member" | "admin"` at the TypeScript level.  
This contradicts:

- The Organization plugin schema, which defines roles as arbitrary strings
- Existing runtime behavior, which already supports custom roles
- Documentation describing custom role provisioning with SSO

As a result, using custom organization roles in SSO flows requires unsafe type assertions.

### Solution
- Widen `getRole` return type to `Promise<string>`
- Widen `defaultRole` to `string`

This aligns SSO plugin types with actual runtime behavior and documentation, without changing any logic.

### Notes
- This is a type-only change
- No runtime behavior is modified
- Role validation remains handled by the Organization plugin schema
- Existing usages remain fully compatible

fixes #7719 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow custom organization roles in SSO provisioning by widening defaultRole and getRole from "member" | "admin" to string. Aligns types with the Organization schema and current behavior; no logic changes (fixes #7719).

<sup>Written for commit 72c8679251c467a01c10b4fbbc44c5af2c4bac43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

