### PR TITLE
docs: fix formatting in Polar integration content

### DIFF
--- a/docs/content/docs/authentication/polar.mdx
+++ b/docs/content/docs/authentication/polar.mdx
@@ -48,7 +48,7 @@ description: Polar provider setup and usage.
 
         ```ts title="auth-client.ts"
         import { createAuthClient } from "better-auth/client"
-        const authClient =  createAuthClient()
+        const authClient = createAuthClient()
 
         const signIn = async () => {
             const data = await authClient.signIn.social({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix formatting in the Polar authentication example by removing an extra space in the `auth-client.ts` snippet so it’s copy‑paste ready and consistent with Prettier/ESLint when importing from `better-auth/client`.

<sup>Written for commit 610997a07b293e92294f3a8f55fd297bc43a334f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

