### PR TITLE
feat(plugin): add field-level encryption plugin for sensitive data at rest

### DIFF
--- a/packages/better-auth/src/plugins/field-encryption/field-encryption.test.ts
+++ b/packages/better-auth/src/plugins/field-encryption/field-encryption.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { fieldEncryption } from ".";
+
+const TEST_SECRET = "test-secret-for-field-encryption-plugin";
+
+describe("fieldEncryption", async () => {
+	const { auth } = await getTestInstance({
+		plugins: [
+			fieldEncryption({
+				encryptionKey: TEST_SECRET,
+				fields: {
+					user: ["name"],
+				},
+			}),
+		],
+	});
+
+	it("should encrypt user fields on create and decrypt on read", async () => {
+		const user = await auth.api.signUpEmail({
+			body: {
+				email: "encrypt-test@example.com",
+				password: "password123",
+				name: "Sensitive Name",
+			},
+		});
+
+		expect(user.user.name).toBe("Sensitive Name");
+
+		// Confirm decryption works on a fresh read from the database
+		const session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${user.token}`,
+			}),
+		});
+		expect(session?.user.name).toBe("Sensitive Name");
+	});
+
+	it("should handle null and empty values without encrypting", async () => {
+		const user = await auth.api.signUpEmail({
+			body: {
+				email: "null-test@example.com",
+				password: "password123",
+				name: "",
+			},
+		});
+
+		// Empty string should pass through without encryption
+		const session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${user.token}`,
+			}),
+		});
+		expect(session?.user.name).toBe("");
+	});
+
+	it("should decrypt correctly after update", async () => {
+		const user = await auth.api.signUpEmail({
+			body: {
+				email: "update-test@example.com",
+				password: "password123",
+				name: "Original Name",
+			},
+		});
+
+		await auth.api.updateUser({
+			body: { name: "Updated Name" },
+			headers: new Headers({
+				authorization: `Bearer ${user.token}`,
+			}),
+		});
+
+		const session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${user.token}`,
+			}),
+		});
+		expect(session?.user.name).toBe("Updated Name");
+	});
+
+	it("should work with auth instance secret as fallback", async () => {
+		const { auth: authWithFallback } = await getTestInstance({
+			plugins: [
+				fieldEncryption({
+					// No encryptionKey — should fall back to ctx.secretConfig
+					fields: {
+						user: ["name"],
+					},
+				}),
+			],
+		});
+
+		const user = await authWithFallback.api.signUpEmail({
+			body: {
+				email: "fallback-key@example.com",
+				password: "password123",
+				name: "Fallback Test",
+			},
+		});
+
+		const session = await authWithFallback.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${user.token}`,
+			}),
+		});
+		expect(session?.user.name).toBe("Fallback Test");
+	});
+
+	it("should handle multiple encrypted fields", async () => {
+		const { auth: multiAuth } = await getTestInstance({
+			plugins: [
+				fieldEncryption({
+					encryptionKey: TEST_SECRET,
+					fields: {
+						user: ["name", "image"],
+					},
+				}),
+			],
+		});
+
+		const user = await multiAuth.api.signUpEmail({
+			body: {
+				email: "multi-field@example.com",
+				password: "password123",
+				name: "Secret Name",
+				image: "https://example.com/secret-avatar.png",
+			},
+		});
+
+		const session = await multiAuth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${user.token}`,
+			}),
+		});
+		expect(session?.user.name).toBe("Secret Name");
+		expect(session?.user.image).toBe("https://example.com/secret-avatar.png");
+	});
+
+	it("should handle special characters in field values", async () => {
+		const user = await auth.api.signUpEmail({
+			body: {
+				email: "special-chars@example.com",
+				password: "password123",
+				name: "José María García-López — 日本語テスト 🔐",
+			},
+		});
+
+		const session = await auth.api.getSession({
+			headers: new Headers({
+				authorization: `Bearer ${user.token}`,
+			}),
+		});
+		expect(session?.user.name).toBe(
+			"José María García-López — 日本語テスト 🔐",
+		);
+	});
+});

--- a/packages/better-auth/src/plugins/field-encryption/index.ts
+++ b/packages/better-auth/src/plugins/field-encryption/index.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthPlugin, SecretConfig } from "@better-auth/core";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import {
 	parseEnvelope,
 	symmetricDecrypt,
@@ -96,25 +97,10 @@ export const fieldEncryption = (options: FieldEncryptionOptions) => {
 	};
 
 	// Build schema with transforms for each configured field
-	const schema: Record<
-		string,
-		{
-			fields: Record<
-				string,
-				{
-					type: "string";
-					required: false;
-					transform: {
-						input: (value: unknown) => Promise<unknown>;
-						output: (value: unknown) => Promise<unknown>;
-					};
-				}
-			>;
-		}
-	> = {};
+	const schema: BetterAuthPluginDBSchema = {};
 
 	for (const [model, fieldNames] of Object.entries(options.fields)) {
-		const fields: (typeof schema)[string]["fields"] = {};
+		const fields: BetterAuthPluginDBSchema[string]["fields"] = {};
 
 		for (const fieldName of fieldNames) {
 			fields[fieldName] = {

--- a/packages/better-auth/src/plugins/field-encryption/index.ts
+++ b/packages/better-auth/src/plugins/field-encryption/index.ts
@@ -1,0 +1,163 @@
+import type { BetterAuthPlugin, SecretConfig } from "@better-auth/core";
+import {
+	parseEnvelope,
+	symmetricDecrypt,
+	symmetricEncrypt,
+} from "../../crypto";
+
+declare module "@better-auth/core" {
+	interface BetterAuthPluginRegistry<AuthOptions, Options> {
+		"field-encryption": {
+			creator: typeof fieldEncryption;
+		};
+	}
+}
+
+export type FieldEncryptionOptions = {
+	/**
+	 * Encryption key. Accepts either:
+	 * - A plain string secret (at least 16 characters recommended)
+	 * - A SecretConfig object for key rotation support
+	 *
+	 * If not provided, falls back to the auth instance's
+	 * configured secret (ctx.secretConfig).
+	 */
+	encryptionKey?: string | SecretConfig | undefined;
+	/**
+	 * Map of model names to arrays of field names that should be encrypted.
+	 *
+	 * @example
+	 * ```ts
+	 * fields: {
+	 *   user: ["phoneNumber", "ssn"],
+	 *   account: ["accessToken"],
+	 * }
+	 * ```
+	 */
+	fields: Record<string, string[]>;
+};
+
+/**
+ * Check if a string looks like encrypted data (envelope or bare hex).
+ * Matches the pattern used by better-auth's symmetric encryption.
+ */
+function isLikelyEncrypted(value: string): boolean {
+	if (parseEnvelope(value) !== null) return true;
+	return (
+		value.length > 0 && value.length % 2 === 0 && /^[0-9a-f]+$/i.test(value)
+	);
+}
+
+/**
+ * Field-level encryption plugin for Better Auth.
+ *
+ * Provides transparent encryption at rest for any schema field.
+ * Uses XChaCha20-Poly1305 (the same algorithm used internally
+ * by Better Auth for OAuth token encryption), with support for
+ * key rotation via SecretConfig.
+ *
+ * Encrypted values are stored as hex strings with an optional
+ * `$ba$<version>$` envelope prefix for versioned keys.
+ *
+ * Fields are encrypted before database writes and decrypted
+ * after reads via schema transforms. Unencrypted values are
+ * passed through transparently, enabling gradual migration.
+ *
+ * @example
+ * ```ts
+ * import { fieldEncryption } from "better-auth/plugins";
+ *
+ * const auth = betterAuth({
+ *   plugins: [
+ *     fieldEncryption({
+ *       fields: {
+ *         user: ["phoneNumber", "ssn"],
+ *       },
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export const fieldEncryption = (options: FieldEncryptionOptions) => {
+	// Mutable reference — set from options or populated by init()
+	// when falling back to the auth instance secret. By the time any
+	// transform runs, init() has already executed.
+	let encryptionKey: string | SecretConfig | undefined = options.encryptionKey;
+
+	const getKey = (): string | SecretConfig => {
+		if (!encryptionKey) {
+			throw new Error(
+				"[field-encryption] No encryption key configured. " +
+					"Provide encryptionKey in plugin options or configure " +
+					"a secret on the auth instance.",
+			);
+		}
+		return encryptionKey;
+	};
+
+	// Build schema with transforms for each configured field
+	const schema: Record<
+		string,
+		{
+			fields: Record<
+				string,
+				{
+					type: "string";
+					required: false;
+					transform: {
+						input: (value: unknown) => Promise<unknown>;
+						output: (value: unknown) => Promise<unknown>;
+					};
+				}
+			>;
+		}
+	> = {};
+
+	for (const [model, fieldNames] of Object.entries(options.fields)) {
+		const fields: (typeof schema)[string]["fields"] = {};
+
+		for (const fieldName of fieldNames) {
+			fields[fieldName] = {
+				type: "string",
+				required: false,
+				transform: {
+					async input(value) {
+						if (value == null || value === "") return value;
+						const str = typeof value === "string" ? value : String(value);
+						if (isLikelyEncrypted(str)) return str;
+						return symmetricEncrypt({ key: getKey(), data: str });
+					},
+					async output(value) {
+						if (value == null || value === "") return value;
+						if (typeof value !== "string") return value;
+						if (!isLikelyEncrypted(value)) return value;
+						try {
+							return await symmetricDecrypt({
+								key: getKey(),
+								data: value,
+							});
+						} catch {
+							// If decryption fails, return as-is. This handles
+							// migration where some rows have unencrypted data
+							// that coincidentally looks like hex.
+							return value;
+						}
+					},
+				},
+			};
+		}
+
+		schema[model] = { fields };
+	}
+
+	return {
+		id: "field-encryption",
+		init(ctx) {
+			if (!encryptionKey) {
+				encryptionKey = ctx.secretConfig;
+			}
+		},
+		schema,
+		options,
+	} satisfies BetterAuthPlugin;
+};

--- a/packages/better-auth/src/plugins/index.ts
+++ b/packages/better-auth/src/plugins/index.ts
@@ -8,6 +8,7 @@ export * from "./captcha";
 export * from "./custom-session";
 export * from "./device-authorization";
 export * from "./email-otp";
+export * from "./field-encryption";
 export * from "./generic-oauth";
 export * from "./haveibeenpwned";
 export * from "./jwt";


### PR DESCRIPTION

## Summary

Adds a `fieldEncryption` plugin that provides transparent encryption at rest for any schema field. Developers specify which fields on which models to encrypt — the plugin handles encrypt-on-write and decrypt-on-read via schema transforms.

**Design decisions:**
- Reuses better-auth's existing `symmetricEncrypt`/`symmetricDecrypt` (XChaCha20-Poly1305)
- Supports key rotation via `SecretConfig` (versioned envelope format `$ba$<version>$<ciphertext>`)
- Falls back to the auth instance's `secretConfig` if no explicit key is provided
- Unencrypted values pass through transparently, enabling gradual migration of existing data

**Usage:**
```typescript
import { fieldEncryption } from "better-auth/plugins";

const auth = betterAuth({
  plugins: [
    fieldEncryption({
      fields: {
        user: ["phoneNumber", "ssn"],
      },
    }),
  ],
});
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `fieldEncryption` plugin that encrypts selected schema fields at rest and decrypts them on read. Uses XChaCha20-Poly1305 with versioned envelopes and supports key rotation to make securing PII straightforward.

- **New Features**
  - Configure fields per model; encrypt-on-write and decrypt-on-read via schema transforms.
  - Reuses `symmetricEncrypt`/`symmetricDecrypt` with versioned envelopes (`$ba$<version>$...`) for key rotation via `SecretConfig`.
  - Falls back to the auth instance secret; passes through null/empty and already-encrypted values; safely returns original on decryption errors for gradual migration.
  - Adds tests (create/update, multi-field, special chars), exports the plugin from `plugins/index`, and fixes linting (no functional changes).

<sup>Written for commit 2b871b3723f7fc8e6e2352b0d53488c57cf292ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

