### PR TITLE
fix(oauth-provider): use pairwise sub in JWT access tokens (RFC 9068 §6)

### DIFF
--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1406,10 +1406,11 @@ Pairwise identifiers are computed using HMAC-SHA256 over the **sector identifier
 
 Pairwise `sub` appears in:
 - `id_token`
+- JWT access tokens (per [RFC 9068 §6](https://datatracker.ietf.org/doc/html/rfc9068#section-6))
 - `/oauth2/userinfo` response
 - Token introspection (`/oauth2/introspect`)
 
-JWT access tokens always use the real user ID as `sub`, since resource servers may need to look up users directly.
+Public clients always use the real user ID as `sub` across all token types.
 
 <Callout type="warn">
 **Limitations:**

--- a/packages/oauth-provider/src/pairwise.test.ts
+++ b/packages/oauth-provider/src/pairwise.test.ts
@@ -286,7 +286,7 @@ describe("pairwise subject identifiers", async () => {
 		expect(refreshedIdToken.sub).toBe(originalIdToken.sub);
 	});
 
-	it("should keep user.id in JWT access token sub (not pairwise)", async () => {
+	it("should use pairwise sub in JWT access token (RFC 9068 §6)", async () => {
 		const tokens = await getTokensForClient(pairwiseClientA!, redirectUriA, {
 			resource: validAudience,
 		});
@@ -294,9 +294,36 @@ describe("pairwise subject identifiers", async () => {
 		const accessToken = decodeJwt(tokens.data!.access_token!);
 		const idToken = decodeJwt(tokens.data!.id_token!);
 
-		// JWT access token uses real user.id for user lookup
+		// JWT access token uses same pairwise sub as id_token per RFC 9068 §6
 		expect(accessToken.sub).toBeDefined();
-		expect(accessToken.sub).not.toBe(idToken.sub);
+		expect(accessToken.sub).toBe(idToken.sub);
+	});
+
+	it("should produce different JWT access token sub across pairwise clients", async () => {
+		const tokensA = await getTokensForClient(pairwiseClientA!, redirectUriA, {
+			resource: validAudience,
+		});
+		const tokensB = await getTokensForClient(pairwiseClientB!, redirectUriB, {
+			resource: validAudience,
+		});
+
+		const accessTokenA = decodeJwt(tokensA.data!.access_token!);
+		const accessTokenB = decodeJwt(tokensB.data!.access_token!);
+
+		// Different sectors → different pairwise sub in JWT access tokens too
+		expect(accessTokenA.sub).not.toBe(accessTokenB.sub);
+	});
+
+	it("should keep user.id in JWT access token for public clients", async () => {
+		const tokens = await getTokensForClient(publicClient!, redirectUriPublic, {
+			resource: validAudience,
+		});
+
+		const accessToken = decodeJwt(tokens.data!.access_token!);
+		const idToken = decodeJwt(tokens.data!.id_token!);
+
+		// Public client: both use real user.id
+		expect(accessToken.sub).toBe(idToken.sub);
 	});
 });
 

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -94,12 +94,17 @@ async function createJwtAccessToken(
 
 	const jwtPluginOptions = getJwtPlugin(ctx.context).options;
 
+	// Resolve pairwise sub for JWT access tokens per RFC 9068 §6:
+	// "the authorization server SHOULD ensure that JWT access tokens meant
+	// for different resource servers have distinct sub values"
+	const resolvedSub = await resolveSubjectIdentifier(user.id, client, opts);
+
 	// Sign token
 	return signJWT(ctx, {
 		options: jwtPluginOptions,
 		payload: {
 			...customClaims,
-			sub: user.id,
+			sub: resolvedSub,
 			aud:
 				typeof audience === "string"
 					? audience


### PR DESCRIPTION
Follow-up to #8292

Missed applying pairwise `sub` resolution to JWT access tokens.

RFC 9068 §6 recommends that "the authorization server SHOULD ensure that JWT access tokens meant for different resource servers have distinct `sub` values that cannot be correlated." The pairwise PR only applied `resolveSubjectIdentifier` to id_tokens, userinfo, and introspection; JWT access tokens still used the raw `user.id`.

This applies the same pairwise resolution to `createJwtAccessToken`. Public clients are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply pairwise subject identifiers to JWT access tokens per RFC 9068 §6 to prevent cross-resource correlation. Public clients are unchanged and still use user.id as sub.

- **Bug Fixes**
  - Sign JWT access tokens with resolveSubjectIdentifier instead of user.id.
  - Tests: ensure access token sub matches id_token for pairwise clients, differs across sectors, and remains user.id for public clients.
  - Docs: note pairwise sub applies to JWT access tokens; clarify public client behavior.

<sup>Written for commit 6f73641ed03e4cd0c891eb10007382ef088c9950. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

