### PR TITLE
Cherry-pick: Docker Compose healthchecks for faster CI service readiness (#8010)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,7 @@ jobs:
 
       - name: Start Docker Containers
         if: github.event_name != 'merge_group'
-        run: |
-          docker compose up -d
-          # Wait for services to be ready (optional)
-          sleep 10
+        run: docker compose up -d --wait --wait-timeout 60
 
       - name: Test
         if: github.event_name != 'merge_group'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,10 +48,7 @@ jobs:
         run: pnpm build
 
       - name: Start Docker Containers
-        run: |
-          docker compose up -d
-          # Wait for services to be ready (optional)
-          sleep 10
+        run: docker compose up -d --wait --wait-timeout 60
 
       - uses: oven-sh/setup-bun@v2
 
@@ -108,14 +105,68 @@ jobs:
 
       - name: Start Docker Containers
         if: github.event_name != 'merge_group'
-        run: |
-          docker compose up -d
-          # Wait for services to be ready (optional)
-          sleep 10
+        run: docker compose up -d --wait --wait-timeout 60
 
       - name: Integration
         if: github.event_name != 'merge_group'
         run: pnpm e2e:integration --filter=./e2e/integration
+
+      - name: Stop Docker Containers
+        if: github.event_name != 'merge_group'
+        run: docker compose down
+  adapter-integration:
+    name: ${{ matrix.packages }} Integration Test
+    runs-on: starsling-ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        packages: [ "@better-auth-test/adapter-factory", "@better-auth-test/drizzle-adapter", "@better-auth-test/kysely-prisma-adapter", "@better-auth-test/memory-adapter", "@better-auth-test/mongo-adapter", "@better-auth-test/prisma-adapter" ]
+        node-version: [ 22.x ]
+    steps:
+      - name: Skip integration tests in merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Skipping integration tests in merge queue"
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        if: github.event_name != 'merge_group'
+        with:
+          fetch-depth: 0
+
+      - name: Cache turbo build setup
+        if: github.event_name != 'merge_group'
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        if: github.event_name != 'merge_group'
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        if: github.event_name != 'merge_group'
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - name: Install
+        if: github.event_name != 'merge_group'
+        run: pnpm install
+
+      - name: Install Playwright Browsers
+        if: github.event_name != 'merge_group'
+        run: pnpm exec playwright install --with-deps
+        working-directory: e2e/integration
+
+      - name: Start Docker Containers
+        if: github.event_name != 'merge_group'
+        run: docker compose up -d --wait --wait-timeout 60
+
+      - name: Adapter Integration
+        if: github.event_name != 'merge_group'
+        run: pnpm e2e:integration --filter=${{ matrix.packages }}
 
       - name: Stop Docker Containers
         if: github.event_name != 'merge_group'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,24 @@
-version: '3.8'
+# cspell:ignore isready uuser ppassword
+x-postgres-healthcheck: &postgres-healthcheck
+  healthcheck:
+    test: ["CMD-SHELL", "pg_isready -U user -d better_auth"]
+    interval: 1s
+    timeout: 5s
+    retries: 10
+
+x-mysql-healthcheck: &mysql-healthcheck
+  healthcheck:
+    # Use 127.0.0.1 (not localhost) to force TCP. localhost resolves to a Unix
+    # socket on Linux, which can falsely succeed against the temporary init
+    # server that runs with --skip-networking.
+    test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uuser", "-ppassword"]
+    interval: 1s
+    timeout: 5s
+    retries: 10
+    # MySQL cold-start (data dir init, system tables, user/db creation) takes
+    # 10-20s in CI. Without start_period, docker compose --wait fails immediately
+    # once retries are exhausted — it does NOT wait for --wait-timeout.
+    start_period: 30s
 
 services:
   mongodb:
@@ -8,9 +28,28 @@ services:
       - "27017:27017"
     volumes:
       - mongodb_data:/data/db
-  
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+
   # drizzle
   postgres:
+    <<: *postgres-healthcheck
     image: postgres:latest
     container_name: postgres
     environment:
@@ -23,6 +62,7 @@ services:
       - postgres_data:/var/lib/postgresql
 
   postgres-kysely:
+    <<: *postgres-healthcheck
     image: postgres:latest
     container_name: postgres-kysely
     environment:
@@ -33,8 +73,9 @@ services:
       - "5433:5432"
     volumes:
       - postgres-kysely_data:/var/lib/postgresql
-  
+
   postgres-kysely2:
+    <<: *postgres-healthcheck
     image: postgres:latest
     container_name: postgres-kysely2
     environment:
@@ -47,6 +88,7 @@ services:
       - postgres-kysely2_data:/var/lib/postgresql
 
   postgres-prisma:
+    <<: *postgres-healthcheck
     image: postgres:latest
     container_name: postgres-prisma
     environment:
@@ -60,6 +102,7 @@ services:
 
   # Drizzle tests
   mysql:
+    <<: *mysql-healthcheck
     image: mysql:latest
     container_name: mysql
     environment:
@@ -72,8 +115,8 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
 
-
   mysql-kysely:
+    <<: *mysql-healthcheck
     image: mysql:latest
     container_name: mysql-kysely
     environment:
@@ -87,6 +130,7 @@ services:
       - mysql-kysely_data:/var/lib/mysql
 
   mysql-prisma:
+    <<: *mysql-healthcheck
     image: mysql:latest
     container_name: mysql-prisma
     environment:
@@ -99,7 +143,6 @@ services:
     volumes:
       - mysql-prisma_data:/var/lib/mysql
 
-
   mssql:
     image: mcr.microsoft.com/mssql/server:latest
     container_name: mssql
@@ -110,6 +153,12 @@ services:
       - "1433:1433"
     volumes:
       - mssql_data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P 'Password123!' -Q 'SELECT 1' -b -o /dev/null"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
 
 volumes:
   mongodb_data:
@@ -121,3 +170,4 @@ volumes:
   mysql-kysely_data:
   mysql-prisma_data: 
   postgres-kysely2_data:
+  redis_data:


### PR DESCRIPTION
Cherry-picks commit 0d24f3f8b52ff822a5fb5eb059951c3aef8d91fd to main.

This adds Docker Compose healthchecks for faster CI service readiness, improving the reliability and speed of CI runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Docker Compose healthchecks and use docker compose --wait in CI so services only start when healthy. This speeds up and stabilizes CI and e2e runs by removing flaky waits.

- **New Features**
  - Healthchecks for MongoDB, Redis, PostgreSQL (all variants), MySQL (all variants, with start_period for cold starts), and MSSQL.
  - Workflows now use docker compose up -d --wait --wait-timeout 60 instead of sleep.
  - Added adapter-integration matrix job to e2e to run adapter tests; installs Playwright browsers and cleanly starts/stops containers.

<sup>Written for commit 12ee0ca6a78fa1d1673ce15400d996536975d04e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

