### PR TITLE
chore: align package.json fields and add missing README.md files

### DIFF
--- a/packages/api-key/README.md
+++ b/packages/api-key/README.md
@@ -1,0 +1,17 @@
+# Better Auth API Key Plugin
+
+API Key plugin for [Better Auth](https://www.better-auth.com) — manage API keys for your users.
+
+## Installation
+
+```bash
+npm install @better-auth/api-key
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/plugins/api-key](https://www.better-auth.com/docs/plugins/api-key).
+
+## License
+
+MIT

--- a/packages/api-key/package.json
+++ b/packages/api-key/package.json
@@ -1,26 +1,39 @@
 {
   "name": "@better-auth/api-key",
   "version": "1.5.0-beta.18",
-  "type": "module",
   "description": "API Key plugin for Better Auth.",
-  "main": "dist/index.mjs",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/plugins/api-key",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/api-key"
   },
-  "homepage": "https://www.better-auth.com/docs/plugins/api-key",
+  "keywords": [
+    "auth",
+    "api-key",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:types": "attw --profile esm-only --pack .",
-    "lint:package": "publint run --strict",
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "typecheck": "tsc --project tsconfig.json"
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",
@@ -51,16 +64,9 @@
       ]
     }
   },
-  "keywords": [
-    "auth",
-    "api-key",
-    "typescript",
-    "better-auth"
-  ],
-  "publishConfig": {
-    "access": "public"
+  "dependencies": {
+    "zod": "^4.3.6"
   },
-  "license": "MIT",
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
@@ -70,11 +76,5 @@
     "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
     "@better-auth/utils": "catalog:"
-  },
-  "dependencies": {
-    "zod": "^4.3.6"
-  },
-  "files": [
-    "dist"
-  ]
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,39 +1,42 @@
 {
   "name": "auth",
   "version": "1.5.0-beta.18",
-  "type": "module",
   "description": "The CLI for Better Auth",
-  "module": "dist/index.mjs",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/concepts/cli",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/cli"
   },
-  "homepage": "https://www.better-auth.com/docs/concepts/cli",
-  "main": "./dist/index.mjs",
-  "scripts": {
-    "build": "tsdown",
-    "start": "node ./dist/index.mjs",
-    "lint:package": "publint run --strict",
-    "lint:types": "attw --profile esm-only --pack .",
-    "dev": "tsx ./src/index.ts",
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "typecheck": "tsc --project tsconfig.json"
-  },
-  "publishConfig": {
-    "access": "public",
-    "executableFiles": [
-      "./dist/index.mjs"
-    ]
-  },
-  "license": "MIT",
   "keywords": [
     "auth",
     "cli",
     "typescript",
     "better-auth"
   ],
+  "publishConfig": {
+    "access": "public",
+    "executableFiles": [
+      "./dist/index.mjs"
+    ]
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsx ./src/index.ts",
+    "start": "node ./dist/index.mjs",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
   "exports": {
     ".": "./dist/index.mjs",
     "./api": {
@@ -50,19 +53,6 @@
   },
   "bin": {
     "better-auth": "./dist/index.mjs"
-  },
-  "devDependencies": {
-    "@better-auth/passkey": "workspace:*",
-    "@types/better-sqlite3": "^7.6.13",
-    "@types/prompts": "^2.4.9",
-    "@types/semver": "^7.7.1",
-    "better-sqlite3": "^12.6.2",
-    "jiti": "^2.6.0",
-    "memfs": "^4.56.10",
-    "tsdown": "catalog:",
-    "tsx": "^4.20.6",
-    "type-fest": "^5.4.4",
-    "typescript": "catalog:"
   },
   "dependencies": {
     "@babel/core": "^7.28.4",
@@ -89,7 +79,17 @@
     "yocto-spinner": "^0.2.3",
     "zod": "^4.3.6"
   },
-  "files": [
-    "dist"
-  ]
+  "devDependencies": {
+    "@better-auth/passkey": "workspace:*",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/prompts": "^2.4.9",
+    "@types/semver": "^7.7.1",
+    "better-sqlite3": "^12.6.2",
+    "jiti": "^2.6.0",
+    "memfs": "^4.56.10",
+    "tsdown": "catalog:",
+    "tsx": "^4.20.6",
+    "type-fest": "^5.4.4",
+    "typescript": "catalog:"
+  }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,17 @@
+# Better Auth Core
+
+Core utilities and types for [Better Auth](https://www.better-auth.com) — the most comprehensive authentication framework for TypeScript.
+
+## Installation
+
+```bash
+npm install @better-auth/core
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com](https://www.better-auth.com).
+
+## License
+
+MIT

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,10 +3,30 @@
   "version": "1.5.0-beta.18",
   "description": "The most comprehensive authentication framework for TypeScript.",
   "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/core"
+  },
+  "keywords": [
+    "auth",
+    "core",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
   "files": [
     "dist",
@@ -118,14 +138,9 @@
       ]
     }
   },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
