### PR TITLE
Auth api context typing

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -42,7 +42,14 @@ const hooksSourceWeakMap = new WeakMap<
 
 type UserInputContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
->;
+> & {
+	/**
+	 * Partial auth context to override default values.
+	 * Useful for server-side calls where you already have
+	 * session data or need to customize the context.
+	 */
+	context?: Partial<AuthContext>;
+};
 
 export function toAuthEndpoints<
 	const E extends Record<
@@ -64,14 +71,19 @@ export function toAuthEndpoints<
 		api[key] = async (context?: UserInputContext) => {
 			const run = async () => {
 				const authContext = await ctx;
+				// Extract user-provided context if any
+				const userProvidedContext = context?.context;
 				let internalContext: InternalContext = {
 					...context,
-					context: {
-						...authContext,
-						returned: undefined,
-						responseHeaders: undefined,
-						session: null,
-					},
+					context: defuReplaceArrays(
+						{
+							returned: undefined,
+							responseHeaders: undefined,
+							session: userProvidedContext?.session ?? null,
+						},
+						userProvidedContext ?? {},
+						authContext,
+					) as InternalContext["context"],
 					path: endpoint.path,
 					headers: context?.headers ? new Headers(context?.headers) : undefined,
 				};

--- a/packages/better-auth/src/types/api.ts
+++ b/packages/better-auth/src/types/api.ts
@@ -1,42 +1,152 @@
-import type { Endpoint } from "better-call";
+import type { AuthContext, BetterAuthOptions } from "@better-auth/core";
+import type { Endpoint, EndpointOptions } from "better-call";
 import type { PrettifyDeep, UnionToIntersection } from "../types/helper";
 
-export type FilteredAPI<API> = Omit<
+/**
+ * Deep partial type that preserves function types
+ */
+type DeepPartialContext<T> = T extends (...args: any[]) => any
+	? T
+	: T extends object
+		? { [K in keyof T]?: DeepPartialContext<T[K]> }
+		: T;
+
+/**
+ * The context input type that users can pass to auth.api calls.
+ * This allows users to pass a partial AuthContext to override
+ * default context values.
+ */
+export type APIContextInput<
+	Options extends BetterAuthOptions = BetterAuthOptions,
+> = {
+	/**
+	 * Partial auth context to override default values.
+	 * Useful for server-side calls where you already have
+	 * session data or need to customize the context.
+	 *
+	 * @example
+	 * ```ts
+	 * // Pass existing session to avoid database lookup
+	 * await auth.api.updateUser({
+	 *   body: { name: "New Name" },
+	 *   headers: request.headers,
+	 *   context: {
+	 *     session: existingSession
+	 *   }
+	 * });
+	 * ```
+	 */
+	context?: DeepPartialContext<AuthContext<Options>>;
+};
+
+/**
+ * Wraps an endpoint type to add the context input parameter.
+ * This preserves all the original endpoint overloads while
+ * adding the ability to pass a partial AuthContext.
+ */
+export type WithContextInput<
+	E extends Endpoint,
+	Options extends BetterAuthOptions = BetterAuthOptions,
+> = E extends {
+	(context: infer C & { asResponse: true }): Promise<Response>;
+	(context?: infer C): Promise<infer R>;
+	options: EndpointOptions;
+	path: infer P;
+}
+	? {
+			(
+				context: C & { asResponse: true } & APIContextInput<Options>,
+			): Promise<Response>;
+			(
+				context: C & {
+					returnHeaders: true;
+					returnStatus: true;
+				} & APIContextInput<Options>,
+			): Promise<{
+				headers: Headers;
+				status: number;
+				response: Awaited<R>;
+			}>;
+			(
+				context: C & {
+					returnHeaders: true;
+					returnStatus?: false;
+				} & APIContextInput<Options>,
+			): Promise<{
+				headers: Headers;
+				response: Awaited<R>;
+			}>;
+			(
+				context: C & {
+					returnHeaders?: false;
+					returnStatus: true;
+				} & APIContextInput<Options>,
+			): Promise<{
+				status: number;
+				response: Awaited<R>;
+			}>;
+			(context?: C & APIContextInput<Options>): Promise<R>;
+			options: E["options"];
+			path: P;
+		}
+	: E;
+
+/**
+ * Maps over all endpoints in the API and adds context input to each.
+ */
+export type AddContextToAPI<
 	API,
-	API extends { [key in infer K]: Endpoint }
-		? K extends string
-			? K extends "getSession"
-				? never
-				: API[K]["options"]["metadata"] extends
-							| { isAction: false }
-							| { scope: "http" }
-					? K
-					: never
+	Options extends BetterAuthOptions = BetterAuthOptions,
+> = {
+	[K in keyof API]: API[K] extends Endpoint
+		? WithContextInput<API[K], Options>
+		: API[K];
+};
+
+export type FilteredAPI<
+	API,
+	Options extends BetterAuthOptions = BetterAuthOptions,
+> = AddContextToAPI<
+	Omit<
+		API,
+		API extends { [key in infer K]: Endpoint }
+			? K extends string
+				? K extends "getSession"
+					? never
+					: API[K]["options"]["metadata"] extends
+								| { isAction: false }
+								| { scope: "http" }
+						? K
+						: never
+				: never
 			: never
-		: never
+	>,
+	Options
 >;
 
-export type InferSessionAPI<API> = API extends {
+export type InferSessionAPI<
+	API,
+	Options extends BetterAuthOptions = BetterAuthOptions,
+> = API extends {
 	[key: string]: infer E;
 }
 	? UnionToIntersection<
 			E extends Endpoint
 				? E["path"] extends "/get-session"
 					? {
-							getSession: <
-								R extends boolean,
-								H extends boolean = false,
-							>(context: {
-								headers: Headers;
-								query?:
-									| {
-											disableCookieCache?: boolean;
-											disableRefresh?: boolean;
-									  }
-									| undefined;
-								asResponse?: R | undefined;
-								returnHeaders?: H | undefined;
-							}) => false extends R
+							getSession: <R extends boolean, H extends boolean = false>(
+								context: {
+									headers: Headers;
+									query?:
+										| {
+												disableCookieCache?: boolean;
+												disableRefresh?: boolean;
+										  }
+										| undefined;
+									asResponse?: R | undefined;
+									returnHeaders?: H | undefined;
+								} & APIContextInput<Options>,
+							) => false extends R
 								? H extends true
 									? Promise<{
 											headers: Headers;
@@ -50,4 +160,7 @@ export type InferSessionAPI<API> = API extends {
 		>
 	: never;
 
-export type InferAPI<API> = InferSessionAPI<API> & FilteredAPI<API>;
+export type InferAPI<
+	API,
+	Options extends BetterAuthOptions = BetterAuthOptions,
+> = InferSessionAPI<API, Options> & FilteredAPI<API, Options>;

--- a/packages/better-auth/src/types/auth.ts
+++ b/packages/better-auth/src/types/auth.ts
@@ -7,7 +7,7 @@ import type { InferPluginErrorCodes } from "./plugins";
 
 export type Auth<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	handler: (request: Request) => Promise<Response>;
-	api: InferAPI<ReturnType<typeof router<Options>>["endpoints"]>;
+	api: InferAPI<ReturnType<typeof router<Options>>["endpoints"], Options>;
 	options: Options;
 	$ERROR_CODES: InferPluginErrorCodes<Options> & typeof BASE_ERROR_CODES;
 	$context: Promise<AuthContext<Options>>;

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
+import type { AuthContext, BetterAuthPlugin } from "@better-auth/core";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAuthEndpoint } from "../api";
 import { organization, twoFactor } from "../plugins";
@@ -199,5 +199,56 @@ describe("general types", async () => {
 		type SessionWithoutPlugins = typeof authWithoutPlugins.$Infer;
 
 		expectTypeOf<SessionWithEmptyPlugins>().toEqualTypeOf<SessionWithoutPlugins>();
+	});
+
+	it("should allow passing partial context to auth.api calls", async () => {
+		const { auth } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+			},
+		});
+
+		// Test that context parameter is accepted in API calls
+		type SignUpEmailParams = NonNullable<
+			Parameters<typeof auth.api.signUpEmail>[0]
+		>;
+
+		// Verify that context property exists and accepts partial AuthContext
+		type ContextParam = SignUpEmailParams["context"];
+		expectTypeOf<ContextParam>().not.toEqualTypeOf<never>();
+
+		// Verify that session can be passed in context
+		expectTypeOf<ContextParam>().toMatchTypeOf<
+			| {
+					session?: {
+						session?: Record<string, any>;
+						user?: Record<string, any>;
+					} | null;
+			  }
+			| undefined
+		>();
+
+		// Verify that internalAdapter can be partially overridden
+		expectTypeOf<ContextParam>().toMatchTypeOf<
+			| {
+					internalAdapter?: Partial<AuthContext["internalAdapter"]>;
+			  }
+			| undefined
+		>();
+	});
+
+	it("should allow passing context to getSession", async () => {
+		const { auth } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+			},
+		});
+
+		// Test that context parameter is accepted in getSession
+		type GetSessionParams = NonNullable<
+			Parameters<typeof auth.api.getSession>[0]
+		>;
+		type ContextParam = GetSessionParams["context"];
+		expectTypeOf<ContextParam>().not.toEqualTypeOf<never>();
 	});
 });


### PR DESCRIPTION
Add typed `context` parameter to all `auth.api` calls to allow users to pass partial `AuthContext` objects.

This enables server-side context overrides and improves type safety for `auth.api` endpoint inputs.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1770771748538879?thread_ts=1770771748.538879&cid=C0A8B5BARUK)

<p><a href="https://cursor.com/background-agent?bcId=bc-55ef9871-c961-57d9-b0cf-7f64f10ee1ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55ef9871-c961-57d9-b0cf-7f64f10ee1ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed context parameter to all auth.api endpoints so callers can pass a partial AuthContext (e.g., session). This enables server-side overrides and avoids extra lookups while improving type safety.

- New Features
  - All endpoints, including getSession, now accept context with a DeepPartial AuthContext.
  - User-provided context is merged with internal defaults; session defaults to null unless supplied; existing endpoint overloads (asResponse/returnHeaders/returnStatus) are preserved.
  - Introduces APIContextInput, WithContextInput, AddContextToAPI; updates InferAPI; adds type tests verifying context support.

<sup>Written for commit 91c957e7a4b3fb4867601db30fd7100cc5b8b88d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

