### PR TITLE
fix(stripe): propagate trial data in subscription webhook handlers

### DIFF
--- a/packages/stripe/src/hooks.ts
+++ b/packages/stripe/src/hooks.ts
@@ -322,9 +322,18 @@ export async function onSubscriptionUpdated(
 				)
 			: subscriptionItem.quantity;
 
+		const trial =
+			subscriptionUpdated.trial_start && subscriptionUpdated.trial_end
+				? {
+						trialStart: new Date(subscriptionUpdated.trial_start * 1000),
+						trialEnd: new Date(subscriptionUpdated.trial_end * 1000),
+					}
+				: {};
+
 		const updatedSubscription = await ctx.context.adapter.update<Subscription>({
 			model: "subscription",
 			update: {
+				...trial,
 				...(plan
 					? {
 							plan: plan.name.toLowerCase(),
@@ -414,6 +423,13 @@ export async function onSubscriptionDeleted(
 			],
 		});
 		if (subscription) {
+			const trial =
+				subscriptionDeleted.trial_start && subscriptionDeleted.trial_end
+					? {
+							trialStart: new Date(subscriptionDeleted.trial_start * 1000),
+							trialEnd: new Date(subscriptionDeleted.trial_end * 1000),
+						}
+					: {};
 			await ctx.context.adapter.update({
 				model: "subscription",
 				where: [
@@ -423,6 +439,7 @@ export async function onSubscriptionDeleted(
 					},
 				],
 				update: {
+					...trial,
 					status: "canceled",
 					updatedAt: new Date(),
 					cancelAtPeriodEnd: subscriptionDeleted.cancel_at_period_end,


### PR DESCRIPTION
Closes https://github.com/better-auth/better-auth/issues/6863
Related to https://github.com/better-auth/better-auth/issues/6863#issuecomment-3879020482