### PR TITLE
fix: use fallback URL as initial baseURL for dynamic config

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -23,6 +23,11 @@ import type {
 import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
 import { createDefu } from "defu";
 import { isAPIError } from "../utils/is-api-error";
+import {
+	getOrigin,
+	isDynamicBaseURLConfig,
+	resolveBaseURL,
+} from "../utils/url";
 
 type InternalContext = Partial<
 	InputContext<string, any, any, any, any, any> &
@@ -105,6 +110,27 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 
 			const run = async () => {
 				const authContext = await ctx;
+
+				let effectiveAuthContext = authContext;
+				if (isDynamicBaseURLConfig(authContext.options.baseURL)) {
+					const basePath = authContext.options.basePath || "/api/auth";
+					const resolved = resolveBaseURL(
+						authContext.options.baseURL,
+						basePath,
+						context?.request,
+					);
+					if (resolved && resolved !== authContext.baseURL) {
+						effectiveAuthContext = {
+							...authContext,
+							baseURL: resolved,
+							options: {
+								...authContext.options,
+								baseURL: getOrigin(resolved) || undefined,
+							},
+						};
+					}
+				}
+
 				const methodName =
 					context?.method ?? context?.request?.method ?? defaultMethod ?? "?";
 				const pathName = context?.path ?? endpoint.path ?? "/:virtual";
@@ -112,7 +138,7 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 				let internalContext: InternalContext = {
 					...context,
 					context: {
-						...authContext,
+						...effectiveAuthContext,
 						returned: undefined,
 						responseHeaders: undefined,
 						session: null,
@@ -128,7 +154,8 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 					},
 					async () =>
 						runWithEndpointContext(internalContext, async () => {
-							const { beforeHooks, afterHooks } = getHooks(authContext);
+							const { beforeHooks, afterHooks } =
+								getHooks(effectiveAuthContext);
 							const before = await runBeforeHooks(
 								internalContext,
 								beforeHooks,
@@ -226,7 +253,7 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 
 							if (
 								isAPIError(result.response) &&
-								shouldPublishLog(authContext.logger.level, "debug")
+								shouldPublishLog(effectiveAuthContext.logger.level, "debug")
 							) {
 								// inherit stack from errorStack if debug mode is enabled
 								result.response.stack = result.response.errorStack;

--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -206,6 +206,62 @@ describe("auth with dynamic baseURL (allowedHosts)", () => {
 		expect(ctx.baseURL).toBe("http://localhost:5173/api/auth");
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8447
+	 */
+	test("should resolve baseURL in direct API calls with request", async () => {
+		const endpoints = {
+			getBaseURL: createAuthEndpoint(
+				"/get-base-url",
+				{ method: "GET" },
+				async (ctx) => {
+					return ctx.json({ baseURL: ctx.context.baseURL });
+				},
+			),
+		};
+		const { auth } = await getTestInstance({
+			baseURL: {
+				allowedHosts: ["myapp.com", "localhost:*"],
+				fallback: "http://localhost:5173",
+			},
+			plugins: [{ id: "test-plugin", endpoints }],
+		});
+
+		const result = await auth.api.getBaseURL({
+			request: new Request("https://myapp.com/api/auth/get-base-url", {
+				headers: {
+					host: "myapp.com",
+				},
+			}),
+		});
+		expect(result.baseURL).toBe("https://myapp.com/api/auth");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8447
+	 */
+	test("should use fallback baseURL in direct API calls without request", async () => {
+		const endpoints = {
+			getBaseURL: createAuthEndpoint(
+				"/get-base-url",
+				{ method: "GET" },
+				async (ctx) => {
+					return ctx.json({ baseURL: ctx.context.baseURL });
+				},
+			),
+		};
+		const { auth } = await getTestInstance({
+			baseURL: {
+				allowedHosts: ["myapp.com", "localhost:*"],
+				fallback: "http://localhost:5173",
+			},
+			plugins: [{ id: "test-plugin", endpoints }],
+		});
+
+		const result = await auth.api.getBaseURL();
+		expect(result.baseURL).toBe("http://localhost:5173/api/auth");
+	});
+
 	test("should use fallback for disallowed host", async () => {
 		let baseURL: string | undefined;
 		const { customFetchImpl } = await getTestInstance({

--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -192,6 +192,20 @@ describe("auth with dynamic baseURL (allowedHosts)", () => {
 		).rejects.toThrow('Host "evil.com" is not in the allowed hosts list');
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8447
+	 */
+	test("should use fallback as initial baseURL for non-request contexts", async () => {
+		const { auth } = await getTestInstance({
+			baseURL: {
+				allowedHosts: ["localhost:*"],
+				fallback: "http://localhost:5173",
+			},
+		});
+		const ctx = await auth.$context;
+		expect(ctx.baseURL).toBe("http://localhost:5173/api/auth");
+	});
+
 	test("should use fallback for disallowed host", async () => {
 		let baseURL: string | undefined;
 		const { customFetchImpl } = await getTestInstance({

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -126,12 +126,16 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 		}
 	}
 
-	const baseURL = isDynamicConfig
-		? undefined
-		: getBaseURL(
-				typeof options.baseURL === "string" ? options.baseURL : undefined,
-				options.basePath,
-			);
+	const basePath = options.basePath || "/api/auth";
+	const baseURL =
+		isDynamicConfig && isDynamicBaseURLConfig(options.baseURL)
+			? options.baseURL.fallback
+				? getBaseURL(options.baseURL.fallback, basePath)
+				: getBaseURL(undefined, basePath, undefined, true)
+			: getBaseURL(
+					typeof options.baseURL === "string" ? options.baseURL : undefined,
+					basePath,
+				);
 
 	if (!baseURL && !isDynamicConfig) {
 		logger.warn(
@@ -178,7 +182,7 @@ Most of the features of Better Auth will not work correctly.`,
 			: baseURL
 				? new URL(baseURL).origin
 				: "",
-		basePath: options.basePath || "/api/auth",
+		basePath,
 		plugins: plugins.concat(internalPlugins),
 	};
 


### PR DESCRIPTION
## Summary

Fixes #8447

- When using dynamic `baseURL` config (with `allowedHosts`), the initial `AuthContext.baseURL` was set to `""` (empty string)
- While per-request resolution in the handler correctly resolved the baseURL, any code accessing `ctx.context.baseURL` outside a request context (e.g. `auth.api.getOpenIdConfig()` or `.well-known/openid-configuration`) got an empty string, producing broken URLs
- Now uses the `fallback` URL (or env vars) to populate the initial baseURL so non-request contexts have a usable value

## Test plan

- [x] Added regression test verifying `ctx.baseURL` uses the fallback URL when dynamic config is used
- [x] All existing dynamic baseURL tests pass
- [x] oauth-provider metadata tests pass
- [x] `pnpm lint`, `pnpm typecheck` pass