### PR TITLE
docs: add secure OAuth guidance for Chrome extensions

### DIFF
--- a/docs/content/docs/guides/browser-extension-guide.mdx
+++ b/docs/content/docs/guides/browser-extension-guide.mdx
@@ -1,212 +1,449 @@
 ---
 title: Browser Extension Guide
-description: A step-by-step guide to creating a browser extension with Better Auth.
+description: Authenticate users in Chrome extensions using Better Auth, including social OAuth sign-in.
 ---
 
-In this guide, we'll walk you through the steps of creating a browser extension using <Link href="https://docs.plasmo.com/">Plasmo</Link> with Better Auth for authentication.
+Browser extensions (Manifest V3) present unique authentication challenges. Extension popups lose context on navigation, service workers have no DOM, and `chrome-extension://` is not accepted as an OAuth redirect URI by many providers. This guide walks you through setting up Better Auth in a Chrome extension, from basic session auth to Google sign-in.
 
-If you would like to view a completed example, you can check out the <Link href="https://github.com/better-auth/examples/tree/main/browser-extension-example">browser extension example</Link>.
+<Callout type="info">
+  This guide is framework-agnostic. Examples use vanilla MV3 code, but the same patterns apply to <Link href="https://wxt.dev">WXT</Link>, <Link href="https://docs.plasmo.com">Plasmo</Link>, <Link href="https://crxjs.dev/vite-plugin">CRXJS</Link>, or another Chromium extension framework.
+</Callout>
 
 <Callout type="warn">
-  The Plasmo framework does not provide a backend for the browser extension.
-  This guide assumes you have{" "}
-  <Link href="/docs/integrations/hono">a backend setup</Link> of Better Auth and
-  are ready to create a browser extension to connect to it.
+  Browser extensions do not provide a backend. This guide assumes you have <Link href="/docs/installation">a Better Auth server set up</Link> and are ready to connect your extension to it.
 </Callout>
+
+## Basic Setup
 
 <Steps>
   <Step>
-    ## Setup & Installations
+    ### Install Better Auth
 
-    Initialize a new Plasmo project with TailwindCSS and a src directory.
+    In your extension project, install the Better Auth client package.
 
-    ```bash
-    pnpm create plasmo --with-tailwindcss --with-src
-    ```
-
-    Then, install the Better Auth package.
-
-    ```bash
-    pnpm add better-auth
-    ```
-
-    To start the Plasmo development server, run the following command.
-
-    ```bash
-    pnpm dev
+    ```package-install
+    better-auth
     ```
   </Step>
 
   <Step>
-    ## Configure tsconfig
+    ### Create the auth client
 
-    Configure the `tsconfig.json` file to include `strict` mode.
+    Create a client instance pointing to your Better Auth server.
 
-    For this demo, we have also changed the import alias from `~` to `@` and set it to the `src` directory.
-
-    ```json title="tsconfig.json"
-    {
-        "compilerOptions": {
-            "paths": {
-                "@/_": [
-                    "./src/_"
-                ]
-            },
-            "strict": true,
-            "baseUrl": "."
-        }
-    }
-    ```
-  </Step>
-
-  <Step>
-    ## Create the client auth instance
-
-    Create a new file at `src/auth/auth-client.ts` and add the following code.
-
-    <Files>
-      <Folder name="src" defaultOpen>
-        <Folder name="auth" defaultOpen>
-          <File name="auth-client.ts" />
-        </Folder>
-      </Folder>
-    </Files>
-
-    ```ts title="auth-client.ts"
+    ```ts title="src/lib/auth-client.ts"
     import { createAuthClient } from "better-auth/react"
 
     export const authClient = createAuthClient({
-        baseURL: "http://localhost:3000" /* Base URL of your Better Auth backend. */,
-        plugins: [],
-    });
+        baseURL: "http://localhost:3000",
+    })
     ```
   </Step>
 
   <Step>
-    ## Configure the manifest
+    ### Configure the manifest
 
