### PR TITLE
feat(passkey): infer authenticator name from AAGUID with override hook

### DIFF
--- a/.changeset/three-plums-vanish.md
+++ b/.changeset/three-plums-vanish.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/passkey": patch
+---
+
+Improve passkey registration naming fallback by prioritizing explicit input name, then custom `getAuthenticatorName({ aaguid })`, then known AAGUID provider suggestions.

--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -421,6 +421,38 @@ until it hits an effective TLD. So `www.example.com` can use the RP IDs `www.exa
   * `discouraged`: No verification required (fastest experience)
   * Default: `preferred`
 
+**getAuthenticatorName**: Optional callback to control the label saved in the `passkey.name` database field after registration verification.
+
+Known AAGUID identifiers are sourced from:
+
+- [https://github.com/passkeydeveloper/passkey-authenticator-aaguids](https://github.com/passkeydeveloper/passkey-authenticator-aaguids)
+
+- Called with: `aaguid` (always present during registration verification).
+- Return a string to set the stored label, or `undefined` to use Better Auth's default best-effort AAGUID provider suggestion.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { passkey } from "@better-auth/passkey";
+
+export const auth = betterAuth({
+    plugins: [
+        passkey({
+            getAuthenticatorName: ({ aaguid }) => {
+                if (aaguid === "b78a0a55-6ef8-d246-a042-ba0f6d55050c") {
+                    return "LastPass";
+                }
+
+                if (aaguid === "11111111-1111-1111-1111-111111111111") {
+                    return "My custom provider";
+                }
+
+                return undefined;
+            },
+        }),
+    ],
+});
+```
+
 **advanced**: Advanced options
 
 * `webAuthnChallengeCookie`: Cookie name for storing WebAuthn challenge ID during authentication flow (Default: `better-auth-passkey`)

--- a/packages/passkey/src/authenticator-metadata.test.ts
+++ b/packages/passkey/src/authenticator-metadata.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getKnownAuthenticatorName } from "./authenticator-metadata";
+
+describe("getKnownAuthenticatorName", () => {
+	it("should resolve known AAGUID", () => {
+		expect(
+			getKnownAuthenticatorName("ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4"),
+		).toBe("Google Password Manager");
+		expect(
+			getKnownAuthenticatorName("fbfc3007-154e-4ecc-8c0b-6e020557d7bd"),
+		).toBe("Apple Passwords");
+		expect(
+			getKnownAuthenticatorName("531126d6-e717-415c-9320-3d9aa6981239"),
+		).toBe("Dashlane");
+	});
+
+	it("should normalize casing and whitespace", () => {
+		expect(
+			getKnownAuthenticatorName("  DD4EC289-E01D-41C9-BB89-70FA845D4BF2  "),
+		).toBe("iCloud Keychain");
+	});
+
+	it("should return undefined for unknown AAGUID", () => {
+		expect(
+			getKnownAuthenticatorName("11111111-1111-1111-1111-111111111111"),
+		).toBeUndefined();
+	});
+});

--- a/packages/passkey/src/authenticator-metadata.ts
+++ b/packages/passkey/src/authenticator-metadata.ts
@@ -1,0 +1,33 @@
+// Known AAGUID values are based on:
+// - https://github.com/passkeydeveloper/passkey-authenticator-aaguids
+const KNOWN_AUTHENTICATOR_PROVIDERS: Record<string, string> = {
+	// Google Password Manager
+	"ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4": "Google Password Manager",
+
+	// Apple Passwords / iCloud Keychain
+	"fbfc3007-154e-4ecc-8c0b-6e020557d7bd": "Apple Passwords",
+	"dd4ec289-e01d-41c9-bb89-70fa845d4bf2": "iCloud Keychain",
+
+	// Dashlane
+	"531126d6-e717-415c-9320-3d9aa6981239": "Dashlane",
+
+	// Microsoft Windows Hello
+	"08987058-cadc-4b81-b6e1-30de50dcbe96": "Windows Hello",
+	"9ddd1817-af5a-4672-a2b9-3e3dd95000a9": "Windows Hello",
+	"6028b017-b1d4-4c02-b4b3-afcdafc96bb2": "Windows Hello",
+
+	// 1Password
+	"bada5566-a7aa-401f-bd96-45619a55120d": "1Password",
+	"b5397571-8af2-4d30-9d48-eeb8eee6e9c6": "1Password",
+
+	// Bitwarden
+	"d548826e-79b4-db40-a3d8-11116f7e8349": "Bitwarden",
+	"cc45f64e-52a2-451b-831a-4edd8022a202": "Bitwarden",
+};
+
+export const getKnownAuthenticatorName = (
+	aaguid: string,
+): string | undefined => {
+	const normalized = aaguid.trim().toLowerCase();
+	return KNOWN_AUTHENTICATOR_PROVIDERS[normalized];
+};

