### PR TITLE
fix: handle falsy filters, nullable invitation return, and oauth redirect key

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -376,6 +376,65 @@ describe("Admin plugin", async () => {
 		});
 	});
 
+	it("should apply filter when filterValue is boolean false", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				filterField: "banned",
+				filterOperator: "eq",
+				filterValue: false,
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data).toBeDefined();
+		expect(res.data?.users).toBeDefined();
+		expect(res.data?.users.every((u) => u.banned !== true)).toBe(true);
+	});
+
+	it("should apply filter when filterValue is 0", async () => {
+		const resAll = await client.admin.listUsers({
+			query: {},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		const res = await client.admin.listUsers({
+			query: {
+				filterField: "role",
+				filterOperator: "eq",
+				filterValue: 0,
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data).toBeDefined();
+		expect(res.data?.users).toBeDefined();
+		expect(res.data?.users.length).toBeLessThanOrEqual(
+			resAll.data?.total ?? 0,
+		);
+	});
+
+	it("should default filterField to email when not provided", async () => {
+		const res = await client.admin.listUsers({
+			query: {
+				filterValue: "test",
+				filterOperator: "contains",
+			},
+			fetchOptions: {
+				headers: adminHeaders,
+			},
+		});
+		expect(res.data).toBeDefined();
+		expect(res.data?.users).toBeDefined();
+		expect(
+			res.data?.users.every((u) =>
+				u.email.toLowerCase().includes("test"),
+			),
+		).toBe(true);
+	});
+
 	it("should filter users by id with ne operator", async () => {
 		const allUsers = await client.admin.listUsers({
 			query: {},

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -658,7 +658,7 @@ export const listUsers = (opts: AdminOptions) =>
 				});
 			}
 
-			if (ctx.query?.filterValue) {
+			if (ctx.query?.filterValue !== undefined) {
 				where.push({
 					field: ctx.query.filterField || "email",
 					operator: ctx.query.filterOperator || "eq",

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -96,8 +96,8 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 						 * The role to assign to the user
 						 */
 						role:
-							| InferOrganizationRolesFromOption<O>
-							| InferOrganizationRolesFromOption<O>[];
+						| InferOrganizationRolesFromOption<O>
+						| InferOrganizationRolesFromOption<O>[];
 						/**
 						 * The organization ID to invite
 						 * the user to
@@ -110,12 +110,12 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 						resend?: boolean | undefined;
 					} & (O extends { teams: { enabled: true } }
 						? {
-								/**
-								 * The team the user is
-								 * being invited to.
-								 */
-								teamId?: (string | string[]) | undefined;
-							}
+							/**
+							 * The team the user is
+							 * being invited to.
+							 */
+							teamId?: (string | string[]) | undefined;
+						}
 						: {}) &
 						InferAdditionalFieldsFromPluginOptions<"invitation", O, false>,
 				},
@@ -365,13 +365,13 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 			const invitationLimit =
 				typeof ctx.context.orgOptions.invitationLimit === "function"
 					? await ctx.context.orgOptions.invitationLimit(
-							{
-								user: session.user,
-								organization,
-								member: member as Member,
-							},
-							ctx.context,
-						)
+						{
+							user: session.user,
+							organization,
+							member: member as Member,
+						},
+						ctx.context,
+					)
 					: (ctx.context.orgOptions.invitationLimit ?? 100);
 
 			const pendingInvitations = await adapter.findPendingInvitations({
@@ -389,7 +389,7 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 				ctx.context.orgOptions.teams &&
 				ctx.context.orgOptions.teams.enabled &&
 				typeof ctx.context.orgOptions.teams.maximumMembersPerTeam !==
-					"undefined" &&
+				"undefined" &&
 				"teamId" in ctx.body &&
 				ctx.body.teamId
 			) {
@@ -414,12 +414,12 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 
 					const maximumMembersPerTeam =
 						typeof ctx.context.orgOptions.teams.maximumMembersPerTeam ===
-						"function"
+							"function"
 							? await ctx.context.orgOptions.teams.maximumMembersPerTeam({
-									teamId,
-									session: session,
-									organizationId: organizationId,
-								})
+								teamId,
+								session: session,
+								organizationId: organizationId,
+							})
 							: ctx.context.orgOptions.teams.maximumMembersPerTeam;
 					if (team.members.length >= maximumMembersPerTeam) {
 						throw APIError.from(
@@ -656,12 +656,12 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 
 						const maximumMembersPerTeam =
 							typeof ctx.context.orgOptions.teams.maximumMembersPerTeam ===
-							"function"
+								"function"
 								? await ctx.context.orgOptions.teams.maximumMembersPerTeam({
-										teamId,
-										session: session,
-										organizationId: invitation.organizationId,
-									})
+									teamId,
+									session: session,
+									organizationId: invitation.organizationId,
+								})
 								: ctx.context.orgOptions.teams.maximumMembersPerTeam;
 
 						if (members >= maximumMembersPerTeam) {
@@ -701,12 +701,10 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				ctx,
 			);
 			if (!acceptedI) {
-				return ctx.json(null, {
-					status: 400,
-					body: {
-						message: ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND.message,
-					},
-				});
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
+				);
 			}
 			if (options?.organizationHooks?.afterAcceptInvitation) {
 				await options?.organizationHooks.afterAcceptInvitation({

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -43,7 +43,7 @@ export async function consentEndpoint(
 	if (!accepted) {
 		return {
 			redirect: true,
-			uri: formatErrorURL(
+			url: formatErrorURL(
 				query.get("redirect_uri") ?? "",
 				"access_denied",
 				"User denied access",
@@ -74,11 +74,11 @@ export async function consentEndpoint(
 				},
 				...(referenceId
 					? [
-							{
-								field: "referenceId",
-								value: referenceId,
-							},
-						]
+						{
+							field: "referenceId",
+							value: referenceId,
+						},
+					]
 					: []),
 			],
 		},
@@ -94,25 +94,25 @@ export async function consentEndpoint(
 	};
 	foundConsent?.id
 		? await ctx.context.adapter.update({
-				model: "oauthConsent",
-				where: [
-					{
-						field: "id",
-						value: foundConsent.id,
-					},
-				],
-				update: {
-					scopes: consent.scopes,
-					updatedAt: new Date(iat * 1000),
+			model: "oauthConsent",
+			where: [
+				{
+					field: "id",
+					value: foundConsent.id,
 				},
-			})
+			],
+			update: {
+				scopes: consent.scopes,
+				updatedAt: new Date(iat * 1000),
+			},
+		})
 		: await ctx.context.adapter.create({
-				model: "oauthConsent",
-				data: {
-					...consent,
-					scopes: consent.scopes,
-				},
-			});
+			model: "oauthConsent",
+			data: {
+				...consent,
+				scopes: consent.scopes,
+			},
+		});
 
 	// Return authorization code
 	ctx?.headers?.set("accept", "application/json");
@@ -121,6 +121,6 @@ export async function consentEndpoint(
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,
-		uri: url,
+		url,
 	};
 }

--- a/packages/oauth-provider/src/continue.ts
+++ b/packages/oauth-provider/src/continue.ts
@@ -41,7 +41,7 @@ async function selected(
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,
-		uri: url,
+		url,
 	};
 }
 
@@ -61,7 +61,7 @@ async function created(
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,
-		uri: url,
+		url,
 	};
 }
 
@@ -84,6 +84,6 @@ async function postLogin(
 	});
 	return {
 		redirect: true,
-		uri: url,
+		url,
 	};
 }


