### PR TITLE
feat(scim): introduce ownership model for SCIM

### DIFF
--- a/docs/content/docs/plugins/scim.mdx
+++ b/docs/content/docs/plugins/scim.mdx
@@ -163,6 +163,44 @@ const auth = betterAuth({
 In our example above, you would need to encode the `some-scim-token:default-scim:the-org` text to base64, resulting in the following scimToken: `c29tZS1zY2ltLXRva2VuOmRlZmF1bHQtc2NpbTp0aGUtb3Jn`
 </Callout>
 
+### SCIM provider connection ownership
+
+SCIM provider connection ownership allows your application to track and restrict access to the SCIM management endpoints
+by linking each connection to the user who generated the token.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { scim } from "@better-auth/scim";
+
+const auth = betterAuth({
+    plugins: [
+        scim({ // [!code highlight]
+            providerOwnership: { // [!code highlight]
+                enabled: true // [!code highlight]
+            } // [!code highlight]
+        }) // [!code highlight]
+    ]
+});
+```
+
+Once enabled, make sure you migrate the database schema (again).
+
+<Tabs items={["migrate", "generate"]}>
+    <Tab value="migrate">
+    ```bash
+    npx @better-auth/cli migrate
+    ```
+    </Tab>
+    <Tab value="generate">
+    ```bash
+    npx @better-auth/cli generate
+    ```
+    </Tab>
+</Tabs>
+
+See the [Schema](#if-you-have-provider-ownership-enabled-via-providerownershipenabled) section to add the fields manually.
+
+
 ### Managing SCIM provider connections
 
 You can manage SCIM provider connections from your application using the following endpoints:
@@ -425,10 +463,28 @@ The plugin requires additional fields in the `scimProvider` table to store the p
     ]}
 />
 
+### If you have provider ownership enabled via `providerOwnership.enabled`:
+
+The `scimProvider` schema is extended as follows:
+
+<DatabaseTable
+    fields={[
+        { name: "userId", type: "string", description: "The user id of the connection owner. Set automatically when generating a token via the API.", isRequired: false },
+    ]}
+/>
+
 
 ## Options
 
 ### Server
+
+- `providerOwnership`: `{ enabled: boolean }` — When enabled, links each provider connection to the user who generated its token. See [Connection ownership](#scim-provider-connection-ownership) for details. Default is `{ enabled: false }`.
+
+```ts title="Enable connection ownership (requires migration)"
+scim({
+    providerOwnership: { enabled: true },
+})
+```
 
 - `defaultSCIM`: Default list of SCIM tokens for testing.
 - `storeSCIMToken`: The method to store the SCIM token in your database, whether `encrypted`, `hashed` or `plain` text. Default is `plain` text.

--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -30,6 +30,7 @@ declare module "@better-auth/core" {
 export const scim = (options?: SCIMOptions) => {
 	const opts = {
 		storeSCIMToken: "plain",
+		providerOwnership: { enabled: false },
 		...options,
 	} satisfies SCIMOptions;
 
@@ -71,6 +72,14 @@ export const scim = (options?: SCIMOptions) => {
 						type: "string",
 						required: false,
 					},
+					...(opts.providerOwnership?.enabled
+						? {
+								userId: {
+									type: "string",
+									required: false,
+								},
+							}
+						: {}),
 				},
 			},
 		},

--- a/packages/scim/src/types.ts
+++ b/packages/scim/src/types.ts
@@ -6,6 +6,7 @@ export interface SCIMProvider {
 	providerId: string;
 	scimToken: string;
 	organizationId?: string;
+	userId?: string;
 }
 
 export type SCIMName = {
@@ -17,6 +18,13 @@ export type SCIMName = {
 export type SCIMEmail = { value?: string; primary?: boolean };
 
 export type SCIMOptions = {
+	/**
+	 * SCIM provider ownership configuration. When enabled, each provider
+	 * connection is linked to the user who generated its token
+	 */
+	providerOwnership?: {
+		enabled: boolean;
+	};
 	/**
 	 * Default list of SCIM providers for testing
 	 * These will take precedence over the database when present


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add optional ownership for SCIM provider connections. When enabled, tokens are tied to their creator and all management endpoints enforce owner or org membership.

- New Features
  - New option: scim({ providerOwnership: { enabled: true } }) (default false).
  - Conditionally adds userId to scimProvider; generateSCIMToken stores the creator’s userId.
  - Access rules: org providers require current org membership; personal providers require the owner when userId exists; unowned personal providers remain accessible.
  - listSCIMProviderConnections returns org providers where the user is a member, owned personal providers for the owner, and unowned providers.
  - Docs updated with setup, option details, and schema changes.

- Migration
  - After enabling providerOwnership: npx @better-auth/cli migrate and npx @better-auth/cli generate.
  - Ensure scimProvider includes an optional userId (string) column.

<sup>Written for commit 35342192c056557e459bd82ac8754bf1876231d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

