### PR TITLE
fix(phone-number): deduplicate verification records on repeated OTP requests

### DIFF
--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -410,6 +410,108 @@ describe("verify phone-number", async () => {
 	});
 });
 
+describe("repeated OTP sends", async () => {
+	let otp = "";
+	let resetOtp = "";
+
+	const { client, db } = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						otp = code;
+					},
+					sendPasswordResetOTP(data) {
+						resetOtp = data.code;
+					},
+					signUpOnVerification: {
+						getTempEmail(phoneNumber) {
+							return `temp-${phoneNumber}`;
+						},
+					},
+					allowedAttempts: 3,
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [phoneNumberClient()],
+			},
+		},
+	);
+
+	it("should not create duplicate verification records on repeated sendOtp", async () => {
+		const phone = "+251900000001";
+		await client.phoneNumber.sendOtp({ phoneNumber: phone });
+		await client.phoneNumber.sendOtp({ phoneNumber: phone });
+		await client.phoneNumber.sendOtp({ phoneNumber: phone });
+
+		const records = await db.findMany({
+			model: "verification",
+			where: [{ field: "identifier", value: phone }],
+		});
+		expect(records).toHaveLength(1);
+	});
+
+	it("should allow wrong-code then correct-code after re-sending OTP", async () => {
+		const phone = "+251900000002";
+		await client.phoneNumber.sendOtp({ phoneNumber: phone });
+
+		await client.phoneNumber.sendOtp({ phoneNumber: phone });
+		const latestCode = otp;
+
+		const wrongRes = await client.phoneNumber.verify({
+			phoneNumber: phone,
+			code: "000000",
+		});
+		expect(wrongRes.error?.status).toBe(400);
+
+		const correctRes = await client.phoneNumber.verify({
+			phoneNumber: phone,
+			code: latestCode,
+		});
+		expect(correctRes.error).toBe(null);
+		expect(correctRes.data?.status).toBe(true);
+	});
+
+	it("should not create duplicate verification records on repeated password reset requests", async () => {
+		const phone = "+251900000003";
+		await client.phoneNumber.sendOtp({ phoneNumber: phone });
+		await client.phoneNumber.verify({ phoneNumber: phone, code: otp });
+
+		await client.phoneNumber.requestPasswordReset({ phoneNumber: phone });
+		await client.phoneNumber.requestPasswordReset({ phoneNumber: phone });
+
+		const records = await db.findMany({
+			model: "verification",
+			where: [
+				{
+					field: "identifier",
+					value: `${phone}-request-password-reset`,
+				},
+			],
+		});
+		expect(records).toHaveLength(1);
+	});
+
+	it("should succeed on repeated password reset requests followed by reset", async () => {
+		const phone = "+251900000004";
+		await client.phoneNumber.sendOtp({ phoneNumber: phone });
+		await client.phoneNumber.verify({ phoneNumber: phone, code: otp });
+
+		await client.phoneNumber.requestPasswordReset({ phoneNumber: phone });
+		await client.phoneNumber.requestPasswordReset({ phoneNumber: phone });
+
+		const res = await client.phoneNumber.resetPassword({
+			phoneNumber: phone,
+			otp: resetOtp,
+			newPassword: "new-password-123",
+		});
+		expect(res.error).toBe(null);
+		expect(res.data?.status).toBe(true);
+	});
+});
+
 describe("reset password flow attempts", async () => {
 	let otp = "";
 	let resetOtp = "";

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -11,6 +11,21 @@ import { getDate } from "../../utils/date";
 import { PHONE_NUMBER_ERROR_CODES } from "./error-codes";
 import type { PhoneNumberOptions, UserWithPhoneNumber } from "./types";
 
+async function createOrReplaceVerification(
+	internalAdapter: {
+		createVerificationValue: (data: {
+			value: string;
+			identifier: string;
+			expiresAt: Date;
+		}) => Promise<unknown>;
+		deleteVerificationByIdentifier: (identifier: string) => Promise<unknown>;
+	},
+	data: { value: string; identifier: string; expiresAt: Date },
+) {
+	await internalAdapter.deleteVerificationByIdentifier(data.identifier);
+	await internalAdapter.createVerificationValue(data);
+}
+
 export type RequiredPhoneNumberOptions = PhoneNumberOptions & {
 	expiresIn: number;
 	otpLength: number;
@@ -119,7 +134,7 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			if (opts.requireVerification) {
 				if (!user.phoneNumberVerified) {
 					const otp = generateOTP(opts.otpLength);
-					await ctx.context.internalAdapter.createVerificationValue({
+					await createOrReplaceVerification(ctx.context.internalAdapter, {
 						value: otp,
 						identifier: phoneNumber,
 						expiresAt: getDate(opts.expiresIn, "sec"),
@@ -275,7 +290,7 @@ export const sendPhoneNumberOTP = (opts: RequiredPhoneNumberOptions) =>
 			}
 
 			const code = generateOTP(opts.otpLength);
-			await ctx.context.internalAdapter.createVerificationValue({
+			await createOrReplaceVerification(ctx.context.internalAdapter, {
 				value: `${code}:0`,
 				identifier: ctx.body.phoneNumber,
 				expiresAt: getDate(opts.expiresIn, "sec"),
@@ -719,7 +734,7 @@ export const requestPasswordResetPhoneNumber = (
 				],
 			});
 			const code = generateOTP(opts.otpLength);
-			await ctx.context.internalAdapter.createVerificationValue({
+			await createOrReplaceVerification(ctx.context.internalAdapter, {
 				value: `${code}:0`,
 				identifier: `${ctx.body.phoneNumber}-request-password-reset`,
 				expiresAt: getDate(opts.expiresIn, "sec"),


### PR DESCRIPTION
## Summary

- **Root cause:** `createVerificationValue` inserts without dedup — when a user requests a second OTP before the first expires, duplicate verification records accumulate. Subsequent calls to `updateVerificationByIdentifier` or `deleteVerificationByIdentifier` then operate on multiple rows for the same identifier, causing 500 errors.
- **Fix:** Add a `createOrReplaceVerification` helper that deletes any existing verification for the identifier before creating a new one. Applied to all 3 `createVerificationValue` call sites in the phone-number plugin:
  - `signInPhoneNumber` (requireVerification flow)
  - `sendPhoneNumberOTP`
  - `requestPasswordResetPhoneNumber`

## Trade-offs

This fix adds an extra DELETE query per OTP send (n+1). In practice, OTP sends are low-frequency user-initiated actions, and the DELETE is a simple indexed lookup on `identifier` — so the DB load is negligible. The cost is primarily the extra network round-trip to the database.

### Single-statement alternatives (follow-up)

Since this helper centralizes the logic in one place, a follow-up could detect DB capabilities and use the optimal strategy per database:

1. **Upsert** — `INSERT ... ON CONFLICT (identifier) DO UPDATE` (Postgres/SQLite) or `ON DUPLICATE KEY UPDATE` (MySQL). Single statement, atomic, no extra round-trip. Requires a unique constraint on `verification.identifier`.
2. **`REPLACE INTO`** (SQLite/MySQL) — atomic delete-then-insert in one statement. Also requires a unique constraint.
3. **Transaction** — wrap DELETE + INSERT in the adapter's `transaction()` method. Atomic, no unique constraint needed, still two statements but could be pipelined. The `DBAdapter` already exposes `transaction` support.

Options 1 and 2 are the cleanest but depend on adding `unique: true` to the `identifier` column in `get-tables.ts` — a breaking change for existing DBs that may already have duplicate records blocking the migration. Option 3 could work today by passing `ctx.context.adapter` into the helper for its transaction support.

If the n+1 is unacceptable for this PR, happy to pursue any of these here. Otherwise they make good follow-ups since the helper already centralizes the logic, making the swap straightforward.

## Test plan

- [x] Added test: repeated `sendOtp` calls produce exactly 1 verification record (not 3)
- [x] Added test: wrong code → re-send OTP → correct latest code succeeds
- [x] Added test: repeated `requestPasswordReset` calls produce exactly 1 verification record (not 2)
- [x] Added test: repeated password reset requests followed by reset succeeds
- [x] All 30 tests pass (4 new + 26 existing, zero regressions)
- [x] No type errors introduced
- [x] Lint clean

## Future improvements

- **Adapter-aware verification replacement** — `DBAdapter` exposes `id`, `options.adapterConfig.adapterId`, and `options.type`, which could be used to select the optimal dedup strategy per database (e.g., `INSERT ... ON CONFLICT DO UPDATE` for Postgres, `REPLACE INTO` for MySQL/SQLite, or `transaction()` as a universal fallback). This could be implemented as a `createOrReplaceVerificationValue` method on `InternalAdapter` that inspects the adapter config and dispatches accordingly.
- Add `unique: true` to `identifier` in `get-tables.ts` (breaking change for existing DBs with duplicates — should be bundled with a minor version bump). Users who want to add it early can do so safely after this fix lands, and `npx auth migrate` won't overwrite it.
- Fix the same latent bug in email-otp and other plugins