### PR TITLE
feat(ciba): add backchannel authentication plugin

### DIFF
--- a/.changeset/ciba-plugin.md
+++ b/.changeset/ciba-plugin.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/ciba": minor
+---
+
+Add `@better-auth/ciba`, an OpenID Connect Client-Initiated Backchannel Authentication plugin. A client (an AI agent, CLI, or device) starts a backchannel request, the user approves on a separate device, and the client receives tokens. No browser redirect is involved.
+
+Supports poll, ping, and push token delivery and DPoP-bound access tokens. The user approves or rejects with either the raw `auth_req_id` from the approval link, or, for a first-party UI that lists a user's own pending requests, the request's `request_id`. Ownership is enforced by the session in both cases.

--- a/docs/content/docs/plugins/ciba.mdx
+++ b/docs/content/docs/plugins/ciba.mdx
@@ -1,0 +1,301 @@
+---
+title: Client-Initiated Backchannel Authentication (CIBA)
+description: Let a client start a login that the user approves on a separate device, with no browser redirect.
+---
+
+`OAuth2` `OIDC`
+
+[Client-Initiated Backchannel Authentication](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html) is an OpenID Connect flow for **decoupled authentication**: the device that asks for the tokens is not the device where the user signs in. The client starts the request on a back channel, the user approves it on their own phone or laptop, and the client receives tokens once they approve. No redirect happens, and the client never sees or controls the user's authentication.
+
+This is the flow to reach for when the thing requesting access cannot open a browser the user trusts:
+
+* An AI agent acting on a user's behalf that has no browser session of its own.
+* A CLI or backend job that needs a real person to approve before it proceeds.
+* A call-center system where the agent triggers a login the customer approves on their phone.
+* A kiosk, smart device, or terminal that should never collect the user's credentials directly.
+
+The plugin extends [`@better-auth/oauth-provider`](./oauth-provider). It adds the backchannel endpoint, the polling grant, and the approval endpoints your UI calls, and it requires `oauth-provider` and `jwt` to be installed.
+
+## How the flow works
+
+Four parties take part, and they map directly onto the endpoints below.
+
+1. The **client** (the agent, CLI, or device) calls `POST /oauth2/bc-authorize` with its credentials, the requested scopes, and a hint identifying the user. It gets back an `auth_req_id` and a polling `interval`.
+2. Your **server** notifies the user out of band through the `sendNotification` callback, typically with a link to your approval page.
+3. The **user** opens that page on their own device and approves or denies the request.
+4. The **client** polls `POST /oauth2/token` with the `auth_req_id`. While the request is pending it receives `authorization_pending`; once the user approves, it receives the tokens.
+
+The user's authentication and the client's token request never share a device or a browser, which is what makes the flow safe for clients that cannot be trusted with credentials.
+
+<Callout type="info">
+  Three delivery modes are supported (CIBA §4): **poll** (the client polls the token endpoint), **ping** (the server notifies the client that the request is ready, then the client polls), and **push** (the server delivers the token set to the client's notification endpoint). The deployment opts into modes with `deliveryModes`, and each client registers the one it uses.
+</Callout>
+
+## Installation
+
+<Steps>
+  <Step>
+    ### Install the plugin
+
+    ```package-install
+    @better-auth/ciba
+    ```
+  </Step>
+
+  <Step>
+    ### Add the plugin to the server
+
+    Install `ciba()` alongside `oauthProvider()` and `jwt()`. Provide a `sendNotification` callback that reaches the user, and an `approvalPage` path that your application serves.
+
+    ```ts title="auth.ts"
+    import { betterAuth } from "better-auth";
+    import { jwt } from "better-auth/plugins";
+    import { oauthProvider } from "@better-auth/oauth-provider";
+    import { ciba } from "@better-auth/ciba"; // [!code highlight]
+
+    export const auth = betterAuth({
+      plugins: [
+        jwt(),
+        oauthProvider({
+          loginPage: "/login",
+          consentPage: "/consent",
+          scopes: ["openid", "profile", "email"],
+        }),
+        ciba({ // [!code highlight]
+          approvalPage: "/ciba/approve", // [!code highlight]
+          sendNotification: async ({ userId, clientName, approvalUrl }) => { // [!code highlight]
+            const user = await getUser(userId); // [!code highlight]
+            await sendEmail({ // [!code highlight]
+              to: user.email, // [!code highlight]
+              subject: `${clientName ?? "An application"} wants to sign in as you`, // [!code highlight]
+              body: `Approve or deny this request: ${approvalUrl}`, // [!code highlight]
+            }); // [!code highlight]
+          }, // [!code highlight]
+        }), // [!code highlight]
+      ],
+    });
+    ```
+  </Step>
+
+  <Step>
+    ### Build the approval page
+
+    CIBA leaves the user's approval experience to you, so the page at `approvalPage` is your application's UI. It reads the request details, shows them to the signed-in user, and calls the approve or reject endpoint. The [Approval page](#approval-page) section shows the client calls.
+  </Step>
+</Steps>
+
+## Register a client for the CIBA grant
+
+A client can use the backchannel flow only when it is registered for the CIBA grant type. Add the grant URI to the client's `grant_types`. CIBA clients are confidential by default, so the client also receives a `client_secret` it uses to authenticate.
+
+```ts title="register-client.ts"
+const client = await auth.api.adminCreateOAuthClient({
+  headers, // an authenticated admin session
+  body: {
+    client_name: "Scheduling Agent",
+    grant_types: ["urn:openid:params:grant-type:ciba"],
+  },
+});
+// store client.client_id and client.client_secret for the agent
+```
+
+## The client (agent) side
+
+The client starts a request at the backchannel endpoint, then polls the token endpoint until the user responds. Both calls authenticate the client; the example uses HTTP Basic, which carries the `client_id` and `client_secret`.
+
+```ts title="agent.ts"
+const basic = btoa(`${clientId}:${clientSecret}`);
+
+// 1. Start the backchannel request.
+const start = await fetch("https://auth.example.com/api/auth/oauth2/bc-authorize", {
+  method: "POST",
+  headers: {
+    authorization: `Basic ${basic}`,
+    "content-type": "application/json",
+  },
+  body: JSON.stringify({
+    scope: "openid profile",
+    login_hint: "ada@example.com",
+  }),
+}).then((r) => r.json());
+// => { auth_req_id, expires_in, interval }
+
+// 2. Poll the token endpoint until the user approves.
+let interval = start.interval;
+async function poll() {
+  const res = await fetch("https://auth.example.com/api/auth/oauth2/token", {
+    method: "POST",
+    headers: {
+      authorization: `Basic ${basic}`,
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "urn:openid:params:grant-type:ciba",
+      auth_req_id: start.auth_req_id,
+    }),
+  });
+  const body = await res.json();
+  if (body.error === "authorization_pending") {
+    setTimeout(poll, interval * 1000);
+    return;
+  }
+  if (body.error === "slow_down") {
+    interval += 5; // each slow_down raises the floor; keep the larger interval
+    setTimeout(poll, interval * 1000);
+    return;
+  }
+  if (body.error) throw new Error(body.error); // access_denied, expired_token, ...
+  return body; // { access_token, token_type, expires_in, id_token, ... }
+}
+```
+
+The client must wait at least `interval` seconds between polls. Polling faster returns `slow_down` and raises the interval by 5 seconds, so honor the larger interval from then on.
+
+## Approval page
+
+Your approval page resolves the request from the `auth_req_id` query parameter, shows it to the signed-in user, and submits their decision. The approve and reject calls require a session, and the session user must be the user the request was created for.
+
+```ts title="approve.tsx"
+import { createAuthClient } from "better-auth/client";
+import { cibaClient } from "@better-auth/ciba";
+
+const authClient = createAuthClient({ plugins: [cibaClient()] });
+
+// Read the pending request to display it.
+const { data } = await authClient.ciba.request({
+  query: { auth_req_id },
+});
+// => { client_name, scope, binding_message, status, expires_at }
+
+// On the user's decision:
+await authClient.ciba.authorize({ auth_req_id });
+// or
+await authClient.ciba.reject({ auth_req_id });
+```
+
+The `auth_req_id` is a high-entropy value that doubles as the secret for reading the request, so the link you send the user does not expose anything an attacker could guess. Approving or rejecting still requires the user's own session, so a leaked link alone cannot complete a request.
+
+A first-party UI that lists a user's own pending requests, rather than opening a per-request link, never holds the raw `auth_req_id`, since only its hash is stored. Such a UI approves or rejects by `request_id` (the request's id), which is interchangeable with `auth_req_id` on the `authorize` and `reject` calls. The session still enforces ownership, so this is not a weaker credential for the resource owner.
+
+## Sender-constrained tokens (DPoP)
+
+DPoP, [Demonstrating Proof of Possession](./oauth-provider), binds an access token to a key the client holds, so a stolen token is useless to anyone who cannot sign with that key. If the client presents a DPoP proof on its token poll, the issued token is bound to its key (`cnf.jkt`) and returned as `token_type: "DPoP"`. No extra CIBA configuration is needed, since the binding flows through the shared token pipeline.
+
+## Endpoints
+
+### `POST /oauth2/bc-authorize`
+
+Starts a backchannel request. Authenticates the client and returns the `auth_req_id`.
+
+| Parameter          | Required | Description                                                                                             |
+| ------------------ | -------- | ------------------------------------------------------------------------------------------------------- |
+| `scope`            | yes      | Space-delimited scopes. Must include `openid`.                                                          |
+| `login_hint`       | yes      | Identifies the user. By default an email, resolved through `resolveUser`.                               |
+| `binding_message`  | no       | A short plain-text message shown on both devices to bind the session.                                   |
+| `resource`         | no       | An [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) resource indicator the token is scoped to. |
+| `requested_expiry` | no       | Requested request lifetime in seconds, capped at `requestExpiry`.                                       |
+
+The response contains `auth_req_id`, `expires_in`, and the polling `interval`.
+
+### `POST /oauth2/token`
+
+The standard token endpoint. With `grant_type` set to `urn:openid:params:grant-type:ciba` and an `auth_req_id`, it returns the tokens once the user approves, or one of the poll errors below.
+
+### `GET /ciba/request`
+
+Returns the request details for your approval page: `client_name`, `scope`, `binding_message`, `status`, and `expires_at`. Identified by the `auth_req_id` query parameter; no session required.
+
+### `POST /ciba/authorize` and `POST /ciba/reject`
+
+Approve or deny a pending request. Both require an authenticated session, and the session user must own the request. Identify the request with exactly one of `auth_req_id` (the raw token, from the approval link) or `request_id` (the request's id, for a first-party UI that lists the user's own requests). Push delivery must use `auth_req_id`, since the pushed token set echoes it back to the client.
+
+## Options
+
+export const cibaOptionsType = {
+	sendNotification: {
+		type: "(data, request?) => void | Promise<void>",
+		description:
+			"Notify the user of a pending request on a separate channel (email, push, SMS). Receives `{ userId, clientId, clientName, scope, bindingMessage, approvalUrl }`. Runs fire-and-forget: a thrown error is logged and the request still returns its `auth_req_id`, so delivery never blocks the client.",
+	},
+	approvalPage: {
+		type: "string",
+		description:
+			"Path of your approval page. The `auth_req_id` is appended as a query parameter to build the `approvalUrl` passed to `sendNotification`. This page is your application's UI; there is no default.",
+	},
+	requestExpiry: {
+		type: "number",
+		default: "300",
+		description:
+			"Lifetime of a backchannel request in seconds. A request not approved in this window expires, and the client receives `expired_token`.",
+	},
+	pollingInterval: {
+		type: "number",
+		default: "5",
+		description:
+			"Minimum seconds the client must wait between token polls, returned as `interval` in the backchannel response.",
+	},
+	resolveUser: {
+		type: "(loginHint, ctx) => { id } | null | Promise<{ id } | null>",
+		default: "email lookup",
+		description:
+			"Resolve the user a `login_hint` identifies. Defaults to an email lookup. Return `null` when no user matches; the client then receives `unknown_user_id`.",
+	},
+	requireConfidentialClient: {
+		type: "boolean",
+		default: "true",
+		description:
+			"Require the client to authenticate with credentials. Set to `false` only if a deployment genuinely needs public clients on the backchannel.",
+	},
+};
+
+<TypeTable type={cibaOptionsType} />
+
+## Error handling
+
+The backchannel endpoint and the token poll use distinct error vocabularies, both defined in [CIBA §13](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_error_response).
+
+The backchannel endpoint (`/oauth2/bc-authorize`) returns `invalid_request`, `invalid_scope`, `invalid_client`, `unauthorized_client`, `invalid_binding_message`, or `unknown_user_id`.
+
+The token poll (`/oauth2/token`) returns one of:
+
+| Error                   | Meaning                                                                           |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| `authorization_pending` | The user has not responded yet. Keep polling.                                     |
+| `slow_down`             | Polling too fast. Increase the interval by 5 seconds.                             |
+| `access_denied`         | The user denied the request.                                                      |
+| `expired_token`         | The `auth_req_id` expired before approval.                                        |
+| `invalid_grant`         | The `auth_req_id` is unknown, belongs to another client, or was already consumed. |
+
+## Schema
+
+The plugin adds one model, `cibaRequest`, holding the state of each pending request. Generate or migrate it with the [CLI](/docs/concepts/cli) as you would any other plugin schema.
+
+| Field             | Type   | Description                                                                                                        |
+| ----------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `authReqId`       | string | The SHA-256 hash of the `auth_req_id`. The raw value is returned to the client and never stored.                   |
+| `clientId`        | string | The client that started the request.                                                                               |
+| `userId`          | string | The user being asked to authenticate.                                                                              |
+| `scope`           | string | The requested scopes.                                                                                              |
+| `bindingMessage`  | string | The optional binding message.                                                                                      |
+| `resource`        | string | The optional resource indicator.                                                                                   |
+| `status`          | string | `pending`, `approved`, or `rejected`. A redeemed request is deleted (single-use), so there is no `consumed` state. |
+| `deliveryMode`    | string | The client's registered delivery mode: `poll`, `ping`, or `push`.                                                  |
+| `pollingInterval` | number | The current minimum poll interval, raised on `slow_down`.                                                          |
+| `lastPolledAt`    | date   | When the client last polled.                                                                                       |
+| `expiresAt`       | date   | When the request expires.                                                                                          |
+| `createdAt`       | date   | When the request was created.                                                                                      |
+
+## Security
+
+* **The `auth_req_id` is stored hashed.** The client receives the raw value, the database keeps only its SHA-256 hash, so a leaked table cannot be used to poll for tokens. This matches how the OAuth provider stores access and refresh tokens.
+* **Token issuance is single-use and race-safe.** Redeeming an approved request deletes it and returns the deleted row in one atomic step (delete-and-return), so of two concurrent polls only one claims the request and mints a token set.
+* **Clients are confidential by default.** The backchannel and poll requests both authenticate the client and confirm it is registered for the CIBA grant, so a public or unregistered client cannot drive the flow unless you opt in with `requireConfidentialClient: false`.
+* **Credential responses are never cached.** The backchannel response carries `Cache-Control: no-store`, and the token response does the same, so proxies and browsers do not retain them.
+* **Binding messages are plain text.** A `binding_message` with control characters is rejected with `invalid_binding_message`. Render it as text in your approval UI so a malicious value cannot inject markup.
+
+## Current limitations
+
+The following are planned:
+
+* **User hints.** Only `login_hint` is accepted; `id_token_hint` and `login_hint_token` are not yet supported.
+* **Rich Authorization Requests.** `authorization_details` ([RFC 9396](https://datatracker.ietf.org/doc/html/rfc9396)) is accepted, validated, and passed to your `buildAccessTokenClaims` hook, but the plugin does not place it in the token response on its own.

--- a/docs/content/docs/plugins/meta.json
+++ b/docs/content/docs/plugins/meta.json
@@ -27,6 +27,7 @@
     "oauth-provider",
     "cimd",
     "mcp",
+    "ciba",
     "device-authorization",
     "stripe",
     "polar",

--- a/packages/ciba/package.json
+++ b/packages/ciba/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@better-auth/ciba",
+  "version": "1.7.0-beta.7",
+  "description": "Client-Initiated Backchannel Authentication (CIBA) plugin for Better Auth",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/plugins/ciba",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/better-auth/better-auth.git",
+    "directory": "packages/ciba"
+  },
+  "keywords": [
+    "auth",
+    "ciba",
+    "backchannel",
+    "decoupled-authentication",
+    "agent",
+    "oauth",
+    "oauth2",
+    "oidc",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict --pack false",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "dev-source": "./src/index.ts",
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/index.d.mts"
+      ]
+    }
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@better-auth/core": "workspace:*",
+    "@better-auth/oauth-provider": "workspace:*",
+    "better-auth": "workspace:*",
+    "jose": "^6.1.3",
+    "tsdown": "catalog:"
+  },
+  "peerDependencies": {
+    "@better-auth/core": "workspace:^",
+    "@better-auth/oauth-provider": "workspace:^",
+    "@better-auth/utils": "catalog:",
+    "better-auth": "workspace:^",
+    "better-call": "catalog:"
+  }
+}

