### PR TITLE
fix(email-otp): typo in OpenAPI response metadata

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -927,7 +927,7 @@ export const resetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) =>
 					responses: {
 						200: {
 							description: "Success",
-							contnt: {
+							content: {
 								"application/json": {
 									schema: {
 										type: "object",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                          
  - Fix typo `contnt` → `content` in OpenAPI response metadata for `resetPasswordWithEmailOTP` endpoint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a typo in the OpenAPI response metadata for the reset password via email OTP endpoint, renaming "contnt" to "content". This restores a valid schema so generators and docs parse the response correctly.

<sup>Written for commit c5001ca90d33c8347ede72cb2504aee1a4534c97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

