### PR TITLE
docs: add quick start section to TanStack Start integration

### DIFF
--- a/docs/content/docs/integrations/tanstack.mdx
+++ b/docs/content/docs/integrations/tanstack.mdx
@@ -7,6 +7,19 @@ This integration guide is assuming you are using TanStack Start.
 
 Before you start, make sure you have a Better Auth instance configured. If you haven't done that yet, check out the [installation](/docs/installation).
 
+## Quick Start
+
+You can create a new TanStack Start project with Better Auth integrated using the following command. This CLI sets up a project with an auth instance configured with the plugin and mounted handlers.
+
+```package-install
+npm create @tanstack/start
+
+◇  What add-ons would you like for your project?
+│  Better Auth
+```
+
+## Usage
+
 ### Mount the handler
 
 We need to mount the handler to a TanStack API endpoint/Server Route.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a Quick Start to the TanStack Start integration guide to help users scaffold a project with Better Auth in one step. It shows running npm create @tanstack/start, selecting the “Better Auth” add-on, and notes the CLI configures the auth plugin and mounts handlers.

<sup>Written for commit 0ad163b646235295329fee4bd3e2b708d7d1e144. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

