### PR TITLE
Fix Session ID Missing From Secondary Storage

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -387,6 +387,29 @@ export const createInternalAdapter = (
 						}
 					: undefined,
 			);
+			if (secondaryStorage && res) {
+				const id = res.id || ctx.generateId({ model: "session" });
+				if (id && id !== res.id) {
+					res.id = id;
+				}
+				if (id) {
+					const cached = await secondaryStorage.get(data.token);
+					if (cached) {
+						const parsed = safeJSONParse<{
+							session: Record<string, any>;
+							user: User;
+						}>(cached);
+						if (parsed?.session && !parsed.session.id) {
+							parsed.session.id = id;
+							await secondaryStorage.set(
+								data.token,
+								JSON.stringify(parsed),
+								getTTLSeconds(data.expiresAt),
+							);
+						}
+					}
+				}
+			}
 			return res as Session;
 		},
 		findSession: async (

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -36,6 +36,7 @@ describe("secondary storage - get returns JSON string", async () => {
 		});
 		expect(s1.data).toMatchObject({
 			session: {
+				id: expect.any(String),
 				userId: expect.any(String),
 				token: expect.any(String),
 				expiresAt: expect.any(Date),
@@ -66,6 +67,101 @@ describe("secondary storage - get returns JSON string", async () => {
 		const after = await client.getSession({ fetchOptions: { headers } });
 		expect(after.data).toBeNull();
 		expect(store.size).toBe(0);
+	});
+});
+
+describe("secondary storage - session id in storage (secondary only)", async () => {
+	const store = new Map<string, string>();
+
+	const { client, signInWithTestUser } = await getTestInstance({
+		secondaryStorage: {
+			set(key, value, ttl) {
+				store.set(key, value);
+			},
+			get(key) {
+				return store.get(key) || null;
+			},
+			delete(key) {
+				store.delete(key);
+			},
+		},
+		rateLimit: {
+			enabled: false,
+		},
+	});
+
+	beforeEach(() => {
+		store.clear();
+	});
+
+	it("should include session id in secondary storage data", async () => {
+		const { headers } = await signInWithTestUser();
+
+		const s1 = await client.getSession({
+			fetchOptions: { headers },
+		});
+		expect(s1.data).not.toBeNull();
+
+		const sessionId = s1.data!.session.id;
+		expect(sessionId).toBeDefined();
+		expect(typeof sessionId).toBe("string");
+		expect(sessionId.length).toBeGreaterThan(0);
+
+		// Verify the raw stored data also contains the id
+		const token = s1.data!.session.token;
+		const raw = store.get(token);
+		expect(raw).toBeDefined();
+		const parsed = JSON.parse(raw!);
+		expect(parsed.session.id).toBe(sessionId);
+	});
+});
+
+describe("secondary storage - session id in storage (both storages)", async () => {
+	const store = new Map<string, string>();
+
+	const { client, signInWithTestUser } = await getTestInstance({
+		session: {
+			storeSessionInDatabase: true,
+		},
+		secondaryStorage: {
+			set(key, value, ttl) {
+				store.set(key, value);
+			},
+			get(key) {
+				return store.get(key) || null;
+			},
+			delete(key) {
+				store.delete(key);
+			},
+		},
+		rateLimit: {
+			enabled: false,
+		},
+	});
+
+	beforeEach(() => {
+		store.clear();
+	});
+
+	it("should include session id in secondary storage data when storeSessionInDatabase is true", async () => {
+		const { headers } = await signInWithTestUser();
+
+		const s1 = await client.getSession({
+			fetchOptions: { headers },
+		});
+		expect(s1.data).not.toBeNull();
+
+		const sessionId = s1.data!.session.id;
+		expect(sessionId).toBeDefined();
+		expect(typeof sessionId).toBe("string");
+		expect(sessionId.length).toBeGreaterThan(0);
+
+		// Verify the raw stored data also contains the id
+		const token = s1.data!.session.token;
+		const raw = store.get(token);
+		expect(raw).toBeDefined();
+		const parsed = JSON.parse(raw!);
+		expect(parsed.session.id).toBe(sessionId);
 	});
 });
 


### PR DESCRIPTION
## Summary

Sessions stored in secondary storage (e.g. Redis) are missing the `id` field, causing any code that reads `session.id` from a cached session to get `undefined`.

This breaks the `@better-auth/oauth-provider` plugin: the authorization code is stored without a `sessionId`, and the token exchange fails with `{"error_description":"session no longer exists","error":"invalid_request"}`.

This bug occurs whenever secondary storage is configured, even when using `storeSessionInDatabase: true`. As long as there is secondary storage, the Redis entry will be missing the `id`.

## Root Cause

In `createSession` (`packages/better-auth/src/db/internal-adapter.ts`), the `data` object built for the new session never includes an `id` — that field is normally generated by the DB adapter's `transformInput` during the `create` call.

In `createWithHooks` (`packages/better-auth/src/db/with-hooks.ts`, lines 48–58), the custom `fn` that writes to secondary storage receives `sessionData` which lacks the `id`:

- When `storeSessionInDatabase` is **false** (default): the DB adapter is never called. `fn` receives `actualData` directly — no `id` is ever generated.
- When `storeSessionInDatabase` is **true**: the DB adapter runs first and returns a record with `id`, but `fn` still stores a session without `id` in secondary storage.

The result: the DB has the full session; secondary storage has a partial one.

Redis entry (note no `id` in `session`):
```json
{
  "session": {
    "ipAddress": "...",
    "userAgent": "...",
    "expiresAt": "...",
    "userId": "usr_xxx",
    "token": "abc123",
    "createdAt": "...",
    "updatedAt": "..."
  },
  "user": { "id": "usr_xxx", "..." }
}
```

## Fix

After `createWithHooks` returns, patch the secondary storage entry to include the `id`:

- If the DB result already contains the `id` (i.e. `storeSessionInDatabase: true`), use that.
- Otherwise (secondary-only mode), fall back to `ctx.generateId({ model: "session" })`.

## Workaround

Until this is released, users can patch the Redis entry via a `databaseHooks.session.create.after` hook:

```typescript
session: {
  create: {
    after: async (session) => {
      if (redisClient && session.id && session.token) {
        try {
          const cached = await redisClient.get(session.token);
          if (cached) {
            const parsed = JSON.parse(cached);
            if (parsed?.session && !parsed.session.id) {
              parsed.session.id = session.id;
              const ttl = await redisClient.ttl(session.token);
              await redisClient.set(
                session.token,
                JSON.stringify(parsed),
                ttl > 0 ? { EX: ttl } : undefined,
              );
            }
          }
        } catch (error) {
          console.error("Failed to patch session id in Redis:", error);
        }
      }
    },
  },
},
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing session.id in secondary storage by updating the cached session after creation. Restores OAuth token exchange by ensuring authorization codes include sessionId.

- **Bug Fixes**
  - After createWithHooks, inject session.id into secondary storage; use DB id when available, otherwise generate one.
  - Added tests for secondary-only and database+secondary modes to verify id is stored.
  - Prevents OAuth token exchange failure ("session no longer exists").

<sup>Written for commit 4118debd9fd9d60d860b1bed545818e19cbdfcad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

