### PR TITLE
fix(admin): optional chain `user` in hooks

### DIFF
--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -93,7 +93,7 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 									}
 									const user = (await ctx.context.internalAdapter.findUserById(
 										session.userId,
-									)) as UserWithRole;
+									)) as UserWithRole | null;
 
 									if (user?.banned) {
 										if (


### PR DESCRIPTION
closes #8022

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented admin hook crashes when no user is found by allowing a null user and guarding ban checks with optional chaining. Aligns with #8022 to handle missing users safely.

- **Bug Fixes**
  - Cast findUserById to UserWithRole | null.
  - Use user?.banned to avoid accessing properties on null.

<sup>Written for commit fb011ba8115913cb95f9128e4bf6381bf2bed3d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

