### PR TITLE
fix(docs): include query in authClient.accountInfo api

### DIFF
--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -100,7 +100,7 @@ To get provider specific account info you can use the `accountInfo` function wit
 
 ```ts
 const info = await authClient.accountInfo({
-  query: { accountId: 'accountId' }, // here you pass in the provider given account id, the provider is automatically detected from the account id
+  query: { accountId: "accountId" }, // here you pass in the provider given account id, the provider is automatically detected from the account id
 })
 ```
 


### PR DESCRIPTION
closes #8744

super simple fix. just adds `query` to the `authClient.accountInfo` api.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix docs for OAuth account info: update `authClient.accountInfo` example to pass `query: { accountId }` instead of a top-level `accountId`, and use double quotes. Aligns the example with the API to prevent confusion.

<sup>Written for commit 8f4996ae657545f75a2801d449aec453ba7dd185. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

