### PR TITLE
docs: fix description code example mismatch

### DIFF
--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -176,7 +176,7 @@ The additional data is available in your hooks during the OAuth callback through
 This usually works for `/callback/:id` paths and the generic OAuth plugin callback path (`/oauth2/callback/:providerId`).
 </Callout>
 
-Example using a before hook:
+Example using an after hook:
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed a mismatch in the OAuth docs: the example is an after hook, not a before hook. No functional changes.

<sup>Written for commit a6955708f7cef1befa954358f37f6c0f9fbda2b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

