### PR TITLE
docs: update comparisons page

### DIFF
--- a/docs/content/docs/comparison.mdx
+++ b/docs/content/docs/comparison.mdx
@@ -13,21 +13,18 @@ Here are non detailed reasons why you may want to use Better Auth over other aut
 - **Advanced features built-in** - 2FA, multi-tenancy, multi-session, rate limiting, and many more
 - **Plugin system** - Extend functionality without forking or complex workarounds
 - **Full control** - Customize auth flows exactly how you want
-
-### vs Self-Hosted Auth Servers
-
-- **No separate infrastructure** - Runs in your app, users stay in your database
-- **Zero server maintenance** - No auth servers to deploy, monitor, or update
-- **Complete feature set** - Everything you need without the operational overhead
+- **Flexible deployment** - Run alongside your app or as a standalone self-hosted auth server
 
 ### vs Managed Auth Services
 
 - **Keep your data** - Users stay in your database, not a third-party service
 - **No per-user costs** - Scale without worrying about auth billing
 - **Single source of truth** - All user data in one place
+- **Self-host anywhere** - Deploy on your own infrastructure with full control
 
 ### vs Rolling Your Own
 
 - **Security handled** - Battle-tested auth flows and security practices
 - **Focus on your product** - Spend time on features that matter to your business
 - **Plugin extensibility** - Add custom features without starting from scratch
+- **Production ready** - Works embedded in your app or as a dedicated auth server


### PR DESCRIPTION
These days, more and more users self-host better auth. I've removed the "versus self-hosted auth server" section and added dot points explaining our flexible deployment solution to either have a standalone self-hosted auth server or run alongside the user's app.