### PR TITLE
fix(sso): include owner role in organization provisioning types

### DIFF
--- a/packages/sso/src/linking/org-assignment.test.ts
+++ b/packages/sso/src/linking/org-assignment.test.ts
@@ -146,6 +146,60 @@ describe("assignOrganizationByDomain", () => {
 		expect(members[0]?.role).toBe("member");
 	});
 
+	it("should assign owner role when provisioning defaultRole is owner", async () => {
+		const { data, createContext } = createTestContext();
+
+		const org = createOrg();
+		data.organization.push(org);
+		data.ssoProvider.push(
+			createProvider({ domainVerified: true, organizationId: org.id }),
+		);
+
+		const user = createUser();
+		data.user.push(user);
+
+		const ctx = (await createContext()) as GenericEndpointContext;
+		await assignOrganizationByDomain(ctx, {
+			user,
+			domainVerification: { enabled: true },
+			provisioningOptions: {
+				defaultRole: "owner",
+			},
+		});
+
+		const members = data.member.filter((m) => m.userId === user.id);
+		expect(members).toHaveLength(1);
+		expect(members[0]?.organizationId).toBe(org.id);
+		expect(members[0]?.role).toBe("owner");
+	});
+
+	it("should assign owner role when provisioning getRole returns owner", async () => {
+		const { data, createContext } = createTestContext();
+
+		const org = createOrg();
+		data.organization.push(org);
+		data.ssoProvider.push(
+			createProvider({ domainVerified: true, organizationId: org.id }),
+		);
+
+		const user = createUser();
+		data.user.push(user);
+
+		const ctx = (await createContext()) as GenericEndpointContext;
+		await assignOrganizationByDomain(ctx, {
+			user,
+			domainVerification: { enabled: true },
+			provisioningOptions: {
+				getRole: async () => "owner",
+			},
+		});
+
+		const members = data.member.filter((m) => m.userId === user.id);
+		expect(members).toHaveLength(1);
+		expect(members[0]?.organizationId).toBe(org.id);
+		expect(members[0]?.role).toBe("owner");
+	});
+
 	it("should NOT assign user when email domain does not match any provider", async () => {
 		const { data, createContext } = createTestContext();
 

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -163,7 +163,7 @@ export interface SSOOptions {
 	organizationProvisioning?:
 		| {
 				disabled?: boolean;
-				defaultRole?: "member" | "admin";
+				defaultRole?: "member" | "admin" | "owner";
 				getRole?: (data: {
 					/**
 					 * The user object from the database
@@ -181,7 +181,7 @@ export interface SSOOptions {
 					 * The SSO provider
 					 */
 					provider: SSOProvider<SSOOptions>;
-				}) => Promise<"member" | "admin">;
+				}) => Promise<"member" | "admin" | "owner">;
 		  }
 		| undefined;
 	/**


### PR DESCRIPTION
## Summary

This PR fixes #8604, a type mismatch in the SSO plugin where organization provisioning role types were too narrow and excluded `"owner"`.

## Problem

In SSO organization provisioning, TypeScript only allowed `"member"` or `"admin"` in exported role unions.  
This caused downstream type errors when checking for `"owner"`, even though `"owner"` is a valid default organization role.

## Root Cause

The public SSO types in [packages/sso/src/types.ts](packages/sso/src/types.ts) were hardcoded to:

- `defaultRole?: "member" | "admin"`
- `getRole?: (...) => Promise<"member" | "admin">`

This did not match organization role defaults.

## Changes

### 1) Type updates

Updated [packages/sso/src/types.ts](packages/sso/src/types.ts):

- `defaultRole` now supports `"member" | "admin" | "owner"`
- `getRole` return type now supports `Promise<"member" | "admin" | "owner">`

### 2) Regression tests

Added tests in [packages/sso/src/linking/org-assignment.test.ts](packages/sso/src/linking/org-assignment.test.ts):

- assigns `"owner"` when `provisioningOptions.defaultRole = "owner"`
- assigns `"owner"` when `provisioningOptions.getRole` returns `"owner"`

## Why this is safe

- Runtime assignment path already supports string roles.
- This change aligns type definitions with valid existing behavior.
- No breaking API or runtime behavior changes.

## Validation

- SSO package typecheck passed.
- Focused test file passed: `src/linking/org-assignment.test.ts` (10/10).

## Breaking Changes

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the "owner" role in SSO organization provisioning types to fix type errors and match valid default roles. This aligns TypeScript types with existing runtime behavior.

- **Bug Fixes**
  - Update `packages/sso/src/types.ts`: include "owner" in `defaultRole` and `getRole` return types.
  - Add tests in `packages/sso/src/linking/org-assignment.test.ts` verifying "owner" is assigned via `defaultRole` or `getRole`.

<sup>Written for commit 795e947ea5ab582599b97c8029075f7b5a973ddf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

