### PR TITLE
fix(adapters): use IS NULL / IS NOT NULL for null value comparisons

### DIFF
--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -19,6 +19,8 @@ import {
 	gt,
 	gte,
 	inArray,
+	isNotNull,
+	isNull,
 	like,
 	lt,
 	lte,
@@ -215,7 +217,11 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					}
 
 					if (w.operator === "ne") {
-						return [ne(schemaModel[field], w.value)];
+						return [
+							w.value === null
+								? isNotNull(schemaModel[field])
+								: ne(schemaModel[field], w.value),
+						];
 					}
 
 					if (w.operator === "gt") {
@@ -226,7 +232,11 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						return [gte(schemaModel[field], w.value)];
 					}
 
-					return [eq(schemaModel[field], w.value)];
+					return [
+						w.value === null
+							? isNull(schemaModel[field])
+							: eq(schemaModel[field], w.value),
+					];
 				}
 				const andGroup = where.filter(
 					(w) => w.connector === "AND" || !w.connector,
@@ -274,9 +284,13 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							return gte(schemaModel[field], w.value);
 						}
 						if (w.operator === "ne") {
-							return ne(schemaModel[field], w.value);
+							return w.value === null
+								? isNotNull(schemaModel[field])
+								: ne(schemaModel[field], w.value);
 						}
-						return eq(schemaModel[field], w.value);
+						return w.value === null
+							? isNull(schemaModel[field])
+							: eq(schemaModel[field], w.value);
 					}),
 				);
 				const orClause = or(
@@ -320,9 +334,13 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							return gte(schemaModel[field], w.value);
 						}
 						if (w.operator === "ne") {
-							return ne(schemaModel[field], w.value);
+							return w.value === null
+								? isNotNull(schemaModel[field])
+								: ne(schemaModel[field], w.value);
 						}
-						return eq(schemaModel[field], w.value);
+						return w.value === null
+							? isNull(schemaModel[field])
+							: eq(schemaModel[field], w.value);
 					}),
 				);
 

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -122,12 +122,17 @@ export const kyselyAdapter = (
 						return res;
 					}
 
-					const value = values[field] || where[0]?.value;
+					const value =
+						values[field] !== undefined ? values[field] : where[0]?.value;
 					res = await db
 						.selectFrom(model)
 						.selectAll()
 						.orderBy(getFieldName({ model, field }), "desc")
-						.where(getFieldName({ model, field }), "=", value)
+						.where(
+							getFieldName({ model, field }),
+							value === null ? "is" : "=",
+							value,
+						)
 						.limit(1)
 						.executeTakeFirst();
 					return res;
