### PR TITLE
chore: remove deprecated downlevelIteration option

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "downlevelIteration": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
This option is deprecated in TypeScript 6.0. It doesn't do anything when `target` is `esnext`, so can be safely removed from this config file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated downlevelIteration option from tsconfig. It’s a no-op with target esnext in TypeScript 6.0, so this simplifies the config and avoids deprecation warnings.

<sup>Written for commit 2ea2d4526b1d38a8c986fc24e64a28feb7389529. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

