### PR TITLE
fix(sso): use internalAdapter for verification operations

### DIFF
--- a/packages/sso/src/domain-verification.test.ts
+++ b/packages/sso/src/domain-verification.test.ts
@@ -29,16 +29,28 @@ describe("Domain verification", async () => {
 		name: "Test User",
 	};
 
-	const createTestAuth = (options?: SSOOptions) => {
-		const data = {
+	const createTestAuth = (
+		options?: SSOOptions,
+		betterAuthOptions?: {
+			secondaryStorage?: {
+				set: (key: string, value: string, ttl?: number) => void;
+				get: (key: string) => string | null;
+				delete: (key: string) => void;
+			};
+		},
+	) => {
+		const data: Record<string, any[]> = {
 			user: [],
 			session: [],
-			verification: [],
 			account: [],
 			ssoProvider: [],
 			member: [],
 			organization: [],
 		};
+
+		if (!betterAuthOptions?.secondaryStorage) {
+			data.verification = [];
+		}
 
 		const memory = memoryAdapter(data);
 
@@ -56,6 +68,7 @@ describe("Domain verification", async () => {
 			emailAndPassword: {
 				enabled: true,
 			},
+			secondaryStorage: betterAuthOptions?.secondaryStorage,
 			plugins: [sso(ssoOptions), organization()],
 		});
 
@@ -587,6 +600,63 @@ describe("Domain verification", async () => {
 				message: "Domain has already been verified",
 				code: "DOMAIN_VERIFIED",
 			});
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8348
+	 */
+	describe("with secondaryStorage (no storeInDatabase)", () => {
+		it("should request and verify domain verification via secondary storage", async () => {
+			const store = new Map<string, string>();
+			const { auth, getAuthHeaders, registerSSOProvider } = createTestAuth(
+				undefined,
+				{
+					secondaryStorage: {
+						set(key, value, ttl) {
+							store.set(key, value);
+						},
+						get(key) {
+							return store.get(key) || null;
+						},
+						delete(key) {
+							store.delete(key);
+						},
+					},
+				},
+			);
+
+			const headers = await getAuthHeaders(testUser);
+			const provider = await registerSSOProvider(headers);
+
+			expect(provider.domainVerificationToken).toBeTypeOf("string");
+
+			// Re-request should return the existing token from secondary storage
+			const response = await auth.api.requestDomainVerification({
+				body: { providerId: provider.providerId },
+				headers,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(201);
+			expect(await response.json()).toEqual({
+				domainVerificationToken: provider.domainVerificationToken,
+			});
+
+			// Verify domain via DNS
+			dnsMock.resolveTxt.mockResolvedValue([
+				[
+					`_better-auth-token-saml-provider-1=${provider.domainVerificationToken}`,
+				],
+			]);
+
+			const verifyResponse = await auth.api.verifyDomain({
+				body: { providerId: provider.providerId },
+				headers,
+				asResponse: true,
+			});
+
+			expect(verifyResponse.status).toBe(204);
 		});
 	});
 });

--- a/packages/sso/src/routes/domain-verification.ts
+++ b/packages/sso/src/routes/domain-verification.ts
@@ -1,4 +1,3 @@
-import type { Verification } from "better-auth";
 import {
 	APIError,
 	createAuthEndpoint,
@@ -101,32 +100,21 @@ export const requestDomainVerification = (options: SSOOptions) => {
 			);
 
 			const activeVerification =
-				await ctx.context.adapter.findOne<Verification>({
-					model: "verification",
-					where: [
-						{
-							field: "identifier",
-							value: identifier,
-						},
-						{ field: "expiresAt", value: new Date(), operator: "gt" },
-					],
-				});
+				await ctx.context.internalAdapter.findVerificationValue(identifier);
 
-			if (activeVerification) {
+			if (
+				activeVerification &&
+				new Date(activeVerification.expiresAt) > new Date()
+			) {
 				ctx.setStatus(201);
 				return ctx.json({ domainVerificationToken: activeVerification.value });
 			}
 
 			const domainVerificationToken = generateRandomString(24);
-			await ctx.context.adapter.create<Verification>({
-				model: "verification",
-				data: {
-					identifier,
-					createdAt: new Date(),
-					updatedAt: new Date(),
-					value: domainVerificationToken,
-					expiresAt: new Date(Date.now() + 3600 * 24 * 7 * 1000), // 1 week
-				},
+			await ctx.context.internalAdapter.createVerificationValue({
+				identifier,
+				value: domainVerificationToken,
+				expiresAt: new Date(Date.now() + 3600 * 24 * 7 * 1000), // 1 week
 			});
 
 			ctx.setStatus(201);
@@ -225,18 +213,12 @@ export const verifyDomain = (options: SSOOptions) => {
 			}
 
 			const activeVerification =
-				await ctx.context.adapter.findOne<Verification>({
-					model: "verification",
-					where: [
-						{
-							field: "identifier",
-							value: identifier,
-						},
-						{ field: "expiresAt", value: new Date(), operator: "gt" },
-					],
-				});
+				await ctx.context.internalAdapter.findVerificationValue(identifier);
 
-			if (!activeVerification) {
+			if (
+				!activeVerification ||
+				new Date(activeVerification.expiresAt) <= new Date()
+			) {
 				throw new APIError("NOT_FOUND", {
 					message: "No pending domain verification exists",
 					code: "NO_PENDING_VERIFICATION",

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1,5 +1,5 @@
 import { BetterFetchError, betterFetch } from "@better-fetch/fetch";
-import type { User, Verification } from "better-auth";
+import type { User } from "better-auth";
 import {
 	createAuthorizationURL,
 	generateState,
@@ -910,15 +910,10 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 				domainVerified = false;
 				domainVerificationToken = generateRandomString(24);
 
-				await ctx.context.adapter.create<Verification>({
-					model: "verification",
-					data: {
-						identifier: getVerificationIdentifier(options, provider.providerId),
-						createdAt: new Date(),
-						updatedAt: new Date(),
-						value: domainVerificationToken as string,
-						expiresAt: new Date(Date.now() + 3600 * 24 * 7 * 1000), // 1 week
-					},
+				await ctx.context.internalAdapter.createVerificationValue({
+					identifier: getVerificationIdentifier(options, provider.providerId),
+					value: domainVerificationToken as string,
+					expiresAt: new Date(Date.now() + 3600 * 24 * 7 * 1000), // 1 week
 				});
 			}
 


### PR DESCRIPTION
## Summary
- SSO domain-verification and provider registration routes were using `ctx.context.adapter` directly with `model: "verification"`, bypassing the internal adapter's secondary storage routing
- When `secondaryStorage` is configured without `verification.storeInDatabase: true`, the verification model is excluded from the schema, causing `Model "verification" not found in schema` errors in these SSO routes
- Switch to `ctx.context.internalAdapter.createVerificationValue` / `findVerificationValue` which properly route through secondary storage

## Test plan
- [x] All 326 SSO tests passing
- [x] `magic-link-secondary-storage.test.ts` passing (6/6)
- [x] `magic-link.test.ts` passing (16/16)
- [x] `internal-adapter.test.ts` passing (33/33)
- [x] `pnpm typecheck` passing
- [x] `pnpm lint` passing

Closes #8348