### PR TITLE
docs: remove ignore-build.sh script

### DIFF
--- a/docs/ignore-build.sh
+++ b/docs/ignore-build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Check if commit message starts with release or docs prefix
-if [[ ! "$message" == "chore(release): version packages"* ]] && [[ ! "$message" == "docs"* ]]; then
-    echo "Skipping build: Not a release or docs commit."
-    exit 1
-fi


### PR DESCRIPTION
This PR removes the `docs/ignore-build.sh` script as it is no longer needed.

The script was used to conditionally skip builds based on commit message prefixes, but it's no longer required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed docs/ignore-build.sh to simplify CI and eliminate commit-message-based build skipping. Builds will no longer be conditionally skipped; the pipeline runs as usual for all commits.

<sup>Written for commit 88750006dde94b454a4aa7871fc87e30cd9f3a25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

