### PR TITLE
fix: handle personal Microsoft account name mapping in Entra ID provider

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1203,6 +1203,142 @@ describe("oauth2", async () => {
 			expect(msConfig.pkce).toBe(true);
 			expect(msConfig.disableImplicitSignUp).toBe(true);
 		});
+
+		describe("getUserInfo name resolution for personal accounts", () => {
+			const createConfig = () =>
+				microsoftEntraId({
+					clientId: "ms-client-id",
+					clientSecret: "ms-client-secret",
+					tenantId: "common",
+				});
+
+			it("should use profile.name when available (work account)", async () => {
+				const msConfig = createConfig();
+				const originalFetch = globalThis.fetch;
+				globalThis.fetch = vi.fn().mockResolvedValue(
+					new Response(
+						JSON.stringify({
+							sub: "user-1",
+							name: "John Doe",
+							email: "john@contoso.com",
+							given_name: "John",
+							family_name: "Doe",
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+				);
+				try {
+					const result = await msConfig.getUserInfo!({
+						accessToken: "test-token",
+						tokenType: "Bearer",
+					});
+					expect(result).not.toBeNull();
+					expect(result!.name).toBe("John Doe");
+				} finally {
+					globalThis.fetch = originalFetch;
+				}
+			});
+
+			it("should fall back to given_name + family_name when name is missing", async () => {
+				const msConfig = createConfig();
+				const originalFetch = globalThis.fetch;
+				globalThis.fetch = vi.fn().mockResolvedValue(
+					new Response(
+						JSON.stringify({
+							sub: "user-2",
+							email: "jane@contoso.com",
+							given_name: "Jane",
+							family_name: "Smith",
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+				);
+				try {
+					const result = await msConfig.getUserInfo!({
+						accessToken: "test-token",
+						tokenType: "Bearer",
+					});
+					expect(result).not.toBeNull();
+					expect(result!.name).toBe("Jane Smith");
+				} finally {
+					globalThis.fetch = originalFetch;
+				}
+			});
+
+			it("should fall back to givenname + familyname for personal accounts (no underscore)", async () => {
+				const msConfig = createConfig();
+				const originalFetch = globalThis.fetch;
+				globalThis.fetch = vi.fn().mockResolvedValue(
+					new Response(
+						JSON.stringify({
+							sub: "user-3",
+							email: "personal@outlook.com",
+							givenname: "Alice",
+							familyname: "Wonder",
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+				);
+				try {
+					const result = await msConfig.getUserInfo!({
+						accessToken: "test-token",
+						tokenType: "Bearer",
+					});
+					expect(result).not.toBeNull();
+					expect(result!.name).toBe("Alice Wonder");
+				} finally {
+					globalThis.fetch = originalFetch;
+				}
+			});
+
+			it("should fall back to email when no name fields are present", async () => {
+				const msConfig = createConfig();
+				const originalFetch = globalThis.fetch;
+				globalThis.fetch = vi.fn().mockResolvedValue(
+					new Response(
+						JSON.stringify({
+							sub: "user-4",
+							email: "noname@outlook.com",
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+				);
+				try {
+					const result = await msConfig.getUserInfo!({
+						accessToken: "test-token",
+						tokenType: "Bearer",
+					});
+					expect(result).not.toBeNull();
+					expect(result!.name).toBe("noname@outlook.com");
+				} finally {
+					globalThis.fetch = originalFetch;
+				}
+			});
+
+			it("should fall back to preferred_username when no name or email", async () => {
+				const msConfig = createConfig();
+				const originalFetch = globalThis.fetch;
+				globalThis.fetch = vi.fn().mockResolvedValue(
+					new Response(
+						JSON.stringify({
+							sub: "user-5",
+							preferred_username: "user5@outlook.com",
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+				);
+				try {
+					const result = await msConfig.getUserInfo!({
+						accessToken: "test-token",
+						tokenType: "Bearer",
+					});
+					expect(result).not.toBeNull();
+					expect(result!.name).toBe("user5@outlook.com");
+				} finally {
+					globalThis.fetch = originalFetch;
+				}
+			});
+		});
 	});
 
 	describe("Slack Provider Helper", () => {

--- a/packages/better-auth/src/plugins/generic-oauth/providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/microsoft-entra-id.ts
@@ -18,6 +18,10 @@ interface MicrosoftEntraIdProfile {
 	picture?: string;
 	given_name?: string;
 	family_name?: string;
+	/** Personal Microsoft accounts may return `givenname` (no underscore) */
+	givenname?: string;
+	/** Personal Microsoft accounts may return `familyname` (no underscore) */
+	familyname?: string;
 	email_verified?: boolean;
 }
 
@@ -69,12 +73,21 @@ export function microsoftEntraId(
 			return null;
 		}
 
+		// Personal Microsoft accounts may return `givenname`/`familyname` (no underscore)
+		// instead of `given_name`/`family_name`. We handle both variants.
+		const givenName = profile.given_name ?? profile.givenname;
+		const familyName = profile.family_name ?? profile.familyname;
+		const resolvedName =
+			profile.name ??
+			([givenName, familyName].filter(Boolean).join(" ") || undefined);
+
 		return {
 			id: profile.sub,
 			name:
-				profile.name ??
-				(`${profile.given_name ?? ""} ${profile.family_name ?? ""}`.trim() ||
-					undefined),
+				resolvedName ??
+				profile.email ??
+				profile.preferred_username ??
+				undefined,
 			email: profile.email ?? profile.preferred_username ?? undefined,
 			image: profile.picture,
 			// Note: Microsoft Entra ID does NOT include email_verified claim by default.

--- a/packages/core/src/social-providers/microsoft-entra-id.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.ts
@@ -273,10 +273,19 @@ export const microsoft = (options: MicrosoftOptions) => {
 								user.verified_secondary_email?.includes(user.email))
 						? true
 						: false;
+			// Personal Microsoft accounts may not include `name` in the ID token.
+			// Fallback: name → given_name + family_name → email → preferred_username
+			const resolvedName =
+				user.name ||
+				[user.given_name, user.family_name].filter(Boolean).join(" ") ||
+				user.email ||
+				user.preferred_username ||
+				undefined;
+
 			return {
 				user: {
 					id: user.sub,
-					name: user.name,
+					name: resolvedName,
 					email: user.email,
 					image: user.picture,
 					emailVerified,


### PR DESCRIPTION
## Summary

Fixes #7787

When using the Microsoft Entra ID provider with personal Microsoft accounts (e.g., Outlook/Hotmail), the `getUserInfo` function fails to resolve the user name, resulting in a `name_is_missing` error.

### Problem

Personal Microsoft accounts return user profile data with different field names than work/school (enterprise) accounts:

- **Work accounts**: `name`, `given_name`, `family_name`
- **Personal accounts**: may omit `name` entirely, and return `givenname`/`familyname` (no underscore) instead of `given_name`/`family_name`

Both the core social provider (`packages/core/src/social-providers/microsoft-entra-id.ts`) and the generic-oauth provider helper (`packages/better-auth/src/plugins/generic-oauth/providers/microsoft-entra-id.ts`) did not account for these variations.

### Changes

**Core social provider** (`packages/core/src/social-providers/microsoft-entra-id.ts`):
- Added name resolution fallback chain: `name` → `given_name + family_name` → `email` → `preferred_username`

**Generic OAuth provider helper** (`packages/better-auth/src/plugins/generic-oauth/providers/microsoft-entra-id.ts`):
- Added `givenname` and `familyname` (no underscore) fields to the `MicrosoftEntraIdProfile` interface
- Updated name resolution to handle both `given_name`/`family_name` and `givenname`/`familyname` variants
- Added fallback to `email` and `preferred_username` when no name fields are present

**Tests** (`packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts`):
- Added 5 test cases covering all name resolution scenarios:
  - Work account with `name` field
  - Missing `name` with `given_name` + `family_name` fallback
  - Personal account with `givenname` + `familyname` (no underscore) fallback
  - Fallback to `email` when no name fields present
  - Fallback to `preferred_username` as last resort


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes name resolution for personal Microsoft accounts in the Entra ID provider, preventing name_is_missing errors and ensuring consistent display names across work and personal accounts.

- **Bug Fixes**
  - Core provider: add fallback chain for name resolution: name → given_name+family_name → email → preferred_username.
  - Generic OAuth helper: support personal account fields (givenname/familyname), handle both underscore and non-underscore variants, and fall back to email/preferred_username.
  - Tests: add cases for work vs personal profiles and all fallback paths.

<sup>Written for commit 0da6b0cff624467192fbc1565c17fc2a9fc689ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

