### PR TITLE
fix: make custom redirectURI work in oauth flow

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2212,4 +2212,44 @@ describe("oauth2", async () => {
 			expect(callbackURL).toBe("http://localhost:3000/new_user");
 		});
 	});
+
+	it("should use custom redirectURI when configured", async () => {
+		const customRedirectURI = "https://custom.example.com/auth/callback";
+		const { customFetchImpl: fetchImpl, cookieSetter: setter } =
+			await getTestInstance({
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "custom-redirect",
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId,
+								clientSecret,
+								redirectURI: customRedirectURI,
+							},
+						],
+					}),
+				],
+			});
+
+		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl: fetchImpl,
+			},
+		});
+
+		const headers = new Headers();
+		const signInRes = await client.signIn.oauth2({
+			providerId: "custom-redirect",
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: {
+				onSuccess: setter(headers),
+			},
+		});
+
+		const authUrl = new URL(signInRes.data?.url || "");
+		expect(authUrl.searchParams.get("redirect_uri")).toBe(customRedirectURI);
+	});
 });

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -120,7 +120,9 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							state: data.state,
 							codeVerifier: c.pkce ? data.codeVerifier : undefined,
 							scopes: c.scopes || [],
-							redirectURI: `${ctx.baseURL}/oauth2/callback/${c.providerId}`,
+							redirectURI:
+								c.redirectURI ||
+								`${ctx.baseURL}/oauth2/callback/${c.providerId}`,
 						});
 					},
 					async validateAuthorizationCode(data: {

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -195,7 +195,8 @@ export const signInWithOAuth2 = (options: GenericOAuthOptions) =>
 				scopes: ctx.body.scopes
 					? [...ctx.body.scopes, ...(scopes || [])]
 					: scopes || [],
-				redirectURI: `${ctx.context.baseURL}/oauth2/callback/${providerId}`,
+				redirectURI:
+					redirectURI || `${ctx.context.baseURL}/oauth2/callback/${providerId}`,
 				prompt,
 				accessType,
 				responseType,
@@ -373,7 +374,9 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 				if (providerConfig.getToken) {
 					tokens = await providerConfig.getToken({
 						code,
-						redirectURI: `${ctx.context.baseURL}/oauth2/callback/${providerConfig.providerId}`,
+						redirectURI:
+							providerConfig.redirectURI ||
+							`${ctx.context.baseURL}/oauth2/callback/${providerConfig.providerId}`,
 						codeVerifier: providerConfig.pkce ? codeVerifier : undefined,
 					});
 				} else {
@@ -392,7 +395,9 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 						headers: providerConfig.authorizationHeaders,
 						code,
 						codeVerifier: providerConfig.pkce ? codeVerifier : undefined,
-						redirectURI: `${ctx.context.baseURL}/oauth2/callback/${providerConfig.providerId}`,
+						redirectURI:
+							providerConfig.redirectURI ||
+							`${ctx.context.baseURL}/oauth2/callback/${providerConfig.providerId}`,
 						options: {
 							clientId: providerConfig.clientId,
 							clientSecret: providerConfig.clientSecret,


### PR DESCRIPTION
I know that #8033 has already been closed, but the bug still persists.
These changes fix the issue. It is now possible to pass the redirectURI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the generic OAuth flow to honor a custom `redirectURI` from the provider config across the sign-in and callback steps. Adds a test that verifies the custom value is used.

- **Bug Fixes**
  - Use provider `redirectURI` when building the auth URL, in `signInWithOAuth2`, and during callback token exchange; fallback to `${baseURL}/oauth2/callback/:providerId` when not provided.

<sup>Written for commit 3991b86456567262fa83c9150302fce5e42c0ebe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

