### PR TITLE
docs: update waku usage

### DIFF
--- a/docs/content/docs/integrations/waku.mdx
+++ b/docs/content/docs/integrations/waku.mdx
@@ -73,12 +73,13 @@ The `api` object exported from the auth instance contains all the actions that y
 "use server" // Waku currently only supports file-level "use server"
 
 import { auth } from "./auth"
-import { unstable_getContext as getContext } from "waku/server"
+import { unstable_getHeaders as getHeaders } from "waku/server"
 
 export const someAuthenticatedAction = async () => {
   "use server"
+  const headers = getHeaders()
   const session = await auth.api.getSession({
-    headers: new Headers(getContext().req.headers),
+      headers,
   })
 };
 ```
@@ -88,20 +89,21 @@ export const someAuthenticatedAction = async () => {
 
 ```tsx
 import { auth } from "../auth"
-import { unstable_getContext as getContext } from "waku/server"
+import { unstable_getHeaders as getHeaders } from "waku/server"
 
 export async function ServerComponent() {
-    const session = await auth.api.getSession({
-        headers: new Headers(getContext().req.headers),
-    })
-    if(!session) {
-        return <div>Not authenticated</div>
-    }
-    return (
-        <div>
-            <h1>Welcome {session.user.name}</h1>
-        </div>
-    )
+  const headers = getHeaders()
+  const session = await auth.api.getSession({
+      headers,
+  })
+  if(!session) {
+      return <div>Not authenticated</div>
+  }
+  return (
+      <div>
+          <h1>Welcome {session.user.name}</h1>
+      </div>
+  )
 }
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Waku integration docs to use unstable_getHeaders instead of unstable_getContext in server action and server component examples. Simplifies header retrieval and aligns getSession usage with the latest Waku API (pass headers from getHeaders directly).

<sup>Written for commit 91d32ada081a4c59c930dfb3481939fe301ce41b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

