### PR TITLE
test(oauth-provider): update remaining consent response assertions from uri to url

### DIFF
--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -978,18 +978,18 @@ describe("oauth - prompt", async () => {
 		);
 
 		expect(consentRes.redirect).toBeTruthy();
-		expect(consentRes.uri).toContain(redirectUri);
-		expect(consentRes.uri).toContain(`code=`);
-		expect(consentRes.uri).not.toContain(`/consent`);
+		expect(consentRes.url).toContain(redirectUri);
+		expect(consentRes.url).toContain(`code=`);
+		expect(consentRes.url).not.toContain(`/consent`);
 
 		// Exchange code for tokens and verify narrowed scopes
-		const callbackUrl = new URL(consentRes.uri);
+		const callbackUrl = new URL(consentRes.url);
 		const code = callbackUrl.searchParams.get("code")!;
 		expect(code).toBeTruthy();
 
 		// Follow the RP callback to exchange the code for tokens
 		let authToken: string | undefined;
-		await client.$fetch(consentRes.uri, {
+		await client.$fetch(consentRes.url, {
 			method: "GET",
 			headers: oauthHeaders,
 			onError(context) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated oauth-provider consent response tests to use url instead of uri, aligning with the current response shape and preventing failures in the prompt consent flow.
Replaced consentRes.uri with consentRes.url in assertions, callback URL parsing, and fetch calls.

<sup>Written for commit f449605a5ff9cb7cccdf200074ca80095a2220c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

