### PR TITLE
fix(sso): fix broken relay state redirect on SAML ACS route

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -2329,7 +2329,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 		async (ctx) => {
 			const { SAMLResponse } = ctx.body;
 			const { providerId } = ctx.params;
-			const currentCallbackPath = `${ctx.context.baseURL}/sso/saml2/acs/${providerId}`;
+			const currentCallbackPath = `${ctx.context.baseURL}/sso/saml2/sp/acs/${providerId}`;
 			const appOrigin = new URL(ctx.context.baseURL).origin;
 
 			const maxResponseSize =


### PR DESCRIPTION
This is a naive fix for #7777 - it carries the same changes from #6675 over to the `/sso/saml/acs/:providerId` route. Please feel free to edit or replace this PR if desired - my only goal here is to get the issue fixed. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RelayState redirects on the SAML ACS route so users return to the correct app page after login, with safe origin validation to prevent open redirects. Aligns /sso/saml/acs/:providerId behavior with the saml2 ACS route.

- **Bug Fixes**
  - Parse RelayState and use relayState.callbackURL instead of the raw value.
  - Validate redirects with getSafeRedirectUrl (origin and callback path checks).
  - Respect parsed RelayState for error redirects; fallback to provider callbackUrl or baseURL.

<sup>Written for commit 84f96d923b1f40bdf00be6a1a35622b713b59d04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

