### PR TITLE
fix(next-js): support streaming request bodies in App Router

### DIFF
--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -4,6 +4,27 @@ import { setShouldSkipSessionRefresh } from "../api/state/should-session-refresh
 import { parseSetCookieHeader } from "../cookies";
 import { PACKAGE_VERSION } from "../version";
 
+/**
+ * Re-create a standard Request with `duplex: 'half'` so that streaming
+ * bodies work in Next.js App Router route handlers.
+ *
+ * Next.js may hand the handler a Request whose body is a ReadableStream,
+ * but the runtime sometimes loses the internal "disturbed" flag when the
+ * request is forwarded between layers. Constructing a fresh Request with
+ * `duplex: 'half'` ensures the body stream is treated correctly.
+ */
+function toPlainRequest(req: Request): Request {
+	const hasBody = req.method !== "GET" && req.method !== "HEAD";
+	return new Request(req.url, {
+		method: req.method,
+		headers: new Headers(req.headers),
+		...(hasBody && {
+			body: req.body,
+			duplex: "half",
+		}),
+	} as RequestInit);
+}
+
 export function toNextJsHandler(
 	auth:
 		| {
@@ -12,6 +33,7 @@ export function toNextJsHandler(
 		| ((request: Request) => Promise<Response>),
 ) {
 	const handler = async (request: Request) => {
+		request = toPlainRequest(request);
 		return "handler" in auth ? auth.handler(request) : auth(request);
 	};
 	return {

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -33,8 +33,12 @@ export function toNextJsHandler(
 		| ((request: Request) => Promise<Response>),
 ) {
 	const handler = async (request: Request) => {
-		request = toPlainRequest(request);
-		return "handler" in auth ? auth.handler(request) : auth(request);
+		const hasBody =
+			request.method !== "GET" &&
+			request.method !== "HEAD" &&
+			request.body != null;
+		const effectiveRequest = hasBody ? toPlainRequest(request) : request;
+		return "handler" in auth ? auth.handler(effectiveRequest) : auth(effectiveRequest);
 	};
 	return {
 		GET: handler,


### PR DESCRIPTION
## Summary

- Adds a `toPlainRequest` helper in `toNextJsHandler` that re-creates the incoming `Request` with `duplex: 'half'`
- Fixes an issue where Next.js App Router forwards a `Request` whose `ReadableStream` body becomes unreadable because the runtime loses the internal "disturbed" flag between layers
- Without this fix, POST requests with bodies (e.g. sign-in, sign-up) fail silently or throw when better-auth tries to consume the body

## Problem

When using `toNextJsHandler` with Next.js App Router route handlers, the `Request` object passed by Next.js may have a streaming body that cannot be consumed. This is because Next.js internally forwards the request between layers, and the `duplex` property is not preserved, causing the body stream to be treated as already consumed.

## Solution

Before forwarding the request to the auth handler, wrap it in a new `Request` constructed with `duplex: 'half'`. This ensures the body stream is properly initialized and readable. Only requests with bodies (non-GET, non-HEAD) include the body and duplex option.

## Test plan

- [ ] Verify POST requests to auth endpoints (sign-in, sign-up, etc.) work correctly in Next.js App Router
- [ ] Verify GET requests continue to work as before
- [ ] Verify no regression in Pages Router usage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable streaming request bodies in Next.js App Router by recreating the Request with duplex: 'half' only when a body is present. Restores POST auth flows (sign-in, sign-up) without affecting GET, HEAD, or Pages Router.

- Bug Fixes
  - Added toPlainRequest to rebuild the Request with duplex: 'half' so streaming bodies stay readable.
  - Only wraps non-GET/HEAD requests that have a body; preserves method, headers, and body.

<sup>Written for commit cf3363c907881d63cc2144296a0065d012584c16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

