### PR TITLE
chore(sso): add missing option types to sso plugin types

### DIFF
--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -145,6 +145,7 @@ export function sso<O extends SSOOptions>(
 ): {
 	id: "sso";
 	endpoints: SSOEndpoints<O>;
+	options: O;
 };
 
 export function sso<O extends SSOOptions>(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add options: O to the sso() return type so consumers have typed access to SSO options. Improves inference and prevents TypeScript errors when reading plugin options.

<sup>Written for commit e2e25867005f9cdcf6e359661c1ba73c13c4fba2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

