### PR TITLE
feat(passkey): allow for `attestationType: "direct"`

### DIFF
--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -323,6 +323,11 @@ until it hits an effective TLD. So `www.example.com` can use the RP IDs `www.exa
 
 **origin**: The origin URL at which your better-auth server is hosted. `http://localhost` and `http://localhost:PORT` are also valid. Do NOT include any trailing /.
 
+**attestationType**: Specifies the attestation type. Helpful for identifying the make and model of the device.
+- `direct`: Requests attestation data from the authenticator
+- `none`: No attestation is requested (most private)
+- Default: `none`
+
 **authenticatorSelection**: Allows customization of WebAuthn authenticator selection criteria. Leave unspecified for default settings.
 
 - `authenticatorAttachment`: Specifies the type of authenticator

--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -170,6 +170,34 @@ describe("passkey", async () => {
 	});
 });
 
+describe("passkey attestationType option", () => {
+	it("should default attestationType to 'none'", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [passkey()],
+		});
+
+		const { headers } = await signInWithTestUser();
+		const options = await auth.api.generatePasskeyRegistrationOptions({
+			headers,
+		});
+
+		expect(options.attestation).toBe("none");
+	});
+
+	it("should forward attestationType 'direct' into registration options", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [passkey({ attestationType: "direct" })],
+		});
+
+		const { headers } = await signInWithTestUser();
+		const options = await auth.api.generatePasskeyRegistrationOptions({
+			headers,
+		});
+
+		expect(options.attestation).toBe("direct");
+	});
+});
+
 describe("passkey expirationTime per-request", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -192,7 +192,7 @@ export const generatePasskeyRegistrationOptions = (
 				userID,
 				userName: ctx.query?.name || session.user.email || session.user.id,
 				userDisplayName: session.user.email || session.user.id,
-				attestationType: "none",
+				attestationType: opts.attestationType || "none",
 				excludeCredentials: userPasskeys.map((passkey) => ({
 					id: passkey.credentialID,
 					transports: passkey.transports?.split(

--- a/packages/passkey/src/types.ts
+++ b/packages/passkey/src/types.ts
@@ -41,6 +41,15 @@ export interface PasskeyOptions {
 	 */
 	authenticatorSelection?: AuthenticatorSelectionCriteria | undefined;
 	/**
+	 * The attestation conveyance preference for passkey registration.
+	 *
+	 * - `"none"`: The relying party is not interested in attestation.
+	 * - `"direct"`: The relying party wants to receive the attestation as-is from the authenticator.
+	 *
+	 * @default "none"
+	 */
+	attestationType?: "none" | "direct" | undefined;
+	/**
 	 * Advanced options
 	 */
 	advanced?:


### PR DESCRIPTION
Following what's described in #6371 (and old PR #2466), this PR allows for `attestationType: "direct"`. This implies always requesting AAGUID from the passkey provider, since with `"none"` it sometimes defaulted to `00000000-0000-0000-0000-000000000000`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for `attestationType: "direct"` in passkey registration while keeping the default `"none"`. Added tests to ensure the default and forwarding behavior.

- **New Features**
  - Add `attestationType?: "none" | "direct"` to `PasskeyOptions`.
  - Forward `opts.attestationType` to registration; fallback to `"none"`.
  - Document `attestationType` in `docs/plugins/passkey.mdx` and add tests for default `"none"` and `"direct"`.

<sup>Written for commit bd57d0475aabf613b59de8ba22e44f9076c72f3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

