### PR TITLE
chore: release should run on github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   release:
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the release workflow to GitHub-hosted runners by changing runs-on from starsling-ubuntu-24.04 to ubuntu-latest. This unblocks the release job and ensures a consistent, maintained runner environment.

<sup>Written for commit b1432f4be99ff0d36a0050ec9a4da343f0510482. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

