### PR TITLE
ci: use per-job concurrency groups to support test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,12 @@ env:
   TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
   BETTER_AUTH_TELEMETRY_ENDPOINT: ${{ vars.BETTER_AUTH_TELEMETRY_ENDPOINT }}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   lint:
     runs-on: starsling-ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-lint-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -88,6 +87,9 @@ jobs:
 
   typecheck:
     runs-on: starsling-ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-typecheck-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -121,6 +123,9 @@ jobs:
   test:
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-test-${{ matrix.node-version }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Moved `concurrency` from workflow-level to job-level so each job (`lint`, `typecheck`, `test`) has its own concurrency group
- The `test` job's concurrency group includes `matrix.node-version`, so Node 22.x and 24.x runs are cancelled independently instead of as a single group

## Test plan
- [ ] Verify CI jobs run correctly on this PR
- [ ] Push a second commit to confirm that only stale jobs for the same matrix entry are cancelled