### PR TITLE
feat(captcha): add endpoint exclusions using `!` prefix

### DIFF
--- a/packages/better-auth/src/plugins/captcha/constants.ts
+++ b/packages/better-auth/src/plugins/captcha/constants.ts
@@ -3,6 +3,7 @@ import type { Provider } from "./types";
 export const defaultEndpoints = [
 	"/sign-up/email",
 	"/sign-in/email",
+	"!/sign-in/email-otp",
 	"/request-password-reset",
 ];
 

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -35,11 +35,11 @@ export const captcha = (options: CaptchaOptions) =>
 				const pathname = new URL(request.url).pathname;
 
 				const isIncluded = includeEndpoints.some((endpoint) =>
-					pathname.url.includes(endpoint),
+					pathname.includes(endpoint),
 				);
 
 				const isExcluded = excludeEndpoints.some((endpoint) =>
-					pathname.url.includes(endpoint),
+					pathname.includes(endpoint),
 				);
 
 				if (isExcluded || !isIncluded) {

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -32,12 +32,14 @@ export const captcha = (options: CaptchaOptions) =>
 					.filter((e) => e.startsWith("!"))
 					.map((e) => e.slice(1));
 
+				const pathname = new URL(request.url).pathname;
+
 				const isIncluded = includeEndpoints.some((endpoint) =>
-					request.url.includes(endpoint),
+					pathname.url.includes(endpoint),
 				);
 
 				const isExcluded = excludeEndpoints.some((endpoint) =>
-					request.url.includes(endpoint),
+					pathname.url.includes(endpoint),
 				);
 
 				if (isExcluded || !isIncluded) {

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -27,8 +27,22 @@ export const captcha = (options: CaptchaOptions) =>
 					? options.endpoints
 					: defaultEndpoints;
 
-				if (!endpoints.some((endpoint) => request.url.includes(endpoint)))
+				const includeEndpoints = endpoints.filter((e) => !e.startsWith("!"));
+				const excludeEndpoints = endpoints
+					.filter((e) => e.startsWith("!"))
+					.map((e) => e.slice(1));
+
+				const isIncluded = includeEndpoints.some((endpoint) =>
+					request.url.includes(endpoint)
+				);
+
+				const isExcluded = excludeEndpoints.some((endpoint) =>
+					request.url.includes(endpoint)
+				);
+
+				if (isExcluded || !isIncluded) {
 					return undefined;
+				}
 
 				if (!options.secretKey) {
 					throw new Error(INTERNAL_ERROR_CODES.MISSING_SECRET_KEY.message);

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -33,11 +33,11 @@ export const captcha = (options: CaptchaOptions) =>
 					.map((e) => e.slice(1));
 
 				const isIncluded = includeEndpoints.some((endpoint) =>
-					request.url.includes(endpoint)
+					request.url.includes(endpoint),
 				);
 
 				const isExcluded = excludeEndpoints.some((endpoint) =>
-					request.url.includes(endpoint)
+					request.url.includes(endpoint),
 				);
 
 				if (isExcluded || !isIncluded) {


### PR DESCRIPTION
Endpoints starting with `!` are treated as exclusions when matching captcha-protected routes.

This fixes an issue when the EmailOTP plugin and Captcha plugins are enabled at the same time.

Example:

```ts
endpoints: [
  "/sign-up/email",
  "/sign-in/email",
  "!/sign-in/email-otp"
]
```

Also updates the defaultEndpoints to exclude `/sign-in/email-otp` out of the box.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `!`-prefixed endpoint exclusions for captcha and default-skip `/sign-in/email-otp` to prevent captcha on Email OTP routes and avoid EmailOTP/Captcha conflicts. Endpoint matching now uses the request `pathname` to ignore query strings.

- **Bug Fixes**
  - Removed incorrect `.url` property usage to fix type errors; matching stays on `new URL(request.url).pathname`.

<sup>Written for commit 7ee42d8c2cbb22606d135f8091acce6a48a7e132. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

