### PR TITLE
feat(community-plugins): add better-auth-vercel-geolocation plugin 

### DIFF
--- a/landing/components/community-plugins-table.tsx
+++ b/landing/components/community-plugins-table.tsx
@@ -290,6 +290,17 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/iamjasonkendrick.png",
 		},
 	},
+	{
+		name: "better-auth-vercel-geolocation",
+		url: "https://github.com/weepaho3/better-auth-vercel-geolocation",
+		description:
+			"Enriches sessions with Vercel Edge geolocation data from x-vercel-ip-* headers — e.g. city, country, region, timezone and more. Optionally updates on session refresh.",
+		author: {
+			name: "weepaho3",
+			github: "weepaho3",
+			avatar: "https://github.com/weepaho3.png",
+		},
+	},
 ];
 export function CommunityPluginsTable() {
 	const [sorting, setSorting] = useState<SortingState>([]);


### PR DESCRIPTION
Adds better-auth-vercel-geolocation to the community plugins list.

What it does: Enriches sessions with Vercel Edge geolocation data from x-vercel-ip-* headers — e.g. city, country, country region, flag, timezone, coordinates, and postal code. Optionally updates on session refresh.

npm: [better-auth-vercel-geolocation](https://www.npmjs.com/package/better-auth-vercel-geolocation)
GitHub: [better-auth-vercel-geolocation](https://github.com/weepaho3/better-auth-vercel-geolocation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds better-auth-vercel-geolocation to the community plugins table. The plugin enriches sessions with Vercel Edge geolocation from x-vercel-ip-* headers (city, country, region, timezone, etc.) and can update on session refresh.

<sup>Written for commit 3641abb75105cc892398e73111dc380628b5df0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

