### PR TITLE
docs: add warning to SQLite documentation for bun:sqlite

### DIFF
--- a/docs/content/docs/adapters/sqlite.mdx
+++ b/docs/content/docs/adapters/sqlite.mdx
@@ -52,6 +52,10 @@ node your-app.js
 
 ### Bun Built-in SQLite
 
+<Callout type="warning">
+  Use `bunx` with the `--bun` flag to run cli commands to prevent seeing type errors related to recognizing the `bun:sqlite` module, eg: `bunx --bun auth@latest generate`
+</Callout>
+
 You can also use the built-in [SQLite](https://bun.com/docs/api/sqlite) module in Bun, which is similar to the Node.js version:
 
 ```ts title="auth.ts"


### PR DESCRIPTION
## Summary

- Add a callout warning for Bun users to use `bunx --bun` flag when running CLI commands to prevent type errors related to the `bun:sqlite` module

Based on #8373

## Test plan

- [ ] Verify the docs page renders the callout correctly