### PR TITLE
fix(nextjs): use explicit .js extension in next/headers imports

### DIFF
--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -36,10 +36,10 @@ export const nextCookies = () => {
 						// In Server Components, `cookies().set()` throws an error.
 						// In Server Actions or Route Handlers, it succeeds.
 						let cookieStore: Awaited<
-							ReturnType<typeof import("next/headers").cookies>
+							ReturnType<typeof import("next/headers.js").cookies>
 						>;
 						try {
-							const { cookies } = await import("next/headers");
+							const { cookies } = await import("next/headers.js");
 							cookieStore = await cookies();
 						} catch {
 							// import failed or not in request context
@@ -67,7 +67,7 @@ export const nextCookies = () => {
 							const setCookies = returned?.get("set-cookie");
 							if (!setCookies) return;
 							const parsed = parseSetCookieHeader(setCookies);
-							const { cookies } = await import("next/headers");
+							const { cookies } = await import("next/headers.js");
 							let cookieHelper: Awaited<ReturnType<typeof cookies>>;
 							try {
 								cookieHelper = await cookies();


### PR DESCRIPTION
## Summary

- Adds `.js` extension to all three `import("next/headers")` calls in `nextCookies()` plugin
- Bare specifier `"next/headers"` fails to resolve under Next.js 16's stricter ESM module resolution, especially when using bun as the runtime
- This causes chunk resolution errors during production builds (`Failed to load chunk server/chunks/ssr/...`)

## Details

Next.js 16 enforces proper ESM specifiers for dynamic imports. The bare `"next/headers"` works with Node.js resolution but fails with bun's runtime and Turbopack's stricter chunking. Adding the `.js` extension makes the import resolve correctly in all environments.

**Before:**
```ts
const { cookies } = await import("next/headers");
```

**After:**
```ts
const { cookies } = await import("next/headers.js");
```

Fixes #6781

## Test plan

- [x] Verified fix resolves the build error in a Next.js 16 + bun monorepo
- [ ] Existing tests should pass — no behavioral change, only import resolution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch nextCookies to use import("next/headers.js") instead of import("next/headers") so Next.js 16 resolves the module correctly and production builds don’t fail with chunk loading errors, especially on bun/Turbopack.

- **Bug Fixes**
  - Replace all dynamic imports of "next/headers" with "next/headers.js".
  - Resolves build-time “Failed to load chunk” errors in Next.js 16 with bun/Turbopack.
  - No behavior change; only fixes ESM import resolution.

<sup>Written for commit dc8a1fbac05e32b7dd16e9454518eefe72535ac7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

