### PR TITLE
feat(i18n): pass `GenericEndpointContext` to `getLocale` callback

### DIFF
--- a/docs/content/docs/plugins/i18n.mdx
+++ b/docs/content/docs/plugins/i18n.mdx
@@ -131,16 +131,16 @@ For advanced use cases, you can provide a custom locale detection function:
 i18n({
     translations: { /* ... */ },
     detection: ["callback", "header"],
-    getLocale: (request, ctx) => {
+    getLocale: (ctx) => {
         // Custom logic: use query param, custom header, etc.
-        if (!request) return null;
-        const url = new URL(request.url);
+        if (!ctx.request) return null;
+        const url = new URL(ctx.request.url);
         return url.searchParams.get("lang");
     },
 })
 ```
 
-The callback receives the request object and the auth context, and should return the locale code or `null`.
+The callback receives the full endpoint context. It should return the locale code or `null`.
 
 ## Error Codes
 
@@ -208,12 +208,12 @@ The field name on the user object that stores their locale preference when using
 
 ### `getLocale`
 
-**Type:** `(request: Request | undefined, ctx: AuthContext) => string | null | Promise<string | null>`
+**Type:** `(ctx: GenericEndpointContext) => string | null | Promise<string | null>`
 
-A custom function to detect the locale when using the `"callback"` detection strategy. Receives the request and auth context, returns the locale code or `null`.
+A custom function to detect the locale when using the `"callback"` detection strategy. Receives the full endpoint context. Returns the locale code or `null`.
 
 <Callout type="info">
-`request` could be undefined for non-HTTP calls.
+`ctx.request` could be undefined for non-HTTP calls.
 </Callout>
 
 ## Fallback Behavior

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -187,9 +187,8 @@ describe("i18n plugin", async () => {
 						translations,
 						defaultLocale: "en",
 						detection: ["callback"],
-						getLocale: (request, _ctx) => {
-							if (!request) return null;
-							return request.headers.get("X-Custom-Locale") ?? null;
+						getLocale: (ctx) => {
+							return ctx.headers?.get("X-Custom-Locale") ?? null;
 						},
 					}),
 				],
@@ -218,7 +217,7 @@ describe("i18n plugin", async () => {
 						translations,
 						defaultLocale: "en",
 						detection: ["callback"],
-						getLocale: (_request, _ctx) => {
+						getLocale: () => {
 							return "fr";
 						},
 					}),

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -1,7 +1,7 @@
 import type {
-	AuthContext,
 	BetterAuthPluginRegistry,
 	BetterAuthPluginRegistryIdentifier,
+	GenericEndpointContext,
 	UnionToIntersection,
 } from "@better-auth/core";
 
@@ -84,14 +84,15 @@ export interface I18nOptions<Locales extends string[]> {
 	userLocaleField?: string | undefined;
 
 	/**
-	 * Custom locale detection function (when "callback" strategy is used)
-	 * Receives a request and an AuthContext, returns a locale code or null.
-	 * Note: `request` may be undefined for non-HTTP calls.
+	 * Custom locale detection function (when "callback" strategy is used).
+	 * @example
+	 * getLocale: (ctx) => {
+	 *   return ctx.headers?.get("X-Custom-Locale") ?? null;
+	 * }
 	 */
 	getLocale?:
 		| undefined
 		| ((
-				request: Request | undefined,
-				ctx: AuthContext,
+				ctx: GenericEndpointContext,
 		  ) => Promise<Locales[number] | null> | Locales[number] | null);
 }


### PR DESCRIPTION
> [!NOTE]
> This is a breaking change, but it only exists in the beta version. 

Related to https://github.com/better-auth/better-auth/issues/7805#issuecomment-3863889055

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass GenericEndpointContext to the i18n getLocale callback to provide full endpoint data and simplify detection across runtimes. This changes the getLocale signature and is breaking in beta.

- **Migration**
  - Change getLocale from (request, ctx) => ... to (ctx) => ...
  - Use ctx.headers for headers, ctx.request for the Request, and ctx.context.session for the user.
  - Remember ctx.request may be undefined for non-HTTP calls.

<sup>Written for commit ef86816474217ed3f9f3d225d72963b34982d76b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

