### PR TITLE
fix(organization): add opt-in role restriction for getFullOrganization endpoint

### DIFF
--- a/packages/better-auth/src/plugins/organization/error-codes.ts
+++ b/packages/better-auth/src/plugins/organization/error-codes.ts
@@ -90,4 +90,6 @@ export const ORGANIZATION_ERROR_CODES = defineErrorCodes({
 	CANNOT_DELETE_A_PRE_DEFINED_ROLE: "Cannot delete a pre-defined role",
 	ROLE_IS_ASSIGNED_TO_MEMBERS:
 		"Cannot delete a role that is assigned to members. Please reassign the members to a different role first",
+	YOU_ARE_NOT_ALLOWED_TO_READ_THIS_ORGANIZATION:
+		"You are not allowed to read this organization",
 });

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -3445,3 +3445,132 @@ describe("organization additionalFields with returned: false", async () => {
 		expect(dbOrg?.secretField).toBe("updated-secret");
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/6038
+ */
+describe("fullOrganizationAccessRoles", async () => {
+	const { auth, signInWithTestUser, signInWithUser } = await getTestInstance({
+		plugins: [
+			organization({
+				fullOrganizationAccessRoles: ["owner", "admin"],
+				async sendInvitationEmail() {},
+			}),
+		],
+	});
+
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	const memberUser = {
+		email: "member-restricted@test.com",
+		password: "test123456",
+		name: "member-restricted",
+	};
+	const adminUser = {
+		email: "admin-restricted@test.com",
+		password: "test123456",
+		name: "admin-restricted",
+	};
+
+	const { headers: ownerHeaders } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "restricted-org",
+			slug: "restricted-org",
+		},
+		{ headers: ownerHeaders },
+	);
+	const organizationId = org.data!.id;
+
+	await client.signUp.email({
+		email: memberUser.email,
+		password: memberUser.password,
+		name: memberUser.name,
+	});
+	await client.signUp.email({
+		email: adminUser.email,
+		password: adminUser.password,
+		name: adminUser.name,
+	});
+
+	const memberInvite = await client.organization.inviteMember(
+		{
+			organizationId,
+			email: memberUser.email,
+			role: "member",
+		},
+		{ headers: ownerHeaders },
+	);
+	const adminInvite = await client.organization.inviteMember(
+		{
+			organizationId,
+			email: adminUser.email,
+			role: "admin",
+		},
+		{ headers: ownerHeaders },
+	);
+
+	const { headers: memberHeaders } = await signInWithUser(
+		memberUser.email,
+		memberUser.password,
+	);
+	await client.organization.acceptInvitation({
+		invitationId: memberInvite.data!.id!,
+		fetchOptions: { headers: memberHeaders },
+	});
+
+	const { headers: adminHeaders } = await signInWithUser(
+		adminUser.email,
+		adminUser.password,
+	);
+	await client.organization.acceptInvitation({
+		invitationId: adminInvite.data!.id!,
+		fetchOptions: { headers: adminHeaders },
+	});
+
+	it("should allow owner to get full organization", async () => {
+		const { headers } = await signInWithTestUser();
+		const org = await client.organization.getFullOrganization({
+			query: { organizationId },
+			fetchOptions: { headers },
+		});
+		expect(org.data).toBeDefined();
+		expect(org.data?.members.length).toBe(3);
+	});
+
+	it("should allow admin to get full organization", async () => {
+		const { headers } = await signInWithUser(
+			adminUser.email,
+			adminUser.password,
+		);
+		await client.organization.setActive({ organizationId }, { headers });
+		const org = await client.organization.getFullOrganization({
+			query: { organizationId },
+			fetchOptions: { headers },
+		});
+		expect(org.data).toBeDefined();
+		expect(org.data?.members.length).toBe(3);
+	});
+
+	it("should deny member from getting full organization", async () => {
+		const { headers } = await signInWithUser(
+			memberUser.email,
+			memberUser.password,
+		);
+		await client.organization.setActive({ organizationId }, { headers });
+		const org = await client.organization.getFullOrganization({
+			query: { organizationId },
+			fetchOptions: { headers },
+		});
+		expect(org.error?.status).toBe(403);
+		expect(org.data).toBeNull();
+	});
+});

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -703,16 +703,30 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 					ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,
 				);
 			}
-			const isMember = await adapter.checkMembership({
+			const member = await adapter.findMemberByOrgId({
 				userId: session.user.id,
 				organizationId: organization.id,
 			});
-			if (!isMember) {
+			if (!member) {
 				await adapter.setActiveOrganization(session.session.token, null, ctx);
 				throw APIError.from(
 					"FORBIDDEN",
 					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
 				);
+			}
+
+			const allowedRoles = options?.fullOrganizationAccessRoles;
+			if (allowedRoles) {
+				const memberRoles = member.role.split(",");
+				const hasAllowedRole = memberRoles.some((role) =>
+					allowedRoles.includes(role),
+				);
+				if (!hasAllowedRole) {
+					throw APIError.from(
+						"FORBIDDEN",
+						ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_READ_THIS_ORGANIZATION,
+					);
+				}
 			}
 
 			type OrganizationReturn = O["teams"] extends { enabled: true }

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -335,6 +335,13 @@ export interface OrganizationOptions {
 		  }
 		| undefined;
 	/**
+	 * Roles allowed to access full organization data via
+	 * `getFullOrganization`. If not set, all members can access.
+	 *
+	 * @default undefined
+	 */
+	fullOrganizationAccessRoles?: string[] | undefined;
+	/**
 	 * Disable organization deletion
 	 *
 	 * @default false


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an opt-in role restriction to getFullOrganization so only specified roles can read full organization data. Default stays the same: all members can access unless you set fullOrganizationAccessRoles.

- **New Features**
  - Added OrganizationOptions.fullOrganizationAccessRoles to configure allowed roles.
  - Enforced role check in getFullOrganization; returns 403 with YOU_ARE_NOT_ALLOWED_TO_READ_THIS_ORGANIZATION when blocked.
  - Switched membership lookup to findMemberByOrgId to access role data.
  - Added tests validating owner/admin access and member denial.

<sup>Written for commit b048c3238331ddd181295134389999f49e97560a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

