### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -202,7 +202,7 @@ See the [Hono integration documentation](/docs/integrations/hono#cloudflare-work
 
 ## Secondary Storage
 
-Secondary storage in Better Auth allows you to use key-value stores for managing session data, rate limiting counters, etc. This can be useful when you want to offload the storage of this intensive records to a high performance storage or even RAM.
+Secondary storage in Better Auth allows you to use key-value stores for managing session data, rate limiting counters, etc. This can be useful when you want to offload the storage of intensive records to a high performance storage or even RAM.
 
 ### Implementation
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed a wording typo in the “Secondary Storage” section of docs/concepts/database.mdx to improve clarity by changing “this intensive records” to “intensive records”.

<sup>Written for commit e2099f5236f07e6c0fb25a9f020a6c917386a0cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

