### PR TITLE
fix(blog): fix RSS feed link path, image path and blog date

### DIFF
--- a/landing/lib/rss.ts
+++ b/landing/lib/rss.ts
@@ -30,7 +30,7 @@ export function getRSS() {
 					: page.data.image
 				: undefined,
 			link: url.startsWith("/") ? `${baseUrl}${url.slice(1)}` : url,
-			date: new Date(page.data.lastModified ?? page.data.date),
+			date: new Date(page.data.date),
 			author: page.data.author
 				? [
 						{


### PR DESCRIPTION
Some blog URLs already include the full domain, so adding `baseUrl` again produced invalid links.

For example, in a local environment it could end up like:
`http://localhost:3000/https://docs.better-auth.com/...`

Now the URL prefix is only added when the URL is relative.

Also fixed the blog date in the RSS feed, instead of using `page.data.lastModified`, we use `page.data.date`

Note: In the better auth site, the url is `https://better-auth.com/https://docs.better-auth.com/...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix malformed RSS feed links and images by only adding `baseUrl` for relative paths, and use the correct post date.

- **Bug Fixes**
  - Links and images: prefix `baseUrl` only when the value starts with "/"; leave absolute URLs unchanged.
  - Date: use `page.data.date` for RSS items.

<sup>Written for commit 7b304e55169d340ee14ebb05e08053c5136031f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



