### PR TITLE
fix(adapters): restore deprecated createAdapter and type exports for backcompat

### DIFF
--- a/docs/content/blogs/1-5.mdx
+++ b/docs/content/blogs/1-5.mdx
@@ -779,7 +779,6 @@ All previously deprecated APIs have been removed. This includes deprecated adapt
 
 | Removed | Replacement |
 | --- | --- |
-| `createAdapter` | `createAdapterFactory` |
 | `Adapter` | `DBAdapter` |
 | `TransactionAdapter` | `DBTransactionAdapter` |
 | `Store` (client) | `ClientStore` |

--- a/packages/better-auth/src/adapters/index.ts
+++ b/packages/better-auth/src/adapters/index.ts
@@ -35,3 +35,23 @@ export {
 	initGetFieldAttributes,
 	initGetIdField,
 };
+
+/**
+ * @deprecated Use `createAdapterFactory` instead.
+ */
+export const createAdapter = createAdapterFactory;
+
+/**
+ * @deprecated Use `AdapterFactoryOptions` instead.
+ */
+export type CreateAdapterOptions = AdapterFactoryOptions;
+
+/**
+ * @deprecated Use `AdapterFactoryConfig` instead.
+ */
+export type AdapterConfig = AdapterFactoryConfig;
+
+/**
+ * @deprecated Use `AdapterFactoryCustomizeAdapterCreator` instead.
+ */
+export type CreateCustomAdapter = AdapterFactoryCustomizeAdapterCreator;


### PR DESCRIPTION
## Summary

- Restores `createAdapter`, `CreateAdapterOptions`, `AdapterConfig`, and `CreateCustomAdapter` exports to `better-auth/adapters`
- These were removed in a minor release (#7623), breaking third-party adapters that depended on them (e.g. the mikro-orm adapter)
- Re-exported as `@deprecated` aliases pointing to their replacements (`createAdapterFactory`, `AdapterFactoryOptions`, etc.)
- Should remain until the next major version per semver conventions

Fixes #8403

## Test plan

- [x] Verify `import { createAdapter } from "better-auth/adapters"` resolves without error
- [x] Verify `createAdapter` behaves identically to `createAdapterFactory`
- [x] `pnpm typecheck` passes