### PR TITLE
fix: Add test to avoid throwing errors during SvelteKit build process

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -56,6 +56,10 @@
 
 				// implicit test dependencies
 				"vitest"
+			],
+			"ignoreUnresolved": [
+				// We intentionally import this to test if we are in a SvelteKit build
+				"$app/environment"
 			]
 		},
 		"packages/cli": {

--- a/packages/core/src/env/env-impl.ts
+++ b/packages/core/src/env/env-impl.ts
@@ -59,7 +59,6 @@ export const isDevelopment = () =>
 /** Detect if we are currently building a SvelteKit project */
 let _isSvelteKitBuilding = false;
 try {
-	/** @lintignore */
 	// @ts-expect-error Will only work if we are in SvelteKit
 	const svelteKitEnv = await import("$app/environment");
 	_isSvelteKitBuilding = svelteKitEnv.building;

--- a/packages/core/src/env/env-impl.ts
+++ b/packages/core/src/env/env-impl.ts
@@ -59,10 +59,10 @@ export const isDevelopment = () =>
 /** Detect if we are currently building a SvelteKit project */
 let _isSvelteKitBuilding = false;
 try {
-	// @ts-ignore Will only work if we are in SvelteKit
+	// @ts-expect-error Will only work if we are in SvelteKit
 	const svelteKitEnv = await import("$app/environment");
 	_isSvelteKitBuilding = svelteKitEnv.building;
-} catch (e) {
+} catch (_e) {
 	// If it fails (e.g., we aren't in SvelteKit), it remains false
 }
 
@@ -71,7 +71,8 @@ export function isSvelteKitBuilding() {
 }
 
 /** Detect if `NODE_ENV` environment variable is `test` */
-export const isTest = () => nodeENV === "test" || toBoolean(env.TEST) || isSvelteKitBuilding();
+export const isTest = () =>
+	nodeENV === "test" || toBoolean(env.TEST) || isSvelteKitBuilding();
 
 /**
  * Get environment variable with fallback

--- a/packages/core/src/env/env-impl.ts
+++ b/packages/core/src/env/env-impl.ts
@@ -56,8 +56,22 @@ export const isProduction = nodeENV === "production";
 export const isDevelopment = () =>
 	nodeENV === "dev" || nodeENV === "development";
 
+/** Detect if we are currently building a SvelteKit project */
+let _isSvelteKitBuilding = false;
+try {
+	// @ts-ignore Will only work if we are in SvelteKit
+	const svelteKitEnv = await import("$app/environment");
+	_isSvelteKitBuilding = svelteKitEnv.building;
+} catch (e) {
+	// If it fails (e.g., we aren't in SvelteKit), it remains false
+}
+
+export function isSvelteKitBuilding() {
+	return _isSvelteKitBuilding;
+}
+
 /** Detect if `NODE_ENV` environment variable is `test` */
-export const isTest = () => nodeENV === "test" || toBoolean(env.TEST);
+export const isTest = () => nodeENV === "test" || toBoolean(env.TEST) || isSvelteKitBuilding();
 
 /**
  * Get environment variable with fallback

--- a/packages/core/src/env/env-impl.ts
+++ b/packages/core/src/env/env-impl.ts
@@ -59,6 +59,7 @@ export const isDevelopment = () =>
 /** Detect if we are currently building a SvelteKit project */
 let _isSvelteKitBuilding = false;
 try {
+	/** @lintignore */
 	// @ts-expect-error Will only work if we are in SvelteKit
 	const svelteKitEnv = await import("$app/environment");
 	_isSvelteKitBuilding = svelteKitEnv.building;

--- a/packages/core/src/env/index.ts
+++ b/packages/core/src/env/index.ts
@@ -7,6 +7,7 @@ export {
 	getEnvVar,
 	isDevelopment,
 	isProduction,
+	isSvelteKitBuilding,
 	isTest,
 	nodeENV,
 } from "./env-impl";


### PR DESCRIPTION
Not very pretty, but it should work. There is no other way to do this.

Also exports a new function to check if we are in a sveltekit build process - may come in handy later.

Solves #8125 #8061 #288 once and for all :)

NOTE: I haven't tested this yet. I don't really see how I can build a good test for this. Open to feedback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect SvelteKit builds and treat them as test mode to prevent env errors during build. Exposes a helper to detect SvelteKit build state.

- **Bug Fixes**
  - Detect build via $app/environment.building, make isTest return true during build, and add knip ignoreUnresolved for $app/environment to silence unresolved import warnings.

- **New Features**
  - Export isSvelteKitBuilding for future checks.

<sup>Written for commit 436585c9cc03258ef1530ae08c26a96facdc49ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

