### PR TITLE
fix(sso): provisionUser inconsistency and option to run on every login

### DIFF
--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -598,7 +598,7 @@ type signInSSO = {
 
 Note: If email is provided and loginHint is not specified, email will be sent as the login_hint to OIDC providers automatically. SAML flows do not support login_hint.
 
-When a user is authenticated, if the user does not exist, the user will be provisioned using the `provisionUser` function. If the organization provisioning is enabled and a provider is associated with an organization, the user will be added to the organization.
+When a user is authenticated, if the user does not exist, the user will be provisioned using the `provisionUser` function. By default, `provisionUser` only runs when a new user is registered. If you want to run it on every login (e.g. to sync upstream identity provider profile changes), set `provisionUserOnEveryLogin` to `true`. If the organization provisioning is enabled and a provider is associated with an organization, the user will be added to the organization.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
@@ -610,6 +610,7 @@ const auth = betterAuth({
             provisionUser: async (user) => {
                 // provision user
             },
+            provisionUserOnEveryLogin: true, // optional, default: false
             organizationProvisioning: {
                 disabled: false,
                 defaultRole: "member",
@@ -628,7 +629,7 @@ The SSO plugin provides powerful provisioning capabilities to automatically set 
 
 ### User Provisioning
 
-User provisioning allows you to run custom logic whenever a user signs in through an SSO provider. This is useful for:
+User provisioning allows you to run custom logic when a user signs in through an SSO provider. By default, `provisionUser` only runs for new users (on registration). To run it on every login, set `provisionUserOnEveryLogin` to `true`. This is useful for:
 
 - Setting up user profiles with additional data from the SSO provider
 - Synchronizing user attributes with external systems
@@ -829,7 +830,7 @@ await auth.api.registerSSOProvider({
 ### Provisioning Best Practices
 
 #### 1. Idempotent Operations
-Make sure your provisioning functions can be safely run multiple times:
+If you enable `provisionUserOnEveryLogin`, make sure your provisioning functions can be safely run multiple times:
 
 ```ts
 provisionUser: async ({ user, userInfo }) => {
@@ -1457,6 +1458,8 @@ For a detailed guide on setting up SAML SSO with examples for Okta and testing w
 
 **provisionUser**: A custom function to provision a user when they sign in with an SSO provider.
 
+**provisionUserOnEveryLogin**: If `true`, the `provisionUser` callback runs on every login, not just on registration. Defaults to `false`.
+
 **organizationProvisioning**: Options for provisioning users to an organization.
 
 **defaultOverrideUserInfo**: Override user info with the provider info by default.
@@ -1470,6 +1473,11 @@ If you want to allow account linking for specific trusted providers, enable the 
     provisionUser: {
         description: "A custom function to provision a user when they sign in with an SSO provider.",
         type: "function",
+    },
+    provisionUserOnEveryLogin: {
+        description: "If true, the provisionUser callback will be called on every login, not just when a new user is registered.",
+        type: "boolean",
+        default: false,
     },
     organizationProvisioning: {
         description: "Options for provisioning users to an organization.",

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -904,6 +904,143 @@ describe("provisionUser should only be called for new users", async () => {
 });
 
 /**
+ * @see https://github.com/better-auth/better-auth/issues/8630
+ */
+describe("provisionUserOnEveryLogin should call provisionUser on every sign-in", async () => {
+	const provisionUserFn = vi.fn();
+	const { auth, signInWithTestUser, customFetchImpl, cookieSetter } =
+		await getTestInstance({
+			trustedOrigins: ["http://localhost:8080"],
+			plugins: [
+				sso({
+					provisionUser: provisionUserFn,
+					provisionUserOnEveryLogin: true,
+				}),
+				organization(),
+			],
+		});
+
+	const authClient = createAuthClient({
+		plugins: [ssoClient()],
+		baseURL: "http://localhost:3000",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	beforeAll(async () => {
+		await server.issuer.keys.generate("RS256");
+		server.service.removeAllListeners("beforeUserinfo");
+		server.service.removeAllListeners("beforeTokenSigning");
+		server.service.on("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				email: "provision-every-login@localhost.com",
+				name: "Provision Every Login",
+				sub: "provision-every-login-sub",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+		server.service.on("beforeTokenSigning", (token) => {
+			token.payload.email = "provision-every-login@localhost.com";
+			token.payload.email_verified = true;
+			token.payload.name = "Provision Every Login";
+			token.payload.picture = "https://test.com/picture.png";
+		});
+		await server.start(8080, "localhost");
+	});
+
+	afterAll(async () => {
+		await server.stop();
+	});
+
+	async function simulateOAuthFlow(authUrl: string, headers: Headers) {
+		let location: string | null = null;
+		await betterFetch(authUrl, {
+			method: "GET",
+			redirect: "manual",
+			onError(context) {
+				location = context.response.headers.get("location");
+			},
+		});
+
+		if (!location) throw new Error("No redirect location found");
+
+		let callbackURL = "";
+		const newHeaders = new Headers();
+		await betterFetch(location, {
+			method: "GET",
+			customFetchImpl,
+			headers,
+			onError(context) {
+				callbackURL = context.response.headers.get("location") || "";
+				cookieSetter(newHeaders)(context);
+			},
+		});
+
+		return { callbackURL, headers: newHeaders };
+	}
+
+	it("should call provisionUser on both first and subsequent sign-ins", async () => {
+		const { headers } = await signInWithTestUser();
+		await auth.api.registerSSOProvider({
+			body: {
+				issuer: server.issuer.url!,
+				domain: "localhost.com",
+				oidcConfig: {
+					clientId: "test",
+					clientSecret: "test",
+					authorizationEndpoint: `${server.issuer.url}/authorize`,
+					tokenEndpoint: `${server.issuer.url}/token`,
+					jwksEndpoint: `${server.issuer.url}/jwks`,
+					discoveryEndpoint: `${server.issuer.url}/.well-known/openid-configuration`,
+					mapping: {
+						id: "sub",
+						email: "email",
+						emailVerified: "email_verified",
+						name: "name",
+						image: "picture",
+					},
+				},
+				providerId: "provision-every-login-test",
+			},
+			headers,
+		});
+
+		provisionUserFn.mockClear();
+
+		// First sign-in: new user -> provisionUser should be called
+		const signInHeaders1 = new Headers();
+		const res1 = await authClient.signIn.sso({
+			email: "user@localhost.com",
+			callbackURL: "/dashboard",
+			fetchOptions: {
+				throw: true,
+				onSuccess: cookieSetter(signInHeaders1),
+			},
+		});
+		await simulateOAuthFlow(res1.url, signInHeaders1);
+		expect(provisionUserFn).toHaveBeenCalledTimes(1);
+
+		provisionUserFn.mockClear();
+
+		// Second sign-in: existing user -> provisionUser should still be called
+		const signInHeaders2 = new Headers();
+		const res2 = await authClient.signIn.sso({
+			email: "user@localhost.com",
+			callbackURL: "/dashboard",
+			fetchOptions: {
+				throw: true,
+				onSuccess: cookieSetter(signInHeaders2),
+			},
+		});
+		await simulateOAuthFlow(res2.url, signInHeaders2);
+		expect(provisionUserFn).toHaveBeenCalledTimes(1);
+	});
+});
+
+/**
  * @see https://github.com/better-auth/better-auth/issues/7693
  */
 describe("SSO shared redirectURI", async () => {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1761,7 +1761,10 @@ async function handleOIDCCallback(
 	}
 	const { session, user } = linked.data!;
 
-	if (options?.provisionUser && linked.isRegister) {
+	if (
+		options?.provisionUser &&
+		(linked.isRegister || options.provisionUserOnEveryLogin)
+	) {
 		await options.provisionUser({
 			user,
 			userInfo,
@@ -2410,7 +2413,10 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 
 			const { session, user } = result.data!;
 
-			if (options?.provisionUser && result.isRegister) {
+			if (
+				options?.provisionUser &&
+				(result.isRegister || options.provisionUserOnEveryLogin)
+			) {
 				await options.provisionUser({
 					user: user as User & Record<string, any>,
 					userInfo,
@@ -2926,7 +2932,10 @@ export const acsEndpoint = (options?: SSOOptions) => {
 
 			const { session, user } = result.data!;
 
-			if (options?.provisionUser && result.isRegister) {
+			if (
+				options?.provisionUser &&
+				(result.isRegister || options.provisionUserOnEveryLogin)
+			) {
 				await options.provisionUser({
 					user: user as User & Record<string, any>,
 					userInfo,

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -5409,3 +5409,118 @@ describe("SAML provisionUser should only be called for new users", async () => {
 		expect(provisionUserFn).toHaveBeenCalledTimes(0);
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8630
+ */
+describe("SAML provisionUserOnEveryLogin should call provisionUser on every sign-in", async () => {
+	const provisionUserFn = vi.fn();
+	const { auth, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			sso({
+				provisionUser: provisionUserFn,
+				provisionUserOnEveryLogin: true,
+			}),
+		],
+	});
+
+	it("should call provisionUser on both first and subsequent sign-ins", async () => {
+		const { headers } = await signInWithTestUser();
+		await auth.api.registerSSOProvider({
+			body: {
+				providerId: "saml-provision-every-login",
+				issuer: "http://localhost:8081",
+				domain: "http://localhost:8081",
+				samlConfig: {
+					entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+					cert: certificate,
+					callbackUrl: "http://localhost:3000/dashboard",
+					wantAssertionsSigned: false,
+					signatureAlgorithm: "sha256",
+					digestAlgorithm: "sha256",
+					idpMetadata: {
+						metadata: idpMetadata,
+					},
+					spMetadata: {
+						metadata: spMetadata,
+					},
+					identifierFormat:
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+				},
+			},
+			headers,
+		});
+
+		provisionUserFn.mockClear();
+
+		// First sign-in: new user -> provisionUser should be called
+		const response1 = await auth.api.signInSSO({
+			body: {
+				providerId: "saml-provision-every-login",
+				callbackURL: "http://localhost:3000/dashboard",
+			},
+			returnHeaders: true,
+		});
+
+		let samlResponse: any;
+		await betterFetch(response1.response?.url, {
+			onSuccess: async (context) => {
+				samlResponse = await context.data;
+			},
+		});
+
+		const samlRedirectUrl1 = new URL(response1.response?.url);
+		await auth.api.callbackSSOSAML({
+			method: "POST",
+			body: {
+				SAMLResponse: samlResponse.samlResponse,
+				RelayState: samlRedirectUrl1.searchParams.get("RelayState") ?? "",
+			},
+			headers: {
+				Cookie: response1.headers.get("set-cookie") ?? "",
+			},
+			params: {
+				providerId: "saml-provision-every-login",
+			},
+			asResponse: true,
+		});
+
+		expect(provisionUserFn).toHaveBeenCalledTimes(1);
+
+		provisionUserFn.mockClear();
+
+		// Second sign-in: existing user -> provisionUser should still be called
+		const response2 = await auth.api.signInSSO({
+			body: {
+				providerId: "saml-provision-every-login",
+				callbackURL: "http://localhost:3000/dashboard",
+			},
+			returnHeaders: true,
+		});
+
+		let samlResponse2: any;
+		await betterFetch(response2.response?.url, {
+			onSuccess: async (context) => {
+				samlResponse2 = await context.data;
+			},
+		});
+
+		const samlRedirectUrl2 = new URL(response2.response?.url);
+		await auth.api.callbackSSOSAML({
+			method: "POST",
+			body: {
+				SAMLResponse: samlResponse2.samlResponse,
+				RelayState: samlRedirectUrl2.searchParams.get("RelayState") ?? "",
+			},
+			headers: {
+				Cookie: response2.headers.get("set-cookie") ?? "",
+			},
+			params: {
+				providerId: "saml-provision-every-login",
+			},
+			asResponse: true,
+		});
+
+		expect(provisionUserFn).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -148,6 +148,16 @@ export interface SSOOptions {
 		  }) => Awaitable<void>)
 		| undefined;
 	/**
+	 * If true, the `provisionUser` callback will be called on every login,
+	 * not just when a new user is registered. This is useful when you need
+	 * to sync upstream identity provider profile changes on each sign-in.
+	 *
+	 * The `provisionUser` callback should be idempotent when this is enabled.
+	 *
+	 * @default false
+	 */
+	provisionUserOnEveryLogin?: boolean;
+	/**
 	 * Organization provisioning options
 	 */
 	organizationProvisioning?:


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/8630

Previously a isRegister check was added to prevent provisionUser from running on every login to the OIDC provider. This PR does add this behaviour to SAML as well to remove this inconsistency.

As some users (including me) will have the need to update the users profile info also for returning users, I also added an option `provisionUserOnEveryLogin: true`, so that `provisionUser` is called on every login.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns SAML with OIDC so `provisionUser` runs only on first sign-in by default, and adds `provisionUserOnEveryLogin` to call it on every login when needed. This enables reliable profile sync from upstream IdPs while keeping safe defaults.

- **New Features**
  - Added `provisionUserOnEveryLogin` in `SSOOptions`; when true, `provisionUser` runs on every sign-in across OIDC and SAML.
  - Updated docs with usage, defaults, and idempotency guidance.

- **Bug Fixes**
  - SAML now matches OIDC: call `provisionUser` only on registration by default.
  - Added OIDC and SAML tests to cover first vs subsequent logins.

<sup>Written for commit f7acec8e9596984510d85b3743a03c238e2f55bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

