### PR TITLE
fix: drizzle transform input crashes dates

### DIFF
--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -630,6 +630,9 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				// not all providers support dates
 				// one such example case is https://github.com/better-auth/better-auth/issues/7819
 				if (fieldAttributes.type === "date") {
+					if (data === null || data === undefined) {
+						return data;
+					}
 					return new Date(data);
 				}
 				return data;


### PR DESCRIPTION
`supportDates` will transform incoming date values to strings before saving into db which is wrong. We only care for transforming output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes date handling in the Drizzle adapter by converting date fields to Date only on read via customTransformOutput. Removes supportsDates to avoid input transforms that stringified dates and caused crashes on some providers.

<sup>Written for commit c6e1c6e19bc572cee4868428b06b1bef9ee1f1aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

