### PR TITLE
fix(db): support verification CRUD operations with secondary storage

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1044,6 +1044,7 @@ export const createInternalAdapter = (
 
 			const verification = await createWithHooks(
 				{
+					id: generateId(),
 					// todo: we should remove auto setting createdAt and updatedAt in the next major release, since the db generators already handle that
 					createdAt: new Date(),
 					updatedAt: new Date(),
@@ -1061,6 +1062,16 @@ export const createInternalAdapter = (
 										JSON.stringify(verificationData),
 										ttl,
 									);
+									// Store reverse mapping from id to identifier so
+									// updateVerificationValue can find the secondary storage
+									// entry by id
+									if (verificationData.id) {
+										await secondaryStorage.set(
+											`verification-id:${verificationData.id}`,
+											storedIdentifier,
+											ttl,
+										);
+									}
 								}
 								return verificationData;
 							},
@@ -1139,11 +1150,17 @@ export const createInternalAdapter = (
 
 			return (verification[0] as Verification) || null;
 		},
-		/**
-		 * Note: In secondary-only mode, this is a no-op since secondary storage
-		 * is keyed by identifier, not id. Use deleteVerificationByIdentifier instead.
-		 */
 		deleteVerificationValue: async (id: string) => {
+			if (secondaryStorage) {
+				const storedIdentifier = await secondaryStorage.get(
+					`verification-id:${id}`,
+				);
+				if (storedIdentifier) {
+					await secondaryStorage.delete(`verification:${storedIdentifier}`);
+					await secondaryStorage.delete(`verification-id:${id}`);
+				}
+			}
+
 			if (!secondaryStorage || options.verification?.storeInDatabase) {
 				await deleteWithHooks(
 					[{ field: "id", value: id }],
@@ -1163,6 +1180,16 @@ export const createInternalAdapter = (
 			);
 
 			if (secondaryStorage) {
+				// Clean up the reverse id mapping
+				const cached = await secondaryStorage.get(
+					`verification:${storedIdentifier}`,
+				);
+				if (cached) {
+					const parsed = safeJSONParse<Verification>(cached);
+					if (parsed?.id) {
+						await secondaryStorage.delete(`verification-id:${parsed.id}`);
+					}
+				}
 				await secondaryStorage.delete(`verification:${storedIdentifier}`);
 			}
 
@@ -1182,7 +1209,40 @@ export const createInternalAdapter = (
 				data,
 				[{ field: "id", value: id }],
 				"verification",
-				undefined,
+				secondaryStorage
+					? {
+							async fn(updateData) {
+								// Look up the identifier from the reverse mapping
+								const storedIdentifier = await secondaryStorage.get(
+									`verification-id:${id}`,
+								);
+								if (storedIdentifier) {
+									const cached = await secondaryStorage.get(
+										`verification:${storedIdentifier}`,
+									);
+									if (cached) {
+										const parsed = safeJSONParse<Verification>(cached);
+										if (parsed) {
+											const updated = { ...parsed, ...updateData };
+											const ttl = getTTLSeconds(
+												updated.expiresAt ?? parsed.expiresAt,
+											);
+											if (ttl > 0) {
+												await secondaryStorage.set(
+													`verification:${storedIdentifier}`,
+													JSON.stringify(updated),
+													ttl,
+												);
+											}
+											return updated;
+										}
+									}
+								}
+								return updateData;
+							},
+							executeMainFn: options.verification?.storeInDatabase,
+						}
+					: undefined,
 			);
 			return verification;
 		},

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -721,3 +721,178 @@ describe("magic link allowedAttempts", async () => {
 		}
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8228
+ */
+describe("magic link with secondary storage", async () => {
+	const store = new Map<string, string>();
+	let verificationEmail: VerificationEmail = {
+		email: "",
+		token: "",
+		url: "",
+	};
+
+	const { customFetchImpl, testUser, sessionSetter } = await getTestInstance({
+		secondaryStorage: {
+			set(key, value, ttl) {
+				store.set(key, value);
+			},
+			get(key) {
+				return store.get(key) || null;
+			},
+			delete(key) {
+				store.delete(key);
+			},
+		},
+		rateLimit: {
+			enabled: false,
+		},
+		plugins: [
+			magicLink({
+				async sendMagicLink(data) {
+					verificationEmail = data;
+				},
+			}),
+		],
+	});
+
+	const client = createAuthClient({
+		plugins: [magicLinkClient()],
+		fetchOptions: {
+			customFetchImpl,
+		},
+		baseURL: "http://localhost:3000",
+		basePath: "/api/auth",
+	});
+
+	it("should send and verify magic link with secondary storage", async () => {
+		await client.signIn.magicLink({
+			email: testUser.email,
+		});
+		expect(verificationEmail).toMatchObject({
+			email: testUser.email,
+			url: expect.stringContaining(
+				"http://localhost:3000/api/auth/magic-link/verify",
+			),
+		});
+
+		const headers = new Headers();
+		const response = await client.magicLink.verify({
+			query: {
+				token: new URL(verificationEmail.url).searchParams.get("token") || "",
+			},
+			fetchOptions: {
+				onSuccess: sessionSetter(headers),
+			},
+		});
+		expect(response.data?.token).toBeDefined();
+		const betterAuthCookie = headers.get("set-cookie");
+		expect(betterAuthCookie).toBeDefined();
+	});
+
+	it("should sign up new user with magic link and secondary storage", async () => {
+		const email = "new-secondary-storage@email.com";
+		await client.signIn.magicLink({
+			email,
+			name: "test-secondary",
+		});
+
+		const headers = new Headers();
+		await client.magicLink.verify({
+			query: {
+				token: new URL(verificationEmail.url).searchParams.get("token") || "",
+			},
+			fetchOptions: {
+				onSuccess: sessionSetter(headers),
+			},
+		});
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(session.data?.user).toMatchObject({
+			name: "test-secondary",
+			email,
+			emailVerified: true,
+		});
+	});
+
+	it("should track attempts with secondary storage", async () => {
+		const {
+			customFetchImpl: attemptsFetchImpl,
+			testUser: attemptsUser,
+			sessionSetter: attemptsSetter,
+		} = await getTestInstance({
+			secondaryStorage: {
+				set(key, value, ttl) {
+					store.set(key, value);
+				},
+				get(key) {
+					return store.get(key) || null;
+				},
+				delete(key) {
+					store.delete(key);
+				},
+			},
+			rateLimit: {
+				enabled: false,
+			},
+			plugins: [
+				magicLink({
+					allowedAttempts: 3,
+					async sendMagicLink(data) {
+						verificationEmail = data;
+					},
+				}),
+			],
+		});
+
+		const attemptsClient = createAuthClient({
+			plugins: [magicLinkClient()],
+			fetchOptions: {
+				customFetchImpl: attemptsFetchImpl,
+			},
+			baseURL: "http://localhost:3000",
+			basePath: "/api/auth",
+		});
+
+		await attemptsClient.signIn.magicLink({
+			email: attemptsUser.email,
+		});
+
+		const token =
+			new URL(verificationEmail.url).searchParams.get("token") || "";
+
+		// 3 attempts should succeed
+		for (let i = 0; i < 3; i++) {
+			const headers = new Headers();
+			const response = await attemptsClient.magicLink.verify({
+				query: {
+					token,
+				},
+				fetchOptions: {
+					onSuccess: attemptsSetter(headers),
+				},
+			});
+			expect(response.data?.token).toBeDefined();
+		}
+
+		// Fourth attempt should be rejected
+		await attemptsClient.magicLink.verify(
+			{
+				query: {
+					token,
+				},
+			},
+			{
+				onError(context) {
+					expect(context.response.status).toBe(302);
+					const location = context.response.headers.get("location");
+					expect(location).toContain("?error=ATTEMPTS_EXCEEDED");
+				},
+			},
+		);
+	});
+});


### PR DESCRIPTION
When secondaryStorage is enabled without verification.storeInDatabase, updateVerificationValue and deleteVerificationValue would fail with "Model verification not found in schema" because they always tried to hit the database directly.

Fixes: https://github.com/better-auth/better-auth/issues/8228