### PR TITLE
feat(auth): support function-based dynamic baseURL config

### DIFF
--- a/.changeset/dynamic-base-url-resolver.md
+++ b/.changeset/dynamic-base-url-resolver.md
@@ -1,0 +1,8 @@
+---
+"@better-auth/core": minor
+"better-auth": minor
+---
+
+Add function-based `baseURL` resolution for request-scoped auth origins. `baseURL` can now be a resolver that receives a Fetch `Request` and returns the origin for the current request, including async lookups for multi-tenant and white-label deployments.
+
+Direct `auth.api` calls that use a function `baseURL` must pass a request or headers so Better Auth can construct the resolver input.

--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -109,6 +109,8 @@ export const auth = betterAuth({
 })
 ```
 
+This also works with [function-based baseURL](/docs/guides/dynamic-base-url#function-resolver) for multi-tenant setups. See the Dynamic Base URL guide for examples and security guidance.
+
 ### Secure Cookies
 
 By default, cookies are secure only when the server is running in production mode. You can force cookies to be always secure by setting `useSecureCookies` to `true` in the `advanced` object in the auth options.

--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -90,6 +90,25 @@ export const auth = betterAuth({
 })
 ```
 
+When using a [dynamic base URL](/docs/guides/dynamic-base-url), you can omit the `domain` property. Better Auth derives the cookie domain from the resolved URL on each request:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+
+export const auth = betterAuth({
+    baseURL: {
+        allowedHosts: ["auth.example1.com", "auth.example2.com"],
+        protocol: "https",
+    },
+    advanced: {
+        crossSubDomainCookies: {
+            enabled: true,
+            // domain is computed per request from the resolved base URL
+        },
+    },
+})
+```
+
 ### Secure Cookies
 
 By default, cookies are secure only when the server is running in production mode. You can force cookies to be always secure by setting `useSecureCookies` to `true` in the `advanced` object in the auth options.

--- a/docs/content/docs/guides/dynamic-base-url.mdx
+++ b/docs/content/docs/guides/dynamic-base-url.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dynamic Base URL
-description: Configure Better Auth for preview deployments, multiple domains, and per-request URL resolution.
+description: Configure Better Auth for preview deployments, multiple domains, white-label apps, and per-request URL resolution.
 ---
 
 Use dynamic base URL when your app is served from more than one hostname, such as:
@@ -8,12 +8,18 @@ Use dynamic base URL when your app is served from more than one hostname, such a
 * custom domains like `myapp.com` and `www.myapp.com`
 * preview deployments like `my-app-abc123.vercel.app`
 * branch environments like `feature-branch.myapp.com`
+* white-label or multi-tenant domains stored outside your deploy config
 
-The configuration itself lives on the [`baseURL` option](/docs/reference/options#baseurl). This guide focuses on when to use it and how to structure it safely.
+The configuration itself lives on the [`baseURL` option](/docs/reference/options#baseurl). This guide focuses on when to use each form and how to structure it safely.
 
-## Basic Setup
+Better Auth supports two dynamic forms:
 
-Configure `baseURL` as an object with an `allowedHosts` allowlist:
+* an `allowedHosts` object for domains known at deploy time
+* a resolver function for domains that must be looked up per request
+
+## Allowed Hosts
+
+Use the object form when all valid hosts are known ahead of time:
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"
@@ -29,7 +35,22 @@ export const auth = betterAuth({
 })
 ```
 
-When a request comes in, Better Auth extracts the host from `x-forwarded-host`, `host` header, or the request URL (in that order), validates it against `allowedHosts`, and uses the matched value to build the request-specific base URL.
+When a request comes in, Better Auth derives the host from the `host` header or the request URL, validates it against `allowedHosts`, and uses the matched value to build the request-specific base URL.
+
+If your deployment only exposes the public host through forwarded headers, opt in explicitly:
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+	baseURL: {
+		allowedHosts: ["myapp.com", "*.vercel.app"],
+	},
+	advanced: {
+		trustedProxyHeaders: true,
+	},
+})
+```
+
+Only enable `trustedProxyHeaders` when your reverse proxy strips client-provided `x-forwarded-host` and `x-forwarded-proto` headers before forwarding requests to your app.
 
 ## Common Deployment Patterns
 
@@ -95,6 +116,52 @@ export const auth = betterAuth({
 
 Use this only when falling back to a canonical domain is clearly preferable to failing the request.
 
+## Function Resolver
+
+Use a function when valid domains are not known at deploy time, such as white-label domains stored in your database:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+import { getTenantByHost } from "./tenants"
+
+export const auth = betterAuth({
+	baseURL: async (request) => {
+		const host = request.headers.get("host")
+		if (!host) {
+			throw new Error("Missing host")
+		}
+
+		const tenant = await getTenantByHost(host)
+		if (!tenant) {
+			throw new Error("Unknown host")
+		}
+
+		return tenant.authOrigin
+	},
+})
+```
+
+The function receives the incoming `Request` and can return a string or `URL`, synchronously or asynchronously. Better Auth appends `basePath` when the returned URL has no path.
+
+With a function resolver:
+
+* the resolved origin is trusted for that request
+* cookies are derived from the resolved URL for that request
+* concurrent requests get isolated auth contexts
+* your function owns host validation
+
+<Callout type="warn">
+  Do not reflect arbitrary request headers into the returned URL. Validate the host against an authoritative source, such as your tenant database or deployment config. If you read `x-forwarded-host`, make sure your proxy strips client-provided forwarded headers.
+</Callout>
+
+When calling `auth.api.*` directly with a dynamic `baseURL`, pass `request` or `headers` so Better Auth can resolve the request-specific base URL:
+
+```ts
+await auth.api.getSession({
+	headers: request.headers,
+})
+```
+
 ## Cookies Across Subdomains
 
 If you need to share cookies across subdomains, you can enable `crossSubDomainCookies` while still using dynamic base URL. Better Auth will derive the cookie domain from the resolved host unless you set `domain` explicitly.
