### PR TITLE
feat(core): add namespace parameter to verification adapter methods

### DIFF
--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -108,6 +108,7 @@ export const requestPasswordReset = createAuthEndpoint(
 			generateId(24);
 			await ctx.context.internalAdapter.findVerificationValue(
 				"dummy-verification-token",
+				"reset-password",
 			);
 			ctx.context.logger.error("Reset Password: User not found", { email });
 			return ctx.json({
@@ -123,11 +124,14 @@ export const requestPasswordReset = createAuthEndpoint(
 			"sec",
 		);
 		const verificationToken = generateId(24);
-		await ctx.context.internalAdapter.createVerificationValue({
-			value: user.user.id,
-			identifier: `reset-password:${verificationToken}`,
-			expiresAt,
-		});
+		await ctx.context.internalAdapter.createVerificationValue(
+			{
+				value: user.user.id,
+				identifier: verificationToken,
+				expiresAt,
+			},
+			"reset-password",
+		);
 		const callbackURL = redirectTo ? encodeURIComponent(redirectTo) : "";
 		const url = `${ctx.context.baseURL}/reset-password/${verificationToken}?callbackURL=${callbackURL}`;
 		await ctx.context.runInBackgroundOrAwait(
@@ -213,7 +217,8 @@ export const requestPasswordResetCallback = createAuthEndpoint(
 		}
 		const verification =
 			await ctx.context.internalAdapter.findVerificationValue(
-				`reset-password:${token}`,
+				token,
+				"reset-password",
 			);
 		if (!verification || verification.expiresAt < new Date()) {
 			throw ctx.redirect(
@@ -287,10 +292,11 @@ export const resetPassword = createAuthEndpoint(
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 		}
 
-		const id = `reset-password:${token}`;
-
 		const verification =
-			await ctx.context.internalAdapter.findVerificationValue(id);
+			await ctx.context.internalAdapter.findVerificationValue(
+				token,
+				"reset-password",
+			);
 		if (!verification || verification.expiresAt < new Date()) {
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_TOKEN);
 		}
@@ -308,7 +314,10 @@ export const resetPassword = createAuthEndpoint(
 		} else {
 			await ctx.context.internalAdapter.updatePassword(userId, hashedPassword);
 		}
-		await ctx.context.internalAdapter.deleteVerificationByIdentifier(id);
+		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+			token,
+			"reset-password",
+		);
 
 		if (ctx.context.options.emailAndPassword?.onPasswordReset) {
 			const user = await ctx.context.internalAdapter.findUserById(userId);

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -505,16 +505,19 @@ export const deleteUser = createAuthEndpoint(
 
 		if (ctx.context.options.user.deleteUser?.sendDeleteAccountVerification) {
 			const token = generateRandomString(32, "0-9", "a-z");
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: session.user.id,
-				identifier: `delete-account-${token}`,
-				expiresAt: new Date(
-					Date.now() +
-						(ctx.context.options.user.deleteUser?.deleteTokenExpiresIn ||
-							60 * 60 * 24) *
-							1000,
-				),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: session.user.id,
+					identifier: token,
+					expiresAt: new Date(
+						Date.now() +
+							(ctx.context.options.user.deleteUser?.deleteTokenExpiresIn ||
+								60 * 60 * 24) *
+								1000,
+					),
+				},
+				"delete-account",
+			);
 			const url = `${
 				ctx.context.baseURL
 			}/delete-user/callback?token=${token}&callbackURL=${encodeURIComponent(
@@ -628,7 +631,8 @@ export const deleteUserCallback = createAuthEndpoint(
 			);
 		}
 		const token = await ctx.context.internalAdapter.findVerificationValue(
-			`delete-account-${ctx.query.token}`,
+			ctx.query.token,
+			"delete-account",
 		);
 		if (!token || token.expiresAt < new Date()) {
 			throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.INVALID_TOKEN);
@@ -644,7 +648,8 @@ export const deleteUserCallback = createAuthEndpoint(
 		await ctx.context.internalAdapter.deleteSessions(session.user.id);
 		await ctx.context.internalAdapter.deleteAccounts(session.user.id);
 		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-			`delete-account-${ctx.query.token}`,
+			ctx.query.token,
+			"delete-account",
 		);
 
 		deleteSessionCookie(ctx);

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -200,70 +200,95 @@ describe("internal adapter test", async () => {
 	});
 
 	it("should delete expired verification values on find", async () => {
-		await internalAdapter.createVerificationValue({
-			identifier: `test-id-1`,
-			value: "test-id-1",
-			expiresAt: new Date(Date.now() - 1000),
-		});
+		await internalAdapter.createVerificationValue(
+			{
+				identifier: `test-id-1`,
+				value: "test-id-1",
+				expiresAt: new Date(Date.now() - 1000),
+			},
+			"test",
+		);
 		expect(hookVerificationCreateBefore).toHaveBeenCalledOnce();
 		expect(hookVerificationCreateAfter).toHaveBeenCalledOnce();
 
-		const value = await internalAdapter.findVerificationValue("test-id-1");
+		const value = await internalAdapter.findVerificationValue(
+			"test-id-1",
+			"test",
+		);
 		expect(value).toMatchObject({
-			identifier: "test-id-1",
+			identifier: "test:test-id-1",
 		});
 		expect(hookVerificationDeleteBefore).toHaveBeenCalledOnce();
 		expect(hookVerificationDeleteAfter).toHaveBeenCalledOnce();
 
-		const value2 = await internalAdapter.findVerificationValue("test-id-1");
+		const value2 = await internalAdapter.findVerificationValue(
+			"test-id-1",
+			"test",
+		);
 		expect(value2).toBeNull();
-		await internalAdapter.createVerificationValue({
-			identifier: `test-id-1`,
-			value: "test-id-1",
-			expiresAt: new Date(Date.now() + 1000),
-		});
-		const value3 = await internalAdapter.findVerificationValue("test-id-1");
+		await internalAdapter.createVerificationValue(
+			{
+				identifier: `test-id-1`,
+				value: "test-id-1",
+				expiresAt: new Date(Date.now() + 1000),
+			},
+			"test",
+		);
+		const value3 = await internalAdapter.findVerificationValue(
+			"test-id-1",
+			"test",
+		);
 		expect(value3).toMatchObject({
-			identifier: "test-id-1",
+			identifier: "test:test-id-1",
 		});
-		const value4 = await internalAdapter.findVerificationValue("test-id-1");
+		const value4 = await internalAdapter.findVerificationValue(
+			"test-id-1",
+			"test",
+		);
 		expect(value4).toMatchObject({
-			identifier: "test-id-1",
+			identifier: "test:test-id-1",
 		});
 	});
 
 	it("should delete verification by value with hooks", async () => {
-		await internalAdapter.createVerificationValue({
-			identifier: `test-id-1`,
-			value: "test-id-1",
-			expiresAt: new Date(Date.now() + 1000),
-		});
+		await internalAdapter.createVerificationValue(
+			{
+				identifier: `test-id-1`,
+				value: "test-id-1",
+				expiresAt: new Date(Date.now() + 1000),
+			},
+			"test",
+		);
 
-		await internalAdapter.deleteVerificationByIdentifier("test-id-1");
+		await internalAdapter.deleteVerificationByIdentifier("test-id-1", "test");
 		expect(hookVerificationDeleteBefore).toHaveBeenCalledOnce();
 		expect(hookVerificationDeleteAfter).toHaveBeenCalledOnce();
 	});
 
 	it("should delete verification by identifier with hooks", async () => {
-		const verification = await internalAdapter.createVerificationValue({
-			identifier: `test-id-1`,
-			value: "test-id-1",
-			expiresAt: new Date(Date.now() + 1000),
-		});
-
-		await internalAdapter.deleteVerificationByIdentifier(
-			verification.identifier,
+		await internalAdapter.createVerificationValue(
+			{
+				identifier: `test-id-1`,
+				value: "test-id-1",
+				expiresAt: new Date(Date.now() + 1000),
+			},
+			"test",
 		);
+
+		await internalAdapter.deleteVerificationByIdentifier("test-id-1", "test");
 		expect(hookVerificationDeleteBefore).toHaveBeenCalledOnce();
 		expect(hookVerificationDeleteAfter).toHaveBeenCalledOnce();
 	});
 
 	it("should not call adapter.delete for missing verification record (prevents Prisma P2025)", async () => {
-		const verification = await internalAdapter.createVerificationValue({
-			identifier: "missing-entity-test",
-			value: "test-value",
-			expiresAt: new Date(Date.now() + 60000),
-		});
+		const verification = await internalAdapter.createVerificationValue(
+			{
+				identifier: "missing-entity-test",
+				value: "test-value",
+				expiresAt: new Date(Date.now() + 60000),
+			},
+			"test",
+		);
 
 		// Remove the DB record so the entity no longer exists
 		await authContext.adapter.deleteMany({
@@ -273,7 +298,10 @@ describe("internal adapter test", async () => {
 
 		const deleteSpy = vi.spyOn(authContext.adapter, "delete");
 
-		await internalAdapter.deleteVerificationByIdentifier("missing-entity-test");
+		await internalAdapter.deleteVerificationByIdentifier(
+			"missing-entity-test",
+			"test",
+		);
 
 		// adapter.delete should NOT have been called because
 		// deleteWithHooks skips deletion when the entity is not found
@@ -297,28 +325,34 @@ describe("internal adapter test", async () => {
 			const hashedCtx = await init(hashedOpts);
 			const hashedAdapter = hashedCtx.internalAdapter;
 
-			const verification = await hashedAdapter.createVerificationValue({
-				identifier: "reset-password:my-token-123",
-				value: "user-id-123",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			const verification = await hashedAdapter.createVerificationValue(
+				{
+					identifier: "my-token-123",
+					value: "user-id-123",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"reset-password",
+			);
 
 			// Stored identifier should be hashed (not equal to original)
 			expect(verification.identifier).not.toBe("reset-password:my-token-123");
 
 			// Should be able to find by original identifier
 			const found = await hashedAdapter.findVerificationValue(
-				"reset-password:my-token-123",
+				"my-token-123",
+				"reset-password",
 			);
 			expect(found).toBeDefined();
 			expect(found?.value).toBe("user-id-123");
 
 			// Should be able to delete by original identifier
 			await hashedAdapter.deleteVerificationByIdentifier(
-				"reset-password:my-token-123",
+				"my-token-123",
+				"reset-password",
 			);
 			const deleted = await hashedAdapter.findVerificationValue(
-				"reset-password:my-token-123",
+				"my-token-123",
+				"reset-password",
 			);
 			expect(deleted).toBeNull();
 		});
@@ -341,21 +375,27 @@ describe("internal adapter test", async () => {
 			const overrideAdapter = overrideCtx.internalAdapter;
 
 			// reset-password should be hashed
-			const hashedVerification = await overrideAdapter.createVerificationValue({
-				identifier: "reset-password:token-abc",
-				value: "user-1",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			const hashedVerification = await overrideAdapter.createVerificationValue(
+				{
+					identifier: "token-abc",
+					value: "user-1",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"reset-password",
+			);
 			expect(hashedVerification.identifier).not.toBe(
 				"reset-password:token-abc",
 			);
 
 			// other identifiers should be plain
-			const plainVerification = await overrideAdapter.createVerificationValue({
-				identifier: "magic-link:token-xyz",
-				value: "user-2",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			const plainVerification = await overrideAdapter.createVerificationValue(
+				{
+					identifier: "token-xyz",
+					value: "user-2",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"magic-link",
+			);
 			expect(plainVerification.identifier).toBe("magic-link:token-xyz");
 		});
 
@@ -370,11 +410,14 @@ describe("internal adapter test", async () => {
 
 			(await getMigrations(plainOpts)).runMigrations();
 			const plainCtx = await init(plainOpts);
-			await plainCtx.internalAdapter.createVerificationValue({
-				identifier: "old-token:abc123",
-				value: "old-value",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			await plainCtx.internalAdapter.createVerificationValue(
+				{
+					identifier: "old-token:abc123",
+					value: "old-value",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
 			// Now switch to hashed storage (simulating config change)
 			const hashedOpts = {
@@ -385,10 +428,10 @@ describe("internal adapter test", async () => {
 			const hashedCtx = await init(hashedOpts);
 
 			// Should still find old plain token via fallback
-			const found =
-				await hashedCtx.internalAdapter.findVerificationValue(
-					"old-token:abc123",
-				);
+			const found = await hashedCtx.internalAdapter.findVerificationValue(
+				"old-token:abc123",
+				"test",
+			);
 			expect(found).toBeDefined();
 			expect(found?.value).toBe("old-value");
 		});
@@ -1177,11 +1220,14 @@ describe("internal adapter test", async () => {
 			(await getMigrations(secondaryOnlyOpts)).runMigrations();
 			const ctx = await init(secondaryOnlyOpts);
 
-			const verification = await ctx.internalAdapter.createVerificationValue({
-				identifier: "test-verification",
-				value: "test-value",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			const verification = await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "test-verification",
+					value: "test-value",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
 			expect(dataMap.has(`verification:${verification.identifier}`)).toBe(true);
 			expect(ttlMap.has(`verification:${verification.identifier}`)).toBe(true);
@@ -1198,16 +1244,21 @@ describe("internal adapter test", async () => {
 			(await getMigrations(secondaryOnlyOpts)).runMigrations();
 			const ctx = await init(secondaryOnlyOpts);
 
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "find-test",
-				value: "find-value",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "find-test",
+					value: "find-value",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
-			const found =
-				await ctx.internalAdapter.findVerificationValue("find-test");
+			const found = await ctx.internalAdapter.findVerificationValue(
+				"find-test",
+				"test",
+			);
 			expect(found).not.toBeNull();
-			expect(found?.identifier).toBe("find-test");
+			expect(found?.identifier).toBe("test:find-test");
 			expect(found?.value).toBe("find-value");
 		});
 
@@ -1222,17 +1273,21 @@ describe("internal adapter test", async () => {
 			(await getMigrations(secondaryOnlyOpts)).runMigrations();
 			const ctx = await init(secondaryOnlyOpts);
 
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "secondary-only-test",
-				value: "test-value",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "secondary-only-test",
+					value: "test-value",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
-			expect(dataMap.has("verification:secondary-only-test")).toBe(true);
+			expect(dataMap.has("verification:test:secondary-only-test")).toBe(true);
 
 			dataMap.clear();
 			const found = await ctx.internalAdapter.findVerificationValue(
 				"secondary-only-test",
+				"test",
 			);
 			expect(found).toBeNull(); // Proves DB was NOT used
 		});
@@ -1248,17 +1303,23 @@ describe("internal adapter test", async () => {
 			(await getMigrations(secondaryOnlyOpts)).runMigrations();
 			const ctx = await init(secondaryOnlyOpts);
 
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "delete-test",
-				value: "delete-value",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "delete-test",
+					value: "delete-value",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
-			expect(dataMap.has("verification:delete-test")).toBe(true);
+			expect(dataMap.has("verification:test:delete-test")).toBe(true);
 
-			await ctx.internalAdapter.deleteVerificationByIdentifier("delete-test");
+			await ctx.internalAdapter.deleteVerificationByIdentifier(
+				"delete-test",
+				"test",
+			);
 
-			expect(dataMap.has("verification:delete-test")).toBe(false);
+			expect(dataMap.has("verification:test:delete-test")).toBe(false);
 		});
 
 		it("should store in both when storeInDatabase is true", async () => {
@@ -1275,17 +1336,22 @@ describe("internal adapter test", async () => {
 			(await getMigrations(dualStorageOpts)).runMigrations();
 			const ctx = await init(dualStorageOpts);
 
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "both-test",
-				value: "both-value",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "both-test",
+					value: "both-value",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
-			expect(dataMap.has("verification:both-test")).toBe(true);
+			expect(dataMap.has("verification:test:both-test")).toBe(true);
 
 			dataMap.clear();
-			const found =
-				await ctx.internalAdapter.findVerificationValue("both-test");
+			const found = await ctx.internalAdapter.findVerificationValue(
+				"both-test",
+				"test",
+			);
 			expect(found).not.toBeNull();
 			expect(found?.value).toBe("both-value");
 		});
@@ -1304,16 +1370,21 @@ describe("internal adapter test", async () => {
 			(await getMigrations(dualStorageOpts)).runMigrations();
 			const ctx = await init(dualStorageOpts);
 
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "fallback-test",
-				value: "fallback-value",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "fallback-test",
+					value: "fallback-value",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
 			dataMap.clear();
 
-			const found =
-				await ctx.internalAdapter.findVerificationValue("fallback-test");
+			const found = await ctx.internalAdapter.findVerificationValue(
+				"fallback-test",
+				"test",
+			);
 			expect(found).not.toBeNull();
 			expect(found?.value).toBe("fallback-value");
 		});
@@ -1332,13 +1403,16 @@ describe("internal adapter test", async () => {
 			const expiresIn = 300000; // 5 minutes in ms
 			const expiresAt = new Date(Date.now() + expiresIn);
 
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "ttl-test",
-				value: "ttl-value",
-				expiresAt,
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "ttl-test",
+					value: "ttl-value",
+					expiresAt,
+				},
+				"test",
+			);
 
-			const ttl = ttlMap.get("verification:ttl-test");
+			const ttl = ttlMap.get("verification:test:ttl-test");
 			expect(ttl).toBeDefined();
 			expect(ttl).toBeGreaterThanOrEqual(298);
 			expect(ttl).toBeLessThanOrEqual(300);
@@ -1385,14 +1459,19 @@ describe("internal adapter test", async () => {
 			(await getMigrations(opts)).runMigrations();
 			const ctx = await init(opts);
 
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "date-test",
-				value: "test-value",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "date-test",
+					value: "test-value",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
-			const found =
-				await ctx.internalAdapter.findVerificationValue("date-test");
+			const found = await ctx.internalAdapter.findVerificationValue(
+				"date-test",
+				"test",
+			);
 			expect(found).not.toBeNull();
 			expect(found!.expiresAt).toBeInstanceOf(Date);
 			expect(found!.createdAt).toBeInstanceOf(Date);
@@ -1410,14 +1489,19 @@ describe("internal adapter test", async () => {
 			await (await getMigrations(opts)).runMigrations();
 			const ctx = await init(opts);
 
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "expiry-check",
-				value: "test-value",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "expiry-check",
+					value: "test-value",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
-			const found =
-				await ctx.internalAdapter.findVerificationValue("expiry-check");
+			const found = await ctx.internalAdapter.findVerificationValue(
+				"expiry-check",
+				"test",
+			);
 			expect(found).not.toBeNull();
 			// This comparison would silently fail if expiresAt were a string
 			// because string < Date coerces to NaN, making it always false
@@ -1437,23 +1521,30 @@ describe("internal adapter test", async () => {
 			const ctx = await init(opts);
 
 			const expiresAt = new Date(Date.now() + 60000);
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "multi-read-test",
-				value: "test-value",
-				expiresAt,
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "multi-read-test",
+					value: "test-value",
+					expiresAt,
+				},
+				"test",
+			);
 
 			// First read: safeJSONParse receives pre-parsed object from storage
-			const first =
-				await ctx.internalAdapter.findVerificationValue("multi-read-test");
+			const first = await ctx.internalAdapter.findVerificationValue(
+				"multi-read-test",
+				"test",
+			);
 			expect(first).not.toBeNull();
 			expect(first!.expiresAt).toBeInstanceOf(Date);
 			expect(first!.createdAt).toBeInstanceOf(Date);
 			expect(first!.updatedAt).toBeInstanceOf(Date);
 
 			// Second read: verify consistency (the stored object wasn't mutated)
-			const second =
-				await ctx.internalAdapter.findVerificationValue("multi-read-test");
+			const second = await ctx.internalAdapter.findVerificationValue(
+				"multi-read-test",
+				"test",
+			);
 			expect(second).not.toBeNull();
 			expect(second!.expiresAt).toBeInstanceOf(Date);
 			expect(second!.expiresAt.getTime()).toBe(first!.expiresAt.getTime());
@@ -1470,17 +1561,22 @@ describe("internal adapter test", async () => {
 			await (await getMigrations(opts)).runMigrations();
 			const ctx = await init(opts);
 
-			await ctx.internalAdapter.createVerificationValue({
-				identifier: "string-field-test",
-				value: "my-token-value-123",
-				expiresAt: new Date(Date.now() + 60000),
-			});
+			await ctx.internalAdapter.createVerificationValue(
+				{
+					identifier: "string-field-test",
+					value: "my-token-value-123",
+					expiresAt: new Date(Date.now() + 60000),
+				},
+				"test",
+			);
 
-			const found =
-				await ctx.internalAdapter.findVerificationValue("string-field-test");
+			const found = await ctx.internalAdapter.findVerificationValue(
+				"string-field-test",
+				"test",
+			);
 			expect(found).not.toBeNull();
 			// Non-date strings must NOT be converted
-			expect(found!.identifier).toBe("string-field-test");
+			expect(found!.identifier).toBe("test:string-field-test");
 			expect(typeof found!.identifier).toBe("string");
 			expect(found!.value).toBe("my-token-value-123");
 			expect(typeof found!.value).toBe("string");

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1032,13 +1032,15 @@ export const createInternalAdapter = (
 		createVerificationValue: async (
 			data: Omit<Verification, "createdAt" | "id" | "updatedAt"> &
 				Partial<Verification>,
+			namespace: string,
 		) => {
+			const prefixedIdentifier = `${namespace}:${data.identifier}`;
 			const storageOption = getStorageOption(
-				data.identifier,
+				prefixedIdentifier,
 				options.verification?.storeIdentifier,
 			);
 			const storedIdentifier = await processIdentifier(
-				data.identifier,
+				prefixedIdentifier,
 				storageOption,
 			);
 
@@ -1070,13 +1072,14 @@ export const createInternalAdapter = (
 			);
 			return verification as Verification;
 		},
-		findVerificationValue: async (identifier: string) => {
+		findVerificationValue: async (identifier: string, namespace: string) => {
+			const prefixedIdentifier = `${namespace}:${identifier}`;
 			const storageOption = getStorageOption(
-				identifier,
+				prefixedIdentifier,
 				options.verification?.storeIdentifier,
 			);
 			const storedIdentifier = await processIdentifier(
-				identifier,
+				prefixedIdentifier,
 				storageOption,
 			);
 
@@ -1092,7 +1095,7 @@ export const createInternalAdapter = (
 				}
 				if (storageOption && storageOption !== "plain") {
 					const plainCached = await secondaryStorage.get(
-						`verification:${identifier}`,
+						`verification:${prefixedIdentifier}`,
 					);
 					if (plainCached) {
 						const parsed = safeJSONParse<Verification>(plainCached);
@@ -1120,7 +1123,7 @@ export const createInternalAdapter = (
 			let verification = await findByIdentifier(storedIdentifier);
 
 			if (!verification.length && storageOption && storageOption !== "plain") {
-				verification = await findByIdentifier(identifier);
+				verification = await findByIdentifier(prefixedIdentifier);
 			}
 
 			if (!options.verification?.disableCleanup) {
@@ -1139,13 +1142,17 @@ export const createInternalAdapter = (
 
 			return (verification[0] as Verification) || null;
 		},
-		deleteVerificationByIdentifier: async (identifier: string) => {
+		deleteVerificationByIdentifier: async (
+			identifier: string,
+			namespace: string,
+		) => {
+			const prefixedIdentifier = `${namespace}:${identifier}`;
 			const storageOption = getStorageOption(
-				identifier,
+				prefixedIdentifier,
 				options.verification?.storeIdentifier,
 			);
 			const storedIdentifier = await processIdentifier(
-				identifier,
+				prefixedIdentifier,
 				storageOption,
 			);
 
@@ -1164,15 +1171,30 @@ export const createInternalAdapter = (
 		updateVerificationByIdentifier: async (
 			identifier: string,
 			data: Partial<Verification>,
+			namespace: string,
 		) => {
+			const prefixedIdentifier = `${namespace}:${identifier}`;
 			const storageOption = getStorageOption(
-				identifier,
+				prefixedIdentifier,
 				options.verification?.storeIdentifier,
 			);
 			const storedIdentifier = await processIdentifier(
-				identifier,
+				prefixedIdentifier,
 				storageOption,
 			);
+
+			const processedData = data.identifier
+				? {
+						...data,
+						identifier: await processIdentifier(
+							`${namespace}:${data.identifier}`,
+							getStorageOption(
+								`${namespace}:${data.identifier}`,
+								options.verification?.storeIdentifier,
+							),
+						),
+					}
+				: data;
 
 			if (secondaryStorage) {
 				const cached = await secondaryStorage.get(
@@ -1181,7 +1203,7 @@ export const createInternalAdapter = (
 				if (cached) {
 					const parsed = safeJSONParse<Verification>(cached);
 					if (parsed) {
-						const updated = { ...parsed, ...data };
+						const updated = { ...parsed, ...processedData };
 						const expiresAt = updated.expiresAt ?? parsed.expiresAt;
 						const ttl = getTTLSeconds(
 							expiresAt instanceof Date ? expiresAt : new Date(expiresAt),
@@ -1202,14 +1224,14 @@ export const createInternalAdapter = (
 
 			if (!secondaryStorage || options.verification?.storeInDatabase) {
 				const verification = await updateWithHooks<Verification>(
-					data,
+					processedData,
 					[{ field: "identifier", value: storedIdentifier }],
 					"verification",
 					undefined,
 				);
 				return verification;
 			}
-			return data as Verification;
+			return processedData as Verification;
 		},
 	};
 };

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -1306,7 +1306,8 @@ describe("custom storeOTP", async () => {
 			});
 			const verificationValue =
 				await authCtx.internalAdapter.findVerificationValue(
-					`sign-in-otp-${userEmail1}`,
+					userEmail1,
+					"sign-in-otp",
 				);
 
 			const storedOtp = verificationValue?.value || "";
@@ -1400,7 +1401,8 @@ describe("custom storeOTP", async () => {
 			});
 			const verificationValue =
 				await authCtx.internalAdapter.findVerificationValue(
-					`sign-in-otp-${userEmail1}`,
+					userEmail1,
+					"sign-in-otp",
 				);
 
 			const storedOtp = verificationValue?.value || "";
@@ -1494,7 +1496,8 @@ describe("custom storeOTP", async () => {
 			});
 			const verificationValue =
 				await authCtx.internalAdapter.findVerificationValue(
-					`sign-in-otp-${userEmail1}`,
+					userEmail1,
+					"sign-in-otp",
 				);
 			const storedOtp = verificationValue?.value || "";
 			const otp = await get();
@@ -1584,7 +1587,8 @@ describe("custom storeOTP", async () => {
 			});
 			const verificationValue =
 				await authCtx.internalAdapter.findVerificationValue(
-					`sign-in-otp-${userEmail1}`,
+					userEmail1,
+					"sign-in-otp",
 				);
 			const storedOtp = verificationValue?.value || "";
 			const otp = await get();
@@ -1917,9 +1921,7 @@ describe("race condition protection", async () => {
 		expect(res1.data?.token).toBeDefined();
 
 		const verificationValue =
-			await authCtx.internalAdapter.findVerificationValue(
-				`sign-in-otp-${email}`,
-			);
+			await authCtx.internalAdapter.findVerificationValue(email, "sign-in-otp");
 		expect(verificationValue).toBeNull();
 
 		const res2 = await client.signIn.emailOtp({ email, otp });
@@ -1941,7 +1943,8 @@ describe("race condition protection", async () => {
 
 		const verificationValue =
 			await authCtx.internalAdapter.findVerificationValue(
-				`email-verification-otp-${email}`,
+				email,
+				"email-verification-otp",
 			);
 		expect(verificationValue).toBeNull();
 
@@ -1966,7 +1969,8 @@ describe("race condition protection", async () => {
 
 		const verificationValue =
 			await authCtx.internalAdapter.findVerificationValue(
-				`forget-password-otp-${email}`,
+				email,
+				"forget-password-otp",
 			);
 		expect(verificationValue).toBeNull();
 

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -103,11 +103,14 @@ export const emailOTP = (options: EmailOTPOptions) => {
 								opts.generateOTP({ email, type: ctx.body.type }, ctx) ||
 								defaultOTPGenerator(opts);
 							const storedOTP = await storeOTP(ctx, opts, otp);
-							await ctx.context.internalAdapter.createVerificationValue({
-								value: `${storedOTP}:0`,
-								identifier: `email-verification-otp-${email}`,
-								expiresAt: getDate(opts.expiresIn, "sec"),
-							});
+							await ctx.context.internalAdapter.createVerificationValue(
+								{
+									value: `${storedOTP}:0`,
+									identifier: email,
+									expiresAt: getDate(opts.expiresIn, "sec"),
+								},
+								"email-verification-otp",
+							);
 							await ctx.context.runInBackgroundOrAwait(
 								options.sendVerificationOTP(
 									{

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -114,23 +114,31 @@ export const sendVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 
 			const storedOTP = await storeOTP(ctx, opts, otp);
 
+			const namespace = `${ctx.body.type}-otp`;
 			await ctx.context.internalAdapter
-				.createVerificationValue({
-					value: `${storedOTP}:0`,
-					identifier: `${ctx.body.type}-otp-${email}`,
-					expiresAt: getDate(opts.expiresIn, "sec"),
-				})
+				.createVerificationValue(
+					{
+						value: `${storedOTP}:0`,
+						identifier: email,
+						expiresAt: getDate(opts.expiresIn, "sec"),
+					},
+					namespace,
+				)
 				.catch(async (error) => {
 					// might be duplicate key error
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						`${ctx.body.type}-otp-${email}`,
+						email,
+						namespace,
 					);
 					//try again
-					await ctx.context.internalAdapter.createVerificationValue({
-						value: `${storedOTP}:0`,
-						identifier: `${ctx.body.type}-otp-${email}`,
-						expiresAt: getDate(opts.expiresIn, "sec"),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							value: `${storedOTP}:0`,
+							identifier: email,
+							expiresAt: getDate(opts.expiresIn, "sec"),
+						},
+						namespace,
+					);
 				});
 			const user = await ctx.context.internalAdapter.findUserByEmail(email);
 			if (!user) {
@@ -138,7 +146,8 @@ export const sendVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 					// allow
 				} else {
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						`${ctx.body.type}-otp-${email}`,
+						email,
+						namespace,
 					);
 					return ctx.json({
 						success: true,
@@ -202,11 +211,14 @@ export const createVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 				opts.generateOTP({ email, type: ctx.body.type }, ctx) ||
 				defaultOTPGenerator(opts);
 			const storedOTP = await storeOTP(ctx, opts, otp);
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${storedOTP}:0`,
-				identifier: `${ctx.body.type}-otp-${email}`,
-				expiresAt: getDate(opts.expiresIn, "sec"),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: `${storedOTP}:0`,
+					identifier: email,
+					expiresAt: getDate(opts.expiresIn, "sec"),
+				},
+				`${ctx.body.type}-otp`,
+			);
 			return otp;
 		},
 	);
@@ -270,7 +282,8 @@ export const getVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 			const email = ctx.query.email.toLowerCase();
 			const verificationValue =
 				await ctx.context.internalAdapter.findVerificationValue(
-					`${ctx.query.type}-otp-${email}`,
+					email,
+					`${ctx.query.type}-otp`,
 				);
 			if (!verificationValue || verificationValue.expiresAt < new Date()) {
 				return ctx.json({
@@ -371,17 +384,19 @@ export const checkVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 			if (!user) {
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.USER_NOT_FOUND);
 			}
+			const namespace = `${ctx.body.type}-otp`;
 			const verificationValue =
 				await ctx.context.internalAdapter.findVerificationValue(
-					`${ctx.body.type}-otp-${email}`,
+					email,
+					namespace,
 				);
 			if (!verificationValue) {
 				throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 			}
-			const otpIdentifier = `${ctx.body.type}-otp-${email}`;
 			if (verificationValue.expiresAt < new Date()) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					otpIdentifier,
+					email,
+					namespace,
 				);
 				throw APIError.from("BAD_REQUEST", ERROR_CODES.OTP_EXPIRED);
 			}
@@ -390,17 +405,19 @@ export const checkVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 			const allowedAttempts = opts?.allowedAttempts || 3;
 			if (attempts && parseInt(attempts) >= allowedAttempts) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					otpIdentifier,
+					email,
+					namespace,
 				);
 				throw APIError.from("FORBIDDEN", ERROR_CODES.TOO_MANY_ATTEMPTS);
 			}
 			const verified = await verifyStoredOTP(ctx, opts, otpValue, ctx.body.otp);
 			if (!verified) {
 				await ctx.context.internalAdapter.updateVerificationByIdentifier(
-					otpIdentifier,
+					email,
 					{
 						value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
 					},
+					namespace,
 				);
 				throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 			}
