### PR TITLE
Fix (expo): expo client no longer creates malformed cookie

### DIFF
--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -108,7 +108,7 @@ export function getCookie(cookie: string) {
 		if (value.expires && new Date(value.expires) < new Date()) {
 			return acc;
 		}
-		return `${acc}; ${key}=${value.value}`;
+		return acc ? `${acc}; ${key}=${value.value}` : `${key}=${value.value}`;
 	}, "");
 	return toSend;
 }


### PR DESCRIPTION
This issue fixes #7674. 

According to my research and different testing when acc is empty it creates a cookie which is starting with a ";" which is not accepted by my google cloud load balancer. Right now I am just overwriting my cookie that is being sent like this:

```
{
	id: 'fix-cookie-header',
	fetchPlugins: [
		{
			id: 'fix-cookie-header',
			name: 'fix-cookie-header',
			init(url, options) {
				const headers = options?.headers as Record<string, string> | undefined;
				if (headers?.cookie?.startsWith('; ')) {
					headers.cookie = headers.cookie.slice(2); // Remove leading "; "
				}
				return { url, options };
			},
		},
	],
},

```

As this is just a temporary fix I created this PR to fix this causing issue.

I did not encounter this issue with my hetzner vps and a traefik reverse proxy, leaving me to believe that Google enforces the RFC 6265 standard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Expo client’s cookie builder to avoid a leading “; ” when constructing the first cookie. This prevents malformed Cookie headers and avoids rejections by RFC 6265–compliant proxies (e.g., Google Cloud Load Balancer).

<sup>Written for commit cd366df52b7bfc101e924fbbfc75a3ec55418457. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

