### PR TITLE
docs: re-add razorpay and payu community plugins

### DIFF
--- a/landing/components/community-plugins-table.tsx
+++ b/landing/components/community-plugins-table.tsx
@@ -268,6 +268,28 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/ramiras123.png",
 		},
 	},
+	{
+		name: "better-auth-razorpay",
+		url: "https://github.com/iamjasonkendrick/better-auth-razorpay",
+		description:
+			"Razorpay payment plugin for Better Auth — integrates Razorpay payments, webhooks, and subscription flows.",
+		author: {
+			name: "iamjasonkendrick",
+			github: "iamjasonkendrick",
+			avatar: "https://github.com/iamjasonkendrick.png",
+		},
+	},
+	{
+		name: "better-auth-payu",
+		url: "https://github.com/iamjasonkendrick/better-auth-payu",
+		description:
+			"PayU payment plugin for Better Auth — integrates PayU payments, webhooks, and subscription flows.",
+		author: {
+			name: "iamjasonkendrick",
+			github: "iamjasonkendrick",
+			avatar: "https://github.com/iamjasonkendrick.png",
+		},
+	},
 ];
 export function CommunityPluginsTable() {
 	const [sorting, setSorting] = useState<SortingState>([]);

--- a/landing/lib/community-plugins-data.ts
+++ b/landing/lib/community-plugins-data.ts
@@ -193,4 +193,26 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/ramiras123.png",
 		},
 	},
+	{
+		name: "better-auth-razorpay",
+		url: "https://github.com/iamjasonkendrick/better-auth-razorpay",
+		description:
+			"Razorpay payment plugin for Better Auth — integrates Razorpay payments, webhooks, and subscription flows.",
+		author: {
+			name: "iamjasonkendrick",
+			github: "iamjasonkendrick",
+			avatar: "https://github.com/iamjasonkendrick.png",
+		},
+	},
+	{
+		name: "better-auth-payu",
+		url: "https://github.com/iamjasonkendrick/better-auth-payu",
+		description:
+			"PayU payment plugin for Better Auth — integrates PayU payments, webhooks, and subscription flows.",
+		author: {
+			name: "iamjasonkendrick",
+			github: "iamjasonkendrick",
+			avatar: "https://github.com/iamjasonkendrick.png",
+		},
+	},
 ];


### PR DESCRIPTION
## Summary
- Re-adds `better-auth-razorpay` and `better-auth-payu` community plugins by @iamjasonkendrick
- These were accidentally dropped during the docs restructuring in #8195
- Fixes https://github.com/better-auth/better-auth/pull/8138#issuecomment-3977621451

## Test plan
- [ ] Verify the community plugins page lists both `better-auth-razorpay` and `better-auth-payu`