### PR TITLE
fix(prisma-adapter): use deleteMany when deleting by non-unique field

### DIFF
--- a/e2e/adapter/test/adapter-factory/basic.ts
+++ b/e2e/adapter/test/adapter-factory/basic.ts
@@ -1,5 +1,10 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
-import type { Account, Session, User } from "@better-auth/core/db";
+import type {
+	Account,
+	Session,
+	User,
+	Verification,
+} from "@better-auth/core/db";
 import { createTestSuite } from "@better-auth/test-utils/adapter";
 import type {
 	Invitation,
@@ -2156,6 +2161,21 @@ export const getNormalTestSuiteTests = (
 					],
 				}),
 			).resolves.not.toThrow();
+		},
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/8313
+		 */
+		"delete - should delete by non-unique field": async () => {
+			const [verification] = await insertRandom("verification");
+			await adapter.delete<Verification>({
+				model: "verification",
+				where: [{ field: "identifier", value: verification.identifier }],
+			});
+			const result = await adapter.findOne<Verification>({
+				model: "verification",
+				where: [{ field: "identifier", value: verification.identifier }],
+			});
+			expect(result).toBeNull();
 		},
 		"deleteMany - should delete many models": async () => {
 			const users = (await insertRandom("user", 3)).map((x) => x[0]);

--- a/packages/prisma-adapter/src/prisma-adapter.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.ts
@@ -497,6 +497,20 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 							`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
 						);
 					}
+					// Prisma's delete() requires a WhereUniqueInput (unique/primary key field).
+					// When deleting by non-unique fields (e.g. identifier), fall back to deleteMany.
+					const hasIdField = where?.some((w) => w.field === "id");
+					if (!hasIdField) {
+						const whereClause = convertWhereClause({
+							model,
+							where,
+							action: "deleteMany",
+						});
+						await db[model]!.deleteMany({
+							where: whereClause,
+						});
+						return;
+					}
 					const whereClause = convertWhereClause({
 						model,
 						where,


### PR DESCRIPTION
## Summary

- Fixes Prisma adapter's `delete()` method to fall back to `deleteMany()` when the where clause doesn't contain an `id` field, since Prisma's `delete()` requires a `WhereUniqueInput` (unique/primary key)
- This fixes the `deleteVerificationByIdentifier` flow where `identifier` is not a unique field on the verification table
- Adds e2e adapter test to verify deletion by non-unique field works across all adapters

Closes #8313

## Test plan

- [x] Added "delete - should delete by non-unique field" test in `e2e/adapter/test/adapter-factory/basic.ts`
- [x] Verified all memory adapter tests pass (412 passed, 1 skipped)
- [x] Verified lint and format checks pass