### PR TITLE
feat(oauth-provider): plugin-extensible token endpoint

### DIFF
--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -461,6 +461,10 @@ By default, the token endpoint supports the following built-in grants:
 
 Plugins can register additional grant types (e.g., CIBA, token exchange) via the `customGrantTypeHandlers` context. Unknown fields in the token request body are passed through to plugin handlers.
 
+<Callout>
+Plugins that register custom grant types must also add their grant type string to the `grantTypes` allowlist during `init()`. The CIBA plugin does this automatically. If `grantTypes` is not configured (or set to `undefined`), all grant types are allowed through to dispatch.
+</Callout>
+
 #### Authorization code grant
 
 The authorization code grant enables clients to obtain access user access tokens and optionally refresh tokens (with the "offline_access" scope).

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -6,4 +6,5 @@ export {
 	oidcServerMetadata,
 } from "./metadata";
 export { getOAuthProviderState, oauthProvider } from "./oauth";
+export { type GrantTypeHandler, type TokenResponse } from "./token";
 export type * from "./types";

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1118,7 +1118,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							.default("client_secret_basic")
 							.optional(),
 						grant_types: z
-							.array(z.string())
+							.array(z.string().trim().min(1))
 							.default(["authorization_code"])
 							.optional(),
 						response_types: z

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -1807,3 +1807,128 @@ describe("oauth token - client secret validation", async () => {
 		expect(responseStatus).toBe(500);
 	});
 });
+
+describe("oauth token - custom grant types", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const MOCK_GRANT = "urn:test:mock-grant";
+
+	const mockPlugin = {
+		id: "mock-grant" as const,
+		init() {
+			return {
+				context: {
+					customGrantTypeHandlers: {
+						[MOCK_GRANT]: async () => ({
+							access_token: "mock-token",
+							token_type: "Bearer",
+							expires_in: 3600,
+							expires_at: Math.floor(Date.now() / 1000) + 3600,
+							scope: "openid",
+						}),
+					},
+				},
+			};
+		},
+	};
+
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({ jwt: { issuer: authServerBaseUrl } }),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				grantTypes: [
+					"authorization_code",
+					"client_credentials",
+					"refresh_token",
+					MOCK_GRANT,
+				],
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			mockPlugin,
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient(), jwtClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: { customFetchImpl, headers },
+	});
+
+	it("should dispatch to a custom grant handler", async ({ expect }) => {
+		const res = await client.$fetch<{
+			access_token?: string;
+			token_type?: string;
+			expires_in?: number;
+			scope?: string;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: new URLSearchParams({ grant_type: MOCK_GRANT }),
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+		});
+		expect(res.data?.access_token).toBe("mock-token");
+		expect(res.data?.token_type).toBe("Bearer");
+		expect(res.data?.expires_in).toBe(3600);
+		expect(res.data?.scope).toBe("openid");
+	});
+
+	it("should reject unknown grant type", async ({ expect }) => {
+		const res = await client.$fetch("/oauth2/token", {
+			method: "POST",
+			body: new URLSearchParams({
+				grant_type: "urn:test:nonexistent",
+			}),
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+		});
+		expect(res.error).toMatchObject({
+			error: "unsupported_grant_type",
+		});
+	});
+
+	it("should reject grant_type=toString (prototype safety)", async ({
+		expect,
+	}) => {
+		const res = await client.$fetch("/oauth2/token", {
+			method: "POST",
+			body: new URLSearchParams({ grant_type: "toString" }),
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+		});
+		expect(res.error).toMatchObject({
+			error: "unsupported_grant_type",
+		});
+	});
+
+	it("should reject grant_type=constructor (prototype safety)", async ({
+		expect,
+	}) => {
+		const res = await client.$fetch("/oauth2/token", {
+			method: "POST",
+			body: new URLSearchParams({ grant_type: "constructor" }),
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+		});
+		expect(res.error).toMatchObject({
+			error: "unsupported_grant_type",
+		});
+	});
+
+	it("should still handle built-in client_credentials grant", async ({
+		expect,
+	}) => {
+		const res = await client.$fetch("/oauth2/token", {
+			method: "POST",
+			body: new URLSearchParams({
+				grant_type: "client_credentials",
+				client_id: "test-client",
+				client_secret: "test-secret",
+			}),
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+		});
+		// Reaches client_credentials handler (may fail on invalid client, not unsupported_grant_type)
+		expect(res.error?.error).not.toBe("unsupported_grant_type");
+	});
+});

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -26,6 +26,25 @@ import {
 	validateClientCredentials,
 } from "./utils";
 