--- a/packages/ciba/src/approval.ts
+++ b/packages/ciba/src/approval.ts
@@ -1,0 +1,273 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import { getOAuthProviderApi } from "@better-auth/oauth-provider";
+import {
+	APIError,
+	createAuthEndpoint,
+	sessionMiddleware,
+} from "better-auth/api";
+import * as z from "zod";
+import { CIBA_GRANT_TYPE } from "./constants";
+import { CIBA_ERROR_CODES } from "./error-codes";
+import { deliverError, deliverPing, deliverPush } from "./push";
+import type { CibaOptions } from "./types";
+import type { CibaRequest } from "./utils";
+import {
+	buildCibaIssuanceExtras,
+	consumePendingCibaRequest,
+	deleteCibaRequest,
+	findCibaRequestByHash,
+	findCibaRequestById,
+	getOAuthOptions,
+	hashAuthReqId,
+	updateCibaRequest,
+} from "./utils";
+
+/**
+ * Approval accepts one of two identifiers:
+ * - `auth_req_id`: the raw, high-entropy token. The out-of-band approval flow
+ *   (a link delivered to the user) carries it; the endpoint hashes it to find
+ *   the request. Required for push delivery, which echoes it back to the client.
+ * - `request_id`: the request's primary id. A first-party, session-authenticated
+ *   UI lists the user's own pending requests by id and never holds the raw token
+ *   (only its hash is stored). Ownership is enforced by the session, so this is
+ *   not a weaker credential for the resource owner.
+ */
+const approvalBody = z
+	.object({
+		auth_req_id: z.string().min(1).optional(),
+		request_id: z.string().min(1).optional(),
+	})
+	.refine((body) => Boolean(body.auth_req_id) !== Boolean(body.request_id), {
+		message: "Provide exactly one of auth_req_id or request_id",
+	});
+
+const DEFAULT_PUSH_RETRY = 3;
+
+/**
+ * Resolves the pending request the caller is acting on, by raw `auth_req_id`
+ * (hashed) or by `request_id`, then enforces ownership, expiry, and pending
+ * status. A missing request and one owned by another user return the same error,
+ * so a session cannot probe for others' request ids.
+ */
+async function resolveOwnedPendingRequest(
+	ctx: GenericEndpointContext,
+	identifier: { authReqId?: string; requestId?: string },
+	userId: string,
+): Promise<CibaRequest> {
+	const request = identifier.requestId
+		? await findCibaRequestById(ctx, identifier.requestId)
+		: await findCibaRequestByHash(
+				ctx,
+				await hashAuthReqId(identifier.authReqId as string),
+			);
+	if (!request || request.userId !== userId) {
+		throw new APIError("NOT_FOUND", {
+			error: "invalid_request",
+			error_description: CIBA_ERROR_CODES.INVALID_GRANT.message,
+		});
+	}
+	if (request.expiresAt < new Date()) {
+		await deleteCibaRequest(ctx, request.id);
+		throw new APIError("BAD_REQUEST", {
+			error: "expired_token",
+			error_description: CIBA_ERROR_CODES.EXPIRED_TOKEN.message,
+		});
+	}
+	if (request.status !== "pending") {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_request",
+			error_description: `Request is already ${request.status}`,
+		});
+	}
+	return request;
+}
+
+/**
+ * Push delivery mints and pushes the token set inline, echoing the raw
+ * `auth_req_id` so the client can correlate it. That value is unrecoverable from
+ * a `request_id` approval (only the hash is stored), so push must be approved
+ * with `auth_req_id`.
+ */
+function assertPushHasRawToken(
+	request: CibaRequest,
+	authReqId: string | undefined,
+): void {
+	if (request.deliveryMode === "push" && !authReqId) {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_request",
+			error_description:
+				"Push delivery requires approval by auth_req_id, not request_id.",
+		});
+	}
+}
+
+/**
+ * POST /ciba/authorize — the authenticated user approves a pending request. The
+ * session user must own the request.
+ *
+ * For poll/ping delivery this is a plain status transition: the single-use gate
+ * is the atomic consume at the token poll (ping additionally notifies the client
+ * that it can poll now). For push delivery the token set is minted and delivered
+ * inline here, so the request is atomically consumed at approval instead.
+ */
+export function createCibaAuthorize(options: CibaOptions) {
+	const pushRetry = options.pushRetryAttempts ?? DEFAULT_PUSH_RETRY;
+
+	return createAuthEndpoint(
+		"/ciba/authorize",
+		{
+			method: "POST",
+			use: [sessionMiddleware],
+			body: approvalBody,
+			metadata: {
+				openapi: { description: "Approve a CIBA authentication request" },
+			},
+		},
+		async (ctx) => {
+			const request = await resolveOwnedPendingRequest(
+				ctx,
+				{ authReqId: ctx.body.auth_req_id, requestId: ctx.body.request_id },
+				ctx.context.session.user.id,
+			);
+			assertPushHasRawToken(request, ctx.body.auth_req_id);
+
+			// Push: mint and deliver the token set inline. The request is atomically
+			// claimed before delivery, so a failed push cannot be replayed by polling.
+			if (request.deliveryMode === "push") {
+				if (
+					!(
+						request.clientNotificationEndpoint &&
+						request.clientNotificationToken
+					)
+				) {
+					throw new APIError("INTERNAL_SERVER_ERROR", {
+						error: "server_error",
+						error_description:
+							"Push request is missing its notification endpoint",
+					});
+				}
+				// Enforce step-up before consuming, so a refusal leaves the pending
+				// row intact for a retry after the user elevates.
+				if (options.enforceTokenAcr) {
+					await options.enforceTokenAcr(request, ctx);
+				}
+				const claimed = await consumePendingCibaRequest(ctx, request.id);
+				if (!claimed) {
+					throw new APIError("BAD_REQUEST", {
+						error: "invalid_request",
+						error_description: CIBA_ERROR_CODES.INVALID_GRANT.message,
+					});
+				}
+				const api = getOAuthProviderApi(
+					ctx,
+					getOAuthOptions(ctx),
+					CIBA_GRANT_TYPE,
+				);
+				const client = await api.getClient(claimed.clientId);
+				if (!client) {
+					throw new APIError("INTERNAL_SERVER_ERROR", {
+						error: "server_error",
+						error_description: "The requesting client no longer exists",
+					});
+				}
+				const extras = await buildCibaIssuanceExtras(ctx, options, claimed);
+				const tokens = await api.issueTokens({
+					client,
+					scopes: claimed.scope.split(" ").filter(Boolean),
+					user: ctx.context.session.user,
+					referenceId: claimed.authReqId,
+					authTime: new Date(),
+					accessTokenClaims: extras.accessTokenClaims,
+					tokenResponse: extras.tokenResponse,
+					resources: extras.resources,
+				});
+				void deliverPush(
+					request.clientNotificationEndpoint,
+					request.clientNotificationToken,
+					{ auth_req_id: ctx.body.auth_req_id as string, ...tokens },
+					pushRetry,
+				).catch(() => {
+					// Tokens are minted and the request consumed; the client must
+					// re-initiate or use the refresh token if delivery fails.
+				});
+				return ctx.json({ status: "approved" });
+			}
+
+			await updateCibaRequest(ctx, request.id, {
+				status: "approved",
+				approvedAt: new Date(),
+			});
+
+			// Ping: tell the client the request is ready to be polled (best-effort).
+			// Skipped on a request_id approval, which has no raw token to correlate;
+			// the client still reaches the approved request on its next poll.
+			if (
+				request.deliveryMode === "ping" &&
+				ctx.body.auth_req_id &&
+				request.clientNotificationEndpoint &&
+				request.clientNotificationToken
+			) {
+				void deliverPing(
+					request.clientNotificationEndpoint,
+					request.clientNotificationToken,
+					ctx.body.auth_req_id,
+					pushRetry,
+				).catch(() => {
+					// Best-effort: the client can still poll if the ping is lost.
+				});
+			}
+
+			return ctx.json({ status: "approved" });
+		},
+	);
+}
+
+/**
+ * POST /ciba/reject — the authenticated user denies a pending request. A poll or
+ * ping client receives `access_denied` on its next poll; a push client is
+ * notified of the denial at its notification endpoint.
+ */
+export function createCibaReject(options: CibaOptions) {
+	const pushRetry = options.pushRetryAttempts ?? DEFAULT_PUSH_RETRY;
+
+	return createAuthEndpoint(
+		"/ciba/reject",
+		{
+			method: "POST",
+			use: [sessionMiddleware],
+			body: approvalBody,
+			metadata: {
+				openapi: { description: "Reject a CIBA authentication request" },
+			},
+		},
+		async (ctx) => {
+			const request = await resolveOwnedPendingRequest(
+				ctx,
+				{ authReqId: ctx.body.auth_req_id, requestId: ctx.body.request_id },
+				ctx.context.session.user.id,
+			);
+			assertPushHasRawToken(request, ctx.body.auth_req_id);
+
+			await updateCibaRequest(ctx, request.id, { status: "rejected" });
+
+			if (
+				request.deliveryMode === "push" &&
+				request.clientNotificationEndpoint &&
+				request.clientNotificationToken
+			) {
+				void deliverError(
+					request.clientNotificationEndpoint,
+					request.clientNotificationToken,
+					ctx.body.auth_req_id as string,
+					"access_denied",
+					CIBA_ERROR_CODES.ACCESS_DENIED.message,
+					pushRetry,
+				).catch(() => {
+					// Best-effort denial notification.
+				});
+			}
+
+			return ctx.json({ status: "rejected" });
+		},
+	);
+}

