### PR TITLE
feat(magic-link): add request metadata to sendMagicLink

### DIFF
--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -20,7 +20,7 @@ Magic link or email link is a way to authenticate users without a password. When
     export const auth = betterAuth({
         plugins: [
             magicLink({ // [!code highlight]
-                sendMagicLink: async ({ email, token, url }, ctx) => { // [!code highlight]
+                sendMagicLink: async ({ email, token, url, metadata }, ctx) => { // [!code highlight]
                     // send email to user // [!code highlight]
                 } // [!code highlight]
             }) // [!code highlight]
@@ -85,6 +85,10 @@ type signInMagicLink = {
      * redirected to the callbackURL with an `error` query parameter.
      */
     errorCallbackURL?: string = "/error"
+    /**
+     * Additional metadata forwarded to the sendMagicLink callback.
+     */
+    metadata?: Record<string, any> = { inviteId: "123" }
 }
 ```
 </APIMethod>
@@ -130,6 +134,7 @@ type magicLinkVerify = {
 - `email`: The email address of the user.
 - `url`: The URL to be sent to the user. This URL contains the token.
 - `token`: The token if you want to send the token with custom URL.
+- `metadata`: Additional request metadata passed from `signIn.magicLink`.
 
 and a `ctx` context object as the second parameter.
 

--- a/packages/better-auth/src/client/client.test.ts
+++ b/packages/better-auth/src/client/client.test.ts
@@ -12,6 +12,7 @@ import {
 	deviceAuthorizationClient,
 	emailOTPClient,
 	genericOAuthClient,
+	magicLinkClient,
 	multiSessionClient,
 	oidcClient,
 	organizationClient,
@@ -268,6 +269,36 @@ describe("type", () => {
 		});
 		expectTypeOf(client.setTestAtom).toEqualTypeOf<(value: boolean) => void>();
 		expectTypeOf(client.test.signOut).toEqualTypeOf<() => Promise<void>>();
+	});
+
+	it("should infer magic link metadata in sign-in request", () => {
+		const client = createReactClient({
+			plugins: [magicLinkClient()],
+		});
+
+		type SignInMagicLinkInput = NonNullable<
+			Parameters<typeof client.signIn.magicLink>[0]
+		>;
+
+		expectTypeOf<SignInMagicLinkInput>().toMatchTypeOf<{
+			email: string;
+			name?: string | undefined;
+			callbackURL?: string | undefined;
+			newUserCallbackURL?: string | undefined;
+			errorCallbackURL?: string | undefined;
+			metadata?: Record<string, any> | undefined;
+		}>();
+
+		const request: SignInMagicLinkInput = {
+			email: "test@email.com",
+			metadata: {
+				inviteId: "123",
+			},
+		};
+
+		expectTypeOf(request.metadata).toEqualTypeOf<
+			Record<string, any> | undefined
+		>();
 	});
 
 	it("should infer session", () => {

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -39,6 +39,7 @@ export interface MagicLinkOptions {
 			email: string;
 			url: string;
 			token: string;
+			metadata?: Record<string, any>;
 		},
 		ctx?: GenericEndpointContext | undefined,
 	) => Awaitable<void>;
@@ -110,6 +111,12 @@ const signInMagicLinkBodySchema = z.object({
 		.string()
 		.meta({
 			description: "URL to redirect after error.",
+		})
+		.optional(),
+	metadata: z
+		.record(z.string(), z.any())
+		.meta({
+			description: "Additional metadata to pass to sendMagicLink.",
 		})
 		.optional(),
 });
@@ -208,7 +215,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					},
 				},
 				async (ctx) => {
-					const { email } = ctx.body;
+					const { email, metadata } = ctx.body;
 
 					const verificationToken = opts?.generateToken
 						? await opts.generateToken(email)
@@ -243,6 +250,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 							email,
 							url: url.toString(),
 							token: verificationToken,
+							metadata,
 						},
 						ctx,
 					);

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -9,6 +9,7 @@ type VerificationEmail = {
 	email: string;
 	token: string;
 	url: string;
+	metadata?: Record<string, any>;
 };
 
 describe("magic link", async () => {
@@ -49,6 +50,23 @@ describe("magic link", async () => {
 			url: expect.stringContaining(
 				"http://localhost:3000/api/auth/magic-link/verify",
 			),
+		});
+		expect(verificationEmail.metadata).toBeUndefined();
+	});
+
+	it("should forward metadata to sendMagicLink", async () => {
+		await client.signIn.magicLink({
+			email: testUser.email,
+			metadata: {
+				inviteId: "123",
+			},
+		});
+
+		expect(verificationEmail).toMatchObject({
+			email: testUser.email,
+			metadata: {
+				inviteId: "123",
+			},
 		});
 	});
 	it("should verify magic link", async () => {


### PR DESCRIPTION
## Summary
- add optional `metadata` to `signIn.magicLink`
- forward request metadata to the magic-link plugin `sendMagicLink` callback
- add runtime, client type, and docs coverage for the new field

## Why
This lets callers attach request-scoped metadata when requesting a magic link so server implementations can use it inside `sendMagicLink` without changing verification, session, or user behavior.

## API changes
- `signIn.magicLink` now accepts `metadata?: Record<string, any>`
- `sendMagicLink` now receives `metadata?: Record<string, any>` in its first argument

## Behavior
- metadata is send-only
- metadata is not stored in the verification record
- metadata is not added to the magic link URL
- metadata does not affect verification, session creation, or user creation

## Validation
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter better-auth exec vitest run src/client/client.test.ts`
- `pnpm --filter better-auth exec vitest run src/plugins/magic-link/magic-link.test.ts`

## Breaking changes
None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional request-scoped `metadata` to `signIn.magicLink` and forward it to the `sendMagicLink` callback. This enables servers to use extra context (e.g., `inviteId`) when sending the email without changing verification or session behavior.

- **New Features**
  - `signIn.magicLink` now accepts `metadata?: Record<string, any>` and passes it to `sendMagicLink({ email, url, token, metadata })`.
  - Validated via schema updates and tested for type inference and forwarding in `packages/better-auth`.
  - Docs updated to include `metadata` in examples and API reference.
  - Metadata is send-only: not stored, not added to the URL, and does not affect verification, session, or user creation.

<sup>Written for commit 2062383f0291e92fa04cbae7ee6319f02e62e174. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

