### PR TITLE
feat(sso): add getMemberData hook for customizing member creation

### DIFF
--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -47,10 +47,16 @@ export {
 	SignatureAlgorithm,
 } from "./saml";
 
-import type { OIDCConfig, SAMLConfig, SSOOptions, SSOProvider } from "./types";
+import type {
+	OIDCConfig,
+	Organization,
+	SAMLConfig,
+	SSOOptions,
+	SSOProvider,
+} from "./types";
 import { PACKAGE_VERSION } from "./version";
 
-export type { SAMLConfig, OIDCConfig, SSOOptions, SSOProvider };
+export type { SAMLConfig, OIDCConfig, Organization, SSOOptions, SSOProvider };
 
 declare module "@better-auth/core" {
 	interface BetterAuthPluginRegistry<AuthOptions, Options> {

--- a/packages/sso/src/linking/org-assignment.test.ts
+++ b/packages/sso/src/linking/org-assignment.test.ts
@@ -21,14 +21,14 @@ describe("assignOrganizationByDomain", () => {
 				organizationId: string | null;
 				userId: string;
 			}[],
-		member: [] as {
-			id: string;
-			organizationId: string;
-			userId: string;
-			role: string;
-			createdAt: Date;
-			[key: string]: any;
-		}[],
+			member: [] as {
+				id: string;
+				organizationId: string;
+				userId: string;
+				role: string;
+				createdAt: Date;
+				[key: string]: any;
+			}[],
 			organization: [] as {
 				id: string;
 				name: string;

--- a/packages/sso/src/linking/org-assignment.test.ts
+++ b/packages/sso/src/linking/org-assignment.test.ts
@@ -2,7 +2,7 @@ import type { GenericEndpointContext, User } from "better-auth";
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { organization } from "better-auth/plugins";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { sso } from "..";
 import { assignOrganizationByDomain } from "./org-assignment";
 
@@ -21,13 +21,14 @@ describe("assignOrganizationByDomain", () => {
 				organizationId: string | null;
 				userId: string;
 			}[],
-			member: [] as {
-				id: string;
-				organizationId: string;
-				userId: string;
-				role: string;
-				createdAt: Date;
-			}[],
+		member: [] as {
+			id: string;
+			organizationId: string;
+			userId: string;
+			role: string;
+			createdAt: Date;
+			[key: string]: any;
+		}[],
 			organization: [] as {
 				id: string;
 				name: string;
@@ -374,5 +375,121 @@ describe("assignOrganizationByDomain", () => {
 		const members = data.member.filter((m) => m.userId === user.id);
 		expect(members).toHaveLength(1);
 		expect(members[0]?.organizationId).toBe(legitOrg.id);
+	});
+
+	it("should use getMemberData hook to add additional fields to member", async () => {
+		const { data, createContext } = createTestContext();
+
+		const org = createOrg();
+		data.organization.push(org);
+		data.ssoProvider.push(
+			createProvider({ domainVerified: true, organizationId: org.id }),
+		);
+
+		const user = createUser({ name: "Alice Smith" });
+		data.user.push(user);
+
+		const getMemberDataSpy = vi.fn(
+			async ({
+				user,
+				organization,
+				defaultData,
+			}: {
+				user: User & Record<string, any>;
+				organization: Record<string, any>;
+				defaultData: Record<string, any>;
+			}) => {
+				return {
+					...defaultData,
+					customField: "custom-value",
+					memberName: user.name,
+					orgName: organization.name,
+				};
+			},
+		);
+
+		const ctx = (await createContext()) as GenericEndpointContext;
+		await assignOrganizationByDomain(ctx, {
+			user,
+			domainVerification: { enabled: true },
+			provisioningOptions: {
+				getMemberData: getMemberDataSpy,
+			},
+		});
+
+		// Verify the hook was called with correct arguments
+		expect(getMemberDataSpy).toHaveBeenCalledTimes(1);
+		const callArgs = getMemberDataSpy.mock.calls[0]?.[0];
+		expect(callArgs?.user.id).toBe(user.id);
+		expect(callArgs?.user.name).toBe("Alice Smith");
+		expect(callArgs?.organization.id).toBe(org.id);
+		expect(callArgs?.organization.name).toBe("Test Org");
+		expect(callArgs?.defaultData.organizationId).toBe(org.id);
+		expect(callArgs?.defaultData.userId).toBe(user.id);
+		expect(callArgs?.defaultData.role).toBe("member");
+
+		// Verify a member was created
+		const members = data.member.filter((m) => m.userId === user.id);
+		expect(members).toHaveLength(1);
+		expect(members[0]?.organizationId).toBe(org.id);
+	});
+
+	it("should use default data when getMemberData returns undefined", async () => {
+		const { data, createContext } = createTestContext();
+
+		const org = createOrg();
+		data.organization.push(org);
+		data.ssoProvider.push(
+			createProvider({ domainVerified: true, organizationId: org.id }),
+		);
+
+		const user = createUser();
+		data.user.push(user);
+
+		const ctx = (await createContext()) as GenericEndpointContext;
+		await assignOrganizationByDomain(ctx, {
+			user,
+			domainVerification: { enabled: true },
+			provisioningOptions: {
+				getMemberData: async () => {
+					return undefined;
+				},
+			},
+		});
+
+		const members = data.member.filter((m) => m.userId === user.id);
+		expect(members).toHaveLength(1);
+		expect(members[0]?.organizationId).toBe(org.id);
+		expect(members[0]?.role).toBe("member");
+	});
+
+	it("should respect defaultRole when using getMemberData", async () => {
+		const { data, createContext } = createTestContext();
+
+		const org = createOrg();
+		data.organization.push(org);
+		data.ssoProvider.push(
+			createProvider({ domainVerified: true, organizationId: org.id }),
+		);
+
+		const user = createUser();
+		data.user.push(user);
+
+		const ctx = (await createContext()) as GenericEndpointContext;
+		await assignOrganizationByDomain(ctx, {
+			user,
+			domainVerification: { enabled: true },
+			provisioningOptions: {
+				defaultRole: "admin",
+				getMemberData: async ({ defaultData }) => {
+					// defaultData should have role: "admin"
+					return defaultData;
+				},
+			},
+		});
+
+		const members = data.member.filter((m) => m.userId === user.id);
+		expect(members).toHaveLength(1);
+		expect(members[0]?.role).toBe("admin");
 	});
 });

--- a/packages/sso/src/linking/org-assignment.ts
+++ b/packages/sso/src/linking/org-assignment.ts
@@ -1,25 +1,41 @@
 import type { GenericEndpointContext, OAuth2Tokens, User } from "better-auth";
-import type { SSOOptions, SSOProvider } from "../types";
+import type { Organization, SSOOptions, SSOProvider } from "../types";
 import { domainMatches } from "../utils";
 import type { NormalizedSSOProfile } from "./types";
 
 export interface OrganizationProvisioningOptions {
-	disabled?: boolean;
-	defaultRole?: string;
-	getRole?: (data: {
-		user: User & Record<string, any>;
-		userInfo: Record<string, any>;
-		token?: OAuth2Tokens;
-		provider: SSOProvider<SSOOptions>;
-	}) => Promise<string>;
+  disabled?: boolean;
+  defaultRole?: string;
+  getRole?: (data: {
+    user: User & Record<string, any>;
+    userInfo: Record<string, any>;
+    token?: OAuth2Tokens;
+    provider: SSOProvider<SSOOptions>;
+  }) => Promise<string>;
+  getMemberData?: (data: {
+    user: User & Record<string, any>;
+    userInfo: Record<string, any>;
+    token?: OAuth2Tokens;
+    provider: SSOProvider<SSOOptions>;
+    organization: Organization & Record<string, any>;
+    defaultData: {
+      organizationId: string;
+      userId: string;
+      role: string;
+      createdAt: Date;
+    };
+  }) =>
+    | Promise<Record<string, any> | undefined>
+    | Record<string, any>
+    | undefined;
 }
 
 export interface AssignOrganizationFromProviderOptions {
-	user: User;
-	profile: NormalizedSSOProfile;
-	provider: SSOProvider<SSOOptions>;
-	token?: OAuth2Tokens;
-	provisioningOptions?: OrganizationProvisioningOptions;
+  user: User;
+  profile: NormalizedSSOProfile;
+  provider: SSOProvider<SSOOptions>;
+  token?: OAuth2Tokens;
+  provisioningOptions?: OrganizationProvisioningOptions;
 }
 
 /**
@@ -27,61 +43,88 @@ export interface AssignOrganizationFromProviderOptions {
  * Used in SSO flows (OIDC, SAML) where the provider is already linked to an org.
  */
 export async function assignOrganizationFromProvider(
-	ctx: GenericEndpointContext,
-	options: AssignOrganizationFromProviderOptions,
+  ctx: GenericEndpointContext,
+  options: AssignOrganizationFromProviderOptions,
 ): Promise<void> {
-	const { user, profile, provider, token, provisioningOptions } = options;
+  const { user, profile, provider, token, provisioningOptions } = options;
+  if (!provider.organizationId) {
+    return;
+  }
 
-	if (!provider.organizationId) {
-		return;
-	}
+  if (provisioningOptions?.disabled) {
+    return;
+  }
 
-	if (provisioningOptions?.disabled) {
-		return;
-	}
+  if (!ctx.context.hasPlugin("organization")) {
+    return;
+  }
 
-	if (!ctx.context.hasPlugin("organization")) {
-		return;
-	}
+  const isAlreadyMember = await ctx.context.adapter.findOne({
+    model: "member",
+    where: [
+      { field: "organizationId", value: provider.organizationId },
+      { field: "userId", value: user.id },
+    ],
+  });
 
-	const isAlreadyMember = await ctx.context.adapter.findOne({
-		model: "member",
-		where: [
-			{ field: "organizationId", value: provider.organizationId },
-			{ field: "userId", value: user.id },
-		],
-	});
+  if (isAlreadyMember) {
+    return;
+  }
 
-	if (isAlreadyMember) {
-		return;
-	}
+  const role = provisioningOptions?.getRole
+    ? await provisioningOptions.getRole({
+        user,
+        userInfo: profile.rawAttributes || {},
+        token,
+        provider,
+      })
+    : provisioningOptions?.defaultRole || "member";
 
-	const role = provisioningOptions?.getRole
-		? await provisioningOptions.getRole({
-				user,
-				userInfo: profile.rawAttributes || {},
-				token,
-				provider,
-			})
-		: provisioningOptions?.defaultRole || "member";
+  const defaultData = {
+    organizationId: provider.organizationId,
+    userId: user.id,
+    role,
+    createdAt: new Date(),
+  };
 
-	await ctx.context.adapter.create({
-		model: "member",
-		data: {
-			organizationId: provider.organizationId,
-			userId: user.id,
-			role,
-			createdAt: new Date(),
-		},
-	});
+  let memberData: Record<string, any> = defaultData;
+
+  if (provisioningOptions?.getMemberData) {
+    const organization = await ctx.context.adapter.findOne<
+      Organization & Record<string, any>
+    >({
+      model: "organization",
+      where: [{ field: "id", value: provider.organizationId }],
+    });
+
+    if (organization) {
+      const customData = await provisioningOptions.getMemberData({
+        user,
+        userInfo: profile.rawAttributes || {},
+        token,
+        provider,
+        organization,
+        defaultData,
+      });
+
+      if (customData) {
+        memberData = { ...defaultData, ...customData };
+      }
+    }
+  }
+
+  const createdMember = await ctx.context.adapter.create({
+    model: "member",
+    data: memberData,
+  });
 }
 
 export interface AssignOrganizationByDomainOptions {
-	user: User;
-	provisioningOptions?: OrganizationProvisioningOptions;
-	domainVerification?: {
-		enabled?: boolean;
-	};
+  user: User;
+  provisioningOptions?: OrganizationProvisioningOptions;
+  domainVerification?: {
+    enabled?: boolean;
+  };
 }
 
 /**
@@ -93,84 +136,120 @@ export interface AssignOrganizationByDomainOptions {
  * (e.g., Google OAuth with @acme.com email gets added to Acme's org).
  */
 export async function assignOrganizationByDomain(
-	ctx: GenericEndpointContext,
-	options: AssignOrganizationByDomainOptions,
+  ctx: GenericEndpointContext,
+  options: AssignOrganizationByDomainOptions,
 ): Promise<void> {
-	const { user, provisioningOptions, domainVerification } = options;
+  const { user, provisioningOptions, domainVerification } = options;
 
-	if (provisioningOptions?.disabled) {
-		return;
-	}
+  if (provisioningOptions?.disabled) {
+    return;
+  }
 
-	if (!ctx.context.hasPlugin("organization")) {
-		return;
-	}
+  if (!ctx.context.hasPlugin("organization")) {
+    return;
+  }
 
-	const domain = user.email.split("@")[1];
-	if (!domain) {
-		return;
-	}
+  const domain = user.email.split("@")[1];
+  if (!domain) {
+    return;
+  }
 
-	// Support comma-separated domains for multi-domain SSO
-	// First try exact match (fast path)
-	const whereClause: { field: string; value: string | boolean }[] = [
-		{ field: "domain", value: domain },
-	];
+  // Support comma-separated domains for multi-domain SSO
+  // First try exact match (fast path)
+  const whereClause: { field: string; value: string | boolean }[] = [
+    { field: "domain", value: domain },
+  ];
 
-	if (domainVerification?.enabled) {
-		whereClause.push({ field: "domainVerified", value: true });
-	}
+  if (domainVerification?.enabled) {
+    whereClause.push({ field: "domainVerified", value: true });
+  }
 
-	let ssoProvider = await ctx.context.adapter.findOne<SSOProvider<SSOOptions>>({
-		model: "ssoProvider",
-		where: whereClause,
-	});
+  let ssoProvider = await ctx.context.adapter.findOne<SSOProvider<SSOOptions>>({
+    model: "ssoProvider",
+    where: whereClause,
+  });
 
-	// If not found, search all providers for comma-separated domain match
-	if (!ssoProvider) {
-		const allProviders = await ctx.context.adapter.findMany<
-			SSOProvider<SSOOptions>
-		>({
-			model: "ssoProvider",
-			where: domainVerification?.enabled
-				? [{ field: "domainVerified", value: true }]
-				: [],
-		});
-		ssoProvider =
-			allProviders.find((p) => domainMatches(domain, p.domain)) ?? null;
-	}
+  // If not found, search all providers for comma-separated domain match
+  if (!ssoProvider) {
+    const allProviders = await ctx.context.adapter.findMany<
+      SSOProvider<SSOOptions>
+    >({
+      model: "ssoProvider",
+      where: domainVerification?.enabled
+        ? [{ field: "domainVerified", value: true }]
+        : [],
+    });
+    ssoProvider =
+      allProviders.find((p) => domainMatches(domain, p.domain)) ?? null;
+  }
 
-	if (!ssoProvider || !ssoProvider.organizationId) {
-		return;
-	}
+  if (!ssoProvider || !ssoProvider.organizationId) {
+    return;
+  }
 
-	const isAlreadyMember = await ctx.context.adapter.findOne({
-		model: "member",
-		where: [
-			{ field: "organizationId", value: ssoProvider.organizationId },
-			{ field: "userId", value: user.id },
-		],
-	});
+  const isAlreadyMember = await ctx.context.adapter.findOne({
+    model: "member",
+    where: [
+      { field: "organizationId", value: ssoProvider.organizationId },
+      { field: "userId", value: user.id },
+    ],
+  });
 
-	if (isAlreadyMember) {
-		return;
-	}
+  if (isAlreadyMember) {
+    return;
+  }
 
-	const role = provisioningOptions?.getRole
-		? await provisioningOptions.getRole({
-				user,
-				userInfo: {},
-				provider: ssoProvider,
-			})
-		: provisioningOptions?.defaultRole || "member";
+  const userInfoFromUser = {
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    image: user.image,
+    emailVerified: user.emailVerified,
+  };
 
-	await ctx.context.adapter.create({
-		model: "member",
-		data: {
-			organizationId: ssoProvider.organizationId,
-			userId: user.id,
-			role,
-			createdAt: new Date(),
-		},
-	});
+  const role = provisioningOptions?.getRole
+    ? await provisioningOptions.getRole({
+        user,
+        userInfo: userInfoFromUser,
+        provider: ssoProvider,
+      })
+    : provisioningOptions?.defaultRole || "member";
+
+  const defaultData = {
+    organizationId: ssoProvider.organizationId,
+    userId: user.id,
+    role,
+    createdAt: new Date(),
+  };
+
+  let memberData: Record<string, any> = defaultData;
+
+  if (provisioningOptions?.getMemberData) {
+    // Fetch the organization for the hook
+    const organization = await ctx.context.adapter.findOne<
+      Organization & Record<string, any>
+    >({
+      model: "organization",
+      where: [{ field: "id", value: ssoProvider.organizationId }],
+    });
+
+    if (organization) {
+      const customData = await provisioningOptions.getMemberData({
+        user,
+        userInfo: userInfoFromUser,
+        provider: ssoProvider,
+        organization,
+        defaultData,
+      });
+
+      if (customData) {
+        memberData = { ...defaultData, ...customData };
+      }
+    }
+  }
+
+  await ctx.context.adapter.create({
+    model: "member",
+    data: memberData,
+  });
 }

--- a/packages/sso/src/linking/org-assignment.ts
+++ b/packages/sso/src/linking/org-assignment.ts
@@ -108,12 +108,14 @@ export async function assignOrganizationFromProvider(
       });
 
       if (customData) {
-        memberData = { ...defaultData, ...customData };
+        // Prevent overriding identity fields while allowing custom fields
+        const { organizationId: _, userId: __, ...safeCustomData } = customData;
+        memberData = { ...defaultData, ...safeCustomData };
       }
     }
   }
 
-  const createdMember = await ctx.context.adapter.create({
+  await ctx.context.adapter.create({
     model: "member",
     data: memberData,
   });
@@ -243,7 +245,9 @@ export async function assignOrganizationByDomain(
       });
 
       if (customData) {
-        memberData = { ...defaultData, ...customData };
+        // Prevent overriding identity fields while allowing custom fields
+        const { organizationId: _, userId: __, ...safeCustomData } = customData;
+        memberData = { ...defaultData, ...safeCustomData };
       }
     }
   }

