### PR TITLE
feat(two-factor): include enabled 2fa methods in sign-in redirect response

### DIFF
--- a/.changeset/two-factor-methods-redirect.md
+++ b/.changeset/two-factor-methods-redirect.md
@@ -1,0 +1,11 @@
+---
+"better-auth": patch
+---
+
+feat(two-factor): include enabled 2fa methods in sign-in redirect response
+
+The 2FA sign-in redirect now returns `twoFactorMethods` (e.g. `["totp", "otp"]`) so frontends can render the correct verification UI without guessing. The `onTwoFactorRedirect` client callback receives `twoFactorMethods` as a context parameter.
+
+- TOTP is included only when the user has a verified TOTP secret and TOTP is not disabled in config.
+- OTP is included when `otpOptions.sendOTP` is configured.
+- Unverified TOTP enrollments are excluded from the methods list.

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -113,7 +113,7 @@ By default, Two Factor requires a credential (password) account. To allow passwo
 
 ### Sign In with 2FA
 
-When a user with 2FA enabled tries to sign in via email, the response object will contain `twoFactorRedirect` set to `true`. This indicates that the user needs to verify their 2FA code.
+When a user with 2FA enabled tries to sign in via email, the response object will contain `twoFactorRedirect` set to `true` and `twoFactorMethods` — an array of the 2FA methods available for the user (e.g. `["totp"]`, `["totp", "otp"]`). Use `twoFactorMethods` to decide which verification UI to show.
 
 You can handle this in the `onSuccess` callback or by providing a `onTwoFactorRedirect` callback in the plugin config.
 
