### PR TITLE
fix(oauth-provider): resource indicators rfc 8707

### DIFF
--- a/.changeset/free-files-tease.md
+++ b/.changeset/free-files-tease.md
@@ -6,9 +6,11 @@ Follow the resource indicator spec RFC 8707.
 
 Improvements:
 
-- Prevents resource value changes between /authorize and /token
-- Restricts refresh and access tokens to resources specified at issuance
+- Prevents resource value changes between `/authorize` and `/token`
+- Restricts refresh and access tokens to resources specified at authorization
 - `resource` supported across all grant types: authorization_code, client_credentials, refresh_token
+- Access tokens with resource provides `aud` field at introspection
+- Ensures consent re-prompting changes in resource
 
 Deprecations:
 

--- a/.changeset/free-files-tease.md
+++ b/.changeset/free-files-tease.md
@@ -1,0 +1,15 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+Follow the resource indicator spec RFC 8707.
+
+Improvements:
+
+- Prevents resource value changes between /authorize and /token
+- Restricts refresh and access tokens to resources specified at issuance
+- `resource` supported across all grant types: authorization_code, client_credentials, refresh_token
+
+Deprecations:
+
+- `customAccessTokenClaims` properly uses the `resources` field to indicate the resource at both `/token` and `/introspect` (`resource` field in this function is deprecated).

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -462,8 +462,7 @@ Important notes:
 * In OAuth 2.1, only `response_type: "code"` is supported.
 * `code_challenge_method: "plain"` will not be supported since this is a security vulnerability.
 * All authorization responses (success and error) include the `iss` parameter for issuer validation ([RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207)).
-
-- Use the `resource` indicators to restrict tokens to a resource ([RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)).
+* Use the `resource` indicators to restrict tokens to a resource ([RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)).
 
 **State**
 

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -462,6 +462,7 @@ Important notes:
 * In OAuth 2.1, only `response_type: "code"` is supported.
 * `code_challenge_method: "plain"` will not be supported since this is a security vulnerability.
 * All authorization responses (success and error) include the `iss` parameter for issuer validation ([RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207)).
+- Use the `resource` indicators to restrict tokens to a resource ([RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)).
 
 **State**
 
@@ -493,6 +494,9 @@ The token endpoint supports the following client authentication methods:
 * **`client_secret_post`** — Client credentials sent in the request body
 * **`private_key_jwt`** — Client authenticates with a signed JWT assertion ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523))
 * **`none`** — Public client (PKCE required)
+
+Important Notes:
+- Use of the `resource` parameter results in a JWT access token (with JWT plugin enabled).
 
 #### Private Key JWT Authentication
 
@@ -615,7 +619,7 @@ Post login must be [configured](#post-login-screen) to perform post login select
 
 This endpoint provides details of the provided token. If the token is additionally tied to a session, the endpoint will ensure the session is `active`.
 
-To provide resource specific claims via `customAccessTokenClaims`, store the allowed resources that a confidential client can use in its `resources` field.
+Use the `resources` field in `customAccessTokenClaims` to add claims based on the audience.
 
 ### Revoke Endpoint
 
@@ -1079,9 +1083,10 @@ oauthProvider({
     };
   },
   // Attach claims to access tokens
-  customAccessTokenClaims: ({ user, scopes, referenceId, resource, metadata }) => {
+  customAccessTokenClaims: ({ user, scopes, referenceId, resources, metadata }) => {
     return {
       "https://example.com/org": referenceId,
+      "https://example.com/resources": resources,
       "https://example.com/roles": ["editor"],
     };
   },

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -462,6 +462,7 @@ Important notes:
 * In OAuth 2.1, only `response_type: "code"` is supported.
 * `code_challenge_method: "plain"` will not be supported since this is a security vulnerability.
 * All authorization responses (success and error) include the `iss` parameter for issuer validation ([RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207)).
+
 - Use the `resource` indicators to restrict tokens to a resource ([RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)).
 
 **State**
@@ -496,7 +497,9 @@ The token endpoint supports the following client authentication methods:
 * **`none`** — Public client (PKCE required)
 
 Important Notes:
-- Use of the `resource` parameter results in a JWT access token (with JWT plugin enabled).
+
+* With the JWT plugin enabled (default), sending `resource` results in a JWT access token with the selected resource in the `aud` claim.
+* With `disableJwtPlugin: true`, access tokens remain opaque. Requested resources are still bound to the token and surfaced through `/oauth2/introspect` and `customAccessTokenClaims` (via `resources`).
 
 #### Private Key JWT Authentication
 

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -1,12 +1,17 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { createAuthEndpoint } from "@better-auth/core/api";
+import { sessionMiddleware } from "better-auth/api";
 import { createAuthClient } from "better-auth/client";
 import { generateRandomString } from "better-auth/crypto";
 import { createAuthorizationURL } from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
 import { beforeAll, describe, expect, it } from "vitest";
+import * as z from "zod";
 import { validateIssuerUrl } from "./authorize";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
+import type { OAuthConsent, Scope } from "./types";
 import type { OAuthClient } from "./types/oauth";
 
 describe("validateIssuerUrl (RFC 9207)", () => {
@@ -418,6 +423,36 @@ describe("oauth authorize - authenticated", async () => {
 		);
 	});
 
+	it("should return invalid_target for invalid resource with explicit description", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "invalid-resource-state");
+		authUrl.searchParams.set("resource", "https://resource.example.com");
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain(redirectUri);
+		expect(errorRedirectUrl).toContain("error=invalid_target");
+		expect(errorRedirectUrl).toContain("state=invalid-resource-state");
+		expect(errorRedirectUrl).toContain(
+			`iss=${encodeURIComponent(authServerBaseUrl)}`,
+		);
+	});
+
 	it("should have metadata issuer match iss parameter (RFC 9207)", async () => {
 		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
 			throw Error("beforeAll not run properly");
@@ -483,5 +518,118 @@ describe("oauth authorize - authenticated", async () => {
 			`iss=${encodeURIComponent(authServerBaseUrl)}`,
 		);
 		expect(callbackRedirectUrl).not.toContain("/consent");
+	});
+});
+
+describe("oauth authorize - consented resources", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://api.example.com";
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validAudiences: [validAudience],
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+			{
+				id: "createLegacyConsentTester",
+				endpoints: {
+					testerCreateConsent: createAuthEndpoint(
+						"/server/oauth2/consent",
+						{
+							method: "POST",
+							body: z.object({
+								clientId: z.string(),
+								scopes: z.array(z.string()),
+								userId: z.string(),
+							}),
+							use: [sessionMiddleware],
+							metadata: {
+								SERVER_ONLY: true,
+							},
+						},
+						async (ctx) => {
+							const iat = Math.floor(Date.now() / 1000);
+							return (await ctx.context.adapter.create({
+								model: "oauthConsent",
+								data: {
+									createdAt: new Date(iat * 1000),
+									updatedAt: new Date(iat * 1000),
+									...ctx.body,
+								},
+							})) as OAuthConsent<Scope[]>;
+						},
+					),
+				},
+			} satisfies BetterAuthPlugin,
+		],
+	});
+
+	const { headers, user } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClientNeedsConsent: OAuthClient | null;
+	beforeAll(async () => {
+		const responseNeedsConsent = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: false,
+			},
+		});
+		expect(responseNeedsConsent?.client_id).toBeDefined();
+		oauthClientNeedsConsent = responseNeedsConsent;
+
+		await auth.api.testerCreateConsent({
+			headers,
+			body: {
+				clientId: responseNeedsConsent.client_id,
+				userId: user.id,
+				scopes: ["openid"],
+			},
+		});
+	});
+
+	it("should re-prompt for consent when stored consent has no resources and a resource is requested", async () => {
+		if (!oauthClientNeedsConsent?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClientNeedsConsent.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "legacy-consent-no-resource");
+		authUrl.searchParams.set("resource", validAudience);
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let consentRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				consentRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(consentRedirectUrl).toContain("/consent");
+		expect(consentRedirectUrl).not.toContain(`${redirectUri}?code=`);
 	});
 });

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -6,7 +6,7 @@ import { generateRandomString } from "better-auth/crypto";
 import { createAuthorizationURL } from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import * as z from "zod";
 import { validateIssuerUrl } from "./authorize";
 import { oauthProviderClient } from "./client";
