### PR TITLE
fix: separate rate limit request and response handling

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -12,7 +12,7 @@ import { createRouter } from "better-call";
 import type { UnionToIntersection } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 import { originCheckMiddleware } from "./middlewares";
-import { onRequestRateLimit } from "./rate-limiter";
+import { onRequestRateLimit, onResponseRateLimit } from "./rate-limiter";
 import {
 	accountInfo,
 	callbackOAuth,
@@ -302,7 +302,8 @@ export const router = <Option extends BetterAuthOptions>(
 
 			return currentRequest;
 		},
-		async onResponse(res) {
+		async onResponse(res, req) {
+			await onResponseRateLimit(req, ctx);
 			for (const plugin of ctx.options.plugins || []) {
 				if (plugin.onResponse) {
 					const response = await plugin.onResponse(res, ctx);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Split rate limiting into a request pre-check and a response update to make limits accurate and the flow clearer. The request hook now only validates and can return 429; the response hook updates counters after the response.

- **Bug Fixes**
  - Added onResponseRateLimit and call it from router onResponse(req).
  - Request hook only checks limits and returns Retry-After when needed.
  - Response hook updates or resets counts; no limit checks there.
  - Shared resolveRateLimitConfig for both paths; skips when IP is missing.

<sup>Written for commit 05ca142064ed10b240eefeea2166afb5501f0f52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

