### PR TITLE
fix(oauth-provider): allow localhost subdomains in isLocalhost function

### DIFF
--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -4,9 +4,9 @@ const DANGEROUS_SCHEMES = ["javascript:", "data:", "vbscript:"];
 
 function isLocalhost(hostname: string): boolean {
 	return (
-		hostname === "localhost" || 
-		hostname === "127.0.0.1" || 
-		hostname === "[::1]" || 
+		hostname === "localhost" ||
+		hostname === "127.0.0.1" ||
+		hostname === "[::1]" ||
 		hostname.endsWith(".localhost")
 	);
 }


### PR DESCRIPTION
This would allow a user to set a subdomain.localhost as a redirect uri for oauth. Currently it will not allow localhost subdomains which are common in some companies development practices. This is a very simple 1 line logic change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat *.localhost as localhost in OAuth redirect URI validation so subdomain.localhost redirects (e.g., app.localhost) work in local development. Refactors isLocalhost in oauth-provider zod types for clarity; fixes lint.

<sup>Written for commit 4371c3fc1e2dfc775ee38e423bf85683afe380d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