@@ -488,7 +505,8 @@ export const verifyEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			await atomicVerifyOTP(
 				ctx,
 				opts,
-				`email-verification-otp-${email}`,
+				email,
+				"email-verification-otp",
 				ctx.body.otp,
 			);
 
@@ -641,7 +659,7 @@ export const signInEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			const email = rawEmail.toLowerCase();
 
 			// Use atomic verification to prevent race conditions
-			await atomicVerifyOTP(ctx, opts, `sign-in-otp-${email}`, otp);
+			await atomicVerifyOTP(ctx, opts, email, "sign-in-otp", otp);
 
 			const user = await ctx.context.internalAdapter.findUserByEmail(email);
 			if (!user) {
@@ -752,15 +770,19 @@ export const requestPasswordResetEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				opts.generateOTP({ email, type: "forget-password" }, ctx) ||
 				defaultOTPGenerator(opts);
 			const storedOTP = await storeOTP(ctx, opts, otp);
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${storedOTP}:0`,
-				identifier: `forget-password-otp-${email}`,
-				expiresAt: getDate(opts.expiresIn, "sec"),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: `${storedOTP}:0`,
+					identifier: email,
+					expiresAt: getDate(opts.expiresIn, "sec"),
+				},
+				"forget-password-otp",
+			);
 			const user = await ctx.context.internalAdapter.findUserByEmail(email);
 			if (!user) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					`forget-password-otp-${email}`,
+					email,
+					"forget-password-otp",
 				);
 				return ctx.json({
 					success: true,
@@ -851,15 +873,19 @@ export const forgetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) => {
 				opts.generateOTP({ email, type: "forget-password" }, ctx) ||
 				defaultOTPGenerator(opts);
 			const storedOTP = await storeOTP(ctx, opts, otp);
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${storedOTP}:0`,
-				identifier: `forget-password-otp-${email}`,
-				expiresAt: getDate(opts.expiresIn, "sec"),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: `${storedOTP}:0`,
+					identifier: email,
+					expiresAt: getDate(opts.expiresIn, "sec"),
+				},
+				"forget-password-otp",
+			);
 			const user = await ctx.context.internalAdapter.findUserByEmail(email);
 			if (!user) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					`forget-password-otp-${email}`,
