### PR TITLE
chore: bump all packages to v1.5.0-beta.16

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-auth",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "description": "The most comprehensive authentication framework for TypeScript.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "description": "The CLI for Better Auth",
   "module": "dist/index.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/core",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "description": "The most comprehensive authentication framework for TypeScript.",
   "type": "module",
   "repository": {

--- a/packages/drizzle-adapter/package.json
+++ b/packages/drizzle-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/drizzle-adapter",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "description": "Drizzle adapter for Better Auth",
   "type": "module",
   "repository": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/electron",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "description": "Better Auth integration for Electron applications.",
   "main": "dist/index.mjs",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/expo",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "description": "Better Auth integration for Expo and React Native applications.",
   "main": "dist/index.mjs",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/i18n",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "description": "i18n plugin for Better Auth - translate error messages",
   "main": "dist/index.mjs",

--- a/packages/kysely-adapter/package.json
+++ b/packages/kysely-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/kysely-adapter",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "description": "Kysely adapter for Better Auth",
   "type": "module",
   "repository": {

--- a/packages/memory-adapter/package.json
+++ b/packages/memory-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/memory-adapter",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "description": "Memory adapter for Better Auth",
   "type": "module",
   "repository": {

--- a/packages/mongo-adapter/package.json
+++ b/packages/mongo-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/mongo-adapter",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "description": "Mongo adapter for Better Auth",
   "type": "module",
   "repository": {

--- a/packages/oauth-provider/package.json
+++ b/packages/oauth-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/oauth-provider",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "description": "An oauth provider plugin for Better Auth",
   "main": "dist/index.mjs",

--- a/packages/passkey/package.json
+++ b/packages/passkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/passkey",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "description": "Passkey plugin for Better Auth",
   "main": "dist/index.mjs",

--- a/packages/prisma-adapter/package.json
+++ b/packages/prisma-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/prisma-adapter",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "description": "Prisma adapter for Better Auth",
   "type": "module",
   "repository": {

--- a/packages/redis-storage/package.json
+++ b/packages/redis-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/redis-storage",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "description": "Redis storage for Better Auth secondary storage",
   "type": "module",
   "repository": {

--- a/packages/scim/package.json
+++ b/packages/scim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@better-auth/scim",
   "author": "Jonathan Samines",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "main": "dist/index.mjs",
   "types": "dist/index.d.mts",

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@better-auth/sso",
   "author": "Bereket Engida",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "main": "dist/index.mjs",
   "types": "dist/index.d.mts",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@better-auth/stripe",
   "author": "Bereket Engida",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "main": "dist/index.mjs",
   "types": "dist/index.d.mts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/telemetry",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "description": "Telemetry package for Better Auth",
   "type": "module",
   "repository": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/test-utils",
-  "version": "1.5.0-beta.15",
+  "version": "1.5.0-beta.16",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR bumps all packages from `v1.5.0-beta.15` to `v1.5.0-beta.16`.

## Changes
- Updated version numbers in all 19 package.json files across the monorepo
- Incremented from `1.5.0-beta.15` to `1.5.0-beta.16`

## Packages Updated
- better-auth
- cli
- core  
- drizzle-adapter
- electron
- expo
- i18n
- kysely-adapter
- memory-adapter
- mongo-adapter
- oauth-provider
- passkey
- prisma-adapter
- redis-storage
- scim
- sso
- stripe
- telemetry
- test-utils

Ready for next beta release! 🚀

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates all packages from 1.5.0-beta.15 to 1.5.0-beta.16 to prepare the next beta release and keep versions in sync across the monorepo.

<sup>Written for commit 27a033c1e127393c445267cc7887419be50047e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

