### PR TITLE
fix(types): preserve plugin endpoint types on server-side auth.api

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -183,7 +183,7 @@ export function getEndpoints<Option extends BetterAuthOptions>(
 		}, {}) ?? {};
 
 	type PluginEndpoint = UnionToIntersection<
-		Option["plugins"] extends Array<infer T>
+		Option["plugins"] extends Array<infer T> | ReadonlyArray<infer T>
 			? T extends BetterAuthPlugin
 				? T extends {
 						endpoints: infer E;

--- a/packages/better-auth/src/auth/full.ts
+++ b/packages/better-auth/src/auth/full.ts
@@ -24,7 +24,7 @@ import { createBetterAuth } from "./base";
  *	  database: drizzleAdapter(db, { provider: "pg" }),
  * });
  */
-export const betterAuth = <Options extends BetterAuthOptions>(
+export const betterAuth = <const Options extends BetterAuthOptions>(
 	options: Options & {},
 ): Auth<Options> => {
 	return createBetterAuth(options, init);

--- a/packages/better-auth/src/auth/minimal.ts
+++ b/packages/better-auth/src/auth/minimal.ts
@@ -8,7 +8,7 @@ export type { BetterAuthOptions };
 /**
  * Better Auth initializer for minimal mode (without Kysely)
  */
-export const betterAuth = <Options extends BetterAuthOptions>(
+export const betterAuth = <const Options extends BetterAuthOptions>(
 	options: Options & {},
 ): Auth<Options> => {
 	return createBetterAuth(options, initMinimal);

--- a/packages/better-auth/src/types/models.ts
+++ b/packages/better-auth/src/types/models.ts
@@ -13,16 +13,17 @@ export type AdditionalSessionFieldsInput<Options extends BetterAuthOptions> =
 	InferDBFieldsFromPluginsInput<"session", Options["plugins"]> &
 		InferDBFieldsFromOptionsInput<Options["session"]>;
 
-export type InferPluginTypes<O extends BetterAuthOptions> =
-	O["plugins"] extends Array<infer P>
-		? UnionToIntersection<
-				P extends BetterAuthPlugin
-					? P["$Infer"] extends Record<string, any>
-						? P["$Infer"]
-						: {}
+export type InferPluginTypes<O extends BetterAuthOptions> = O["plugins"] extends
+	| Array<infer P>
+	| ReadonlyArray<infer P>
+	? UnionToIntersection<
+			P extends BetterAuthPlugin
+				? P["$Infer"] extends Record<string, any>
+					? P["$Infer"]
 					: {}
-			>
-		: {};
+				: {}
+		>
+	: {};
 
 export type {
 	Account,

--- a/packages/better-auth/src/types/plugins.ts
+++ b/packages/better-auth/src/types/plugins.ts
@@ -22,7 +22,7 @@ export type InferOptionSchema<S extends BetterAuthPluginDBSchema> =
 		: never;
 
 export type InferPluginErrorCodes<O extends BetterAuthOptions> =
-	O["plugins"] extends Array<infer P>
+	O["plugins"] extends Array<infer P> | ReadonlyArray<infer P>
 		? UnionToIntersection<
 				P extends BetterAuthPlugin
 					? P["$ERROR_CODES"] extends Record<string, any>
@@ -32,10 +32,11 @@ export type InferPluginErrorCodes<O extends BetterAuthOptions> =
 			>
 		: {};
 
-export type InferPluginIDs<O extends BetterAuthOptions> =
-	O["plugins"] extends Array<infer P>
-		? UnionToIntersection<P extends BetterAuthPlugin ? P["id"] : never>
-		: never;
+export type InferPluginIDs<O extends BetterAuthOptions> = O["plugins"] extends
+	| Array<infer P>
+	| ReadonlyArray<infer P>
+	? UnionToIntersection<P extends BetterAuthPlugin ? P["id"] : never>
+	: never;
 
 type ExtractInitContext<P extends BetterAuthPlugin> = P["init"] extends (
 	...args: any[]
@@ -48,7 +49,7 @@ type ExtractInitContext<P extends BetterAuthPlugin> = P["init"] extends (
 	: {};
 
 export type InferPluginContext<O extends BetterAuthOptions> =
-	O["plugins"] extends Array<infer P>
+	O["plugins"] extends Array<infer P> | ReadonlyArray<infer P>
 		? UnionToIntersection<
 				P extends BetterAuthPlugin ? ExtractInitContext<P> : {}
 			>

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -1,7 +1,8 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAuthEndpoint } from "../api";
-import { organization, twoFactor } from "../plugins";
+import { betterAuth } from "../auth/full";
+import { admin, organization, twoFactor } from "../plugins";
 import { getTestInstance } from "../test-utils/test-instance";
 
 type TestTypeOptions = {
@@ -221,5 +222,45 @@ describe("general types", async () => {
 		type SessionWithoutPlugins = typeof authWithoutPlugins.$Infer;
 
 		expectTypeOf<SessionWithEmptyPlugins>().toEqualTypeOf<SessionWithoutPlugins>();
+	});
+
+	it("should preserve plugin endpoint types in lazy singleton pattern", () => {
+		// Common pattern: betterAuth() inside a factory function,
+		// with `typeof auth` used downstream.
+		// Without readonly support + const generic, plugin endpoints
+		// are erased when the plugins tuple widens to BetterAuthPlugin[].
+		function createAuth() {
+			return betterAuth({
+				database: {} as any,
+				plugins: [admin()],
+			});
+		}
+
+		type LazyAuth = ReturnType<typeof createAuth>;
+
+		// Admin plugin endpoints must be present on auth.api
+		expectTypeOf<LazyAuth["api"]>().toHaveProperty("createUser");
+		expectTypeOf<LazyAuth["api"]>().toHaveProperty("removeUser");
+		expectTypeOf<LazyAuth["api"]>().toHaveProperty("listUsers");
+		expectTypeOf<LazyAuth["api"]>().toHaveProperty("banUser");
+		expectTypeOf<LazyAuth["api"]>().toHaveProperty("setRole");
+	});
+
+	it("should preserve plugin endpoint types with mixed plugins", () => {
+		// When multiple plugins are combined (some with endpoints, some without),
+		// the array should not widen and lose endpoint types.
+		function createAuth() {
+			return betterAuth({
+				database: {} as any,
+				plugins: [admin(), twoFactor()],
+			});
+		}
+
+		type MixedAuth = ReturnType<typeof createAuth>;
+
+		// Admin endpoints
+		expectTypeOf<MixedAuth["api"]>().toHaveProperty("createUser");
+		expectTypeOf<MixedAuth["api"]>().toHaveProperty("removeUser");
+		expectTypeOf<MixedAuth["api"]>().toHaveProperty("listUsers");
 	});
 });

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -263,4 +263,41 @@ describe("general types", async () => {
 		expectTypeOf<MixedAuth["api"]>().toHaveProperty("removeUser");
 		expectTypeOf<MixedAuth["api"]>().toHaveProperty("listUsers");
 	});
+
+	it("should preserve plugin types with explicit readonly plugins", () => {
+		// When plugins are declared as a readonly tuple (e.g., via `as const`
+		// or `satisfies`), endpoint types must still be preserved.
+		function createAuth() {
+			const plugins = [admin(), twoFactor()] as const;
+			return betterAuth({
+				database: {} as any,
+				plugins,
+			});
+		}
+
+		type ReadonlyAuth = ReturnType<typeof createAuth>;
+
+		// Admin endpoints must be present
+		expectTypeOf<ReadonlyAuth["api"]>().toHaveProperty("createUser");
+		expectTypeOf<ReadonlyAuth["api"]>().toHaveProperty("removeUser");
+		expectTypeOf<ReadonlyAuth["api"]>().toHaveProperty("listUsers");
+	});
+
+	it("should preserve plugin context types (hasPlugin / getPlugin)", async () => {
+		// The $context.hasPlugin() and getPlugin() methods rely on
+		// InferPluginID which must also handle readonly plugin arrays.
+		function createAuth() {
+			return betterAuth({
+				database: {} as any,
+				plugins: [admin(), twoFactor()],
+			});
+		}
+
+		type ContextAuth = ReturnType<typeof createAuth>;
+		type Context = Awaited<ContextAuth["$context"]>;
+
+		// hasPlugin should return `true` (not just `boolean`) for known plugins
+		type HasAdmin = ReturnType<Context["hasPlugin"]>;
+		expectTypeOf<HasAdmin>().not.toEqualTypeOf<never>();
+	});
 });

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -296,8 +296,16 @@ describe("general types", async () => {
 		type ContextAuth = ReturnType<typeof createAuth>;
 		type Context = Awaited<ContextAuth["$context"]>;
 
-		// hasPlugin should return `true` (not just `boolean`) for known plugins
-		type HasAdmin = ReturnType<Context["hasPlugin"]>;
-		expectTypeOf<HasAdmin>().not.toEqualTypeOf<never>();
+		// hasPlugin should narrow to `true` for known plugin IDs
+		const hasPlugin = {} as Context["hasPlugin"];
+		const hasAdmin = hasPlugin("admin");
+		expectTypeOf(hasAdmin).toEqualTypeOf<true>();
+
+		// hasPlugin should stay `boolean` for unknown plugin IDs
+		const hasUnknown = hasPlugin("not-installed");
+		expectTypeOf(hasUnknown).toEqualTypeOf<boolean>();
+
+		// getPlugin type should be callable (not never)
+		expectTypeOf<Context["getPlugin"]>().not.toEqualTypeOf<never>();
 	});
 });

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -119,10 +119,10 @@ export type InferDBFieldsFromOptions<
 
 export type InferDBFieldsFromPluginsInput<
 	ModelName extends string,
-	Plugins extends unknown[] | undefined,
+	Plugins extends readonly unknown[] | undefined,
 > = Plugins extends []
 	? {}
-	: Plugins extends [infer P, ...infer Rest]
+	: Plugins extends readonly [infer P, ...infer Rest]
 		? P extends {
 				schema: {
 					[key in ModelName]: {
@@ -141,10 +141,10 @@ export type InferDBFieldsFromPluginsInput<
 
 export type InferDBFieldsFromPlugins<
 	ModelName extends string,
-	Plugins extends unknown[] | undefined,
+	Plugins extends readonly unknown[] | undefined,
 > = Plugins extends []
 	? {}
-	: Plugins extends [infer P, ...infer Rest]
+	: Plugins extends readonly [infer P, ...infer Rest]
 		? P extends {
 				schema: {
 					[key in ModelName]: {

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -23,12 +23,13 @@ import type { SecretConfig } from "./secret";
 /**
  * @internal
  */
-type InferPluginID<O extends BetterAuthOptions> =
-	O["plugins"] extends Array<infer P>
-		? P extends BetterAuthPlugin
-			? P["id"]
-			: never
-		: never;
+type InferPluginID<O extends BetterAuthOptions> = O["plugins"] extends
+	| Array<infer P>
+	| ReadonlyArray<infer P>
+	? P extends BetterAuthPlugin
+		? P["id"]
+		: never
+	: never;
 
 /**
  * @internal
@@ -36,16 +37,15 @@ type InferPluginID<O extends BetterAuthOptions> =
 type InferPluginOptions<
 	O extends BetterAuthOptions,
 	ID extends BetterAuthPluginRegistryIdentifier | LiteralString,
-> =
-	O["plugins"] extends Array<infer P>
-		? P extends BetterAuthPlugin
-			? P["id"] extends ID
-				? P extends { options: infer O }
-					? O
-					: never
+> = O["plugins"] extends Array<infer P> | ReadonlyArray<infer P>
+	? P extends BetterAuthPlugin
+		? P["id"] extends ID
+			? P extends { options: infer O }
+				? O
 				: never
 			: never
-		: never;
+		: never
+	: never;
 
 /**
  * Mutators are defined in each plugin

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -770,7 +770,7 @@ export type BetterAuthOptions = {
 	/**
 	 * List of Better Auth plugins
 	 */
-	plugins?: ([] | BetterAuthPlugin[]) | undefined;
+	plugins?: ([] | BetterAuthPlugin[] | readonly BetterAuthPlugin[]) | undefined;
 	/**
 	 * User configuration
 	 */


### PR DESCRIPTION
## Summary

Fixes server-side `auth.api` losing plugin-contributed endpoint types (e.g., `createUser`, `removeUser` from `admin()`) when `betterAuth()` is used in a lazy singleton / factory pattern.

**Root cause:** All plugin type extraction utilities use `Array<infer T>` which silently fails on `ReadonlyArray`. Combined with no `const` generic on `betterAuth()`, TypeScript can widen the plugin tuple and erase endpoint types.

**Changes:**
- Accept `readonly BetterAuthPlugin[]` in `BetterAuthOptions.plugins`
- Handle `ReadonlyArray<infer T>` in all server-side plugin type extraction:
  - `PluginEndpoint` (in `getEndpoints`)
  - `InferPluginTypes`, `InferPluginErrorCodes`, `InferPluginIDs`, `InferPluginContext`
  - `InferDBFieldsFromPluginsInput`, `InferDBFieldsFromPlugins` (also updated tuple destructuring to `readonly [infer P, ...infer Rest]`)
  - `InferPluginID`, `InferPluginOptions` (in `context.ts` — fixes `hasPlugin`/`getPlugin` inference)
- Add `const` type parameter to `betterAuth()` (full + minimal) for narrower inference
- Add type regression tests: lazy singleton, mixed plugins, `as const` readonly, and `$context` hasPlugin/getPlugin

**Files changed (9):**
- `packages/core/src/types/init-options.ts` — accept readonly plugins
- `packages/core/src/types/context.ts` — `ReadonlyArray` in `InferPluginID` + `InferPluginOptions`
- `packages/core/src/db/type.ts` — readonly constraint + tuple destructuring in `InferDBFieldsFromPlugins*`
- `packages/better-auth/src/auth/full.ts` — `const` generic
- `packages/better-auth/src/auth/minimal.ts` — `const` generic
- `packages/better-auth/src/api/index.ts` — `ReadonlyArray` in `PluginEndpoint`
- `packages/better-auth/src/types/models.ts` — `ReadonlyArray` in `InferPluginTypes`
- `packages/better-auth/src/types/plugins.ts` — `ReadonlyArray` in 3 utility types
- `packages/better-auth/src/types/types.test.ts` — 4 type regression tests

**Known limitations:**
- **`satisfies BetterAuthOptions` pattern:** If options are contextually typed via `satisfies` before reaching `betterAuth()`, plugins may already be widened to `BetterAuthPlugin[]`. The `const` generic cannot recover types that were already erased. Inline options or `as const` work correctly.
- **Client-side consumers:** `client/types.ts` and `client/plugins/infer-plugin.ts` also use `Array<infer P>`. Those are left out of scope for this server-side fix. Happy to expand or open a follow-up PR for #7043.
- **TS version:** The `const` type parameter requires TypeScript 5.0+. The repo uses TS ^5.9.3. If Better Auth needs to support TS 4.x consumers, this would need a different approach.

Fixes #8823
Refs #3015