### PR TITLE
Fix account linking example

### DIFF
--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -408,7 +408,7 @@ Then whenever you retrieve back the account make sure to decrypt the tokens befo
 
 ### Account Linking
 
-Account linking enables users to associate multiple authentication methods with a single account. With Better Auth, users can connect additional social sign-ons or OAuth providers to their existing accounts if the provider confirms the user's email as verified.
+Account linking is [enabled by default](https://www.better-auth.com/docs/reference/options#accountlinking) and lets users associate multiple authentication methods with a single account. With Better Auth, users can connect additional social sign-ons or OAuth providers to their existing accounts if the provider confirms the user's email as verified.
 
 If account linking is disabled, no accounts can be linked, regardless of the provider or email verification status.
 
@@ -418,7 +418,7 @@ import { betterAuth } from "better-auth";
 export const auth = betterAuth({
     account: {
         accountLinking: {
-            enabled: true, 
+            enabled: false, 
         }
     },
 });


### PR DESCRIPTION
It should describe disabled use case. This also clarifies that it's enabled by default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified account linking in the docs: it’s enabled by default, and added a config example showing how to disable it (enabled: false) and that no accounts can be linked when disabled.

<sup>Written for commit 16d6f3435af0ed8d16690925b31e71385b4de29f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

