### PR TITLE
fix(two-factor): handle undefined options verifyTwoFactor

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -80,7 +80,7 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 				expireCookie(ctx, twoFactorCookie);
 				if (ctx.body.trustDevice) {
 					const plugin = ctx.context.getPlugin("two-factor");
-					const trustDeviceMaxAge = plugin!.options.trustDeviceMaxAge;
+					const trustDeviceMaxAge = plugin!.options?.trustDeviceMaxAge;
 					const maxAge = trustDeviceMaxAge ?? TRUST_DEVICE_COOKIE_MAX_AGE;
 					const trustDeviceCookie = ctx.context.createAuthCookie(
 						TRUST_DEVICE_COOKIE_NAME,


### PR DESCRIPTION
This PR fixes when `twoFactor()` is called without arguments, `plugin.options` is undefined. 

Before:
```ts
plugins: [
    twoFactor({}),
],
```

After:
```ts
plugins: [
    twoFactor(),
],
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runtime error in two-factor verification when the plugin is used without options. We now read plugin.options?.trustDeviceMaxAge and fall back to the default cookie max age, so twoFactor() works without arguments.

<sup>Written for commit da361e8efc95d156f5b5e65571728d9d9e4760a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

