### PR TITLE
fix(organization): filter null organizations in listUserInvitations

### DIFF
--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -930,9 +930,9 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					organization: true,
 				},
 			});
-			return invitations.map(({ organization, ...inv }) => ({
+			return invitations.filter(Boolean).map(({ organization, ...inv }) => ({
 				...inv,
-				organizationName: organization.name,
+				organizationName: organization?.name,
 			}));
 		},
 		createInvitation: async ({


### PR DESCRIPTION
## Summary

- Fixed a crash in `listUserInvitations` caused by invitations whose associated organization has been deleted (or is otherwise missing from a join result).
- Added `.filter(Boolean)` to skip null/undefined entries before mapping.
- Used optional chaining (`organization?.name`) to safely access the organization name.

## Background

When `listUserInvitations` performs a joined query over the `invitation` model, it's possible for the resolved `organization` to be `null` — for example, if the organization was deleted after the invitation was created but before the invitations were listed. Previously this caused an uncaught runtime crash when destructuring `{ organization, ...inv }` and then accessing `organization.name` on a null value.

## Changes

**`packages/better-auth/src/plugins/organization/adapter.ts`**
- `listUserInvitations`: added `.filter(Boolean)` before `.map(...)` to drop null entries returned from the join.
- Changed `organization.name` → `organization?.name` to safely handle any null organization that slips through.

## Breaking Changes

None.

## Deprecations

None.

## Screenshots

N/A — no UI changes.

## Related Issues

Fixes a runtime crash in the organization plugin when listing invitations for a user whose invitation's organization no longer exists.

Issue: https://github.com/better-auth/better-auth/issues/8691


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented crashes in `listUserInvitations` when an invitation’s organization is null. We now filter out falsy invitations and safely read the organization name with optional chaining.

<sup>Written for commit 6b52652fb121f73d6e0d91eb62bd90d2102f92ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

