### PR TITLE
docs: fix import order in `organization.mdx`

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -647,9 +647,9 @@ type setActiveOrganization = {
 To automatically set an active organization when a session is created, you can use [database hooks](/docs/concepts/database#database-hooks). You'll need to implement logic to determine which organization to set as the initial active organization.
 
 ```ts title="auth.ts"
-export const auth = betterAuth({
-  import { betterAuth } from "better-auth";
+import { betterAuth } from "better-auth";
 
+export const auth = betterAuth({
   databaseHooks: {
     session: {
       create: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the code sample in `organization.mdx` by importing `betterAuth` from `better-auth` before using it. This makes the snippet compile and avoids confusion for readers.

<sup>Written for commit abb011b94489a86ba7020ee10e246cffbc4452b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