+export type TokenResponse = {
+	access_token: string;
+	expires_in: number;
+	expires_at: number;
+	token_type: string;
+	scope: string;
+	refresh_token?: string;
+	id_token?: string;
+	[key: string]: unknown;
+};
+
+/**
+ * Handler for a custom grant type registered by a plugin via `customGrantTypeHandlers`.
+ */
+export type GrantTypeHandler = (
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+) => Promise<TokenResponse>;
+
 /**
  * Handles the /oauth2/token endpoint by delegating
  * the grant types
@@ -33,7 +52,7 @@ import {
 export async function tokenEndpoint(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
-) {
+): Promise<TokenResponse> {
 	const grantType: string | undefined = ctx.body?.grant_type;
 
 	if (opts.grantTypes && grantType && !opts.grantTypes.includes(grantType)) {
@@ -56,19 +75,19 @@ export async function tokenEndpoint(
 				error: "unsupported_grant_type",
 			});
 		default: {
+			// Dispatch to custom grant type handlers registered by plugins.
+			// Guards: prototype chain, non-object handlers, non-function values.
 			const handlers = (ctx.context as Record<string, unknown>)
-				.customGrantTypeHandlers as
-				| Record<
-						string,
-						(
-							ctx: GenericEndpointContext,
-							opts: OAuthOptions<Scope[]>,
-						) => Promise<Response>
-				  >
-				| undefined;
-			const handler = handlers?.[grantType];
-			if (handler) {
-				return handler(ctx, opts);
+				.customGrantTypeHandlers;
+			if (
+				handlers != null &&
+				typeof handlers === "object" &&
+				Object.hasOwn(handlers as object, grantType)
+			) {
+				const handler = (handlers as Record<string, unknown>)[grantType];
+				if (typeof handler === "function") {
+					return (handler as GrantTypeHandler)(ctx, opts);
+				}
 			}
 			throw new APIError("BAD_REQUEST", {
 				error_description: `unsupported grant_type ${grantType}`,
@@ -389,7 +408,7 @@ async function createUserTokens(
 		refreshToken?: OAuthRefreshToken<Scope[]> & { id: string };
 	},
 	authTime?: Date,
-) {
+): Promise<TokenResponse> {
 	const iat = Math.floor(Date.now() / 1000);
 	const defaultExp = iat + (opts.accessTokenExpiresIn ?? 3600);
 	const exp = opts.scopeExpirations
@@ -496,23 +515,17 @@ async function createUserTokens(
 			: undefined,
 	]);
 
-	return ctx.json(
-		{
-			access_token: accessToken,
-			expires_in: exp - iat,
-			expires_at: exp,
-			token_type: "Bearer",
-			refresh_token: refreshToken?.token,
-			scope: scopes.join(" "),
-			id_token: idToken,
-		},
-		{
-			headers: {
-				"Cache-Control": "no-store",
-				Pragma: "no-cache",
-			},
-		},
-	);
+	ctx.setHeader("Cache-Control", "no-store");
+	ctx.setHeader("Pragma", "no-cache");
+	return {
+		access_token: accessToken,
+		expires_in: exp - iat,
+		expires_at: exp,
+		token_type: "Bearer",
+		refresh_token: refreshToken?.token,
+		scope: scopes.join(" "),
+		id_token: idToken,
+	};
 }
 
 /** Checks verification value */
