### PR TITLE
feat: Cherry-pick latest commit from canary

### DIFF
--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -368,7 +368,7 @@ Then whenever you retrieve back the account make sure to decrypt the tokens befo
 
 ### Account Linking
 
-Account linking enables users to associate multiple authentication methods with a single account. With Better Auth, users can connect additional social sign-ons or OAuth providers to their existing accounts if the provider confirms the user's email as verified.
+Account linking is [enabled by default](https://www.better-auth.com/docs/reference/options#accountlinking) and lets users associate multiple authentication methods with a single account. With Better Auth, users can connect additional social sign-ons or OAuth providers to their existing accounts if the provider confirms the user's email as verified.
 
 If account linking is disabled, no accounts can be linked, regardless of the provider or email verification status.
 
@@ -376,7 +376,7 @@ If account linking is disabled, no accounts can be linked, regardless of the pro
 export const auth = betterAuth({
     account: {
         accountLinking: {
-            enabled: true, 
+            enabled: false, 
         }
     },
 });


### PR DESCRIPTION
This PR cherry-picks the latest commit from the `canary` branch (`b633d0745d13cca052e6927d2f7da992b943161c`) into `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cherry-picks a docs update from canary to clarify account linking behavior. The section now states it’s enabled by default and the example correctly shows how to disable it (enabled: false).

<sup>Written for commit 759dc5b50dddc832ed8a1ffe3786529b808eaf2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

