### PR TITLE
fix(multi-session): ensure after hooks run on OAuth redirect

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -44,6 +44,17 @@ type UserInputContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
 >;
 
+/**
+ * Check if a value is a redirect Response (3xx status)
+ */
+function isRedirectResponse(e: unknown): e is Response {
+	return (
+		e instanceof Response &&
+		e.status >= 300 &&
+		e.status < 400
+	);
+}
+
 export function toAuthEndpoints<
 	const E extends Record<
 		string,
@@ -132,6 +143,17 @@ export function toAuthEndpoints<
 								headers: e.headers ? new Headers(e.headers) : null,
 							};
 						}
+						/**
+						 * Handle redirect responses (e.g., from c.redirect())
+						 * so that after hooks can run and add cookies/headers
+						 */
+						if (isRedirectResponse(e)) {
+							return {
+								response: e,
+								status: e.status,
+								headers: e.headers ? new Headers(e.headers) : null,
+							};
+						}
 						throw e;
 					})) as {
 						headers: Headers;
@@ -151,6 +173,26 @@ export function toAuthEndpoints<
 
 					if (after.response) {
 						result.response = after.response;
+					}
+
+					/**
+					 * For redirect responses, merge the original redirect
+					 * with any headers set by after hooks (e.g., Set-Cookie)
+					 */
+					if (result.response instanceof Response && after.headers) {
+						const mergedHeaders = new Headers(result.response.headers);
+						after.headers.forEach((value, key) => {
+							if (key.toLowerCase() === "set-cookie") {
+								mergedHeaders.append(key, value);
+							} else {
+								mergedHeaders.set(key, value);
+							}
+						});
+						return new Response(result.response.body, {
+							status: result.response.status,
+							statusText: result.response.statusText,
+							headers: mergedHeaders,
+						});
 					}
 
 					if (


### PR DESCRIPTION
## Bug Report

OAuth sessions were not appearing in `listDeviceSessions()` because the multi-session cookie (`*_multi-*`) was not being set during OAuth login flows.

## Root Cause

When the OAuth callback succeeds (packages/better-auth/src/api/routes/callback.ts), it calls `setSessionCookie()` then `throw c.redirect(toRedirectTo)`. 

The issue is in `packages/better-auth/src/api/to-auth-endpoints.ts`:
- The endpoint runner's `.catch()` block only handles `APIError`
- `c.redirect()` throws a `Response` object with a 3xx status code, not an `APIError`
- The redirect response was being re-thrown, so after hooks never executed
- The multi-session plugin's after hook sets the `_multi-*` cookie, but it never ran
- Without this cookie, `listDeviceSessions()` doesn't include the OAuth session

## The Fix

1. Added `isRedirectResponse()` helper to detect Response objects with 3xx status codes
2. Extended the catch block to also handle redirect responses like APIError
3. After hooks now run on redirects, allowing the multi-session plugin to set its cookie
4. Headers from after hooks (e.g., `Set-Cookie`) are merged into the final redirect response

## Files Changed

- `packages/better-auth/src/api/to-auth-endpoints.ts` - Handle redirect responses to ensure after hooks run

## Testing

Please verify:
1. Sign in via OAuth (Google/Apple/etc.)
2. Call `authClient.multiSession.listDeviceSessions()` 
3. The OAuth session should now appear in the list
4. Email/password sign-ins should continue to work as before

Fixes #8060

Fixes #8060

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures after hooks run on OAuth redirects so the multi-session cookie is set and OAuth sessions appear in listDeviceSessions. Fixes #8060.

- **Bug Fixes**
  - Detect and handle 3xx redirect Response values with isRedirectResponse in to-auth-endpoints.
  - Run after hooks on redirects and merge their headers (including Set-Cookie) into the final response.
  - Multi-session plugin now sets the _multi-* cookie during OAuth flows; email/password flows unchanged.

<sup>Written for commit 4a9bd1fd62856fb7369a000670376cce1719f655. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

