### PR TITLE
fix(oauth-provider): fix dist declaration type errors

### DIFF
--- a/packages/oauth-provider/src/client-resource.ts
+++ b/packages/oauth-provider/src/client-resource.ts
@@ -32,11 +32,14 @@ export const oauthProviderResourceClient = <T extends Auth | undefined>(
 		}
 		return jwtPlugin?.options;
 	};
-	const getAuthorizationServer = async () => {
+	const authServerBaseUrl =
+		typeof auth?.options.baseURL === "string"
+			? auth.options.baseURL
+			: undefined;
+	const getAuthorizationServer = async (): Promise<string | undefined> => {
 		const jwtPluginOptions = await getJwtPluginOptions();
 		return jwtPluginOptions?.jwt?.issuer ?? authServerBaseUrl;
 	};
-	const authServerBaseUrl = auth?.options.baseURL;
 	const authServerBasePath = auth?.options.basePath;
 
 	return {

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -120,7 +120,7 @@ export async function consentEndpoint(
 	}
 	ctx?.headers?.set("accept", "application/json");
 	ctx.query = deleteFromPrompt(query, "consent");
-	ctx.context.postLogin = true;
+	(ctx.context as Record<string, unknown>).postLogin = true;
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -446,7 +446,7 @@ export function schemaToOAuth(input: SchemaClient<Scope[]>): OAuthClient {
 		software_version: softwareVersion ?? undefined,
 		software_statement: softwareStatement ?? undefined,
 		// Authentication Metadata
-		redirect_uris: redirectUris ?? undefined,
+		redirect_uris: redirectUris ?? [],
 		post_logout_redirect_uris: postLogoutRedirectUris ?? undefined,
 		token_endpoint_auth_method: tokenEndpointAuthMethod ?? undefined,
 		grant_types: grantTypes ?? undefined,

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -55,7 +55,7 @@ export const getOAuthProviderPlugin = (ctx: AuthContext) => {
 export const getJwtPlugin = (ctx: AuthContext) => {
 	const plugin = ctx.getPlugin("jwt") satisfies ReturnType<typeof jwt> | null;
 	if (!plugin) {
-		throw new BetterAuthError("jwt_config", "jwt plugin not found");
+		throw new BetterAuthError("jwt_config");
 	}
 	return plugin;
 };


### PR DESCRIPTION
## Summary

The `oauth-provider` package has **8 type errors** in its emitted `.d.mts` declarations that are invisible during development but break external consumers. This PR fixes them and adds CI validation to prevent regressions.

### Why these errors are hidden

The monorepo uses `customConditions: ["dev-source"]` in `tsconfig.base.json`, which resolves workspace imports to **source `.ts` files** instead of built `dist/` output:

```jsonc
// tsconfig.base.json
"customConditions": ["dev-source"]
```

Each package exports a `dev-source` condition:

```json
"dev-source": "./src/index.ts"
```

So `pnpm typecheck` (root `tsc --build`) resolves all cross-package imports to source — types are always consistent. **But the published dist declarations have real type issues.**

| Scenario | What TypeScript sees | Result |
|---|---|---|
| Root `tsc --build` | Source `.ts` via dev-source | Passes |
| Package-level `tsc --noEmit` | Source with dist deps (no build mode) | **8 errors** |
| External consumer via npm | Dist `.d.mts` files | **Broken types** |

### Commit 1: Fix the 8 type errors

1. **`client-resource.ts`** (5 errors) — `auth?.options.baseURL` typed as `BaseURLConfig` (includes `DynamicBaseURLConfig`) in dist. **Fix:** narrow to `string | undefined` with a `typeof` check.

2. **`consent.ts`** (1 error) — `ctx.context.postLogin` doesn't exist on dist `AuthContext` (dynamically added at runtime). **Fix:** cast to `Record<string, unknown>`.

3. **`register.ts`** (1 error) — `redirect_uris` typed as `string[] | undefined` in dist, assigned to `string[]`. **Fix:** default to `[]`.

4. **`utils/index.ts`** (1 error) — `BetterAuthError("jwt_config", "jwt plugin not found")` — second arg is a string but constructor expects `{ cause?: unknown }`. Silently ignored at runtime. **Fix:** drop invalid second arg.

### Commit 2: Add dist declaration CI check

Adds `tsconfig.dist-check.json` at the repo root that:
- Clears `customConditions` (disables `dev-source` resolution)
- Sets `composite: false` + `noEmit: true`
- Includes all downstream package sources, excluding `better-auth`, `core`, and `electron` (top-level packages that can't be dist-checked against themselves due to module augmentation conflicts)

Available locally via `pnpm typecheck:dist` and runs in CI after the build step.

### How to reproduce

```bash
pnpm build
pnpm typecheck:dist  # Should pass (0 errors with this PR)

# Without this PR's fixes:
git stash
pnpm typecheck:dist  # Shows 8 oauth-provider errors
```

## Test plan

- [x] `pnpm typecheck` (root, dev-source) still passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck:dist` — 0 errors (was 8)
- [x] 216/216 oauth-provider tests pass