-    "lint:types": "attw --profile esm-only --pack .",
-    "typecheck": "tsc --project tsconfig.json",
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul"
+  "dependencies": {
+    "@standard-schema/spec": "^1.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@better-auth/utils": "catalog:",
@@ -135,10 +150,6 @@
     "kysely": "^0.28.10",
     "nanostores": "^1.1.0",
     "tsdown": "catalog:"
-  },
-  "dependencies": {
-    "@standard-schema/spec": "^1.0.0",
-    "zod": "^4.3.6"
   },
   "peerDependencies": {
     "@better-auth/utils": "catalog:",

--- a/packages/drizzle-adapter/README.md
+++ b/packages/drizzle-adapter/README.md
@@ -1,0 +1,17 @@
+# Better Auth Drizzle Adapter
+
+Drizzle ORM adapter for [Better Auth](https://www.better-auth.com).
+
+## Installation
+
+```bash
+npm install @better-auth/drizzle-adapter
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/adapters/drizzle](https://www.better-auth.com/docs/adapters/drizzle).
+
+## License
+
+MIT

--- a/packages/drizzle-adapter/package.json
+++ b/packages/drizzle-adapter/package.json
@@ -3,11 +3,34 @@
   "version": "1.5.0-beta.18",
   "description": "Drizzle adapter for Better Auth",
   "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/adapters/drizzle",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/drizzle-adapter"
   },
+  "keywords": [
+    "auth",
+    "drizzle",
+    "adapter",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -17,12 +40,6 @@
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     }
-  },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "test": "vitest",
-    "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
     "@better-auth/core": "workspace:*",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,36 +1,39 @@
 {
   "name": "@better-auth/electron",
   "version": "1.5.0-beta.18",
-  "type": "module",
   "description": "Better Auth integration for Electron applications.",
-  "main": "dist/index.mjs",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.mts",
-  "publishConfig": {
-    "access": "public"
-  },
+  "type": "module",
   "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/integrations/electron",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
+    "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/electron"
   },
-  "homepage": "https://www.better-auth.com/docs/integrations/electron",
   "keywords": [
     "electron",
     "auth",
     "better-auth",
     "typescript"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:package": "publint run --strict",
-    "lint:types": "attw --profile esm-only --pack .",
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "typecheck": "tsc --project tsconfig.json"
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",
@@ -77,23 +80,6 @@
       ]
     }
   },
-  "peerDependenciesMeta": {
-    "electron": {
-      "optional": true
-    },
-    "conf": {
-      "optional": true
-    }
-  },
-  "peerDependencies": {
-    "@better-auth/core": "workspace:*",
-    "@better-auth/utils": "catalog:",
-    "@better-fetch/fetch": "catalog:",
-    "better-auth": "workspace:*",
-    "better-call": "catalog:",
-    "conf": "^15.0.2",
-    "electron": ">=36.0.0"
-  },
   "dependencies": {
     "zod": "^4.3.6"
   },
@@ -105,10 +91,24 @@
     "electron": "^38.8.0",
     "tsdown": "catalog:"
   },
+  "peerDependencies": {
+    "@better-auth/core": "workspace:*",
+    "@better-auth/utils": "catalog:",
+    "@better-fetch/fetch": "catalog:",
+    "better-auth": "workspace:*",
+    "better-call": "catalog:",
+    "conf": "^15.0.2",
+    "electron": ">=36.0.0"
+  },
+  "peerDependenciesMeta": {
+    "electron": {
+      "optional": true
+    },
+    "conf": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=22.0.0"
-  },
-  "files": [
-    "dist"
-  ]
+  }
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,26 +1,40 @@
 {
   "name": "@better-auth/expo",
   "version": "1.5.0-beta.18",
-  "type": "module",
   "description": "Better Auth integration for Expo and React Native applications.",
-  "main": "dist/index.mjs",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/integrations/expo",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/expo"
   },
-  "homepage": "https://www.better-auth.com/docs/integrations/expo",
+  "keywords": [
+    "auth",
+    "expo",
+    "react-native",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:types": "attw --profile esm-only --pack .",
-    "lint:package": "publint run --strict",
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "typecheck": "tsc --project tsconfig.json"
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",
@@ -51,17 +65,11 @@
       ]
     }
   },
-  "keywords": [
-    "auth",
-    "expo",
-    "react-native",
-    "typescript",
-    "better-auth"
-  ],
-  "publishConfig": {
-    "access": "public"
+  "dependencies": {
+    "@better-fetch/fetch": "catalog:",
+    "better-call": "catalog:",
+    "zod": "^4.3.6"
   },
-  "license": "MIT",
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "@better-fetch/fetch": "catalog:",
@@ -94,13 +102,5 @@
     "expo-web-browser": {
       "optional": true
     }
-  },
-  "dependencies": {
-    "@better-fetch/fetch": "catalog:",
-    "better-call": "catalog:",
-    "zod": "^4.3.6"
-  },
-  "files": [
-    "dist"
-  ]
+  }
 }

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,0 +1,17 @@
+# Better Auth i18n Plugin
+
+Internationalization plugin for [Better Auth](https://www.better-auth.com) — translate error messages and UI strings.
+
+## Installation
+
+```bash
+npm install @better-auth/i18n
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/plugins/i18n](https://www.better-auth.com/docs/plugins/i18n).
+
+## License
+
+MIT

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,23 +1,40 @@
 {
   "name": "@better-auth/i18n",
   "version": "1.5.0-beta.18",
-  "type": "module",
   "description": "i18n plugin for Better Auth - translate error messages",
-  "main": "dist/index.mjs",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/plugins/i18n",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/better-auth/better-auth.git",
+    "directory": "packages/i18n"
+  },
+  "keywords": [
+    "auth",
+    "i18n",
+    "internationalization",
+    "typescript",
+    "better-auth"
+  ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:package": "publint run --strict",
-    "lint:types": "attw --profile esm-only --pack .",
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "typecheck": "tsc --project tsconfig.json"
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",
@@ -48,22 +65,5 @@
   "peerDependencies": {
     "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*"
-  },
-  "files": [
-    "dist"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/better-auth/better-auth.git",
-    "directory": "packages/i18n"
-  },
-  "homepage": "https://www.better-auth.com/docs/plugins/i18n",
-  "keywords": [
-    "auth",
-    "i18n",
-    "internationalization",
-    "typescript",
-    "better-auth"
-  ],
-  "license": "MIT"
+  }
 }

--- a/packages/kysely-adapter/README.md
+++ b/packages/kysely-adapter/README.md
@@ -1,0 +1,17 @@
+# Better Auth Kysely Adapter
+
+Kysely adapter for [Better Auth](https://www.better-auth.com).
+
+## Installation
+
+```bash
+npm install @better-auth/kysely-adapter
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/adapters/kysely](https://www.better-auth.com/docs/adapters/kysely).
+
+## License
+
+MIT

--- a/packages/kysely-adapter/package.json
+++ b/packages/kysely-adapter/package.json
@@ -3,11 +3,34 @@
   "version": "1.5.0-beta.18",
   "description": "Kysely adapter for Better Auth",
   "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/adapters/kysely",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/kysely-adapter"
   },
+  "keywords": [
+    "auth",
+    "kysely",
+    "adapter",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -22,12 +45,6 @@
       "types": "./dist/node-sqlite-dialect.d.mts",
       "default": "./dist/node-sqlite-dialect.mjs"
     }
-  },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "test": "vitest",
-    "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
     "@better-auth/core": "workspace:*",

--- a/packages/memory-adapter/README.md
+++ b/packages/memory-adapter/README.md
@@ -1,0 +1,17 @@
+# Better Auth Memory Adapter
+
+In-memory adapter for [Better Auth](https://www.better-auth.com) — useful for development and testing.
+
+## Installation
+
+```bash
+npm install @better-auth/memory-adapter
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com](https://www.better-auth.com).
+
+## License
+
+MIT

--- a/packages/memory-adapter/package.json
+++ b/packages/memory-adapter/package.json
@@ -3,11 +3,34 @@
   "version": "1.5.0-beta.18",
   "description": "Memory adapter for Better Auth",
   "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/memory-adapter"
   },
+  "keywords": [
+    "auth",
+    "memory",
+    "adapter",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -17,12 +40,6 @@
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     }
-  },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "test": "vitest",
-    "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
     "@better-auth/core": "workspace:*",

