### PR TITLE
fix: hashed verification identifiers for OAuth state

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -477,6 +477,14 @@ const hook = createAuthMiddleware(async (ctx) => {
 });
 ```
 
+### `storeStateStrategy`
+
+Controls how OAuth state is stored during social sign-in.
+
+- `"database"` stores OAuth state in Better Auth's shared verification layer
+- `"cookie"` stores OAuth state in an encrypted cookie and bypasses the verification table entirely
+- Default: `"database"` when a database is configured, otherwise `"cookie"`
+
 ### `accountLinking`
 
 Configuration for account linking.
@@ -507,10 +515,10 @@ export const auth = betterAuth({
 - `modelName`: The model name for the verification table
 - `fields`: Map fields to different column names
 - `disableCleanup`: Disable cleaning up expired values when a verification value is fetched
-- `storeIdentifier`: How to store verification identifiers such as tokens and OTP keys. Supports `"plain"`, `"hashed"`, or a custom hasher. You can also use `{ default, overrides }` to apply different strategies per identifier prefix.
+- `storeIdentifier`: How to store verification identifiers such as tokens and OTP keys. Supports `"plain"`, `"hashed"`, or a custom hasher. You can also use `{ default, overrides }` to apply different strategies per identifier prefix. Database-backed OAuth state also uses this shared verification layer under the internal `oauth-state:` prefix, so use `overrides: { "oauth-state:": ... }` to target OAuth state specifically.
 - `storeInDatabase`: Store verification records in the database even when `secondaryStorage` is configured. Default is `false`.
 
-If `secondaryStorage` is configured, verification records are stored there by default. That behavior applies to flows that use Better Auth's shared verification layer, including OTP and magic-link style flows.
+If `secondaryStorage` is configured, verification records are stored there by default. That behavior applies to flows that use Better Auth's shared verification layer, including OTP, magic-link style flows, and database-backed OAuth state. If you set `account.storeStateStrategy` to `"cookie"`, OAuth state bypasses the verification table and this setting does not apply to that flow.
 
 ## `rateLimit`
 

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -989,6 +989,170 @@ describe("oauth2", async () => {
 		expect(session.data?.user.name).toBe("OAuth2 Cookie State");
 	});
 
+	it("should work with hashed verification identifiers and database-backed state storage", async () => {
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				email: "oauth2-hashed-state@test.com",
+				name: "OAuth2 Hashed State",
+				sub: "oauth2-hashed-state",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			verification: {
+				storeIdentifier: "hashed",
+			},
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "test-hashed-state",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+		const headers = new Headers();
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const res = await authClient.signIn.oauth2({
+			providerId: "test-hashed-state",
+			callbackURL: "http://localhost:3000/dashboard",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
+
+		const state = new URL(res.data?.url || "").searchParams.get("state");
+		expect(state).toBeTruthy();
+
+		const ctx = await auth.$context;
+		const verification = await ctx.internalAdapter.findVerificationValue(
+			`oauth-state:${state}`,
+		);
+		expect(verification).not.toBeNull();
+
+		const { callbackURL, headers: newHeaders } = await simulateOAuthFlow(
+			res.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		expect(callbackURL).toBe("http://localhost:3000/new_user");
+
+		const session = await authClient.getSession({
+			fetchOptions: {
+				headers: newHeaders,
+			},
+		});
+
+		expect(session.data).not.toBeNull();
+		expect(session.data?.user.email).toBe("oauth2-hashed-state@test.com");
+		expect(
+			await ctx.internalAdapter.findVerificationValue(`oauth-state:${state}`),
+		).toBeNull();
+	});
+
+	it("should respect oauth-state overrides for verification identifier storage", async () => {
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				email: "oauth2-overridden-state@test.com",
+				name: "OAuth2 Overridden State",
+				sub: "oauth2-overridden-state",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			verification: {
+				storeIdentifier: {
+					default: "plain",
+					overrides: {
+						"oauth-state:": "hashed",
+					},
+				},
+			},
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "test-overridden-state",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+		const headers = new Headers();
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const res = await authClient.signIn.oauth2({
+			providerId: "test-overridden-state",
+			callbackURL: "http://localhost:3000/dashboard",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
+
+		const state = new URL(res.data?.url || "").searchParams.get("state");
+		expect(state).toBeTruthy();
+
+		const ctx = await auth.$context;
+		const verifications = await ctx.adapter.findMany<{
+			id: string;
+			identifier: string;
+		}>({
+			model: "verification",
+		});
+		expect(verifications).toHaveLength(1);
+		expect(verifications[0]?.identifier).not.toBe(`oauth-state:${state}`);
+
+		const { callbackURL, headers: newHeaders } = await simulateOAuthFlow(
+			res.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		expect(callbackURL).toBe("http://localhost:3000/new_user");
+
+		const session = await authClient.getSession({
+			fetchOptions: {
+				headers: newHeaders,
+			},
+		});
+
+		expect(session.data).not.toBeNull();
+		expect(session.data?.user.email).toBe("oauth2-overridden-state@test.com");
+	});
+
 	it("should await async mapProfileToUser", async () => {
 		const { auth } = await getTestInstance({
 			plugins: [

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1153,6 +1153,92 @@ describe("oauth2", async () => {
 		expect(session.data?.user.email).toBe("oauth2-overridden-state@test.com");
 	});
 
+	it("should accept legacy raw oauth-state verification identifiers during callback", async () => {
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				email: "oauth2-legacy-state@test.com",
+				name: "OAuth2 Legacy State",
+				sub: "oauth2-legacy-state",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			verification: {
+				storeIdentifier: "hashed",
+			},
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "test-legacy-state",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+		const headers = new Headers();
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const res = await authClient.signIn.oauth2({
+			providerId: "test-legacy-state",
+			callbackURL: "http://localhost:3000/dashboard",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
+
+		const state = new URL(res.data?.url || "").searchParams.get("state");
+		expect(state).toBeTruthy();
+
+		const ctx = await auth.$context;
+		const prefixed = await ctx.internalAdapter.findVerificationValue(
+			`oauth-state:${state}`,
+		);
+		expect(prefixed).not.toBeNull();
+
+		await ctx.internalAdapter.createVerificationValue({
+			identifier: state!,
+			value: prefixed!.value,
+			expiresAt: prefixed!.expiresAt,
+		});
+		await ctx.internalAdapter.deleteVerificationByIdentifier(
+			`oauth-state:${state}`,
+		);
+
+		const { callbackURL, headers: newHeaders } = await simulateOAuthFlow(
+			res.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		expect(callbackURL).toBe("http://localhost:3000/new_user");
+
+		const session = await authClient.getSession({
+			fetchOptions: {
+				headers: newHeaders,
+			},
+		});
+
+		expect(session.data).not.toBeNull();
+		expect(session.data?.user.email).toBe("oauth2-legacy-state@test.com");
+		expect(await ctx.internalAdapter.findVerificationValue(state!)).toBeNull();
+	});
+
 	it("should await async mapProfileToUser", async () => {
 		const { auth } = await getTestInstance({
 			plugins: [

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -17,7 +17,7 @@ import { parseSetCookieHeader } from "../../cookies/cookie-utils";
 import { symmetricDecrypt, symmetricEncrypt } from "../../crypto";
 import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import type { StateData } from "../../state";
-import { parseGenericState } from "../../state";
+import { findStoredOAuthState, parseGenericState } from "../../state";
 import type { Account, User } from "../../types";
 import { getOrigin } from "../../utils/url";
 import { PACKAGE_VERSION } from "../../version";
@@ -526,15 +526,15 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							}
 						} else {
 							// Database mode - read from DB
-							const verification =
-								await ctx.context.internalAdapter.findVerificationValue(
-									originalState,
-								);
-							if (verification) {
+							const storedState = await findStoredOAuthState(
+								ctx,
+								originalState,
+							);
+							if (storedState) {
 								// Encrypt the verification value so it matches cookie mode format
 								stateCookieValue = await symmetricEncrypt({
 									key: getEncryptionKey(ctx),
-									data: verification.value,
+									data: storedState.data.value,
 								});
 							}
 						}

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -31,6 +31,26 @@ function getOAuthStateIdentifier(state: string) {
 	return `${OAUTH_STATE_IDENTIFIER_PREFIX}${state}`;
 }
 
+export async function findStoredOAuthState(
+	c: GenericEndpointContext,
+	state: string,
+) {
+	const identifier = getOAuthStateIdentifier(state);
+	const data =
+		await c.context.internalAdapter.findVerificationValue(identifier);
+	if (data) {
+		return { data, identifier };
+	}
+
+	const legacyData =
+		await c.context.internalAdapter.findVerificationValue(state);
+	if (legacyData) {
+		return { data: legacyData, identifier: state };
+	}
+
+	return null;
+}
+
 export type StateErrorCode =
 	| "state_generation_error"
 	| "state_invalid"
@@ -170,18 +190,15 @@ export async function parseGenericState(
 		expireCookie(c, stateCookie);
 	} else {
 		// Default: database strategy
-		const verificationIdentifier = getOAuthStateIdentifier(state);
-		const data = await c.context.internalAdapter.findVerificationValue(
-			verificationIdentifier,
-		);
-		if (!data) {
+		const storedState = await findStoredOAuthState(c, state);
+		if (!storedState) {
 			throw new StateError("State mismatch: verification not found", {
 				code: "state_mismatch",
 				details: { state },
 			});
 		}
 
-		parsedData = stateDataSchema.parse(JSON.parse(data.value));
+		parsedData = stateDataSchema.parse(JSON.parse(storedState.data.value));
 
 		const stateCookie = c.context.createAuthCookie(
 			settings?.cookieName ?? "state",
@@ -218,7 +235,7 @@ export async function parseGenericState(
 
 		// Delete verification value after retrieval
 		await c.context.internalAdapter.deleteVerificationByIdentifier(
-			verificationIdentifier,
+			storedState.identifier,
 		);
 	}
 

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -25,6 +25,12 @@ const stateDataSchema = z.looseObject({
 
 export type StateData = z.infer<typeof stateDataSchema>;
 
+const OAUTH_STATE_IDENTIFIER_PREFIX = "oauth-state:";
+
+function getOAuthStateIdentifier(state: string) {
+	return `${OAUTH_STATE_IDENTIFIER_PREFIX}${state}`;
+}
+
 export type StateErrorCode =
 	| "state_generation_error"
 	| "state_invalid"
@@ -98,9 +104,10 @@ export async function generateGenericState(
 	const expiresAt = new Date();
 	expiresAt.setMinutes(expiresAt.getMinutes() + 10);
 
+	const verificationIdentifier = getOAuthStateIdentifier(state);
 	const verification = await c.context.internalAdapter.createVerificationValue({
 		value: JSON.stringify(stateData),
-		identifier: state,
+		identifier: verificationIdentifier,
 		expiresAt,
 	});
 
@@ -114,7 +121,7 @@ export async function generateGenericState(
 	}
 
 	return {
-		state: verification.identifier,
+		state,
 		codeVerifier: stateData.codeVerifier,
 	};
 }
@@ -163,7 +170,10 @@ export async function parseGenericState(
 		expireCookie(c, stateCookie);
 	} else {
 		// Default: database strategy
-		const data = await c.context.internalAdapter.findVerificationValue(state);
+		const verificationIdentifier = getOAuthStateIdentifier(state);
+		const data = await c.context.internalAdapter.findVerificationValue(
+			verificationIdentifier,
+		);
 		if (!data) {
 			throw new StateError("State mismatch: verification not found", {
 				code: "state_mismatch",
@@ -207,7 +217,9 @@ export async function parseGenericState(
 		expireCookie(c, stateCookie);
 
 		// Delete verification value after retrieval
-		await c.context.internalAdapter.deleteVerificationByIdentifier(state);
+		await c.context.internalAdapter.deleteVerificationByIdentifier(
+			verificationIdentifier,
+		);
 	}
 
 	// Check expiration

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -113,13 +113,16 @@ describe("expo", async () => {
 			provider: "google",
 			callbackURL: "/dashboard",
 		});
-		const stateId = res?.url?.split("state=")[1]!.split("&")[0];
 		const ctx = await auth.$context;
-		if (!stateId) {
-			throw new Error("State ID not found");
-		}
-		const state = await ctx.internalAdapter.findVerificationValue(stateId);
-		const callbackURL = JSON.parse(state?.value || "{}").callbackURL;
+		const states = await ctx.adapter.findMany<{ value: string }>({
+			model: "verification",
+			sortBy: {
+				field: "createdAt",
+				direction: "desc",
+			},
+			limit: 1,
+		});
+		const callbackURL = JSON.parse(states[0]?.value || "{}").callbackURL;
 		expect(callbackURL).toBe("better-auth:///dashboard");
 		expect(res).toMatchObject({
 			url: expect.stringContaining("accounts.google"),


### PR DESCRIPTION
## Summary

This fixes OAuth social sign-in when `verification.storeIdentifier` is set to `"hashed"` and OAuth state is stored in the database.

Previously, Better Auth stored the raw OAuth state in the signed cookie but returned the transformed verification identifier in the public `state` query param. When identifier hashing was enabled, that caused the callback to compare the raw cookie state against a hashed callback state and fail with `state_security_mismatch`.

## Fixes: #8727 

## What changed

- Store database-backed OAuth state in the verification table under an internal `oauth-state:${state}` identifier
- Keep the public OAuth `state` value raw for the cookie and provider callback
- Continue using the shared verification storage layer so `verification.storeIdentifier.overrides` can target OAuth state with the `oauth-state:` prefix
- Document the behavior in the options reference, including that `account.storeStateStrategy: "cookie"` bypasses the verification table for OAuth state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth sign-in when `verification.storeIdentifier` is `hashed` by storing database-backed OAuth state under an internal `oauth-state:` key while keeping the public `state` raw. Adds backward compatibility for legacy raw OAuth state and documents `storeStateStrategy` defaults.

- **Bug Fixes**
  - Store DB-backed OAuth state as `oauth-state:${state}` and delete it after use.
  - Keep the cookie/provider `state` raw to avoid mismatches with hashed storage.
  - Add a shared lookup that reads `oauth-state:${state}` and legacy raw `state` in both callback and the `oauth-proxy` DB path.
  - Document `storeStateStrategy` (default `"database"` with a DB, otherwise `"cookie"`) and that DB-backed state uses the shared verification layer and `secondaryStorage`; can be targeted via `verification.storeIdentifier.overrides` with the `oauth-state:` prefix.

<sup>Written for commit 04f0905b4bc4b80465ce65a06779f4cbdb3be5eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

