### PR TITLE
fix(sso): only call `provisionUser` for new users

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1701,7 +1701,7 @@ export const callbackSSO = (options?: SSOOptions) => {
 			}
 			const { session, user } = linked.data!;
 
-			if (options?.provisionUser) {
+			if (options?.provisionUser && linked.isRegister) {
 				await options.provisionUser({
 					user,
 					userInfo,
@@ -2276,7 +2276,7 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 
 			const { session, user } = result.data!;
 
-			if (options?.provisionUser) {
+			if (options?.provisionUser && result.isRegister) {
 				await options.provisionUser({
 					user: user as User & Record<string, any>,
 					userInfo,
@@ -2759,7 +2759,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 
 			const { session, user } = result.data!;
 
-			if (options?.provisionUser) {
+			if (options?.provisionUser && result.isRegister) {
 				await options.provisionUser({
 					user: user as User & Record<string, any>,
 					userInfo,


### PR DESCRIPTION
- Closes #7857

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Call provisionUser only when a user is first created via SSO, not on every sign-in. This avoids duplicate provisioning and side effects on repeat logins.

- **Bug Fixes**
  - Gate provisionUser behind isRegister in callbackSSO, callbackSSOSAML, and acsEndpoint.
  - Add test to verify it runs on first sign-in and not on subsequent sign-ins.

<sup>Written for commit 3e1952c50e99c2af08050551a3b773e206093977. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

