### PR TITLE
fix(oauth): support case-insensitive email matching for social account linking

### DIFF
--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -309,7 +309,8 @@ export const linkSocialAccount = createAuthEndpoint(
 			}
 
 			if (
-				linkingUserInfo.user.email?.toLowerCase() !== session.user.email &&
+				linkingUserInfo.user.email?.toLowerCase() !==
+					session.user.email.toLowerCase() &&
 				c.context.options.account?.accountLinking?.allowDifferentEmails !== true
 			) {
 				throw APIError.from("UNAUTHORIZED", {

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -187,7 +187,7 @@ export const callbackOAuth = createAuthEndpoint(
 			}
 
 			if (
-				userInfo.email?.toLowerCase() !== link.email &&
+				userInfo.email?.toLowerCase() !== link.email.toLowerCase() &&
 				c.context.options.account?.accountLinking?.allowDifferentEmails !== true
 			) {
 				return redirectOnError("email_doesn't_match");

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -231,6 +231,9 @@ describe("oauth2 - email verification on link", async () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/7806
+ */
 describe("oauth2 - account linking with case insensitive email", async () => {
 	const { auth, client, cookieSetter } = await getTestInstance({
 		socialProviders: {

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -454,7 +454,7 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 				if (
 					ctx.context.options.account?.accountLinking?.allowDifferentEmails !==
 						true &&
-					link.email !== userInfo.email
+					link.email.toLowerCase() !== userInfo.email.toLowerCase()
 				) {
 					return redirectOnError("email_doesn't_match");
 				}


### PR DESCRIPTION
This ensures that social account linking succeeds even if the email
returned by the OAuth provider has different casing than the email
currently associated with the user.

- Update `linkSocialAccount` and `callbackOAuth` to use case-insensitive email comparison.
- Added comprehensive tests for both callback and idToken flows.
- Prevents "email_doesn't_match" errors due to case sensitivity.

Closes #7806

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make email comparison case-insensitive during social account linking. This prevents mismatches when OAuth providers return different casing, so linking succeeds instead of showing "email_doesn't_match".

- **Bug Fixes**
  - Compare emails case-insensitively in linkSocialAccount, callbackOAuth, and the generic OAuth callback route.
  - Add tests for callback and idToken flows that cover casing differences.

<sup>Written for commit 199d42032f7b55f142a1e40090d5af99fa4f0562. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

