### PR TITLE
docs: fix incorrect cookie method names in hooks documentation

### DIFF
--- a/docs/content/docs/concepts/hooks.mdx
+++ b/docs/content/docs/concepts/hooks.mdx
@@ -137,8 +137,8 @@ const hook = createAuthMiddleware(async (ctx) => {
 
 #### Cookies
 
-- Set cookies: `ctx.setCookies` or `ctx.setSignedCookie`.
-- Get cookies: `ctx.getCookies` or `ctx.getSignedCookie`.
+- Set cookies: `ctx.setCookie` or `ctx.setSignedCookie`.
+- Get cookies: `ctx.getCookie` or `ctx.getSignedCookie`.
 
 Example:
 
@@ -146,12 +146,12 @@ Example:
 import { createAuthMiddleware } from "better-auth/api";
 
 const hook = createAuthMiddleware(async (ctx) => {
-    ctx.setCookies("my-cookie", "value");
+    ctx.setCookie("my-cookie", "value");
     await ctx.setSignedCookie("my-signed-cookie", "value", ctx.context.secret, {
         maxAge: 1000,
     });
 
-    const cookie = ctx.getCookies("my-cookie");
+    const cookie = ctx.getCookie("my-cookie");
     const signedCookie = await ctx.getSignedCookie("my-signed-cookie");
 });
 ```


### PR DESCRIPTION
## What does this PR do?
Fixes the documentation typos reported in #8789.

Note: This PR only addresses the **documentation part** of #8789. 
The before hook cookie propagation bug is a separate issue 
and is not covered here.

## Changes
- `ctx.setCookies()` → `ctx.setCookie()` (singular)
- `ctx.getCookies()` → `ctx.getCookie()` (singular)

## Related Issue
Partially resolves #8789

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect cookie method names in the hooks docs to match the API and prevent confusion. Replaces `ctx.setCookies`/`ctx.getCookies` with `ctx.setCookie`/`ctx.getCookie` in the method list and examples.

<sup>Written for commit 45c3affc7168ce77fa5741c9158f53adba5903bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

