### PR TITLE
fix: include haveIBeenPawened error logs 

### DIFF
--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -1,5 +1,6 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { getCurrentAuthContext } from "@better-auth/core/context";
+import { createLogger } from "@better-auth/core/env";
 import { defineErrorCodes } from "@better-auth/core/utils/error-codes";
 import { createHash } from "@better-auth/utils/hash";
 import { betterFetch } from "@better-fetch/fetch";
@@ -59,6 +60,8 @@ async function checkPasswordCompromise(
 		}
 	} catch (error) {
 		if (isAPIError(error)) throw error;
+		const logger = createLogger();
+		logger.error("Failed to check password against HaveIBeenPwned API", error);
 		throw new APIError("INTERNAL_SERVER_ERROR", {
 			message: "Failed to check password. Please try again later.",
 		});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add server-side logging for failures when checking passwords against the HaveIBeenPwned API. Uses createLogger to record the error before returning a generic INTERNAL_SERVER_ERROR to clients for better observability without leaking details.

<sup>Written for commit c168072edd8d0f68b89689a078c94ca2907e41f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

