### PR TITLE
docs: fix wording on session cookie checks in Next.js integration

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -127,7 +127,7 @@ const signIn = async () => {
 
 ## Auth Protection
 
-In Next.js proxy/middleware, it's recommended to only check for the existence of a session cookie to handle redirection. To avoid blocking requests by making API or database calls.
+In Next.js proxy/middleware, it's recommended to only check for the existence of a session cookie to handle redirection to avoid blocking requests by making API or database calls.
 
 ### Next.js 16+ (Proxy)
 


### PR DESCRIPTION
## Summary
- Clarified wording in Next.js integration docs to recommend only checking for the presence of a session cookie in proxy/middleware, so redirects don't block on API or database calls.

Cherry-picked from #7662.