### PR TITLE
fix(email-otp): avoid user enumeration when disabled sign-up

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -676,7 +676,7 @@ export const signInEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			const user = await ctx.context.internalAdapter.findUserByEmail(email);
 			if (!user) {
 				if (opts.disableSignUp) {
-					throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.USER_NOT_FOUND);
+					throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 				}
 				const additionalFields = parseUserInput(
 					ctx.context.options,


### PR DESCRIPTION
closes #7944

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When sign-up is disabled, email OTP sign-in now returns INVALID_OTP instead of USER_NOT_FOUND. This prevents leaking whether an email exists and standardizes the error response.

<sup>Written for commit e2abc2d1972eb58966a98c96cfa0e581bc791032. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

