### PR TITLE
docs(sitemap): add sitemap for all pages, dynamically generating docs and blog routes

### DIFF
--- a/landing/app/sitemap.ts
+++ b/landing/app/sitemap.ts
@@ -35,6 +35,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
+		{
+			url: `${BASE_URL}/products/framework`,
+			lastModified: new Date(),
+			changeFrequency: "weekly",
+			priority: 0.8,
+		},
+		{
+			url: `${BASE_URL}/products/infrastructure`,
+			lastModified: new Date(),
+			changeFrequency: "weekly",
+			priority: 0.8,
+		},
 	];
 
 	const docPages: MetadataRoute.Sitemap = await Promise.all(
@@ -56,21 +68,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		priority: 0.6,
 	}));
 
-	// These pages are not being used
-	//
-	// const changelogPages: MetadataRoute.Sitemap = changelogs
-	// 	.getPages()
-	// 	.map((page) => ({
-	// 		url: `${BASE_URL}${page.url}`,
-	// 		lastModified: page.data.date ? new Date(page.data.date) : new Date(),
-	// 		changeFrequency: "monthly",
-	// 		priority: 0.6,
-	// 	}));
-
-	return [
-		...basePages,
-		...docPages,
-		...blogPages,
-		//  ...changelogPages
-	];
+	return [...basePages, ...docPages, ...blogPages];
 }


### PR DESCRIPTION
Added a sitemap for the docs site, covering all pages and dynamically generating routes for the docs and blog routes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Next.js sitemap for the docs site that covers all pages, including dynamic docs and blog routes, and fixes path mismatches to improve SEO and indexing. Uses the same generation logic as the old docs.

- **New Features**
  - New `landing/app/sitemap.ts` builds absolute URLs with `BASE_URL` and sets `changeFrequency`, `priority`, and `lastModified`.
  - Includes docs via `source.getPages()` and blog posts via `blogs.getPages()`, normalizing `/blogs/*` to `/blog/*`.
  - Adds base routes: `/`, `/blog`, `/changelog`, `/community`, `/enterprise`, `/products/framework`, `/products/infrastructure`.

- **Bug Fixes**
  - Aligns sitemap structure and metadata with the old docs to avoid URL and date mismatches.
  - Corrects changelog path to `/changelog`.

<sup>Written for commit 65408624d4508ad704160af6a90eb8b0599ac720. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

