### PR TITLE
fix(admin): handle falsy filter values in listUsers

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -376,6 +376,65 @@ describe("Admin plugin", async () => {
 		});
 	});
 
+	it("should apply filter when filterValue is boolean false", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				filterField: "banned",
+				filterOperator: "eq",
+				filterValue: false,
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data).toBeDefined();
+		expect(res.data?.users).toBeDefined();
+		expect(res.data?.users.every((u) => u.banned !== true)).toBe(true);
+	});
+
+	it("should apply filter when filterValue is 0", async () => {
+		const resAll = await client.admin.listUsers({
+			query: {},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		const res = await client.admin.listUsers({
+			query: {
+				filterField: "role",
+				filterOperator: "eq",
+				filterValue: 0,
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data).toBeDefined();
+		expect(res.data?.users).toBeDefined();
+		expect(res.data?.users.length).toBeLessThanOrEqual(
+			resAll.data?.total ?? 0,
+		);
+	});
+
+	it("should default filterField to email when not provided", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				filterValue: "test",
+				filterOperator: "contains",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data).toBeDefined();
+		expect(res.data?.users).toBeDefined();
+		expect(
+			res.data?.users.every((u) =>
+				u.email.toLowerCase().includes("test"),
+			),
+		).toBe(true);
+	});
+
 	it("should filter users by id with ne operator", async () => {
 		const allUsers = await client.admin.listUsers({
 			query: {},

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -658,7 +658,7 @@ export const listUsers = (opts: AdminOptions) =>
 				});
 			}
 
-			if (ctx.query?.filterValue) {
+			if (ctx.query?.filterValue !== undefined) {
 				where.push({
 					field: ctx.query.filterField || "email",
 					operator: ctx.query.filterOperator || "eq",


### PR DESCRIPTION
## Problem
The `listUsers` admin route uses a truthy check (`if (ctx.query?.filterValue)`) to decide whether to apply a filter. This silently drops valid falsy values like `false`, `0`, and empty string `""`, making it impossible to filter by e.g. `banned = false`.

## Changes
- Changed the condition from `if (ctx.query?.filterValue)` to `if (ctx.query?.filterValue !== undefined)` so falsy values are correctly passed through to the query builder.
- Added edge-case tests for:
  - Filtering by boolean `false` (`banned = false`)
  - Filtering by numeric `0`
  - Default `filterField` fallback when not provided

## Test plan
- `npx vitest run packages/better-auth/src/plugins/admin/admin.test.ts` — 71/71 tests pass
- `npx tsc --noEmit` in `packages/better-auth` — clean

Fixes #7837

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes filtering in the admin listUsers route to accept falsy filter values (false, 0, ""). This allows filters like banned=false and role=0 to work.

- **Bug Fixes**
  - Changed filter check to use filterValue !== undefined.
  - Added tests for false and 0 values.
  - Confirmed default filterField falls back to email.

<sup>Written for commit 96af62814e2b973c8a3d66a45b53994132c2019d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

