### PR TITLE
fix(core): resolve user/account modelName collisions in adapter mapping and joins

### DIFF
--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -152,6 +152,8 @@ export const createAdapterFactory =
 			usePlural: config.usePlural,
 			schema,
 		});
+		const resolveSchemaModelKey = (model: string) =>
+			schema[model] ? model : getDefaultModelName(model);
 
 		const getModelName = initGetModelName({
 			usePlural: config.usePlural,
@@ -603,18 +605,18 @@ export const createAdapterFactory =
 			const transformedJoin: JoinConfig = {};
 			for (const [model, join] of Object.entries(unsanitizedJoin)) {
 				if (!join) continue;
-				const defaultModelName = getDefaultModelName(model);
-				const defaultBaseModelName = getDefaultModelName(baseModel);
+				const defaultModelName = resolveSchemaModelKey(model);
+				const defaultBaseModelName = resolveSchemaModelKey(baseModel);
 
 				// First, check if the joined model has FKs to the base model (forward join)
 				let foreignKeys = Object.entries(
 					schema[defaultModelName]!.fields,
-				).filter(
-					([field, fieldAttributes]) =>
-						fieldAttributes.references &&
-						getDefaultModelName(fieldAttributes.references.model) ===
-							defaultBaseModelName,
-				);
+					).filter(
+						([field, fieldAttributes]) =>
+							fieldAttributes.references &&
+							resolveSchemaModelKey(fieldAttributes.references.model) ===
+								defaultBaseModelName,
+					);
 
 				let isForwardJoin = true;
 
@@ -625,7 +627,7 @@ export const createAdapterFactory =
 					).filter(
 						([field, fieldAttributes]) =>
 							fieldAttributes.references &&
-							getDefaultModelName(fieldAttributes.references.model) ===
+							resolveSchemaModelKey(fieldAttributes.references.model) ===
 								defaultModelName,
 					);
 					isForwardJoin = false;
@@ -659,12 +661,12 @@ export const createAdapterFactory =
 					// The field we need in select is the referenced field in the base model
 					requiredSelectField = foreignKeyAttributes.references.field;
 					from = getFieldName({
-						model: baseModel,
+						model: defaultBaseModelName,
 						field: requiredSelectField,
 					});
 
 					to = getFieldName({
-						model,
+						model: defaultModelName,
 						field: foreignKey,
 					});
 				} else {
@@ -672,12 +674,12 @@ export const createAdapterFactory =
 					// The field we need in select is the foreign key field in the base model
 					requiredSelectField = foreignKey;
 					from = getFieldName({
-						model: baseModel,
+						model: defaultBaseModelName,
 						field: requiredSelectField,
 					});
 
 					to = getFieldName({
-						model,
+						model: defaultModelName,
 						field: foreignKeyAttributes.references.field,
 					});
 				}

