### PR TITLE
fix(oauth-provider): advertise "none" auth method in metadata when public clients exist

### DIFF
--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -252,6 +252,32 @@ describe("oauth metadata", async () => {
 		const oauthMetadata = await auth.api.getOAuthServerConfig();
 		expect(oauthMetadata).toMatchObject(metadata ?? {});
 	});
+
+	it("should advertise 'none' in token_endpoint_auth_methods_supported when a public client exists", async () => {
+		const { auth } = await createTestInstance();
+
+		await auth.api.adminCreateOAuthClient({
+			body: {
+				token_endpoint_auth_method: "none",
+				redirect_uris: ["http://localhost:3000/callback"],
+				type: "native",
+			},
+		});
+
+		const oauthMetadata = await auth.api.getOAuthServerConfig();
+		expect(
+			oauthMetadata.token_endpoint_auth_methods_supported,
+		).toContain("none");
+	});
+
+	it("should not advertise 'none' in token_endpoint_auth_methods_supported when no public clients exist", async () => {
+		const { auth } = await createTestInstance();
+
+		const oauthMetadata = await auth.api.getOAuthServerConfig();
+		expect(
+			oauthMetadata.token_endpoint_auth_methods_supported,
+		).not.toContain("none");
+	});
 });
 
 describe("oauth resource metadata", async () => {

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -68,6 +68,7 @@ export function authServerMetadata(
 export function oidcServerMetadata(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]> & { claims?: string[] },
+	overrides?: { public_client_supported?: boolean },
 ) {
 	const baseURL = ctx.context.baseURL;
 	const jwtPluginOptions = opts.disableJwtPlugin
@@ -75,7 +76,7 @@ export function oidcServerMetadata(
 		: getJwtPlugin(ctx.context).options;
 	const authMetadata = authServerMetadata(ctx, jwtPluginOptions, {
 		scopes_supported: opts.advertisedMetadata?.scopes_supported ?? opts.scopes,
-		public_client_supported: opts.allowUnauthenticatedClientRegistration,
+		public_client_supported: overrides?.public_client_supported ?? opts.allowUnauthenticatedClientRegistration,
 		grant_types_supported: opts.grantTypes,
 		jwt_disabled: opts.disableJwtPlugin,
 	});

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -292,26 +292,34 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				{
 					method: "GET",
 					metadata: {
-						SERVER_ONLY: true,
+					SERVER_ONLY: true,
 					},
 				},
 				async (ctx) => {
+					const publicClients = await ctx.context.adapter.findMany("oauthClient", {
+					where: [{ field: "tokenEndpointAuthMethod", value: "none" }],
+					limit: 1,
+					});
+					const hasPublicClients =
+					opts.allowUnauthenticatedClientRegistration || publicClients.length > 0;
+
 					if (opts.scopes && opts.scopes.includes("openid")) {
-						const metadata = oidcServerMetadata(ctx, opts);
-						return metadata;
+					const metadata = oidcServerMetadata(ctx, opts, {
+						public_client_supported: hasPublicClients,
+					});
+					return metadata;
 					} else {
-						const jwtPluginOptions = opts.disableJwtPlugin
-							? undefined
-							: getJwtPlugin(ctx.context)?.options;
-						const authMetadata = authServerMetadata(ctx, jwtPluginOptions, {
-							scopes_supported:
-								opts.advertisedMetadata?.scopes_supported ?? opts.scopes,
-							public_client_supported:
-								opts.allowUnauthenticatedClientRegistration,
-							grant_types_supported: opts.grantTypes,
-							jwt_disabled: opts.disableJwtPlugin,
-						});
-						return authMetadata;
+					const jwtPluginOptions = opts.disableJwtPlugin
+						? undefined
+						: getJwtPlugin(ctx.context)?.options;
+					const authMetadata = authServerMetadata(ctx, jwtPluginOptions, {
+						scopes_supported:
+						opts.advertisedMetadata?.scopes_supported ?? opts.scopes,
+						public_client_supported: hasPublicClients,
+						grant_types_supported: opts.grantTypes,
+						jwt_disabled: opts.disableJwtPlugin,
+					});
+					return authMetadata;
 					}
 				},
 			),


### PR DESCRIPTION
## Summary

Fixes #8423

When a public OAuth client is registered with `tokenEndpointAuthMethod: "none"`, 
the discovery metadata (`/.well-known/oauth-authorization-server`) was not 
advertising `"none"` in `token_endpoint_auth_methods_supported`.

## Root Cause

`getOAuthServerConfig` was passing `public_client_supported` based solely on 
`opts.allowUnauthenticatedClientRegistration`, ignoring clients already registered 
in the database with `tokenEndpointAuthMethod: "none"`.

## Changes

- **`oauth.ts`**: Query the database for public clients before building metadata. 
  `hasPublicClients` is computed once and passed to both the OIDC and non-OIDC branches.
- **`metadata.ts`**: Added optional `overrides` parameter to `oidcServerMetadata` 
  to accept `public_client_supported` from the caller.
- **`metadata.test.ts`**: Added two tests covering the presence and absence of 
  `"none"` in `token_endpoint_auth_methods_supported`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth discovery metadata to advertise "none" in token_endpoint_auth_methods_supported when public clients exist. Ensures public clients can reliably detect support via the well-known endpoint.

- **Bug Fixes**
  - Query existing public clients (`tokenEndpointAuthMethod: "none"`) and compute a single hasPublicClients flag.
  - Pass hasPublicClients into both OIDC and non-OIDC metadata; added an optional overrides param to `oidcServerMetadata`.
  - Added tests for presence/absence of "none" in token_endpoint_auth_methods_supported.

<sup>Written for commit c9b5eaac4960a99f7a7b84f35c9c6a0e1653bcf1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

