### PR TITLE
feat: add meaningful prefixes to verification API identifiers

### DIFF
--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -215,7 +215,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 						: generateRandomString(32, "a-z", "A-Z");
 					const storedToken = await storeToken(ctx, verificationToken);
 					await ctx.context.internalAdapter.createVerificationValue({
-						identifier: storedToken,
+						identifier: `magic-link:${storedToken}`,
 						value: JSON.stringify({ email, name: ctx.body.name, attempt: 0 }),
 						expiresAt: new Date(Date.now() + (opts.expiresIn || 60 * 5) * 1000),
 					});
@@ -346,16 +346,22 @@ export const magicLink = (options: MagicLinkOptions) => {
 						ctx.context.baseURL,
 					).toString();
 					const storedToken = await storeToken(ctx, token);
-					const tokenValue =
+					let tokenValue =
 						await ctx.context.internalAdapter.findVerificationValue(
+							`magic-link:${storedToken}`,
+						);
+					if (!tokenValue) {
+						// backward compatibility: check unprefixed identifier
+						tokenValue = await ctx.context.internalAdapter.findVerificationValue(
 							storedToken,
 						);
+					}
 					if (!tokenValue) {
 						redirectWithError("INVALID_TOKEN");
 					}
 					if (tokenValue.expiresAt < new Date()) {
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							storedToken,
+							tokenValue.identifier,
 						);
 						redirectWithError("EXPIRED_TOKEN");
 					}
