### PR TITLE
docs: update SolidStart auth handler file path

### DIFF
--- a/docs/content/docs/integrations/solid-start.mdx
+++ b/docs/content/docs/integrations/solid-start.mdx
@@ -7,9 +7,9 @@ Before you start, make sure you have a Better Auth instance configured. If you h
 
 ### Mount the handler
 
-We need to mount the handler to SolidStart server. Put the following code in your `*auth.ts` file inside `/routes/api/auth` folder.
+We need to mount the handler to SolidStart server. Put the following code in your `[...auth].ts` file inside `/routes/api/auth` folder.
 
-```ts title="*auth.ts"
+```ts title="[...auth].ts"
 import { auth } from "~/lib/auth";
 import { toSolidStartHandler } from "better-auth/solid-start";
 


### PR DESCRIPTION
Change route file from `*auth.ts` in `/routes/api/auth/` to `[...auth].ts` in `/routes/api/auth`

`*auth.ts` is no longer supported

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update SolidStart integration docs to use `[...auth].ts` under `/routes/api/auth`, replacing the outdated `*auth.ts`. Updates both the instruction text and code sample title so the handler mounts correctly.

<sup>Written for commit 9e6b158928acea59eda0d3ee2296d2a3c4c9ebc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

