### PR TITLE
fix(oauth-provider): add missing oauthClient createdAt/updatedAt values

### DIFF
--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -257,11 +257,6 @@ describe("oauth authorize - authenticated", async () => {
 		);
 	});
 
-	it("should advertise authorization_response_iss_parameter_supported in metadata", async () => {
-		const metadata = await auth.api.getOpenIdConfig();
-		expect(metadata.authorization_response_iss_parameter_supported).toBe(true);
-	});
-
 	it("should have metadata issuer match iss parameter (RFC 9207)", async () => {
 		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
 			throw Error("beforeAll not run properly");

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -100,6 +100,7 @@ describe("oauth metadata", async () => {
 				"client_secret_post",
 			],
 			code_challenge_methods_supported: ["S256"],
+			authorization_response_iss_parameter_supported: true,
 			claims_supported: baseClaims,
 			userinfo_endpoint: `${baseURL}/oauth2/userinfo`,
 			subject_types_supported: ["public"],
@@ -150,6 +151,7 @@ describe("oauth metadata", async () => {
 				"client_secret_post",
 			],
 			code_challenge_methods_supported: ["S256"],
+			authorization_response_iss_parameter_supported: true,
 		});
 	});
 

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -299,6 +299,10 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						const authMetadata = authServerMetadata(ctx, jwtPluginOptions, {
 							scopes_supported:
 								opts.advertisedMetadata?.scopes_supported ?? opts.scopes,
+							public_client_supported:
+								opts.allowUnauthenticatedClientRegistration,
+							grant_types_supported: opts.grantTypes,
+							jwt_disabled: opts.disableJwtPlugin,
 						});
 						return authMetadata;
 					}

--- a/packages/oauth-provider/src/oauthClient/endpoints.test.ts
+++ b/packages/oauth-provider/src/oauthClient/endpoints.test.ts
@@ -55,6 +55,7 @@ describe("oauthClient", async () => {
 		expect(client?.data?.client_id).toBeDefined();
 		expect(client?.data?.user_id).toBeDefined();
 		expect(client?.data?.client_secret).toBeDefined();
+		expect(client.data?.client_id_issued_at).toBeDefined();
 		oauthClient = client.data!;
 
 		const publicClient = await authClient.oauth2.createClient({
@@ -64,6 +65,7 @@ describe("oauthClient", async () => {
 		expect(publicClient?.data?.client_id).toBeDefined();
 		expect(publicClient?.data?.user_id).toBeDefined();
 		expect(publicClient?.data?.client_secret).toBeUndefined();
+		expect(publicClient.data?.client_id_issued_at).toBeDefined();
 		oauthPublicClient = publicClient.data!;
 
 		const uiClient = await authClient.oauth2.createClient({
@@ -73,6 +75,7 @@ describe("oauthClient", async () => {
 		expect(uiClient?.data?.client_id).toBeDefined();
 		expect(uiClient?.data?.user_id).toBeDefined();
 		expect(uiClient?.data?.client_secret).toBeDefined();
+		expect(uiClient.data?.client_id_issued_at).toBeDefined();
 		oauthUiClient = uiClient.data!;
 	});
 

--- a/packages/oauth-provider/src/oauthClient/endpoints.ts
+++ b/packages/oauth-provider/src/oauthClient/endpoints.ts
@@ -269,7 +269,10 @@ export async function updateClientEndpoint(
 					value: clientId,
 				},
 			],
-			update: oauthToSchema(updates),
+			update: {
+				...oauthToSchema(updates),
+				updatedAt: new Date(Math.floor(Date.now() / 1000) * 1000),
+			},
 		},
 	);
 	if (!updatedClient) {
@@ -351,8 +354,8 @@ export async function rotateClientSecretEndpoint(
 				},
 			],
 			update: {
-				...schemaToOAuth(client),
 				clientSecret: storedClientSecret,
+				updatedAt: new Date(Math.floor(Date.now() / 1000) * 1000),
 			},
 		},
 	);

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -133,7 +133,7 @@ describe("oauth register", async () => {
 			scope: "create:test delete:test",
 			//---- Recommended client data ----//
 			user_id: "bad-actor",
-			client_id_issued_at: Math.round(Date.now() / 1000),
+			client_id_issued_at: Math.floor(Date.now() / 1000),
 			//---- UI Metadata ----//
 			client_name: "accept name",
 			client_uri: "https://example.com/ok",

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -188,7 +188,11 @@ export async function createOAuthClientEndpoint(
 	});
 	const client = await ctx.context.adapter.create<SchemaClient<Scope[]>>({
 		model: "oauthClient",
-		data: schema,
+		data: {
+			...schema,
+			createdAt: new Date(iat * 1000),
+			updatedAt: new Date(iat * 1000),
+		},
 	});
 	// Format the response according to RFC7591
 	return ctx.json(


### PR DESCRIPTION
Adds missing `createdAt` and `updatedAt` values and fixes the `metadata` endpoint in some configurations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing createdAt/updatedAt for OAuth clients and completes provider metadata based on config. Fixes the metadata endpoint so it consistently advertises RFC 9207 and rounds timestamps to whole seconds.

- **New Features**
  - Metadata now includes public_client_supported, grant_types_supported, jwt_disabled; scopes_supported reflects configured scopes.
  - Advertises authorization_response_iss_parameter_supported; assertions moved to the metadata test suite.

- **Bug Fixes**
  - Set createdAt/updatedAt on client creation; update updatedAt on client updates and secret rotation.
  - Use floor-second precision for client_id_issued_at and timestamp conversions to match spec and tests.

<sup>Written for commit 687c4a749092894e90e0448fbd807f55ee030ba1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

