### PR TITLE
fix(generic-oauth): emit duplicate id warning

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -53,6 +53,23 @@ export type BaseOAuthProviderOptions = Omit<
  * A generic OAuth plugin that can be used to add OAuth support to any provider
  */
 export const genericOAuth = (options: GenericOAuthOptions) => {
+	const seenIds = new Set<string>();
+	const nonUniqueIds = new Set<string>();
+
+	for (const config of options.config) {
+		const id = config.providerId;
+		if (seenIds.has(id)) {
+			nonUniqueIds.add(id);
+		}
+		seenIds.add(id);
+	}
+
+	if (nonUniqueIds.size > 0) {
+		console.warn(
+			`Duplicate provider IDs found: ${Array.from(nonUniqueIds).join(", ")}`,
+		);
+	}
+
 	return {
 		id: "generic-oauth",
 		init: (ctx: AuthContext) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Detect duplicate provider IDs in the generic OAuth plugin and log a console warning listing the duplicates to prevent misconfiguration. Adds tests for single, multiple, and no-duplicate scenarios to ensure correct behavior.

<sup>Written for commit 0a6920a25a28431ee2b53fb1430415694fbfb3e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