--- a/packages/sso/src/linking/org-assignment.ts
+++ b/packages/sso/src/linking/org-assignment.ts
@@ -4,38 +4,38 @@ import { domainMatches } from "../utils";
 import type { NormalizedSSOProfile } from "./types";
 
 export interface OrganizationProvisioningOptions {
-  disabled?: boolean;
-  defaultRole?: string;
-  getRole?: (data: {
-    user: User & Record<string, any>;
-    userInfo: Record<string, any>;
-    token?: OAuth2Tokens;
-    provider: SSOProvider<SSOOptions>;
-  }) => Promise<string>;
-  getMemberData?: (data: {
-    user: User & Record<string, any>;
-    userInfo: Record<string, any>;
-    token?: OAuth2Tokens;
-    provider: SSOProvider<SSOOptions>;
-    organization: Organization & Record<string, any>;
-    defaultData: {
-      organizationId: string;
-      userId: string;
-      role: string;
-      createdAt: Date;
-    };
-  }) =>
-    | Promise<Record<string, any> | undefined>
-    | Record<string, any>
-    | undefined;
+	disabled?: boolean;
+	defaultRole?: string;
+	getRole?: (data: {
+		user: User & Record<string, any>;
+		userInfo: Record<string, any>;
+		token?: OAuth2Tokens;
+		provider: SSOProvider<SSOOptions>;
+	}) => Promise<string>;
+	getMemberData?: (data: {
+		user: User & Record<string, any>;
+		userInfo: Record<string, any>;
+		token?: OAuth2Tokens;
+		provider: SSOProvider<SSOOptions>;
+		organization: Organization & Record<string, any>;
+		defaultData: {
+			organizationId: string;
+			userId: string;
+			role: string;
+			createdAt: Date;
+		};
+	}) =>
+		| Promise<Record<string, any> | undefined>
+		| Record<string, any>
+		| undefined;
 }
 
 export interface AssignOrganizationFromProviderOptions {
-  user: User;
-  profile: NormalizedSSOProfile;
-  provider: SSOProvider<SSOOptions>;
-  token?: OAuth2Tokens;
-  provisioningOptions?: OrganizationProvisioningOptions;
+	user: User;
+	profile: NormalizedSSOProfile;
+	provider: SSOProvider<SSOOptions>;
+	token?: OAuth2Tokens;
+	provisioningOptions?: OrganizationProvisioningOptions;
 }
 
 /**
@@ -43,90 +43,90 @@ export interface AssignOrganizationFromProviderOptions {
  * Used in SSO flows (OIDC, SAML) where the provider is already linked to an org.
  */
 export async function assignOrganizationFromProvider(
-  ctx: GenericEndpointContext,
-  options: AssignOrganizationFromProviderOptions,
+	ctx: GenericEndpointContext,
+	options: AssignOrganizationFromProviderOptions,
 ): Promise<void> {
-  const { user, profile, provider, token, provisioningOptions } = options;
-  if (!provider.organizationId) {
-    return;
-  }
+	const { user, profile, provider, token, provisioningOptions } = options;
+	if (!provider.organizationId) {
+		return;
+	}
 
-  if (provisioningOptions?.disabled) {
-    return;
-  }
+	if (provisioningOptions?.disabled) {
+		return;
+	}
 
-  if (!ctx.context.hasPlugin("organization")) {
-    return;
-  }
+	if (!ctx.context.hasPlugin("organization")) {
+		return;
+	}
 
-  const isAlreadyMember = await ctx.context.adapter.findOne({
-    model: "member",
-    where: [
-      { field: "organizationId", value: provider.organizationId },
-      { field: "userId", value: user.id },
-    ],
-  });
+	const isAlreadyMember = await ctx.context.adapter.findOne({
+		model: "member",
+		where: [
+			{ field: "organizationId", value: provider.organizationId },
+			{ field: "userId", value: user.id },
+		],
+	});
 
-  if (isAlreadyMember) {
-    return;
-  }
+	if (isAlreadyMember) {
+		return;
+	}
 
-  const role = provisioningOptions?.getRole
-    ? await provisioningOptions.getRole({
-        user,
-        userInfo: profile.rawAttributes || {},
-        token,
-        provider,
-      })
-    : provisioningOptions?.defaultRole || "member";
+	const role = provisioningOptions?.getRole
+		? await provisioningOptions.getRole({
+				user,
+				userInfo: profile.rawAttributes || {},
+				token,
+				provider,
+			})
+		: provisioningOptions?.defaultRole || "member";
 
-  const defaultData = {
-    organizationId: provider.organizationId,
-    userId: user.id,
-    role,
-    createdAt: new Date(),
-  };
+	const defaultData = {
+		organizationId: provider.organizationId,
+		userId: user.id,
+		role,
+		createdAt: new Date(),
+	};
 
-  let memberData: Record<string, any> = defaultData;
+	let memberData: Record<string, any> = defaultData;
 
-  if (provisioningOptions?.getMemberData) {
-    const organization = await ctx.context.adapter.findOne<
-      Organization & Record<string, any>
-    >({
-      model: "organization",
-      where: [{ field: "id", value: provider.organizationId }],
-    });
+	if (provisioningOptions?.getMemberData) {
+		const organization = await ctx.context.adapter.findOne<
+			Organization & Record<string, any>
+		>({
+			model: "organization",
+			where: [{ field: "id", value: provider.organizationId }],
+		});
 
-    if (organization) {
-      const customData = await provisioningOptions.getMemberData({
-        user,
-        userInfo: profile.rawAttributes || {},
-        token,
-        provider,
-        organization,
-        defaultData,
-      });
+		if (organization) {
+			const customData = await provisioningOptions.getMemberData({
+				user,
+				userInfo: profile.rawAttributes || {},
+				token,
+				provider,
+				organization,
+				defaultData,
+			});
 
-      if (customData) {
-        // Prevent overriding identity fields while allowing custom fields
-        const { organizationId: _, userId: __, ...safeCustomData } = customData;
-        memberData = { ...defaultData, ...safeCustomData };
-      }
-    }
-  }
+			if (customData) {
+				// Prevent overriding identity fields while allowing custom fields
+				const { organizationId: _, userId: __, ...safeCustomData } = customData;
+				memberData = { ...defaultData, ...safeCustomData };
+			}
+		}
+	}
 
-  await ctx.context.adapter.create({
-    model: "member",
-    data: memberData,
-  });
+	await ctx.context.adapter.create({
+		model: "member",
+		data: memberData,
+	});
 }
 
 export interface AssignOrganizationByDomainOptions {
-  user: User;
-  provisioningOptions?: OrganizationProvisioningOptions;
-  domainVerification?: {
-    enabled?: boolean;
-  };
+	user: User;
+	provisioningOptions?: OrganizationProvisioningOptions;
+	domainVerification?: {
+		enabled?: boolean;
+	};
 }
 
 /**
@@ -138,122 +138,122 @@ export interface AssignOrganizationByDomainOptions {
  * (e.g., Google OAuth with @acme.com email gets added to Acme's org).
  */
 export async function assignOrganizationByDomain(
-  ctx: GenericEndpointContext,
-  options: AssignOrganizationByDomainOptions,
+	ctx: GenericEndpointContext,
+	options: AssignOrganizationByDomainOptions,
 ): Promise<void> {
-  const { user, provisioningOptions, domainVerification } = options;
+	const { user, provisioningOptions, domainVerification } = options;
 
-  if (provisioningOptions?.disabled) {
-    return;
-  }
+	if (provisioningOptions?.disabled) {
+		return;
+	}
 
-  if (!ctx.context.hasPlugin("organization")) {
-    return;
-  }
+	if (!ctx.context.hasPlugin("organization")) {
+		return;
+	}
 
-  const domain = user.email.split("@")[1];
-  if (!domain) {
-    return;
-  }
+	const domain = user.email.split("@")[1];
+	if (!domain) {
+		return;
+	}
 
-  // Support comma-separated domains for multi-domain SSO
-  // First try exact match (fast path)
-  const whereClause: { field: string; value: string | boolean }[] = [
-    { field: "domain", value: domain },
-  ];
+	// Support comma-separated domains for multi-domain SSO
+	// First try exact match (fast path)
+	const whereClause: { field: string; value: string | boolean }[] = [
+		{ field: "domain", value: domain },
+	];
 
-  if (domainVerification?.enabled) {
-    whereClause.push({ field: "domainVerified", value: true });
-  }
+	if (domainVerification?.enabled) {
+		whereClause.push({ field: "domainVerified", value: true });
+	}
 
-  let ssoProvider = await ctx.context.adapter.findOne<SSOProvider<SSOOptions>>({
-    model: "ssoProvider",
-    where: whereClause,
-  });
+	let ssoProvider = await ctx.context.adapter.findOne<SSOProvider<SSOOptions>>({
+		model: "ssoProvider",
+		where: whereClause,
+	});
 
-  // If not found, search all providers for comma-separated domain match
-  if (!ssoProvider) {
-    const allProviders = await ctx.context.adapter.findMany<
-      SSOProvider<SSOOptions>
-    >({
-      model: "ssoProvider",
-      where: domainVerification?.enabled
-        ? [{ field: "domainVerified", value: true }]
-        : [],
-    });
-    ssoProvider =
-      allProviders.find((p) => domainMatches(domain, p.domain)) ?? null;
-  }
+	// If not found, search all providers for comma-separated domain match
+	if (!ssoProvider) {
+		const allProviders = await ctx.context.adapter.findMany<
+			SSOProvider<SSOOptions>
+		>({
+			model: "ssoProvider",
+			where: domainVerification?.enabled
+				? [{ field: "domainVerified", value: true }]
+				: [],
+		});
+		ssoProvider =
+			allProviders.find((p) => domainMatches(domain, p.domain)) ?? null;
+	}
 
-  if (!ssoProvider || !ssoProvider.organizationId) {
-    return;
-  }
+	if (!ssoProvider || !ssoProvider.organizationId) {
+		return;
+	}
 
-  const isAlreadyMember = await ctx.context.adapter.findOne({
-    model: "member",
-    where: [
-      { field: "organizationId", value: ssoProvider.organizationId },
-      { field: "userId", value: user.id },
-    ],
-  });
+	const isAlreadyMember = await ctx.context.adapter.findOne({
+		model: "member",
+		where: [
+			{ field: "organizationId", value: ssoProvider.organizationId },
+			{ field: "userId", value: user.id },
+		],
+	});
 
-  if (isAlreadyMember) {
-    return;
-  }
+	if (isAlreadyMember) {
+		return;
+	}
 
-  const userInfoFromUser = {
-    id: user.id,
-    email: user.email,
-    name: user.name,
-    image: user.image,
-    emailVerified: user.emailVerified,
-  };
+	const userInfoFromUser = {
+		id: user.id,
+		email: user.email,
+		name: user.name,
+		image: user.image,
+		emailVerified: user.emailVerified,
+	};
 
-  const role = provisioningOptions?.getRole
-    ? await provisioningOptions.getRole({
-        user,
-        userInfo: userInfoFromUser,
-        provider: ssoProvider,
-      })
-    : provisioningOptions?.defaultRole || "member";
+	const role = provisioningOptions?.getRole
+		? await provisioningOptions.getRole({
+				user,
+				userInfo: userInfoFromUser,
+				provider: ssoProvider,
+			})
+		: provisioningOptions?.defaultRole || "member";
 
-  const defaultData = {
-    organizationId: ssoProvider.organizationId,
-    userId: user.id,
-    role,
-    createdAt: new Date(),
-  };
+	const defaultData = {
+		organizationId: ssoProvider.organizationId,
+		userId: user.id,
+		role,
+		createdAt: new Date(),
+	};
 
-  let memberData: Record<string, any> = defaultData;
+	let memberData: Record<string, any> = defaultData;
 
-  if (provisioningOptions?.getMemberData) {
-    // Fetch the organization for the hook
-    const organization = await ctx.context.adapter.findOne<
-      Organization & Record<string, any>
-    >({
-      model: "organization",
-      where: [{ field: "id", value: ssoProvider.organizationId }],
-    });
+	if (provisioningOptions?.getMemberData) {
+		// Fetch the organization for the hook
+		const organization = await ctx.context.adapter.findOne<
+			Organization & Record<string, any>
+		>({
+			model: "organization",
+			where: [{ field: "id", value: ssoProvider.organizationId }],
+		});
 
-    if (organization) {
-      const customData = await provisioningOptions.getMemberData({
-        user,
-        userInfo: userInfoFromUser,
-        provider: ssoProvider,
-        organization,
-        defaultData,
-      });
+		if (organization) {
+			const customData = await provisioningOptions.getMemberData({
+				user,
+				userInfo: userInfoFromUser,
+				provider: ssoProvider,
+				organization,
+				defaultData,
+			});
 
-      if (customData) {
-        // Prevent overriding identity fields while allowing custom fields
-        const { organizationId: _, userId: __, ...safeCustomData } = customData;
-        memberData = { ...defaultData, ...safeCustomData };
-      }
-    }
-  }
+			if (customData) {
+				// Prevent overriding identity fields while allowing custom fields
+				const { organizationId: _, userId: __, ...safeCustomData } = customData;
+				memberData = { ...defaultData, ...safeCustomData };
+			}
+		}
+	}
 
-  await ctx.context.adapter.create({
-    model: "member",
-    data: memberData,
-  });
+	await ctx.context.adapter.create({
+		model: "member",
+		data: memberData,
+	});
 }

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -252,9 +252,10 @@ export interface SSOOptions {
 						role: string;
 						createdAt: Date;
 					};
