### PR TITLE
fix(bearer): use semicolon separator when merging cookie headers

### DIFF
--- a/packages/better-auth/src/plugins/bearer/index.ts
+++ b/packages/better-auth/src/plugins/bearer/index.ts
@@ -78,9 +78,14 @@ export const bearer = (options?: BearerOptions | undefined) => {
 						const headers = new Headers({
 							...Object.fromEntries(existingHeaders?.entries()),
 						});
-						headers.append(
+						// Use headers.set() with "; " separator per RFC 6265.
+						// headers.append("cookie") joins with ", " in some runtimes
+						// (e.g. Deno, Cloudflare Workers), which breaks cookie parsing.
+						const existingCookie = headers.get("cookie");
+						const newCookie = `${c.context.authCookies.sessionToken.name}=${signedToken}`;
+						headers.set(
 							"cookie",
-							`${c.context.authCookies.sessionToken.name}=${signedToken}`,
+							existingCookie ? `${existingCookie}; ${newCookie}` : newCookie,
 						);
 						return {
 							context: {


### PR DESCRIPTION
I tested it:
in Node.js and Bun, values are separated by “; “, while in Deno and Cloudflare Workers they’re separated by “, “. Since our Vitest runs on the Node.js runtime, adding a test case wouldn’t be meaningful, so I just left a comment in the code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cookie header merging in the bearer plugin by using headers.set() and joining with "; " per RFC 6265. This prevents cookie parsing issues in Deno/Cloudflare and ensures consistent behavior across runtimes when adding the sessionToken.

<sup>Written for commit 9f05d8429ed74c9b9fb6236299a8b324c3758ceb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

