### PR TITLE
fix(prisma-adapter): fall back to updateMany for non-unique updates

### DIFF
--- a/packages/prisma-adapter/src/prisma-adapter.test.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.test.ts
@@ -1,14 +1,113 @@
+import type { BetterAuthOptions } from "@better-auth/core";
 import { describe, expect, it, vi } from "vitest";
 import { prismaAdapter } from "./prisma-adapter";
 
 describe("prisma-adapter", () => {
+	const createTestAdapter = (prisma: Record<string, unknown>) =>
+		prismaAdapter(prisma as never, {
+			provider: "sqlite",
+		})({} as BetterAuthOptions);
+
 	it("should create prisma adapter", () => {
 		const prisma = {
 			$transaction: vi.fn(),
-		} as any;
-		const adapter = prismaAdapter(prisma, {
+		};
+		const adapter = prismaAdapter(prisma as never, {
 			provider: "sqlite",
 		});
 		expect(adapter).toBeDefined();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8365
+	 */
+	it("should fall back to updateMany for non-unique verification identifiers", async () => {
+		const update = vi.fn();
+		const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const findFirst = vi.fn().mockResolvedValue({
+			id: "verification-id",
+			identifier: "magic-link-token",
+			value: "updated-value",
+		});
+		const adapter = createTestAdapter({
+			$transaction: vi.fn(),
+			verification: {
+				findFirst,
+				update,
+				updateMany,
+			},
+		});
+
+		const result = await adapter.update({
+			model: "verification",
+			where: [{ field: "identifier", value: "magic-link-token" }],
+			update: { value: "updated-value" },
+		});
+
+		expect(update).not.toHaveBeenCalled();
+		expect(updateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					identifier: "magic-link-token",
+				},
+				data: expect.objectContaining({
+					value: "updated-value",
+					updatedAt: expect.any(Date),
+				}),
+			}),
+		);
+		expect(findFirst).toHaveBeenCalledWith({
+			where: {
+				identifier: "magic-link-token",
+			},
+		});
+		expect(result).toEqual({
+			id: "verification-id",
+			identifier: "magic-link-token",
+			value: "updated-value",
+		});
+	});
+
+	it("should keep using update for unique non-id fields", async () => {
+		const update = vi.fn().mockResolvedValue({
+			id: "session-id",
+			token: "session-token",
+			userId: "user-id",
+		});
+		const updateMany = vi.fn();
+		const findFirst = vi.fn();
+		const adapter = createTestAdapter({
+			$transaction: vi.fn(),
+			session: {
+				findFirst,
+				update,
+				updateMany,
+			},
+		});
+
+		const result = await adapter.update({
+			model: "session",
+			where: [{ field: "token", value: "session-token" }],
+			update: { userId: "user-id" },
+		});
+
+		expect(update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					token: "session-token",
+				},
+				data: expect.objectContaining({
+					userId: "user-id",
+					updatedAt: expect.any(Date),
+				}),
+			}),
+		);
+		expect(updateMany).not.toHaveBeenCalled();
+		expect(findFirst).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			id: "session-id",
+			token: "session-token",
+			userId: "user-id",
+		});
 	});
 });

--- a/packages/prisma-adapter/src/prisma-adapter.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.ts
@@ -183,6 +183,35 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 						return operator;
 				}
 			}
+			const hasRootUniqueWhereCondition = (
+				model: string,
+				where?: Where[] | undefined,
+			) => {
+				if (!where?.length) {
+					return false;
+				}
+
+				return where.some((condition) => {
+					if (condition.connector === "OR") {
+						return false;
+					}
+
+					if (condition.operator && condition.operator !== "eq") {
+						return false;
+					}
+
+					if (condition.field === "id") {
+						return true;
+					}
+
+					return (
+						getFieldAttributes({
+							model,
+							field: condition.field,
+						})?.unique === true
+					);
+				});
+			};
 			const convertWhereClause = ({
 				action,
 				model,
@@ -462,6 +491,28 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 						throw new BetterAuthError(
 							`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
 						);
+					}
+					const hasRootUniqueCondition = hasRootUniqueWhereCondition(
+						model,
+						where,
+					);
+					if (!hasRootUniqueCondition) {
+						const whereClause = convertWhereClause({
+							model,
+							where,
+							action: "updateMany",
+						});
+						const result = await db[model]!.updateMany({
+							where: whereClause,
+							data: update,
+						});
+						if (!result?.count) {
+							return null;
+						}
+
+						return await db[model]!.findFirst({
+							where: whereClause,
+						});
 					}
 					const whereClause = convertWhereClause({
 						model,


### PR DESCRIPTION
## Summary

- Prisma's `update()` requires a `WhereUniqueInput`, so updating by non-unique fields like `verification.identifier` causes a `PrismaClientValidationError`
- Detect whether the `where` clause contains a root-level unique field (`id` or a field marked `unique` in the schema)
- When no unique field is present, use `updateMany` + `findFirst` instead of `update`
- Keep the existing `update` path for unique fields like `id` and unique session tokens

Closes #8365

## Test plan

- [x] Add regression test for non-unique verification identifier updates
- [x] Add test to ensure unique non-id fields (e.g. session token) still use `update`
- [x] Verify existing prisma adapter test still passes
- [x] `pnpm biome check` passes on changed files