### PR TITLE
fix(oauth-provider): scope storeSessionInDatabase guard to secondaryStorage

### DIFF
--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -85,6 +85,90 @@ describe("oauth - init", () => {
 			}),
 		).resolves.not.toThrowError();
 	});
+
+	it("should pass with session options but no secondaryStorage", async () => {
+		await expect(
+			getTestInstance({
+				session: {
+					expiresIn: 60 * 60 * 24,
+				},
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).resolves.not.toThrowError();
+	});
+
+	it("should fail with secondaryStorage but without storeSessionInDatabase", async () => {
+		const store = new Map<string, string>();
+		await expect(
+			getTestInstance({
+				secondaryStorage: {
+					set(key, value) {
+						store.set(key, value);
+					},
+					get(key) {
+						return store.get(key) || null;
+					},
+					delete(key) {
+						store.delete(key);
+					},
+				},
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).rejects.toThrowError("storeSessionInDatabase");
+	});
+
+	it("should pass with secondaryStorage and storeSessionInDatabase", async () => {
+		const store = new Map<string, string>();
+		await expect(
+			getTestInstance({
+				secondaryStorage: {
+					set(key, value) {
+						store.set(key, value);
+					},
+					get(key) {
+						return store.get(key) || null;
+					},
+					delete(key) {
+						store.delete(key);
+					},
+				},
+				session: {
+					storeSessionInDatabase: true,
+				},
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).resolves.not.toThrowError();
+	});
 });
 
 describe("oauth", async () => {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -166,8 +166,11 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		id: "oauth-provider",
 		options: opts as NoInfer<O>,
 		init: (ctx) => {
-			// Require session id storage on database (secondary-storage only solution not yet supported)
-			if (ctx.options.session && !ctx.options.session.storeSessionInDatabase) {
+			// OAuth Provider requires sessions in the DB (secondary-storage-only is not supported)
+			if (
+				ctx.options.secondaryStorage &&
+				!ctx.options.session?.storeSessionInDatabase
+			) {
 				throw new BetterAuthError(
 					"OAuth Provider requires `session.storeSessionInDatabase: true` when using secondaryStorage",
 				);


### PR DESCRIPTION
## Summary

The OAuth provider's init guard required `session.storeSessionInDatabase: true` whenever *any* `session` option was set, regardless of whether `secondaryStorage` was configured. This produced a false `BetterAuthError` for users who configured session properties like `expiresIn` without using secondary storage.

The guard was checking the wrong precondition. Without `secondaryStorage`, sessions always persist to the database, which means `storeSessionInDatabase` is irrelevant.

The fix narrows the guard to check `ctx.options.secondaryStorage` first, and only then verifies `storeSessionInDatabase`