### PR TITLE
fix: set stateless cookieCache maxAge to match session expiresIn

### DIFF
--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -102,6 +102,8 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 					enabled: true,
 					strategy: "jwe" as const,
 					refreshCache: true,
+					// match session expiresIn, default 7 days
+					maxAge: options.session?.expiresIn || 60 * 60 * 24 * 7,
 				},
 			},
 			account: {


### PR DESCRIPTION
## Summary

- When no database is provided, Better Auth auto-configures stateless mode with `cookieCache` enabled and `refreshCache: true`. However, `maxAge` was not being set, so it defaulted to 5 minutes (`60 * 5`). This caused users in stateless mode to get logged out after 5 minutes instead of the documented 7 days.
- Now `maxAge` defaults to `session.expiresIn` (7 days by default), matching the documented behavior.

Fixes #8638

## Test plan

- [ ] Verify that in stateless mode (no database), the `cookieCache.maxAge` defaults to 7 days (604800 seconds)
- [ ] Verify that if `session.expiresIn` is explicitly set, `maxAge` uses that value instead
- [ ] Verify that stateful mode (with database) is unaffected by this change