### PR TITLE
fix: remove request header leak from before-hook early return

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -436,6 +436,71 @@ describe("after hook", async () => {
 	});
 });
 
+describe("before hook early return should not leak request headers", async () => {
+	const endpoints = {
+		earlyReturn: createAuthEndpoint(
+			"/early-return",
+			{
+				method: "GET",
+			},
+			async () => {
+				return { shouldNotReach: true };
+			},
+		),
+	};
+
+	const authContext = init({
+		hooks: {
+			before: createAuthMiddleware(async () => {
+				return { earlyReturnData: true };
+			}),
+		},
+	});
+
+	const authEndpoints = toAuthEndpoints(endpoints, authContext);
+
+	it("should not leak request headers when asResponse is true", async () => {
+		const requestHeaders = new Headers({
+			"content-length": "42",
+			"host": "example.com",
+			"accept": "text/html",
+			"user-agent": "TestAgent/1.0",
+			"x-custom-request": "should-not-leak",
+		});
+
+		const response = await authEndpoints.earlyReturn({
+			asResponse: true,
+			headers: requestHeaders,
+		});
+
+		expect(response).toBeInstanceOf(Response);
+		// Request-only headers must not appear on the response
+		expect(response.headers.has("content-length")).toBe(false);
+		expect(response.headers.has("host")).toBe(false);
+		expect(response.headers.has("accept")).toBe(false);
+		expect(response.headers.has("user-agent")).toBe(false);
+	});
+
+	it("should not leak request headers when returnHeaders is true", async () => {
+		const requestHeaders = new Headers({
+			"content-length": "100",
+			"host": "example.com",
+			"cookie": "session=abc",
+		});
+
+		const result = await authEndpoints.earlyReturn({
+			returnHeaders: true,
+			headers: requestHeaders,
+		});
+
+		// The headers returned should be empty response headers, not the request headers
+		expect(result.headers).toBeDefined();
+		expect(result.headers.has("content-length")).toBe(false);
+		expect(result.headers.has("host")).toBe(false);
+		expect(result.headers.has("cookie")).toBe(false);
+	});
+});
+
 describe("disabled paths", async () => {
 	it("should return 404 for disabled paths", async () => {
 		const { client } = await getTestInstance({

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -479,6 +479,8 @@ describe("before hook early return should not leak request headers", async () =>
 		expect(response.headers.has("host")).toBe(false);
 		expect(response.headers.has("accept")).toBe(false);
 		expect(response.headers.has("user-agent")).toBe(false);
+		// toResponse should still set appropriate response headers
+		expect(response.headers.get("content-type")).toBe("application/json");
 	});
 
 	it("should not leak request headers when returnHeaders is true", async () => {

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -462,8 +462,8 @@ describe("before hook early return should not leak request headers", async () =>
 	it("should not leak request headers when asResponse is true", async () => {
 		const requestHeaders = new Headers({
 			"content-length": "42",
-			"host": "example.com",
-			"accept": "text/html",
+			host: "example.com",
+			accept: "text/html",
 			"user-agent": "TestAgent/1.0",
 			"x-custom-request": "should-not-leak",
 		});
@@ -486,8 +486,8 @@ describe("before hook early return should not leak request headers", async () =>
 	it("should not leak request headers when returnHeaders is true", async () => {
 		const requestHeaders = new Headers({
 			"content-length": "100",
-			"host": "example.com",
-			"cookie": "session=abc",
+			host: "example.com",
+			cookie: "session=abc",
 		});
 
 		const result = await authEndpoints.earlyReturn({

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -161,12 +161,10 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 							} else if (before) {
 								/* Return before hook response if it's anything other than a context return */
 								return context?.asResponse
-									? toResponse(before, {
-											headers: context?.headers,
-										})
+									? toResponse(before)
 									: context?.returnHeaders
 										? {
-												headers: context?.headers,
+												headers: new Headers(),
 												response: before,
 											}
 										: before;


### PR DESCRIPTION
## Summary

When a `hooks.before` middleware short-circuits (returns early without a `context` key), the response incorrectly receives the **request's** headers — including `Content-Length`, `Host`, `Cookie`, etc. This causes `net::ERR_CONTENT_LENGTH_MISMATCH` in browsers.

A companion defensive fix in better-call is at https://github.com/better-auth/better-call/pull/120.

## Root Cause

In `to-auth-endpoints.ts` lines 161-172, when a before hook returns a non-context value (early return), the code was:

```typescript
return context?.asResponse
    ? toResponse(before, { headers: context?.headers })  // ← request headers!
    : context?.returnHeaders
        ? { headers: context?.headers, response: before } // ← request headers!
        : before;
```

At this point in execution, `internalContext.context.responseHeaders` is `undefined` (line 117) — no response headers have been accumulated. `context?.headers` contains the **request** headers (set at line 121 from `new Headers(context?.headers)`). Passing these to `toResponse()` grafts request headers onto the response.

## Fix

Remove `context?.headers` from the early-return path entirely:

```typescript
return context?.asResponse
    ? toResponse(before)          // no headers — toResponse sets its own
    : context?.returnHeaders
        ? { headers: new Headers(), response: before }  // empty response headers
        : before;
```

This is correct because:
1. No response headers exist at this point (`responseHeaders` is `undefined`)
2. The hook's return value IS the response — it doesn't need request headers grafted onto it
3. `toResponse()` sets appropriate headers (like `Content-Type`) based on the data type

## Test plan

- [x] New test: before hook early return with `asResponse: true` does not leak request headers
- [x] New test: before hook early return with `returnHeaders: true` does not leak request headers
- [x] Verify `content-type: application/json` is correctly set on early-return responses
- [x] All 36 existing + new tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in `better-auth` where early returns in before hooks leaked request headers into responses, causing browser `net::ERR_CONTENT_LENGTH_MISMATCH` errors.

- **Bug Fixes**
  - Stop passing `context.headers` to `toResponse()` on early return.
  - Return empty headers when `returnHeaders: true`.
  - Add tests to ensure no header leak and correct `content-type` is set.

<sup>Written for commit 724a978259c1b8751fe0cbafc093a8e962797446. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

