### PR TITLE
fix(stripe): remove `getSubscriptionUsage` endpoint

### DIFF
--- a/packages/stripe/src/error-codes.ts
+++ b/packages/stripe/src/error-codes.ts
@@ -30,5 +30,4 @@ export const STRIPE_ERROR_CODES = defineErrorCodes({
 	ORGANIZATION_REFERENCE_ID_REQUIRED:
 		"Reference ID is required. Provide referenceId or set activeOrganizationId in session",
 	UNKNOWN_METER: "Unknown meter event name",
-	METER_ID_NOT_FOUND: "Could not resolve Stripe Meter ID for event name",
 });

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -9,7 +9,6 @@ import {
 	cancelSubscription,
 	cancelSubscriptionCallback,
 	createBillingPortal,
-	getSubscriptionUsage,
 	ingestSubscriptionUsage,
 	listActiveSubscriptions,
 	restoreSubscription,
@@ -47,7 +46,6 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 		subscriptionSuccess: subscriptionSuccess(options),
 		createBillingPortal: createBillingPortal(options),
 		stripeIngestUsage: ingestSubscriptionUsage(options),
-		stripeGetUsage: getSubscriptionUsage(options),
 	};
 
 	return {

--- a/packages/stripe/src/utils.ts
+++ b/packages/stripe/src/utils.ts
@@ -107,29 +107,6 @@ export async function resolvePlanItem(
 }
 
 /**
- * Create a meter ID resolver scoped to a Stripe client instance.
- * Results are cached with a 5-minute TTL.
- */
-export function createMeterIdResolver(stripeClient: Stripe) {
-	let cache: Map<string, string> | null = null;
-	let expiry = 0;
-
-	return async (): Promise<Map<string, string>> => {
-		if (cache && Date.now() < expiry) return cache;
-		const result = new Map<string, string>();
-		for await (const meter of stripeClient.billing.meters.list({
-			status: "active",
-			limit: 100,
-		})) {
-			result.set(meter.event_name, meter.id);
-		}
-		cache = result;
-		expiry = Date.now() + 5 * 60 * 1000; // 5 min
-		return cache;
-	};
-}
-
-/**
  * Validate that the given event name is registered in any plan's meters.
  */
 export function validateEventName(


### PR DESCRIPTION
It doesn't seem very valuable to handle aggregation at the plugin level, since most people will likely customize and build their own dashboards anyway.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the getSubscriptionUsage endpoint and related utilities to simplify the Stripe plugin API and avoid plugin-level aggregation. Fetch usage data directly from Stripe when building dashboards.

- **Refactors**
  - Removed /subscription/usage route and stripeGetUsage export.
  - Deleted createMeterIdResolver and the METER_ID_NOT_FOUND error code.
  - Cleaned up related tests.

- **Migration**
  - Replace any client.subscription.usage or stripeGetUsage calls with direct Stripe Billing Meters queries (e.g., listEventSummaries).
  - If you relied on createMeterIdResolver, move meter ID resolution/caching into your app.
  - Remove references to STRIPE_ERROR_CODES.METER_ID_NOT_FOUND.

<sup>Written for commit 2ed01b172648fa5b36a9aae4a065bd204cf6958c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

