### PR TITLE
fix(expo): support wildcard trusted origins in deep link cookie injection

### DIFF
--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -74,12 +74,19 @@ export const expo = (options?: ExpoOptions | undefined) => {
 						if (isProxyURL) {
 							return;
 						}
-						const trustedOrigins = ctx.context.trustedOrigins.filter(
-							(origin: string) => !origin.startsWith("http"),
-						);
-						const isTrustedOrigin = trustedOrigins.some((origin: string) =>
-							location?.startsWith(origin),
-						);
+						let redirectURL: URL;
+						try {
+							redirectURL = new URL(location);
+						} catch {
+							return;
+						}
+						const isHttpRedirect =
+							redirectURL.protocol === "http:" ||
+							redirectURL.protocol === "https:";
+						if (isHttpRedirect) {
+							return;
+						}
+						const isTrustedOrigin = ctx.context.isTrustedOrigin(location);
 						if (!isTrustedOrigin) {
 							return;
 						}
@@ -87,9 +94,8 @@ export const expo = (options?: ExpoOptions | undefined) => {
 						if (!cookie) {
 							return;
 						}
-						const url = new URL(location);
-						url.searchParams.set("cookie", cookie);
-						ctx.setHeader("location", url.toString());
+						redirectURL.searchParams.set("cookie", cookie);
+						ctx.setHeader("location", redirectURL.toString());
 					}),
 				},
 			],

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -780,6 +780,7 @@ describe("expo deep link cookie injection", async () => {
 			callbackURL: "myapp:///dashboard",
 		});
 
+		let redirectHandled = false;
 		const { error } = await client.magicLink.verify({
 			query: {
 				token: magicLinkToken,
@@ -787,6 +788,7 @@ describe("expo deep link cookie injection", async () => {
 			},
 			fetchOptions: {
 				onError(context) {
+					redirectHandled = true;
 					expect(context.response.status).toBe(302);
 					const location = context.response.headers.get("location");
 					expect(location).toContain("myapp://");
@@ -798,7 +800,73 @@ describe("expo deep link cookie injection", async () => {
 				},
 			},
 		});
-		expect(error).toBeDefined();
+		expect(redirectHandled).toBe(true);
+		expect(error?.status).toBe(302);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/6810
+ */
+describe("expo deep link cookie injection with wildcard trustedOrigins", async () => {
+	let magicLinkToken = "";
+	const storage = new Map<string, string>();
+
+	const { client } = await getTestInstance(
+		{
+			plugins: [
+				expo(),
+				magicLink({
+					async sendMagicLink({ token }) {
+						magicLinkToken = token;
+					},
+				}),
+			],
+			trustedOrigins: ["myapp://*"],
+		},
+		{
+			clientOptions: {
+				plugins: [
+					expoClient({
+						storage: {
+							getItem: (key) => storage.get(key) || null,
+							setItem: async (key, value) => storage.set(key, value),
+						},
+					}),
+					magicLinkClient(),
+				],
+			},
+		},
+	);
+
+	it("should inject cookie into deep link for wildcard trusted origin", async () => {
+		await client.signIn.magicLink({
+			email: "wildcard-test@example.com",
+			callbackURL: "myapp:///dashboard",
+		});
+
+		let redirectHandled = false;
+		const { error } = await client.magicLink.verify({
+			query: {
+				token: magicLinkToken,
+				callbackURL: "myapp:///dashboard",
+			},
+			fetchOptions: {
+				onError(context) {
+					redirectHandled = true;
+					expect(context.response.status).toBe(302);
+					const location = context.response.headers.get("location");
+					expect(location).toContain("myapp://");
+
+					const url = new URL(location!);
+					const cookie = url.searchParams.get("cookie");
+					expect(cookie).toBeDefined();
+					expect(cookie).toContain("better-auth.session_token");
+				},
+			},
+		});
+		expect(redirectHandled).toBe(true);
+		expect(error?.status).toBe(302);
 	});
 });
 
@@ -844,6 +912,7 @@ describe("expo deep link cookie injection for verify-email", async () => {
 
 		expect(verificationToken).toBeTruthy();
 
+		let redirectHandled = false;
 		const { error } = await client.verifyEmail(
 			{
 				query: {
@@ -853,6 +922,7 @@ describe("expo deep link cookie injection for verify-email", async () => {
 			},
 			{
 				onError(context) {
+					redirectHandled = true;
 					expect(context.response.status).toBe(302);
 					const location = context.response.headers.get("location");
 					expect(location).toContain("myapp://");
@@ -864,7 +934,8 @@ describe("expo deep link cookie injection for verify-email", async () => {
 				},
 			},
 		);
-		expect(error).toBeDefined();
+		expect(redirectHandled).toBe(true);
+		expect(error?.status).toBe(302);
 	});
 });
 


### PR DESCRIPTION
Related to https://github.com/better-auth/better-auth/issues/6810#issuecomment-3910276678

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds wildcard support for trusted origins in Expo deep link cookie injection and hardens redirect handling to only process app scheme links. Fixes cookie injection for patterns like myapp://* and prevents injection on http/https redirects.

- **Bug Fixes**
  - Use ctx.context.isTrustedOrigin to correctly handle wildcard trustedOrigins.
  - Safely parse redirect URL; skip malformed and http/https redirects before injecting cookies.
  - Expand tests to cover wildcard origins and verify-email flows, asserting 302 and cookie in Location.

<sup>Written for commit 72aa53cf64858a030c44e227ccc65f30a973a460. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

