### PR TITLE
fix(stripe): prevent duplicate line item when priceId equals seatPriceId

### DIFF
--- a/packages/stripe/src/routes.ts
+++ b/packages/stripe/src/routes.ts
@@ -817,9 +817,7 @@ export const upgradeSubscription = (options: StripeOptions) => {
 								? [
 										{
 											price: priceIdToUse,
-											...(isAutoManagedSeats
-												? {}
-												: { quantity: ctx.body.seats || 1 }),
+											quantity: isAutoManagedSeats ? 1 : ctx.body.seats || 1,
 										},
 									]
 								: []),

--- a/packages/stripe/test/seat-based-billing.test.ts
+++ b/packages/stripe/test/seat-based-billing.test.ts
@@ -124,8 +124,10 @@ describe("seat-based billing", () => {
 
 			const createCall = mockStripe.checkout.sessions.create.mock.calls[0]?.[0];
 			expect(createCall).toBeDefined();
-			expect(createCall.line_items[0]).toEqual({ price: "price_team_base" });
-			expect(createCall.line_items[0]).not.toHaveProperty("quantity");
+			expect(createCall.line_items[0]).toEqual({
+				price: "price_team_base",
+				quantity: 1,
+			});
 			expect(createCall.line_items[1]).toMatchObject({
 				price: "price_team_seat",
 				quantity: expect.any(Number),
@@ -240,7 +242,10 @@ describe("seat-based billing", () => {
 			const createCall = mockStripe.checkout.sessions.create.mock.calls[0]?.[0];
 			expect(createCall).toBeDefined();
 			expect(createCall.line_items).toHaveLength(4); // base + seat + 2 meters
-			expect(createCall.line_items[0]).toEqual({ price: "price_pro_base" });
+			expect(createCall.line_items[0]).toEqual({
+				price: "price_pro_base",
+				quantity: 1,
+			});
 			expect(createCall.line_items[1]).toMatchObject({
 				price: "price_pro_seat",
 				quantity: expect.any(Number),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicate items for seat‑only Stripe plans and ensures base items include a quantity. Applies to checkout and portal upgrades so totals and Stripe requests are correct.

- **Bug Fixes**
  - Skip the base item when priceId === seatPriceId in checkout and portal upgrades to avoid duplicates.
  - Always send a quantity for the base item (quantity: 1 when seats are auto‑managed); updated tests for checkout and portal to reflect this.

<sup>Written for commit 4ba863dcb14006f3eba833a3a5cf0e0cbf0f6c45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