@@ -187,11 +192,13 @@ export const kyselyAdapter = (
 						}
 
 						if (operator === "eq") {
-							return eb(f, "=", value);
+							return value === null ? eb(f, "is", null) : eb(f, "=", value);
 						}
 
 						if (operator === "ne") {
-							return eb(f, "<>", value);
+							return value === null
+								? eb(f, "is not", null)
+								: eb(f, "<>", value);
 						}
 
 						if (operator === "gt") {

--- a/packages/test-utils/src/adapter/suites/basic.ts
+++ b/packages/test-utils/src/adapter/suites/basic.ts
@@ -3174,6 +3174,171 @@ export const getNormalTestSuiteTests = (
 				expect(result!.email).toBe(user.email);
 				expect(result!.id).toBe(user.id);
 			},
+
+		"findMany - eq operator with null value (single condition) should use IS NULL":
+			async () => {
+				const withNull = await adapter.create<User>({
+					model: "user",
+					data: { ...(await generate("user")), image: null },
+					forceAllowId: true,
+				});
+				const withImage = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: "https://example.com/avatar.png",
+					},
+					forceAllowId: true,
+				});
+
+				const nullResult = await adapter.findMany<User>({
+					model: "user",
+					where: [{ field: "image", operator: "eq", value: null }],
+				});
+				const nullIds = nullResult.map((u) => u.id);
+				expect(nullIds).toContain(withNull.id);
+				expect(nullIds).not.toContain(withImage.id);
+
+				const notNullResult = await adapter.findMany<User>({
+					model: "user",
+					where: [{ field: "image", operator: "ne", value: null }],
+				});
+				const notNullIds = notNullResult.map((u) => u.id);
+				expect(notNullIds).not.toContain(withNull.id);
+				expect(notNullIds).toContain(withImage.id);
+			},
+
+		"findMany - eq and ne operators with null value in AND group should use IS NULL / IS NOT NULL":
+			async () => {
+				const nullVerified = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: null,
+						emailVerified: true,
+					},
+					forceAllowId: true,
+				});
+				const nullUnverified = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: null,
+						emailVerified: false,
+					},
+					forceAllowId: true,
+				});
+				const imageVerified = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: "https://example.com/avatar.png",
+						emailVerified: true,
+					},
+					forceAllowId: true,
+				});
+
+				// image IS NULL AND emailVerified = true → only nullVerified
+				const eqResult = await adapter.findMany<User>({
+					model: "user",
+					where: [
+						{ field: "image", operator: "eq", value: null, connector: "AND" },
+						{ field: "emailVerified", value: true, connector: "AND" },
+					],
+				});
+				const eqIds = eqResult.map((u) => u.id);
+				expect(eqIds).toContain(nullVerified.id);
+				expect(eqIds).not.toContain(nullUnverified.id);
+				expect(eqIds).not.toContain(imageVerified.id);
+
+				// image IS NOT NULL AND emailVerified = true → only imageVerified
+				const neResult = await adapter.findMany<User>({
+					model: "user",
+					where: [
+						{ field: "image", operator: "ne", value: null, connector: "AND" },
+						{ field: "emailVerified", value: true, connector: "AND" },
+					],
+				});
+				const neIds = neResult.map((u) => u.id);
+				expect(neIds).not.toContain(nullVerified.id);
+				expect(neIds).not.toContain(nullUnverified.id);
+				expect(neIds).toContain(imageVerified.id);
+			},
+
+		"findMany - eq and ne operators with null value in OR group should use IS NULL / IS NOT NULL":
+			async () => {
+				const withNull = await adapter.create<User>({
+					model: "user",
+					data: { ...(await generate("user")), image: null },
+					forceAllowId: true,
+				});
+				const targetImage = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: "https://example.com/target.png",
+					},
+					forceAllowId: true,
+				});
+				const otherImage = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: "https://example.com/other.png",
+					},
+					forceAllowId: true,
+				});
+
+				// image IS NULL OR email = targetImage.email → withNull + targetImage
+				const eqResult = await adapter.findMany<User>({
+					model: "user",
+					where: [
+						{ field: "image", operator: "eq", value: null, connector: "OR" },
+						{ field: "email", value: targetImage.email, connector: "OR" },
+					],
+				});
+				const eqIds = eqResult.map((u) => u.id);
+				expect(eqIds).toContain(withNull.id);
+				expect(eqIds).toContain(targetImage.id);
+				expect(eqIds).not.toContain(otherImage.id);
+
+				// image IS NOT NULL OR email = withNull.email → targetImage + otherImage + withNull (by email)
+				const neResult = await adapter.findMany<User>({
+					model: "user",
+					where: [
+						{ field: "image", operator: "ne", value: null, connector: "OR" },
+						{ field: "email", value: withNull.email, connector: "OR" },
+					],
+				});
+				const neIds = neResult.map((u) => u.id);
+				expect(neIds).toContain(withNull.id); // matched by email OR clause
+				expect(neIds).toContain(targetImage.id);
+				expect(neIds).toContain(otherImage.id);
+			},
+
+		"update - should return updated record when where condition uses null value":
+			async () => {
+				const withNull = await adapter.create<User>({
+					model: "user",
+					data: { ...(await generate("user")), image: null },
+					forceAllowId: true,
+				});
+
+				// Update WHERE image IS NULL AND id = withNull.id
+				const result = await adapter.update<User>({
+					model: "user",
+					where: [
+						{ field: "id", value: withNull.id },
+						{ field: "image", operator: "eq", value: null },
+					],
+					update: { name: "null-where-updated" },
+				});
+
+				// On MySQL the re-fetch after UPDATE must use IS NULL, not = NULL
+				expect(result).toBeDefined();
+				expect(result!.id).toBe(withNull.id);
+				expect(result!.name).toBe("null-where-updated");
+			},
 	};
 };
 


### PR DESCRIPTION
## Summary
In SQL, `column = NULL` and `column != NULL` always evaluate to `UNKNOWN` and return zero rows — `IS NULL` / `IS NOT NULL` are required for null comparisons. The `drizzle-orm` and `kysely` adapters were passing `null` directly to their equality helpers (`eq`, `ne`, `eb(f, "=", ...)`, `eb(f, "<>", ...)`), silently producing zero rows for any where-clause with `value: null`.

## Changes
- **`packages/drizzle-adapter`** — add `isNull` / `isNotNull` guards for the `eq` and `ne` operators across all three `convertWhereClause` code paths (single-condition early-return, AND group, OR group)
- **`packages/kysely-adapter`** — add `IS NULL` / `IS NOT NULL` guards for the `eq` and `ne` operators
- **`packages/test-utils`** — add three regression tests to the shared `normalTestSuite` covering:
  1. single-condition `{ operator: "eq", value: null }` → `IS NULL` /`{ operator: "ne", value: null }` → `IS NOT NULL`
  2. null condition inside an AND group
  3. null condition inside an OR group

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes null comparisons in `drizzle-adapter` and `kysely-adapter`. `eq`/`ne` with `null` now emit `IS NULL`/`IS NOT NULL` in queries and during update re-fetch, preventing zero-row results.

- **Bug Fixes**
  - `packages/drizzle-adapter`: use `isNull`/`isNotNull` for `eq`/`ne` when value is `null` in single, AND, and OR groups.
  - `packages/kysely-adapter`: use `IS`/`IS NOT` for `eq`/`ne` with `null`, including the single-condition re-fetch path; use `values[field] !== undefined` to preserve falsy values like `0`/`false`.
  - `packages/test-utils`: add regression tests for single, AND, and OR `findMany` cases with `null`, plus an `update` case verifying re-fetch with `IS NULL`.

<sup>Written for commit b8f0f75255d2f0f54f5eb4c059783a1dbb07ef15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

