### PR TITLE
docs: add warning about localhost in trusted origins

### DIFF
--- a/docs/content/docs/reference/security.mdx
+++ b/docs/content/docs/reference/security.mdx
@@ -200,7 +200,7 @@ Trusted origins prevent CSRF attacks and block open redirects. You can set a lis
 
 ### Basic Usage
 
-The most basic usage is to specify exact origins:
+The most basic usage is to specify exact origins, below is an example of a trusted origins configuration:
 
 ```typescript
 {
@@ -211,6 +211,9 @@ The most basic usage is to specify exact origins:
   ]
 }
 ```
+<Callout type="warning">
+  Do not leave the localhost origin in a trusted origins list of a production auth instance.
+</Callout>
 
 ### Wildcard Origins
 


### PR DESCRIPTION
## Summary
Cherry-pick of #3808 (docs change only)

- Add warning callout about not leaving localhost in trusted origins for production auth instances

## Test plan
- [x] Verify docs render correctly with new Callout warning