### PR TITLE
fix(drizzle-adapter): resolve db.query key mismatch when config.schema keys differ from schema exports

### DIFF
--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.plural-joins.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.plural-joins.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Regression test: db.query[model] lookup fails when the Drizzle schema
+ * object passed to drizzle() has plural export names ("users", "sessions")
+ * but config.schema maps singular Better Auth model names to the tables.
+ *
+ * This is the standard setup when users have a hand-written Drizzle schema
+ * (common with ORMs) and map it to Better Auth's singular model names:
+ *
+ *   drizzleAdapter(db, {
+ *     schema: { user: schema.users, session: schema.sessions, ... },
+ *     provider: "pg",
+ *   })
+ *
+ * The adapter correctly resolves getSchema("user") → schema.users via
+ * config.schema, but the join code path does db.query["user"] directly,
+ * which fails because db.query keys are "users", "sessions", etc.
+ */
+import type { Session, User } from "@better-auth/core/db";
+import { drizzleAdapter } from "@better-auth/drizzle-adapter";
+import Database from "better-sqlite3";
+import { relations } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// ── Schema with PLURAL export names (typical Drizzle convention) ──
+
+const users = sqliteTable("user", {
+	id: text("id").primaryKey(),
+	name: text("name").notNull(),
+	email: text("email").notNull(),
+	emailVerified: integer("emailVerified", { mode: "boolean" }).notNull(),
+	image: text("image"),
+	createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+	updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+});
+
+const sessions = sqliteTable("session", {
+	id: text("id").primaryKey(),
+	userId: text("userId")
+		.notNull()
+		.references(() => users.id),
+	token: text("token").notNull(),
+	expiresAt: integer("expiresAt", { mode: "timestamp" }).notNull(),
+	ipAddress: text("ipAddress"),
+	userAgent: text("userAgent"),
+	createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+	updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+});
+
+const accounts = sqliteTable("account", {
+	id: text("id").primaryKey(),
+	accountId: text("accountId").notNull(),
+	providerId: text("providerId").notNull(),
+	userId: text("userId")
+		.notNull()
+		.references(() => users.id),
+	accessToken: text("accessToken"),
+	refreshToken: text("refreshToken"),
+	idToken: text("idToken"),
+	accessTokenExpiresAt: integer("accessTokenExpiresAt", {
+		mode: "timestamp",
+	}),
+	refreshTokenExpiresAt: integer("refreshTokenExpiresAt", {
+		mode: "timestamp",
+	}),
+	scope: text("scope"),
+	password: text("password"),
+	createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+	updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+});
+
+const verifications = sqliteTable("verification", {
+	id: text("id").primaryKey(),
+	identifier: text("identifier").notNull(),
+	value: text("value").notNull(),
+	expiresAt: integer("expiresAt", { mode: "timestamp" }).notNull(),
+	createdAt: integer("createdAt", { mode: "timestamp" }),
+	updatedAt: integer("updatedAt", { mode: "timestamp" }),
+});
+
+// ── Relations ──
+
+const usersRelations = relations(users, ({ many }) => ({
+	sessions: many(sessions),
+	accounts: many(accounts),
+}));
+
+const sessionsRelations = relations(sessions, ({ one }) => ({
+	user: one(users, { fields: [sessions.userId], references: [users.id] }),
+}));
+
+const accountsRelations = relations(accounts, ({ one }) => ({
+	user: one(users, { fields: [accounts.userId], references: [users.id] }),
+}));
+
+// Schema passed to drizzle() — keys are plural JS export names.
+// db.query keys: "users", "sessions", "accounts", "verifications"
+const drizzleSchema = {
+	users,
+	sessions,
+	accounts,
+	verifications,
+	usersRelations,
+	sessionsRelations,
+	accountsRelations,
+};
+
+// Schema passed to the adapter — keys are SINGULAR Better Auth model names.
+// This is the standard config pattern: { user: schema.users, session: schema.sessions, ... }
+const adapterSchema = {
+	user: users,
+	session: sessions,
+	account: accounts,
+	verification: verifications,
+};
+
+// ── Tests ──
+
+describe("drizzle adapter: singular config.schema keys with plural db.query keys + experimental.joins", () => {
+	let sqliteDb: InstanceType<typeof Database>;
+	let db: ReturnType<typeof drizzle>;
+
+	beforeAll(() => {
+		sqliteDb = new Database(":memory:");
+		sqliteDb.exec(`
+			CREATE TABLE user (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				email TEXT NOT NULL,
+				emailVerified INTEGER NOT NULL DEFAULT 0,
+				image TEXT,
+				createdAt INTEGER NOT NULL,
+				updatedAt INTEGER NOT NULL
+			);
+			CREATE TABLE session (
+				id TEXT PRIMARY KEY,
+				userId TEXT NOT NULL REFERENCES user(id),
+				token TEXT NOT NULL,
+				expiresAt INTEGER NOT NULL,
+				ipAddress TEXT,
+				userAgent TEXT,
+				createdAt INTEGER NOT NULL,
+				updatedAt INTEGER NOT NULL
+			);
+			CREATE TABLE account (
+				id TEXT PRIMARY KEY,
+				accountId TEXT NOT NULL,
+				providerId TEXT NOT NULL,
+				userId TEXT NOT NULL REFERENCES user(id),
+				accessToken TEXT,
+				refreshToken TEXT,
+				idToken TEXT,
+				accessTokenExpiresAt INTEGER,
+				refreshTokenExpiresAt INTEGER,
+				scope TEXT,
+				password TEXT,
+				createdAt INTEGER NOT NULL,
+				updatedAt INTEGER NOT NULL
+			);
+			CREATE TABLE verification (
+				id TEXT PRIMARY KEY,
+				identifier TEXT NOT NULL,
+				value TEXT NOT NULL,
+				expiresAt INTEGER NOT NULL,
+				createdAt INTEGER,
+				updatedAt INTEGER
+			);
+		`);
+		// db.query keys will be: "users", "sessions", "accounts", "verifications"
+		db = drizzle(sqliteDb, { schema: drizzleSchema });
+	});
+
+	afterAll(() => {
+		sqliteDb.close();
+	});
+
+	it("findOne should use relational query (not fall back) when db.query keys differ from model names", async () => {
+		const adapterFactory = drizzleAdapter(db, {
+			// Singular keys — matches Better Auth internal model names
+			schema: adapterSchema,
+			provider: "sqlite",
+			// usePlural is NOT set (default: false) — this is the common config
+		});
+
+		const adapter = adapterFactory({
+			experimental: { joins: true },
+		});
+
+		const now = new Date();
+		const nowTs = now.getTime();
+
+		// Seed data via raw SQL to avoid adapter id-generation issues in test
+		sqliteDb.exec(`
+			INSERT OR REPLACE INTO user (id, name, email, emailVerified, createdAt, updatedAt)
+			VALUES ('u1', 'Test User', 'test@example.com', 0, ${nowTs}, ${nowTs});
+
+			INSERT OR REPLACE INTO session (id, userId, token, expiresAt, ipAddress, userAgent, createdAt, updatedAt)
+			VALUES ('s1', 'u1', 'test-token', ${nowTs + 86400000}, '127.0.0.1', 'vitest', ${nowTs}, ${nowTs});
+		`);
+
+		// findOne WITHOUT join — should work regardless (baseline)
+		const userBasic = await adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: "test@example.com" }],
+		});
+		expect(userBasic).not.toBeNull();
+		expect(userBasic?.id).toBe("u1");
+
+		// findOne WITH join — this is the bug path.
+		// The adapter does db.query["user"].findFirst() but db.query has "users" not "user".
+		// Without the fix: falls back to SELECT, session data is lost.
+		const userWithSessions = await adapter.findOne<
+			User & { session: Session[] }
+		>({
+			model: "user",
+			where: [{ field: "id", value: "u1" }],
+			join: {
+				session: true,
+			},
+		});
+
+		expect(userWithSessions).not.toBeNull();
+		expect(userWithSessions?.id).toBe("u1");
+		// Critical assertion: joined session data must be present.
+		// Without the fix, the adapter falls back to a plain SELECT and
+		// session data is undefined.
+		expect(userWithSessions?.session).toBeDefined();
+		expect(Array.isArray(userWithSessions?.session)).toBe(true);
+		expect(userWithSessions?.session).toHaveLength(1);
+		expect(userWithSessions?.session[0]?.id).toBe("s1");
+	});
+
+	it("findMany should use relational query (not fall back) when db.query keys differ from model names", async () => {
+		const adapterFactory = drizzleAdapter(db, {
+			schema: adapterSchema,
+			provider: "sqlite",
+		});
+
+		const adapter = adapterFactory({
+			experimental: { joins: true },
+		});
+
+		// findMany with join — exercises the findMany join path
+		const allUsers = await adapter.findMany<User & { session: Session[] }>({
+			model: "user",
+			join: {
+				session: true,
+			},
+		});
+
+		expect(allUsers).toHaveLength(1);
+		expect(allUsers[0]?.id).toBe("u1");
+		// Same critical assertion: joined data must be present
+		expect(allUsers[0]?.session).toBeDefined();
+		expect(Array.isArray(allUsers[0]?.session)).toBe(true);
+		expect(allUsers[0]?.session).toHaveLength(1);
+	});
+});

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -351,6 +351,43 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				}
 			}
 
