### PR TITLE
chore: bump `better-call`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 1.1.21
       version: 1.1.21
     better-call:
-      specifier: 1.2.0
-      version: 1.2.0
+      specifier: 1.2.1
+      version: 1.2.1
     tsdown:
       specifier: ^0.20.1
       version: 0.20.1
@@ -1273,7 +1273,7 @@ importers:
         version: 5.22.0(prisma@5.22.0)
       better-call:
         specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
+        version: 1.2.1(zod@4.3.6)
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -1510,7 +1510,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
+        version: 1.2.1(zod@4.3.6)
       jose:
         specifier: ^6.1.0
         version: 6.1.3
@@ -1549,7 +1549,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
+        version: 1.2.1(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1652,7 +1652,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
+        version: 1.2.1(zod@4.3.6)
       jose:
         specifier: ^6.1.0
         version: 6.1.3
@@ -1692,7 +1692,7 @@ importers:
         version: 13.2.2
       better-call:
         specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
+        version: 1.2.1(zod@4.3.6)
       nanostores:
         specifier: ^1.0.1
         version: 1.1.0
@@ -1763,7 +1763,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
+        version: 1.2.1(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1813,7 +1813,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
+        version: 1.2.1(zod@4.3.6)
       body-parser:
         specifier: ^2.2.2
         version: 2.2.2
@@ -1844,7 +1844,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.2.0(zod@4.3.6)
+        version: 1.2.1(zod@4.3.6)
       stripe:
         specifier: ^20.2.0
         version: 20.2.0(@types/node@25.0.10)
@@ -8289,6 +8289,14 @@ packages:
 
   better-call@1.2.0:
     resolution: {integrity: sha512-7msprrikJah2Pq+OPJOUkqqlDOpVQysBPfxLfXQZr1XeIPqUD3O5z6qxh0vsAU8m/GDFbJD0n1a4vvTnekM7Kw==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  better-call@1.2.1:
+    resolution: {integrity: sha512-Ccgd5hj2Fmtu9Vjb9APXNYxutJWPRDhJanWAzFLwSzYAiOvkXN61OmYdvSirfrL2Z7REuK7TRklP8SIbZRlGwA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -23031,6 +23039,15 @@ snapshots:
       validator: 13.15.15
 
   better-call@1.2.0(zod@4.3.6):
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      zod: 4.3.6
+
+  better-call@1.2.1(zod@4.3.6):
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ blockExoticSubdeps: true
 catalog:
   '@better-auth/utils': 0.3.1
   '@better-fetch/fetch': 1.1.21
-  better-call: 1.2.0
+  better-call: 1.2.1
   tsdown: ^0.20.1
   typescript: ^5.9.3
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade better-call from 1.2.0 to 1.2.1 to pull in the latest patch and ensure consistent dependency resolution across the workspace. Changes are limited to pnpm-workspace.yaml and pnpm-lock.yaml; no application code is affected.

<sup>Written for commit 6690f603c8479f9c183d6baff70faab6d8debd2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

