### PR TITLE
fix(stripe): increase test timeout to fix CI flaky failures

### DIFF
--- a/packages/stripe/vitest.config.ts
+++ b/packages/stripe/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineProject({
 		clearMocks: true,
 		restoreMocks: true,
 		globals: true,
+		testTimeout: 10_000,
 	},
 });


### PR DESCRIPTION
## Summary
- Bumps `testTimeout` in `packages/stripe/vitest.config.ts` from the default 5000ms to 10000ms
- The `seat-based-billing.test.ts` "should sync seat quantity when a member accepts an invitation" test times out intermittently in CI due to resource contention
- Same class of fix as the recent SCIM test timeout fix (#8208)

## Test plan
- [x] All 137 stripe tests pass locally (`pnpm vitest packages/stripe/test/ --run`)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes