### PR TITLE
fix(api): normalize headers for server-side calls

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -145,6 +145,71 @@ describe("before hook", async () => {
 			expect(res).toMatchObject({ key: "value", name: "headers" });
 		});
 
+		it("should accept a Next.js ReadonlyHeaders-like object", async () => {
+			class ReadonlyHeadersLike {
+				private readonly inner: Headers;
+				constructor(init: Record<string, string>) {
+					this.inner = new Headers(init);
+				}
+				get(name: string) {
+					return this.inner.get(name);
+				}
+				entries() {
+					return this.inner.entries();
+				}
+			}
+
+			const readonlyHeaders = new ReadonlyHeadersLike({
+				key: "value",
+				cookie: "better-auth.session_token=abc",
+			});
+
+			const res = await authEndpoints.headers({
+				// Next.js `headers()` is not a real `Headers` instance
+				headers: readonlyHeaders as any,
+			});
+
+			expect(res).toMatchObject({
+				key: "value",
+				name: "headers",
+				cookie: "better-auth.session_token=abc",
+			});
+		});
+
+		it("should accept a header-like object with get/forEach (non-iterable)", async () => {
+			class ForEachHeadersLike {
+				private readonly map = new Map<string, string>();
+				constructor(init: Record<string, string>) {
+					for (const [k, v] of Object.entries(init)) {
+						this.map.set(k.toLowerCase(), v);
+					}
+				}
+				get(name: string) {
+					return this.map.get(name.toLowerCase()) ?? null;
+				}
+				forEach(cb: (value: string, key: string) => void) {
+					for (const [k, v] of this.map.entries()) {
+						cb(v, k);
+					}
+				}
+			}
+
+			const readonlyHeaders = new ForEachHeadersLike({
+				key: "value",
+				cookie: "better-auth.session_token=abc",
+			});
+
+			const res = await authEndpoints.headers({
+				headers: readonlyHeaders as any,
+			});
+
+			expect(res).toMatchObject({
+				key: "value",
+				name: "headers",
+				cookie: "better-auth.session_token=abc",
+			});
+		});
+
 		it("should replace existing array when hook provides another array", async () => {
 			const endpoint = {
 				body: createAuthEndpoint(

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -15,6 +15,7 @@ import type {
 import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
 import { createDefu } from "defu";
 import { isAPIError } from "../utils/is-api-error";
+import { toHeaders } from "../utils/headers";
 
 type InternalContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
@@ -73,7 +74,9 @@ export function toAuthEndpoints<
 						session: null,
 					},
 					path: endpoint.path,
-					headers: context?.headers ? new Headers(context?.headers) : undefined,
+					headers: context?.headers
+						? (toHeaders(context.headers as any) ?? new Headers())
+						: undefined,
 				};
 				return runWithEndpointContext(internalContext, async () => {
 					const { beforeHooks, afterHooks } = getHooks(authContext);
@@ -96,6 +99,9 @@ export function toAuthEndpoints<
 						 * header
 						 */
 						if (headers) {
+							if (!internalContext.headers) {
+								internalContext.headers = new Headers();
+							}
 							headers.forEach((value, key) => {
 								(internalContext.headers as Headers).set(key, value);
 							});

--- a/packages/better-auth/src/utils/headers.test.ts
+++ b/packages/better-auth/src/utils/headers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { toHeaders } from "./headers";
+
+describe("toHeaders", () => {
+	it("should return undefined for undefined input", () => {
+		expect(toHeaders(undefined)).toBeUndefined();
+	});
+
+	it("should clone a Headers instance", () => {
+		const input = new Headers({ cookie: "a=b" });
+		const output = toHeaders(input);
+		expect(output).toBeInstanceOf(Headers);
+		expect(output).not.toBe(input);
+		expect(output?.get("cookie")).toBe("a=b");
+	});
+
+	it("should support Node.js IncomingHttpHeaders-style records", () => {
+		const output = toHeaders({
+			cookie: "a=b",
+			"x-test": ["a", "b"],
+		});
+		expect(output?.get("cookie")).toBe("a=b");
+		// Multiple values are joined per Fetch semantics
+		expect(output?.get("x-test")).toBe("a, b");
+	});
+
+	it("should support Next.js ReadonlyHeaders-style objects via entries()", () => {
+		class ReadonlyHeadersLike {
+			private readonly inner: Headers;
+			constructor(init: Record<string, string>) {
+				this.inner = new Headers(init);
+			}
+			get(name: string) {
+				return this.inner.get(name);
+			}
+			entries() {
+				return this.inner.entries();
+			}
+		}
+
+		const output = toHeaders(
+			new ReadonlyHeadersLike({ cookie: "a=b", "x-test": "1" }) as any,
+		);
+		expect(output?.get("cookie")).toBe("a=b");
+		expect(output?.get("x-test")).toBe("1");
+	});
+
+	it("should support header-like objects via get/forEach()", () => {
+		class ForEachHeadersLike {
+			private readonly map = new Map<string, string>();
+			constructor(init: Record<string, string>) {
+				for (const [k, v] of Object.entries(init)) {
+					this.map.set(k.toLowerCase(), v);
+				}
+			}
+			get(name: string) {
+				return this.map.get(name.toLowerCase()) ?? null;
+			}
+			forEach(cb: (value: string, key: string) => void) {
+				for (const [k, v] of this.map.entries()) {
+					cb(v, k);
+				}
+			}
+		}
+
+		const output = toHeaders(
+			new ForEachHeadersLike({ cookie: "a=b", "x-test": "1" }) as any,
+		);
+		expect(output?.get("cookie")).toBe("a=b");
+		expect(output?.get("x-test")).toBe("1");
+	});
+});
+

--- a/packages/better-auth/src/utils/headers.ts
+++ b/packages/better-auth/src/utils/headers.ts
@@ -1,0 +1,90 @@
+export type HeadersLike =
+	| Headers
+	| Iterable<[string, string]>
+	| {
+			entries: () => Iterable<[string, string]>;
+	  }
+	| {
+			forEach: (cb: (value: unknown, key: unknown) => void) => void;
+			get: (key: string) => string | null;
+	  }
+	| Record<string, string | string[] | number | boolean | null | undefined>;
+
+function hasAnyHeader(headers: Headers): boolean {
+	return !headers.keys().next().done;
+}
+
+/**
+ * Convert "headers-like" inputs into a real Web `Headers` instance.
+ *
+ * This is used for server-side usage such as:
+ * - Next.js App Router `headers()` (ReadonlyHeaders) which is not a real `Headers`
+ * - Node.js `IncomingHttpHeaders` (record with possibly array values)
+ */
+export function toHeaders(input: HeadersLike | undefined): Headers | undefined {
+	if (!input) return undefined;
+
+	// Already a Web Headers instance
+	if (input instanceof Headers) {
+		return new Headers(input);
+	}
+
+	const anyInput = input as any;
+
+	// Next.js `ReadonlyHeaders` provides `.entries()` but is not a real `HeadersInit`.
+	if (typeof anyInput?.entries === "function") {
+		try {
+			return new Headers(Array.from(anyInput.entries()) as any);
+		} catch {
+			// fall through
+		}
+	}
+
+	// Some runtimes provide a header-like object with `forEach`/`get`
+	if (typeof anyInput?.forEach === "function" && typeof anyInput?.get === "function") {
+		try {
+			const headers = new Headers();
+			anyInput.forEach((value: unknown, key: unknown) => {
+				if (value === undefined || value === null) return;
+				headers.append(String(key), String(value));
+			});
+			return hasAnyHeader(headers) ? headers : undefined;
+		} catch {
+			// fall through
+		}
+	}
+
+	// Iterable of [key, value] pairs (e.g. Map, string[][])
+	if (typeof anyInput?.[Symbol.iterator] === "function") {
+		try {
+			return new Headers(Array.from(anyInput) as any);
+		} catch {
+			// fall through
+		}
+	}
+
+	// Plain object record (e.g. Node IncomingHttpHeaders)
+	if (typeof anyInput === "object") {
+		const headers = new Headers();
+		for (const [key, value] of Object.entries(anyInput as Record<string, unknown>)) {
+			if (value === undefined || value === null) continue;
+			if (Array.isArray(value)) {
+				for (const v of value) {
+					if (v === undefined || v === null) continue;
+					headers.append(key, String(v));
+				}
+			} else {
+				headers.set(key, String(value));
+			}
+		}
+		return hasAnyHeader(headers) ? headers : undefined;
+	}
+
+	// Last resort
+	try {
+		return new Headers(input as any);
+	} catch {
+		return undefined;
+	}
+}
+

--- a/packages/better-auth/src/utils/index.ts
+++ b/packages/better-auth/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "../oauth2/state";
 export type { StateData } from "../state";
 export { generateGenericState, parseGenericState } from "../state";
+export * from "./headers";
 export * from "./hide-metadata";
 export * from "./url";


### PR DESCRIPTION
## Problem
When calling endpoints via `auth.api.*` inside Next.js App Router server components, users often pass `headers()` (a ReadonlyHeaders instance). This object is not a real Web `Headers`, so `auth.api.getSession({ headers })` could lose the `cookie` header and return `null`.

## Changes
- Normalize header-like inputs into a real Web `Headers` instance inside `toAuthEndpoints`.
- Add a small helper `toHeaders()` that supports:
  - Next.js ReadonlyHeaders (`entries()`)
  - header-like objects (`get`/`forEach`)
  - Node-style header records (including array values)
- Add regression tests for the edge cases above.

## Test plan
- `pnpm typecheck`
- `pnpm -F better-auth exec vitest -t \"ReadonlyHeaders-like\"`
- `pnpm -F better-auth exec vitest -t \"toHeaders\"`

Fixes #7008

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost cookies when calling auth.api.* from server code (e.g., Next.js App Router headers()). Header-like inputs are now normalized to a real Web Headers so session lookups don’t return null.

- **Bug Fixes**
  - Normalize inputs to Headers via toHeaders() (ReadonlyHeaders, get/forEach objects, iterables, and Node-style records with arrays).
  - Initialize internal headers before merging hook-provided headers.
  - Add regression tests for these cases. Fixes #7008.

<sup>Written for commit 69d8079c25faff23419a5415a8eb06306d33f4a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