@@ -127,7 +127,8 @@ await authClient.signIn.email({
     {
         async onSuccess(context) {
             if (context.data.twoFactorRedirect) {
-                // Handle the 2FA verification in place
+                const methods = context.data.twoFactorMethods // e.g. ["totp", "otp"]
+                // Show the appropriate 2FA verification UI based on available methods
             }
         },
     }
@@ -143,7 +144,8 @@ import { twoFactorClient } from "better-auth/client/plugins";
 const authClient = createAuthClient({
     plugins: [
         twoFactorClient({
-            onTwoFactorRedirect(){
+            onTwoFactorRedirect({ twoFactorMethods }){
+                // twoFactorMethods is e.g. ["totp", "otp"]
                 // Handle the 2FA verification globally
             },
         }),
@@ -193,6 +195,7 @@ const { headers: responseHeaders, response } = await auth.api.signInEmail({
 });
 
 if ("twoFactorRedirect" in response) {
+	// response.twoFactorMethods is e.g. ["totp", "otp"]
 	// Forward the cookies from responseHeaders into the next auth.api 2FA call.
 	// Handle the 2FA verification in place
 }
@@ -599,7 +602,8 @@ import { twoFactorClient } from "better-auth/client/plugins"
 const authClient =  createAuthClient({
     plugins: [
         twoFactorClient({ // [!code highlight]
-            onTwoFactorRedirect(){ // [!code highlight]
+            onTwoFactorRedirect({ twoFactorMethods }){ // [!code highlight]
+                // twoFactorMethods is e.g. ["totp", "otp"] // [!code highlight]
                 window.location.href = "/2fa" // Handle the 2FA verification redirect // [!code highlight]
             } // [!code highlight]
         }) // [!code highlight]
@@ -610,4 +614,4 @@ const authClient =  createAuthClient({
 
 **Options**
 
-`onTwoFactorRedirect`: A callback that will be called when the user needs to verify their 2FA code. This can be used to redirect the user to the 2FA page.
+`onTwoFactorRedirect`: A callback that will be called when the user needs to verify their 2FA code. Receives a context object with `twoFactorMethods` — an array of enabled 2FA methods (e.g. `["totp", "otp"]`). This can be used to redirect the user to the appropriate 2FA page.

--- a/packages/better-auth/src/plugins/two-factor/client.ts
+++ b/packages/better-auth/src/plugins/two-factor/client.ts
@@ -18,8 +18,18 @@ export const twoFactorClient = (
 				/**
 				 * a redirect function to call if a user needs to verify
 				 * their two factor
+				 *
+				 * @param context.twoFactorMethods - The list of
+				 * enabled two factor providers (e.g. ["totp", "otp"]).
+				 * Use this to determine which 2FA UI to show.
 				 */
-				onTwoFactorRedirect?: () => void | Promise<void>;
+				onTwoFactorRedirect?: (context: {
+					/**
+					 * The list of enabled two factor providers
+					 * for the user (e.g. ["totp", "otp"]).
+					 */
+					twoFactorMethods?: string[];
+				}) => void | Promise<void>;
 		  }
 		| undefined,
 ) => {
@@ -51,7 +61,9 @@ export const twoFactorClient = (
 					async onSuccess(context) {
 						if (context.data?.twoFactorRedirect) {
 							if (options?.onTwoFactorRedirect) {
-								await options.onTwoFactorRedirect();
+								await options.onTwoFactorRedirect({
+									twoFactorMethods: context.data.twoFactorMethods,
+								});
 								return;
 							}
 

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -495,16 +495,17 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 						 * that the user actually has a secret stored.
 						 */
 						if (!options?.totpOptions?.disable) {
-							const userTotpSecret = await ctx.context.adapter.findOne({
-								model: opts.twoFactorTable,
-								where: [
-									{
-										field: "userId",
-										value: data.user.id,
-									},
-								],
-							});
-							if (userTotpSecret) {
+							const userTotpSecret =
+								await ctx.context.adapter.findOne<TwoFactorTable>({
+									model: opts.twoFactorTable,
+									where: [
+										{
+											field: "userId",
+											value: data.user.id,
+										},
+									],
+								});
+							if (userTotpSecret && userTotpSecret.verified !== false) {
 								twoFactorMethods.push("totp");
 							}
 						}

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -488,10 +488,35 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							ctx.context.secret,
 							twoFactorCookie.attributes,
 						);
-						const twoFactorMethods = [
-							!options?.totpOptions?.disable && "totp",
-							!!options?.otpOptions?.sendOTP && "otp",
-						].filter(Boolean) as string[];
+						const twoFactorMethods: string[] = [];
+
+						/**
+						 * totp requires per-user setup, so we check
+						 * that the user actually has a secret stored.
+						 */
+						if (!options?.totpOptions?.disable) {
+							const userTotpSecret = await ctx.context.adapter.findOne({
+								model: opts.twoFactorTable,
+								where: [
+									{
+										field: "userId",
+										value: data.user.id,
+									},
+								],
+							});
+							if (userTotpSecret) {
+								twoFactorMethods.push("totp");
+							}
+						}
+
+						/**
+						 * otp is server-level — if sendOTP is configured,
+						 * any user with 2fa enabled can receive a code.
+						 */
+						if (options?.otpOptions?.sendOTP) {
+							twoFactorMethods.push("otp");
+						}
+
 						return ctx.json({
 							twoFactorRedirect: true,
 							twoFactorMethods,

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -488,8 +488,13 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							ctx.context.secret,
 							twoFactorCookie.attributes,
 						);
+						const twoFactorMethods = [
+							!options?.totpOptions?.disable && "totp",
+							!!options?.otpOptions?.sendOTP && "otp",
+						].filter(Boolean) as string[];
 						return ctx.json({
 							twoFactorRedirect: true,
+							twoFactorMethods,
 						});
 					}),
 				},

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -176,6 +176,7 @@ describe("two factor", async () => {
 			},
 		});
 		expect((res.data as any)?.twoFactorRedirect).toBe(true);
+		expect((res.data as any)?.twoFactorMethods).toEqual(["totp", "otp"]);
 		await client.twoFactor.sendOtp({
 			fetchOptions: {
 				headers,

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -2112,3 +2112,196 @@ describe("checkPassword must not leak credential presence via error codes", asyn
 		}
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/4101
+ */
+describe("twoFactorMethods in sign-in response", () => {
+	describe("totp enabled in config, otp disabled", async () => {
+		const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [twoFactor()],
+		});
+		const { user } = await signInWithTestUser();
+
+		it("should not redirect when user has not verified totp", async () => {
+			const signInRes = await auth.api.signInEmail({
+				body: {
+					email: testUser.email,
+					password: testUser.password,
+				},
+			});
+			expect(signInRes.user).toBeDefined();
+			expect((signInRes as any).twoFactorRedirect).toBeUndefined();
+		});
+
+		it("should return twoFactorMethods: ['totp'] when user has verified totp", async () => {
+			const { headers } = await auth.api
+				.signInEmail({
+					body: {
+						email: testUser.email,
+						password: testUser.password,
+					},
+					asResponse: true,
+				})
+				.then((res) => ({
+					headers: convertSetCookieToCookie(res.headers),
+				}));
+
+			await auth.api.enableTwoFactor({
+				body: { password: testUser.password },
+				headers,
+				asResponse: true,
+			});
+
+			const twoFactorRow = await db.findOne<TwoFactorTable>({
+				model: "twoFactor",
+				where: [{ field: "userId", value: user.id }],
+			});
+			const decrypted = await symmetricDecrypt({
+				key: DEFAULT_SECRET,
+				data: twoFactorRow!.secret,
+			});
+			const code = await createOTP(decrypted).totp();
+			await auth.api.verifyTOTP({
+				body: { code },
+				headers,
+			});
+
+			const signInRes = await auth.api.signInEmail({
+				body: {
+					email: testUser.email,
+					password: testUser.password,
+				},
+			});
+			expect((signInRes as any).twoFactorRedirect).toBe(true);
+			expect((signInRes as any).twoFactorMethods).toEqual(["totp"]);
+		});
+	});
+
+	describe("totp enabled in config, otp enabled", async () => {
+		const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: {
+						sendOTP() {},
+					},
+				}),
+			],
+		});
+		const { user } = await signInWithTestUser();
+
+		it("should return twoFactorMethods: ['otp'] when user has 2fa enabled but no totp row", async () => {
+			await db.update({
+				model: "user",
+				where: [{ field: "id", value: user.id }],
+				update: { twoFactorEnabled: true },
+			});
+
+			const signInRes = await auth.api.signInEmail({
+				body: {
+					email: testUser.email,
+					password: testUser.password,
+				},
+			});
+			expect((signInRes as any).twoFactorRedirect).toBe(true);
+			expect((signInRes as any).twoFactorMethods).toEqual(["otp"]);
+		});
+
+		it("should return twoFactorMethods: ['totp', 'otp'] when user has verified totp", async () => {
+			// reset twoFactorEnabled so we can sign in normally
+			await db.update({
+				model: "user",
+				where: [{ field: "id", value: user.id }],
+				update: { twoFactorEnabled: false },
+			});
+
+			const { headers } = await auth.api
+				.signInEmail({
+					body: {
+						email: testUser.email,
+						password: testUser.password,
+					},
+					asResponse: true,
+				})
+				.then((res) => ({
+					headers: convertSetCookieToCookie(res.headers),
+				}));
+
+			await auth.api.enableTwoFactor({
+				body: { password: testUser.password },
+				headers,
+				asResponse: true,
+			});
+
+			const twoFactorRow = await db.findOne<TwoFactorTable>({
+				model: "twoFactor",
+				where: [{ field: "userId", value: user.id }],
+			});
+			const decrypted = await symmetricDecrypt({
+				key: DEFAULT_SECRET,
+				data: twoFactorRow!.secret,
+			});
+			const code = await createOTP(decrypted).totp();
+			await auth.api.verifyTOTP({
+				body: { code },
+				headers,
+			});
+
+			const signInRes = await auth.api.signInEmail({
+				body: {
+					email: testUser.email,
+					password: testUser.password,
+				},
+			});
+			expect((signInRes as any).twoFactorRedirect).toBe(true);
+			expect((signInRes as any).twoFactorMethods).toEqual(["totp", "otp"]);
+		});
+	});
+
+	describe("totp disabled in config, otp enabled", async () => {
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					totpOptions: { disable: true },
+					otpOptions: {
+						sendOTP() {},
+					},
+					skipVerificationOnEnable: true,
+				}),
+			],
+		});
+		await signInWithTestUser();
+
+		it("should return twoFactorMethods: ['otp'] even when user has a totp row", async () => {
+			const { headers } = await auth.api
+				.signInEmail({
+					body: {
+						email: testUser.email,
+						password: testUser.password,
+					},
+					asResponse: true,
+				})
+				.then((res) => ({
+					headers: convertSetCookieToCookie(res.headers),
+				}));
+
+			await auth.api.enableTwoFactor({
+				body: { password: testUser.password },
+				headers,
+				asResponse: true,
+			});
+
+			const signInRes = await auth.api.signInEmail({
+				body: {
+					email: testUser.email,
+					password: testUser.password,
+				},
+			});
+			expect((signInRes as any).twoFactorRedirect).toBe(true);
+			expect((signInRes as any).twoFactorMethods).toEqual(["otp"]);
+		});
+	});
+});

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -2209,6 +2209,47 @@ describe("twoFactorMethods in sign-in response", () => {
 			expect((signInRes as any).twoFactorMethods).toEqual(["otp"]);
 		});
 
+		it("should exclude unverified totp from twoFactorMethods", async () => {
+			// Create an unverified TOTP row (abandoned enrollment)
+			await db.update({
+				model: "user",
+				where: [{ field: "id", value: user.id }],
+				update: { twoFactorEnabled: false },
+			});
+			const { headers } = await auth.api
+				.signInEmail({
+					body: {
+						email: testUser.email,
+						password: testUser.password,
+					},
+					asResponse: true,
+				})
+				.then((res) => ({
+					headers: convertSetCookieToCookie(res.headers),
+				}));
+			await auth.api.enableTwoFactor({
+				body: { password: testUser.password },
+				headers,
+				asResponse: true,
+			});
+			// enableTwoFactor creates verified=false; force twoFactorEnabled
+			// back to true to simulate OTP-enrolled user adding TOTP
+			await db.update({
+				model: "user",
+				where: [{ field: "id", value: user.id }],
+				update: { twoFactorEnabled: true },
+			});
+
+			const signInRes = await auth.api.signInEmail({
+				body: {
+					email: testUser.email,
+					password: testUser.password,
+				},
+			});
+			expect((signInRes as any).twoFactorRedirect).toBe(true);
+			expect((signInRes as any).twoFactorMethods).toEqual(["otp"]);
+		});
+
 		it("should return twoFactorMethods: ['totp', 'otp'] when user has verified totp", async () => {
 			// reset twoFactorEnabled so we can sign in normally
 			await db.update({


### PR DESCRIPTION
closes #4101

when a user with 2fa signs in, the redirect response used to only return `{ twoFactorRedirect: true }` with no way to know whether they had totp, otp, or both. frontends had to guess or do hacky workarounds to figure out which verification ui to show.

now the response includes `twoFactorMethods` (e.g. `["totp", "otp"]`), and the `onTwoFactorRedirect` client callback receives it as a context param.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `twoFactorMethods` in the 2FA sign-in redirect and pass it to `onTwoFactorRedirect` so UIs can show the right flow. Methods are based on verified TOTP status and `otpOptions.sendOTP`, and exclude disabled or unverified providers.

- New Features
  - `twoFactor` in `better-auth` now returns `{ twoFactorRedirect: true, twoFactorMethods: [...] }`: adds `"totp"` only if the user has a verified TOTP secret and TOTP isn’t disabled; adds `"otp"` when `otpOptions.sendOTP` is set.
  - `twoFactorClient` calls `onTwoFactorRedirect({ twoFactorMethods })`. Docs updated; tests cover TOTP/OTP combinations, disabled-TOTP, and unverified-TOTP exclusion.

<sup>Written for commit 35356a2bc87f67c2a8cc9750534768e6c6630258. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

