### PR TITLE
fix(expo): `expo-web-browser` is not installed as a dependency

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -375,7 +375,7 @@ export const expoClient = (opts: ExpoClientOptions) => {
 
 							if (Platform.OS === "android") {
 								try {
-									Browser.dismissAuthSession();
+									Browser!.dismissAuthSession();
 								} catch {}
 							}
 
@@ -391,7 +391,7 @@ export const expoClient = (opts: ExpoClientOptions) => {
 								params.append("oauthState", oauthStateValue);
 							}
 							const proxyURL = `${context.request.baseURL}/expo-authorization-proxy?${params.toString()}`;
-							const result = await Browser.openAuthSessionAsync(
+							const result = await Browser!.openAuthSessionAsync(
 								proxyURL,
 								to,
 								opts?.webBrowserOptions,


### PR DESCRIPTION
Fix: Error: "expo-web-browser" is not installed as a dependency!
- Closes #7739

## Unit Tests

Don't see how this could be unit tested as the `expo-web-browser` import is mocked.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the false “expo-web-browser is not installed” error by trying require() when the dynamic import fails, and adds non-null assertions around Browser calls. Restores compatibility in Nx monorepos and mixed CJS/ESM setups.

- **Bug Fixes**
  - If import("expo-web-browser") fails, fall back to require(); only throw if both fail.
  - Use Browser! for dismissAuthSession and openAuthSessionAsync to prevent undefined access.

<sup>Written for commit d8a6620d823fbd3b2556addff48ad2da4e6927e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





