### PR TITLE
docs: sidebar navigation accordion text tracking

### DIFF
--- a/landing/components/docs/docs-sidebar.tsx
+++ b/landing/components/docs/docs-sidebar.tsx
@@ -117,7 +117,7 @@ export function DocsSidebar() {
 									}}
 								>
 									<section.Icon className="size-4.5" />
-									<span className="grow">{section.title}</span>
+									<span className="grow tracking-normal">{section.title}</span>
 									<ChevronDownIcon
 										className={cn(
 											"h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",


### PR DESCRIPTION
The accordion is inheriting wider tracking from the parent div (meant for other buttons with all-caps monospaced titles). This makes the accordion titles/labels look weird. Fixed that by adding `tracking-normal` class to the section title.

Here's how it looks:
<img width="3200" height="1790" alt="before-after-comparison" src="https://github.com/user-attachments/assets/9cc4cc3d-0a28-41e4-9e70-592c9b2b667f" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the docs sidebar accordion label spacing by overriding inherited wide tracking. Adds `tracking-normal` to the section title span so text renders with correct letter-spacing and stays consistent with other items.

<sup>Written for commit 5e3f62038cd96ef46f673d439946e60028c01cfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