+			/**
+			 * Resolve the db.query key for a model.
+			 *
+			 * When `usePlural` is false (default), Better Auth uses singular model
+			 * names like "user", but Drizzle's db.query is keyed by the schema
+			 * export names (often plural like "users"). This function:
+			 *
+			 * 1. Tries the model name directly (works when schema keys match)
+			 * 2. If usePlural is set, tries appending "s"
+			 * 3. Falls back to scanning config.schema to find which db.query key
+			 *    corresponds to the same table object
+			 */
+			function getQueryModel(model: string): string | null {
+				if (db.query[model]) return model;
+
+				if (config.usePlural) {
+					const plural = `${model}s`;
+					if (db.query[plural]) return plural;
+				}
+
+				if (config.schema) {
+					const targetTable = config.schema[model];
+					if (targetTable) {
+						const fullSchema = db._.fullSchema;
+						if (fullSchema) {
+							for (const key of Object.keys(db.query)) {
+								if (fullSchema[key] === targetTable) {
+									return key;
+								}
+							}
+						}
+					}
+				}
+
+				return null;
+			}
+
 			return {
 				async create({ model, data: values }) {
 					const schemaModel = getSchema(model);
@@ -364,7 +401,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					const clause = convertWhereClause(where, model);
 
 					if (options.experimental?.joins) {
-						if (!db.query || !db.query[model]) {
+						const queryModel = getQueryModel(model);
+						if (!db.query || !queryModel) {
 							logger.error(
 								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx auth@latest generate".`,
 							);
@@ -393,7 +431,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 									}
 								}
 							}
-							const query = db.query[model].findFirst({
+							const query = db.query[queryModel].findFirst({
 								where: clause[0],
 								columns:
 									select?.length && select.length > 0
@@ -450,7 +488,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					const sortFn = sortBy?.direction === "desc" ? desc : asc;
 
 					if (options.experimental?.joins) {
-						if (!db.query[model]) {
+						const queryModel = getQueryModel(model);
+						if (!queryModel) {
 							logger.error(
 								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx auth@latest generate".`,
 							);
@@ -486,7 +525,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 									),
 								];
 							}
-							const query = db.query[model].findMany({
+							const query = db.query[queryModel].findMany({
 								where: clause[0],
 								with: includes,
 								columns:


### PR DESCRIPTION
When users pass singular model names in config.schema (e.g. { user: schema.users }) but drizzle() receives plural schema exports, db.query is keyed by the export names ("users"), not the config.schema keys ("user"). The join code path did db.query[model] directly, which errored with "model not found in the query object" when the keys didn't match.

Add getQueryModel() helper that scans config.schema to find the matching db.query key via table object identity when direct lookup fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Drizzle adapter join queries when config.schema uses singular model names but the Drizzle schema exports are plural. Joins now resolve the correct db.query key and return related data as expected.

- **Bug Fixes**
  - Added getQueryModel() to resolve the db.query key by trying the model name, an optional plural (when usePlural is true), and finally matching the table object from config.schema against db._.fullSchema.
  - Updated findOne/findMany join paths to use the resolved key; logs once and falls back only if no match is found.
  - Added an e2e regression test covering singular config keys with plural schema exports to ensure joins return related records.

<sup>Written for commit 5440036c98e66d8ed6fc501653a4429b252c73a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

