### PR TITLE
fix(oauth-provider): login via a sign-in provider redirects

### DIFF
--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -98,42 +98,42 @@ describe("cookies", async () => {
 		);
 	});
 
-	// describe("production environment", () => {
-	// 	afterEach(() => {
-	// 		vi.unstubAllEnvs();
-	// 		vi.resetModules();
-	// 	});
+	describe("production environment", () => {
+		afterEach(() => {
+			vi.unstubAllEnvs();
+			vi.resetModules();
+		});
 
-	// 	it("should use secure cookies when baseURL is not configured", async () => {
-	// 		// Set NODE_ENV to production
-	// 		vi.stubEnv("NODE_ENV", "production");
+		it("should use secure cookies when baseURL is not configured", async () => {
+			// Set NODE_ENV to production
+			vi.stubEnv("NODE_ENV", "production");
 
-	// 		// Reset modules to reload with new NODE_ENV
-	// 		vi.resetModules();
+			// Reset modules to reload with new NODE_ENV
+			vi.resetModules();
 
-	// 		// Re-import modules after NODE_ENV change
-	// 		const { getTestInstance: getTestInstanceReloaded } = await import(
-	// 			"../test-utils/test-instance"
-	// 		);
+			// Re-import modules after NODE_ENV change
+			const { getTestInstance: getTestInstanceReloaded } = await import(
+				"../test-utils/test-instance"
+			);
 
-	// 		const { client, testUser } = await getTestInstanceReloaded({
-	// 			baseURL: undefined,
-	// 		});
+			const { client, testUser } = await getTestInstanceReloaded({
+				baseURL: undefined,
+			});
 
-	// 		await client.signIn.email(
-	// 			{
-	// 				email: testUser.email,
-	// 				password: testUser.password,
-	// 			},
-	// 			{
-	// 				onResponse(context) {
-	// 					const setCookie = context.response.headers.get("set-cookie");
-	// 					expect(setCookie).toContain("Secure");
-	// 				},
-	// 			},
-	// 		);
-	// 	});
-	// });
+			await client.signIn.email(
+				{
+					email: testUser.email,
+					password: testUser.password,
+				},
+				{
+					onResponse(context) {
+						const setCookie = context.response.headers.get("set-cookie");
+						expect(setCookie).toContain("Secure");
+					},
+				},
+			);
+		});
+	});
 });
 
 describe("crossSubdomainCookies", () => {

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -35,10 +35,8 @@ export function createCookieGetter(options: BetterAuthOptions) {
 	const secure =
 		options.advanced?.useSecureCookies !== undefined
 			? options.advanced?.useSecureCookies
-			: options.baseURL !== undefined
+			: options.baseURL?.length
 				? options.baseURL.startsWith("https://")
-					? true
-					: false
 				: isProduction;
 	const secureCookiePrefix = secure ? SECURE_COOKIE_PREFIX : "";
 	const crossSubdomainEnabled =


### PR DESCRIPTION
Additionally uses `isProduction` for an empty string which is set in the `createAuthContext` function for baseURL. Fixes redirection from an oauth flow back to the original application for the oauth-provider plugin.

Related: #7558