### PR TITLE
chore: bump `better-call`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 1.1.21
       version: 1.1.21
     better-call:
-      specifier: 1.3.1
-      version: 1.3.1
+      specifier: 1.3.2
+      version: 1.3.2
     tsdown:
       specifier: ^0.20.1
       version: 0.20.1
@@ -1355,7 +1355,7 @@ importers:
         version: 5.22.0(prisma@5.22.0)
       better-call:
         specifier: 'catalog:'
-        version: 1.3.1(zod@4.3.6)
+        version: 1.3.2(zod@4.3.6)
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -1592,7 +1592,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 1.3.1(zod@4.3.6)
+        version: 1.3.2(zod@4.3.6)
       jose:
         specifier: ^6.1.0
         version: 6.1.3
@@ -1668,7 +1668,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 1.3.1(zod@4.3.6)
+        version: 1.3.2(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1882,7 +1882,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.3.1(zod@4.3.6)
+        version: 1.3.2(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1932,7 +1932,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.3.1(zod@4.3.6)
+        version: 1.3.2(zod@4.3.6)
       body-parser:
         specifier: ^2.2.2
         version: 2.2.2
@@ -1963,7 +1963,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 1.3.1(zod@4.3.6)
+        version: 1.3.2(zod@4.3.6)
       stripe:
         specifier: ^20.2.0
         version: 20.2.0(@types/node@25.2.0)
@@ -8632,8 +8632,8 @@ packages:
       zod:
         optional: true
 
-  better-call@1.3.1:
-    resolution: {integrity: sha512-Wtv4Z/pNTaG3KBpba6TEBAIRm0c6GyxlwsvnDiI8eDNdx+/OrLOc09EU4BtL8a/RSfEJcSlYpnn0W9w9mMBIVg==}
+  better-call@1.3.2:
+    resolution: {integrity: sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -13664,6 +13664,10 @@ packages:
 
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+    engines: {node: '>=0.6'}
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -25096,7 +25100,7 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  better-call@1.3.1(zod@4.3.6):
+  better-call@1.3.2(zod@4.3.6):
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
@@ -25149,7 +25153,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.14.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -31320,6 +31324,11 @@ snapshots:
   qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+    optional: true
 
   quansync@0.2.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ blockExoticSubdeps: true
 catalog:
   '@better-auth/utils': 0.3.1
   '@better-fetch/fetch': 1.1.21
-  better-call: 1.3.1
+  better-call: 1.3.2
   tsdown: ^0.20.1
   typescript: ^5.9.3
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded better-call to 1.3.2 across the workspace to pick up the latest fixes and maintain compatibility.
Updated pnpm lockfile; qs resolves to 6.14.2 via body-parser.

<sup>Written for commit 33ada2aee10ec62148bf64ceeceb8e14bd6b40cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

