### PR TITLE
fix(organization): sync members role if the role name was changed

### DIFF
--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -258,13 +258,19 @@ export const organizationClient = <CO extends OrganizationClientOptions>(
 			},
 			{
 				matcher(path) {
-					return path.includes("/organization/update-member-role");
+					return (
+						path.includes("/organization/update-member-role") ||
+						path.includes("/organization/update-role")
+					);
 				},
 				signal: "$activeMemberSignal",
 			},
 			{
 				matcher(path) {
-					return path.includes("/organization/update-member-role");
+					return (
+						path.includes("/organization/update-member-role") ||
+						path.includes("/organization/update-role")
+					);
 				},
 				signal: "$activeMemberRoleSignal",
 			},

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
@@ -653,6 +653,88 @@ describe("dynamic access control", async (it) => {
 		expect(targetMemberAfter?.role).toBe(newRoleName);
 	});
 
+	it("should update member's role when member has multiple roles", async () => {
+		// Create two dynamic roles
+		const role1 = await authClient.organization.createRole(
+			{
+				role: "update-multi-1",
+				permission: { project: ["read"] },
+				additionalFields: { color: "#000000" },
+			},
+			{ headers },
+		);
+		const role2 = await authClient.organization.createRole(
+			{
+				role: "update-multi-2",
+				permission: { project: ["create"] },
+				additionalFields: { color: "#111111" },
+			},
+			{ headers },
+		);
+		if (!role1.data || !role2.data) throw new Error("Roles not created");
+
+		// Create a member with multiple roles
+		const memberDetails = {
+			email: `multi-role-update-${crypto.randomUUID()}@email.com`,
+			name: "test-member",
+			password: `password-${crypto.randomUUID()}`,
+		};
+		const memberUser = await auth.api.signUpEmail({ body: memberDetails });
+		await auth.api.addMember({
+			body: {
+				// @ts-expect-error - for testing purposes
+				role: ["update-multi-1", "update-multi-2"],
+				userId: memberUser.user.id,
+				organizationId: org.data?.id,
+			},
+			headers,
+		});
+
+		// Verify member has both roles
+		const memberBefore = await auth.api.listMembers({
+			query: { organizationId: org.data?.id },
+			headers,
+		});
+		const targetBefore = memberBefore.members?.find(
+			(m) => m.userId === memberUser.user.id,
+		);
+		expect(targetBefore?.role).toBe("update-multi-1,update-multi-2");
+
+		// Update role1's name
+		await auth.api.updateOrgRole({
+			body: {
+				roleName: "update-multi-1",
+				data: { roleName: "updated-multi-1" },
+			},
+			headers,
+		});
+
+		// Verify the member's role is updated (only role1 should change)
+		const memberAfter = await auth.api.listMembers({
+			query: { organizationId: org.data?.id },
+			headers,
+		});
+		const targetAfter = memberAfter.members?.find(
+			(m) => m.userId === memberUser.user.id,
+		);
+		expect(targetAfter?.role).toBe("updated-multi-1,update-multi-2");
+
+		// Clean up
+		const memberId = targetAfter?.id!;
+		await auth.api.updateMemberRole({
+			body: { memberId, role: "member" },
+			headers,
+		});
+		await auth.api.deleteOrgRole({
+			body: { roleName: "updated-multi-1" },
+			headers,
+		});
+		await auth.api.deleteOrgRole({
+			body: { roleName: "update-multi-2" },
+			headers,
+		});
+	});
+
 	it("should not be allowed to update a role without the right ac resource permissions", async () => {
 		const testRole = await authClient.organization.createRole(
 			{

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -10,7 +10,7 @@ import type { AccessControl } from "../../access";
 import { orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { hasPermission } from "../has-permission";
-import type { Member, OrganizationRole } from "../schema";
+import type { Invitation, Member, OrganizationRole } from "../schema";
 import type { OrganizationOptions } from "../types";
 
 type IsExactlyEmptyObject<T> = keyof T extends never // no keys
@@ -1106,6 +1106,87 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 								{
 									field: "id",
 									value: member.id,
+									operator: "eq",
+								},
+							],
+							update: {
+								role: updatedRoles.join(","),
+							},
+						});
+					}),
+				);
+
+				// Batch update - pending invitations with exactly this single role
+				await ctx.context.adapter.update<Invitation>({
+					model: "invitation",
+					where: [
+						{
+							field: "organizationId",
+							value: organizationId,
+							operator: "eq",
+							connector: "AND",
+						},
+						{
+							field: "role",
+							value: oldRoleName,
+							operator: "eq",
+							connector: "AND",
+						},
+						{
+							field: "status",
+							value: "pending",
+							operator: "eq",
+						},
+					],
+					update: {
+						role: newRoleName,
+					},
+				});
+
+				// Individual updates - pending invitations with multiple roles
+				const invitationsInOrg = await ctx.context.adapter.findMany<Invitation>(
+					{
+						model: "invitation",
+						where: [
+							{
+								field: "organizationId",
+								value: organizationId,
+								operator: "eq",
+								connector: "AND",
+							},
+							{
+								field: "status",
+								value: "pending",
+								operator: "eq",
+							},
+						],
+					},
+				);
+
+				const invitationsWithMultipleRoles = invitationsInOrg.filter(
+					(invitation) => {
+						if (!invitation.role.includes(",")) return false;
+						const invitationRoles = invitation.role
+							.split(",")
+							.map((r) => r.trim());
+						return invitationRoles.includes(oldRoleName);
+					},
+				);
+
+				await Promise.all(
+					invitationsWithMultipleRoles.map((invitation) => {
+						const invitationRoles = invitation.role
+							.split(",")
+							.map((r) => r.trim());
+						const updatedRoles = invitationRoles.map((r) =>
+							r === oldRoleName ? newRoleName : r,
+						);
+						return ctx.context.adapter.update<Invitation>({
+							model: "invitation",
+							where: [
+								{
+									field: "id",
+									value: invitation.id,
 									operator: "eq",
 								},
 							],

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -1050,6 +1050,30 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 			});
 
 			// -----
+			// Update members role if the role name was changed
+			if (updateData.role && updateData.role !== role.role) {
+				await ctx.context.adapter.update<Member>({
+					model: "member",
+					where: [
+						{
+							field: "organizationId",
+							value: organizationId,
+							operator: "eq",
+							connector: "AND",
+						},
+						{
+							field: "role",
+							value: role.role,
+							operator: "eq",
+						},
+					],
+					update: {
+						role: updateData.role,
+					},
+				});
+			}
+
+			// -----
 			// Return the updated role
 			return ctx.json({
 				success: true,


### PR DESCRIPTION
- Closes #7727

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renaming an organization role now automatically updates all member records and pending invitations using that role, including multi‑role cases, keeping access control consistent. The client also reacts to role updates so active member and role state stay in sync. Addresses #7727.

- **Bug Fixes**
  - UpdateOrgRole cascades the new role name to members in the org, including multi‑role members.
  - Pending invitations are updated to the new role name, including multi‑role invites.
  - Client listeners watch /organization/update-role to refresh active member and role signals.
  - Added tests for role rename updates for members and invitations.

<sup>Written for commit 2717b40288a46bbc67405d138332e02e373c62ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

