### PR TITLE
feat(magic-link): add additionalData support for sendMagicLink

### DIFF
--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -20,7 +20,7 @@ Magic link or email link is a way to authenticate users without a password. When
     export const auth = betterAuth({
         plugins: [
             magicLink({ // [!code highlight]
-                sendMagicLink: async ({ email, token, url }, ctx) => { // [!code highlight]
+                sendMagicLink: async ({ email, token, url, additionalData }, ctx) => { // [!code highlight]
                     // send email to user // [!code highlight]
                 } // [!code highlight]
             }) // [!code highlight]
@@ -85,6 +85,11 @@ type signInMagicLink = {
      * redirected to the callbackURL with an `error` query parameter.
      */
     errorCallbackURL?: string = "/error"
+    /**
+     * If you want to provide additional data to the `sendMagicLink` function you can do so in key-value
+     * pairs here. See below on how to make a schema to validate these values.
+     */
+    additionalData?: Record<string, JsonValue> = { message: "Hello from better-auth!" }
 }
 ```
 </APIMethod>
@@ -123,13 +128,59 @@ type magicLinkVerify = {
 ```
 </APIMethod>
 
+### Additional Data
+
+If you want to include additional data for your sendMagicLink function, for type-safety and runtime schema validation you can supply a [Zod schema](https://zod.dev/) to the plugin through options.
+
+```ts title="server.ts"
+import { betterAuth } from "better-auth";
+import { magicLink } from "better-auth/plugins";
+
+export const auth = betterAuth({
+    plugins: [
+        magicLink({
+            sendMagicLink: async ({ email, token, url, additionalData }, ctx) => {
+                const message = additionalData?.message ?? "No message provided!"; // [!code highlight]
+
+                // send email to user
+            }
+        })
+    ]
+})
+```
+
+```ts title="server.ts"
+import { betterAuth } from "better-auth";
+import { magicLink } from "better-auth/plugins";
+import { z } from "zod"; // [!code highlight]
+
+export const auth = betterAuth({
+    plugins: [
+        magicLink({
+            additionalDataSchema: z.object({ message: z.string() }), // Create your schema here! // [!code highlight]
+            sendMagicLink: async ({ email, token, url, additionalData }, ctx) => {
+                const message = additionalData?.message ?? "No message provided!";
+
+                // send email to user
+            }
+        })
+    ]
+})
+```
+<Callout type="warn">
+  If no `additionalDataSchema` is provided, the type will default to `Record<string, JsonValue>` and the value is not validated during runtime. JsonValue is a "generic" type that is constrained to only types that can be serialized into JSON.
+</Callout>
+
 ## Configuration Options
+
+**additionalDataSchema**: [Zod schema](https://zod.dev/) used for validation and type-safety of the `additionalData` field in `sendMagicLink`.
 
 **sendMagicLink**: The `sendMagicLink` function is called when a user requests a magic link. It takes an object with the following properties:
 
 - `email`: The email address of the user.
 - `url`: The URL to be sent to the user. This URL contains the token.
 - `token`: The token if you want to send the token with custom URL.
+- `additionalData`: Additional properties provided when calling the `signIn.magicLink()` function.
 
 and a `ctx` context object as the second parameter.
 

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -19,7 +19,28 @@ declare module "@better-auth/core" {
 	}
 }
 
-export interface MagicLinkOptions {
+type JsonValue =
+	| string
+	| number
+	| boolean
+	| null
+	| JsonValue[]
+	| { [key: string]: JsonValue };
+
+const jsonSchema: z.ZodType<JsonValue> = z.lazy(() =>
+	z.union([
+		z.string(),
+		z.number(),
+		z.boolean(),
+		z.null(),
+		z.array(jsonSchema),
+		z.record(z.string(), jsonSchema),
+	]),
+);
+
+export interface MagicLinkOptions<
+	DS extends z.ZodType = z.ZodRecord<z.ZodString, typeof jsonSchema>,
+> {
 	/**
 	 * Time in seconds until the magic link expires.
 	 * @default (60 * 5) // 5 minutes
@@ -39,9 +60,19 @@ export interface MagicLinkOptions {
 			email: string;
 			url: string;
 			token: string;
+			additionalData?: z.infer<DS>;
 		},
 		ctx?: GenericEndpointContext | undefined,
 	) => Awaitable<void>;
+	/**
+	 * Zod schema for the additionalData property of the sendMagicLink function.
+	 * This schema is used to validate and type-safeguard the additional data
+	 * passed to the sign-in endpoint.
+	 *
+	 * @default z.record(z.string(), jsonSchema)
+	 * @see {@link https://zod.dev/basics}
+	 */
+	additionalDataSchema?: DS;
 	/**
 	 * Disable sign up if user is not found.
 	 *
@@ -113,6 +144,16 @@ const signInMagicLinkBodySchema = z.object({
 		})
 		.optional(),
 });
+const createSignInMagicLinkBodySchema = <DS extends z.ZodType>(
+	additionalDataSchema: DS,
+) =>
+	signInMagicLinkBodySchema.extend({
+		additionalData: additionalDataSchema
+			.meta({
+				description: "Additional data to pass to the sendMagicLink function",
+			})
+			.optional(),
+	});
 const magicLinkVerifyQuerySchema = z.object({
 	token: z.string().meta({
 		description: "Verification token",
@@ -138,12 +179,16 @@ const magicLinkVerifyQuerySchema = z.object({
 		})
 		.optional(),
 });
-export const magicLink = (options: MagicLinkOptions) => {
+export const magicLink = <
+	DS extends z.ZodType<JsonValue> = z.ZodRecord<z.ZodString, typeof jsonSchema>,
+>(
+	options: MagicLinkOptions<DS>,
+) => {
 	const opts = {
 		storeToken: "plain",
 		allowedAttempts: 1,
 		...options,
-	} satisfies MagicLinkOptions;
+	} satisfies MagicLinkOptions<DS>;
 
 	async function storeToken(ctx: GenericEndpointContext, token: string) {
 		if (opts.storeToken === "hashed") {
@@ -158,6 +203,9 @@ export const magicLink = (options: MagicLinkOptions) => {
 		}
 		return token;
 	}
+
+	const additionalDataSchema = (options.additionalDataSchema ??
+		z.record(z.string(), jsonSchema)) as DS;
 
 	return {
 		id: "magic-link",
@@ -182,7 +230,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 				{
 					method: "POST",
 					requireHeaders: true,
-					body: signInMagicLinkBodySchema,
+					body: createSignInMagicLinkBodySchema(additionalDataSchema),
 					metadata: {
 						openapi: {
 							operationId: "signInWithMagicLink",
@@ -208,7 +256,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					},
 				},
 				async (ctx) => {
-					const { email } = ctx.body;
+					const { email, additionalData } = ctx.body;
 
 					const verificationToken = opts?.generateToken
 						? await opts.generateToken(email)
@@ -243,6 +291,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 							email,
 							url: url.toString(),
 							token: verificationToken,
+							additionalData,
 						},
 						ctx,
 					);

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import * as z from "zod";
 import { createAuthClient } from "../../client";
 import { getTestInstance } from "../../test-utils/test-instance";
+import type { MagicLinkOptions } from ".";
 import { magicLink } from ".";
 import { magicLinkClient } from "./client";
 import { defaultKeyHasher } from "./utils";
@@ -719,5 +721,125 @@ describe("magic link allowedAttempts", async () => {
 			const betterAuthCookie = headers.get("set-cookie");
 			expect(betterAuthCookie).toBeDefined();
 		}
+	});
+});
+
+describe("magic link additionalData", async () => {
+	it("should pass additionalData to sendMagicLink", async () => {
+		let receivedData: Record<string, unknown> | undefined;
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			plugins: [
+				magicLink({
+					async sendMagicLink(data) {
+						receivedData = data.additionalData;
+					},
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.signInMagicLink({
+			body: {
+				email: testUser.email,
+				additionalData: { message: "hello" },
+			},
+			headers,
+		});
+		expect(receivedData).toEqual({ message: "hello" });
+	});
+
+	it("should work without additionalData", async () => {
+		let receivedData: unknown = "not-called";
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			plugins: [
+				magicLink({
+					async sendMagicLink(data) {
+						receivedData = data.additionalData;
+					},
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.signInMagicLink({
+			body: {
+				email: testUser.email,
+			},
+			headers,
+		});
+		expect(receivedData).toBeUndefined();
+	});
+
+	it("should validate additionalData with custom schema", async () => {
+		let receivedData: { message: string } | undefined;
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			plugins: [
+				magicLink({
+					additionalDataSchema: z.object({ message: z.string() }),
+					async sendMagicLink(data) {
+						receivedData = data.additionalData;
+					},
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.signInMagicLink({
+			body: {
+				email: testUser.email,
+				additionalData: { message: "typed hello" },
+			},
+			headers,
+		});
+		expect(receivedData).toEqual({ message: "typed hello" });
+	});
+
+	it("should infer additionalData type from custom schema", () => {
+		const schema = z.object({ message: z.string(), count: z.number() });
+
+		type Opts = MagicLinkOptions<typeof schema>;
+		type SendData = Parameters<Opts["sendMagicLink"]>[0];
+
+		expectTypeOf<SendData["additionalData"]>().toEqualTypeOf<
+			{ message: string; count: number } | undefined
+		>();
+	});
+
+	it("should default additionalData type to Record<string, JsonValue>", () => {
+		type DefaultOpts = MagicLinkOptions;
+		type SendData = Parameters<DefaultOpts["sendMagicLink"]>[0];
+
+		expectTypeOf<SendData["additionalData"]>().not.toEqualTypeOf<undefined>();
+		expectTypeOf<SendData>().toHaveProperty("additionalData");
+	});
+
+	it("should pass additionalData from client", async () => {
+		let receivedData: Record<string, unknown> | undefined;
+		const { customFetchImpl, testUser } = await getTestInstance({
+			plugins: [
+				magicLink({
+					async sendMagicLink(data) {
+						receivedData = data.additionalData;
+					},
+				}),
+			],
+		});
+
+		const client = createAuthClient({
+			plugins: [magicLinkClient()],
+			fetchOptions: {
+				customFetchImpl,
+			},
+			baseURL: "http://localhost:3000/api/auth",
+		});
+
+		await client.signIn.magicLink({
+			email: testUser.email,
+			additionalData: { source: "client", nested: { key: "value" } },
+		});
+		expect(receivedData).toEqual({
+			source: "client",
+			nested: { key: "value" },
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Added `additionalData` field to the magic link sign-in request body, allowing custom data to be passed from the client to the `sendMagicLink` function
- Added `additionalDataSchema` option accepting a Zod schema for runtime validation and type safety of the additional data
- When no schema is provided, defaults to `Record<string, JsonValue>` (unvalidated)
- Updated documentation with usage examples and configuration details

Ported from #3417 and adapted to the current canary codebase (which has been refactored since the original PR — different imports, extracted body schema, `ctx` parameter instead of `request`).

## Test plan

- [x] All 16 existing magic-link tests pass
- [x] Lint passes
- [x] Verify `additionalData` flows through to `sendMagicLink` callback with and without a custom schema
- [x] Verify type inference works correctly when `additionalDataSchema` is provided