### PR TITLE
fix: compare account cookie by provider accountId instead of internal id

### DIFF
--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -6,6 +6,7 @@ import type { MockInstance } from "vitest";
 import {
 	afterAll,
 	afterEach,
+	assert,
 	beforeAll,
 	describe,
 	expect,
@@ -549,7 +550,7 @@ describe("account", async () => {
 		expect(accessTokenRes.data?.accessToken).toBe("test");
 	});
 
-	it("should match account cookie by accountId (not internal id) in getAccessToken", async () => {
+	it("should use account cookie when accountId is omitted in getAccessToken", async () => {
 		const { auth, client, cookieSetter } = await getTestInstance({
 			socialProviders: {
 				google: {
@@ -662,9 +663,9 @@ describe("account", async () => {
 			fetchOptions: { headers },
 		});
 		const googleAccount = accounts.data?.find((a) => a.providerId === "google");
-		expect(googleAccount).toBeDefined();
+		assert(googleAccount, "google account should exist");
 		// Internal id and provider accountId must differ
-		expect(googleAccount!.id).not.toBe(googleAccount!.accountId);
+		assert(googleAccount.id !== googleAccount.accountId);
 
 		const findAccountsSpy = vi.spyOn(testCtx.internalAdapter, "findAccounts");
 
@@ -672,7 +673,7 @@ describe("account", async () => {
 		const accessTokenRes = await client.getAccessToken(
 			{
 				providerId: "google",
-				accountId: googleAccount!.accountId,
+				accountId: googleAccount.accountId,
 			},
 			{
 				headers,

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -596,10 +596,7 @@ describe("account", async () => {
 		});
 
 		// Spy on findAccounts to verify cookie path is used (no DB fallback)
-		const findAccountsSpy = vi.spyOn(
-			testCtx.internalAdapter,
-			"findAccounts",
-		);
+		const findAccountsSpy = vi.spyOn(testCtx.internalAdapter, "findAccounts");
 
 		const accessTokenRes = await client.getAccessToken(
 			{
@@ -664,17 +661,12 @@ describe("account", async () => {
 		const accounts = await client.listAccounts({
 			fetchOptions: { headers },
 		});
-		const googleAccount = accounts.data?.find(
-			(a) => a.providerId === "google",
-		);
+		const googleAccount = accounts.data?.find((a) => a.providerId === "google");
 		expect(googleAccount).toBeDefined();
 		// Internal id and provider accountId must differ
 		expect(googleAccount!.id).not.toBe(googleAccount!.accountId);
 
-		const findAccountsSpy = vi.spyOn(
-			testCtx.internalAdapter,
-			"findAccounts",
-		);
+		const findAccountsSpy = vi.spyOn(testCtx.internalAdapter, "findAccounts");
 
 		// Pass explicit accountId (provider-issued) - this should match cookie
 		const accessTokenRes = await client.getAccessToken(

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -549,6 +549,150 @@ describe("account", async () => {
 		expect(accessTokenRes.data?.accessToken).toBe("test");
 	});
 
+	it("should match account cookie by accountId (not internal id) in getAccessToken", async () => {
+		const { auth, client, cookieSetter } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				storeAccountCookie: true,
+			},
+		});
+
+		const testCtx = await auth.$context;
+		const headers = new Headers();
+		email = "account-cookie-match@test.com";
+
+		// Start OAuth sign-in flow
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const state =
+			signInRes.data && "url" in signInRes.data && signInRes.data.url
+				? new URL(signInRes.data.url).searchParams.get("state") || ""
+				: "";
+
+		// Complete OAuth callback
+		await client.$fetch("/callback/google", {
+			query: {
+				state,
+				code: "test",
+			},
+			headers,
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				cookieSetter(headers)({ response: context.response });
+			},
+		});
+
+		// Spy on findAccounts to verify cookie path is used (no DB fallback)
+		const findAccountsSpy = vi.spyOn(
+			testCtx.internalAdapter,
+			"findAccounts",
+		);
+
+		const accessTokenRes = await client.getAccessToken(
+			{
+				providerId: "google",
+			},
+			{
+				headers,
+			},
+		);
+
+		expect(accessTokenRes.data?.accessToken).toBe("test");
+		// Cookie should have matched directly, no DB lookup needed
+		expect(findAccountsSpy).not.toHaveBeenCalled();
+		findAccountsSpy.mockRestore();
+	});
+
+	it("should match account cookie by accountId in getAccessToken when accountId is provided", async () => {
+		const { auth, client, cookieSetter } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				storeAccountCookie: true,
+			},
+		});
+
+		const testCtx = await auth.$context;
+		const headers = new Headers();
+		email = "account-cookie-accountid@test.com";
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const state =
+			signInRes.data && "url" in signInRes.data && signInRes.data.url
+				? new URL(signInRes.data.url).searchParams.get("state") || ""
+				: "";
+
+		await client.$fetch("/callback/google", {
+			query: {
+				state,
+				code: "test",
+			},
+			headers,
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				cookieSetter(headers)({ response: context.response });
+			},
+		});
+
+		// Get the provider accountId from the cookie/DB
+		const accounts = await client.listAccounts({
+			fetchOptions: { headers },
+		});
+		const googleAccount = accounts.data?.find(
+			(a) => a.providerId === "google",
+		);
+		expect(googleAccount).toBeDefined();
+		// Internal id and provider accountId must differ
+		expect(googleAccount!.id).not.toBe(googleAccount!.accountId);
+
+		const findAccountsSpy = vi.spyOn(
+			testCtx.internalAdapter,
+			"findAccounts",
+		);
+
+		// Pass explicit accountId (provider-issued) - this should match cookie
+		const accessTokenRes = await client.getAccessToken(
+			{
+				providerId: "google",
+				accountId: googleAccount!.accountId,
+			},
+			{
+				headers,
+			},
+		);
+
+		expect(accessTokenRes.data?.accessToken).toBe("test");
+		// Cookie should have matched by accountId, no DB fallback
+		expect(findAccountsSpy).not.toHaveBeenCalled();
+		findAccountsSpy.mockRestore();
+	});
+
 	it("should persist refreshed idToken in database during getAccessToken auto-refresh", async () => {
 		const { auth, client, cookieSetter } = await getTestInstance({
 			socialProviders: {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -524,6 +524,7 @@ export const getAccessToken = createAuthEndpoint(
 		let account: Account | undefined = undefined;
 		if (
 			accountData &&
+			accountData.userId === resolvedUserId &&
 			providerId === accountData.providerId &&
 			(!accountId || accountData.accountId === accountId)
 		) {
@@ -715,6 +716,7 @@ export const refreshToken = createAuthEndpoint(
 		const accountData = await getAccountCookie(ctx);
 		if (
 			accountData &&
+			accountData.userId === resolvedUserId &&
 			(!providerId || providerId === accountData?.providerId)
 		) {
 			account = accountData;

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -525,7 +525,7 @@ export const getAccessToken = createAuthEndpoint(
 		if (
 			accountData &&
 			providerId === accountData.providerId &&
-			(!accountId || accountData.id === accountId)
+			(!accountId || accountData.accountId === accountId)
 		) {
 			account = accountData;
 		} else {


### PR DESCRIPTION
Looks like a leftover from the PR #8346