### PR TITLE
docs: fix default secret value in options reference

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -137,7 +137,7 @@ By default, Better Auth will look for the following environment variables:
 - `process.env.BETTER_AUTH_SECRET`
 - `process.env.AUTH_SECRET`
 
-If none of these environment variables are set, it will default to `"better-auth-secret-123456789"`. In production, if it's not set, it will throw an error.
+If none of these environment variables are set, it will default to `"better-auth-secret-12345678901234567890"`. In production, if it's not set, it will throw an error.
 
 You can generate a good secret using the following command:
 


### PR DESCRIPTION
## Summary
- Update the default secret value in docs from `"better-auth-secret-123456789"` to `"better-auth-secret-12345678901234567890"` to match the actual value in `packages/better-auth/src/utils/constants.ts`

Closes #8283

## Test plan
- [x] Verify the value in docs matches `packages/better-auth/src/utils/constants.ts`