+					email,
+					"forget-password-otp",
 				);
 				return ctx.json({
 					success: true,
@@ -946,7 +972,8 @@ export const resetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			await atomicVerifyOTP(
 				ctx,
 				opts,
-				`forget-password-otp-${email}`,
+				email,
+				"forget-password-otp",
 				ctx.body.otp,
 			);
 
@@ -1093,15 +1120,16 @@ export const requestEmailChangeEmailOTP = (opts: RequiredEmailOTPOptions) =>
 
 				const currentEmailVerificationValue =
 					await ctx.context.internalAdapter.findVerificationValue(
-						`email-verification-otp-${email}`,
+						email,
+						"email-verification-otp",
 					);
 				if (!currentEmailVerificationValue) {
 					throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 				}
-				const currentEmailIdentifier = `email-verification-otp-${email}`;
 				if (currentEmailVerificationValue.expiresAt < new Date()) {
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						currentEmailIdentifier,
+						email,
+						"email-verification-otp",
 					);
 					throw APIError.from("BAD_REQUEST", ERROR_CODES.OTP_EXPIRED);
 				}
@@ -1112,7 +1140,8 @@ export const requestEmailChangeEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				const allowedAttempts = opts?.allowedAttempts || 3;
 				if (attempts && parseInt(attempts) >= allowedAttempts) {
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						currentEmailIdentifier,
+						email,
+						"email-verification-otp",
 					);
 					throw APIError.from("FORBIDDEN", ERROR_CODES.TOO_MANY_ATTEMPTS);
 				}
