### PR TITLE
feat(oauth-provider): export oAuthState for config use

### DIFF
--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -3,6 +3,7 @@ import { getSessionFromCtx } from "better-auth/api";
 import { generateRandomString, makeSignature } from "better-auth/crypto";
 import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
+import { oAuthState } from "./oauth";
 import type {
 	OAuthAuthorizationQuery,
 	OAuthConsent,
@@ -131,6 +132,10 @@ export async function authorizeEndpoint(
 
 	// Check request
 	const query: OAuthAuthorizationQuery = ctx.query;
+	await oAuthState.set({
+		query: query.toString(),
+	});
+
 	if (!query.client_id) {
 		throw ctx.redirect(
 			getErrorURL(ctx, "invalid_client", "client_id is required"),

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -5,5 +5,5 @@ export {
 	oauthProviderOpenIdConfigMetadata,
 	oidcServerMetadata,
 } from "./metadata";
-export { oauthProvider } from "./oauth";
+export { getOAuthProviderState, oauthProvider } from "./oauth";
 export type * from "./types";

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -41,6 +41,7 @@ declare module "@better-auth/core" {
 export const oAuthState = defineRequestState<{ query?: string } | null>(
 	() => null,
 );
+export const getOAuthProviderState = oAuthState.get;
 
 /**
  * oAuth 2.1 provider plugin for Better Auth.


### PR DESCRIPTION
Export oAuthState via `getOAuthProviderState` for use within the auth config. This allows users to make flow decisions based on signed custom `oauth_query` authorize params.

Closes: #7630
Feature discussion: https://github.com/better-auth/better-auth/discussions/3505#discussioncomment-15728097


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose request-scoped OAuth state to auth config by exporting getOAuthProviderState and setting it during /authorize, so apps can make flow decisions from signed oauth_query params.

- **New Features**
  - Export getOAuthProviderState from the OAuth provider.
  - Store the authorize query (string) in request-scoped state during /authorize for use in config.

<sup>Written for commit 6afa9f7041b27f5fdb5967c4ecc6db23d084455e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

