### PR TITLE
docs: update Upstash Redis TTL example to use `redis.set`

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -278,7 +278,7 @@ export const redisSecondaryStorage: SecondaryStorage = {
 
       if (ttl) {
         // Set with TTL in seconds
-        await redis.setex(key, ttl, stringValue);
+        await redis.set(key, stringValue, { ex: ttl });
       } else {
         // Set without TTL
         await redis.set(key, stringValue);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated database docs example to replace deprecated `setex` with `redis.set(key, value, { ex: ttl })`. Aligns with the current `@upstash/redis` API and avoids deprecation warnings.

<sup>Written for commit 83b7d09c64d2d3f590d782431819d166baefcfd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

