### PR TITLE
fix(oauth-proxy): add generic OAuth support to proxy (#8082)

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -127,9 +127,13 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						codeVerifier?: string | undefined;
 						deviceId?: string | undefined;
 					}) {
+						const codeVerifier = c.pkce ? data.codeVerifier : undefined;
 						// Use custom getToken if provided
 						if (c.getToken) {
-							return c.getToken(data);
+							return c.getToken({
+								...data,
+								codeVerifier,
+							});
 						}
 
 						// Standard token exchange flow
@@ -153,15 +157,17 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 								GENERIC_OAUTH_ERROR_CODES.TOKEN_URL_NOT_FOUND,
 							);
 						}
+						// Use data.redirectURI for token exchange so it matches the redirect_uri
+						// from the authorization request (required by OAuth2; mismatch causes invalid_code).
 						return validateAuthorizationCode({
 							headers: c.authorizationHeaders,
 							code: data.code,
-							codeVerifier: data.codeVerifier,
+							codeVerifier,
 							redirectURI: data.redirectURI,
 							options: {
 								clientId: c.clientId,
 								clientSecret: c.clientSecret,
-								redirectURI: c.redirectURI,
+								redirectURI: data.redirectURI,
 							},
 							tokenEndpoint: finalTokenUrl,
 							authentication: c.authentication,

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -369,11 +369,16 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 			}
 
 			try {
+				const callbackRedirectURI =
+					ctx.request?.url != null
+						? new URL(ctx.request.url).origin +
+							new URL(ctx.request.url).pathname
+						: `${ctx.context.baseURL}/oauth2/callback/${providerConfig.providerId}`;
 				// Use custom getToken if provided
 				if (providerConfig.getToken) {
 					tokens = await providerConfig.getToken({
 						code,
-						redirectURI: `${ctx.context.baseURL}/oauth2/callback/${providerConfig.providerId}`,
+						redirectURI: callbackRedirectURI,
 						codeVerifier: providerConfig.pkce ? codeVerifier : undefined,
 					});
 				} else {
@@ -392,11 +397,11 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 						headers: providerConfig.authorizationHeaders,
 						code,
 						codeVerifier: providerConfig.pkce ? codeVerifier : undefined,
-						redirectURI: `${ctx.context.baseURL}/oauth2/callback/${providerConfig.providerId}`,
+						redirectURI: callbackRedirectURI,
 						options: {
 							clientId: providerConfig.clientId,
 							clientSecret: providerConfig.clientSecret,
-							redirectURI: providerConfig.redirectURI,
+							redirectURI: callbackRedirectURI,
 						},
 						tokenEndpoint: finalTokenUrl,
 						authentication: providerConfig.authentication,

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -99,6 +99,10 @@ const oauthCallbackQuerySchema = z.object({
 	error: z.string().optional(),
 });
 
+function isOAuthCallbackPath(path: string | undefined) {
+	return path === "/callback/:id" || path === "/oauth2/callback/:providerId";
+}
+
 export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 	const maxAge = opts?.maxAge ?? 60; // Default 60 seconds
 
@@ -286,7 +290,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 				{
 					// Intercept OAuth callback on production to handle passthrough
 					matcher(context) {
-						return context.path === "/callback/:id";
+						return isOAuthCallbackPath(context.path);
 					},
 					handler: createAuthMiddleware(async (ctx) => {
 						const state = ctx.query?.state || ctx.body?.state;
@@ -359,7 +363,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 						}
 
 						// Find the OAuth provider
-						const providerId = ctx.params?.id;
+						const providerId = ctx.params?.id || ctx.params?.providerId;
 						const provider = ctx.context.socialProviders.find(
 							(p) => p.id === providerId,
 						);
@@ -370,11 +374,20 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 
 						// Exchange code for tokens
 						let tokens: OAuth2Tokens | null;
+						const fallbackCallbackPath =
+							ctx.params?.providerId != null
+								? `/oauth2/callback/${provider.id}`
+								: `/callback/${provider.id}`;
+						const callbackRedirectURI =
+							ctx.request?.url != null
+								? new URL(ctx.request.url).origin +
+									new URL(ctx.request.url).pathname
+								: `${ctx.context.baseURL}${fallbackCallbackPath}`;
 						try {
 							tokens = await provider.validateAuthorizationCode({
 								code,
 								codeVerifier: stateData.codeVerifier,
-								redirectURI: `${ctx.context.baseURL}/callback/${provider.id}`,
+								redirectURI: callbackRedirectURI,
 							});
 						} catch (e) {
 							ctx.context.logger.error(
@@ -546,7 +559,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 				},
 				{
 					matcher(context) {
-						return context.path === "/callback/:id";
+						return isOAuthCallbackPath(context.path);
 					},
 					handler: createAuthMiddleware(async (ctx) => {
 						const headers = ctx.context.responseHeaders;

--- a/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
@@ -6,10 +6,12 @@ import { parseJSON } from "../../client/parser";
 import { signJWT, symmetricDecrypt, symmetricEncrypt } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../../utils/constants";
+import { genericOAuth } from "../generic-oauth";
 import { oAuthProxy } from ".";
 
 let testIdToken: string;
 let handlers: ReturnType<typeof http.post>[];
+const GENERIC_PROVIDER_ID = "generic-test";
 
 const server = setupServer();
 
@@ -41,6 +43,13 @@ beforeAll(async () => {
 				id_token: testIdToken,
 			});
 		}),
+		http.post("https://oauth.example.com/token", () => {
+			return HttpResponse.json({
+				access_token: "test",
+				refresh_token: "test",
+				id_token: testIdToken,
+			});
+		}),
 	];
 
 	server.listen({ onUnhandledRequest: "bypass" });
@@ -55,6 +64,106 @@ afterEach(() => {
 afterAll(() => server.close());
 
 describe("oauth-proxy", async () => {
+	it("should redirect generic oauth callback to proxy url with profile data", async () => {
+		const { client } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: GENERIC_PROVIDER_ID,
+							authorizationUrl: "https://oauth.example.com/authorize",
+							tokenUrl: "https://oauth.example.com/token",
+							clientId: "test",
+							clientSecret: "test",
+						},
+					],
+				}),
+				oAuthProxy({
+					currentURL: "http://preview-localhost:3000",
+				}),
+			],
+		});
+
+		const signInRes = (await client.$fetch("/sign-in/oauth2", {
+			method: "POST",
+			body: {
+				providerId: GENERIC_PROVIDER_ID,
+				callbackURL: "/dashboard",
+			},
+		})) as { url: string };
+
+		const state = new URL(signInRes.url).searchParams.get("state");
+		expect(state).toBeTruthy();
+
+		await client.$fetch(
+			`/oauth2/callback/${GENERIC_PROVIDER_ID}?code=test&state=${encodeURIComponent(state!)}`,
+			{
+				onError(context) {
+					const location = context.response.headers.get("location") ?? "";
+					if (!location) {
+						throw new Error("Location header not found");
+					}
+					expect(location).toContain(
+						"http://preview-localhost:3000/api/auth/oauth-proxy-callback",
+					);
+					expect(location).toContain("callbackURL");
+					const profile = new URL(location).searchParams.get("profile");
+					expect(profile).toBeTruthy();
+				},
+			},
+		);
+	});
+
+	it("shouldn't redirect generic oauth callback to proxy on same origin", async () => {
+		const { client, cookieSetter } = await getTestInstance({
+			baseURL: "https://myapp.com",
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: GENERIC_PROVIDER_ID,
+							authorizationUrl: "https://oauth.example.com/authorize",
+							tokenUrl: "https://oauth.example.com/token",
+							clientId: "test",
+							clientSecret: "test",
+						},
+					],
+				}),
+				oAuthProxy({
+					productionURL: "https://myapp.com",
+				}),
+			],
+		});
+
+		const headers = new Headers();
+		const signInRes = (await client.$fetch("/sign-in/oauth2", {
+			method: "POST",
+			body: {
+				providerId: GENERIC_PROVIDER_ID,
+				callbackURL: "/dashboard",
+			},
+			onSuccess: cookieSetter(headers),
+		})) as { url: string };
+
+		const state = new URL(signInRes.url).searchParams.get("state");
+		expect(state).toBeTruthy();
+
+		await client.$fetch(
+			`/oauth2/callback/${GENERIC_PROVIDER_ID}?code=test&state=${encodeURIComponent(state!)}`,
+			{
+				headers,
+				onError(context) {
+					const location = context.response.headers.get("location");
+					if (!location) {
+						throw new Error("Location header not found");
+					}
+					expect(location).not.toContain("/oauth-proxy-callback");
+					expect(location).toContain("/dashboard");
+				},
+			},
+		);
+	});
+
 	it("should redirect to proxy url with profile data (passthrough)", async () => {
 		const { client } = await getTestInstance({
 			plugins: [

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -200,8 +200,8 @@ export async function parseGenericState(
 
 		expireCookie(c, stateCookie);
 
-		// Delete verification value after retrieval
-		await c.context.internalAdapter.deleteVerificationValue(data.id);
+		// Delete verification by identifier so it works with any id type (e.g. UUID)
+		await c.context.internalAdapter.deleteVerificationByIdentifier(state);
 	}
 
 	// Check expiration


### PR DESCRIPTION
Cherry-pick of the latest canary commit (`0deaaa4e67c3067bd3b0570b3adfef2b532c7085`) to main.

**Original PR:** #8082

**Changes:**
- Adds generic OAuth support to the oauth-proxy
- Ensures `redirect_uri` always matches the actual callback URL to prevent `invalid_code` during token exchange
- Unifies callback matching and fixes state cleanup for UUID/database mode

**Files changed:**
- `packages/better-auth/src/plugins/generic-oauth/index.ts`
- `packages/better-auth/src/plugins/generic-oauth/routes.ts`
- `packages/better-auth/src/plugins/oauth-proxy/index.ts`
- `packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts`
- `packages/better-auth/src/state.ts`