@@ -525,6 +525,7 @@ describe("oauth authorize - consented resources", async () => {
 	const authServerBaseUrl = "http://localhost:3000";
 	const rpBaseUrl = "http://localhost:5000";
 	const validAudience = "https://api.example.com";
+	const secondValidAudience = "https://api.secondary.example.com";
 	const providerId = "test";
 	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
 
@@ -534,7 +535,7 @@ describe("oauth authorize - consented resources", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				validAudiences: [validAudience],
+				validAudiences: [validAudience, secondValidAudience],
 				silenceWarnings: {
 					oauthAuthServerConfig: true,
 					openidConfig: true,
@@ -631,5 +632,121 @@ describe("oauth authorize - consented resources", async () => {
 
 		expect(consentRedirectUrl).toContain("/consent");
 		expect(consentRedirectUrl).not.toContain(`${redirectUri}?code=`);
+	});
+
+	it("should persist multiple resource values onto OAuthConsent.resources", async ({
+		onTestFinished,
+	}) => {
+		if (!oauthClientNeedsConsent?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClientNeedsConsent.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "multiple-resources-persist");
+		authUrl.searchParams.append("resource", validAudience);
+		authUrl.searchParams.append("resource", secondValidAudience);
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let consentRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				consentRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(consentRedirectUrl).toContain("/consent");
+
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(consentRedirectUrl, authServerBaseUrl).search,
+			},
+		});
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const consentResult = await client.oauth2.consent(
+			{
+				accept: true,
+			},
+			{
+				throw: true,
+			},
+		);
+
+		expect(consentResult.url).toContain(`${redirectUri}?code=`);
+
+		const context = await auth.$context;
+		const savedConsent = await context.adapter.findOne<OAuthConsent<Scope[]>>({
+			model: "oauthConsent",
+			where: [
+				{
+					field: "clientId",
+					value: oauthClientNeedsConsent.client_id,
+				},
+				{
+					field: "userId",
+					value: user.id,
+				},
+			],
+		});
+
+		expect(savedConsent?.resources).toEqual([
+			validAudience,
+			secondValidAudience,
+		]);
+	});
+
+	it("should return consent_required for prompt=none when requested resource is not covered by prior consent", async () => {
+		const dedicatedClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: false,
+			},
+		});
+		if (!dedicatedClient?.client_id) {
+			throw Error("unable to create dedicated client");
+		}
+
+		await auth.api.testerCreateConsent({
+			headers,
+			body: {
+				clientId: dedicatedClient.client_id,
+				userId: user.id,
+				scopes: ["openid"],
+			},
+		});
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", dedicatedClient.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "prompt-none-resource-consent");
+		authUrl.searchParams.set("prompt", "none");
+		authUrl.searchParams.set("resource", validAudience);
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain("error=consent_required");
+		expect(callbackRedirectUrl).toContain("state=prompt-none-resource-consent");
+		expect(callbackRedirectUrl).toContain(
+			`iss=${encodeURIComponent(authServerBaseUrl)}`,
+		);
+		expect(callbackRedirectUrl).not.toContain("/consent");
 	});
 });

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -7,7 +7,6 @@ import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
 import { oAuthState } from "./oauth";
 import type { OAuthErrorCode, OAuthRedirectOnError } from "./oauth-endpoint";
