### PR TITLE
feat: add customizable password validation hook

### DIFF
--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -481,3 +481,77 @@ describe("verify password", async () => {
 		}
 	});
 });
+
+describe("forget password custom password validation", async () => {
+	let token = "";
+
+	const { client, testUser } = await getTestInstance({
+		emailAndPassword: {
+			enabled: true,
+			password: {
+				validate: (password) => password.includes("!"),
+			},
+			async sendResetPassword({ url }) {
+				token = url.split("?")[0]!.split("/").pop() || "";
+			},
+		},
+	});
+
+	it("should return PASSWORD_DOES_NOT_MATCH_REQUIREMENTS when custom validation fails", async () => {
+		await client.requestPasswordReset({
+			email: testUser.email,
+			redirectTo: "http://localhost:3000",
+		});
+
+		const res = await client.resetPassword(
+			{
+				newPassword: "invalidpassword",
+			},
+			{
+				query: {
+					token,
+				},
+			},
+		);
+
+		expect(res.error?.status).toBe(400);
+		expect(res.error?.code).toBe("PASSWORD_DOES_NOT_MATCH_REQUIREMENTS");
+	});
+});
+
+describe("forget password async custom password validation", async () => {
+	let token = "";
+
+	const { client, testUser } = await getTestInstance({
+		emailAndPassword: {
+			enabled: true,
+			password: {
+				validate: (async () => true) as any,
+			},
+			async sendResetPassword({ url }) {
+				token = url.split("?")[0]!.split("/").pop() || "";
+			},
+		},
+	});
+
+	it("should return ASYNC_VALIDATION_NOT_SUPPORTED for async validators", async () => {
+		await client.requestPasswordReset({
+			email: testUser.email,
+			redirectTo: "http://localhost:3000",
+		});
+
+		const res = await client.resetPassword(
+			{
+				newPassword: "validpassword!",
+			},
+			{
+				query: {
+					token,
+				},
+			},
+		);
+
+		expect(res.error?.status).toBe(400);
+		expect(res.error?.code).toBe("ASYNC_VALIDATION_NOT_SUPPORTED");
+	});
+});

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -489,7 +489,8 @@ describe("forget password custom password validation", async () => {
 		emailAndPassword: {
 			enabled: true,
 			password: {
-				validate: (password) => password.includes("!"),
+				validate: (password) =>
+					password === "test123456" || password.includes("!"),
 			},
 			async sendResetPassword({ url }) {
 				token = url.split("?")[0]!.split("/").pop() || "";
@@ -526,7 +527,8 @@ describe("forget password async custom password validation", async () => {
 		emailAndPassword: {
 			enabled: true,
 			password: {
-				validate: (async () => true) as any,
+				validate: ((password: string) =>
+					password === "test123456" ? true : Promise.resolve(true)) as any,
 			},
 			async sendResetPassword({ url }) {
 				token = url.split("?")[0]!.split("/").pop() || "";

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -4,7 +4,7 @@ import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import { generateId } from "@better-auth/core/utils/id";
 import * as z from "zod";
 import { getDate } from "../../utils/date";
-import { validatePassword } from "../../utils/password";
+import { assertPasswordPolicy, validatePassword } from "../../utils/password";
 import { originCheck } from "../middlewares";
 import { sensitiveSessionMiddleware } from "./session";
 
@@ -277,15 +277,7 @@ export const resetPassword = createAuthEndpoint(
 		}
 
 		const { newPassword } = ctx.body;
-
-		const minLength = ctx.context.password?.config.minPasswordLength;
-		const maxLength = ctx.context.password?.config.maxPasswordLength;
-		if (newPassword.length < minLength) {
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
-		}
-		if (newPassword.length > maxLength) {
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
-		}
+		assertPasswordPolicy(ctx, newPassword);
 
 		const id = `reset-password:${token}`;
 

--- a/packages/better-auth/src/api/routes/sign-up.test.ts
+++ b/packages/better-auth/src/api/routes/sign-up.test.ts
@@ -199,6 +199,33 @@ describe("sign-up with custom fields", async () => {
 	});
 });
 
+describe("sign-up custom password validation", async () => {
+	const { client } = await getTestInstance(
+		{
+			emailAndPassword: {
+				enabled: true,
+				password: {
+					validate: (password) => password.includes("!"),
+				},
+			},
+		},
+		{
+			disableTestUser: true,
+		},
+	);
+
+	it("should return PASSWORD_DOES_NOT_MATCH_REQUIREMENTS when custom validation fails", async () => {
+		const res = await client.signUp.email({
+			email: "validator-signup@test.com",
+			password: "invalidpassword",
+			name: "Validator User",
+		});
+
+		expect(res.error?.status).toBe(400);
+		expect(res.error?.code).toBe("PASSWORD_DOES_NOT_MATCH_REQUIREMENTS");
+	});
+});
+
 describe("sign-up CSRF protection", async () => {
 	const { auth } = await getTestInstance(
 		{

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -9,6 +9,7 @@ import { parseUserInput } from "../../db";
 import { parseUserOutput } from "../../db/schema";
 import type { AdditionalUserFieldsInput, User } from "../../types";
 import { isAPIError } from "../../utils/is-api-error";
+import { assertPasswordPolicy } from "../../utils/password";
 import { formCsrfMiddleware } from "../middlewares/origin-check";
 import { createEmailVerificationToken } from "./email-verification";
 
@@ -213,23 +214,8 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_PASSWORD);
 				}
 
-				const minPasswordLength = ctx.context.password.config.minPasswordLength;
-				if (password.length < minPasswordLength) {
-					ctx.context.logger.error("Password is too short");
-					throw APIError.from(
-						"BAD_REQUEST",
-						BASE_ERROR_CODES.PASSWORD_TOO_SHORT,
-					);
-				}
+				assertPasswordPolicy(ctx, password);
 
-				const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
-				if (password.length > maxPasswordLength) {
-					ctx.context.logger.error("Password is too long");
-					throw APIError.from(
-						"BAD_REQUEST",
-						BASE_ERROR_CODES.PASSWORD_TOO_LONG,
-					);
-				}
 				const dbUser = await ctx.context.internalAdapter.findUserByEmail(email);
 				if (dbUser?.user) {
 					ctx.context.logger.info(

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -455,14 +455,17 @@ describe("updateUser", async () => {
 });
 
 describe("changePassword custom password validation", async () => {
-	const { client, signInWithTestUser, testUser } = await getTestInstance({
-		emailAndPassword: {
-			enabled: true,
-			password: {
-				validate: (password) => password.includes("!"),
+	const { client, signInWithTestUser, testUser } = await getTestInstance(
+		{
+			emailAndPassword: {
+				enabled: true,
+				password: {
+					validate: (password) =>
+						password === "test123456" || password.includes("!"),
+				},
 			},
 		},
-	});
+	);
 
 	it("should return PASSWORD_DOES_NOT_MATCH_REQUIREMENTS when custom validation fails", async () => {
 		const { runWithUser } = await signInWithTestUser();

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -454,6 +454,31 @@ describe("updateUser", async () => {
 	});
 });
 
+describe("changePassword custom password validation", async () => {
+	const { client, signInWithTestUser, testUser } = await getTestInstance({
+		emailAndPassword: {
+			enabled: true,
+			password: {
+				validate: (password) => password.includes("!"),
+			},
+		},
+	});
+
+	it("should return PASSWORD_DOES_NOT_MATCH_REQUIREMENTS when custom validation fails", async () => {
+		const { runWithUser } = await signInWithTestUser();
+
+		await runWithUser(async () => {
+			const res = await client.changePassword({
+				newPassword: "invalidpassword",
+				currentPassword: testUser.password,
+			});
+
+			expect(res.error?.status).toBe(400);
+			expect(res.error?.code).toBe("PASSWORD_DOES_NOT_MATCH_REQUIREMENTS");
+		});
+	});
+});
+
 describe("delete user", async () => {
 	it("should not delete user if deleteUser is disabled", async () => {
 		const { client, signInWithTestUser } = await getTestInstance({

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -455,17 +455,15 @@ describe("updateUser", async () => {
 });
 
 describe("changePassword custom password validation", async () => {
-	const { client, signInWithTestUser, testUser } = await getTestInstance(
-		{
-			emailAndPassword: {
-				enabled: true,
-				password: {
-					validate: (password) =>
-						password === "test123456" || password.includes("!"),
-				},
+	const { client, signInWithTestUser, testUser } = await getTestInstance({
+		emailAndPassword: {
+			enabled: true,
+			password: {
+				validate: (password) =>
+					password === "test123456" || password.includes("!"),
 			},
 		},
-	);
+	});
 
 	it("should return PASSWORD_DOES_NOT_MATCH_REQUIREMENTS when custom validation fails", async () => {
 		const { runWithUser } = await signInWithTestUser();

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -6,6 +6,7 @@ import { deleteSessionCookie, setSessionCookie } from "../../cookies";
 import { generateRandomString } from "../../crypto";
 import { parseUserInput, parseUserOutput } from "../../db/schema";
 import type { AdditionalUserFieldsInput } from "../../types";
+import { assertPasswordPolicy } from "../../utils/password";
 import { originCheck } from "../middlewares";
 import { createEmailVerificationToken } from "./email-verification";
 import {
@@ -250,18 +251,7 @@ export const changePassword = createAuthEndpoint(
 	async (ctx) => {
 		const { newPassword, currentPassword, revokeOtherSessions } = ctx.body;
 		const session = ctx.context.session;
-		const minPasswordLength = ctx.context.password.config.minPasswordLength;
-		if (newPassword.length < minPasswordLength) {
-			ctx.context.logger.error("Password is too short");
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
-		}
-
-		const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
-
-		if (newPassword.length > maxPasswordLength) {
-			ctx.context.logger.error("Password is too long");
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
-		}
+		assertPasswordPolicy(ctx, newPassword);
 
 		const accounts = await ctx.context.internalAdapter.findAccounts(
 			session.user.id,
@@ -329,18 +319,7 @@ export const setPassword = createAuthEndpoint(
 	async (ctx) => {
 		const { newPassword } = ctx.body;
 		const session = ctx.context.session;
-		const minPasswordLength = ctx.context.password.config.minPasswordLength;
-		if (newPassword.length < minPasswordLength) {
-			ctx.context.logger.error("Password is too short");
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
-		}
-
-		const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
-
-		if (newPassword.length > maxPasswordLength) {
-			ctx.context.logger.error("Password is too long");
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
-		}
+		assertPasswordPolicy(ctx, newPassword);
 
 		const accounts = await ctx.context.internalAdapter.findAccounts(
 			session.user.id,

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -630,7 +630,7 @@ describe("base context creation", () => {
 			expect(res.password.validate).toBeUndefined();
 		});
 
-		it("should allow custom password length limits", async () => {
+		it("should allow custom password length limits and validation", async () => {
 			const customValidate = vi.fn((password: string) =>
 				/(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[^A-Za-z0-9]).+/.test(
 					password,

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -627,18 +627,28 @@ describe("base context creation", () => {
 			const res = await initBase({});
 			expect(res.password.config.minPasswordLength).toBe(8);
 			expect(res.password.config.maxPasswordLength).toBe(128);
+			expect(res.password.validate).toBeUndefined();
 		});
 
 		it("should allow custom password length limits", async () => {
+			const customValidate = vi.fn((password: string) =>
+				/(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[^A-Za-z0-9]).+/.test(
+					password,
+				),
+			);
 			const res = await initBase({
 				emailAndPassword: {
 					enabled: true,
 					minPasswordLength: 12,
 					maxPasswordLength: 256,
+					password: {
+						validate: customValidate,
+					},
 				},
 			});
 			expect(res.password.config.minPasswordLength).toBe(12);
 			expect(res.password.config.maxPasswordLength).toBe(256);
+			expect(res.password.validate).toBe(customValidate);
 		});
 
 		it("should use custom hash and verify functions", async () => {

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -293,6 +293,7 @@ Most of the features of Better Auth will not work correctly.`,
 		password: {
 			hash: options.emailAndPassword?.password?.hash || hashPassword,
 			verify: options.emailAndPassword?.password?.verify || verifyPassword,
+			validate: options.emailAndPassword?.password?.validate,
 			config: {
 				minPasswordLength: options.emailAndPassword?.minPasswordLength || 8,
 				maxPasswordLength: options.emailAndPassword?.maxPasswordLength || 128,

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -1025,7 +1025,8 @@ describe("Admin plugin custom password validation", async () => {
 			emailAndPassword: {
 				enabled: true,
 				password: {
-					validate: (password) => password.includes("!"),
+					validate: (password) =>
+						password === "test123456" || password.includes("!"),
 				},
 			},
 			plugins: [admin()],

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -167,7 +167,7 @@ describe("Admin plugin", async () => {
 			{
 				name: "Test User",
 				email: "user@email.com",
-				password: "test",
+				password: "test123!",
 				role: "user",
 			},
 			{
@@ -216,7 +216,7 @@ describe("Admin plugin", async () => {
 			{
 				name: "Test User mr",
 				email: "testmr@test.com",
-				password: "test",
+				password: "test123!",
 				role: ["user", "admin"],
 			},
 			{
@@ -250,7 +250,7 @@ describe("Admin plugin", async () => {
 			{
 				name: "Test User",
 				email: "test2@test.com",
-				password: "test",
+				password: "test123!",
 				role: "user",
 			},
 			{
@@ -1016,6 +1016,36 @@ describe("Admin plugin", async () => {
 		);
 		expect(res.error?.status).toBe(403);
 		expect(res.error?.code).toBe("YOU_ARE_NOT_ALLOWED_TO_UPDATE_USERS");
+	});
+});
+
+describe("Admin plugin custom password validation", async () => {
+	const { client, signInWithTestUser } = await getTestInstance({
+		emailAndPassword: {
+			enabled: true,
+			password: {
+				validate: (password) => password.includes("!"),
+			},
+		},
+		plugins: [admin()],
+	});
+
+	it("should reject admin createUser when custom validation fails", async () => {
+		const { headers } = await signInWithTestUser();
+		const res = await client.admin.createUser(
+			{
+				name: "Validation User",
+				email: "admin-validator@test.com",
+				password: "invalidpassword",
+				role: "user",
+			},
+			{
+				headers,
+			},
+		);
+
+		expect(res.error?.status).toBe(400);
+		expect(res.error?.code).toBe("PASSWORD_DOES_NOT_MATCH_REQUIREMENTS");
 	});
 });
 

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -506,7 +506,7 @@ describe("Admin plugin", async () => {
 			{
 				name: "Test User mr",
 				email: "testmr@test.com",
-				password: "test",
+				password: "test123!",
 				role: "user",
 			},
 			{
@@ -590,7 +590,7 @@ describe("Admin plugin", async () => {
 	it("should not allow banned user to sign in", async () => {
 		const res = await client.signIn.email({
 			email: newUser?.email || "",
-			password: "test",
+			password: "test123!",
 		});
 		expect(res.error?.code).toBe("BANNED_USER");
 		expect(res.error?.status).toBe(403);
@@ -629,7 +629,7 @@ describe("Admin plugin", async () => {
 	it("should change banned user message", async () => {
 		const res = await client.signIn.email({
 			email: newUser?.email || "",
-			password: "test",
+			password: "test123!",
 		});
 		expect(res.error?.message).toBe("Custom banned user message");
 	});
@@ -639,7 +639,7 @@ describe("Admin plugin", async () => {
 		await vi.advanceTimersByTimeAsync(60 * 60 * 24 * 1000);
 		const res = await client.signIn.email({
 			email: newUser?.email || "",
-			password: "test",
+			password: "test123!",
 		});
 		expect(res.data?.user).toBeDefined();
 	});
@@ -1030,10 +1030,29 @@ describe("Admin plugin custom password validation", async () => {
 				},
 			},
 			plugins: [admin()],
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => {
+							if (user.name === "Admin") {
+								return {
+									data: {
+										...user,
+										role: "admin",
+									},
+								};
+							}
+						},
+					},
+				},
+			},
 		},
 		{
 			clientOptions: {
 				plugins: [adminClient()],
+			},
+			testUser: {
+				name: "Admin",
 			},
 		},
 	);
@@ -1502,7 +1521,7 @@ describe("access control", async () => {
 			{
 				name: "Test User mr",
 				email: "testmr@test.com",
-				password: "test",
+				password: "test123!",
 				role: ["user"],
 			},
 			{
@@ -1533,7 +1552,7 @@ describe("access control", async () => {
 			{
 				name: "Test User mr",
 				email: "testmr@test.com",
-				password: "test",
+				password: "test123!",
 				role: "user",
 			},
 			{
@@ -1572,7 +1591,7 @@ describe("access control", async () => {
 			{
 				name: "Test User with Support Role",
 				email: "support-role@test.com",
-				password: "test",
+				password: "test123!",
 				role: "support", // This should be accepted as "support" is a custom role
 			},
 			{

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -1020,15 +1020,22 @@ describe("Admin plugin", async () => {
 });
 
 describe("Admin plugin custom password validation", async () => {
-	const { client, signInWithTestUser } = await getTestInstance({
-		emailAndPassword: {
-			enabled: true,
-			password: {
-				validate: (password) => password.includes("!"),
+	const { client, signInWithTestUser } = await getTestInstance(
+		{
+			emailAndPassword: {
+				enabled: true,
+				password: {
+					validate: (password) => password.includes("!"),
+				},
+			},
+			plugins: [admin()],
+		},
+		{
+			clientOptions: {
+				plugins: [adminClient()],
 			},
 		},
-		plugins: [admin()],
-	});
+	);
 
 	it("should reject admin createUser when custom validation fails", async () => {
 		const { headers } = await signInWithTestUser();

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -379,6 +379,7 @@ export const createUser = <O extends AdminOptions>(opts: O) =>
 			}
 			// Only create credential account if password is provided
 			if (ctx.body.password) {
+				assertPasswordPolicy(ctx, ctx.body.password);
 				const hashedPassword = await ctx.context.password.hash(
 					ctx.body.password,
 				);

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -15,6 +15,7 @@ import {
 } from "../../cookies";
 import { parseSessionOutput, parseUserOutput } from "../../db/schema";
 import { getDate } from "../../utils/date";
+import { assertPasswordPolicy } from "../../utils/password";
 import type { AccessControl } from "../access";
 import type { defaultStatements } from "./access";
 import { ADMIN_ERROR_CODES } from "./error-codes";
@@ -1529,16 +1530,7 @@ export const setUserPassword = (opts: AdminOptions) =>
 			}
 
 			const { newPassword, userId } = ctx.body;
-			const minPasswordLength = ctx.context.password.config.minPasswordLength;
-			if (newPassword.length < minPasswordLength) {
-				ctx.context.logger.error("Password is too short");
-				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
-			}
-			const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
-			if (newPassword.length > maxPasswordLength) {
-				ctx.context.logger.error("Password is too long");
-				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
-			}
+			assertPasswordPolicy(ctx, newPassword);
 			const hashedPassword = await ctx.context.password.hash(newPassword);
 			await ctx.context.internalAdapter.updatePassword(userId, hashedPassword);
 			return ctx.json({

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -605,6 +605,49 @@ describe("custom rate limiting storage", async () => {
 	});
 });
 
+describe("email-otp custom password validation", async () => {
+	let otp = "";
+	const { client, testUser } = await getTestInstance(
+		{
+			emailAndPassword: {
+				enabled: true,
+				password: {
+					validate: (password: string) => password.includes("!"),
+				},
+			},
+			plugins: [
+				emailOTP({
+					async sendVerificationOTP({ otp: _otp, type }) {
+						if (type === "forget-password") {
+							otp = _otp;
+						}
+					},
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [emailOTPClient()],
+			},
+		},
+	);
+
+	it("should return PASSWORD_DOES_NOT_MATCH_REQUIREMENTS when custom validation fails", async () => {
+		await client.emailOtp.requestPasswordReset({
+			email: testUser.email,
+		});
+
+		const res = await client.emailOtp.resetPassword({
+			email: testUser.email,
+			otp,
+			password: "invalidpassword",
+		});
+
+		expect(res.error?.status).toBe(400);
+		expect(res.error?.code).toBe("PASSWORD_DOES_NOT_MATCH_REQUIREMENTS");
+	});
+});
+
 describe("custom generate otpFn", async () => {
 	const { client, testUser } = await getTestInstance(
 		{

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -612,7 +612,8 @@ describe("email-otp custom password validation", async () => {
 			emailAndPassword: {
 				enabled: true,
 				password: {
-					validate: (password: string) => password.includes("!"),
+					validate: (password: string) =>
+						password === "test123456" || password.includes("!"),
 				},
 			},
 			plugins: [

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -7,6 +7,7 @@ import { setCookieCache, setSessionCookie } from "../../cookies";
 import { generateRandomString, symmetricDecrypt } from "../../crypto";
 import { parseUserInput, parseUserOutput } from "../../db/schema";
 import { getDate } from "../../utils/date";
+import { assertPasswordPolicy } from "../../utils/password";
 import { storeOTP, verifyStoredOTP } from "./otp-token";
 import type { EmailOTPOptions } from "./types";
 import { splitAtLastColon } from "./utils";
@@ -1011,14 +1012,7 @@ export const resetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			if (!user) {
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.USER_NOT_FOUND);
 			}
-			const minPasswordLength = ctx.context.password.config.minPasswordLength;
-			if (ctx.body.password.length < minPasswordLength) {
-				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
-			}
-			const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
-			if (ctx.body.password.length > maxPasswordLength) {
-				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
-			}
+			assertPasswordPolicy(ctx, ctx.body.password);
 			const passwordHash = await ctx.context.password.hash(ctx.body.password);
 			const account = user.accounts?.find(
 				(account) => account.providerId === "credential",

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -8,6 +8,7 @@ import { parseUserInput } from "../../db";
 import { parseUserOutput } from "../../db/schema";
 import type { User } from "../../types";
 import { getDate } from "../../utils/date";
+import { assertPasswordPolicy } from "../../utils/password";
 import { PHONE_NUMBER_ERROR_CODES } from "./error-codes";
 import type { PhoneNumberOptions, UserWithPhoneNumber } from "./types";
 
@@ -825,14 +826,7 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 					PHONE_NUMBER_ERROR_CODES.UNEXPECTED_ERROR,
 				);
 			}
-			const minLength = ctx.context.password.config.minPasswordLength;
-			const maxLength = ctx.context.password.config.maxPasswordLength;
-			if (ctx.body.newPassword.length < minLength) {
-				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
-			}
-			if (ctx.body.newPassword.length > maxLength) {
-				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
-			}
+			assertPasswordPolicy(ctx, ctx.body.newPassword);
 			const hashedPassword = await ctx.context.password.hash(
 				ctx.body.newPassword,
 			);

--- a/packages/better-auth/src/utils/password.ts
+++ b/packages/better-auth/src/utils/password.ts
@@ -15,11 +15,25 @@ export function assertPasswordPolicy(
 		throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 	}
 
-	if (ctx.context.password.validate && !ctx.context.password.validate(password)) {
-		throw APIError.from(
-			"BAD_REQUEST",
-			BASE_ERROR_CODES.PASSWORD_DOES_NOT_MATCH_REQUIREMENTS,
-		);
+	if (ctx.context.password.validate) {
+		const validationResult = ctx.context.password.validate(password);
+		if (
+			typeof validationResult === "object" &&
+			validationResult !== null &&
+			"then" in validationResult
+		) {
+			throw APIError.from(
+				"BAD_REQUEST",
+				BASE_ERROR_CODES.ASYNC_VALIDATION_NOT_SUPPORTED,
+			);
+		}
+
+		if (validationResult !== true) {
+			throw APIError.from(
+				"BAD_REQUEST",
+				BASE_ERROR_CODES.PASSWORD_DOES_NOT_MATCH_REQUIREMENTS,
+			);
+		}
 	}
 }
 

--- a/packages/better-auth/src/utils/password.ts
+++ b/packages/better-auth/src/utils/password.ts
@@ -1,6 +1,28 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 
+export function assertPasswordPolicy(
+	ctx: GenericEndpointContext,
+	password: string,
+) {
+	const { minPasswordLength, maxPasswordLength } = ctx.context.password.config;
+
+	if (password.length < minPasswordLength) {
+		throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
+	}
+
+	if (password.length > maxPasswordLength) {
+		throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
+	}
+
+	if (ctx.context.password.validate && !ctx.context.password.validate(password)) {
+		throw APIError.from(
+			"BAD_REQUEST",
+			BASE_ERROR_CODES.PASSWORD_DOES_NOT_MATCH_REQUIREMENTS,
+		);
+	}
+}
+
 export async function validatePassword(
 	ctx: GenericEndpointContext,
 	data: {

--- a/packages/core/src/error/codes.ts
+++ b/packages/core/src/error/codes.ts
@@ -33,6 +33,7 @@ export const BASE_ERROR_CODES = defineErrorCodes({
 	EMAIL_NOT_VERIFIED: "Email not verified",
 	PASSWORD_TOO_SHORT: "Password too short",
 	PASSWORD_TOO_LONG: "Password too long",
+	PASSWORD_DOES_NOT_MATCH_REQUIREMENTS: "Password does not match requirements",
 	USER_ALREADY_EXISTS: "User already exists.",
 	USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL:
 		"User already exists. Use another email.",

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -345,6 +345,7 @@ export type AuthContext<Options extends BetterAuthOptions = BetterAuthOptions> =
 			password: {
 				hash: (password: string) => Promise<string>;
 				verify: (data: { password: string; hash: string }) => Promise<boolean>;
+				validate?: (password: string) => boolean;
 				config: {
 					minPasswordLength: number;
 					maxPasswordLength: number;

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -615,6 +615,13 @@ export type BetterAuthOptions = {
 						hash: string;
 						password: string;
 					}) => Promise<boolean>;
+					/**
+					 * Custom password validator.
+					 *
+					 * Return `true` for valid passwords and `false` for invalid passwords.
+					 * The built-in min/max length checks are still applied before this validator.
+					 */
+					validate?: (password: string) => boolean;
 				};
 				/**
 				 * Automatically sign in the user after sign up

--- a/packages/telemetry/src/detectors/detect-auth-config.ts
+++ b/packages/telemetry/src/detectors/detect-auth-config.ts
@@ -34,6 +34,7 @@ export async function getTelemetryAuthConfig(
 			password: {
 				hash: !!options.emailAndPassword?.password?.hash,
 				verify: !!options.emailAndPassword?.password?.verify,
+				validate: !!options.emailAndPassword?.password?.validate,
 			},
 			autoSignIn: !!options.emailAndPassword?.autoSignIn,
 			revokeSessionsOnPasswordReset:


### PR DESCRIPTION
## Summary
- add support for a single custom password validation function via `emailAndPassword.password.validate`
- keep existing built-in min/max password length checks
- centralize password policy enforcement through `assertPasswordPolicy` across password-related flows
- return `PASSWORD_DOES_NOT_MATCH_REQUIREMENTS` when custom validation fails

## Why this approach
This follows maintainer feedback from [#2543](https://github.com/better-auth/better-auth/pull/2543):
- avoid adding many new password-complexity config flags
- prefer one extensible function hook

## Behavior
- built-in checks run first: `minPasswordLength` and `maxPasswordLength`
- if provided, `emailAndPassword.password.validate(password)` runs next
- on custom validation failure, API returns `PASSWORD_DOES_NOT_MATCH_REQUIREMENTS`

## Scope
Applied consistently to:
- sign-up
- reset password
- change/set password
- admin set-user-password
- email-otp reset password
- phone-number re
## Summrd

Closes #2484

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a customizable, sync-only password validation hook and enforce one password policy across all flows (sign-up; change/reset/set password; admin createUser/setUserPassword; email/phone OTP resets). Custom rules run after min/max length; async validators are rejected with clear errors.

- **New Features**
  - Added emailAndPassword.password.validate(password) hook (sync boolean).
  - Returns PASSWORD_DOES_NOT_MATCH_REQUIREMENTS on custom validation failure; ASYNC_VALIDATION_NOT_SUPPORTED for async validators.

- **Refactors**
  - Centralized checks via assertPasswordPolicy across all password flows, including admin createUser/setUserPassword and email/phone OTP resets.
  - Exposed validate in context/types and telemetry; removed inline length checks.

<sup>Written for commit 6579eabd1867f8347d28e26d3ae29e683ac814b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

