### PR TITLE
fix: safely coerce date values from DB in OAuth provider plugin

### DIFF
--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -236,8 +236,8 @@ async function validateOpaqueAccessToken(
 		client_id: accessToken.clientId,
 		sub: user?.id,
 		sid: sessionId,
-		exp: Math.floor(accessToken.expiresAt.getTime() / 1000),
-		iat: Math.floor(accessToken.createdAt.getTime() / 1000),
+		exp: Math.floor(new Date(accessToken.expiresAt).getTime() / 1000),
+		iat: Math.floor(new Date(accessToken.createdAt).getTime() / 1000),
 		scope: accessToken.scopes?.join(" "),
 	} as JWTPayload;
 }
@@ -323,8 +323,8 @@ async function validateRefreshToken(
 		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
 		sub: user?.id,
 		sid: sessionId,
-		exp: Math.floor(refreshToken.expiresAt.getTime() / 1000),
-		iat: Math.floor(refreshToken.createdAt.getTime() / 1000),
+		exp: Math.floor(new Date(refreshToken.expiresAt).getTime() / 1000),
+		iat: Math.floor(new Date(refreshToken.createdAt).getTime() / 1000),
 		scope: refreshToken.scopes?.join(" "),
 	} as JWTPayload;
 }

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -356,10 +356,10 @@ export function schemaToOAuth(input: SchemaClient<Scope[]>): OAuthClient {
 
 	// Type conversions
 	const _expiresAt = expiresAt
-		? Math.round(expiresAt.getTime() / 1000)
+		? Math.round(new Date(expiresAt).getTime() / 1000)
 		: undefined;
 	const _createdAt = createdAt
-		? Math.round(createdAt.getTime() / 1000)
+		? Math.round(new Date(createdAt).getTime() / 1000)
 		: undefined;
 	const _scopes = scopes?.join(" ");
 	const _metadata = parseClientMetadata(metadata);


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/pull/7885

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely coerce DB date fields to Date in the OAuth provider so JWT exp/iat and client timestamps are computed correctly. Prevents crashes and wrong timestamps when DB drivers return strings.

- **Bug Fixes**
  - Wrap expiresAt/createdAt with new Date(...) before getTime() in token introspection and client registration.
  - Ensures consistent token introspection and registration across different DB drivers/ORMs.

<sup>Written for commit d3bb991166f9a86e70ec705f05cab3c9ef4dabd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

