### PR TITLE
feat(oauth-provider): auth_session passthrough for first-party app step-up

### DIFF
--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -7,6 +7,7 @@ import {
 	createAuthorizationCodeRequest,
 	createAuthorizationURL,
 	createRefreshAccessTokenRequest,
+	generateCodeChallenge,
 } from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
@@ -14,8 +15,9 @@ import { createLocalJWKSet, decodeJwt, jwtVerify } from "jose";
 import { beforeAll, describe, expect, it } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
-import type { OAuthOptions, Scope } from "./types";
+import type { OAuthOptions, Scope, VerificationValue } from "./types";
 import type { OAuthClient } from "./types/oauth";
+import { storeToken } from "./utils";
 
 type MakeRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
@@ -1805,5 +1807,180 @@ describe("oauth token - client secret validation", async () => {
 			},
 		);
 		expect(responseStatus).toBe(500);
+	});
+});
+
+describe("auth_session passthrough", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const { auth, signInWithTestUser, customFetchImpl, testUser } =
+		await getTestInstance({
+			baseURL: authServerBaseUrl,
+			plugins: [
+				jwt({
+					jwt: {
+						issuer: authServerBaseUrl,
+					},
+				}),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient(), jwtClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const state = "passthrough-state";
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		oauthClient = response;
+	});
+
+	it("should not include auth_session in normal token response", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const codeVerifier = generateRandomString(32);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes: ["openid"],
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		const url = new URL(callbackRedirectUrl);
+		const code = url.searchParams.get("code")!;
+
+		const { body, headers: tokenHeaders } = createAuthorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			auth_session?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.auth_session).toBeUndefined();
+	});
+
+	it("should include auth_session when verification value has authSession", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const ctx = await auth.$context;
+		const dbUser = await ctx.internalAdapter.findUserByEmail(testUser.email);
+		if (!dbUser) throw Error("test user not found");
+
+		const sessions = await ctx.adapter.findMany<{ id: string }>({
+			model: "session",
+			where: [{ field: "userId", value: dbUser.user.id }],
+			limit: 1,
+		});
+		if (!sessions.length) throw Error("test session not found");
+
+		const code = generateRandomString(32, "a-z", "A-Z", "0-9");
+		const codeVerifier = generateRandomString(32);
+		const codeChallenge = await generateCodeChallenge(codeVerifier);
+		const authTimeMs = Date.now();
+		const expectedAuthSession = "fpa-session-abc123";
+
+		const verificationValue: VerificationValue = {
+			type: "authorization_code",
+			query: {
+				response_type: "code",
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				scope: "openid",
+				state,
+				code_challenge: codeChallenge,
+				code_challenge_method: "S256",
+			},
+			userId: dbUser.user.id,
+			sessionId: sessions[0].id,
+			authTime: authTimeMs,
+			authSession: expectedAuthSession,
+		};
+
+		await ctx.internalAdapter.createVerificationValue({
+			identifier: await storeToken("hashed", code, "authorization_code"),
+			expiresAt: new Date(authTimeMs + 600_000),
+			value: JSON.stringify(verificationValue),
+		});
+
+		const { body, headers: tokenHeaders } = createAuthorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			auth_session?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.auth_session).toBe(expectedAuthSession);
 	});
 });

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -375,6 +375,9 @@ async function createUserTokens(
 		refreshToken?: OAuthRefreshToken<Scope[]> & { id: string };
 	},
 	authTime?: Date,
+	extra?: {
+		tokenResponse?: Record<string, unknown>;
+	},
 ) {
 	const iat = Math.floor(Date.now() / 1000);
 	const defaultExp = iat + (opts.accessTokenExpiresIn ?? 3600);
@@ -484,6 +487,7 @@ async function createUserTokens(
 
 	return ctx.json(
 		{
+			...extra?.tokenResponse,
 			access_token: accessToken,
 			expires_in: exp - iat,
 			expires_at: exp,
@@ -762,6 +766,10 @@ async function handleAuthorizationCodeGrant(
 			? new Date(verificationValue.authTime)
 			: new Date(session.createdAt);
 
+	const extra = verificationValue.authSession
+		? { tokenResponse: { auth_session: verificationValue.authSession } }
+		: undefined;
+
 	return createUserTokens(
 		ctx,
 		opts,
@@ -773,6 +781,7 @@ async function handleAuthorizationCodeGrant(
 		verificationValue.query?.nonce,
 		undefined,
 		authTime,
+		extra,
 	);
 }
 

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -803,6 +803,12 @@ export interface VerificationValue {
 	userId: string;
 	referenceId?: string;
 	authTime?: number;
+	/**
+	 * When set, the token response will include `auth_session` for
+	 * first-party app step-up re-authentication. Only set this field
+	 * from trusted server-side code — never from client input.
+	 */
+	authSession?: string;
 }
 
 /**


### PR DESCRIPTION
## Context

This is a building block for `draft-ietf-oauth-first-party-apps` (Authorization Challenge Endpoint) support. It is not a complete FPA implementation; it adds one specific capability that the pattern requires.

## Problem

First-party apps (CLI tools, native apps by the same provider) use an Authorization Challenge Endpoint to authenticate without browser redirects. When a protected action requires step-up re-authentication (e.g., a CIBA token exchange fails `acr_values`), the client needs a reference to its existing auth session to re-authenticate via the challenge endpoint rather than starting a new session.

The authorization code can carry this session reference (set by the challenge endpoint when issuing the code), but the token endpoint currently discards it. There is no mechanism to pass opaque metadata from the authorization code through to the token response.

## Changes

- Add optional `authSession?: string` field to `VerificationValue` type (the authorization code payload)
- In `handleAuthorizationCodeGrant`, when `verificationValue.authSession` is set, inject `auth_session` into the token response body via the `extra.tokenResponse` mechanism

The challenge endpoint (not in this PR) sets `authSession` when creating the authorization code. The client receives it in the token response and uses it for subsequent challenge requests.

## References

- [draft-ietf-oauth-first-party-apps — Authorization Challenge Endpoint](https://datatracker.ietf.org/doc/draft-ietf-oauth-first-party-apps/)
- [RFC 9470 — OAuth 2.0 Step-Up Authentication Challenge Protocol](https://datatracker.ietf.org/doc/html/rfc9470)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `auth_session` passthrough in `oauth-provider` token responses to support first‑party app step‑up. When an auth code includes an `authSession` reference, the token response echoes it as `auth_session`.

- **New Features**
  - Types: add `authSession?: string` to `VerificationValue`.
  - Token: if `authSession` is present, include `auth_session` in the token response; otherwise unchanged. `createUserTokens` now accepts `extra.tokenResponse` to merge custom fields.
  - Tests: cover inclusion and omission of `auth_session` in token responses.

<sup>Written for commit 4f1a685a52a2ddd6c337e305650d5406ac72130c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

