### PR TITLE
Expo state mismatch

### DIFF
--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -478,6 +478,62 @@ describe("expo", async () => {
 		expect(proxyUrl.searchParams.has("authorizationURL")).toBe(true);
 		expect(proxyUrl.searchParams.has("oauthState")).toBe(false);
 	});
+
+	it("should set signed state cookie in browser context via expo-authorization-proxy (database strategy)", async () => {
+		fn.mockClear();
+
+		const expoWebBrowser = await import("expo-web-browser");
+		const { parseSetCookieHeader } = await import("../src/client");
+
+		vi.mocked(expoWebBrowser.openAuthSessionAsync).mockImplementationOnce(
+			async (proxyURL, to, webBrowserOptions) => {
+				const proxyUrlStr = String(proxyURL);
+				const proxyUrl = new URL(proxyUrlStr);
+
+				// Verify database strategy doesn't include oauthState
+				expect(proxyUrl.searchParams.has("oauthState")).toBe(false);
+
+				// Extract state from the authorizationURL parameter
+				const authorizationURL = proxyUrl.searchParams.get("authorizationURL");
+				expect(authorizationURL).toBeTruthy();
+				const authUrl = new URL(authorizationURL!);
+				const stateFromUrl = authUrl.searchParams.get("state");
+				expect(stateFromUrl).toBeTruthy();
+
+				// Call the proxy endpoint
+				const res = await auth.handler(
+					new Request(proxyUrlStr, { method: "GET" }),
+				);
+
+				expect(res.status).toBe(302);
+
+				// Verify signed state cookie is set
+				const setCookie = res.headers.get("set-cookie");
+				expect(setCookie).toBeTruthy();
+
+				const cookieMap = parseSetCookieHeader(setCookie!);
+				const stateCookie = [...cookieMap.entries()].find(
+					([name]) => name.includes(".state") && !name.includes("oauth_state"),
+				);
+
+				expect(stateCookie).toBeTruthy();
+				// The signed cookie value should contain the state
+				expect(stateCookie![1].value).toContain(stateFromUrl);
+
+				fn(proxyURL, to, webBrowserOptions);
+				return {
+					type: "success",
+					url: "better-auth://?cookie=better-auth.session_token=dummy",
+				};
+			},
+		);
+
+		await client.signIn.social({
+			provider: "google",
+			callbackURL: "/dashboard",
+		});
+		expect(fn).toHaveBeenCalled();
+	});
 });
 
 describe("expo with cookieCache", async () => {


### PR DESCRIPTION
Add an end-to-end test for the Expo database strategy to verify correct state cookie handling by the `expo-authorization-proxy`.

This PR addresses state mismatch issues with Expo by adding a test to ensure the `expo-authorization-proxy` correctly sets the signed state cookie when using the database strategy. This validates the fix introduced in v1.5.0-beta.7+ (PR #6933), which was designed to bridge the gap where Expo's system browser couldn't access cookies set by the native app, leading to state validation failures.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1770060223898539?thread_ts=1770060223.898539&cid=C0A8B5BARUK)

<a href="https://cursor.com/background-agent?bcId=bc-c2798645-ca10-59b3-96cd-fce3d60ef323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c2798645-ca10-59b3-96cd-fce3d60ef323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end test for the Expo OAuth database strategy to ensure the expo-authorization-proxy sets a signed state cookie in the browser. This guards against state mismatch by verifying oauthState is not in the proxy URL, the state is read from authorizationURL, and a signed state cookie is issued.

<sup>Written for commit dbe888a948186aa51841c194c4abe284cf69d9ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

