### PR TITLE
chore: fix type inference for future TS compatibility

### DIFF
--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -140,14 +140,14 @@ export function sso<
 	id: "sso";
 	endpoints: SSOEndpoints<O> & DomainVerificationEndpoints;
 	schema: NonNullable<BetterAuthPlugin["schema"]>;
-	options: O;
+	options: NoInfer<O>;
 };
 export function sso<O extends SSOOptions>(
 	options?: O | undefined,
 ): {
 	id: "sso";
 	endpoints: SSOEndpoints<O>;
-	options: O;
+	options: NoInfer<O>;
 };
 
 export function sso<O extends SSOOptions>(


### PR DESCRIPTION
Apply the same `NoInfer<O>` fix from #6643 and #6689 to the SSO plugin. Without this, tsgo collapses O to Record<string, any> when sso() is used inside betterAuth({ plugins: [...] }), causing TS7031 errors in callback parameters like provisionUser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes type inference in the SSO plugin by wrapping `options` with `NoInfer<O>` to stop TypeScript from collapsing them to `Record<string, any>` when used in `betterAuth({ plugins: [...] })`. Prevents TS7031 errors in callbacks like `provisionUser` and improves future TypeScript compatibility.

<sup>Written for commit 7f224c98713b690d32ddd77de4f1f8877a560df5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

