### PR TITLE
fix: drizzle-adapter failing date transformation

### DIFF
--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -671,10 +671,17 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					? true
 					: false,
 			supportsArrays: config.provider === "pg" ? true : false,
-			// not all providers support dates
-			// one such example case is https://github.com/better-auth/better-auth/issues/7819
-			// it's safe to set to `false` without checking for provider, because it it is dates the transformation doesn't apply anyway.
-			supportsDates: false,
+			customTransformOutput: ({ data, fieldAttributes }) => {
+				// not all providers support dates
+				// one such example case is https://github.com/better-auth/better-auth/issues/7819
+				if (fieldAttributes.type === "date") {
+					if (data === null || data === undefined) {
+						return data;
+					}
+					return new Date(data);
+				}
+				return data;
+			},
 			transaction:
 				(config.transaction ?? false)
 					? (cb) =>


### PR DESCRIPTION
This fix has been applied and unapplied several times, most likely due to merge conflicts or some out-of-sync commits that overwritten it. I've re-applied the correct code.