### PR TITLE
fix(i18n): translate errors thrown from plugin before hooks

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -135,6 +135,43 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 								endpoint,
 								operationId,
 							);
+
+							/**
+							 * If a before hook threw an APIError, route it
+							 * through after hooks (e.g. i18n translation)
+							 * before returning/throwing the error.
+							 */
+							if (
+								before &&
+								typeof before === "object" &&
+								"_beforeHookError" in before
+							) {
+								const beforeError = before._beforeHookError as APIError;
+								internalContext.context.returned = beforeError;
+								internalContext.context.responseHeaders = beforeError.headers
+									? new Headers(beforeError.headers)
+									: undefined;
+
+								const after = await runAfterHooks(
+									internalContext,
+									afterHooks,
+									endpoint,
+									operationId,
+								);
+
+								const errorToThrow = isAPIError(after.response)
+									? after.response
+									: beforeError;
+
+								if (context?.asResponse) {
+									return toResponse(errorToThrow, {
+										headers: after.headers,
+										status: errorToThrow.statusCode,
+									});
+								}
+								throw errorToThrow;
+							}
+
 							/**
 							 * If `before.context` is returned, it should
 							 * get merged with the original context
@@ -313,15 +350,24 @@ async function runBeforeHooks(
 						returnHeaders: false,
 					}),
 			).catch((e: unknown) => {
-				if (
-					isAPIError(e) &&
-					shouldPublishLog(context.context.logger.level, "debug")
-				) {
-					// inherit stack from errorStack if debug mode is enabled
-					e.stack = e.errorStack;
+				if (isAPIError(e)) {
+					if (shouldPublishLog(context.context.logger.level, "debug")) {
+						// inherit stack from errorStack if debug mode is enabled
+						e.stack = e.errorStack;
+					}
+					return {
+						_beforeHookError: e as APIError,
+					};
 				}
 				throw e;
 			});
+			if (
+				result &&
+				typeof result === "object" &&
+				"_beforeHookError" in result
+			) {
+				return result;
+			}
 			if (result && typeof result === "object") {
 				if ("context" in result && typeof result.context === "object") {
 					const { headers, ...rest } =
@@ -388,7 +434,7 @@ async function runAfterHooks(
 				response: any;
 				headers: Headers;
 			};
-			if (result.headers) {
+			if (result?.headers) {
 				result.headers.forEach((value, key) => {
 					if (!context.context.responseHeaders) {
 						context.context.responseHeaders = new Headers({
@@ -403,7 +449,7 @@ async function runAfterHooks(
 					}
 				});
 			}
-			if (result.response) {
+			if (result?.response) {
 				context.context.returned = result.response;
 			}
 		}

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -1,3 +1,4 @@
+import { username } from "better-auth/plugins";
 import { getTestInstance } from "better-auth/test";
 import { describe, expect, it } from "vitest";
 import { i18n } from ".";
@@ -263,6 +264,110 @@ describe("i18n plugin", async () => {
 				expect(data).toHaveProperty("session");
 				expect(data).toHaveProperty("user");
 			});
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8492
+	 */
+	describe("before hook error translation", () => {
+		it("should translate errors thrown from plugin before hooks", async () => {
+			const { auth: authWithUsername } = await getTestInstance({
+				plugins: [
+					username(),
+					i18n({
+						translations: {
+							fr: {
+								USERNAME_IS_ALREADY_TAKEN:
+									"Le nom d'utilisateur est déjà pris.",
+								USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL:
+									"L'utilisateur existe déjà.",
+							},
+						},
+						defaultLocale: "fr",
+						detection: ["header"],
+					}),
+				],
+			});
+
+			// Create a user with a username
+			await authWithUsername.api.signUpEmail({
+				body: {
+					email: "test@example.com",
+					username: "testuser",
+					password: "password123",
+					name: "Test User",
+				},
+			});
+
+			// Try to sign up with the same username — this error comes from the
+			// username plugin's before hook
+			const response = await authWithUsername.api.signUpEmail({
+				body: {
+					email: "other@example.com",
+					username: "testuser",
+					password: "password123",
+					name: "Test User 2",
+				},
+				headers: {
+					"Accept-Language": "fr",
+				},
+				asResponse: true,
+			});
+
+			const body = await response.json();
+			expect(body.code).toBe("USERNAME_IS_ALREADY_TAKEN");
+			expect(body.message).toBe("Le nom d'utilisateur est déjà pris.");
+			expect(body.originalMessage).toBe(
+				"Username is already taken. Please try another.",
+			);
+		});
+
+		it("should translate errors from before hooks without asResponse", async () => {
+			const { auth: authWithUsername } = await getTestInstance({
+				plugins: [
+					username(),
+					i18n({
+						translations: {
+							fr: {
+								USERNAME_IS_ALREADY_TAKEN:
+									"Le nom d'utilisateur est déjà pris.",
+							},
+						},
+						defaultLocale: "fr",
+						detection: ["header"],
+					}),
+				],
+			});
+
+			// Create a user with a username
+			await authWithUsername.api.signUpEmail({
+				body: {
+					email: "test2@example.com",
+					username: "testuser2",
+					password: "password123",
+					name: "Test User",
+				},
+			});
+
+			// Try to sign up with the same username — should throw translated error
+			try {
+				await authWithUsername.api.signUpEmail({
+					body: {
+						email: "other2@example.com",
+						username: "testuser2",
+						password: "password123",
+						name: "Test User 2",
+					},
+					headers: {
+						"Accept-Language": "fr",
+					},
+				});
+				expect.unreachable("Should have thrown");
+			} catch (e: any) {
+				expect(e.body?.code).toBe("USERNAME_IS_ALREADY_TAKEN");
+				expect(e.body?.message).toBe("Le nom d'utilisateur est déjà pris.");
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Route `APIError`s from before hooks through after hooks before throwing, so after-hook-based plugins like i18n can translate them
- Previously, before-hook errors (e.g. `USERNAME_IS_ALREADY_TAKEN` from the username plugin) bypassed `runAfterHooks()` entirely, so the i18n plugin never got a chance to translate them
- Added optional chaining in `runAfterHooks()` to safely handle hooks that return `undefined`

Closes #8492

## Test plan

- [x] Added test: before-hook error (`USERNAME_IS_ALREADY_TAKEN`) is translated when using `asResponse: true`
- [x] Added test: before-hook error is translated when calling `auth.api` directly (throws translated error)
- [x] All 17 i18n tests pass
- [x] All 34 `to-auth-endpoints` tests pass
- [x] All 32 username plugin tests pass
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes