### PR TITLE
fix: prevent double encoded cookie

### DIFF
--- a/packages/better-auth/src/cookies/cookie-utils.ts
+++ b/packages/better-auth/src/cookies/cookie-utils.ts
@@ -1,3 +1,11 @@
+function tryDecode(str: string): string {
+	try {
+		return decodeURIComponent(str);
+	} catch {
+		return str;
+	}
+}
+
 export interface CookieAttributes {
 	value: string;
 	"max-age"?: number | undefined;
@@ -85,7 +93,8 @@ export function parseSetCookieHeader(
 			return;
 		}
 
-		const attrObj: CookieAttributes = { value };
+		const decodedValue = value.includes("%") ? tryDecode(value) : value;
+		const attrObj: CookieAttributes = { value: decodedValue };
 
 		attributes.forEach((attribute) => {
 			const [attrName, ...attrValueParts] = attribute!.split("=");

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -226,6 +226,12 @@ describe("cookie-utils parseSetCookieHeader", () => {
 		);
 	});
 
+	it("decodes URI-encoded cookie values", () => {
+		const header = "token=hello%20world%3Dfoo; Path=/";
+		const map = parseSetCookieHeader(header);
+		expect(map.get("token")?.value).toBe("hello world=foo");
+	});
+
 	it("handles cookie with Expires followed by cookie without Expires", () => {
 		const map = parseSetCookieHeader(
 			"session=xyz; Expires=Mon, 01 Jan 2026 00:00:00 GMT, token=abc",

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -100,7 +100,7 @@ export const nextCookies = () => {
 									path: value.path,
 								} as const;
 								try {
-									cookieHelper.set(key, decodeURIComponent(value.value), opts);
+									cookieHelper.set(key, value.value, opts);
 								} catch {
 									// this will fail if the cookie is being set on server component
 								}

--- a/packages/better-auth/src/integrations/svelte-kit.ts
+++ b/packages/better-auth/src/integrations/svelte-kit.ts
@@ -78,7 +78,7 @@ export const sveltekitCookies = (
 
 							for (const [name, { value, ...ops }] of parsed) {
 								try {
-									event.cookies.set(name, decodeURIComponent(value), {
+									event.cookies.set(name, value, {
 										sameSite: ops.samesite,
 										path: ops.path || "/",
 										expires: ops.expires,

--- a/packages/better-auth/src/integrations/tanstack-start-solid.ts
+++ b/packages/better-auth/src/integrations/tanstack-start-solid.ts
@@ -51,7 +51,7 @@ export const tanstackStartCookies = () => {
 									path: value.path,
 								} as const;
 								try {
-									setCookie(key, decodeURIComponent(value.value), opts);
+									setCookie(key, value.value, opts);
 								} catch {
 									// this will fail if the cookie is being set on server component
 								}

--- a/packages/better-auth/src/integrations/tanstack-start.ts
+++ b/packages/better-auth/src/integrations/tanstack-start.ts
@@ -51,7 +51,7 @@ export const tanstackStartCookies = () => {
 									path: value.path,
 								} as const;
 								try {
-									setCookie(key, decodeURIComponent(value.value), opts);
+									setCookie(key, value.value, opts);
 								} catch {
 									// this will fail if the cookie is being set on server component
 								}

--- a/packages/better-auth/src/plugins/custom-session/index.ts
+++ b/packages/better-auth/src/plugins/custom-session/index.ts
@@ -132,11 +132,7 @@ export const customSession = <
 					for (const cookieStr of session.headers.getSetCookie()) {
 						const parsed = parseSetCookieHeader(cookieStr);
 						parsed.forEach((attrs, name) => {
-							let decodedValue = attrs.value;
-							try {
-								decodedValue = decodeURIComponent(attrs.value);
-							} catch {}
-							ctx.setCookie(name, decodedValue, {
+							ctx.setCookie(name, attrs.value, {
 								maxAge: attrs["max-age"],
 								expires: attrs.expires,
 								domain: attrs.domain,


### PR DESCRIPTION
Fix #8127

Decode forwarded `Set-Cookie` values in `customSession` before calling `ctx.setCookie(...)` so `/get-session` refresh does not double-encode session cookies (`%25`).

- decode parsed cookie value before re-setting cookie
- add regression test for refresh cookie encoding

Tests
- `corepack pnpm --dir packages/better-auth exec vitest run src/plugins/custom-session/custom-session.test.ts --maxWorkers=1`
- `corepack pnpm --dir packages/better-auth exec vitest run src/cookies/cookies.test.ts --maxWorkers=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double-encoding of session cookies during get-session refresh in the customSession plugin, fixing #8127. Cookie values are decoded once when parsing Set-Cookie so better-auth.session_token stays unchanged on refresh.

- **Bug Fixes**
  - Centralize decoding in parseSetCookieHeader using a safe tryDecode only when "%" is present; add a unit test for URI-decoded values.
  - Remove redundant decode calls in Next.js, SvelteKit, and TanStack Start integrations.
  - Add a regression test to ensure the session token is identical after refresh and contains no %25.

<sup>Written for commit 1d345729d5493498b7319737a41821d0baea64c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

