### PR TITLE
fix(oauth-provider): defensive Date coercion for Drizzle/SQLite compatibility

### DIFF
--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -18,6 +18,7 @@ import {
 	getJwtPlugin,
 	getStoredToken,
 	parseClientMetadata,
+	toDate,
 	validateClientCredentials,
 } from "./utils";
 
@@ -54,10 +55,10 @@ async function validateJwtAccessToken(
 			jwksFetch: jwtPluginOptions?.jwks?.remoteUrl
 				? jwtPluginOptions.jwks.remoteUrl
 				: async () => {
-						const jwksRes = await jwtPlugin?.endpoints.getJwks(ctx);
-						// @ts-expect-error response is a JSONWebKeySet but within the response field
-						return jwksRes?.response as JSONWebKeySet | undefined;
-					},
+					const jwksRes = await jwtPlugin?.endpoints.getJwks(ctx);
+					// @ts-expect-error response is a JSONWebKeySet but within the response field
+					return jwksRes?.response as JSONWebKeySet | undefined;
+				},
 			verifyOptions: {
 				audience: opts.validAudiences ?? ctx.context.baseURL,
 				issuer: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
@@ -216,11 +217,11 @@ async function validateOpaqueAccessToken(
 	// Add Custom Claims
 	const customClaims = opts.customAccessTokenClaims
 		? await opts.customAccessTokenClaims({
-				user,
-				scopes: accessToken.scopes,
-				referenceId: accessToken?.referenceId,
-				metadata: parseClientMetadata(client?.metadata),
-			})
+			user,
+			scopes: accessToken.scopes,
+			referenceId: accessToken?.referenceId,
+			metadata: parseClientMetadata(client?.metadata),
+		})
 		: {};
 
 	// Return the access token in introspection format
@@ -236,8 +237,8 @@ async function validateOpaqueAccessToken(
 		client_id: accessToken.clientId,
 		sub: user?.id,
 		sid: sessionId,
-		exp: Math.floor(accessToken.expiresAt.getTime() / 1000),
-		iat: Math.floor(accessToken.createdAt.getTime() / 1000),
+		exp: Math.floor(toDate(accessToken.expiresAt).getTime() / 1000),
+		iat: Math.floor(toDate(accessToken.createdAt).getTime() / 1000),
 		scope: accessToken.scopes?.join(" "),
 	} as JWTPayload;
 }
@@ -323,8 +324,8 @@ async function validateRefreshToken(
 		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
 		sub: user?.id,
 		sid: sessionId,
-		exp: Math.floor(refreshToken.expiresAt.getTime() / 1000),
-		iat: Math.floor(refreshToken.createdAt.getTime() / 1000),
+		exp: Math.floor(toDate(refreshToken.expiresAt).getTime() / 1000),
+		iat: Math.floor(toDate(refreshToken.createdAt).getTime() / 1000),
 		scope: refreshToken.scopes?.join(" "),
 	} as JWTPayload;
 }

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -4,7 +4,7 @@ import { generateRandomString } from "better-auth/crypto";
 import { toExpJWT } from "better-auth/plugins";
 import type { OAuthOptions, SchemaClient, Scope } from "./types";
 import type { OAuthClient } from "./types/oauth";
