### PR TITLE
fix(core): exclude tsconfig.json from published package 

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,8 @@
     "directory": "packages/core"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Closes #7956

The `@better-auth/core` package currently publishes its internal tsconfig.json because it lacks a files whitelist in package.json. This causes editor type resolution errors for consumers, as the published tsconfig.json attempts to extend a tsconfig.base.json file that does not exist in the npm package tree.

This PR restricts the published files to the dist directory, ensuring internal configuration files are excluded from the registry.

Changes
- Added "files": ["dist"] to packages/core/package.json.

This aligns `@better-auth/core` with the publishing strategy used in the main better-auth package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Whitelist dist and src for @better-auth/core publishing to exclude internal config files like tsconfig.json and support dev-source resolution. Fixes editor TypeScript resolution errors caused by the previously published tsconfig.json extending a non-existent tsconfig.base.json (closes #7956).

<sup>Written for commit a220ae68a6dffa7505f8f0b14620307f0107f2c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