-    We must ensure the extension knows the URL to the Better Auth backend.
+    Add `host_permissions` so extension pages and the service worker can make cross-origin requests to your backend. A content script remains subject to the page's same-origin policy, so authenticated requests from content scripts should be proxied through the service worker.
 
-    Head to your package.json file, and add the following code.
-
-    ```json title="package.json"
+    ```json title="manifest.json"
     {
-        //...
-        "manifest": {
-            "host_permissions": [
-                "https://URL_TO_YOUR_BACKEND" // localhost works too (e.g. http://localhost:3000)
-            ]
-        }
-    }
-    ```
-  </Step>
-
-  <Step>
-    ## You're now ready!
-
-    You have now set up Better Auth for your browser extension.
-
-    Add your desired UI and create your dream extension!
-
-    To learn more about the client Better Auth API, check out the <Link href="/docs/concepts/client">client documentation</Link>.
-
-    Here's a quick example 😎
-
-    ```tsx title="src/popup.tsx"
-    import { authClient } from "./auth/auth-client"
-
-
-    function IndexPopup() {
-        const {data, isPending, error} = authClient.useSession();
-        if(isPending){
-            return <>Loading...</>
-        }
-        if(error){
-            return <>Error: {error.message}</>
-        }
-        if(data){
-            return <>Signed in as {data.user.name}</>
-        }
-    }
-
-    export default IndexPopup;
-    ```
-  </Step>
-
-  <Step>
-    ## Bundle your extension
-
-    To get a production build, run the following command.
-
-    ```bash
-    pnpm build
-    ```
-
-    Head over to <Link href="chrome://extensions" target="_blank">chrome://extensions</Link> and enable developer mode.
-
-    <img src="https://docs.plasmo.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Fdeveloper_mode.76f090f7.png&w=1920&q=75" />
-
-    Click on "Load Unpacked" and navigate to your extension's `build/chrome-mv3-dev` (or `build/chrome-mv3-prod`) directory.
-
-    To see your popup, click on the puzzle piece icon on the Chrome toolbar, and click on your extension.
-
-    Learn more about <Link href="https://docs.plasmo.com/framework#loading-the-extension-in-chrome">bundling your extension here.</Link>
-  </Step>
-
-  <Step>
-    ## Configure the server auth instance
-
-    First, we will need your extension URL.
-
-    An extension URL formed like this: `chrome-extension://YOUR_EXTENSION_ID`.
-
-    You can find your extension ID at <Link href="chrome://extensions" target="_blank">chrome://extensions</Link>.
-
-    <img src="/extension-id.png" width={500} />
-
-    Head to your server's auth file, and make sure that your extension's URL is added to the `trustedOrigins` list.
-
-    ```ts title="server.ts"
-    import { betterAuth } from "better-auth"
-    import { auth } from "@/auth/auth"
-
-    export const auth = betterAuth({
-        trustedOrigins: ["chrome-extension://YOUR_EXTENSION_ID"],
-    })
-    ```
-
-    If you're developing multiple extensions or need to support different browser extensions with different IDs, you can use wildcard patterns:
-
-    ```ts title="server.ts"
-    export const auth = betterAuth({
-        trustedOrigins: [
-            // Support a specific extension ID
-            "chrome-extension://YOUR_EXTENSION_ID",
-            
-            // Or support multiple extensions with wildcard (less secure)
-            "chrome-extension://*"
+        "host_permissions": [
+            "http://localhost:3000/*"
         ],
-    })
+        "permissions": ["storage"]
+    }
     ```
 
-    <Callout type="warn">
-      Using wildcards for extension origins (`chrome-extension://*`) reduces security by trusting all extensions.
-      It's safer to explicitly list each extension ID you trust. Only use wildcards for development and testing.
+    For production, replace with your actual backend URL (e.g. `https://api.example.com/*`).
+
+    <Callout type="info">
+      In Plasmo, add this to the `manifest` field in `package.json`. In WXT, set it in `wxt.config.ts` under `manifest.host_permissions`.
     </Callout>
   </Step>
 
   <Step>
