### PR TITLE
fix: use invalid_grant instead of invalid_request for refresh token errors

### DIFF
--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -971,7 +971,7 @@ async function handleRefreshTokenGrant(
 	if (!refreshToken) {
 		throw new APIError("BAD_REQUEST", {
 			error_description: "session not found",
-			error: "invalid_request",
+			error: "invalid_grant",
 		});
 	}
 	if (refreshToken.clientId !== client_id) {
@@ -983,7 +983,7 @@ async function handleRefreshTokenGrant(
 	if (refreshToken.expiresAt < new Date()) {
 		throw new APIError("BAD_REQUEST", {
 			error_description: "invalid refresh token",
-			error: "invalid_request",
+			error: "invalid_grant",
 		});
 	}
 	// Replay revoke (delete all tokens for that user-client)
@@ -1003,7 +1003,7 @@ async function handleRefreshTokenGrant(
 		});
 		throw new APIError("BAD_REQUEST", {
 			error_description: "invalid refresh token",
-			error: "invalid_request",
+			error: "invalid_grant",
 		});
 	}
 


### PR DESCRIPTION
Fixes #8099

## Problem
When an invalid refresh token is provided, the OAuth token endpoint was 
returning `invalid_request` instead of `invalid_grant`, which prevented 
clients from triggering a clean reauthentication flow.

## Changes
Updated three cases in `packages/oauth-provider/src/token.ts` to return 
`invalid_grant` as per RFC 6749:

- Token not found in database (`session not found`)
- Token expired
- Token revoked

All three cases represent an invalid grant and should trigger 
reauthentication on the client side, as specified in the OAuth 2.0 spec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return invalid_grant for refresh token errors to align with RFC 6749 and trigger clean client reauthentication.

- **Bug Fixes**
  - Return invalid_grant when session not found.
  - Return invalid_grant when refresh token expired.
  - Return invalid_grant when refresh token revoked.

<sup>Written for commit 5ab651664de954d3d9b049e042cb46cf7fcbace6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

