### PR TITLE
fix(two-factor): wire twoFactorTable option to schema modelName

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -441,7 +441,15 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 				},
 			],
 		},
-		schema: mergeSchema(schema, options?.schema),
+		schema: mergeSchema(schema, {
+			...options?.schema,
+			twoFactor: {
+				...options?.schema?.twoFactor,
+				...(options?.twoFactorTable
+					? { modelName: options.twoFactorTable }
+					: {}),
+			},
+		}),
 		rateLimit: [
 			{
 				pathMatcher(path) {

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -1394,6 +1394,45 @@ describe("twoFactorCookieMaxAge", async () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8424
+ */
+describe("twoFactorTable option", async () => {
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [
+			twoFactor({
+				twoFactorTable: "custom_two_factor",
+				skipVerificationOnEnable: true,
+			}),
+		],
+	});
+
+	let { headers } = await signInWithTestUser();
+
+	it("should use custom table name for two factor data", async () => {
+		const enableRes = await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+		expect(enableRes.status).toBe(200);
+		headers = convertSetCookieToCookie(enableRes.headers);
+
+		const twoFactorRecord = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [
+				{
+					field: "userId",
+					value: (await auth.api.getSession({ headers }))?.user.id as string,
+				},
+			],
+		});
+		expect(twoFactorRecord).toBeDefined();
+		expect(twoFactorRecord?.secret).toBeDefined();
+	});
+});
+
 describe("OTP storage modes", async () => {
 	describe("hashed OTP storage", async () => {
 		let OTP = "";

--- a/packages/better-auth/src/plugins/two-factor/types.ts
+++ b/packages/better-auth/src/plugins/two-factor/types.ts
@@ -11,6 +11,13 @@ export interface TwoFactorOptions {
 	 */
 	issuer?: string | undefined;
 	/**
+	 * The name of the table that stores the two factor
+	 * authentication data.
+	 *
+	 * @default "twoFactor"
+	 */
+	twoFactorTable?: string | undefined;
+	/**
 	 * TOTP OPtions
 	 */
 	totpOptions?: Omit<TOTPOptions, "issuer"> | undefined;


### PR DESCRIPTION
## Summary
- The `twoFactorTable` option in the two-factor plugin was documented but never actually wired up — it was always hardcoded to `"twoFactor"`
- Now `twoFactorTable` correctly sets the schema `modelName`, so the adapter maps queries to the user-specified table name
- Added `twoFactorTable` property to the `TwoFactorOptions` type

Closes #8424

## Test plan
- [x] Added regression test that configures `twoFactorTable: "custom_two_factor"` and verifies enable/query works
- [x] Existing two-factor tests still pass
- [x] Typecheck passes
- [x] Lint passes