### PR TITLE
fix(cli): warn when old @better-auth/cli is used with better-auth v1.5.x+

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module";
+import chalk from "chalk";
 import { Command } from "commander";
+import semver from "semver";
 import { generate } from "./commands/generate";
 import { info } from "./commands/info";
 import { init } from "./commands/init";
@@ -25,6 +28,28 @@ async function main() {
 	} catch {
 		// it doesn't matter if we can't read the package.json file, we'll just use an empty object
 	}
+
+	const cliVersion = packageInfo.version || "1.1.2";
+
+	try {
+		const _require = createRequire(process.cwd() + "/");
+		const betterAuthPkg = _require("better-auth/package.json");
+
+		if (betterAuthPkg.version && semver.gte(betterAuthPkg.version, "1.5.0")) {
+			console.warn(
+				chalk.yellow(
+					`\nWarning: You are using @better-auth/cli (v${cliVersion}) with better-auth v${betterAuthPkg.version}.\n` +
+						`The old CLI may produce unexpected results with better-auth v1.5.x or later.\n` +
+						`Please use the new CLI instead: `,
+				) +
+					chalk.cyan("npx auth@latest") +
+					"\n",
+			);
+		}
+	} catch {
+		// better-auth may not be installed yet — skip the check
+	}
+
 	program
 		.addCommand(init)
 		.addCommand(migrate)

--- a/packages/cli/test/version-warning.test.ts
+++ b/packages/cli/test/version-warning.test.ts
@@ -1,0 +1,81 @@
+import { exec } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cliPath } from "./utils";
+
+const execAsync = promisify(exec);
+
+let tmpDir: string;
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8622
+ */
+describe("version warning for better-auth v1.5.x+", () => {
+	beforeEach(async () => {
+		const tmp = path.join(
+			process.cwd(),
+			"node_modules",
+			".cache",
+			"version_warning_test-",
+		);
+		await fs.mkdir(path.dirname(tmp), { recursive: true });
+		tmpDir = await fs.mkdtemp(tmp);
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true });
+	});
+
+	async function setupBetterAuth(version: string) {
+		const pkgDir = path.join(tmpDir, "node_modules", "better-auth");
+		await fs.mkdir(pkgDir, { recursive: true });
+		await fs.writeFile(
+			path.join(pkgDir, "package.json"),
+			JSON.stringify({ name: "better-auth", version }),
+		);
+		// Create a minimal entry point so require.resolve works
+		await fs.writeFile(path.join(pkgDir, "index.js"), "");
+	}
+
+	it("should warn when better-auth >= 1.5.0 is installed", async () => {
+		await setupBetterAuth("1.5.0");
+
+		const { stderr } = await execAsync(`node ${cliPath} --help`, {
+			cwd: tmpDir,
+		});
+
+		expect(stderr).toContain("You are using @better-auth/cli");
+		expect(stderr).toContain("npx auth@latest");
+	});
+
+	it("should warn for better-auth 1.5.3", async () => {
+		await setupBetterAuth("1.5.3");
+
+		const { stderr } = await execAsync(`node ${cliPath} --help`, {
+			cwd: tmpDir,
+		});
+
+		expect(stderr).toContain("better-auth v1.5.3");
+		expect(stderr).toContain("npx auth@latest");
+	});
+
+	it("should not warn when better-auth < 1.5.0 is installed", async () => {
+		await setupBetterAuth("1.4.21");
+
+		const { stderr } = await execAsync(`node ${cliPath} --help`, {
+			cwd: tmpDir,
+		});
+
+		expect(stderr).not.toContain("npx auth@latest");
+	});
+
+	it("should not warn when better-auth is not installed", async () => {
+		const { stderr } = await execAsync(`node ${cliPath} --help`, {
+			cwd: tmpDir,
+		});
+
+		expect(stderr).not.toContain("npx auth@latest");
+	});
+});


### PR DESCRIPTION
## Summary

Closes #8622

- When the old `@better-auth/cli` detects `better-auth` >= 1.5.0 is installed, it prints a warning directing users to `npx auth@latest`
- Uses `createRequire` from the user's CWD to resolve `better-auth`'s `package.json` and `semver.gte` for version comparison
- Uses `chalk` for terminal colors (consistent with the rest of the CLI, respects `NO_COLOR`)
- Silently skips the check if `better-auth` is not installed yet

This is the correct target branch (`v1.4.x`) since the warning belongs in the **old** `@better-auth/cli` package, not the new `auth` CLI on `canary`.

See also: #8624 (same intent but incorrectly targets `canary`)

## Test plan

- [ ] Install `better-auth@1.5.0` in a test project, run `npx @better-auth/cli generate` — should see the yellow warning
- [ ] Install `better-auth@1.4.21` in a test project, run `npx @better-auth/cli generate` — should NOT see a warning
- [ ] Uninstall `better-auth` entirely, run `npx @better-auth/cli init` — should NOT see a warning (silent skip)