### PR TITLE
feat: expose /api-key/verify to clients

### DIFF
--- a/packages/api-key/src/client.ts
+++ b/packages/api-key/src/client.ts
@@ -10,6 +10,7 @@ export const apiKeyClient = () => {
 		$InferServerPlugin: {} as ReturnType<typeof apiKey>,
 		pathMethods: {
 			"/api-key/create": "POST",
+			"/api-key/verify": "POST",
 			"/api-key/delete": "POST",
 			"/api-key/delete-all-expired-api-keys": "POST",
 		},

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -250,6 +250,7 @@ export function verifyApiKey({
 	): Promise<void>;
 }) {
 	return createAuthEndpoint(
+		"/api-key/verify",
 		{
 			method: "POST",
 			body: verifyApiKeyBodySchema,


### PR DESCRIPTION
Added POST /api-key/verify as a concrete API key route and registered it in the API key client plugin. This enables client-side access to API key verification through authClient.apiKey.verify(...) and supports HTTP-based verification flows that were not previously available.

Fixes: https://github.com/better-auth/better-auth/issues/8535

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposed POST `/api-key/verify` to clients. Apps can now call `authClient.apiKey.verify(...)` to verify API keys over HTTP.

<sup>Written for commit 6e211c4cdd1d70ef508af66303b19d633c2f5956. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

