### PR TITLE
fix(nextjs): detect RSC context to prevent unnecessary session refresh

### DIFF
--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -269,8 +269,10 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 
 							const timeUntilExpiry = sessionDataPayload.expiresAt - Date.now();
 							const updateAge = cookieRefreshCache.updateAge * 1000; // Convert to milliseconds
+							const shouldSkipSessionRefresh =
+								await getShouldSkipSessionRefresh();
 
-							if (timeUntilExpiry < updateAge) {
+							if (timeUntilExpiry < updateAge && !shouldSkipSessionRefresh) {
 								const cookieMaxAge =
 									ctx.context.options.session?.cookieCache?.maxAge || 60 * 5;
 								const newExpiresAt = getDate(cookieMaxAge, "sec");


### PR DESCRIPTION
> [!NOTE]
> References:
> https://github.com/vercel/next.js/issues/65787#issuecomment-2701037353
> https://nextjs.org/docs/app/api-reference/functions/cookies#good-to-know 

The changes in PR #7625 were incomplete because RSC headers are inaccessible. I've updated it to detect RSC by using the constraints of `cookies.set()` in reverse.

- Closes #7394

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects Server Component context in Next.js by probing cookie mutability and skips session refresh when cookies can’t be set. This prevents unnecessary refreshes and avoids DB/cookie mismatches in RSC requests. Closes #7394.

- **Bug Fixes**
  - Added /get-session middleware that attempts cookies().set; on failure, flags shouldSkipSessionRefresh for RSC requests.
  - Updated getSession route to honor shouldSkipSessionRefresh before refreshing sessions near expiry.

<sup>Written for commit f18c36435d638e92a7291c8826847d1a927da6b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

