### PR TITLE
fix(api): align fresh age with session creation time

### DIFF
--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -68,6 +68,10 @@ describe("session", async () => {
 	});
 
 	it("should require a fresh session based on session creation time", async () => {
+		vi.useFakeTimers();
+		const now = new Date("2026-01-01T00:00:00.000Z");
+		vi.setSystemTime(now);
+
 		const freshSessionPlugin = {
 			id: "fresh-session-test",
 			endpoints: {
@@ -83,7 +87,7 @@ describe("session", async () => {
 		};
 		const { auth, client, signInWithTestUser, db } = await getTestInstance({
 			session: {
-				freshAge: 1,
+				freshAge: 60,
 			},
 			plugins: [freshSessionPlugin],
 		});
@@ -102,8 +106,8 @@ describe("session", async () => {
 				},
 			],
 			update: {
-				createdAt: new Date(Date.now() - 5_000),
-				updatedAt: new Date(),
+				createdAt: new Date(now.getTime() - 5 * 60 * 1000),
+				updatedAt: now,
 			},
 		});
 

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -1,4 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
+import { createAuthEndpoint } from "@better-auth/core/api";
 import { runWithEndpointContext } from "@better-auth/core/context";
 import type { MemoryDB } from "@better-auth/memory-adapter";
 import { memoryAdapter } from "@better-auth/memory-adapter";
@@ -15,6 +16,7 @@ import { parseCookies, parseSetCookieHeader } from "../../cookies";
 import { signJWT, verifyJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { getDate } from "../../utils/date";
+import { freshSessionMiddleware } from "./session";
 
 describe("session", async () => {
 	const { client, testUser, sessionSetter, cookieSetter, auth } =
@@ -63,6 +65,58 @@ describe("session", async () => {
 	it("should return null when not authenticated", async () => {
 		const response = await client.getSession();
 		expect(response.data).toBeNull();
+	});
+
+	it("should require a fresh session based on session creation time", async () => {
+		const freshSessionPlugin = {
+			id: "fresh-session-test",
+			endpoints: {
+				freshSessionCheck: createAuthEndpoint(
+					"/fresh-session-check",
+					{
+						method: "GET",
+						use: [freshSessionMiddleware],
+					},
+					async () => ({ status: true }),
+				),
+			},
+		};
+		const { auth, client, signInWithTestUser, db } = await getTestInstance({
+			session: {
+				freshAge: 1,
+			},
+			plugins: [freshSessionPlugin],
+		});
+
+		const { headers } = await signInWithTestUser();
+		const currentSession = await auth.api.getSession({ headers });
+		const sessionId = currentSession?.session.id;
+		expect(sessionId).toBeDefined();
+
+		await db.update({
+			model: "session",
+			where: [
+				{
+					field: "id",
+					value: sessionId!,
+				},
+			],
+			update: {
+				createdAt: new Date(Date.now() - 5_000),
+				updatedAt: new Date(),
+			},
+		});
+
+		const response = await client.$fetch("/fresh-session-check", {
+			method: "GET",
+			headers,
+		});
+		expect(response.data).toBeNull();
+		expect(response.error).toMatchObject({
+			status: 403,
+			statusText: "FORBIDDEN",
+			code: "SESSION_NOT_FRESH",
+		});
 	});
 
 	it("should update session when update age is reached", async () => {

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -628,19 +628,12 @@ export const freshSessionMiddleware = createAuthMiddleware(async (ctx) => {
 			code: "UNAUTHORIZED",
 		});
 	}
-	if (ctx.context.sessionConfig.freshAge === 0) {
-		return {
-			session,
-		};
-	}
-	const freshAge = ctx.context.sessionConfig.freshAge;
-	const lastUpdated = new Date(
-		session.session.updatedAt || session.session.createdAt,
-	).getTime();
-	const now = Date.now();
-	const isFresh = now - lastUpdated < freshAge * 1000;
-	if (!isFresh) {
-		throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.SESSION_NOT_FRESH);
+	if (ctx.context.sessionConfig.freshAge !== 0) {
+		const createdAt = new Date(session.session.createdAt).getTime();
+		const freshAge = ctx.context.sessionConfig.freshAge * 1000;
+		if (Date.now() - createdAt >= freshAge) {
+			throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.SESSION_NOT_FRESH);
+		}
 	}
 	return {
 		session,

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -537,10 +537,9 @@ export const deleteUser = createAuthEndpoint(
 		}
 
 		if (!ctx.body.password && ctx.context.sessionConfig.freshAge !== 0) {
-			const currentAge = new Date(session.session.createdAt).getTime();
+			const createdAt = new Date(session.session.createdAt).getTime();
 			const freshAge = ctx.context.sessionConfig.freshAge * 1000;
-			const now = Date.now();
-			if (now - currentAge > freshAge) {
+			if (Date.now() - createdAt >= freshAge) {
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.SESSION_EXPIRED);
 			}
 		}


### PR DESCRIPTION
> [!NOTE]
> `freshAge` is determined based on `createdAt`
> https://better-auth.com/docs/concepts/session-management#session-freshness

This fixes an inconsistency, but since it changes runtime behavior, it is a breaking change. That said, I consider it a bug fix to align with the documentation.