### PR TITLE
Auth0 custom domain redirect

### DIFF
--- a/landing/app/docs/[[...slug]]/page.client.tsx
+++ b/landing/app/docs/[[...slug]]/page.client.tsx
@@ -66,6 +66,7 @@ export function LLMCopyButton() {
 				await navigator.clipboard.write([
 					new ClipboardItem({
 						"text/plain": fetch(url).then(async (res) => {
+							if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
 							const content = await res.text();
 							cache.set(url, content);
 

--- a/landing/app/llms.mdx/[[...slug]]/route.ts
+++ b/landing/app/llms.mdx/[[...slug]]/route.ts
@@ -1,0 +1,27 @@
+import type { InferPageType } from "fumadocs-core/source";
+import { notFound } from "next/navigation";
+import { source } from "@/lib/source";
+
+export const revalidate = false;
+
+async function getLLMText(page: InferPageType<typeof source>) {
+	const content = await page.data.getText("raw");
+	return `# ${page.data.title}\n\nURL: ${page.url}\n\n${content}`;
+}
+
+export async function GET(
+	_req: Request,
+	{ params }: { params: Promise<{ slug: string[] }> },
+) {
+	const { slug } = await params;
+	const page = source.getPage(slug);
+	if (!page) notFound();
+
+	return new Response(await getLLMText(page), {
+		headers: { "Content-Type": "text/markdown" },
+	});
+}
+
+export function generateStaticParams() {
+	return source.generateParams();
+}

--- a/landing/next.config.js
+++ b/landing/next.config.js
@@ -42,6 +42,10 @@ const nextConfig = {
 					source: "/docs-assets/_next/:path*",
 					destination: "/_next/:path*",
 				},
+				{
+					source: "/docs/:path*.mdx",
+					destination: "/llms.mdx/:path*",
+				},
 			],
 		};
 	},


### PR DESCRIPTION
Fixes the "Copy MD" button by adding a route handler to serve raw MDX content and improving error handling.

The "Copy MD" button fetched `window.location.pathname + ".mdx"` but no route existed to serve this content, resulting in Next.js error pages being copied instead of the raw MDX. This PR introduces a new route handler to correctly serve the MDX content and adds `res.ok` checking to prevent caching error responses.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1772347314996549?thread_ts=1772347314.996549&cid=C0A8B5BARUK)

<p><a href="https://cursor.com/agents/bc-648af251-a9d4-529d-81d1-4ba0ffa1c9e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-648af251-a9d4-529d-81d1-4ba0ffa1c9e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

