### PR TITLE
fix(organization): add warning for missing roles in hasPermission

### DIFF
--- a/packages/better-auth/src/plugins/organization/permission.ts
+++ b/packages/better-auth/src/plugins/organization/permission.ts
@@ -18,7 +18,13 @@ export const hasPermissionFn = (
 
 	for (const role of roles) {
 		const _role = acRoles[role as keyof typeof acRoles];
-		const result = _role?.authorize(input.permissions);
+		if (!_role) {
+			console.warn(
+				`[Better Auth] [hasPermission] Role "${role}" not found in configured roles. Available roles: ${Object.keys(acRoles).join(", ")}`,
+			);
+			continue;
+		}
+		const result = _role.authorize(input.permissions);
 		if (result?.success) {
 			return true;
 		}


### PR DESCRIPTION
## Summary

Fixes #6081

The `hasPermission` method in the Organization plugin silently returns `false` when a user's role doesn't exist in the configured roles. This makes it impossible to distinguish between:
- Role exists but lacks permission ❌
- Role doesn't exist in configuration (likely a bug/misconfiguration)

## Changes

Added a warning log when a role is not found in `acRoles`:

```typescript
if (!_role) {
    console.warn(
        `[Better Auth] [hasPermission] Role "${role}" not found in configured roles. Available roles: ${Object.keys(acRoles).join(", ")}`,
    );
    continue;
}
```

## Before

```typescript
for (const role of roles) {
    const _role = acRoles[role as keyof typeof acRoles];
    const result = _role?.authorize(input.permissions);  // Silent failure when _role is undefined
    if (result?.success) {
        return true;
    }
}
return false;  // No indication of which role was missing!
```

## After

```typescript
for (const role of roles) {
    const _role = acRoles[role as keyof typeof acRoles];
    if (!_role) {
        console.warn(
            `[Better Auth] [hasPermission] Role "${role}" not found in configured roles. Available roles: ${Object.keys(acRoles).join(", ")}`,
        );
        continue;
    }
    const result = _role.authorize(input.permissions);
    if (result?.success) {
        return true;
    }
}
return false;
```

## Problem Solved

This helps developers debug configuration issues when:
1. Custom roles override defaults (forgetting to include `owner`, `admin`, `member`)
2. Database has a role that doesn't exist in configuration
3. Typos in role names (e.g., `admn` vs `admin`)
4. Migration issues where roles change but database isn't updated

**Example warning output:**
```
[Better Auth] [hasPermission] Role "owner" not found in configured roles. Available roles: projectManager
```

This immediately tells the developer they forgot to include `...defaultRoles` when defining custom roles.

## Scope of Change

- **Breaking change?** No - this only adds a console warning
- **Performance impact?** Negligible - only runs when permission check runs against a missing role
- **Behavior change?** No - still returns `false`, but now with helpful debugging info

## Related
- Issue #6081
- PR #4842 (Admin plugin already throws on invalid roles - this brings similar debugging help to org plugin)

Fixes #6081

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a warning when Organization.hasPermission encounters a role not found in configured roles, making misconfigurations visible instead of failing silently. Fixes #6081; behavior stays the same (still returns false), now with actionable logs.

- **Bug Fixes**
  - Logs a warning with the missing role and the list of available roles when a role isn’t in acRoles.

<sup>Written for commit 54dc125f55cbddbee180fa7fd00332b5d0cf4a91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

