### PR TITLE
docs: update Upstash Redis TTL example to use `redis.set`

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -278,7 +278,7 @@ export const redisSecondaryStorage: SecondaryStorage = {
 
       if (ttl) {
         // Set with TTL in seconds
-        await redis.setex(key, ttl, stringValue);
+        await redis.set(key, stringValue, { ex: ttl });
       } else {
         // Set without TTL
         await redis.set(key, stringValue);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the database docs to replace deprecated Upstash Redis `redis.setex(key, ttl, value)` with `redis.set(key, value, { ex: ttl })` in the TTL example. This corrects the sample and matches the current Upstash Redis API.

<sup>Written for commit c0ce3af2fd73c85c9d3503860f9d62a8947054ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

