### PR TITLE
fix(landing): remove react-grab/mcp scripts that cause network scanning

### DIFF
--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -1,7 +1,6 @@
 import { GeistPixelSquare } from "geist/font/pixel";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Script from "next/script";
 import type { ReactNode } from "react";
 import { CommandMenuProvider } from "@/components/command-menu";
 import { StaggeredNavFiles } from "@/components/landing/staggered-nav-files";
@@ -66,25 +65,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                   `,
 					}}
 				/>
-				{process.env.NODE_ENV === "development" && (
-					<Script
-						src="//unpkg.com/react-grab/dist/index.global.js"
-						crossOrigin="anonymous"
-						strategy="beforeInteractive"
-						data-options={JSON.stringify({
-							activationKey: " ",
-							activationMode: "toggle",
-							allowActivationInsideInput: false,
-							maxContextLines: 3,
-						})}
-					/>
-				)}
-				{process.env.NODE_ENV === "development" && (
-					<Script
-						src="//unpkg.com/@react-grab/mcp/dist/client.global.js"
-						strategy="lazyOnload"
-					/>
-				)}
 			</head>
 			<body
 				className={`${fontSans.variable} ${fontMono.variable} ${GeistPixelSquare.variable} font-sans antialiased overflow-x-hidden`}

--- a/landing/package.json
+++ b/landing/package.json
@@ -73,7 +73,6 @@
     "zod": "^4.1.5"
   },
   "devDependencies": {
-    "@react-grab/mcp": "^0.1.15",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^25.3.2",
     "@types/react": "^19.0.0",


### PR DESCRIPTION
## Summary
- Removed `react-grab` and `@react-grab/mcp` script tags from `landing/app/layout.tsx` that were causing local network device discovery/scanning for visitors
- Removed unused `next/script` import and `@react-grab/mcp` devDependency from `landing/package.json`
- The scripts used `next/script` with `strategy="beforeInteractive"` which injects into server-rendered HTML, potentially leaking past the `NODE_ENV === "development"` guard into production builds

## Test plan
- [ ] Verify the landing page loads correctly in dev (`pnpm dev` in `landing/`)
- [ ] Verify no network scanning/device discovery requests in browser DevTools Network tab
- [ ] Confirm production build (`pnpm build` in `landing/`) succeeds without errors