### PR TITLE
Og image dynamic url

### DIFF
--- a/docs/content/blogs/1-5.mdx
+++ b/docs/content/blogs/1-5.mdx
@@ -6,7 +6,7 @@ author:
   name: "Alex Yang"
   avatar: "/avatars/alex.png"
   twitter: "himseIf_65"
-image: "https://docs.better-auth.com/release-og/1-5.png"
+image: "/release-og/1-5.png"
 tags: ["1.5", "CLI", "MCP", "oauth-provider", "electron", "i18n", "adapters", "cloudflare", "d1", "stripe", "SSO", "SCIM", "test-utils"]
 ---
 

--- a/landing/app/blog/[[...slug]]/page.tsx
+++ b/landing/app/blog/[[...slug]]/page.tsx
@@ -272,8 +272,20 @@ export async function generateMetadata({
 	}
 	const page = blogs.getPage(slug);
 	if (!page) return notFound();
-	const { title, description } = page.data;
-	return { title, description };
+	const { title, description, image } = page.data;
+	return {
+		title,
+		description,
+		...(image && {
+			openGraph: {
+				images: [image],
+			},
+			twitter: {
+				card: "summary_large_image" as const,
+				images: [image],
+			},
+		}),
+	};
 }
 
 export function generateStaticParams() {

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -17,7 +17,14 @@ const fontMono = Geist_Mono({
 	variable: "--font-mono",
 });
 
+const baseUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
+	? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+	: process.env.VERCEL_URL
+		? `https://${process.env.VERCEL_URL}`
+		: "http://localhost:3000";
+
 export const metadata = {
+	metadataBase: new URL(baseUrl),
 	title: {
 		template: "%s | Better Auth",
 		default: "Better Auth",


### PR DESCRIPTION
Dynamically resolve OG image URLs by setting `metadataBase` to Vercel environment variables.

Previously, OG images either used hardcoded domains or relative paths without a base URL, resulting in incorrect or static image links. This change configures Next.js's `metadataBase` in the root layout, allowing all relative metadata URLs to automatically resolve to the correct production or preview URL provided by Vercel.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1772348458564899?thread_ts=1772348458.564899&cid=C0A8B5BARUK)

<p><a href="https://cursor.com/agents/bc-7b6ab034-f641-5d4c-9202-e0288c599e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b6ab034-f641-5d4c-9202-e0288c599e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

