### PR TITLE
fix(core): coerce string where values to match field types in adapter

### DIFF
--- a/packages/better-auth/src/db/db.test.ts
+++ b/packages/better-auth/src/db/db.test.ts
@@ -100,16 +100,20 @@ describe("db", async () => {
 	it("should coerce string where values to match field types", async () => {
 		// HTTP query params arrive as strings.
 		// The adapter should coerce values to match the field's schema type.
-		const { db } = await getTestInstance({
-			user: {
-				additionalFields: {
-					age: {
-						type: "number",
-						required: false,
+		const { auth, db } = await getTestInstance(
+			{
+				user: {
+					additionalFields: {
+						age: { type: "number", required: false },
 					},
 				},
 			},
-		});
+			{
+				// Uses MongoDB because SQLite/MySQL/PostgreSQL silently cast types,
+				// which would make this test pass even without the coercion code.
+				testWith: "mongodb",
+			},
+		);
 
 		// boolean: "false" → false, "true" → true
 		const users = await db.findMany<{ emailVerified: boolean }>({
@@ -118,11 +122,6 @@ describe("db", async () => {
 		});
 		expect(users.length).toBeGreaterThanOrEqual(1);
 		expect(users.every((u) => u.emailVerified === false)).toBe(true);
-		const verifiedUsers = await db.findMany<{ emailVerified: boolean }>({
-			model: "user",
-			where: [{ field: "emailVerified", operator: "eq", value: "true" }],
-		});
-		expect(verifiedUsers.every((u) => u.emailVerified === true)).toBe(true);
 
 		// number: "25" → 25
 		await db.update({
@@ -136,6 +135,30 @@ describe("db", async () => {
 		});
 		expect(byAge.length).toBeGreaterThanOrEqual(1);
 		expect(byAge.every((u) => u.age === 25)).toBe(true);
+
+		// number array: ["25", "30"] → [25, 30]
+		await auth.api.signUpEmail({
+			body: {
+				email: "age30@test.com",
+				password: "password",
+				name: "user-30",
+				age: 30,
+			},
+		});
+		await auth.api.signUpEmail({
+			body: {
+				email: "age40@test.com",
+				password: "password",
+				name: "user-40",
+				age: 40,
+			},
+		});
+		const byAgeIn = await db.findMany<{ age: number | null }>({
+			model: "user",
+			where: [{ field: "age", operator: "in", value: ["25", "30"] }],
+		});
+		expect(byAgeIn).toHaveLength(2);
+		expect(byAgeIn.map((u) => u.age).sort()).toEqual([25, 30]);
 	});
 
 	it("delete hooks", async () => {

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -544,10 +544,19 @@ export const createAdapterFactory =
 					newValue = newValue === "true";
 				}
 
-				if (fieldAttr.type === "number" && typeof newValue === "string") {
-					const parsed = Number(newValue);
-					if (!Number.isNaN(parsed)) {
-						newValue = parsed;
+				if (fieldAttr.type === "number") {
+					if (typeof newValue === "string" && newValue.trim() !== "") {
+						const parsed = Number(newValue);
+						if (!Number.isNaN(parsed)) {
+							newValue = parsed;
+						}
+					} else if (Array.isArray(newValue)) {
+						const parsed = newValue.map((v) =>
+							typeof v === "string" && v.trim() !== "" ? Number(v) : NaN,
+						);
+						if (parsed.every((n) => !Number.isNaN(n))) {
+							newValue = parsed;
+						}
 					}
 				}
 


### PR DESCRIPTION
> [!NOTE]
> You can see this issue by using `filterValue` in `authClient.admin.listUsers`
> https://www.better-auth.com/docs/plugins/admin#list-users 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coerces string where values in the DB adapter to match schema types (boolean/number), including arrays, and ignores empty strings. This makes filters from HTTP query params work consistently across adapters.

- **Bug Fixes**
  - Convert "true"/"false" and numeric strings (and arrays) to typed values based on schema before queries.
  - Guard against empty strings when coercing numbers.
  - Preserve boolean-to-1/0 mapping when the adapter doesn’t support booleans; added tests for boolean, number, and number array "in" coercion in findMany.

<sup>Written for commit a62f5a289eeb17a813e09a23b141dd8425e33e87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