@@ -370,12 +376,12 @@ export const magicLink = (options: MagicLinkOptions) => {
 					};
 					if (attempt >= opts.allowedAttempts) {
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							storedToken,
+							tokenValue.identifier,
 						);
 						redirectWithError("ATTEMPTS_EXCEEDED");
 					}
 					await ctx.context.internalAdapter.updateVerificationByIdentifier(
-						storedToken,
+						tokenValue.identifier,
 						{
 							value: JSON.stringify({
 								email,

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -407,7 +407,7 @@ describe("magic link storeToken", async () => {
 		});
 		const hashedToken = await defaultKeyHasher(verificationEmail.token);
 		const storedToken =
-			await internalAdapter.findVerificationValue(hashedToken);
+			await internalAdapter.findVerificationValue(`magic-link:${hashedToken}`);
 		expect(storedToken).toBeDefined();
 		const response2 = await auth.api.signInMagicLink({
 			body: {
@@ -450,7 +450,7 @@ describe("magic link storeToken", async () => {
 		});
 		const hashedToken = `${verificationEmail.token}hashed`;
 		const storedToken =
-			await internalAdapter.findVerificationValue(hashedToken);
+			await internalAdapter.findVerificationValue(`magic-link:${hashedToken}`);
 		expect(storedToken).toBeDefined();
 		const response2 = await auth.api.signInMagicLink({
 			body: {

--- a/packages/better-auth/src/plugins/mcp/authorize.ts
+++ b/packages/better-auth/src/plugins/mcp/authorize.ts
@@ -200,7 +200,7 @@ export async function authorizeMCPOAuth(
 				codeChallengeMethod: query.code_challenge_method,
 				nonce: query.nonce,
 			}),
-			identifier: code,
+			identifier: `mcp-code:${code}`,
 			expiresAt,
 		});
 	} catch {

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -474,7 +474,7 @@ export const mcp = (options: MCPOptions) => {
 					 */
 					const verificationValue =
 						await ctx.context.internalAdapter.findVerificationValue(
-							code.toString(),
+							`mcp-code:${code.toString()}`,
 						);
 					if (!verificationValue) {
 						throw new APIError("UNAUTHORIZED", {
@@ -490,7 +490,7 @@ export const mcp = (options: MCPOptions) => {
 					}
 
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						code.toString(),
+						`mcp-code:${code.toString()}`,
 					);
 
 					if (!client_id) {
@@ -613,7 +613,7 @@ export const mcp = (options: MCPOptions) => {
 
 					const requestedScopes = value.scope;
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						code.toString(),
+						`mcp-code:${code.toString()}`,
 					);
 					const accessToken = generateRandomString(32, "a-z", "A-Z");
 					const refreshToken = generateRandomString(32, "A-Z", "a-z");

--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -294,7 +294,7 @@ export async function authorize(
 				codeChallengeMethod: query.code_challenge_method,
 				nonce: query.nonce,
 			}),
-			identifier: code,
+			identifier: `oidc-code:${code}`,
 			expiresAt,
 		});
 	} catch {

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -564,7 +564,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 
 					const verification =
 						await ctx.context.internalAdapter.findVerificationValue(
-							consentCode,
+							`oidc-code:${consentCode}`,
 						);
 					if (!verification) {
 						throw new APIError("UNAUTHORIZED", {
@@ -595,7 +595,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 
 					if (!ctx.body.accept) {
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							consentCode,
+							`oidc-code:${consentCode}`,
 						);
 						return ctx.json({
 							redirectURI: `${value.redirectURI}?error=access_denied&error_description=User denied access`,
@@ -606,13 +606,13 @@ export const oidcProvider = (options: OIDCOptions) => {
 						(opts?.codeExpiresIn ?? DEFAULT_CODE_EXPIRES_IN) * 1000;
 					const expiresAt = new Date(Date.now() + codeExpiresInMs);
 					await ctx.context.internalAdapter.updateVerificationByIdentifier(
-						consentCode,
+						`oidc-code:${consentCode}`,
 						{
 							value: JSON.stringify({
 								...value,
 								requireConsent: false,
 							}),
-							identifier: code,
+							identifier: `oidc-code:${code}`,
 							expiresAt,
 						},
 					);
@@ -797,7 +797,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					 */
 					const verificationValue =
 						await ctx.context.internalAdapter.findVerificationValue(
-							code.toString(),
+							`oidc-code:${code.toString()}`,
 						);
 					if (!verificationValue) {
 						throw new APIError("UNAUTHORIZED", {
@@ -813,7 +813,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					}
 
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						code.toString(),
+						`oidc-code:${code.toString()}`,
 					);
 					if (!client_id) {
 						throw new APIError("UNAUTHORIZED", {
@@ -922,7 +922,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 
 					const requestedScopes = value.scope;
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						code.toString(),
+						`oidc-code:${code.toString()}`,
 					);
 					const accessToken = generateRandomString(32, "a-z", "A-Z");
 					const refreshToken = generateRandomString(32, "A-Z", "a-z");

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -121,7 +121,7 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 					const otp = generateOTP(opts.otpLength);
 					await ctx.context.internalAdapter.createVerificationValue({
 						value: otp,
-						identifier: phoneNumber,
+						identifier: `phone-number:${phoneNumber}`,
 						expiresAt: getDate(opts.expiresIn, "sec"),
 					});
 					if (opts.sendOTP) {
@@ -277,7 +277,7 @@ export const sendPhoneNumberOTP = (opts: RequiredPhoneNumberOptions) =>
 			const code = generateOTP(opts.otpLength);
 			await ctx.context.internalAdapter.createVerificationValue({
 				value: `${code}:0`,
-				identifier: ctx.body.phoneNumber,
+				identifier: `phone-number:${ctx.body.phoneNumber}`,
 				expiresAt: getDate(opts.expiresIn, "sec"),
 			});
 			await ctx.context.runInBackgroundOrAwait(
@@ -470,17 +470,17 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 
 				// Clean up verification value
 				const otp = await ctx.context.internalAdapter.findVerificationValue(
-					ctx.body.phoneNumber,
+					`phone-number:${ctx.body.phoneNumber}`,
 				);
 				if (otp) {
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						ctx.body.phoneNumber,
+						`phone-number:${ctx.body.phoneNumber}`,
 					);
 				}
 			} else {
 				// Default internal verification logic
 				const otp = await ctx.context.internalAdapter.findVerificationValue(
-					ctx.body.phoneNumber,
+					`phone-number:${ctx.body.phoneNumber}`,
 				);
 
 				if (!otp || otp.expiresAt < new Date()) {
@@ -499,7 +499,7 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				const allowedAttempts = opts?.allowedAttempts || 3;
 				if (attempts && parseInt(attempts) >= allowedAttempts) {
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						ctx.body.phoneNumber,
+						`phone-number:${ctx.body.phoneNumber}`,
 					);
 					throw APIError.from(
 						"FORBIDDEN",
@@ -508,7 +508,7 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				}
 				if (otpValue !== ctx.body.code) {
 					await ctx.context.internalAdapter.updateVerificationByIdentifier(
-						ctx.body.phoneNumber,
+						`phone-number:${ctx.body.phoneNumber}`,
 						{
 							value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
 						},
@@ -520,7 +520,7 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				}
 
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					ctx.body.phoneNumber,
+					`phone-number:${ctx.body.phoneNumber}`,
 				);
 			}
 
@@ -707,7 +707,7 @@ export const requestPasswordResetPhoneNumber = (
 			const code = generateOTP(opts.otpLength);
 			await ctx.context.internalAdapter.createVerificationValue({
 				value: `${code}:0`,
-				identifier: `${ctx.body.phoneNumber}-request-password-reset`,
+				identifier: `phone-number:${ctx.body.phoneNumber}:request-password-reset`,
 				expiresAt: getDate(opts.expiresIn, "sec"),
 			});
 			// to avoid leaking the existence of the phone number
@@ -782,7 +782,7 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 		async (ctx) => {
 			const verification =
 				await ctx.context.internalAdapter.findVerificationValue(
-					`${ctx.body.phoneNumber}-request-password-reset`,
+					`phone-number:${ctx.body.phoneNumber}:request-password-reset`,
 				);
 			if (!verification) {
 				throw APIError.from(
@@ -798,7 +798,7 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			}
 			const [otpValue, attempts] = verification.value.split(":");
 			const allowedAttempts = opts?.allowedAttempts || 3;
-			const phoneResetIdentifier = `${ctx.body.phoneNumber}-request-password-reset`;
+			const phoneResetIdentifier = `phone-number:${ctx.body.phoneNumber}:request-password-reset`;
 			if (attempts && parseInt(attempts) >= allowedAttempts) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 					phoneResetIdentifier,


### PR DESCRIPTION
## Summary

Follow-up to #7600 — extends the `magic-link:` prefix pattern to all plugins that store data in the shared `verification` table without a meaningful prefix.

- **magic-link**: adds `magic-link:${token}` prefix with backward-compatibility fallback for tokens stored before this change
- **phone-number**: adds `phone-number:${phoneNumber}` prefix (basic OTP) and `phone-number:${phoneNumber}:request-password-reset` (password reset OTP)
- **oidc-provider**: adds `oidc-code:${code}` prefix for authorization codes (both initial store and consent-flow update)
- **mcp**: adds `mcp-code:${code}` prefix for authorization codes

Already had prefixes (no changes needed): `one-time-token:`, `siwe:`, `email-verification-otp-`/dynamic OTP prefixes, `2fa-otp-`, `trust-device-`, `reset-password:`, `2fa-`.

## Test plan

- [x] All existing magic-link tests pass (16 tests)
- [x] All existing phone-number tests pass (26 tests)
- [x] All existing oidc-provider tests pass (35 tests)
- [x] All existing mcp tests pass (36 tests)