### PR TITLE
feat(sso): add prompt parameter support for OIDC authorization requests

### DIFF
--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -382,6 +382,7 @@ function mergeOIDCConfig(
 		tokenEndpointAuthentication:
 			updates.tokenEndpointAuthentication ??
 			current.tokenEndpointAuthentication,
+		prompt: updates.prompt ?? current.prompt,
 	};
 }
 

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -38,6 +38,17 @@ const oidcConfigSchema = z.object({
 	pkce: z.boolean().optional(),
 	overrideUserInfo: z.boolean().optional(),
 	mapping: oidcMappingSchema,
+	prompt: z
+		.enum([
+			"none",
+			"login",
+			"create",
+			"consent",
+			"select_account",
+			"select_account consent",
+			"login consent",
+		])
+		.optional(),
 });
 
 const samlConfigSchema = z.object({

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -826,6 +826,7 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 							`${body.issuer}/.well-known/openid-configuration`,
 						mapping: body.oidcConfig.mapping,
 						scopes: body.oidcConfig.scopes,
+						prompt: body.oidcConfig.prompt,
 						userInfoEndpoint: body.oidcConfig.userInfoEndpoint,
 						overrideUserInfo:
 							ctx.body.overrideUserInfo ||
@@ -849,6 +850,7 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 					discoveryEndpoint: hydratedOIDCConfig.discoveryEndpoint,
 					mapping: body.oidcConfig.mapping,
 					scopes: body.oidcConfig.scopes,
+					prompt: body.oidcConfig.prompt,
 					userInfoEndpoint: hydratedOIDCConfig.userInfoEndpoint,
 					overrideUserInfo:
 						ctx.body.overrideUserInfo ||
@@ -1016,6 +1018,21 @@ const signInSSOBodySchema = z.object({
 				"Explicitly request sign-up. Useful when disableImplicitSignUp is true for this provider",
 		})
 		.optional(),
+	prompt: z
+		.enum([
+			"none",
+			"login",
+			"create",
+			"consent",
+			"select_account",
+			"select_account consent",
+			"login consent",
+		])
+		.meta({
+			description:
+				"Prompt parameter for the OIDC authorization request. Controls the authentication experience (e.g., force account selection or consent). Overrides the provider-level default if set.",
+		})
+		.optional(),
 	providerType: z.enum(["oidc", "saml"]).optional(),
 });
 
@@ -1069,6 +1086,20 @@ export const signInSSO = (options?: SSOOptions) => {
 											type: "string",
 											description:
 												"Login hint to send to the identity provider (e.g., email or identifier). If supported, sent as 'login_hint'.",
+										},
+										prompt: {
+											type: "string",
+											enum: [
+												"none",
+												"login",
+												"create",
+												"consent",
+												"select_account",
+												"select_account consent",
+												"login consent",
+											],
+											description:
+												"Prompt parameter for the OIDC authorization request. Controls the authentication experience (e.g., force account selection or consent). Overrides the provider-level default if set.",
 										},
 									},
 									required: ["callbackURL"],