--- a/packages/mongo-adapter/README.md
+++ b/packages/mongo-adapter/README.md
@@ -1,0 +1,17 @@
+# Better Auth MongoDB Adapter
+
+MongoDB adapter for [Better Auth](https://www.better-auth.com).
+
+## Installation
+
+```bash
+npm install @better-auth/mongo-adapter
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/adapters/mongodb](https://www.better-auth.com/docs/adapters/mongodb).
+
+## License
+
+MIT

--- a/packages/mongo-adapter/package.json
+++ b/packages/mongo-adapter/package.json
@@ -3,11 +3,34 @@
   "version": "1.5.0-beta.18",
   "description": "Mongo adapter for Better Auth",
   "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/adapters/mongodb",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/mongo-adapter"
   },
+  "keywords": [
+    "auth",
+    "mongodb",
+    "adapter",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -17,12 +40,6 @@
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     }
-  },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "test": "vitest",
-    "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
     "@better-auth/core": "workspace:*",

--- a/packages/oauth-provider/README.md
+++ b/packages/oauth-provider/README.md
@@ -1,0 +1,17 @@
+# Better Auth OAuth Provider Plugin
+
+OAuth provider plugin for [Better Auth](https://www.better-auth.com) — turn your application into an OAuth 2.0 provider.
+
+## Installation
+
+```bash
+npm install @better-auth/oauth-provider
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/plugins/oauth-provider](https://www.better-auth.com/docs/plugins/oauth-provider).
+
+## License
+
+MIT

--- a/packages/oauth-provider/package.json
+++ b/packages/oauth-provider/package.json
@@ -1,21 +1,39 @@
 {
   "name": "@better-auth/oauth-provider",
   "version": "1.5.0-beta.18",
-  "type": "module",
   "description": "An oauth provider plugin for Better Auth",
-  "main": "dist/index.mjs",
-  "module": "dist/index.mjs",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/plugins/oauth-provider",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/better-auth/better-auth.git",
+    "directory": "packages/oauth-provider"
+  },
+  "keywords": [
+    "auth",
+    "oauth",
+    "typescript",
+    "better-auth"
+  ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:package": "publint run --strict",
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "typecheck": "tsc --project tsconfig.json"
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",
@@ -46,6 +64,10 @@
       ]
     }
   },
