### PR TITLE
docs: clarify `strictNullChecks` behavior under `strict`

### DIFF
--- a/docs/content/docs/concepts/typescript.mdx
+++ b/docs/content/docs/concepts/typescript.mdx
@@ -30,9 +30,7 @@ if you can't set `strict` to `true`, you can enable `strictNullChecks`:
 }
 ```
 
-<Callout type="warn">
-If `strict` is set to `true` but `strictNullChecks` is explicitly set to `false`, the override takes precedence and disables null checks. This can cause type inference issues with Better Auth. Either remove the `strictNullChecks: false` override or ensure it is set to `true`.
-</Callout>
+When `strict` is `true`, `strictNullChecks` is enabled as well. If you explicitly set `strictNullChecks` to `false`, type inference issues could occur.
 
 <Callout type="warn">
 If you're running into issues with TypeScript inference exceeding maximum length the compiler will serialize,


### PR DESCRIPTION
Add a warning to the Strict Mode documentation about `strictNullChecks: false` overriding `strict: true` and causing type inference issues.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1772480021473299?thread_ts=1772480021.473299&cid=C0A8B5BARUK)

<p><a href="https://cursor.com/agents/bc-96c26d6d-5b08-57c8-b7c8-2915bfdaa9cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96c26d6d-5b08-57c8-b7c8-2915bfdaa9cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