@@ -1301,6 +1332,7 @@ export const signInSSO = (options?: SSOOptions) => {
 					scopes: ctx.body.scopes ||
 						config.scopes || ["openid", "email", "profile", "offline_access"],
 					loginHint: ctx.body.loginHint || email,
+					prompt: ctx.body.prompt || config.prompt,
 					authorizationEndpoint: config.authorizationEndpoint,
 				});
 				return ctx.json({

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -36,6 +36,33 @@ export interface OIDCConfig {
 		| undefined;
 	jwksEndpoint?: string | undefined;
 	mapping?: OIDCMapping | undefined;
+	/**
+	 * Prompt parameter for the OIDC authorization request.
+	 * Controls the authentication experience for the user.
+	 *
+	 * Common values:
+	 * - `"none"` — No interaction; fail if user is not already authenticated
+	 * - `"login"` — Force re-authentication even if user has an active session
+	 * - `"consent"` — Force consent screen even if previously granted
+	 * - `"select_account"` — Force account selection when user has multiple accounts
+	 *
+	 * Can be combined (e.g., `"login consent"` or `"select_account consent"`).
+	 *
+	 * When set on the provider config, this acts as the default prompt for
+	 * all sign-in requests using this provider. It can be overridden per-request
+	 * via the `prompt` parameter on `signIn.sso()`.
+	 */
+	prompt?:
+		| (
+				| "none"
+				| "login"
+				| "create"
+				| "consent"
+				| "select_account"
+				| "select_account consent"
+				| "login consent"
+		  )
+		| undefined;
 }
 
 export interface SAMLConfig {


### PR DESCRIPTION
## Summary

Adds the standard OIDC `prompt` parameter to the SSO plugin, enabling control over the authentication experience when signing in with OIDC identity providers.

This is useful when users have multiple accounts with an identity provider and need to be prompted to select which account to use, or when applications need to force re-consent.

### Problem

The SSO plugin's OIDC flow currently provides no way to control the `prompt` parameter in the authorization request. The core `createAuthorizationURL` function already supports it, and the Generic OAuth plugin already passes it through — but the SSO plugin does not.

This means SSO consumers cannot force account selection, consent, or re-authentication when needed.

### Solution

- **Provider-level default**: Added `prompt` to `OIDCConfig` interface and provider registration schemas, so a default prompt can be configured per provider (both `defaultSSO` in code and database-stored providers)
- **Per-request override**: Added `prompt` to the `signIn.sso()` body schema, allowing per-request override of the provider default
- **Precedence**: Request-level `prompt` takes precedence over provider-level default (`ctx.body.prompt || config.prompt`)

### Changes

| File | Change |
|------|--------|
| `types.ts` | Added `prompt` field to `OIDCConfig` interface with JSDoc |
| `routes/schemas.ts` | Added `prompt` to `oidcConfigSchema` for provider registration |
| `routes/sso.ts` | Added `prompt` to `signInSSOBodySchema`, `buildOIDCConfig`, `createAuthorizationURL` call, and OpenAPI metadata |
| `routes/providers.ts` | Added `prompt` to `mergeOIDCConfig` for provider updates |

### Supported values

Per the [OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest):

- `none` — No interaction; fail if not already authenticated
- `login` — Force re-authentication
- `consent` — Force consent screen
- `select_account` — Force account selection
- `create` — Prompt for account creation
- `select_account consent` — Account selection + consent
- `login consent` — Re-authentication + consent

### Usage

```typescript
// Provider-level default (in defaultSSO config)
sso({
  defaultSSO: [{
    domain: "example.com",
    providerId: "my-idp",
    oidcConfig: {
      // ...
      prompt: "select_account",
    },
  }],
})

// Per-request override (client-side)
await authClient.signIn.sso({
  email: "user@example.com",
  callbackURL: "/dashboard",
  prompt: "select_account consent",
})
```

## Test plan

- [ ] Verify `prompt` is persisted when registering a new SSO provider
- [ ] Verify `prompt` is included in the authorization URL when set on provider config
- [ ] Verify per-request `prompt` overrides provider-level default
- [ ] Verify `prompt` is preserved during provider updates via `mergeOIDCConfig`
- [ ] Verify backward compatibility — existing providers without `prompt` continue to work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the OIDC `prompt` parameter in `@better-auth/sso` authorization requests. Apps can now force login, consent, account selection, or sign-up; set a provider default and override per request.

- **New Features**
  - Provider default: `prompt` in `OIDCConfig` (persisted for discovery and skip-discovery providers).
  - Per-request override: `signIn.sso({ prompt })`; request value takes precedence.
  - Wiring: pass through registration/update (`mergeOIDCConfig`) to `createAuthorizationURL`; update Zod schemas and OpenAPI.
  - Backward compatible.

<sup>Written for commit 1d9b7446232f7ded41429f26448417e3c0e3e27f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