-import { parseClientMetadata, storeClientSecret } from "./utils";
+import { parseClientMetadata, storeClientSecret, toDate } from "./utils";
 
 export async function registerEndpoint(
 	ctx: GenericEndpointContext,
@@ -161,9 +161,9 @@ export async function createOAuthClientEndpoint(
 	const iat = Math.floor(Date.now() / 1000);
 	const referenceId = opts.clientReference
 		? await opts.clientReference({
-				user: session?.user,
-				session: session?.session,
-			})
+			user: session?.user,
+			session: session?.session,
+		})
 		: undefined;
 	const schema = oauthToSchema({
 		...((body ?? {}) as OAuthClient),
@@ -356,10 +356,10 @@ export function schemaToOAuth(input: SchemaClient<Scope[]>): OAuthClient {
 
 	// Type conversions
 	const _expiresAt = expiresAt
-		? Math.round(expiresAt.getTime() / 1000)
+		? Math.round(toDate(expiresAt).getTime() / 1000)
 		: undefined;
 	const _createdAt = createdAt
-		? Math.round(createdAt.getTime() / 1000)
+		? Math.round(toDate(createdAt).getTime() / 1000)
 		: undefined;
 	const _scopes = scopes?.join(" ");
 	const _metadata = parseClientMetadata(metadata);

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -22,6 +22,7 @@ import {
 	getStoredToken,
 	parseClientMetadata,
 	storeToken,
+	toDate,
 	validateClientCredentials,
 } from "./utils";
 
@@ -82,12 +83,12 @@ async function createJwtAccessToken(
 	const exp = overrides?.exp ?? iat + (opts.accessTokenExpiresIn ?? 3600);
 	const customClaims = opts.customAccessTokenClaims
 		? await opts.customAccessTokenClaims({
-				user,
-				scopes,
-				resource: ctx.body.resource,
-				referenceId,
-				metadata: parseClientMetadata(client.metadata),
-			})
+			user,
+			scopes,
+			resource: ctx.body.resource,
+			referenceId,
+			metadata: parseClientMetadata(client.metadata),
+		})
 		: {};
 
 	const jwtPluginOptions = getJwtPlugin(ctx.context).options;
@@ -131,8 +132,8 @@ async function createIdToken(
 	const exp = iat + (opts.idTokenExpiresIn ?? 36000);
 	const userClaims = userNormalClaims(user, scopes);
 	const authTime = Math.floor(
-		(ctx.context.session?.session.createdAt ?? new Date(iat * 1000)).getTime() /
-			1000,
+		toDate(ctx.context.session?.session.createdAt ?? new Date(iat * 1000)).getTime() /
+		1000,
 	);
 	// TODO: this should be validated against the login process
 	// - bronze : password only
@@ -141,10 +142,10 @@ async function createIdToken(
 
 	const customClaims = opts.customIdTokenClaims
 		? await opts.customIdTokenClaims({
-				user,
-				scopes,
-				metadata: parseClientMetadata(client.metadata),
-			})
+			user,
+			scopes,
+			metadata: parseClientMetadata(client.metadata),
+		})
 		: {};
 
 	const jwtPluginOptions = opts.disableJwtPlugin
@@ -173,20 +174,20 @@ async function createIdToken(
 
 	return opts.disableJwtPlugin
 		? new SignJWT(payload)
-				.setProtectedHeader({ alg: "HS256" })
-				.sign(
-					new TextEncoder().encode(
-						await decryptStoredClientSecret(
-							ctx,
-							opts.storeClientSecret,
-							client.clientSecret!,
-						),
+			.setProtectedHeader({ alg: "HS256" })
+			.sign(
+				new TextEncoder().encode(
+					await decryptStoredClientSecret(
+						ctx,
+						opts.storeClientSecret,
+						client.clientSecret!,
 					),
-				)
+				),
+			)
 		: signJWT(ctx, {
-				options: jwtPluginOptions,
-				payload,
-			});
+			options: jwtPluginOptions,
+			payload,
+		});
 }
 
 /**
@@ -375,14 +376,14 @@ async function createUserTokens(
 	const defaultExp = iat + (opts.accessTokenExpiresIn ?? 3600);
 	const exp = opts.scopeExpirations
 		? scopes
-				.map((sc) =>
-					opts.scopeExpirations?.[sc]
-						? toExpJWT(opts.scopeExpirations[sc], iat)
-						: defaultExp,
-				)
-				.reduce((prev, curr) => {
-					return prev < curr ? prev : curr;
-				}, defaultExp)
+			.map((sc) =>
+				opts.scopeExpirations?.[sc]
+					? toExpJWT(opts.scopeExpirations[sc], iat)
+					: defaultExp,
+			)
+			.reduce((prev, curr) => {
+				return prev < curr ? prev : curr;
+			}, defaultExp)
 		: defaultExp;
 
 	// Check requested audience if sent as the resource parameter
@@ -397,6 +398,56 @@ async function createUserTokens(
 	const earlyRefreshToken =
 		isRefreshToken && !isJwtAccessToken
 			? await createRefreshToken(
+				ctx,
+				opts,
+				user,
+				referenceId,
+				client,
+				scopes,
+				{
+					iat,
+					exp: iat + (opts.refreshTokenExpiresIn ?? 2592000),
+					sid: sessionId,
+				},
+				additional?.refreshToken,
+			)
+			: undefined;
+
+	// Sign jwt and refresh tokens in parallel
+	const [accessToken, refreshToken, idToken] = await Promise.all([
+		isJwtAccessToken
+			? createJwtAccessToken(
+				ctx,
+				opts,
+				user,
+				client,
+				audience,
+				scopes,
+				referenceId,
+				{
+					iat,
+					exp,
+					sid: sessionId,
+				},
+			)
+			: createOpaqueAccessToken(
+				ctx,
+				opts,
+				user,
+				client,
+				scopes,
+				{
+					iat,
+					exp,
+					sid: sessionId,
+				},
+				referenceId,
+				earlyRefreshToken?.id,
+			),
+		earlyRefreshToken
+			? earlyRefreshToken
+			: isRefreshToken
+				? createRefreshToken(
 					ctx,
 					opts,
 					user,
@@ -410,56 +461,6 @@ async function createUserTokens(
 					},
 					additional?.refreshToken,
 				)
-			: undefined;
-
-	// Sign jwt and refresh tokens in parallel
-	const [accessToken, refreshToken, idToken] = await Promise.all([
-		isJwtAccessToken
-			? createJwtAccessToken(
-					ctx,
-					opts,
-					user,
-					client,
-					audience,
-					scopes,
-					referenceId,
-					{
-						iat,
-						exp,
-						sid: sessionId,
-					},
-				)
-			: createOpaqueAccessToken(
-					ctx,
-					opts,
-					user,
-					client,
-					scopes,
-					{
-						iat,
-						exp,
-						sid: sessionId,
-					},
-					referenceId,
-					earlyRefreshToken?.id,
-				),
-		earlyRefreshToken
-			? earlyRefreshToken
-			: isRefreshToken
-				? createRefreshToken(
-						ctx,
-						opts,
-						user,
-						referenceId,
-						client,
-						scopes,
-						{
-							iat,
-							exp: iat + (opts.refreshTokenExpiresIn ?? 2592000),
-							sid: sessionId,
-						},
-						additional?.refreshToken,
-					)
 				: undefined,
 		isIdToken
 			? createIdToken(ctx, opts, user, client, scopes, nonce, sessionId)
@@ -804,49 +805,49 @@ async function handleClientCredentialsGrant(
 	const exp =
 		opts.scopeExpirations && requestedScopes
 			? requestedScopes
-					.map((sc) =>
-						opts.scopeExpirations?.[sc]
-							? toExpJWT(opts.scopeExpirations[sc], iat)
-							: defaultExp,
-					)
-					.reduce((prev, curr) => {
-						return prev < curr ? prev : curr;
-					}, defaultExp)
+				.map((sc) =>
+					opts.scopeExpirations?.[sc]
+						? toExpJWT(opts.scopeExpirations[sc], iat)
+						: defaultExp,
+				)
+				.reduce((prev, curr) => {
+					return prev < curr ? prev : curr;
+				}, defaultExp)
 			: defaultExp;
 
 	const customClaims = opts.customAccessTokenClaims
 		? await opts.customAccessTokenClaims({
-				scopes: requestedScopes,
-				resource: ctx.body.resource,
-				metadata: parseClientMetadata(client.metadata),
-			})
+			scopes: requestedScopes,
+			resource: ctx.body.resource,
+			metadata: parseClientMetadata(client.metadata),
+		})
 		: {};
 
 	const accessToken =
 		audience && !opts.disableJwtPlugin
 			? await signJWT(ctx, {
-					options: jwtPluginOptions,
-					payload: {
-						...customClaims,
-						aud: audience,
-						azp: client.clientId,
-						scope: requestedScopes.join(" "),
-						iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
-						iat,
-						exp,
-					},
-				})
+				options: jwtPluginOptions,
+				payload: {
+					...customClaims,
+					aud: audience,
+					azp: client.clientId,
+					scope: requestedScopes.join(" "),
+					iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+					iat,
+					exp,
+				},
+			})
 			: await createOpaqueAccessToken(
-					ctx,
-					opts,
-					undefined,
-					client,
-					requestedScopes,
-					{
-						iat,
-						exp,
-					},
-				);
+				ctx,
+				opts,
+				undefined,
+				client,
+				requestedScopes,
+				{
+					iat,
+					exp,
+				},
+			);
 
 	return ctx.json(
 		{

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -20,7 +20,7 @@ import type {
 
 class TTLCache<K, V extends { expiresAt?: Date }> {
 	private cache = new Map<K, V>();
-	constructor() {}
+	constructor() { }
 
 	set(key: K, value: V) {
 		this.cache.set(key, value);
@@ -424,4 +424,16 @@ export function deleteFromPrompt(query: URLSearchParams, prompt: Prompt) {
 			: query.delete("prompt");
 	}
 	return Object.fromEntries(query);
+}
+
+/**
+ * Defensively coerces a value to a Date object.
+ * Needed because some database adapters (e.g. Drizzle with SQLite)
+ * may return date columns as strings or numbers instead of Date objects.
+ *
+ * @internal
+ */
+export function toDate(value: unknown): Date {
+	if (value instanceof Date) return value;
+	return new Date(value as string | number);
 }


### PR DESCRIPTION
## Problem

The oauth-provider plugin calls `.getTime()` directly on date values retrieved from the database (`expiresAt`, `createdAt`). When using the Drizzle adapter with SQLite, these values may be returned as ISO strings or Unix timestamps rather than native `Date` objects, causing:

```
TypeError: expiresAt.getTime is not a function
```

This affects token introspection, client registration responses, and id token generation.

## Changes

- **`packages/oauth-provider/src/utils/index.ts`**: Added a `toDate()` utility that defensively coerces `string | number | Date` to a `Date` object. Only calls `new Date()` if the value is not already a `Date` instance.
- **`packages/oauth-provider/src/introspect.ts`**: Wrapped 4 `.getTime()` calls with `toDate()` — opaque access token `expiresAt`/`createdAt` and refresh token `expiresAt`/`createdAt`.
- **`packages/oauth-provider/src/register.ts`**: Wrapped 2 `.getTime()` calls with `toDate()` — client `expiresAt` and `createdAt` in `schemaToOAuth`.
- **`packages/oauth-provider/src/token.ts`**: Wrapped 1 `.getTime()` call with `toDate()` — `session.createdAt` used for id token `auth_time` claim.

## Test plan
- `npx tsc --noEmit` in `packages/oauth-provider` — clean
- `npx tsc --noEmit` in `packages/better-auth` — clean

Fixes #7819

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defensively coerce DB date fields to Date objects in oauth-provider to avoid runtime errors with Drizzle/SQLite. This fixes bad exp/iat calculations in introspection, client registration responses, and id token auth_time. Fixes #7819.

- **Bug Fixes**
  - Added toDate(value) utility to normalize string|number|Date to Date.
  - Wrapped getTime() usages in introspect (access/refresh token exp/iat) and register (client expiresAt/createdAt).
  - Wrapped session.createdAt in token.ts when computing id token auth_time.

<sup>Written for commit 2fde5a6678809bb1d873ea5e72d518450af95998. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

