### PR TITLE
ci: add dist declaration typecheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Typecheck dist declarations
+        run: pnpm typecheck:dist
+
   test:
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "coverage:open": "open coverage/lcov-report/index.html",
     "e2e:smoke": "turbo e2e:smoke",
     "e2e:integration": "turbo e2e:integration",
-    "typecheck": "tsc --build"
+    "typecheck": "tsc --build",
+    "typecheck:dist": "tsc --project tsconfig.dist-check.json"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",

--- a/tsconfig.dist-check.json
+++ b/tsconfig.dist-check.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "customConditions": [],
+    "composite": false,
+    "noEmit": true
+  },
+  "include": ["packages/*/src/**/*.ts"],
+  "exclude": [
+    "**/dist/**",
+    "**/node_modules/**",
+    "**/*.test.ts",
+    "**/demo/**",
+    "**/docs/**",
+    "**/e2e/**",
+    "**/test/**",
+    "packages/better-auth/src/**",
+    "packages/core/src/**",
+    "packages/electron/src/**"
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to #8701 — adds CI validation that catches dist declaration type errors before they reach consumers.

### What it does

Adds a `typecheck:dist` step that typechecks package source against workspace dependencies' **dist `.d.mts` declarations** instead of source files. This disables the `customConditions: ["dev-source"]` condition that normally resolves all imports to source `.ts`.

### Why it's needed

The monorepo's `pnpm typecheck` (`tsc --build`) uses `dev-source` to resolve workspace imports to source, so type errors in dist declarations are invisible. #8701 fixed 8 such errors in `oauth-provider` — this CI step prevents new ones.

| Check | What it validates | When it catches errors |
|---|---|---|
| `pnpm typecheck` | Source against source | Always (but masks dist issues) |
| `pnpm typecheck:dist` | Source against dist declarations | When dist types diverge from source |
| `pnpm lint:types` (`attw`) | Export resolution correctness | When package.json exports are wrong |

### How it works

`tsconfig.dist-check.json` extends the base config but:
- Clears `customConditions` (disables `dev-source`)
- Sets `composite: false` + `noEmit: true`
- Excludes `better-auth`, `core`, `electron` source (their `declare module` augmentations conflict with their own dist when both are visible)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI step to typecheck against built dist declarations to catch type errors that `pnpm typecheck` misses due to the `dev-source` condition. Prevents regressions like the issues found in #8701 from reaching consumers.

- **New Features**
  - Adds `typecheck:dist` (uses `tsconfig.dist-check.json`) and runs it in CI after Typecheck.
  - Resolves workspace imports against dist `.d.mts` instead of source.
  - Excludes `better-auth`, `core`, and `electron` sources to avoid module augmentation conflicts.

<sup>Written for commit e77e56e125242354609744110fa0ff171e8821f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

