### PR TITLE
test(email-otp): simplify test assertions and improve error handling

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -706,23 +706,20 @@ describe("custom storeOTP", async () => {
 		});
 
 		it("should not be allowed to get otp if storeOTP is hashed", async () => {
-			try {
-				await auth.api.getVerificationOTP({
+			await expect(
+				auth.api.getVerificationOTP({
 					query: {
 						email: userEmail1,
 						type: "sign-in",
 					},
-				});
-			} catch (error: any) {
-				expect(error.statusCode).toBe(400);
-				expect(error.status).toBe("BAD_REQUEST");
-				expect(error.body.code).toBe(
-					"OTP_IS_HASHED_CANNOT_RETURN_THE_PLAIN_TEXT_OTP",
-				);
-				return;
-			}
-			// Should not reach here given the above should throw and thus return.
-			expect(true).toBe(false);
+				}),
+			).rejects.toMatchObject({
+				statusCode: 400,
+				status: "BAD_REQUEST",
+				body: {
+					code: "OTP_IS_HASHED_CANNOT_RETURN_THE_PLAIN_TEXT_OTP",
+				},
+			});
 		});
 
 		it("should be able to sign in with normal otp", async () => {
@@ -807,22 +804,14 @@ describe("custom storeOTP", async () => {
 		});
 
 		it("should be allowed to get otp if storeOTP is encrypted", async () => {
-			try {
-				const res = await auth.api.getVerificationOTP({
-					query: {
-						email: userEmail1,
-						type: "sign-in",
-					},
-				});
-				if (!res.otp) {
-					expect(true).toBe(false);
-					return;
-				}
-				expect(res.otp).toEqual(validOTP);
-				expect(res.otp.length).toBe(6);
-			} catch (error: any) {
-				expect(error).not.toBeDefined();
-			}
+			const res = await auth.api.getVerificationOTP({
+				query: {
+					email: userEmail1,
+					type: "sign-in",
+				},
+			});
+			expect(res.otp).toEqual(validOTP);
+			expect(res.otp?.length).toBe(6);
 		});
 
 		it("should be able to sign in with encrypted otp", async () => {
@@ -912,23 +901,14 @@ describe("custom storeOTP", async () => {
 		});
 
 		it("should be allowed to get otp if storeOTP is custom encryptor", async () => {
-			try {
-				const res = await auth.api.getVerificationOTP({
-					query: {
-						email: userEmail1,
-						type: "sign-in",
-					},
-				});
-				if (!res.otp) {
-					expect(true).toBe(false);
-					return;
-				}
-				expect(res.otp).toEqual(validOTP);
-				expect(res.otp.length).toBe(6);
-			} catch (error: any) {
-				console.error(error);
-				expect(error).not.toBeDefined();
-			}
+			const res = await auth.api.getVerificationOTP({
+				query: {
+					email: userEmail1,
+					type: "sign-in",
+				},
+			});
+			expect(res.otp).toEqual(validOTP);
+			expect(res.otp?.length).toBe(6);
 		});
 
 		it("should be able to sign in with custom encryptor otp", async () => {
@@ -1015,23 +995,20 @@ describe("custom storeOTP", async () => {
 		});
 
 		it("should be allowed to get otp if storeOTP is custom hasher", async () => {
-			try {
-				await auth.api.getVerificationOTP({
+			await expect(
+				auth.api.getVerificationOTP({
 					query: {
 						email: userEmail1,
 						type: "sign-in",
 					},
-				});
-			} catch (error: any) {
-				expect(error.statusCode).toBe(400);
-				expect(error.status).toBe("BAD_REQUEST");
-				expect(error.body.code).toBe(
-					"OTP_IS_HASHED_CANNOT_RETURN_THE_PLAIN_TEXT_OTP",
-				);
-				return;
-			}
-			// Should not reach here given the above should throw and thus return.
-			expect(true).toBe(false);
+				}),
+			).rejects.toMatchObject({
+				statusCode: 400,
+				status: "BAD_REQUEST",
+				body: {
+					code: "OTP_IS_HASHED_CANNOT_RETURN_THE_PLAIN_TEXT_OTP",
+				},
+			});
 		});
 
 		it("should be able to sign in with custom hasher otp", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified email-otp test assertions and tightened error handling. Tests now explicitly assert BAD_REQUEST for hashed OTP and validate OTP value and length for encrypted/custom encryptor modes.

- **Refactors**
  - Replaced try/catch with expect(...).rejects.toMatchObject for failure cases, asserting 400 BAD_REQUEST with code OTP_IS_HASHED_CANNOT_RETURN_THE_PLAIN_TEXT_OTP.
  - Streamlined success path: direct checks for res.otp === validOTP and length 6; removed unreachable guards and console logs.

<sup>Written for commit 2a3e703c3b90761ca705d75e1bdda8c0b3f660a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

