### PR TITLE
feat: support infer init context

### DIFF
--- a/packages/better-auth/src/types/auth.ts
+++ b/packages/better-auth/src/types/auth.ts
@@ -3,14 +3,14 @@ import type { BASE_ERROR_CODES } from "@better-auth/core/error";
 import type { router } from "../api";
 import type { InferAPI } from "./api";
 import type { InferPluginTypes, Session, User } from "./models";
-import type { InferPluginErrorCodes } from "./plugins";
+import type { InferPluginContext, InferPluginErrorCodes } from "./plugins";
 
 export type Auth<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	handler: (request: Request) => Promise<Response>;
 	api: InferAPI<ReturnType<typeof router<Options>>["endpoints"]>;
 	options: Options;
 	$ERROR_CODES: InferPluginErrorCodes<Options> & typeof BASE_ERROR_CODES;
-	$context: Promise<AuthContext<Options>>;
+	$context: Promise<AuthContext<Options> & InferPluginContext<Options>>;
 	/**
 	 * Share types
 	 */

--- a/packages/better-auth/src/types/plugins.ts
+++ b/packages/better-auth/src/types/plugins.ts
@@ -1,4 +1,8 @@
-import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
+import type {
+	AuthContext,
+	BetterAuthOptions,
+	BetterAuthPlugin,
+} from "@better-auth/core";
 
 import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import type { UnionToIntersection } from "./helper";
@@ -32,3 +36,20 @@ export type InferPluginIDs<O extends BetterAuthOptions> =
 	O["plugins"] extends Array<infer P>
 		? UnionToIntersection<P extends BetterAuthPlugin ? P["id"] : never>
 		: never;
+
+type ExtractInitContext<P extends BetterAuthPlugin> = P["init"] extends (
+	...args: any[]
+) => infer R
+	? Awaited<R> extends { context?: infer C }
+		? C extends Record<string, any>
+			? Omit<C, keyof AuthContext>
+			: {}
+		: {}
+	: {};
+
+export type InferPluginContext<O extends BetterAuthOptions> =
+	O["plugins"] extends Array<infer P>
+		? UnionToIntersection<
+				P extends BetterAuthPlugin ? ExtractInitContext<P> : {}
+			>
+		: {};

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -179,6 +179,28 @@ describe("general types", async () => {
 		}>();
 	});
 
+	it("should infer plugin-contributed context from init", async () => {
+		const testUtilsPlugin = {
+			id: "test-utils" as const,
+			init() {
+				return {
+					context: {
+						testValue: 42 as number,
+						testHelper: () => "hello" as string,
+					},
+				};
+			},
+		} satisfies BetterAuthPlugin;
+
+		const { auth } = await getTestInstance({
+			plugins: [testUtilsPlugin],
+		});
+
+		const context = await auth.$context;
+		expectTypeOf(context.testValue).toEqualTypeOf<number>();
+		expectTypeOf(context.testHelper).toEqualTypeOf<() => string>();
+	});
+
 	it("should infer the same types for empty plugins and no plugins", async () => {
 		const { auth: authWithEmptyPlugins } = await getTestInstance({
 			plugins: [],

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -45,7 +45,8 @@ export type BetterAuthPlugin = BetterAuthPluginErrorCodePart & {
 	init?:
 		| ((ctx: AuthContext) =>
 				| Awaitable<{
-						context?: DeepPartial<Omit<AuthContext, "options">>;
+						context?: DeepPartial<Omit<AuthContext, "options">> &
+							Record<string, unknown>;
 						options?: Partial<BetterAuthOptions>;
 				  }>
 				| void


### PR DESCRIPTION
Related: https://github.com/better-auth/better-auth/pull/7746

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds type inference for plugin init context so plugin-provided values are strongly typed on auth.$context.

- **New Features**
  - Introduced InferPluginContext and merged it into auth.$context.
  - Plugins can return extra context keys from init; they’re included in $context typing.
  - Prevents conflicts by omitting core AuthContext keys when inferring.
  - Added a test that verifies custom values and helpers are correctly inferred.

<sup>Written for commit aff9d84b511546a7a8f24c02927824657dd9db8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

