### PR TITLE
feat(sso): Add logging for when code validation fails in oidc callback

### DIFF
--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1601,6 +1601,7 @@ async function handleOIDCCallback(
 				? "post"
 				: "basic",
 	}).catch((e) => {
+		ctx.context.logger.error("Error validating authorization code", e);
 		if (e instanceof BetterFetchError) {
 			throw ctx.redirect(
 				`${


### PR DESCRIPTION
When code exchange fails, the error object is thrown:

https://github.com/better-auth/better-auth/blob/b1be9cf61b1e6a61bcab476397b0d5eaff0785f0/packages/core/src/oauth2/validate-authorization-code.ts#L154-L161

But further up the call stack this gets swallowed:

https://github.com/better-auth/better-auth/blob/b1be9cf61b1e6a61bcab476397b0d5eaff0785f0/packages/sso/src/routes/sso.ts#L1603-L1612

This is not a `BetterFetchError`, so this redirect is missed and a generic error replaces it.

The generic error is fine, but it'd be really great to see what is happening here, as OIDC provider errors are lost otherwise.