### PR TITLE
fix(sso): preserve OAuth provider state through SSO authentication flows

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -379,7 +379,7 @@ export { getIp } from "../utils/get-request-ip";
 export { isAPIError } from "../utils/is-api-error";
 export * from "./middlewares";
 export * from "./routes";
-export { getOAuthState } from "./state/oauth";
+export { getOAuthState, setOAuthState } from "./state/oauth";
 export {
 	getShouldSkipSessionRefresh,
 	setShouldSkipSessionRefresh,

--- a/packages/oauth-provider/src/client.ts
+++ b/packages/oauth-provider/src/client.ts
@@ -37,11 +37,12 @@ export const oauthProviderClient = () => {
 							typeof ctx.url === "string"
 								? new URL(ctx.url).pathname
 								: ctx.url.pathname;
-						// Should only need to run for /sign-in/email, /sign-in/social, /sign-in/oauth2, /oauth2/consent, /oauth2/continue
+						// Should only need to run for /sign-in/email, /sign-in/social, /sign-in/oauth2, /sign-in/sso, /oauth2/consent, /oauth2/continue
 						if (
 							pathname.endsWith("/sign-in/email") ||
 							pathname.endsWith("/sign-in/social") ||
 							pathname.endsWith("/sign-in/oauth2") ||
+							pathname.endsWith("/sign-in/sso") ||
 							pathname.endsWith("/oauth2/consent") ||
 							pathname.endsWith("/oauth2/continue")
 						) {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -224,10 +224,11 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							query: new URLSearchParams(queryParams).toString(),
 						});
 
-						// If path starts oauth2 authorize (ie /sign-in/social, /sign-in/oauth2), add to additional data body
+						// If path starts oauth2 authorize (ie /sign-in/social, /sign-in/oauth2, /sign-in/sso), add to additional data body
 						if (
 							ctx.path === "/sign-in/social" ||
-							ctx.path === "/sign-in/oauth2"
+							ctx.path === "/sign-in/oauth2" ||
+							ctx.path === "/sign-in/sso"
 						) {
 							if (ctx.body.additionalData?.query) return;
 							if (!ctx.body.additionalData) ctx.body.additionalData = {};

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -254,6 +254,26 @@ describe("SSO", async () => {
 		expect(callbackURL).toContain("/dashboard");
 	});
 
+	it("should accept additionalData in sign-in request", async () => {
+		const headers = new Headers();
+		const res = await authClient.signIn.sso({
+			providerId: "test",
+			callbackURL: "/dashboard",
+			additionalData: {
+				client_id: "test-oauth-client",
+				redirect_uri: "http://localhost:3001/callback",
+				response_type: "code",
+			},
+			fetchOptions: {
+				throw: true,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		expect(res.url).toContain("http://localhost:8080/authorize");
+		const { callbackURL } = await simulateOAuthFlow(res.url, headers);
+		expect(callbackURL).toContain("/dashboard");
+	});
+
 	it("should normalize email to lowercase in OIDC authentication", async () => {
 		const { headers } = await signInWithTestUser();
 

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -13,6 +13,7 @@ import {
 	createAuthEndpoint,
 	getSessionFromCtx,
 	sessionMiddleware,
+	setOAuthState,
 } from "better-auth/api";
 import { setSessionCookie } from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
@@ -970,6 +971,12 @@ const signInSSOBodySchema = z.object({
 		})
 		.optional(),
 	providerType: z.enum(["oidc", "saml"]).optional(),
+	additionalData: z
+		.record(z.string(), z.any())
+		.meta({
+			description: "Additional data to be passed through the SSO flow",
+		})
+		.optional(),
 });
 
 export const signInSSO = (options?: SSOOptions) => {
@@ -1228,7 +1235,11 @@ export const signInSSO = (options?: SSOOptions) => {
 						message: "Invalid OIDC configuration. Authorization URL not found.",
 					});
 				}
-				const state = await generateState(ctx, undefined, false);
+				const state = await generateState(
+					ctx,
+					undefined,
+					ctx.body.additionalData,
+				);
 				const redirectURI = `${ctx.context.baseURL}/sso/callback/${provider.providerId}`;
 				const authorizationURL = await createAuthorizationURL({
 					id: provider.issuer,
@@ -1341,7 +1352,7 @@ export const signInSSO = (options?: SSOOptions) => {
 				const { state: relayState } = await generateRelayState(
 					ctx,
 					undefined,
-					false,
+					ctx.body.additionalData,
 				);
 
 				const shouldSaveRequest =
@@ -1708,6 +1719,19 @@ export const callbackSSO = (options?: SSOOptions) => {
 				token: tokenResponse,
 				provisioningOptions: options?.organizationProvisioning,
 			});
+
+			// If state contains OAuth query params (from oauth-provider flow),
+			// set the OAuth state so the oauth-provider's after hook can continue the flow
+			if ((stateData as Record<string, unknown>).query) {
+				await setOAuthState({
+					callbackURL: stateData.callbackURL,
+					codeVerifier: stateData.codeVerifier,
+					errorURL: stateData.errorURL,
+					newUserURL: stateData.newUserURL,
+					expiresAt: stateData.expiresAt,
+					query: (stateData as Record<string, unknown>).query as string,
+				});
+			}
 
 			await setSessionCookie(ctx, {
 				session,
@@ -2742,6 +2766,19 @@ export const acsEndpoint = (options?: SSOOptions) => {
 				provider,
 				provisioningOptions: options?.organizationProvisioning,
 			});
+
+			// If RelayState contains OAuth query params (from oauth-provider flow),
+			// set the OAuth state so the oauth-provider's after hook can continue the flow
+			if (relayState?.query) {
+				await setOAuthState({
+					callbackURL: relayState.callbackURL,
+					codeVerifier: relayState.codeVerifier,
+					errorURL: relayState.errorURL,
+					newUserURL: relayState.newUserURL,
+					expiresAt: relayState.expiresAt,
+					query: relayState.query,
+				});
+			}
 
 			await setSessionCookie(ctx, { session, user });
 			throw ctx.redirect(callbackUrl);

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1718,19 +1718,6 @@ export const callbackSSO = (options?: SSOOptions) => {
 				provisioningOptions: options?.organizationProvisioning,
 			});
 
-			// If state contains OAuth query params (from oauth-provider flow),
-			// set the OAuth state so the oauth-provider's after hook can continue the flow
-			if ((stateData as Record<string, unknown>).query) {
-				await setOAuthState({
-					callbackURL: stateData.callbackURL,
-					codeVerifier: stateData.codeVerifier,
-					errorURL: stateData.errorURL,
-					newUserURL: stateData.newUserURL,
-					expiresAt: stateData.expiresAt,
-					query: (stateData as Record<string, unknown>).query as string,
-				});
-			}
-
 			await setSessionCookie(ctx, {
 				session,
 				user,

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -586,6 +586,25 @@ describe("SAML SSO with defaultSSO array", async () => {
 			redirect: true,
 		});
 	});
+
+	it("should accept additionalData in SAML sign-in request", async () => {
+		const signInResponse = await auth.api.signInSSO({
+			body: {
+				providerId: "default-saml",
+				callbackURL: "http://localhost:3000/dashboard",
+				additionalData: {
+					client_id: "test-oauth-client",
+					redirect_uri: "http://localhost:3001/callback",
+					response_type: "code",
+				},
+			},
+		});
+
+		expect(signInResponse).toEqual({
+			url: expect.stringContaining("http://localhost:8081"),
+			redirect: true,
+		});
+	});
 });
 
 describe("SAML SSO with signed AuthnRequests", async () => {


### PR DESCRIPTION
When using the SSO plugin (SAML in my case) with the OAuth provider plugin, the OAuth authorization flow would break after SSO authentication. Users would authenticate successfully via SAML or OIDC, but instead of being directed to the consent screen or registration flow, they would be redirected to the callback URL without completing the OAuth flow.

The root cause is that OAuth authorization parameters (client_id, redirect_uri, scope, etc.) were not preserved through the SSO authentication round-trip. The SSO sign-in endpoint was explicitly passing false for additionalData when generating state, and there was no mechanism to restore OAuth state after the IdP callback.

Note: This PR builds on work in https://github.com/better-auth/better-auth/pull/7781

This PR makes the following changes:
1. OAuth provider "before" hook: Extended to inject oauth_query into additionalData for /sign-in/sso (in addition to existing /sign-in/social and /sign-in/oauth2)
2. SSO sign-in endpoint: Now accepts additionalData in the request body and passes it through to generateState() (OIDC) and generateRelayState() (SAML)
3. SSO callback endpoints: After parsing state/RelayState, if OAuth query params are present, calls setOAuthState() to make them available to the OAuth provider's "after" hook
4. Export setOAuthState: Exposed from better-auth/api to enable cross-plugin OAuth state management

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves OAuth provider state across SSO (SAML/OIDC) so the OAuth flow resumes after IdP login. Users now reach consent/registration instead of being redirected to the callback early.

- **Bug Fixes**
  - Added query to additionalData for /sign-in/sso in the OAuth provider "before" hook.
  - SSO sign-in now accepts additionalData and forwards it to generateState (OIDC) and generateRelayState (SAML).
  - SSO callbacks restore OAuth context by calling setOAuthState when OAuth params are present.
  - Exported setOAuthState from better-auth/api for cross-plugin state handoff.

<sup>Written for commit 7fb22332b5a33323ec41714272ff05a41e64c6d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

