### PR TITLE
fix(last-login-method): avoid store cookie when `storeInDatabase` is `true`

### DIFF
--- a/docs/content/docs/plugins/last-login-method.mdx
+++ b/docs/content/docs/plugins/last-login-method.mdx
@@ -72,14 +72,14 @@ import { Badge } from "@/components/ui/badge"
 
 export function SignInPage() {
     const lastMethod = authClient.getLastUsedLoginMethod()
-    
+
     return (
         <div className="space-y-4">
             <h1>Sign In</h1>
-            
+
             {/* Email sign in */}
             <div className="relative">
-                <Button 
+                <Button
                     onClick={() => authClient.signIn.email({...})}
                     variant={lastMethod === "email" ? "default" : "outline"}
                     className="w-full"
@@ -90,10 +90,10 @@ export function SignInPage() {
                     )}
                 </Button>
             </div>
-            
+
             {/* OAuth providers */}
             <div className="relative">
-                <Button 
+                <Button
                     onClick={() => authClient.signIn.social({ provider: "google" })}
                     variant={lastMethod === "google" ? "default" : "outline"}
                     className="w-full"
@@ -104,9 +104,9 @@ export function SignInPage() {
                     )}
                 </Button>
             </div>
-            
+
             <div className="relative">
-                <Button 
+                <Button
                     onClick={() => authClient.signIn.social({ provider: "github" })}
                     variant={lastMethod === "github" ? "default" : "outline"}
                     className="w-full"
@@ -122,9 +122,10 @@ export function SignInPage() {
 }
 ```
 
-## Database Persistence
+## Storing in Database instead of Cookies
 
 By default, the last login method is stored only in cookies. For more persistent tracking and analytics, you can enable database storage.
+This also means that no cookie will be created which can be beneficial for GDPR compliance.
 
 <Steps>
     <Step>
@@ -232,10 +233,10 @@ export const auth = betterAuth({
             // Cookie configuration
             cookieName: "better-auth.last_used_login_method", // Default: "better-auth.last_used_login_method"
             maxAge: 60 * 60 * 24 * 30, // Default: 30 days in seconds
-            
+
             // Database persistence
             storeInDatabase: false, // Default: false
-            
+
             // Custom method resolution
             customResolveMethod: (ctx) => {
                 // Custom logic to determine the login method
@@ -245,7 +246,7 @@ export const auth = betterAuth({
                 // Return null to use default resolution
                 return null
             },
-            
+
             // Schema customization (when storeInDatabase is true)
             schema: {
                 user: {
@@ -262,7 +263,7 @@ export const auth = betterAuth({
 - Default: `"better-auth.last_used_login_method"`
 - **Note**: This cookie is `httpOnly: false` to allow client-side JavaScript access for UI features
 
-**maxAge**: `number`  
+**maxAge**: `number`
 - Cookie expiration time in seconds
 - Default: `2592000` (30 days)
 
@@ -311,7 +312,7 @@ By default, the plugin tracks these authentication methods:
 
 The plugin automatically detects the method from these endpoints:
 - `/callback/:id` - OAuth callback with provider ID
-- `/oauth2/callback/:id` - OAuth2 callback with provider ID  
+- `/oauth2/callback/:id` - OAuth2 callback with provider ID
 - `/sign-in/email` - Email sign in
 - `/sign-up/email` - Email sign up
 
@@ -342,17 +343,17 @@ export const auth = betterAuth({
                 if (ctx.path === "/saml/callback") {
                     return "saml"
                 }
-                
+
                 // Track magic link authentication
                 if (ctx.path === "/magic-link/verify") {
                     return "magic-link"
                 }
-                
+
                 // Track phone authentication
                 if (ctx.path === "/sign-in/phone") {
                     return "phone"
                 }
-                
+
                 // Return null to use default logic
                 return null
             }

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -141,6 +141,7 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 						return true;
 					},
 					handler: createAuthMiddleware(async (ctx) => {
+						if (config.storeInDatabase) return;
 						const lastUsedLoginMethod =
 							config.customResolveMethod?.(ctx) ?? defaultResolveMethod(ctx);
 						if (lastUsedLoginMethod) {

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -146,7 +146,7 @@ describe("lastLoginMethod", async () => {
 							headers.append("set-cookie", value);
 						}
 					});
-				}
+				},
 			},
 		);
 
@@ -241,52 +241,131 @@ describe("lastLoginMethod", async () => {
 		const cookies = parseCookies(headers.get("cookie") || "");
 		expect(cookies.get("better-auth.last_used_login_method")).toBeUndefined();
 	});
-	it("should update the last login method in the database on subsequent logins", async () => {
+	it("should update the last login method in the database on subsequent logins if storeInDatabase is true", async () => {
+		const headers = new Headers();
 		const { client, auth } = await getTestInstance({
 			plugins: [lastLoginMethod({ storeInDatabase: true })],
 		});
 
-		await client.signUp.email(
+		const signUpRes = await client.signUp.email(
 			{
 				email: "test@example.com",
 				password: "password123",
 				name: "Test User",
 			},
-			{ throw: true },
+			{
+				throw: true,
+				onSuccess(context) {
+					context.response.headers.forEach((value, key) => {
+						if (key.toLowerCase() === "set-cookie") {
+							headers.append("set-cookie", value);
+						}
+					});
+				},
+			},
 		);
 
+		const cookiesSignUp = parseSetCookieHeader(headers.get("set-cookie") || "");
+		// When storeInDatabase is true, it should NOT set a cookie
+		expect(
+			cookiesSignUp.get("better-auth.last_used_login_method"),
+		).toBeUndefined();
+
+		// Check session right after sign up to confirm it was set on user creation
+		let session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${signUpRes.token}`,
+			}),
+		});
+
+		// Expected to be defined as user field from the DB
+		expect((session?.user as any).lastLoginMethod).toBe("email");
+
+		await client.signOut();
+
+		// Also check subsequent login sets it correctly and no cookie
 		const emailSignInData = await client.signIn.email(
 			{
 				email: "test@example.com",
 				password: "password123",
 			},
-			{ throw: true },
+			{
+				throw: true,
+				onSuccess(context) {
+					context.response.headers.forEach((value, key) => {
+						if (key.toLowerCase() === "set-cookie") {
+							headers.append("set-cookie", value);
+						}
+					});
+				},
+			},
 		);
 
