### PR TITLE
Fix: handle multi-role member.role in organization invite check

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -263,7 +263,7 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 			}
 
 			if (
-				member.role !== creatorRole &&
+				!member.role.split(",").includes(creatorRole) &&
 				roles.split(",").includes(creatorRole)
 			) {
 				throw APIError.from(


### PR DESCRIPTION
Fixes a bug where member.role may contain multiple comma-separated roles and the code treated it as a single value, causing incorrect permission checks.

References: better-auth/better-auth#8385

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect permission checks when creating organization invitations if member.role contains multiple comma-separated roles. We now split roles and verify inclusion, preventing valid creators from being blocked.

<sup>Written for commit 4bac70bb16b6bcfc9c01161846e1b9fcf20f245d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

