### PR TITLE
fix(oauth-provider): handle dynamic baseURL config in init

### DIFF
--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -85,6 +85,50 @@ describe("oauth - init", () => {
 			}),
 		).resolves.not.toThrowError();
 	});
+
+	it("should pass with dynamic baseURL config when ctx.baseURL is unresolved during init", async () => {
+		await expect(
+			getTestInstance({
+				baseURL: {
+					allowedHosts: ["localhost:3000"],
+					protocol: "http",
+				},
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).resolves.not.toThrowError();
+	});
+
+	it("should still fail for an invalid configured jwt issuer", async () => {
+		await expect(
+			getTestInstance({
+				plugins: [
+					jwt({
+						jwt: {
+							issuer: "not-a-valid-url",
+						},
+					}),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).rejects.toThrowError("Invalid URL");
+	});
 });
 
 describe("oauth", async () => {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -177,12 +177,20 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 
 				// Issuer and well-known endpoint checks
 				const issuer = jwtPluginOptions?.jwt?.issuer ?? ctx.baseURL;
+				const isDynamicBaseURLInit =
+					jwtPluginOptions?.jwt?.issuer == null &&
+					typeof ctx.options.baseURL === "object" &&
+					ctx.options.baseURL !== null &&
+					"allowedHosts" in ctx.options.baseURL;
 				let issuerPath: string;
 				try {
 					issuerPath = new URL(issuer).pathname;
-				} catch {
+				} catch (error) {
 					// baseURL may not be available during init when using dynamic baseURL config
-					return;
+					if (isDynamicBaseURLInit && issuer === "") {
+						return;
+					}
+					throw error;
 				}
 				// oAuth Server Config
 				if (


### PR DESCRIPTION
## Summary
- The oauth-provider plugin's `init()` crashes with `TypeError: Invalid URL` when `baseURL` uses the object format `{ allowedHosts, protocol }`
- `ctx.baseURL` is an empty string during initialization (it's only resolved per-request for dynamic configs)
- Now gracefully skips init warnings when the URL can't be parsed

Closes #8559

## Test plan
- Configure `baseURL` with object format `{ allowedHosts, protocol }` alongside `oauthProvider` plugin
- Run `npx auth generate` — should no longer crash with `TypeError: Invalid URL`