-import { checkResource } from "./token";
 import type {
 	OAuthAuthorizationQuery,
 	OAuthConsent,
@@ -17,6 +16,7 @@ import type {
 } from "./types";
 
 import {
+	checkResource,
 	getClient,
 	getJwtPlugin,
 	isPKCERequired,

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -7,6 +7,7 @@ import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
 import { oAuthState } from "./oauth";
 import type { OAuthErrorCode, OAuthRedirectOnError } from "./oauth-endpoint";
+import { checkResource } from "./token";
 import type {
 	OAuthAuthorizationQuery,
 	OAuthConsent,
@@ -471,6 +472,26 @@ export async function authorizeEndpoint(
 		}
 	}
 
+	// Validate the resource sent to the authorize endpoint
+	const resource = query.resource;
+	try {
+		await checkResource(ctx, opts, resource, requestedScopes);
+	} catch (err) {
+		if (err instanceof APIError) {
+			return handleRedirect(
+				ctx,
+				formatErrorURL(
+					query.redirect_uri,
+					"invalid_target",
+					err?.message ?? err.body?.message ?? "invalid_resource",
+					query.state,
+					getIssuer(ctx, opts),
+				),
+			);
+		}
+		throw err;
+	}
+
 	// Check for session
 	const session = await getSessionFromCtx(ctx);
 	if (!session || promptSet?.has("login") || promptSet?.has("create")) {
@@ -615,6 +636,28 @@ export async function authorizeEndpoint(
 	if (
 		!consent ||
 		!requestedScopes.every((val) => consent.scopes.includes(val))
+	) {
+		if (promptNone) {
+			return redirectWithPromptNoneError(
+				ctx,
+				opts,
+				query,
+				"consent_required",
+				"End-User consent is required",
+			);
+		}
+		return redirectWithPromptCode(ctx, opts, "consent");
+	}
+
+	// Consent should be given for that resource if different than original consent
+	const consentedResources = consent?.resources;
+	const requestedResources =
+		typeof resource === "string" ? [resource] : resource;
+	if (
+		consentedResources &&
+		(!requestedResources ||
+			requestedResources.length === 0 ||
+			!requestedResources.every((v) => consentedResources.includes(v)))
 	) {
 		if (promptNone) {
 			return redirectWithPromptNoneError(

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -474,22 +474,23 @@ export async function authorizeEndpoint(
 
 	// Validate the resource sent to the authorize endpoint
 	const resource = query.resource;
-	try {
-		await checkResource(ctx, opts, resource, requestedScopes);
-	} catch (err) {
-		if (err instanceof APIError) {
-			return handleRedirect(
-				ctx,
-				formatErrorURL(
-					query.redirect_uri,
-					"invalid_target",
-					err?.message ?? err.body?.message ?? "invalid_resource",
-					query.state,
-					getIssuer(ctx, opts),
-				),
-			);
-		}
-		throw err;
+	const resourceResult = await checkResource(
+		ctx,
+		opts,
+		resource,
+		requestedScopes,
+	);
+	if (!resourceResult.success) {
+		return handleRedirect(
+			ctx,
+			formatErrorURL(
+				query.redirect_uri,
+				"invalid_target",
+				"requested resource invalid",
+				query.state,
+				getIssuer(ctx, opts),
+			),
+		);
 	}
 
 	// Check for session
@@ -649,15 +650,17 @@ export async function authorizeEndpoint(
 		return redirectWithPromptCode(ctx, opts, "consent");
 	}
 
-	// Consent should be given for that resource if different than original consent
-	const consentedResources = consent?.resources;
-	const requestedResources =
-		typeof resource === "string" ? [resource] : resource;
+	// Prompt again whenever a requested resource is not covered by stored consent.
+	const requestedResources = Array.isArray(resource)
+		? resource
+		: resource
+			? [resource]
+			: [];
+	const consentedResources = consent?.resources ?? [];
 	if (
-		consentedResources &&
-		(!requestedResources ||
-			requestedResources.length === 0 ||
-			!requestedResources.every((v) => consentedResources.includes(v)))
+		requestedResources.some(
+			(requestedResource) => !consentedResources.includes(requestedResource),
+		)
 	) {
 		if (promptNone) {
 			return redirectWithPromptNoneError(

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -22,6 +22,7 @@ import {
 	isPKCERequired,
 	parsePrompt,
 	storeToken,
+	toResourceList,
 } from "./utils";
 
 /**
@@ -492,6 +493,7 @@ export async function authorizeEndpoint(
 			),
 		);
 	}
+	const requestedResources = toResourceList(resource) ?? [];
 
 	// Check for session
 	const session = await getSessionFromCtx(ctx);
@@ -610,6 +612,7 @@ export async function authorizeEndpoint(
 			sessionId: session.session.id,
 			authTime: new Date(session.session.createdAt).getTime(),
 			referenceId,
+			resource: requestedResources,
 		});
 	}
 	const consent = await ctx.context.adapter.findOne<OAuthConsent<Scope[]>>({
@@ -651,11 +654,6 @@ export async function authorizeEndpoint(
 	}
 
 	// Prompt again whenever a requested resource is not covered by stored consent.
-	const requestedResources = Array.isArray(resource)
-		? resource
-		: resource
-			? [resource]
-			: [];
 	const consentedResources = consent?.resources ?? [];
 	if (
 		requestedResources.some(
@@ -681,6 +679,7 @@ export async function authorizeEndpoint(
 		sessionId: session.session.id,
 		authTime: new Date(session.session.createdAt).getTime(),
 		referenceId,
+		resource: requestedResources,
 	});
 }
 
@@ -709,6 +708,7 @@ async function redirectWithAuthorizationCode(
 		sessionId: string;
 		authTime: number;
 		referenceId?: string;
+		resource?: string[];
 	},
 ) {
 	const code = generateRandomString(32, "a-z", "A-Z", "0-9");
@@ -726,6 +726,7 @@ async function redirectWithAuthorizationCode(
 			sessionId: verificationValue?.sessionId,
 			referenceId: verificationValue.referenceId,
 			authTime: verificationValue.authTime,
+			resource: verificationValue.resource,
 		} satisfies VerificationValue),
 	};
 	await ctx.context.internalAdapter.createVerificationValue({

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -84,12 +84,14 @@ export async function consentEndpoint(
 		},
 	);
 	const iat = Math.floor(Date.now() / 1000);
+	const resource = query.getAll("resource");
 	const consent: Omit<OAuthConsent<Scope[]>, "id"> = {
 		clientId: clientId,
 		userId: session?.user.id!,
 		scopes: requestedScopes ?? originalRequestedScopes,
 		createdAt: new Date(iat * 1000),
 		updatedAt: new Date(iat * 1000),
+		resources: resource.length ? resource : undefined,
 		referenceId,
 	};
 	foundConsent?.id
@@ -102,6 +104,7 @@ export async function consentEndpoint(
 					},
 				],
 				update: {
+					resources: consent.resources,
 					scopes: consent.scopes,
 					updatedAt: new Date(iat * 1000),
 				},

--- a/packages/oauth-provider/src/introspect.test.ts
+++ b/packages/oauth-provider/src/introspect.test.ts
@@ -714,4 +714,192 @@ describe("oauth introspect - config", async () => {
 			iat: expect.any(Number),
 		});
 	});
+
+	it("should include aud in opaque access token introspection response", async () => {
+		const testScopes = ["openid", "profile", "email", "offline_access"];
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig: {
+				disableJwtPlugin: true,
+				scopes: testScopes,
+			},
+		});
+		if (!oauthClient) expect.unreachable();
+
+		const { url: authUrl, codeVerifier } = await createAuthUrl(oauthClient, {
+			scopes: testScopes,
+		});
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const url = new URL(callbackRedirectUrl);
+		const tokens = await client.oauth2.token(
+			{
+				grant_type: "authorization_code",
+				code: url.searchParams.get("code") ?? undefined,
+				code_verifier: codeVerifier,
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				scope: testScopes.join(" "),
+				resource: validAudience,
+				redirect_uri: redirectUri,
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+
+		const introspection = await client.oauth2.introspect(
+			{
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				token: tokens.data?.access_token ?? "",
+				token_type_hint: "access_token",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			aud: validAudience,
+		});
+	});
+
+	it("should pass resources to customAccessTokenClaims for jwt and opaque introspection", async () => {
+		const testScopes = ["openid", "profile", "email", "offline_access"];
+		const customAccessTokenClaims = ({
+			resources,
+		}: {
+			resources?: string[];
+		}) => ({
+			resource_count: resources?.length ?? 0,
+			first_resource: resources?.[0],
+		});
+
+		const jwtInstance = await createTestInstance({
+			oauthProviderConfig: {
+				scopes: testScopes,
+				customAccessTokenClaims,
+			},
+		});
+		if (!jwtInstance.oauthClient) expect.unreachable();
+
+		const { url: jwtAuthUrl, codeVerifier: jwtCodeVerifier } =
+			await createAuthUrl(jwtInstance.oauthClient, {
+				scopes: testScopes,
+			});
+		let jwtCallbackRedirectUrl = "";
+		await jwtInstance.client.$fetch(jwtAuthUrl.toString(), {
+			onError(context) {
+				jwtCallbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const jwtCallbackUrl = new URL(jwtCallbackRedirectUrl);
+		const jwtTokens = await jwtInstance.client.oauth2.token(
+			{
+				grant_type: "authorization_code",
+				code: jwtCallbackUrl.searchParams.get("code") ?? undefined,
+				code_verifier: jwtCodeVerifier,
+				client_id: jwtInstance.oauthClient?.client_id,
+				client_secret: jwtInstance.oauthClient?.client_secret,
+				scope: testScopes.join(" "),
+				resource: validAudience,
+				redirect_uri: redirectUri,
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		const jwtIntrospection = await jwtInstance.client.oauth2.introspect(
+			{
+				client_id: jwtInstance.oauthClient?.client_id,
+				client_secret: jwtInstance.oauthClient?.client_secret,
+				token: jwtTokens.data?.access_token ?? "",
+				token_type_hint: "access_token",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		expect(jwtIntrospection.data).toMatchObject({
+			active: true,
+			resource_count: 1,
+			first_resource: validAudience,
+		});
+
+		const opaqueInstance = await createTestInstance({
+			oauthProviderConfig: {
+				disableJwtPlugin: true,
+				scopes: testScopes,
+				customAccessTokenClaims,
+			},
+		});
+		if (!opaqueInstance.oauthClient) expect.unreachable();
+
+		const { url: opaqueAuthUrl, codeVerifier: opaqueCodeVerifier } =
+			await createAuthUrl(opaqueInstance.oauthClient, {
+				scopes: testScopes,
+			});
+		let opaqueCallbackRedirectUrl = "";
+		await opaqueInstance.client.$fetch(opaqueAuthUrl.toString(), {
+			onError(context) {
+				opaqueCallbackRedirectUrl =
+					context.response.headers.get("Location") || "";
+			},
+		});
+		const opaqueCallbackUrl = new URL(opaqueCallbackRedirectUrl);
+		const opaqueTokens = await opaqueInstance.client.oauth2.token(
+			{
+				grant_type: "authorization_code",
+				code: opaqueCallbackUrl.searchParams.get("code") ?? undefined,
+				code_verifier: opaqueCodeVerifier,
+				client_id: opaqueInstance.oauthClient?.client_id,
+				client_secret: opaqueInstance.oauthClient?.client_secret,
+				scope: testScopes.join(" "),
+				resource: validAudience,
+				redirect_uri: redirectUri,
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		const opaqueIntrospection = await opaqueInstance.client.oauth2.introspect(
+			{
+				client_id: opaqueInstance.oauthClient?.client_id,
+				client_secret: opaqueInstance.oauthClient?.client_secret,
+				token: opaqueTokens.data?.access_token ?? "",
+				token_type_hint: "access_token",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		expect(opaqueIntrospection.data).toMatchObject({
+			active: true,
+			resource_count: 1,
+			first_resource: validAudience,
+		});
+	});
 });

--- a/packages/oauth-provider/src/introspect.test.ts
+++ b/packages/oauth-provider/src/introspect.test.ts
@@ -771,7 +771,7 @@ describe("oauth introspect - config", async () => {
 		expect(introspection.data).toMatchObject({
 			active: true,
 			client_id: oauthClient?.client_id,
-			aud: validAudience,
+			aud: [validAudience, `${authServerBaseUrl}/api/auth/oauth2/userinfo`],
 		});
 	});
 

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -218,6 +218,13 @@ async function validateOpaqueAccessToken(
 	const resources = Array.isArray(accessToken.resources)
 		? accessToken.resources
 		: undefined;
+	const audience = resources ? [...resources] : undefined;
+	if (audience?.length && accessToken.scopes?.includes("openid")) {
+		const userInfoEndpoint = `${ctx.context.baseURL}/oauth2/userinfo`;
+		if (!audience.includes(userInfoEndpoint)) {
+			audience.push(userInfoEndpoint);
+		}
+	}
 
 	// Add Custom Claims
 	const customClaims = opts.customAccessTokenClaims
@@ -240,7 +247,7 @@ async function validateOpaqueAccessToken(
 		...customClaims,
 		active: true,
 		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
-		aud: toAudienceClaim(resources),
+		aud: toAudienceClaim(audience),
 		client_id: accessToken.clientId,
 		sub: user?.id,
 		sid: sessionId,

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -20,6 +20,7 @@ import {
 	getStoredToken,
 	parseClientMetadata,
 	resolveSubjectIdentifier,
+	toAudienceClaim,
 	validateClientCredentials,
 } from "./utils";
 
@@ -214,6 +215,9 @@ async function validateOpaqueAccessToken(
 	if (accessToken.userId) {
 		user = await ctx.context.internalAdapter.findUserById(accessToken?.userId);
 	}
+	const resources = Array.isArray(accessToken.resources)
+		? accessToken.resources
+		: undefined;
 
 	// Add Custom Claims
 	const customClaims = opts.customAccessTokenClaims
@@ -221,7 +225,7 @@ async function validateOpaqueAccessToken(
 				user,
 				scopes: accessToken.scopes,
 				referenceId: accessToken?.referenceId,
-				resources: accessToken?.resources,
+				resources,
 				metadata: parseClientMetadata(client?.metadata),
 			})
 		: {};
@@ -236,6 +240,7 @@ async function validateOpaqueAccessToken(
 		...customClaims,
 		active: true,
 		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+		aud: toAudienceClaim(resources),
 		client_id: accessToken.clientId,
 		sub: user?.id,
 		sid: sessionId,

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -221,6 +221,7 @@ async function validateOpaqueAccessToken(
 				user,
 				scopes: accessToken.scopes,
 				referenceId: accessToken?.referenceId,
+				resources: accessToken?.resources,
 				metadata: parseClientMetadata(client?.metadata),
 			})
 		: {};
@@ -296,7 +297,7 @@ async function validateRefreshToken(
 			where: [
 				{
 					field: "id",
-					value: refreshToken.sessionId,
+					value: sessionId,
 				},
 			],
 		});

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -2745,7 +2745,7 @@ describe("oauth - config", () => {
 				iat: expect.any(Number),
 				exp: expect.any(Number),
 			});
-			if (resource && !(resource && disableJwtPlugin)) {
+			if (resource) {
 				expect(payload?.aud).toStrictEqual([
 					validAudience,
 					`${authServerUrl}/oauth2/userinfo`,

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -391,6 +391,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							.pipe(z.enum(["S256"]))
 							.optional(),
 						nonce: z.string().optional(),
+						resource: z
+							.union([SafeUrlSchema, z.array(SafeUrlSchema).min(1)])
+							.optional(),
 						prompt: z
 							.string()
 							.pipe(
@@ -477,6 +480,14 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 									required: false,
 									schema: { type: "string" },
 									description: "OpenID Connect nonce",
+								},
+								{
+									name: "resource",
+									in: "query",
+									required: false,
+									schema: { type: "array", items: { type: "string" } },
+									description:
+										"Requested token resource(s) (ie audience) to obtain a JWT formatted access token. May be supplied multiple times as repeated 'resource' query parameters (RFC 8707) or as an array of strings.",
 								},
 								{
 									name: "prompt",
@@ -643,7 +654,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						code_verifier: z.string().optional(),
 						redirect_uri: SafeUrlSchema.optional(),
 						refresh_token: z.string().optional(),
-						resource: z.string().optional(),
+						resource: z
+							.union([SafeUrlSchema, z.array(SafeUrlSchema).min(1)])
+							.optional(),
 						scope: z.string().optional(),
 					}),
 					errorCodesByField: {
@@ -702,9 +715,19 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 														"Refresh token (for refresh_token grant)",
 												},
 												resource: {
-													type: "string",
+													oneOf: [
+														{
+															type: "string",
+															description: "Single resource (URL)",
+														},
+														{
+															type: "array",
+															items: { type: "string" },
+															description: "Multiple resources (URLs)",
+														},
+													],
 													description:
-														"Requested token resource (ie audience) to obtain a JWT formatted access token",
+														"Requested token resource(s) (ie audience) to obtain a JWT formatted access token",
 												},
 												scope: {
 													type: "string",
@@ -825,11 +848,6 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 													type: "string",
 													description:
 														"Hint about the token type. Recognized values: `access_token`, `refresh_token`.",
-												},
-												resource: {
-													type: "string",
-													description:
-														"Introspects a token for a specific resource.",
 												},
 											},
 											required: ["token"],

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -412,6 +412,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					redirectOnError: authorizeRedirectOnError(opts),
 					errorCodesByField: {
 						response_type: { invalid: "unsupported_response_type" },
+						resource: { invalid: "invalid_target" },
 					},
 					metadata: {
 						openapi: {
@@ -664,6 +665,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							missing: "invalid_request",
 							invalid: "unsupported_grant_type",
 						},
+						resource: { invalid: "invalid_target" },
 					},
 					metadata: {
 						allowedMediaTypes: ["application/x-www-form-urlencoded"],

--- a/packages/oauth-provider/src/schema.ts
+++ b/packages/oauth-provider/src/schema.ts
@@ -185,6 +185,10 @@ export const schema = {
 				type: "string",
 				required: false,
 			},
+			resources: {
+				type: "string[]",
+				required: false,
+			},
 			expiresAt: {
 				type: "date",
 			},
@@ -257,6 +261,10 @@ export const schema = {
 				type: "string",
 				required: false,
 			},
+			resources: {
+				type: "string[]",
+				required: false,
+			},
 			refreshId: {
 				type: "string",
 				required: false,
@@ -299,6 +307,10 @@ export const schema = {
 			},
 			referenceId: {
 				type: "string",
+				required: false,
+			},
+			resources: {
+				type: "string[]",
 				required: false,
 			},
 			scopes: {

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -992,6 +992,140 @@ describe("oauth token - refresh_token", async () => {
 		});
 		expect(newTokensRefresh.error?.status).toBeDefined();
 	});
+
+	it("chained narrowing: authorize([a,b]) → refresh(a) → refresh() returns [a,b] (RFC 8707 §2.2)", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const audienceA = validAudience;
+		const scopes = ["openid", "offline_access"];
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+			additionalParams: { resource: audienceA },
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const url = new URL(callbackRedirectUrl);
+
+		// Step 1: initial exchange (no resource narrowing – gets refresh token with [audienceA])
+		const initialTokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+		});
+		expect(initialTokens.data?.refresh_token).toBeDefined();
+
+		// Step 2: refresh with resource=audienceA (same as original – no narrowing in this test)
+		const { body: body1, headers: headers1 } = createRefreshAccessTokenRequest({
+			refreshToken: initialTokens.data?.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			extraParams: { scope: scopes.join(" ") },
+			resource: audienceA,
+		});
+		const step2Tokens = await client.$fetch<{
+			access_token?: string;
+			refresh_token?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body1,
+			headers: headers1,
+		});
+		expect(step2Tokens.data?.refresh_token).toBeDefined();
+		expect(step2Tokens.data?.access_token).toBeDefined();
+		// Verify the access token aud is audienceA (not narrowed further)
+		const step2AT = await jwtVerify(step2Tokens.data?.access_token!, jwks, {
+			audience: audienceA,
+			issuer: authServerBaseUrl,
+		});
+		expect(step2AT.payload.aud).toContain(audienceA);
+
+		// Step 3: refresh with no resource → should fall back to full original grant [audienceA]
+		const { body: body2, headers: headers2 } = createRefreshAccessTokenRequest({
+			refreshToken: step2Tokens.data?.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			extraParams: { scope: scopes.join(" ") },
+		});
+		const step3Tokens = await client.$fetch<{
+			access_token?: string;
+			refresh_token?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body2,
+			headers: headers2,
+		});
+		expect(step3Tokens.data?.access_token).toBeDefined();
+		// With no resource in request the server falls back to the stored grant set
+		const step3AT = await jwtVerify(step3Tokens.data?.access_token!, jwks, {
+			audience: audienceA,
+			issuer: authServerBaseUrl,
+		});
+		expect(step3AT.payload.aud).toContain(audienceA);
+	});
+
+	it("refresh: body resource not in refresh token's resources emits invalid_target", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const audienceA = validAudience;
+		const disjointAudience = "https://other-api.example.com";
+		const scopes = ["openid", "offline_access"];
+
+		// Authorize with audienceA only
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+			additionalParams: { resource: audienceA },
+		});
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const url = new URL(callbackRedirectUrl);
+		const initialTokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+		});
+		expect(initialTokens.data?.refresh_token).toBeDefined();
+
+		// Attempt refresh with a resource not in the original grant
+		const { body, headers } = createRefreshAccessTokenRequest({
+			refreshToken: initialTokens.data?.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			extraParams: { scope: scopes.join(" ") },
+			resource: disjointAudience,
+		});
+		const badTokens = await client.$fetch("/oauth2/token", {
+			method: "POST",
+			body,
+			headers,
+		});
+		expect(badTokens.error?.status).toBeDefined();
+	});
 });
 
 describe("oauth token - client_credentials", async () => {
@@ -1178,6 +1312,58 @@ describe("oauth token - client_credentials", async () => {
 		expect(accessToken.payload.iat).toBeDefined();
 		expect(accessToken.payload.exp).toBe(tokens.data?.expires_at);
 		expect(accessToken.payload.scope).toBe(scopes.join(" "));
+	});
+
+	it("resource produces JWT with correct aud; disallowed resource emits invalid_target", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["read:posts"];
+
+		// Valid resource → JWT access token with correct aud
+		const { body: validBody, headers: validHeaders } =
+			createClientCredentialsTokenRequest({
+				scope: scopes.join(" "),
+				options: {
+					clientId: oauthClient.client_id,
+					clientSecret: oauthClient.client_secret,
+					redirectURI: redirectUri,
+				},
+				resource: validAudience,
+			});
+		const validTokens = await client.$fetch<{
+			access_token?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: validBody,
+			headers: validHeaders,
+		});
+		expect(validTokens.data?.access_token).toBeDefined();
+		const at = await jwtVerify(validTokens.data?.access_token!, jwks, {
+			audience: validAudience,
+			issuer: authServerBaseUrl,
+		});
+		expect(at.payload.aud).toContain(validAudience);
+
+		// Disallowed resource → invalid_target
+		const { body: badBody, headers: badHeaders } =
+			createClientCredentialsTokenRequest({
+				scope: scopes.join(" "),
+				options: {
+					clientId: oauthClient.client_id,
+					clientSecret: oauthClient.client_secret,
+					redirectURI: redirectUri,
+				},
+				resource: "https://not-registered.example.com",
+			});
+		const badTokens = await client.$fetch("/oauth2/token", {
+			method: "POST",
+			body: badBody,
+			headers: badHeaders,
+		});
+		expect(badTokens.error?.status).toBeDefined();
 	});
 });
 
@@ -2746,6 +2932,213 @@ describe("customTokenResponseFields", async () => {
 
 		expect(tokens.data?.access_token).toBeDefined();
 		expect(tokens.data?.server_time).toBe("2024-01-01");
+	});
+});
+
+describe("oauth token - authorization_code resource narrowing (RFC 8707)", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const audienceA = "https://api-a.example.com";
+	const audienceB = "https://api-b.example.com";
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({ jwt: { issuer: authServerBaseUrl } }),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validAudiences: [audienceA, audienceB],
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient(), jwtClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: { customFetchImpl, headers },
+	});
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
+	const state = "rfc8707";
+	let jwks: ReturnType<typeof createLocalJWKSet>;
+	let oauthClient: OAuthClient | null;
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: { redirect_uris: [redirectUri], skip_consent: true },
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+
+		const jwksResult = await client.jwks();
+		if (!jwksResult.data) {
+			throw new Error("Unable to fetch jwks");
+		}
+		jwks = createLocalJWKSet(jwksResult.data);
+	});
+
+	async function authorizeWithResources(
+		resources: string[],
+		scopes = ["openid", "offline_access"],
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(32);
+		const url = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes,
+			codeVerifier,
+		});
+
+		// Append resource params directly since additionalParams uses set() (single-value only)
+		for (const r of resources) {
+			url.searchParams.append("resource", r);
+		}
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(url.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const callbackUrl = new URL(callbackRedirectUrl);
+		const code = callbackUrl.searchParams.get("code");
+		if (!code) {
+			throw new Error(`No code in callback URL: ${callbackRedirectUrl}`);
+		}
+		return { code, codeVerifier, scopes };
+	}
+
+	async function exchangeCode(
+		code: string,
+		codeVerifier: string,
+		resource?: string | string[],
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const { body, headers: reqHeaders } = createAuthorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			resource,
+		});
+		return client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_at?: number;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: reqHeaders,
+		});
+	}
+
+	it("resource is a proper subset: access token aud narrows, refresh token keeps full set", async ({
+		expect,
+	}) => {
+		// Authorize for [audienceA, audienceB]
+		const { code, codeVerifier } = await authorizeWithResources([
+			audienceA,
+			audienceB,
+		]);
+
+		// Token exchange with only audienceA (proper subset)
+		const tokens = await exchangeCode(code, codeVerifier, audienceA);
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeDefined();
+
+		// Access token audience should be narrowed to audienceA only
+		const at = await jwtVerify(tokens.data?.access_token!, jwks, {
+			audience: audienceA,
+			issuer: authServerBaseUrl,
+		});
+		const audClaim = at.payload.aud;
+		const audArray = Array.isArray(audClaim) ? audClaim : [audClaim];
+		expect(audArray).toContain(audienceA);
+		expect(audArray.filter((a) => a === audienceB)).toHaveLength(0);
+
+		// Refresh with no resource: the refresh token should have kept [audienceA, audienceB],
+		// so the new access token should cover both audiences.
+		const { body: refreshBody, headers: refreshHeaders } =
+			createRefreshAccessTokenRequest({
+				refreshToken: tokens.data?.refresh_token!,
+				options: {
+					clientId: oauthClient!.client_id,
+					clientSecret: oauthClient!.client_secret,
+					redirectURI: redirectUri,
+				},
+			});
+		const refreshedTokens = await client.$fetch<{
+			access_token?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: refreshBody,
+			headers: refreshHeaders,
+		});
+		expect(refreshedTokens.data?.access_token).toBeDefined();
+		// Access token should be a JWT covering the full original grant [audienceA, audienceB]
+		const refreshedAt = await jwtVerify(
+			refreshedTokens.data?.access_token!,
+			jwks,
+			{ audience: audienceA, issuer: authServerBaseUrl },
+		);
+		const refreshedAud = Array.isArray(refreshedAt.payload.aud)
+			? refreshedAt.payload.aud
+			: [refreshedAt.payload.aud];
+		expect(refreshedAud).toContain(audienceA);
+		expect(refreshedAud).toContain(audienceB);
+	});
+
+	it("resource superset of authorized emits invalid_target", async ({
+		expect,
+	}) => {
+		// Authorize for [audienceA] only
+		const { code, codeVerifier } = await authorizeWithResources([audienceA]);
+
+		// Token exchange requesting [audienceA, audienceB] — audienceB was not authorized
+		const tokens = await exchangeCode(code, codeVerifier, [
+			audienceA,
+			audienceB,
+		]);
+		expect(tokens.error?.status).toBeDefined();
+	});
+
+	it("resource disjoint from authorized emits invalid_target", async ({
+		expect,
+	}) => {
+		// Authorize for [audienceA] only
+		const { code, codeVerifier } = await authorizeWithResources([audienceA]);
+
+		// Token exchange with audienceB alone — completely disjoint
+		const tokens = await exchangeCode(code, codeVerifier, audienceB);
+		expect(tokens.error?.status).toBeDefined();
 	});
 });
 

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -360,6 +360,52 @@ describe("oauth token - authorization_code", async () => {
 		expect(accessToken.payload.exp).toBe(tokens.data?.expires_at);
 		expect(accessToken.payload.scope).toBe(scopes.join(" "));
 	});
+
+	it("should fall back to authorized resource when token request omits resource", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "offline_access"];
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+			additionalParams: {
+				resource: validAudience,
+			},
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain(`code=`);
+		expect(callbackRedirectUrl).toContain(`state=123`);
+		const url = new URL(callbackRedirectUrl);
+
+		const tokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.id_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeDefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+
+		const accessToken = await jwtVerify(tokens.data?.access_token!, jwks, {
+			audience: validAudience,
+			issuer: authServerBaseUrl,
+		});
+		expect(accessToken.payload.azp).toBe(oauthClient.client_id);
+		expect(accessToken.payload.sub).toBeDefined();
+		expect(accessToken.payload.iat).toBeDefined();
+		expect(accessToken.payload.exp).toBe(tokens.data?.expires_at);
+		expect(accessToken.payload.scope).toBe(scopes.join(" "));
+	});
 });
 
 describe("oauth token - refresh_token", async () => {

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -429,6 +429,9 @@ interface CreateUserTokensParams {
 	authTime?: Date;
 	verificationValue?: VerificationValue;
 	resources?: string[];
+	/** Full original authorized resources for the grant, used to seed the refresh token
+	 * when the token request narrows the resource (RFC 8707 §2.2). */
+	originalResources?: string[];
 }
 
 async function createUserTokens(
@@ -499,7 +502,11 @@ async function createUserTokens(
 		: undefined;
 
 	// Refresh token MUST retain the full original set of resources from the previous refresh token per RFC 8707 section 2.2
-	const refreshResources = params?.refreshToken?.resources ?? params?.resources;
+	// For the initial auth-code exchange, params.originalResources carries the full authorized set (before any request narrowing).
+	const refreshResources =
+		params?.refreshToken?.resources ??
+		params?.originalResources ??
+		params?.resources;
 
 	// Refresh token may need to be created beforehand for id field
 	const earlyRefreshToken =
@@ -700,6 +707,7 @@ async function checkVerificationValue(
 	return {
 		verificationValue,
 		effectiveResources,
+		authorizedResources: storedResources,
 	};
 }
 
@@ -764,7 +772,7 @@ async function handleAuthorizationCodeGrant(
 	}
 
 	/** Get and check Verification Value */
-	const { verificationValue, effectiveResources } =
+	const { verificationValue, effectiveResources, authorizedResources } =
 		await checkVerificationValue(
 			ctx,
 			opts,
@@ -907,6 +915,7 @@ async function handleAuthorizationCodeGrant(
 		authTime,
 		verificationValue,
 		resources: effectiveResources,
+		originalResources: authorizedResources,
 	});
 }
 

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -17,6 +17,7 @@ import type { GrantType } from "./types/oauth";
 import { verificationValueSchema } from "./types/zod";
 import { userNormalClaims } from "./userinfo";
 import {
+	checkResource,
 	decryptStoredClientSecret,
 	destructureCredentials,
 	extractClientCredentials,
@@ -370,49 +371,6 @@ async function createRefreshToken(
 	return {
 		id: refreshToken.id,
 		token: await encodeRefreshToken(opts, token, sessionId),
-	};
-}
-
-/**
- * Checks the resource parameter, if provided,
- * and returns either a valid audience or a tagged validation error.
- */
-export async function checkResource(
-	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
-	resource: string | string[] | undefined,
-	scopes: string[],
-) {
-	const normalizedResource = toResourceList(resource);
-	const audience = normalizedResource ? [...normalizedResource] : undefined;
-	if (audience) {
-		// Adds /userinfo to audience
-		const hasOpenId = scopes.includes("openid");
-		const baseUrl = ctx.context.baseURL;
-		const userInfoEndpoint = `${baseUrl}/oauth2/userinfo`;
-		if (hasOpenId) {
-			audience.push(userInfoEndpoint);
-		}
-		// Check valid audiences
-		const filteredValidAudiences = opts.validAudiences?.filter(
-			(aud) => aud.length,
-		);
-		const validAudiences = new Set(
-			filteredValidAudiences?.length ? filteredValidAudiences : [baseUrl],
-		);
-		if (hasOpenId) validAudiences.add(userInfoEndpoint);
-		for (const aud of audience) {
-			if (!validAudiences.has(aud)) {
-				return {
-					success: false,
-					error: "invalid_resource",
-				};
-			}
-		}
-	}
-	return {
-		success: true,
-		audience: toAudienceClaim(audience),
 	};
 }
 
@@ -938,7 +896,8 @@ async function handleClientCredentialsGrant(
 		clientSecret: client_secret,
 		preVerifiedClient,
 	} = destructureCredentials(credentials);
-	const { scope, resource }: { scope?: string; resource?: string } = ctx.body;
+	const { scope, resource }: { scope?: string; resource?: string | string[] } =
+		ctx.body;
 	const resources = toResourceList(resource);
 
 	if (!client_id) {

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -388,20 +388,20 @@ export async function checkResource(
 	const audience = normalizedResource ? [...normalizedResource] : undefined;
 	if (audience) {
 		// Adds /userinfo to audience
-		if (scopes.includes("openid")) {
-			audience.push(`${ctx.context.baseURL}/oauth2/userinfo`);
+		const hasOpenId = scopes.includes("openid");
+		const baseUrl = ctx.context.baseURL;
+		const userInfoEndpoint = `${baseUrl}/oauth2/userinfo`;
+		if (hasOpenId) {
+			audience.push(userInfoEndpoint);
 		}
 		// Check valid audiences
-		const validAudiences = new Set(
-			[
-				...(opts.validAudiences ?? [ctx.context.baseURL]),
-				scopes?.includes("openid")
-					? `${ctx.context.baseURL}/oauth2/userinfo`
-					: undefined,
-			]
-				.flat()
-				.filter((v) => v?.length),
+		const filteredValidAudiences = opts.validAudiences?.filter(
+			(aud) => aud.length,
 		);
+		const validAudiences = new Set(
+			filteredValidAudiences?.length ? filteredValidAudiences : [baseUrl],
+		);
+		if (hasOpenId) validAudiences.add(userInfoEndpoint);
 		for (const aud of audience) {
 			if (!validAudiences.has(aud)) {
 				return {

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -379,7 +379,7 @@ async function createRefreshToken(
 
 /**
  * Checks the resource parameter, if provided,
- * and returns a valid audience based on the request
+ * and returns either a valid audience or a tagged validation error.
  */
 export async function checkResource(
 	ctx: GenericEndpointContext,
@@ -411,14 +411,17 @@ export async function checkResource(
 		);
 		for (const aud of audience) {
 			if (!validAudiences.has(aud)) {
-				throw new APIError("BAD_REQUEST", {
-					error_description: "requested resource invalid",
-					error: "invalid_target",
-				});
+				return {
+					success: false,
+					error: "invalid_resource",
+				};
 			}
 		}
 	}
-	return audience?.length === 1 ? audience.at(0) : audience;
+	return {
+		success: true,
+		audience: audience?.length === 1 ? audience.at(0) : audience,
+	};
 }
 
 interface CreateUserTokensParams {
@@ -471,7 +474,19 @@ async function createUserTokens(
 		: defaultExp;
 
 	// Check requested audience if sent as the resource parameter
-	const audience = await checkResource(ctx, opts, params?.resources, scopes);
+	const resourceResult = await checkResource(
+		ctx,
+		opts,
+		params?.resources,
+		scopes,
+	);
+	if (!resourceResult.success) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "requested resource invalid",
+			error: "invalid_target",
+		});
+	}
+	const audience = resourceResult.audience;
 	const isRefreshToken =
 		user &&
 		(existingRefreshToken?.scopes?.includes("offline_access") ||

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -84,7 +84,6 @@ async function createJwtAccessToken(
 				user,
 				scopes,
 				resources,
-				resource: ctx.body.resource,
 				referenceId,
 				metadata: parseClientMetadata(client.metadata),
 			})

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -67,6 +67,7 @@ async function createJwtAccessToken(
 	client: SchemaClient<Scope[]>,
 	audience: string | string[],
 	scopes: string[],
+	resources?: string[],
 	referenceId?: string,
 	overrides?: {
 		iat?: number;
@@ -80,6 +81,7 @@ async function createJwtAccessToken(
 		? await opts.customAccessTokenClaims({
 				user,
 				scopes,
+				resources,
 				resource: ctx.body.resource,
 				referenceId,
 				metadata: parseClientMetadata(client.metadata),
@@ -292,6 +294,7 @@ async function createOpaqueAccessToken(
 	client: SchemaClient<Scope[]>,
 	scopes: string[],
 	payload: JWTPayload,
+	resources?: string[],
 	referenceId?: string,
 	refreshId?: string,
 ) {
@@ -308,6 +311,7 @@ async function createOpaqueAccessToken(
 			sessionId: payload?.sid,
 			userId: user?.id,
 			referenceId,
+			resources,
 			refreshId,
 			scopes,
 			createdAt: new Date(iat * 1000),
@@ -327,6 +331,7 @@ async function createRefreshToken(
 	payload: JWTPayload,
 	originalRefresh?: OAuthRefreshToken<Scope[]> & { id: string },
 	authTime?: Date,
+	resources?: string[],
 ) {
 	const iat = payload.iat ?? Math.floor(Date.now() / 1000);
 	const exp = payload?.exp ?? iat + (opts.refreshTokenExpiresIn ?? 2592000);
@@ -360,6 +365,7 @@ async function createRefreshToken(
 			userId: user.id,
 			referenceId,
 			authTime,
+			resources,
 			scopes,
 			createdAt: new Date(iat * 1000),
 			expiresAt: new Date(exp * 1000),
@@ -375,12 +381,12 @@ async function createRefreshToken(
  * Checks the resource parameter, if provided,
  * and returns a valid audience based on the request
  */
-async function checkResource(
+export async function checkResource(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
+	resource: string | string[] | undefined,
 	scopes: string[],
 ) {
-	const resource: string | string[] | undefined = ctx.body.resource;
 	const audience =
 		typeof resource === "string"
 			? [resource]
@@ -407,7 +413,7 @@ async function checkResource(
 			if (!validAudiences.has(aud)) {
 				throw new APIError("BAD_REQUEST", {
 					error_description: "requested resource invalid",
-					error: "invalid_request",
+					error: "invalid_target",
 				});
 			}
 		}
@@ -426,6 +432,7 @@ interface CreateUserTokensParams {
 	refreshToken?: OAuthRefreshToken<Scope[]> & { id: string };
 	authTime?: Date;
 	verificationValue?: VerificationValue;
+	resources?: string[];
 }
 
 async function createUserTokens(
@@ -464,7 +471,7 @@ async function createUserTokens(
 		: defaultExp;
 
 	// Check requested audience if sent as the resource parameter
-	const audience = await checkResource(ctx, opts, scopes);
+	const audience = await checkResource(ctx, opts, params?.resources, scopes);
 	const isRefreshToken =
 		user &&
 		(existingRefreshToken?.scopes?.includes("offline_access") ||
@@ -483,6 +490,9 @@ async function createUserTokens(
 			})
 		: undefined;
 
+	// Refresh token MUST retain the full original set of resources from the previous refresh token per RFC 8707 section 2.2
+	const refreshResources = params?.refreshToken?.resources ?? params?.resources;
+
 	// Refresh token may need to be created beforehand for id field
 	const earlyRefreshToken =
 		isRefreshToken && user && !isJwtAccessToken
@@ -500,6 +510,7 @@ async function createUserTokens(
 					},
 					existingRefreshToken,
 					authTime,
+					refreshResources,
 				)
 			: undefined;
 
@@ -513,6 +524,7 @@ async function createUserTokens(
 					client,
 					audience,
 					scopes,
+					params?.resources,
 					referenceId,
 					{
 						iat,
@@ -531,6 +543,7 @@ async function createUserTokens(
 						exp,
 						sid: sessionId,
 					},
+					params?.resources,
 					referenceId,
 					earlyRefreshToken?.id,
 				),
@@ -551,6 +564,7 @@ async function createUserTokens(
 						},
 						existingRefreshToken,
 						authTime,
+						refreshResources,
 					)
 				: undefined,
 	]);
@@ -597,6 +611,7 @@ async function checkVerificationValue(
 	code: string,
 	client_id: string,
 	redirect_uri?: string,
+	resource?: string[],
 ) {
 	const verification = await ctx.context.internalAdapter.findVerificationValue(
 		await storeToken(opts.storeTokens, code, "authorization_code"),
@@ -655,8 +670,28 @@ async function checkVerificationValue(
 			error: "invalid_request",
 		});
 	}
+	const verificationResources =
+		typeof verificationValue.query.resource === "string"
+			? [verificationValue.query.resource]
+			: verificationValue.query.resource;
+	const effectiveResources = resource ?? verificationResources;
+	if (resource && verificationResources) {
+		const requestedSet = new Set(resource);
+		const authorizedSet = new Set(verificationResources);
+		for (const r of requestedSet) {
+			if (!authorizedSet.has(r)) {
+				throw new APIError("BAD_REQUEST", {
+					error_description: "requested resource not authorized",
+					error: "invalid_target",
+				});
+			}
+		}
+	}
 
-	return verificationValue;
+	return {
+		verificationValue,
+		effectiveResources,
+	};
 }
 
 /**
@@ -681,11 +716,14 @@ async function handleAuthorizationCodeGrant(
 		code,
 		code_verifier,
 		redirect_uri,
+		resource,
 	}: {
 		code?: string;
 		code_verifier?: string;
 		redirect_uri?: string;
+		resource?: string | string[];
 	} = ctx.body;
+	const resources = typeof resource === "string" ? [resource] : resource;
 
 	if (!client_id) {
 		throw new APIError("BAD_REQUEST", {
@@ -717,13 +755,15 @@ async function handleAuthorizationCodeGrant(
 	}
 
 	/** Get and check Verification Value */
-	const verificationValue = await checkVerificationValue(
-		ctx,
-		opts,
-		code,
-		client_id,
-		redirect_uri,
-	);
+	const { verificationValue, effectiveResources } =
+		await checkVerificationValue(
+			ctx,
+			opts,
+			code,
+			client_id,
+			redirect_uri,
+			resources,
+		);
 	const scopes = verificationValue.query.scope?.split(" ");
 	if (!scopes) {
 		throw new APIError("INTERNAL_SERVER_ERROR", {
@@ -857,6 +897,7 @@ async function handleAuthorizationCodeGrant(
 		nonce: verificationValue.query?.nonce,
 		authTime,
 		verificationValue,
+		resources: effectiveResources,
 	});
 }
 
@@ -880,8 +921,8 @@ async function handleClientCredentialsGrant(
 		clientSecret: client_secret,
 		preVerifiedClient,
 	} = destructureCredentials(credentials);
-
-	const { scope }: { scope?: string } = ctx.body;
+	const { scope, resource }: { scope?: string; resource?: string } = ctx.body;
+	const _resources = typeof resource === "string" ? [resource] : resource;
 
 	if (!client_id) {
 		throw new APIError("BAD_REQUEST", {
@@ -939,6 +980,7 @@ async function handleClientCredentialsGrant(
 		client,
 		scopes: requestedScopes,
 		grantType: "client_credentials",
+		resources: _resources,
 	});
 }
 
@@ -966,10 +1008,13 @@ async function handleRefreshTokenGrant(
 	const {
 		refresh_token,
 		scope,
+		resource,
 	}: {
 		refresh_token?: string;
 		scope?: string;
+		resource?: string | string[];
 	} = ctx.body;
+	const resources = typeof resource === "string" ? [resource] : resource;
 
 	if (!client_id) {
 		throw new APIError("BAD_REQUEST", {
@@ -1043,6 +1088,18 @@ async function handleRefreshTokenGrant(
 		});
 	}
 
+	// Check body resources against refresh token resources
+	if (
+		resources &&
+		refreshToken.resources &&
+		!resources.every((v) => refreshToken.resources?.includes(v))
+	) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "requested resource invalid",
+			error: "invalid_target",
+		});
+	}
+
 	// Check session scopes
 	const scopes = refreshToken?.scopes;
 	const requestedScopes = scope?.split(" ");
@@ -1091,6 +1148,7 @@ async function handleRefreshTokenGrant(
 		referenceId: refreshToken.referenceId,
 		sessionId: refreshToken.sessionId,
 		refreshToken,
+		resources: resources ?? refreshToken.resources,
 		authTime,
 	});
 }

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -28,6 +28,8 @@ import {
 	resolveSessionAuthTime,
 	resolveSubjectIdentifier,
 	storeToken,
+	toAudienceClaim,
+	toResourceList,
 	validateClientCredentials,
 } from "./utils";
 
@@ -96,12 +98,7 @@ async function createJwtAccessToken(
 		payload: {
 			...customClaims,
 			sub: user?.id,
-			aud:
-				typeof audience === "string"
-					? audience
-					: audience?.length === 1
-						? audience.at(0)
-						: audience,
+			aud: toAudienceClaim(audience),
 			azp: client.clientId,
 			scope: scopes.join(" "),
 			sid: overrides?.sid,
@@ -387,12 +384,8 @@ export async function checkResource(
 	resource: string | string[] | undefined,
 	scopes: string[],
 ) {
-	const audience =
-		typeof resource === "string"
-			? [resource]
-			: resource
-				? [...resource]
-				: undefined;
+	const normalizedResource = toResourceList(resource);
+	const audience = normalizedResource ? [...normalizedResource] : undefined;
 	if (audience) {
 		// Adds /userinfo to audience
 		if (scopes.includes("openid")) {
@@ -420,7 +413,7 @@ export async function checkResource(
 	}
 	return {
 		success: true,
-		audience: audience?.length === 1 ? audience.at(0) : audience,
+		audience: toAudienceClaim(audience),
 	};
 }
 
@@ -685,14 +678,15 @@ async function checkVerificationValue(
 			error: "invalid_request",
 		});
 	}
-	const verificationResources =
-		typeof verificationValue.query.resource === "string"
-			? [verificationValue.query.resource]
-			: verificationValue.query.resource;
-	const effectiveResources = resource ?? verificationResources;
-	if (resource && verificationResources) {
+	// Prefer the new top-level field, but keep compatibility with legacy values in query.resource.
+	const storedResources =
+		toResourceList(verificationValue.resource) ??
+		toResourceList(verificationValue.query.resource);
+	const effectiveResources = resource ?? storedResources;
+
+	if (resource && storedResources) {
 		const requestedSet = new Set(resource);
-		const authorizedSet = new Set(verificationResources);
+		const authorizedSet = new Set(storedResources);
 		for (const r of requestedSet) {
 			if (!authorizedSet.has(r)) {
 				throw new APIError("BAD_REQUEST", {
@@ -738,7 +732,7 @@ async function handleAuthorizationCodeGrant(
 		redirect_uri?: string;
 		resource?: string | string[];
 	} = ctx.body;
-	const resources = typeof resource === "string" ? [resource] : resource;
+	const resources = toResourceList(resource);
 
 	if (!client_id) {
 		throw new APIError("BAD_REQUEST", {
@@ -937,7 +931,7 @@ async function handleClientCredentialsGrant(
 		preVerifiedClient,
 	} = destructureCredentials(credentials);
 	const { scope, resource }: { scope?: string; resource?: string } = ctx.body;
-	const _resources = typeof resource === "string" ? [resource] : resource;
+	const resources = toResourceList(resource);
 
 	if (!client_id) {
 		throw new APIError("BAD_REQUEST", {
@@ -995,7 +989,7 @@ async function handleClientCredentialsGrant(
 		client,
 		scopes: requestedScopes,
 		grantType: "client_credentials",
-		resources: _resources,
+		resources,
 	});
 }
 
@@ -1029,7 +1023,7 @@ async function handleRefreshTokenGrant(
 		scope?: string;
 		resource?: string | string[];
 	} = ctx.body;
-	const resources = typeof resource === "string" ? [resource] : resource;
+	const resources = toResourceList(resource);
 
 	if (!client_id) {
 		throw new APIError("BAD_REQUEST", {

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -564,8 +564,6 @@ export interface OAuthOptions<
 		scopes: Scopes;
 		/** The resources requested. */
 		resources?: string[];
-		/** The resource requesting. Provided by the token endpoint. @deprecated */
-		resource?: string;
 		/** oAuthClient metadata */
 		metadata?: Record<string, any>;
 	}) => Awaitable<Record<string, any>>;

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1123,7 +1123,7 @@ export interface OAuthRefreshToken<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
 > {
 	token: string;
-	sessionId?: string;
+	sessionId: string;
 	userId: string;
 	referenceId?: string;
 	clientId?: string;

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -562,7 +562,9 @@ export interface OAuthOptions<
 		referenceId?: string;
 		/** Scopes granted for this token */
 		scopes: Scopes;
-		/** The resource requesting. Provided by the token endpoint. */
+		/** The resources requested. */
+		resources?: string[];
+		/** The resource requesting. Provided by the token endpoint. @deprecated */
 		resource?: string;
 		/** oAuthClient metadata */
 		metadata?: Record<string, any>;
@@ -907,6 +909,10 @@ export interface OAuthAuthorizationQuery {
 	 * with the Claim Value being the nonce value sent in the Authentication Request.
 	 */
 	nonce?: string;
+	/**
+	 * Resource parameter as specified by [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)
+	 */
+	resource?: string | string[];
 }
 
 /**
@@ -921,6 +927,7 @@ export interface VerificationValue {
 	query: OAuthAuthorizationQuery;
 	sessionId: string;
 	userId: string;
+	resource?: string | string[];
 	referenceId?: string;
 	authTime?: number;
 }
@@ -1103,6 +1110,10 @@ export interface OAuthOpaqueAccessToken<
 	 * Shall match the refreshId.scopes if refreshId is provided.
 	 */
 	scopes: Scopes;
+	/**
+	 * Resources allowed for this access token.
+	 */
+	resources?: string[];
 }
 
 /**
@@ -1112,7 +1123,7 @@ export interface OAuthRefreshToken<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
 > {
 	token: string;
-	sessionId: string;
+	sessionId?: string;
 	userId: string;
 	referenceId?: string;
 	clientId?: string;
@@ -1133,6 +1144,10 @@ export interface OAuthRefreshToken<
 	 * Considered Immutable once granted.
 	 */
 	scopes: Scopes;
+	/**
+	 * Resources allowed for this refresh token
+	 */
+	resources?: string[];
 }
 
 /**
@@ -1144,6 +1159,7 @@ export type OAuthConsent<
 	id: string;
 	clientId: string;
 	userId: string;
+	resources?: string[];
 	referenceId?: string;
 	scopes: Scopes;
 	createdAt: Date;

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -927,7 +927,7 @@ export interface VerificationValue {
 	query: OAuthAuthorizationQuery;
 	sessionId: string;
 	userId: string;
-	resource?: string | string[];
+	resource?: string[];
 	referenceId?: string;
 	authTime?: number;
 }

--- a/packages/oauth-provider/src/types/zod.test.ts
+++ b/packages/oauth-provider/src/types/zod.test.ts
@@ -79,6 +79,11 @@ describe("SafeUrlSchema", () => {
 	});
 
 	describe("URL parsing", () => {
+		it("should reject URLs with fragments", () => {
+			const result = SafeUrlSchema.safeParse("https://api.example.com#frag");
+			expect(result.success).toBe(false);
+		});
+
 		it("should reject invalid URLs", () => {
 			const result = SafeUrlSchema.safeParse("not-a-valid-url");
 			expect(result.success).toBe(false);

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -62,6 +62,15 @@ export const SafeUrlSchema = z.url().superRefine((val, ctx) => {
 
 	const u = new URL(val);
 
+	// Disallow URL fragments
+	if (u.hash && u.hash.length > 0) {
+		ctx.addIssue({
+			code: "custom",
+			message: "URL must not contain a fragment",
+		});
+		return;
+	}
+
 	if (DANGEROUS_SCHEMES.includes(u.protocol)) {
 		ctx.addIssue({
 			code: "custom",

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -135,6 +135,28 @@ export function resolveSessionAuthTime(value: unknown): Date | undefined {
 	);
 }
 
+/**
+ * Normalizes OAuth resource values into a non-empty string array.
+ */
+export function toResourceList(
+	value: string | string[] | undefined,
+): string[] | undefined {
+	if (typeof value === "string") return [value];
+	if (!value?.length) return undefined;
+	return value;
+}
+
+/**
+ * Normalizes audience values for JWT claims.
+ */
+export function toAudienceClaim(
+	audience: string | string[] | undefined,
+): string | string[] | undefined {
+	if (typeof audience === "string") return audience;
+	if (!audience?.length) return undefined;
+	return audience.length === 1 ? audience.at(0) : audience;
+}
+
 const cachedTrustedClients = new TTLCache<string, SchemaClient<Scope[]>>();
 
 export async function verifyOAuthQueryParams(

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -157,6 +157,49 @@ export function toAudienceClaim(
 	return audience.length === 1 ? audience.at(0) : audience;
 }
 
+/**
+ * Checks the resource parameter, if provided,
+ * and returns either a valid audience or a tagged validation error.
+ */
+export async function checkResource(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	resource: string | string[] | undefined,
+	scopes: string[],
+) {
+	const normalizedResource = toResourceList(resource);
+	const audience = normalizedResource ? [...normalizedResource] : undefined;
+	if (audience) {
+		// Adds /userinfo to audience
+		const hasOpenId = scopes.includes("openid");
+		const baseUrl = ctx.context.baseURL;
+		const userInfoEndpoint = `${baseUrl}/oauth2/userinfo`;
+		if (hasOpenId && !audience.includes(userInfoEndpoint)) {
+			audience.push(userInfoEndpoint);
+		}
+		// Check valid audiences
+		const filteredValidAudiences = opts.validAudiences?.filter(
+			(aud) => aud.length,
+		);
+		const validAudiences = new Set(
+			filteredValidAudiences?.length ? filteredValidAudiences : [baseUrl],
+		);
+		if (hasOpenId) validAudiences.add(userInfoEndpoint);
+		for (const aud of audience) {
+			if (!validAudiences.has(aud)) {
+				return {
+					success: false,
+					error: "invalid_resource",
+				};
+			}
+		}
+	}
+	return {
+		success: true,
+		audience: toAudienceClaim(audience),
+	};
+}
+
 const cachedTrustedClients = new TTLCache<string, SchemaClient<Scope[]>>();
 
 export async function verifyOAuthQueryParams(


### PR DESCRIPTION
Follows the resource indicator spec [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html).

**Improvements**:
- Prevents resource value changes between `/authorize` and `/token`
- Restricts refresh and access tokens to resources specified at authorization
- `resource` supported across all grant types: authorization_code, client_credentials, refresh_token
- Access tokens with resource provides `aud` field at introspection
- Ensures consent re-prompting changes in resource

**Deprecations**:

- `customAccessTokenClaims` properly uses the `resources` field to indicate the resource at both `/token` and `/introspect` (`resource` field in this function is deprecated).

Follow the resource indicator spec RFC 8707.

Improvements:

- Prevents resource value changes between `/authorize` and `/token`
- Restricts refresh and access tokens to resources specified at authorization
- `resource` supported across all grant types: authorization_code, client_credentials, refresh_token
- Access tokens with resource provides `aud` field at introspection
- Ensures consent re-prompting changes in resource

Deprecations:

- `customAccessTokenClaims` properly uses the `resources` field to indicate the resource at both `/token` and `/introspect` (`resource` field in this function is deprecated).

Closes: #8298

After upgrading, users may also need to run one of the following to update the schema:

```bash
npx auth migrate
```
or
```bash
npx auth generate
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements RFC 8707 resource indicators in `@better-auth/oauth-provider` with strict URL validation (no fragments), consent-aware authorization, and resource-bound tokens across all grants. Adds `aud` to JWTs and to opaque token introspection, supports multiple resources, and enforces resource narrowing with safe fallbacks per spec.

- **New Features**
  - Accepts `resource` on `/authorize` and `/token` as string, array, or repeated param; invalid values return `invalid_target`. Validates against `validAudiences` and appends `userinfo` when `openid`.
  - Records requested resources in the authorization code and prevents widening at `/token`. Omitting `resource` falls back to the authorized set; provided values must be a subset. Refresh tokens retain the full original resources (RFC 8707 §2.2).
  - Consent saves selected resources and re-prompts if new ones are requested; `prompt=none` returns `consent_required`. Opaque tokens now expose `aud` via `/oauth2/introspect`. `customAccessTokenClaims` receives `resources` for both JWT and opaque tokens.

- **Migration**
  - Replace `customAccessTokenClaims.resource` with `customAccessTokenClaims.resources` (array).
  - Do not send `resource` to `/oauth2/introspect`; use `resources` via `customAccessTokenClaims` for audience-based claims.

<sup>Written for commit 0f4b2e6e9bc3a02347381144b275cd33ad9c5de2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







