### PR TITLE
docs: update project structure to reflect correct documentation directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The Better Auth monorepo is organized as follows:
 * `/packages/expo` - Expo integration
 * `/packages/stripe` - Stripe payment integration
 * `/packages/sso` - SSO plugin with SAML and OIDC support
-* `/docs` - Documentation website
+* `/landing` - Documentation website
 * `/examples` - Example applications
 * `/demo` - Demo applications
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Correct the documentation directory in CONTRIBUTING.md: /docs → /landing. Avoids confusion for contributors navigating the repo.

<sup>Written for commit fd30ac039945155b429050b9e85255015107f081. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

