### PR TITLE
fix(oidc-provider): public client registration

### DIFF
--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -753,6 +753,46 @@ export const oidcProvider = (options: OIDCOptions) => {
 								error: "invalid_grant",
 							});
 						}
+
+						// Validate client credentials for refresh token exchange
+						const client = await getClient(
+							client_id.toString(),
+							trustedClients,
+						);
+						if (!client) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "invalid client_id",
+								error: "invalid_client",
+							});
+						}
+						if (client.disabled) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "client is disabled",
+								error: "invalid_client",
+							});
+						}
+						if (client.type !== "public") {
+							// Confidential clients must authenticate with client_secret
+							if (!client.clientSecret || !client_secret) {
+								throw new APIError("UNAUTHORIZED", {
+									error_description:
+										"client_secret is required for confidential clients",
+									error: "invalid_client",
+								});
+							}
+							const isValidSecret = await verifyStoredClientSecret(
+								ctx,
+								client.clientSecret,
+								client_secret.toString(),
+							);
+							if (!isValidSecret) {
+								throw new APIError("UNAUTHORIZED", {
+									error_description: "invalid client_secret",
+									error: "invalid_client",
+								});
+							}
+						}
+
 						const accessToken = generateRandomString(32, "a-z", "A-Z");
 						const newRefreshToken = generateRandomString(32, "a-z", "A-Z");
 
@@ -993,7 +1033,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 						Math.floor(Date.now() / 1000) +
 						(opts?.accessTokenExpiresIn ?? DEFAULT_ACCESS_TOKEN_EXPIRES_IN);
 
