### PR TITLE
fix(ci): increase test timeout for sso, api-key, oauth-provider and add CI job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
 
   test:
     runs-on: starsling-ubuntu-24.04
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/packages/api-key/vitest.config.ts
+++ b/packages/api-key/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineProject({
 	test: {
 		clearMocks: true,
 		restoreMocks: true,
+		testTimeout: 10_000,
 	},
 });

--- a/packages/oauth-provider/vitest.config.ts
+++ b/packages/oauth-provider/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineProject({
 	test: {
 		clearMocks: true,
 		restoreMocks: true,
+		testTimeout: 10_000,
 	},
 });

--- a/packages/sso/vitest.config.ts
+++ b/packages/sso/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineProject({
 	test: {
 		clearMocks: true,
 		restoreMocks: true,
+		testTimeout: 10_000,
 	},
 });


### PR DESCRIPTION
## Summary
- Add `testTimeout: 10_000` to `packages/sso`, `packages/api-key`, and `packages/oauth-provider` vitest configs to prevent flaky CI timeout failures on large test suites (matching the pattern already applied to `better-auth`, `scim`, and `stripe`)
- Add `timeout-minutes: 30` to the CI `test` job to catch hung tests early instead of waiting for GitHub's default 6-hour timeout

## Test plan
- [ ] CI passes on this PR
- [ ] Verify sso, api-key, and oauth-provider tests no longer hit the default 5s timeout