+  "dependencies": {
+    "jose": "^6.1.0",
+    "zod": "^4.3.6"
+  },
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0",
@@ -53,31 +75,11 @@
     "listhen": "^1.9.0",
     "tsdown": "catalog:"
   },
-  "dependencies": {
-    "jose": "^6.1.0",
-    "zod": "^4.3.6"
-  },
   "peerDependencies": {
     "@better-auth/core": "workspace:*",
     "@better-auth/utils": "catalog:",
     "@better-fetch/fetch": "catalog:",
     "better-auth": "workspace:*",
     "better-call": "catalog:"
-  },
-  "files": [
-    "dist"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/better-auth/better-auth",
-    "directory": "packages/oauth-provider"
-  },
-  "homepage": "https://www.better-auth.com/docs/plugins/oauth-provider",
-  "keywords": [
-    "auth",
-    "oauth",
-    "typescript",
-    "better-auth"
-  ],
-  "license": "MIT"
+  }
 }

--- a/packages/passkey/package.json
+++ b/packages/passkey/package.json
@@ -1,23 +1,39 @@
 {
   "name": "@better-auth/passkey",
   "version": "1.5.0-beta.18",
-  "type": "module",
   "description": "Passkey plugin for Better Auth",
-  "main": "dist/index.mjs",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/plugins/passkey",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/better-auth/better-auth.git",
+    "directory": "packages/passkey"
+  },
+  "keywords": [
+    "auth",
+    "passkey",
+    "typescript",
+    "better-auth"
+  ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:package": "publint run --strict",
-    "lint:types": "attw --profile esm-only --pack .",
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "typecheck": "tsc --project tsconfig.json"
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",
@@ -40,15 +56,15 @@
       ]
     }
   },