@@ -141,14 +208,32 @@ See [Cookies](/docs/concepts/cookies#cross-subdomain-cookies) for the full cooki
 
 ## Security Model
 
-Dynamic base URL uses an allowlist model:
+The object form uses an allowlist model:
 
 1. Only hosts listed in `allowedHosts` are accepted
-2. `x-forwarded-host` and `host` headers are sanitized and validated before use
+2. `host` and request URL-derived values are sanitized and validated before use
 3. Unknown hosts throw unless you provide `fallback`
-4. `allowedHosts` are automatically added to [`trustedOrigins`](/docs/reference/options#trustedorigins) (localhost entries get both `http` and `https`)
+4. `allowedHosts` are automatically added to [`trustedOrigins`](/docs/reference/options#trustedorigins)
+5. `x-forwarded-host` and `x-forwarded-proto` are ignored unless `trustedProxyHeaders` is enabled
+
+The function form uses your resolver as the security boundary:
+
+1. Return only origins your app controls
+2. Throw for unknown hosts
+3. Prefer `https` in production
+4. Validate forwarded headers through your proxy and application data
 
 This keeps multi-domain support explicit instead of trusting arbitrary headers or platform-specific behavior.
+
+## Choosing a Form
+
+| Use case | Recommended form |
+| --- | --- |
+| Preview deployments with predictable host patterns | `allowedHosts` |
+| Multiple known production domains | `allowedHosts` |
+| Tenant domains stored in a database | Function resolver |
+| White-label custom domains | Function resolver |
+| Unknown hosts should fail closed | Either form, without `fallback` |
 
 ## Reference
 

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -20,17 +20,40 @@ export const auth = betterAuth({
 
 ## `baseURL`
 
-Base URL for Better Auth. This is typically the root URL where your application server is hosted. You can configure it as either:
+Base URL for Better Auth. This is typically the root URL where your application server is hosted. You can configure it as:
 
 * a static string for single-domain deployments
 * an object for dynamic per-request resolution across multiple allowed hosts
+* a function for fully dynamic per-request resolution
 
 If you include a path in the baseURL string, it will take precedence over the default path.
 
 ```ts
 import { betterAuth } from "better-auth";
+import { getTenantByHost } from "./tenants";
+
+// Static string
 export const auth = betterAuth({
 	baseURL: "https://example.com",
+})
+
+// Allowed hosts (multi-domain)
+export const auth = betterAuth({
+	baseURL: {
+		allowedHosts: ["myapp.com", "*.vercel.app"],
+	},
+})
+
+// Function (multi-tenant, white-label)
+export const auth = betterAuth({
+	baseURL: async (request) => {
+		const host = request.headers.get("host");
+		const tenant = host ? await getTenantByHost(host) : null;
+		if (!tenant) {
+			throw new Error("Unknown host");
+		}
+		return tenant.authOrigin;
+	},
 })
 ```
 
@@ -61,12 +84,14 @@ export const auth = betterAuth({
 ```
 
 * `allowedHosts`: List of accepted host patterns. Supports exact matches (`myapp.com`), wildcards (`*.vercel.app`, `preview-*.myapp.com`), and port wildcards (`localhost:*`). Automatically added to [`trustedOrigins`](#trustedorigins) (localhost entries get both `http` and `https`)
-* `protocol`: Protocol for URL construction. `"http"`, `"https"`, or `"auto"` (default). `"auto"` derives from `x-forwarded-proto`, then request URL, then defaults to HTTPS. Also affects the cookie `Secure` flag: `"https"` → secure, `"http"` → not secure, `"auto"` or unset → `NODE_ENV === "production"`. Override with `advanced.useSecureCookies`
+* `protocol`: Protocol for URL construction. `"http"`, `"https"`, or `"auto"` (default). `"auto"` derives from trusted forwarded headers when `advanced.trustedProxyHeaders` is enabled, then request URL, then defaults to HTTPS. Also affects the cookie `Secure` flag: `"https"` → secure, `"http"` → not secure, `"auto"` or unset → `NODE_ENV === "production"`. Override with `advanced.useSecureCookies`
 * `fallback`: URL to use when the incoming host does not match. Without it, unknown hosts throw. Its origin is also added to `trustedOrigins`
 
 <Callout type="warn">
   Use `fallback` carefully. It can hide deployment or proxy misconfiguration that would otherwise fail loudly.
 </Callout>
+
+Use the function form when the valid host must be resolved from application data. The function receives the current `Request` and may return a string or `URL`, synchronously or asynchronously. Validate the host before returning an origin.
 
 When `crossSubDomainCookies` is enabled, the cookie domain is derived from the resolved request host unless you set `domain` explicitly.
 

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -968,6 +968,63 @@ describe("dynamic baseURL resolution", () => {
 		expect(res.baseURL).toBe("https://example.com/api/auth");
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/4151
+	 */
+	it("should resolve function baseURL from headers for direct auth.api calls", async () => {
+		const authContext = init({
+			baseURL: (request) => new URL(request.url).origin,
+		});
+		const authEndpoints = toAuthEndpoints(endpoints, authContext);
+
+		const res = await authEndpoints.readBaseURL({
+			headers: new Headers({ host: "tenant.example.com" }),
+		});
+		expect(res.baseURL).toBe("https://tenant.example.com/api/auth");
+	});
+
+	it("should ignore x-forwarded headers for function baseURL when trustedProxyHeaders is not configured", async () => {
+		const authContext = init({
+			baseURL: (request) => new URL(request.url).origin,
+		});
+		const authEndpoints = toAuthEndpoints(endpoints, authContext);
+
+		const res = await authEndpoints.readBaseURL({
+			headers: new Headers({
+				host: "example.com",
+				"x-forwarded-host": "proxy.example.com",
+				"x-forwarded-proto": "http",
+			}),
+		});
+		expect(res.baseURL).toBe("https://example.com/api/auth");
+	});
+
+	it("should honor x-forwarded headers for function baseURL when trustedProxyHeaders is enabled", async () => {
+		const authContext = init({
+			baseURL: (request) => new URL(request.url).origin,
+			advanced: { trustedProxyHeaders: true },
+		});
+		const authEndpoints = toAuthEndpoints(endpoints, authContext);
+
+		const res = await authEndpoints.readBaseURL({
+			headers: new Headers({
+				host: "example.com",
+				"x-forwarded-host": "proxy.example.com",
+				"x-forwarded-proto": "http",
+			}),
+		});
+		expect(res.baseURL).toBe("http://proxy.example.com/api/auth");
+	});
+
+	it("should throw APIError when function baseURL is called with no source", async () => {
+		const authContext = init({
+			baseURL: (request) => new URL(request.url).origin,
+		});
+		const authEndpoints = toAuthEndpoints(endpoints, authContext);
+
+		await expect(authEndpoints.readBaseURL()).rejects.toSatisfy(isAPIError);
+	});
+
 	it("should leave baseURL untouched for static string config", async () => {
 		const authContext = init({
 			baseURL: "https://static.example.com",

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -15,7 +15,11 @@ import {
 	resolveDynamicTrustedProxyHeaders,
 	resolveRequestContext,
 } from "../context/helpers";
-import { isDynamicBaseURLConfig, isRequestLike } from "../utils/url";
+import {
+	isDynamicBaseURLConfig,
+	isPerRequestBaseURL,
+	isRequestLike,
+} from "../utils/url";
 import { dispatchAuthEndpoint, getOperationId } from "./dispatch";
 
 type UserInputContext = Partial<
@@ -90,7 +94,7 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 
 			const run = async () => {
 				const rawContext = await ctx;
-				const authContext = isDynamicBaseURLConfig(rawContext.options.baseURL)
+				const authContext = isPerRequestBaseURL(rawContext.options.baseURL)
 					? await resolveDynamicContext(rawContext, context)
 					: rawContext;
 

--- a/packages/better-auth/src/auth/base.ts
+++ b/packages/better-auth/src/auth/base.ts
@@ -9,7 +9,7 @@ import {
 	resolveRequestContext,
 } from "../context/helpers";
 import type { Auth } from "../types";
-import { getBaseURL, getOrigin, isDynamicBaseURLConfig } from "../utils/url";
+import { getBaseURL, getOrigin, isPerRequestBaseURL } from "../utils/url";
 
 export const createBetterAuth = <Options extends BetterAuthOptions>(
 	options: Options,
@@ -32,7 +32,7 @@ export const createBetterAuth = <Options extends BetterAuthOptions>(
 
 		let handlerCtx: AuthContext;
 
-		if (isDynamicBaseURLConfig(options.baseURL)) {
+		if (isPerRequestBaseURL(options.baseURL)) {
 			// Per-request clone avoids mutating shared ctx under concurrent
 			// requests that may resolve to different hosts.
 			handlerCtx = await resolveRequestContext(

--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -668,6 +668,47 @@ describe("auth with function baseURL", () => {
 		});
 		expect(cookieDomain).toBe("auth.example2.com");
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8478
+	 */
+	test("should expose resolved baseURL inside database hook context", async () => {
+		let hookBaseURL: string | undefined;
+		const { client } = await getTestInstance(
+			{
+				baseURL: (request: Request) => {
+					const host = request.headers.get("x-forwarded-host") || "default.com";
+					return `https://${host}`;
+				},
+				databaseHooks: {
+					user: {
+						create: {
+							after: async (_user, ctx) => {
+								hookBaseURL = ctx?.context.baseURL;
+							},
+						},
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		await client.signUp.email(
+			{
+				email: "hook-context@example.com",
+				password: "password123",
+				name: "Hook Context",
+			},
+			{
+				headers: {
+					"x-forwarded-host": "tenant-hook.example.com",
+					"x-forwarded-proto": "https",
+				},
+			},
+		);
+
+		expect(hookBaseURL).toBe("https://tenant-hook.example.com/api/auth");
+	});
 });
 
 /**
@@ -716,11 +757,16 @@ describe("auth with function baseURL (behavioral)", () => {
 	});
 
 	test("handler should throw when function throws", async () => {
-		const { auth } = await getTestInstance({
-			baseURL: () => {
-				throw new Error("DB connection failed");
+		const { auth } = await getTestInstance(
+			{
+				baseURL: () => {
+					throw new Error("DB connection failed");
+				},
 			},
-		});
+			{
+				disableTestUser: true,
+			},
+		);
 
 		await expect(
 			auth.handler(
@@ -732,9 +778,14 @@ describe("auth with function baseURL (behavioral)", () => {
 	});
 
 	test("handler should throw when function returns empty", async () => {
-		const { auth } = await getTestInstance({
-			baseURL: () => "",
-		});
+		const { auth } = await getTestInstance(
+			{
+				baseURL: () => "",
+			},
+			{
+				disableTestUser: true,
+			},
+		);
 
 		await expect(
 			auth.handler(

--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -477,3 +477,373 @@ describe("auth with dynamic baseURL (allowedHosts)", () => {
 		expect(internalAdapter).toBeDefined();
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/4151
+ */
+describe("auth with function baseURL", () => {
+	test("should resolve baseURL from function return value", async () => {
+		let baseURL: string | undefined;
+		let optionsBaseURL: string | undefined;
+		const { customFetchImpl } = await getTestInstance({
+			baseURL: (request: Request) => {
+				const host = request.headers.get("x-forwarded-host") || "fallback.com";
+				const proto = request.headers.get("x-forwarded-proto") || "https";
+				return `${proto}://${host}`;
+			},
+			hooks: {
+				before: createAuthMiddleware(async (ctx) => {
+					baseURL = ctx.context.baseURL;
+					optionsBaseURL = ctx.context.options.baseURL as string;
+				}),
+			},
+		});
+		const client = createAuthClient({
+			fetchOptions: {
+				customFetchImpl,
+			},
+			baseURL: "http://localhost:3000",
+		});
+		await client.$fetch("/ok", {
+			headers: {
+				"x-forwarded-host": "tenant-a.example.com",
+				"x-forwarded-proto": "https",
+			},
+		});
+		expect(baseURL).toBe("https://tenant-a.example.com/api/auth");
+		expect(optionsBaseURL).toBe("https://tenant-a.example.com");
+	});
+
+	test("should handle async functions", async () => {
+		let baseURL: string | undefined;
+		const { customFetchImpl } = await getTestInstance({
+			baseURL: async (request: Request) => {
+				// Simulate async lookup (e.g. database query)
+				const host = request.headers.get("x-forwarded-host") || "default.com";
+				return `https://${host}`;
+			},
+			hooks: {
+				before: createAuthMiddleware(async (ctx) => {
+					baseURL = ctx.context.baseURL;
+				}),
+			},
+		});
+		const client = createAuthClient({
+			fetchOptions: {
+				customFetchImpl,
+			},
+			baseURL: "http://localhost:3000",
+		});
+		await client.$fetch("/ok", {
+			headers: {
+				"x-forwarded-host": "white-label.customer.com",
+				"x-forwarded-proto": "https",
+			},
+		});
+		expect(baseURL).toBe("https://white-label.customer.com/api/auth");
+	});
+
+	test("should isolate per-request context for concurrent requests", async () => {
+		const resolvedBaseURLs: string[] = [];
+		const { customFetchImpl } = await getTestInstance({
+			baseURL: (request: Request) => {
+				const host = request.headers.get("x-forwarded-host") || "default.com";
+				return `https://${host}`;
+			},
+			hooks: {
+				before: createAuthMiddleware(async (ctx) => {
+					if (ctx.context.baseURL) {
+						resolvedBaseURLs.push(ctx.context.baseURL);
+					}
+				}),
+			},
+		});
+		const client = createAuthClient({
+			fetchOptions: {
+				customFetchImpl,
+			},
+			baseURL: "http://localhost:3000",
+		});
+
+		// Clear any URLs captured during test setup
+		resolvedBaseURLs.length = 0;
+
+		// Fire two requests with different hosts concurrently
+		await Promise.all([
+			client.$fetch("/ok", {
+				headers: {
+					"x-forwarded-host": "tenant-a.example.com",
+					"x-forwarded-proto": "https",
+				},
+			}),
+			client.$fetch("/ok", {
+				headers: {
+					"x-forwarded-host": "tenant-b.example.com",
+					"x-forwarded-proto": "https",
+				},
+			}),
+		]);
+
+		expect(resolvedBaseURLs).toContain("https://tenant-a.example.com/api/auth");
+		expect(resolvedBaseURLs).toContain("https://tenant-b.example.com/api/auth");
+		// Verify no cross-contamination
+		const tenantACount = resolvedBaseURLs.filter(
+			(u) => u === "https://tenant-a.example.com/api/auth",
+		).length;
+		const tenantBCount = resolvedBaseURLs.filter(
+			(u) => u === "https://tenant-b.example.com/api/auth",
+		).length;
+		expect(tenantACount).toBe(1);
+		expect(tenantBCount).toBe(1);
+	});
+
+	test("should include resolved origin in trustedOrigins", async () => {
+		let trustedOrigins: string[] = [];
+		const { customFetchImpl } = await getTestInstance({
+			baseURL: (request: Request) => {
+				const host = request.headers.get("x-forwarded-host") || "default.com";
+				return `https://${host}`;
+			},
+			hooks: {
+				before: createAuthMiddleware(async (ctx) => {
+					trustedOrigins = ctx.context.trustedOrigins;
+				}),
+			},
+		});
+		const client = createAuthClient({
+			fetchOptions: {
+				customFetchImpl,
+			},
+			baseURL: "http://localhost:3000",
+		});
+
+		await client.$fetch("/ok", {
+			headers: {
+				"x-forwarded-host": "myapp.com",
+				"x-forwarded-proto": "https",
+			},
+		});
+
+		expect(trustedOrigins).toContain("https://myapp.com");
+	});
+
+	test("should set cookie domain dynamically with crossSubDomainCookies", async () => {
+		let cookieDomain: string | undefined;
+		const { customFetchImpl } = await getTestInstance({
+			baseURL: (request: Request) => {
+				const host = request.headers.get("x-forwarded-host") || "default.com";
+				return `https://${host}`;
+			},
+			advanced: {
+				crossSubDomainCookies: {
+					enabled: true,
+				},
+			},
+			hooks: {
+				before: createAuthMiddleware(async (ctx) => {
+					cookieDomain = ctx.context.authCookies.sessionToken.attributes.domain;
+				}),
+			},
+		});
+		const client = createAuthClient({
+			fetchOptions: {
+				customFetchImpl,
+			},
+			baseURL: "http://localhost:3000",
+		});
+
+		await client.$fetch("/ok", {
+			headers: {
+				"x-forwarded-host": "auth.example1.com",
+				"x-forwarded-proto": "https",
+			},
+		});
+		expect(cookieDomain).toBe("auth.example1.com");
+
+		await client.$fetch("/ok", {
+			headers: {
+				"x-forwarded-host": "auth.example2.com",
+				"x-forwarded-proto": "https",
+			},
+		});
+		expect(cookieDomain).toBe("auth.example2.com");
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/4151
+ *
+ * Behavioral tests that verify end-to-end outcomes (HTTP responses,
+ * headers, redirects) rather than internal context state.
+ */
+describe("auth with function baseURL (behavioral)", () => {
+	test("OAuth redirect_uri should use the resolved host", async () => {
+		const { customFetchImpl } = await getTestInstance({
+			baseURL: (request: Request) => {
+				const host = request.headers.get("x-forwarded-host") || "default.com";
+				return `https://${host}`;
+			},
+			socialProviders: {
+				github: {
+					clientId: "test",
+					clientSecret: "test",
+				},
+			},
+		});
+		const client = createAuthClient({
+			fetchOptions: {
+				customFetchImpl,
+			},
+			baseURL: "http://localhost:3000",
+		});
+
+		const res = await client.signIn.social({
+			provider: "github",
+			callbackURL: "/callback",
+			fetchOptions: {
+				headers: {
+					"x-forwarded-host": "tenant-a.example.com",
+					"x-forwarded-proto": "https",
+				},
+			},
+		});
+		expect(res.data?.url).toBeDefined();
+		const authorizationURL = new URL(res.data!.url!);
+		const redirectURI = authorizationURL.searchParams.get("redirect_uri");
+		expect(redirectURI).toBe(
+			"https://tenant-a.example.com/api/auth/callback/github",
+		);
+	});
+
+	test("handler should throw when function throws", async () => {
+		const { auth } = await getTestInstance({
+			baseURL: () => {
+				throw new Error("DB connection failed");
+			},
+		});
+
+		await expect(
+			auth.handler(
+				new Request("http://localhost:3000/api/auth/ok", {
+					method: "GET",
+				}),
+			),
+		).rejects.toThrow("baseURL function threw an error");
+	});
+
+	test("handler should throw when function returns empty", async () => {
+		const { auth } = await getTestInstance({
+			baseURL: () => "",
+		});
+
+		await expect(
+			auth.handler(
+				new Request("http://localhost:3000/api/auth/ok", {
+					method: "GET",
+				}),
+			),
+		).rejects.toThrow("baseURL function returned an empty value");
+	});
+
+	test("CSRF should accept POST from resolved origin", async () => {
+		const { customFetchImpl, testUser } = await getTestInstance({
+			baseURL: (request: Request) => {
+				const host = request.headers.get("x-forwarded-host") || "default.com";
+				return `https://${host}`;
+			},
+			emailAndPassword: {
+				enabled: true,
+			},
+			advanced: {
+				disableCSRFCheck: false,
+				disableOriginCheck: false,
+			},
+		});
+		const client = createAuthClient({
+			fetchOptions: {
+				customFetchImpl,
+				headers: {
+					"x-forwarded-host": "tenant-a.example.com",
+					"x-forwarded-proto": "https",
+					origin: "https://tenant-a.example.com",
+				},
+			},
+			baseURL: "http://localhost:3000",
+		});
+
+		const res = await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+		});
+		expect(res.data?.user).toBeDefined();
+	});
+
+	test("CSRF should reject POST from non-matching origin", async () => {
+		const { customFetchImpl, testUser } = await getTestInstance({
+			baseURL: (request: Request) => {
+				const host = request.headers.get("x-forwarded-host") || "default.com";
+				return `https://${host}`;
+			},
+			emailAndPassword: {
+				enabled: true,
+			},
+			advanced: {
+				disableCSRFCheck: false,
+				disableOriginCheck: false,
+			},
+		});
+		const client = createAuthClient({
+			fetchOptions: {
+				customFetchImpl,
+				headers: {
+					"x-forwarded-host": "tenant-a.example.com",
+					"x-forwarded-proto": "https",
+					origin: "https://evil.com",
+					cookie: "session=123",
+				},
+			},
+			baseURL: "http://localhost:3000",
+		});
+
+		const res = await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+		});
+		expect(res.error?.status).toBe(403);
+	});
+
+	test("Set-Cookie domain should match resolved host with crossSubDomainCookies", async () => {
+		const { auth, testUser } = await getTestInstance({
+			baseURL: (request: Request) => {
+				const host = request.headers.get("x-forwarded-host") || "default.com";
+				return `https://${host}`;
+			},
+			emailAndPassword: {
+				enabled: true,
+			},
+			advanced: {
+				crossSubDomainCookies: {
+					enabled: true,
+				},
+			},
+		});
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/sign-in/email", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					"x-forwarded-host": "auth.tenant-a.com",
+					"x-forwarded-proto": "https",
+				},
+				body: JSON.stringify({
+					email: testUser.email,
+					password: testUser.password,
+				}),
+			}),
+		);
+		expect(response.status).toBe(200);
+		const setCookie = response.headers.get("set-cookie") || "";
+		expect(setCookie).toContain("Domain=auth.tenant-a.com");
+	});
+});

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -25,7 +25,11 @@ import type { JwtOptions } from "../plugins/jwt/types";
 import { DEFAULT_SECRET } from "../utils/constants";
 import { isPromise } from "../utils/is-promise";
 import { checkPassword } from "../utils/password";
