### PR TITLE
fix(sso): allow bare domains for SSO domain verification 

### DIFF
--- a/packages/sso/src/domain-verification.test.ts
+++ b/packages/sso/src/domain-verification.test.ts
@@ -122,12 +122,13 @@ describe("Domain verification", async () => {
 		async function registerSSOProvider(
 			headers: Headers,
 			organizationId?: string,
+			domain = "hello.com",
 		) {
 			return auth.api.registerSSOProvider({
 				body: {
 					providerId: "saml-provider-1",
 					issuer: "http://hello.com:8081",
-					domain: "http://hello.com:8081",
+					domain,
 					samlConfig: {
 						entryPoint: "http://idp.com:",
 						cert: "the-cert",
@@ -472,6 +473,43 @@ describe("Domain verification", async () => {
 			const { auth, getAuthHeaders, registerSSOProvider } = createTestAuth();
 			const headers = await getAuthHeaders(testUser);
 			const provider = await registerSSOProvider(headers);
+
+			expect(provider.domain).toBe("hello.com");
+			expect(provider.domainVerified).toBe(false);
+			expect(provider.domainVerificationToken).toBeTypeOf("string");
+
+			dnsMock.resolveTxt.mockResolvedValue([
+				["google-site-verification=the-token"],
+				[
+					"v=spf1 ip4:50.242.118.232/29 include:_spf.google.com include:mail.zendesk.com ~all",
+				],
+				[
+					`_better-auth-token-saml-provider-1=${provider.domainVerificationToken}`,
+				],
+			]);
+
+			const response = await auth.api.verifyDomain({
+				body: {
+					providerId: provider.providerId,
+				},
+				headers,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(204);
+			expect(dnsMock.resolveTxt).toHaveBeenCalledWith(
+				"_better-auth-token-saml-provider-1.hello.com",
+			);
+		});
+
+		it("should verify a provider domain ownership when provider domain is a URL", async () => {
+			const { auth, getAuthHeaders, registerSSOProvider } = createTestAuth();
+			const headers = await getAuthHeaders(testUser);
+			const provider = await registerSSOProvider(
+				headers,
+				undefined,
+				"http://hello.com:8081",
+			);
 
 			expect(provider.domain).toBe("http://hello.com:8081");
 			expect(provider.domainVerified).toBe(false);

--- a/packages/sso/src/routes/domain-verification.ts
+++ b/packages/sso/src/routes/domain-verification.ts
@@ -9,6 +9,7 @@ import type { SSOOptions, SSOProvider } from "../types";
 
 const DNS_LABEL_MAX_LENGTH = 63;
 const DEFAULT_TOKEN_PREFIX = "better-auth-token";
+const SCHEME_REGEX = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//;
 
 const domainVerificationBodySchema = z.object({
 	providerId: z.string(),
@@ -21,6 +22,15 @@ export function getVerificationIdentifier(
 	const tokenPrefix =
 		options.domainVerification?.tokenPrefix || DEFAULT_TOKEN_PREFIX;
 	return `_${tokenPrefix}-${providerId}`;
+}
+
+function getHostnameFromDomainInput(domain: string): string {
+	const trimmedDomain = domain.trim();
+	const normalizedDomain = SCHEME_REGEX.test(trimmedDomain)
+		? trimmedDomain
+		: `https://${trimmedDomain}`;
+
+	return new URL(normalizedDomain).hostname;
 }
 
 export const requestDomainVerification = (options: SSOOptions) => {
@@ -242,7 +252,7 @@ export const verifyDomain = (options: SSOOptions) => {
 			}
 
 			try {
-				const hostname = new URL(provider.domain).hostname;
+				const hostname = getHostnameFromDomainInput(provider.domain);
 				const dnsRecords = await dns.resolveTxt(`${identifier}.${hostname}`);
 				records = dnsRecords.flat();
 			} catch (error) {


### PR DESCRIPTION
Resolves #8361

### Description
The SSO `requestDomainVerification` and `verifyDomain` endpoints previously threw an `ERR_INVALID_URL` if the SSO provider was registered with a bare domain (e.g., `github.com`) instead of a full URL (e.g., `https://github.com`). This mismatch occurred because the native `URL` constructor requires a protocol scheme.

This PR introduces an internal normalization helper (`getHostnameFromDomainInput`) that prepends a secure scheme (`https://`) to bare domains before parsing them. 

### Changes
- Replaced direct `new URL()` calls with a normalization function in `packages/sso/src/routes/domain-verification.ts`.
- Updated test fixtures to use a bare domain (`hello.com`) as the default to prevent future regressions.
- Added a dedicated test case to ensure full URLs (`http://hello.com:8081`) continue to be parsed correctly, preserving backward compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SSO domain verification to accept bare domains (e.g., github.com) without throwing ERR_INVALID_URL. We normalize inputs by adding https when missing and parse the hostname, keeping full URLs supported.

- **Bug Fixes**
  - Added getHostnameFromDomainInput to normalize domain inputs and safely extract the hostname.
  - Updated tests to default to a bare domain and added a case for full URLs to prevent regressions.

<sup>Written for commit 4f29c609bd6274f2ae6d7d7e5a07363e9f2dc875. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

