### PR TITLE
fix: preserve fresh account cookie set during OAuth callback

### DIFF
--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -1661,6 +1661,156 @@ describe("account", async () => {
 		expect(reLoginAccessToken.data?.accessToken).toBe("test");
 	});
 
+	it("should not overwrite fresh account cookie with stale request data on re-login", async () => {
+		const { auth, client, cookieSetter } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				storeAccountCookie: true,
+			},
+			session: {
+				cookieCache: {
+					enabled: true,
+					strategy: "jwe",
+				},
+			},
+		});
+
+		const ctx = await auth.$context;
+		const accountDataCookieName = ctx.authCookies.accountData.name;
+
+		const headers = new Headers();
+		email = "stale-cookie-test@test.com";
+
+		// First login
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const state =
+			signInRes.data && "url" in signInRes.data && signInRes.data.url
+				? new URL(signInRes.data.url).searchParams.get("state") || ""
+				: "";
+
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test" },
+			headers,
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				cookieSetter(headers)({ response: context.response });
+			},
+		});
+
+		// Verify first login tokens
+		const firstAccessToken = await client.getAccessToken(
+			{ providerId: "google" },
+			{ headers },
+		);
+		expect(firstAccessToken.data?.accessToken).toBe("test");
+
+		// Change the mock to return different tokens for the second login.
+		// This lets us distinguish fresh tokens from stale ones.
+		server.use(
+			http.post(
+				"https://oauth2.googleapis.com/token",
+				async () => {
+					const data: GoogleProfile = {
+						email,
+						email_verified: true,
+						name: "First Last",
+						picture:
+							"https://lh3.googleusercontent.com/a-/AOh14GjQ4Z7Vw",
+						exp: 1234567890,
+						sub: "1234567890",
+						iat: 1234567890,
+						aud: "test",
+						azp: "test",
+						nbf: 1234567890,
+						iss: "test",
+						locale: "en",
+						jti: "test",
+						given_name: "First",
+						family_name: "Last",
+					};
+					const testIdToken = await signJWT(data, DEFAULT_SECRET);
+					return HttpResponse.json({
+						access_token: "refreshed_token",
+						refresh_token: "refreshed_refresh",
+						id_token: testIdToken,
+					});
+				},
+				{ once: true },
+			),
+		);
+
+		// Re-login WITHOUT signing out. The old account cookie from the
+		// first login is still in the request headers. This is the scenario
+		// that triggers the bug: setCookieCache re-reads the old cookie from
+		// the request and overwrites the fresh one from handleOAuthUserInfo.
+		const reLoginRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const reLoginState =
+			reLoginRes.data && "url" in reLoginRes.data && reLoginRes.data.url
+				? new URL(reLoginRes.data.url).searchParams.get("state") || ""
+				: "";
+
+		let freshAccountCookieValue: string | undefined;
+		await client.$fetch("/callback/google", {
+			query: { state: reLoginState, code: "test" },
+			headers,
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+
+				const cookies = parseSetCookieHeader(
+					context.response.headers.get("set-cookie") || "",
+				);
+				freshAccountCookieValue =
+					cookies.get(accountDataCookieName)?.value;
+
+				cookieSetter(headers)({ response: context.response });
+			},
+		});
+
+		// The account cookie must be present
+		expect(freshAccountCookieValue).toBeDefined();
+
+		// Decrypt and verify the cookie contains the NEW tokens, not the
+		// stale ones from the first login
+		const accountData = await symmetricDecodeJWT<Account>(
+			freshAccountCookieValue!,
+			ctx.secret,
+			"better-auth-account",
+		);
+
+		expect(accountData).toBeDefined();
+		expect(accountData!.accessToken).toBe("refreshed_token");
+		expect(accountData!.refreshToken).toBe("refreshed_refresh");
+
+		// Also verify getAccessToken returns the fresh token
+		const reLoginAccessToken = await client.getAccessToken(
+			{ providerId: "google" },
+			{ headers },
+		);
+		expect(reLoginAccessToken.data?.accessToken).toBe("refreshed_token");
+	});
+
 	it("should refresh account_data cookie when session is refreshed", async () => {
 		const sessionExpiresIn = 60 * 60 * 24 * 7;
 		const sessionUpdateAge = 10;

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -256,11 +256,23 @@ export async function setCookieCache(
 		ctx.setCookie(ctx.context.authCookies.sessionData.name, data, options);
 	}
 
-	// Refresh account cookie to keep it in sync
+	// Refresh account cookie to keep its expiry in sync with the session cache.
+	// However, if the account cookie was already set in this response (e.g. by
+	// handleOAuthUserInfo during an OAuth callback), skip the refresh. Reading
+	// from the incoming request would return stale data and overwrite the fresh
+	// cookie that was just set.
 	if (ctx.context.options.account?.storeAccountCookie) {
-		const accountData = await getAccountCookie(ctx);
-		if (accountData) {
-			await setAccountCookie(ctx, accountData);
+		const setCookieHeader =
+			ctx.responseHeaders?.get("set-cookie") || "";
+		const accountCookieName = ctx.context.authCookies.accountData.name;
+		const alreadySetInResponse =
+			setCookieHeader.includes(accountCookieName);
+
+		if (!alreadySetInResponse) {
+			const accountData = await getAccountCookie(ctx);
+			if (accountData) {
+				await setAccountCookie(ctx, accountData);
+			}
 		}
 	}
 }

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -261,12 +261,17 @@ export async function setCookieCache(
 	// handleOAuthUserInfo during an OAuth callback), skip the refresh. Reading
 	// from the incoming request would return stale data and overwrite the fresh
 	// cookie that was just set.
+	//
+	// Note: we use ctx.responseHeaders (better-call's internal accumulator) rather
+	// than ctx.context.responseHeaders. The latter is populated by to-auth-endpoints.ts
+	// only after the handler returns, so it is undefined during handler execution.
 	if (ctx.context.options.account?.storeAccountCookie) {
 		const setCookieHeader =
 			ctx.responseHeaders?.get("set-cookie") || "";
 		const accountCookieName = ctx.context.authCookies.accountData.name;
-		const alreadySetInResponse =
-			setCookieHeader.includes(accountCookieName);
+		const alreadySetInResponse = setCookieHeader.includes(
+			`${accountCookieName}=`,
+		);
 
 		if (!alreadySetInResponse) {
 			const accountData = await getAccountCookie(ctx);

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -82,6 +82,13 @@ export type GenericEndpointContext<
 	Options extends BetterAuthOptions = BetterAuthOptions,
 > = EndpointContext<string, any> & {
 	context: AuthContext<Options>;
+	/**
+	 * The response headers accumulator that `setCookie` and `setHeader`
+	 * write to during handler execution. Provided by better-call's
+	 * `createInternalContext` at runtime but not yet exposed on the
+	 * public `EndpointContext` type.
+	 */
+	responseHeaders: Headers;
 };
 
 export interface InternalAdapter<

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -87,8 +87,14 @@ export type GenericEndpointContext<
 	 * write to during handler execution. Provided by better-call's
 	 * `createInternalContext` at runtime but not yet exposed on the
 	 * public `EndpointContext` type.
+	 *
+	 * Declared optional because `EndpointContext` (from better-call) does not
+	 * include this field in its type, so making it required would break every
+	 * assignment of a concrete `EndpointContext` to `GenericEndpointContext`.
+	 * At runtime the property is always present when called through better-call's
+	 * handler machinery.
 	 */
-	responseHeaders: Headers;
+	responseHeaders?: Headers;
 };
 
 export interface InternalAdapter<


### PR DESCRIPTION
## Problem

When `storeAccountCookie` is enabled, the OAuth callback flow sets a fresh account cookie (with new tokens from the provider) in `handleOAuthUserInfo`. Immediately after, `setSessionCookie` calls [`setCookieCache`](https://github.com/better-auth/better-auth/blob/84565ccc2a6bc0ae704d290028691adc7e9a4957/packages/better-auth/src/cookies/index.ts#L147), which reads the account cookie from the incoming request (stale data) and writes it back, overwriting the fresh cookie.

This means users end up with expired OAuth tokens after every re-login unless they fully clear their cookies first.

Root cause (`src/cookies/index.ts` lines 255-261)

https://github.com/better-auth/better-auth/blob/84565ccc2a6bc0ae704d290028691adc7e9a4957/packages/better-auth/src/cookies/index.ts#L255-L261

`getAccountCookie` reads from the incoming request via `ctx.getCookie`/`ctx.headers`. It has no awareness of cookies already set in the current response.

## Fix

Check `ctx.responseHeaders` (the `better-call` response accumulator that `ctx.setCookie` appends to) before deciding whether to refresh the account cookie. If the account cookie was already set in this response, skip the refresh since the fresh data is already there.

Also adds `responseHeaders` attribute to `GenericEndpointContext` in `@better-auth/core`, since this property exists at runtime (from better-call's `createInternalContext`) but was not exposed on the public type.

Fixes #8159

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale request data from overwriting the fresh account cookie during OAuth callbacks, so users keep new tokens after re-login. Fixes #8159.

- **Bug Fixes**
  - In `setCookieCache`, skip account cookie refresh if it was already set in this response (detected via `set-cookie` on `ctx.responseHeaders`). Session refresh behavior is unchanged.
  - Added a re-login test that decrypts the cookie and verifies `getAccessToken` returns the fresh token.

- **Refactors**
  - Exposed optional `responseHeaders?: Headers` on `GenericEndpointContext` and used it for the in-response cookie check.

<sup>Written for commit d0e63632673a8fca8d2ccc078dcd1b20d300359c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/8161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

