### PR TITLE
docs: document Safari ITP blocks third-party cookies

### DIFF
--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -155,7 +155,7 @@ This makes the request appear first-party to Safari, allowing cookies to functio
 
 ```ts title="vercel.json"
 {
-  "redirects": [
+  "rewrites": [
     {
       "source": "/api/:path*",
       "destination": "https://domainA.com/api/:path*"
@@ -173,13 +173,7 @@ https://app.example.com
 https://api.example.com
 ```
 
-Then, configure cookies with:
-
-```
-Domain=.example.com
-SameSite=Lax (or None if required)
-Secure=true
-```
+Then, enable cross-subdomain cookies with the domain:
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"
@@ -189,13 +183,11 @@ export const auth = betterAuth({
         crossSubDomainCookies: {
             enabled: true,
             domain: "example.com",
-            attributes: {
-                sameSite: "lax",
-                secure: true,
-            },
         },
     },
 })
 ```
+
+Learn more about cross-subdomain cookies in the [documentation above](#cross-subdomain-cookies).
 
 This avoids Safari treating the API as third-party.


### PR DESCRIPTION
Documents Safari behaviour around  a privacy feature called Intelligent Tracking Prevention (ITP) that blocks third-party cookies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how Safari ITP blocks third‑party cookies in cross‑domain auth setups and how to avoid session failures. Adds reverse proxy examples (Netlify/Vercel) and explains using a shared parent domain with cross‑subdomain cookies; fixes minor errors.

<sup>Written for commit 66cad48877ae0838b40d6f49c33b0ac91af8b52e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

