### PR TITLE
test: use vitest best practice

### DIFF
--- a/packages/better-auth/src/api/middlewares/origin-check.test.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.test.ts
@@ -1,12 +1,12 @@
 import { createAuthEndpoint } from "@better-auth/core/api";
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import * as z from "zod";
 import { createAuthClient } from "../../client";
 import { parseSetCookieHeader } from "../../cookies";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { originCheck } from "./origin-check";
 
-describe("Origin Check", async (it) => {
+describe("Origin Check", async () => {
 	const { customFetchImpl, testUser } = await getTestInstance({
 		trustedOrigins: [
 			"http://localhost:5000",
@@ -245,7 +245,7 @@ describe("Origin Check", async (it) => {
 	});
 });
 
-describe("Fetch Metadata CSRF Protection", async (it) => {
+describe("Fetch Metadata CSRF Protection", async () => {
 	const { testUser, auth } = await getTestInstance({
 		trustedOrigins: ["http://localhost:3000", "https://app.example.com"],
 		emailAndPassword: {
@@ -493,7 +493,7 @@ describe("Fetch Metadata CSRF Protection", async (it) => {
 	});
 });
 
-describe("origin check middleware", async (it) => {
+describe("origin check middleware", async () => {
 	it("should return invalid origin", async () => {
 		const { client } = await getTestInstance({
 			trustedOrigins: ["https://trusted-site.com"],
@@ -539,7 +539,7 @@ describe("origin check middleware", async (it) => {
 	});
 });
 
-describe("trusted origins with baseURL inferred from request", async (it) => {
+describe("trusted origins with baseURL inferred from request", async () => {
 	it("should respect trustedOrigins array when baseURL is NOT in config", async () => {
 		const { customFetchImpl, testUser } = await getTestInstance({
 			baseURL: undefined,
@@ -732,7 +732,7 @@ describe("trusted origins with baseURL inferred from request", async (it) => {
 	});
 });
 
-describe("disableCSRFCheck and disableOriginCheck separation", async (it) => {
+describe("disableCSRFCheck and disableOriginCheck separation", async () => {
 	it("disableCSRFCheck should allow untrusted origins with cookies (CSRF bypass)", async () => {
 		const { customFetchImpl, testUser } = await getTestInstance({
 			trustedOrigins: ["http://localhost:3000"],

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -57,6 +57,7 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
+	vi.useRealTimers();
 	server.resetHandlers();
 	server.use(...handlers);
 });
@@ -91,6 +92,7 @@ describe("account", async () => {
 		googleVerifyIdTokenMock = vi.spyOn(googleProvider, "verifyIdToken");
 		googleGetUserInfoMock = vi.spyOn(googleProvider, "getUserInfo");
 	});
+
 	afterEach(() => {
 		googleVerifyIdTokenMock.mockClear();
 		googleGetUserInfoMock.mockClear();

--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 
 describe("Email Verification", async () => {
@@ -15,6 +15,10 @@ describe("Email Verification", async () => {
 				mockSendEmail(user.email, url);
 			},
 		},
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it("should send a verification email when enabled", async () => {

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -1,9 +1,9 @@
 import { APIError } from "better-call";
-import { describe, expect, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils";
 import type { Account } from "../../types";
 
-describe("forget password", async (it) => {
+describe("forget password", async () => {
 	const mockSendEmail = vi.fn();
 	const mockOnPasswordReset = vi.fn();
 	let token = "";
@@ -25,6 +25,10 @@ describe("forget password", async (it) => {
 			testWith: "sqlite",
 		},
 	);
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should send a reset password email when enabled", async () => {
 		await client.requestPasswordReset({
 			email: testUser.email,
@@ -318,7 +322,7 @@ describe("forget password", async (it) => {
 	});
 });
 
-describe("revoke sessions on password reset", async (it) => {
+describe("revoke sessions on password reset", async () => {
 	const mockSendEmail = vi.fn();
 	let token = "";
 
@@ -404,7 +408,7 @@ describe("revoke sessions on password reset", async (it) => {
 	});
 });
 
-describe("verify password", async (it) => {
+describe("verify password", async () => {
 	const { testUser, auth } = await getTestInstance({
 		emailAndPassword: {
 			enabled: true,

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -2,7 +2,15 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { runWithEndpointContext } from "@better-auth/core/context";
 import type { MemoryDB } from "@better-auth/memory-adapter";
 import { memoryAdapter } from "@better-auth/memory-adapter";
-import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	expectTypeOf,
+	it,
+	vi,
+} from "vitest";
 import { parseCookies, parseSetCookieHeader } from "../../cookies";
 import { signJWT, verifyJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
@@ -11,6 +19,10 @@ import { getDate } from "../../utils/date";
 describe("session", async () => {
 	const { client, testUser, sessionSetter, cookieSetter, auth } =
 		await getTestInstance();
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
 	it("should set cookies correctly on sign in", async () => {
 		const headers = new Headers();
@@ -491,6 +503,10 @@ describe("cookie cache", async () => {
 	});
 	const ctx = await auth.$context;
 
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should cache cookies", async () => {});
 	const fn = vi.spyOn(ctx.adapter, "findOne");
 
@@ -598,6 +614,10 @@ describe("cookie cache with JWT strategy", async () => {
 		},
 	});
 	const ctx = await auth.$context;
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
 	const fn = vi.spyOn(ctx.adapter, "findOne");
 
@@ -748,6 +768,10 @@ describe("cookie cache with JWE strategy", async () => {
 	});
 	const ctx = await auth.$context;
 
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	const fn = vi.spyOn(ctx.adapter, "findOne");
 
 	const headers = new Headers();
@@ -881,6 +905,10 @@ describe("cookie cache refreshCache", async () => {
 	});
 	const ctx = await auth.$context;
 	const fn = vi.spyOn(ctx.adapter, "findOne");
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
 	const headers = new Headers();
 
@@ -1417,6 +1445,10 @@ describe("cookie cache versioning", async () => {
 });
 
 describe("deferSessionRefresh", async () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should return needsRefresh flag on GET when enabled", async () => {
 		const { auth, testUser } = await getTestInstance({
 			session: {
@@ -1696,6 +1728,10 @@ describe("deferSessionRefresh", async () => {
 });
 
 describe("date field type consistency", async () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should have consistent date types between cookie cache and refresh paths", async () => {
 		const { auth, testUser } = await getTestInstance({
 			database: undefined, // stateless mode

--- a/packages/better-auth/src/api/routes/sign-in.test.ts
+++ b/packages/better-auth/src/api/routes/sign-in.test.ts
@@ -1,12 +1,12 @@
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parseSetCookieHeader } from "../../cookies";
 import { getTestInstance } from "../../test-utils/test-instance";
 
 /**
  * More test can be found in `session.test.ts`
  */
-describe("sign-in", async (it) => {
+describe("sign-in", async () => {
 	const { auth, testUser, cookieSetter } = await getTestInstance();
 
 	it("should return a response with a set-cookie header", async () => {
@@ -105,7 +105,7 @@ describe("sign-in", async (it) => {
 	});
 });
 
-describe("url checks", async (it) => {
+describe("url checks", async () => {
 	it("should reject untrusted origins", async () => {
 		const { client } = await getTestInstance({
 			advanced: {
@@ -137,7 +137,7 @@ describe("url checks", async (it) => {
 	});
 });
 
-describe("sign-in CSRF protection", async (it) => {
+describe("sign-in CSRF protection", async () => {
 	const { auth, testUser } = await getTestInstance({
 		trustedOrigins: ["http://localhost:3000"],
 		emailAndPassword: {
@@ -246,7 +246,7 @@ describe("sign-in CSRF protection", async (it) => {
 	});
 });
 
-describe("sign-in with additionalFields", async (it) => {
+describe("sign-in with additionalFields", async () => {
 	const { auth } = await getTestInstance(
 		{
 			user: {
@@ -292,7 +292,7 @@ describe("sign-in with additionalFields", async (it) => {
 	});
 });
 
-describe("sign-in with form data", async (it) => {
+describe("sign-in with form data", async () => {
 	const { auth, testUser } = await getTestInstance({
 		trustedOrigins: ["http://localhost:3000"],
 		emailAndPassword: {

--- a/packages/better-auth/src/api/routes/sign-out.test.ts
+++ b/packages/better-auth/src/api/routes/sign-out.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 
-describe("sign-out", async (it) => {
+describe("sign-out", async () => {
 	const afterSessionDeleted = vi.fn();
 	const { signInWithTestUser, client } = await getTestInstance({
 		databaseHooks: {

--- a/packages/better-auth/src/api/routes/sign-up.test.ts
+++ b/packages/better-auth/src/api/routes/sign-up.test.ts
@@ -1,9 +1,13 @@
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
-import { afterEach, describe, expect, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 
-describe("sign-up with custom fields", async (it) => {
+describe("sign-up with custom fields", async () => {
 	const mockFn = vi.fn();
+
+	afterEach(() => {
+		mockFn.mockReset();
+	});
 	const { auth, db } = await getTestInstance(
 		{
 			account: {
@@ -43,10 +47,6 @@ describe("sign-up with custom fields", async (it) => {
 			disableTestUser: true,
 		},
 	);
-
-	afterEach(() => {
-		mockFn.mockReset();
-	});
 
 	it("should work with custom fields on account table", async () => {
 		const res = await auth.api.signUpEmail({
@@ -199,7 +199,7 @@ describe("sign-up with custom fields", async (it) => {
 	});
 });
 
-describe("sign-up CSRF protection", async (it) => {
+describe("sign-up CSRF protection", async () => {
 	const { auth } = await getTestInstance(
 		{
 			trustedOrigins: ["http://localhost:3000"],
@@ -317,7 +317,7 @@ describe("sign-up CSRF protection", async (it) => {
 	});
 });
 
-describe("sign-up with form data", async (it) => {
+describe("sign-up with form data", async () => {
 	const { auth } = await getTestInstance(
 		{
 			trustedOrigins: ["http://localhost:3000"],
@@ -413,7 +413,7 @@ describe("sign-up with form data", async (it) => {
 	});
 });
 
-describe("sign-up sendOnSignUp option behavior", async (it) => {
+describe("sign-up sendOnSignUp option behavior", async () => {
 	it("should not send verification email when sendOnSignUp is false, even with requireEmailVerification", async () => {
 		const sendVerificationEmail = vi.fn();
 		const { auth } = await getTestInstance(

--- a/packages/better-auth/src/client/client.test.ts
+++ b/packages/better-auth/src/client/client.test.ts
@@ -4,7 +4,7 @@ import { isProxy } from "node:util/types";
 import type { BetterFetchError } from "@better-fetch/fetch";
 import type { ReadableAtom } from "nanostores";
 import type { Accessor } from "solid-js";
-import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { Ref } from "vue";
 import type { Session, SessionQueryParams } from "../types";
 import {
@@ -30,6 +30,10 @@ import { createAuthClient as createVanillaClient } from "./vanilla";
 import { createAuthClient as createVueClient } from "./vue";
 
 describe("run time proxy", async () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("atom in proxy should not be proxy", async () => {
 		const client = createVanillaClient();
 		const atom = client.$store.atoms.session;

--- a/packages/better-auth/src/client/proxy.test.ts
+++ b/packages/better-auth/src/client/proxy.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDynamicPathProxy } from "./proxy";
 
 describe("createDynamicPathProxy", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should avoid duplicate signal processing", async () => {
 		const client = vi.fn(async (path, options) => {
 			if (options?.onSuccess) {

--- a/packages/better-auth/src/client/session-refresh.test.ts
+++ b/packages/better-auth/src/client/session-refresh.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { atom } from "nanostores";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getGlobalOnlineManager } from "./online-manager";
 import type { SessionAtom } from "./session-atom";
 import { createSessionRefreshManager } from "./session-refresh";
@@ -11,6 +11,10 @@ describe("session-refresh", () => {
 		const onlineManager = getGlobalOnlineManager();
 		onlineManager.setOnline(true);
 		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it("should trigger network fetch and update session when refetchInterval fires", async () => {

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -616,9 +616,9 @@ describe("base context creation", () => {
 			expect(fn).toHaveBeenCalled();
 			const regex = /Misconfiguration detected/;
 			expect(fn).toHaveBeenCalledWith(expect.stringMatching(regex));
-			fn.mockRestore();
 			const id = res.generateId({ model: "user" });
 			expect(id).toBe(false);
+			fn.mockRestore();
 		});
 	});
 

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -281,7 +281,6 @@ describe("internal adapter test", async () => {
 			(call) => call[0].model === "verification",
 		);
 		expect(verificationDeleteCalls.length).toBe(0);
-
 		deleteSpy.mockRestore();
 	});
 

--- a/packages/better-auth/src/db/to-zod.test.ts
+++ b/packages/better-auth/src/db/to-zod.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import { toZodSchema } from "./to-zod";
 
 describe("toZodSchema", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/7489
+	 */
 	describe("returned: false field handling (issue #7489)", () => {
 		it("should include fields with returned: false in input schema (isClientSide: true)", () => {
 			const schema = toZodSchema({

--- a/packages/better-auth/src/oauth2/utils.test.ts
+++ b/packages/better-auth/src/oauth2/utils.test.ts
@@ -78,6 +78,9 @@ describe("decryptOAuthToken", () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/6018
+ */
 describe("migration scenario - issue #6018", () => {
 	it("should handle Google OAuth token stored before encryption was enabled", async () => {
 		// Simulate the exact bug scenario from issue #6018:

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -112,6 +112,11 @@ describe("Admin plugin", async () => {
 	});
 
 	const { headers: adminHeaders } = await signInWithTestUser();
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	let newUser: UserWithRole | undefined;
 	const testNonAdminUser = {
 		id: "123",
@@ -968,7 +973,7 @@ describe("Admin plugin", async () => {
 	});
 });
 
-describe("access control", async (it) => {
+describe("access control", async () => {
 	const ac = createAccessControl({
 		user: [
 			"create",

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -57,9 +57,9 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
+	vi.restoreAllMocks();
 	server.resetHandlers();
 	server.use(...handlers);
-	vi.restoreAllMocks();
 });
 
 afterAll(() => server.close());

--- a/packages/better-auth/src/plugins/api-key/api-key.test.ts
+++ b/packages/better-auth/src/plugins/api-key/api-key.test.ts
@@ -1,5 +1,5 @@
 import type { APIError } from "@better-auth/core/error";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { isAPIError } from "../../utils/is-api-error";
 import { apiKey, API_KEY_ERROR_CODES as ERROR_CODES } from ".";
@@ -27,6 +27,10 @@ describe("api-key", async () => {
 		},
 	);
 	const { headers, user } = await signInWithTestUser();
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
 	// =========================================================================
 	// CREATE API KEY

--- a/packages/better-auth/src/plugins/captcha/captcha.test.ts
+++ b/packages/better-auth/src/plugins/captcha/captcha.test.ts
@@ -1,5 +1,5 @@
 import * as betterFetchModule from "@better-fetch/fetch";
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { captcha } from ".";
 
@@ -11,7 +11,7 @@ vi.mock("@better-fetch/fetch", async (importOriginal) => {
 	};
 });
 
-describe("captcha", async (it) => {
+describe("captcha", async () => {
 	const mockBetterFetch = betterFetchModule.betterFetch as ReturnType<
 		typeof vi.fn
 	>;
@@ -112,7 +112,7 @@ describe("captcha", async (it) => {
 		expect(res.error?.status).toBe(500);
 	});
 
-	describe("cloudflare-turnstile", async (it) => {
+	describe("cloudflare-turnstile", async () => {
 		const { client } = await getTestInstance({
 			plugins: [
 				captcha({
@@ -191,7 +191,7 @@ describe("captcha", async (it) => {
 		});
 	});
 
-	describe("google-recaptcha", async (it) => {
+	describe("google-recaptcha", async () => {
 		const { client } = await getTestInstance({
 			plugins: [
 				captcha({ provider: "google-recaptcha", secretKey: "xx-secret-key" }),
@@ -287,7 +287,7 @@ describe("captcha", async (it) => {
 			expect(res.error?.status).toBe(403);
 		});
 	});
-	describe("hcaptcha", async (it) => {
+	describe("hcaptcha", async () => {
 		const { client } = await getTestInstance({
 			plugins: [
 				captcha({
@@ -365,7 +365,7 @@ describe("captcha", async (it) => {
 		});
 	});
 
-	describe("captchafox", async (it) => {
+	describe("captchafox", async () => {
 		const { client } = await getTestInstance({
 			plugins: [
 				captcha({

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { deviceAuthorization, deviceAuthorizationOptionsSchema } from ".";
 import { deviceAuthorizationClient } from "./client";
@@ -172,6 +172,10 @@ describe("device authorization flow", async () => {
 	});
 
 	describe("device token polling", () => {
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
 		it("should return authorization_pending when not approved", async () => {
 			const { device_code } = await auth.api.deviceCode({
 				body: {

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAuthClient } from "../../client";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { bearer } from "../bearer";
@@ -31,6 +31,10 @@ describe("email-otp", async () => {
 			},
 		},
 	);
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
 	it("should verify email with otp", async () => {
 		const res = await client.emailOtp.sendVerificationOtp({
@@ -555,7 +559,11 @@ describe("custom rate limiting storage", async () => {
 		],
 	});
 
-	it.each([
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it.for([
 		{
 			path: "/email-otp/send-verification-otp",
 			body: {

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1700,7 +1700,6 @@ describe("oauth2", async () => {
 			expect(warnSpy).toHaveBeenCalledWith(
 				"Duplicate provider IDs found: duplicate-id",
 			);
-
 			warnSpy.mockRestore();
 		});
 
@@ -1746,7 +1745,6 @@ describe("oauth2", async () => {
 			const warningMessage = warnSpy.mock.calls[0]?.[0] as string;
 			expect(warningMessage).toContain("dup-1");
 			expect(warningMessage).toContain("dup-2");
-
 			warnSpy.mockRestore();
 		});
 
@@ -1775,7 +1773,6 @@ describe("oauth2", async () => {
 			});
 
 			expect(warnSpy).not.toHaveBeenCalled();
-
 			warnSpy.mockRestore();
 		});
 
@@ -1798,7 +1795,6 @@ describe("oauth2", async () => {
 			});
 
 			expect(warnSpy).not.toHaveBeenCalled();
-
 			warnSpy.mockRestore();
 		});
 
@@ -1835,7 +1831,6 @@ describe("oauth2", async () => {
 			expect(warnSpy).toHaveBeenCalledWith(
 				"Duplicate provider IDs found: triple-dup",
 			);
-
 			warnSpy.mockRestore();
 		});
 	});

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -300,7 +300,7 @@ describe("jwt", async () => {
 	}
 });
 
-describe.each([
+describe.for([
 	{
 		alg: "EdDSA",
 		crv: "Ed25519",

--- a/packages/better-auth/src/plugins/jwt/rotation.test.ts
+++ b/packages/better-auth/src/plugins/jwt/rotation.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { jwt } from ".";
 import type { Jwk } from "./types";
 
 describe("jwt rotation", async () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should rotate keys when expired", async () => {
 		vi.useFakeTimers();
 		const storage: Jwk[] = [];

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAuthClient } from "../../client";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { magicLink } from ".";
@@ -34,6 +34,10 @@ describe("magic link", async () => {
 		},
 		baseURL: "http://localhost:3000",
 		basePath: "/api/auth",
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it("should send magic link", async () => {

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -783,6 +783,9 @@ describe("oidc", async () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/4594
+	 */
 	describe("cookie persistence bug (issue #4594)", () => {
 		// Reproduce issue #4594: oidc_login_prompt cookie persists after OIDC flow
 		// and causes subsequent normal logins to redirect to OIDC client
@@ -1003,7 +1006,7 @@ describe("oidc storage", async () => {
 		}
 	});
 
-	test.each([
+	test.for([
 		{
 			storeClientSecret: undefined,
 		},
@@ -1387,7 +1390,7 @@ describe("oidc-jwt", async () => {
 		}
 	});
 
-	test.each([
+	test.for([
 		{ useJwt: true, description: "with jwt plugin", expected: "EdDSA" },
 		{ useJwt: false, description: "without jwt plugin", expected: "HS256" },
 	])("testing oidc-provider $description to return token signed with $expected", async ({

--- a/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
+++ b/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { isAPIError } from "../../utils/is-api-error";
 import { oneTimeToken } from ".";
@@ -16,6 +16,11 @@ describe("One-time token", async () => {
 			},
 		},
 	);
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should work", async () => {
 		const { headers } = await signInWithTestUser();
 		const response = await auth.api.generateOneTimeToken({

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { openAPI } from ".";
 
-describe("open-api", async (it) => {
+describe("open-api", async () => {
 	const { auth } = await getTestInstance({
 		plugins: [openAPI()],
 		user: {

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1,7 +1,7 @@
 import type { APIError } from "@better-auth/core/error";
 import { memoryAdapter } from "@better-auth/memory-adapter";
 import type { Prettify } from "better-call";
-import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import type {
 	BetterFetchError,
 	PreinitializedWritableAtom,
@@ -27,10 +27,6 @@ import type {
 } from "./schema";
 import type { OrganizationOptions } from "./types";
 
-vi.setConfig({
-	testTimeout: 10_000,
-});
-
 describe("organization type", () => {
 	it("empty org type should works", () => {
 		expectTypeOf({} satisfies OrganizationOptions);
@@ -38,7 +34,7 @@ describe("organization type", () => {
 	});
 });
 
-describe("organization", async (it) => {
+describe("organization", async () => {
 	const { auth, signInWithTestUser, signInWithUser, cookieSetter } =
 		await getTestInstance({
 			user: {
@@ -370,7 +366,7 @@ describe("organization", async (it) => {
 		expect(org?.members.length).toBe(1);
 	});
 
-	it.each([
+	it.for([
 		{
 			role: "owner" as const,
 			newUser: {
@@ -1506,7 +1502,7 @@ describe("invitation expiration and filtering", async () => {
 	});
 });
 
-describe("access control", async (it) => {
+describe("access control", async () => {
 	const ac = createAccessControl({
 		project: ["create", "read", "update", "delete"],
 		sales: ["create", "read", "update", "delete"],
@@ -2046,7 +2042,7 @@ describe("owner can update roles", async () => {
 		};
 });
 
-describe("types", async (it) => {
+describe("types", async () => {
 	const { auth } = await getTestInstance({
 		plugins: [organization({})],
 	});
@@ -2936,7 +2932,7 @@ async function getAtomValue<Result>(
 		| { data: Result; error: null }
 		| { data: null; error: BetterFetchError };
 }
-describe("organization hooks", async (it) => {
+describe("organization hooks", async () => {
 	let hooksCalled: string[] = [];
 
 	const { auth, signInWithTestUser } = await getTestInstance({

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
@@ -1,5 +1,5 @@
 import type { DBFieldAttribute } from "@better-auth/core/db";
-import { describe, expect, expectTypeOf } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAuthClient } from "../../../client";
 import { parseSetCookieHeader } from "../../../cookies";
 import { getTestInstance } from "../../../test-utils/test-instance";
@@ -9,7 +9,7 @@ import { inferOrgAdditionalFields, organizationClient } from "../client";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { organization } from "../organization";
 
-describe("dynamic access control", async (it) => {
+describe("dynamic access control", async () => {
 	const ac = createAccessControl({
 		project: ["create", "read", "update", "delete"],
 		sales: ["create", "read", "update", "delete"],

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createAuthClient } from "../../client";
 import { setCookieToHeader } from "../../cookies";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { organizationClient } from "./client";
 import { organization } from "./organization";
 
-describe("team", async (it) => {
+describe("team", async () => {
 	const { auth, signInWithTestUser, cookieSetter } = await getTestInstance({
 		user: {
 			modelName: "users",
@@ -348,7 +348,7 @@ describe("team", async (it) => {
 	});
 });
 
-describe("multi team support", async (it) => {
+describe("multi team support", async () => {
 	const { auth, signInWithTestUser } = await getTestInstance(
 		{
 			plugins: [

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { bearer } from "../bearer";
 import { phoneNumber } from ".";
 import { phoneNumberClient } from "./client";
 
-describe("phone-number", async (it) => {
+describe("phone-number", async () => {
 	let otp = "";
 
 	const { client, sessionSetter } = await getTestInstance(
@@ -32,6 +32,11 @@ describe("phone-number", async (it) => {
 	const headers = new Headers();
 
 	const testPhoneNumber = "+251911121314";
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should send verification code", async () => {
 		const res = await client.phoneNumber.sendOtp({
 			phoneNumber: testPhoneNumber,
@@ -212,7 +217,7 @@ describe("phone auth flow", async () => {
 	});
 });
 
-describe("verify phone-number", async (it) => {
+describe("verify phone-number", async () => {
 	let otp = "";
 
 	const { client, sessionSetter } = await getTestInstance(
@@ -241,6 +246,10 @@ describe("verify phone-number", async (it) => {
 	const headers = new Headers();
 
 	const testPhoneNumber = "+251911121314";
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
 	it("should verify the last code", async () => {
 		await client.phoneNumber.sendOtp({
@@ -292,7 +301,7 @@ describe("verify phone-number", async (it) => {
 	});
 });
 
-describe("reset password flow attempts", async (it) => {
+describe("reset password flow attempts", async () => {
 	let otp = "";
 	let resetOtp = "";
 
@@ -383,7 +392,7 @@ describe("reset password flow attempts", async (it) => {
 	});
 });
 
-describe("reset password session revocation", async (it) => {
+describe("reset password session revocation", async () => {
 	let otp = "";
 	let resetOtp = "";
 

--- a/packages/better-auth/src/plugins/siwe/siwe.test.ts
+++ b/packages/better-auth/src/plugins/siwe/siwe.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { siweClient } from "./client";
 import { siwe } from "./index";
 
-describe("siwe", async (it) => {
+describe("siwe", async () => {
 	const walletAddress = "0x000000000000000000000000000000000000dEaD";
 	const domain = "example.com";
 	const chainId = 1; // Ethereum mainnet

--- a/packages/better-auth/src/plugins/username/username.test.ts
+++ b/packages/better-auth/src/plugins/username/username.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { USERNAME_ERROR_CODES, username } from ".";
 import { usernameClient } from "./client";
 
-describe("username", async (it) => {
+describe("username", async () => {
 	const { client, sessionSetter, signInWithTestUser } = await getTestInstance(
 		{
 			plugins: [
@@ -296,7 +296,7 @@ describe("username", async (it) => {
 	});
 });
 
-describe("username custom normalization", async (it) => {
+describe("username custom normalization", async () => {
 	const { client } = await getTestInstance(
 		{
 			plugins: [
@@ -362,7 +362,7 @@ describe("username custom normalization", async (it) => {
 	});
 });
 
-describe("username with displayUsername validation", async (it) => {
+describe("username with displayUsername validation", async () => {
 	const { client, sessionSetter } = await getTestInstance(
 		{
 			plugins: [
@@ -471,7 +471,7 @@ describe("username with displayUsername validation", async (it) => {
 	});
 });
 
-describe("isUsernameAvailable with custom validator", async (it) => {
+describe("isUsernameAvailable with custom validator", async () => {
 	const { client } = await getTestInstance(
 		{
 			plugins: [
@@ -529,7 +529,7 @@ describe("isUsernameAvailable with custom validator", async (it) => {
 	});
 });
 
-describe("post normalization flow", async (it) => {
+describe("post normalization flow", async () => {
 	it("should set displayUsername to username if only username is provided", async () => {
 		const { auth } = await getTestInstance({
 			plugins: [
@@ -562,7 +562,7 @@ describe("post normalization flow", async (it) => {
 	});
 });
 
-describe("username email verification flow (no info leak)", async (it) => {
+describe("username email verification flow (no info leak)", async () => {
 	const { client } = await getTestInstance(
 		{
 			emailAndPassword: { enabled: true, requireEmailVerification: true },

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
-import { describe, expect, expectTypeOf } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAuthEndpoint } from "../api";
 import { organization, twoFactor } from "../plugins";
 import { getTestInstance } from "../test-utils/test-instance";
@@ -45,7 +45,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-describe("general types", async (it) => {
+describe("general types", async () => {
 	it("should infer base session", async () => {
 		const { auth } = await getTestInstance();
 		type Session = typeof auth.$Infer.Session;

--- a/packages/better-auth/vitest.config.adapters.ts
+++ b/packages/better-auth/vitest.config.adapters.ts
@@ -2,6 +2,8 @@ import { defineProject } from "vitest/config";
 
 export default defineProject({
 	test: {
+		clearMocks: true,
+		restoreMocks: true,
 		execArgv: ["--expose-gc"],
 		// No exclude for adapter tests - this config is specifically for adapter tests
 		include: ["src/adapters/**/*.test.ts"],

--- a/packages/better-auth/vitest.config.ts
+++ b/packages/better-auth/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineProject } from "vitest/config";
 
 export default defineProject({
 	test: {
+		testTimeout: 10_000,
 		execArgv: ["--expose-gc"],
 		// Exclude adapter tests by default - they are run separately via test:adapters
 		exclude: [

--- a/packages/cli/test/info.test.ts
+++ b/packages/cli/test/info.test.ts
@@ -29,7 +29,6 @@ describe("info command", () => {
 
 	afterEach(async () => {
 		await fs.rm(tmpDir, { recursive: true });
-		vi.restoreAllMocks();
 	});
 
 	it("should display system information without auth config", async () => {

--- a/packages/cli/test/migrate.test.ts
+++ b/packages/cli/test/migrate.test.ts
@@ -1,7 +1,7 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { betterAuth } from "better-auth";
 import Database from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { migrateAction } from "../src/commands/migrate";
 import * as config from "../src/utils/get-config";
 
@@ -21,10 +21,6 @@ describe("migrate base auth instance", () => {
 			return code as never;
 		});
 		vi.spyOn(config, "getConfig").mockImplementation(async () => auth.options);
-	});
-
-	afterEach(async () => {
-		vi.restoreAllMocks();
 	});
 
 	it("should migrate the database and sign-up a user", async () => {
@@ -74,10 +70,6 @@ describe("migrate auth instance with plugins", () => {
 			return code as never;
 		});
 		vi.spyOn(config, "getConfig").mockImplementation(async () => auth.options);
-	});
-
-	afterEach(async () => {
-		vi.restoreAllMocks();
 	});
 
 	it("should migrate the database and sign-up a user", async () => {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/core/src/oauth2/refresh-access-token.test.ts
+++ b/packages/core/src/oauth2/refresh-access-token.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@better-fetch/fetch", () => ({
 	betterFetch: vi.fn(),
@@ -10,10 +10,6 @@ import { refreshAccessToken } from "./refresh-access-token";
 const mockedBetterFetch = vi.mocked(betterFetch);
 
 describe("refreshAccessToken", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
-
 	it("should set accessTokenExpiresAt when expires_in is returned", async () => {
 		const now = Date.now();
 		mockedBetterFetch.mockResolvedValueOnce({

--- a/packages/core/src/oauth2/validate-token.test.ts
+++ b/packages/core/src/oauth2/validate-token.test.ts
@@ -1,14 +1,6 @@
 import type { JWK } from "jose";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
-import {
-	afterAll,
-	beforeAll,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	vi,
-} from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { validateToken } from "./validate-authorization-code";
 
 describe("validateToken", () => {
@@ -22,10 +14,6 @@ describe("validateToken", () => {
 
 	afterAll(() => {
 		globalThis.fetch = originalFetch;
-	});
-
-	beforeEach(() => {
-		mockedFetch.mockReset();
 	});
 
 	async function createTestJWKS(alg: string, crv?: string) {

--- a/packages/core/src/utils/deprecate.test.ts
+++ b/packages/core/src/utils/deprecate.test.ts
@@ -36,7 +36,6 @@ describe("deprecate", () => {
 		deprecatedFn();
 
 		expect(consoleWarn).toHaveBeenCalledWith("[Deprecation] test message");
-		consoleWarn.mockRestore();
 	});
 
 	it("should pass arguments and return value correctly", () => {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/drizzle-adapter/vitest.config.ts
+++ b/packages/drizzle-adapter/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/electron/test/electron.test.ts
+++ b/packages/electron/test/electron.test.ts
@@ -492,7 +492,6 @@ describe("Electron", () => {
 		expect(data?.token).toBeDefined();
 		expect(data?.user.id).toBe(user.id);
 		expect(spy).toHaveBeenCalled();
-		spy.mockRestore();
 	});
 
 	describe("transferUser", () => {
@@ -1239,7 +1238,6 @@ describe("Electron", () => {
 		expect(mockElectron.app.setAsDefaultProtocolClient).toHaveBeenCalled();
 		expect(spy).toHaveBeenCalled();
 
-		spy.mockRestore();
 		mockElectron.app.setAsDefaultProtocolClient = original;
 	});
 

--- a/packages/electron/vitest.config.ts
+++ b/packages/electron/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from "vitest/config";
 
 export default defineProject({
 	test: {
+		clearMocks: true,
+		restoreMocks: true,
 		server: {
 			deps: {
 				external: ["electron"],

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -463,8 +463,6 @@ describe("expo", async () => {
 	});
 
 	it("should NOT include oauthState param in proxy URL when using database strategy", async () => {
-		fn.mockClear();
-
 		await client.signIn.social({
 			provider: "google",
 			callbackURL: "/dashboard",
@@ -686,8 +684,6 @@ describe("expo with cookie storeStateStrategy", async () => {
 	});
 
 	it("should include oauthState param in proxy URL", async () => {
-		fn.mockClear();
-
 		await client.signIn.social({
 			provider: "google",
 			callbackURL: "/dashboard",
@@ -702,8 +698,6 @@ describe("expo with cookie storeStateStrategy", async () => {
 	});
 
 	it("should set oauth_state cookie in browser context via expo-authorization-proxy (cookie strategy)", async () => {
-		fn.mockClear();
-
 		const expoWebBrowser = await import("expo-web-browser");
 		const { parseSetCookieHeader } = await import("../src/client");
 

--- a/packages/expo/vitest.config.ts
+++ b/packages/expo/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from "vitest/config";
 
 export default defineProject({
 	test: {
+		clearMocks: true,
+		restoreMocks: true,
 		server: {
 			deps: {
 				external: ["react-native"],

--- a/packages/i18n/vitest.config.ts
+++ b/packages/i18n/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/kysely-adapter/vitest.config.ts
+++ b/packages/kysely-adapter/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/memory-adapter/vitest.config.ts
+++ b/packages/memory-adapter/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/mongo-adapter/vitest.config.ts
+++ b/packages/mongo-adapter/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/oauth-provider/src/mcp.test.ts
+++ b/packages/oauth-provider/src/mcp.test.ts
@@ -35,7 +35,7 @@ describe("mcp", async () => {
 		baseURL: apiServerBaseUrl,
 	});
 
-	it.each([
+	it.for([
 		{
 			resource: apiServerBaseUrl,
 			expected: `Bearer resource_metadata="${apiServerBaseUrl}/.well-known/oauth-protected-resource"`,

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -1328,7 +1328,7 @@ describe("oauth - config", () => {
 		});
 	}
 
-	it.each([
+	it.for([
 		{
 			storeClientSecret: undefined,
 		},
@@ -1432,7 +1432,7 @@ describe("oauth - config", () => {
 		expect(callbackURL).toContain("/success");
 	});
 
-	it.each([
+	it.for([
 		{
 			storeClientSecret: "encrypted",
 		},
@@ -1533,7 +1533,7 @@ describe("oauth - config", () => {
 		expect(callbackURL).toContain("/success");
 	});
 
-	it.each([
+	it.for([
 		{ disableJwtPlugin: false, publicClient: false, resource: false },
 		{ disableJwtPlugin: true, publicClient: false, resource: false },
 		{ disableJwtPlugin: false, publicClient: true, resource: false },

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -96,7 +96,7 @@ describe("oauth register", async () => {
 		expect(response.error?.status).toBe(400);
 	});
 
-	it.each([
+	it.for([
 		"native",
 		"user-agent-based",
 	] as OAuthClient["type"][])("should fail with type '%s' check for confidential client request", async (type) => {
@@ -108,7 +108,7 @@ describe("oauth register", async () => {
 		expect(response.error?.status).toBe(400);
 	});
 
-	it.each([
+	it.for([
 		"native",
 		"user-agent-based",
 	] as OAuthClient["type"][])("should register public '%s' client with minimum requirements via server", async (type) => {

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -1188,7 +1188,7 @@ describe("oauth token - config", async () => {
 	}
 
 	// Client Credentials Grant
-	it.each([
+	it.for([
 		{
 			testScopes: ["read:payments"],
 			result: 1800, // 30m lowest
@@ -1237,7 +1237,7 @@ describe("oauth token - config", async () => {
 	});
 
 	// Authorization Code and Refresh Token grants
-	it.each([
+	it.for([
 		{
 			testScopes: ["read:payments", "offline_access"],
 			result: 1800, // 30m lowest

--- a/packages/oauth-provider/vitest.config.ts
+++ b/packages/oauth-provider/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/passkey/vitest.config.ts
+++ b/packages/passkey/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/prisma-adapter/vitest.config.ts
+++ b/packages/prisma-adapter/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/scim/src/scim.test.ts
+++ b/packages/scim/src/scim.test.ts
@@ -1361,7 +1361,7 @@ describe("SCIM", () => {
 	});
 
 	describe("PATCH /scim/v2/users", () => {
-		it.each([
+		it.for([
 			"replace",
 			"add",
 		])("should partially update a user resource with %s", async (op) => {
@@ -1516,7 +1516,7 @@ describe("SCIM", () => {
 			});
 		});
 
-		it.each([
+		it.for([
 			"replace",
 			"add",
 		])("should partially update multiple name sub-attributes with %s", async (op) => {
@@ -1559,7 +1559,7 @@ describe("SCIM", () => {
 			expect(updatedUser.name.formatted).toBe("Updated Value");
 		});
 
-		it.each([
+		it.for([
 			"replace",
 			"add",
 		])("should %s nested object values with path prefix", async (op) => {
@@ -1615,7 +1615,7 @@ describe("SCIM", () => {
 			expect(updatedUser.userName).toBe("nested-test-user-updated");
 		});
 
-		it.each([
+		it.for([
 			"replace",
 			"add",
 		])("should support operations without explicit path with %s", async (op) => {
@@ -1701,7 +1701,7 @@ describe("SCIM", () => {
 			expect(updatedUser.userName).toBe("username");
 		});
 
-		it.each([
+		it.for([
 			"replace",
 			"add",
 		])("should handle %s operation case-insensitively", async (op) => {
@@ -1785,7 +1785,7 @@ describe("SCIM", () => {
 			);
 		});
 
-		it.each([
+		it.for([
 			"replace",
 			"add",
 		])("should ignore %s on non-existing path", async (op) => {

--- a/packages/scim/vitest.config.ts
+++ b/packages/scim/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/sso/src/domain-verification.test.ts
+++ b/packages/sso/src/domain-verification.test.ts
@@ -137,7 +137,6 @@ describe("Domain verification", async () => {
 	};
 
 	afterEach(() => {
-		vi.clearAllMocks();
 		vi.useRealTimers();
 	});
 

--- a/packages/sso/src/oidc/discovery.test.ts
+++ b/packages/sso/src/oidc/discovery.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	computeDiscoveryUrl,
 	discoverOIDCConfig,
@@ -560,7 +560,7 @@ describe("OIDC Discovery", () => {
 			);
 		});
 
-		it.each([
+		it.for([
 			[
 				"/oauth2/token",
 				"https://idp.example.com/base",
@@ -577,8 +577,11 @@ describe("OIDC Discovery", () => {
 				"issuer with trailing slash",
 			],
 			["//oauth2/token", "https://idp.example.com/base//", "multiple slashes"],
-		])("should resolve relative endpoint preserving issuer base path (%s, %s) - %s", (endpoint, issuer) => {
-			expect(normalizeUrl("url", endpoint, issuer)).toBe(
+		])("should resolve relative endpoint preserving issuer base path (%s, %s) - %s", ([
+			endpoint,
+			issuer,
+		]) => {
+			expect(normalizeUrl("url", endpoint!, issuer!)).toBe(
 				"https://idp.example.com/base/oauth2/token",
 			);
 		});
@@ -637,10 +640,6 @@ describe("OIDC Discovery", () => {
 
 	describe("fetchDiscoveryDocument", () => {
 		const mockBetterFetch = betterFetch as ReturnType<typeof vi.fn>;
-
-		beforeEach(() => {
-			vi.clearAllMocks();
-		});
 
 		it("should fetch and parse valid discovery document", async () => {
 			const expectedDoc = createMockDiscoveryDocument();
@@ -793,10 +792,6 @@ describe("OIDC Discovery", () => {
 		const mockBetterFetch = betterFetch as ReturnType<typeof vi.fn>;
 		const issuer = "https://idp.example.com";
 		const isTrustedOrigin = vi.fn().mockReturnValue(true);
-
-		beforeEach(() => {
-			vi.clearAllMocks();
-		});
 
 		it("should return hydrated config from valid discovery", async () => {
 			const discoveryDoc = createMockDiscoveryDocument({

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -889,8 +889,6 @@ describe("SAML SSO", async () => {
 		data.verification = [];
 		data.account = [];
 		data.ssoProvider = [];
-
-		vi.clearAllMocks();
 	});
 
 	async function getAuthHeaders() {
@@ -2330,8 +2328,6 @@ describe("SAML SSO with custom fields", () => {
 		data.verification = [];
 		data.account = [];
 		data.sso_provider = [];
-
-		vi.clearAllMocks();
 	});
 
 	async function getAuthHeaders() {

--- a/packages/sso/src/saml/algorithms.test.ts
+++ b/packages/sso/src/saml/algorithms.test.ts
@@ -1,5 +1,5 @@
 /* cspell:ignore xenc */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import * as alg from "./algorithms";
 
 const encryptedAssertionXml = `
@@ -41,10 +41,6 @@ const plainAssertionXml = `
 `;
 
 describe("validateSAMLAlgorithms", () => {
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
 	describe("signature validation", () => {
 		it("should accept secure signature algorithms", () => {
 			expect(() =>
@@ -205,10 +201,6 @@ describe("algorithm constants", () => {
 });
 
 describe("validateConfigAlgorithms", () => {
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
 	describe("signature algorithm validation", () => {
 		it("should accept secure signature algorithms", () => {
 			expect(() =>

--- a/packages/sso/src/utils.test.ts
+++ b/packages/sso/src/utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { validateEmailDomain } from "./utils";
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/7324
+ */
 describe("validateEmailDomain", () => {
 	// Tests for issue #7324: Enterprise multi-domain SSO support
 	// https://github.com/better-auth/better-auth/issues/7324

--- a/packages/sso/vitest.config.ts
+++ b/packages/sso/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/stripe/test/stripe-organization.test.ts
+++ b/packages/stripe/test/stripe-organization.test.ts
@@ -81,10 +81,6 @@ describe("stripe - organization customer", () => {
 		},
 	} satisfies StripeOptions;
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
-
 	it("should create a Stripe customer for organization when upgrading subscription", async () => {
 		const onCustomerCreate = vi.fn();
 		const stripeOptionsWithOrgCallback: StripeOptions = {
@@ -1736,7 +1732,6 @@ describe("stripe - organizationHooks integration", () => {
 	};
 
 	beforeEach(() => {
-		vi.resetAllMocks();
 		mockStripeHooks.subscriptions.list.mockResolvedValue({ data: [] });
 		mockStripeHooks.customers.list.mockResolvedValue({ data: [] });
 	});

--- a/packages/stripe/test/stripe.test.ts
+++ b/packages/stripe/test/stripe.test.ts
@@ -230,8 +230,6 @@ describe("stripe", () => {
 		data.account = [];
 		data.customer = [];
 		data.subscription = [];
-
-		vi.clearAllMocks();
 	});
 
 	const memory = memoryAdapter(data);
@@ -2108,7 +2106,7 @@ describe("stripe", () => {
 		expect(mockStripe.billingPortal.sessions.create).toHaveBeenCalled();
 	});
 
-	it.each([
+	it.for([
 		{
 			name: "past",
 			periodEnd: new Date(Date.now() - 24 * 60 * 60 * 1000),

--- a/packages/stripe/vitest.config.ts
+++ b/packages/stripe/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineProject } from "vitest/config";
 export default defineProject({
 	test: {
 		clearMocks: true,
+		restoreMocks: true,
 		globals: true,
 	},
 });

--- a/packages/telemetry/src/telemetry.test.ts
+++ b/packages/telemetry/src/telemetry.test.ts
@@ -46,7 +46,6 @@ vi.mock("./detectors/detect-project-info", () => ({
 
 beforeEach(() => {
 	vi.resetModules();
-	vi.clearAllMocks();
 	process.env.BETTER_AUTH_TELEMETRY = "";
 	process.env.BETTER_AUTH_TELEMETRY_DEBUG = "";
 });

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -1,3 +1,8 @@
 import { defineProject } from "vitest/config";
 
-export default defineProject({});
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized Vitest usage across the repo to improve test reliability and reduce flakiness by fixing timer/mocking cleanup and replacing non-standard patterns.

- **Refactors**
  - Removed passing “it” into describe; use standard describe/it imports.
  - Replaced .each with typed .for helpers where available for parameterized tests.
  - Added afterEach vi.useRealTimers in tests that use fake timers; centralized mock lifecycle by enabling clearMocks/restoreMocks in vitest.config.
  - Set default testTimeout and cleaned up redundant mockReset/mockRestore calls.
  - Minor test tidy-ups and added issue references in comments for clarity.

<sup>Written for commit f0e3a6c6b2c2cae51db00e4f2fc94095c451f998. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

