### PR TITLE
chore: align zod imports to use namespace import from "zod"

### DIFF
--- a/packages/api-key/src/routes/list-api-keys.ts
+++ b/packages/api-key/src/routes/list-api-keys.ts
@@ -2,7 +2,7 @@ import type { AuthContext } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { sessionMiddleware } from "better-auth/api";
-import * as z from "zod/v4";
+import * as z from "zod";
 import {
 	batchMigrateLegacyMetadata,
 	listApiKeys as listApiKeysFromStorage,

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -11,7 +11,7 @@ import chalk from "chalk";
 import { Command } from "commander";
 import prompts from "prompts";
 import yoctoSpinner from "yocto-spinner";
-import * as z from "zod/v4";
+import * as z from "zod";
 import { generateSchema } from "../generators";
 import { getConfig } from "../utils/get-config";
 

--- a/packages/cli/src/commands/init/configs/temp-plugins.config.ts
+++ b/packages/cli/src/commands/init/configs/temp-plugins.config.ts
@@ -1,6 +1,6 @@
 // This is a temporary plugin config file until we support actually using the plugin config files.
 
-import * as z from "zod/v4";
+import * as z from "zod";
 import type { GetArgumentsOptions } from "../generate-auth";
 import type { ImportGroup } from "../utility/imports";
 import { createImport } from "../utility/imports";

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -6,7 +6,7 @@ import { Command } from "commander";
 import open from "open";
 import prompts from "prompts";
 import yoctoSpinner from "yocto-spinner";
-import z from "zod";
+import * as z from "zod";
 import { cliVersion } from "../..";
 import { generateDrizzleSchema } from "../../generators/drizzle";
 import { generatePrismaSchema } from "../../generators/prisma";

--- a/packages/cli/src/commands/init/utility/plugin.test.ts
+++ b/packages/cli/src/commands/init/utility/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import * as z from "zod/v4";
+import * as z from "zod";
 import type { PluginConfig } from "../configs/temp-plugins.config";
 import { tempPluginsConfig } from "../configs/temp-plugins.config";
 import type { GetArgumentsFn } from "../generate-auth";

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -10,7 +10,7 @@ import chalk from "chalk";
 import { Command } from "commander";
 import prompts from "prompts";
 import yoctoSpinner from "yocto-spinner";
-import * as z from "zod/v4";
+import * as z from "zod";
 import { getConfig } from "../utils/get-config";
 
 /** @internal */

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -5,7 +5,7 @@ import { Command } from "commander";
 import prompts from "prompts";
 import * as semver from "semver";
 import yoctoSpinner from "yocto-spinner";
-import * as z from "zod/v4";
+import * as z from "zod";
 import { detectPackageManager } from "../utils/check-package-managers";
 import { fetchLatestVersion } from "../utils/fetch-latest-version";
 import { getPackageInfo } from "../utils/get-package-info";

--- a/packages/sso/src/routes/domain-verification.ts
+++ b/packages/sso/src/routes/domain-verification.ts
@@ -5,7 +5,7 @@ import {
 	sessionMiddleware,
 } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
-import * as z from "zod/v4";
+import * as z from "zod";
 import type { SSOOptions, SSOProvider } from "../types";
 
 const DNS_LABEL_MAX_LENGTH = 63;

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -4,7 +4,7 @@ import {
 	createAuthEndpoint,
 	sessionMiddleware,
 } from "better-auth/api";
-import z from "zod/v4";
+import * as z from "zod";
 import { DEFAULT_MAX_SAML_METADATA_SIZE } from "../constants";
 import { validateConfigAlgorithms } from "../saml";
 import type { Member, OIDCConfig, SAMLConfig, SSOOptions } from "../types";

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import * as z from "zod";
 
 const oidcMappingSchema = z
 	.object({

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -23,7 +23,7 @@ import saml from "samlify";
 import type { BindingContext } from "samlify/types/src/entity";
 import type { IdentityProvider } from "samlify/types/src/entity-idp";
 import type { FlowResult } from "samlify/types/src/flow";
-import z from "zod/v4";
+import * as z from "zod";
 import { getVerificationIdentifier } from "./domain-verification";
 
 interface AuthnRequestRecord {

--- a/packages/stripe/src/routes.ts
+++ b/packages/stripe/src/routes.ts
@@ -7,7 +7,7 @@ import type { Organization } from "better-auth/plugins/organization";
 import { defu } from "defu";
 import type Stripe from "stripe";
 import type { Stripe as StripeType } from "stripe";
-import * as z from "zod/v4";
+import * as z from "zod";
 import { STRIPE_ERROR_CODES } from "./error-codes";
 import {
 	onCheckoutSessionCompleted,


### PR DESCRIPTION
## Summary

- Standardize all zod imports across packages to use `import * as z from "zod"` instead of the `zod/v4` subpath or default imports
- Ensures consistent import style across the monorepo

## Affected packages

- `packages/api-key`
- `packages/cli`
- `packages/sso`
- `packages/stripe`