-    ## That's it!
+    ### Configure the server
 
-    Everything is set up! You can now start developing your extension. 🎉
+    Add your extension's origin to the `trustedOrigins` list so Better Auth accepts requests from it.
+
+    You can find your extension ID at `chrome://extensions` after loading it.
+
+    ```ts title="auth.ts"
+    import { betterAuth } from "better-auth"
+    import { bearer } from "better-auth/plugins"
+
+    export const auth = betterAuth({
+        trustedOrigins: ["chrome-extension://YOUR_EXTENSION_ID"],
+        plugins: [bearer()],
+    })
+    ```
+
+    <Callout type="warn">
+      Using wildcards (`chrome-extension://*`) trusts **all** extensions. It's safer to explicitly list each extension ID. Only use wildcards during development.
+    </Callout>
+
+    The Bearer plugin lets the extension use the session token returned after sign-in instead of relying on cross-site cookies.
+  </Step>
+
+  <Step>
+    ### Use the auth client
+
+    You can now use `authClient` in your popup, side panel, or options page. When the backend is on another origin, store the returned session token and use it as a Bearer token for later requests.
+
+    ```tsx title="src/popup.tsx"
+    import { authClient } from "./lib/auth-client"
+
+    async function signInWithEmail(email: string, password: string) {
+        const { data, error } = await authClient.signIn.email({ email, password })
+
+        if (error) throw new Error(error.message)
+        if (!data?.token) throw new Error("No session token returned")
+
+        // Prevent content scripts from reading the session token.
+        await chrome.storage.local.setAccessLevel({
+            accessLevel: "TRUSTED_CONTEXTS",
+        })
+
+        await chrome.storage.local.set({
+            session: { token: data.token, user: data.user },
+        })
+
+        return data.user
+    }
+    ```
   </Step>
 </Steps>
 
-## Wrapping Up
+## Social OAuth in Extensions
 
-Congratulations! You've successfully created a browser extension using Better Auth and Plasmo.
-We highly recommend you visit the <Link href="https://docs.plasmo.com/">Plasmo documentation</Link> to learn more about the framework.
+Social sign-in (`authClient.signIn.social()`) normally redirects the current page to the OAuth provider. In an extension popup, that destroys the popup context: the popup closes and the provider cannot redirect to a `chrome-extension://` URL.
 
-If you would like to view a completed example, you can check out the <Link href="https://github.com/better-auth/examples/tree/main/browser-extension-example">browser extension example</Link>.
+For Google, request an OIDC ID token with `chrome.identity.launchWebAuthFlow()`, then exchange that token for a Better Auth session. This avoids putting a Google access token in the redirect URL.
 
