### PR TITLE
docs: remove unused getSrc utility

### DIFF
--- a/landing/lib/utils.ts
+++ b/landing/lib/utils.ts
@@ -2,14 +2,6 @@ import type { ClassValue } from "clsx";
 import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-const ASSET_BASE_URL =
-	process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
-
-export function getSrc(path: string): string {
-	const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-	return ASSET_BASE_URL ? `${ASSET_BASE_URL}${normalizedPath}` : normalizedPath;
-}
-
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## Summary
- Remove dead `getSrc` function and `ASSET_BASE_URL` constant from `landing/lib/utils.ts`
- After #8229, there are no callers — Next.js serves public assets at root-relative paths, making this helper unnecessary

## Test plan
- [ ] Verify landing page builds and videos still load correctly