### PR TITLE
docs: add warning to SQLite documentation for bun:sqlite

### DIFF
--- a/docs/content/docs/adapters/sqlite.mdx
+++ b/docs/content/docs/adapters/sqlite.mdx
@@ -52,6 +52,10 @@ node your-app.js
 
 ### Bun Built-in SQLite
 
+<Callout type="warning">
+  Use `bunx` with the `--bun` flag to run cli commands to prevent seeing type errors related to recognizing the `bun:sqlite` module, eg: `bunx --bun auth@latest generate`
+</Callout>
+
 You can also use the built-in [SQLite](https://bun.com/docs/api/sqlite) module in Bun, which is similar to the Node.js version:
 
 ```ts title="auth.ts"


### PR DESCRIPTION
I ran into the issue with `bun:sqlite` that if you dont use `bunx --bun` to run the cli commands, the cli fails because it does not recognize the `bun:sqlite` module. This is quite frustrating to figure out so I thought adding it to the docs makes sense.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a warning callout in the SQLite adapter docs telling Bun users to run CLI commands with bunx --bun (e.g., bunx --bun auth@latest generate) to avoid bun:sqlite type errors.

<sup>Written for commit d471e2f2977c7e7004502a6fc6df1d2cbe8824f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

