### PR TITLE
fix(sso): resolve TXT record at verification subdomain instead of root domain

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -1264,7 +1264,7 @@ You can use this token to prove ownership over the domain.
 #### Create `TXT` DNS record
 To do this, you'll need to add a `TXT` record to your domain's DNS settings:
 
-    *   **Host:** `better-auth-token-{your-provider-id}` (**Note:** This assumes the default token prefix, which can be customized through the `domainVerification.tokenPrefix` option)
+    *   **Host:** `_better-auth-token-{your-provider-id}` (**Note:** An underscore is automatically prepended to follow DNS infrastructure subdomain conventions. The `better-auth-token` part can be customized through the `domainVerification.tokenPrefix` option)
     *   **Value:** The verification token you were given.
 
 **Save the record and wait for it to propagate.** This can take up to 48 hours, but it's usually much faster.
@@ -1454,10 +1454,10 @@ If you want to allow account linking for specific trusted providers, enable the 
                 required: false
             },
             tokenPrefix: {
-                description: "Prefix to append to the verification token identifier",
+                description: "Prefix used to generate the domain verification identifier. An underscore is automatically prepended.",
                 type: "string",
                 required: false,
-                default: "better-auth-token-"
+                default: "better-auth-token"
             },
         },
     },

--- a/packages/sso/src/domain-verification.test.ts
+++ b/packages/sso/src/domain-verification.test.ts
@@ -285,7 +285,7 @@ describe("Domain verification", async () => {
 
 			dnsMock.resolveTxt.mockResolvedValue([
 				[
-					`better-auth-token-saml-provider-1=${provider.domainVerificationToken}`,
+					`_better-auth-token-saml-provider-1=${provider.domainVerificationToken}`,
 				],
 			]);
 
@@ -470,7 +470,7 @@ describe("Domain verification", async () => {
 					"v=spf1 ip4:50.242.118.232/29 include:_spf.google.com include:mail.zendesk.com ~all",
 				],
 				[
-					`better-auth-token-saml-provider-1=${provider.domainVerificationToken}`,
+					`_better-auth-token-saml-provider-1=${provider.domainVerificationToken}`,
 				],
 			]);
 
@@ -484,7 +484,7 @@ describe("Domain verification", async () => {
 
 			expect(response.status).toBe(204);
 			expect(dnsMock.resolveTxt).toHaveBeenCalledWith(
-				"better-auth-token-saml-provider-1.hello.com",
+				"_better-auth-token-saml-provider-1.hello.com",
 			);
 		});
 
@@ -500,7 +500,7 @@ describe("Domain verification", async () => {
 				[
 					"v=spf1 ip4:50.242.118.232/29 include:_spf.google.com include:mail.zendesk.com ~all",
 				],
-				[`auth-prefix-saml-provider-1=${provider.domainVerificationToken}`],
+				[`_auth-prefix-saml-provider-1=${provider.domainVerificationToken}`],
 			]);
 
 			const response = await auth.api.verifyDomain({
@@ -513,7 +513,7 @@ describe("Domain verification", async () => {
 
 			expect(response.status).toBe(204);
 			expect(dnsMock.resolveTxt).toHaveBeenCalledWith(
-				"auth-prefix-saml-provider-1.hello.com",
+				"_auth-prefix-saml-provider-1.hello.com",
 			);
 		});
 
@@ -560,7 +560,7 @@ describe("Domain verification", async () => {
 
 			dnsMock.resolveTxt.mockResolvedValue([
 				[
-					`better-auth-token-saml-provider-1=${provider.domainVerificationToken}`,
+					`_better-auth-token-saml-provider-1=${provider.domainVerificationToken}`,
 				],
 			]);
 

--- a/packages/sso/src/routes/domain-verification.ts
+++ b/packages/sso/src/routes/domain-verification.ts
@@ -15,13 +15,13 @@ const domainVerificationBodySchema = z.object({
 	providerId: z.string(),
 });
 
-function getVerificationIdentifier(
+export function getVerificationIdentifier(
 	options: SSOOptions,
 	providerId: string,
 ): string {
 	const tokenPrefix =
 		options.domainVerification?.tokenPrefix || DEFAULT_TOKEN_PREFIX;
-	return `${tokenPrefix}-${providerId}`;
+	return `_${tokenPrefix}-${providerId}`;
 }
 
 export const requestDomainVerification = (options: SSOOptions) => {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -25,6 +25,7 @@ import type { BindingContext } from "samlify/types/src/entity";
 import type { IdentityProvider } from "samlify/types/src/entity-idp";
 import type { FlowResult } from "samlify/types/src/flow";
 import z from "zod/v4";
+import { getVerificationIdentifier } from "./domain-verification";
 
 interface AuthnRequestRecord {
 	id: string;
@@ -864,9 +865,7 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 				await ctx.context.adapter.create<Verification>({
 					model: "verification",
 					data: {
-						identifier: options.domainVerification?.tokenPrefix
-							? `${options.domainVerification?.tokenPrefix}-${provider.providerId}`
-							: `better-auth-token-${provider.providerId}`,
+						identifier: getVerificationIdentifier(options, provider.providerId),
 						createdAt: new Date(),
 						updatedAt: new Date(),
 						value: domainVerificationToken as string,

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -253,9 +253,12 @@ export interface SSOOptions {
 		 */
 		enabled?: boolean;
 		/**
-		 * Prefix used to generate the domain verification token
+		 * Prefix used to generate the domain verification token.
+		 * An underscore is automatically prepended to follow DNS
+		 * infrastructure subdomain conventions (RFC 8552), so do
+		 * not include a leading underscore.
 		 *
-		 * @default "better-auth-token-"
+		 * @default "better-auth-token"
 		 */
 		tokenPrefix?: string;
 	};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes SSO domain verification by resolving TXT on a verification subdomain instead of the root domain. Adopts an underscore-prefixed identifier per RFC 8552 and adds a DNS label length check.

- **Bug Fixes**
  - Resolve TXT at "_<tokenPrefix>-<providerId>.<hostname>" instead of the root domain.
  - Enforce identifier length <= 63; return 400 with code IDENTIFIER_TOO_LONG.
  - Centralize identifier generation via getVerificationIdentifier; underscore is added automatically; default tokenPrefix is "better-auth-token".
  - Update docs and tests for underscore-prefixed subdomains, custom prefixes, and long provider IDs.

<sup>Written for commit eb935656e934743adda70e6d693a2ad356dc669c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

