### PR TITLE
fix(passkey): use `deleteVerificationByIdentifier` for secondary-storage cleanup

### DIFF
--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -1,10 +1,19 @@
 import { APIError } from "@better-auth/core/error";
+import { base64 } from "@better-auth/utils/base64";
 import { createAuthClient } from "better-auth/client";
 import { getTestInstance } from "better-auth/test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Passkey } from ".";
 import { passkey } from ".";
 import { passkeyClient } from "./client";
+
+vi.mock("@simplewebauthn/server", async (importOriginal) => {
+	const mod = await importOriginal<typeof import("@simplewebauthn/server")>();
+	return {
+		...mod,
+		verifyAuthenticationResponse: vi.fn(mod.verifyAuthenticationResponse),
+	};
+});
 
 describe("passkey", async () => {
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
@@ -150,5 +159,115 @@ describe("passkey", async () => {
 			},
 		});
 		expect(deleteResult.status).toBe(true);
+	});
+});
+
+describe("passkey with secondary storage", async () => {
+	const store = new Map<string, string>();
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		plugins: [passkey()],
+		secondaryStorage: {
+			set(key, value, ttl) {
+				store.set(key, value);
+			},
+			get(key) {
+				return store.get(key) || null;
+			},
+			delete(key) {
+				store.delete(key);
+			},
+		},
+		rateLimit: {
+			enabled: false,
+		},
+	});
+
+	it("should clean up verification from secondary storage after passkey authentication", async () => {
+		const { verifyAuthenticationResponse } = await import(
+			"@simplewebauthn/server"
+		);
+		vi.mocked(verifyAuthenticationResponse).mockResolvedValueOnce({
+			verified: true,
+			authenticationInfo: {
+				newCounter: 1,
+				credentialID: "cleanup-test-credential",
+				credentialDeviceType: "singleDevice",
+				credentialBackedUp: false,
+				origin: "http://localhost:3000",
+				rpID: "localhost",
+				userVerified: true,
+				authenticatorExtensionResults: undefined,
+			},
+		});
+
+		const { headers, user } = await signInWithTestUser();
+		const ctx = await auth.$context;
+
+		await ctx.adapter.create<Omit<Passkey, "id">, Passkey>({
+			model: "passkey",
+			data: {
+				userId: user.id,
+				credentialID: "cleanup-test-credential",
+				publicKey: base64.encode(new Uint8Array(32)),
+				counter: 0,
+				deviceType: "singleDevice",
+				backedUp: false,
+				transports: "internal",
+				createdAt: new Date(),
+				aaguid: "00000000-0000-0000-0000-000000000000",
+				name: "Test Passkey",
+			} satisfies Omit<Passkey, "id">,
+		});
+
+		// Generate authentication options — creates verification in secondary storage
+		const generateRes = await customFetchImpl(
+			"http://localhost:3000/api/auth/passkey/generate-authenticate-options",
+			{ method: "GET", headers },
+		);
+		const setCookie = generateRes.headers.get("set-cookie");
+		const passkeyCookie = setCookie?.split(";")[0] || "";
+
+		// Verification should exist in secondary storage
+		const verificationKeys = [...store.keys()].filter((k) =>
+			k.startsWith("verification:"),
+		);
+		expect(verificationKeys.length).toBe(1);
+
+		// Verify authentication
+		const sessionCookie = headers.get("cookie") || "";
+		const verifyRes = await customFetchImpl(
+			"http://localhost:3000/api/auth/passkey/verify-authentication",
+			{
+				method: "POST",
+				headers: {
+					cookie: `${passkeyCookie}; ${sessionCookie}`,
+					origin: "http://localhost:3000",
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					response: {
+						id: "cleanup-test-credential",
+						rawId: "cleanup-test-credential",
+						response: {
+							authenticatorData: "mock",
+							clientDataJSON: "mock",
+							signature: "mock",
+						},
+						type: "public-key",
+						authenticatorAttachment: "platform",
+						clientExtensionResults: {},
+					},
+				}),
+			},
+		);
+
+		expect(verifyRes.status).toBe(200);
+
+		// Verification should be cleaned up from secondary storage
+		const remainingKeys = [...store.keys()].filter((k) =>
+			k.startsWith("verification:"),
+		);
+		expect(remainingKeys.length).toBe(0);
 	});
 });

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -516,7 +516,9 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 					model: "passkey",
 					data: newPasskey,
 				});
-				await ctx.context.internalAdapter.deleteVerificationValue(data.id);
+				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+					verificationToken,
+				);
 				return ctx.json(newPasskeyRes, {
 					status: 200,
 				});
@@ -678,7 +680,9 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 					session: s,
 					user,
 				});
-				await ctx.context.internalAdapter.deleteVerificationValue(data.id);
+				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+					verificationToken,
+				);
 
 				return ctx.json(
 					{


### PR DESCRIPTION
verifications created through secondary-storage do not have an id

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes passkey verification cleanup by using deleteVerificationByIdentifier so secondary-storage tokens (which don’t have an id) are removed after registration and authentication.

- **Bug Fixes**
  - Replace deleteVerificationValue(data.id) with deleteVerificationByIdentifier(verificationToken) in registration and authentication routes to correctly clean up secondary-storage verifications.

- **Tests**
  - Add a secondary-storage test that verifies the verification token is removed after successful passkey authentication.
  - Mock verifyAuthenticationResponse to simulate a valid response.

<sup>Written for commit b786d5f8c34a2c34c6c7418fcbcc050a2ea301be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

