### PR TITLE
Allow provider config to add extra fields to linked accounts

### DIFF
--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -7,17 +7,20 @@ import {
 	afterAll,
 	afterEach,
 	beforeAll,
+	beforeEach,
 	describe,
 	expect,
 	it,
 	vi,
 } from "vitest";
-import { parseSetCookieHeader } from "../../cookies";
+import { parseSetCookieHeader, setCookieToHeader } from "../../cookies";
 import { signJWT, symmetricDecodeJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 import type { Account } from "../../types";
 import { DEFAULT_SECRET } from "../../utils/constants";
-
+import type { OAuth2UserInfo } from "@better-auth/core/oauth2";
+import type { AuthClient } from "../../client";
+import type { BetterAuthClientOptions } from "@better-auth/core";
 let email = "";
 let handlers: ReturnType<typeof http.post>[];
 
@@ -1403,17 +1406,23 @@ describe("account", async () => {
 		expect(refreshedAccountCookie).toBe(true);
 	});
 
-	it("should allow additional account fields to be set based on provider configuration", async () => {
-		const { signInWithTestUser, client } = await getTestInstance({
+	describe("with additional account fields in the provider configuration", async () => {
+		let someAccountField = "";
+
+		beforeEach(() => {
+			someAccountField = "initial-value";
+		})
+
+		const authOptions = {
 			disableTestUser: true,
 			socialProviders: {
 				google: {
 					clientId: "test",
 					clientSecret: "test",
 					enabled: true,
-					getAccountFields: async (_token, userInfo) => {
+					getAccountFields: async (_token: unknown, userInfo: OAuth2UserInfo) => {
 						return {
-							foo: "bar",
+							someAccountField,
 							providerEmail: userInfo.email,
 						};
 					},
@@ -1424,7 +1433,7 @@ describe("account", async () => {
 					allowDifferentEmails: true,
 				},
 				additionalFields: {
-					foo: {
+					someAccountField: {
 						type: "string",
 						required: false,
 					},
@@ -1434,11 +1443,9 @@ describe("account", async () => {
 					},
 				},
 			},
-		});
+		} as const;
 
-		const { runWithUser: runWithClient2 } = await signInWithTestUser();
-
-		await runWithClient2(async (headers) => {
+		const linkSocial = async (client: AuthClient<BetterAuthClientOptions>, headers: Headers, emailToLink: string) => {
 			const linkAccountRes = await client.linkSocial(
 				{
 					provider: "google",
@@ -1462,9 +1469,9 @@ describe("account", async () => {
 			});
 			const state =
 				linkAccountRes.data && "url" in linkAccountRes.data
-					? new URL(linkAccountRes.data.url).searchParams.get("state") || ""
-					: "";
-			email = "test2@test.com";
+				? new URL(linkAccountRes.data.url).searchParams.get("state") || ""
+				: "";
+			email = emailToLink;
 			await client.$fetch("/callback/google", {
 				query: {
 					state,
@@ -1478,16 +1485,125 @@ describe("account", async () => {
 					expect(location).toContain("/callback");
 				},
 			});
+		}
+
+		const signInSocial = async (client: AuthClient<BetterAuthClientOptions>, cookieSetter: typeof setCookieToHeader) => {
+			const headers = new Headers();
+			email = "oauth-test@test.com";
+
+			// Start OAuth sign-in flow
+			const signInRes = await client.signIn.social({
+				provider: "google",
+				callbackURL: "/callback",
+				fetchOptions: {
+					onSuccess: cookieSetter(headers),
+				},
+			});
+
+			expect(signInRes.data).toMatchObject({
+				url: expect.stringContaining("google.com"),
+				redirect: true,
+			});
+
+			const state =
+				signInRes.data && "url" in signInRes.data && signInRes.data.url
+				? new URL(signInRes.data.url).searchParams.get("state") || ""
+				: "";
+
+			// Complete OAuth callback
+			await client.$fetch("/callback/google", {
+				query: {
+					state,
+					code: "test",
+				},
+				headers,
+				method: "GET",
+				onError(context) {
+					expect(context.response.status).toBe(302);
+					const location = context.response.headers.get("location");
+					expect(location).toBeDefined();
+					expect(location).toContain("/callback");
+
+					cookieSetter(headers)({ response: context.response });
+				},
+			});
+
+			return {
+				headers,
+			};
+		}
+
+		describe("creating new accounts", async () => {
+			it("should set additional account fields when linking a new account", async () => {
+				const { signInWithTestUser, client } = await getTestInstance(authOptions);
+				const { runWithUser: runWithClient2 } = await signInWithTestUser();
+
+				await runWithClient2(async (headers) => {
+					await linkSocial(client, headers, "test2@test.com")
+				});
+
+				const { runWithUser: runWithClient3 } = await signInWithTestUser();
+				await runWithClient3(async () => {
+					const accounts = await client.listAccounts();
+					expect(accounts.data?.length).toBe(2);
+					const newAccount = accounts.data?.[1] as Record<string, any>;
+					expect(newAccount.someAccountField).toEqual("initial-value");
+					expect(newAccount.providerEmail).toEqual("test2@test.com");
+				});
+			});
+
+			it("should set additional account fields when signing in via oauth flow", async () => {
+				const { client, cookieSetter } = await getTestInstance(authOptions);
+				const { headers } = await signInSocial(client, cookieSetter);
+
+				const accounts = await client.listAccounts({ fetchOptions: { headers } });
+				expect(accounts.data?.length).toBe(1);
+				const newAccount = accounts.data?.[0] as Record<string, any>;
+				expect(newAccount.someAccountField).toEqual("initial-value");
+				expect(newAccount.providerEmail).toEqual("oauth-test@test.com");
+			});
 		});
 
-		const { runWithUser: runWithClient3 } = await signInWithTestUser();
+		describe("updating new accounts", async () => {
+			it("should update existing accounts when linking an already-linked account", async () => {
+				const { signInWithTestUser, client } = await getTestInstance(authOptions);
+				const { runWithUser: runWithClient2 } = await signInWithTestUser();
 
-		await runWithClient3(async () => {
-			const accounts = await client.listAccounts();
-			expect(accounts.data?.length).toBe(2);
-			const newAccount = accounts.data?.[1] as Record<string, any>;
-			expect(newAccount.foo).toEqual("bar");
-			expect(newAccount.providerEmail).toEqual("test2@test.com");
+				await runWithClient2(async (headers) => {
+					await linkSocial(client, headers, "test2@test.com")
+				});
+
+				someAccountField = "new-value";
+
+				const { runWithUser: runWithClient3 } = await signInWithTestUser();
+				await runWithClient3(async (headers) => {
+					await linkSocial(client, headers, "test2@test.com")
+				});
+
+				const { runWithUser: runWithClient4 } = await signInWithTestUser();
+				await runWithClient4(async () => {
+					const accounts = await client.listAccounts();
+					expect(accounts.data?.length).toBe(2);
+					const newAccount = accounts.data?.[1] as Record<string, any>;
+					expect(newAccount.someAccountField).toEqual("new-value");
+					expect(newAccount.providerEmail).toEqual("test2@test.com");
+				});
+			});
+
+			it("should update existing accounts when signing in", async () => {
+				const { client, cookieSetter } = await getTestInstance(authOptions);
+				await signInSocial(client, cookieSetter);
+
+				someAccountField = "new-value";
+
+				const { headers } = await signInSocial(client, cookieSetter);
+
+				const accounts = await client.listAccounts({ fetchOptions: { headers } });
+				expect(accounts.data?.length).toBe(1);
+				const newAccount = accounts.data?.[0] as Record<string, any>;
+				expect(newAccount.someAccountField).toEqual("new-value");
+				expect(newAccount.providerEmail).toEqual("oauth-test@test.com");
+			});
 		});
 	});
 });

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -1403,38 +1403,38 @@ describe("account", async () => {
 		expect(refreshedAccountCookie).toBe(true);
 	});
 
-  it("should allow additional account fields to be set based on provider configuration", async () => {
-    const { signInWithTestUser, client } = await getTestInstance({
-      disableTestUser: true,
-      socialProviders: {
-        google: {
-          clientId: "test",
-          clientSecret: "test",
-          enabled: true,
-          getAccountFields: async (_token, userInfo) => {
-            return {
-              foo: "bar",
-              providerEmail: userInfo.email,
-            }
-          },
-        },
-      },
-      account: {
-        accountLinking: {
-          allowDifferentEmails: true,
-        },
-        additionalFields: {
-          foo: {
-            type: "string",
-            required: false,
-          },
-          providerEmail: {
-            type: "string",
-            required: false,
-          },
-        },
-      },
-    });
+	it("should allow additional account fields to be set based on provider configuration", async () => {
+		const { signInWithTestUser, client } = await getTestInstance({
+			disableTestUser: true,
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+					getAccountFields: async (_token, userInfo) => {
+						return {
+							foo: "bar",
+							providerEmail: userInfo.email,
+						};
+					},
+				},
+			},
+			account: {
+				accountLinking: {
+					allowDifferentEmails: true,
+				},
+				additionalFields: {
+					foo: {
+						type: "string",
+						required: false,
+					},
+					providerEmail: {
+						type: "string",
+						required: false,
+					},
+				},
+			},
+		});
 
 		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 
@@ -1485,9 +1485,9 @@ describe("account", async () => {
 		await runWithClient3(async () => {
 			const accounts = await client.listAccounts();
 			expect(accounts.data?.length).toBe(2);
-      const newAccount = accounts.data?.[1] as Record<string,any>
-      expect(newAccount.foo).toEqual("bar");
-      expect(newAccount.providerEmail).toEqual("test2@test.com");
+			const newAccount = accounts.data?.[1] as Record<string, any>;
+			expect(newAccount.foo).toEqual("bar");
+			expect(newAccount.providerEmail).toEqual("test2@test.com");
 		});
-  })
+	});
 });

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -1402,4 +1402,92 @@ describe("account", async () => {
 		expect(refreshedSessionCookie).toBe(true);
 		expect(refreshedAccountCookie).toBe(true);
 	});
+
+  it("should allow additional account fields to be set based on provider configuration", async () => {
+    const { signInWithTestUser, client } = await getTestInstance({
+      disableTestUser: true,
+      socialProviders: {
+        google: {
+          clientId: "test",
+          clientSecret: "test",
+          enabled: true,
+          getAccountFields: async (_token, userInfo) => {
+            return {
+              foo: "bar",
+              providerEmail: userInfo.email,
+            }
+          },
+        },
+      },
+      account: {
+        accountLinking: {
+          allowDifferentEmails: true,
+        },
+        additionalFields: {
+          foo: {
+            type: "string",
+            required: false,
+          },
+          providerEmail: {
+            type: "string",
+            required: false,
+          },
+        },
+      },
+    });
+
+		const { runWithUser: runWithClient2 } = await signInWithTestUser();
+
+		await runWithClient2(async (headers) => {
+			const linkAccountRes = await client.linkSocial(
+				{
+					provider: "google",
+					callbackURL: "/callback",
+				},
+				{
+					onSuccess(context) {
+						const cookies = parseSetCookieHeader(
+							context.response.headers.get("set-cookie") || "",
+						);
+						headers.set(
+							"cookie",
+							`better-auth.state=${cookies.get("better-auth.state")?.value}`,
+						);
+					},
+				},
+			);
+			expect(linkAccountRes.data).toMatchObject({
+				url: expect.stringContaining("google.com"),
+				redirect: true,
+			});
+			const state =
+				linkAccountRes.data && "url" in linkAccountRes.data
+					? new URL(linkAccountRes.data.url).searchParams.get("state") || ""
+					: "";
+			email = "test2@test.com";
+			await client.$fetch("/callback/google", {
+				query: {
+					state,
+					code: "test",
+				},
+				method: "GET",
+				onError(context) {
+					expect(context.response.status).toBe(302);
+					const location = context.response.headers.get("location");
+					expect(location).toBeDefined();
+					expect(location).toContain("/callback");
+				},
+			});
+		});
+
+		const { runWithUser: runWithClient3 } = await signInWithTestUser();
+
+		await runWithClient3(async () => {
+			const accounts = await client.listAccounts();
+			expect(accounts.data?.length).toBe(2);
+      const newAccount = accounts.data?.[1] as Record<string,any>
+      expect(newAccount.foo).toEqual("bar");
+      expect(newAccount.providerEmail).toEqual("test2@test.com");
+		});
+  })
 });

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -1,4 +1,6 @@
+import type { BetterAuthClientOptions } from "@better-auth/core";
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
+import type { OAuth2UserInfo } from "@better-auth/core/oauth2";
 import type { GoogleProfile } from "@better-auth/core/social-providers";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
@@ -13,14 +15,14 @@ import {
 	it,
 	vi,
 } from "vitest";
-import { parseSetCookieHeader, setCookieToHeader } from "../../cookies";
+import type { AuthClient } from "../../client";
+import type { setCookieToHeader } from "../../cookies";
+import { parseSetCookieHeader } from "../../cookies";
 import { signJWT, symmetricDecodeJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 import type { Account } from "../../types";
 import { DEFAULT_SECRET } from "../../utils/constants";
-import type { OAuth2UserInfo } from "@better-auth/core/oauth2";
-import type { AuthClient } from "../../client";
-import type { BetterAuthClientOptions } from "@better-auth/core";
+
 let email = "";
 let handlers: ReturnType<typeof http.post>[];
 
@@ -1411,7 +1413,7 @@ describe("account", async () => {
 
 		beforeEach(() => {
 			someAccountField = "initial-value";
-		})
+		});
 
 		const authOptions = {
 			disableTestUser: true,
@@ -1420,7 +1422,10 @@ describe("account", async () => {
 					clientId: "test",
 					clientSecret: "test",
 					enabled: true,
-					getAccountFields: async (_token: unknown, userInfo: OAuth2UserInfo) => {
+					getAccountFields: async (
+						_token: unknown,
+						userInfo: OAuth2UserInfo,
+					) => {
 						return {
 							someAccountField,
 							providerEmail: userInfo.email,
@@ -1445,7 +1450,11 @@ describe("account", async () => {
 			},
 		} as const;
 
-		const linkSocial = async (client: AuthClient<BetterAuthClientOptions>, headers: Headers, emailToLink: string) => {
+		const linkSocial = async (
+			client: AuthClient<BetterAuthClientOptions>,
+			headers: Headers,
+			emailToLink: string,
+		) => {
 			const linkAccountRes = await client.linkSocial(
 				{
 					provider: "google",
@@ -1469,8 +1478,8 @@ describe("account", async () => {
 			});
 			const state =
 				linkAccountRes.data && "url" in linkAccountRes.data
-				? new URL(linkAccountRes.data.url).searchParams.get("state") || ""
-				: "";
+					? new URL(linkAccountRes.data.url).searchParams.get("state") || ""
+					: "";
 			email = emailToLink;
 			await client.$fetch("/callback/google", {
 				query: {
@@ -1485,9 +1494,12 @@ describe("account", async () => {
 					expect(location).toContain("/callback");
 				},
 			});
-		}
+		};
 
-		const signInSocial = async (client: AuthClient<BetterAuthClientOptions>, cookieSetter: typeof setCookieToHeader) => {
+		const signInSocial = async (
+			client: AuthClient<BetterAuthClientOptions>,
+			cookieSetter: typeof setCookieToHeader,
+		) => {
 			const headers = new Headers();
 			email = "oauth-test@test.com";
 
@@ -1507,8 +1519,8 @@ describe("account", async () => {
 
 			const state =
 				signInRes.data && "url" in signInRes.data && signInRes.data.url
-				? new URL(signInRes.data.url).searchParams.get("state") || ""
-				: "";
+					? new URL(signInRes.data.url).searchParams.get("state") || ""
+					: "";
 
 			// Complete OAuth callback
 			await client.$fetch("/callback/google", {
@@ -1531,15 +1543,16 @@ describe("account", async () => {
 			return {
 				headers,
 			};
-		}
+		};
 
 		describe("creating new accounts", async () => {
 			it("should set additional account fields when linking a new account", async () => {
-				const { signInWithTestUser, client } = await getTestInstance(authOptions);
+				const { signInWithTestUser, client } =
+					await getTestInstance(authOptions);
 				const { runWithUser: runWithClient2 } = await signInWithTestUser();
 
 				await runWithClient2(async (headers) => {
-					await linkSocial(client, headers, "test2@test.com")
+					await linkSocial(client, headers, "test2@test.com");
 				});
 
 				const { runWithUser: runWithClient3 } = await signInWithTestUser();
@@ -1556,7 +1569,9 @@ describe("account", async () => {
 				const { client, cookieSetter } = await getTestInstance(authOptions);
 				const { headers } = await signInSocial(client, cookieSetter);
 
-				const accounts = await client.listAccounts({ fetchOptions: { headers } });
+				const accounts = await client.listAccounts({
+					fetchOptions: { headers },
+				});
 				expect(accounts.data?.length).toBe(1);
 				const newAccount = accounts.data?.[0] as Record<string, any>;
 				expect(newAccount.someAccountField).toEqual("initial-value");
@@ -1566,18 +1581,19 @@ describe("account", async () => {
 
 		describe("updating new accounts", async () => {
 			it("should update existing accounts when linking an already-linked account", async () => {
-				const { signInWithTestUser, client } = await getTestInstance(authOptions);
+				const { signInWithTestUser, client } =
+					await getTestInstance(authOptions);
 				const { runWithUser: runWithClient2 } = await signInWithTestUser();
 
 				await runWithClient2(async (headers) => {
-					await linkSocial(client, headers, "test2@test.com")
+					await linkSocial(client, headers, "test2@test.com");
 				});
 
 				someAccountField = "new-value";
 
 				const { runWithUser: runWithClient3 } = await signInWithTestUser();
 				await runWithClient3(async (headers) => {
-					await linkSocial(client, headers, "test2@test.com")
+					await linkSocial(client, headers, "test2@test.com");
 				});
 
 				const { runWithUser: runWithClient4 } = await signInWithTestUser();
@@ -1598,7 +1614,9 @@ describe("account", async () => {
 
 				const { headers } = await signInSocial(client, cookieSetter);
 
-				const accounts = await client.listAccounts({ fetchOptions: { headers } });
+				const accounts = await client.listAccounts({
+					fetchOptions: { headers },
+				});
 				expect(accounts.data?.length).toBe(1);
 				const newAccount = accounts.data?.[0] as Record<string, any>;
 				expect(newAccount.someAccountField).toEqual("new-value");

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -174,6 +174,8 @@ export const callbackOAuth = createAuthEndpoint(
 			throw redirectOnError("no_callback_url");
 		}
 
+    const additionalAccountFields = await provider.options?.getAccountFields?.(tokens, userInfo)
+
 		if (link) {
 			const isTrustedProvider = c.context.trustedProviders.includes(
 				provider.id,
@@ -209,6 +211,7 @@ export const callbackOAuth = createAuthEndpoint(
 						accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 						refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
 						scope: tokens.scopes?.join(","),
+            ...additionalAccountFields,
 					}).filter(([_, value]) => value !== undefined),
 				);
 				await c.context.internalAdapter.updateAccount(
@@ -224,6 +227,7 @@ export const callbackOAuth = createAuthEndpoint(
 					accessToken: await setTokenUtil(tokens.accessToken, c.context),
 					refreshToken: await setTokenUtil(tokens.refreshToken, c.context),
 					scope: tokens.scopes?.join(","),
+          ...additionalAccountFields,
 				});
 				if (!newAccount) {
 					return redirectOnError("unable_to_link_account");
@@ -250,6 +254,7 @@ export const callbackOAuth = createAuthEndpoint(
 			accountId: String(userInfo.id),
 			...tokens,
 			scope: tokens.scopes?.join(","),
+      ...additionalAccountFields,
 		};
 		const result = await handleOAuthUserInfo(c, {
 			userInfo: {

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -253,11 +253,11 @@ export const callbackOAuth = createAuthEndpoint(
 			return redirectOnError("email_not_found");
 		}
 		const accountData = {
+			...additionalAccountFields,
 			providerId: provider.id,
 			accountId: String(userInfo.id),
 			...tokens,
 			scope: tokens.scopes?.join(","),
-			...additionalAccountFields,
 		};
 		const result = await handleOAuthUserInfo(c, {
 			userInfo: {

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -174,7 +174,10 @@ export const callbackOAuth = createAuthEndpoint(
 			throw redirectOnError("no_callback_url");
 		}
 
-    const additionalAccountFields = await provider.options?.getAccountFields?.(tokens, userInfo)
+		const additionalAccountFields = await provider.options?.getAccountFields?.(
+			tokens,
+			userInfo,
+		);
 
 		if (link) {
 			const isTrustedProvider = c.context.trustedProviders.includes(
@@ -211,7 +214,7 @@ export const callbackOAuth = createAuthEndpoint(
 						accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 						refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
 						scope: tokens.scopes?.join(","),
-            ...additionalAccountFields,
+						...additionalAccountFields,
 					}).filter(([_, value]) => value !== undefined),
 				);
 				await c.context.internalAdapter.updateAccount(
@@ -227,7 +230,7 @@ export const callbackOAuth = createAuthEndpoint(
 					accessToken: await setTokenUtil(tokens.accessToken, c.context),
 					refreshToken: await setTokenUtil(tokens.refreshToken, c.context),
 					scope: tokens.scopes?.join(","),
-          ...additionalAccountFields,
+					...additionalAccountFields,
 				});
 				if (!newAccount) {
 					return redirectOnError("unable_to_link_account");
@@ -254,7 +257,7 @@ export const callbackOAuth = createAuthEndpoint(
 			accountId: String(userInfo.id),
 			...tokens,
 			scope: tokens.scopes?.join(","),
-      ...additionalAccountFields,
+			...additionalAccountFields,
 		};
 		const result = await handleOAuthUserInfo(c, {
 			userInfo: {

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -272,10 +272,13 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 					});
 					throw APIError.from("UNAUTHORIZED", BASE_ERROR_CODES.INVALID_TOKEN);
 				}
-				const userInfo = await provider.getUserInfo({
+        const tokens = {
 					idToken: token,
 					accessToken: c.body.idToken.accessToken,
 					refreshToken: c.body.idToken.refreshToken,
+        };
+				const userInfo = await provider.getUserInfo({
+          ...tokens,
 					user: c.body.idToken.user,
 				});
 				if (!userInfo || !userInfo?.user) {
@@ -296,6 +299,7 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						BASE_ERROR_CODES.USER_EMAIL_NOT_FOUND,
 					);
 				}
+        const additionalAccountFields = await provider.options?.getAccountFields?.(tokens, userInfo.user)
 				const data = await handleOAuthUserInfo(c, {
 					userInfo: {
 						...userInfo.user,
@@ -309,6 +313,7 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						providerId: provider.id,
 						accountId: String(userInfo.user.id),
 						accessToken: c.body.idToken.accessToken,
+            ...additionalAccountFields,
 					},
 					callbackURL: c.body.callbackURL,
 					disableSignUp:

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -299,8 +299,6 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						BASE_ERROR_CODES.USER_EMAIL_NOT_FOUND,
 					);
 				}
-				const additionalAccountFields =
-					await provider.options?.getAccountFields?.(tokens, userInfo.user);
 				const data = await handleOAuthUserInfo(c, {
 					userInfo: {
 						...userInfo.user,
@@ -314,7 +312,6 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						providerId: provider.id,
 						accountId: String(userInfo.user.id),
 						accessToken: c.body.idToken.accessToken,
-						...additionalAccountFields,
 					},
 					callbackURL: c.body.callbackURL,
 					disableSignUp:

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -272,13 +272,13 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 					});
 					throw APIError.from("UNAUTHORIZED", BASE_ERROR_CODES.INVALID_TOKEN);
 				}
-        const tokens = {
+				const tokens = {
 					idToken: token,
 					accessToken: c.body.idToken.accessToken,
 					refreshToken: c.body.idToken.refreshToken,
-        };
+				};
 				const userInfo = await provider.getUserInfo({
-          ...tokens,
+					...tokens,
 					user: c.body.idToken.user,
 				});
 				if (!userInfo || !userInfo?.user) {
@@ -299,7 +299,8 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						BASE_ERROR_CODES.USER_EMAIL_NOT_FOUND,
 					);
 				}
-        const additionalAccountFields = await provider.options?.getAccountFields?.(tokens, userInfo.user)
+				const additionalAccountFields =
+					await provider.options?.getAccountFields?.(tokens, userInfo.user);
 				const data = await handleOAuthUserInfo(c, {
 					userInfo: {
 						...userInfo.user,
@@ -313,7 +314,7 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						providerId: provider.id,
 						accountId: String(userInfo.user.id),
 						accessToken: c.body.idToken.accessToken,
-            ...additionalAccountFields,
+						...additionalAccountFields,
 					},
 					callbackURL: c.body.callbackURL,
 					disableSignUp:

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -120,25 +120,25 @@ export async function handleOAuthUserInfo(
 			}
 
 			const {
-        accountId: _,
-        providerId: __,
-        accessToken: ___,
-        refreshToken: ____,
-        idToken: _____,
-        accessTokenExpiresAt: ______,
-        refreshTokenExpiresAt: _______,
-        scope: ________,
+				accountId: _,
+				providerId: __,
+				accessToken: ___,
+				refreshToken: ____,
+				idToken: _____,
+				accessTokenExpiresAt: ______,
+				refreshTokenExpiresAt: _______,
+				scope: ________,
 				...additionalAccountFields
 			} = account;
 
-			if (Object.keys(freshTokens).length > 0 || Object.keys(additionalAccountFields).length > 0) {
-				await c.context.internalAdapter.updateAccount(
-					linkedAccount.id,
-          {
-            ...freshTokens,
-            ...additionalAccountFields,
-          },
-				);
+			if (
+				Object.keys(freshTokens).length > 0 ||
+				Object.keys(additionalAccountFields).length > 0
+			) {
+				await c.context.internalAdapter.updateAccount(linkedAccount.id, {
+					...freshTokens,
+					...additionalAccountFields,
+				});
 			}
 
 			if (

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -158,12 +158,12 @@ export async function handleOAuthUserInfo(
 		}
 		try {
 			const { id: _, ...restUserInfo } = userInfo;
-      const { accessToken, refreshToken, ...restAccount } = account
+			const { accessToken, refreshToken, ...restAccount } = account;
 			const accountData = {
 				accessToken: await setTokenUtil(account.accessToken, c.context),
 				refreshToken: await setTokenUtil(account.refreshToken, c.context),
 				idToken: account.idToken,
-        ...restAccount,
+				...restAccount,
 				accountId: userInfo.id.toString(),
 			};
 			const { user: createdUser, account: createdAccount } =

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -158,14 +158,12 @@ export async function handleOAuthUserInfo(
 		}
 		try {
 			const { id: _, ...restUserInfo } = userInfo;
+      const { accessToken, refreshToken, ...restAccount } = account
 			const accountData = {
 				accessToken: await setTokenUtil(account.accessToken, c.context),
 				refreshToken: await setTokenUtil(account.refreshToken, c.context),
 				idToken: account.idToken,
-				accessTokenExpiresAt: account.accessTokenExpiresAt,
-				refreshTokenExpiresAt: account.refreshTokenExpiresAt,
-				scope: account.scope,
-				providerId: account.providerId,
+        ...restAccount,
 				accountId: userInfo.id.toString(),
 			};
 			const { user: createdUser, account: createdAccount } =

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -119,10 +119,25 @@ export async function handleOAuthUserInfo(
 				});
 			}
 
-			if (Object.keys(freshTokens).length > 0) {
+			const {
+        accountId: _,
+        providerId: __,
+        accessToken: ___,
+        refreshToken: ____,
+        idToken: _____,
+        accessTokenExpiresAt: ______,
+        refreshTokenExpiresAt: _______,
+        scope: ________,
+				...additionalAccountFields
+			} = account;
+
+			if (Object.keys(freshTokens).length > 0 || Object.keys(additionalAccountFields).length > 0) {
 				await c.context.internalAdapter.updateAccount(
 					linkedAccount.id,
-					freshTokens,
+          {
+            ...freshTokens,
+            ...additionalAccountFields,
+          },
 				);
 			}
 

--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -191,8 +191,11 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 	 * Custom function to get account fields from userInfo
 	 */
 	getAccountFields?:
-		| ((token: OAuth2Tokens, userInfo: OAuth2UserInfo) => Promise<{
-        [key: string]: any;
+		| ((
+				token: OAuth2Tokens,
+				userInfo: OAuth2UserInfo,
+		  ) => Promise<{
+				[key: string]: any;
 		  } | null>)
 		| undefined;
 	/**

--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -188,6 +188,14 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 				  }>)
 		| undefined;
 	/**
+	 * Custom function to get account fields from userInfo
+	 */
+	getAccountFields?:
+		| ((token: OAuth2Tokens, userInfo: OAuth2UserInfo) => Promise<{
+        [key: string]: any;
+		  } | null>)
+		| undefined;
+	/**
 	 * Disable implicit sign up for new users. When set to true for the provider,
 	 * sign-in need to be called with with requestSignUp as true to create new users.
 	 */

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,7 @@ onlyBuiltDependencies:
   - '@swc/core'
   - '@tsparticles/engine'
   - better-sqlite3
+  - electron
   - esbuild
   - less
   - msw


### PR DESCRIPTION
This allows users to do things like add an additional column to the accounts table with the email address of the linked account (see #2272).

## Example usage

```typescript
export const auth = betterAuth({
  socialProviders: {
    google: {
      getAccountFields: async (_token, userInfo) => {
        // Use `token` to make additional API requests if needed.
        // Otherwise, extract relevant data from userInfo.
        return { providerEmail: userInfo.email };
      },
    },
  },
  account: {
    accountLinking: {
      allowDifferentEmails: true,
    },
    additionalFields: {
      providerEmail: {
        type: "string",
      },
    },
  },
});
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-level `getAccountFields` hook to add extra, provider-derived fields to OAuth accounts during linking and sign-in. Fields are merged on create and on updates; core account properties stay protected.

- **New Features**
  - Added `getAccountFields(tokens, userInfo)` to provider options; returned fields are merged into the account during the OAuth callback and sign-in. Undefined values are ignored.
  - Existing accounts are updated with new fields on re-link and sign-in; fields cannot overwrite `providerId`, `accountId`, tokens, scope, or expirations.
  - Expanded tests cover linking new/existing accounts and OAuth sign-in for new/existing accounts.

- **Migration**
  - Define each new field under `account.additionalFields` to persist it.
  - Implement `getAccountFields` in the provider (e.g., return `{ providerEmail: userInfo.email }`).

<sup>Written for commit 33d9800e4a8cd16d417d4ca72a4791a672ff8ca2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

