### PR TITLE
fix: remove max validation on siwe verify endpoint

### DIFF
--- a/packages/better-auth/src/plugins/siwe/index.ts
+++ b/packages/better-auth/src/plugins/siwe/index.ts
@@ -81,12 +81,7 @@ export const siwe = (options: SIWEPluginOptions) =>
 								.string()
 								.regex(/^0[xX][a-fA-F0-9]{40}$/i)
 								.length(42),
-							chainId: z
-								.number()
-								.int()
-								.positive()
-								.optional()
-								.default(1),
+							chainId: z.number().int().positive().optional().default(1),
 							email: z.email().optional(),
 						})
 						.refine((data) => options.anonymous !== false || !!data.email, {


### PR DESCRIPTION
I forgot to remove the validation on the SIWE verify endpoint. The error occurs because I’m using the beta version (1.5.0-beta.19).

<img width="907" height="715" alt="Screenshot 2026-02-26 at 13 45 43" src="https://github.com/user-attachments/assets/d4935d27-5664-4375-91d6-21215b22e9e4" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the max(2147483647) constraint from the SIWE verify endpoint schema to prevent validation errors on v1.5.0-beta.19 and allow valid requests to pass. Also simplified the chainId zod schema formatting.

<sup>Written for commit 78e6bbbb9433cf7a6ef3e34591079c55f7f9e4e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

