### PR TITLE
fix(custom-session): support comma-separated set-cookie

### DIFF
--- a/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
+++ b/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
@@ -81,6 +81,59 @@ describe("Custom Session Plugin Tests", async () => {
 		});
 	});
 
+	/**
+	 * Verifies that multiple Set-Cookie headers are sent as separate headers,
+	 * not comma-joined into a single header (which would corrupt cookie attributes).
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/7878
+	 */
+	it("should send multiple Set-Cookie headers separately (not comma-joined)", async () => {
+		const { headers } = await signInWithTestUser();
+		await client.getSession({
+			fetchOptions: {
+				headers,
+				onResponse(context) {
+					// Use getSetCookie() to get individual Set-Cookie headers as an array
+					// This is the correct way to read multiple Set-Cookie headers
+					const setCookies = context.response.headers.getSetCookie();
+
+					// Should have at least 2 cookies (session_token and session_data)
+					expect(setCookies.length).toBeGreaterThanOrEqual(2);
+
+					// Find the session_token and session_data cookies
+					const sessionTokenCookie = setCookies.find((c) =>
+						c.startsWith("better-auth.session_token="),
+					);
+					const sessionDataCookie = setCookies.find((c) =>
+						c.startsWith("better-auth.session_data="),
+					);
+
+					expect(sessionTokenCookie).toBeDefined();
+					expect(sessionDataCookie).toBeDefined();
+
+					// Each cookie should have its own Max-Age attribute
+					expect(sessionTokenCookie).toMatch(/Max-Age=\d+/);
+					expect(sessionDataCookie).toMatch(/Max-Age=\d+/);
+
+					// Critical: each cookie string should only contain ONE cookie
+					// If they were comma-joined incorrectly, one cookie string would
+					// contain both cookie names
+					expect(sessionTokenCookie).not.toContain("better-auth.session_data");
+					expect(sessionDataCookie).not.toContain("better-auth.session_token");
+
+					// Verify each cookie has proper structure (name=value; attributes)
+					// and hasn't been corrupted by comma-joining
+					expect(sessionTokenCookie!.split(";")[0]).toMatch(
+						/^better-auth\.session_token=[^,]+$/,
+					);
+					expect(sessionDataCookie!.split(";")[0]).toMatch(
+						/^better-auth\.session_data=[^,]+$/,
+					);
+				},
+			},
+		});
+	});
+
 	it("should return the custom session for multi-session", async () => {
 		const headers = new Headers();
 		const testUser = {

--- a/packages/better-auth/src/plugins/custom-session/index.ts
+++ b/packages/better-auth/src/plugins/custom-session/index.ts
@@ -10,6 +10,7 @@ import {
 import type { Session, User } from "@better-auth/core/db";
 import * as z from "zod";
 import { getSession } from "../../api";
+import { parseSetCookieHeader } from "../../cookies";
 import { getEndpointResponse } from "../../utils/plugin-helper";
 
 declare module "@better-auth/core" {
@@ -128,11 +129,24 @@ export const customSession = <
 					}
 					const fnResult = await fn(session.response as any, ctx);
 
-					const setCookie = session.headers.get("set-cookie");
-					if (setCookie) {
-						ctx.setHeader("set-cookie", setCookie);
-						session.headers.delete("set-cookie");
+					// Forward Set-Cookie headers from the internal getSession call
+					// Using getSetCookie() + parseSetCookieHeader to properly handle
+					// multiple cookies without comma-joining corruption
+					for (const cookieStr of session.headers.getSetCookie()) {
+						const parsed = parseSetCookieHeader(cookieStr);
+						parsed.forEach((attrs, name) => {
+							ctx.setCookie(name, attrs.value, {
+								maxAge: attrs["max-age"],
+								expires: attrs.expires,
+								domain: attrs.domain,
+								path: attrs.path,
+								secure: attrs.secure,
+								httpOnly: attrs.httponly,
+								sameSite: attrs.samesite,
+							});
+						});
 					}
+					session.headers.delete("set-cookie");
 
 					session.headers.forEach((value, key) => {
 						ctx.setHeader(key, value);


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/7878

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom-session cookie forwarding so multiple Set-Cookie headers are handled individually instead of being comma-joined, preventing corrupted cookies and broken attributes. Addresses github.com/better-auth/better-auth/issues/7878.

- **Bug Fixes**
  - Forward cookies using headers.getSetCookie() + parseSetCookieHeader and set each cookie via ctx.setCookie to preserve attributes (Max-Age, Expires, SameSite, etc.).
  - Added a test that asserts session_token and session_data are sent as separate Set-Cookie headers with intact attributes.

<sup>Written for commit 960935592bb2d7f6fc7d9e52d1a7d65849d7a309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

