### PR TITLE
feat(magic-link): add opt-in server-only token return

### DIFF
--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -89,25 +89,13 @@ type signInMagicLink = {
 ```
 </APIMethod>
 
-On success, `signIn.magicLink` returns the generated magic-link payload:
-
-```ts
-const response = await authClient.signIn.magicLink({
-  email: "user@email.com",
-});
-
-response.data;
-// {
-//   status: true,
-//   url: "https://example.com/api/auth/magic-link/verify?token=...",
-//   token: "..."
-// }
-```
-
-The returned `url` and `token` are the same values passed to `sendMagicLink`.
-
 <Callout>
 If the user has not signed up, unless `disableSignUp` is set to `true`, the user will be signed up automatically.
+</Callout>
+
+<Callout type="warn">
+  `signIn.magicLink` and `POST /sign-in/magic-link` do not return the raw magic-link token.
+  The token stays in the out-of-band delivery channel handled by `sendMagicLink`.
 </Callout>
 
 ### Verify Magic Link
@@ -173,3 +161,26 @@ The `storeToken` function can be one of the following:
 - `"plain"`: The token is stored in plain text.
 - `"hashed"`: The token is hashed using the default hasher.
 - `{ type: "custom-hasher", hash: (token: string) => Promise<string> }`: The token is hashed using a custom hasher.
+
+**returnToken**: If set to `true`, trusted server-side code can call `auth.api.signInMagicLinkServer()` to receive the generated `url` and raw `token`.
+
+```ts
+const response = await auth.api.signInMagicLinkServer({
+  body: {
+    email: "user@email.com",
+  },
+  headers: new Headers(),
+});
+
+if ("token" in response) {
+  response.token;
+  response.url;
+}
+```
+
+This does not change the HTTP response for `signIn.magicLink`.
+
+<Callout type="warn">
+  Only enable `returnToken` for trusted server-side workflows such as tests or custom delivery logic.
+  Never expose the returned token to browser clients, logs, or analytics.
+</Callout>

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -43,6 +43,15 @@ export interface MagicLinkOptions {
 		ctx?: GenericEndpointContext | undefined,
 	) => Awaitable<void>;
 	/**
+	 * Allow trusted server-side code to receive the generated magic link URL and token
+	 * via `auth.api.signInMagicLinkServer`.
+	 *
+	 * This does not change the HTTP/client response for `signIn.magicLink`.
+	 *
+	 * @default false
+	 */
+	returnToken?: boolean | undefined;
+	/**
 	 * Disable sign up if user is not found.
 	 *
 	 * @default false
@@ -138,8 +147,29 @@ const magicLinkVerifyQuerySchema = z.object({
 		})
 		.optional(),
 });
-export const magicLink = (options: MagicLinkOptions) => {
+type SignInMagicLinkBody = z.infer<typeof signInMagicLinkBodySchema>;
+
+type MagicLinkResponse = {
+	status: true;
+};
+
+type MagicLinkServerResponse = MagicLinkResponse & {
+	url: string;
+	token: string;
+};
+
+type MagicLinkDeliveryData = {
+	email: string;
+	url: string;
+	token: string;
+};
+
+type MagicLinkServerResult<ReturnToken extends boolean | undefined> =
+	ReturnToken extends true ? MagicLinkServerResponse : MagicLinkResponse;
+
+export const magicLink = <const O extends MagicLinkOptions>(options: O) => {
 	const opts = {
+		returnToken: false,
 		storeToken: "plain",
 		allowedAttempts: 1,
 		...options,
@@ -157,6 +187,47 @@ export const magicLink = (options: MagicLinkOptions) => {
 			return await opts.storeToken.hash(token);
 		}
 		return token;
+	}
+
+	async function createMagicLink(
+		ctx: GenericEndpointContext & {
+			body: SignInMagicLinkBody;
+		},
+	): Promise<MagicLinkDeliveryData> {
+		const { email } = ctx.body;
+
+		const verificationToken = opts?.generateToken
+			? await opts.generateToken(email)
+			: generateRandomString(32, "a-z", "A-Z");
+		const storedToken = await storeToken(ctx, verificationToken);
+		await ctx.context.internalAdapter.createVerificationValue({
+			identifier: storedToken,
+			value: JSON.stringify({ email, name: ctx.body.name, attempt: 0 }),
+			expiresAt: new Date(Date.now() + (opts.expiresIn || 60 * 5) * 1000),
+		});
+		const realBaseURL = new URL(ctx.context.baseURL);
+		const pathname = realBaseURL.pathname === "/" ? "" : realBaseURL.pathname;
+		const basePath = pathname ? "" : ctx.context.options.basePath || "";
+		const url = new URL(
+			`${pathname}${basePath}/magic-link/verify`,
+			realBaseURL.origin,
+		);
+		url.searchParams.set("token", verificationToken);
+		url.searchParams.set("callbackURL", ctx.body.callbackURL || "/");
+		if (ctx.body.newUserCallbackURL) {
+			url.searchParams.set("newUserCallbackURL", ctx.body.newUserCallbackURL);
+		}
+		if (ctx.body.errorCallbackURL) {
+			url.searchParams.set("errorCallbackURL", ctx.body.errorCallbackURL);
+		}
+		const magicLinkURL = url.toString();
+		const magicLinkData = {
+			email,
+			url: magicLinkURL,
+			token: verificationToken,
+		};
+		await options.sendMagicLink(magicLinkData, ctx);
+		return magicLinkData;
 	}
 
 	return {
@@ -198,14 +269,8 @@ export const magicLink = (options: MagicLinkOptions) => {
 													status: {
 														type: "boolean",
 													},
-													url: {
-														type: "string",
-													},
-													token: {
-														type: "string",
-													},
 												},
-												required: ["status", "url", "token"],
+												required: ["status"],
 											},
 										},
 									},
@@ -214,57 +279,45 @@ export const magicLink = (options: MagicLinkOptions) => {
 						},
 					},
 				},
-				async (
-					ctx,
-				): Promise<{
-					status: true;
-					url: string;
-					token: string;
-				}> => {
-					const { email } = ctx.body;
-
-					const verificationToken = opts?.generateToken
-						? await opts.generateToken(email)
-						: generateRandomString(32, "a-z", "A-Z");
-					const storedToken = await storeToken(ctx, verificationToken);
-					await ctx.context.internalAdapter.createVerificationValue({
-						identifier: storedToken,
-						value: JSON.stringify({ email, name: ctx.body.name, attempt: 0 }),
-						expiresAt: new Date(Date.now() + (opts.expiresIn || 60 * 5) * 1000),
-					});
-					const realBaseURL = new URL(ctx.context.baseURL);
-					const pathname =
-						realBaseURL.pathname === "/" ? "" : realBaseURL.pathname;
-					const basePath = pathname ? "" : ctx.context.options.basePath || "";
-					const url = new URL(
-						`${pathname}${basePath}/magic-link/verify`,
-						realBaseURL.origin,
-					);
-					url.searchParams.set("token", verificationToken);
-					url.searchParams.set("callbackURL", ctx.body.callbackURL || "/");
-					if (ctx.body.newUserCallbackURL) {
-						url.searchParams.set(
-							"newUserCallbackURL",
-							ctx.body.newUserCallbackURL,
-						);
-					}
-					if (ctx.body.errorCallbackURL) {
-						url.searchParams.set("errorCallbackURL", ctx.body.errorCallbackURL);
-					}
-					const magicLinkURL = url.toString();
-					await options.sendMagicLink(
-						{
-							email,
-							url: magicLinkURL,
-							token: verificationToken,
-						},
-						ctx,
-					);
+				async (ctx): Promise<MagicLinkResponse> => {
+					await createMagicLink(ctx);
 					return ctx.json({
 						status: true,
-						url: magicLinkURL,
-						token: verificationToken,
 					});
+				},
+			),
+			/**
+			 * ### Endpoint
+			 *
+			 * Server-only helper for creating a magic link.
+			 *
+			 * ### API Methods
+			 *
+			 * **server:**
+			 * `auth.api.signInMagicLinkServer`
+			 */
+			signInMagicLinkServer: createAuthEndpoint(
+				{
+					method: "POST",
+					requireHeaders: true,
+					body: signInMagicLinkBodySchema,
+					metadata: {
+						scope: "server",
+						SERVER_ONLY: true,
+					},
+				},
+				async (ctx): Promise<MagicLinkServerResult<O["returnToken"]>> => {
+					const magicLinkData = await createMagicLink(ctx);
+					if (!opts.returnToken) {
+						return ctx.json({
+							status: true,
+						}) as MagicLinkServerResult<O["returnToken"]>;
+					}
+					return ctx.json({
+						status: true,
+						url: magicLinkData.url,
+						token: magicLinkData.token,
+					}) as MagicLinkServerResult<O["returnToken"]>;
 				},
 			),
 			/**

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -48,16 +48,14 @@ describe("magic link", async () => {
 		});
 		expectTypeOf(response.data).toMatchTypeOf<{
 			status: boolean;
-			url: string;
-			token: string;
 		} | null>();
-		expect(response.data).toMatchObject({
+		expect(response.data).toEqual({
 			status: true,
-			url: verificationEmail.url,
-			token: verificationEmail.token,
 		});
-		expect(new URL(response.data!.url).searchParams.get("token")).toBe(
-			response.data!.token,
+		expect(response.data).not.toHaveProperty("url");
+		expect(response.data).not.toHaveProperty("token");
+		expect(new URL(verificationEmail.url).searchParams.get("token")).toBe(
+			verificationEmail.token,
 		);
 		expect(verificationEmail).toMatchObject({
 			email: testUser.email,
@@ -67,7 +65,7 @@ describe("magic link", async () => {
 		});
 	});
 
-	it("should return magic link payload from server api", async () => {
+	it("should keep the public server api status-only", async () => {
 		const response = await auth.api.signInMagicLink({
 			body: {
 				email: testUser.email,
@@ -77,16 +75,93 @@ describe("magic link", async () => {
 
 		expectTypeOf(response).toMatchTypeOf<{
 			status: boolean;
+		}>();
+		expect(response).toEqual({
+			status: true,
+		});
+	});
+
+	it("should keep the server helper status-only when returnToken is disabled", async () => {
+		const response = await auth.api.signInMagicLinkServer({
+			body: {
+				email: testUser.email,
+			},
+			headers: new Headers(),
+		});
+
+		expectTypeOf(response).toMatchTypeOf<{
+			status: boolean;
+		}>();
+		expect(response).toEqual({
+			status: true,
+		});
+		expect(response).not.toHaveProperty("url");
+		expect(response).not.toHaveProperty("token");
+	});
+
+	it("should only expose token on the server helper when returnToken is enabled", async () => {
+		let serverVerificationEmail: VerificationEmail = {
+			email: "",
+			token: "",
+			url: "",
+		};
+
+		const {
+			auth: serverAuth,
+			customFetchImpl: serverFetchImpl,
+			testUser: serverTestUser,
+		} =
+			await getTestInstance({
+				plugins: [
+					magicLink({
+						returnToken: true,
+						async sendMagicLink(data) {
+							serverVerificationEmail = data;
+						},
+					}),
+				],
+			});
+
+		const serverClient = createAuthClient({
+			plugins: [magicLinkClient()],
+			fetchOptions: {
+				customFetchImpl: serverFetchImpl,
+			},
+			baseURL: "http://localhost:3000",
+			basePath: "/api/auth",
+		});
+
+		const clientResponse = await serverClient.signIn.magicLink({
+			email: serverTestUser.email,
+		});
+		expectTypeOf(clientResponse.data).toMatchTypeOf<{
+			status: boolean;
+		} | null>();
+		expect(clientResponse.data).toEqual({
+			status: true,
+		});
+		expect(clientResponse.data).not.toHaveProperty("url");
+		expect(clientResponse.data).not.toHaveProperty("token");
+
+		const serverResponse = await serverAuth.api.signInMagicLinkServer({
+			body: {
+				email: serverTestUser.email,
+			},
+			headers: new Headers(),
+		});
+
+		expectTypeOf(serverResponse).toMatchTypeOf<{
+			status: boolean;
 			url: string;
 			token: string;
 		}>();
-		expect(response).toMatchObject({
+		expect(serverResponse).toMatchObject({
 			status: true,
-			url: verificationEmail.url,
-			token: verificationEmail.token,
+			url: serverVerificationEmail.url,
+			token: serverVerificationEmail.token,
 		});
-		expect(new URL(response.url).searchParams.get("token")).toBe(
-			response.token,
+		expect(new URL(serverResponse.url).searchParams.get("token")).toBe(
+			serverResponse.token,
 		);
 	});
 
@@ -314,10 +389,9 @@ describe("magic link", async () => {
 
 		expect(customGenerateToken).toHaveBeenCalled();
 		expect(verificationEmail.token).toBe("custom_token");
-		expect(response.data?.token).toBe("custom_token");
-		expect(new URL(response.data!.url).searchParams.get("token")).toBe(
-			"custom_token",
-		);
+		expect(response.data).toEqual({
+			status: true,
+		});
 	});
 });
 
@@ -432,6 +506,7 @@ describe("magic link storeToken", async () => {
 		const { auth, signInWithTestUser, testUser } = await getTestInstance({
 			plugins: [
 				magicLink({
+					returnToken: true,
 					storeToken: "hashed",
 					sendMagicLink(data, request) {
 						verificationEmail = data;
@@ -442,7 +517,7 @@ describe("magic link storeToken", async () => {
 
 		const internalAdapter = (await auth.$context).internalAdapter;
 		const { headers } = await signInWithTestUser();
-		const response = await auth.api.signInMagicLink({
+		const response = await auth.api.signInMagicLinkServer({
 			body: {
 				email: testUser.email,
 			},
@@ -465,7 +540,7 @@ describe("magic link storeToken", async () => {
 		const storedToken =
 			await internalAdapter.findVerificationValue(hashedToken);
 		expect(storedToken).toBeDefined();
-		const response2 = await auth.api.signInMagicLink({
+		const response2 = await auth.api.signInMagicLinkServer({
 			body: {
 				email: testUser.email,
 			},
@@ -485,6 +560,7 @@ describe("magic link storeToken", async () => {
 		const { auth, signInWithTestUser, testUser } = await getTestInstance({
 			plugins: [
 				magicLink({
+					returnToken: true,
 					storeToken: {
 						type: "custom-hasher",
 						async hash(token) {
@@ -500,7 +576,7 @@ describe("magic link storeToken", async () => {
 
 		const internalAdapter = (await auth.$context).internalAdapter;
 		const { headers } = await signInWithTestUser();
-		const response = await auth.api.signInMagicLink({
+		const response = await auth.api.signInMagicLinkServer({
 			body: {
 				email: testUser.email,
 			},
@@ -518,7 +594,7 @@ describe("magic link storeToken", async () => {
 		const storedToken =
 			await internalAdapter.findVerificationValue(hashedToken);
 		expect(storedToken).toBeDefined();
-		const response2 = await auth.api.signInMagicLink({
+		const response2 = await auth.api.signInMagicLinkServer({
 			body: {
 				email: testUser.email,
 			},
@@ -540,7 +616,7 @@ describe("magic link openapi", async () => {
 		],
 	});
 
-	it("should expose url and token in the sign-in response schema", async () => {
+	it("should keep the public sign-in response schema token-free", async () => {
 		const schema = await auth.api.generateOpenAPISchema();
 		const paths = schema.paths as Record<string, any>;
 		const responseSchema =
@@ -551,15 +627,9 @@ describe("magic link openapi", async () => {
 		expect(responseSchema.properties.status).toEqual({
 			type: "boolean",
 		});
-		expect(responseSchema.properties.url).toEqual({
-			type: "string",
-		});
-		expect(responseSchema.properties.token).toEqual({
-			type: "string",
-		});
-		expect(responseSchema.required).toEqual(
-			expect.arrayContaining(["status", "url", "token"]),
-		);
+		expect(responseSchema.properties.url).toBeUndefined();
+		expect(responseSchema.properties.token).toBeUndefined();
+		expect(responseSchema.required).toEqual(["status"]);
 	});
 });
 


### PR DESCRIPTION
## Summary
- restore the public `signIn.magicLink` HTTP response to status-only so the raw token never reaches browser clients
- add an explicit `returnToken` option and a server-only `auth.api.signInMagicLinkServer()` helper for trusted server-side workflows
- update docs and tests with the security warning, opt-in server-only usage, and hashed/custom storage coverage

## Validation
- `pnpm --filter better-auth exec vitest run src/plugins/magic-link/magic-link.test.ts`

## Notes
- `authClient.signIn.magicLink()` and `POST /sign-in/magic-link` still return only `{ status: true }`
- when `returnToken: true` is enabled, `auth.api.signInMagicLinkServer()` returns the generated `url` and raw `token`
- the raw token remains opt-in and server-only; it is never added to the public HTTP/OpenAPI contract
- supersedes #8572


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down magic-link sign-in so public endpoints return status-only, and add an opt-in server-only helper that can return the URL and raw token for trusted workflows. This prevents the token from reaching browsers while enabling secure server-side use cases.

- **New Features**
  - Added `returnToken` option (default `false`).
  - Introduced server-only `auth.api.signInMagicLinkServer` that returns `{ status }`, or `{ status, url, token }` when `returnToken: true`.
  - Updated docs with guidance and warnings; expanded tests (including hashed/custom token storage).

- **Bug Fixes**
  - Restored `signIn.magicLink` and `POST /sign-in/magic-link` to return only `{ status: true }`.
  - Kept the token out of the HTTP/OpenAPI contract; `openAPI` schema requires only `status` and has no `token` or `url`.
  - Token remains in the out-of-band channel handled by `sendMagicLink`.

<sup>Written for commit fe5416686234916074f6067cd71091437b0ce319. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