-				}) => Promise<Record<string, any> | undefined>
-				| Record<string, any>
-				| undefined;
+				}) =>
+					| Promise<Record<string, any> | undefined>
+					| Record<string, any>
+					| undefined;
 		  }
 		| undefined;
 	/**

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -1,6 +1,15 @@
 import type { Awaitable, OAuth2Tokens, User } from "better-auth";
 import type { AlgorithmValidationOptions } from "./saml/algorithms";
 
+export interface Organization {
+	id: string;
+	name: string;
+	slug: string;
+	logo?: string | null;
+	metadata?: Record<string, any> | null;
+	createdAt: Date;
+}
+
 export interface OIDCMapping {
 	id?: string | undefined;
 	email?: string | undefined;
@@ -193,6 +202,57 @@ export interface SSOOptions {
 					 */
 					provider: SSOProvider<SSOOptions>;
 				}) => Promise<"member" | "admin">;
+				/**
+				 * Custom function to provide additional member data when auto-provisioning
+				 * organization members via SSO.
+				 *
+				 * Use this to populate required fields on the member table (like "name")
+				 * or any additional fields defined in the organization plugin's member schema.
+				 *
+				 * @example
+				 * ```ts
+				 * getMemberData: async ({ user, userInfo, defaultData }) => {
+				 *   return {
+				 *     ...defaultData,
+				 *     name: userInfo.name || user.name,
+				 *     department: userInfo.department,
+				 *   };
+				 * }
+				 * ```
+				 */
+				getMemberData?: (data: {
+					/**
+					 * The user object from the database
+					 */
+					user: User & Record<string, any>;
+					/**
+					 * The raw user info/attributes from the SSO provider
+					 * (SAML attributes or OIDC claims)
+					 */
+					userInfo: Record<string, any>;
+					/**
+					 * The OAuth2 tokens from the provider (OIDC only)
+					 */
+					token?: OAuth2Tokens;
+					/**
+					 * The SSO provider configuration
+					 */
+					provider: SSOProvider<SSOOptions>;
+					/**
+					 * The organization the user is being added to
+					 */
+					organization: Organization & Record<string, any>;
+					/**
+					 * The default member data that will be used if this function
+					 * is not provided or returns undefined
+					 */
+					defaultData: {
+						organizationId: string;
+						userId: string;
+						role: string;
+						createdAt: Date;
+					};
+				}) => Awaitable<Record<string, any> | undefined>;
 		  }
 		| undefined;
 	/**

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -252,7 +252,9 @@ export interface SSOOptions {
 						role: string;
 						createdAt: Date;
 					};
-				}) => Awaitable<Record<string, any> | undefined>;
+				}) => Promise<Record<string, any> | undefined>
+				| Record<string, any>
+				| undefined;
 		  }
 		| undefined;
 	/**


### PR DESCRIPTION
Add getMemberData callback to organizationProvisioning options in the SSO plugin. This allows users to customize member data during auto- provisioning, enabling population of required additionalFields from SSO provider claims.

Closes #7828

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `getMemberData` hook to SSO organization provisioning so apps can customize member creation during auto‑provisioning. Maps SSO claims to extra member fields, respects `defaultRole`, and works in both provider and domain flows. Closes #7828.

- **New Features**
  - Added `organizationProvisioning.getMemberData({ user, userInfo, token, provider, organization, defaultData })` to extend member fields; falls back to `defaultData` when undefined.
  - Safe merge blocks overrides to `organizationId` and `userId` while allowing custom fields.
  - Applied in both `assignOrganizationFromProvider` (passes `rawAttributes`) and `assignOrganizationByDomain` (passes basic `userInfo`); `getRole` in the domain flow now also receives basic `userInfo`.
  - Exported `Organization` type in the public API; tests cover custom fields, default fallback, `defaultRole`, and hook call arguments.

<sup>Written for commit 2ce7d5ce927aaeb457955db0d52130a6a7747057. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/7829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

