### PR TITLE
feat: allow OAuth endpoint overrides for social providers

### DIFF
--- a/.changeset/provider-emulator-support.md
+++ b/.changeset/provider-emulator-support.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Add social provider endpoint override options for emulator, local OAuth, and sandbox environments.

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -332,6 +332,35 @@ export const auth = betterAuth({
 });
 ```
 
+### authorizationEndpoint, tokenEndpoint, userInfoEndpoint, jwksEndpoint
+
+Optional endpoint overrides for the provider's OAuth flow. These are useful when testing against local OAuth emulators, mock servers, or sandbox environments without changing the provider's default production endpoints.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  // Other configurations...
+  socialProviders: {
+    google: {
+      clientId: "YOUR_GOOGLE_CLIENT_ID",
+      clientSecret: "YOUR_GOOGLE_CLIENT_SECRET",
+      authorizationEndpoint: "http://localhost:3000/o/oauth2/v2/auth",
+      tokenEndpoint: "http://localhost:3000/oauth2/token",
+      userInfoEndpoint: "http://localhost:3000/oauth2/v2/userinfo",
+      jwksEndpoint: "http://localhost:3000/oauth2/v3/certs",
+    },
+  },
+});
+```
+
+All four options are optional:
+
+- `authorizationEndpoint`: Override the authorization URL used to start sign-in
+- `tokenEndpoint`: Override the token exchange and refresh URL
+- `userInfoEndpoint`: Override the user info/profile URL
+- `jwksEndpoint`: Override the JWKS URL used for ID token verification
+
 ### disableSignUp
 
 Disables sign-up for new users.

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -354,7 +354,10 @@ export const auth = betterAuth({
 * `verifyIdToken`: Custom function to verify the ID token (optional)
 * `disableIdTokenSignIn`: Disable sign in with ID token sent from the client (optional)
 * `disableDefaultScope`: Disable the provider's default scopes (optional)
-* `authorizationEndpoint`: Custom authorization endpoint URL (optional)
+* `authorizationEndpoint`: Custom authorization endpoint URL for emulators, local OAuth servers, or sandbox environments (optional)
+* `tokenEndpoint`: Custom token endpoint URL for emulators, local OAuth servers, or sandbox environments (optional)
+* `userInfoEndpoint`: Custom user info endpoint URL for emulators, local OAuth servers, or sandbox environments (optional)
+* `jwksEndpoint`: Custom JWKS endpoint URL for emulators, local OAuth servers, or sandbox environments (optional)
 
 ## `plugins`
 

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -8,6 +8,14 @@ import type {
 	RailwayProfile,
 	VercelProfile,
 } from "@better-auth/core/social-providers";
+import {
+	paypal,
+	reddit,
+	roblox,
+	slack,
+	vk,
+	zoom,
+} from "@better-auth/core/social-providers";
 import { betterFetch } from "@better-fetch/fetch";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { HttpResponse, http } from "msw";
@@ -711,6 +719,285 @@ describe("Social Providers", async (c) => {
 		expect(gitlabTokenEndpointHit).toBe(true);
 		expect(gitlabUserInfoEndpointHit).toBe(true);
 		expect(userInfo?.user.email).toBe("gitlab-emulator@example.com");
+	});
+
+	it("should support WeChat refresh endpoint overrides", async () => {
+		let wechatRefreshEndpointHit = false;
+
+		mswServer.use(
+			http.get(
+				`http://localhost:${port}/emulator/wechat/refresh-token`,
+				async ({ request }) => {
+					wechatRefreshEndpointHit = true;
+					const url = new URL(request.url);
+					expect(url.searchParams.get("appid")).toBe("wechat-emulator-client");
+					expect(url.searchParams.get("grant_type")).toBe("refresh_token");
+					expect(url.searchParams.get("refresh_token")).toBe(
+						"wechat-emulator-refresh-token",
+					);
+
+					return HttpResponse.json({
+						access_token: "wechat-emulator-access-token",
+						expires_in: 3600,
+						refresh_token: "wechat-emulator-refresh-token-next",
+						openid: "wechat-emulator-openid",
+						scope: "snsapi_login",
+					});
+				},
+			),
+		);
+
+		const { auth } = await getTestInstance(
+			{
+				socialProviders: {
+					wechat: {
+						clientId: "wechat-emulator-client",
+						clientSecret: "wechat-emulator-secret",
+						refreshTokenEndpoint: `http://localhost:${port}/emulator/wechat/refresh-token`,
+					},
+				},
+			},
+			{
+				disableTestUser: true,
+			},
+		);
+
+		const ctx = await auth.$context;
+		const wechatProvider = ctx.socialProviders.find((p) => p.id === "wechat");
+		expect(wechatProvider?.refreshAccessToken).toBeDefined();
+
+		const tokens = await wechatProvider!.refreshAccessToken!(
+			"wechat-emulator-refresh-token",
+		);
+
+		expect(wechatRefreshEndpointHit).toBe(true);
+		expect(tokens.accessToken).toBe("wechat-emulator-access-token");
+		expect(tokens.refreshToken).toBe("wechat-emulator-refresh-token-next");
+	});
+
+	it("should use Reddit token endpoint overrides for auth code exchange", async () => {
+		let redditTokenEndpointHit = false;
+
+		mswServer.use(
+			http.post(`http://localhost:${port}/emulator/reddit/token`, async () => {
+				redditTokenEndpointHit = true;
+				return HttpResponse.json({
+					access_token: "reddit-emulator-access-token",
+					refresh_token: "reddit-emulator-refresh-token",
+					token_type: "bearer",
+					expires_in: 3600,
+				});
+			}),
+		);
+
+		const redditProvider = reddit({
+			clientId: "reddit-emulator-client",
+			clientSecret: "reddit-emulator-secret",
+			tokenEndpoint: `http://localhost:${port}/emulator/reddit/token`,
+		});
+
+		const tokens = await redditProvider.validateAuthorizationCode({
+			code: "reddit_emulator_code",
+			redirectURI: "http://localhost:3000/callback/reddit",
+		});
+
+		expect(redditTokenEndpointHit).toBe(true);
+		expect(tokens?.accessToken).toBe("reddit-emulator-access-token");
+		expect(tokens?.refreshToken).toBe("reddit-emulator-refresh-token");
+	});
+
+	it("should use Slack user info endpoint overrides", async () => {
+		let slackUserInfoEndpointHit = false;
+
+		mswServer.use(
+			http.get(`http://localhost:${port}/emulator/slack/userinfo`, async () => {
+				slackUserInfoEndpointHit = true;
+				return HttpResponse.json({
+					ok: true,
+					sub: "slack-emulator-sub",
+					"https://slack.com/user_id": "slack-emulator-user",
+					"https://slack.com/team_id": "team-1",
+					email: "slack-emulator@example.com",
+					email_verified: true,
+					date_email_verified: 1234567890,
+					name: "Slack Emulator",
+					picture: "https://test.com/slack-emulator.png",
+					given_name: "Slack",
+					family_name: "Emulator",
+					locale: "en-US",
+					"https://slack.com/team_name": "Emulator Team",
+					"https://slack.com/team_domain": "emulator",
+					"https://slack.com/user_image_24": "",
+					"https://slack.com/user_image_32": "",
+					"https://slack.com/user_image_48": "",
+					"https://slack.com/user_image_72": "",
+					"https://slack.com/user_image_192": "",
+					"https://slack.com/user_image_512": "",
+					"https://slack.com/team_image_34": "",
+					"https://slack.com/team_image_44": "",
+					"https://slack.com/team_image_68": "",
+					"https://slack.com/team_image_88": "",
+					"https://slack.com/team_image_102": "",
+					"https://slack.com/team_image_132": "",
+					"https://slack.com/team_image_230": "",
+					"https://slack.com/team_image_default": false,
+				});
+			}),
+		);
+
+		const slackProvider = slack({
+			clientId: "slack-emulator-client",
+			userInfoEndpoint: `http://localhost:${port}/emulator/slack/userinfo`,
+		});
+
+		const userInfo = await slackProvider.getUserInfo({
+			accessToken: "slack-emulator-access-token",
+		});
+
+		expect(slackUserInfoEndpointHit).toBe(true);
+		expect(userInfo?.user.email).toBe("slack-emulator@example.com");
+	});
+
+	it("should preserve query params when overriding PayPal user info endpoints", async () => {
+		let paypalUserInfoEndpointHit = false;
+
+		mswServer.use(
+			http.get(
+				`http://localhost:${port}/emulator/paypal/userinfo`,
+				async ({ request }) => {
+					paypalUserInfoEndpointHit = true;
+					const url = new URL(request.url);
+					expect(url.searchParams.get("existing")).toBe("1");
+					expect(url.searchParams.get("schema")).toBe("paypalv1.1");
+
+					return HttpResponse.json({
+						user_id: "paypal-emulator-user",
+						name: "PayPal Emulator",
+						given_name: "PayPal",
+						family_name: "Emulator",
+						email: "paypal-emulator@example.com",
+						email_verified: true,
+					});
+				},
+			),
+		);
+
+		const paypalProvider = paypal({
+			clientId: "paypal-emulator-client",
+			clientSecret: "paypal-emulator-secret",
+			userInfoEndpoint: `http://localhost:${port}/emulator/paypal/userinfo?existing=1`,
+		});
+
+		const userInfo = await paypalProvider.getUserInfo({
+			accessToken: "paypal-emulator-access-token",
+		});
+
+		expect(paypalUserInfoEndpointHit).toBe(true);
+		expect(userInfo?.user.email).toBe("paypal-emulator@example.com");
+	});
+
+	it("should preserve query params when overriding Roblox authorization endpoints", async () => {
+		const robloxProvider = roblox({
+			clientId: "roblox-emulator-client",
+			authorizationEndpoint: `http://localhost:${port}/emulator/roblox/authorize?existing=1`,
+		});
+
+		const authorizationUrl = await robloxProvider.createAuthorizationURL({
+			state: "roblox-emulator-state",
+			codeVerifier: "roblox-emulator-code-verifier",
+			redirectURI: "http://localhost:3000/callback/roblox",
+		});
+
+		expect(authorizationUrl.origin).toBe(`http://localhost:${port}`);
+		expect(authorizationUrl.pathname).toBe("/emulator/roblox/authorize");
+		expect(authorizationUrl.searchParams.get("existing")).toBe("1");
+		expect(authorizationUrl.searchParams.get("client_id")).toBe(
+			"roblox-emulator-client",
+		);
+		expect(authorizationUrl.searchParams.get("state")).toBe(
+			"roblox-emulator-state",
+		);
+	});
+
+	it("should use Zoom user info endpoint overrides", async () => {
+		let zoomUserInfoEndpointHit = false;
+
+		mswServer.use(
+			http.get(`http://localhost:${port}/emulator/zoom/userinfo`, async () => {
+				zoomUserInfoEndpointHit = true;
+				return HttpResponse.json({
+					id: "zoom-emulator-user",
+					display_name: "Zoom Emulator",
+					pic_url: "https://test.com/zoom-emulator.png",
+					email: "zoom-emulator@example.com",
+					verified: 1,
+				});
+			}),
+		);
+
+		const zoomProvider = zoom({
+			clientId: "zoom-emulator-client",
+			clientSecret: "zoom-emulator-secret",
+			userInfoEndpoint: `http://localhost:${port}/emulator/zoom/userinfo`,
+		});
+
+		const userInfo = await zoomProvider.getUserInfo({
+			accessToken: "zoom-emulator-access-token",
+		});
+
+		expect(zoomUserInfoEndpointHit).toBe(true);
+		expect(userInfo?.user.email).toBe("zoom-emulator@example.com");
+	});
+
+	it("should use VK authorization and user info endpoint overrides", async () => {
+		let vkUserInfoEndpointHit = false;
+
+		mswServer.use(
+			http.post(
+				`http://localhost:${port}/emulator/vk/userinfo`,
+				async ({ request }) => {
+					vkUserInfoEndpointHit = true;
+					const body = await request.text();
+					const params = new URLSearchParams(body);
+					expect(params.get("client_id")).toBe("vk-emulator-client");
+					expect(params.get("access_token")).toBe("vk-emulator-access-token");
+
+					return HttpResponse.json({
+						user: {
+							user_id: "vk-emulator-user",
+							first_name: "VK",
+							last_name: "Emulator",
+							email: "vk-emulator@example.com",
+							avatar: "https://test.com/vk-emulator.png",
+							birthday: "2000-01-01",
+						},
+					});
+				},
+			),
+		);
+
+		const vkProvider = vk({
+			clientId: "vk-emulator-client",
+			clientSecret: "vk-emulator-secret",
+			authorizationEndpoint: `http://localhost:${port}/emulator/vk/authorize`,
+			userInfoEndpoint: `http://localhost:${port}/emulator/vk/userinfo`,
+		});
+
+		const authorizationUrl = await vkProvider.createAuthorizationURL({
+			state: "vk-emulator-state",
+			scopes: ["profile"],
+			codeVerifier: "vk-emulator-code-verifier",
+			redirectURI: "http://localhost:3000/callback/vk",
+		});
+		const userInfo = await vkProvider.getUserInfo({
+			accessToken: "vk-emulator-access-token",
+		});
+
+		expect(authorizationUrl.toString()).toContain(
+			`http://localhost:${port}/emulator/vk/authorize`,
+		);
+		expect(vkUserInfoEndpointHit).toBe(true);
+		expect(userInfo?.user.email).toBe("vk-emulator@example.com");
 	});
 });
 describe("Redirect URI", async () => {

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -451,6 +451,267 @@ describe("Social Providers", async (c) => {
 			refreshToken: "new-refresh-token",
 		});
 	});
