### PR TITLE
docs: fix code block formatting in username plugin content

### DIFF
--- a/docs/content/docs/plugins/username.mdx
+++ b/docs/content/docs/plugins/username.mdx
@@ -146,7 +146,7 @@ type isUsernameAvailable = {
     username: string = "new-username"
 }
 
-if(response?.available) {
+if (response?.available) {
     console.log("Username is available");
 } else {
     console.log("Username is not available");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix formatting in the username availability example to improve readability and match our code style.
Adds a space in the conditional: `if (response?.available)`.

<sup>Written for commit 5a0f2d3a4cf0995a4dd5d14352d95ffd1ff7dd01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

