### PR TITLE
fix(passkey): use message

### DIFF
--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -191,8 +191,8 @@ export const getPasskeyActions = (
 					code: "UNKNOWN_ERROR",
 					message:
 						e instanceof Error
-						? e.message
-						: PASSKEY_ERROR_CODES.UNKNOWN_ERROR.message,
+							? e.message
+							: PASSKEY_ERROR_CODES.UNKNOWN_ERROR.message,
 					status: 500,
 					statusText: "INTERNAL_SERVER_ERROR",
 				},


### PR DESCRIPTION
This PR uses `message` instead of message type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return correct error message strings in the passkey client by reading the `.message` from `PASSKEY_ERROR_CODES` instead of returning the whole object. Applies to `AUTH_CANCELLED`, `PREVIOUSLY_REGISTERED`, `REGISTRATION_CANCELLED`, and the `UNKNOWN_ERROR` fallback, ensuring consistent, serializable error.message values.

<sup>Written for commit 1004b837971c46e6a5e11d7151363891d5094951. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

