### PR TITLE
fix: move adapter packages to dependencies to fix missing module errors

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -489,8 +489,11 @@
   },
   "dependencies": {
     "@better-auth/core": "workspace:*",
+    "@better-auth/drizzle-adapter": "workspace:*",
     "@better-auth/kysely-adapter": "workspace:*",
     "@better-auth/memory-adapter": "workspace:*",
+    "@better-auth/mongo-adapter": "workspace:*",
+    "@better-auth/prisma-adapter": "workspace:*",
     "@better-auth/telemetry": "workspace:*",
     "@better-auth/utils": "catalog:",
     "@better-fetch/fetch": "catalog:",
@@ -504,9 +507,6 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@better-auth/drizzle-adapter": "workspace:*",
-    "@better-auth/mongo-adapter": "workspace:*",
-    "@better-auth/prisma-adapter": "workspace:*",
     "@lynx-js/react": "^0.116.3",
     "@sveltejs/kit": "^2.53.3",
     "@tanstack/react-start": "^1.163.2",
@@ -538,9 +538,6 @@
     "vue": "^3.5.29"
   },
   "peerDependencies": {
-    "@better-auth/drizzle-adapter": "workspace:*",
-    "@better-auth/mongo-adapter": "workspace:*",
-    "@better-auth/prisma-adapter": "workspace:*",
     "@lynx-js/react": "*",
     "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "@sveltejs/kit": "^2.0.0",
@@ -562,15 +559,6 @@
     "vue": "^3.0.0"
   },
   "peerDependenciesMeta": {
-    "@better-auth/drizzle-adapter": {
-      "optional": true
-    },
-    "@better-auth/mongo-adapter": {
-      "optional": true
-    },
-    "@better-auth/prisma-adapter": {
-      "optional": true
-    },
     "@lynx-js/react": {
       "optional": true
     },

--- a/packages/prisma-adapter/package.json
+++ b/packages/prisma-adapter/package.json
@@ -41,9 +41,6 @@
       "default": "./dist/index.mjs"
     }
   },
-  "dependencies": {
-    "@prisma/client": "^7.4.1"
-  },
   "peerDependencies": {
     "@better-auth/core": "workspace:*",
     "@better-auth/utils": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -987,12 +987,21 @@ importers:
       '@better-auth/core':
         specifier: workspace:*
         version: link:../core
+      '@better-auth/drizzle-adapter':
+        specifier: workspace:*
+        version: link:../drizzle-adapter
       '@better-auth/kysely-adapter':
         specifier: workspace:*
         version: link:../kysely-adapter
       '@better-auth/memory-adapter':
         specifier: workspace:*
         version: link:../memory-adapter
+      '@better-auth/mongo-adapter':
+        specifier: workspace:*
+        version: link:../mongo-adapter
+      '@better-auth/prisma-adapter':
+        specifier: workspace:*
+        version: link:../prisma-adapter
       '@better-auth/telemetry':
         specifier: workspace:*
         version: link:../telemetry
@@ -1051,15 +1060,6 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@better-auth/drizzle-adapter':
-        specifier: workspace:*
-        version: link:../drizzle-adapter
-      '@better-auth/mongo-adapter':
-        specifier: workspace:*
-        version: link:../mongo-adapter
-      '@better-auth/prisma-adapter':
-        specifier: workspace:*
-        version: link:../prisma-adapter
       '@lynx-js/react':
         specifier: ^0.116.3
         version: 0.116.3(@types/react@19.2.14)
@@ -1529,7 +1529,7 @@ importers:
   packages/prisma-adapter:
     dependencies:
       '@prisma/client':
-        specifier: ^7.4.1
+        specifier: ^5.0.0 || ^6.0.0 || ^7.0.0
         version: 7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       '@better-auth/core':


### PR DESCRIPTION
## Summary
- Moves `@better-auth/prisma-adapter`, `@better-auth/drizzle-adapter`, and `@better-auth/mongo-adapter` from `devDependencies` + `peerDependencies` → `dependencies` in the `better-auth` package
- Removes `@prisma/client` from `@better-auth/prisma-adapter`'s `dependencies` (already a `peerDependency`), so users aren't forced to install a specific version

This fixes the issue where `import ... from "better-auth/adapters/prisma"` (and drizzle/mongodb) fails at runtime because the underlying `@better-auth/*-adapter` packages aren't installed. The adapter packages themselves already declare their heavy deps (`@prisma/client`, `drizzle-orm`, `mongodb`) as peer dependencies, so users only install those if they actually use the adapter.

Closes #8382

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm typecheck` passes (no new errors)
- [x] Verify `better-auth/adapters/prisma` resolves correctly when `better-auth` is installed without explicitly installing `@better-auth/prisma-adapter`