### PR TITLE
fix(api): preserve response metadata for early before hook returns

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -199,6 +199,15 @@ describe("before hook", async () => {
 					return { response: true };
 				},
 			),
+			responseHeaders: createAuthEndpoint(
+				"/response-headers",
+				{
+					method: "POST",
+				},
+				async (c) => {
+					return { response: true };
+				},
+			),
 		};
 
 		const authContext = init({
@@ -206,6 +215,15 @@ describe("before hook", async () => {
 				before: createAuthMiddleware(async (c) => {
 					if (c.path === "/json") {
 						return { before: true };
+					}
+					if (c.path === "/response-headers") {
+						return new Response(JSON.stringify({ before: true }), {
+							status: 201,
+							headers: {
+								"content-type": "application/json",
+								"x-hook": "before",
+							},
+						});
 					}
 					return new Response(JSON.stringify({ before: true }));
 				}),
@@ -221,6 +239,39 @@ describe("before hook", async () => {
 		it("should return the hook response", async () => {
 			const response = await authEndpoints.json();
 			expect(response).toMatchObject({ before: true });
+		});
+
+		it("should not leak request headers into early before responses", async () => {
+			const response = await authEndpoints.responseHeaders({
+				asResponse: true,
+				headers: new Headers({
+					"content-length": "999",
+					"x-request": "leak-me-not",
+				}),
+			});
+
+			expect(response.status).toBe(201);
+			expect(response.headers.get("x-hook")).toBe("before");
+			expect(response.headers.get("x-request")).toBeNull();
+			expect(response.headers.get("content-length")).toBeNull();
+			await expect(response.json()).resolves.toMatchObject({ before: true });
+		});
+
+		it("should return response headers and status for early before responses", async () => {
+			const result = await authEndpoints.responseHeaders({
+				returnHeaders: true,
+				returnStatus: true,
+				headers: new Headers({
+					"content-length": "999",
+					"x-request": "leak-me-not",
+				}),
+			});
+
+			expect(result.status).toBe(201);
+			expect(result.headers.get("x-hook")).toBe("before");
+			expect(result.headers.get("x-request")).toBeNull();
+			expect(result.headers.get("content-length")).toBeNull();
+			expect(result.response).toBeInstanceOf(Response);
 		});
 	});
 });

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -160,16 +160,28 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 								internalContext = defuReplaceArrays(rest, internalContext);
 							} else if (before) {
 								/* Return before hook response if it's anything other than a context return */
-								return context?.asResponse
-									? toResponse(before, {
-											headers: context?.headers,
-										})
-									: context?.returnHeaders
+								const response = toResponse(before);
+								if (context?.asResponse) {
+									return response;
+								}
+								if (context?.returnHeaders) {
+									return context?.returnStatus
 										? {
-												headers: context?.headers,
+												headers: response.headers,
 												response: before,
+												status: response.status,
 											}
-										: before;
+										: {
+												headers: response.headers,
+												response: before,
+											};
+								}
+								return context?.returnStatus
+									? {
+											response: before,
+											status: response.status,
+										}
+									: before;
 							}
 
 							internalContext.asResponse = false;


### PR DESCRIPTION
## Summary
- stop passing request headers into `toResponse()` for early `before` hook returns
- preserve actual response headers and status when `returnHeaders` / `returnStatus` are requested
- add regression coverage for request-header leakage on early `before` responses

## Root Cause
Early `before` hook responses were being converted with `context?.headers`, which are request headers. That could leak request `content-length` and other request metadata into the response.

## Changes
- derive response headers and status from `toResponse(before)`
- return those derived headers/status for the early `before` short-circuit path
- keep existing behavior for non-response return values

## Testing
- `pnpm --filter better-auth exec vitest run src/api/to-auth-endpoints.test.ts`
- `pnpm exec biome check packages/better-auth/src/api/to-auth-endpoints.ts packages/better-auth/src/api/to-auth-endpoints.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix early before hook handling in `better-auth` to preserve response headers and status and prevent leaking request headers. `asResponse`, `returnHeaders`, and `returnStatus` now reflect the actual `Response` from the hook.

- **Bug Fixes**
  - Use `toResponse(before)` to derive headers and status; no longer reuse request headers.
  - For early `before` returns: respect `asResponse`, and return real headers/status for `returnHeaders`/`returnStatus`.
  - Add regression tests to ensure request headers (e.g., `content-length`, `x-request`) don’t leak into responses.

<sup>Written for commit 0cbdf5fb2db245370b8a53b93065cc459677e43f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

