### PR TITLE
fix(cli): treat omitted `required` as `true` in Drizzle and Prisma generators

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -266,7 +266,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 								}
 							}
 
-							return `${fieldName}: ${type}${attr.required ? ".notNull()" : ""}${
+							return `${fieldName}: ${type}${attr.required !== false ? ".notNull()" : ""}${
 								attr.unique ? ".unique()" : ""
 							}${
 								attr.references

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -229,7 +229,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 							})
 						: getType({
 								isBigint: attr?.bigint || false,
-								isOptional: !attr?.required,
+								isOptional: attr?.required === false,
 								type:
 									attr.references?.field === "id"
 										? useNumberId
@@ -362,7 +362,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 						.field(
 							referencedCustomModelName.toLowerCase(),
 							`${capitalizeFirstLetter(referencedCustomModelName)}${
-								!attr.required ? "?" : ""
+								attr.required === false ? "?" : ""
 							}`,
 						)
 						.attribute(relationField);

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-enum.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-enum.txt
@@ -16,7 +16,7 @@ export const user = sqliteTable("user", {
     .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
-  priority: text({ enum: ["high", "medium", "low"] }),
+  priority: text({ enum: ["high", "medium", "low"] }).notNull(),
 });
 
 export const session = sqliteTable(

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -263,6 +263,117 @@ describe("generate", async () => {
 		);
 	});
 
+	it("should treat fields with omitted required as notNull (default true)", async () => {
+		const pluginWithOmittedRequired = (): BetterAuthPlugin => ({
+			id: "omitted-required-test",
+			schema: {
+				testTable: {
+					fields: {
+						requiredField: {
+							type: "string",
+							// required is omitted — should default to true
+						},
+						explicitRequired: {
+							type: "string",
+							required: true,
+						},
+						explicitOptional: {
+							type: "string",
+							required: false,
+						},
+					},
+				},
+			},
+		});
+
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: {
+					provider: "pg",
+					schema: {},
+				},
+			} as any,
+			options: {
+				database: {} as any,
+				plugins: [pluginWithOmittedRequired()],
+			} as BetterAuthOptions,
+		});
+
+		// Fields with omitted `required` should have .notNull()
+		expect(schema.code).toContain(
+			'requiredField: text("required_field").notNull()',
+		);
+		// Fields with explicit `required: true` should have .notNull()
+		expect(schema.code).toContain(
+			'explicitRequired: text("explicit_required").notNull()',
+		);
+		// Fields with explicit `required: false` should NOT have .notNull()
+		expect(schema.code).not.toMatch(/explicitOptional:.*\.notNull\(\)/);
+	});
+
+	it("should treat fields with omitted required as non-optional in prisma schema", async () => {
+		const originalCwd = process.cwd();
+		const tmpDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "prisma-required-test-"),
+		);
+
+		try {
+			fs.writeFileSync(
+				path.join(tmpDir, "package.json"),
+				JSON.stringify({
+					dependencies: { prisma: "^7.0.0" },
+				}),
+			);
+			process.chdir(tmpDir);
+
+			const pluginWithOmittedRequired = (): BetterAuthPlugin => ({
+				id: "omitted-required-test",
+				schema: {
+					testTable: {
+						fields: {
+							requiredField: {
+								type: "string",
+								// required is omitted — should default to true
+							},
+							explicitRequired: {
+								type: "string",
+								required: true,
+							},
+							explicitOptional: {
+								type: "string",
+								required: false,
+							},
+						},
+					},
+				},
+			});
+
+			const schema = await generatePrismaSchema({
+				file: "test.prisma",
+				adapter: prismaAdapter(
+					{},
+					{ provider: "postgresql" },
+				)({} as BetterAuthOptions),
+				options: {
+					database: prismaAdapter({}, { provider: "postgresql" }),
+					plugins: [pluginWithOmittedRequired()],
+				},
+			});
+
+			// Fields with omitted `required` should NOT have "?" (= required)
+			expect(schema.code).toMatch(/requiredField\s+String(?!\?)/);
+			// Fields with explicit `required: true` should NOT have "?"
+			expect(schema.code).toMatch(/explicitRequired\s+String(?!\?)/);
+			// Fields with explicit `required: false` should have "?"
+			expect(schema.code).toMatch(/explicitOptional\s+String\?/);
+		} finally {
+			process.chdir(originalCwd);
+			fs.rmSync(tmpDir, { recursive: true });
+		}
+	});
+
 	// Minimal plugin that reproduces the bug: two fields referencing the same model
 	const testPlugin = (): BetterAuthPlugin => {
 		return {
@@ -499,7 +610,8 @@ describe("JSON field support in CLI generators", () => {
 				},
 			} as BetterAuthOptions,
 		});
-		expect(schema.code).toContain("preferences   Json?");
+		// required omitted → defaults to true → non-nullable
+		expect(schema.code).toMatch(/preferences\s+Json(?!\?)/);
 	});
 
 	it("should generate Prisma schema with JSON default values of arrays and objects", async () => {
@@ -533,8 +645,8 @@ describe("JSON field support in CLI generators", () => {
 				},
 			} as BetterAuthOptions,
 		});
-		expect(schema.code).toContain("preferences   Json?");
-		// expect(schema.code).toContain(JSON.stringify(`@default("{\"premiumuser\":true}")`).slice(1,-1));
+		// required omitted → defaults to true → non-nullable
+		expect(schema.code).toMatch(/preferences\s+Json(?!\?)/);
 		expect(schema.code).toContain('@default("{\\"premiumuser\\":true}")');
 		expect(schema.code).toContain(
 			'@default("[{\\"name\\":\\"john\\",\\"subscribed\\":false},{\\"name\\":\\"doe\\",\\"subscribed\\":true}]")',


### PR DESCRIPTION
Fields with omitted required (which defaults to true per DBFieldAttributeConfig) were incorrectly treated as nullable due to a falsy check on undefined.

https://github.com/better-auth/better-auth/blob/canary/packages/core/src/db/type.ts#L185-L189