-  "devDependencies": {
-    "@better-auth/core": "workspace:*",
-    "better-auth": "workspace:*",
-    "tsdown": "catalog:"
-  },
   "dependencies": {
     "@simplewebauthn/browser": "^13.2.2",
     "@simplewebauthn/server": "^13.2.2",
     "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@better-auth/core": "workspace:*",
+    "better-auth": "workspace:*",
+    "tsdown": "catalog:"
   },
   "peerDependencies": {
     "@better-auth/core": "workspace:*",
@@ -57,21 +73,5 @@
     "better-auth": "workspace:*",
     "better-call": "catalog:",
     "nanostores": "^1.0.1"
-  },
-  "files": [
-    "dist"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/better-auth/better-auth.git",
-    "directory": "packages/passkey"
-  },
-  "homepage": "https://www.better-auth.com/docs/plugins/passkey",
-  "keywords": [
-    "auth",
-    "passkey",
-    "typescript",
-    "better-auth"
-  ],
-  "license": "MIT"
+  }
 }

--- a/packages/prisma-adapter/README.md
+++ b/packages/prisma-adapter/README.md
@@ -1,0 +1,17 @@
+# Better Auth Prisma Adapter
+
+Prisma adapter for [Better Auth](https://www.better-auth.com).
+
+## Installation
+
+```bash
+npm install @better-auth/prisma-adapter
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/adapters/prisma](https://www.better-auth.com/docs/adapters/prisma).
+
+## License
+
+MIT

--- a/packages/prisma-adapter/package.json
+++ b/packages/prisma-adapter/package.json
@@ -3,11 +3,34 @@
   "version": "1.5.0-beta.18",
   "description": "Prisma adapter for Better Auth",
   "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/adapters/prisma",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/prisma-adapter"
   },
+  "keywords": [
+    "auth",
+    "prisma",
+    "adapter",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -17,12 +40,6 @@
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     }
-  },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "test": "vitest",
-    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@prisma/client": "^5.0.0"

--- a/packages/redis-storage/README.md
+++ b/packages/redis-storage/README.md
@@ -1,0 +1,17 @@
+# Better Auth Redis Storage
+
+Redis storage for [Better Auth](https://www.better-auth.com) secondary storage — use Redis for session caching and rate limiting.
+
+## Installation
+
+```bash
+npm install @better-auth/redis-storage
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/storage](https://www.better-auth.com/docs/storage).
+
+## License
+
+MIT

--- a/packages/redis-storage/package.json
+++ b/packages/redis-storage/package.json
@@ -3,11 +3,34 @@
   "version": "1.5.0-beta.18",
   "description": "Redis storage for Better Auth secondary storage",
   "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/storage",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/redis-storage"
   },
+  "keywords": [
+    "auth",
+    "redis",
+    "storage",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -17,12 +40,6 @@
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     }
-  },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "test": "vitest",
-    "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
     "@better-auth/core": "workspace:*",

