### PR TITLE
Issue 8307 validation

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -575,11 +575,35 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				filterOutputFields(team, teamAdditionalFields),
 			);
 
+			let teamsWithMembers = filteredTeams;
+			if (includeTeams && filteredTeams && filteredTeams.length > 0) {
+				const teamIds = filteredTeams.map((team) => team.id);
+				const teamMembers =
+					teamIds.length > 0
+						? await adapter.findMany<TeamMember>({
+								model: "teamMember",
+								where: [{ field: "teamId", value: teamIds, operator: "in" }],
+							})
+						: [];
+
+				const teamMembersByTeamId = new Map<string, TeamMember[]>();
+				for (const tm of teamMembers) {
+					const existing = teamMembersByTeamId.get(tm.teamId) || [];
+					existing.push(tm);
+					teamMembersByTeamId.set(tm.teamId, existing);
+				}
+
+				teamsWithMembers = filteredTeams.map((team) => ({
+					...team,
+					members: teamMembersByTeamId.get(team.id) || [],
+				}));
+			}
+
 			return {
 				...filteredOrg,
 				invitations: filteredInvitations,
 				members: membersWithUsers,
-				teams: filteredTeams,
+				teams: teamsWithMembers,
 			};
 		},
 		listOrganizations: async (

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2515,6 +2515,12 @@ describe("Additional Fields", async () => {
 			teamRequiredField: string;
 			teamOptionalField?: string | undefined;
 			teamHiddenField?: string | undefined;
+			members: {
+				id: string;
+				teamId: string;
+				userId: string;
+				createdAt: Date;
+			}[];
 		}>();
 	});
 
@@ -2774,6 +2780,23 @@ describe("Additional Fields", async () => {
 			teamRequiredField: string;
 			teamOptionalField?: string | undefined;
 			teamHiddenField?: string | undefined;
+			members: {
+				id: string;
+				teamId: string;
+				userId: string;
+				createdAt: Date;
+			}[];
+		}[];
+
+		type ExpectedBaseTeams = {
+			id: string;
+			name: string;
+			organizationId: string;
+			createdAt: Date;
+			updatedAt?: Date | undefined;
+			teamRequiredField: string;
+			teamOptionalField?: string | undefined;
+			teamHiddenField?: string | undefined;
 		}[];
 
 		type O = typeof orgOptions;
@@ -2783,7 +2806,7 @@ describe("Additional Fields", async () => {
 
 		expectTypeOf<Members>().toEqualTypeOf<ExpectedMembers>();
 		expectTypeOf<Invitations>().toEqualTypeOf<ExpectedInvitations>();
-		expectTypeOf<Teams>().toEqualTypeOf<ExpectedTeams>();
+		expectTypeOf<Teams>().toEqualTypeOf<ExpectedBaseTeams>();
 
 		expectTypeOf<NonNullable<Result>>().toEqualTypeOf<{
 			id: string;

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -5,6 +5,7 @@ import { getSessionFromCtx, requestOnlySessionMiddleware } from "../../../api";
 import { setSessionCookie } from "../../../cookies";
 import type { InferAdditionalFieldsFromPluginOptions } from "../../../db";
 import { toZodSchema } from "../../../db";
+import type { Prettify } from "../../../types/helper";
 import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
@@ -719,7 +720,7 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 				? {
 						members: InferMember<O>[];
 						invitations: InferInvitation<O>[];
-						teams: InferTeam<O>[];
+						teams: Prettify<InferTeam<O> & { members: TeamMember[] }>[];
 					} & InferOrganization<O>
 				: {
 						members: InferMember<O>[];
@@ -860,7 +861,7 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 				? {
 						members: InferMember<O>[];
 						invitations: InferInvitation<O>[];
-						teams: InferTeam<O>[];
+						teams: Prettify<InferTeam<O> & { members: TeamMember[] }>[];
 					} & InferOrganization<O>
 				: {
 						members: InferMember<O>[];

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -192,6 +192,33 @@ describe("team", async () => {
 		expect(teamNames).toContain("Marketing Team");
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8307
+	 */
+	it("should include team members in getFullOrganization response", async () => {
+		const organization = await client.organization.getFullOrganization({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const teams = organization.data?.teams;
+		expect(teams).toBeDefined();
+
+		for (const team of teams!) {
+			expect(team.members).toBeDefined();
+			expect(Array.isArray(team.members)).toBe(true);
+		}
+
+		const devTeam = teams!.find((t) => t.name === "Development Team");
+		expect(devTeam).toBeDefined();
+		expect(devTeam!.members.length).toBeGreaterThanOrEqual(1);
+		const firstMember = devTeam!.members[0]!;
+		expect(firstMember).toHaveProperty("teamId");
+		expect(firstMember).toHaveProperty("userId");
+		expect(firstMember.teamId).toBe(devTeam!.id);
+	});
+
 	it("should get all teams", async () => {
 		const teamsResponse = await client.organization.listTeams({
 			fetchOptions: { headers },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Include team members in `getFullOrganization` response and update related types and tests.

This PR resolves #8307 by ensuring that `auth.api.getFullOrganization()` returns team-member relationship data, allowing clients to know which members belong to which teams without additional API calls.

---
[Slack Thread](https://betterauth.slack.com/archives/C0A8B5BARUK/p1772525506017609?thread_ts=1772525506.017609&cid=C0A8B5BARUK)

<p><a href="https://cursor.com/agents/bc-2ee54af4-9303-5955-ad7b-d93854e2bc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ee54af4-9303-5955-ad7b-d93854e2bc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->