### PR TITLE
fix(captcha): add `$ERROR_CODES`

### DIFF
--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -8,6 +8,7 @@ import * as verifyHandlers from "./verify-handlers";
 export const captcha = (options: CaptchaOptions) =>
 	({
 		id: "captcha",
+		$ERROR_CODES: EXTERNAL_ERROR_CODES,
 		onRequest: async (request, ctx) => {
 			try {
 				const endpoints = options.endpoints?.length


### PR DESCRIPTION
Currently captcha has custom error messages that are not exposed in the lib due to it missing `$ERROR_CODES`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose captcha error codes by adding $ERROR_CODES to the captcha plugin. This fixes the missing export so clients can read and handle consistent error codes from the library.

<sup>Written for commit 8431cf813a6260ad42d728a83d95cc96f0fb4ed0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

