### PR TITLE
docs: fix import statement in your-first-plugin.mdx

### DIFF
--- a/docs/content/docs/guides/your-first-plugin.mdx
+++ b/docs/content/docs/guides/your-first-plugin.mdx
@@ -118,8 +118,7 @@ In our case we want to match any requests going to the signup path:
 
 And for our logic, we’ll write the following code to check the if user’s birthday makes them above 5 years old.
 ```ts title="Imports"
-import { APIError } from "better-auth/api";
-import { createAuthMiddleware } from "better-auth/plugins";
+import { createAuthMiddleware, APIError } from "better-auth/api";
 ```
 ```ts title="Before hook"
 {


### PR DESCRIPTION
Change `createAuthMiddleware` import from `better-auth/plugins` (invalid) to importing from`better-auth/api`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the import example in the Your First Plugin guide to prevent copy-paste errors. `createAuthMiddleware` and `APIError` are now both imported from `better-auth/api` instead of `createAuthMiddleware` from `better-auth/plugins`.

<sup>Written for commit d09923d7373267f5983ee8b28a6b560fb5d24fe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

