### PR TITLE
docs: add mongoose example to mongodb adapter docs 

### DIFF
--- a/docs/content/docs/adapters/mongo.mdx
+++ b/docs/content/docs/adapters/mongo.mdx
@@ -19,6 +19,9 @@ To use the MongoDB adapter, you need to install the `@better-auth/mongo-adapter`
 
 You can use the MongoDB adapter to connect to your database as follows.
 
+<Tabs items={["Native Driver", "Mongoose"]}>
+<Tab value="Native Driver">
+
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
 import { MongoClient } from "mongodb";
@@ -34,6 +37,42 @@ export const auth = betterAuth({
   }),
 });
 ```
+
+</Tab>
+<Tab value="Mongoose">
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import mongoose from "mongoose";
+import dotenv from "dotenv";
+import { mongodbAdapter } from "better-auth/adapters/mongodb";
+
+dotenv.config();
+
+const connectDB = async () => {
+  if (mongoose.connection.readyState === 0) {
+    await mongoose.connect(process.env.DATABASE_URI || "");
+  }
+  return mongoose.connection;
+};
+
+const connection = await connectDB();
+const db = connection.getClient().db();
+
+export const auth = betterAuth({
+  database: mongodbAdapter(db),
+  baseURL: // your base url,
+  basePath: // your base path,
+  secret: // your secret key,
+  emailAndPassword: {
+    enabled: true,
+  },
+});
+
+```
+
+</Tab>
+</Tabs>
 
 ## Schema generation & migration
 

--- a/docs/content/docs/adapters/mongo.mdx
+++ b/docs/content/docs/adapters/mongo.mdx
@@ -61,9 +61,9 @@ const db = connection.getClient().db();
 
 export const auth = betterAuth({
   database: mongodbAdapter(db),
-  baseURL: // your base url,
-  basePath: // your base path,
-  secret: // your secret key,
+  baseURL: "https://your-base-url",
+  basePath: "/your-base-path",
+  secret: "your-secret-key",
   emailAndPassword: {
     enabled: true,
   },


### PR DESCRIPTION
<img width="1365" height="686" alt="image" src="https://github.com/user-attachments/assets/52c81e38-9779-4f9f-bfb2-ef67aae61160" />

### Add Mongoose example to MongoDB adapter documentation

**Description**
Adds a tabbed interface to the MongoDB adapter documentation showing both the native MongoDB driver and Mongoose as alternatives for connecting to MongoDB.

**Motivation**
Many developers prefer using Mongoose for MongoDB integration due to its schema validation and additional features. This PR provides clear examples for both approaches, making it easier for users to integrate Better Auth with their preferred MongoDB client.

**Changes**
Added tabs component to MongoDB adapter docs
Included Mongoose setup example with connection handling
Kept existing native driver example in first tab
Both examples show proper mongodbAdapter usage

Checklist
 

- [x] Documentation updated

 

- [x] Code formatted with BiomeJS

 

- [x] Changes follow contribution guidelines

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a tabbed example to the MongoDB adapter docs for both the native driver and `mongoose`. The `mongoose` tab now includes `dotenv`-based connection reuse (`mongoose.connection.readyState`), uses `connection.getClient().db()`, and shows `mongodbAdapter` in a full `better-auth` config (`better-auth/adapters/mongodb`).

<sup>Written for commit fb6e948803e556129950efb2c0d9854e112f7b30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

