### PR TITLE
feat(oauth-provider): add validateRedirectUri option for custom redirect validation

### DIFF
--- a/.changeset/custom-redirect-uri-validation.md
+++ b/.changeset/custom-redirect-uri-validation.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+feat(oauth-provider): add `validateRedirectUri` option for custom redirect URI validation
+
+Adds a new `validateRedirectUri` option to `OAuthOptions` that allows custom validation logic for redirect URIs. This enables safe wildcard-like matching patterns for preview deployments and multi-tenant applications while keeping the default exact-match behavior (with RFC 8252 §7.3 loopback IP support).

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1063,6 +1063,7 @@ oauthProvider({
 ### Custom Redirect URI Validation
 
 By default, the OAuth provider validates redirect URIs with:
+
 1. Exact string matching against registered redirect URIs
 2. [RFC 8252 §7.3](https://www.rfc-editor.org/rfc/rfc8252#section-7.3) loopback IP support (`127.0.0.1` and `[::1]` with flexible ports)
 
@@ -1088,28 +1089,30 @@ oauthProvider({
 
 **Composition Patterns:**
 
-| Pattern | Code | Use Case |
-|---------|------|----------|
-| Extend | `return defaultResult \|\| customCheck(uri)` | Add preview deployments, tenant subdomains |
-| Replace | `return customCheck(uri)` | Full custom control (ignores defaults) |
-| Restrict | `return defaultResult && !isBlocked(uri)` | Add extra constraints on top of defaults |
+| Pattern  | Code                                         | Use Case                                   |
+| -------- | -------------------------------------------- | ------------------------------------------ |
+| Extend   | `return defaultResult \|\| customCheck(uri)` | Add preview deployments, tenant subdomains |
+| Replace  | `return customCheck(uri)`                    | Full custom control (ignores defaults)     |
+| Restrict | `return defaultResult && !isBlocked(uri)`    | Add extra constraints on top of defaults   |
 
 **Common Use Cases:**
-- **Preview deployments**: Match `*.preview.example.com` for Vercel, Netlify, Cloudflare Pages
-- **Multi-tenant applications**: Dynamic tenant subdomains
-- **Development environments**: Additional localhost patterns
+
+* **Preview deployments**: Match `*.preview.example.com` for Vercel, Netlify, Cloudflare Pages
+* **Multi-tenant applications**: Dynamic tenant subdomains
+* **Development environments**: Additional localhost patterns
 
 <Callout type="warn">
-**Security Considerations:**
-- Never allow overly broad patterns like `*` or `*.com`
-- Validate the full URI (protocol, host, path) - not just the hostname
-- Consider using a library like `tldts` to prevent matches on public suffixes (e.g., `*.co.uk`, `*.github.io`)
-- Always require HTTPS (except for localhost)
-- If the validator throws, the request is rejected (fail-closed)
+  **Security Considerations:**
+
+  * Never allow overly broad patterns like `*` or `*.com`
+  * Validate the full URI (protocol, host, path) - not just the hostname
+  * Consider using a library like `tldts` to prevent matches on public suffixes (e.g., `*.co.uk`, `*.github.io`)
+  * Always require HTTPS (except for localhost)
+  * If the validator throws, the request is rejected (fail-closed)
 </Callout>
 
 <Callout type="info">
-**Pairwise Subject Identifiers:** If you use [pairwise subject identifiers](/docs/plugins/oauth-provider#pairwise-subject-identifiers), the sector identifier is derived from the first registered redirect URI. Custom-validated URIs that don't appear in `client.redirectUris` will share the same sector, which may affect subject isolation for multi-tenant scenarios. Consider using a consistent `sector_identifier_uri` for such clients.
+  **Pairwise Subject Identifiers:** If you use [pairwise subject identifiers](/docs/plugins/oauth-provider#pairwise-subject-identifiers), the sector identifier is derived from the first registered redirect URI. Custom-validated URIs that don't appear in `client.redirectUris` will share the same sector, which may affect subject isolation for multi-tenant scenarios. Consider using a consistent `sector_identifier_uri` for such clients.
 </Callout>
 
 ### Claims

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1060,6 +1060,47 @@ oauthProvider({
 })
 ```
 
+### Custom Redirect URI Validation
+
+By default, the OAuth provider performs exact string matching against registered redirect URIs. The `validateRedirectUri` option allows you to implement custom validation logic, such as wildcard pattern matching for preview deployments. The validator can be synchronous or asynchronous (e.g., for fetching tenant configuration from a database).
+
+**Common Use Cases:**
+- **Preview deployments**: Platforms like Vercel, Netlify, or Cloudflare Pages generate unique subdomains for each PR/branch (e.g., `pr-123.preview.example.com`). Instead of registering each preview URL individually, you can use wildcard matching.
+- **Multi-tenant applications**: Match `*.tenants.example.com` where each tenant has their own subdomain.
+- **Development environments**: Match `localhost` with any port for local development.
+
+```ts title="auth.ts"
+oauthProvider({
+  validateRedirectUri: (uri, registeredUris) => {
+    // First check exact match
+    if (registeredUris.includes(uri)) {
+      return true;
+    }
+    
+    // Custom wildcard matching logic
+    return registeredUris.some((pattern) => {
+      if (!pattern.includes('*')) {
+        return false;
+      }
+      // Convert *.example.com to regex pattern
+      // First escape all regex special chars including *
+      const escaped = pattern.replace(/[.+?^${}()|[\]\\*]/g, '\\$&');
+      // Then replace escaped \* with pattern to match single subdomain label
+      const regex = new RegExp('^' + escaped.replace(/\\\*/g, '[^.]+') + '$');
+      return regex.test(uri);
+    });
+  },
+})
+```
+
+<Callout type="warn">
+**Security Considerations:**
+- Never allow overly broad patterns like `*` or `*.com`
+- Wildcard should only match a single subdomain level (per RFC 6125)
+- Consider using a library like `tldts` to prevent wildcards on public suffixes (e.g., `*.co.uk`, `*.github.io`)
+- Always require HTTPS (except for localhost)
+</Callout>
+
 ### Claims
 
 Internally, we support the following claims are supported: \["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp"].

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1062,33 +1062,36 @@ oauthProvider({
 
 ### Custom Redirect URI Validation
 
-By default, the OAuth provider performs exact string matching against registered redirect URIs. The `validateRedirectUri` option allows you to implement custom validation logic, such as wildcard pattern matching for preview deployments. The validator can be synchronous or asynchronous (e.g., for fetching tenant configuration from a database).
+By default, the OAuth provider performs exact string matching against registered redirect URIs, plus [RFC 8252 §7.3](https://www.rfc-editor.org/rfc/rfc8252#section-7.3) loopback IP support (matching `127.0.0.1` and `[::1]` while ignoring port differences).
+
+The `validateRedirectUri` option allows you to **extend** this default behavior with custom validation logic. When provided, the default validation runs first; your custom validator is only called if the default validation fails. This ensures native app loopback callbacks continue working without reimplementing RFC 8252 logic.
 
 **Common Use Cases:**
-- **Preview deployments**: Platforms like Vercel, Netlify, or Cloudflare Pages generate unique subdomains for each PR/branch (e.g., `pr-123.preview.example.com`). Instead of registering each preview URL individually, you can use wildcard matching.
-- **Multi-tenant applications**: Match `*.tenants.example.com` where each tenant has their own subdomain.
-- **Development environments**: Match `localhost` with any port for local development.
+- **Preview deployments**: Platforms like Vercel, Netlify, or Cloudflare Pages generate unique subdomains for each PR/branch (e.g., `pr-123.preview.example.com`).
+- **Multi-tenant applications**: Dynamic tenant subdomains like `acme.app.example.com`.
+- **Development environments**: Additional localhost patterns beyond the default loopback support.
 
 ```ts title="auth.ts"
 oauthProvider({
   validateRedirectUri: (uri, registeredUris) => {
-    // First check exact match
-    if (registeredUris.includes(uri)) {
-      return true;
-    }
+    // This validator is called AFTER default validation fails.
+    // Default validation already handles:
+    // - Exact string matches against registeredUris
+    // - RFC 8252 §7.3 loopback IP port flexibility
     
-    // Custom wildcard matching logic
-    return registeredUris.some((pattern) => {
-      if (!pattern.includes('*')) {
-        return false;
+    // Example: Allow any subdomain of preview.example.com
+    // Note: This matches against the FULL URI, not just the host
+    try {
+      const url = new URL(uri);
+      if (
+        url.protocol === 'https:' &&
+        url.hostname.endsWith('.preview.example.com')
+      ) {
+        return true;
       }
-      // Convert *.example.com to regex pattern
-      // First escape all regex special chars including *
-      const escaped = pattern.replace(/[.+?^${}()|[\]\\*]/g, '\\$&');
-      // Then replace escaped \* with pattern to match single subdomain label
-      const regex = new RegExp('^' + escaped.replace(/\\\*/g, '[^.]+') + '$');
-      return regex.test(uri);
-    });
+    } catch {}
+    
+    return false;
   },
 })
 ```
@@ -1096,9 +1099,13 @@ oauthProvider({
 <Callout type="warn">
 **Security Considerations:**
 - Never allow overly broad patterns like `*` or `*.com`
-- Wildcard should only match a single subdomain level (per RFC 6125)
-- Consider using a library like `tldts` to prevent wildcards on public suffixes (e.g., `*.co.uk`, `*.github.io`)
+- Validate the full URI (protocol, host, path) - not just the hostname
+- Consider using a library like `tldts` to prevent matches on public suffixes (e.g., `*.co.uk`, `*.github.io`)
 - Always require HTTPS (except for localhost)
+</Callout>
+
+<Callout type="info">
+**Pairwise Subject Identifiers:** If you use [pairwise subject identifiers](/docs/plugins/oauth-provider#pairwise-subject-identifiers), the sector identifier is derived from the first registered redirect URI. Custom-validated URIs that don't appear in `client.redirectUris` will share the same sector, which may affect subject isolation for multi-tenant scenarios. Consider using a consistent `sector_identifier_uri` for such clients.
 </Callout>
 
 ### Claims

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1062,39 +1062,42 @@ oauthProvider({
 
 ### Custom Redirect URI Validation
 
-By default, the OAuth provider performs exact string matching against registered redirect URIs, plus [RFC 8252 §7.3](https://www.rfc-editor.org/rfc/rfc8252#section-7.3) loopback IP support (matching `127.0.0.1` and `[::1]` while ignoring port differences).
+By default, the OAuth provider validates redirect URIs with:
+1. Exact string matching against registered redirect URIs
+2. [RFC 8252 §7.3](https://www.rfc-editor.org/rfc/rfc8252#section-7.3) loopback IP support (`127.0.0.1` and `[::1]` with flexible ports)
 
-The `validateRedirectUri` option allows you to **extend** this default behavior with custom validation logic. When provided, the default validation runs first; your custom validator is only called if the default validation fails. This ensures native app loopback callbacks continue working without reimplementing RFC 8252 logic.
-
-**Common Use Cases:**
-- **Preview deployments**: Platforms like Vercel, Netlify, or Cloudflare Pages generate unique subdomains for each PR/branch (e.g., `pr-123.preview.example.com`).
-- **Multi-tenant applications**: Dynamic tenant subdomains like `acme.app.example.com`.
-- **Development environments**: Additional localhost patterns beyond the default loopback support.
+The `validateRedirectUri` option provides composable validation through a `defaultResult` parameter, enabling flexible patterns:
 
 ```ts title="auth.ts"
 oauthProvider({
-  validateRedirectUri: (uri, registeredUris) => {
-    // This validator is called AFTER default validation fails.
-    // Default validation already handles:
-    // - Exact string matches against registeredUris
-    // - RFC 8252 §7.3 loopback IP port flexibility
+  // Extend: add preview deployment support while preserving defaults (recommended)
+  validateRedirectUri: (uri, registeredUris, defaultResult) => {
+    if (defaultResult) return true;
     
-    // Example: Allow any subdomain of preview.example.com
-    // Note: This matches against the FULL URI, not just the host
     try {
       const url = new URL(uri);
-      if (
+      return (
         url.protocol === 'https:' &&
         url.hostname.endsWith('.preview.example.com')
-      ) {
-        return true;
-      }
+      );
     } catch {}
-    
     return false;
   },
 })
 ```
+
+**Composition Patterns:**
+
+| Pattern | Code | Use Case |
+|---------|------|----------|
+| Extend | `return defaultResult \|\| customCheck(uri)` | Add preview deployments, tenant subdomains |
+| Replace | `return customCheck(uri)` | Full custom control (ignores defaults) |
+| Restrict | `return defaultResult && !isBlocked(uri)` | Add extra constraints on top of defaults |
+
+**Common Use Cases:**
+- **Preview deployments**: Match `*.preview.example.com` for Vercel, Netlify, Cloudflare Pages
+- **Multi-tenant applications**: Dynamic tenant subdomains
+- **Development environments**: Additional localhost patterns
 
 <Callout type="warn">
 **Security Considerations:**
@@ -1102,6 +1105,7 @@ oauthProvider({
 - Validate the full URI (protocol, host, path) - not just the hostname
 - Consider using a library like `tldts` to prevent matches on public suffixes (e.g., `*.co.uk`, `*.github.io`)
 - Always require HTTPS (except for localhost)
+- If the validator throws, the request is rejected (fail-closed)
 </Callout>
 
 <Callout type="info">

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1203,6 +1203,63 @@ oauthProvider({
 })
 ```
 
+### Custom Redirect URI Validation
+
+By default, the OAuth provider validates redirect URIs with:
+
+1. Exact string matching against registered redirect URIs
+2. [RFC 8252 §7.3](https://www.rfc-editor.org/rfc/rfc8252#section-7.3) loopback IP support (`127.0.0.0/8` and `[::1]` with flexible ports)
+
+The `validateRedirectUri` option provides composable validation through a `defaultResult` parameter, enabling flexible patterns:
+
+```ts title="auth.ts"
+oauthProvider({
+  // Extend: add preview deployment support while preserving defaults (recommended)
+  validateRedirectUri: (uri, registeredUris, defaultResult) => {
+    if (defaultResult) return true;
+
+    try {
+      const url = new URL(uri);
+      return (
+        url.protocol === 'https:' &&
+        url.hostname.endsWith('.preview.example.com')
+      );
+    } catch {}
+    return false;
+  },
+})
+```
+
+**Composition Patterns:**
+
+| Pattern  | Code                                         | Use Case                                   |
+| -------- | -------------------------------------------- | ------------------------------------------ |
+| Extend   | `return defaultResult \|\| customCheck(uri)` | Add preview deployments, tenant subdomains |
+| Replace  | `return customCheck(uri)`                    | Full custom control (ignores defaults)     |
+| Restrict | `return defaultResult && !isBlocked(uri)`    | Add extra constraints on top of defaults   |
+
+**Common Use Cases:**
+
+* **Preview deployments**: Match `*.preview.example.com` for Vercel, Netlify, Cloudflare Pages
+* **Multi-tenant applications**: Dynamic tenant subdomains
+* **Development environments**: Additional localhost patterns
+
+<Callout type="warn">
+  **Security Considerations:**
+
+  * Never allow overly broad patterns like `*` or `*.com`
+  * Validate the full URI (protocol, host, path) - not just the hostname
+  * Consider using a library like `tldts` to prevent matches on public suffixes (e.g., `*.co.uk`, `*.github.io`)
+  * Always require HTTPS (except for localhost)
+  * If the validator throws, the request is rejected (fail-closed)
+
+  The validator also decides whether authorization errors may be redirected to the requested `redirect_uri` ([RFC 6749 §4.1.2.1](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1)); on rejection or exception, errors fall back to the server error page.
+</Callout>
+
+<Callout type="info">
+  **Pairwise Subject Identifiers:** If you use [pairwise subject identifiers](/docs/plugins/oauth-provider#pairwise-subject-identifiers), the sector identifier is derived from the first registered redirect URI. Custom-validated URIs that don't appear in `client.redirectUris` will share the same sector, which may affect subject isolation for multi-tenant scenarios. Consider using a consistent `sector_identifier_uri` for such clients.
+</Callout>
+
 ### Claims
 
 Internally supported claims include \["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp"].

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1229,6 +1229,63 @@ oauthProvider({
 })
 ```
 
+### Custom Redirect URI Validation
+
+By default, the OAuth provider validates redirect URIs with:
+
+1. Exact string matching against registered redirect URIs
+2. [RFC 8252 §7.3](https://www.rfc-editor.org/rfc/rfc8252#section-7.3) loopback IP support (`127.0.0.0/8` and `[::1]` with flexible ports)
+
+The `validateRedirectUri` option provides composable validation through a `defaultResult` parameter, enabling flexible patterns:
+
+```ts title="auth.ts"
+oauthProvider({
+  // Extend: add preview deployment support while preserving defaults (recommended)
+  validateRedirectUri: (uri, registeredUris, defaultResult) => {
+    if (defaultResult) return true;
+
+    try {
+      const url = new URL(uri);
+      return (
+        url.protocol === 'https:' &&
+        url.hostname.endsWith('.preview.example.com')
+      );
+    } catch {}
+    return false;
+  },
+})
+```
+
+**Composition Patterns:**
+
+| Pattern  | Code                                         | Use Case                                   |
+| -------- | -------------------------------------------- | ------------------------------------------ |
+| Extend   | `return defaultResult \|\| customCheck(uri)` | Add preview deployments, tenant subdomains |
+| Replace  | `return customCheck(uri)`                    | Full custom control (ignores defaults)     |
+| Restrict | `return defaultResult && !isBlocked(uri)`    | Add extra constraints on top of defaults   |
+
+**Common Use Cases:**
+
+* **Preview deployments**: Match `*.preview.example.com` for Vercel, Netlify, Cloudflare Pages
+* **Multi-tenant applications**: Dynamic tenant subdomains
+* **Development environments**: Additional localhost patterns
+
+<Callout type="warn">
+  **Security Considerations:**
+
+  * Never allow overly broad patterns like `*` or `*.com`
+  * Validate the full URI (protocol, host, path) - not just the hostname
+  * Consider using a library like `tldts` to prevent matches on public suffixes (e.g., `*.co.uk`, `*.github.io`)
+  * Always require HTTPS (except for localhost)
+  * If the validator throws, the request is rejected (fail-closed)
+
+  The validator also decides whether authorization errors may be redirected to the requested `redirect_uri` ([RFC 6749 §4.1.2.1](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1)); on rejection or exception, errors fall back to the server error page.
+</Callout>
+
+<Callout type="info">
+  **Pairwise Subject Identifiers:** If you use [pairwise subject identifiers](/docs/plugins/oauth-provider#pairwise-subject-identifiers), the sector identifier is derived from the client's first registered redirect URI. Custom-validated URIs that don't appear in `client.redirectUris` therefore inherit that sector, so every preview or tenant host accepted by your validator resolves to the same `sub` as the first registered URI. `sector_identifier_uri` is not supported yet, so there is no way to opt into a different sector — if a multi-tenant client needs distinct subject identifiers per tenant, register a separate client per tenant instead of relying on `validateRedirectUri`.
+</Callout>
+
 ### Claims
 
 Internally supported claims include \["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp"].

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -490,10 +490,13 @@ describe("oauth authorize - custom validateRedirectUri", async () => {
 	const authServerBaseUrl = "http://localhost:3000";
 	const rpBaseUrl = "http://localhost:5000";
 
-	const customValidator = (uri: string, registeredUris: string[]): boolean => {
-		if (registeredUris.includes(uri)) {
-			return true;
-		}
+	const customValidator = (
+		uri: string,
+		registeredUris: string[],
+		defaultResult: boolean,
+	): boolean => {
+		// Extend default validation with custom *.localhost pattern
+		if (defaultResult) return true;
 		try {
 			const url = new URL(uri);
 			if (url.hostname.endsWith(".localhost")) {
@@ -623,6 +626,7 @@ describe("oauth authorize - validateRedirectUri error handling", async () => {
 	const throwingValidator = (
 		uri: string,
 		_registeredUris: string[],
+		_defaultResult: boolean,
 	): boolean => {
 		if (uri.includes("throw-error")) {
 			throw new Error("Validator intentionally threw");
@@ -705,12 +709,12 @@ describe("oauth authorize - async validateRedirectUri", async () => {
 	const asyncValidator = async (
 		uri: string,
 		registeredUris: string[],
+		defaultResult: boolean,
 	): Promise<boolean> => {
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
-		if (registeredUris.includes(uri)) {
-			return true;
-		}
+		// Extend default validation with custom *.localhost pattern
+		if (defaultResult) return true;
 		try {
 			const url = new URL(uri);
 			if (url.hostname.endsWith(".localhost")) {

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -485,3 +485,314 @@ describe("oauth authorize - authenticated", async () => {
 		expect(callbackRedirectUrl).not.toContain("/consent");
 	});
 });
+
+describe("oauth authorize - custom validateRedirectUri", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	const customValidator = (uri: string, registeredUris: string[]): boolean => {
+		if (registeredUris.includes(uri)) {
+			return true;
+		}
+		try {
+			const url = new URL(uri);
+			if (url.hostname.endsWith(".localhost")) {
+				return registeredUris.some((registered) => {
+					const registeredUrl = new URL(registered);
+					return (
+						registeredUrl.hostname === "localhost" &&
+						registeredUrl.port === url.port &&
+						registeredUrl.pathname === url.pathname
+					);
+				});
+			}
+		} catch {
+			return false;
+		}
+		return false;
+	};
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validateRedirectUri: customValidator,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const registeredUri = `${rpBaseUrl}/callback`;
+	const subdomainUri = "http://pr-123.localhost:5000/callback";
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [registeredUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("should accept redirect_uri matching custom validation logic", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: subdomainUri,
+			state: "custom-validator-test",
+			scopes: ["openid"],
+			responseType: "code",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(callbackRedirectUrl).toContain("pr-123.localhost");
+		expect(callbackRedirectUrl).toContain("code=");
+		expect(callbackRedirectUrl).toContain("state=custom-validator-test");
+	});
+
+	it("should reject redirect_uri not matching custom validation", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		const unauthorizedUri = "http://localhost:9999/evil";
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", unauthorizedUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "unauthorized-test");
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=invalid_redirect");
+		expect(errorRedirectUrl).not.toContain("localhost:9999");
+	});
+});
+
+describe("oauth authorize - validateRedirectUri error handling", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	const registeredThrowingUri = `${rpBaseUrl}/throw-error-callback`;
+
+	const throwingValidator = (
+		uri: string,
+		_registeredUris: string[],
+	): boolean => {
+		if (uri.includes("throw-error")) {
+			throw new Error("Validator intentionally threw");
+		}
+		return uri === `${rpBaseUrl}/callback`;
+	};
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validateRedirectUri: throwingValidator,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [`${rpBaseUrl}/callback`, registeredThrowingUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("should fail closed when validator throws an exception", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", registeredThrowingUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "validator-throws-test");
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=invalid_redirect");
+		expect(errorRedirectUrl).not.toContain("throw-error");
+	});
+});
+
+describe("oauth authorize - async validateRedirectUri", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	const asyncValidator = async (
+		uri: string,
+		registeredUris: string[],
+	): Promise<boolean> => {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		if (registeredUris.includes(uri)) {
+			return true;
+		}
+		try {
+			const url = new URL(uri);
+			if (url.hostname.endsWith(".localhost")) {
+				return registeredUris.some((registered) => {
+					const registeredUrl = new URL(registered);
+					return (
+						registeredUrl.hostname === "localhost" &&
+						registeredUrl.port === url.port &&
+						registeredUrl.pathname === url.pathname
+					);
+				});
+			}
+		} catch {
+			return false;
+		}
+		return false;
+	};
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validateRedirectUri: asyncValidator,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const registeredUri = `${rpBaseUrl}/callback`;
+	const subdomainUri = "http://async-test.localhost:5000/callback";
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [registeredUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("should support async validator returning a Promise", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: subdomainUri,
+			state: "async-validator-test",
+			scopes: ["openid"],
+			responseType: "code",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(callbackRedirectUrl).toContain("async-test.localhost");
+		expect(callbackRedirectUrl).toContain("code=");
+		expect(callbackRedirectUrl).toContain("state=async-validator-test");
+	});
+});

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -616,7 +616,9 @@ describe("oauth authorize - validateRedirectUri error handling", async () => {
 	const authServerBaseUrl = "http://localhost:3000";
 	const rpBaseUrl = "http://localhost:5000";
 
-	const registeredThrowingUri = `${rpBaseUrl}/throw-error-callback`;
+	// URI that triggers the validator to throw - NOT in registered URIs
+	// so default validation fails and custom validator is called
+	const unregisteredThrowingUri = `${rpBaseUrl}/throw-error-callback`;
 
 	const throwingValidator = (
 		uri: string,
@@ -659,7 +661,9 @@ describe("oauth authorize - validateRedirectUri error handling", async () => {
 		const response = await auth.api.adminCreateOAuthClient({
 			headers,
 			body: {
-				redirect_uris: [`${rpBaseUrl}/callback`, registeredThrowingUri],
+				// Only register /callback - NOT the throwing URI
+				// This ensures default validation fails and custom validator is called
+				redirect_uris: [`${rpBaseUrl}/callback`],
 				skip_consent: true,
 			},
 		});
@@ -673,7 +677,9 @@ describe("oauth authorize - validateRedirectUri error handling", async () => {
 		}
 		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
 		authUrl.searchParams.set("client_id", oauthClient.client_id);
-		authUrl.searchParams.set("redirect_uri", registeredThrowingUri);
+		// Use unregistered URI that triggers throw - default validation fails first,
+		// then custom validator is called and throws
+		authUrl.searchParams.set("redirect_uri", unregisteredThrowingUri);
 		authUrl.searchParams.set("response_type", "code");
 		authUrl.searchParams.set("scope", "openid");
 		authUrl.searchParams.set("state", "validator-throws-test");

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -1421,3 +1421,378 @@ describe("oauth authorize - consented resources", async () => {
 		expect(callbackRedirectUrl).not.toContain("/consent");
 	});
 });
+
+describe("oauth authorize - custom validateRedirectUri", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	const customValidator = (
+		uri: string,
+		registeredUris: readonly string[],
+		defaultResult: boolean,
+	): boolean => {
+		// Extend default validation with custom *.localhost pattern
+		if (defaultResult) return true;
+		try {
+			const url = new URL(uri);
+			if (url.hostname.endsWith(".localhost")) {
+				return registeredUris.some((registered) => {
+					const registeredUrl = new URL(registered);
+					return (
+						registeredUrl.hostname === "localhost" &&
+						registeredUrl.port === url.port &&
+						registeredUrl.pathname === url.pathname
+					);
+				});
+			}
+		} catch {
+			return false;
+		}
+		return false;
+	};
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validateRedirectUri: customValidator,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const registeredUri = `${rpBaseUrl}/callback`;
+	const subdomainUri = "http://pr-123.localhost:5000/callback";
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [registeredUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("should accept redirect_uri matching custom validation logic", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: subdomainUri,
+			state: "custom-validator-test",
+			scopes: ["openid"],
+			responseType: "code",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(callbackRedirectUrl).toContain("pr-123.localhost");
+		expect(callbackRedirectUrl).toContain("code=");
+		expect(callbackRedirectUrl).toContain("state=custom-validator-test");
+	});
+
+	it("should reject redirect_uri not matching custom validation", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		const unauthorizedUri = "http://localhost:9999/evil";
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", unauthorizedUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "unauthorized-test");
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=invalid_redirect");
+		expect(errorRedirectUrl).not.toContain("localhost:9999");
+	});
+
+	it("should forward early protocol errors to a custom-validated redirect_uri", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		// `request` objects are unsupported; the error is raised before the
+		// authorize endpoint's own redirect_uri validation, so error forwarding
+		// relies on resolveTrustedRedirectUri honoring the custom validator
+		// (RFC 6749 §4.1.2.1).
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", subdomainUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "early-error-forwarding-test");
+		authUrl.searchParams.set("request", "some-request-object");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("pr-123.localhost");
+		expect(errorRedirectUrl).toContain("error=request_not_supported");
+		expect(errorRedirectUrl).toContain("state=early-error-forwarding-test");
+	});
+});
+
+describe("oauth authorize - validateRedirectUri error handling", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	// URI that triggers the validator to throw - NOT in registered URIs
+	// so default validation fails and custom validator is called
+	const unregisteredThrowingUri = `${rpBaseUrl}/throw-error-callback`;
+
+	const throwingValidator = (
+		uri: string,
+		_registeredUris: readonly string[],
+		_defaultResult: boolean,
+	): boolean => {
+		if (uri.includes("throw-error")) {
+			throw new Error("Validator intentionally threw");
+		}
+		return uri === `${rpBaseUrl}/callback`;
+	};
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validateRedirectUri: throwingValidator,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				// Only register /callback - NOT the throwing URI
+				// This ensures default validation fails and custom validator is called
+				redirect_uris: [`${rpBaseUrl}/callback`],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("should fail closed when validator throws an exception", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		// Use unregistered URI that triggers throw - default validation fails first,
+		// then custom validator is called and throws
+		authUrl.searchParams.set("redirect_uri", unregisteredThrowingUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "validator-throws-test");
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=invalid_redirect");
+		expect(errorRedirectUrl).not.toContain("throw-error");
+	});
+
+	it("should fail closed in the error-forwarding path when validator throws", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		// Trigger an early protocol error (`request` object unsupported) with a
+		// redirect_uri that makes the validator throw: the error must fall back
+		// to the server error page instead of redirecting to the requested URI.
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", unregisteredThrowingUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "error-path-throw-test");
+		authUrl.searchParams.set("request", "some-request-object");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=request_not_supported");
+		expect(errorRedirectUrl).not.toContain("throw-error");
+	});
+});
+
+describe("oauth authorize - async validateRedirectUri", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	const asyncValidator = async (
+		uri: string,
+		registeredUris: readonly string[],
+		defaultResult: boolean,
+	): Promise<boolean> => {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// Extend default validation with custom *.localhost pattern
+		if (defaultResult) return true;
+		try {
+			const url = new URL(uri);
+			if (url.hostname.endsWith(".localhost")) {
+				return registeredUris.some((registered) => {
+					const registeredUrl = new URL(registered);
+					return (
+						registeredUrl.hostname === "localhost" &&
+						registeredUrl.port === url.port &&
+						registeredUrl.pathname === url.pathname
+					);
+				});
+			}
+		} catch {
+			return false;
+		}
+		return false;
+	};
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validateRedirectUri: asyncValidator,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const registeredUri = `${rpBaseUrl}/callback`;
+	const subdomainUri = "http://async-test.localhost:5000/callback";
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [registeredUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("should support async validator returning a Promise", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: subdomainUri,
+			state: "async-validator-test",
+			scopes: ["openid"],
+			responseType: "code",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(callbackRedirectUrl).toContain("async-test.localhost");
+		expect(callbackRedirectUrl).toContain("code=");
+		expect(callbackRedirectUrl).toContain("state=async-validator-test");
+	});
+});

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -1498,3 +1498,369 @@ describe("oauth authorize - consented resources", async () => {
 		expect(callbackRedirectUrl).not.toContain("/consent");
 	});
 });
+
+/**
+ * Extends the default redirect URI validation with a `*.localhost` pattern that
+ * must still match a registered `localhost` URI's port and path. Shared by the
+ * sync and async `validateRedirectUri` suites below.
+ */
+const allowLocalhostSubdomain = (
+	uri: string,
+	registeredUris: readonly string[],
+	defaultResult: boolean,
+): boolean => {
+	if (defaultResult) return true;
+	try {
+		const url = new URL(uri);
+		if (url.hostname.endsWith(".localhost")) {
+			return registeredUris.some((registered) => {
+				const registeredUrl = new URL(registered);
+				return (
+					registeredUrl.hostname === "localhost" &&
+					registeredUrl.port === url.port &&
+					registeredUrl.pathname === url.pathname
+				);
+			});
+		}
+	} catch {
+		return false;
+	}
+	return false;
+};
+
+describe("oauth authorize - custom validateRedirectUri", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validateRedirectUri: allowLocalhostSubdomain,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const registeredUri = `${rpBaseUrl}/callback`;
+	const subdomainUri = "http://pr-123.localhost:5000/callback";
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [registeredUri],
+				application_type: "native",
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("should accept redirect_uri matching custom validation logic", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: subdomainUri,
+			state: "custom-validator-test",
+			scopes: ["openid"],
+			responseType: "code",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(callbackRedirectUrl).toContain("pr-123.localhost");
+		expect(callbackRedirectUrl).toContain("code=");
+		expect(callbackRedirectUrl).toContain("state=custom-validator-test");
+	});
+
+	it("should reject redirect_uri not matching custom validation", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		const unauthorizedUri = "http://localhost:9999/evil";
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", unauthorizedUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "unauthorized-test");
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=invalid_redirect");
+		expect(errorRedirectUrl).not.toContain("localhost:9999");
+	});
+
+	it("should forward early protocol errors to a custom-validated redirect_uri", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		// `request` objects are unsupported; the error is raised before the
+		// authorize endpoint's own redirect_uri validation, so error forwarding
+		// relies on resolveTrustedRedirectUri honoring the custom validator
+		// (RFC 6749 §4.1.2.1).
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", subdomainUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "early-error-forwarding-test");
+		authUrl.searchParams.set("request", "some-request-object");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("pr-123.localhost");
+		expect(errorRedirectUrl).toContain("error=request_not_supported");
+		expect(errorRedirectUrl).toContain("state=early-error-forwarding-test");
+	});
+});
+
+describe("oauth authorize - validateRedirectUri error handling", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	// URI that triggers the validator to throw - NOT in registered URIs
+	// so default validation fails and custom validator is called
+	const unregisteredThrowingUri = `${rpBaseUrl}/throw-error-callback`;
+
+	const throwingValidator = (
+		uri: string,
+		_registeredUris: readonly string[],
+		_defaultResult: boolean,
+	): boolean => {
+		if (uri.includes("throw-error")) {
+			throw new Error("Validator intentionally threw");
+		}
+		return uri === `${rpBaseUrl}/callback`;
+	};
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validateRedirectUri: throwingValidator,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				// Only register /callback - NOT the throwing URI
+				// This ensures default validation fails and custom validator is called
+				redirect_uris: [`${rpBaseUrl}/callback`],
+				application_type: "native",
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("should fail closed when validator throws an exception", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		// Use unregistered URI that triggers throw - default validation fails first,
+		// then custom validator is called and throws
+		authUrl.searchParams.set("redirect_uri", unregisteredThrowingUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "validator-throws-test");
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=invalid_redirect");
+		expect(errorRedirectUrl).not.toContain("throw-error");
+	});
+
+	it("should fail closed in the error-forwarding path when validator throws", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		// Trigger an early protocol error (`request` object unsupported) with a
+		// redirect_uri that makes the validator throw: the error must fall back
+		// to the server error page instead of redirecting to the requested URI.
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", unregisteredThrowingUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "error-path-throw-test");
+		authUrl.searchParams.set("request", "some-request-object");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=request_not_supported");
+		expect(errorRedirectUrl).not.toContain("throw-error");
+	});
+});
+
+describe("oauth authorize - async validateRedirectUri", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	// Same logic as the sync suite, but resolved asynchronously to prove the
+	// provider awaits the validator.
+	const asyncValidator = async (
+		uri: string,
+		registeredUris: readonly string[],
+		defaultResult: boolean,
+	): Promise<boolean> => {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		return allowLocalhostSubdomain(uri, registeredUris, defaultResult);
+	};
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				validateRedirectUri: asyncValidator,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const registeredUri = `${rpBaseUrl}/callback`;
+	const subdomainUri = "http://async-test.localhost:5000/callback";
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [registeredUri],
+				application_type: "native",
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("should support async validator returning a Promise", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: subdomainUri,
+			state: "async-validator-test",
+			scopes: ["openid"],
+			responseType: "code",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(callbackRedirectUrl).toContain("async-test.localhost");
+		expect(callbackRedirectUrl).toContain("code=");
+		expect(callbackRedirectUrl).toContain("state=async-validator-test");
+	});
+});

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -264,8 +264,8 @@ export async function authorizeEndpoint(
 	let isValidRedirectUri = false;
 	if (query.redirect_uri) {
 		try {
-			// Always run default validation first (exact match + RFC 8252 §7.3 loopback IP support)
-			isValidRedirectUri = registeredUris.some((url) => {
+			// Default validation: exact match + RFC 8252 §7.3 loopback IP support
+			const defaultResult = registeredUris.some((url) => {
 				if (url === query.redirect_uri) return true;
 				try {
 					const registered = new URL(url);
@@ -284,12 +284,15 @@ export async function authorizeEndpoint(
 				return false;
 			});
 
-			// If default validation fails, try custom validator as fallback
-			if (!isValidRedirectUri && opts.validateRedirectUri) {
+			if (opts.validateRedirectUri) {
+				// Custom validator receives defaultResult for composition
 				isValidRedirectUri = await opts.validateRedirectUri(
 					query.redirect_uri,
 					registeredUris,
+					defaultResult,
 				);
+			} else {
+				isValidRedirectUri = defaultResult;
 			}
 		} catch {
 			isValidRedirectUri = false;

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -260,25 +260,42 @@ export async function authorizeEndpoint(
 		);
 	}
 
-	const redirectUri = client.redirectUris?.find((url) => {
-		if (url === query.redirect_uri) return true;
+	const registeredUris = client.redirectUris ?? [];
+	let isValidRedirectUri = false;
+	if (query.redirect_uri) {
 		try {
-			const registered = new URL(url);
-			const requested = new URL(query.redirect_uri);
-			// RFC 8252 §7.3: loopback IPs match on scheme+host+path+query, ignoring port
-			if (
-				(registered.hostname === "127.0.0.1" ||
-					registered.hostname === "[::1]") &&
-				registered.hostname === requested.hostname &&
-				registered.pathname === requested.pathname &&
-				registered.protocol === requested.protocol &&
-				registered.search === requested.search
-			)
-				return true;
-		} catch {}
-		return false;
-	});
-	if (!redirectUri || !query.redirect_uri) {
+			if (opts.validateRedirectUri) {
+				// Use custom validation if provided
+				isValidRedirectUri = await opts.validateRedirectUri(
+					query.redirect_uri,
+					registeredUris,
+				);
+			} else {
+				// Default validation with RFC 8252 §7.3 loopback IP support
+				isValidRedirectUri = registeredUris.some((url) => {
+					if (url === query.redirect_uri) return true;
+					try {
+						const registered = new URL(url);
+						const requested = new URL(query.redirect_uri);
+						// RFC 8252 §7.3: loopback IPs match on scheme+host+path+query, ignoring port
+						if (
+							(registered.hostname === "127.0.0.1" ||
+								registered.hostname === "[::1]") &&
+							registered.hostname === requested.hostname &&
+							registered.pathname === requested.pathname &&
+							registered.protocol === requested.protocol &&
+							registered.search === requested.search
+						)
+							return true;
+					} catch {}
+					return false;
+				});
+			}
+		} catch {
+			isValidRedirectUri = false;
+		}
+	}
+	if (!isValidRedirectUri) {
 		return handleRedirect(
 			ctx,
 			getErrorURL(ctx, "invalid_redirect", "invalid redirect uri"),

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -264,32 +264,32 @@ export async function authorizeEndpoint(
 	let isValidRedirectUri = false;
 	if (query.redirect_uri) {
 		try {
-			if (opts.validateRedirectUri) {
-				// Use custom validation if provided
+			// Always run default validation first (exact match + RFC 8252 §7.3 loopback IP support)
+			isValidRedirectUri = registeredUris.some((url) => {
+				if (url === query.redirect_uri) return true;
+				try {
+					const registered = new URL(url);
+					const requested = new URL(query.redirect_uri);
+					// RFC 8252 §7.3: loopback IPs match on scheme+host+path+query, ignoring port
+					if (
+						(registered.hostname === "127.0.0.1" ||
+							registered.hostname === "[::1]") &&
+						registered.hostname === requested.hostname &&
+						registered.pathname === requested.pathname &&
+						registered.protocol === requested.protocol &&
+						registered.search === requested.search
+					)
+						return true;
+				} catch {}
+				return false;
+			});
+
+			// If default validation fails, try custom validator as fallback
+			if (!isValidRedirectUri && opts.validateRedirectUri) {
 				isValidRedirectUri = await opts.validateRedirectUri(
 					query.redirect_uri,
 					registeredUris,
 				);
-			} else {
-				// Default validation with RFC 8252 §7.3 loopback IP support
-				isValidRedirectUri = registeredUris.some((url) => {
-					if (url === query.redirect_uri) return true;
-					try {
-						const registered = new URL(url);
-						const requested = new URL(query.redirect_uri);
-						// RFC 8252 §7.3: loopback IPs match on scheme+host+path+query, ignoring port
-						if (
-							(registered.hostname === "127.0.0.1" ||
-								registered.hostname === "[::1]") &&
-							registered.hostname === requested.hostname &&
-							registered.pathname === requested.pathname &&
-							registered.protocol === requested.protocol &&
-							registered.search === requested.search
-						)
-							return true;
-					} catch {}
-					return false;
-				});
 			}
 		} catch {
 			isValidRedirectUri = false;

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -281,9 +281,11 @@ function findRegisteredRedirectUri(
 
 /**
  * Loads the client, verifies it's enabled, and returns the requested
- * redirect_uri when it matches a registered entry. Returns null whenever the
- * RP cannot be safely reached, so callers can fall back to the server error
- * page (avoiding open-redirect risk on validation failures).
+ * redirect_uri when it matches a registered entry (or is accepted by the
+ * custom `validateRedirectUri` option, mirroring the authorize endpoint's
+ * validation). Returns null whenever the RP cannot be safely reached, so
+ * callers can fall back to the server error page (avoiding open-redirect
+ * risk on validation failures).
  */
 async function resolveTrustedRedirectUri(
 	ctx: GenericEndpointContext,
@@ -299,7 +301,20 @@ async function resolveTrustedRedirectUri(
 		return null;
 	}
 	if (!client || client.disabled) return null;
-	const matched = findRegisteredRedirectUri(client.redirectUris, redirectUri);
+	const registeredUris = client.redirectUris ?? [];
+	const matched = findRegisteredRedirectUri(registeredUris, redirectUri);
+	if (opts.validateRedirectUri) {
+		try {
+			const isValid = await opts.validateRedirectUri(
+				redirectUri,
+				registeredUris,
+				Boolean(matched),
+			);
+			return isValid ? redirectUri : null;
+		} catch {
+			return null;
+		}
+	}
 	return matched ? redirectUri : null;
 }
 
@@ -515,11 +530,30 @@ export async function authorizeEndpoint(
 		);
 	}
 
-	const redirectUri = findRegisteredRedirectUri(
-		client.redirectUris,
-		query.redirect_uri,
-	);
-	if (!redirectUri || !query.redirect_uri) {
+	const registeredUris = client.redirectUris ?? [];
+	let isValidRedirectUri = false;
+	if (query.redirect_uri) {
+		// Default validation: exact match + RFC 8252 §7.3 loopback IP support
+		const defaultResult = Boolean(
+			findRegisteredRedirectUri(registeredUris, query.redirect_uri),
+		);
+		if (opts.validateRedirectUri) {
+			try {
+				// Custom validator receives defaultResult for composition
+				isValidRedirectUri = await opts.validateRedirectUri(
+					query.redirect_uri,
+					registeredUris,
+					defaultResult,
+				);
+			} catch {
+				// Fail closed: a throwing validator rejects the request
+				isValidRedirectUri = false;
+			}
+		} else {
+			isValidRedirectUri = defaultResult;
+		}
+	}
+	if (!isValidRedirectUri) {
 		return handleRedirect(
 			ctx,
 			getErrorURL(ctx, "invalid_redirect", "invalid redirect uri"),

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -279,9 +279,11 @@ function findRegisteredRedirectUri(
 
 /**
  * Loads the client, verifies it's enabled, and returns the requested
- * redirect_uri when it matches a registered entry. Returns null whenever the
- * RP cannot be safely reached, so callers can fall back to the server error
- * page (avoiding open-redirect risk on validation failures).
+ * redirect_uri when it matches a registered entry (or is accepted by the
+ * custom `validateRedirectUri` option, mirroring the authorize endpoint's
+ * validation). Returns null whenever the RP cannot be safely reached, so
+ * callers can fall back to the server error page (avoiding open-redirect
+ * risk on validation failures).
  */
 async function resolveTrustedRedirectUri(
 	ctx: GenericEndpointContext,
@@ -297,7 +299,20 @@ async function resolveTrustedRedirectUri(
 		return null;
 	}
 	if (!client || client.disabled) return null;
-	const matched = findRegisteredRedirectUri(client.redirectUris, redirectUri);
+	const registeredUris = client.redirectUris ?? [];
+	const matched = findRegisteredRedirectUri(registeredUris, redirectUri);
+	if (opts.validateRedirectUri) {
+		try {
+			const isValid = await opts.validateRedirectUri(
+				redirectUri,
+				registeredUris,
+				Boolean(matched),
+			);
+			return isValid ? redirectUri : null;
+		} catch {
+			return null;
+		}
+	}
 	return matched ? redirectUri : null;
 }
 
@@ -506,11 +521,30 @@ export async function authorizeEndpoint(
 		);
 	}
 
-	const redirectUri = findRegisteredRedirectUri(
-		client.redirectUris,
-		query.redirect_uri,
-	);
-	if (!redirectUri || !query.redirect_uri) {
+	const registeredUris = client.redirectUris ?? [];
+	let isValidRedirectUri = false;
+	if (query.redirect_uri) {
+		// Default validation: exact match + RFC 8252 §7.3 loopback IP support
+		const defaultResult = Boolean(
+			findRegisteredRedirectUri(registeredUris, query.redirect_uri),
+		);
+		if (opts.validateRedirectUri) {
+			try {
+				// Custom validator receives defaultResult for composition
+				isValidRedirectUri = await opts.validateRedirectUri(
+					query.redirect_uri,
+					registeredUris,
+					defaultResult,
+				);
+			} catch {
+				// Fail closed: a throwing validator rejects the request
+				isValidRedirectUri = false;
+			}
+		} else {
+			isValidRedirectUri = defaultResult;
+		}
+	}
+	if (!isValidRedirectUri) {
 		return handleRedirect(
 			ctx,
 			getErrorURL(ctx, "invalid_redirect", "invalid redirect uri"),

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -137,8 +137,10 @@ export interface OAuthOptions<
 	 * - If the validator throws, the request is rejected (fail-closed)
 	 *
 	 * **Pairwise Subject Note:** For clients using pairwise subject identifiers,
-	 * the sector identifier is derived from registered URIs. Custom-validated
-	 * URIs not in `registeredUris` will share the same sector.
+	 * the sector identifier is derived from the client's first registered
+	 * redirect URI. Custom-validated URIs that are not that registered URI
+	 * will still share the same sector derived from the first registered
+	 * redirect URI.
 	 *
 	 * @param redirectUri - The redirect_uri from the authorization request
 	 * @param registeredUris - Array of registered redirect URIs for the client

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -96,19 +96,36 @@ export interface OAuthOptions<
 	 */
 	scopes?: Scopes;
 	/**
-	 * Custom redirect URI validation function that **extends** the default behavior.
+	 * Custom redirect URI validation function for composable validation logic.
 	 *
 	 * By default, the OAuth provider validates redirect URIs with:
 	 * 1. Exact string matching against registered redirect URIs
 	 * 2. RFC 8252 §7.3 loopback IP support (127.0.0.1/[::1] with flexible ports)
 	 *
-	 * This validator is called **only if default validation fails**, allowing you
-	 * to add custom logic without breaking existing native app loopback callbacks.
+	 * The `defaultResult` parameter provides the result of the default validation,
+	 * enabling flexible composition patterns:
+	 *
+	 * @example
+	 * ```ts
+	 * // Extend: add preview deployment support while preserving defaults
+	 * validateRedirectUri: (uri, registered, defaultResult) => {
+	 *   return defaultResult || uri.includes('.preview.example.com');
+	 * }
+	 *
+	 * // Replace: full custom control (use with caution)
+	 * validateRedirectUri: (uri, registered, _defaultResult) => {
+	 *   return myCustomValidation(uri, registered);
+	 * }
+	 *
+	 * // Restrict: add extra constraints on top of defaults
+	 * validateRedirectUri: (uri, registered, defaultResult) => {
+	 *   return defaultResult && !isBlocklisted(uri);
+	 * }
+	 * ```
 	 *
 	 * **Use Cases:**
 	 * - **Preview deployments**: Match `*.preview.example.com` for platforms
-	 *   like Vercel, Netlify, or Cloudflare Pages where each PR/branch gets
-	 *   a unique subdomain.
+	 *   like Vercel, Netlify, or Cloudflare Pages.
 	 * - **Multi-tenant applications**: Dynamic tenant subdomains.
 	 *
 	 * **Security Considerations:**
@@ -125,11 +142,13 @@ export interface OAuthOptions<
 	 *
 	 * @param redirectUri - The redirect_uri from the authorization request
 	 * @param registeredUris - Array of registered redirect URIs for the client
+	 * @param defaultResult - Result of the default validation (exact match + RFC 8252 loopback)
 	 * @returns `true` if the redirect URI is valid, `false` otherwise.
 	 */
 	validateRedirectUri?: (
 		redirectUri: string,
 		registeredUris: string[],
+		defaultResult: boolean,
 	) => Awaitable<boolean>;
 	/**
 	 * List of valid audiences if there are multiple.

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -96,32 +96,36 @@ export interface OAuthOptions<
 	 */
 	scopes?: Scopes;
 	/**
-	 * Custom redirect URI validation function.
+	 * Custom redirect URI validation function that **extends** the default behavior.
 	 *
-	 * By default, the OAuth provider performs exact string matching against
-	 * registered redirect URIs. This option allows you to implement custom
-	 * validation logic, such as wildcard pattern matching.
+	 * By default, the OAuth provider validates redirect URIs with:
+	 * 1. Exact string matching against registered redirect URIs
+	 * 2. RFC 8252 §7.3 loopback IP support (127.0.0.1/[::1] with flexible ports)
+	 *
+	 * This validator is called **only if default validation fails**, allowing you
+	 * to add custom logic without breaking existing native app loopback callbacks.
 	 *
 	 * **Use Cases:**
 	 * - **Preview deployments**: Match `*.preview.example.com` for platforms
 	 *   like Vercel, Netlify, or Cloudflare Pages where each PR/branch gets
 	 *   a unique subdomain.
-	 * - **Multi-tenant applications**: Match `*.tenants.example.com` where
-	 *   each tenant has their own subdomain.
-	 * - **Development environments**: Match `localhost` with any port.
+	 * - **Multi-tenant applications**: Dynamic tenant subdomains.
 	 *
 	 * **Security Considerations:**
 	 * - Never allow overly broad patterns like `*` or `*.com`
-	 * - Wildcard should only match a single subdomain level (RFC 6125)
-	 * - Consider using a library like `tldts` to prevent wildcards on
+	 * - Validate the full URI (protocol, host, path) - not just the hostname
+	 * - Consider using a library like `tldts` to prevent matches on
 	 *   public suffixes (e.g., `*.co.uk`, `*.github.io`)
 	 * - Always require HTTPS (except for localhost)
 	 * - If the validator throws, the request is rejected (fail-closed)
 	 *
+	 * **Pairwise Subject Note:** For clients using pairwise subject identifiers,
+	 * the sector identifier is derived from registered URIs. Custom-validated
+	 * URIs not in `registeredUris` will share the same sector.
+	 *
 	 * @param redirectUri - The redirect_uri from the authorization request
 	 * @param registeredUris - Array of registered redirect URIs for the client
 	 * @returns `true` if the redirect URI is valid, `false` otherwise.
-	 * @default Exact string match against registered URIs
 	 */
 	validateRedirectUri?: (
 		redirectUri: string,

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -96,6 +96,38 @@ export interface OAuthOptions<
 	 */
 	scopes?: Scopes;
 	/**
+	 * Custom redirect URI validation function.
+	 *
+	 * By default, the OAuth provider performs exact string matching against
+	 * registered redirect URIs. This option allows you to implement custom
+	 * validation logic, such as wildcard pattern matching.
+	 *
+	 * **Use Cases:**
+	 * - **Preview deployments**: Match `*.preview.example.com` for platforms
+	 *   like Vercel, Netlify, or Cloudflare Pages where each PR/branch gets
+	 *   a unique subdomain.
+	 * - **Multi-tenant applications**: Match `*.tenants.example.com` where
+	 *   each tenant has their own subdomain.
+	 * - **Development environments**: Match `localhost` with any port.
+	 *
+	 * **Security Considerations:**
+	 * - Never allow overly broad patterns like `*` or `*.com`
+	 * - Wildcard should only match a single subdomain level (RFC 6125)
+	 * - Consider using a library like `tldts` to prevent wildcards on
+	 *   public suffixes (e.g., `*.co.uk`, `*.github.io`)
+	 * - Always require HTTPS (except for localhost)
+	 * - If the validator throws, the request is rejected (fail-closed)
+	 *
+	 * @param redirectUri - The redirect_uri from the authorization request
+	 * @param registeredUris - Array of registered redirect URIs for the client
+	 * @returns `true` if the redirect URI is valid, `false` otherwise.
+	 * @default Exact string match against registered URIs
+	 */
+	validateRedirectUri?: (
+		redirectUri: string,
+		registeredUris: string[],
+	) => Awaitable<boolean>;
+	/**
 	 * List of valid audiences if there are multiple.
 	 *
 	 * @default baseURL

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -472,6 +472,77 @@ export interface OAuthOptions<
 	 */
 	scopes?: Scopes;
 	/**
+	 * Custom redirect URI validation function for composable validation logic.
+	 *
+	 * By default, the OAuth provider validates redirect URIs with:
+	 * 1. Exact string matching against registered redirect URIs
+	 * 2. RFC 8252 §7.3 loopback IP support (127.0.0.0/8 and [::1] with flexible ports)
+	 *
+	 * The `defaultResult` parameter provides the result of the default validation,
+	 * enabling flexible composition patterns:
+	 *
+	 * @example
+	 * ```ts
+	 * // Extend: add preview deployment support while preserving defaults
+	 * validateRedirectUri: (uri, registered, defaultResult) => {
+	 *   if (defaultResult) return true;
+	 *   try {
+	 *     const url = new URL(uri);
+	 *     return (
+	 *       url.protocol === "https:" &&
+	 *       url.hostname.endsWith(".preview.example.com")
+	 *     );
+	 *   } catch {
+	 *     return false;
+	 *   }
+	 * }
+	 *
+	 * // Replace: full custom control (use with caution)
+	 * validateRedirectUri: (uri, registered, _defaultResult) => {
+	 *   return myCustomValidation(uri, registered);
+	 * }
+	 *
+	 * // Restrict: add extra constraints on top of defaults
+	 * validateRedirectUri: (uri, registered, defaultResult) => {
+	 *   return defaultResult && !isBlocklisted(uri);
+	 * }
+	 * ```
+	 *
+	 * **Use Cases:**
+	 * - **Preview deployments**: Match `*.preview.example.com` for platforms
+	 *   like Vercel, Netlify, or Cloudflare Pages.
+	 * - **Multi-tenant applications**: Dynamic tenant subdomains.
+	 *
+	 * **Security Considerations:**
+	 * - Never allow overly broad patterns like `*` or `*.com`
+	 * - Validate the full URI (protocol, host, path) - not just the hostname
+	 * - Consider using a library like `tldts` to prevent matches on
+	 *   public suffixes (e.g., `*.co.uk`, `*.github.io`)
+	 * - Always require HTTPS (except for localhost)
+	 * - If the validator throws, the request is rejected (fail-closed)
+	 *
+	 * The validator is also consulted when deciding whether authorization
+	 * errors may be redirected to the requested redirect_uri
+	 * (RFC 6749 §4.1.2.1); on rejection or exception, errors fall back to
+	 * the server error page.
+	 *
+	 * **Pairwise Subject Note:** For clients using pairwise subject identifiers,
+	 * the sector identifier is derived from the client's first registered
+	 * redirect URI. Custom-validated URIs that are not that registered URI
+	 * will still share the same sector derived from the first registered
+	 * redirect URI.
+	 *
+	 * @param redirectUri - The redirect_uri from the authorization request
+	 * @param registeredUris - Array of registered redirect URIs for the client
+	 * @param defaultResult - Result of the default validation (exact match + RFC 8252 loopback)
+	 * @returns `true` if the redirect URI is valid, `false` otherwise.
+	 */
+	validateRedirectUri?: (
+		redirectUri: string,
+		registeredUris: readonly string[],
+		defaultResult: boolean,
+	) => Awaitable<boolean>;
+	/**
 	 * Protected resources the AS issues access tokens for. Promotes the
 	 * resource model into a first-class persisted entity with per-resource
 	 * token policy.

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -517,6 +517,83 @@ export interface OAuthOptions<
 	 */
 	scopes?: Scopes;
 	/**
+	 * Custom redirect URI validation function for composable validation logic.
+	 *
+	 * By default, the OAuth provider validates redirect URIs with:
+	 * 1. Exact string matching against registered redirect URIs
+	 * 2. RFC 8252 §7.3 loopback IP support (127.0.0.0/8 and [::1] with flexible ports)
+	 *
+	 * The `defaultResult` parameter provides the result of the default validation,
+	 * enabling flexible composition patterns:
+	 *
+	 * @example
+	 * ```ts
+	 * // Extend: add preview deployment support while preserving defaults
+	 * validateRedirectUri: (uri, registered, defaultResult) => {
+	 *   if (defaultResult) return true;
+	 *   // Registration rejects fragments; keep custom validation just as strict.
+	 *   if (uri.includes("#")) return false;
+	 *   try {
+	 *     const url = new URL(uri);
+	 *     return (
+	 *       url.protocol === "https:" &&
+	 *       // Suffix match only — never `includes()`, or `evil.com/?x=.preview.example.com` slips through.
+	 *       url.hostname.endsWith(".preview.example.com") &&
+	 *       // Pin the callback path so the host alone is not enough.
+	 *       url.pathname === "/api/auth/oauth2/callback" &&
+	 *       url.search === ""
+	 *     );
+	 *   } catch {
+	 *     return false;
+	 *   }
+	 * }
+	 *
+	 * // Replace: full custom control (use with caution)
+	 * validateRedirectUri: (uri, registered, _defaultResult) => {
+	 *   return myCustomValidation(uri, registered);
+	 * }
+	 *
+	 * // Restrict: add extra constraints on top of defaults
+	 * validateRedirectUri: (uri, registered, defaultResult) => {
+	 *   return defaultResult && !isBlocklisted(uri);
+	 * }
+	 * ```
+	 *
+	 * **Use Cases:**
+	 * - **Preview deployments**: Match `*.preview.example.com` for platforms
+	 *   like Vercel, Netlify, or Cloudflare Pages.
+	 * - **Multi-tenant applications**: Dynamic tenant subdomains.
+	 *
+	 * **Security Considerations:**
+	 * - Never allow overly broad patterns like `*` or `*.com`
+	 * - Validate the full URI (protocol, host, path) - not just the hostname
+	 * - Consider using a library like `tldts` to prevent matches on
+	 *   public suffixes (e.g., `*.co.uk`, `*.github.io`)
+	 * - Always require HTTPS (except for localhost)
+	 * - If the validator throws, the request is rejected (fail-closed)
+	 *
+	 * The validator is also consulted when deciding whether authorization
+	 * errors may be redirected to the requested redirect_uri
+	 * (RFC 6749 §4.1.2.1); on rejection or exception, errors fall back to
+	 * the server error page.
+	 *
+	 * **Pairwise Subject Note:** For clients using pairwise subject identifiers,
+	 * the sector identifier is derived from the client's first registered
+	 * redirect URI. Custom-validated URIs that are not that registered URI
+	 * will still share the same sector derived from the first registered
+	 * redirect URI.
+	 *
+	 * @param redirectUri - The redirect_uri from the authorization request
+	 * @param registeredUris - Array of registered redirect URIs for the client
+	 * @param defaultResult - Result of the default validation (exact match + RFC 8252 loopback)
+	 * @returns `true` if the redirect URI is valid, `false` otherwise.
+	 */
+	validateRedirectUri?: (
+		redirectUri: string,
+		registeredUris: readonly string[],
+		defaultResult: boolean,
+	) => Awaitable<boolean>;
+	/**
 	 * Protected resources the AS issues access tokens for. Promotes the
 	 * resource model into a first-class persisted entity with per-resource
 	 * token policy.


### PR DESCRIPTION
## Summary

Add a `validateRedirectUri` option to the OAuth provider that allows custom redirect URI validation logic. This enables use cases like wildcard pattern matching for preview deployments without requiring database modification or workarounds.

## Motivation

Platforms like **Vercel**, **Netlify**, and **Cloudflare Pages** generate unique subdomains for each PR/branch preview deployment (e.g., `pr-123.preview.example.com`, `deploy-preview-456.netlify.app`). Currently, Better Auth only supports exact string matching for redirect URIs, which means:

1. Each preview URL must be registered individually (impractical)
2. Users resort to workarounds like database hooks to temporarily inject URIs (security concerns)

This PR provides a clean, secure API to implement custom validation logic.

## Use Cases

- **Preview deployments**: Match `*.preview.example.com` for CI/CD preview URLs
- **Multi-tenant applications**: Match `*.tenants.example.com` for tenant subdomains
- **Development environments**: Match `localhost` with any port

## Changes

### `packages/oauth-provider/src/types/index.ts`
- Added `validateRedirectUri` option to `OAuthOptions` interface
- Comprehensive JSDoc documentation with use cases and security considerations

### `packages/oauth-provider/src/authorize.ts`
- Modified redirect URI validation to use custom validator when provided
- Added try-catch to handle validator exceptions (fail-closed for security)
- Falls back to exact string matching when no validator is provided (backward compatible)

### `packages/oauth-provider/src/authorize.test.ts`
- Added test suite for custom `validateRedirectUri` functionality
- Tests cover: acceptance of matching URIs, rejection of non-matching URIs, exception handling

### `docs/content/docs/plugins/oauth-provider.mdx`
- Added "Custom Redirect URI Validation" section
- Includes code examples and security warnings

## API

```typescript
oauthProvider({
  validateRedirectUri: (redirectUri, registeredUris) => {
    // Return true if valid, false otherwise
    // Example: implement wildcard matching
    return registeredUris.some((pattern) => {
      if (!pattern.includes('*')) return pattern === redirectUri;
      const regex = new RegExp('^' + pattern.replace(/\*/g, '[^.]+') + '$');
      return regex.test(redirectUri);
    });
  },
})
```

## Security Considerations

The implementation follows security best practices:

1. **Fail-closed**: If no validator is provided, exact string matching is used
2. **Exception handling**: If the custom validator throws, the request is rejected (fail-closed)
3. **No information leakage**: Invalid redirect URIs are redirected to an error page, not to the attacker-controlled URI
4. **Documentation warnings**: Clear warnings about public suffixes, HTTPS requirements, and overly broad patterns

## Test Plan

- [x] Existing tests pass
- [x] New tests for custom validator functionality
- [x] Test for validator exception handling (fail-closed)
- [x] Lint and format pass
- [x] Build succeeds

## Breaking Changes

None. This is a purely additive change with full backward compatibility.