-					let idToken: string;
+					let idToken: string | undefined;
 
 					// The JWT plugin is enabled, so we use the JWKS keys to sign
 					if (options.useJWTPlugin) {
@@ -1052,7 +1092,15 @@ export const oidcProvider = (options: OIDCOptions) => {
 						);
 
 						// If the JWT token is not enabled, create a key and use it to sign
-					} else {
+					} else if (requestedScopes.includes("openid")) {
+						if (client.type === "public") {
+							throw new APIError("INTERNAL_SERVER_ERROR", {
+								error_description:
+									"Public clients require the JWT plugin for ID token signing. " +
+									"Set `useJWTPlugin: true` in oidcProvider options and add the JWT plugin to your plugins array.",
+								error: "server_error",
+							});
+						}
 						idToken = await new SignJWT(payload)
 							.setProtectedHeader({ alg: "HS256" })
 							.setIssuedAt(iat)
@@ -1290,7 +1338,9 @@ export const oidcProvider = (options: OIDCOptions) => {
 													},
 													clientSecret: {
 														type: "string",
-														description: "Secret key for the client",
+														nullable: true,
+														description:
+															"Secret key for the client. Null for public clients.",
 													},
 													redirectURLs: {
 														type: "array",
@@ -1300,13 +1350,17 @@ export const oidcProvider = (options: OIDCOptions) => {
 													type: {
 														type: "string",
 														description: "Type of the client",
-														enum: ["web"],
+														enum: ["web", "public"],
 													},
 													authenticationScheme: {
 														type: "string",
 														description:
 															"Authentication scheme used by the client",
-														enum: ["client_secret"],
+														enum: [
+															"client_secret_basic",
+															"client_secret_post",
+															"none",
+														],
 													},
 													disabled: {
 														type: "boolean",
@@ -1333,7 +1387,6 @@ export const oidcProvider = (options: OIDCOptions) => {
 												required: [
 													"name",
 													"clientId",
-													"clientSecret",
 													"redirectURLs",
 													"type",
 													"authenticationScheme",
@@ -1403,11 +1456,15 @@ export const oidcProvider = (options: OIDCOptions) => {
 					const clientId =
 						options.generateClientId?.() ||
 						generateRandomString(32, "a-z", "A-Z");
-					const clientSecret =
-						options.generateClientSecret?.() ||
-						generateRandomString(32, "a-z", "A-Z");
+					const isPublicClient = body.token_endpoint_auth_method === "none";
+					const clientSecret = isPublicClient
+						? null
+						: options.generateClientSecret?.() ||
+							generateRandomString(32, "a-z", "A-Z");
 
-					const storedClientSecret = await storeClientSecret(ctx, clientSecret);
+					const storedClientSecret = clientSecret
+						? await storeClientSecret(ctx, clientSecret)
+						: null;
 
 					// Create the client with the existing schema
 					const client: Client = await ctx.context.adapter.create({

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -1441,7 +1441,6 @@ export const oidcProvider = (options: OIDCOptions) => {
 									}
 								: {}),
 							client_id_issued_at: Math.floor(Date.now() / 1000),
-							client_secret_expires_at: 0, // 0 means it doesn't expire
 							redirect_uris: body.redirect_uris,
 							token_endpoint_auth_method:
 								body.token_endpoint_auth_method ?? "client_secret_basic",

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -985,6 +985,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 							: undefined,
 						nonce: value.nonce,
 						acr: "urn:mace:incommon:iap:silver", // default to silver - ⚠︎ this should be configurable and should be validated against the client's metadata
+						scope: requestedScopes.join(" "),
 						...userClaims,
 						...additionalUserClaims,
 					};
@@ -1037,7 +1038,15 @@ export const oidcProvider = (options: OIDCOptions) => {
 											? ctx.context.options.baseURL
 											: undefined),
 									expirationTime,
-									definePayload: () => payload,
+									definePayload: async (session) => {
+										const basePayload = jwtPlugin.options?.jwt?.definePayload
+											? await jwtPlugin.options.jwt.definePayload(session)
+											: {};
+										return {
+											...basePayload,
+											...payload,
+										};
+									},
 								},
 							},
 						);
@@ -1410,9 +1419,10 @@ export const oidcProvider = (options: OIDCOptions) => {
 							clientId: clientId,
 							clientSecret: storedClientSecret,
 							redirectUrls: body.redirect_uris.join(","),
-							type: "web",
+							type:
+								body.token_endpoint_auth_method === "none" ? "public" : "web",
 							authenticationScheme:
-								body.token_endpoint_auth_method || "client_secret_basic",
+								body.token_endpoint_auth_method ?? "client_secret_basic",
 							disabled: false,
 							userId: session?.session.userId,
 							createdAt: new Date(),
@@ -1434,7 +1444,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 							client_secret_expires_at: 0, // 0 means it doesn't expire
 							redirect_uris: body.redirect_uris,
 							token_endpoint_auth_method:
-								body.token_endpoint_auth_method || "client_secret_basic",
+								body.token_endpoint_auth_method ?? "client_secret_basic",
 							grant_types: body.grant_types || ["authorization_code"],
 							response_types: body.response_types || ["code"],
 							client_name: body.client_name,

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -169,7 +169,7 @@ describe("oidc", async () => {
 		if (createdClient.data) {
 			application = {
 				clientId: createdClient.data.client_id,
-				clientSecret: createdClient.data.client_secret,
+				clientSecret: createdClient.data.client_secret ?? undefined,
 				redirectUrls: createdClient.data.redirect_uris,
 				metadata: {},
 				icon: createdClient.data.logo_uri,
@@ -1130,7 +1130,7 @@ describe("oidc storage", async () => {
 		if (createdClient.data) {
 			application = {
 				clientId: createdClient.data.client_id,
-				clientSecret: createdClient.data.client_secret,
+				clientSecret: createdClient.data.client_secret ?? undefined,
 				redirectUrls: createdClient.data.redirect_uris,
 				metadata: {},
 				icon: createdClient.data.logo_uri || "",
@@ -1274,7 +1274,7 @@ describe("oidc token response format", async () => {
 							{
 								providerId: "test",
 								clientId: application.clientId,
-								clientSecret: application.clientSecret,
+								clientSecret: application.clientSecret || "",
 								authorizationUrl:
 									"http://localhost:3000/api/auth/oauth2/authorize",
 								tokenUrl: "http://localhost:3000/api/auth/oauth2/token",
@@ -1509,7 +1509,7 @@ describe("oidc-jwt", async () => {
 		if (createdClient.data) {
 			application = {
 				clientId: createdClient.data.client_id,
-				clientSecret: createdClient.data.client_secret,
+				clientSecret: createdClient.data.client_secret ?? undefined,
 				redirectUrls: createdClient.data.redirect_uris,
 				metadata: {},
 				icon: createdClient.data.logo_uri || "",
@@ -1695,6 +1695,9 @@ describe("oidc public client registration", async () => {
 		await server.close();
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/8625
+	 */
 	it("should register public client when token_endpoint_auth_method is none", async ({
 		expect,
 	}) => {
@@ -1715,6 +1718,9 @@ describe("oidc public client registration", async () => {
 		expect(res.data).not.toHaveProperty("client_secret_expires_at");
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/8625
+	 */
 	it("should preserve token_endpoint_auth_method none (not falsy-replace)", async ({
 		expect,
 	}) => {
@@ -1725,5 +1731,361 @@ describe("oidc public client registration", async () => {
 		});
 		// "none" should not be replaced by "client_secret_basic"
 		expect(res.data?.token_endpoint_auth_method).toBe("none");
+	});
+});
+
+describe("oidc public client token exchange", async () => {
+	let server: Listener | null = null;
+
+	afterEach(async () => {
+		if (server) {
+			await server.close();
+			server = null;
+		}
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/8625
+	 */
+	it("should complete full OIDC flow with public client using JWT plugin", async ({
+		expect,
+	}) => {
+		const {
+			auth: authorizationServer,
+			signInWithTestUser,
+			customFetchImpl,
+			testUser,
+		} = await getTestInstance({
+			baseURL: "http://localhost:3000",
+			plugins: [
+				oidcProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					requirePKCE: true,
+					allowDynamicClientRegistration: true,
+					useJWTPlugin: true,
+				}),
+				jwt(),
+			],
+		});
+		const { headers } = await signInWithTestUser();
+		const serverClient = createAuthClient({
+			plugins: [oidcClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				headers,
+			},
+		});
+		server = await listen(toNodeHandler(authorizationServer.handler), {
+			port: 3000,
+		});
+
+		// Register a public client
+		const createdClient = await serverClient.oauth2.register({
+			client_name: "public-test-app",
+			redirect_uris: ["http://localhost:3000/api/auth/oauth2/callback/test"],
+			token_endpoint_auth_method: "none",
+			grant_types: ["authorization_code"],
+			response_types: ["code"],
+		});
+		expect(createdClient.data).toBeDefined();
+		expect(createdClient.data).not.toHaveProperty("client_secret");
+		const publicClientId = createdClient.data!.client_id;
+
+		// The RP (Relying Party) - the client application using PKCE (no client_secret)
+		const { customFetchImpl: customFetchImplRP, cookieSetter } =
+			await getTestInstance({
+				account: {
+					accountLinking: {
+						trustedProviders: ["test"],
+					},
+				},
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "test",
+								clientId: publicClientId,
+								clientSecret: "", // Public client has no secret
+								authorizationUrl:
+									"http://localhost:3000/api/auth/oauth2/authorize",
+								tokenUrl: "http://localhost:3000/api/auth/oauth2/token",
+								scopes: ["openid", "profile", "email"],
+								pkce: true,
+							},
+						],
+					}),
+				],
+			});
+
+		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:5000",
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+		const oAuthHeaders = new Headers();
+		const data = await client.signIn.oauth2(
+			{
+				providerId: "test",
+				callbackURL: "/dashboard",
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(oAuthHeaders),
+			},
+		);
+		expect(data.url).toContain(
+			"http://localhost:3000/api/auth/oauth2/authorize",
+		);
+		expect(data.url).toContain(`client_id=${publicClientId}`);
+
+		let redirectURI = "";
+		const consentHeaders = new Headers();
+		await serverClient.$fetch(data.url, {
+			method: "GET",
+			onError(context) {
+				redirectURI = context.response.headers.get("Location") || "";
+				cookieSetter(consentHeaders)(context);
+			},
+		});
+
+		// Handle consent flow if required
+		redirectURI = await handleConsentFlow(
+			redirectURI,
+			serverClient,
+			headers,
+			consentHeaders,
+		);
+		expect(redirectURI).toContain(
+			"http://localhost:3000/api/auth/oauth2/callback/test?code=",
+		);
+
+		let authToken = undefined;
+		let callbackURL = "";
+		await client.$fetch(redirectURI, {
+			headers: oAuthHeaders,
+			onError(context) {
+				callbackURL = context.response.headers.get("Location") || "";
+				authToken = context.response.headers.get("set-auth-token")!;
+			},
+		});
+		expect(callbackURL).toContain("/dashboard");
+		const accessToken = await client.getAccessToken(
+			{ providerId: "test", userId: testUser.id },
+			{
+				auth: {
+					type: "Bearer",
+					token: authToken,
+				},
+			},
+		);
+
+		// Verify the ID token is signed with EdDSA (asymmetric, via JWT plugin)
+		const decoded = decodeProtectedHeader(accessToken.data?.idToken!);
+		expect(decoded.alg).toBe("EdDSA");
+
+		// Verify signature using JWKS
+		const jwks = await authorizationServer.api.getJwks();
+		const jwkSet = createLocalJWKSet(jwks);
+		const checkSignature = await jwtVerify(accessToken.data?.idToken!, jwkSet);
+		expect(checkSignature).toBeDefined();
+
+		// Verify standard OIDC claims
+		expect(checkSignature.payload.sub).toBeDefined();
+		expect(checkSignature.payload.aud).toBe(publicClientId);
+		expect(Number.isInteger(checkSignature.payload.iat)).toBeTruthy();
+		expect(Number.isInteger(checkSignature.payload.exp)).toBeTruthy();
+		expect(checkSignature.payload.scope).toBeDefined();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/8625
+	 */
+	it("should reject public client token exchange without JWT plugin", async ({
+		expect,
+	}) => {
+		const {
+			auth: authorizationServer,
+			signInWithTestUser,
+			customFetchImpl,
+		} = await getTestInstance({
+			baseURL: "http://localhost:3000",
+			plugins: [
+				oidcProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					requirePKCE: true,
+					allowDynamicClientRegistration: true,
+					// useJWTPlugin is false by default - HS256 can't work for public clients
+				}),
+			],
+		});
+		const { headers } = await signInWithTestUser();
+		const serverClient = createAuthClient({
+			plugins: [oidcClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				headers,
+			},
+		});
+		server = await listen(toNodeHandler(authorizationServer.handler), {
+			port: 3000,
+		});
+
+		// Register a public client
+		const createdClient = await serverClient.oauth2.register({
+			client_name: "public-no-jwt",
+			redirect_uris: ["http://localhost:3000/api/auth/oauth2/callback/test"],
+			token_endpoint_auth_method: "none",
+			grant_types: ["authorization_code"],
+			response_types: ["code"],
+		});
+		expect(createdClient.data).toBeDefined();
+		expect(createdClient.data).not.toHaveProperty("client_secret");
+
+		const publicClientId = createdClient.data!.client_id;
+
+		// The RP - public client with PKCE
+		const { customFetchImpl: customFetchImplRP, cookieSetter } =
+			await getTestInstance({
+				account: {
+					accountLinking: {
+						trustedProviders: ["test"],
+					},
+				},
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "test",
+								clientId: publicClientId,
+								clientSecret: "",
+								authorizationUrl:
+									"http://localhost:3000/api/auth/oauth2/authorize",
+								tokenUrl: "http://localhost:3000/api/auth/oauth2/token",
+								scopes: ["openid", "profile", "email"],
+								pkce: true,
+							},
+						],
+					}),
+				],
+			});
+
+		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:5000",
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+		const oAuthHeaders = new Headers();
+		const data = await client.signIn.oauth2(
+			{
+				providerId: "test",
+				callbackURL: "/dashboard",
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(oAuthHeaders),
+			},
+		);
+
+		let redirectURI = "";
+		const consentHeaders = new Headers();
+		await serverClient.$fetch(data.url, {
+			method: "GET",
+			onError(context) {
+				redirectURI = context.response.headers.get("Location") || "";
+				cookieSetter(consentHeaders)(context);
+			},
+		});
+
+		// Handle consent flow if required
+		redirectURI = await handleConsentFlow(
+			redirectURI,
+			serverClient,
+			headers,
+			consentHeaders,
+		);
+
+		// The token exchange should fail because public client + HS256 is not supported
+		let callbackURL = "";
+		await client.$fetch(redirectURI, {
+			headers: oAuthHeaders,
+			onError(context) {
+				callbackURL = context.response.headers.get("Location") || "";
+			},
+		});
+		// The callback should fail - no dashboard redirect since token exchange errors
+		expect(callbackURL).not.toContain("/dashboard");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/8625
+	 */
+	it("should require code_verifier for public client token exchange", async ({
+		expect,
+	}) => {
+		const {
+			auth: authorizationServer,
+			customFetchImpl,
+			signInWithTestUser,
+		} = await getTestInstance({
+			baseURL: "http://localhost:3000",
+			plugins: [
+				oidcProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					requirePKCE: true,
+					allowDynamicClientRegistration: true,
+					useJWTPlugin: true,
+				}),
+				jwt(),
+			],
+		});
+		const { headers } = await signInWithTestUser();
+		const serverClient = createAuthClient({
+			plugins: [oidcClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				headers,
+			},
+		});
+		server = await listen(toNodeHandler(authorizationServer.handler), {
+			port: 3000,
+		});
+
+		// Register a public client
+		const createdClient = await serverClient.oauth2.register({
+			client_name: "public-pkce-test",
+			redirect_uris: ["http://localhost:3000/callback"],
+			token_endpoint_auth_method: "none",
+			grant_types: ["authorization_code"],
+		});
+		expect(createdClient.data).toBeDefined();
+
+		// Attempt token exchange without code_verifier should fail
+		const tokenRes = await authorizationServer.handler(
+			new Request("http://localhost:3000/api/auth/oauth2/token", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					grant_type: "authorization_code",
+					code: "invalid-code",
+					redirect_uri: "http://localhost:3000/callback",
+					client_id: createdClient.data!.client_id,
+					// No code_verifier - should be rejected for public clients
+				}).toString(),
+			}),
+		);
+		// Should fail - either because the code is invalid or because code_verifier is missing
+		expect(tokenRes.ok).toBe(false);
 	});
 });

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -1655,3 +1655,74 @@ describe("oidc-jwt", async () => {
 		expect(decoded.alg).toBe(expected);
 	});
 });
+
+describe("oidc public client registration", async () => {
+	const {
+		auth: authorizationServer,
+		signInWithTestUser,
+		customFetchImpl,
+	} = await getTestInstance({
+		baseURL: "http://localhost:3000",
+		plugins: [
+			oidcProvider({
+				loginPage: "/login",
+				consentPage: "/oauth2/authorize",
+				requirePKCE: true,
+				allowDynamicClientRegistration: true,
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const serverClient = createAuthClient({
+		plugins: [oidcClient()],
+		baseURL: "http://localhost:3000",
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let server: Listener;
+
+	beforeAll(async () => {
+		server = await listen(toNodeHandler(authorizationServer.handler), {
+			port: 3000,
+		});
+	});
+
+	afterAll(async () => {
+		await server.close();
+	});
+
+	it("should register public client when token_endpoint_auth_method is none", async ({
+		expect,
+	}) => {
+		const res = await serverClient.oauth2.register({
+			client_name: "mcp-public-client",
+			redirect_uris: ["http://localhost:3000/callback"],
+			token_endpoint_auth_method: "none",
+			grant_types: ["authorization_code"],
+		});
+		expect(res.data).toMatchObject({
+			client_id: expect.any(String),
+			client_name: "mcp-public-client",
+			token_endpoint_auth_method: "none",
+		});
+		// Public clients should not receive client_secret
+		// (they only get one if type !== "public", see registration response)
+		expect(res.data?.client_id).toBeDefined();
+	});
+
+	it("should preserve token_endpoint_auth_method none (not falsy-replace)", async ({
+		expect,
+	}) => {
+		const res = await serverClient.oauth2.register({
+			client_name: "mcp-none-check",
+			redirect_uris: ["http://localhost:3000/callback"],
+			token_endpoint_auth_method: "none",
+		});
+		// "none" should not be replaced by "client_secret_basic"
+		expect(res.data?.token_endpoint_auth_method).toBe("none");
+	});
+});

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -1709,9 +1709,10 @@ describe("oidc public client registration", async () => {
 			client_name: "mcp-public-client",
 			token_endpoint_auth_method: "none",
 		});
-		// Public clients should not receive client_secret
-		// (they only get one if type !== "public", see registration response)
+		// Public clients should not receive client_secret or client_secret_expires_at
 		expect(res.data?.client_id).toBeDefined();
+		expect(res.data).not.toHaveProperty("client_secret");
+		expect(res.data).not.toHaveProperty("client_secret_expires_at");
 	});
 
 	it("should preserve token_endpoint_auth_method none (not falsy-replace)", async ({

--- a/test/unit/oidc/scope-consent.spec.ts
+++ b/test/unit/oidc/scope-consent.spec.ts
@@ -115,7 +115,7 @@ describe("oidc scope consent", async () => {
 		const config = await client.discovery(
 			new URL(`${url}/api/auth/.well-known/openid-configuration`),
 			clientReg.client_id,
-			clientReg.client_secret,
+			clientReg.client_secret ?? undefined,
 		);
 
 		// 4. Initial request with base scopes


### PR DESCRIPTION
fixes three issues preventing MCP/public clients (`token_endpoint_auth_method: "none"`) from completing OAuth:

- hardcoded `type: "web"` → now `"public"` when auth method is `"none"`
- `||` treats `"none"` as falsy → replaced with `??`
- `definePayload` override loses JWT plugin claims → now merges with base payload, adds `scope`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables full OIDC dynamic registration and token flows for public clients. Supports `token_endpoint_auth_method: "none"`, requires ID token signing via the `jwt` plugin when `openid` is requested, and enforces client auth on refresh tokens.

- **Bug Fixes**
  - Public registration: set type "public" when auth method is "none", preserve "none" via `??`, skip generating/storing `client_secret`, and omit secret fields (incl. `client_secret_expires_at`) in responses. OpenAPI: `type` enum adds "public", `authenticationScheme` enum lists "client_secret_basic" | "client_secret_post" | "none", `clientSecret` is nullable and not required.
  - ID token: merge the `jwt` plugin’s base payload in `definePayload`, add `scope`. Require the `jwt` plugin for public clients only when `openid` is requested; reject HS256 for them. Allow access-token-only exchanges without the `jwt` plugin when no `openid` scope.
  - Refresh tokens: validate client and reject disabled/unknown. Confidential clients must present a valid `client_secret` (verified against stored secret).

<sup>Written for commit 76667c18e0108a96c333a7f7141db7d674c787c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

