### PR TITLE
chore: disable `enableGlobalVirtualStore`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,6 @@ packages:
 
 blockExoticSubdeps: true
 
-enableGlobalVirtualStore: true
-
 catalog:
   '@better-auth/utils': 0.4.0
   '@better-fetch/fetch': 1.1.21


### PR DESCRIPTION
https://pnpm.io/settings#enableglobalvirtualstore

It was added in PR https://github.com/better-auth/better-auth/pull/8600, but it’s clearly an experimental option and may have compatibility issues with Turbopack. While it can help with a worktree-based workflow, I don’t think that justifies using an experimental option.

---

pnpm is improving this option, and there's no need for us to use it right now.
- https://github.com/pnpm/pnpm/issues/9696