+
+	it("should support Google emulator endpoint overrides", async () => {
+		const googleKid = "google-emulator-kid";
+		const googleKeyPair = await generateKeyPair("RS256");
+		const googleJwk = await exportJWK(googleKeyPair.publicKey);
+		googleJwk.kid = googleKid;
+		googleJwk.alg = "RS256";
+		googleJwk.use = "sig";
+
+		let googleTokenEndpointHit = false;
+		let googleJwksEndpointHit = false;
+
+		mswServer.use(
+			http.post(`http://localhost:${port}/emulator/google/token`, async () => {
+				googleTokenEndpointHit = true;
+				const profile: GoogleProfile = {
+					aud: "google-emulator-client",
+					azp: "google-emulator-client",
+					email: "google-emulator@example.com",
+					email_verified: true,
+					exp: 1234567890,
+					family_name: "Emulator",
+					given_name: "Google",
+					iat: 1234567890,
+					iss: "https://accounts.google.com",
+					name: "Google Emulator",
+					picture: "https://test.com/google-emulator.png",
+					sub: "google-emulator-user",
+				};
+				const idToken = await signJWT(profile, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: "google-emulator-access-token",
+					refresh_token: "google-emulator-refresh-token",
+					id_token: idToken,
+					token_type: "Bearer",
+					expires_in: 3600,
+				});
+			}),
+			http.get(`http://localhost:${port}/emulator/google/jwks`, async () => {
+				googleJwksEndpointHit = true;
+				return HttpResponse.json({
+					keys: [googleJwk],
+				});
+			}),
+		);
+
+		const { auth } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "google-emulator-client",
+						clientSecret: "google-emulator-secret",
+						authorizationEndpoint: `http://localhost:${port}/emulator/google/authorize`,
+						tokenEndpoint: `http://localhost:${port}/emulator/google/token`,
+						jwksEndpoint: `http://localhost:${port}/emulator/google/jwks`,
+					},
+				},
+			},
+			{
+				disableTestUser: true,
+			},
+		);
+
+		const ctx = await auth.$context;
+		const googleProvider = ctx.socialProviders.find((p) => p.id === "google");
+		expect(googleProvider).toBeDefined();
+		expect(googleProvider?.options?.tokenEndpoint).toBe(
+			`http://localhost:${port}/emulator/google/token`,
+		);
+
+		const authorizationUrl = await googleProvider!.createAuthorizationURL({
+			state: "google-emulator-state",
+			codeVerifier: "google-emulator-code-verifier",
+			redirectURI: "http://localhost:3000/callback/google",
+		});
+
+		expect(authorizationUrl.toString()).toContain(
+			`http://localhost:${port}/emulator/google/authorize`,
+		);
+
+		const tokens = await googleProvider!.validateAuthorizationCode({
+			code: "google_emulator_code",
+			codeVerifier: "google-emulator-code-verifier",
+			redirectURI: "http://localhost:3000/callback/google",
+		});
+
+		expect(tokens?.accessToken).toBe("google-emulator-access-token");
+		expect(googleTokenEndpointHit).toBe(true);
+
+		const emulatorIdToken = await new SignJWT({
+			email: "google-emulator@example.com",
+			email_verified: true,
+			family_name: "Emulator",
+			given_name: "Google",
+			name: "Google Emulator",
+			picture: "https://test.com/google-emulator.png",
+			sub: "google-emulator-user",
+		})
+			.setProtectedHeader({ alg: "RS256", kid: googleKid })
+			.setIssuedAt()
+			.setIssuer("https://accounts.google.com")
+			.setAudience("google-emulator-client")
+			.setExpirationTime("1h")
+			.sign(googleKeyPair.privateKey);
+
+		const validIdToken = await googleProvider!.verifyIdToken?.(emulatorIdToken);
+		expect(validIdToken).toBe(true);
+		expect(googleJwksEndpointHit).toBe(true);
+	});
+
+	it("should support user info endpoint overrides", async () => {
+		let railwayTokenEndpointHit = false;
+		let railwayUserInfoEndpointHit = false;
+
+		mswServer.use(
+			http.post(`http://localhost:${port}/emulator/railway/token`, async () => {
+				railwayTokenEndpointHit = true;
+				return HttpResponse.json({
+					access_token: "railway-emulator-access-token",
+					token_type: "Bearer",
+					expires_in: 3600,
+				});
+			}),
+			http.get(
+				`http://localhost:${port}/emulator/railway/userinfo`,
+				async () => {
+					railwayUserInfoEndpointHit = true;
+					return HttpResponse.json({
+						sub: "railway-emulator-user",
+						email: "railway-emulator@example.com",
+						name: "Railway Emulator User",
+						picture: "https://test.com/railway-emulator.png",
+					} satisfies RailwayProfile);
+				},
+			),
+		);
+
+		const { auth } = await getTestInstance(
+			{
+				socialProviders: {
+					railway: {
+						clientId: "railway-emulator-client",
+						clientSecret: "railway-emulator-secret",
+						authorizationEndpoint: `http://localhost:${port}/emulator/railway/authorize`,
+						tokenEndpoint: `http://localhost:${port}/emulator/railway/token`,
+						userInfoEndpoint: `http://localhost:${port}/emulator/railway/userinfo`,
+					},
+				},
+			},
+			{
+				disableTestUser: true,
+			},
+		);
+
+		const ctx = await auth.$context;
+		const railwayProvider = ctx.socialProviders.find((p) => p.id === "railway");
+		expect(railwayProvider).toBeDefined();
+
+		const authorizationUrl = await railwayProvider!.createAuthorizationURL({
+			state: "railway-emulator-state",
+			codeVerifier: "railway-emulator-code-verifier",
+			redirectURI: "http://localhost:3000/callback/railway",
+		});
+
+		expect(authorizationUrl.toString()).toContain(
+			`http://localhost:${port}/emulator/railway/authorize`,
+		);
+
+		const tokens = await railwayProvider!.validateAuthorizationCode({
+			code: "railway_emulator_code",
+			codeVerifier: "railway-emulator-code-verifier",
+			redirectURI: "http://localhost:3000/callback/railway",
+		});
+
+		const userInfo = await railwayProvider!.getUserInfo(tokens!);
+
+		expect(railwayTokenEndpointHit).toBe(true);
+		expect(railwayUserInfoEndpointHit).toBe(true);
+		expect(userInfo?.user.email).toBe("railway-emulator@example.com");
+		expect(userInfo?.user.name).toBe("Railway Emulator User");
+	});
+
+	it("should prefer explicit overrides over issuer-derived GitLab endpoints", async () => {
+		let gitlabTokenEndpointHit = false;
+		let gitlabUserInfoEndpointHit = false;
+
+		mswServer.use(
+			http.post(`http://localhost:${port}/emulator/gitlab/token`, async () => {
+				gitlabTokenEndpointHit = true;
+				return HttpResponse.json({
+					access_token: "gitlab-emulator-access-token",
+					token_type: "Bearer",
+					expires_in: 3600,
+				});
+			}),
+			http.get(
+				`http://localhost:${port}/emulator/gitlab/userinfo`,
+				async () => {
+					gitlabUserInfoEndpointHit = true;
+					return HttpResponse.json({
+						id: 42,
+						username: "gitlab-emulator",
+						email: "gitlab-emulator@example.com",
+						name: "GitLab Emulator User",
+						state: "active",
+						avatar_url: "https://test.com/gitlab-emulator.png",
+						web_url: "https://gitlab.example.com/gitlab-emulator",
+						created_at: "2024-01-01T00:00:00.000Z",
+						bot: false,
+					});
+				},
+			),
+		);
+
+		const { auth } = await getTestInstance(
+			{
+				socialProviders: {
+					gitlab: {
+						clientId: "gitlab-emulator-client",
+						clientSecret: "gitlab-emulator-secret",
+						issuer: "https://gitlab.example.com",
+						authorizationEndpoint: `http://localhost:${port}/emulator/gitlab/authorize`,
+						tokenEndpoint: `http://localhost:${port}/emulator/gitlab/token`,
+						userInfoEndpoint: `http://localhost:${port}/emulator/gitlab/userinfo`,
+					},
+				},
+			},
+			{
+				disableTestUser: true,
+			},
+		);
+
+		const ctx = await auth.$context;
+		const gitlabProvider = ctx.socialProviders.find((p) => p.id === "gitlab");
+		expect(gitlabProvider).toBeDefined();
+
+		const authorizationUrl = await gitlabProvider!.createAuthorizationURL({
+			state: "gitlab-emulator-state",
+			codeVerifier: "gitlab-emulator-code-verifier",
+			redirectURI: "http://localhost:3000/callback/gitlab",
+		});
+
+		expect(authorizationUrl.toString()).toContain(
+			`http://localhost:${port}/emulator/gitlab/authorize`,
+		);
+		expect(authorizationUrl.toString()).not.toContain(
+			"gitlab.example.com/oauth/authorize",
+		);
+
+		const tokens = await gitlabProvider!.validateAuthorizationCode({
+			code: "gitlab_emulator_code",
+			codeVerifier: "gitlab-emulator-code-verifier",
+			redirectURI: "http://localhost:3000/callback/gitlab",
+		});
+
+		const userInfo = await gitlabProvider!.getUserInfo(tokens!);
+
+		expect(gitlabTokenEndpointHit).toBe(true);
+		expect(gitlabUserInfoEndpointHit).toBe(true);
+		expect(userInfo?.user.email).toBe("gitlab-emulator@example.com");
+	});
 });
 describe("Redirect URI", async () => {
 	it("should infer redirect uri", async () => {

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -9,10 +9,13 @@ import type {
 	VercelProfile,
 } from "@better-auth/core/social-providers";
 import {
+	discord,
+	github,
 	paypal,
 	reddit,
 	roblox,
 	slack,
+	tiktok,
 	vk,
 	zoom,
 } from "@better-auth/core/social-providers";
@@ -998,6 +1001,109 @@ describe("Social Providers", async (c) => {
 		);
 		expect(vkUserInfoEndpointHit).toBe(true);
 		expect(userInfo?.user.email).toBe("vk-emulator@example.com");
+	});
+
+	it("should preserve GitHub email fallback for custom user endpoints", async () => {
+		let githubProfileEndpointHit = false;
+		let githubEmailEndpointHit = false;
+
+		mswServer.use(
+			http.get(`http://localhost:${port}/emulator/github/user`, async () => {
+				githubProfileEndpointHit = true;
+				return HttpResponse.json({
+					id: "github-emulator-user",
+					login: "github-emulator",
+					name: "GitHub Emulator",
+					avatar_url: "https://test.com/github-emulator.png",
+					email: null,
+				});
+			}),
+			http.get(
+				`http://localhost:${port}/emulator/github/user/emails`,
+				async () => {
+					githubEmailEndpointHit = true;
+					return HttpResponse.json([
+						{
+							email: "github-emulator@example.com",
+							primary: true,
+							verified: true,
+							visibility: "private",
+						},
+					]);
+				},
+			),
+		);
+
+		const githubProvider = github({
+			clientId: "github-emulator-client",
+			clientSecret: "github-emulator-secret",
+			userInfoEndpoint: `http://localhost:${port}/emulator/github/user`,
+		});
+
+		const userInfo = await githubProvider.getUserInfo({
+			accessToken: "github-emulator-access-token",
+		});
+
+		expect(githubProfileEndpointHit).toBe(true);
+		expect(githubEmailEndpointHit).toBe(true);
+		expect(userInfo?.user.email).toBe("github-emulator@example.com");
+		expect(userInfo?.user.emailVerified).toBe(true);
+	});
+
+	it("should preserve query params when overriding TikTok authorization endpoints", async () => {
+		const tiktokProvider = tiktok({
+			clientKey: "tiktok-emulator-client-key",
+			clientSecret: "tiktok-emulator-secret",
+			authorizationEndpoint: `http://localhost:${port}/emulator/tiktok/authorize?existing=1`,
+		});
+
+		const authorizationUrl = await tiktokProvider.createAuthorizationURL({
+			state: "tiktok-emulator-state",
+			codeVerifier: "tiktok-emulator-code-verifier",
+			scopes: ["video.list"],
+			redirectURI: "http://localhost:3000/callback/tiktok",
+		});
+
+		expect(authorizationUrl.origin).toBe(`http://localhost:${port}`);
+		expect(authorizationUrl.pathname).toBe("/emulator/tiktok/authorize");
+		expect(authorizationUrl.searchParams.get("existing")).toBe("1");
+		expect(authorizationUrl.searchParams.get("client_key")).toBe(
+			"tiktok-emulator-client-key",
+		);
+		expect(authorizationUrl.searchParams.get("state")).toBe(
+			"tiktok-emulator-state",
+		);
+		expect(authorizationUrl.searchParams.get("scope")).toContain(
+			"user.info.profile",
+		);
+		expect(authorizationUrl.searchParams.get("scope")).toContain("video.list");
+	});
+
+	it("should preserve query params when overriding Discord authorization endpoints", async () => {
+		const discordProvider = discord({
+			clientId: "discord-emulator-client",
+			authorizationEndpoint: `http://localhost:${port}/emulator/discord/authorize?existing=1`,
+			permissions: 8,
+		});
+
+		const authorizationUrl = await discordProvider.createAuthorizationURL({
+			state: "discord-emulator-state",
+			codeVerifier: "discord-emulator-code-verifier",
+			scopes: ["bot"],
+			redirectURI: "http://localhost:3000/callback/discord",
+		});
+
+		expect(authorizationUrl.origin).toBe(`http://localhost:${port}`);
+		expect(authorizationUrl.pathname).toBe("/emulator/discord/authorize");
+		expect(authorizationUrl.searchParams.get("existing")).toBe("1");
+		expect(authorizationUrl.searchParams.get("client_id")).toBe(
+			"discord-emulator-client",
+		);
+		expect(authorizationUrl.searchParams.get("state")).toBe(
+			"discord-emulator-state",
+		);
+		expect(authorizationUrl.searchParams.get("permissions")).toBe("8");
+		expect(authorizationUrl.searchParams.get("scope")).toContain("bot");
 	});
 });
 describe("Redirect URI", async () => {

--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -132,6 +132,24 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 	 */
 	authorizationEndpoint?: string | undefined;
 	/**
+	 * Custom token endpoint URL.
+	 * Use this to override the default token endpoint of the provider.
+	 * Useful for testing with local OAuth servers or using sandbox environments.
+	 */
+	tokenEndpoint?: string | undefined;
+	/**
+	 * Custom user info endpoint URL.
+	 * Use this to override the default user info endpoint of the provider.
+	 * Useful for testing with local OAuth servers or using sandbox environments.
+	 */
+	userInfoEndpoint?: string | undefined;
+	/**
+	 * Custom JWKS endpoint URL.
+	 * Use this to override the default JWKS endpoint of the provider.
+	 * Useful for testing with local OAuth servers or using sandbox environments.
+	 */
+	jwksEndpoint?: string | undefined;
+	/**
 	 * The client key of your application
 	 * Tiktok Social Provider uses this field instead of clientId
 	 */

--- a/packages/core/src/oauth2/refresh-access-token.ts
+++ b/packages/core/src/oauth2/refresh-access-token.ts
@@ -147,7 +147,7 @@ export async function refreshAccessToken({
 		token_type?: string | undefined;
 		scope?: string | undefined;
 		id_token?: string | undefined;
-	}>(tokenEndpoint, {
+	}>(options.tokenEndpoint ?? tokenEndpoint, {
 		method: "POST",
 		body,
 		headers,

--- a/packages/core/src/oauth2/validate-authorization-code.ts
+++ b/packages/core/src/oauth2/validate-authorization-code.ts
@@ -161,13 +161,14 @@ export async function validateAuthorizationCode({
 	additionalParams?: Record<string, string> | undefined;
 	resource?: (string | string[]) | undefined;
 }) {
-	options = typeof options === "function" ? await options() : options;
+	const resolvedOptions =
+		typeof options === "function" ? await options() : options;
 
-	const { body, headers: requestHeaders } = createAuthorizationCodeRequest({
+	const { body, headers: requestHeaders } = await authorizationCodeRequest({
 		code,
 		codeVerifier,
 		redirectURI,
-		options,
+		options: resolvedOptions,
 		authentication,
 		clientAssertion,
 		tokenEndpoint,
@@ -178,7 +179,7 @@ export async function validateAuthorizationCode({
 	});
 
 	const { data, error } = await betterFetch<object>(
-		options.tokenEndpoint ?? tokenEndpoint,
+		resolvedOptions.tokenEndpoint ?? tokenEndpoint,
 		{
 			method: "POST",
 			body: body,

--- a/packages/core/src/oauth2/validate-authorization-code.ts
+++ b/packages/core/src/oauth2/validate-authorization-code.ts
@@ -161,7 +161,9 @@ export async function validateAuthorizationCode({
 	additionalParams?: Record<string, string> | undefined;
 	resource?: (string | string[]) | undefined;
 }) {
-	const { body, headers: requestHeaders } = await authorizationCodeRequest({
+	options = typeof options === "function" ? await options() : options;
+
+	const { body, headers: requestHeaders } = createAuthorizationCodeRequest({
 		code,
 		codeVerifier,
 		redirectURI,
@@ -175,11 +177,14 @@ export async function validateAuthorizationCode({
 		resource,
 	});
 
-	const { data, error } = await betterFetch<object>(tokenEndpoint, {
-		method: "POST",
-		body: body,
-		headers: requestHeaders,
-	});
+	const { data, error } = await betterFetch<object>(
+		options.tokenEndpoint ?? tokenEndpoint,
+		{
+			method: "POST",
+			body: body,
+			headers: requestHeaders,
+		},
+	);
 	if (error) {
 		throw error;
 	}

--- a/packages/core/src/social-providers/apple.ts
+++ b/packages/core/src/social-providers/apple.ts
@@ -110,7 +110,7 @@ export const apple = (options: AppleOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		async verifyIdToken(token, nonce) {
@@ -124,7 +124,7 @@ export const apple = (options: AppleOptions) => {
 				const decodedHeader = decodeProtectedHeader(token);
 				const { kid, alg: jwtAlg } = decodedHeader;
 				if (!kid || !jwtAlg) return false;
-				const publicKey = await getApplePublicKey(kid);
+				const publicKey = await getApplePublicKey(kid, options.jwksEndpoint);
 				const { payload: jwtClaims } = await jwtVerify(token, publicKey, {
 					algorithms: [jwtAlg],
 					issuer: "https://appleid.apple.com",
@@ -155,7 +155,7 @@ export const apple = (options: AppleOptions) => {
 					return refreshAccessToken({
 						refreshToken,
 						options,
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {
@@ -205,7 +205,7 @@ export const apple = (options: AppleOptions) => {
 	} satisfies OAuthProvider<AppleProfile>;
 };
 
-export const getApplePublicKey = async (kid: string) => {
+export const getApplePublicKey = async (kid: string, jwksEndpoint?: string) => {
 	const APPLE_BASE_URL = "https://appleid.apple.com";
 	const JWKS_APPLE_URI = "/auth/keys";
 	const { data } = await betterFetch<{
@@ -217,7 +217,7 @@ export const getApplePublicKey = async (kid: string) => {
 			n: string;
 			e: string;
 		}>;
-	}>(`${APPLE_BASE_URL}${JWKS_APPLE_URI}`);
+	}>(jwksEndpoint ?? `${APPLE_BASE_URL}${JWKS_APPLE_URI}`);
 	if (!data?.keys) {
 		throw new APIError("BAD_REQUEST", {
 			message: "Keys not found",

--- a/packages/core/src/social-providers/atlassian.ts
+++ b/packages/core/src/social-providers/atlassian.ts
@@ -71,7 +71,7 @@ export const atlassian = (options: AtlassianOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 
@@ -84,7 +84,7 @@ export const atlassian = (options: AtlassianOptions) => {
 							clientId: options.clientId,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 

--- a/packages/core/src/social-providers/cognito.ts
+++ b/packages/core/src/social-providers/cognito.ts
@@ -55,7 +55,8 @@ export const cognito = (options: CognitoOptions) => {
 	const cleanDomain = options.domain.replace(/^https?:\/\//, "");
 	const authorizationEndpoint = `https://${cleanDomain}/oauth2/authorize`;
 	const tokenEndpoint = `https://${cleanDomain}/oauth2/token`;
-	const userInfoEndpoint = `https://${cleanDomain}/oauth2/userinfo`;
+	const userInfoEndpoint =
+		options.userInfoEndpoint ?? `https://${cleanDomain}/oauth2/userinfo`;
 
 	return {
 		id: "cognito",
@@ -112,7 +113,7 @@ export const cognito = (options: CognitoOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 
@@ -126,7 +127,7 @@ export const cognito = (options: CognitoOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 
@@ -147,6 +148,7 @@ export const cognito = (options: CognitoOptions) => {
 					kid,
 					options.region,
 					options.userPoolId,
+					options.jwksEndpoint,
 				);
 				const expectedIssuer = `https://cognito-idp.${options.region}.amazonaws.com/${options.userPoolId}`;
 
@@ -247,6 +249,7 @@ export const getCognitoPublicKey = async (
 	kid: string,
 	region: string,
 	userPoolId: string,
+	jwksEndpoint?: string,
 ) => {
 	const COGNITO_JWKS_URI = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}/.well-known/jwks.json`;
 
@@ -260,7 +263,7 @@ export const getCognitoPublicKey = async (
 				n: string;
 				e: string;
 			}>;
-		}>(COGNITO_JWKS_URI);
+		}>(jwksEndpoint ?? COGNITO_JWKS_URI);
 
 		if (!data?.keys) {
 			throw new APIError("BAD_REQUEST", {

--- a/packages/core/src/social-providers/discord.ts
+++ b/packages/core/src/social-providers/discord.ts
@@ -89,22 +89,20 @@ export const discord = (options: DiscordOptions) => {
 			if (scopes) _scopes.push(...scopes);
 			if (options.scope) _scopes.push(...options.scope);
 			const hasBotScope = _scopes.includes("bot");
-			const permissionsParam =
-				hasBotScope && options.permissions !== undefined
-					? `&permissions=${options.permissions}`
-					: "";
-			return new URL(
-				`${
-					options.authorizationEndpoint ??
-					"https://discord.com/api/oauth2/authorize"
-				}?scope=${_scopes.join("+")}&response_type=code&client_id=${
-					options.clientId
-				}&redirect_uri=${encodeURIComponent(
-					options.redirectURI || redirectURI,
-				)}&state=${state}&prompt=${
-					options.prompt || "none"
-				}${permissionsParam}`,
+			const url = new URL(
+				options.authorizationEndpoint ??
+					"https://discord.com/api/oauth2/authorize",
 			);
+			url.searchParams.set("scope", _scopes.join(" "));
+			url.searchParams.set("response_type", "code");
+			url.searchParams.set("client_id", options.clientId);
+			url.searchParams.set("redirect_uri", options.redirectURI || redirectURI);
+			url.searchParams.set("state", state);
+			url.searchParams.set("prompt", options.prompt || "none");
+			if (hasBotScope && options.permissions !== undefined) {
+				url.searchParams.set("permissions", `${options.permissions}`);
+			}
+			return url;
 		},
 		validateAuthorizationCode: async ({ code, redirectURI }) => {
 			return validateAuthorizationCode({

--- a/packages/core/src/social-providers/discord.ts
+++ b/packages/core/src/social-providers/discord.ts
@@ -94,9 +94,10 @@ export const discord = (options: DiscordOptions) => {
 					? `&permissions=${options.permissions}`
 					: "";
 			return new URL(
-				`https://discord.com/api/oauth2/authorize?scope=${_scopes.join(
-					"+",
-				)}&response_type=code&client_id=${
+				`${
+					options.authorizationEndpoint ??
+					"https://discord.com/api/oauth2/authorize"
+				}?scope=${_scopes.join("+")}&response_type=code&client_id=${
 					options.clientId
 				}&redirect_uri=${encodeURIComponent(
 					options.redirectURI || redirectURI,
@@ -110,7 +111,7 @@ export const discord = (options: DiscordOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -123,7 +124,7 @@ export const discord = (options: DiscordOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/dropbox.ts
+++ b/packages/core/src/social-providers/dropbox.ts
@@ -61,7 +61,7 @@ export const dropbox = (options: DropboxOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -74,7 +74,7 @@ export const dropbox = (options: DropboxOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/facebook.ts
+++ b/packages/core/src/social-providers/facebook.ts
@@ -40,6 +40,8 @@ export interface FacebookOptions extends ProviderOptions<FacebookProfile> {
 }
 
 export const facebook = (options: FacebookOptions) => {
+	const userInfoEndpoint =
+		options.userInfoEndpoint ?? "https://graph.facebook.com/me";
 	return {
 		id: "facebook",
 		name: "Facebook",
@@ -75,7 +77,9 @@ export const facebook = (options: FacebookOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint: "https://graph.facebook.com/v24.0/oauth/access_token",
+				tokenEndpoint:
+					options.tokenEndpoint ??
+					"https://graph.facebook.com/v24.0/oauth/access_token",
 			});
 		},
 		async verifyIdToken(token, nonce) {
@@ -96,7 +100,8 @@ export const facebook = (options: FacebookOptions) => {
 						createRemoteJWKSet(
 							// https://developers.facebook.com/docs/facebook-login/limited-login/token/#jwks
 							new URL(
-								"https://limited.facebook.com/.well-known/oauth/openid/jwks/",
+								options.jwksEndpoint ??
+									"https://limited.facebook.com/.well-known/oauth/openid/jwks/",
 							),
 						),
 						{
@@ -130,6 +135,7 @@ export const facebook = (options: FacebookOptions) => {
 							clientSecret: options.clientSecret,
 						},
 						tokenEndpoint:
+							options.tokenEndpoint ??
 							"https://graph.facebook.com/v24.0/oauth/access_token",
 					});
 				},
@@ -185,8 +191,10 @@ export const facebook = (options: FacebookOptions) => {
 				"picture",
 				...(options?.fields || []),
 			];
+			const userInfoUrl = new URL(userInfoEndpoint);
+			userInfoUrl.searchParams.set("fields", fields.join(","));
 			const { data: profile, error } = await betterFetch<FacebookProfile>(
-				"https://graph.facebook.com/me?fields=" + fields.join(","),
+				userInfoUrl.toString(),
 				{
 					auth: {
 						type: "Bearer",

--- a/packages/core/src/social-providers/figma.ts
+++ b/packages/core/src/social-providers/figma.ts
@@ -57,7 +57,7 @@ export const figma = (options: FigmaOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 				authentication: "basic",
 			});
 		},
@@ -71,7 +71,7 @@ export const figma = (options: FigmaOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 						authentication: "basic",
 					});
 				},

--- a/packages/core/src/social-providers/github.ts
+++ b/packages/core/src/social-providers/github.ts
@@ -60,6 +60,8 @@ export interface GithubOptions extends ProviderOptions<GithubProfile> {
 }
 export const github = (options: GithubOptions) => {
 	const tokenEndpoint = "https://github.com/login/oauth/access_token";
+	const userInfoEndpoint =
+		options.userInfoEndpoint ?? "https://api.github.com/user";
 	return {
 		id: "github",
 		name: "GitHub",
@@ -98,7 +100,7 @@ export const github = (options: GithubOptions) => {
 			const { data, error } = await betterFetch<
 				| { access_token: string; token_type: string; scope: string }
 				| { error: string; error_description?: string; error_uri?: string }
-			>(tokenEndpoint, {
+			>(options.tokenEndpoint ?? tokenEndpoint, {
 				method: "POST",
 				body: body,
 				headers: requestHeaders,
@@ -126,7 +128,7 @@ export const github = (options: GithubOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {
@@ -134,7 +136,7 @@ export const github = (options: GithubOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<GithubProfile>(
-				"https://api.github.com/user",
+				userInfoEndpoint,
 				{
 					headers: {
 						"User-Agent": "better-auth",
@@ -145,19 +147,23 @@ export const github = (options: GithubOptions) => {
 			if (error) {
 				return null;
 			}
-			const { data: emails } = await betterFetch<
-				{
-					email: string;
-					primary: boolean;
-					verified: boolean;
-					visibility: "public" | "private";
-				}[]
-			>("https://api.github.com/user/emails", {
-				headers: {
-					Authorization: `Bearer ${token.accessToken}`,
-					"User-Agent": "better-auth",
-				},
-			});
+			const emails = options.userInfoEndpoint
+				? undefined
+				: (
+						await betterFetch<
+							{
+								email: string;
+								primary: boolean;
+								verified: boolean;
+								visibility: "public" | "private";
+							}[]
+						>("https://api.github.com/user/emails", {
+							headers: {
+								Authorization: `Bearer ${token.accessToken}`,
+								"User-Agent": "better-auth",
+							},
+						})
+					).data;
 
 			if (!profile.email && emails) {
 				profile.email = (emails.find((e) => e.primary) ?? emails[0])

--- a/packages/core/src/social-providers/github.ts
+++ b/packages/core/src/social-providers/github.ts
@@ -62,6 +62,22 @@ export const github = (options: GithubOptions) => {
 	const tokenEndpoint = "https://github.com/login/oauth/access_token";
 	const userInfoEndpoint =
 		options.userInfoEndpoint ?? "https://api.github.com/user";
+	const emailEndpoint = (() => {
+		try {
+			const url = new URL(userInfoEndpoint);
+			const normalizedPathname = url.pathname.endsWith("/")
+				? url.pathname.slice(0, -1)
+				: url.pathname;
+			if (!normalizedPathname.endsWith("/user")) {
+				return undefined;
+			}
+			url.pathname = `${normalizedPathname}/emails`;
+			url.search = "";
+			return url.toString();
+		} catch {
+			return undefined;
+		}
+	})();
 	return {
 		id: "github",
 		name: "GitHub",
@@ -147,9 +163,8 @@ export const github = (options: GithubOptions) => {
 			if (error) {
 				return null;
 			}
-			const emails = options.userInfoEndpoint
-				? undefined
-				: (
+			const emails = emailEndpoint
+				? (
 						await betterFetch<
 							{
 								email: string;
@@ -157,13 +172,14 @@ export const github = (options: GithubOptions) => {
 								verified: boolean;
 								visibility: "public" | "private";
 							}[]
-						>("https://api.github.com/user/emails", {
+						>(emailEndpoint, {
 							headers: {
 								Authorization: `Bearer ${token.accessToken}`,
 								"User-Agent": "better-auth",
 							},
 						})
-					).data;
+					).data
+				: undefined;
 
 			if (!profile.email && emails) {
 				profile.email = (emails.find((e) => e.primary) ?? emails[0])

--- a/packages/core/src/social-providers/gitlab.ts
+++ b/packages/core/src/social-providers/gitlab.ts
@@ -108,7 +108,7 @@ export const gitlab = (options: GitlabOptions) => {
 				redirectURI,
 				options,
 				codeVerifier,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -121,7 +121,7 @@ export const gitlab = (options: GitlabOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {
@@ -129,7 +129,7 @@ export const gitlab = (options: GitlabOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<GitlabProfile>(
-				userinfoEndpoint,
+				options.userInfoEndpoint ?? userinfoEndpoint,
 				{ headers: { authorization: `Bearer ${token.accessToken}` } },
 			);
 			if (error || profile.state !== "active" || profile.locked) {

--- a/packages/core/src/social-providers/google.ts
+++ b/packages/core/src/social-providers/google.ts
@@ -104,7 +104,8 @@ export const google = (options: GoogleOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint: "https://oauth2.googleapis.com/token",
+				tokenEndpoint:
+					options.tokenEndpoint ?? "https://oauth2.googleapis.com/token",
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -117,7 +118,8 @@ export const google = (options: GoogleOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: "https://oauth2.googleapis.com/token",
+						tokenEndpoint:
+							options.tokenEndpoint ?? "https://oauth2.googleapis.com/token",
 					});
 				},
 		async verifyIdToken(token, nonce) {
@@ -135,7 +137,7 @@ export const google = (options: GoogleOptions) => {
 				const { kid, alg: jwtAlg } = decodeProtectedHeader(token);
 				if (!kid || !jwtAlg) return false;
 
-				const publicKey = await getGooglePublicKey(kid);
+				const publicKey = await getGooglePublicKey(kid, options.jwksEndpoint);
 				const { payload: jwtClaims } = await jwtVerify(token, publicKey, {
 					algorithms: [jwtAlg],
 					issuer: ["https://accounts.google.com", "accounts.google.com"],
@@ -177,7 +179,10 @@ export const google = (options: GoogleOptions) => {
 	} satisfies OAuthProvider<GoogleProfile>;
 };
 
-export const getGooglePublicKey = async (kid: string) => {
+export const getGooglePublicKey = async (
+	kid: string,
+	jwksEndpoint?: string,
+) => {
 	const { data } = await betterFetch<{
 		keys: Array<{
 			kid: string;
@@ -187,7 +192,7 @@ export const getGooglePublicKey = async (kid: string) => {
 			n: string;
 			e: string;
 		}>;
-	}>("https://www.googleapis.com/oauth2/v3/certs");
+	}>(jwksEndpoint ?? "https://www.googleapis.com/oauth2/v3/certs");
 
 	if (!data?.keys) {
 		throw new APIError("BAD_REQUEST", {

--- a/packages/core/src/social-providers/huggingface.ts
+++ b/packages/core/src/social-providers/huggingface.ts
@@ -69,7 +69,7 @@ export const huggingface = (options: HuggingFaceOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -82,7 +82,7 @@ export const huggingface = (options: HuggingFaceOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {
@@ -90,7 +90,7 @@ export const huggingface = (options: HuggingFaceOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<HuggingFaceProfile>(
-				"https://huggingface.co/oauth/userinfo",
+				options.userInfoEndpoint ?? "https://huggingface.co/oauth/userinfo",
 				{
 					method: "GET",
 					headers: {

--- a/packages/core/src/social-providers/kakao.ts
+++ b/packages/core/src/social-providers/kakao.ts
@@ -126,7 +126,7 @@ export const kakao = (options: KakaoOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -139,7 +139,7 @@ export const kakao = (options: KakaoOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/kick.ts
+++ b/packages/core/src/social-providers/kick.ts
@@ -53,7 +53,8 @@ export const kick = (options: KickOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint: "https://id.kick.com/oauth/token",
+				tokenEndpoint:
+					options.tokenEndpoint ?? "https://id.kick.com/oauth/token",
 				codeVerifier,
 			});
 		},
@@ -66,7 +67,8 @@ export const kick = (options: KickOptions) => {
 							clientId: options.clientId,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: "https://id.kick.com/oauth/token",
+						tokenEndpoint:
+							options.tokenEndpoint ?? "https://id.kick.com/oauth/token",
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/line.ts
+++ b/packages/core/src/social-providers/line.ts
@@ -44,7 +44,8 @@ export interface LineOptions
 export const line = (options: LineOptions) => {
 	const authorizationEndpoint = "https://access.line.me/oauth2/v2.1/authorize";
 	const tokenEndpoint = "https://api.line.me/oauth2/v2.1/token";
-	const userInfoEndpoint = "https://api.line.me/oauth2/v2.1/userinfo";
+	const userInfoEndpoint =
+		options.userInfoEndpoint ?? "https://api.line.me/oauth2/v2.1/userinfo";
 	const verifyIdTokenEndpoint = "https://api.line.me/oauth2/v2.1/verify";
 
 	return {
@@ -79,7 +80,7 @@ export const line = (options: LineOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -91,7 +92,7 @@ export const line = (options: LineOptions) => {
 							clientId: options.clientId,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async verifyIdToken(token, nonce) {

--- a/packages/core/src/social-providers/linear.ts
+++ b/packages/core/src/social-providers/linear.ts
@@ -50,7 +50,7 @@ export const linear = (options: LinearOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -63,7 +63,7 @@ export const linear = (options: LinearOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/linkedin.ts
+++ b/packages/core/src/social-providers/linkedin.ts
@@ -58,7 +58,7 @@ export const linkedin = (options: LinkedInOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -71,7 +71,7 @@ export const linkedin = (options: LinkedInOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {
@@ -79,7 +79,7 @@ export const linkedin = (options: LinkedInOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<LinkedInProfile>(
-				"https://api.linkedin.com/v2/userinfo",
+				options.userInfoEndpoint ?? "https://api.linkedin.com/v2/userinfo",
 				{
 					method: "GET",
 					headers: {

--- a/packages/core/src/social-providers/microsoft-entra-id.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.ts
@@ -182,7 +182,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		async verifyIdToken(token, nonce) {
@@ -197,7 +197,12 @@ export const microsoft = (options: MicrosoftOptions) => {
 				const { kid, alg: jwtAlg } = decodeProtectedHeader(token);
 				if (!kid || !jwtAlg) return false;
 
-				const publicKey = await getMicrosoftPublicKey(kid, tenant, authority);
+				const publicKey = await getMicrosoftPublicKey(
+					kid,
+					tenant,
+					authority,
+					options.jwksEndpoint,
+				);
 				const verifyOptions: {
 					algorithms: [string];
 					audience: string | string[];
@@ -312,7 +317,7 @@ export const microsoft = (options: MicrosoftOptions) => {
 						extraParams: {
 							scope: scopes.join(" "), // Include the scopes in request to microsoft
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		options,
@@ -323,6 +328,7 @@ export const getMicrosoftPublicKey = async (
 	kid: string,
 	tenant: string,
 	authority: string,
+	jwksEndpoint?: string,
 ) => {
 	const { data } = await betterFetch<{
 		keys: Array<{
@@ -335,7 +341,7 @@ export const getMicrosoftPublicKey = async (
 			x5c?: string[];
 			x5t?: string;
 		}>;
-	}>(`${authority}/${tenant}/discovery/v2.0/keys`);
+	}>(jwksEndpoint ?? `${authority}/${tenant}/discovery/v2.0/keys`);
 
 	if (!data?.keys) {
 		throw new APIError("BAD_REQUEST", {

--- a/packages/core/src/social-providers/naver.ts
+++ b/packages/core/src/social-providers/naver.ts
@@ -62,7 +62,7 @@ export const naver = (options: NaverOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -75,7 +75,7 @@ export const naver = (options: NaverOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/notion.ts
+++ b/packages/core/src/social-providers/notion.ts
@@ -50,7 +50,7 @@ export const notion = (options: NotionOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 				authentication: "basic",
 			});
 		},
@@ -64,7 +64,7 @@ export const notion = (options: NotionOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/paybin.ts
+++ b/packages/core/src/social-providers/paybin.ts
@@ -76,7 +76,7 @@ export const paybin = (options: PaybinOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -89,7 +89,7 @@ export const paybin = (options: PaybinOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/paypal.ts
+++ b/packages/core/src/social-providers/paypal.ts
@@ -227,8 +227,13 @@ export const paypal = (options: PayPalOptions) => {
 			}
 
 			try {
+				const userInfoUrl = new URL(
+					options.userInfoEndpoint ?? userInfoEndpoint,
+				);
+				userInfoUrl.searchParams.set("schema", "paypalv1.1");
+
 				const response = await betterFetch<PayPalProfile>(
-					`${options.userInfoEndpoint ?? userInfoEndpoint}?schema=paypalv1.1`,
+					userInfoUrl.toString(),
 					{
 						headers: {
 							Authorization: `Bearer ${token.accessToken}`,

--- a/packages/core/src/social-providers/paypal.ts
+++ b/packages/core/src/social-providers/paypal.ts
@@ -117,20 +117,23 @@ export const paypal = (options: PayPalOptions) => {
 			);
 
 			try {
-				const response = await betterFetch(tokenEndpoint, {
-					method: "POST",
-					headers: {
-						Authorization: `Basic ${credentials}`,
-						Accept: "application/json",
-						"Accept-Language": "en_US",
-						"Content-Type": "application/x-www-form-urlencoded",
+				const response = await betterFetch(
+					options.tokenEndpoint ?? tokenEndpoint,
+					{
+						method: "POST",
+						headers: {
+							Authorization: `Basic ${credentials}`,
+							Accept: "application/json",
+							"Accept-Language": "en_US",
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							grant_type: "authorization_code",
+							code: code,
+							redirect_uri: redirectURI,
+						}).toString(),
 					},
-					body: new URLSearchParams({
-						grant_type: "authorization_code",
-						code: code,
-						redirect_uri: redirectURI,
-					}).toString(),
-				});
+				);
 
 				if (!response.data) {
 					throw new BetterAuthError("FAILED_TO_GET_ACCESS_TOKEN");
@@ -162,19 +165,22 @@ export const paypal = (options: PayPalOptions) => {
 					);
 
 					try {
-						const response = await betterFetch(tokenEndpoint, {
-							method: "POST",
-							headers: {
-								Authorization: `Basic ${credentials}`,
-								Accept: "application/json",
-								"Accept-Language": "en_US",
-								"Content-Type": "application/x-www-form-urlencoded",
+						const response = await betterFetch(
+							options.tokenEndpoint ?? tokenEndpoint,
+							{
+								method: "POST",
+								headers: {
+									Authorization: `Basic ${credentials}`,
+									Accept: "application/json",
+									"Accept-Language": "en_US",
+									"Content-Type": "application/x-www-form-urlencoded",
+								},
+								body: new URLSearchParams({
+									grant_type: "refresh_token",
+									refresh_token: refreshToken,
+								}).toString(),
 							},
-							body: new URLSearchParams({
-								grant_type: "refresh_token",
-								refresh_token: refreshToken,
-							}).toString(),
-						});
+						);
 
 						if (!response.data) {
 							throw new BetterAuthError("FAILED_TO_REFRESH_ACCESS_TOKEN");
@@ -222,7 +228,7 @@ export const paypal = (options: PayPalOptions) => {
 
 			try {
 				const response = await betterFetch<PayPalProfile>(
-					`${userInfoEndpoint}?schema=paypalv1.1`,
+					`${options.userInfoEndpoint ?? userInfoEndpoint}?schema=paypalv1.1`,
 					{
 						headers: {
 							Authorization: `Bearer ${token.accessToken}`,

--- a/packages/core/src/social-providers/polar.ts
+++ b/packages/core/src/social-providers/polar.ts
@@ -60,7 +60,7 @@ export const polar = (options: PolarOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -73,7 +73,7 @@ export const polar = (options: PolarOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {
@@ -81,7 +81,7 @@ export const polar = (options: PolarOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<PolarProfile>(
-				"https://api.polar.sh/v1/oauth2/userinfo",
+				options.userInfoEndpoint ?? "https://api.polar.sh/v1/oauth2/userinfo",
 				{
 					headers: {
 						Authorization: `Bearer ${token.accessToken}`,

--- a/packages/core/src/social-providers/railway.ts
+++ b/packages/core/src/social-providers/railway.ts
@@ -51,7 +51,7 @@ export const railway = (options: RailwayOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 				authentication: "basic",
 			});
 		},
@@ -65,7 +65,7 @@ export const railway = (options: RailwayOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 						authentication: "basic",
 					});
 				},
@@ -74,7 +74,7 @@ export const railway = (options: RailwayOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<RailwayProfile>(
-				userinfoEndpoint,
+				options.userInfoEndpoint ?? userinfoEndpoint,
 				{ headers: { authorization: `Bearer ${token.accessToken}` } },
 			);
 			if (error || !profile) {

--- a/packages/core/src/social-providers/reddit.ts
+++ b/packages/core/src/social-providers/reddit.ts
@@ -81,7 +81,9 @@ export const reddit = (options: RedditOptions) => {
 							clientSecret: options.clientSecret,
 						},
 						authentication: "basic",
-						tokenEndpoint: "https://www.reddit.com/api/v1/access_token",
+						tokenEndpoint:
+							options.tokenEndpoint ??
+							"https://www.reddit.com/api/v1/access_token",
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/reddit.ts
+++ b/packages/core/src/social-providers/reddit.ts
@@ -22,6 +22,8 @@ export interface RedditOptions extends ProviderOptions<RedditProfile> {
 }
 
 export const reddit = (options: RedditOptions) => {
+	const tokenEndpoint =
+		options.tokenEndpoint ?? "https://www.reddit.com/api/v1/access_token";
 	return {
 		id: "reddit",
 		name: "Reddit",
@@ -54,14 +56,11 @@ export const reddit = (options: RedditOptions) => {
 				)}`,
 			};
 
-			const { data, error } = await betterFetch<object>(
-				"https://www.reddit.com/api/v1/access_token",
-				{
-					method: "POST",
-					headers,
-					body: body.toString(),
-				},
-			);
+			const { data, error } = await betterFetch<object>(tokenEndpoint, {
+				method: "POST",
+				headers,
+				body: body.toString(),
+			});
 
 			if (error) {
 				throw error;
@@ -81,9 +80,7 @@ export const reddit = (options: RedditOptions) => {
 							clientSecret: options.clientSecret,
 						},
 						authentication: "basic",
-						tokenEndpoint:
-							options.tokenEndpoint ??
-							"https://www.reddit.com/api/v1/access_token",
+						tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/roblox.ts
+++ b/packages/core/src/social-providers/roblox.ts
@@ -42,9 +42,10 @@ export const roblox = (options: RobloxOptions) => {
 			if (options.scope) _scopes.push(...options.scope);
 			if (scopes) _scopes.push(...scopes);
 			return new URL(
-				`https://apis.roblox.com/oauth/v1/authorize?scope=${_scopes.join(
-					"+",
-				)}&response_type=code&client_id=${
+				`${
+					options.authorizationEndpoint ??
+					"https://apis.roblox.com/oauth/v1/authorize"
+				}?scope=${_scopes.join("+")}&response_type=code&client_id=${
 					options.clientId
 				}&redirect_uri=${encodeURIComponent(
 					options.redirectURI || redirectURI,
@@ -56,7 +57,7 @@ export const roblox = (options: RobloxOptions) => {
 				code,
 				redirectURI: options.redirectURI || redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 				authentication: "post",
 			});
 		},
@@ -70,7 +71,7 @@ export const roblox = (options: RobloxOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {
@@ -78,7 +79,7 @@ export const roblox = (options: RobloxOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<RobloxProfile>(
-				"https://apis.roblox.com/oauth/v1/userinfo",
+				options.userInfoEndpoint ?? "https://apis.roblox.com/oauth/v1/userinfo",
 				{
 					headers: {
 						authorization: `Bearer ${token.accessToken}`,

--- a/packages/core/src/social-providers/roblox.ts
+++ b/packages/core/src/social-providers/roblox.ts
@@ -41,16 +41,20 @@ export const roblox = (options: RobloxOptions) => {
 			const _scopes = options.disableDefaultScope ? [] : ["openid", "profile"];
 			if (options.scope) _scopes.push(...options.scope);
 			if (scopes) _scopes.push(...scopes);
-			return new URL(
-				`${
-					options.authorizationEndpoint ??
-					"https://apis.roblox.com/oauth/v1/authorize"
-				}?scope=${_scopes.join("+")}&response_type=code&client_id=${
-					options.clientId
-				}&redirect_uri=${encodeURIComponent(
-					options.redirectURI || redirectURI,
-				)}&state=${state}&prompt=${options.prompt || "select_account consent"}`,
+			const url = new URL(
+				options.authorizationEndpoint ??
+					"https://apis.roblox.com/oauth/v1/authorize",
 			);
+			url.searchParams.set("scope", _scopes.join(" "));
+			url.searchParams.set("response_type", "code");
+			url.searchParams.set("client_id", options.clientId);
+			url.searchParams.set("redirect_uri", options.redirectURI || redirectURI);
+			url.searchParams.set("state", state);
+			url.searchParams.set(
+				"prompt",
+				options.prompt || "select_account consent",
+			);
+			return url;
 		},
 		validateAuthorizationCode: async ({ code, redirectURI }) => {
 			return validateAuthorizationCode({

--- a/packages/core/src/social-providers/salesforce.ts
+++ b/packages/core/src/social-providers/salesforce.ts
@@ -98,7 +98,7 @@ export const salesforce = (options: SalesforceOptions) => {
 				codeVerifier,
 				redirectURI: options.redirectURI || redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 
@@ -111,7 +111,7 @@ export const salesforce = (options: SalesforceOptions) => {
 							clientId: options.clientId,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 
@@ -122,7 +122,7 @@ export const salesforce = (options: SalesforceOptions) => {
 
 			try {
 				const { data: user } = await betterFetch<SalesforceProfile>(
-					userInfoEndpoint,
+					options.userInfoEndpoint ?? userInfoEndpoint,
 					{
 						headers: {
 							Authorization: `Bearer ${token.accessToken}`,

--- a/packages/core/src/social-providers/slack.ts
+++ b/packages/core/src/social-providers/slack.ts
@@ -39,6 +39,8 @@ export interface SlackOptions extends ProviderOptions<SlackProfile> {
 
 export const slack = (options: SlackOptions) => {
 	const tokenEndpoint = "https://slack.com/api/openid.connect.token";
+	const userInfoEndpoint =
+		options.userInfoEndpoint ?? "https://slack.com/api/openid.connect.userInfo";
 	return {
 		id: "slack",
 		name: "Slack",
@@ -85,7 +87,7 @@ export const slack = (options: SlackOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<SlackProfile>(
-				"https://slack.com/api/openid.connect.userInfo",
+				userInfoEndpoint,
 				{
 					headers: {
 						authorization: `Bearer ${token.accessToken}`,

--- a/packages/core/src/social-providers/slack.ts
+++ b/packages/core/src/social-providers/slack.ts
@@ -48,7 +48,10 @@ export const slack = (options: SlackOptions) => {
 				: ["openid", "profile", "email"];
 			if (scopes) _scopes.push(...scopes);
 			if (options.scope) _scopes.push(...options.scope);
-			const url = new URL("https://slack.com/openid/connect/authorize");
+			const url = new URL(
+				options.authorizationEndpoint ??
+					"https://slack.com/openid/connect/authorize",
+			);
 			url.searchParams.set("scope", _scopes.join(" "));
 			url.searchParams.set("response_type", "code");
 			url.searchParams.set("client_id", options.clientId);
@@ -61,7 +64,7 @@ export const slack = (options: SlackOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -74,7 +77,7 @@ export const slack = (options: SlackOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/spotify.ts
+++ b/packages/core/src/social-providers/spotify.ts
@@ -44,7 +44,7 @@ export const spotify = (options: SpotifyOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -57,7 +57,7 @@ export const spotify = (options: SpotifyOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/tiktok.ts
+++ b/packages/core/src/social-providers/tiktok.ts
@@ -135,16 +135,16 @@ export const tiktok = (options: TiktokOptions) => {
 			const _scopes = options.disableDefaultScope ? [] : ["user.info.profile"];
 			if (options.scope) _scopes.push(...options.scope);
 			if (scopes) _scopes.push(...scopes);
-			return new URL(
-				`${
-					options.authorizationEndpoint ??
-					"https://www.tiktok.com/v2/auth/authorize"
-				}?scope=${_scopes.join(
-					",",
-				)}&response_type=code&client_key=${options.clientKey}&redirect_uri=${encodeURIComponent(
-					options.redirectURI || redirectURI,
-				)}&state=${state}`,
+			const url = new URL(
+				options.authorizationEndpoint ??
+					"https://www.tiktok.com/v2/auth/authorize",
 			);
+			url.searchParams.set("scope", _scopes.join(","));
+			url.searchParams.set("response_type", "code");
+			url.searchParams.set("client_key", options.clientKey);
+			url.searchParams.set("redirect_uri", options.redirectURI || redirectURI);
+			url.searchParams.set("state", state);
+			return url;
 		},
 
 		validateAuthorizationCode: async ({ code, redirectURI }) => {

--- a/packages/core/src/social-providers/tiktok.ts
+++ b/packages/core/src/social-providers/tiktok.ts
@@ -136,7 +136,10 @@ export const tiktok = (options: TiktokOptions) => {
 			if (options.scope) _scopes.push(...options.scope);
 			if (scopes) _scopes.push(...scopes);
 			return new URL(
-				`https://www.tiktok.com/v2/auth/authorize?scope=${_scopes.join(
+				`${
+					options.authorizationEndpoint ??
+					"https://www.tiktok.com/v2/auth/authorize"
+				}?scope=${_scopes.join(
 					",",
 				)}&response_type=code&client_key=${options.clientKey}&redirect_uri=${encodeURIComponent(
 					options.redirectURI || redirectURI,
@@ -152,7 +155,7 @@ export const tiktok = (options: TiktokOptions) => {
 					clientKey: options.clientKey,
 					clientSecret: options.clientSecret,
 				},
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -163,7 +166,7 @@ export const tiktok = (options: TiktokOptions) => {
 						options: {
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 						authentication: "post",
 						extraParams: {
 							client_key: options.clientKey,

--- a/packages/core/src/social-providers/twitch.ts
+++ b/packages/core/src/social-providers/twitch.ts
@@ -68,7 +68,7 @@ export const twitch = (options: TwitchOptions) => {
 				code,
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -81,7 +81,7 @@ export const twitch = (options: TwitchOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/twitter.ts
+++ b/packages/core/src/social-providers/twitter.ts
@@ -131,7 +131,7 @@ export const twitter = (options: TwitterOption) => {
 				authentication: "basic",
 				redirectURI,
 				options,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 
@@ -146,7 +146,7 @@ export const twitter = (options: TwitterOption) => {
 							clientSecret: options.clientSecret,
 						},
 						authentication: "basic",
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/vercel.ts
+++ b/packages/core/src/social-providers/vercel.ts
@@ -48,7 +48,8 @@ export const vercel = (options: VercelOptions) => {
 				codeVerifier,
 				redirectURI,
 				options,
-				tokenEndpoint: "https://api.vercel.com/login/oauth/token",
+				tokenEndpoint:
+					options.tokenEndpoint ?? "https://api.vercel.com/login/oauth/token",
 			});
 		},
 		async getUserInfo(token) {
@@ -57,7 +58,8 @@ export const vercel = (options: VercelOptions) => {
 			}
 
 			const { data: profile, error } = await betterFetch<VercelProfile>(
-				"https://api.vercel.com/login/oauth/userinfo",
+				options.userInfoEndpoint ??
+					"https://api.vercel.com/login/oauth/userinfo",
 				{
 					headers: {
 						Authorization: `Bearer ${token.accessToken}`,

--- a/packages/core/src/social-providers/vk.ts
+++ b/packages/core/src/social-providers/vk.ts
@@ -27,6 +27,10 @@ export interface VkOption extends ProviderOptions {
 
 export const vk = (options: VkOption) => {
 	const tokenEndpoint = "https://id.vk.com/oauth2/auth";
+	const authorizationEndpoint =
+		options.authorizationEndpoint ?? "https://id.vk.com/authorize";
+	const userInfoEndpoint =
+		options.userInfoEndpoint ?? "https://id.vk.com/oauth2/user_info";
 	return {
 		id: "vk",
 		name: "VK",
@@ -34,7 +38,6 @@ export const vk = (options: VkOption) => {
 			const _scopes = options.disableDefaultScope ? [] : ["email", "phone"];
 			if (options.scope) _scopes.push(...options.scope);
 			if (scopes) _scopes.push(...scopes);
-			const authorizationEndpoint = "https://id.vk.com/authorize";
 
 			return createAuthorizationURL({
 				id: "vk",
@@ -86,7 +89,7 @@ export const vk = (options: VkOption) => {
 				client_id: options.clientId,
 			}).toString();
 			const { data: profile, error } = await betterFetch<VkProfile>(
-				"https://id.vk.com/oauth2/user_info",
+				userInfoEndpoint,
 				{
 					method: "POST",
 					headers: {

--- a/packages/core/src/social-providers/vk.ts
+++ b/packages/core/src/social-providers/vk.ts
@@ -58,7 +58,7 @@ export const vk = (options: VkOption) => {
 				redirectURI: options.redirectURI || redirectURI,
 				options,
 				deviceId,
-				tokenEndpoint,
+				tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -71,7 +71,7 @@ export const vk = (options: VkOption) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint,
+						tokenEndpoint: options.tokenEndpoint ?? tokenEndpoint,
 					});
 				},
 		async getUserInfo(data) {

--- a/packages/core/src/social-providers/wechat.ts
+++ b/packages/core/src/social-providers/wechat.ts
@@ -65,7 +65,10 @@ export const wechat = (options: WeChatOptions) => {
 
 			// WeChat uses non-standard OAuth2 parameters (appid instead of client_id)
 			// and requires a fragment (#wechat_redirect), so we construct the URL manually.
-			const url = new URL("https://open.weixin.qq.com/connect/qrconnect");
+			const url = new URL(
+				options.authorizationEndpoint ??
+					"https://open.weixin.qq.com/connect/qrconnect",
+			);
 			url.searchParams.set("scope", _scopes.join(","));
 			url.searchParams.set("response_type", "code");
 			url.searchParams.set("appid", options.clientId);
@@ -98,8 +101,10 @@ export const wechat = (options: WeChatOptions) => {
 				errcode?: number;
 				errmsg?: string;
 			}>(
-				"https://api.weixin.qq.com/sns/oauth2/access_token?" +
-					params.toString(),
+				`${
+					options.tokenEndpoint ??
+					"https://api.weixin.qq.com/sns/oauth2/access_token"
+				}?${params.toString()}`,
 				{
 					method: "GET",
 				},
@@ -187,9 +192,14 @@ export const wechat = (options: WeChatOptions) => {
 
 			const { data: profile, error } = await betterFetch<
 				WeChatProfile & { errcode?: number; errmsg?: string }
-			>("https://api.weixin.qq.com/sns/userinfo?" + params.toString(), {
-				method: "GET",
-			});
+			>(
+				`${
+					options.userInfoEndpoint ?? "https://api.weixin.qq.com/sns/userinfo"
+				}?${params.toString()}`,
+				{
+					method: "GET",
+				},
+			);
 
 			if (error || !profile || profile.errcode) {
 				return null;

--- a/packages/core/src/social-providers/wechat.ts
+++ b/packages/core/src/social-providers/wechat.ts
@@ -52,6 +52,11 @@ export interface WeChatOptions extends ProviderOptions<WeChatProfile> {
 	 * @default "cn" if left undefined
 	 */
 	lang?: "cn" | "en";
+	/**
+	 * Custom refresh token endpoint URL.
+	 * WeChat uses a separate refresh endpoint from the authorization code exchange.
+	 */
+	refreshTokenEndpoint?: string;
 }
 
 export const wechat = (options: WeChatOptions) => {
@@ -149,8 +154,10 @@ export const wechat = (options: WeChatOptions) => {
 						errcode?: number;
 						errmsg?: string;
 					}>(
-						"https://api.weixin.qq.com/sns/oauth2/refresh_token?" +
-							params.toString(),
+						`${
+							options.refreshTokenEndpoint ??
+							"https://api.weixin.qq.com/sns/oauth2/refresh_token"
+						}?${params.toString()}`,
 						{
 							method: "GET",
 						},

--- a/packages/core/src/social-providers/zoom.ts
+++ b/packages/core/src/social-providers/zoom.ts
@@ -148,6 +148,8 @@ export const zoom = (userOptions: ZoomOptions) => {
 		pkce: true,
 		...userOptions,
 	};
+	const userInfoEndpoint =
+		options.userInfoEndpoint ?? "https://api.zoom.us/v2/users/me";
 
 	return {
 		id: "zoom",
@@ -201,7 +203,7 @@ export const zoom = (userOptions: ZoomOptions) => {
 				return options.getUserInfo(token);
 			}
 			const { data: profile, error } = await betterFetch<ZoomProfile>(
-				"https://api.zoom.us/v2/users/me",
+				userInfoEndpoint,
 				{
 					headers: {
 						authorization: `Bearer ${token.accessToken}`,

--- a/packages/core/src/social-providers/zoom.ts
+++ b/packages/core/src/social-providers/zoom.ts
@@ -166,7 +166,9 @@ export const zoom = (userOptions: ZoomOptions) => {
 				params.set("code_challenge", codeChallenge);
 			}
 
-			const url = new URL("https://zoom.us/oauth/authorize");
+			const url = new URL(
+				options.authorizationEndpoint ?? "https://zoom.us/oauth/authorize",
+			);
 			url.search = params.toString();
 
 			return url;
@@ -177,7 +179,7 @@ export const zoom = (userOptions: ZoomOptions) => {
 				redirectURI: options.redirectURI || redirectURI,
 				codeVerifier,
 				options,
-				tokenEndpoint: "https://zoom.us/oauth/token",
+				tokenEndpoint: options.tokenEndpoint ?? "https://zoom.us/oauth/token",
 				authentication: "post",
 			});
 		},
@@ -191,7 +193,8 @@ export const zoom = (userOptions: ZoomOptions) => {
 							clientKey: options.clientKey,
 							clientSecret: options.clientSecret,
 						},
-						tokenEndpoint: "https://zoom.us/oauth/token",
+						tokenEndpoint:
+							options.tokenEndpoint ?? "https://zoom.us/oauth/token",
 					}),
 		async getUserInfo(token) {
 			if (options.getUserInfo) {


### PR DESCRIPTION
## Summary

This adds optional OAuth endpoint overrides for social providers so local emulators, sandbox environments, and custom OAuth servers can be used without changing provider defaults.

## Closes
#8811 

### What changed

- added optional provider config fields:
  - `authorizationEndpoint`
  - `tokenEndpoint`
  - `userInfoEndpoint`
  - `jwksEndpoint`
- updated shared OAuth helpers to respect overridden token endpoints
- updated social providers to prefer explicit endpoint overrides over derived/default URLs
- preserved existing behavior when overrides are not provided
- added coverage for:
  - Google auth/token/JWKS override flow
  - Railway token + userinfo override flow
  - GitLab explicit override precedence over issuer-derived endpoints
- documented the new options in the reference docs

## Why

Several social providers had hardcoded authorization, token, userinfo, or JWKS URLs, which made local OAuth emulator support difficult or impossible. This change enables emulator-based development and testing while keeping production defaults unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional OAuth endpoint overrides across social providers to support local emulators, sandboxes, and custom OAuth servers.

- **New Features**
  - Providers now accept `authorizationEndpoint`, `tokenEndpoint`, `userInfoEndpoint`, and `jwksEndpoint`; JWKS overrides are used by Apple, Google, Cognito, Microsoft, and Facebook. WeChat also supports `refreshTokenEndpoint`.
  - Core auth-code and refresh flows use `options.tokenEndpoint`; authorization URLs and user info requests honor custom endpoints and preserve existing query params (Discord, TikTok, Roblox, Slack, Zoom, VK, PayPal).
  - GitHub derives the emails API from a custom `userInfoEndpoint`; GitLab prefers explicit overrides.
  - Tests cover emulator/override flows across major providers (Google JWKS, Railway token/userinfo, GitLab precedence, WeChat refresh, Reddit token, Slack/Zoom userinfo, PayPal userinfo params, Roblox/VK/Discord/TikTok authorization params, GitHub email fallback). Docs add override examples and update the options reference.

- **Bug Fixes**
  - Captcha no longer blocks `/sign-in/email-otp`.
  - OpenAPI for `POST /sign-in/social`: correct required fields and response (session vs. redirect).
  - Organization: scope `setActiveTeam` to the active org; allow passing `id` via `beforeCreateTeam` and `beforeCreateInvitation`.
  - OAuth: clearer logs and consistent errors when providers omit email; OAuth provider now accepts flows without `state` (clients still generate/validate).
  - Core: fix adapter factory instrumentation resolution; Passkey: fix middleware usage when `requireSession` is false (exactOptionalPropertyTypes).

<sup>Written for commit e9a2a6da91c10c6d1149d0f14cef1fbafe81beca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