-If you have any questions, feel free to open an issue on our <Link href="https://github.com/better-auth/better-auth/issues">GitHub repo</Link>, or join our <Link href="https://discord.gg/better-auth">Discord server</Link> for support.
+### Use `chrome.identity.launchWebAuthFlow`
+
+`chrome.identity.launchWebAuthFlow()` opens a browser-managed popup for OAuth. After the user consents, the browser intercepts the redirect to `https://<extension-id>.chromiumapp.org/` and returns the final URL to your extension code. You then extract the ID token from the URL fragment and exchange it with Better Auth.
+
+This pattern requires a provider that can return an OIDC `id_token` in the URL fragment and that Better Auth can verify. The example below is intentionally limited to Google. Do not adapt it to a provider that only returns an OAuth access token.
+
+<Steps>
+  <Step>
+    #### Pin your extension ID
+
+    An unpacked extension's ID is derived from its installation path and can differ across machines. OAuth redirect URIs must be registered in the provider's console, so use a stable ID during development.
+
+    1. Upload your extension to the [Chrome Developer Dashboard](https://chrome.google.com/webstore/devconsole) (you don't need to publish it)
+    2. Copy the public key from the package info
+    3. Add it to your manifest:
+
+    ```json title="manifest.json"
+    {
+        "key": "YOUR_PUBLIC_KEY_FROM_CHROME_DEVELOPER_DASHBOARD"
+    }
+    ```
+
+    <Callout type="warn">
+      Only include the `key` in development builds. Published extensions get their key from the Chrome Web Store automatically.
+    </Callout>
+  </Step>
+
+  <Step>
+    #### Add the `identity` permission
+
+    This permission is required for `chrome.identity.launchWebAuthFlow`.
+
+    ```json title="manifest.json"
+    {
+        "permissions": ["identity", "storage"]
+    }
+    ```
+
+    <Callout type="info">
+      If your manifest defines a custom `content_security_policy`, make sure `connect-src` includes your Better Auth server URL. Without this, the service worker's requests to Better Auth will be blocked.
+    </Callout>
+  </Step>
+
+  <Step>
+    #### Register the redirect URI with your OAuth provider
+
+    In your OAuth provider's console (e.g. Google Cloud Console), create a **Web application** OAuth client and add this redirect URI:
+
+    ```
+    https://YOUR_EXTENSION_ID.chromiumapp.org/
+    ```
+
+    You can get this URL at runtime with `chrome.identity.getRedirectURL()`.
+
+    <Callout type="warn">
+      `chrome.identity.getRedirectURL()` returns a URL with a **trailing slash**. Make sure the URI registered in the provider console matches exactly, including the trailing slash.
+    </Callout>
+
+    <Callout type="info">
+      Use a **Web application** OAuth client type, not "Chrome App". The `launchWebAuthFlow` API uses the implicit flow with a web redirect URI, not Chrome's built-in `getAuthToken`.
+    </Callout>
+
+    Configure the same OAuth client ID in `socialProviders.google` on the Better Auth server. Better Auth checks the ID token's audience against that configured client ID.
+  </Step>
+
+  <Step>
+    #### Implement the OAuth flow in the service worker
+
+    The service worker builds the OAuth URL, launches the auth flow, and extracts the ID token from the response.
+
+    ```ts title="src/background.ts"
+    async function getGoogleIdToken() {
+        const redirectUrl = chrome.identity.getRedirectURL()
+        const nonce = crypto.randomUUID()
+        const state = crypto.randomUUID()
+
+        const url = new URL("https://accounts.google.com/o/oauth2/v2/auth")
+        url.searchParams.set("client_id", "YOUR_GOOGLE_CLIENT_ID")
+        url.searchParams.set("redirect_uri", redirectUrl)
+        url.searchParams.set("response_type", "id_token")
+        url.searchParams.set("scope", "openid email profile")
+        url.searchParams.set("nonce", nonce)
+        url.searchParams.set("state", state)
+        url.searchParams.set("prompt", "select_account")
+
+        return new Promise<{ idToken: string; nonce: string }>((resolve, reject) => {
+            chrome.identity.launchWebAuthFlow(
+                { url: url.toString(), interactive: true },
+                (responseUrl) => {
+                    if (chrome.runtime.lastError || !responseUrl) {
+                        reject(
+                            new Error(
+                                chrome.runtime.lastError?.message ?? "Auth cancelled",
+                            ),
+                        )
+                        return
+                    }
+
+                    const params = new URLSearchParams(
+                        responseUrl.split("#")[1] ?? "",
+                    )
+
+                    if (params.get("state") !== state) {
+                        reject(new Error("Invalid OAuth state"))
+                        return
+                    }
+
+                    const idToken = params.get("id_token")
+                    if (!idToken) {
+                        reject(new Error("No id_token in response"))
+                        return
+                    }
+
+                    resolve({
+                        idToken,
+                        nonce,
+                    })
+                },
+            )
+        })
+    }
+    ```
+  </Step>
+
+  <Step>
+    #### Exchange the ID token with Better Auth
+
+    Send the ID token to Better Auth's `signIn.social` method with the `idToken` parameter. Better Auth verifies the token cryptographically using the provider's public JWKS keys — no client secret is needed on the extension side.
+
+    ```ts title="src/background.ts"
+    import { createAuthClient } from "better-auth/client"
+
+    const authClient = createAuthClient({
+        baseURL: "http://localhost:3000",
+    })
+
+    async function signInWithGoogle() {
+        const { idToken, nonce } = await getGoogleIdToken()
+
+        const { data } = await authClient.signIn.social({
+            provider: "google",
+            idToken: {
+                token: idToken,
+                nonce,
+            },
+        })
+
+        // data: { token: string, user: { id, email, name, ... }, redirect: false }
+        return data
+    }
+    ```
+
+    <Callout>
+      When an `idToken` is provided, no redirect happens. Better Auth verifies the token server-side and creates a session directly. The response contains a `token` (session token) and a `user` object. See the <Link href="/docs/authentication/google#sign-in-with-google-with-id-token">Google ID Token docs</Link> for more details.
+    </Callout>
+
+    <Callout type="info">
+      If your Google provider sets `disableImplicitSignUp: true`, pass `requestSignUp: true` when you explicitly want this request to create a new user. It is not required with the default provider configuration.
+    </Callout>
+  </Step>
+
+  <Step>
+    #### Store the session
+
+    The `signIn.social` call with `idToken` returns a `token` (session token) and a `user` object. Store them from the service worker for use in subsequent API calls.
+
+    ```ts title="src/background.ts"
+    async function signInWithGoogle() {
+        const { idToken, nonce } = await getGoogleIdToken()
+
+        const { data } = await authClient.signIn.social({
+            provider: "google",
+            idToken: {
+                token: idToken,
+                nonce,
+            },
+        })
+
+        if (data?.token) {
+            // Prevent content scripts from reading the session token.
+            await chrome.storage.local.setAccessLevel({
+                accessLevel: "TRUSTED_CONTEXTS",
+            })
+
+            await chrome.storage.local.set({
+                session: {
+                    token: data.token,
+                    user: data.user,
+                },
+            })
+        }
+    }
+    ```
+
+    <Callout type="info">
+      Persist the session in the service worker, not the popup. Chrome 116 and newer allow `identity.launchWebAuthFlow()` to run past the normal service-worker timeout while its user prompt is open. Code outside that API call must still tolerate the worker stopping and restarting.
+    </Callout>
+
+    For subsequent API calls, attach the token as a Bearer header:
+
+    ```ts title="src/background.ts"
+    const { session } = await chrome.storage.local.get("session")
+
+    const response = await fetch("https://your-backend.com/api/protected", {
+        headers: {
+            Authorization: `Bearer ${session.token}`,
+        },
+    })
+    ```
+
+    <Callout type="info">
+      Use the <Link href="/docs/plugins/bearer">Bearer plugin</Link> on the server so Better Auth accepts the session token in the `Authorization` header. This is the recommended approach for extensions — it avoids cookie issues entirely.
+    </Callout>
+  </Step>
+</Steps>
+
+### Providers without an ID token redirect
+
+Do not send a Better Auth session token from a website to an extension ID supplied in a URL. That creates a token-exfiltration vulnerability. Providers such as GitHub and browser flows with special callback requirements need a hosted callback designed for your application.
+
+A safe hosted flow should:
+
+* bind the request to a fixed, allowlisted extension ID and a transaction-specific state value
+* complete the provider callback on your server
+* transfer a short-lived, single-use value, such as one created by the <Link href="/docs/plugins/one-time-token">One-Time Token plugin</Link>, rather than the session token
+* validate the sender origin and redeem the value once in the extension before storing the resulting session
+
+Website-to-extension messaging through `externally_connectable` is not supported by Firefox. Treat such a bridge as Chromium-specific and provide a separate browser-specific implementation when supporting Firefox.
+
+## Cookie Configuration
+
+If you use cookie-based sessions instead of Bearer tokens, the default `SameSite: Lax` setting **blocks cookies from `chrome-extension://` origins** in production. You'll see auth working on localhost but failing when deployed.
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+    trustedOrigins: ["chrome-extension://YOUR_EXTENSION_ID"],
+    advanced: {
+        cookies: {
+            session_token: {
+                attributes: {
+                    sameSite: "none",
+                    secure: true,
+                },
+            },
+        },
+    },
+})
+```
+
+<Callout type="warn">
+  `SameSite: None` requires `Secure: true`, which means HTTPS only. This won't work on `http://localhost`. The recommended approach for extensions is to use the <Link href="/docs/plugins/bearer">Bearer plugin</Link> instead, which avoids cookie issues entirely.
+</Callout>
+
+## Content Script Authentication
+
+Content scripts run in an isolated JavaScript world, but their network requests are still associated with the page origin. They cannot reliably make authenticated cross-origin requests directly due to CSP and CORS restrictions.
+
+**Recommended:** Proxy all authenticated requests through the service worker.
+
+```ts title="src/content-script.ts"
+const response = await chrome.runtime.sendMessage({
+    type: "get-profile",
+})
+```
+
+In the service worker, handle the request:
+
+```ts title="src/background.ts"
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (sender.id !== chrome.runtime.id || message.type !== "get-profile") {
+        return false
+    }
+
+    void (async () => {
+        try {
+            const { session } = await chrome.storage.local.get("session")
+            if (!session?.token) {
+                sendResponse({ error: "Not authenticated" })
+                return
+            }
+
+            const response = await fetch(
+                "https://your-backend.com/api/protected-endpoint",
+                {
+                    headers: { Authorization: `Bearer ${session.token}` },
+                },
+            )
+
+            if (!response.ok) {
+                sendResponse({ error: "Request failed" })
+                return
+            }
+
+            sendResponse(await response.json())
+        } catch {
+            sendResponse({ error: "Request failed" })
+        }
+    })()
+
+    return true // keep sendResponse channel open
+})
+```
+
+Keep the destination and allowed operations in the service worker. Do not accept an arbitrary URL from a content script, because doing so can leak the Bearer token or expose other hosts available through the extension's permissions.
+
+## Troubleshooting
+
+### `redirect_uri_mismatch` from Google
+
+* Ensure the redirect URI in Google Console **exactly** matches `chrome.identity.getRedirectURL()`, including the trailing slash
+* Use a **Web application** client type, not "Chrome App"
+* Make sure you're using the pinned extension ID (via the `key` field), not a randomly assigned one
+
+### Auth works on localhost but breaks in production
+
+* Check cookie `SameSite` settings — the default `Lax` blocks cross-origin requests from extensions
+* Switch to Bearer tokens (recommended) or set `SameSite: None; Secure: true`
+
+### Service worker dies during OAuth
+
+* Use Chrome 116 or newer when relying on `identity.launchWebAuthFlow()` to outlive the normal service-worker timeout
+* Persist important state instead of keeping it only in global variables
+* Do not rely on opening a long-lived messaging port; opening a port alone does not reset the service-worker timers
+
+### The provider does not return an ID token
+
+Do not exchange an OAuth access token as though it were an ID token. Use a provider-specific hosted flow that follows the security requirements in [Providers without an ID token redirect](#providers-without-an-id-token-redirect).


### PR DESCRIPTION
## Summary

Rewrites the browser extension guide around secure, current Chrome Manifest V3 patterns.

- adds framework-agnostic setup with exact trusted origins and Bearer sessions
- documents Google sign-in with `launchWebAuthFlow()` and an OIDC ID token
- restricts extension storage so content scripts cannot read session tokens
- uses a fixed-operation service-worker proxy for authenticated content-script requests
- outlines a safe hosted flow for providers that cannot return a verifiable ID token

## Security and compatibility

- avoids putting OAuth access tokens in redirect URLs
- removes the raw-session website bridge pattern
- reflects Chrome 114/116 service-worker lifetime behavior
- identifies website-to-extension messaging as Chromium-specific

## Validation

- rebased onto the current `main`
- focused Remark validation passed
- Fumadocs MDX generation passed
- `git diff --check` passed