-		let session = await auth.api.getSession({
+		const cookiesSignIn = parseSetCookieHeader(headers.get("set-cookie") || "");
+		// Ensure that even on subsequent sign-ins, the cookie is not created if storeInDatabase is true
+		expect(
+			cookiesSignIn.get("better-auth.last_used_login_method"),
+		).toBeUndefined();
+
+		// Fetch session again to verify the DB field remains intact or updated
+		session = await auth.api.getSession({
 			headers: new Headers({
 				authorization: `Bearer ${emailSignInData.token}`,
 			}),
 		});
+		// Ensure the method is still correctly stored/updated in the DB
 		expect((session?.user as any).lastLoginMethod).toBe("email");
+	});
+
+	it("should set the last login method cookie on subsequent logins (when not storing in DB)", async () => {
+		const { client, cookieSetter } = await getTestInstance({
+			plugins: [lastLoginMethod()],
+		});
+
+		const headers = new Headers();
+		// Test cookie behavior on sign up
+		await client.signUp.email(
+			{
+				email: "test2@example.com",
+				password: "password123",
+				name: "Test User 2",
+			},
+			{
+				throw: true,
+				onSuccess(context) {
+					cookieSetter(headers)(context);
+				},
+			},
+		);
+
+		const cookiesSignUp = parseCookies(headers.get("cookie") || "");
+		// Ensure the cookie is set correctly during sign up when using the default behavior
+		expect(cookiesSignUp.get("better-auth.last_used_login_method")).toBe(
+			"email",
+		);
 
 		await client.signOut();
 
-		const emailSignInData2 = await client.signIn.email(
+		const signinHeaders = new Headers();
+		// Test cookie behavior on subsequent sign in
+		await client.signIn.email(
 			{
-				email: "test@example.com",
+				email: "test2@example.com",
 				password: "password123",
 			},
-			{ throw: true },
+			{
+				throw: true,
+				onSuccess(context) {
+					cookieSetter(signinHeaders)(context);
+				},
+			},
 		);
 
-		session = await auth.api.getSession({
-			headers: new Headers({
-				authorization: `Bearer ${emailSignInData2.token}`,
-			}),
-		});
-
-		expect((session?.user as any).lastLoginMethod).toBe("email");
+		const cookiesSignIn = parseCookies(signinHeaders.get("cookie") || "");
+		// Ensure the cookie is correctly set/updated during subsequent logins
+		expect(cookiesSignIn.get("better-auth.last_used_login_method")).toBe(
+			"email",
+		);
 	});
 
 	it("should update the last login method in the database on subsequent logins with email and OAuth", async () => {
@@ -361,10 +440,9 @@ describe("lastLoginMethod", async () => {
 				);
 				const lastLoginMethod = cookies.get(
 					"better-auth.last_used_login_method",
-				)?.value;
-				if (lastLoginMethod) {
-					expect(lastLoginMethod).toBe("google");
-				}
+				);
+				// When storeInDatabase is true, it should NOT set a cookie
+				expect(lastLoginMethod).toBeUndefined();
 			},
 		});
 

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -131,13 +131,28 @@ describe("lastLoginMethod", async () => {
 		const { client, auth } = await getTestInstance({
 			plugins: [lastLoginMethod({ storeInDatabase: true })],
 		});
+		const headers = new Headers();
 		const data = await client.signIn.email(
 			{
 				email: testUser.email,
 				password: testUser.password,
 			},
-			{ throw: true },
+			{
+				throw: true,
+				onSuccess(context) {
+					// Extract headers to test if cookies were set
+					context.response.headers.forEach((value, key) => {
+						if (key.toLowerCase() === "set-cookie") {
+							headers.append("set-cookie", value);
+						}
+					});
+				}
+			},
 		);
+
+		const cookies = parseSetCookieHeader(headers.get("set-cookie") || "");
+		expect(cookies.get("better-auth.last_used_login_method")).toBeUndefined();
+
 		const session = await auth.api.getSession({
 			headers: new Headers({
 				authorization: `Bearer ${data.token}`,


### PR DESCRIPTION
This is more as the user would expect - storeInDatabase should not both set a cookie and a database key.

The advantage of this is that it redundant, and that it enables EU cookie law compliance, by not storing functionally unnecessary cookies.

I also wrote tests - i think this fix is quite elegant and simple.

Fixes #5727 #5753 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Change last-login-method to not set the last_used_login_method cookie when storeInDatabase is true. This removes redundant storage and supports GDPR/EU cookie compliance; tests and docs updated for both DB-only and default cookie modes.

<sup>Written for commit 05e537387fca99581e77188f490a9b68c32cead9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

