### PR TITLE
docs: add better-auth-devtools to community plugins

### DIFF
--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -29,3 +29,4 @@ iamjasonkendrick
 ejirocodes
 0-Sandy
 qamarq
+C-W-D-Harshit

--- a/landing/components/community-plugins-table.tsx
+++ b/landing/components/community-plugins-table.tsx
@@ -312,6 +312,17 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/qamarq.png",
 		},
 	},
+	{
+		name: "better-auth-devtools",
+		url: "https://github.com/C-W-D-Harshit/better-auth-devtools",
+		description:
+			"A devtools panel for Better Auth that lets you create managed test users from templates, switch between sessions instantly, inspect live session data, and edit fields like roles on the fly. All from a floating React UI that only runs in development.",
+		author: {
+			name: "C-W-D-Harshit",
+			github: "C-W-D-Harshit",
+			avatar: "https://github.com/C-W-D-Harshit.png",
+		},
+	},
 ];
 export function CommunityPluginsTable() {
 	const [sorting, setSorting] = useState<SortingState>([]);

--- a/landing/lib/community-plugins-data.ts
+++ b/landing/lib/community-plugins-data.ts
@@ -226,4 +226,15 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/qamarq.png",
 		},
 	},
+	{
+		name: "better-auth-devtools",
+		url: "https://github.com/C-W-D-Harshit/better-auth-devtools",
+		description:
+			"A devtools panel for Better Auth that lets you create managed test users from templates, switch between sessions instantly, inspect live session data, and edit fields like roles on the fly. All from a floating React UI that only runs in development.",
+		author: {
+			name: "C-W-D-Harshit",
+			github: "C-W-D-Harshit",
+			avatar: "https://github.com/C-W-D-Harshit.png",
+		},
+	},
 ];


### PR DESCRIPTION
# Add better-auth-devtools to Community Plugins

**Description**
This PR adds `better-auth-devtools` to the community plugins list — a development-only devtools panel for Better Auth.

**What it does**
- Create managed test users from templates (e.g., admin, viewer)
- Switch between sessions instantly
- Inspect live session data
- Edit fields like roles on the fly from a floating React UI
- Environment-guarded: only runs when `DEV_AUTH_ENABLED=true`, never in production
- Next.js App Router compatible with server/client separation

**Links**
- npm: https://www.npmjs.com/package/better-auth-devtools
- GitHub: https://github.com/C-W-D-Harshit/better-auth-devtools

**Changes**
- `.cspell/names.txt` — added `C-W-D-Harshit`
- `landing/lib/community-plugins-data.ts` — added plugin entry
- `landing/components/community-plugins-table.tsx` — added plugin entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `better-auth-devtools` to the Community Plugins list. The plugin is a dev-only Better Auth panel with a floating React UI to create test users from templates, switch sessions instantly, and inspect or edit session data.

<sup>Written for commit ff441affbc66e9045f69fc9d41bf719f526042c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

