### PR TITLE
fix: handle falsy filter values in admin listUsers API

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -437,6 +437,57 @@ describe("Admin plugin", async () => {
 		expect(res.data?.users[0]!.email).toBe("test@test.com");
 	});
 
+	it("should handle falsy filter values (false, 0, empty string)", async () => {
+		// filterValue = false should apply the filter, not be ignored
+		const resFalse = await client.admin.listUsers({
+			query: {
+				filterValue: false,
+				filterField: "emailVerified",
+				filterOperator: "eq",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		// The filter should be applied (not ignored), so we get a filtered result
+		expect(resFalse.data).toBeDefined();
+		expect(resFalse.data?.users).toBeDefined();
+		// All returned users should have emailVerified === false
+		for (const user of resFalse.data?.users || []) {
+			expect(user.emailVerified).toBe(false);
+		}
+
+		// filterValue = 0 should apply the filter, not be ignored
+		const resZero = await client.admin.listUsers({
+			query: {
+				filterValue: 0,
+				filterField: "emailVerified",
+				filterOperator: "eq",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(resZero.data).toBeDefined();
+		expect(resZero.data?.users).toBeDefined();
+
+		// filterValue = "" (empty string) should apply the filter, not be ignored
+		const resEmpty = await client.admin.listUsers({
+			query: {
+				filterValue: "",
+				filterField: "name",
+				filterOperator: "eq",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(resEmpty.data).toBeDefined();
+		expect(resEmpty.data?.users).toBeDefined();
+		// No users should have an empty name, so we expect 0 results
+		expect(resEmpty.data?.users.length).toBe(0);
+	});
+
 	it("should allow to set user role", async () => {
 		const res = await client.admin.setRole(
 			{

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -647,7 +647,7 @@ export const listUsers = (opts: AdminOptions) =>
 
 			const where: Where[] = [];
 
-			if (ctx.query?.searchValue) {
+			if (ctx.query?.searchValue !== undefined && ctx.query?.searchValue !== null) {
 				where.push({
 					field: ctx.query.searchField || "email",
 					operator: ctx.query.searchOperator || "contains",
@@ -655,7 +655,7 @@ export const listUsers = (opts: AdminOptions) =>
 				});
 			}
 
-			if (ctx.query?.filterValue) {
+			if (ctx.query?.filterValue !== undefined && ctx.query?.filterValue !== null) {
 				where.push({
 					field: ctx.query.filterField || "email",
 					operator: ctx.query.filterOperator || "eq",


### PR DESCRIPTION
## Summary

Fixes #7837

The `listUsers` API in the admin plugin was ignoring falsy filter values (`false`, `0`, `""`) because the code used a truthy check (`if (ctx.query?.filterValue)`) to determine whether to apply the filter. This caused valid filter values like `false`, `0`, and empty string to be silently skipped.

## Changes

- **`packages/better-auth/src/plugins/admin/routes.ts`**: Changed both `filterValue` and `searchValue` checks from truthy checks to strict `!== undefined && !== null` checks, so falsy values are properly handled.
- **`packages/better-auth/src/plugins/admin/admin.test.ts`**: Added test case covering `filterValue = false`, `filterValue = 0`, and `filterValue = ""` to ensure they are not ignored.

## Before

```typescript
if (ctx.query?.filterValue) {  // skips false, 0, ""
```

## After

```typescript
if (ctx.query?.filterValue !== undefined && ctx.query?.filterValue !== null) {  // only skips undefined/null
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes listUsers in the admin plugin to correctly apply filters when values are falsy (false, 0, ""), so valid filters are no longer ignored and search behaves as expected.

- **Bug Fixes**
  - Use explicit undefined/null checks for filterValue and searchValue instead of truthy checks.
  - Add tests covering false, 0, and empty string to ensure filters are applied and prevent regressions.

<sup>Written for commit 47145e12d9a12689fe590987373564b68c5cad63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

