### PR TITLE
fix(oauth): handle `refresh_token_expires_in` in `refreshAccessToken`

### DIFF
--- a/packages/core/src/oauth2/refresh-access-token.test.ts
+++ b/packages/core/src/oauth2/refresh-access-token.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@better-fetch/fetch", () => ({
+	betterFetch: vi.fn(),
+}));
+
+import { betterFetch } from "@better-fetch/fetch";
+import { refreshAccessToken } from "./refresh-access-token";
+
+const mockedBetterFetch = vi.mocked(betterFetch);
+
+describe("refreshAccessToken", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should set accessTokenExpiresAt when expires_in is returned", async () => {
+		const now = Date.now();
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "new-access-token",
+				refresh_token: "new-refresh-token",
+				expires_in: 3600,
+				token_type: "Bearer",
+			},
+			error: null,
+		});
+
+		const tokens = await refreshAccessToken({
+			refreshToken: "old-refresh-token",
+			options: { clientId: "test-client", clientSecret: "test-secret" },
+			tokenEndpoint: "https://example.com/token",
+		});
+
+		expect(tokens.accessToken).toBe("new-access-token");
+		expect(tokens.refreshToken).toBe("new-refresh-token");
+		expect(tokens.accessTokenExpiresAt).toBeInstanceOf(Date);
+		expect(tokens.accessTokenExpiresAt!.getTime()).toBeGreaterThanOrEqual(
+			now + 3600 * 1000 - 1000,
+		);
+		expect(tokens.refreshTokenExpiresAt).toBeUndefined();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/7682
+	 */
+	it("should set refreshTokenExpiresAt when refresh_token_expires_in is returned", async () => {
+		const now = Date.now();
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "new-access-token",
+				refresh_token: "new-refresh-token",
+				expires_in: 3600,
+				refresh_token_expires_in: 86400,
+				token_type: "Bearer",
+			},
+			error: null,
+		});
+
+		const tokens = await refreshAccessToken({
+			refreshToken: "old-refresh-token",
+			options: { clientId: "test-client", clientSecret: "test-secret" },
+			tokenEndpoint: "https://example.com/token",
+		});
+
+		expect(tokens.accessToken).toBe("new-access-token");
+		expect(tokens.refreshToken).toBe("new-refresh-token");
+		expect(tokens.accessTokenExpiresAt).toBeInstanceOf(Date);
+		expect(tokens.refreshTokenExpiresAt).toBeInstanceOf(Date);
+		expect(tokens.refreshTokenExpiresAt!.getTime()).toBeGreaterThanOrEqual(
+			now + 86400 * 1000 - 1000,
+		);
+	});
+
+	it("should not set refreshTokenExpiresAt when refresh_token_expires_in is not returned", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "new-access-token",
+				refresh_token: "new-refresh-token",
+				expires_in: 3600,
+				token_type: "Bearer",
+			},
+			error: null,
+		});
+
+		const tokens = await refreshAccessToken({
+			refreshToken: "old-refresh-token",
+			options: { clientId: "test-client", clientSecret: "test-secret" },
+			tokenEndpoint: "https://example.com/token",
+		});
+
+		expect(tokens.refreshTokenExpiresAt).toBeUndefined();
+	});
+});

--- a/packages/core/src/oauth2/refresh-access-token.ts
+++ b/packages/core/src/oauth2/refresh-access-token.ts
@@ -119,6 +119,7 @@ export async function refreshAccessToken({
 		access_token: string;
 		refresh_token?: string | undefined;
 		expires_in?: number | undefined;
+		refresh_token_expires_in?: number | undefined;
 		token_type?: string | undefined;
 		scope?: string | undefined;
 		id_token?: string | undefined;
@@ -142,6 +143,13 @@ export async function refreshAccessToken({
 		const now = new Date();
 		tokens.accessTokenExpiresAt = new Date(
 			now.getTime() + data.expires_in * 1000,
+		);
+	}
+
+	if (data.refresh_token_expires_in) {
+		const now = new Date();
+		tokens.refreshTokenExpiresAt = new Date(
+			now.getTime() + data.refresh_token_expires_in * 1000,
 		);
 	}
 


### PR DESCRIPTION
> [!NOTE]
> It has already been handled in `getOAuth2Tokens`, but not in `refreshAccessToken`

- Closes #7682

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle refresh_token_expires_in in refreshAccessToken to set refreshTokenExpiresAt correctly, aligning behavior with getOAuth2Tokens and improving token expiry handling.

- **Bug Fixes**
  - Parse refresh_token_expires_in and set refreshTokenExpiresAt.
  - Keep behavior unchanged when the field is not returned.
  - Add unit tests covering expires_in and refresh_token_expires_in scenarios.

<sup>Written for commit a4f44520138f7634a7e5f28cd2048453c05ad91e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

