### PR TITLE
docs: note that Context7 MCP endpoint requires API key

### DIFF
--- a/docs/content/docs/introduction.mdx
+++ b/docs/content/docs/introduction.mdx
@@ -33,6 +33,10 @@ npx skills add better-auth/skills
 
 Better Auth provides an MCP server so you can use it with any AI model that supports the Model Context Protocol (MCP).
 
+<Callout>
+  Context7 MCP endpoints require an API key — see [Context7's docs](https://context7.com/docs/resources/all-clients) for how to configure credentials.
+</Callout>
+
 <AddToCursor />
 
 #### Manual Configuration


### PR DESCRIPTION
Fixes #8657

Users following the MCP setup instructions in `docs/content/docs/introduction.mdx` were not informed that Context7 MCP endpoints require an API key, leading to confusion when connections failed silently. The documentation omitted this credential requirement entirely. Adds a `<Callout>` component directly above `<AddToCursor />` in the MCP section to surface this requirement at the point where users configure the integration, linking to Context7's client configuration docs. Verified by reviewing the rendered MDX structure and confirming placement before the manual configuration steps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a callout in the MCP section of `docs/content/docs/introduction.mdx` stating that Context7 MCP endpoints require an API key, with a link to client configuration docs. The note appears above `<AddToCursor />` so users see it before setup, preventing silent connection failures (fixes #8657).

<sup>Written for commit c783954e0ed3640c11c16021ee463fcca3bd76e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

