### PR TITLE
fix(expo): make expo-network non-optional

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -88,9 +88,6 @@
     "expo-linking": {
       "optional": true
     },
-    "expo-network": {
-      "optional": true
-    },
     "expo-web-browser": {
       "optional": true
     }


### PR DESCRIPTION
Remove `expo-network` from `peerDependenciesMeta` to fix "Unable to resolve module expo-network" errors.

Metro (React Native bundler) attempts to resolve all imports at bundle time, even dynamic ones. Marking `expo-network` as optional in `peerDependenciesMeta` while it's always imported in `online-manager.ts` caused resolution failures if the package wasn't explicitly installed. By removing it from `peerDependenciesMeta`, it becomes a required peer dependency, ensuring it's always installed.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1770059765236129?thread_ts=1770059765.236129&cid=C0A8B5BARUK)

<a href="https://cursor.com/background-agent?bcId=bc-a4e41e15-8bab-50e7-a1aa-86bb7d510741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4e41e15-8bab-50e7-a1aa-86bb7d510741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make expo-network a required peer dependency in the Expo package to prevent Metro “Unable to resolve module expo-network” errors. Remove expo-network from peerDependenciesMeta because online-manager always imports it.

<sup>Written for commit 62c2c721dda35cc7a1ae0eb75a7ae888fd49fe7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

