### PR TITLE
docs: fix formatting in Polar integration content

### DIFF
--- a/docs/content/docs/authentication/polar.mdx
+++ b/docs/content/docs/authentication/polar.mdx
@@ -48,7 +48,7 @@ description: Polar provider setup and usage.
 
         ```ts title="auth-client.ts"
         import { createAuthClient } from "better-auth/client"
-        const authClient =  createAuthClient()
+        const authClient = createAuthClient()
 
         const signIn = async () => {
             const data = await authClient.signIn.social({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix formatting in the Polar authentication docs by removing an extra space in the `auth-client.ts` example, making the `createAuthClient()` line copy‑paste ready.

<sup>Written for commit 48538a76e1813ce75f96e83fba05f960085ef2bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

