### PR TITLE
fix(captcha): include error codes in middleware responses

### DIFF
--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -39,6 +39,7 @@ export const captcha = (options: CaptchaOptions) =>
 				if (!captchaResponse) {
 					return middlewareResponse({
 						message: EXTERNAL_ERROR_CODES.MISSING_RESPONSE.message,
+						code: EXTERNAL_ERROR_CODES.MISSING_RESPONSE.code,
 						status: 400,
 					});
 				}
@@ -88,6 +89,7 @@ export const captcha = (options: CaptchaOptions) =>
 
 				return middlewareResponse({
 					message: EXTERNAL_ERROR_CODES.UNKNOWN_ERROR.message,
+					code: EXTERNAL_ERROR_CODES.UNKNOWN_ERROR.code,
 					status: 500,
 				});
 			}

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/captchafox.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/captchafox.ts
@@ -55,6 +55,7 @@ export const captchaFox = async ({
 	if (!response.data.success) {
 		return middlewareResponse({
 			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.message,
+			code: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.code,
 			status: 403,
 		});
 	}

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/cloudflare-turnstile.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/cloudflare-turnstile.ts
@@ -47,6 +47,7 @@ export const cloudflareTurnstile = async ({
 	if (!response.data.success) {
 		return middlewareResponse({
 			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.message,
+			code: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.code,
 			status: 403,
 		});
 	}

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/google-recaptcha.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/google-recaptcha.ts
@@ -67,6 +67,7 @@ export const googleRecaptcha = async ({
 	) {
 		return middlewareResponse({
 			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.message,
+			code: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.code,
 			status: 403,
 		});
 	}

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/h-captcha.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/h-captcha.ts
@@ -60,6 +60,7 @@ export const hCaptcha = async ({
 	if (!response.data.success) {
 		return middlewareResponse({
 			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.message,
+			code: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.code,
 			status: 403,
 		});
 	}

--- a/packages/better-auth/src/utils/middleware-response.ts
+++ b/packages/better-auth/src/utils/middleware-response.ts
@@ -1,12 +1,14 @@
 type Params = {
 	message: string;
 	status: number;
+	code: string;
 };
 
-export const middlewareResponse = ({ message, status }: Params) => ({
+export const middlewareResponse = ({ message, status, code }: Params) => ({
 	response: new Response(
 		JSON.stringify({
 			message,
+			code,
 		}),
 		{
 			status,


### PR DESCRIPTION
Fixes: https://github.com/better-auth/better-auth/issues/7969

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include error codes in all captcha middleware responses so clients can reliably handle failures. The JSON body now returns message and code across all providers.

- **Bug Fixes**
  - middlewareResponse now accepts and returns code in the response body.
  - All captcha handlers send specific codes: MISSING_RESPONSE (400), VERIFICATION_FAILED (403 for CaptchaFox, Cloudflare Turnstile, Google reCAPTCHA, hCaptcha), and UNKNOWN_ERROR (500).

<sup>Written for commit 2b8ae7194b49034fb74ab2b0d4523ef04f4945d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

