### PR TITLE
fix: Updated incorrect import

### DIFF
--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -450,8 +450,7 @@ A middleware that checks if the client has a valid session. If the client has a 
 
 ```ts title="plugin.ts"
 import type { BetterAuthPlugin } from "better-auth";
-import { createAuthEndpoint } from "better-auth/plugins";
-import { sessionMiddleware } from "better-auth/api";
+import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
 
 const myPlugin = () => {
     return {


### PR DESCRIPTION
The import was missing for `createAuthEndpoint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the plugins docs example by replacing the incorrect createAuthMiddleware import and consolidating imports. The snippet now imports createAuthEndpoint and sessionMiddleware from better-auth/api, making it accurate and compilable.

<sup>Written for commit 2f082eac36511b769a1371fbf4d11754ea7248d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

