### PR TITLE
Better-auth js integration

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -324,7 +324,10 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							// Only process and notify if the Set-Cookie header contains better-auth cookies
 							// This prevents infinite refetching when other cookies (like Cloudflare's __cf_bm) are present
 							if (hasBetterAuthCookies(setCookie, cookiePrefix)) {
-								const prevCookie = storage.getItem(cookieName);
+								// Support both sync and async storage implementations
+								const prevCookie = await Promise.resolve(
+									storage.getItem(cookieName),
+								);
 								const toSetCookie = getSetCookie(
 									setCookie || "",
 									prevCookie ?? undefined,
@@ -377,7 +380,10 @@ export const expoClient = (opts: ExpoClientOptions) => {
 								} catch {}
 							}
 
-							const storedCookieJson = storage.getItem(cookieName);
+							// Support both sync and async storage implementations
+							const storedCookieJson = await Promise.resolve(
+								storage.getItem(cookieName),
+							);
 							const oauthStateValue = getOAuthStateValue(
 								storedCookieJson,
 								cookiePrefix,
@@ -398,7 +404,10 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							const url = new URL(result.url);
 							const cookie = url.searchParams.get("cookie");
 							if (!cookie) return;
-							const prevCookie = storage.getItem(cookieName);
+							// Support both sync and async storage implementations
+							const prevCookie = await Promise.resolve(
+								storage.getItem(cookieName),
+							);
 							const toSetCookie = getSetCookie(cookie, prevCookie ?? undefined);
 							storage.setItem(cookieName, toSetCookie);
 							store?.notify("$sessionSignal");
@@ -413,7 +422,10 @@ export const expoClient = (opts: ExpoClientOptions) => {
 						};
 					}
 					options = options || {};
-					const storedCookie = storage.getItem(cookieName);
+					// Support both sync and async storage implementations
+					const storedCookie = await Promise.resolve(
+						storage.getItem(cookieName),
+					);
 					const cookie = getCookie(storedCookie || "{}");
 					options.credentials = "omit";
 					options.headers = {


### PR DESCRIPTION
Fix Expo plugin sign-out not removing sessions from the database by awaiting async storage operations.

The Expo client's `storage.getItem()` calls were not `await`ed, leading to incorrect cookie values when an asynchronous storage implementation (like `AsyncStorage`) was used. This prevented the session token from being sent during sign-out, thus failing to delete the session on the server.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1770059909493239?thread_ts=1770059909.493239&cid=C0A8B5BARUK)

<a href="https://cursor.com/background-agent?bcId=bc-87f4e6d8-6aec-5638-b1d1-8137d65d01f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87f4e6d8-6aec-5638-b1d1-8137d65d01f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Expo client sign-out by awaiting storage.getItem so async storage (e.g., AsyncStorage) reads cookies correctly and the server session is deleted.

- **Bug Fixes**
  - Await storage.getItem with Promise.resolve to support both sync and async storage.
  - Sign-out now reliably sends the session token and deletes the DB session; tests added for async storage and bearer-token flows.

<sup>Written for commit 7c2cee6ddfa0604dfd463b91b464bf78ec5dad3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

