### PR TITLE
fix(core): avoid throwing on required session fields when collecting defaults

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -16,7 +16,7 @@ import type { Account, Session, User, Verification } from "../types";
 import { getDate } from "../utils/date";
 import { getIp } from "../utils/get-request-ip";
 import {
-	parseSessionInput,
+	getSessionDefaultFields,
 	parseSessionOutput,
 	parseUserOutput,
 } from "./schema";
@@ -294,7 +294,7 @@ export const createInternalAdapter = (
 			} = override || {};
 
 			// we're parsing default values for session additional fields
-			const defaultAdditionalFields = parseSessionInput(options, {});
+			const defaultAdditionalFields = getSessionDefaultFields(options);
 			const data = {
 				ipAddress: headers ? getIp(headers, options) || "" : "",
 				userAgent: headers?.get("user-agent") || "",

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -195,6 +195,20 @@ export function parseSessionInput(
 	return parseInputData(session, { fields: schema, action });
 }
 
+export function getSessionDefaultFields(options: BetterAuthOptions) {
+	const fields = getFields(options, "session", "input");
+	const defaults: Record<string, any> = {};
+	for (const key in fields) {
+		if (fields[key]!.defaultValue !== undefined) {
+			defaults[key] =
+				typeof fields[key]!.defaultValue === "function"
+					? fields[key]!.defaultValue()
+					: fields[key]!.defaultValue;
+		}
+	}
+	return defaults;
+}
+
 export function mergeSchema<S extends BetterAuthPluginDBSchema>(
 	schema: S,
 	newSchema?:


### PR DESCRIPTION
`parseSessionInput` in `packages/better-auth/src/db/internal-adapter.ts` was being called with an empty object to get default values for session additional fields. The problem is this runs through `parseInputData` which validates required fields — so if any plugin adds a required field to the session schema, it throws before the database hooks even get a chance to run.                                                                                                                                                        Introduced in #5763 
                                                                                                                                                                              
Added `getSessionDefaultFields` helper in `packages/better-auth/src/db/schema.ts` that just collects fields with default values without doing any required field validation. Replaced the `parseSessionInput({})` call with it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed session creation failing when plugins add required session fields by collecting default values without running validation. Introduces getSessionDefaultFields and updates the internal adapter to use it.

- **Bug Fixes**
  - Added getSessionDefaultFields to read session defaults without required checks.
  - Replaced parseSessionInput usage in the internal adapter so DB hooks can handle required fields without early errors.

<sup>Written for commit d5bdf7002419eae72d33f0fd38b47038b8e9e00c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

