### PR TITLE
fix(next): prevent empty __better-auth-cookie-store cookie leak

### DIFF
--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -46,10 +46,11 @@ export const nextCookies = () => {
 							return;
 						}
 						try {
-							cookieStore.set("__better-auth-cookie-store", "1", { maxAge: 0 });
-							// If cookie was set successfully, we should clean up.
-							cookieStore.delete("__better-auth-cookie-store");
+							// Try to set a cookie to detect if we're in a Server Component
+							// (where cookies are read-only). Use a unique name to avoid conflicts.
+							cookieStore.set("__better_auth_sc_test", "1", { maxAge: 0 });
 						} catch {
+							// If set throws, we're in a Server Component - skip session refresh
 							await setShouldSkipSessionRefresh(true);
 						}
 					}),


### PR DESCRIPTION
## Summary

The `nextCookies` plugin was leaking an empty `__better-auth-cookie-store` cookie to clients because `cookieStore.delete()` in Next.js only sets the cookie value to empty without removing the key from the internal map.

## Changes

- Removed the `cookieStore.delete()` call after setting the test cookie
- The test cookie uses `maxAge: 0` so it expires immediately anyway
- Server Component detection still works via try/catch on `set()`

## Issue

Fixes #8784

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaking an empty `__better-auth-cookie-store` cookie in Next.js by removing cookieStore.delete() in the `nextCookies` plugin. The test cookie now expires with maxAge: 0 and is renamed to `__better_auth_sc_test`; Server Component detection still uses try/catch on set, fixing #8784.

<sup>Written for commit 45fa12cdad9059dee75f56767332d68304cee2d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

