### PR TITLE
docs: fix api-key import path in api-key docs

### DIFF
--- a/docs/content/docs/plugins/api-key/advanced.mdx
+++ b/docs/content/docs/plugins/api-key/advanced.mdx
@@ -67,7 +67,7 @@ Or optionally, you can pass a `customAPIKeyGetter` function to the plugin option
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"
-import { apiKey } from "better-auth/plugins"
+import { apiKey } from "@better-auth/api-key"
 
 export const auth = betterAuth({
   plugins: [

--- a/docs/content/docs/plugins/api-key/reference.mdx
+++ b/docs/content/docs/plugins/api-key/reference.mdx
@@ -171,7 +171,7 @@ Default is `false`.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
-import { apiKey } from "better-auth/plugins"
+import { apiKey } from "@better-auth/api-key"
 
 export const auth = betterAuth({
   secondaryStorage: {
@@ -202,7 +202,7 @@ Useful when you want to use a different storage backend specifically for API key
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
-import { apiKey } from "better-auth/plugins"
+import { apiKey } from "@better-auth/api-key"
 
 export const auth = betterAuth({
   plugins: [
@@ -307,7 +307,7 @@ You can configure default permissions that will be applied to all newly created 
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"
-import { apiKey } from "better-auth/plugins"
+import { apiKey } from "@better-auth/api-key"
 
 export const auth = betterAuth({
   plugins: [
@@ -327,7 +327,7 @@ You can also provide a function that returns permissions dynamically:
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"
-import { apiKey } from "better-auth/plugins"
+import { apiKey } from "@better-auth/api-key"
 
 export const auth = betterAuth({
   plugins: [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated API key plugin docs to use the correct import path so copy-paste examples work.
All samples now import `apiKey` from `@better-auth/api-key` instead of `better-auth/plugins`.

<sup>Written for commit fa6593e8128c1206eab6f38db53d347ed34a538c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

