### PR TITLE
docs: fix firefox rubber-banding

### DIFF
--- a/landing/components/docs/stepper-toc.tsx
+++ b/landing/components/docs/stepper-toc.tsx
@@ -209,11 +209,18 @@ export function StepperTOC({ items, children }: StepperTOCProps) {
 										key={sub.url}
 										ref={(el) => {
 											if (isSubActive && el) {
-												el.scrollIntoView({
-													behavior: "smooth",
-													block: "nearest",
-													inline: "center",
-												});
+												const container = el.parentElement;
+												if (container) {
+													const containerWidth = container.clientWidth;
+													const elementLeft = el.offsetLeft;
+													const elementWidth = el.offsetWidth;
+													const scrollTarget =
+														elementLeft - containerWidth / 2 + elementWidth / 2;
+													container.scrollTo({
+														left: scrollTarget,
+														behavior: "smooth",
+													});
+												}
 											}
 										}}
 										href={sub.url}


### PR DESCRIPTION
This pr fixes this issue:
<img width="2326" height="982" alt="CleanShot 2026-03-01 at 01 15 56@2x" src="https://github.com/user-attachments/assets/5a4f239b-79d2-49e6-9f82-dffacb7d33ef" />
