### PR TITLE
chore: add `definePlugin` API

### DIFF
--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { setShouldSkipSessionRefresh } from "../api/state/should-session-refresh";
 import { parseSetCookieHeader } from "../cookies";
 
@@ -23,7 +23,7 @@ export function toNextJsHandler(
 }
 
 export const nextCookies = () => {
-	return {
+	return createPlugin({
 		id: "next-cookies",
 		hooks: {
 			before: [
@@ -109,5 +109,5 @@ export const nextCookies = () => {
 				},
 			],
 		},
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/integrations/svelte-kit.ts
+++ b/packages/better-auth/src/integrations/svelte-kit.ts
@@ -1,7 +1,8 @@
 import { createAuthMiddleware } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import type { RequestEvent } from "@sveltejs/kit";
 import { parseSetCookieHeader } from "../cookies";
-import type { BetterAuthOptions, BetterAuthPlugin } from "../types";
+import type { BetterAuthOptions } from "../types";
 
 export const toSvelteKitHandler = (auth: {
 	handler: (request: Request) => Response | Promise<Response>;
@@ -54,7 +55,7 @@ export function isAuthPath(url: string, options: BetterAuthOptions) {
 export const sveltekitCookies = (
 	getRequestEvent: () => RequestEvent<any, any>,
 ) => {
-	return {
+	return createPlugin({
 		id: "sveltekit-cookies",
 		hooks: {
 			after: [
@@ -94,5 +95,5 @@ export const sveltekitCookies = (
 				},
 			],
 		},
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/integrations/tanstack-start-solid.ts
+++ b/packages/better-auth/src/integrations/tanstack-start-solid.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { parseSetCookieHeader } from "../cookies";
 
 /**
@@ -20,7 +20,7 @@ import { parseSetCookieHeader } from "../cookies";
  * ```
  */
 export const tanstackStartCookies = () => {
-	return {
+	return createPlugin({
 		id: "tanstack-start-cookies-solid",
 		hooks: {
 			after: [
@@ -62,5 +62,5 @@ export const tanstackStartCookies = () => {
 				},
 			],
 		},
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/integrations/tanstack-start.ts
+++ b/packages/better-auth/src/integrations/tanstack-start.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { parseSetCookieHeader } from "../cookies";
 
 /**
@@ -20,7 +20,7 @@ import { parseSetCookieHeader } from "../cookies";
  * ```
  */
 export const tanstackStartCookies = () => {
-	return {
+	return createPlugin({
 		id: "tanstack-start-cookies",
 		hooks: {
 			after: [
@@ -62,5 +62,5 @@ export const tanstackStartCookies = () => {
 				},
 			],
 		},
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -1,6 +1,6 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
 import { APIError, BetterAuthError } from "@better-auth/core/error";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { mergeSchema } from "../../db/schema";
 import { getEndpointResponse } from "../../utils/plugin-helper";
 import { defaultRoles } from "./access";
@@ -67,7 +67,7 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 		}
 	}
 
-	return {
+	return createPlugin({
 		id: "admin",
 		init() {
 			return {
@@ -178,5 +178,5 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 		$ERROR_CODES: ADMIN_ERROR_CODES,
 		schema: mergeSchema(schema, opts.schema),
 		options: options as NoInfer<O>,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -1,8 +1,8 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { generateId } from "@better-auth/core/utils/id";
 import * as z from "zod";
 import {
@@ -56,7 +56,7 @@ async function getAnonUserEmail(
 }
 
 export const anonymous = (options?: AnonymousOptions | undefined) => {
-	return {
+	return createPlugin({
 		id: "anonymous",
 		endpoints: {
 			signInAnonymous: createAuthEndpoint(
@@ -330,7 +330,7 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 		options,
 		schema: mergeSchema(schema, options?.schema),
 		$ERROR_CODES: ANONYMOUS_ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export type * from "./types";

--- a/packages/better-auth/src/plugins/api-key/index.ts
+++ b/packages/better-auth/src/plugins/api-key/index.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { base64Url } from "@better-auth/utils/base64";
 import { createHash } from "@better-auth/utils/hash";
 import { APIError } from "../../api";
@@ -107,7 +107,7 @@ export const apiKey = (options?: ApiKeyOptions | undefined) => {
 
 	const routes = createApiKeyRoutes({ keyGenerator, opts, schema });
 
-	return {
+	return createPlugin({
 		id: "api-key",
 		$ERROR_CODES: API_KEY_ERROR_CODES,
 		hooks: {
@@ -322,7 +322,7 @@ export const apiKey = (options?: ApiKeyOptions | undefined) => {
 		},
 		schema,
 		options,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export type * from "./types";

--- a/packages/better-auth/src/plugins/bearer/index.ts
+++ b/packages/better-auth/src/plugins/bearer/index.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { createHMAC } from "@better-auth/utils/hmac";
 import { serializeSignedCookie } from "better-call";
 import { parseSetCookieHeader } from "../../cookies";
@@ -27,7 +27,7 @@ export interface BearerOptions {
  * Converts bearer token to session cookie
  */
 export const bearer = (options?: BearerOptions | undefined) => {
-	return {
+	return createPlugin({
 		id: "bearer",
 		hooks: {
 			before: [
@@ -132,5 +132,5 @@ export const bearer = (options?: BearerOptions | undefined) => {
 			],
 		},
 		options,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { getIp } from "../../utils/get-request-ip";
 import { middlewareResponse } from "../../utils/middleware-response";
 import { defaultEndpoints, Providers, siteVerifyMap } from "./constants";
@@ -18,7 +18,7 @@ import * as verifyHandlers from "./verify-handlers";
 export type * from "./types";
 
 export const captcha = (options: CaptchaOptions) =>
-	({
+	createPlugin({
 		id: "captcha",
 		onRequest: async (request, ctx) => {
 			try {
@@ -93,4 +93,4 @@ export const captcha = (options: CaptchaOptions) =>
 			}
 		},
 		options,
-	}) satisfies BetterAuthPlugin;
+	});

--- a/packages/better-auth/src/plugins/custom-session/index.ts
+++ b/packages/better-auth/src/plugins/custom-session/index.ts
@@ -1,6 +1,5 @@
 import type {
 	BetterAuthOptions,
-	BetterAuthPlugin,
 	GenericEndpointContext,
 } from "@better-auth/core";
 import {
@@ -8,6 +7,7 @@ import {
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import type { Session, User } from "@better-auth/core/db";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import * as z from "zod";
 import { getSession } from "../../api";
 import { getEndpointResponse } from "../../utils/plugin-helper";
@@ -65,7 +65,7 @@ export const customSession = <
 	options?: O | undefined,
 	pluginOptions?: CustomSessionPluginOptions | undefined,
 ) => {
-	return {
+	return createPlugin({
 		id: "custom-session",
 		hooks: {
 			after: [
@@ -145,5 +145,5 @@ export const customSession = <
 			Session: {} as Awaited<ReturnType<typeof fn>>,
 		},
 		options: pluginOptions,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import * as z from "zod";
 import { mergeSchema } from "../../db";
 import type { InferOptionSchema } from "../../types/plugins";
@@ -130,7 +130,7 @@ export const deviceAuthorization = (
 ) => {
 	const opts = deviceAuthorizationOptionsSchema.parse(options);
 
-	return {
+	return createPlugin({
 		id: "device-authorization",
 		schema: mergeSchema(schema, options?.schema),
 		endpoints: {
@@ -142,7 +142,7 @@ export const deviceAuthorization = (
 		},
 		$ERROR_CODES: DEVICE_AUTHORIZATION_ERROR_CODES,
 		options,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export type * from "../../utils/time";

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { generateRandomString } from "../../crypto";
 import { getDate } from "../../utils/date";
 import { getEndpointResponse } from "../../utils/plugin-helper";
@@ -41,7 +41,7 @@ export const emailOTP = (options: EmailOTPOptions) => {
 
 	const sendVerificationOTPAction = sendVerificationOTP(opts);
 
-	return {
+	return createPlugin({
 		id: "email-otp",
 		init(ctx) {
 			if (!opts.overrideDefaultEmailVerification) {
@@ -173,5 +173,5 @@ export const emailOTP = (options: EmailOTPOptions) => {
 		],
 		options,
 		$ERROR_CODES: EMAIL_OTP_ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -1,4 +1,4 @@
-import type { AuthContext, BetterAuthPlugin } from "@better-auth/core";
+import type { AuthContext } from "@better-auth/core";
 import { APIError } from "@better-auth/core/error";
 import type { OAuth2Tokens, OAuthProvider } from "@better-auth/core/oauth2";
 import {
@@ -6,6 +6,7 @@ import {
 	refreshAccessToken,
 	validateAuthorizationCode,
 } from "@better-auth/core/oauth2";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { betterFetch } from "@better-fetch/fetch";
 import { GENERIC_OAUTH_ERROR_CODES } from "./error-codes";
 import {
@@ -70,7 +71,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 		);
 	}
 
-	return {
+	return createPlugin({
 		id: "generic-oauth",
 		init: (ctx: AuthContext) => {
 			const genericProviders = options.config.map((c) => {
@@ -238,5 +239,5 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 		},
 		options,
 		$ERROR_CODES: GENERIC_OAUTH_ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { getCurrentAuthContext } from "@better-auth/core/context";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { defineErrorCodes } from "@better-auth/core/utils/error-codes";
 import { createHash } from "@better-auth/utils/hash";
 import { betterFetch } from "@better-fetch/fetch";
@@ -82,7 +82,7 @@ export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions | undefined) => {
 		"/reset-password",
 	];
 
-	return {
+	return createPlugin({
 		id: "have-i-been-pwned",
 		init(ctx) {
 			const originalHash = ctx.password.hash;
@@ -107,5 +107,5 @@ export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions | undefined) => {
 		},
 		options,
 		$ERROR_CODES: ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -1,9 +1,9 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import { BetterAuthError } from "@better-auth/core/error";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import type { JSONWebKeySet, JWTPayload } from "jose";
 import * as z from "zod";
 import { APIError, sessionMiddleware } from "../../api";
@@ -65,7 +65,7 @@ export const jwt = <O extends JwtOptions>(options?: O) => {
 		);
 	}
 
-	return {
+	return createPlugin({
 		id: "jwt",
 		options: options as NoInfer<O>,
 		endpoints: {
@@ -346,7 +346,7 @@ export const jwt = <O extends JwtOptions>(options?: O) => {
 			],
 		},
 		schema: mergeSchema(schema, options?.schema),
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export { getJwtToken };

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -1,8 +1,6 @@
-import type {
-	BetterAuthPlugin,
-	GenericEndpointContext,
-} from "@better-auth/core";
+import type { GenericEndpointContext } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 
 declare module "@better-auth/core" {
 	interface BetterAuthPluginRegistry<AuthOptions, Options> {
@@ -82,7 +80,7 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 		...userConfig,
 	} satisfies LastLoginMethodOptions;
 
-	return {
+	return createPlugin({
 		id: "last-login-method",
 		init(ctx) {
 			return {
@@ -197,5 +195,5 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 				}
 			: undefined,
 		options: userConfig as NoInfer<O>,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -1,9 +1,6 @@
-import type {
-	Awaitable,
-	BetterAuthPlugin,
-	GenericEndpointContext,
-} from "@better-auth/core";
+import type { Awaitable, GenericEndpointContext } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import * as z from "zod";
 import { originCheck } from "../../api";
 import { setSessionCookie } from "../../cookies";
@@ -152,7 +149,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 		return token;
 	}
 
-	return {
+	return createPlugin({
 		id: "magic-link",
 		endpoints: {
 			/**
@@ -425,5 +422,5 @@ export const magicLink = (options: MagicLinkOptions) => {
 			},
 		],
 		options,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -1,6 +1,5 @@
 import type {
 	BetterAuthOptions,
-	BetterAuthPlugin,
 	GenericEndpointContext,
 } from "@better-auth/core";
 import {
@@ -8,6 +7,7 @@ import {
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import { isProduction, logger } from "@better-auth/core/env";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { getWebcryptoSubtle } from "@better-auth/utils";
 import { base64 } from "@better-auth/utils/base64";
@@ -183,7 +183,7 @@ export const mcp = (options: MCPOptions) => {
 		oauthConsent: "oauthConsent",
 	};
 	const provider = oidcProvider(opts);
-	return {
+	return createPlugin({
 		id: "mcp",
 		hooks: {
 			after: [
@@ -960,7 +960,7 @@ export const mcp = (options: MCPOptions) => {
 		},
 		schema,
 		options,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export const withMcpAuth = <

--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -1,8 +1,8 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import * as z from "zod";
 import { APIError, sessionMiddleware } from "../../api";
 import {
@@ -56,7 +56,7 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 
 	const isMultiSessionCookie = (key: string) => key.includes("_multi-");
 
-	return {
+	return createPlugin({
 		id: "multi-session",
 		endpoints: {
 			/**
@@ -405,5 +405,5 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 		},
 		options,
 		$ERROR_CODES: ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -1,9 +1,9 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import type { OAuth2Tokens } from "@better-auth/core/oauth2";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import * as z from "zod";
 import { originCheck } from "../../api";
 import { parseJSON } from "../../client/parser";
@@ -102,7 +102,7 @@ const oauthCallbackQuerySchema = z.object({
 export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 	const maxAge = opts?.maxAge ?? 60; // Default 60 seconds
 
-	return {
+	return createPlugin({
 		id: "oauth-proxy",
 		options: opts as NoInfer<O>,
 		endpoints: {
@@ -582,5 +582,5 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 				},
 			],
 		},
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -1,12 +1,10 @@
-import type {
-	BetterAuthPlugin,
-	GenericEndpointContext,
-} from "@better-auth/core";
+import type { GenericEndpointContext } from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import { getCurrentAuthContext } from "@better-auth/core/context";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { base64 } from "@better-auth/utils/base64";
 import { createHash } from "@better-auth/utils/hash";
 import type { OpenAPIParameter } from "better-call";
@@ -379,7 +377,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 		return clientSecret === storedClientSecret;
 	}
 
-	return {
+	return createPlugin({
 		id: "oidc-provider",
 		hooks: {
 			after: [
@@ -1755,6 +1753,6 @@ export const oidcProvider = (options: OIDCOptions) => {
 		get options() {
 			return opts;
 		},
-	} satisfies BetterAuthPlugin;
+	});
 };
 export type * from "./types";

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import * as z from "zod";
 import { APIError } from "../../api";
@@ -39,7 +39,7 @@ const oneTapCallbackBodySchema = z.object({
 });
 
 export const oneTap = (options?: OneTapOptions | undefined) =>
-	({
+	createPlugin({
 		id: "one-tap",
 		endpoints: {
 			oneTapCallback: createAuthEndpoint(
@@ -184,4 +184,4 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 			),
 		},
 		options,
-	}) satisfies BetterAuthPlugin;
+	});

--- a/packages/better-auth/src/plugins/one-time-token/index.ts
+++ b/packages/better-auth/src/plugins/one-time-token/index.ts
@@ -1,11 +1,9 @@
-import type {
-	BetterAuthPlugin,
-	GenericEndpointContext,
-} from "@better-auth/core";
+import type { GenericEndpointContext } from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import * as z from "zod";
 import { sessionMiddleware } from "../../api";
 import { setSessionCookie } from "../../cookies";
@@ -114,7 +112,7 @@ export const oneTimeToken = (options?: OneTimeTokenOptions | undefined) => {
 		return token;
 	}
 
-	return {
+	return createPlugin({
 		id: "one-time-token",
 		endpoints: {
 			/**
@@ -245,5 +243,5 @@ export const oneTimeToken = (options?: OneTimeTokenOptions | undefined) => {
 			],
 		},
 		options,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/open-api/index.ts
+++ b/packages/better-auth/src/plugins/open-api/index.ts
@@ -1,5 +1,6 @@
-import type { BetterAuthPlugin, LiteralString } from "@better-auth/core";
+import type { LiteralString } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { APIError } from "../../api";
 import { HIDE_METADATA } from "../../utils";
 import { generator } from "./generator";
@@ -100,7 +101,7 @@ export interface OpenAPIOptions {
 
 export const openAPI = <O extends OpenAPIOptions>(options?: O | undefined) => {
 	const path = options?.path ?? "/reference";
-	return {
+	return createPlugin({
 		id: "open-api",
 		endpoints: {
 			generateOpenAPISchema: createAuthEndpoint(
@@ -133,7 +134,7 @@ export const openAPI = <O extends OpenAPIOptions>(options?: O | undefined) => {
 			),
 		},
 		options: options as NoInfer<O>,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export type * from "./generator";

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -1,7 +1,8 @@
-import type { AuthContext, BetterAuthPlugin } from "@better-auth/core";
+import type { AuthContext } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import { APIError } from "@better-auth/core/error";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import * as z from "zod";
 import { getSessionFromCtx } from "../../api";
 import { shimContext } from "../../utils/shim";
@@ -1199,7 +1200,7 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 		},
 	});
 
-	return {
+	return createPlugin({
 		id: "organization",
 		endpoints: {
 			...(api as OrganizationEndpoints<O>),
@@ -1263,5 +1264,5 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 		},
 		$ERROR_CODES: ORGANIZATION_ERROR_CODES,
 		options: opts as NoInfer<O>,
-	} satisfies BetterAuthPlugin;
+	});
 }

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -1,6 +1,6 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
 import { APIError } from "@better-auth/core/error";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { mergeSchema } from "../../db/schema";
 import { PHONE_NUMBER_ERROR_CODES } from "./error-codes";
 import type { RequiredPhoneNumberOptions } from "./routes";
@@ -35,7 +35,7 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 		createdAt: "createdAt",
 	};
 
-	return {
+	return createPlugin({
 		id: "phone-number",
 		hooks: {
 			before: [
@@ -77,5 +77,5 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 		],
 		options,
 		$ERROR_CODES: PHONE_NUMBER_ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/better-auth/src/plugins/siwe/index.ts
+++ b/packages/better-auth/src/plugins/siwe/index.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import * as z from "zod";
 import { APIError } from "../../api";
 import { setSessionCookie } from "../../cookies";
@@ -44,7 +44,7 @@ const getSiweNonceBodySchema = z.object({
 });
 
 export const siwe = (options: SIWEPluginOptions) =>
-	({
+	createPlugin({
 		id: "siwe",
 		schema: mergeSchema(schema, options?.schema) as WalletAddressSchema,
 		endpoints: {
@@ -309,4 +309,4 @@ export const siwe = (options: SIWEPluginOptions) =>
 			),
 		},
 		options,
-	}) satisfies BetterAuthPlugin;
+	});

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -1,9 +1,9 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { createHMAC } from "@better-auth/utils/hmac";
 import { createOTP } from "@better-auth/utils/otp";
 import * as z from "zod";
@@ -72,7 +72,7 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 	const backupCode = backupCode2fa(backupCodeOptions);
 	const otp = otp2fa(options?.otpOptions);
 
-	return {
+	return createPlugin({
 		id: "two-factor",
 		endpoints: {
 			...totp.endpoints,
@@ -452,7 +452,7 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 			},
 		],
 		$ERROR_CODES: TWO_FACTOR_ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export * from "./client";

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -1,10 +1,10 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import type { Account, User } from "@better-auth/core/db";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import * as z from "zod";
 import { createEmailVerificationToken } from "../../api";
 import { setSessionCookie } from "../../cookies";
@@ -135,7 +135,7 @@ export const username = (options?: UsernameOptions | undefined) => {
 			: displayUsername;
 	};
 
-	return {
+	return createPlugin({
 		id: "username",
 		init(ctx) {
 			return {
@@ -594,5 +594,5 @@ export const username = (options?: UsernameOptions | undefined) => {
 		},
 		options,
 		$ERROR_CODES: ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -26,6 +26,7 @@ export type {
 export type {
 	BetterAuthPlugin,
 	BetterAuthPluginErrorCodePart,
+	BetterAuthPluginV2,
 	HookEndpointContext,
 } from "./plugin";
 export type {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -29,6 +29,23 @@ export type HookEndpointContext = Partial<
 	headers?: Headers | undefined;
 };
 
+export type BetterAuthPluginV2<
+	ID extends string,
+	Endpoints extends Record<string, Endpoint>,
+	Schema extends BetterAuthPluginDBSchema,
+	ERROR_CODES extends Record<string, RawError>,
+	Options extends object,
+> = {
+	id: ID;
+	endpoints?: Endpoints;
+	options?: Options;
+	schema?: Schema;
+	$ERROR_CODES?: ERROR_CODES;
+} & Omit<
+	BetterAuthPlugin,
+	"id" | "endpoints" | "$ERROR_CODES" | "options" | "schema"
+>;
+
 export type BetterAuthPluginErrorCodePart = {
 	/**
 	 * The error codes returned by the plugin

--- a/packages/core/src/utils/create-plugin.ts
+++ b/packages/core/src/utils/create-plugin.ts
@@ -1,0 +1,16 @@
+import type { Endpoint } from "better-call";
+import type { BetterAuthPluginDBSchema } from "../db";
+import type { BetterAuthPluginV2 } from "../types";
+import type { RawError } from "./error-codes";
+
+export function createPlugin<
+	ID extends string,
+	Endpoints extends Record<string, Endpoint> = {},
+	ERROR_CODES extends Record<string, RawError> = {},
+	Schema extends BetterAuthPluginDBSchema = {},
+	Options extends object = {},
+>(
+	plugin: BetterAuthPluginV2<ID, Endpoints, Schema, ERROR_CODES, Options>,
+): BetterAuthPluginV2<ID, Endpoints, Schema, ERROR_CODES, Options> {
+	return plugin;
+}

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -3,7 +3,7 @@
 import type { HookEndpointContext } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
 import { APIError } from "@better-auth/core/error";
-import type { BetterAuthPlugin } from "better-auth";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { safeJSONParse } from "better-auth";
 import { generateRandomString } from "better-auth/crypto";
 import * as z from "zod";
@@ -43,7 +43,7 @@ export const electron = (options?: ElectronOptions | undefined) => {
 		);
 	};
 
-	return {
+	return createPlugin({
 		id: "electron",
 		async onRequest(request, _ctx) {
 			if (opts.disableOriginOverride || request.headers.get("origin")) {
@@ -192,7 +192,7 @@ export const electron = (options?: ElectronOptions | undefined) => {
 		},
 		options: opts,
 		$ERROR_CODES: ELECTRON_ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export type * from "./types";

--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -1,5 +1,5 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { expoAuthorizationProxy } from "./routes";
 
 export interface ExpoOptions {
@@ -19,7 +19,7 @@ declare module "@better-auth/core" {
 }
 
 export const expo = (options?: ExpoOptions | undefined) => {
-	return {
+	return createPlugin({
 		id: "expo",
 		init: (ctx) => {
 			const trustedOrigins =
@@ -98,5 +98,5 @@ export const expo = (options?: ExpoOptions | undefined) => {
 			expoAuthorizationProxy,
 		},
 		options,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,4 +1,5 @@
-import type { AuthContext, BetterAuthPlugin } from "@better-auth/core";
+import type { AuthContext } from "@better-auth/core";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { APIError, createAuthMiddleware, isAPIError } from "better-auth/api";
 import { parseCookies } from "better-auth/cookies";
 import type { I18nOptions, LocaleDetectionStrategy } from "./types";
@@ -148,9 +149,8 @@ export const i18n = <Locales extends string[]>(
 		return opts.defaultLocale;
 	}
 
-	return {
+	return createPlugin({
 		id: "i18n",
-
 		hooks: {
 			after: [
 				{
@@ -190,5 +190,5 @@ export const i18n = <Locales extends string[]>(
 		},
 
 		options: opts,
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1,6 +1,7 @@
 import { defineRequestState } from "@better-auth/core/context";
 import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import {
 	APIError,
 	createAuthEndpoint,
@@ -11,7 +12,6 @@ import {
 import { parseSetCookieHeader } from "better-auth/cookies";
 import { constantTimeEqual, makeSignature } from "better-auth/crypto";
 import { mergeSchema } from "better-auth/db";
-import type { BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
 import { authorizeEndpoint } from "./authorize";
 import { consentEndpoint } from "./consent";
@@ -151,7 +151,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		);
 	}
 
-	return {
+	return createPlugin({
 		id: "oauth-provider",
 		options: opts as NoInfer<O>,
 		init: (ctx) => {
@@ -1362,5 +1362,5 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					]
 				: []),
 		],
-	} satisfies BetterAuthPlugin;
+	});
 };

--- a/packages/passkey/src/index.ts
+++ b/packages/passkey/src/index.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { mergeSchema } from "better-auth/db";
 import { PASSKEY_ERROR_CODES } from "./error-codes";
 import {
@@ -33,7 +33,7 @@ export const passkey = (options?: PasskeyOptions | undefined) => {
 		},
 	};
 
-	return {
+	return createPlugin({
 		id: "passkey",
 		endpoints: {
 			generatePasskeyRegistrationOptions: generatePasskeyRegistrationOptions(
@@ -53,7 +53,7 @@ export const passkey = (options?: PasskeyOptions | undefined) => {
 		schema: mergeSchema(schema, options?.schema),
 		$ERROR_CODES: PASSKEY_ERROR_CODES,
 		options,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export type { Passkey, PasskeyOptions };

--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthPlugin } from "better-auth";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import { authMiddlewareFactory } from "./middlewares";
 import {
 	createSCIMUser,
@@ -32,7 +32,7 @@ export const scim = (options?: SCIMOptions) => {
 
 	const authMiddleware = authMiddlewareFactory(opts);
 
-	return {
+	return createPlugin({
 		id: "scim",
 		endpoints: {
 			generateSCIMToken: generateSCIMToken(opts),
@@ -69,7 +69,7 @@ export const scim = (options?: SCIMOptions) => {
 			},
 		},
 		options,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export * from "./types";

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -43,6 +43,7 @@ export {
 	SignatureAlgorithm,
 } from "./saml";
 
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
 import type { OIDCConfig, SAMLConfig, SSOOptions, SSOProvider } from "./types";
 
 export type { SAMLConfig, OIDCConfig, SSOOptions, SSOProvider };
@@ -171,7 +172,7 @@ export function sso<O extends SSOOptions>(
 		};
 	}
 
-	return {
+	return createPlugin({
 		id: "sso",
 		init(ctx) {
 			const existing = ctx.skipOriginCheck;
@@ -261,5 +262,5 @@ export function sso<O extends SSOOptions>(
 			},
 		},
 		options: options as NoInfer<O>,
-	} satisfies BetterAuthPlugin;
+	});
 }

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1,4 +1,5 @@
-import type { BetterAuthPlugin, User } from "better-auth";
+import { createPlugin } from "@better-auth/core/utils/create-plugin";
+import type { User } from "better-auth";
 import { APIError } from "better-auth";
 import type { Organization } from "better-auth/plugins/organization";
 import { defu } from "defu";
@@ -46,7 +47,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 		createBillingPortal: createBillingPortal(options),
 	};
 
-	return {
+	return createPlugin({
 		id: "stripe",
 		endpoints: {
 			stripeWebhook: stripeWebhook(options),
@@ -307,7 +308,7 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 		schema: getSchema(options),
 		options: options as NoInfer<O>,
 		$ERROR_CODES: STRIPE_ERROR_CODES,
-	} satisfies BetterAuthPlugin;
+	});
 };
 
 export type StripePlugin<O extends StripeOptions> = ReturnType<


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduced createPlugin to standardize plugin definition and improve type inference, and refactored all first-party plugins/integrations to use it. This is a types/DX cleanup with no behavior changes.

- **Refactors**
  - Added core/utils/create-plugin with createPlugin helper.
  - Introduced and exported BetterAuthPluginV2 type.
  - Replaced BetterAuthPlugin imports and satisfies usage with createPlugin across all plugins and framework integrations.

- **Migration**
  - Third-party plugin authors can optionally wrap plugins with createPlugin from @better-auth/core/utils/create-plugin for better type inference. Existing plugin shapes continue to work.

<sup>Written for commit 0bc1d0f374d6605698a1c5ac94d1282442eceba2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

