### PR TITLE
fix(adapter): use `getCurrentAdapter` for user lookup to avoid transaction deadlock

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -358,7 +358,9 @@ export const createInternalAdapter = (
 									);
 								}
 
-								const user = await adapter.findOne<User>({
+								const user = await (
+									await getCurrentAdapter(adapter)
+								).findOne<User>({
 									model: "user",
 									where: [
 										{


### PR DESCRIPTION
- Problem: direct calls to adapter.findOne(...) can bypass the transaction-bound adapter when running inside runWithTransaction, causing potential deadlocks.
- Fix: replace direct adapter.findOne calls with await (await getCurrentAdapter(adapter)).findOne(...) so lookups use the transaction-aware adapter.
- Impact: prevents transaction deadlocks during user lookup; run transactional tests to verify.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route user lookups in InternalAdapter through getCurrentAdapter so they use the transaction-bound adapter. Prevents deadlocks when running inside runWithTransaction.

<sup>Written for commit 74116c483a5fa8cdc2254fc804aea46df5898bf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

