### PR TITLE
docs: correct video link

### DIFF
--- a/docs/content/docs/reference/resources.mdx
+++ b/docs/content/docs/reference/resources.mdx
@@ -76,7 +76,7 @@ A curated collection of resources to help you learn and master Better Auth. From
 			title: "Nextjs 15 Authentication Made EASY with Better Auth",
 			description:
 				"A practical guide showing how to seamlessly integrate Better Auth with Next.js 15 for robust authentication.",
-			href: "https://www.youtube.com/watch?v=lxslnp-ZEMw",
+			href: "https://www.youtube.com/watch?v=D2f_gN1uZbc",
 			tags: ["nextjs", "implementation", "tutorial"],
 		},
 		{


### PR DESCRIPTION
In the docs: https://www.better-auth.com/docs/reference/resources
The original link to video: "Nextjs 15 Authentication Made EASY with Better Auth" was pointing to **Theo's** "The State of Authentication" instead of the one from **OrcDev**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the docs resource link for “Next.js 15 Authentication Made EASY with Better Auth” to point to the correct OrcDev YouTube video. Ensures users land on the intended tutorial from the Resources page.

<sup>Written for commit 7d44634c405895241893065a896e662c23d51303. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

