### PR TITLE
fix(drizzle-adapter): handle sqlite json-mode arrays

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -51,6 +51,13 @@ To generate and apply the migration, run the following commands:
     </Tabs>
 
 
+## JSON mode columns (SQLite / MySQL)
+
+When using SQLite or MySQL, the generated Drizzle schema stores `json`, `string[]`, and `number[]` fields using `mode: "json"` columns (for example `text("field", { mode: "json" })`).
+
+- Provide **native objects/arrays** for these fields (do not pre-`JSON.stringify` them).
+- If you have existing rows where these values were stored as JSON strings, you may need a one-time data migration.
+
 ## Joins (Experimental)
 
 Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -14,4 +14,195 @@ describe("drizzle-adapter", () => {
 		const adapter = drizzleAdapter(db, config);
 		expect(adapter).toBeDefined();
 	});
+
+	it("should not stringify json/array fields for sqlite inputs", async () => {
+		let capturedValues: Record<string, unknown> | null = null;
+
+		const db = {
+			_: {
+				fullSchema: {
+					user: {
+						id: true,
+						name: true,
+						email: true,
+						emailVerified: true,
+						image: true,
+						createdAt: true,
+						updatedAt: true,
+						notificationTokens: true,
+						profile: true,
+					},
+				},
+			},
+			insert: () => ({
+				values: (values: Record<string, unknown>) => {
+					capturedValues = values;
+					return {
+						returning: async () => [values],
+					};
+				},
+			}),
+		} as any;
+
+		const adapter = drizzleAdapter(db, { provider: "sqlite" })({
+			user: {
+				additionalFields: {
+					notificationTokens: {
+						type: "string[]",
+						required: true,
+						input: true,
+					},
+					profile: {
+						type: "json",
+						required: true,
+						input: true,
+					},
+				},
+			},
+		} as any);
+
+		await adapter.create({
+			model: "user",
+			data: {
+				name: "test",
+				email: "test@example.com",
+				notificationTokens: ["token1", "token2"],
+				profile: { hello: "world" },
+			},
+		});
+
+		const captured = capturedValues as any;
+		expect(captured).toBeTruthy();
+		expect(captured.notificationTokens).toEqual(["token1", "token2"]);
+		expect(captured.profile).toEqual({ hello: "world" });
+	});
+
+	it("should parse legacy json-string values for sqlite outputs", async () => {
+		const db = {
+			_: {
+				fullSchema: {
+					user: {
+						id: true,
+						name: true,
+						email: true,
+						emailVerified: true,
+						image: true,
+						createdAt: true,
+						updatedAt: true,
+						notificationTokens: true,
+						profile: true,
+					},
+				},
+			},
+			insert: () => ({
+				values: () => ({
+					returning: async () => [
+						{
+							id: "1",
+							name: "test",
+							email: "test@example.com",
+							emailVerified: false,
+							image: null,
+							createdAt: new Date(),
+							updatedAt: new Date(),
+							notificationTokens: '["token1","token2"]',
+							profile: '{"hello":"world"}',
+						},
+					],
+				}),
+			}),
+		} as any;
+
+		const adapter = drizzleAdapter(db, { provider: "sqlite" })({
+			user: {
+				additionalFields: {
+					notificationTokens: {
+						type: "string[]",
+						required: true,
+						input: true,
+					},
+					profile: {
+						type: "json",
+						required: true,
+						input: true,
+					},
+				},
+			},
+		} as any);
+
+		const created = await adapter.create({
+			model: "user",
+			data: {
+				name: "test",
+				email: "test@example.com",
+				notificationTokens: ["token1", "token2"],
+				profile: { hello: "world" },
+			},
+		});
+
+		expect(created.notificationTokens).toEqual(["token1", "token2"]);
+		expect(created.profile).toEqual({ hello: "world" });
+	});
+
+	it("should accept json-string inputs for sqlite array/json fields", async () => {
+		let capturedValues: Record<string, unknown> | null = null;
+
+		const db = {
+			_: {
+				fullSchema: {
+					user: {
+						id: true,
+						name: true,
+						email: true,
+						emailVerified: true,
+						image: true,
+						createdAt: true,
+						updatedAt: true,
+						notificationTokens: true,
+						profile: true,
+					},
+				},
+			},
+			insert: () => ({
+				values: (values: Record<string, unknown>) => {
+					capturedValues = values;
+					return {
+						returning: async () => [values],
+					};
+				},
+			}),
+		} as any;
+
+		const adapter = drizzleAdapter(db, { provider: "sqlite" })({
+			user: {
+				additionalFields: {
+					notificationTokens: {
+						type: "string[]",
+						required: true,
+						input: true,
+					},
+					profile: {
+						type: "json",
+						required: true,
+						input: true,
+					},
+				},
+			},
+		} as any);
+
+		await adapter.create({
+			model: "user",
+			data: {
+				name: "test",
+				email: "test@example.com",
+				notificationTokens: '["token1","token2"]',
+				profile: '{"hello":"world"}',
+			},
+		});
+
+		const captured = capturedValues as any;
+		expect(captured).toBeTruthy();
+		expect(captured.notificationTokens).toEqual(["token1", "token2"]);
+		expect(captured.profile).toEqual({ hello: "world" });
+	});
 });

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -27,6 +27,7 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
+import { tryParseJSON } from "./json";
 
 export interface DB {
 	[key: string]: any;
@@ -622,10 +623,35 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 			debugLogs: config.debugLogs ?? false,
 			supportsUUIDs: config.provider === "pg" ? true : false,
 			supportsJSON:
-				config.provider === "pg" // even though mysql also supports it, mysql requires to pass stringified json anyway.
+				(config.provider === "pg" || config.provider === "sqlite") // even though mysql also supports it, mysql requires to pass stringified json anyway.
 					? true
 					: false,
-			supportsArrays: config.provider === "pg" ? true : false,
+			supportsArrays:
+				config.provider === "pg" || config.provider === "sqlite" ? true : false,
+			customTransformInput: ({ data, fieldAttributes }) => {
+				if (config.provider !== "sqlite") return data;
+				if (
+					typeof fieldAttributes.type === "string" &&
+					(fieldAttributes.type === "json" ||
+						fieldAttributes.type === "string[]" ||
+						fieldAttributes.type === "number[]")
+				) {
+					return tryParseJSON(data);
+				}
+				return data;
+			},
+			customTransformOutput: ({ data, fieldAttributes }) => {
+				if (config.provider !== "sqlite") return data;
+				if (
+					typeof fieldAttributes.type === "string" &&
+					(fieldAttributes.type === "json" ||
+						fieldAttributes.type === "string[]" ||
+						fieldAttributes.type === "number[]")
+				) {
+					return tryParseJSON(data);
+				}
+				return data;
+			},
 			transaction:
 				(config.transaction ?? false)
 					? (cb) =>

--- a/packages/drizzle-adapter/src/json.test.ts
+++ b/packages/drizzle-adapter/src/json.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { tryParseJSON } from "./json";
+
+describe("tryParseJSON", () => {
+	it("should parse JSON arrays and objects", () => {
+		expect(tryParseJSON('["a","b"]')).toEqual(["a", "b"]);
+		expect(tryParseJSON('{"hello":"world"}')).toEqual({ hello: "world" });
+	});
+
+	it("should return original value for non-JSON strings", () => {
+		expect(tryParseJSON("hello")).toBe("hello");
+		expect(tryParseJSON('"hello"')).toBe('"hello"');
+		expect(tryParseJSON("")).toBe("");
+		expect(tryParseJSON("   ")).toBe("   ");
+	});
+
+	it("should return original value for invalid JSON", () => {
+		expect(tryParseJSON("{not-json")).toBe("{not-json");
+		expect(tryParseJSON("[not-json")).toBe("[not-json");
+	});
+
+	it("should pass through non-string values", () => {
+		expect(tryParseJSON(["a"])).toEqual(["a"]);
+		expect(tryParseJSON({ a: 1 })).toEqual({ a: 1 });
+		expect(tryParseJSON(null)).toBe(null);
+		expect(tryParseJSON(undefined)).toBe(undefined);
+	});
+});
+

--- a/packages/drizzle-adapter/src/json.ts
+++ b/packages/drizzle-adapter/src/json.ts
@@ -1,0 +1,17 @@
+export function tryParseJSON(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+
+	const trimmed = value.trim();
+	if (!trimmed) return value;
+
+	// Fast-path: only parse JSON objects/arrays
+	const first = trimmed[0];
+	if (first !== "{" && first !== "[") return value;
+
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return value;
+	}
+}
+


