### PR TITLE
refactor: remove unused trailing AND connectors

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -156,7 +156,6 @@ export const createOrgRole = <O extends OrganizationOptions>(options: O) => {
 						field: "userId",
 						value: user.id,
 						operator: "eq",
-						connector: "AND",
 					},
 				],
 			});
@@ -215,7 +214,6 @@ export const createOrgRole = <O extends OrganizationOptions>(options: O) => {
 						field: "organizationId",
 						value: organizationId,
 						operator: "eq",
-						connector: "AND",
 					},
 				],
 			});
@@ -348,7 +346,6 @@ export const deleteOrgRole = <O extends OrganizationOptions>(options: O) => {
 						field: "userId",
 						value: user.id,
 						operator: "eq",
-						connector: "AND",
 					},
 				],
 			});
@@ -419,14 +416,12 @@ export const deleteOrgRole = <O extends OrganizationOptions>(options: O) => {
 					field: "role",
 					value: ctx.body.roleName,
 					operator: "eq",
-					connector: "AND",
 				};
 			} else if (ctx.body.roleId) {
 				condition = {
 					field: "id",
 					value: ctx.body.roleId,
 					operator: "eq",
-					connector: "AND",
 				};
 			} else {
 				// shouldn't be able to reach here given the schema validation.
@@ -541,7 +536,6 @@ export const listOrgRoles = <O extends OrganizationOptions>(options: O) => {
 						field: "userId",
 						value: user.id,
 						operator: "eq",
-						connector: "AND",
 					},
 				],
 			});
@@ -594,7 +588,6 @@ export const listOrgRoles = <O extends OrganizationOptions>(options: O) => {
 						field: "organizationId",
 						value: organizationId,
 						operator: "eq",
-						connector: "AND",
 					},
 				],
 			});
@@ -680,7 +673,6 @@ export const getOrgRole = <O extends OrganizationOptions>(options: O) => {
 						field: "userId",
 						value: user.id,
 						operator: "eq",
-						connector: "AND",
 					},
 				],
 			});
@@ -737,7 +729,6 @@ export const getOrgRole = <O extends OrganizationOptions>(options: O) => {
 					field: "id",
 					value: ctx.query.roleId,
 					operator: "eq",
-					connector: "AND",
 				};
 			} else {
 				// shouldn't be able to reach here given the schema validation.
@@ -884,7 +875,6 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 						field: "userId",
 						value: user.id,
 						operator: "eq",
-						connector: "AND",
 					},
 				],
 			});
@@ -936,7 +926,6 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 					field: "id",
 					value: ctx.body.roleId,
 					operator: "eq",
-					connector: "AND",
 				};
 			} else {
 				// shouldn't be able to reach here given the schema validation.
@@ -1220,7 +1209,6 @@ async function checkIfRoleNameIsTakenByRoleInDB({
 				field: "role",
 				value: role,
 				operator: "eq",
-				connector: "AND",
 			},
 		],
 	});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unnecessary "connector: 'AND'" fields from organization role access-control queries. This aligns with the filter API and avoids malformed filters.

- **Refactors**
  - Dropped trailing AND connectors from single-condition filters across role create, delete, list, get, and update routes.
  - No behavior change; queries use the builder’s default AND handling.

<sup>Written for commit c8e52e28320586b4e6448abe51a2f20647587a03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