--- a/packages/core/src/db/adapter/get-default-field-name.ts
+++ b/packages/core/src/db/adapter/get-default-field-name.ts
@@ -37,7 +37,9 @@ export const initGetDefaultFieldName = ({
 		if (field === "id" || field === "_id") {
 			return "id";
 		}
-		const model = getDefaultModelName(unsafeModel); // Just to make sure the model name is correct.
+		const model = schema[unsafeModel]
+			? unsafeModel
+			: getDefaultModelName(unsafeModel); // Just to make sure the model name is correct.
 
 		let f = schema[model]?.fields[field];
 		if (!f) {

--- a/packages/core/src/db/adapter/get-default-model-name.ts
+++ b/packages/core/src/db/adapter/get-default-model-name.ts
@@ -24,11 +24,11 @@ export const initGetDefaultModelName = ({
 		// Thus we'll try the search but without the trailing `s`.
 		if (usePlural && model.charAt(model.length - 1) === "s") {
 			const pluralessModel = model.slice(0, -1);
-			let m = schema[pluralessModel] ? pluralessModel : undefined;
+			let m = Object.entries(schema).find(
+				([_, f]) => f.modelName === pluralessModel,
+			)?.[0];
 			if (!m) {
-				m = Object.entries(schema).find(
-					([_, f]) => f.modelName === pluralessModel,
-				)?.[0];
+				m = schema[pluralessModel] ? pluralessModel : undefined;
 			}
 
 			if (m) {
@@ -36,9 +36,9 @@ export const initGetDefaultModelName = ({
 			}
 		}
 
-		let m = schema[model] ? model : undefined;
+		let m = Object.entries(schema).find(([_, f]) => f.modelName === model)?.[0];
 		if (!m) {
-			m = Object.entries(schema).find(([_, f]) => f.modelName === model)?.[0];
+			m = schema[model] ? model : undefined;
 		}
 
 		if (!m) {

--- a/packages/core/src/db/adapter/get-field-name.ts
+++ b/packages/core/src/db/adapter/get-field-name.ts
@@ -33,7 +33,7 @@ export const initGetFieldName = ({
 		model: string;
 		field: string;
 	}) {
-		const model = getDefaultModelName(modelName);
+		const model = schema[modelName] ? modelName : getDefaultModelName(modelName);
 		const field = getDefaultFieldName({ model, field: fieldName });
 
 		return schema[model]?.fields[field]?.fieldName || field;

--- a/packages/core/src/db/adapter/get-model-name.ts
+++ b/packages/core/src/db/adapter/get-model-name.ts
@@ -18,19 +18,9 @@ export const initGetModelName = ({
 	 * then we should return the model name ending with an `s`.
 	 */
 	const getModelName = (model: string) => {
-		const defaultModelKey = getDefaultModelName(model);
-		const useCustomModelName =
-			schema &&
-			schema[defaultModelKey] &&
-			schema[defaultModelKey].modelName !== model;
-
-		if (useCustomModelName) {
-			return usePlural
-				? `${schema[defaultModelKey]!.modelName}s`
-				: schema[defaultModelKey]!.modelName;
-		}
-
-		return usePlural ? `${model}s` : model;
+		const defaultModelKey = schema[model] ? model : getDefaultModelName(model);
+		const resolvedModelName = schema[defaultModelKey]?.modelName || model;
+		return usePlural ? `${resolvedModelName}s` : resolvedModelName;
 	};
 	return getModelName;
 };

--- a/packages/core/src/db/get-tables.ts
+++ b/packages/core/src/db/get-tables.ts
@@ -1,6 +1,8 @@
 import type { BetterAuthOptions } from "../types";
 import type { BetterAuthDBSchema, DBFieldAttribute } from "./type";
 
+const USER_MODEL_KEY = "user";
+
 export const getAuthTables = (
 	options: BetterAuthOptions,
 ): BetterAuthDBSchema => {
@@ -96,7 +98,7 @@ export const getAuthTables = (
 					type: "string",
 					fieldName: options.session?.fields?.userId || "userId",
 					references: {
-						model: options.user?.modelName || "user",
+						model: USER_MODEL_KEY,
 						field: "id",
 						onDelete: "cascade",
 					},
@@ -112,7 +114,7 @@ export const getAuthTables = (
 
 	return {
 		user: {
-			modelName: options.user?.modelName || "user",
+			modelName: options.user?.modelName || USER_MODEL_KEY,
 			fields: {
 				name: {
 					type: "string",
@@ -177,7 +179,7 @@ export const getAuthTables = (
 				userId: {
 					type: "string",
 					references: {
-						model: options.user?.modelName || "user",
+						model: USER_MODEL_KEY,
 						field: "id",
 						onDelete: "cascade",
 					},

--- a/packages/core/src/db/test/factory-join.test.ts
+++ b/packages/core/src/db/test/factory-join.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { createAdapterFactory } from "../adapter/factory";
+import type { JoinConfig } from "../adapter";
+
+describe("adapter factory joins", () => {
+	it("builds account join config when user modelName is account", async () => {
+		let capturedJoin: JoinConfig | undefined;
+		const adapterFactory = createAdapterFactory({
+			config: {
+				adapterId: "test",
+			},
+			adapter: () => ({
+				create: async ({ data }) => data as any,
+				update: async () => null,
+				updateMany: async () => 0,
+				findOne: async ({ join }) => {
+					capturedJoin = join;
+					return null;
+				},
+				findMany: async () => [],
+				delete: async () => {},
+				deleteMany: async () => 0,
+				count: async () => 0,
+			}),
+		});
+
+		const adapter = adapterFactory({
+			experimental: {
+				joins: {
+					enabled: true,
+				},
+			},
+			user: {
+				modelName: "account",
+			},
+			account: {
+				modelName: "identity",
+			},
+		} as any);
+
+		await expect(
+			adapter.findOne({
+				model: "user",
+				where: [{ field: "id", value: "u1" }],
+				join: {
+					account: true,
+				},
+			}),
+		).resolves.toBeNull();
+
+		expect(capturedJoin).toBeDefined();
+		expect(capturedJoin?.identity?.on.from).toBe("id");
+		expect(capturedJoin?.identity?.on.to).toBe("userId");
+	});
+});

--- a/packages/core/src/db/test/get-default-model-name.test.ts
+++ b/packages/core/src/db/test/get-default-model-name.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { initGetDefaultModelName } from "../adapter/get-default-model-name";
+
+describe("initGetDefaultModelName", () => {
+	it("prefers modelName match over schema key to avoid account collision", () => {
+		const getDefaultModelName = initGetDefaultModelName({
+			usePlural: false,
+			schema: {
+				user: {
+					modelName: "account",
+					fields: {},
+				},
+				account: {
+					modelName: "identity",
+					fields: {},
+				},
+			},
+		});
+
+		expect(getDefaultModelName("account")).toBe("user");
+		expect(getDefaultModelName("identity")).toBe("account");
+	});
+});

--- a/packages/core/src/db/test/get-field-name.test.ts
+++ b/packages/core/src/db/test/get-field-name.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { initGetFieldName } from "../adapter/get-field-name";
+
+describe("initGetFieldName", () => {
+	it("resolves fields using explicit schema key for ambiguous model names", () => {
+		const getFieldName = initGetFieldName({
+			usePlural: false,
+			schema: {
+				user: {
+					modelName: "account",
+					fields: {
+						email: { type: "string", fieldName: "email" },
+					},
+				},
+				account: {
+					modelName: "identity",
+					fields: {
+						userId: { type: "string", fieldName: "account_id" },
+					},
+				},
+			},
+		});
+
+		expect(getFieldName({ model: "user", field: "email" })).toBe("email");
+		expect(getFieldName({ model: "account", field: "userId" })).toBe(
+			"account_id",
+		);
+	});
+});

--- a/packages/core/src/db/test/get-model-name.test.ts
+++ b/packages/core/src/db/test/get-model-name.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { initGetModelName } from "../adapter/get-model-name";
+
+describe("initGetModelName", () => {
+	it("prefers explicit schema key before reverse modelName lookup", () => {
+		const getModelName = initGetModelName({
+			usePlural: false,
+			schema: {
+				user: {
+					modelName: "account",
+					fields: {},
+				},
+				account: {
+					modelName: "identity",
+					fields: {},
+				},
+			},
+		});
+
+		expect(getModelName("user")).toBe("account");
+		expect(getModelName("account")).toBe("identity");
+		expect(getModelName("identity")).toBe("identity");
+	});
+});

--- a/packages/core/src/db/test/get-tables.test.ts
+++ b/packages/core/src/db/test/get-tables.test.ts
@@ -80,4 +80,20 @@ describe("getAuthTables", () => {
 		expect(newField.fieldName).toBe("new_field");
 		expect(newField.type).toBe("string");
 	});
+
+	it("should keep user references on the base user model key when user modelName is account", () => {
+		const tables = getAuthTables({
+			user: {
+				modelName: "account",
+			},
+			account: {
+				modelName: "identity",
+			},
+		});
+
+		expect(tables.user?.modelName).toBe("account");
+		expect(tables.account?.modelName).toBe("identity");
+		expect(tables.session?.fields.userId?.references?.model).toBe("user");
+		expect(tables.account?.fields.userId?.references?.model).toBe("user");
+	});
 });


### PR DESCRIPTION
## Summary
This PR fixes schema/model resolution edge cases when user.modelName collides with the default account model key (for example: user.modelName = "account", account.modelName = "identity").

## What changed
- getDefaultModelName: prefer reverse lookup by modelName before schema-key lookup to correctly map DB model names back to base keys.
- getModelName: prefer explicit schema key when provided, then resolve by model-name fallback.
- getDefaultFieldName / getFieldName: prefer explicit schema key before reverse model lookup.
- adapter/factory join transformation: use schema-key-aware resolution for base/join/reference model resolution and field mapping.
- getAuthTables: keep FK references targeting the base user key (not custom user.modelName) to avoid broken relations in adapter join logic.

## Tests
Added regression tests covering collisions and joins:
- src/db/test/get-default-model-name.test.ts
- src/db/test/get-model-name.test.ts
- src/db/test/get-field-name.test.ts
- src/db/test/factory-join.test.ts
- updated src/db/test/get-tables.test.ts with user-reference assertions

## Verification
Executed:

pnpm --filter @better-auth/core exec vitest run \
  src/db/test/get-default-model-name.test.ts \
  src/db/test/get-model-name.test.ts \
  src/db/test/get-field-name.test.ts \
  src/db/test/get-tables.test.ts \
  src/db/test/factory-join.test.ts

All passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model-name collisions between schema keys and custom model names (e.g., user → account) so adapters resolve models, fields, and joins correctly. Foreign key references now consistently point to the base “user” key to prevent broken relations.

- **Bug Fixes**
  - Model resolution: prefer the explicit schema key; otherwise resolve by modelName to avoid user/account collisions.
  - Field resolution: use schema key-aware lookup in getFieldName/getDefaultFieldName.
  - Joins: resolve base and joined models via schema keys; compute on.from/on.to using the correct model.
  - Auth tables: keep FK references targeting the “user” base key even when user.modelName changes.

<sup>Written for commit fce3f70b97c65deb279fabffa3d3f31b56149a42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

