### PR TITLE
chore(electron): construct channel prefix consistently

### DIFF
--- a/packages/electron/src/authenticate.ts
+++ b/packages/electron/src/authenticate.ts
@@ -8,6 +8,7 @@ import { signInSocial } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
 import { shell } from "electron";
 import * as z from "zod";
+import { getChannelPrefixWithDelimiter } from "./bridges";
 import type { ElectronClientOptions } from "./types/client";
 import { isProcessType } from "./utils";
 
@@ -124,7 +125,7 @@ export async function authenticate(
 		},
 		onSuccess: (ctx) => {
 			getWindow()?.webContents.send(
-				`${options.channelPrefix || "better-auth"}:authenticated`,
+				`${getChannelPrefixWithDelimiter(options.channelPrefix)}authenticated`,
 				ctx.data.user,
 			);
 		},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use getChannelPrefixWithDelimiter to build the IPC channel for the "authenticated" event in Electron. This standardizes the prefix and delimiter and avoids mismatched listeners when a custom channelPrefix is used.

<sup>Written for commit f60b5d29e6c2b59dc95d883272034b6b639b12d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