@@ -799,7 +812,7 @@ async function handleAuthorizationCodeGrant(
 async function handleClientCredentialsGrant(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
-) {
+): Promise<TokenResponse> {
 	let {
 		client_id,
 		client_secret,
@@ -923,21 +936,15 @@ async function handleClientCredentialsGrant(
 					},
 				);
 
-	return ctx.json(
-		{
-			access_token: accessToken,
-			expires_in: exp - iat,
-			expires_at: exp,
-			token_type: "Bearer",
-			scope: requestedScopes.join(" "),
-		},
-		{
-			headers: {
-				"Cache-Control": "no-store",
-				Pragma: "no-cache",
-			},
-		},
-	);
+	ctx.setHeader("Cache-Control", "no-store");
+	ctx.setHeader("Pragma", "no-cache");
+	return {
+		access_token: accessToken,
+		expires_in: exp - iat,
+		expires_at: exp,
+		token_type: "Bearer",
+		scope: requestedScopes.join(" "),
+	} satisfies TokenResponse;
 }
 
 /**

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -8,7 +8,11 @@ import type { Prompt } from ".";
  * Built-in grants: "authorization_code", "client_credentials", "refresh_token".
  * Plugins register additional grant types via customGrantTypeHandlers.
  */
-export type GrantType = string;
+export type GrantType =
+	| "authorization_code"
+	| "client_credentials"
+	| "refresh_token"
+	| (string & {});
 
 export type AuthMethod =
 	| "client_secret_basic" // Basic header


### PR DESCRIPTION
## Problem

The token endpoint is the convergence point for every feature that touches the OAuth token flow. Grant dispatch, token creation, id_token creation, and grant-specific handlers all live in `token.ts`. When the endpoint lacks extension points, every plugin that adds a grant type must modify the same shared code. Features that are functionally independent (CIBA, token exchange, device authorization) become structurally coupled through edits to the same file and the same type definitions.

Two specific constraints enforce this coupling:

1. **Zod strips unknown fields.** The body schema uses `z.object({...})` which discards any field not declared in the schema. A plugin that needs `auth_req_id` (CIBA), `subject_token` (token exchange), or `client_assertion` (JWT auth) must add its field to the core schema, creating a dependency between the plugin and oauth-provider's source.

2. **`grant_type` is a closed enum.** `z.enum(["authorization_code", "client_credentials", "refresh_token"])` rejects any value outside the three built-in types before the handler runs. The switch statement's default case throws unconditionally. A plugin cannot register a custom grant type without modifying both the Zod schema and the switch statement in token.ts.

The `GrantType` TypeScript type reinforces this: it's a closed union, so code that checks `opts.grantTypes.includes(grantType)` requires a cast when the grant type is a plugin-defined string. OAuth 2.x grant types are extensible URIs by spec (RFC 6749 §8.5); the type system should reflect this rather than fight it.

## Changes

### Type layer

`GrantType` is now `type GrantType = string`. The alias preserves semantic meaning in signatures (`grantTypes?: GrantType[]` reads better than `grantTypes?: string[]`) without constraining the runtime set. No casts needed anywhere.

### Zod schema

- `grant_type` widened to `z.string().trim().min(1)`
- `.passthrough()` on the token endpoint body, so plugin-specific fields survive Zod parsing without being pre-declared in the core schema
- DCR `grant_types` widened to `z.array(z.string())` per RFC 7591 §2 (the spec defines this field as an array of grant type strings, not a closed set)

### Dispatch

The switch default case looks up `customGrantTypeHandlers` from the endpoint context before throwing `unsupported_grant_type`. Plugins register handlers via `init()`:

```ts
init(ctx) {
  return {
    context: {
      customGrantTypeHandlers: {
        [MY_GRANT_TYPE]: myHandler,
      },
    },
  };
}
```

With these three changes, a plugin that adds a grant type (CIBA, token exchange, device authorization) touches zero lines in oauth-provider. It registers its handler, declares its grant type string, and reads its own fields from the passthrough body.

### Docs

- Updated token endpoint section to mention plugin extensibility
- Updated `grantTypes` config description
- Fixed DCR OpenAPI description (was "Requested authentication method")

## References

- [RFC 6749 §8.5 — Defining New Grant Types](https://datatracker.ietf.org/doc/html/rfc6749#section-8.5)
- [RFC 7591 §2 — Client Metadata (`grant_types`)](https://datatracker.ietf.org/doc/html/rfc7591#section-2)
- [RFC 8693 — OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693)
- [CIBA Core §10 — Token Request](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.10)