### PR TITLE
fix(sso): use namespace import for samlify to fix ESM compatibility

### DIFF
--- a/e2e/smoke/test/saml.spec.ts
+++ b/e2e/smoke/test/saml.spec.ts
@@ -1,11 +1,9 @@
 import assert from "node:assert/strict";
-import { createRequire } from "node:module";
 import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "node:test";
+import { sso } from "@better-auth/sso";
 import { betterAuth } from "better-auth";
 import { getMigrations } from "better-auth/db/migration";
-
-const { sso } = createRequire(import.meta.url)("@better-auth/sso");
 
 const TEST_CERT = `MIIDXTCCAkWgAwIBAgIJAOxEm08dOr3PMA0GCSqGSIb3DqEBCwUAMEUxCzAJBgNV
 BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
@@ -29,6 +27,21 @@ r1PAFY+X3xF+5qDTbPpcHFPTIEWLpJFJPkSS+Q==`;
 const IDP_ENTRY_POINT = "https://idp.example.com/saml2/sso";
 
 describe("SAML SSO", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8695
+	 *
+	 * samlify is a CJS module with __esModule: true but no exports.default.
+	 * Using `import saml from "samlify"` resolves to undefined in ESM,
+	 * causing `saml.setSchemaValidator(...)` to throw at module load time.
+	 * This test verifies that @better-auth/sso loads without error under ESM
+	 * by using a native ESM import (not createRequire).
+	 */
+	test("should load @better-auth/sso via ESM without samlify import error", async () => {
+		const mod = await import("@better-auth/sso");
+		assert.ok(mod.sso, "sso export should be defined");
+		assert.equal(typeof mod.sso, "function", "sso should be a function");
+	});
+
 	test("should generate SAML login request URL via defaultSSO", async () => {
 		const database = new DatabaseSync(":memory:");
 		const auth = betterAuth({

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -1,7 +1,7 @@
 import type { BetterAuthPlugin } from "better-auth";
 import { createAuthMiddleware, getSessionFromCtx } from "better-auth/api";
 import { XMLValidator } from "fast-xml-parser";
-import saml from "samlify";
+import * as saml from "samlify";
 import { SAML_SESSION_BY_ID_PREFIX } from "./constants";
 import { assignOrganizationByDomain } from "./linking";
 import {

--- a/packages/sso/src/routes/helpers.ts
+++ b/packages/sso/src/routes/helpers.ts
@@ -1,5 +1,5 @@
 import type { DBAdapter } from "@better-auth/core/db/adapter";
-import saml from "samlify";
+import * as saml from "samlify";
 import type { SAMLConfig, SSOOptions, SSOProvider } from "../types";
 import { safeJsonParse } from "../utils";
 

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -19,7 +19,7 @@ import { generateRandomString } from "better-auth/crypto";
 import { handleOAuthUserInfo } from "better-auth/oauth2";
 import { XMLParser } from "fast-xml-parser";
 import { decodeJwt } from "jose";
-import saml from "samlify";
+import * as saml from "samlify";
 import type { BindingContext } from "samlify/types/src/entity";
 import type { IdentityProvider } from "samlify/types/src/entity-idp";
 import type { FlowResult } from "samlify/types/src/flow";


### PR DESCRIPTION
## Summary

- Fix `TypeError: Cannot read properties of undefined (reading 'setSchemaValidator')` during SAML initialization in ESM runtimes
- `samlify` is a CJS module with `__esModule: true` but no `exports.default`. Using `import saml from "samlify"` resolves to `undefined` in ESM, causing `saml.setSchemaValidator(...)` to throw at module load time
- Switch all three source files (`index.ts`, `routes/sso.ts`, `routes/helpers.ts`) from `import saml from "samlify"` to `import * as saml from "samlify"`
- Update the smoke test to use native ESM import (`import { sso } from "@better-auth/sso"`) instead of `createRequire`, and add a dedicated regression test for ESM module loading

## Test plan

- [x] All 96 SAML unit tests pass (`vitest packages/sso/src/saml.test.ts`)
- [x] All 3 SAML smoke tests pass (`node --test e2e/smoke/test/saml.spec.ts`)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes