### PR TITLE
docs: update adapter test imports to `@better-auth/test-utils/adapter`

### DIFF
--- a/docs/content/blogs/1-5.mdx
+++ b/docs/content/blogs/1-5.mdx
@@ -713,7 +713,7 @@ The `/forget-password/email-otp` endpoint has been removed. Use the standard pas
 
 ### Adapter Imports
 
-The `better-auth/adapters/test` export has been removed. Use the `testUtils` plugin instead.
+The `better-auth/adapters/test` export has been removed. Use `testAdapter` and `createTestSuite` from `@better-auth/test-utils/adapter` instead. See the [Create a Database Adapter](/docs/guides/create-a-db-adapter#test-your-adapter) guide for details.
 
 ### API Key Plugin Moved to `@better-auth/api-key`
 

--- a/docs/content/docs/guides/create-a-db-adapter.mdx
+++ b/docs/content/docs/guides/create-a-db-adapter.mdx
@@ -359,59 +359,49 @@ createSchema: async ({ file, tables }) => {
 
 ## Test your adapter
 
-We've provided a test suite that you can use to test your adapter. It requires you to use `vitest`.
+We've provided a test suite via the `@better-auth/test-utils` package that you can use to test your adapter. It requires you to use `vitest`.
+
+First, install the test utilities:
+
+```bash
+npm install -D @better-auth/test-utils
+```
+
+Then create a test file using `testAdapter` and `createTestSuite`:
 
 ```ts title="my-adapter.test.ts"
-import { expect, test, describe } from "vitest";
-import { runAdapterTest } from "better-auth/adapters/test";
+import { testAdapter, createTestSuite } from "@better-auth/test-utils/adapter";
 import { myAdapter } from "./my-adapter";
 
-describe("My Adapter Tests", async () => {
-  afterAll(async () => {
-    // Run DB cleanup here...
-  });
-  const adapter = myAdapter({
-    debugLogs: {
-      // If your adapter config allows passing in debug logs, then pass this here.
-      isRunningAdapterTests: true, // This is our super secret flag to let us know to only log debug logs if a test fails.
-    },
-  });
+const normalTestSuite = createTestSuite("Normal", ({ test, adapter }) => [
+  test("should create and find a user", async () => {
+    // Write your adapter tests here using the adapter instance
+  }),
+]);
 
-  runAdapterTest({
-    getAdapter: async (betterAuthOptions = {}) => {
-      return adapter(betterAuthOptions);
-    },
-  });
+const { execute } = await testAdapter({
+  adapter: (options) => {
+    return myAdapter(/* your adapter config */);
+  },
+  runMigrations: async (options) => {
+    // Run your database migrations here
+  },
+  tests: [
+    normalTestSuite(),
+  ],
+  async onFinish() {
+    // Optional: cleanup after all tests (e.g., delete a DB file)
+  },
 });
+
+execute();
 ```
 
-### Numeric ID tests
+The `testAdapter` function handles the test lifecycle for you, including running migrations before tests and cleaning up all tables after tests complete.
 
-If your database supports numeric IDs, then you should run this test as well:
-
-```ts title="my-adapter.number-id.test.ts"
-import { expect, test, describe } from "vitest";
-import { runNumberIdAdapterTest } from "better-auth/adapters/test";
-import { myAdapter } from "./my-adapter";
-
-describe("My Adapter Numeric ID Tests", async () => {
-  afterAll(async () => {
-    // Run DB cleanup here...
-  });
-  const adapter = myAdapter({
-    debugLogs: {
-      // If your adapter config allows passing in debug logs, then pass this here.
-      isRunningAdapterTests: true, // This is our super secret flag to let us know to only log debug logs if a test fails.
-    },
-  });
-
-  runNumberIdAdapterTest({
-    getAdapter: async (betterAuthOptions = {}) => {
-      return adapter(betterAuthOptions);
-    },
-  });
-});
-```
+<Callout type="info">
+  In v1.4, adapter tests used `runAdapterTest` and `runNumberIdAdapterTest` from `better-auth/adapters/test`. That export has been removed in v1.5. Use `@better-auth/test-utils/adapter` instead.
+</Callout>
 
 ## Config
 


### PR DESCRIPTION
## Summary
- Update the "Create a Database Adapter" guide to use `testAdapter` and `createTestSuite` from `@better-auth/test-utils/adapter` instead of the removed `better-auth/adapters/test` export
- Fix the v1.5 blog post breaking change note to reference the correct new package with a link to the updated guide

## Context
The `better-auth/adapters/test` export (with `runAdapterTest` / `runNumberIdAdapterTest`) was removed in v1.5, but the docs still referenced it. The replacement is `@better-auth/test-utils/adapter`.