### PR TITLE
feat(anonymous): add body params to signInAnonymous

### DIFF
--- a/docs/content/docs/plugins/anonymous.mdx
+++ b/docs/content/docs/plugins/anonymous.mdx
@@ -74,6 +74,19 @@ To sign in a user anonymously, use the `signIn.anonymous()` method.
 const user = await authClient.signIn.anonymous()
 ```
 
+You can optionally pass a `name` and `image` to set the user's profile:
+
+```ts title="example.ts"
+const user = await authClient.signIn.anonymous({
+    name: "Guest User",
+    image: "https://example.com/avatar.png"
+})
+```
+
+<Callout type="info">
+If both `name` is provided in the request body and `generateName` is configured, the body value takes priority.
+</Callout>
+
 ### Link Account
 
 If a user is already signed in anonymously and tries to `signIn` or `signUp` with another method,
@@ -181,6 +194,10 @@ and the `/delete-anonymous-user` endpoint will no longer be accessible to anonym
 ### `generateName`
 
 A callback function that is called to generate a name for the anonymous user. Useful if you want to have random names for anonymous users, or if `name` is unique in your database.
+
+<Callout type="info">
+If a `name` is provided in the request body when calling `signIn.anonymous()`, it will take priority over `generateName`.
+</Callout>
 
 ## Schema
 

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -179,6 +179,75 @@ describe("anonymous", async () => {
 		expect(res.data?.user.name).toBe("i-am-anonymous");
 	});
 
+	it("should accept name in the body", async () => {
+		const testHeaders = new Headers();
+		const { client, sessionSetter } = await getTestInstance(
+			{
+				plugins: [anonymous()],
+			},
+			{
+				clientOptions: {
+					plugins: [anonymousClient()],
+				},
+			},
+		);
+		const res = await client.signIn.anonymous({
+			name: "custom-name",
+			fetchOptions: {
+				onSuccess: sessionSetter(testHeaders),
+			},
+		});
+		expect(res.data?.user.name).toBe("custom-name");
+	});
+
+	it("should accept image in the body", async () => {
+		const testHeaders = new Headers();
+		const { client, sessionSetter } = await getTestInstance(
+			{
+				plugins: [anonymous()],
+			},
+			{
+				clientOptions: {
+					plugins: [anonymousClient()],
+				},
+			},
+		);
+		const res = await client.signIn.anonymous({
+			image: "https://example.com/avatar.png",
+			fetchOptions: {
+				onSuccess: sessionSetter(testHeaders),
+			},
+		});
+		expect(res.data?.user.image).toBe("https://example.com/avatar.png");
+	});
+
+	it("should prioritize body name over generateName option", async () => {
+		const testHeaders = new Headers();
+		const { client, sessionSetter } = await getTestInstance(
+			{
+				plugins: [
+					anonymous({
+						generateName() {
+							return "generated-name";
+						},
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [anonymousClient()],
+				},
+			},
+		);
+		const res = await client.signIn.anonymous({
+			name: "body-name",
+			fetchOptions: {
+				onSuccess: sessionSetter(testHeaders),
+			},
+		});
+		expect(res.data?.user.name).toBe("body-name");
+	});
+
 	it("should work with generateRandomEmail", async () => {
 		const testHeaders = new Headers();
 		const { client, sessionSetter } = await getTestInstance(

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -15,7 +15,7 @@ import {
 	parseSetCookieHeader,
 	setSessionCookie,
 } from "../../cookies";
-import { mergeSchema, parseUserOutput } from "../../db/schema";
+import { mergeSchema, parseUserInput, parseUserOutput } from "../../db/schema";
 import { ANONYMOUS_ERROR_CODES } from "./error-codes";
 import { schema } from "./schema";
 import type {
@@ -63,9 +63,35 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 				"/sign-in/anonymous",
 				{
 					method: "POST",
+					body: z
+						.object({
+							name: z.string().optional(),
+							image: z.string().optional(),
+						})
+						.and(z.record(z.string(), z.any())),
 					metadata: {
 						openapi: {
 							description: "Sign in anonymously",
+							requestBody: {
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												name: {
+													type: "string",
+													description: "The name of the anonymous user",
+												},
+												image: {
+													type: "string",
+													description:
+														"The profile image URL of the anonymous user",
+												},
+											},
+										},
+									},
+								},
+							},
 							responses: {
 								200: {
 									description: "Sign in anonymously",
@@ -104,13 +130,20 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 						);
 					}
 
+					const { name, image, ...rest } = ctx.body;
 					const email = await getAnonUserEmail(options);
-					const name = (await options?.generateName?.(ctx)) || "Anonymous";
+					const additionalFields = parseUserInput(
+						ctx.context.options,
+						rest,
+						"create",
+					);
 					const newUser = await ctx.context.internalAdapter.createUser({
 						email,
 						emailVerified: false,
+						name: name ?? (await options?.generateName?.(ctx)) ?? "Anonymous",
+						image,
+						...additionalFields,
 						isAnonymous: true,
-						name,
 						createdAt: new Date(),
 						updatedAt: new Date(),
 					});


### PR DESCRIPTION
Includes following changes for the anonymous plugin: 
  - Adds optional name and image body parameters to the `signInAnonymous` endpoint                                                                                                               
  - Allows passing additional user fields through the request body (uses `parseUserInput` for schema validation)                                                                                 
  - Body name takes priority over `generateName` option, falling back to "Anonymous" if neither is provided
  - Updates related docs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for passing name, image, and extra validated user fields in the signIn.anonymous request body to set anonymous profile data. The body name overrides generateName, with a fallback to "Anonymous"; docs and tests updated.

<sup>Written for commit df144cc94673fec2f9642362f0e20484b20734e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

