### PR TITLE
fix(cookie): add deprecated `options` alias for backward compatibility

### DIFF
--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -63,18 +63,21 @@ export function createCookieGetter(options: BetterAuthOptions) {
 		const attributes =
 			options.advanced?.cookies?.[cookieName as "session_token"]?.attributes;
 
+		const resolvedAttributes: CookieOptions = {
+			secure: !!secureCookiePrefix,
+			sameSite: "lax",
+			path: "/",
+			httpOnly: true,
+			...(crossSubdomainEnabled ? { domain } : {}),
+			...options.advanced?.defaultCookieAttributes,
+			...overrideAttributes,
+			...attributes,
+		};
+
 		return {
 			name: `${secureCookiePrefix}${name}`,
-			attributes: {
-				secure: !!secureCookiePrefix,
-				sameSite: "lax",
-				path: "/",
-				httpOnly: true,
-				...(crossSubdomainEnabled ? { domain } : {}),
-				...options.advanced?.defaultCookieAttributes,
-				...overrideAttributes,
-				...attributes,
-			},
+			attributes: resolvedAttributes,
+			options: resolvedAttributes,
 		} satisfies BetterAuthCookie;
 	}
 	return createCookie;
@@ -97,6 +100,7 @@ export function getCookies(options: BetterAuthOptions) {
 		sessionToken: {
 			name: sessionToken.name,
 			attributes: sessionToken.attributes,
+			options: sessionToken.attributes,
 		},
 		/**
 		 * This cookie is used to store the session data in the cookie
@@ -105,14 +109,17 @@ export function getCookies(options: BetterAuthOptions) {
 		sessionData: {
 			name: sessionData.name,
 			attributes: sessionData.attributes,
+			options: sessionData.attributes,
 		},
 		dontRememberToken: {
 			name: dontRememberToken.name,
 			attributes: dontRememberToken.attributes,
+			options: dontRememberToken.attributes,
 		},
 		accountData: {
 			name: accountData.name,
 			attributes: accountData.attributes,
+			options: accountData.attributes,
 		},
 	};
 }
@@ -283,7 +290,7 @@ export async function setSessionCookie(
  */
 export function expireCookie(
 	ctx: GenericEndpointContext,
-	cookie: BetterAuthCookie,
+	cookie: Pick<BetterAuthCookie, "name" | "attributes">,
 ) {
 	ctx.setCookie(cookie.name, "", {
 		...cookie.attributes,

--- a/packages/core/src/types/cookie.ts
+++ b/packages/core/src/types/cookie.ts
@@ -1,6 +1,13 @@
 import type { CookieOptions } from "better-call";
 
-export type BetterAuthCookie = { name: string; attributes: CookieOptions };
+export type BetterAuthCookie = {
+	name: string;
+	attributes: CookieOptions;
+	/**
+	 * @deprecated Use `attributes` instead. This alias is kept for backward compatibility.
+	 */
+	options: CookieOptions;
+};
 
 export type BetterAuthCookies = {
 	sessionToken: BetterAuthCookie;


### PR DESCRIPTION
This is the breaking change since https://github.com/better-auth/better-auth/pull/7363, and I mistakenly cherry-picked it to 1.4.x.