--- a/packages/scim/README.md
+++ b/packages/scim/README.md
@@ -1,0 +1,17 @@
+# Better Auth SCIM Plugin
+
+SCIM (System for Cross-domain Identity Management) plugin for [Better Auth](https://www.better-auth.com) — enable enterprise user provisioning.
+
+## Installation
+
+```bash
+npm install @better-auth/scim
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/plugins/scim](https://www.better-auth.com/docs/plugins/scim).
+
+## License
+
+MIT

--- a/packages/scim/package.json
+++ b/packages/scim/package.json
@@ -1,34 +1,40 @@
 {
   "name": "@better-auth/scim",
-  "author": "Jonathan Samines",
   "version": "1.5.0-beta.18",
+  "description": "SCIM plugin for Better Auth",
   "type": "module",
-  "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
   "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/plugins/scim",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/scim"
   },
+  "author": "Jonathan Samines",
   "keywords": [
     "auth",
-    "scim"
+    "scim",
+    "typescript",
+    "better-auth"
   ],
   "publishConfig": {
     "access": "public"
   },
-  "module": "dist/index.mjs",
-  "description": "SCIM plugin for Better Auth",
   "scripts": {
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:package": "publint run --strict",
-    "lint:types": "attw --profile esm-only --pack .",
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "typecheck": "tsc --project tsconfig.json"
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",

--- a/packages/sso/README.md
+++ b/packages/sso/README.md
@@ -1,0 +1,17 @@
+# Better Auth SSO Plugin
+
+Single Sign-On plugin for [Better Auth](https://www.better-auth.com) — add SAML and OIDC enterprise SSO to your application.
+
+## Installation
+
+```bash
+npm install @better-auth/sso
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/plugins/sso](https://www.better-auth.com/docs/plugins/sso).
+
+## License
+
+MIT

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -1,43 +1,46 @@
 {
   "name": "@better-auth/sso",
-  "author": "Bereket Engida",
   "version": "1.5.0-beta.18",
+  "description": "SSO plugin for Better Auth",
   "type": "module",
-  "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "license": "MIT",
   "homepage": "https://www.better-auth.com/docs/plugins/sso",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/sso"
   },
-  "license": "MIT",
+  "author": "Bereket Engida",
   "keywords": [
     "sso",
     "auth",
-    "sso",
     "saml",
     "oauth",
     "oidc",
     "openid",
     "openid connect",
-    "openid connect",
-    "single sign on"
+    "single sign on",
+    "typescript",
+    "better-auth"
   ],
   "publishConfig": {
     "access": "public"
   },
-  "module": "dist/index.mjs",
-  "description": "SSO plugin for Better Auth",
   "scripts": {
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:package": "publint run --strict",
-    "lint:types": "attw --profile esm-only --pack .",
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "typecheck": "tsc --project tsconfig.json"
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -1,0 +1,17 @@
+# Better Auth Stripe Plugin
+
+Stripe plugin for [Better Auth](https://www.better-auth.com) — integrate Stripe billing with your authentication system.
+
+## Installation
+
+```bash
+npm install @better-auth/stripe
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com/docs/plugins/stripe](https://www.better-auth.com/docs/plugins/stripe).
+
+## License
+
+MIT

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,10 +1,8 @@
 {
   "name": "@better-auth/stripe",
-  "author": "Bereket Engida",
   "version": "1.5.0-beta.18",
+  "description": "Stripe plugin for Better Auth",
   "type": "module",
-  "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
   "license": "MIT",
   "homepage": "https://www.better-auth.com/docs/plugins/stripe",
   "repository": {
@@ -12,25 +10,32 @@
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/stripe"
   },
+  "author": "Bereket Engida",
   "keywords": [
     "stripe",
     "auth",
-    "stripe"
+    "payments",
+    "typescript",
+    "better-auth"
   ],
-  "module": "dist/index.mjs",
-  "description": "Stripe plugin for Better Auth",
-  "scripts": {
-    "test": "vitest",
-    "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:package": "publint run --strict",
-    "lint:types": "attw --profile esm-only --pack .",
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "typecheck": "tsc --project tsconfig.json"
-  },
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",
@@ -57,17 +62,17 @@
     "defu": "^6.1.4",
     "zod": "^4.3.6"
   },
-  "peerDependencies": {
-    "@better-auth/core": "workspace:*",
-    "better-auth": "workspace:*",
-    "better-call": "catalog:",
-    "stripe": "^18 || ^19 || ^20"
-  },
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "better-auth": "workspace:*",
     "better-call": "catalog:",
     "stripe": "^20.2.0",
     "tsdown": "catalog:"
+  },
+  "peerDependencies": {
+    "@better-auth/core": "workspace:*",
+    "better-auth": "workspace:*",
+    "better-call": "catalog:",
+    "stripe": "^18 || ^19 || ^20"
   }
 }

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,0 +1,17 @@
+# Better Auth Telemetry
+
+Telemetry package for [Better Auth](https://www.better-auth.com) — anonymous usage analytics to help improve the framework.
+
+## Installation
+
+```bash
+npm install @better-auth/telemetry
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com](https://www.better-auth.com).
+
+## License
+
+MIT

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -3,11 +3,32 @@
   "version": "1.5.0-beta.18",
   "description": "Telemetry package for Better Auth",
   "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/telemetry"
   },
+  "keywords": [
+    "auth",
+    "telemetry",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -25,21 +46,14 @@
       ]
     }
   },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
