### PR TITLE
fix: force drizzle-adapter to return dates correctly

### DIFF
--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -626,6 +626,10 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					? true
 					: false,
 			supportsArrays: config.provider === "pg" ? true : false,
+			// not all providers support dates
+			// one such example case is https://github.com/better-auth/better-auth/issues/7819
+			// it's safe to set to `false` without checking for provider, because it it is dates the transformation doesn't apply anyway.
+			supportsDates: false,
 			transaction:
 				(config.transaction ?? false)
 					? (cb) =>


### PR DESCRIPTION
On very specific cases using specific dialects with a specific field configuration, dates fields are returned as either strings or numbers and not truly dates.

This PR applies a transformation on fields that are meant to be dates, if a field is already a date then it will skip transformation, so there is no need for checking for specific cases in the code.

closes https://github.com/better-auth/better-auth/issues/7819

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure date fields in drizzle-adapter always return Date objects across providers by forcing adapter-level normalization. Fixes cases where some dialects returned strings or numbers for dates.

- **Bug Fixes**
  - Set supportsDates: false to always run the date transformation; it’s a no-op when the value is already a Date.
  - Resolves incorrect date values in specific dialect/field configurations (issue #7819).

<sup>Written for commit 61df1ca716669e32f35d2e2405516f887637fa38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

