### PR TITLE
feat(test-utils): export adapter test suites from `@better-auth/test-utils/adapter`

### DIFF
--- a/e2e/adapter/test/adapter-factory/index.ts
+++ b/e2e/adapter/test/adapter-factory/index.ts
@@ -1,6 +1,9 @@
-export * from "./auth-flow";
-export * from "./basic";
-export * from "./joins";
-export * from "./number-id";
-export * from "./transactions";
-export * from "./uuid";
+export {
+	authFlowTestSuite,
+	getNormalTestSuiteTests,
+	joinsTestSuite,
+	normalTestSuite,
+	numberIdTestSuite,
+	transactionsTestSuite,
+	uuidTestSuite,
+} from "@better-auth/test-utils/adapter";

--- a/packages/test-utils/src/adapter/index.ts
+++ b/packages/test-utils/src/adapter/index.ts
@@ -4,4 +4,5 @@ export {
 	type TestEntry,
 	type TestSuiteStats,
 } from "./create-test-suite";
+export * from "./suites";
 export { type Logger, testAdapter } from "./test-adapter";

--- a/packages/test-utils/src/adapter/suites/auth-flow.ts
+++ b/packages/test-utils/src/adapter/suites/auth-flow.ts
@@ -1,7 +1,7 @@
 import type { Session, User } from "@better-auth/core/db";
-import { createTestSuite } from "@better-auth/test-utils/adapter";
 import { setCookieToHeader } from "better-auth/cookies";
 import { expect } from "vitest";
+import { createTestSuite } from "../create-test-suite";
 
 /**
  * This test suite tests basic authentication flow using the adapter.

--- a/packages/test-utils/src/adapter/suites/basic.ts
+++ b/packages/test-utils/src/adapter/suites/basic.ts
@@ -5,7 +5,6 @@ import type {
 	User,
 	Verification,
 } from "@better-auth/core/db";
-import { createTestSuite } from "@better-auth/test-utils/adapter";
 import type {
 	Invitation,
 	Member,
@@ -14,6 +13,7 @@ import type {
 } from "better-auth/plugins/organization";
 import { organization } from "better-auth/plugins/organization";
 import { expect } from "vitest";
+import { createTestSuite } from "../create-test-suite";
 
 /**
  * This test suite tests the basic CRUD operations of the adapter.

--- a/packages/test-utils/src/adapter/suites/index.ts
+++ b/packages/test-utils/src/adapter/suites/index.ts
@@ -1,0 +1,6 @@
+export * from "./auth-flow";
+export * from "./basic";
+export * from "./joins";
+export * from "./number-id";
+export * from "./transactions";
+export * from "./uuid";

--- a/packages/test-utils/src/adapter/suites/joins.ts
+++ b/packages/test-utils/src/adapter/suites/joins.ts
@@ -1,5 +1,5 @@
-import { createTestSuite } from "@better-auth/test-utils/adapter";
 import { expect } from "vitest";
+import { createTestSuite } from "../create-test-suite";
 import { getNormalTestSuiteTests } from "./basic";
 
 export const joinsTestSuite = createTestSuite(

--- a/packages/test-utils/src/adapter/suites/number-id.ts
+++ b/packages/test-utils/src/adapter/suites/number-id.ts
@@ -1,6 +1,6 @@
-import { createTestSuite } from "@better-auth/test-utils/adapter";
 import type { User } from "better-auth/types";
 import { expect } from "vitest";
+import { createTestSuite } from "../create-test-suite";
 import { getNormalTestSuiteTests } from "./basic";
 
 export const numberIdTestSuite = createTestSuite(
@@ -23,10 +23,7 @@ export const numberIdTestSuite = createTestSuite(
 		return {
 			"init - tests": async () => {
 				const opts = helpers.getBetterAuthOptions();
-				expect(
-					opts.advanced?.database?.useNumberId ||
-						opts.advanced?.database?.generateId === "serial",
-				).toBe(true);
+				expect(opts.advanced?.database?.generateId === "serial").toBe(true);
 			},
 			"create - should return a number id": async () => {
 				const user = await helpers.generate("user");

--- a/packages/test-utils/src/adapter/suites/transactions.ts
+++ b/packages/test-utils/src/adapter/suites/transactions.ts
@@ -1,6 +1,6 @@
-import { createTestSuite } from "@better-auth/test-utils/adapter";
 import type { User } from "better-auth/db";
 import { expect } from "vitest";
+import { createTestSuite } from "../create-test-suite";
 
 /**
  * This test suite tests the transaction functionality of the adapter.

--- a/packages/test-utils/src/adapter/suites/uuid.ts
+++ b/packages/test-utils/src/adapter/suites/uuid.ts
@@ -1,6 +1,6 @@
 import type { User } from "@better-auth/core/db";
-import { createTestSuite } from "@better-auth/test-utils/adapter";
 import { expect } from "vitest";
+import { createTestSuite } from "../create-test-suite";
 import { getNormalTestSuiteTests } from "./basic";
 
 export const uuidTestSuite = createTestSuite(


### PR DESCRIPTION
Related to https://github.com/get-convex/better-auth/pull/292#issuecomment-4041495725

This code was used for our internal e2e tests, so I'm not sure if it's appropriate to export it from the package. While it could be helpful for external users building adapters, it would also make it harder for us to freely change our internal tests and introduce additional maintenance overhead. I think we should check whether merging this is the right approach.

cc @ping-maxwell @himself65 