### PR TITLE
fix(cli): add `.env.local` to dotenv

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -230,6 +230,9 @@ export async function getConfig({
 						};
 					}>({
 						configFile: possiblePath,
+						dotenv: {
+							fileName: [".env", ".env.local"],
+						},
 						jitiOptions: jitiOptions(cwd),
 						cwd,
 					});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
CLI now loads .env.local alongside .env when resolving project config, for both explicit and discovered config files. This ensures local overrides are applied during CLI runs.

<sup>Written for commit 42ecca0b8ac83fbb4a5e8a5aac129ae6ca50421c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

