### PR TITLE
fix(types): enforce strict keys for additionalFields config

### DIFF
--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -73,10 +73,10 @@ describe("auth type", () => {
 
 describe("additionalFields config typing", () => {
 	test("should reject extraneous keys in user.additionalFields", () => {
-		// @ts-expect-error - unknown key should not be allowed
 		betterAuth({
 			user: {
 				additionalFields: {
+					// @ts-expect-error - unknown key should not be allowed
 					test: {
 						type: "boolean",
 						abc: "def",
@@ -85,13 +85,43 @@ describe("additionalFields config typing", () => {
 			},
 		});
 
-		// @ts-expect-error - misspelled required should not be allowed
 		betterAuth({
 			user: {
 				additionalFields: {
+					// @ts-expect-error - misspelled required should not be allowed
 					test: {
 						type: "boolean",
 						require: true,
+					},
+				},
+			},
+		});
+	});
+
+	test("should reject extraneous keys when passed as a variable (structural strictness)", () => {
+		const badConfig = {
+			user: {
+				additionalFields: {
+					test: {
+						type: "boolean" as const,
+						abc: "def",
+					},
+				},
+			},
+		};
+
+		// @ts-expect-error - extraneous keys should fail even when structurally typed
+		betterAuth(badConfig);
+	});
+
+	test("should reject extraneous keys in session.additionalFields", () => {
+		betterAuth({
+			session: {
+				additionalFields: {
+					// @ts-expect-error - unknown key should not be allowed
+					test: {
+						type: "string",
+						abc: "def",
 					},
 				},
 			},
@@ -114,6 +144,23 @@ describe("additionalFields config typing", () => {
 
 		expectTypeOf<
 			typeof auth.$Infer.Session.user.role
+		>().toEqualTypeOf<string>();
+
+		const authWithSessionField = betterAuth({
+			session: {
+				additionalFields: {
+					deviceId: {
+						type: "string",
+						required: true,
+						input: true,
+						returned: true,
+					},
+				},
+			},
+		});
+
+		expectTypeOf<
+			typeof authWithSessionField.$Infer.Session.session.deviceId
 		>().toEqualTypeOf<string>();
 	});
 });

--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -71,6 +71,56 @@ describe("auth type", () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8305
+ */
+describe("additionalFields config typing", () => {
+	test("should reject extraneous keys in user.additionalFields", () => {
+		// @ts-expect-error - unknown key should not be allowed
+		betterAuth({
+			user: {
+				additionalFields: {
+					test: {
+						type: "boolean",
+						abc: "def",
+					},
+				},
+			},
+		});
+
+		// @ts-expect-error - misspelled required should not be allowed
+		betterAuth({
+			user: {
+				additionalFields: {
+					test: {
+						type: "boolean",
+						require: true,
+					},
+				},
+			},
+		});
+	});
+
+	test("should allow valid additionalFields keys and preserve inference", () => {
+		const auth = betterAuth({
+			user: {
+				additionalFields: {
+					role: {
+						type: "string",
+						required: true,
+						input: true,
+						returned: true,
+					},
+				},
+			},
+		});
+
+		expectTypeOf<
+			typeof auth.$Infer.Session.user.role
+		>().toEqualTypeOf<string>();
+	});
+});
+
 describe("auth with trusted proxy headers", () => {
 	test("shouldn't infer base url from proxy headers if trusted", async () => {
 		let baseURL: string | undefined;

--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -71,9 +71,6 @@ describe("auth type", () => {
 	});
 });
 
-/**
- * @see https://github.com/better-auth/better-auth/issues/8305
- */
 describe("additionalFields config typing", () => {
 	test("should reject extraneous keys in user.additionalFields", () => {
 		// @ts-expect-error - unknown key should not be allowed

--- a/packages/better-auth/src/auth/full.ts
+++ b/packages/better-auth/src/auth/full.ts
@@ -4,6 +4,9 @@ import type { Auth } from "../types";
 import { createBetterAuth } from "./base";
 import type { StrictAdditionalFieldsOptions } from "./strict-additional-fields";
 
+type NormalizeOptions<Options extends BetterAuthOptions> =
+	keyof Options extends never ? BetterAuthOptions : Options;
+
 /**
  * Better Auth initializer for full mode (with Kysely)
  *
@@ -25,10 +28,9 @@ import type { StrictAdditionalFieldsOptions } from "./strict-additional-fields";
  *	  database: drizzleAdapter(db, { provider: "pg" }),
  * });
  */
-export function betterAuth(options: Record<string, never>): Auth;
 export function betterAuth<Options extends BetterAuthOptions>(
 	options: Options & StrictAdditionalFieldsOptions<Options>,
-): Auth<Options>;
+): Auth<NormalizeOptions<Options>>;
 export function betterAuth(options: BetterAuthOptions): Auth {
 	return createBetterAuth(options, init);
 }

--- a/packages/better-auth/src/auth/full.ts
+++ b/packages/better-auth/src/auth/full.ts
@@ -2,6 +2,7 @@ import type { BetterAuthOptions } from "@better-auth/core";
 import { init } from "../context/init";
 import type { Auth } from "../types";
 import { createBetterAuth } from "./base";
+import type { StrictAdditionalFieldsOptions } from "./strict-additional-fields";
 
 /**
  * Better Auth initializer for full mode (with Kysely)
@@ -24,8 +25,10 @@ import { createBetterAuth } from "./base";
  *	  database: drizzleAdapter(db, { provider: "pg" }),
  * });
  */
-export const betterAuth = <Options extends BetterAuthOptions>(
-	options: Options & {},
-): Auth<Options> => {
+export function betterAuth(options: Record<string, never>): Auth;
+export function betterAuth<Options extends BetterAuthOptions>(
+	options: Options & StrictAdditionalFieldsOptions<Options>,
+): Auth<Options>;
+export function betterAuth(options: BetterAuthOptions): Auth {
 	return createBetterAuth(options, init);
-};
+}

--- a/packages/better-auth/src/auth/minimal.test.ts
+++ b/packages/better-auth/src/auth/minimal.test.ts
@@ -72,10 +72,10 @@ describe("auth-minimal", () => {
 
 describe("minimal additionalFields config typing", () => {
 	it("should reject extraneous keys in user.additionalFields", () => {
-		// @ts-expect-error - unknown key should not be allowed
 		betterAuth({
 			user: {
 				additionalFields: {
+					// @ts-expect-error - unknown key should not be allowed
 					test: {
 						type: "boolean",
 						abc: "def",
@@ -84,13 +84,43 @@ describe("minimal additionalFields config typing", () => {
 			},
 		});
 
-		// @ts-expect-error - misspelled required should not be allowed
 		betterAuth({
 			user: {
 				additionalFields: {
+					// @ts-expect-error - misspelled required should not be allowed
 					test: {
 						type: "boolean",
 						require: true,
+					},
+				},
+			},
+		});
+	});
+
+	it("should reject extraneous keys when passed as a variable (structural strictness)", () => {
+		const badConfig = {
+			user: {
+				additionalFields: {
+					test: {
+						type: "boolean" as const,
+						abc: "def",
+					},
+				},
+			},
+		};
+
+		// @ts-expect-error - extraneous keys should fail even when structurally typed
+		betterAuth(badConfig);
+	});
+
+	it("should reject extraneous keys in session.additionalFields", () => {
+		betterAuth({
+			session: {
+				additionalFields: {
+					// @ts-expect-error - unknown key should not be allowed
+					test: {
+						type: "string",
+						abc: "def",
 					},
 				},
 			},
@@ -113,6 +143,23 @@ describe("minimal additionalFields config typing", () => {
 
 		expectTypeOf<
 			typeof auth.$Infer.Session.user.role
+		>().toEqualTypeOf<string>();
+
+		const authWithSessionField = betterAuth({
+			session: {
+				additionalFields: {
+					deviceId: {
+						type: "string",
+						required: true,
+						input: true,
+						returned: true,
+					},
+				},
+			},
+		});
+
+		expectTypeOf<
+			typeof authWithSessionField.$Infer.Session.session.deviceId
 		>().toEqualTypeOf<string>();
 	});
 });

--- a/packages/better-auth/src/auth/minimal.test.ts
+++ b/packages/better-auth/src/auth/minimal.test.ts
@@ -69,3 +69,50 @@ describe("auth-minimal", () => {
 		sqliteDB.close();
 	});
 });
+
+describe("minimal additionalFields config typing", () => {
+	it("should reject extraneous keys in user.additionalFields", () => {
+		// @ts-expect-error - unknown key should not be allowed
+		betterAuth({
+			user: {
+				additionalFields: {
+					test: {
+						type: "boolean",
+						abc: "def",
+					},
+				},
+			},
+		});
+
+		// @ts-expect-error - misspelled required should not be allowed
+		betterAuth({
+			user: {
+				additionalFields: {
+					test: {
+						type: "boolean",
+						require: true,
+					},
+				},
+			},
+		});
+	});
+
+	it("should allow valid additionalFields keys and preserve inference", () => {
+		const auth = betterAuth({
+			user: {
+				additionalFields: {
+					role: {
+						type: "string",
+						required: true,
+						input: true,
+						returned: true,
+					},
+				},
+			},
+		});
+
+		expectTypeOf<
+			typeof auth.$Infer.Session.user.role
+		>().toEqualTypeOf<string>();
+	});
+});

--- a/packages/better-auth/src/auth/minimal.ts
+++ b/packages/better-auth/src/auth/minimal.ts
@@ -2,14 +2,17 @@ import type { BetterAuthOptions } from "@better-auth/core";
 import { initMinimal } from "../context/init-minimal";
 import type { Auth } from "../types";
 import { createBetterAuth } from "./base";
+import type { StrictAdditionalFieldsOptions } from "./strict-additional-fields";
 
 export type { BetterAuthOptions };
 
 /**
  * Better Auth initializer for minimal mode (without Kysely)
  */
-export const betterAuth = <Options extends BetterAuthOptions>(
-	options: Options & {},
-): Auth<Options> => {
+export function betterAuth(options: Record<string, never>): Auth;
+export function betterAuth<Options extends BetterAuthOptions>(
+	options: Options & StrictAdditionalFieldsOptions<Options>,
+): Auth<Options>;
+export function betterAuth(options: BetterAuthOptions): Auth {
 	return createBetterAuth(options, initMinimal);
-};
+}

--- a/packages/better-auth/src/auth/minimal.ts
+++ b/packages/better-auth/src/auth/minimal.ts
@@ -6,13 +6,15 @@ import type { StrictAdditionalFieldsOptions } from "./strict-additional-fields";
 
 export type { BetterAuthOptions };
 
+type NormalizeOptions<Options extends BetterAuthOptions> =
+	keyof Options extends never ? BetterAuthOptions : Options;
+
 /**
  * Better Auth initializer for minimal mode (without Kysely)
  */
-export function betterAuth(options: Record<string, never>): Auth;
 export function betterAuth<Options extends BetterAuthOptions>(
 	options: Options & StrictAdditionalFieldsOptions<Options>,
-): Auth<Options>;
+): Auth<NormalizeOptions<Options>>;
 export function betterAuth(options: BetterAuthOptions): Auth {
 	return createBetterAuth(options, initMinimal);
 }

--- a/packages/better-auth/src/auth/strict-additional-fields.ts
+++ b/packages/better-auth/src/auth/strict-additional-fields.ts
@@ -1,0 +1,31 @@
+import type { BetterAuthOptions } from "@better-auth/core";
+import type { DBFieldAttribute } from "@better-auth/core/db";
+
+type StrictDBFieldAttribute<Field> = Field extends DBFieldAttribute
+	? Exclude<keyof Field, keyof DBFieldAttribute> extends never
+		? Field
+		: never
+	: Field;
+
+type StrictAdditionalFields<Fields> =
+	Fields extends Record<string, DBFieldAttribute>
+		? {
+				[K in keyof Fields]: StrictDBFieldAttribute<Fields[K]>;
+			}
+		: Fields;
+
+type StrictModelAdditionalFields<Model> = Model extends {
+	additionalFields?: infer Fields;
+}
+	? Omit<Model, "additionalFields"> & {
+			additionalFields?: StrictAdditionalFields<NonNullable<Fields>>;
+		}
+	: Model;
+
+export type StrictAdditionalFieldsOptions<Options extends BetterAuthOptions> =
+	Omit<Options, "user" | "session" | "account" | "verification"> & {
+		user?: StrictModelAdditionalFields<Options["user"]>;
+		session?: StrictModelAdditionalFields<Options["session"]>;
+		account?: StrictModelAdditionalFields<Options["account"]>;
+		verification?: StrictModelAdditionalFields<Options["verification"]>;
+	};

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -23,19 +23,6 @@ type CurrentUserContext = {
 	headers: Headers;
 };
 
-type TestDynamicBaseURLConfig = {
-	allowedHosts: string[];
-	fallback?: string | undefined;
-	protocol?: "http" | "https" | "auto" | undefined;
-};
-
-type TestInstanceOptions<O extends Partial<BetterAuthOptions>> = Omit<
-	O,
-	"baseURL"
-> & {
-	baseURL?: O["baseURL"] | TestDynamicBaseURLConfig;
-};
-
 const currentUserContextStorage = new AsyncLocalStorage<CurrentUserContext>();
 
 afterAll(async () => {
@@ -49,7 +36,7 @@ export async function getTestInstance<
 	O extends Partial<BetterAuthOptions>,
 	C extends BetterAuthClientOptions,
 >(
-	options?: TestInstanceOptions<O> | undefined,
+	options?: O | undefined,
 	config?:
 		| {
 				clientOptions?: C;

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -8,6 +8,7 @@ import type { SuccessContext } from "@better-fetch/fetch";
 import { sql } from "kysely";
 import { afterAll } from "vitest";
 import { betterAuth } from "../auth/full";
+import type { StrictAdditionalFieldsOptions } from "../auth/strict-additional-fields";
 import { createAuthClient } from "../client";
 import { parseSetCookieHeader, setCookieToHeader } from "../cookies";
 import { getAdapter } from "../db/adapter-kysely";
@@ -21,6 +22,20 @@ const cleanupSet = new Set<Function>();
 type CurrentUserContext = {
 	headers: Headers;
 };
+
+type TestDynamicBaseURLConfig = {
+	allowedHosts: string[];
+	fallback?: string | undefined;
+	protocol?: "http" | "https" | "auto" | undefined;
+};
+
+type TestInstanceOptions<O extends Partial<BetterAuthOptions>> = Omit<
+	O,
+	"baseURL"
+> & {
+	baseURL?: O["baseURL"] | TestDynamicBaseURLConfig;
+};
+
 const currentUserContextStorage = new AsyncLocalStorage<CurrentUserContext>();
 
 afterAll(async () => {
@@ -34,7 +49,7 @@ export async function getTestInstance<
 	O extends Partial<BetterAuthOptions>,
 	C extends BetterAuthClientOptions,
 >(
-	options?: O | undefined,
+	options?: TestInstanceOptions<O> | undefined,
 	config?:
 		| {
 				clientOptions?: C;
@@ -124,12 +139,12 @@ export async function getTestInstance<
 		},
 	} satisfies BetterAuthOptions;
 
-	const auth = betterAuth({
+	const auth = betterAuth<O>({
 		baseURL: "http://localhost:" + (config?.port || 3000),
 		...opts,
 		...options,
 		plugins: [bearer(), ...(options?.plugins || [])],
-	} as unknown as O);
+	} as unknown as O & StrictAdditionalFieldsOptions<O>);
 
 	const testUser = {
 		email: "test@test.com",
@@ -141,8 +156,11 @@ export async function getTestInstance<
 		if (config?.disableTestUser) {
 			return;
 		}
-		//@ts-expect-error
-		await auth.api.signUpEmail({
+		const signUpEmail = (auth.api as Record<string, unknown>).signUpEmail;
+		if (typeof signUpEmail !== "function") {
+			throw new Error("signUpEmail endpoint is not available");
+		}
+		await signUpEmail({
 			body: testUser,
 		});
 	}


### PR DESCRIPTION
Fixes #8305

This PR enforces strict typing for additionalFields keys so typos/extraneous keys (e.g. require) fail at compile time.

**Changes**
- Added StrictAdditionalFieldsOptions to validate field keys against DBFieldAttribute.
- Applied strict validation at betterAuth boundaries in:
  - src/auth/full.ts
  - src/auth/minimal.ts
- Covers user, session, account, and verification.
- Added regression type tests (negative + positive) in:
  - src/auth/full.test.ts
  - src/auth/minimal.test.ts
- Updated test-instance.ts typing for dynamic baseURL and removed an unused @ts-expect-error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strict typing for additionalFields so typos and extra keys fail at compile time in both full and minimal `betterAuth`. Preserves accurate inference with new overloads and normalized options, preventing mistakes like `require` vs `required`.

- **Bug Fixes**
  - Enforce strict `additionalFields` keys for user, session, account, and verification, including when configs are passed via variables (structural strictness) across both entry points.
  - Add `StrictAdditionalFieldsOptions` in `strict-additional-fields.ts` and `betterAuth` overloads with `NormalizeOptions` to keep inference accurate; expand type tests for user/session; update test utils with typed `baseURL` and safer `signUpEmail` invocation.

<sup>Written for commit 1afd67b8ee7a1126df812cdc9a8e1a99b8636ae6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