--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -1,4 +1,5 @@
 import { APIError } from "@better-auth/core/error";
+import { verifyRegistrationResponse } from "@simplewebauthn/server";
 import type { Verification } from "better-auth";
 import { createAuthClient } from "better-auth/client";
 import { getTestInstance } from "better-auth/test";
@@ -922,6 +923,155 @@ describe("passkey", async () => {
 		} finally {
 			consumeSpy.mockRestore();
 		}
+	});
+});
+
+describe("passkey registration naming fallback", async () => {
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		plugins: [
+			passkey({
+				getAuthenticatorName: ({ aaguid }) => {
+					if (aaguid === "d3452668-01fd-4c12-926c-83a4204853aa") {
+						return "My custom provider";
+					}
+					return undefined;
+				},
+			}),
+		],
+	});
+	const mockWebAuthnRegistrationResponse = {
+		response: { transports: ["internal"] },
+	};
+
+	function mockRegistrationVerification(aaguid: string) {
+		vi.mocked(verifyRegistrationResponse).mockResolvedValueOnce({
+			verified: true,
+			registrationInfo: {
+				aaguid,
+				credentialDeviceType: "singleDevice",
+				credentialBackedUp: false,
+				credential: {
+					id: "mock-credential-id",
+					publicKey: new Uint8Array([1, 2, 3]),
+					counter: 0,
+				},
+			},
+		} as Awaited<ReturnType<typeof verifyRegistrationResponse>>);
+	}
+
+	async function getVerifyHeaders(
+		client: ReturnType<typeof createAuthClient>,
+		headers: HeadersInit,
+	) {
+		let challengeCookie = "";
+		await client.$fetch("/passkey/generate-register-options", {
+			headers,
+			method: "GET",
+			onResponse(context) {
+				challengeCookie =
+					(context.response.headers.get("Set-Cookie") || "").split(";")[0] ||
+					"";
+			},
+		});
+
+		const verifyHeaders = new Headers(headers);
+		verifyHeaders.set(
+			"cookie",
+			[verifyHeaders.get("cookie") || "", challengeCookie]
+				.filter(Boolean)
+				.join("; "),
+		);
+		verifyHeaders.set("content-type", "application/json");
+		verifyHeaders.set("origin", "http://localhost:3000");
+		return verifyHeaders;
+	}
+
+	it("should use explicit name when provided", async () => {
+		const { headers } = await signInWithTestUser();
+		mockRegistrationVerification("d3452668-01fd-4c12-926c-83a4204853aa");
+
+		const client = createAuthClient({
+			plugins: [passkeyClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				headers,
+				customFetchImpl,
+			},
+		});
+
+		const verifyHeaders = await getVerifyHeaders(client, headers);
+
+		await client.$fetch("/passkey/verify-registration", {
+			method: "POST",
+			headers: verifyHeaders,
+			body: JSON.stringify({
+				response: mockWebAuthnRegistrationResponse,
+				name: "My explicit name",
+			}),
+		});
+
+		const passkeys = await auth.api.listPasskeys({ headers });
+		expect(
+			passkeys.some((passkey) => passkey.name === "My explicit name"),
+		).toBe(true);
+	});
+
+	it("should use getAuthenticatorName return when no explicit name is provided", async () => {
+		const { headers } = await signInWithTestUser();
+		mockRegistrationVerification("d3452668-01fd-4c12-926c-83a4204853aa");
+
+		const client = createAuthClient({
+			plugins: [passkeyClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				headers,
+				customFetchImpl,
+			},
+		});
+
+		const verifyHeaders = await getVerifyHeaders(client, headers);
+
+		await client.$fetch("/passkey/verify-registration", {
+			method: "POST",
+			headers: verifyHeaders,
+			body: JSON.stringify({
+				response: mockWebAuthnRegistrationResponse,
+			}),
+		});
+
+		const passkeys = await auth.api.listPasskeys({ headers });
+		expect(
+			passkeys.some((passkey) => passkey.name === "My custom provider"),
+		).toBe(true);
+	});
+
+	it("should fall back to known AAGUID suggestion when explicit name and override are absent", async () => {
+		const { headers } = await signInWithTestUser();
+		mockRegistrationVerification("ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4");
+
+		const client = createAuthClient({
+			plugins: [passkeyClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				headers,
+				customFetchImpl,
+			},
+		});
+
+		const verifyHeaders = await getVerifyHeaders(client, headers);
+
+		await client.$fetch("/passkey/verify-registration", {
+			method: "POST",
+			headers: verifyHeaders,
+			body: JSON.stringify({
+				response: mockWebAuthnRegistrationResponse,
+			}),
+		});
+
+		const passkeys = await auth.api.listPasskeys({ headers });
+		expect(
+			passkeys.some((passkey) => passkey.name === "Google Password Manager"),
+		).toBe(true);
 	});
 });
 

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -22,6 +22,7 @@ import {
 import { setSessionCookie } from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
 import * as z from "zod";
+import { getKnownAuthenticatorName } from "./authenticator-metadata";
 import { PASSKEY_ERROR_CODES } from "./error-codes";
 import type {
 	Passkey,
@@ -634,9 +635,13 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) => {
 						targetUserId = result.userId;
 					}
 				}
