### PR TITLE
fix(client): allow custom baseURL protocols

### DIFF
--- a/packages/better-auth/src/client/client.test.ts
+++ b/packages/better-auth/src/client/client.test.ts
@@ -56,6 +56,29 @@ describe("run time proxy", async () => {
 		expect(apiCalled).toBe(true);
 	});
 
+	it("should reject custom protocol baseURL by default", () => {
+		expect(() => createSolidClient({ baseURL: "electronapp://api" })).toThrow(
+			"URL must include 'http://' or 'https://'",
+		);
+	});
+
+	it("should allow custom protocol baseURL when allowCustomBaseURLProtocol is true", async () => {
+		let capturedUrl: string | null = null;
+		const client = createSolidClient({
+			baseURL: "electronapp://api",
+			allowCustomBaseURLProtocol: true,
+			plugins: [testClientPlugin()],
+			fetchOptions: {
+				customFetchImpl: async (url) => {
+					capturedUrl = url.toString();
+					return new Response();
+				},
+			},
+		});
+		await client.test();
+		expect(capturedUrl).toContain("electronapp://api");
+	});
+
 	it("state listener should be called on matched path", async () => {
 		const client = createSolidClient({
 			plugins: [testClientPlugin()],

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -16,8 +16,16 @@ export const getClientConfig = (
 ) => {
 	/* check if the credentials property is supported. Useful for cf workers */
 	const isCredentialsSupported = "credentials" in Request.prototype;
+	const protocolPolicy = options?.allowCustomBaseURLProtocol ? "any" : "http";
 	const baseURL =
-		getBaseURL(options?.baseURL, options?.basePath, undefined, loadEnv) ??
+		getBaseURL(
+			options?.baseURL,
+			options?.basePath,
+			undefined,
+			loadEnv,
+			undefined,
+			protocolPolicy,
+		) ??
 		"/api/auth";
 	const pluginsFetchPlugins =
 		options?.plugins

--- a/packages/better-auth/src/utils/url.test.ts
+++ b/packages/better-auth/src/utils/url.test.ts
@@ -260,4 +260,24 @@ describe("getBaseURL", () => {
 			expect(result).toBe("https://api.v1.staging.example.com/auth");
 		});
 	});
+
+	describe("protocol policy", () => {
+		it("should reject custom protocols by default", () => {
+			expect(() => getBaseURL("electronapp://api", "/auth", undefined, false)).toThrow(
+				"URL must include 'http://' or 'https://'",
+			);
+		});
+
+		it("should allow custom protocols when protocolPolicy is 'any'", () => {
+			const result = getBaseURL(
+				"electronapp://api",
+				"/auth",
+				undefined,
+				false,
+				undefined,
+				"any",
+			);
+			expect(result).toBe("electronapp://api/auth");
+		});
+	});
 });

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -1,6 +1,8 @@
 import { env } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
 
+export type BaseURLProtocolPolicy = "http" | "any";
+
 function checkHasPath(url: string): boolean {
 	try {
 		const parsedUrl = new URL(url);
@@ -13,10 +15,17 @@ function checkHasPath(url: string): boolean {
 	}
 }
 
-function assertHasProtocol(url: string): void {
+function assertHasProtocol(
+	url: string,
+	protocolPolicy: BaseURLProtocolPolicy,
+): void {
 	try {
 		const parsedUrl = new URL(url);
-		if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+		if (
+			protocolPolicy === "http" &&
+			parsedUrl.protocol !== "http:" &&
+			parsedUrl.protocol !== "https:"
+		) {
 			throw new BetterAuthError(
 				`Invalid base URL: ${url}. URL must include 'http://' or 'https://'`,
 			);
@@ -34,8 +43,12 @@ function assertHasProtocol(url: string): void {
 	}
 }
 
-function withPath(url: string, path = "/api/auth") {
-	assertHasProtocol(url);
+function withPath(
+	url: string,
+	path = "/api/auth",
+	protocolPolicy: BaseURLProtocolPolicy,
+) {
+	assertHasProtocol(url, protocolPolicy);
 
 	const hasPath = checkHasPath(url);
 	if (hasPath) {
@@ -109,9 +122,11 @@ export function getBaseURL(
 	request?: Request,
 	loadEnv?: boolean,
 	trustedProxyHeaders?: boolean | undefined,
+	protocolPolicy?: BaseURLProtocolPolicy | undefined,
 ) {
+	const protocolPolicyResolved = protocolPolicy ?? "http";
 	if (url) {
-		return withPath(url, path);
+		return withPath(url, path, protocolPolicyResolved);
 	}
 
 	if (loadEnv !== false) {
@@ -124,7 +139,7 @@ export function getBaseURL(
 			(env.BASE_URL !== "/" ? env.BASE_URL : undefined);
 
 		if (fromEnv) {
-			return withPath(fromEnv, path);
+			return withPath(fromEnv, path, protocolPolicyResolved);
 		}
 	}
 
@@ -136,7 +151,11 @@ export function getBaseURL(
 			validateProxyHeader(fromRequest, "host")
 		) {
 			try {
-				return withPath(`${fromRequestProto}://${fromRequest}`, path);
+				return withPath(
+					`${fromRequestProto}://${fromRequest}`,
+					path,
+					protocolPolicyResolved,
+				);
 			} catch (_error) {}
 		}
 	}
@@ -148,11 +167,11 @@ export function getBaseURL(
 				"Could not get origin from request. Please provide a valid base URL.",
 			);
 		}
-		return withPath(url, path);
+		return withPath(url, path, protocolPolicyResolved);
 	}
 
 	if (typeof window !== "undefined" && window.location) {
-		return withPath(window.location.origin, path);
+		return withPath(window.location.origin, path, protocolPolicyResolved);
 	}
 	return undefined;
 }

--- a/packages/core/src/types/plugin-client.ts
+++ b/packages/core/src/types/plugin-client.ts
@@ -71,6 +71,18 @@ export interface BetterAuthClientOptions {
 	plugins?: BetterAuthClientPlugin[] | undefined;
 	baseURL?: string | undefined;
 	basePath?: string | undefined;
+	/**
+	 * Allow non-HTTP(S) protocols in `baseURL` (e.g. `app://`, `electronapp://`).
+	 *
+	 * This is primarily intended for desktop runtimes (Electron/Tauri/etc.) where
+	 * requests may be proxied through a custom protocol.
+	 *
+	 * When enabled, Better Auth will accept any valid URL protocol in `baseURL`
+	 * instead of only `http:` / `https:`.
+	 *
+	 * @default false
+	 */
+	allowCustomBaseURLProtocol?: boolean | undefined;
 	disableDefaultFetchPlugins?: boolean | undefined;
 	$InferAuth?: BetterAuthOptions | undefined;
 	sessionOptions?: RevalidateOptions | undefined;


### PR DESCRIPTION
## Problem
Better Auth client rejects non-http(s) `baseURL` values (e.g. `electronapp://api`) due to strict protocol validation in `getBaseURL()`. This blocks Electron/Tauri-style setups that proxy requests through a custom protocol.

## Changes
- Add `allowCustomBaseURLProtocol?: boolean` to `BetterAuthClientOptions`.
- Extend `getBaseURL()` with an explicit protocol policy (default remains strict http/https).
- When `allowCustomBaseURLProtocol` is enabled, client config resolves `baseURL` with protocolPolicy=`any`.
- Add regression tests covering default rejection + opt-in allowance.

## Why this approach
- Keeps **default** behavior strict for web/server usage.
- Allows desktop runtimes to opt in explicitly, avoiding accidental loosening.

## Test plan
- `pnpm build`
- `pnpm -F better-auth test` (requires Postgres running for the oauth-proxy postgres suite)

Fixes #7149