### PR TITLE
feat(crypto): native scrypt support for CF Workers

### DIFF
--- a/packages/better-auth/src/crypto/password.test.ts
+++ b/packages/better-auth/src/crypto/password.test.ts
@@ -1,3 +1,5 @@
+import { hex } from "@better-auth/utils/hex";
+import { scryptAsync } from "@noble/hashes/scrypt.js";
 import { describe, expect, it } from "vitest";
 import { hashPassword, verifyPassword } from "./password";
 
@@ -59,5 +61,29 @@ describe("Password hashing and verification", () => {
 		const hash = await hashPassword(password);
 		const isValid = await verifyPassword({ hash, password });
 		expect(isValid).toBe(true);
+	});
+
+	it("should verify a password hashed with @noble/hashes (cross-compatibility)", async () => {
+		const password = "crossCompatTest!";
+		const salt = hex.encode(crypto.getRandomValues(new Uint8Array(16)));
+		const key = await scryptAsync(password.normalize("NFKC"), salt, {
+			N: 16384,
+			p: 1,
+			r: 16,
+			dkLen: 64,
+			maxmem: 128 * 16384 * 16 * 2,
+		});
+		const nobleHash = `${salt}:${hex.encode(key)}`;
+		const isValid = await verifyPassword({ hash: nobleHash, password });
+		expect(isValid).toBe(true);
+	});
+
+	it("should verify a known test vector", async () => {
+		const password = "betterAuthTestVector";
+		const hash = await hashPassword(password);
+		const isValid = await verifyPassword({ hash, password });
+		expect(isValid).toBe(true);
+		const isInvalid = await verifyPassword({ hash, password: "wrong" });
+		expect(isInvalid).toBe(false);
 	});
 });

--- a/packages/better-auth/src/crypto/password.ts
+++ b/packages/better-auth/src/crypto/password.ts
@@ -11,8 +11,51 @@ const config = {
 	dkLen: 64,
 };
 
-async function generateKey(password: string, salt: string) {
-	return await scryptAsync(password.normalize("NFKC"), salt, {
+const nativeScryptFn: Promise<typeof import("node:crypto").scrypt | null> =
+	(async () => {
+		try {
+			const { scrypt } = await import("node:crypto");
+			if (typeof scrypt === "function") return scrypt;
+			return null;
+		} catch {
+			return null;
+		}
+	})();
+
+function nativeGenerateKey(
+	scryptFn: typeof import("node:crypto").scrypt,
+	password: string,
+	salt: string,
+): Promise<Uint8Array> {
+	return new Promise((resolve, reject) => {
+		scryptFn(
+			password,
+			salt,
+			config.dkLen,
+			{
+				N: config.N,
+				r: config.r,
+				p: config.p,
+				maxmem: 128 * config.N * config.r * 2,
+			},
+			(err, derivedKey) => {
+				if (err) reject(err);
+				else resolve(new Uint8Array(derivedKey));
+			},
+		);
+	});
+}
+
+async function generateKey(
+	password: string,
+	salt: string,
+): Promise<Uint8Array> {
+	const normalizedPassword = password.normalize("NFKC");
+	const scryptFn = await nativeScryptFn;
+	if (scryptFn) {
+		return nativeGenerateKey(scryptFn, normalizedPassword, salt);
+	}
+	return scryptAsync(normalizedPassword, salt, {
 		N: config.N,
 		p: config.p,
 		r: config.r,


### PR DESCRIPTION
## Summary

- Adds native `node:crypto` scrypt detection at import time (cached promise)
- Prefers native scrypt when available (Node.js, Cloudflare Workers), falls back to `@noble/hashes/scrypt`
- No change to hash format — fully backwards compatible with existing stored hashes
- Adds cross-compatibility test (hash with noble, verify through main path) and round-trip test

## Motivation

Cloudflare Workers now support `node:crypto.scrypt`. This change lets CF Workers users benefit from the native (faster) implementation automatically, without any configuration.

Closes #8456

## Test plan

- [x] `vitest packages/better-auth/src/crypto/password.test.ts --run` — 9/9 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native node:crypto scrypt support for Cloudflare Workers and Node, with automatic detection and fallback to @noble/hashes. Hash format remains the same, so existing password hashes keep working.

- **New Features**
  - Detects native scrypt at import time (cached promise) and prefers it when available.
  - Falls back to @noble/hashes/scrypt in environments without native support.
  - Adds cross-compatibility and round-trip tests to ensure verification across both paths.

<sup>Written for commit dbf2c2e87a02495518e287d9e3c79215a10ddff2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

