### PR TITLE
fix(expo): construct the new Request to avoid immutable headers error on Cloudflare Workers

### DIFF
--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -43,8 +43,12 @@ export const expo = (options?: ExpoOptions | undefined) => {
 			if (!expoOrigin) {
 				return;
 			}
-			const req = new Request(request.url, request);
-			req.headers.set("origin", expoOrigin);
+
+			// Construct new Headers with new Request to avoid mutating the original request
+			const newHeaders = new Headers(request.headers);
+			newHeaders.set("origin", expoOrigin);
+			const req = new Request(request, { headers: newHeaders });
+
 			return {
 				request: req,
 			};


### PR DESCRIPTION
> [!NOTE]
> https://developers.cloudflare.com/workers/examples/modify-request-property

We previously resolved the issue in the user's reproducible repo, but it still occurs when I test it in a Cloudflare Workers environment.

Related to https://github.com/better-auth/better-auth/issues/7014

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build a new Request with fresh Headers in the Expo integration so we can set the Origin header on Cloudflare Workers. This avoids the “immutable headers” error and restores compatibility (related to better-auth/better-auth#7014).

<sup>Written for commit a1d2407890e561cb90ac3d5904abd1ff9114804a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

