### PR TITLE
fix(oauth-provider): support prompt=none per OIDC spec

### DIFF
--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -278,6 +278,19 @@ export async function authorizeEndpoint(
 	// Check for session
 	const session = await getSessionFromCtx(ctx);
 	if (!session || promptSet?.has("login") || promptSet?.has("create")) {
+		// Handle prompt=none per OIDC spec - must return error instead of redirecting to login
+		if (promptSet?.has("none")) {
+			return handleRedirect(
+				ctx,
+				formatErrorURL(
+					redirectUri,
+					"login_required",
+					"Authentication required but prompt is none",
+					query.state,
+					getIssuer(ctx, opts),
+				),
+			);
+		}
 		return redirectWithPromptCode(
 			ctx,
 			opts,
@@ -384,6 +397,19 @@ export async function authorizeEndpoint(
 		!consent ||
 		!requestedScopes.every((val) => consent.scopes.includes(val))
 	) {
+		// Handle prompt=none per OIDC spec - must return error instead of redirecting to consent
+		if (promptSet?.has("none")) {
+			return handleRedirect(
+				ctx,
+				formatErrorURL(
+					redirectUri,
+					"consent_required",
+					"Consent required but prompt is none",
+					query.state,
+					getIssuer(ctx, opts),
+				),
+			);
+		}
 		return redirectWithPromptCode(ctx, opts, "consent");
 	}
 

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -107,7 +107,13 @@ describe("oauth metadata", async () => {
 			id_token_signing_alg_values_supported: ["EdDSA"],
 			end_session_endpoint: `${baseURL}/oauth2/end-session`,
 			acr_values_supported: ["urn:mace:incommon:iap:bronze"],
-			prompt_values_supported: ["login", "consent", "create", "select_account"],
+			prompt_values_supported: [
+				"login",
+				"consent",
+				"create",
+				"select_account",
+				"none",
+			],
 		});
 		const oauthMetadata = await auth.api.getOAuthServerConfig();
 		expect(oauthMetadata).toMatchObject(metadata ?? {});

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -100,7 +100,13 @@ export function oidcServerMetadata(
 				: ["EdDSA"],
 		end_session_endpoint: `${baseURL}/oauth2/end-session`,
 		acr_values_supported: ["urn:mace:incommon:iap:bronze"],
-		prompt_values_supported: ["login", "consent", "create", "select_account"],
+		prompt_values_supported: [
+			"login",
+			"consent",
+			"create",
+			"select_account",
+			"none",
+		],
 	};
 	return metadata;
 }

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -1437,6 +1437,116 @@ describe("oauth - prompt", async () => {
 
 		enablePostLogin = false;
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/7700
+	 */
+	it("none - should return login_required error when user not authenticated", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		// Build authorize URL with prompt=none directly (no session)
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid profile email");
+		authUrl.searchParams.set("state", "test-state");
+		authUrl.searchParams.set("prompt", "none");
+		authUrl.searchParams.set("code_challenge", "test-challenge");
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		// Use a fresh client without session cookies
+		const unauthHeaders = new Headers();
+		let loginRequiredRedirectUri = "";
+		await serverClient.$fetch(authUrl.toString(), {
+			method: "GET",
+			headers: unauthHeaders,
+			onError(context) {
+				loginRequiredRedirectUri =
+					context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(loginRequiredRedirectUri).toContain("error=login_required");
+		expect(loginRequiredRedirectUri).toContain("error_description=");
+		expect(loginRequiredRedirectUri).toContain("state=test-state");
+		expect(loginRequiredRedirectUri).toContain(redirectUri.split("?")[0]);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/7700
+	 */
+	it("none - should return consent_required error when consent is needed", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		// Register a new client so there's no prior consent
+		const newRedirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/consent-test`;
+		const newClient = await authorizationServer.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [newRedirectUri],
+			},
+		});
+		expect(newClient?.client_id).toBeDefined();
+
+		// Build authorize URL with prompt=none (with active session but no consent)
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", newClient!.client_id);
+		authUrl.searchParams.set("redirect_uri", newRedirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid profile email");
+		authUrl.searchParams.set("state", "test-state");
+		authUrl.searchParams.set("prompt", "none");
+		authUrl.searchParams.set("code_challenge", "test-challenge");
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let consentRequiredRedirectUri = "";
+		await serverClient.$fetch(authUrl.toString(), {
+			method: "GET",
+			headers,
+			onError(context) {
+				consentRequiredRedirectUri =
+					context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(consentRequiredRedirectUri).toContain("error=consent_required");
+		expect(consentRequiredRedirectUri).toContain("error_description=");
+		expect(consentRequiredRedirectUri).toContain("state=test-state");
+		expect(consentRequiredRedirectUri).toContain(newRedirectUri.split("?")[0]);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/7700
+	 */
+	it("none - should not redirect to invalid redirect_uri", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const attackerRedirect = "https://malicious.com/callback";
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", attackerRedirect);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "x");
+		authUrl.searchParams.set("prompt", "none");
+
+		let location = "";
+		await serverClient.$fetch(authUrl.toString(), {
+			method: "GET",
+			onError(context) {
+				location = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(location).not.toContain("malicious.com");
+	});
 });
 
 describe("oauth - config", () => {


### PR DESCRIPTION
## Summary

Adds `prompt=none` support to the new `@better-auth/oauth-provider` plugin per the OIDC specification.

- When `prompt=none` is set and the user has **no active session**, redirect to `redirect_uri` with `error=login_required` instead of the login page
- When `prompt=none` is set and **consent is needed**, redirect to `redirect_uri` with `error=consent_required` instead of the consent page
- Add `"none"` to `prompt_values_supported` in the OIDC discovery metadata

## Context

PR #8398 (commit 9dff8c5) fixed `redirect_uri` validation for `prompt=none` in the **old** `oidc-provider` plugin (`packages/better-auth/src/plugins/oidc-provider/`), but the same feature was missing in the **new** `@better-auth/oauth-provider` package (`packages/oauth-provider/`). As noted in [this comment](https://github.com/better-auth/better-auth/issues/7700#issuecomment-4035862756), the fix was applied to the wrong plugin.

Note: The `redirect_uri` validation security concern from #8398 is already handled by the new plugin's existing flow — `redirect_uri` is validated against the registered client URIs before reaching the `prompt=none` check.

Closes #7700

## Test plan

- [x] `login_required` error returned when user is not authenticated with `prompt=none`
- [x] `consent_required` error returned when consent is needed with `prompt=none`
- [x] Invalid `redirect_uri` is rejected (not used for error redirects)
- [x] Metadata advertises `"none"` in `prompt_values_supported`
- [x] All existing oauth-provider tests still pass (50/50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)