--- a/packages/ciba/src/bc-authorize.ts
+++ b/packages/ciba/src/bc-authorize.ts
@@ -1,0 +1,286 @@
+import { getOAuthProviderApi } from "@better-auth/oauth-provider";
+import { APIError, createAuthEndpoint } from "better-auth/api";
+import * as z from "zod";
+import {
+	ALL_DELIVERY_MODES,
+	BC_AUTHORIZE_PATH,
+	CIBA_GRANT_TYPE,
+	DEFAULT_POLLING_INTERVAL,
+	DEFAULT_REQUEST_EXPIRY,
+} from "./constants";
+import { CIBA_ERROR_CODES } from "./error-codes";
+import type { CibaOptions } from "./types";
+import type { CibaDeliveryMode } from "./utils";
+import {
+	generateAuthReqId,
+	getClientDeliveryMode,
+	getOAuthOptions,
+	hashAuthReqId,
+	isSecureEndpoint,
+} from "./utils";
+
+// C0 controls plus DEL: a binding message must be short plain text (CIBA §7.1).
+// Built from an escaped string so the source carries no literal control bytes.
+const CONTROL_CHARS = new RegExp("[\\u0000-\\u001f\\u007f]");
+
+export function createBcAuthorize(options: CibaOptions) {
+	const requestExpiry = options.requestExpiry ?? DEFAULT_REQUEST_EXPIRY;
+	const pollingInterval = options.pollingInterval ?? DEFAULT_POLLING_INTERVAL;
+	const supportedModes: CibaDeliveryMode[] = options.deliveryModes ?? ["poll"];
+
+	return createAuthEndpoint(
+		BC_AUTHORIZE_PATH,
+		{
+			method: "POST",
+			body: z.object({
+				client_id: z.string().optional(),
+				client_secret: z.string().optional(),
+				scope: z.string().min(1),
+				// All three hints are modeled so the exactly-one rule (CIBA §7.1) is
+				// enforced. Only login_hint is implemented; the others are rejected
+				// explicitly rather than silently dropped.
+				login_hint: z.string().optional(),
+				id_token_hint: z.string().optional(),
+				login_hint_token: z.string().optional(),
+				binding_message: z.string().max(256).optional(),
+				// RFC 9396 RAR, RFC 8707 resource indicator, and OIDC step-up.
+				authorization_details: z.string().optional(),
+				resource: z.string().optional(),
+				acr_values: z.string().optional(),
+				// Ping/push delivery (CIBA §7.1).
+				client_notification_token: z.string().optional(),
+				client_notification_uri: z.string().url().optional(),
+				requested_expiry: z.coerce.number().int().positive().optional(),
+			}),
+			metadata: {
+				// Response carries the auth_req_id credential: no-store on success
+				// and on every error response.
+				noStore: true,
+				allowedMediaTypes: [
+					"application/x-www-form-urlencoded",
+					"application/json",
+				],
+				openapi: {
+					description: "Initiate a CIBA backchannel authentication request",
+					responses: {
+						"200": {
+							description: "Authentication request accepted",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											auth_req_id: { type: "string" },
+											expires_in: { type: "number" },
+											interval: { type: "number" },
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const oauthOpts = getOAuthOptions(ctx);
+			const scopes = ctx.body.scope.split(" ").filter(Boolean);
+
+			// Authenticate the client first, so an unauthenticated caller cannot
+			// probe request-shape validation. Enforces CIBA-grant registration and
+			// rejects public clients unless the deployment opts in.
+			const { client, clientId } = await getOAuthProviderApi(
+				ctx,
+				oauthOpts,
+				CIBA_GRANT_TYPE,
+			).authenticateClient({
+				scopes,
+				requireCredentials: options.requireConfidentialClient !== false,
+			});
+
+			// CIBA §4: the delivery mode is a registered client property. The client
+			// must register one mode the deployment supports; an unregistered or
+			// unsupported mode is rejected.
+			const registeredMode = getClientDeliveryMode(client) as
+				| CibaDeliveryMode
+				| undefined;
+			if (
+				!registeredMode ||
+				!supportedModes.includes(registeredMode) ||
+				!ALL_DELIVERY_MODES.includes(registeredMode)
+			) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_request",
+					error_description: CIBA_ERROR_CODES.UNSUPPORTED_DELIVERY_MODE.message,
+				});
+			}
+
+			if (!scopes.includes("openid")) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_scope",
+					error_description: CIBA_ERROR_CODES.INVALID_SCOPE.message,
+				});
+			}
+
+			if (
+				ctx.body.binding_message &&
+				CONTROL_CHARS.test(ctx.body.binding_message)
+			) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_binding_message",
+					error_description: CIBA_ERROR_CODES.INVALID_BINDING_MESSAGE.message,
+				});
+			}
+
+			// Exactly one hint (CIBA §7.1/§7.2). Multiple or none is invalid_request.
+			const hints = {
+				login_hint: ctx.body.login_hint,
+				id_token_hint: ctx.body.id_token_hint,
+				login_hint_token: ctx.body.login_hint_token,
+			};
+			const presentHints = Object.entries(hints).filter(([, v]) => v);
+			if (presentHints.length !== 1) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_request",
+					error_description: CIBA_ERROR_CODES.EXACTLY_ONE_HINT.message,
+				});
+			}
+			if (!ctx.body.login_hint) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_request",
+					error_description: CIBA_ERROR_CODES.UNSUPPORTED_HINT.message,
+				});
+			}
+
+			// Validate RAR JSON now, so a malformed value is rejected at request
+			// time rather than silently dropped at issuance.
+			let parsedAuthorizationDetails: unknown;
+			if (ctx.body.authorization_details) {
+				try {
+					parsedAuthorizationDetails = JSON.parse(
+						ctx.body.authorization_details,
+					);
+				} catch {
+					throw new APIError("BAD_REQUEST", {
+						error: "invalid_request",
+						error_description: "authorization_details must be valid JSON",
+					});
+				}
+			}
+
+			// Ping/push need a notification endpoint and token (CIBA §7.1). Resolve
+			// the endpoint from the request or the deployment, and require TLS.
+			let notificationEndpoint: string | undefined;
+			if (registeredMode === "ping" || registeredMode === "push") {
+				notificationEndpoint =
+					ctx.body.client_notification_uri ??
+					(options.resolveClientNotificationEndpoint
+						? await options.resolveClientNotificationEndpoint(clientId, ctx)
+						: undefined);
+				if (!ctx.body.client_notification_token) {
+					throw new APIError("BAD_REQUEST", {
+						error: "invalid_request",
+						error_description:
+							"client_notification_token is required for ping/push delivery",
+					});
+				}
+				if (!notificationEndpoint) {
+					throw new APIError("BAD_REQUEST", {
+						error: "invalid_request",
+						error_description:
+							"A client notification endpoint is required for ping/push delivery",
+					});
+				}
+				if (!isSecureEndpoint(notificationEndpoint)) {
+					throw new APIError("BAD_REQUEST", {
+						error: "invalid_request",
+						error_description:
+							"client_notification_uri must use HTTPS (CIBA §10.2)",
+					});
+				}
+			}
+
+			const user = options.resolveUser
+				? await options.resolveUser(ctx.body.login_hint, ctx)
+				: ((
+						await ctx.context.internalAdapter.findUserByEmail(
+							ctx.body.login_hint,
+						)
+					)?.user ?? null);
+			if (!user) {
+				throw new APIError("BAD_REQUEST", {
+					error: "unknown_user_id",
+					error_description: CIBA_ERROR_CODES.UNKNOWN_USER_ID.message,
+				});
+			}
+
+			const expiresIn = ctx.body.requested_expiry
+				? Math.min(ctx.body.requested_expiry, requestExpiry)
+				: requestExpiry;
+
+			const authReqId = generateAuthReqId();
+			await ctx.context.adapter.create({
+				model: "cibaRequest",
+				data: {
+					authReqId: await hashAuthReqId(authReqId),
+					clientId,
+					userId: user.id,
+					scope: ctx.body.scope,
+					bindingMessage: ctx.body.binding_message,
+					authorizationDetails: ctx.body.authorization_details,
+					resource: ctx.body.resource,
+					acrValues: ctx.body.acr_values,
+					status: "pending",
+					deliveryMode: registeredMode,
+					clientNotificationToken: ctx.body.client_notification_token,
+					clientNotificationEndpoint: notificationEndpoint,
+					pollingInterval,
+					expiresAt: new Date(Date.now() + expiresIn * 1000),
+					createdAt: new Date(),
+				},
+			});
+
+			const approvalUrl = new URL(options.approvalPage, ctx.context.baseURL);
+			approvalUrl.searchParams.set("auth_req_id", authReqId);
+			try {
+				await options.sendNotification(
+					{
+						userId: user.id,
+						clientId,
+						clientName: client.name,
+						scope: ctx.body.scope,
+						bindingMessage: ctx.body.binding_message,
+						authorizationDetails: parsedAuthorizationDetails,
+						acrValues: ctx.body.acr_values,
+						approvalUrl: approvalUrl.toString(),
+						attestationJwt:
+							ctx.request?.headers.get("OAuth-Client-Attestation") ?? undefined,
+						attestationPopJwt:
+							ctx.request?.headers.get("OAuth-Client-Attestation-PoP") ??
+							undefined,
+					},
+					ctx.request,
+				);
+			} catch (error) {
+				// Log the message only; the raw provider error can carry the
+				// recipient address or response body.
+				ctx.context.logger?.error(
+					`CIBA sendNotification failed; the request is still pending: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+
+			// Push mode omits the polling interval: the client waits for delivery
+			// rather than polling (CIBA §7.3).
+			const response: Record<string, unknown> = {
+				auth_req_id: authReqId,
+				expires_in: expiresIn,
+			};
+			if (registeredMode !== "push") {
+				response.interval = pollingInterval;
+			}
+			return ctx.json(response);
+		},
+	);
+}

--- a/packages/ciba/src/ciba.test.ts
+++ b/packages/ciba/src/ciba.test.ts
@@ -1,0 +1,1051 @@
+import type { OAuthClient } from "@better-auth/oauth-provider";
+import { oauthProvider } from "@better-auth/oauth-provider";
+import { APIError } from "better-auth/api";
+import { deriveDpopJkt } from "better-auth/oauth2";
+import { jwt } from "better-auth/plugins/jwt";
+import { getTestInstance } from "better-auth/test";
+import type { JWK } from "jose";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { CibaRequest, SendNotificationData } from "./index";
+import { CIBA_GRANT_TYPE, ciba } from "./index";
+import { hashAuthReqId } from "./utils";
+
+const baseURL = "http://localhost:3000";
+const POLL_INTERVAL = 2;
+
+let lastNotification: SendNotificationData | undefined;
+
+const { auth, signInWithTestUser, signInWithUser, customFetchImpl, testUser } =
+	await getTestInstance({
+		baseURL,
+		plugins: [
+			jwt({ jwt: { issuer: baseURL } }),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
+			}),
+			ciba({
+				approvalPage: "/approve",
+				pollingInterval: POLL_INTERVAL,
+				sendNotification: (data) => {
+					lastNotification = data;
+				},
+			}),
+		],
+	});
+
+const { headers } = await signInWithTestUser();
+
+const secondUser = {
+	email: "second@example.com",
+	password: "password1234",
+	name: "Second User",
+};
+
+let confidentialClient: OAuthClient;
+let otherClient: OAuthClient;
+let noModeClient: OAuthClient;
+let basicAuth: string;
+let otherAuth: string;
+let secondUserHeaders: Headers;
+
+function basicAuthFor(client: OAuthClient): string {
+	return `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`;
+}
+
+beforeAll(async () => {
+	confidentialClient = await auth.api.adminCreateOAuthClient({
+		headers,
+		body: {
+			grant_types: [CIBA_GRANT_TYPE],
+			redirect_uris: [`${baseURL}/callback`],
+			skip_consent: true,
+			metadata: { backchannel_token_delivery_mode: "poll" },
+		},
+	});
+	basicAuth = basicAuthFor(confidentialClient);
+	// A second confidential CIBA client, used to prove one client cannot redeem
+	// another's auth_req_id.
+	otherClient = await auth.api.adminCreateOAuthClient({
+		headers,
+		body: {
+			grant_types: [CIBA_GRANT_TYPE],
+			metadata: { backchannel_token_delivery_mode: "poll" },
+		},
+	});
+	otherAuth = basicAuthFor(otherClient);
+	// Registered for the CIBA grant but with no delivery mode.
+	noModeClient = await auth.api.adminCreateOAuthClient({
+		headers,
+		body: { grant_types: [CIBA_GRANT_TYPE] },
+	});
+	// A second user, used to prove a session cannot approve another user's request.
+	await auth.api.signUpEmail({ body: secondUser });
+	secondUserHeaders = (
+		await signInWithUser(secondUser.email, secondUser.password)
+	).headers;
+});
+
+async function bcAuthorize(
+	body: Record<string, string>,
+	authHeader: string | null = basicAuth,
+) {
+	const res = await customFetchImpl(`${baseURL}/api/auth/oauth2/bc-authorize`, {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			...(authHeader ? { authorization: authHeader } : {}),
+		},
+		body: JSON.stringify(body),
+	});
+	return { status: res.status, headers: res.headers, body: await res.json() };
+}
+
+async function poll(
+	authReqId: string,
+	authHeader: string | undefined = basicAuth,
+) {
+	const res = await customFetchImpl(`${baseURL}/api/auth/oauth2/token`, {
+		method: "POST",
+		headers: {
+			"content-type": "application/x-www-form-urlencoded",
+			...(authHeader ? { authorization: authHeader } : {}),
+		},
+		body: new URLSearchParams({
+			grant_type: CIBA_GRANT_TYPE,
+			auth_req_id: authReqId,
+		}).toString(),
+	});
+	return { status: res.status, body: await res.json() };
+}
+
+async function createDpopProof(privateKey: CryptoKey, publicJwk: JWK) {
+	return new SignJWT({
+		jti: "ciba-dpop-proof",
+		htm: "POST",
+		htu: `${baseURL}/api/auth/oauth2/token`,
+		iat: Math.floor(Date.now() / 1000),
+	})
+		.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk: publicJwk })
+		.sign(privateKey);
+}
+
+describe("ciba poll flow", () => {
+	it("runs the decoupled poll flow", async () => {
+		const start = await bcAuthorize({
+			scope: "openid profile",
+			login_hint: testUser.email,
+		});
+		expect(start.status).toBe(200);
+		expect(start.headers.get("Cache-Control")).toBe("no-store");
+		expect(start.body.auth_req_id).toBeDefined();
+		expect(start.body.expires_in).toBe(300);
+		expect(start.body.interval).toBe(POLL_INTERVAL);
+		expect(lastNotification?.approvalUrl).toContain(
+			`auth_req_id=${start.body.auth_req_id}`,
+		);
+
+		const authReqId = start.body.auth_req_id as string;
+		await auth.api.cibaAuthorize({ headers, body: { auth_req_id: authReqId } });
+
+		const issued = await poll(authReqId);
+		expect(issued.status).toBe(200);
+		expect(issued.body.access_token).toBeDefined();
+		expect(issued.body.token_type).toBe("Bearer");
+
+		// Single-use: the request was consumed on issuance, so a second poll fails.
+		const replay = await poll(authReqId);
+		expect(replay.status).toBe(400);
+		expect(replay.body.error).toBe("invalid_grant");
+	});
+
+	it("returns authorization_pending before approval", async () => {
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const pending = await poll(start.body.auth_req_id as string);
+		expect(pending.status).toBe(400);
+		expect(pending.body.error).toBe("authorization_pending");
+	});
+
+	it("issues to only one of two concurrent polls of an approved request", async () => {
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		await auth.api.cibaAuthorize({ headers, body: { auth_req_id: authReqId } });
+
+		const [a, b] = await Promise.all([poll(authReqId), poll(authReqId)]);
+		const statuses = [a.status, b.status].sort();
+		expect(statuses).toEqual([200, 400]);
+		const won = a.status === 200 ? a : b;
+		const lost = a.status === 200 ? b : a;
+		expect(won.body.access_token).toBeDefined();
+		expect(lost.body.error).toBe("invalid_grant");
+	});
+
+	it("rejects fast polls with slow_down and ratchets the interval (CIBA §11)", async () => {
+		const ctx = await auth.$context;
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+
+		const first = await poll(authReqId);
+		expect(first.body.error).toBe("authorization_pending");
+
+		const tooFast = await poll(authReqId);
+		expect(tooFast.status).toBe(400);
+		expect(tooFast.body.error).toBe("slow_down");
+
+		const row = await ctx.adapter.findOne<{ pollingInterval: number }>({
+			model: "cibaRequest",
+			where: [{ field: "authReqId", value: await hashAuthReqId(authReqId) }],
+		});
+		expect(row?.pollingInterval).toBe(POLL_INTERVAL + 5);
+	});
+
+	it("binds the polled token to the agent's DPoP key when a proof is sent", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256", {
+			extractable: true,
+		});
+		const publicJwk = await exportJWK(publicKey);
+		const jkt = await deriveDpopJkt(publicJwk);
+
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		await auth.api.cibaAuthorize({ headers, body: { auth_req_id: authReqId } });
+
+		const res = await customFetchImpl(`${baseURL}/api/auth/oauth2/token`, {
+			method: "POST",
+			headers: {
+				authorization: basicAuth,
+				"content-type": "application/x-www-form-urlencoded",
+				dpop: await createDpopProof(privateKey, publicJwk),
+			},
+			body: new URLSearchParams({
+				grant_type: CIBA_GRANT_TYPE,
+				auth_req_id: authReqId,
+			}).toString(),
+		});
+		const body = await res.json();
+		expect(res.status).toBe(200);
+		expect(body.token_type).toBe("DPoP");
+
+		const introspectRes = await customFetchImpl(
+			`${baseURL}/api/auth/oauth2/introspect`,
+			{
+				method: "POST",
+				headers: {
+					authorization: basicAuth,
+					"content-type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					token: body.access_token,
+					token_type_hint: "access_token",
+				}).toString(),
+			},
+		);
+		const introspection = await introspectRes.json();
+		expect(introspection.cnf).toEqual({ jkt });
+	});
+
+	it("returns access_denied when the user rejects", async () => {
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		await auth.api.cibaReject({ headers, body: { auth_req_id: authReqId } });
+		const denied = await poll(authReqId);
+		expect(denied.status).toBe(400);
+		expect(denied.body.error).toBe("access_denied");
+	});
+
+	it("rejects a client not registered with a poll delivery mode", async () => {
+		const noModeAuth = `Basic ${btoa(`${noModeClient.client_id}:${noModeClient.client_secret}`)}`;
+		const res = await bcAuthorize(
+			{ scope: "openid", login_hint: testUser.email },
+			noModeAuth,
+		);
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_request");
+	});
+
+	it("rejects a scope without openid", async () => {
+		const res = await bcAuthorize({
+			scope: "profile",
+			login_hint: testUser.email,
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_scope");
+	});
+
+	it("rejects an unknown user hint", async () => {
+		const res = await bcAuthorize({
+			scope: "openid",
+			login_hint: "nobody@example.com",
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("unknown_user_id");
+	});
+
+	it("rejects a request with more than one hint", async () => {
+		const res = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+			id_token_hint: "some-token",
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_request");
+	});
+
+	it("rejects a request with no hint", async () => {
+		const res = await bcAuthorize({ scope: "openid" });
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_request");
+	});
+
+	it("rejects an unsupported hint type", async () => {
+		const res = await bcAuthorize({ scope: "openid", id_token_hint: "x" });
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_request");
+	});
+
+	it("rejects a request from an unauthenticated client", async () => {
+		const res = await bcAuthorize(
+			{
+				client_id: confidentialClient.client_id,
+				scope: "openid",
+				login_hint: testUser.email,
+			},
+			null,
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects a poll from a client other than the requester", async () => {
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		await auth.api.cibaAuthorize({ headers, body: { auth_req_id: authReqId } });
+
+		// A different (authenticated) client cannot redeem the approved request.
+		const stolen = await poll(authReqId, otherAuth);
+		expect(stolen.status).toBe(400);
+		expect(stolen.body.error).toBe("invalid_grant");
+
+		// The request is untouched, so the original client still succeeds.
+		const issued = await poll(authReqId);
+		expect(issued.status).toBe(200);
+		expect(issued.body.access_token).toBeDefined();
+	});
+
+	it("rejects a poll with an unknown auth_req_id", async () => {
+		const res = await poll("auth-req-id-that-was-never-issued");
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_grant");
+	});
+
+	it("returns expired_token once the request has expired", async () => {
+		const ctx = await auth.$context;
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		await ctx.adapter.update({
+			model: "cibaRequest",
+			where: [{ field: "authReqId", value: await hashAuthReqId(authReqId) }],
+			update: { expiresAt: new Date(Date.now() - 1000) },
+		});
+		const res = await poll(authReqId);
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("expired_token");
+	});
+
+	it("clamps requested_expiry to the configured maximum", async () => {
+		const within = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+			requested_expiry: "120",
+		});
+		expect(within.body.expires_in).toBe(120);
+
+		const beyond = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+			requested_expiry: "100000",
+		});
+		expect(beyond.body.expires_in).toBe(300);
+	});
+
+	it("rejects a binding_message containing control characters", async () => {
+		const res = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+			binding_message: "approve\u0001now",
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_binding_message");
+	});
+
+	it("forwards a valid binding_message to the notification", async () => {
+		await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+			binding_message: "Approve sign-in on Acme",
+		});
+		expect(lastNotification?.bindingMessage).toBe("Approve sign-in on Acme");
+	});
+
+	it("does not let another user approve the request", async () => {
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+
+		await expect(
+			auth.api.cibaAuthorize({
+				headers: secondUserHeaders,
+				body: { auth_req_id: authReqId },
+			}),
+		).rejects.toThrow();
+
+		// The foreign approval was a no-op: the request is still pending.
+		const pending = await poll(authReqId);
+		expect(pending.body.error).toBe("authorization_pending");
+	});
+
+	it("approves by request_id for the owning session", async () => {
+		const ctx = await auth.$context;
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		// A first-party UI lists the request by id and never holds the raw token
+		// (only its hash is stored), so it approves by request_id instead.
+		const row = await ctx.adapter.findOne<{ id: string }>({
+			model: "cibaRequest",
+			where: [{ field: "authReqId", value: await hashAuthReqId(authReqId) }],
+		});
+		expect(row?.id).toBeDefined();
+
+		await auth.api.cibaAuthorize({
+			headers,
+			body: { request_id: row?.id as string },
+		});
+
+		const issued = await poll(authReqId);
+		expect(issued.status).toBe(200);
+		expect(issued.body.access_token).toBeDefined();
+	});
+
+	it("does not let another user approve by request_id", async () => {
+		const ctx = await auth.$context;
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		const row = await ctx.adapter.findOne<{ id: string }>({
+			model: "cibaRequest",
+			where: [{ field: "authReqId", value: await hashAuthReqId(authReqId) }],
+		});
+
+		await expect(
+			auth.api.cibaAuthorize({
+				headers: secondUserHeaders,
+				body: { request_id: row?.id as string },
+			}),
+		).rejects.toThrow();
+
+		const pending = await poll(authReqId);
+		expect(pending.body.error).toBe("authorization_pending");
+	});
+
+	it("rejects by request_id for the owning session", async () => {
+		const ctx = await auth.$context;
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		const row = await ctx.adapter.findOne<{ id: string }>({
+			model: "cibaRequest",
+			where: [{ field: "authReqId", value: await hashAuthReqId(authReqId) }],
+		});
+
+		await auth.api.cibaReject({
+			headers,
+			body: { request_id: row?.id as string },
+		});
+
+		const denied = await poll(authReqId);
+		expect(denied.status).toBe(400);
+		expect(denied.body.error).toBe("access_denied");
+	});
+
+	it("requires exactly one of auth_req_id or request_id", async () => {
+		await expect(
+			auth.api.cibaAuthorize({ headers, body: {} }),
+		).rejects.toThrow();
+	});
+});
+
+describe("ciba public client", () => {
+	it("lets a public client complete the flow when confidential is not required", async () => {
+		const pubURL = "http://localhost:3010";
+		const {
+			auth: pubAuth,
+			signInWithTestUser: pubSignIn,
+			customFetchImpl: pubFetch,
+			testUser: pubUser,
+		} = await getTestInstance({
+			baseURL: pubURL,
+			plugins: [
+				jwt({ jwt: { issuer: pubURL } }),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
+				}),
+				ciba({
+					approvalPage: "/approve",
+					pollingInterval: POLL_INTERVAL,
+					requireConfidentialClient: false,
+					sendNotification: () => {},
+				}),
+			],
+		});
+		const { headers: pubHeaders } = await pubSignIn();
+		const publicClient = await pubAuth.api.adminCreateOAuthClient({
+			headers: pubHeaders,
+			body: {
+				grant_types: [CIBA_GRANT_TYPE],
+				token_endpoint_auth_method: "none",
+				metadata: { backchannel_token_delivery_mode: "poll" },
+			},
+		});
+
+		const start = await pubFetch(`${pubURL}/api/auth/oauth2/bc-authorize`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				client_id: publicClient.client_id,
+				scope: "openid",
+				login_hint: pubUser.email,
+			}),
+		});
+		expect(start.status).toBe(200);
+		const { auth_req_id } = (await start.json()) as { auth_req_id: string };
+
+		await pubAuth.api.cibaAuthorize({
+			headers: pubHeaders,
+			body: { auth_req_id },
+		});
+
+		const tokenRes = await pubFetch(`${pubURL}/api/auth/oauth2/token`, {
+			method: "POST",
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: CIBA_GRANT_TYPE,
+				auth_req_id,
+				client_id: publicClient.client_id,
+			}).toString(),
+		});
+		const body = (await tokenRes.json()) as { access_token?: string };
+		expect(tokenRes.status).toBe(200);
+		expect(body.access_token).toBeDefined();
+	});
+});
+
+describe("ciba request details", () => {
+	async function getRequest(authReqId: string) {
+		const res = await customFetchImpl(
+			`${baseURL}/api/auth/ciba/request?auth_req_id=${encodeURIComponent(authReqId)}`,
+			{ method: "GET" },
+		);
+		return { status: res.status, headers: res.headers, body: await res.json() };
+	}
+
+	it("returns the details an approval page renders", async () => {
+		const start = await bcAuthorize({
+			scope: "openid profile",
+			login_hint: testUser.email,
+			binding_message: "Approve on Acme",
+		});
+		const details = await getRequest(start.body.auth_req_id as string);
+		expect(details.status).toBe(200);
+		expect(details.headers.get("Cache-Control")).toBe("no-store");
+		expect(details.body.scope).toBe("openid profile");
+		expect(details.body.binding_message).toBe("Approve on Acme");
+		expect(details.body.status).toBe("pending");
+		expect(details.body.expires_at).toBeDefined();
+	});
+
+	it("returns 404 for an unknown auth_req_id", async () => {
+		const details = await getRequest("never-issued");
+		expect(details.status).toBe(404);
+	});
+});
+
+describe("ciba discovery metadata", () => {
+	it("advertises the backchannel endpoint and poll delivery mode", async () => {
+		const metadata = (await auth.api.getOpenIdConfig()) as Record<
+			string,
+			unknown
+		>;
+		expect(metadata.backchannel_authentication_endpoint).toContain(
+			"/oauth2/bc-authorize",
+		);
+		expect(metadata.backchannel_token_delivery_modes_supported).toEqual([
+			"poll",
+		]);
+		expect(metadata.backchannel_user_code_parameter_supported).toBe(false);
+	});
+});
+
+describe("ciba agent claims (act.sub, RAR)", () => {
+	const rar = JSON.stringify([
+		{ type: "purchase", actions: ["buy"], locations: ["https://shop.example"] },
+	]);
+
+	async function introspect(accessToken: string) {
+		const res = await customFetchImpl(`${baseURL}/api/auth/oauth2/introspect`, {
+			method: "POST",
+			headers: {
+				authorization: basicAuth,
+				"content-type": "application/x-www-form-urlencoded",
+			},
+			body: new URLSearchParams({
+				token: accessToken,
+				token_type_hint: "access_token",
+			}).toString(),
+		});
+		return (await res.json()) as Record<string, unknown>;
+	}
+
+	it("stamps act.sub on the token (visible at opaque introspection)", async () => {
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		await auth.api.cibaAuthorize({ headers, body: { auth_req_id: authReqId } });
+
+		const issued = await poll(authReqId);
+		expect(issued.status).toBe(200);
+
+		// act.sub (RFC 8693) names the calling client as the actor. The CIBA
+		// claims contributor re-derives it at introspection, where the token is
+		// opaque and the grant type is unknown.
+		const introspection = await introspect(issued.body.access_token as string);
+		expect(introspection.active).toBe(true);
+		expect(introspection.act).toEqual({ sub: confidentialClient.client_id });
+	});
+
+	it("round-trips authorization_details into the token response", async () => {
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+			authorization_details: rar,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		await auth.api.cibaAuthorize({ headers, body: { auth_req_id: authReqId } });
+		const issued = await poll(authReqId);
+		expect(issued.status).toBe(200);
+		// RFC 9396 RAR is echoed in the token response body.
+		expect(issued.body.authorization_details).toEqual(JSON.parse(rar));
+	});
+
+	it("issues without authorization_details when none was requested", async () => {
+		const start = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+		});
+		const authReqId = start.body.auth_req_id as string;
+		await auth.api.cibaAuthorize({ headers, body: { auth_req_id: authReqId } });
+		const issued = await poll(authReqId);
+		expect(issued.body.authorization_details).toBeUndefined();
+	});
+
+	it("forwards parsed authorization_details to the notification", async () => {
+		await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+			authorization_details: rar,
+		});
+		expect(lastNotification?.authorizationDetails).toEqual(JSON.parse(rar));
+	});
+
+	it("rejects malformed authorization_details at request time", async () => {
+		const res = await bcAuthorize({
+			scope: "openid",
+			login_hint: testUser.email,
+			authorization_details: "{not json",
+		});
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_request");
+	});
+});
+
+const baseURL2 = "http://localhost:3020";
+const seenRequests: CibaRequest[] = [];
+let acrNotification: SendNotificationData | undefined;
+const pushDeliveries: Array<Record<string, unknown>> = [];
+const pingDeliveries: string[] = [];
+
+const {
+	auth: auth2,
+	signInWithTestUser: signIn2,
+	customFetchImpl: fetch2,
+	testUser: user2,
+} = await getTestInstance({
+	baseURL: baseURL2,
+	plugins: [
+		jwt({ jwt: { issuer: baseURL2 } }),
+		oauthProvider({
+			loginPage: "/login",
+			consentPage: "/consent",
+			silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
+		}),
+		ciba({
+			approvalPage: "/approve",
+			pollingInterval: POLL_INTERVAL,
+			deliveryModes: ["poll", "ping", "push"],
+			pushRetryAttempts: 0,
+			sendNotification: (data) => {
+				acrNotification = data;
+			},
+			// Step-up: refuse issuance when the request carried acr_values.
+			enforceTokenAcr: (request) => {
+				if (request.acrValues === "tier-3") {
+					throw new APIError("FORBIDDEN", {
+						error: "insufficient_authorization",
+						error_description: "User does not satisfy acr_values: tier-3",
+					});
+				}
+			},
+			// authContextId write-through: a deployment stamps an auth-context id
+			// after approval and reads it back into a claim here.
+			buildAccessTokenClaims: (request) => {
+				seenRequests.push(request);
+				return request.authContextId
+					? { auth_context_id: request.authContextId }
+					: {};
+			},
+		}),
+	],
+});
+
+const { headers: headers2 } = await signIn2();
+
+/**
+ * Intercepts the plugin's outbound ping/push call to a single endpoint while
+ * delegating every other request to the real `fetch`. Returns a restore fn.
+ */
+function interceptFetch(
+	endpoint: string,
+	handler: (request: Request) => Promise<Response>,
+): () => void {
+	const realFetch = globalThis.fetch;
+	const patched: typeof fetch = (input, init) => {
+		const url = typeof input === "string" ? input : input.toString();
+		if (url === endpoint) {
+			return handler(new Request(url, init));
+		}
+		return realFetch(input, init);
+	};
+	patched.preconnect = realFetch.preconnect;
+	globalThis.fetch = patched;
+	return () => {
+		globalThis.fetch = realFetch;
+	};
+}
+
+describe("ciba step-up, hooks, and ping/push delivery", () => {
+	let pollClient: OAuthClient;
+	let pingClient: OAuthClient;
+	let pushClient: OAuthClient;
+	let pushEndpoint: string;
+
+	beforeAll(async () => {
+		// A push/ping notification sink served by the same fetch impl.
+		pushEndpoint = `${baseURL2}/__notify`;
+		pollClient = await auth2.api.adminCreateOAuthClient({
+			headers: headers2,
+			body: {
+				grant_types: [CIBA_GRANT_TYPE],
+				metadata: { backchannel_token_delivery_mode: "poll" },
+			},
+		});
+		pingClient = await auth2.api.adminCreateOAuthClient({
+			headers: headers2,
+			body: {
+				grant_types: [CIBA_GRANT_TYPE],
+				metadata: { backchannel_token_delivery_mode: "ping" },
+			},
+		});
+		pushClient = await auth2.api.adminCreateOAuthClient({
+			headers: headers2,
+			body: {
+				grant_types: [CIBA_GRANT_TYPE],
+				metadata: { backchannel_token_delivery_mode: "push" },
+			},
+		});
+	});
+
+	function basic(client: OAuthClient): string {
+		return `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`;
+	}
+
+	async function bc(body: Record<string, string>, client: OAuthClient) {
+		const res = await fetch2(`${baseURL2}/api/auth/oauth2/bc-authorize`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: basic(client),
+			},
+			body: JSON.stringify(body),
+		});
+		return { status: res.status, body: await res.json() };
+	}
+
+	async function poll2(authReqId: string, client: OAuthClient) {
+		const res = await fetch2(`${baseURL2}/api/auth/oauth2/token`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/x-www-form-urlencoded",
+				authorization: basic(client),
+			},
+			body: new URLSearchParams({
+				grant_type: CIBA_GRANT_TYPE,
+				auth_req_id: authReqId,
+			}).toString(),
+		});
+		return { status: res.status, body: await res.json() };
+	}
+
+	it("advertises all configured delivery modes in discovery metadata", async () => {
+		const metadata = (await auth2.api.getOpenIdConfig()) as Record<
+			string,
+			unknown
+		>;
+		expect(metadata.backchannel_token_delivery_modes_supported).toEqual([
+			"poll",
+			"ping",
+			"push",
+		]);
+	});
+
+	it("refuses issuance when acr_values are not satisfied (step-up)", async () => {
+		const start = await bc(
+			{ scope: "openid", login_hint: user2.email, acr_values: "tier-3" },
+			pollClient,
+		);
+		expect(start.status).toBe(200);
+		expect(acrNotification?.acrValues).toBe("tier-3");
+		const authReqId = start.body.auth_req_id as string;
+		await auth2.api.cibaAuthorize({
+			headers: headers2,
+			body: { auth_req_id: authReqId },
+		});
+		const denied = await poll2(authReqId, pollClient);
+		expect(denied.status).toBe(403);
+		expect(denied.body.error).toBe("insufficient_authorization");
+
+		// The refusal ran before the single-use consume, so the approved request
+		// survives for a retry after the user elevates (here it stays approved).
+		const ctx = await auth2.$context;
+		const row = await ctx.adapter.findOne<{ status: string }>({
+			model: "cibaRequest",
+			where: [{ field: "authReqId", value: await hashAuthReqId(authReqId) }],
+		});
+		expect(row?.status).toBe("approved");
+	});
+
+	it("issues when acr_values are satisfied", async () => {
+		const start = await bc(
+			{ scope: "openid", login_hint: user2.email, acr_values: "tier-1" },
+			pollClient,
+		);
+		const authReqId = start.body.auth_req_id as string;
+		await auth2.api.cibaAuthorize({
+			headers: headers2,
+			body: { auth_req_id: authReqId },
+		});
+		const issued = await poll2(authReqId, pollClient);
+		expect(issued.status).toBe(200);
+		expect(issued.body.access_token).toBeDefined();
+	});
+
+	it("persists authContextId and reads it back at issuance via the hook", async () => {
+		const start = await bc(
+			{ scope: "openid", login_hint: user2.email },
+			pollClient,
+		);
+		const authReqId = start.body.auth_req_id as string;
+
+		// Approve, then a deployment stamps an auth-context id on the persisted row
+		// before the agent polls (the plugin owns the column; the deployment writes
+		// it). The issuance hook receives the row, proving the write-through.
+		await auth2.api.cibaAuthorize({
+			headers: headers2,
+			body: { auth_req_id: authReqId },
+		});
+		const ctx = await auth2.$context;
+		await ctx.adapter.update({
+			model: "cibaRequest",
+			where: [{ field: "authReqId", value: await hashAuthReqId(authReqId) }],
+			update: { authContextId: "auth-ctx-123" },
+		});
+
+		const issued = await poll2(authReqId, pollClient);
+		expect(issued.status).toBe(200);
+		expect(seenRequests.some((r) => r.authContextId === "auth-ctx-123")).toBe(
+			true,
+		);
+	});
+
+	it("delivers tokens inline for push mode and consumes the request once", async () => {
+		const handler = async (request: Request) => {
+			pushDeliveries.push((await request.json()) as Record<string, unknown>);
+			return new Response(null, { status: 204 });
+		};
+		const start = await bc(
+			{
+				scope: "openid",
+				login_hint: user2.email,
+				client_notification_token: "push-notification-token",
+				client_notification_uri: pushEndpoint,
+			},
+			pushClient,
+		);
+		expect(start.status).toBe(200);
+		// Push response omits the polling interval (CIBA §7.3).
+		expect(start.body.interval).toBeUndefined();
+		const authReqId = start.body.auth_req_id as string;
+
+		// Intercept the AS -> client notification call.
+		const restore = interceptFetch(pushEndpoint, handler);
+		try {
+			await auth2.api.cibaAuthorize({
+				headers: headers2,
+				body: { auth_req_id: authReqId },
+			});
+			// Allow the fire-and-forget push to settle.
+			await new Promise((r) => setTimeout(r, 50));
+		} finally {
+			restore();
+		}
+
+		expect(pushDeliveries).toHaveLength(1);
+		const delivered = pushDeliveries[0]!;
+		expect(delivered.auth_req_id).toBe(authReqId);
+		expect(typeof delivered.access_token).toBe("string");
+
+		// act.sub is visible at introspection of the pushed (opaque) token.
+		const introspectRes = await fetch2(
+			`${baseURL2}/api/auth/oauth2/introspect`,
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+					authorization: basic(pushClient),
+				},
+				body: new URLSearchParams({
+					token: delivered.access_token as string,
+					token_type_hint: "access_token",
+				}).toString(),
+			},
+		);
+		const introspection = (await introspectRes.json()) as Record<
+			string,
+			unknown
+		>;
+		expect(introspection.act).toEqual({ sub: pushClient.client_id });
+
+		// Single-use: the push request was consumed at approval, so a poll fails.
+		const replay = await poll2(authReqId, pushClient);
+		expect(replay.status).toBe(400);
+	});
+
+	it("pings the client to poll for ping mode, then issues on poll", async () => {
+		const handler = async (request: Request) => {
+			const body = (await request.json()) as { auth_req_id: string };
+			pingDeliveries.push(body.auth_req_id);
+			return new Response(null, { status: 204 });
+		};
+		const pingEndpoint = `${baseURL2}/__ping`;
+		const start = await bc(
+			{
+				scope: "openid",
+				login_hint: user2.email,
+				client_notification_token: "ping-notification-token",
+				client_notification_uri: pingEndpoint,
+			},
+			pingClient,
+		);
+		expect(start.status).toBe(200);
+		expect(start.body.interval).toBe(POLL_INTERVAL);
+		const authReqId = start.body.auth_req_id as string;
+
+		const restore = interceptFetch(pingEndpoint, handler);
+		try {
+			await auth2.api.cibaAuthorize({
+				headers: headers2,
+				body: { auth_req_id: authReqId },
+			});
+			await new Promise((r) => setTimeout(r, 50));
+		} finally {
+			restore();
+		}
+
+		expect(pingDeliveries).toContain(authReqId);
+
+		// Ping mode still issues by polling (the AS only signaled readiness).
+		const issued = await poll2(authReqId, pingClient);
+		expect(issued.status).toBe(200);
+		expect(issued.body.access_token).toBeDefined();
+	});
+
+	it("requires a notification endpoint for ping/push requests", async () => {
+		const res = await bc(
+			{
+				scope: "openid",
+				login_hint: user2.email,
+				client_notification_token: "notification-token",
+			},
+			pushClient,
+		);
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_request");
+	});
+
+	it("rejects a non-HTTPS notification endpoint for push", async () => {
+		const res = await bc(
+			{
+				scope: "openid",
+				login_hint: user2.email,
+				client_notification_token: "notification-token",
+				client_notification_uri: "http://insecure.example/notify",
+			},
+			pushClient,
+		);
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_request");
+	});
+});

--- a/packages/ciba/src/client.ts
+++ b/packages/ciba/src/client.ts
@@ -1,0 +1,20 @@
+import type { BetterAuthClientPlugin } from "@better-auth/core";
+import type { ciba } from "./index";
+import { PACKAGE_VERSION } from "./version";
+
+/**
+ * Client plugin for CIBA. Exposes the approval-page actions on the auth client:
+ * `ciba.request()` (GET request details), `ciba.authorize()`, and
+ * `ciba.reject()`. The agent-facing backchannel endpoint is a server-to-server
+ * call and is not surfaced here.
+ */
+export const cibaClient = () => {
+	return {
+		id: "ciba",
+		version: PACKAGE_VERSION,
+		$InferServerPlugin: {} as ReturnType<typeof ciba>,
+		pathMethods: {
+			"/ciba/request": "GET",
+		},
+	} satisfies BetterAuthClientPlugin;
+};

--- a/packages/ciba/src/constants.ts
+++ b/packages/ciba/src/constants.ts
@@ -1,0 +1,28 @@
+/**
+ * OAuth grant type for the CIBA token-delivery poll, registered with the OAuth
+ * provider's token endpoint.
+ *
+ * @see https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.7.3
+ */
+export const CIBA_GRANT_TYPE = "urn:openid:params:grant-type:ciba";
+
+/** Backchannel authentication endpoint path, co-located with the OAuth routes. */
+export const BC_AUTHORIZE_PATH = "/oauth2/bc-authorize";
+
+/** Default lifetime of a backchannel auth request, in seconds (CIBA §7.3). */
+export const DEFAULT_REQUEST_EXPIRY = 300;
+
+/** Default minimum interval a client must wait between token polls, in seconds. */
+export const DEFAULT_POLLING_INTERVAL = 5;
+
+/** Seconds the polling interval ratchets up on each `slow_down` (CIBA §11). */
+export const SLOW_DOWN_INCREMENT = 5;
+
+/**
+ * Registered client-metadata field naming the CIBA token delivery mode (CIBA
+ * §4). A client must register one of `poll`, `ping`, or `push`.
+ */
+export const DELIVERY_MODE_METADATA_KEY = "backchannel_token_delivery_mode";
+
+/** All CIBA token delivery modes, in the order metadata advertises them. */
+export const ALL_DELIVERY_MODES = ["poll", "ping", "push"] as const;

--- a/packages/ciba/src/error-codes.ts
+++ b/packages/ciba/src/error-codes.ts
@@ -1,0 +1,29 @@
+import { defineErrorCodes } from "@better-auth/core/utils/error-codes";
+
+/**
+ * CIBA error vocabulary. The backchannel authentication endpoint and the
+ * token-endpoint poll use distinct OAuth error codes (CIBA §11 and §13); these
+ * descriptions are the single source for both the wire `error_description` and
+ * the plugin's `$ERROR_CODES` catalog.
+ *
+ * @see https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.13
+ */
+export const CIBA_ERROR_CODES = defineErrorCodes({
+	// Backchannel authentication endpoint (CIBA §13).
+	INVALID_REQUEST: "The request is malformed or missing a required parameter",
+	INVALID_SCOPE: "The requested scope is invalid; it must include 'openid'",
+	INVALID_BINDING_MESSAGE: "The binding_message is unacceptable",
+	UNKNOWN_USER_ID: "The user identified by the hint could not be found",
+	UNSUPPORTED_HINT:
+		"Only login_hint is supported; id_token_hint and login_hint_token are not yet implemented",
+	EXACTLY_ONE_HINT:
+		"Exactly one of login_hint, id_token_hint, or login_hint_token is required",
+	UNSUPPORTED_DELIVERY_MODE:
+		"The client is not registered with a backchannel_token_delivery_mode this deployment supports",
+	// Token endpoint poll (CIBA §11).
+	AUTHORIZATION_PENDING: "The authorization request is still pending",
+	SLOW_DOWN: "Polling too frequently; increase the interval",
+	EXPIRED_TOKEN: "The auth_req_id has expired",
+	ACCESS_DENIED: "The user denied the authorization request",
+	INVALID_GRANT: "The auth_req_id is invalid or has already been consumed",
+});

--- a/packages/ciba/src/grant-handler.ts
+++ b/packages/ciba/src/grant-handler.ts
@@ -1,0 +1,161 @@
+import type { OAuthExtensionGrantHandler } from "@better-auth/oauth-provider";
+import { APIError } from "better-auth/api";
+import { SLOW_DOWN_INCREMENT } from "./constants";
+import { CIBA_ERROR_CODES } from "./error-codes";
+import type { CibaOptions } from "./types";
+import {
+	buildCibaIssuanceExtras,
+	consumeApprovedCibaRequest,
+	deleteCibaRequest,
+	findCibaRequestByHash,
+	hashAuthReqId,
+	ratchetPollingInterval,
+	updateCibaRequest,
+} from "./utils";
+
+/**
+ * Token-endpoint handler for the CIBA grant. The agent polls here with its
+ * `auth_req_id`; once the user has approved, the request is atomically claimed
+ * (consumed) and the token set is issued through the shared provider.
+ *
+ * @see https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.11
+ */
+export function createCibaGrantHandler(
+	options: CibaOptions,
+): OAuthExtensionGrantHandler {
+	return async ({ ctx, provider }) => {
+		const rawAuthReqId = ctx.body?.auth_req_id;
+		if (!rawAuthReqId || typeof rawAuthReqId !== "string") {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_request",
+				error_description: "auth_req_id is required for the CIBA grant",
+			});
+		}
+
+		const request = await findCibaRequestByHash(
+			ctx,
+			await hashAuthReqId(rawAuthReqId),
+		);
+		if (!request) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_grant",
+				error_description: CIBA_ERROR_CODES.INVALID_GRANT.message,
+			});
+		}
+
+		const scopes = request.scope.split(" ").filter(Boolean);
+		// Re-authenticate the polling client and re-validate the stored scopes
+		// against the current client record (catches scopes revoked after the
+		// request was created). The bound grant type enforces CIBA registration.
+		// `confirmation` carries any sender-constraint the auth step proved
+		// (mTLS / extension strategy) and is forwarded to issuance.
+		const { client, clientId, confirmation } =
+			await provider.authenticateClient({
+				scopes,
+				requireCredentials: options.requireConfidentialClient !== false,
+			});
+		if (request.clientId !== clientId) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_grant",
+				error_description: CIBA_ERROR_CODES.INVALID_GRANT.message,
+			});
+		}
+
+		// slow_down: a poll faster than the interval ratchets the interval up for
+		// this and subsequent polls (CIBA §11) and is rejected. lastPolledAt is left
+		// untouched in that branch so the gate keeps measuring from the last accepted
+		// poll. This read-then-write check is not atomic, so a client that fans out
+		// simultaneous polls can occasionally slip an extra one through; slow_down is
+		// advisory rate limiting, and the hard single-use guarantee is the atomic
+		// consume below, not this gate.
+		const now = Date.now();
+		if (
+			request.lastPolledAt &&
+			now - new Date(request.lastPolledAt).getTime() <
+				request.pollingInterval * 1000
+		) {
+			await ratchetPollingInterval(ctx, request.id, SLOW_DOWN_INCREMENT);
+			throw new APIError("BAD_REQUEST", {
+				error: "slow_down",
+				error_description: CIBA_ERROR_CODES.SLOW_DOWN.message,
+			});
+		}
+		await updateCibaRequest(ctx, request.id, { lastPolledAt: new Date() });
+
+		if (request.expiresAt < new Date()) {
+			await deleteCibaRequest(ctx, request.id);
+			throw new APIError("BAD_REQUEST", {
+				error: "expired_token",
+				error_description: CIBA_ERROR_CODES.EXPIRED_TOKEN.message,
+			});
+		}
+
+		// A push-mode request was already redeemed inline at approval; it is not
+		// pollable (CIBA §5). The row is gone by now, so this is defensive.
+		if (request.deliveryMode === "push") {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_grant",
+				error_description: CIBA_ERROR_CODES.UNSUPPORTED_DELIVERY_MODE.message,
+			});
+		}
+
+		if (request.status === "pending") {
+			throw new APIError("BAD_REQUEST", {
+				error: "authorization_pending",
+				error_description: CIBA_ERROR_CODES.AUTHORIZATION_PENDING.message,
+			});
+		}
+		if (request.status === "rejected") {
+			await deleteCibaRequest(ctx, request.id);
+			throw new APIError("BAD_REQUEST", {
+				error: "access_denied",
+				error_description: CIBA_ERROR_CODES.ACCESS_DENIED.message,
+			});
+		}
+
+		// Step-up safety net: re-check the request's acr_values against the user
+		// before claiming the request, so a refusal leaves the approved row intact
+		// for a retry after the user elevates their authentication. The hook
+		// resolves the user's assurance itself and throws to refuse (for example a
+		// 403 insufficient_authorization step-up challenge).
+		if (options.enforceTokenAcr) {
+			await options.enforceTokenAcr(request, ctx);
+		}
+
+		// Atomically claim the approved request: concurrent polls contend on this
+		// delete-and-return, and only the winner issues tokens (single-use).
+		const claimed = await consumeApprovedCibaRequest(ctx, {
+			id: request.id,
+			clientId,
+		});
+		if (!claimed) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_grant",
+				error_description: CIBA_ERROR_CODES.INVALID_GRANT.message,
+			});
+		}
+
+		const user = await ctx.context.internalAdapter.findUserById(claimed.userId);
+		if (!user) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_grant",
+				error_description: "The authorizing user no longer exists",
+			});
+		}
+
+		const extras = await buildCibaIssuanceExtras(ctx, options, claimed);
+
+		return provider.issueTokens({
+			client,
+			scopes: claimed.scope.split(" ").filter(Boolean),
+			user,
+			referenceId: claimed.authReqId,
+			// The user authenticated at approval time, not at this poll (OIDC auth_time).
+			authTime: claimed.approvedAt ?? new Date(),
+			confirmation,
+			accessTokenClaims: extras.accessTokenClaims,
+			tokenResponse: extras.tokenResponse,
+			resources: extras.resources,
+		});
+	};
+}

--- a/packages/ciba/src/index.ts
+++ b/packages/ciba/src/index.ts
@@ -1,0 +1,98 @@
+import { extendOAuthProvider } from "@better-auth/oauth-provider";
+import type { BetterAuthPlugin } from "better-auth";
+import { createCibaAuthorize, createCibaReject } from "./approval";
+import { createBcAuthorize } from "./bc-authorize";
+import { BC_AUTHORIZE_PATH, CIBA_GRANT_TYPE } from "./constants";
+import { CIBA_ERROR_CODES } from "./error-codes";
+import { createCibaGrantHandler } from "./grant-handler";
+import { createCibaGetRequest } from "./request";
+import { schema } from "./schema";
+import type { CibaOptions } from "./types";
+import type { CibaDeliveryMode } from "./utils";
+import { PACKAGE_VERSION } from "./version";
+
+declare module "@better-auth/core" {
+	interface BetterAuthPluginRegistry<AuthOptions, Options> {
+		ciba: {
+			creator: typeof ciba;
+		};
+	}
+}
+
+/**
+ * Client-Initiated Backchannel Authentication (CIBA) plugin.
+ *
+ * Adds OpenID Connect decoupled authentication to an `oauth-provider` instance:
+ * a client (an AI agent, CLI, or device) starts a request at the backchannel
+ * endpoint, the user approves on a separate device, and tokens are delivered by
+ * one of three modes (CIBA §4): `poll` (the client polls the token endpoint),
+ * `ping` (the AS notifies the client to poll), or `push` (the AS delivers the
+ * token set to the client). The deployment opts into modes via `deliveryModes`.
+ *
+ * Requires the `oauth-provider` and `jwt` plugins.
+ *
+ * @see https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html
+ */
+export const ciba = (options: CibaOptions) => {
+	const deliveryModes: CibaDeliveryMode[] = options.deliveryModes ?? ["poll"];
+	return {
+		id: "ciba",
+		version: PACKAGE_VERSION,
+		schema,
+		init(ctx) {
+			extendOAuthProvider(ctx, {
+				grants: { [CIBA_GRANT_TYPE]: createCibaGrantHandler(options) },
+				metadata: ({ ctx: endpointCtx }) => ({
+					backchannel_authentication_endpoint: `${endpointCtx.context.baseURL}${BC_AUTHORIZE_PATH}`,
+					backchannel_token_delivery_modes_supported: deliveryModes,
+					backchannel_user_code_parameter_supported: false,
+				}),
+				claims: {
+					// `act.sub` (RFC 8693 §4.1) names the calling client as the actor
+					// acting on the user's behalf, which is true only for tokens issued
+					// through the CIBA grant. Emit it for that grant, and also when the
+					// grant type is unknown (`undefined`) so opaque-token introspection,
+					// which re-derives claims without a grant type, still reports the actor
+					// on a CIBA token. A client registered for both `authorization_code`
+					// and CIBA therefore keeps an `act`-free access token on its code flow;
+					// only introspection of such a client's opaque tokens can over-attribute,
+					// the unavoidable cost of re-derivation without per-token storage.
+					accessToken: ({ client, grantType }) =>
+						client.grantTypes?.includes(CIBA_GRANT_TYPE) &&
+						(grantType === CIBA_GRANT_TYPE || grantType === undefined)
+							? { act: { sub: client.clientId } }
+							: {},
+				},
+			});
+		},
+		endpoints: {
+			bcAuthorize: createBcAuthorize(options),
+			cibaGetRequest: createCibaGetRequest(),
+			cibaAuthorize: createCibaAuthorize(options),
+			cibaReject: createCibaReject(options),
+		},
+		// The backchannel endpoint fires a user notification per request and the
+		// request endpoint is unauthenticated, so both need tighter limits than the
+		// generic per-IP default.
+		rateLimit: [
+			{
+				pathMatcher: (path: string) => path === BC_AUTHORIZE_PATH,
+				window: 60,
+				max: 10,
+			},
+			{
+				pathMatcher: (path: string) => path === "/ciba/request",
+				window: 60,
+				max: 30,
+			},
+		],
+		$ERROR_CODES: CIBA_ERROR_CODES,
+	} satisfies BetterAuthPlugin;
+};
+
+export { cibaClient } from "./client";
+export { CIBA_GRANT_TYPE } from "./constants";
+export { CIBA_ERROR_CODES } from "./error-codes";
+export { deliverPing, deliverPush } from "./push";
+export type { CibaOptions, SendNotificationData } from "./types";
+export type { CibaDeliveryMode, CibaRequest } from "./utils";

--- a/packages/ciba/src/push.ts
+++ b/packages/ciba/src/push.ts
@@ -1,0 +1,106 @@
+/**
+ * Ping and push token delivery (CIBA §10.2/§10.3). In ping mode the AS notifies
+ * the client that the request is ready and the client polls for tokens; in push
+ * mode the AS delivers the full token set to the client notification endpoint.
+ * Delivery is best-effort with bounded exponential-backoff retry; on exhaustion
+ * the request is already consumed, so the client must re-initiate or, for ping,
+ * the notification simply never arrives.
+ */
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+async function fetchWithRetry(
+	url: string,
+	init: RequestInit,
+	maxRetries: number,
+): Promise<void> {
+	let lastError: Error | undefined;
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		try {
+			const res = await fetch(url, {
+				...init,
+				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			});
+			if (res.ok) {
+				return;
+			}
+			lastError = new Error(`HTTP ${res.status}`);
+		} catch (err) {
+			lastError = err as Error;
+		}
+		if (attempt < maxRetries) {
+			// Exponential backoff: 1s, 2s, 4s, ...
+			await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** attempt));
+		}
+	}
+	throw lastError ?? new Error("Notification delivery failed");
+}
+
+/** Push mode: deliver the full token response to the client endpoint. */
+export async function deliverPush(
+	endpoint: string,
+	notificationToken: string,
+	payload: Record<string, unknown>,
+	maxRetries: number,
+): Promise<void> {
+	await fetchWithRetry(
+		endpoint,
+		{
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${notificationToken}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify(payload),
+		},
+		maxRetries,
+	);
+}
+
+/** Ping mode: notify the client that the request is ready to be polled. */
+export async function deliverPing(
+	endpoint: string,
+	notificationToken: string,
+	authReqId: string,
+	maxRetries: number,
+): Promise<void> {
+	await fetchWithRetry(
+		endpoint,
+		{
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${notificationToken}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({ auth_req_id: authReqId }),
+		},
+		maxRetries,
+	);
+}
+
+/** Push mode: notify the client that the user denied the request. */
+export async function deliverError(
+	endpoint: string,
+	notificationToken: string,
+	authReqId: string,
+	error: string,
+	errorDescription: string,
+	maxRetries: number,
+): Promise<void> {
+	await fetchWithRetry(
+		endpoint,
+		{
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${notificationToken}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				auth_req_id: authReqId,
+				error,
+				error_description: errorDescription,
+			}),
+		},
+		maxRetries,
+	);
+}

--- a/packages/ciba/src/request.ts
+++ b/packages/ciba/src/request.ts
@@ -1,0 +1,65 @@
+import { getOAuthProviderApi } from "@better-auth/oauth-provider";
+import { APIError, createAuthEndpoint } from "better-auth/api";
+import * as z from "zod";
+import { findCibaRequestByHash, getOAuthOptions, hashAuthReqId } from "./utils";
+
+/**
+ * GET /ciba/request — returns the non-sensitive details an approval page renders
+ * (client name, scopes, binding message). The high-entropy `auth_req_id` is the
+ * only credential; this endpoint reads, it does not verify or change state.
+ */
+export function createCibaGetRequest() {
+	return createAuthEndpoint(
+		"/ciba/request",
+		{
+			method: "GET",
+			query: z.object({ auth_req_id: z.string().min(1) }),
+			metadata: {
+				// The auth_req_id is a bearer credential in the query string and the
+				// body returns request details: never cache it.
+				noStore: true,
+				openapi: {
+					description: "Get CIBA request details for the approval page",
+				},
+			},
+		},
+		async (ctx) => {
+			const request = await findCibaRequestByHash(
+				ctx,
+				await hashAuthReqId(ctx.query.auth_req_id),
+			);
+			if (!request || request.expiresAt < new Date()) {
+				throw new APIError("NOT_FOUND", {
+					error: "invalid_request",
+					error_description: "CIBA request not found or expired",
+				});
+			}
+
+			const client = await getOAuthProviderApi(
+				ctx,
+				getOAuthOptions(ctx),
+			).getClient(request.clientId);
+
+			// RAR is returned parsed so the approval page can render the requested
+			// actions; a malformed stored value is surfaced as null rather than failing.
+			let authorizationDetails: unknown;
+			if (request.authorizationDetails) {
+				try {
+					authorizationDetails = JSON.parse(request.authorizationDetails);
+				} catch {
+					authorizationDetails = null;
+				}
+			}
+
+			return ctx.json({
+				client_name: client?.name,
+				scope: request.scope,
+				binding_message: request.bindingMessage,
+				authorization_details: authorizationDetails,
+				acr_values: request.acrValues,
+				status: request.status,
+				expires_at: request.expiresAt.toISOString(),
+			});
+		},
+	);
+}

--- a/packages/ciba/src/schema.ts
+++ b/packages/ciba/src/schema.ts
@@ -1,0 +1,144 @@
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
+
+/**
+ * Persistent state for a backchannel auth request.
+ *
+ * Lifecycle: `pending` -> `approved` | `rejected`. A poll-mode approved request
+ * is atomically claimed and deleted at token issuance (single-use); rejected or
+ * expired requests are deleted when next encountered, so the row never outlives
+ * the flow. A push-mode request is consumed at approval time.
+ */
+export const schema = {
+	cibaRequest: {
+		modelName: "cibaRequest",
+		fields: {
+			/**
+			 * SHA-256 hash of the raw `auth_req_id`. The raw value is returned to the
+			 * client and never stored, so a leaked table cannot be used to poll.
+			 */
+			authReqId: {
+				type: "string",
+				unique: true,
+				required: true,
+			},
+			clientId: {
+				type: "string",
+				required: true,
+				references: {
+					model: "oauthClient",
+					field: "clientId",
+				},
+			},
+			userId: {
+				type: "string",
+				required: true,
+				references: {
+					model: "user",
+					field: "id",
+				},
+			},
+			scope: {
+				type: "string",
+				required: true,
+			},
+			bindingMessage: {
+				type: "string",
+				required: false,
+			},
+			/**
+			 * RFC 9396 Rich Authorization Requests, stored as the raw JSON string the
+			 * client sent. Round-tripped into the access token (`authorization_details`
+			 * claim) and the token response at issuance.
+			 */
+			authorizationDetails: {
+				type: "string",
+				required: false,
+			},
+			/**
+			 * RFC 8707 resource indicator the request is scoped to. Forwarded to
+			 * `issueTokens` so the issued token's audience is bound to it.
+			 */
+			resource: {
+				type: "string",
+				required: false,
+			},
+			/**
+			 * Requested `acr_values` (OIDC §3.1.2.1, space-delimited). The deployment
+			 * enforces step-up against these at approval and at issuance through the
+			 * {@link CibaOptions.enforceTokenAcr} hook.
+			 */
+			acrValues: {
+				type: "string",
+				required: false,
+			},
+			/**
+			 * Application-defined authentication-context identifier the deployment
+			 * stamps after approval (for example a step-up session row id). Opaque to
+			 * the plugin; persisted for the deployment to read back at issuance.
+			 */
+			authContextId: {
+				type: "string",
+				required: false,
+			},
+			/** One of `pending`, `approved`, `rejected`. */
+			status: {
+				type: "string",
+				required: true,
+			},
+			/**
+			 * CIBA token delivery mode for this request: `poll`, `ping`, or `push`
+			 * (CIBA §4). Set from the requesting client's registered delivery mode.
+			 */
+			deliveryMode: {
+				type: "string",
+				required: true,
+			},
+			/**
+			 * Bearer token the client supplied for ping/push notification delivery
+			 * (CIBA §7.1, `client_notification_token`). Sent as the `Authorization`
+			 * header when the AS calls the client notification endpoint.
+			 */
+			clientNotificationToken: {
+				type: "string",
+				required: false,
+			},
+			/**
+			 * Resolved HTTPS endpoint the AS notifies for ping/push delivery (CIBA
+			 * §10.2). From `client_notification_uri` or the deployment's
+			 * {@link CibaOptions.resolveClientNotificationEndpoint}.
+			 */
+			clientNotificationEndpoint: {
+				type: "string",
+				required: false,
+			},
+			/** When the user approved; stamped as the ID token `auth_time`. */
+			approvedAt: {
+				type: "date",
+				required: false,
+			},
+			pollingInterval: {
+				type: "number",
+				required: true,
+			},
+			/**
+			 * Timestamp of the last accepted token-endpoint poll, used by the
+			 * `slow_down` gate (CIBA §11). The plugin writes a `Date`; a consumer
+			 * mirroring this column in Drizzle must use
+			 * `integer({ mode: "timestamp_ms" })`, never `text`, so the adapter's
+			 * `.getTime()` write path does not crash.
+			 */
+			lastPolledAt: {
+				type: "date",
+				required: false,
+			},
+			expiresAt: {
+				type: "date",
+				required: true,
+			},
+			createdAt: {
+				type: "date",
+				required: true,
+			},
+		},
+	},
+} satisfies BetterAuthPluginDBSchema;

--- a/packages/ciba/src/types.ts
+++ b/packages/ciba/src/types.ts
@@ -1,0 +1,153 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import type { CibaDeliveryMode, CibaRequest } from "./utils";
+
+/**
+ * Payload handed to {@link CibaOptions.sendNotification} so the deployment can
+ * reach the user on a separate device and link them to the approval page.
+ */
+export interface SendNotificationData {
+	/** The user the client is asking to authenticate. */
+	userId: string;
+	/** The authenticated client requesting authorization. */
+	clientId: string;
+	/** Registered display name of the client, when known. */
+	clientName?: string;
+	/** Space-delimited scopes the client requested. */
+	scope: string;
+	/** Human-readable message to display on both devices to bind the session (CIBA §7.1). */
+	bindingMessage?: string;
+	/** Parsed RFC 9396 `authorization_details`, when the request carried it. */
+	authorizationDetails?: unknown;
+	/** Requested `acr_values` (OIDC §3.1.2.1), when the request carried it. */
+	acrValues?: string;
+	/**
+	 * Absolute URL of the approval page, with the `auth_req_id` already attached.
+	 * Send this to the user; the page calls the CIBA endpoints to approve or deny.
+	 */
+	approvalUrl: string;
+	/**
+	 * RFC 9449-style client attestation JWT from the `OAuth-Client-Attestation`
+	 * header, when present. Lets the deployment record runtime proof of the
+	 * calling agent before notifying the user.
+	 *
+	 * @see https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-08.html
+	 */
+	attestationJwt?: string;
+	/**
+	 * Client attestation PoP JWT from the `OAuth-Client-Attestation-PoP` header,
+	 * when present.
+	 */
+	attestationPopJwt?: string;
+}
+
+export interface CibaOptions {
+	/**
+	 * Notify the user of a pending backchannel request on a separate channel
+	 * (email, push, SMS, ...). Best-effort: it is awaited so delivery is attempted
+	 * before the backchannel responds, which keeps it reliable on serverless where
+	 * work scheduled after the response can be frozen. A thrown error is caught
+	 * and logged, and the request still returns its `auth_req_id`. Because it is
+	 * awaited, a slow channel delays the response; keep the handler fast or enqueue
+	 * the slow work yourself.
+	 */
+	sendNotification: (
+		data: SendNotificationData,
+		request?: Request,
+	) => Promise<void> | void;
+
+	/**
+	 * Path of the approval page the user lands on from the notification. The
+	 * `auth_req_id` is appended as a query parameter. This page is your
+	 * application's UI; CIBA leaves the authentication-device interaction
+	 * undefined, so there is no default.
+	 */
+	approvalPage: string;
+
+	/**
+	 * Token delivery modes the deployment supports (CIBA §4). A request whose
+	 * client registered a mode not listed here is rejected. Advertised in
+	 * discovery metadata as `backchannel_token_delivery_modes_supported`.
+	 *
+	 * @default ["poll"]
+	 */
+	deliveryModes?: CibaDeliveryMode[];
+
+	/**
+	 * Lifetime of a backchannel auth request, in seconds. A request not approved
+	 * within this window expires and the agent receives `expired_token`.
+	 *
+	 * @default 300
+	 */
+	requestExpiry?: number;
+
+	/**
+	 * Minimum interval the agent must wait between token-endpoint polls, in
+	 * seconds. Returned as `interval` in the backchannel response.
+	 *
+	 * @default 5
+	 */
+	pollingInterval?: number;
+
+	/**
+	 * Resolve the user a `login_hint` identifies. Defaults to an email lookup via
+	 * the internal adapter. Return `null` when no user matches.
+	 */
+	resolveUser?: (
+		loginHint: string,
+		ctx: GenericEndpointContext,
+	) => Promise<{ id: string } | null> | { id: string } | null;
+
+	/**
+	 * Resolve the client notification endpoint for ping/push delivery when the
+	 * client did not pass `client_notification_uri` on the request. Typically
+	 * reads an endpoint stored in client metadata at registration.
+	 */
+	resolveClientNotificationEndpoint?: (
+		clientId: string,
+		ctx: GenericEndpointContext,
+	) => Promise<string | undefined> | string | undefined;
+
+	/**
+	 * Retry attempts for push/ping notification delivery.
+	 *
+	 * @default 3
+	 */
+	pushRetryAttempts?: number;
+
+	/**
+	 * Require the calling client to authenticate with credentials. CIBA clients
+	 * are confidential by default; set to `false` only if a deployment genuinely
+	 * needs public clients on the backchannel.
+	 *
+	 * @default true
+	 */
+	requireConfidentialClient?: boolean;
+
+	/**
+	 * Build extra access-token claims for a CIBA issuance. Called after the
+	 * request is claimed and before tokens are minted, with the consumed request
+	 * row, so the deployment can derive claims from request state (scope, RAR,
+	 * `acr_values`, `authContextId`). Returned claims are merged into the access
+	 * token JWT; reserved RFC 9068 names stay owned by the authorization server.
+	 */
+	buildAccessTokenClaims?: (
+		cibaRequest: CibaRequest,
+		ctx: GenericEndpointContext,
+	) => Promise<Record<string, unknown>> | Record<string, unknown>;
+
+	/**
+	 * Enforce the request's `acr_values` against the authorizing user at token
+	 * issuance (CIBA's analogue of an authorization-time step-up check). Called
+	 * with the approved request just before it is consumed and tokens are minted;
+	 * the user is loaded and the request is approved but not yet claimed. Throw an
+	 * `APIError` to refuse issuance (for example a `403 insufficient_authorization`
+	 * step-up challenge). Because this runs before the single-use consume, a
+	 * refusal leaves the approved row intact so the client can retry after the user
+	 * elevates their authentication; bound repeated step-up failures inside the
+	 * hook if you need to limit retries.
+	 */
+	enforceTokenAcr?: (
+		cibaRequest: CibaRequest,
+		ctx: GenericEndpointContext,
+	) => Promise<void> | void;
+}

--- a/packages/ciba/src/utils.ts
+++ b/packages/ciba/src/utils.ts
@@ -1,0 +1,281 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import type { OAuthOptions, Scope } from "@better-auth/oauth-provider";
+import { base64Url } from "@better-auth/utils/base64";
+import { createHash } from "@better-auth/utils/hash";
+import { BetterAuthError } from "better-auth";
+import { generateRandomString } from "better-auth/crypto";
+import { DELIVERY_MODE_METADATA_KEY } from "./constants";
+import type { CibaOptions } from "./types";
+
+export type CibaStatus = "pending" | "approved" | "rejected";
+
+export type CibaDeliveryMode = "poll" | "ping" | "push";
+
+export interface CibaRequest {
+	id: string;
+	/** SHA-256 hash of the raw auth_req_id (see {@link hashAuthReqId}). */
+	authReqId: string;
+	clientId: string;
+	userId: string;
+	scope: string;
+	bindingMessage?: string;
+	/** RFC 9396 Rich Authorization Requests, stored as the raw JSON string. */
+	authorizationDetails?: string;
+	/** RFC 8707 resource indicator the issued token is bound to. */
+	resource?: string;
+	/** Requested `acr_values` (OIDC §3.1.2.1, space-delimited). */
+	acrValues?: string;
+	/** Deployment-stamped authentication-context identifier (opaque). */
+	authContextId?: string;
+	status: CibaStatus;
+	/** CIBA token delivery mode (CIBA §4). */
+	deliveryMode: CibaDeliveryMode;
+	/** Bearer token for ping/push notification delivery (CIBA §7.1). */
+	clientNotificationToken?: string;
+	/** Resolved HTTPS endpoint for ping/push delivery (CIBA §10.2). */
+	clientNotificationEndpoint?: string;
+	/** When the user approved, used as the ID token `auth_time` (OIDC Core §2). */
+	approvedAt?: Date;
+	pollingInterval: number;
+	lastPolledAt?: Date;
+	expiresAt: Date;
+	createdAt: Date;
+}
+
+/**
+ * Resolves the OAuth provider's options from the request context. CIBA depends
+ * on the oauth-provider plugin; its absence is a configuration error caught at
+ * startup by `extendOAuthProvider`, so reaching here without it is unexpected.
+ */
+export function getOAuthOptions(
+	ctx: GenericEndpointContext,
+): OAuthOptions<Scope[]> {
+	const provider = ctx.context.getPlugin("oauth-provider");
+	if (!provider) {
+		throw new BetterAuthError(
+			"The CIBA plugin requires the oauth-provider plugin",
+		);
+	}
+	return provider.options as OAuthOptions<Scope[]>;
+}
+
+/** Generates a raw auth_req_id with ~190 bits of entropy (CIBA §7.3). */
+export function generateAuthReqId(): string {
+	return generateRandomString(32, "a-z", "A-Z", "0-9");
+}
+
+/**
+ * Hashes a raw auth_req_id for storage and lookup, using the same SHA-256 +
+ * base64url scheme the OAuth provider uses for tokens. The raw value is a bearer
+ * credential, so only the hash is ever persisted.
+ */
+export async function hashAuthReqId(authReqId: string): Promise<string> {
+	const digest = await createHash("SHA-256").digest(
+		new TextEncoder().encode(authReqId),
+	);
+	return base64Url.encode(new Uint8Array(digest), { padding: false });
+}
+
+export async function findCibaRequestByHash(
+	ctx: GenericEndpointContext,
+	authReqIdHash: string,
+): Promise<CibaRequest | null> {
+	return ctx.context.adapter.findOne<CibaRequest>({
+		model: "cibaRequest",
+		where: [{ field: "authReqId", value: authReqIdHash }],
+	});
+}
+
+/**
+ * Looks up a request by its primary id. Used by the session-authenticated
+ * approval endpoints, where a first-party UI references a request it owns by id
+ * rather than by the raw `auth_req_id` (which it never holds, since only the
+ * hash is stored).
+ */
+export async function findCibaRequestById(
+	ctx: GenericEndpointContext,
+	id: string,
+): Promise<CibaRequest | null> {
+	return ctx.context.adapter.findOne<CibaRequest>({
+		model: "cibaRequest",
+		where: [{ field: "id", value: id }],
+	});
+}
+
+/** Applies a single-row update keyed on the primary id (no compare-and-swap). */
+export async function updateCibaRequest(
+	ctx: GenericEndpointContext,
+	id: string,
+	update: Partial<CibaRequest>,
+): Promise<void> {
+	await ctx.context.adapter.update({
+		model: "cibaRequest",
+		where: [{ field: "id", value: id }],
+		update,
+	});
+}
+
+/**
+ * Atomically claims an approved request for redemption: deletes it and returns
+ * the deleted row, or `null` if it was not approved or another poll already
+ * claimed it. This is the single race gate for token issuance, so concurrent
+ * polls cannot both mint a token set (adapter `consumeOne`, the documented
+ * race-safe single-use primitive).
+ */
+export async function consumeApprovedCibaRequest(
+	ctx: GenericEndpointContext,
+	params: { id: string; clientId: string },
+): Promise<CibaRequest | null> {
+	return ctx.context.adapter.consumeOne<CibaRequest>({
+		model: "cibaRequest",
+		where: [
+			{ field: "id", value: params.id },
+			{ field: "clientId", value: params.clientId },
+			{ field: "status", value: "approved" },
+		],
+	});
+}
+
+/**
+ * Atomically claims a still-pending request for immediate redemption: deletes it
+ * and returns the deleted row, or `null` if it was already approved, rejected, or
+ * claimed by a concurrent caller. Used by push/ping approval, where the token is
+ * minted inline at approval rather than at a later poll, so the same single-use
+ * gate that protects poll issuance also protects push issuance.
+ */
+export async function consumePendingCibaRequest(
+	ctx: GenericEndpointContext,
+	id: string,
+): Promise<CibaRequest | null> {
+	return ctx.context.adapter.consumeOne<CibaRequest>({
+		model: "cibaRequest",
+		where: [
+			{ field: "id", value: id },
+			{ field: "status", value: "pending" },
+		],
+	});
+}
+
+export async function deleteCibaRequest(
+	ctx: GenericEndpointContext,
+	id: string,
+): Promise<void> {
+	await ctx.context.adapter.delete({
+		model: "cibaRequest",
+		where: [{ field: "id", value: id }],
+	});
+}
+
+/**
+ * Validates that a client notification endpoint uses TLS (CIBA §10.2). Loopback
+ * hosts are exempt for local development (RFC 8252 §8.3).
+ */
+export function isSecureEndpoint(endpoint: string): boolean {
+	try {
+		const url = new URL(endpoint);
+		const isLoopback =
+			url.hostname === "localhost" ||
+			url.hostname === "127.0.0.1" ||
+			url.hostname === "[::1]";
+		return url.protocol === "https:" || isLoopback;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Atomically raises the stored polling interval (the `slow_down` ratchet). Uses
+ * the guarded-counter primitive so concurrent slow polls cannot lose the
+ * increment (CIBA §11: the interval increases for this and subsequent requests).
+ */
+export async function ratchetPollingInterval(
+	ctx: GenericEndpointContext,
+	id: string,
+	by: number,
+): Promise<void> {
+	await ctx.context.adapter.incrementOne({
+		model: "cibaRequest",
+		where: [{ field: "id", value: id }],
+		increment: { pollingInterval: by },
+	});
+}
+
+/**
+ * Extra token contributions for a CIBA issuance: per-issuance JWT access-token
+ * claims and extra token-response envelope fields.
+ */
+export interface CibaIssuanceExtras {
+	accessTokenClaims: Record<string, unknown>;
+	tokenResponse: Record<string, unknown>;
+	/** RFC 8707 resource indicator to bind the issued token to, if any. */
+	resources?: string[];
+}
+
+/**
+ * Builds the extra token contributions shared by both issuance paths (poll at
+ * the token endpoint, push at approval):
+ *
+ * - `authorization_details` (RFC 9396 RAR) in both the access token and the
+ *   token response, round-tripped from the stored request.
+ * - the RFC 8707 `resource` the token is bound to, if any.
+ * - any deployment-supplied claims from {@link CibaOptions.buildAccessTokenClaims}.
+ *
+ * `act.sub` is contributed separately by the extension's grant-type-stable
+ * `claims.accessToken` contributor, so it also survives opaque introspection and
+ * is not set here. Malformed stored RAR JSON is skipped rather than failing
+ * issuance.
+ */
+export async function buildCibaIssuanceExtras(
+	ctx: GenericEndpointContext,
+	options: CibaOptions,
+	request: CibaRequest,
+): Promise<CibaIssuanceExtras> {
+	const extras: CibaIssuanceExtras = {
+		accessTokenClaims: {},
+		tokenResponse: {},
+	};
+
+	if (request.authorizationDetails) {
+		try {
+			const parsed: unknown = JSON.parse(request.authorizationDetails);
+			extras.accessTokenClaims.authorization_details = parsed;
+			extras.tokenResponse.authorization_details = parsed;
+		} catch {
+			// Malformed RAR JSON: issue without authorization_details.
+		}
+	}
+
+	if (request.resource) {
+		extras.resources = [request.resource];
+	}
+
+	if (options.buildAccessTokenClaims) {
+		const custom = await options.buildAccessTokenClaims(request, ctx);
+		Object.assign(extras.accessTokenClaims, custom);
+	}
+
+	return extras;
+}
+
+/**
+ * Reads a client's registered `backchannel_token_delivery_mode` from its stored
+ * metadata, tolerating the JSON-string or already-parsed object shapes adapters
+ * return.
+ */
+export function getClientDeliveryMode(client: {
+	metadata?: unknown;
+}): string | undefined {
+	const raw = client.metadata;
+	let meta: Record<string, unknown> | undefined;
+	if (typeof raw === "string") {
+		try {
+			meta = JSON.parse(raw) as Record<string, unknown>;
+		} catch {
+			meta = undefined;
+		}
+	} else if (raw && typeof raw === "object") {
+		meta = raw as Record<string, unknown>;
+	}
+	const mode = meta?.[DELIVERY_MODE_METADATA_KEY];
+	return typeof mode === "string" ? mode : undefined;
+}

--- a/packages/ciba/src/version.ts
+++ b/packages/ciba/src/version.ts
@@ -1,0 +1,3 @@
+import pkg from "../package.json" with { type: "json" };
+
+export const PACKAGE_VERSION = pkg.version;

--- a/packages/ciba/tsconfig.json
+++ b/packages/ciba/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src", "./package.json"],
+  "references": [
+    {
+      "path": "../better-auth/tsconfig.json"
+    },
+    {
+      "path": "../core/tsconfig.json"
+    },
+    {
+      "path": "../oauth-provider/tsconfig.json"
+    }
+  ]
+}

--- a/packages/ciba/tsdown.config.ts
+++ b/packages/ciba/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	dts: { build: true, incremental: true },
+	format: ["esm"],
+	entry: ["./src/index.ts"],
+	treeshake: true,
+});

--- a/packages/ciba/vitest.config.ts
+++ b/packages/ciba/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+		testTimeout: 10_000,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1023,6 +1023,34 @@ importers:
         specifier: ^3.5.29
         version: 3.5.29(typescript@5.9.3)
 
+  packages/ciba:
+    dependencies:
+      '@better-auth/utils':
+        specifier: 'catalog:'
+        version: 0.4.2
+      better-call:
+        specifier: 'catalog:'
+        version: 1.3.6(zod@4.3.6)
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@better-auth/core':
+        specifier: workspace:*
+        version: link:../core
+      '@better-auth/oauth-provider':
+        specifier: workspace:*
+        version: link:../oauth-provider
+      better-auth:
+        specifier: workspace:*
+        version: link:../better-auth
+      jose:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.1(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.19.0)(publint@0.3.17)(typescript@5.9.3)
+
   packages/cimd:
     dependencies:
       better-call:
@@ -2343,14 +2371,8 @@ packages:
     resolution: {integrity: sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@better-auth/utils@0.4.1':
-    resolution: {integrity: sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==}
-
   '@better-auth/utils@0.4.2':
     resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
-
-  '@better-fetch/fetch@1.3.0':
-    resolution: {integrity: sha512-Lgkl18IrUURFqa1nE38GNDWXf7XGzfxXQDCE/alCQV0yZ98YrPGtlmW61ch1T4YRt3lxrSAGA+Ft73FzuWWb3A==}
 
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
@@ -15315,15 +15337,9 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
 
-  '@better-auth/utils@0.4.1':
-    dependencies:
-      '@noble/hashes': 2.0.1
-
   '@better-auth/utils@0.4.2':
     dependencies:
       '@noble/hashes': 2.0.1
-
-  '@better-fetch/fetch@1.3.0': {}
 
   '@better-fetch/fetch@1.3.1': {}
 
@@ -20929,8 +20945,8 @@ snapshots:
 
   better-call@1.3.6(zod@4.3.6):
     dependencies:
-      '@better-auth/utils': 0.4.1
-      '@better-fetch/fetch': 1.3.0
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
       rou3: 0.7.12
       set-cookie-parser: 3.1.0
     optionalDependencies:


### PR DESCRIPTION
Adds `@better-auth/ciba`, bringing OpenID Connect Client-Initiated Backchannel Authentication to the OAuth provider, for clients that cannot drive a browser the user trusts. The plugin is a pure consumer of the `oauth-provider` extension surface: it registers its grant and discovery metadata through `extendOAuthProvider`, and resolves clients, authenticates, and mints through `getOAuthProviderApi`, so it ships with no changes to `oauth-provider`, `better-auth`, or `core`. Routing through the shared pipeline rather than a private one also means a client that polls with a DPoP proof receives a sender-constrained token with no CIBA-specific code.

It follows `device-authorization`, the framework's existing polling-approval grant, for its persistence and concurrency contract. Points worth a close look:

- Single-use is the adapter's atomic `consumeOne` at redemption, so of two concurrent polls exactly one mints a token set and the other gets `invalid_grant`.
- The `auth_req_id` is stored hashed; the raw value is returned to the client and never persisted.
- The ID token `auth_time` is the approval instant, persisted when the user approves, rather than the poll time, so `max_age` stays accurate.
- CIBA clients are confidential by default and must be registered for the CIBA grant with a delivery mode the deployment supports; a backchannel request from a client without that registration is rejected. A sender-constraint proved at client authentication (DPoP or mTLS) is carried into issuance.

Scope: poll, ping, and push delivery (the deployment opts in via `deliveryModes`, and each client registers the one it uses) with the `login_hint` hint. `authorization_details` (RFC 9396) is accepted, validated, and exposed to the `buildAccessTokenClaims` hook. Out of scope here: the `id_token_hint` and `login_hint_token` hints, and the CIBA `private_key_jwt` audience set.
