### PR TITLE
fix(sso): read SAML InResponseTo from correct path

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -2173,9 +2173,8 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 				logger: ctx.context.logger,
 			});
 
-			const inResponseTo = (extract as SAMLAssertionExtract).inResponseTo as
-				| string
-				| undefined;
+			const inResponseTo = (extract as SAMLAssertionExtract).response
+				?.inResponseTo;
 			const shouldValidateInResponseTo =
 				options?.saml?.enableInResponseToValidation;
 
@@ -2689,9 +2688,8 @@ export const acsEndpoint = (options?: SSOOptions) => {
 				logger: ctx.context.logger,
 			});
 
-			const inResponseToAcs = (extract as SAMLAssertionExtract).inResponseTo as
-				| string
-				| undefined;
+			const inResponseToAcs = (extract as SAMLAssertionExtract).response
+				?.inResponseTo;
 			const shouldValidateInResponseToAcs =
 				options?.saml?.enableInResponseToValidation;
 

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -99,10 +99,12 @@ export interface SAMLSessionRecord {
 export interface SAMLAssertionExtract {
 	nameID?: string;
 	sessionIndex?: string;
-	inResponseTo?: string;
 	conditions?: {
 		notBefore?: string;
 		notOnOrAfter?: string;
+	};
+	response?: {
+		inResponseTo?: string;
 	};
 }
 


### PR DESCRIPTION
## Summary
- Fix SAML InResponseTo validation that always fails when `enableInResponseToValidation` is enabled
- `samlify`'s extractor nests `InResponseTo` under `extract.response`, but the two login handlers read `extract.inResponseTo` (always `undefined`)
- The logout handler already used the correct path `extract?.response?.inResponseTo`

Closes #8607
Closes #8608

## Test plan
- Enable `enableInResponseToValidation` with `allowIdpInitiated: false`
- Initiate SP-initiated SAML login — should now succeed instead of being rejected