### PR TITLE
chore: enable global virtual store for git worktree support

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ packages:
 
 blockExoticSubdeps: true
 
+enableGlobalVirtualStore: true
+
 catalog:
   '@better-auth/utils': 0.3.1
   '@better-fetch/fetch': 1.1.21


### PR DESCRIPTION
## Summary

- Adds `enableGlobalVirtualStore: true` to `pnpm-workspace.yaml` to enable pnpm's [git worktree support](https://pnpm.io/next/git-worktrees)
- This allows multiple git worktrees to share a single content-addressable store, so each worktree's `node_modules` contains only symlinks instead of duplicated packages

## Test plan

- [x] Verify `pnpm install` works correctly in the main checkout
- [x] Verify `pnpm install` works correctly in a git worktree