@@ -1125,15 +1154,17 @@ export const requestEmailChangeEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				);
 				if (!verified) {
 					await ctx.context.internalAdapter.updateVerificationByIdentifier(
-						currentEmailIdentifier,
+						email,
 						{
 							value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
 						},
+						"email-verification-otp",
 					);
 					throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 				}
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					currentEmailIdentifier,
+					email,
+					"email-verification-otp",
 				);
 			} else {
 				if (ctx.body.otp) {
@@ -1149,16 +1180,20 @@ export const requestEmailChangeEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				opts.generateOTP({ email: newEmail, type: "change-email" }, ctx) ||
 				defaultOTPGenerator(opts);
 			const storedOTP = await storeOTP(ctx, opts, otp);
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${storedOTP}:0`,
-				identifier: `change-email-otp-${email}-${newEmail}`,
-				expiresAt: getDate(opts.expiresIn, "sec"),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: `${storedOTP}:0`,
+					identifier: `${email}-${newEmail}`,
+					expiresAt: getDate(opts.expiresIn, "sec"),
+				},
+				"change-email-otp",
+			);
 
 			const user = await ctx.context.internalAdapter.findUserByEmail(newEmail);
 			if (user) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					`change-email-otp-${email}-${newEmail}`,
+					`${email}-${newEmail}`,
+					"change-email-otp",
 				);
 				return ctx.json({
 					success: true,
@@ -1260,17 +1295,19 @@ export const changeEmailEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				});
 			}
 
+			const changeEmailId = `${email}-${newEmail}`;
 			const verificationValue =
 				await ctx.context.internalAdapter.findVerificationValue(
-					`change-email-otp-${email}-${newEmail}`,
+					changeEmailId,
+					"change-email-otp",
 				);
 			if (!verificationValue) {
 				throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 			}
-			const changeEmailIdentifier = `change-email-otp-${email}-${newEmail}`;
 			if (verificationValue.expiresAt < new Date()) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					changeEmailIdentifier,
+					changeEmailId,
+					"change-email-otp",
 				);
 				throw APIError.from("BAD_REQUEST", ERROR_CODES.OTP_EXPIRED);
 			}
@@ -1279,7 +1316,8 @@ export const changeEmailEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			const allowedAttempts = opts?.allowedAttempts || 3;
 			if (attempts && parseInt(attempts) >= allowedAttempts) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					changeEmailIdentifier,
+					changeEmailId,
+					"change-email-otp",
 				);
 				throw APIError.from("FORBIDDEN", ERROR_CODES.TOO_MANY_ATTEMPTS);
 			}
@@ -1287,15 +1325,17 @@ export const changeEmailEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			const verified = await verifyStoredOTP(ctx, opts, otpValue, ctx.body.otp);
 			if (!verified) {
 				await ctx.context.internalAdapter.updateVerificationByIdentifier(
-					changeEmailIdentifier,
+					changeEmailId,
 					{
 						value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
 					},
+					"change-email-otp",
 				);
 				throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 			}
 			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-				changeEmailIdentifier,
+				changeEmailId,
+				"change-email-otp",
 			);
 
 			const currentUser =
@@ -1364,10 +1404,14 @@ async function atomicVerifyOTP(
 	ctx: GenericEndpointContext,
 	opts: RequiredEmailOTPOptions,
 	identifier: string,
+	namespace: string,
 	providedOTP: string,
 ): Promise<void> {
 	const verificationValue =
-		await ctx.context.internalAdapter.findVerificationValue(identifier);
+		await ctx.context.internalAdapter.findVerificationValue(
+			identifier,
+			namespace,
+		);
 
 	if (!verificationValue) {
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
@@ -1376,6 +1420,7 @@ async function atomicVerifyOTP(
 	if (verificationValue.expiresAt < new Date()) {
 		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 			identifier,
+			namespace,
 		);
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.OTP_EXPIRED);
 	}
@@ -1386,22 +1431,29 @@ async function atomicVerifyOTP(
 	if (attempts && parseInt(attempts) >= allowedAttempts) {
 		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 			identifier,
+			namespace,
 		);
 		throw APIError.from("FORBIDDEN", ERROR_CODES.TOO_MANY_ATTEMPTS);
 	}
 
 	// Atomically delete token before verification to prevent race condition
-	await ctx.context.internalAdapter.deleteVerificationByIdentifier(identifier);
+	await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+		identifier,
+		namespace,
+	);
 
 	const verified = await verifyStoredOTP(ctx, opts, otpValue, providedOTP);
 
 	if (!verified) {
 		// Re-create with incremented attempts
-		await ctx.context.internalAdapter.createVerificationValue({
-			value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
-			identifier,
-			expiresAt: verificationValue.expiresAt,
-		});
+		await ctx.context.internalAdapter.createVerificationValue(
+			{
+				value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
+				identifier,
+				expiresAt: verificationValue.expiresAt,
+			},
+			namespace,
+		);
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 	}
 }

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -214,11 +214,16 @@ export const magicLink = (options: MagicLinkOptions) => {
 						? await opts.generateToken(email)
 						: generateRandomString(32, "a-z", "A-Z");
 					const storedToken = await storeToken(ctx, verificationToken);
-					await ctx.context.internalAdapter.createVerificationValue({
-						identifier: storedToken,
-						value: JSON.stringify({ email, name: ctx.body.name, attempt: 0 }),
-						expiresAt: new Date(Date.now() + (opts.expiresIn || 60 * 5) * 1000),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							identifier: storedToken,
+							value: JSON.stringify({ email, name: ctx.body.name, attempt: 0 }),
+							expiresAt: new Date(
+								Date.now() + (opts.expiresIn || 60 * 5) * 1000,
+							),
+						},
+						"magic-link",
+					);
 					const realBaseURL = new URL(ctx.context.baseURL);
 					const pathname =
 						realBaseURL.pathname === "/" ? "" : realBaseURL.pathname;
@@ -349,6 +354,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					const tokenValue =
 						await ctx.context.internalAdapter.findVerificationValue(
 							storedToken,
+							"magic-link",
 						);
 					if (!tokenValue) {
 						redirectWithError("INVALID_TOKEN");
@@ -356,6 +362,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					if (tokenValue.expiresAt < new Date()) {
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 							storedToken,
+							"magic-link",
 						);
 						redirectWithError("EXPIRED_TOKEN");
 					}
@@ -371,6 +378,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					if (attempt >= opts.allowedAttempts) {
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 							storedToken,
+							"magic-link",
 						);
 						redirectWithError("ATTEMPTS_EXCEEDED");
 					}
@@ -383,6 +391,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 								attempt: attempt + 1,
 							}),
 						},
+						"magic-link",
 					);
 
 					let isNewUser = false;

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -406,8 +406,10 @@ describe("magic link storeToken", async () => {
 			headers,
 		});
 		const hashedToken = await defaultKeyHasher(verificationEmail.token);
-		const storedToken =
-			await internalAdapter.findVerificationValue(hashedToken);
+		const storedToken = await internalAdapter.findVerificationValue(
+			hashedToken,
+			"magic-link",
+		);
 		expect(storedToken).toBeDefined();
 		const response2 = await auth.api.signInMagicLink({
 			body: {
@@ -449,8 +451,10 @@ describe("magic link storeToken", async () => {
 			headers,
 		});
 		const hashedToken = `${verificationEmail.token}hashed`;
-		const storedToken =
-			await internalAdapter.findVerificationValue(hashedToken);
+		const storedToken = await internalAdapter.findVerificationValue(
+			hashedToken,
+			"magic-link",
+		);
 		expect(storedToken).toBeDefined();
 		const response2 = await auth.api.signInMagicLink({
 			body: {

--- a/packages/better-auth/src/plugins/mcp/authorize.ts
+++ b/packages/better-auth/src/plugins/mcp/authorize.ts
@@ -175,34 +175,37 @@ export async function authorizeMCPOAuth(
 		/**
 		 * Save the code in the database
 		 */
-		await ctx.context.internalAdapter.createVerificationValue({
-			value: JSON.stringify({
-				clientId: client.clientId,
-				redirectURI: query.redirect_uri,
-				scope: requestScope,
-				userId: session.user.id,
-				authTime: new Date(session.session.createdAt).getTime(),
-				/**
-				 * If the prompt is set to `consent`, then we need
-				 * to require the user to consent to the scopes.
-				 *
-				 * This means the code now needs to be treated as a
-				 * consent request.
-				 *
-				 * once the user consents, the code will be updated
-				 * with the actual code. This is to prevent the
-				 * client from using the code before the user
-				 * consents.
-				 */
-				requireConsent: query.prompt === "consent",
-				state: query.prompt === "consent" ? query.state : null,
-				codeChallenge: query.code_challenge,
-				codeChallengeMethod: query.code_challenge_method,
-				nonce: query.nonce,
-			}),
-			identifier: code,
-			expiresAt,
-		});
+		await ctx.context.internalAdapter.createVerificationValue(
+			{
+				value: JSON.stringify({
+					clientId: client.clientId,
+					redirectURI: query.redirect_uri,
+					scope: requestScope,
+					userId: session.user.id,
+					authTime: new Date(session.session.createdAt).getTime(),
+					/**
+					 * If the prompt is set to `consent`, then we need
+					 * to require the user to consent to the scopes.
+					 *
+					 * This means the code now needs to be treated as a
+					 * consent request.
+					 *
+					 * once the user consents, the code will be updated
+					 * with the actual code. This is to prevent the
+					 * client from using the code before the user
+					 * consents.
+					 */
+					requireConsent: query.prompt === "consent",
+					state: query.prompt === "consent" ? query.state : null,
+					codeChallenge: query.code_challenge,
+					codeChallengeMethod: query.code_challenge_method,
+					nonce: query.nonce,
+				}),
+				identifier: code,
+				expiresAt,
+			},
+			"oidc-code",
+		);
 	} catch {
 		throw ctx.redirect(
 			redirectErrorURL(

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -475,6 +475,7 @@ export const mcp = (options: MCPOptions) => {
 					const verificationValue =
 						await ctx.context.internalAdapter.findVerificationValue(
 							code.toString(),
+							"oidc-code",
 						);
 					if (!verificationValue) {
 						throw new APIError("UNAUTHORIZED", {
@@ -491,6 +492,7 @@ export const mcp = (options: MCPOptions) => {
 
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 						code.toString(),
+						"oidc-code",
 					);
 
 					if (!client_id) {
@@ -614,6 +616,7 @@ export const mcp = (options: MCPOptions) => {
 					const requestedScopes = value.scope;
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 						code.toString(),
+						"oidc-code",
 					);
 					const accessToken = generateRandomString(32, "a-z", "A-Z");
 					const refreshToken = generateRandomString(32, "A-Z", "a-z");

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -501,6 +501,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							const verification =
 								await ctx.context.internalAdapter.findVerificationValue(
 									originalState,
+									"state",
 								);
 							if (verification) {
 								// Encrypt the verification value so it matches cookie mode format

--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -272,31 +272,34 @@ export async function authorize(
 		/**
 		 * Save the code in the database
 		 */
-		await ctx.context.internalAdapter.createVerificationValue({
-			value: JSON.stringify({
-				clientId: client.clientId,
-				redirectURI: query.redirect_uri,
-				scope: requestScope,
-				userId: session.user.id,
-				authTime: new Date(session.session.createdAt).getTime(),
-				/**
-				 * Consent is required per OIDC spec unless:
-				 * 1. Client is trusted (skipConsent = true)
-				 * 2. User has already consented (and prompt is not "consent")
-				 *
-				 * When consent is required, the code needs to be treated as a
-				 * consent request. Once the user consents, the code will be
-				 * updated with the actual authorization code.
-				 */
-				requireConsent,
-				state: requireConsent ? query.state : null,
-				codeChallenge: query.code_challenge,
-				codeChallengeMethod: query.code_challenge_method,
-				nonce: query.nonce,
-			}),
-			identifier: code,
-			expiresAt,
-		});
+		await ctx.context.internalAdapter.createVerificationValue(
+			{
+				value: JSON.stringify({
+					clientId: client.clientId,
+					redirectURI: query.redirect_uri,
+					scope: requestScope,
+					userId: session.user.id,
+					authTime: new Date(session.session.createdAt).getTime(),
+					/**
+					 * Consent is required per OIDC spec unless:
+					 * 1. Client is trusted (skipConsent = true)
+					 * 2. User has already consented (and prompt is not "consent")
+					 *
+					 * When consent is required, the code needs to be treated as a
+					 * consent request. Once the user consents, the code will be
+					 * updated with the actual authorization code.
+					 */
+					requireConsent,
+					state: requireConsent ? query.state : null,
+					codeChallenge: query.code_challenge,
+					codeChallengeMethod: query.code_challenge_method,
+					nonce: query.nonce,
+				}),
+				identifier: code,
+				expiresAt,
+			},
+			"oidc-code",
+		);
 	} catch {
 		return handleRedirect(
 			formatErrorURL(

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -565,6 +565,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					const verification =
 						await ctx.context.internalAdapter.findVerificationValue(
 							consentCode,
+							"oidc-code",
 						);
 					if (!verification) {
 						throw new APIError("UNAUTHORIZED", {
@@ -596,6 +597,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					if (!ctx.body.accept) {
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 							consentCode,
+							"oidc-code",
 						);
 						return ctx.json({
 							redirectURI: `${value.redirectURI}?error=access_denied&error_description=User denied access`,
@@ -615,6 +617,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 							identifier: code,
 							expiresAt,
 						},
+						"oidc-code",
 					);
 					await ctx.context.adapter.create({
 						model: modelName.oauthConsent,
@@ -798,6 +801,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					const verificationValue =
 						await ctx.context.internalAdapter.findVerificationValue(
 							code.toString(),
+							"oidc-code",
 						);
 					if (!verificationValue) {
 						throw new APIError("UNAUTHORIZED", {
@@ -814,6 +818,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 						code.toString(),
+						"oidc-code",
 					);
 					if (!client_id) {
 						throw new APIError("UNAUTHORIZED", {
@@ -923,6 +928,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 					const requestedScopes = value.scope;
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 						code.toString(),
+						"oidc-code",
 					);
 					const accessToken = generateRandomString(32, "a-z", "A-Z");
 					const refreshToken = generateRandomString(32, "A-Z", "a-z");

--- a/packages/better-auth/src/plugins/one-time-token/index.ts
+++ b/packages/better-auth/src/plugins/one-time-token/index.ts
@@ -106,11 +106,14 @@ export const oneTimeToken = (options?: OneTimeTokenOptions | undefined) => {
 			: generateRandomString(32);
 		const expiresAt = new Date(Date.now() + (opts?.expiresIn ?? 3) * 60 * 1000);
 		const storedToken = await storeToken(c, token);
-		await c.context.internalAdapter.createVerificationValue({
-			value: session.session.token,
-			identifier: `one-time-token:${storedToken}`,
-			expiresAt,
-		});
+		await c.context.internalAdapter.createVerificationValue(
+			{
+				value: session.session.token,
+				identifier: storedToken,
+				expiresAt,
+			},
+			"one-time-token",
+		);
 		return token;
 	}
 
@@ -176,7 +179,8 @@ export const oneTimeToken = (options?: OneTimeTokenOptions | undefined) => {
 					const storedToken = await storeToken(c, token);
 					const verificationValue =
 						await c.context.internalAdapter.findVerificationValue(
-							`one-time-token:${storedToken}`,
+							storedToken,
+							"one-time-token",
 						);
 					if (!verificationValue) {
 						throw c.error("BAD_REQUEST", {
@@ -184,7 +188,8 @@ export const oneTimeToken = (options?: OneTimeTokenOptions | undefined) => {
 						});
 					}
 					await c.context.internalAdapter.deleteVerificationByIdentifier(
-						`one-time-token:${storedToken}`,
+						storedToken,
+						"one-time-token",
 					);
 					if (verificationValue.expiresAt < new Date()) {
 						throw c.error("BAD_REQUEST", {

--- a/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
+++ b/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
@@ -147,7 +147,8 @@ describe("One-time token", async () => {
 
 				const hashedToken = await defaultKeyHasher(response.token);
 				const storedToken = await internalAdapter.findVerificationValue(
-					`one-time-token:${hashedToken}`,
+					hashedToken,
+					"one-time-token",
 				);
 				expect(storedToken).toBeDefined();
 
@@ -188,7 +189,8 @@ describe("One-time token", async () => {
 
 				const hashedToken = response.token + "hashed";
 				const storedToken = await internalAdapter.findVerificationValue(
-					`one-time-token:${hashedToken}`,
+					hashedToken,
+					"one-time-token",
 				);
 				expect(storedToken).toBeDefined();
 

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -119,11 +119,14 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			if (opts.requireVerification) {
 				if (!user.phoneNumberVerified) {
 					const otp = generateOTP(opts.otpLength);
-					await ctx.context.internalAdapter.createVerificationValue({
-						value: otp,
-						identifier: phoneNumber,
-						expiresAt: getDate(opts.expiresIn, "sec"),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							value: otp,
+							identifier: phoneNumber,
+							expiresAt: getDate(opts.expiresIn, "sec"),
+						},
+						"phone-number",
+					);
 					if (opts.sendOTP) {
 						await ctx.context.runInBackgroundOrAwait(
 							opts.sendOTP(
@@ -275,11 +278,14 @@ export const sendPhoneNumberOTP = (opts: RequiredPhoneNumberOptions) =>
 			}
 
 			const code = generateOTP(opts.otpLength);
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${code}:0`,
-				identifier: ctx.body.phoneNumber,
-				expiresAt: getDate(opts.expiresIn, "sec"),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: `${code}:0`,
+					identifier: ctx.body.phoneNumber,
+					expiresAt: getDate(opts.expiresIn, "sec"),
+				},
+				"phone-number",
+			);
 			await ctx.context.runInBackgroundOrAwait(
 				opts.sendOTP(
 					{
@@ -471,16 +477,19 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				// Clean up verification value
 				const otp = await ctx.context.internalAdapter.findVerificationValue(
 					ctx.body.phoneNumber,
+					"phone-number",
 				);
 				if (otp) {
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 						ctx.body.phoneNumber,
+						"phone-number",
 					);
 				}
 			} else {
 				// Default internal verification logic
 				const otp = await ctx.context.internalAdapter.findVerificationValue(
 					ctx.body.phoneNumber,
+					"phone-number",
 				);
 
 				if (!otp || otp.expiresAt < new Date()) {
@@ -500,6 +509,7 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				if (attempts && parseInt(attempts) >= allowedAttempts) {
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 						ctx.body.phoneNumber,
+						"phone-number",
 					);
 					throw APIError.from(
 						"FORBIDDEN",
@@ -512,6 +522,7 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 						{
 							value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
 						},
+						"phone-number",
 					);
 					throw APIError.from(
 						"BAD_REQUEST",
@@ -521,6 +532,7 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 					ctx.body.phoneNumber,
+					"phone-number",
 				);
 			}
 
@@ -705,11 +717,14 @@ export const requestPasswordResetPhoneNumber = (
 				],
 			});
 			const code = generateOTP(opts.otpLength);
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${code}:0`,
-				identifier: `${ctx.body.phoneNumber}-request-password-reset`,
-				expiresAt: getDate(opts.expiresIn, "sec"),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: `${code}:0`,
+					identifier: ctx.body.phoneNumber,
+					expiresAt: getDate(opts.expiresIn, "sec"),
+				},
+				"phone-number-password-reset",
+			);
 			// to avoid leaking the existence of the phone number
 			if (!user) {
 				return ctx.json({
@@ -782,7 +797,8 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 		async (ctx) => {
 			const verification =
 				await ctx.context.internalAdapter.findVerificationValue(
-					`${ctx.body.phoneNumber}-request-password-reset`,
+					ctx.body.phoneNumber,
+					"phone-number-password-reset",
 				);
 			if (!verification) {
 				throw APIError.from(
@@ -798,10 +814,11 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			}
 			const [otpValue, attempts] = verification.value.split(":");
 			const allowedAttempts = opts?.allowedAttempts || 3;
-			const phoneResetIdentifier = `${ctx.body.phoneNumber}-request-password-reset`;
+			const phoneResetIdentifier = ctx.body.phoneNumber;
 			if (attempts && parseInt(attempts) >= allowedAttempts) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 					phoneResetIdentifier,
+					"phone-number-password-reset",
 				);
 				throw APIError.from(
 					"FORBIDDEN",
@@ -814,6 +831,7 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 					{
 						value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
 					},
+					"phone-number-password-reset",
 				);
 				throw APIError.from(
 					"BAD_REQUEST",
@@ -870,6 +888,7 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			}
 			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 				phoneResetIdentifier,
+				"phone-number-password-reset",
 			);
 
 			if (ctx.context.options.emailAndPassword?.onPasswordReset) {

--- a/packages/better-auth/src/plugins/siwe/index.ts
+++ b/packages/better-auth/src/plugins/siwe/index.ts
@@ -60,11 +60,14 @@ export const siwe = (options: SIWEPluginOptions) =>
 					const nonce = await options.getNonce();
 
 					// Store nonce with wallet address and chain ID context
-					await ctx.context.internalAdapter.createVerificationValue({
-						identifier: `siwe:${walletAddress}:${chainId}`,
-						value: nonce,
-						expiresAt: new Date(Date.now() + 15 * 60 * 1000),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							identifier: `${walletAddress}:${chainId}`,
+							value: nonce,
+							expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+						},
+						"siwe",
+					);
 
 					return ctx.json({ nonce });
 				},
@@ -113,7 +116,8 @@ export const siwe = (options: SIWEPluginOptions) =>
 						// Find stored nonce with wallet address and chain ID context
 						const verification =
 							await ctx.context.internalAdapter.findVerificationValue(
-								`siwe:${walletAddress}:${chainId}`,
+								`${walletAddress}:${chainId}`,
+								"siwe",
 							);
 
 						// Ensure nonce is valid and not expired
@@ -154,7 +158,8 @@ export const siwe = (options: SIWEPluginOptions) =>
 
 						// Clean up used nonce
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							`siwe:${walletAddress}:${chainId}`,
+							`${walletAddress}:${chainId}`,
+							"siwe",
 						);
 
 						// Look for existing user by their wallet addresses

--- a/packages/better-auth/src/plugins/test-utils/index.ts
+++ b/packages/better-auth/src/plugins/test-utils/index.ts
@@ -114,13 +114,14 @@ export const testUtils = (options: TestUtilsOptions = {}) => {
 										// The format is typically "otp:retryCount" or just "otp"
 										const otpPart = verification.value.split(":")[0];
 										if (otpPart) {
-											// Extract base identifier (remove prefix like "email-verification-otp-")
+											// Extract base identifier (remove namespace prefix like "email-verification-otp:")
 											let identifier = verification.identifier;
 											const prefixes = [
-												"email-verification-otp-",
-												"sign-in-otp-",
-												"forget-password-otp-",
-												"phone-verification-otp-",
+												"email-verification-otp:",
+												"sign-in-otp:",
+												"forget-password-otp:",
+												"phone-verification-otp:",
+												"phone-number:",
 											];
 											for (const prefix of prefixes) {
 												if (identifier.startsWith(prefix)) {

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -310,6 +310,7 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 						if (trustId) {
 							await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 								trustId,
+								"trust-device",
 							);
 						}
 						expireCookie(ctx, disableTrustCookie);
@@ -367,6 +368,7 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 									const verificationRecord =
 										await ctx.context.internalAdapter.findVerificationValue(
 											trustIdentifier,
+											"trust-device",
 										);
 									if (
 										verificationRecord &&
@@ -375,8 +377,9 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 									) {
 										await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 											trustIdentifier,
+											"trust-device",
 										);
-										const newTrustIdentifier = `trust-device-${generateRandomString(32)}`;
+										const newTrustIdentifier = generateRandomString(32);
 										const newToken = await createHMAC(
 											"SHA-256",
 											"base64urlnopad",
@@ -384,13 +387,16 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 											ctx.context.secret,
 											`${data.user.id}!${newTrustIdentifier}`,
 										);
-										await ctx.context.internalAdapter.createVerificationValue({
-											value: data.user.id,
-											identifier: newTrustIdentifier,
-											expiresAt: new Date(
-												Date.now() + trustDeviceMaxAge * 1000,
-											),
-										});
+										await ctx.context.internalAdapter.createVerificationValue(
+											{
+												value: data.user.id,
+												identifier: newTrustIdentifier,
+												expiresAt: new Date(
+													Date.now() + trustDeviceMaxAge * 1000,
+												),
+											},
+											"trust-device",
+										);
 										const newTrustDeviceCookie = ctx.context.createAuthCookie(
 											TRUST_DEVICE_COOKIE_NAME,
 											{
@@ -422,12 +428,15 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 								maxAge,
 							},
 						);
-						const identifier = `2fa-${generateRandomString(20)}`;
-						await ctx.context.internalAdapter.createVerificationValue({
-							value: data.user.id,
-							identifier,
-							expiresAt: new Date(Date.now() + maxAge * 1000),
-						});
+						const identifier = generateRandomString(20);
+						await ctx.context.internalAdapter.createVerificationValue(
+							{
+								value: data.user.id,
+								identifier,
+								expiresAt: new Date(Date.now() + maxAge * 1000),
+							},
+							"2fa",
+						);
 						await ctx.setSignedCookie(
 							twoFactorCookie.name,
 							identifier,

--- a/packages/better-auth/src/plugins/two-factor/otp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/otp/index.ts
@@ -207,11 +207,14 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 			const { session, key } = await verifyTwoFactor(ctx);
 			const code = generateRandomString(opts.digits, "0-9");
 			const hashedCode = await storeOTP(ctx, code);
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${hashedCode}:0`,
-				identifier: `2fa-otp-${key}`,
-				expiresAt: new Date(Date.now() + opts.period),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					value: `${hashedCode}:0`,
+					identifier: key,
+					expiresAt: new Date(Date.now() + opts.period),
+				},
+				"2fa-otp",
+			);
 			const sendOTPResult = options.sendOTP(
 				{ user: session.user as UserWithTwoFactor, otp: code },
 				ctx,
@@ -306,14 +309,13 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 		async (ctx) => {
 			const { session, key, valid, invalid } = await verifyTwoFactor(ctx);
 			const toCheckOtp =
-				await ctx.context.internalAdapter.findVerificationValue(
-					`2fa-otp-${key}`,
-				);
+				await ctx.context.internalAdapter.findVerificationValue(key, "2fa-otp");
 			const [otp, counter] = toCheckOtp?.value?.split(":") ?? [];
 			if (!toCheckOtp || toCheckOtp.expiresAt < new Date()) {
 				if (toCheckOtp) {
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						`2fa-otp-${key}`,
+						key,
+						"2fa-otp",
 					);
 				}
 				throw APIError.from(
@@ -324,7 +326,8 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 			const allowedAttempts = options?.allowedAttempts || 5;
 			if (parseInt(counter!) >= allowedAttempts) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					`2fa-otp-${key}`,
+					key,
+					"2fa-otp",
 				);
 				throw APIError.from(
 					"BAD_REQUEST",
@@ -374,10 +377,11 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 				return valid(ctx);
 			} else {
 				await ctx.context.internalAdapter.updateVerificationByIdentifier(
-					`2fa-otp-${key}`,
+					key,
 					{
 						value: `${otp}:${(parseInt(counter!, 10) || 0) + 1}`,
 					},
+					"2fa-otp",
 				);
 				return invalid("INVALID_CODE");
 			}

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -927,7 +927,12 @@ describe("trust device server-side validation", async () => {
 			expiresAt: Date;
 		}>({
 			model: "verification",
-			where: [{ field: "identifier", value: trustIdentifier! }],
+			where: [
+				{
+					field: "identifier",
+					value: `trust-device:${trustIdentifier!}`,
+				},
+			],
 		});
 		expect(verificationRecord).toBeDefined();
 
@@ -1239,7 +1244,12 @@ describe("trustDeviceMaxAge", async () => {
 			expiresAt: Date;
 		}>({
 			model: "verification",
-			where: [{ field: "identifier", value: trustIdentifier! }],
+			where: [
+				{
+					field: "identifier",
+					value: `trust-device:${trustIdentifier!}`,
+				},
+			],
 		});
 		expect(verificationRecord).toBeDefined();
 

--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -36,6 +36,7 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 		const verificationToken =
 			await ctx.context.internalAdapter.findVerificationValue(
 				signedTwoFactorCookie,
+				"2fa",
 			);
 		if (!verificationToken) {
 			throw APIError.from(
@@ -71,6 +72,7 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 				// Delete the verification token from the database after successful verification
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 					signedTwoFactorCookie,
+					"2fa",
 				);
 				await setSessionCookie(ctx, {
 					session,
@@ -93,16 +95,19 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 					 * Store it in the verification table with an expiration
 					 * so the server can validate and revoke it.
 					 */
-					const trustIdentifier = `trust-device-${generateRandomString(32)}`;
+					const trustIdentifier = generateRandomString(32);
 					const token = await createHMAC("SHA-256", "base64urlnopad").sign(
 						ctx.context.secret,
 						`${user.id}!${trustIdentifier}`,
 					);
-					await ctx.context.internalAdapter.createVerificationValue({
-						value: user.id,
-						identifier: trustIdentifier,
-						expiresAt: new Date(Date.now() + maxAge * 1000),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							value: user.id,
+							identifier: trustIdentifier,
+							expiresAt: new Date(Date.now() + maxAge * 1000),
+						},
+						"trust-device",
+					);
 					await ctx.setSignedCookie(
 						trustDeviceCookie.name,
 						`${token}!${trustIdentifier}`,

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -98,11 +98,14 @@ export async function generateGenericState(
 	const expiresAt = new Date();
 	expiresAt.setMinutes(expiresAt.getMinutes() + 10);
 
-	const verification = await c.context.internalAdapter.createVerificationValue({
-		value: JSON.stringify(stateData),
-		identifier: state,
-		expiresAt,
-	});
+	const verification = await c.context.internalAdapter.createVerificationValue(
+		{
+			value: JSON.stringify(stateData),
+			identifier: state,
+			expiresAt,
+		},
+		"state",
+	);
 
 	if (!verification) {
 		throw new StateError(
@@ -114,7 +117,7 @@ export async function generateGenericState(
 	}
 
 	return {
-		state: verification.identifier,
+		state,
 		codeVerifier: stateData.codeVerifier,
 	};
 }
@@ -163,7 +166,10 @@ export async function parseGenericState(
 		expireCookie(c, stateCookie);
 	} else {
 		// Default: database strategy
-		const data = await c.context.internalAdapter.findVerificationValue(state);
+		const data = await c.context.internalAdapter.findVerificationValue(
+			state,
+			"state",
+		);
 		if (!data) {
 			throw new StateError("State mismatch: verification not found", {
 				code: "state_mismatch",
@@ -201,7 +207,10 @@ export async function parseGenericState(
 		expireCookie(c, stateCookie);
 
 		// Delete verification value after retrieval
-		await c.context.internalAdapter.deleteVerificationByIdentifier(state);
+		await c.context.internalAdapter.deleteVerificationByIdentifier(
+			state,
+			"state",
+		);
 	}
 
 	// Check expiration

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -202,15 +202,23 @@ export interface InternalAdapter<
 	createVerificationValue(
 		data: Omit<Verification, "createdAt" | "id" | "updatedAt"> &
 			Partial<Verification>,
+		namespace: string,
 	): Promise<Verification>;
 
-	findVerificationValue(identifier: string): Promise<Verification | null>;
+	findVerificationValue(
+		identifier: string,
+		namespace: string,
+	): Promise<Verification | null>;
 
-	deleteVerificationByIdentifier(identifier: string): Promise<void>;
+	deleteVerificationByIdentifier(
+		identifier: string,
+		namespace: string,
+	): Promise<void>;
 
 	updateVerificationByIdentifier(
 		identifier: string,
 		data: Partial<Verification>,
+		namespace: string,
 	): Promise<Verification>;
 }
 

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -83,16 +83,19 @@ export const electron = (options?: ElectronOptions | undefined) => {
 		const identifier = generateRandomString(32, "a-z", "A-Z", "0-9");
 		const codeExpiresInMs = opts.codeExpiresIn * 1000;
 		const expiresAt = new Date(Date.now() + codeExpiresInMs);
-		await ctx.context.internalAdapter.createVerificationValue({
-			identifier: `electron:${identifier}`,
-			value: JSON.stringify({
-				userId,
-				codeChallenge: code_challenge,
-				codeChallengeMethod: code_challenge_method.toLowerCase(),
-				state,
-			}),
-			expiresAt,
-		});
+		await ctx.context.internalAdapter.createVerificationValue(
+			{
+				identifier,
+				value: JSON.stringify({
+					userId,
+					codeChallenge: code_challenge,
+					codeChallengeMethod: code_challenge_method.toLowerCase(),
+					state,
+				}),
+				expiresAt,
+			},
+			"electron",
+		);
 
 		const redirectToken = base64Url.encode(
 			new TextEncoder().encode(JSON.stringify({ identifier, state })),

--- a/packages/electron/src/routes.ts
+++ b/packages/electron/src/routes.ts
@@ -59,7 +59,8 @@ export const electronToken = (_opts: ElectronOptions) =>
 		},
 		async (ctx) => {
 			const token = await ctx.context.internalAdapter.findVerificationValue(
-				`electron:${ctx.body.token}`,
+				ctx.body.token,
+				"electron",
 			);
 			if (!token || token.expiresAt < new Date()) {
 				throw APIError.from("NOT_FOUND", ELECTRON_ERROR_CODES.INVALID_TOKEN);
@@ -109,7 +110,8 @@ export const electronToken = (_opts: ElectronOptions) =>
 				}
 			}
 			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-				`electron:${ctx.body.token}`,
+				ctx.body.token,
+				"electron",
 			);
 
 			const user = await ctx.context.internalAdapter.findUserById(

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -118,7 +118,10 @@ describe("expo", async () => {
 		if (!stateId) {
 			throw new Error("State ID not found");
 		}
-		const state = await ctx.internalAdapter.findVerificationValue(stateId);
+		const state = await ctx.internalAdapter.findVerificationValue(
+			stateId,
+			"state",
+		);
 		const callbackURL = JSON.parse(state?.value || "{}").callbackURL;
 		expect(callbackURL).toBe("better-auth:///dashboard");
 		expect(res).toMatchObject({

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -424,10 +424,13 @@ async function redirectWithAuthorizationCode(
 			authTime: verificationValue.authTime,
 		} satisfies VerificationValue),
 	};
-	await ctx.context.internalAdapter.createVerificationValue({
-		...data,
-		createdAt: new Date(iat * 1000),
-	});
+	await ctx.context.internalAdapter.createVerificationValue(
+		{
+			...data,
+			createdAt: new Date(iat * 1000),
+		},
+		"oauth-authorization-code",
+	);
 
 	const redirectUriWithCode = new URL(verificationValue.query.redirect_uri);
 	redirectUriWithCode.searchParams.set("code", code);

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -509,6 +509,7 @@ async function checkVerificationValue(
 ) {
 	const verification = await ctx.context.internalAdapter.findVerificationValue(
 		await storeToken(opts.storeTokens, code, "authorization_code"),
+		"oauth-authorization-code",
 	);
 	const verificationValue: VerificationValue = verification
 		? JSON.parse(verification?.value)
@@ -524,6 +525,7 @@ async function checkVerificationValue(
 	// Delete used code
 	await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 		await storeToken(opts.storeTokens, code, "authorization_code"),
+		"oauth-authorization-code",
 	);
 
 	// Check verification

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -224,16 +224,19 @@ export const generatePasskeyRegistrationOptions = (
 				},
 			);
 			const expirationTime = new Date(Date.now() + maxAgeInSeconds * 1000);
-			await ctx.context.internalAdapter.createVerificationValue({
-				identifier: verificationToken,
-				value: JSON.stringify({
-					expectedChallenge: options.challenge,
-					userData: {
-						id: session.user.id,
-					},
-				}),
-				expiresAt: expirationTime,
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					identifier: verificationToken,
+					value: JSON.stringify({
+						expectedChallenge: options.challenge,
+						userData: {
+							id: session.user.id,
+						},
+					}),
+					expiresAt: expirationTime,
+				},
+				"passkey",
+			);
 			return ctx.json(options, {
 				status: 200,
 			});
@@ -392,11 +395,14 @@ export const generatePasskeyAuthenticationOptions = (
 				},
 			);
 			const expirationTime = new Date(Date.now() + maxAgeInSeconds * 1000);
-			await ctx.context.internalAdapter.createVerificationValue({
-				identifier: verificationToken,
-				value: JSON.stringify(data),
-				expiresAt: expirationTime,
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					identifier: verificationToken,
+					value: JSON.stringify(data),
+					expiresAt: expirationTime,
+				},
+				"passkey",
+			);
 			return ctx.json(options, {
 				status: 200,
 			});
@@ -465,10 +471,10 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 				);
 			}
 
-			const data =
-				await ctx.context.internalAdapter.findVerificationValue(
-					verificationToken,
-				);
+			const data = await ctx.context.internalAdapter.findVerificationValue(
+				verificationToken,
+				"passkey",
+			);
 			if (!data) {
 				throw APIError.from(
 					"BAD_REQUEST",
@@ -529,6 +535,7 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) =>
 				});
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 					verificationToken,
+					"passkey",
 				);
 				return ctx.json(newPasskeyRes, {
 					status: 200,
@@ -607,10 +614,10 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 				);
 			}
 
-			const data =
-				await ctx.context.internalAdapter.findVerificationValue(
-					verificationToken,
-				);
+			const data = await ctx.context.internalAdapter.findVerificationValue(
+				verificationToken,
+				"passkey",
+			);
 			if (!data) {
 				throw APIError.from(
 					"BAD_REQUEST",
@@ -697,6 +704,7 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 				});
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 					verificationToken,
+					"passkey",
 				);
 
 				return ctx.json(

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -2,7 +2,6 @@ import type { BetterAuthPlugin } from "better-auth";
 import { createAuthMiddleware, getSessionFromCtx } from "better-auth/api";
 import { XMLValidator } from "fast-xml-parser";
 import saml from "samlify";
-import { SAML_SESSION_BY_ID_PREFIX } from "./constants";
 import { assignOrganizationByDomain } from "./linking";
 import {
 	requestDomainVerification,
@@ -212,17 +211,23 @@ export function sso<O extends SSOOptions>(
 						if (!session?.session?.id) {
 							return;
 						}
-						const sessionLookupKey = `${SAML_SESSION_BY_ID_PREFIX}${session.session.id}`;
 						const sessionLookup =
 							await ctx.context.internalAdapter.findVerificationValue(
-								sessionLookupKey,
+								session.session.id,
+								"saml-session-by-id",
 							);
 						if (sessionLookup?.value) {
 							await ctx.context.internalAdapter
-								.deleteVerificationByIdentifier(sessionLookup.value)
+								.deleteVerificationByIdentifier(
+									sessionLookup.value,
+									"saml-session",
+								)
 								.catch(() => {});
 							await ctx.context.internalAdapter
-								.deleteVerificationByIdentifier(sessionLookupKey)
+								.deleteVerificationByIdentifier(
+									session.session.id,
+									"saml-session-by-id",
+								)
 								.catch(() => {});
 						}
 					}),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1433,11 +1433,14 @@ export const signInSSO = (options?: SSOOptions) => {
 						createdAt: Date.now(),
 						expiresAt: Date.now() + ttl,
 					};
-					await ctx.context.internalAdapter.createVerificationValue({
-						identifier: `${constants.AUTHN_REQUEST_KEY_PREFIX}${record.id}`,
-						value: JSON.stringify(record),
-						expiresAt: new Date(record.expiresAt),
-					});
+					await ctx.context.internalAdapter.createVerificationValue(
+						{
+							identifier: record.id,
+							value: JSON.stringify(record),
+							expiresAt: new Date(record.expiresAt),
+						},
+						"saml-authn-request",
+					);
 				}
 
 				return ctx.json({
@@ -2192,7 +2195,8 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 
 					const verification =
 						await ctx.context.internalAdapter.findVerificationValue(
-							`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
+							inResponseTo,
+							"saml-authn-request",
 						);
 					if (verification) {
 						try {
@@ -2232,7 +2236,8 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 						);
 
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
+							inResponseTo,
+							"saml-authn-request",
 						);
 						const redirectUrl =
 							relayState?.callbackURL ||
@@ -2244,7 +2249,8 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 					}
 
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
+						inResponseTo,
+						"saml-authn-request",
 					);
 				} else if (!allowIdpInitiated) {
 					ctx.context.logger.error(
@@ -2280,7 +2286,8 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 
 				const existingAssertion =
 					await ctx.context.internalAdapter.findVerificationValue(
-						`${constants.USED_ASSERTION_KEY_PREFIX}${assertionId}`,
+						assertionId,
+						"saml-used-assertion",
 					);
 
 				let isReplay = false;
@@ -2316,17 +2323,20 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 					);
 				}
 
-				await ctx.context.internalAdapter.createVerificationValue({
-					identifier: `${constants.USED_ASSERTION_KEY_PREFIX}${assertionId}`,
-					value: JSON.stringify({
-						assertionId,
-						issuer,
-						providerId: provider.providerId,
-						usedAt: Date.now(),
-						expiresAt,
-					}),
-					expiresAt: new Date(expiresAt),
-				});
+				await ctx.context.internalAdapter.createVerificationValue(
+					{
+						identifier: assertionId,
+						value: JSON.stringify({
+							assertionId,
+							issuer,
+							providerId: provider.providerId,
+							usedAt: Date.now(),
+							expiresAt,
+						}),
+						expiresAt: new Date(expiresAt),
+					},
+					"saml-used-assertion",
+				);
 			} else {
 				ctx.context.logger.warn(
 					"Could not extract assertion ID for replay protection",
@@ -2439,7 +2449,7 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 			await setSessionCookie(ctx, { session, user });
 
 			if (options?.saml?.enableSingleLogout && extract.nameID) {
-				const samlSessionKey = `${constants.SAML_SESSION_KEY_PREFIX}${provider.providerId}:${extract.nameID}`;
+				const samlSessionKey = `${provider.providerId}:${extract.nameID}`;
 				const samlSessionData: SAMLSessionRecord = {
 					sessionId: session.id,
 					providerId: provider.providerId,
@@ -2447,22 +2457,28 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 					sessionIndex: (extract as SAMLAssertionExtract).sessionIndex,
 				};
 				await ctx.context.internalAdapter
-					.createVerificationValue({
-						identifier: samlSessionKey,
-						value: JSON.stringify(samlSessionData),
-						expiresAt: session.expiresAt,
-					})
+					.createVerificationValue(
+						{
+							identifier: samlSessionKey,
+							value: JSON.stringify(samlSessionData),
+							expiresAt: session.expiresAt,
+						},
+						"saml-session",
+					)
 					.catch((e) =>
 						ctx.context.logger.warn("Failed to create SAML session record", {
 							error: e,
 						}),
 					);
 				await ctx.context.internalAdapter
-					.createVerificationValue({
-						identifier: `${constants.SAML_SESSION_BY_ID_PREFIX}${session.id}`,
-						value: samlSessionKey,
-						expiresAt: session.expiresAt,
-					})
+					.createVerificationValue(
+						{
+							identifier: session.id,
+							value: samlSessionKey,
+							expiresAt: session.expiresAt,
+						},
+						"saml-session-by-id",
+					)
 					.catch((e) =>
 						ctx.context.logger.warn(
 							"Failed to create SAML session lookup record",
@@ -2708,7 +2724,8 @@ export const acsEndpoint = (options?: SSOOptions) => {
 
 					const verification =
 						await ctx.context.internalAdapter.findVerificationValue(
-							`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseToAcs}`,
+							inResponseToAcs,
+							"saml-authn-request",
 						);
 					if (verification) {
 						try {
@@ -2747,7 +2764,8 @@ export const acsEndpoint = (options?: SSOOptions) => {
 							},
 						);
 						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseToAcs}`,
+							inResponseToAcs,
+							"saml-authn-request",
 						);
 						const redirectUrl =
 							relayState?.callbackURL ||
@@ -2759,7 +2777,8 @@ export const acsEndpoint = (options?: SSOOptions) => {
 					}
 
 					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseToAcs}`,
+						inResponseToAcs,
+						"saml-authn-request",
 					);
 				} else if (!allowIdpInitiated) {
 					ctx.context.logger.error(
@@ -2795,7 +2814,8 @@ export const acsEndpoint = (options?: SSOOptions) => {
 
 				const existingAssertion =
 					await ctx.context.internalAdapter.findVerificationValue(
-						`${constants.USED_ASSERTION_KEY_PREFIX}${assertionIdAcs}`,
+						assertionIdAcs,
+						"saml-used-assertion",
 					);
 
 				let isReplay = false;
@@ -2831,17 +2851,20 @@ export const acsEndpoint = (options?: SSOOptions) => {
 					);
 				}
 
-				await ctx.context.internalAdapter.createVerificationValue({
-					identifier: `${constants.USED_ASSERTION_KEY_PREFIX}${assertionIdAcs}`,
-					value: JSON.stringify({
-						assertionId: assertionIdAcs,
-						issuer,
-						providerId,
-						usedAt: Date.now(),
-						expiresAt,
-					}),
-					expiresAt: new Date(expiresAt),
-				});
+				await ctx.context.internalAdapter.createVerificationValue(
+					{
+						identifier: assertionIdAcs,
+						value: JSON.stringify({
+							assertionId: assertionIdAcs,
+							issuer,
+							providerId,
+							usedAt: Date.now(),
+							expiresAt,
+						}),
+						expiresAt: new Date(expiresAt),
+					},
+					"saml-used-assertion",
+				);
 			} else {
 				ctx.context.logger.warn(
 					"Could not extract assertion ID for replay protection",
@@ -2954,7 +2977,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 
 			await setSessionCookie(ctx, { session, user });
 			if (options?.saml?.enableSingleLogout && extract.nameID) {
-				const samlSessionKey = `${constants.SAML_SESSION_KEY_PREFIX}${providerId}:${extract.nameID}`;
+				const samlSessionKey = `${providerId}:${extract.nameID}`;
 				const samlSessionData: SAMLSessionRecord = {
 					sessionId: session.id,
 					providerId,
@@ -2962,22 +2985,28 @@ export const acsEndpoint = (options?: SSOOptions) => {
 					sessionIndex: (extract as SAMLAssertionExtract).sessionIndex,
 				};
 				await ctx.context.internalAdapter
-					.createVerificationValue({
-						identifier: samlSessionKey,
-						value: JSON.stringify(samlSessionData),
-						expiresAt: session.expiresAt,
-					})
+					.createVerificationValue(
+						{
+							identifier: samlSessionKey,
+							value: JSON.stringify(samlSessionData),
+							expiresAt: session.expiresAt,
+						},
+						"saml-session",
+					)
 					.catch((e) =>
 						ctx.context.logger.warn("Failed to create SAML session record", {
 							error: e,
 						}),
 					);
 				await ctx.context.internalAdapter
-					.createVerificationValue({
-						identifier: `${constants.SAML_SESSION_BY_ID_PREFIX}${session.id}`,
-						value: samlSessionKey,
-						expiresAt: session.expiresAt,
-					})
+					.createVerificationValue(
+						{
+							identifier: session.id,
+							value: samlSessionKey,
+							expiresAt: session.expiresAt,
+						},
+						"saml-session-by-id",
+					)
 					.catch((e) =>
 						ctx.context.logger.warn(
 							"Failed to create SAML session lookup record",
@@ -3116,9 +3145,11 @@ async function handleLogoutResponse(
 
 	const inResponseTo = extract?.response?.inResponseTo;
 	if (inResponseTo) {
-		const key = `${constants.LOGOUT_REQUEST_KEY_PREFIX}${inResponseTo}`;
 		const pendingRequest =
-			await ctx.context.internalAdapter.findVerificationValue(key);
+			await ctx.context.internalAdapter.findVerificationValue(
+				inResponseTo,
+				"saml-logout-request",
+			);
 
 		if (!pendingRequest) {
 			ctx.context.logger.warn(
@@ -3128,7 +3159,7 @@ async function handleLogoutResponse(
 		}
 
 		await ctx.context.internalAdapter
-			.deleteVerificationByIdentifier(key)
+			.deleteVerificationByIdentifier(inResponseTo, "saml-logout-request")
 			.catch((e: unknown) =>
 				ctx.context.logger.warn(
 					"Failed to delete logout request verification value",
@@ -3176,8 +3207,11 @@ async function handleLogoutRequest(
 	const { nameID } = parsed.extract;
 	const sessionIndex = (parsed.extract as SAMLAssertionExtract).sessionIndex;
 
-	const key = `${constants.SAML_SESSION_KEY_PREFIX}${providerId}:${nameID}`;
-	const stored = await ctx.context.internalAdapter.findVerificationValue(key);
+	const samlSessionId = `${providerId}:${nameID}`;
+	const stored = await ctx.context.internalAdapter.findVerificationValue(
+		samlSessionId,
+		"saml-session",
+	);
 
 	if (stored) {
 		const data = safeJsonParse<SAMLSessionRecord>(stored.value);
@@ -3195,9 +3229,7 @@ async function handleLogoutRequest(
 						}),
 					);
 				await ctx.context.internalAdapter
-					.deleteVerificationByIdentifier(
-						`${constants.SAML_SESSION_BY_ID_PREFIX}${data.sessionId}`,
-					)
+					.deleteVerificationByIdentifier(data.sessionId, "saml-session-by-id")
 					.catch((e: unknown) =>
 						ctx.context.logger.warn(
 							"Failed to delete SAML session lookup during SLO",
@@ -3216,7 +3248,7 @@ async function handleLogoutRequest(
 			}
 		}
 		await ctx.context.internalAdapter
-			.deleteVerificationByIdentifier(key)
+			.deleteVerificationByIdentifier(samlSessionId, "saml-session")
 			.catch((e: unknown) =>
 				ctx.context.logger.warn(
 					"Failed to delete SAML session key during SLO",
@@ -3309,10 +3341,10 @@ export const initiateSLO = (options?: SSOOptions) => {
 			const idp = createIdP(config);
 
 			const session = ctx.context.session;
-			const sessionLookupKey = `${constants.SAML_SESSION_BY_ID_PREFIX}${session.session.id}`;
 			const sessionLookup =
 				await ctx.context.internalAdapter.findVerificationValue(
-					sessionLookupKey,
+					session.session.id,
+					"saml-session-by-id",
 				);
 
 			let nameID = session.user.email;
@@ -3321,10 +3353,10 @@ export const initiateSLO = (options?: SSOOptions) => {
 
 			if (sessionLookup) {
 				samlSessionKey = sessionLookup.value;
-				const stored =
-					await ctx.context.internalAdapter.findVerificationValue(
-						samlSessionKey,
-					);
+				const stored = await ctx.context.internalAdapter.findVerificationValue(
+					samlSessionKey,
+					"saml-session",
+				);
 				if (stored) {
 					const data = safeJsonParse<SAMLSessionRecord>(stored.value);
 					if (data) {
@@ -3343,15 +3375,18 @@ export const initiateSLO = (options?: SSOOptions) => {
 			const ttl =
 				options?.saml?.logoutRequestTTL ??
 				constants.DEFAULT_LOGOUT_REQUEST_TTL_MS;
-			await ctx.context.internalAdapter.createVerificationValue({
-				identifier: `${constants.LOGOUT_REQUEST_KEY_PREFIX}${logoutRequest.id}`,
-				value: providerId,
-				expiresAt: new Date(Date.now() + ttl),
-			});
+			await ctx.context.internalAdapter.createVerificationValue(
+				{
+					identifier: logoutRequest.id,
+					value: providerId,
+					expiresAt: new Date(Date.now() + ttl),
+				},
+				"saml-logout-request",
+			);
 
 			if (samlSessionKey) {
 				await ctx.context.internalAdapter
-					.deleteVerificationByIdentifier(samlSessionKey)
+					.deleteVerificationByIdentifier(samlSessionKey, "saml-session")
 					.catch((e) =>
 						ctx.context.logger.warn(
 							"Failed to delete SAML session key during logout",
@@ -3360,7 +3395,10 @@ export const initiateSLO = (options?: SSOOptions) => {
 					);
 			}
 			await ctx.context.internalAdapter
-				.deleteVerificationByIdentifier(sessionLookupKey)
+				.deleteVerificationByIdentifier(
+					session.session.id,
+					"saml-session-by-id",
+				)
 				.catch((e) =>
 					ctx.context.logger.warn(
 						"Failed to delete session lookup key during logout",


### PR DESCRIPTION
## Summary

- Add a required `namespace: string` parameter to all 4 verification adapter methods (`createVerificationValue`, `findVerificationValue`, `deleteVerificationByIdentifier`, `updateVerificationByIdentifier`)
- The adapter auto-prefixes identifiers as `namespace:identifier`, centralizing what was previously ad-hoc inline prefixing (e.g., `reset-password:${token}`, `2fa-otp-${key}`) across all call sites
- All existing call sites updated: inline prefixes extracted into the namespace parameter, leaving identifiers clean

### Namespace mapping

| Namespace | Used by |
|-----------|---------|
| `state` | OAuth state |
| `reset-password` | Password reset tokens |
| `delete-account` | Account deletion tokens |
| `magic-link` | Magic link tokens |
| `${type}-otp` | Email OTP (sign-in, email-verification, etc.) |
| `forget-password-otp` | Password reset OTP |
| `change-email-otp` | Change email OTP |
| `email-verification-otp` | Email verification OTP |
| `phone-number` | Phone number verification |
| `phone-number-password-reset` | Phone password reset |
| `2fa-otp` | Two-factor OTP |
| `2fa` | Two-factor session cookie |
| `trust-device` | Trust device tokens |
| `one-time-token` | One-time tokens |
| `siwe` | Sign-In with Ethereum |
| `oidc-code` | OIDC provider + MCP authorization codes |
| `oauth-authorization-code` | OAuth provider codes |
| `electron` | Electron plugin |
| `passkey` | Passkey verification |
| `saml-authn-request` | SSO SAML auth requests |
| `saml-used-assertion` | SSO SAML replay protection |
| `saml-session` | SSO SAML sessions |
| `saml-session-by-id` | SSO SAML session lookup |
| `saml-logout-request` | SSO SAML logout |

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] 590 tests pass across 29 test suites covering all affected packages
- [x] internal-adapter, magic-link, email-otp, phone-number, two-factor, one-time-token, siwe, oidc-provider, mcp, passkey, electron, expo, oauth-provider, sso, magic-link-secondary-storage tests all verified