### PR DESCRIPTION
## Problem

Three related response-handling bugs across admin, organization, and oauth-provider plugins:

1. **Admin `listUsers` ignores falsy filter values (#7837)** — The truthy check `if (ctx.query?.filterValue)` silently drops valid falsy values like `false`, `0`, and `""`, making it impossible to filter by e.g. `banned = false`.

2. **`acceptInvitation` nullable return type (#7824)** — A redundant guard returns `ctx.json(null, ...)` instead of throwing an `APIError`, polluting TypeScript's return type inference so consumers must handle `null` even though the code path is unreachable.

3. **`/oauth2/continue` and `/oauth2/consent` return `uri` instead of `url` (#7807)** — The client-side redirect plugin checks `context.data?.url` but the server returns `uri`, breaking automatic client-side redirects after consent/continue flows.

## Changes

- **`packages/better-auth/src/plugins/admin/routes.ts`**: Changed `if (ctx.query?.filterValue)` to `if (ctx.query?.filterValue !== undefined)` so falsy values pass through to the query builder.
- **`packages/better-auth/src/plugins/organization/routes/crud-invites.ts`**: Replaced `ctx.json(null, { status: 400, ... })` with `throw APIError.from("BAD_REQUEST", ...)` for correct type narrowing.
- **`packages/oauth-provider/src/continue.ts`**: Renamed `uri` property to `url` in all 3 response objects (`selected`, `created`, `postLogin`).
- **`packages/oauth-provider/src/consent.ts`**: Renamed `uri` property to `url` in both response objects (denied + accepted consent).
- **`packages/better-auth/src/plugins/admin/admin.test.ts`**: Added edge-case tests for boolean `false`, numeric `0`, and default `filterField` fallback.

## Test plan
- `npx vitest run packages/better-auth/src/plugins/admin/admin.test.ts` — 71/71 tests pass
- `npx tsc --noEmit` in `packages/better-auth` — clean
- `npx tsc --noEmit` in `packages/oauth-provider` — clean

Fixes #7837, fixes #7824, fixes #7807

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three response-handling edge cases across admin, organization, and OAuth plugins: falsy filters are honored, acceptInvitation no longer returns null, and OAuth endpoints return url for redirects. Fixes #7837, #7824, #7807.

- **Bug Fixes**
  - Admin listUsers: treat filterValue as present when !== undefined, enabling false/0/"" filters.
  - Organization acceptInvitation: throw BAD_REQUEST instead of returning null to keep return type non-null.
  - OAuth continue/consent: use url (not uri) in responses so client redirects work.

<sup>Written for commit f2749849ef7b9b2237ef7ba63c131d312abe33ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

