### PR TITLE
fix: resolve duplicate operationId in admin plugin endpoints

### DIFF
--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -427,7 +427,7 @@ export const adminUpdateUser = (opts: AdminOptions) =>
 			use: [adminMiddleware],
 			metadata: {
 				openapi: {
-					operationId: "updateUser",
+					operationId: "adminUpdateUser",
 					summary: "Update a user",
 					description: "Update a user's details",
 					responses: {
@@ -728,7 +728,7 @@ export const listUserSessions = (opts: AdminOptions) =>
 			body: listUserSessionsBodySchema,
 			metadata: {
 				openapi: {
-					operationId: "listUserSessions",
+					operationId: "adminListUserSessions",
 					summary: "List user sessions",
 					description: "List user sessions",
 					responses: {


### PR DESCRIPTION
Retargeting PR #8567 to `canary` as requested by @bytaesu.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed OpenAPI operationIds for admin endpoints to avoid collisions with core endpoints. This prevents duplicate types during schema generation with tools like `orval` and resolves TS2300 errors.

- **Bug Fixes**
  - `updateUser` → `adminUpdateUser` (admin endpoint)
  - `listUserSessions` → `adminListUserSessions` (admin endpoint)

<sup>Written for commit bbaa588e85eaa924cea1cc4d818b47ea924bc091. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