### PR DESCRIPTION
## Problem
With the Drizzle adapter on SQLite, Better Auth could pre-`JSON.stringify` values for `json`, `string[]`, and `number[]` fields. When those fields use Drizzle `mode: \"json\"` columns (as generated by the CLI), this results in JSON being stored as a *string* (and can lead to double-stringification).

This shows up as `string[]` additional fields being returned as a stringified JSON array when querying the database directly via Drizzle.

## Changes
- Treat SQLite as supporting JSON + array values for the adapter factory (so native objects/arrays are passed to Drizzle).
- Add lightweight parsing for legacy JSON-string values on both input and output for SQLite.
- Add regression tests for:
  - native array/object inputs
  - legacy JSON-string outputs
  - JSON-string inputs for smoother upgrades
- Document JSON-mode columns behavior in the Drizzle adapter docs.

## Test plan
- `pnpm typecheck`
- `pnpm -F @better-auth/drizzle-adapter test`

Fixes #7440

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SQLite handling in the Drizzle adapter so json and array fields using Drizzle mode: "json" store native objects/arrays instead of stringified JSON. Also parses legacy JSON-string values on input/output to avoid breakage during upgrades.

- **Bug Fixes**
  - Treat SQLite as supporting JSON and arrays; pass native values to Drizzle.
  - Parse legacy JSON strings for json/string[]/number[] on read and write.
  - Prevent double-stringification and string[] being returned as JSON strings.

- **Migration**
  - For JSON-mode columns, send native objects/arrays (do not JSON.stringify).
  - If older rows stored JSON as strings, consider a one-time data migration.

<sup>Written for commit 8c0bd1bda6c2eb6990b713545bf88496563046de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

