### PR TITLE
chore: correct environment variable name in baseURL warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,14 +201,3 @@ test-results/
 state.txt
 
 .cursor/
-
-# Auto Claude data directory
-.auto-claude/
-
-# Auto Claude generated files
-.auto-claude-security.json
-.auto-claude-status
-.claude_settings.json
-.worktrees/
-.security-key
-logs/security/


### PR DESCRIPTION
Fix: ENV variable name in warning for Base URL
Misc: add auto-claude files to gitignore

Closes: #7748

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the base URL warning to use BETTER_AUTH_URL, fixing the incorrect env var reference (closes #7748).

<sup>Written for commit e6f2999937d7fc81f461a3cd26b950b1378f6b23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

