### PR TITLE
docs: add description `disableDefaultFetchPlugins` to Client concept

### DIFF
--- a/docs/content/docs/concepts/client.mdx
+++ b/docs/content/docs/concepts/client.mdx
@@ -217,9 +217,7 @@ const authClient = createAuthClient({
 
 ### Disabling Default Fetch Plugins
 
-By default, the auth client includes a redirect plugin that automatically handles browser redirects (e.g., after social sign-in) by setting `window.location.href`. This works well for browser-based applications but can cause issues in non-browser environments.
-
-You can disable the default fetch plugins by setting `disableDefaultFetchPlugins` to `true`:
+The auth client includes default fetch plugins that handle browser-specific behaviors like automatic redirects. For non-browser environments (e.g., React Native/Expo), you can disable these by setting `disableDefaultFetchPlugins` to `true`:
 
 ```ts title="auth-client.ts"
 import { createAuthClient } from "better-auth/client"
@@ -227,17 +225,7 @@ import { createAuthClient } from "better-auth/client"
 const authClient = createAuthClient({
     disableDefaultFetchPlugins: true,
 })
-```
-
-This is particularly useful for:
-
-- **React Native / Expo apps**: These environments don't have `window.location`, so automatic redirects won't work. Use this option alongside platform-specific plugins like `expoClient` that handle navigation appropriately.
-- **Custom redirect handling**: If you want full control over how redirects are processed (e.g., using a router's navigation methods instead of `window.location`).
-- **Server-side rendering**: When you need to handle redirects differently on the server.
-
-<Callout type="info">
-When disabling default fetch plugins, make sure you have appropriate handling for redirects if your authentication flow requires them (e.g., OAuth/social login).
-</Callout>         
+```         
 
 You can also pass fetch options to most of the client functions. Either as the second argument or as a property in the object.
 


### PR DESCRIPTION
Add documentation for `disableDefaultFetchPlugins` to the Client concept page to cover its use in non-browser environments.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1770322423016989?thread_ts=1770322423.016989&cid=C0A8B5BARUK)

<p><a href="https://cursor.com/background-agent?bcId=bc-71b9c77f-fef0-5590-8d85-60eb4bc01013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-71b9c77f-fef0-5590-8d85-60eb4bc01013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added documentation for the disableDefaultFetchPlugins option on the Client concept page. It explains disabling browser-specific fetch plugins in non-browser environments (e.g., React Native/Expo) and includes a usage example.

<sup>Written for commit 82a44e70ba8ce80a2f82e4dcd6f65b7b2dfde940. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

