### PR TITLE
fix(oauth-provider): return `url` instead of `uri` in continue and consent endpoints

### DIFF
--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -43,7 +43,7 @@ export async function consentEndpoint(
 	if (!accepted) {
 		return {
 			redirect: true,
-			uri: formatErrorURL(
+			url: formatErrorURL(
 				query.get("redirect_uri") ?? "",
 				"access_denied",
 				"User denied access",
@@ -121,6 +121,6 @@ export async function consentEndpoint(
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,
-		uri: url,
+		url,
 	};
 }

--- a/packages/oauth-provider/src/continue.ts
+++ b/packages/oauth-provider/src/continue.ts
@@ -41,7 +41,7 @@ async function selected(
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,
-		uri: url,
+		url,
 	};
 }
 
@@ -61,7 +61,7 @@ async function created(
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,
-		uri: url,
+		url,
 	};
 }
 
@@ -84,6 +84,6 @@ async function postLogin(
 	});
 	return {
 		redirect: true,
-		uri: url,
+		url,
 	};
 }

--- a/packages/oauth-provider/src/mcp.test.ts
+++ b/packages/oauth-provider/src/mcp.test.ts
@@ -332,7 +332,7 @@ describe("mcp - server-client flows", async () => {
 					},
 				},
 			);
-			const url = new URL(consentRes.data?.uri ?? "");
+			const url = new URL(consentRes.data?.url ?? "");
 			const _state = url.searchParams.get("state");
 			if ((state || _state) && state !== _state) {
 				throw new Error("state mismatch");

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -774,11 +774,11 @@ describe("oauth - prompt", async () => {
 			},
 		);
 		expect(consentRes.redirect).toBeTruthy();
-		expect(consentRes.uri).toContain(redirectUri);
-		expect(consentRes.uri).toContain(`code=`);
+		expect(consentRes.url).toContain(redirectUri);
+		expect(consentRes.url).toContain(`code=`);
 		vi.stubGlobal("window", {
 			location: {
-				search: new URL(consentRes.uri, authServerBaseUrl).search,
+				search: new URL(consentRes.url, authServerBaseUrl).search,
 			},
 		});
 		onTestFinished(() => {
@@ -786,7 +786,7 @@ describe("oauth - prompt", async () => {
 		});
 
 		let callbackURL = "";
-		await client.$fetch(consentRes.uri, {
+		await client.$fetch(consentRes.url, {
 			method: "GET",
 			headers: oauthHeaders,
 			onError(context) {
@@ -985,7 +985,7 @@ describe("oauth - prompt", async () => {
 			},
 		);
 		expect(selectedAccountRes.redirect).toBeTruthy();
-		const selectedAccountRedirectUri = selectedAccountRes?.uri;
+		const selectedAccountRedirectUri = selectedAccountRes?.url;
 		expect(selectedAccountRedirectUri).toContain(redirectUri);
 		expect(selectedAccountRedirectUri).toContain(`code=`);
 
@@ -1142,7 +1142,7 @@ describe("oauth - prompt", async () => {
 			},
 		);
 		expect(selectedAccountRes.redirect).toBeTruthy();
-		const consentRedirectUri = selectedAccountRes?.uri;
+		const consentRedirectUri = selectedAccountRes?.url;
 		expect(consentRedirectUri).toContain(`/consent`);
 		expect(consentRedirectUri).toContain(`client_id=${oauthClient.client_id}`);
 		expect(consentRedirectUri).toContain(`scope=`);
@@ -1235,7 +1235,7 @@ describe("oauth - prompt", async () => {
 			},
 		);
 		expect(selectedAccountRes.redirect).toBeTruthy();
-		const consentRedirectUri = selectedAccountRes?.uri;
+		const consentRedirectUri = selectedAccountRes?.url;
 		expect(consentRedirectUri).toContain(`/consent`);
 		expect(consentRedirectUri).toContain(`client_id=${oauthClient.client_id}`);
 		expect(consentRedirectUri).toContain(`scope=`);
@@ -1260,8 +1260,8 @@ describe("oauth - prompt", async () => {
 				onResponse: cookieSetter(headers),
 			},
 		);
-		expect(consentRes.uri).toContain(redirectUri);
-		expect(consentRes.uri).toContain(`code=`);
+		expect(consentRes.url).toContain(redirectUri);
+		expect(consentRes.url).toContain(`code=`);
 
 		enablePostLogin = false;
 	});


### PR DESCRIPTION
> [!NOTE]
> This is a breaking change to the API response field names, but it needs to be fixed because the existing code already breaks compatibility with the DefaultFetchPlugins
>
> https://github.com/better-auth/better-auth/blob/canary/packages/better-auth/src/client/fetch-plugins.ts#L8

 - Closes #7807

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch consent and continue endpoint responses from uri to url to match client fetch plugins and fix redirect handling. This is a breaking change; tests updated to expect url.

- **Migration**
  - Read data.url instead of data.uri from consent and continue endpoints.
  - Update any redirects that use res.uri to use res.url (e.g., new URL(res.data.url)).

<sup>Written for commit 3f2330961b689aeaf11b889dd80010985084be15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

