### PR TITLE
feat(account): support server-side accountInfo calls without session headers

### DIFF
--- a/.changeset/eager-cloths-stay.md
+++ b/.changeset/eager-cloths-stay.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+support server-side accountInfo calls without session headers

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -108,7 +108,10 @@ server-side usage:
 
 ```ts
 await auth.api.accountInfo({
-  query: { accountId: "accountId" },
+  query: {
+    accountId: "accountId",
+    userId: "userId", // optional, if you don't provide headers with authenticated token
+  },
   headers: await headers() // headers containing the user's session token
 });
 ```

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -820,6 +820,13 @@ const accountInfoQuerySchema = z.optional(
 					"The provider given account id for which to get the account info",
 			})
 			.optional(),
+		userId: z
+			.string()
+			.meta({
+				description:
+					"The user ID associated with the account. Optional — only needed for server-side calls without session headers.",
+			})
+			.optional(),
 	}),
 );
 
@@ -827,7 +834,6 @@ export const accountInfo = createAuthEndpoint(
 	"/account-info",
 	{
 		method: "GET",
-		use: [sessionMiddleware],
 		metadata: {
 			openapi: {
 				description: "Get the account info provided by the provider",
@@ -878,7 +884,17 @@ export const accountInfo = createAuthEndpoint(
 		query: accountInfoQuerySchema,
 	},
 	async (ctx) => {
-		const providedAccountId = ctx.query?.accountId;
+		const { accountId: providedAccountId, userId } = ctx.query || {};
+		const req = ctx.request;
+		const session = await getSessionFromCtx(ctx);
+		if (req && !session) {
+			throw ctx.error("UNAUTHORIZED");
+		}
+		const resolvedUserId = session?.user?.id || userId;
+		if (!resolvedUserId) {
+			throw ctx.error("UNAUTHORIZED");
+		}
+
 		let account: Account | undefined = undefined;
 		if (!providedAccountId) {
 			if (ctx.context.options.account?.storeAccountCookie) {
@@ -895,7 +911,7 @@ export const accountInfo = createAuthEndpoint(
 			}
 		}
 
-		if (!account || account.userId !== ctx.context.session.user.id) {
+		if (!account || account.userId !== resolvedUserId) {
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.ACCOUNT_NOT_FOUND);
 		}
 


### PR DESCRIPTION
## Summary

- Remove `sessionMiddleware` from `accountInfo` and add manual session resolution following the same pattern as `getAccessToken`
- Add optional `userId` query parameter so server-side callers can use `auth.api.accountInfo()` without needing to construct session headers
- Update docs to show the new `userId` parameter in the server-side example
- Fully backwards compatible
- Tested patching node_modules locally and it worked

Closes #8350 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable server-side accountInfo calls without session headers by adding an optional userId and aligning auth with getAccessToken. Calls can use a session token or userId and remain backward compatible; docs now show a server-side example.

- **New Features**
  - Added `query.userId` for server-side calls without session headers.
  - Replaced session middleware with manual session resolution; require session or userId and validate the account against the resolved user.

<sup>Written for commit 5617cd4606f747fa6f55cbf39562ba5f94d22771. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



