### PR TITLE
docs: add better-email to community plugins

### DIFF
--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -323,6 +323,16 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/C-W-D-Harshit.png",
 		},
 	},
+	{
+		name: "@nuntly/better-email",
+		url: "https://github.com/nuntly/better-email",
+		description: "Better Auth emails made simple with Better Email.",
+		author: {
+			name: "obazoud",
+			github: "nuntly",
+			avatar: "https://github.com/obazoud.png",
+		},
+	},
 ];
 export function CommunityPluginsTable() {
 	const [sorting, setSorting] = useState<SortingState>([]);


### PR DESCRIPTION
* Add `better-email` to the community plugins table
* It si a new Better Auth plugin that centralizes all email sending callbacks through a single ESP-agnostic provider and template renderer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `@nuntly/better-email` to the community plugins table. This surfaces a Better Auth plugin that centralizes all email sending callbacks through an ESP-agnostic provider and template renderer.

<sup>Written for commit 76a9588861c2bb53743a77bb6312e24a9a8d53aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