+				const name =
+					ctx.body.name?.trim() ||
+					options.getAuthenticatorName?.({ aaguid }) ||
+					getKnownAuthenticatorName(aaguid);
 				const pubKey = base64.encode(credential.publicKey);
 				const newPasskey: Omit<Passkey, "id"> = {
-					name: ctx.body.name,
+					name,
 					userId: targetUserId,
 					credentialID: credential.id,
 					publicKey: pubKey,

--- a/packages/passkey/src/types.ts
+++ b/packages/passkey/src/types.ts
@@ -119,6 +119,21 @@ export interface PasskeyOptions {
 	 */
 	authenticatorSelection?: AuthenticatorSelectionCriteria | undefined;
 	/**
+	 * Provide a passkey label based on the authenticator AAGUID.
+	 *
+	 * This callback is only used when no `name` is provided during passkey
+	 * registration verification. It only affects the stored DB label.
+	 *
+	 * Known AAGUID identifiers are sourced from:
+	 * - https://github.com/passkeydeveloper/passkey-authenticator-aaguids
+	 *
+	 * @default A best-effort provider suggestion is inferred from known AAGUID
+	 * values.
+	 */
+	getAuthenticatorName?:
+		| ((context: { aaguid: string }) => string | undefined)
+		| undefined;
+	/**
 	 * Advanced options
 	 */
 	advanced?:


### PR DESCRIPTION
This PR adds AAGUID-based passkey labeling during registration

When a user does not provide a name,  resolve the stored label using the developer override via `getAuthenticatorName` and fallback to the built-in best-effort provider suggestion from known AAGUID values

## Why
Some ecosystems surface passkey provider names from AAGUID metadata. This improves default naming UX without introducing new DB storage concerns.

## References
Passkey AAGUID source: https://github.com/passkeydeveloper/passkey-authenticator-aaguids
ASP.Net Core implementation: https://github.com/dotnet/aspnetcore/pull/65343
Related discussion: https://github.com/better-auth/better-auth/discussions/7912