### PR TITLE
fix(oauth-provider): redirect with uri

### DIFF
--- a/packages/better-auth/src/client/fetch-plugins.ts
+++ b/packages/better-auth/src/client/fetch-plugins.ts
@@ -5,11 +5,12 @@ export const redirectPlugin = {
 	name: "Redirect",
 	hooks: {
 		onSuccess(context) {
-			if (context.data?.url && context.data?.redirect) {
+			const redirectUri = context.data?.url ?? context.data?.uri;
+			if (redirectUri && context.data?.redirect) {
 				if (typeof window !== "undefined" && window.location) {
 					if (window.location) {
 						try {
-							window.location.href = context.data.url;
+							window.location.href = redirectUri;
 						} catch {}
 					}
 				}


### PR DESCRIPTION
Redirects using the redirect plugin for return type.

```ts
{
    redirect: true,
    uri: string,
}
```

Alternative: #7811
Closes: #7807

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the redirect plugin to support responses that use uri, not just url. This fixes OAuth flows that return { redirect: true, uri } by redirecting to the correct location.

<sup>Written for commit 95dce467663987f29a46fa4bba96a4ff34475160. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