-import { getBaseURL, isDynamicBaseURLConfig } from "../utils/url";
+import {
+	getBaseURL,
+	isDynamicBaseURLConfig,
+	isPerRequestBaseURL,
+} from "../utils/url";
 import {
 	getInternalPlugins,
 	getTrustedOrigins,
@@ -130,7 +134,7 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 	const internalPlugins = getInternalPlugins(options);
 	const logger = createLogger(options.logger);
 
-	const isDynamicConfig = isDynamicBaseURLConfig(options.baseURL);
+	const isDynamicConfig = isPerRequestBaseURL(options.baseURL);
 
 	if (isDynamicBaseURLConfig(options.baseURL)) {
 		const { allowedHosts } = options.baseURL;

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -14,10 +14,14 @@ import { createInternalAdapter } from "../db";
 import { isPromise } from "../utils/is-promise";
 import {
 	getBaseURL,
+	getHostFromSource,
 	getOrigin,
+	getProtocolFromSource,
 	isDynamicBaseURLConfig,
+	isFunctionBaseURLConfig,
 	isRequestLike,
 	resolveBaseURL,
+	resolveFunctionBaseURL,
 } from "../utils/url";
 
 export async function runPluginInit(context: AuthContext) {
@@ -201,6 +205,28 @@ export function resolveDynamicTrustedProxyHeaders(
 	return options.advanced?.trustedProxyHeaders ?? false;
 }
 
+function createBaseURLResolverRequest(
+	source: Request | Headers | undefined,
+	trustedProxyHeaders?: boolean,
+): Request {
+	if (isRequestLike(source)) {
+		return source;
+	}
+	if (!source) {
+		throw new BetterAuthError(
+			"Could not resolve baseURL from function config. Pass a Request or headers to the auth call.",
+		);
+	}
+	const host = getHostFromSource(source, trustedProxyHeaders);
+	if (!host) {
+		throw new BetterAuthError(
+			"Could not determine host from request headers. Pass a Request or headers with a host header.",
+		);
+	}
+	const protocol = getProtocolFromSource(source, undefined, trustedProxyHeaders);
+	return new Request(`${protocol}://${host}`, { headers: source });
+}
+
 /**
  * Per-request clone with `baseURL`, `trustedOrigins`, `trustedProviders`
  * and cookies rehydrated for the resolved host. Throws `BetterAuthError`
@@ -214,16 +240,22 @@ export async function resolveRequestContext(
 ): Promise<AuthContext> {
 	const dynamicBaseURLConfig = ctx.options.baseURL;
 	const basePath = ctx.options.basePath || "/api/auth";
-	const baseURL = resolveBaseURL(
-		dynamicBaseURLConfig,
-		basePath,
-		source,
-		undefined,
-		trustedProxyHeaders,
-	);
+	const baseURL = isFunctionBaseURLConfig(dynamicBaseURLConfig)
+		? await resolveFunctionBaseURL(
+				dynamicBaseURLConfig,
+				createBaseURLResolverRequest(source, trustedProxyHeaders),
+				basePath,
+			)
+		: resolveBaseURL(
+				dynamicBaseURLConfig,
+				basePath,
+				source,
+				undefined,
+				trustedProxyHeaders,
+			);
 	if (!baseURL) {
 		throw new BetterAuthError(
-			"Could not resolve base URL from request. Check your allowedHosts config.",
+			"Could not resolve base URL from request. Check your baseURL config.",
 		);
 	}
 
@@ -237,11 +269,14 @@ export async function resolveRequestContext(
 		baseURL: getOrigin(baseURL) || undefined,
 	};
 
-	// Pass the dynamic config so getTrustedOrigins can expand `allowedHosts`.
-	const trustedOriginOptions: BetterAuthOptions = {
-		...resolved.options,
-		baseURL: dynamicBaseURLConfig,
-	};
+	const trustedOriginOptions: BetterAuthOptions = isDynamicBaseURLConfig(
+		dynamicBaseURLConfig,
+	)
+		? {
+				...resolved.options,
+				baseURL: dynamicBaseURLConfig,
+			}
+		: resolved.options;
 	// Only synthesize a Request for the user-facing callbacks that need one.
 	const needsRequest =
 		typeof ctx.options.trustedOrigins === "function" ||
@@ -267,10 +302,8 @@ export async function resolveRequestContext(
 		callbackRequest,
 	);
 
-	if (ctx.options.advanced?.crossSubDomainCookies?.enabled) {
-		resolved.authCookies = getCookies(resolved.options);
-		resolved.createAuthCookie = createCookieGetter(resolved.options);
-	}
+	resolved.authCookies = getCookies(resolved.options);
+	resolved.createAuthCookie = createCookieGetter(resolved.options);
 
 	return resolved;
 }

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -223,7 +223,11 @@ function createBaseURLResolverRequest(
 			"Could not determine host from request headers. Pass a Request or headers with a host header.",
 		);
 	}
-	const protocol = getProtocolFromSource(source, undefined, trustedProxyHeaders);
+	const protocol = getProtocolFromSource(
+		source,
+		undefined,
+		trustedProxyHeaders,
+	);
 	return new Request(`${protocol}://${host}`, { headers: source });
 }
 

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -30,7 +30,7 @@ import type { Session, User } from "../types";
 import { getDate } from "../utils/date";
 import { isPromise } from "../utils/is-promise";
 import { sec } from "../utils/time";
-import { isDynamicBaseURLConfig } from "../utils/url";
+import { isPerRequestBaseURL } from "../utils/url";
 import {
 	parseCookies,
 	SECURE_COOKIE_PREFIX,
@@ -84,7 +84,7 @@ export function createCookieGetter(options: BetterAuthOptions) {
 	if (
 		crossSubdomainEnabled &&
 		!domain &&
-		!isDynamicBaseURLConfig(options.baseURL)
+		!isPerRequestBaseURL(options.baseURL)
 	) {
 		throw new BetterAuthError(
 			"baseURL is required when crossSubdomainCookies are enabled.",

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -15,7 +15,12 @@ import { getAdapter } from "../db/adapter-kysely";
 import { getMigrations } from "../db/get-migration";
 import { bearer } from "../plugins";
 import type { Session, User } from "../types";
-import { getBaseURL, isPerRequestBaseURL } from "../utils/url";
+import {
+	getBaseURL,
+	isDynamicBaseURLConfig,
+	isFunctionBaseURLConfig,
+	isPerRequestBaseURL,
+} from "../utils/url";
 
 const cleanupSet = new Set<Function>();
 
@@ -162,8 +167,9 @@ export async function getTestInstance<
 		// Synthesize a host header from allowedHosts so setup resolves under
 		// dynamic baseURL. `?` is a wildcard, not a query-string delimiter,
 		// so it's replaced, not split on.
-		const dynamicBaseURL = isDynamicBaseURLConfig(auth.options.baseURL)
-			? auth.options.baseURL
+		const baseURLConfig = auth.options.baseURL;
+		const dynamicBaseURL = isDynamicBaseURLConfig(baseURLConfig)
+			? baseURLConfig
 			: undefined;
 		const pattern =
 			dynamicBaseURL?.allowedHosts.find(
@@ -174,7 +180,11 @@ export async function getTestInstance<
 			.split(/[/#]/)[0]
 			?.replace(/\*/g, "test")
 			.replace(/\?/g, "x");
-		const headers = host ? new Headers({ host }) : undefined;
+		const headers = host
+			? new Headers({ host })
+			: isFunctionBaseURLConfig(baseURLConfig)
+				? new Headers({ host: "localhost:3000" })
+				: undefined;
 		//@ts-expect-error
 		await auth.api.signUpEmail({
 			body: testUser,

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -15,7 +15,7 @@ import { getAdapter } from "../db/adapter-kysely";
 import { getMigrations } from "../db/get-migration";
 import { bearer } from "../plugins";
 import type { Session, User } from "../types";
-import { getBaseURL, isDynamicBaseURLConfig } from "../utils/url";
+import { getBaseURL, isPerRequestBaseURL } from "../utils/url";
 
 const cleanupSet = new Set<Function>();
 
@@ -266,7 +266,7 @@ export async function getTestInstance<
 		);
 	};
 
-	const clientBaseURL = isDynamicBaseURLConfig(options?.baseURL)
+	const clientBaseURL = isPerRequestBaseURL(options?.baseURL)
 		? getBaseURL(
 				"http://localhost:" + (config?.port || 3000),
 				options?.basePath || "/api/auth",

--- a/packages/better-auth/src/utils/url.test.ts
+++ b/packages/better-auth/src/utils/url.test.ts
@@ -1,13 +1,16 @@
-import type { DynamicBaseURLConfig } from "@better-auth/core";
+import type { BaseURLResolver, DynamicBaseURLConfig } from "@better-auth/core";
 import { describe, expect, it } from "vitest";
 import {
 	getBaseURL,
 	getHostFromSource,
 	getProtocolFromSource,
 	isDynamicBaseURLConfig,
+	isFunctionBaseURLConfig,
+	isPerRequestBaseURL,
 	matchesHostPattern,
 	resolveBaseURL,
 	resolveDynamicBaseURL,
+	resolveFunctionBaseURL,
 	trimTrailingSlashes,
 } from "./url";
 
@@ -493,7 +496,9 @@ describe("isDynamicBaseURLConfig", () => {
 	});
 
 	it("should return false for object without allowedHosts", () => {
-		expect(isDynamicBaseURLConfig({} as any)).toBe(false);
+		expect(isDynamicBaseURLConfig({} as unknown as DynamicBaseURLConfig)).toBe(
+			false,
+		);
 	});
 });
 
@@ -644,5 +649,170 @@ describe("resolveBaseURL", () => {
 		const result = resolveBaseURL(undefined, "/api/auth", request);
 
 		expect(result).toBe("http://example.com:3000/api/auth");
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/4151
+ */
+describe("isFunctionBaseURLConfig", () => {
+	it("should return true for a function", () => {
+		expect(isFunctionBaseURLConfig(() => "https://myapp.com")).toBe(true);
+	});
+
+	it("should return true for an async function", () => {
+		expect(isFunctionBaseURLConfig(async () => "https://myapp.com")).toBe(true);
+	});
+
+	it("should return false for a string", () => {
+		expect(isFunctionBaseURLConfig("https://myapp.com")).toBe(false);
+	});
+
+	it("should return false for a DynamicBaseURLConfig object", () => {
+		expect(isFunctionBaseURLConfig({ allowedHosts: ["myapp.com"] })).toBe(
+			false,
+		);
+	});
+
+	it("should return false for undefined", () => {
+		expect(isFunctionBaseURLConfig(undefined)).toBe(false);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/4151
+ */
+describe("isPerRequestBaseURL", () => {
+	it("should return true for a function", () => {
+		expect(isPerRequestBaseURL(() => "https://myapp.com")).toBe(true);
+	});
+
+	it("should return true for a DynamicBaseURLConfig", () => {
+		expect(isPerRequestBaseURL({ allowedHosts: ["myapp.com"] })).toBe(true);
+	});
+
+	it("should return false for a string", () => {
+		expect(isPerRequestBaseURL("https://myapp.com")).toBe(false);
+	});
+
+	it("should return false for undefined", () => {
+		expect(isPerRequestBaseURL(undefined)).toBe(false);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/4151
+ */
+describe("resolveFunctionBaseURL", () => {
+	it("should resolve a sync function", async () => {
+		const fn = () => "https://myapp.com";
+		const request = new Request("http://localhost:3000/test");
+
+		const result = await resolveFunctionBaseURL(fn, request, "/api/auth");
+
+		expect(result).toBe("https://myapp.com/api/auth");
+	});
+
+	it("should resolve an async function", async () => {
+		const fn = async () => "https://tenant.example.com";
+		const request = new Request("http://localhost:3000/test");
+
+		const result = await resolveFunctionBaseURL(fn, request, "/api/auth");
+
+		expect(result).toBe("https://tenant.example.com/api/auth");
+	});
+
+	it("should resolve a URL object", async () => {
+		const fn: BaseURLResolver = () => new URL("https://tenant.example.com");
+		const request = new Request("http://localhost:3000/test");
+
+		const result = await resolveFunctionBaseURL(fn, request, "/api/auth");
+
+		expect(result).toBe("https://tenant.example.com/api/auth");
+	});
+
+	it("should pass the request to the function", async () => {
+		const fn = (req: Request) => {
+			const host = req.headers.get("x-forwarded-host") || "fallback.com";
+			return `https://${host}`;
+		};
+		const request = new Request("http://localhost:3000/test", {
+			headers: { "x-forwarded-host": "custom.example.com" },
+		});
+
+		const result = await resolveFunctionBaseURL(fn, request, "/api/auth");
+
+		expect(result).toBe("https://custom.example.com/api/auth");
+	});
+
+	it("should throw on empty return value", async () => {
+		const fn = () => "";
+		const request = new Request("http://localhost:3000/test");
+
+		await expect(
+			resolveFunctionBaseURL(fn, request, "/api/auth"),
+		).rejects.toThrow("baseURL function returned an empty value");
+	});
+
+	it("should not append basePath if URL already contains it", async () => {
+		const fn = () => "https://myapp.com/api/auth";
+		const request = new Request("http://localhost:3000/test");
+
+		const result = await resolveFunctionBaseURL(fn, request, "/api/auth");
+
+		expect(result).toBe("https://myapp.com/api/auth");
+	});
+
+	it("should wrap function errors with actionable BetterAuthError", async () => {
+		const fn = () => {
+			throw new Error("DB connection failed");
+		};
+		const request = new Request("http://localhost:3000/test");
+
+		await expect(
+			resolveFunctionBaseURL(fn, request, "/api/auth"),
+		).rejects.toThrow("baseURL function threw an error");
+	});
+
+	it("should preserve original error as cause when function throws", async () => {
+		const originalError = new Error("DB connection failed");
+		const fn = () => {
+			throw originalError;
+		};
+		const request = new Request("http://localhost:3000/test");
+
+		try {
+			await resolveFunctionBaseURL(fn, request, "/api/auth");
+			expect.unreachable("should have thrown");
+		} catch (error: unknown) {
+			expect((error as Error & { cause?: unknown }).cause).toBe(originalError);
+		}
+	});
+
+	it("should throw on URL without protocol", async () => {
+		const fn = () => "myapp.com";
+		const request = new Request("http://localhost:3000/test");
+
+		await expect(
+			resolveFunctionBaseURL(fn, request, "/api/auth"),
+		).rejects.toThrow("Invalid base URL");
+	});
+
+	it("should throw on null return value", async () => {
+		const fn = (() => null) as unknown as BaseURLResolver;
+		const request = new Request("http://localhost:3000/test");
+
+		await expect(
+			resolveFunctionBaseURL(fn, request, "/api/auth"),
+		).rejects.toThrow("baseURL function returned an empty value");
+	});
+
+	it("should throw on undefined return value", async () => {
+		const fn = (() => undefined) as unknown as BaseURLResolver;
+		const request = new Request("http://localhost:3000/test");
+
+		await expect(
+			resolveFunctionBaseURL(fn, request, "/api/auth"),
+		).rejects.toThrow("baseURL function returned an empty value");
 	});
 });

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -275,12 +275,12 @@ export async function resolveFunctionBaseURL(
 			{ cause: error },
 		);
 	}
-	const urlString = typeof url === "string" ? url : url.toString();
-	if (!urlString) {
+	if (!url) {
 		throw new BetterAuthError(
 			"baseURL function returned an empty value. Return a valid URL.",
 		);
 	}
+	const urlString = typeof url === "string" ? url : url.toString();
 	return withPath(urlString, basePath);
 }
 

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -1,4 +1,8 @@
-import type { BaseURLConfig, DynamicBaseURLConfig } from "@better-auth/core";
+import type {
+	BaseURLConfig,
+	BaseURLResolver,
+	DynamicBaseURLConfig,
+} from "@better-auth/core";
 import { env } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
 import { wildcardMatch } from "./wildcard";
@@ -237,6 +241,50 @@ export function isDynamicBaseURLConfig(
 }
 
 /**
+ * Checks if the baseURL config is a per-request resolver function.
+ */
+export function isFunctionBaseURLConfig(
+	config: BaseURLConfig | undefined,
+): config is BaseURLResolver {
+	return typeof config === "function";
+}
+
+/**
+ * True for any config that requires per-request resolution.
+ */
+export function isPerRequestBaseURL(
+	config: BaseURLConfig | undefined,
+): config is DynamicBaseURLConfig | BaseURLResolver {
+	return isDynamicBaseURLConfig(config) || isFunctionBaseURLConfig(config);
+}
+
+/**
+ * Resolves the base URL by calling a user-provided function.
+ */
+export async function resolveFunctionBaseURL(
+	fn: BaseURLResolver,
+	request: Request,
+	basePath: string,
+): Promise<string> {
+	let url: string | URL;
+	try {
+		url = await fn(request);
+	} catch (error) {
+		throw new BetterAuthError(
+			"baseURL function threw an error. Ensure your function returns a valid URL.",
+			{ cause: error },
+		);
+	}
+	const urlString = typeof url === "string" ? url : url.toString();
+	if (!urlString) {
+		throw new BetterAuthError(
+			"baseURL function returned an empty value. Return a valid URL.",
+		);
+	}
+	return withPath(urlString, basePath);
+}
+
+/**
  * Check if a value is a `Request`
  * - `instanceof`: works for native Request instances
  * - `toString`: handles where instanceof check fails but the object is still a
@@ -455,6 +503,10 @@ export function resolveBaseURL(
 	loadEnv?: boolean,
 	trustedProxyHeaders?: boolean,
 ): string | undefined {
+	if (isFunctionBaseURLConfig(config)) {
+		return undefined;
+	}
+
 	if (isDynamicBaseURLConfig(config)) {
 		if (source) {
 			return resolveDynamicBaseURL(

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -15,6 +15,7 @@ export type {
 export type * from "./helper";
 export type {
 	BaseURLConfig,
+	BaseURLResolver,
 	BetterAuthAdvancedOptions,
 	BetterAuthDBOptions,
 	BetterAuthOptions,

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -182,9 +182,7 @@ export type DynamicBaseURLConfig = {
 /**
  * Resolves the base URL for the current request.
  */
-export type BaseURLResolver = (
-	request: Request,
-) => Awaitable<string | URL>;
+export type BaseURLResolver = (request: Request) => Awaitable<string | URL>;
 
 /**
  * Base URL configuration.

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -180,10 +180,18 @@ export type DynamicBaseURLConfig = {
 };
 
 /**
- * Base URL configuration.
- * Can be a static string or a dynamic config for multi-domain deployments.
+ * Resolves the base URL for the current request.
  */
-export type BaseURLConfig = string | DynamicBaseURLConfig;
+export type BaseURLResolver = (
+	request: Request,
+) => Awaitable<string | URL>;
+
+/**
+ * Base URL configuration.
+ * Can be a static string, a dynamic config with allowed hosts,
+ * or a function for fully dynamic per-request resolution.
+ */
+export type BaseURLConfig = string | DynamicBaseURLConfig | BaseURLResolver;
 
 export interface BetterAuthRateLimitStorage {
 	/**
@@ -509,6 +517,7 @@ export type BetterAuthOptions = {
 	 * Can be configured as:
 	 * - A static string: `"https://myapp.com"`
 	 * - A dynamic config with allowed hosts for multi-domain deployments
+	 * - A function for fully dynamic per-request resolution
 	 *
 	 * If not explicitly set, the system will check environment variables:
 	 * `BETTER_AUTH_URL`, `NEXT_PUBLIC_BETTER_AUTH_URL`, etc.
@@ -522,6 +531,12 @@ export type BetterAuthOptions = {
 	 * baseURL: {
 	 *   allowedHosts: ["myapp.com", "*.vercel.app", "preview-*.myapp.com"],
 	 *   fallback: "https://myapp.com"
+	 * }
+	 *
+	 * // Function (for multi-tenant, white-label, etc.)
+	 * baseURL: async (request) => {
+	 *   const host = request.headers.get("host");
+	 *   return `https://${host}`;
 	 * }
 	 * ```
 	 */


### PR DESCRIPTION
## Summary

Allow `baseURL` to accept `(request: Request) => Awaitable<string>` for multi-tenant and white-label apps where valid domains are stored in a database and not known at deploy time. This completes the work started in #8009 (allowedHosts), which only covers static domain lists.

- Extends `BaseURLConfig` type to include function variant alongside string and `DynamicBaseURLConfig`
- Reuses the per-request context isolation (`Object.create`) from the allowedHosts feature — no new architecture
- Resolves the function to a string before downstream consumers access `ctx.context.options.baseURL`, so plugins, routes, and cookies need zero changes
- Wraps user function errors in `BetterAuthError` with `cause` for debuggability
- Simplifies MCP plugin's baseURL resolution from 3-way dispatch to 2-way

## Test plan

- [x] 13 unit tests: type guards, sync/async resolution, error wrapping with cause preservation, invalid URL, null/undefined returns
- [x] 11 integration tests: context-level (baseURL resolution, async functions, concurrent isolation, trustedOrigins, crossSubDomainCookies) and behavioral (OAuth redirect_uri, handler error propagation, CSRF origin validation, Set-Cookie domain)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes

Fixes #4151

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-request function support for `baseURL` so multi-tenant and white-label domains can be resolved at runtime. Improves origin trust, cookies, and OAuth/CSRF behavior, with updated docs and tests.

- **New Features**
  - `baseURL` now accepts `(request: Request) => Awaitable<string | URL>` and is resolved per request with context isolation; applied to `ctx.context.baseURL` and `ctx.context.options.baseURL`.
  - Direct `auth.api.*` calls with a function `baseURL` must pass a `Request` or `headers`; throws if missing. Forwarded headers are ignored unless `advanced.trustedProxyHeaders` is enabled.
  - URL utils/types: added `resolveFunctionBaseURL`, `isFunctionBaseURLConfig`, and `isPerRequestBaseURL`; exported `BaseURLResolver`. Core, cookies, and endpoints use these for function resolution.
  - Trusted origins and cookies: the resolved origin is trusted for that request; cross-subdomain cookies derive `domain` per request; OAuth `redirect_uri` and CSRF checks use the resolved host.
  - Validation/docs/tests: empty/invalid URLs are rejected; function errors are wrapped in `BetterAuthError` with `cause`; docs add function patterns and proxy guidance (unsafe Host header examples removed); unit and integration tests cover sync/async, isolation, `auth.api` paths, proxy header behavior, OAuth, CSRF, and Set-Cookie.

<sup>Written for commit d3295ea3996d20d6b4ed08e5c0816795ba648582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/8548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

