### PR TITLE
fix(db): skip 'adapter.delete' in deleteWithHooks when entity not found

### DIFF
--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -226,8 +226,10 @@ export function getWithHooks(
 			? await customDeleteFn.fn(where)
 			: null;
 
+		const shouldRunAdapterDelete =
+			!customDeleteFn || customDeleteFn.executeMainFn;
 		const deleted =
-			!customDeleteFn || customDeleteFn.executeMainFn
+			shouldRunAdapterDelete && entityToDelete
 				? await (await getCurrentAdapter(adapter)).delete({
 						model,
 						where,


### PR DESCRIPTION
> [!NOTE]
> https://www.prisma.io/docs/orm/reference/error-reference#p2025 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip adapter.delete in deleteWithHooks when the entity is missing to prevent Prisma P2025 errors. Adds a test to ensure deletion is not attempted for missing verification records.

- **Bug Fixes**
  - Only run adapter.delete when a target entity exists (via entityToDelete) and when customDeleteFn allows it.
  - Added test that deletes a verification record first, then verifies adapter.delete is not called.

<sup>Written for commit 0bcd7d5fb5f20864653e8f6986c4d83c1fa415dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

