### PR TITLE
docs: add 'better-auth-audit-logs' plugin to community table

### DIFF
--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -301,6 +301,17 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/iamjasonkendrick.png",
 		},
 	},
+	{
+		name: "better-auth-audit-logs",
+		url: "https://github.com/ejirocodes/better-auth-audit-logs",
+		description:
+			"Audit log plugin for Better Auth. Auto-captures auth events with severity inference, PII redaction, custom storage backends, and retention policies.",
+		author: {
+			name: "ejirocodes",
+			github: "ejirocodes",
+			avatar: "https://github.com/ejirocodes.png",
+		},
+	},
 ];
 export function CommunityPluginsTable() {
 	const [sorting, setSorting] = useState<SortingState>([]);


### PR DESCRIPTION
Added a new community plugin 'better-auth-audit-logs' with details.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the "better-auth-audit-logs" plugin to the Community Plugins table in docs. Includes link, description, and author details to surface an audit logging plugin for Better Auth.

<sup>Written for commit 937f76c73b1a7a6a1081d433393add93275b2ad9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

