### PR TITLE
docs(admin.mdx): export const ac

### DIFF
--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -503,7 +503,7 @@ The plugin provides an easy way to define your own set of permissions for each r
         project: ["create", "share", "update", "delete"], // <-- Permissions available for created roles
     } as const;
 
-    const ac = createAccessControl(statement);
+    export const ac = createAccessControl(statement);
 
     export const user = ac.newRole({ // [!code highlight]
         project: ["create"], // [!code highlight]


### PR DESCRIPTION
The const ac need to be exported, if we'd like to import it elsewhere

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export ac in the admin plugin docs example so it can be imported elsewhere. Changes const ac = createAccessControl(statement) to export const ac = createAccessControl(statement).

<sup>Written for commit 5416895571f81ec671bbcc9450120dd46be3af17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