-    "lint:types": "attw --profile esm-only --pack .",
-    "typecheck": "tsc --project tsconfig.json"
+  "dependencies": {
+    "@better-auth/utils": "catalog:",
+    "@better-fetch/fetch": "catalog:"
   },
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "tsdown": "catalog:",
     "type-fest": "^5.4.4"
-  },
-  "dependencies": {
-    "@better-auth/utils": "catalog:",
-    "@better-fetch/fetch": "catalog:"
   },
   "peerDependencies": {
     "@better-auth/core": "workspace:*"

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -1,0 +1,17 @@
+# Better Auth Test Utils
+
+Testing utilities for [Better Auth](https://www.better-auth.com) adapter development and integration testing.
+
+## Installation
+
+```bash
+npm install @better-auth/test-utils
+```
+
+## Documentation
+
+For full documentation, visit [better-auth.com](https://www.better-auth.com).
+
+## License
+
+MIT

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,21 +1,37 @@
 {
   "name": "@better-auth/test-utils",
   "version": "1.5.0-beta.18",
+  "description": "Testing utilities for Better Auth adapter development",
   "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/better-auth/better-auth.git"
+    "url": "git+https://github.com/better-auth/better-auth.git",
+    "directory": "packages/test-utils"
   },
+  "keywords": [
+    "auth",
+    "testing",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch"
+  },
+  "files": [
+    "dist"
+  ],
   "exports": {
     "./adapter": {
       "dev-source": "./src/adapter.ts",
       "default": "./dist/adapter.mjs",
       "types": "./dist/adapter.d.mts"
     }
-  },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch"
   },
   "devDependencies": {
     "@better-auth/core": "workspace:*",


### PR DESCRIPTION
Add README.md to 15 packages that were missing them. Standardize package.json across all 20 packages: add missing license, homepage, keywords, publishConfig, files, and lint scripts. Fix duplicate keywords in sso and stripe, normalize repository URLs, and ensure consistent field ordering and ./dist path prefixes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing READMEs and align package metadata across the monorepo to improve publish quality and consistency. No runtime code changes; only README and package.json updates.

- **Refactors**
  - Added README.md to 15 packages.
  - Standardized package.json across 20 packages: license, homepage, keywords, publishConfig, and files.
  - Normalized repository URLs, field order, and ./dist path prefixes for main/module/types.
  - Aligned scripts: build, dev, typecheck, test, coverage, lint:package, lint:types.
  - Removed duplicate keywords (sso, stripe) and cleaned up peer/dev dependency blocks.

<sup>Written for commit a3ee8e16a37fa2b2f7c3479d1c1f1c5464591bd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

