### PR TITLE
Remove max chainId validation

### DIFF
--- a/packages/better-auth/src/plugins/siwe/index.ts
+++ b/packages/better-auth/src/plugins/siwe/index.ts
@@ -40,7 +40,7 @@ const getSiweNonceBodySchema = z.object({
 		.string()
 		.regex(/^0[xX][a-fA-F0-9]{40}$/i)
 		.length(42),
-	chainId: z.number().int().positive().max(2147483647).optional().default(1),
+	chainId: z.number().int().positive().optional().default(1),
 });
 
 export const siwe = (options: SIWEPluginOptions) =>


### PR DESCRIPTION
We need to remove this validation. if you see the some other networks chainId, it higher than the 2147483647.
for example: https://mendoza.hoodi.arkiv.network/ 
the chainId is 60138453056

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the max chainId validation in the SIWE nonce schema so sign-in works with networks that use very large chainIds (e.g., > 2,147,483,647).

<sup>Written for commit 50e5ea17a1f3b81cccf2e248965bcad650fd53b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

