### PR TITLE
docs: add test-utils plugin to sidebar navigation

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -5,6 +5,7 @@ import {
 	Book,
 	CircleHelp,
 	Database,
+	FlaskConical,
 	Gauge,
 	Key,
 	KeyRound,
@@ -2004,6 +2005,12 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 					</svg>
 				),
 				href: "/docs/plugins/jwt",
+			},
+			{
+				title: "Test Utils",
+				href: "/docs/plugins/test-utils",
+				icon: () => <FlaskConical className="w-4 h-4" />,
+				isNew: true,
 			},
 			{
 				title: "Payments",


### PR DESCRIPTION
## Summary
- The test-utils plugin was added in #7746 but was missing from the docs sidebar navigation
- Adds "Test Utils" entry to the **Utility** plugin group in `sidebar-content.tsx` with a `FlaskConical` icon and `isNew` badge

## Test plan
- [ ] Verify the test-utils plugin appears in the sidebar under **Plugins > Utility**
- [ ] Verify clicking the sidebar entry navigates to `/docs/plugins/test-utils`
- [ ] Verify the "New" badge is shown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “Test Utils” to the docs sidebar under Plugins > Utility so it’s easy to find.
Links to /docs/plugins/test-utils and shows a flask icon with a “New” badge.

<sup>Written for commit 5fa95f0ef5f95f246b0898158d8f71a3900364af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

