### PR TITLE
docs: fix railway developer portal link

### DIFF
--- a/docs/content/docs/authentication/railway.mdx
+++ b/docs/content/docs/authentication/railway.mdx
@@ -6,7 +6,7 @@ description: Railway provider setup and usage.
 <Steps>
     <Step> 
         ### Get your Railway credentials
-        To use Railway sign in, you need a client ID and client secret. You can get them from the [Railway Developer Settings](https://railway.com/account/developer).
+        To use Railway sign in, you need a client ID and client secret. You can get them from the [Railway Developer Settings](https://railway.com/workspace/developer).
 
         1. Go to your Railway account's Developer Settings
         2. Click "Create OAuth App"


### PR DESCRIPTION
Fixed the hyperlink

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Railway Developer Settings link in the authentication docs to the correct /workspace/developer URL so users can create OAuth apps without hitting a 404.

<sup>Written for commit 4a2f3dd92898ce76367f11a99024d88a55c7b3c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

