### PR TITLE
feat: extended `organization.listInvitations` with filtering & query options

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1024,6 +1024,38 @@ type listInvitations = {
      * An optional ID of the organization to list invitations for. If not provided, will default to the user's active organization. 
      */
     organizationId?: string = "organization-id"
+    /**
+     * The Email address of the invitation
+     */
+    email?: string = "user@example.com"
+    /**
+     * Array of roles to filter invitation for
+     */
+    role?: string[] = ["member"]
+    /**
+     * Array of status to filter invitation for
+     */
+    status?: string[] = ["pending", "accepted", "rejected", "canceled"]
+    /**
+     * Id of the user who sent the invitation
+     */
+    inviterId?: string[] = "some_user_id"
+    /**
+     * The limit of members to return.
+     */
+    limit?: number = 100
+    /**
+     * The offset to start from.
+     */
+    offset?: number = 0
+    /**
+     * The field to sort by.
+     */
+    sortBy?: string = "createdAt"
+    /**
+     * The direction to sort by.
+     */
+    sortDirection?: "asc" | "desc" = "desc"
 }
 ```
 </APIMethod>

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1,6 +1,6 @@
 import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
 import { getCurrentAdapter } from "@better-auth/core/context";
-import type { WhereOperator } from "@better-auth/core/db/adapter";
+import type { Where, WhereOperator } from "@better-auth/core/db/adapter";
 import { BetterAuthError } from "@better-auth/core/error";
 import { filterOutputFields } from "@better-auth/core/utils/db";
 import { parseJSON } from "../../client/parser";
@@ -13,6 +13,7 @@ import type {
 	InferOrganization,
 	InferTeam,
 	InvitationInput,
+	InvitationStatus,
 	Member,
 	MemberInput,
 	OrganizationInput,
@@ -1029,7 +1030,49 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				(invite) => new Date(invite.expiresAt) > new Date(),
 			);
 		},
-		listInvitations: async (data: { organizationId: string }) => {
+		listInvitations: async (data: {
+			organizationId: string;
+			email?: string;
+			role?: string[];
+			status?: InvitationStatus;
+			inviterId?: string;
+			limit?: number;
+			offset?: number;
+			sortBy?: string | undefined;
+			sortOrder?: ("asc" | "desc") | undefined;
+		}) => {
+			const filters: Where[] = [];
+
+			if (data.email) {
+				filters.push({
+					field: "email",
+					value: data.email,
+				});
+			}
+
+			if (data.role !== undefined && data.role.length > 0) {
+				filters.push({
+					operator: "in",
+					field: "role",
+					value: data.role,
+				});
+			}
+
+			if (data.status !== undefined) {
+				filters.push({
+					operator: "in",
+					field: "status",
+					value: data.status,
+				});
+			}
+
+			if (data.inviterId) {
+				filters.push({
+					field: "inviterId",
+					value: data.inviterId,
+				});
+			}
+
 			const adapter = await getCurrentAdapter(baseAdapter);
 			const invitations = await adapter.findMany<InferInvitation<O, false>>({
 				model: "invitation",
@@ -1038,7 +1081,13 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 						field: "organizationId",
 						value: data.organizationId,
 					},
+					...filters,
 				],
+				limit: data.limit,
+				offset: data.offset,
+				sortBy: data.sortBy
+					? { field: data.sortBy, direction: data.sortOrder || "asc" }
+					: undefined,
 			});
 			return invitations;
 		},

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1034,7 +1034,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			organizationId: string;
 			email?: string;
 			role?: string[];
-			status?: InvitationStatus;
+			status?: InvitationStatus | InvitationStatus[];
 			inviterId?: string;
 			limit?: number;
 			offset?: number;
@@ -1060,6 +1060,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 
 			if (data.status !== undefined) {
 				filters.push({
+					...(Array.isArray(data.status) ? { operator: "in" } : {}),
 					field: "status",
 					value: data.status,
 				});

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1046,7 +1046,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			if (data.email) {
 				filters.push({
 					field: "email",
-					value: data.email,
+					value: data.email.toLowerCase(),
 				});
 			}
 
@@ -1060,7 +1060,6 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 
 			if (data.status !== undefined) {
 				filters.push({
-					operator: "in",
 					field: "status",
 					value: data.status,
 				});

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2288,6 +2288,13 @@ describe("listInvitations filters by inviterId", async () => {
 
 		expect(result.data?.length).toBe(1);
 		expect(result.data?.[0]?.inviterId).toBe(inviterId);
+
+		const resultEmpty = await client.organization.listInvitations({
+			query: { inviterId: "non-existent-id" },
+			fetchOptions: { headers },
+		});
+
+		expect(resultEmpty.data?.length).toBe(0);
 	});
 });
 
@@ -2393,12 +2400,12 @@ describe("listInvitations filters with limit & offset", async () => {
 		);
 
 		const first = await client.organization.listInvitations({
-			query: { limit: 1, offset: 0 },
+			query: { limit: 1, offset: 0, sortBy: "createdAt", sortOrder: "asc" },
 			fetchOptions: { headers },
 		});
 
 		const second = await client.organization.listInvitations({
-			query: { limit: 1, offset: 1 },
+			query: { limit: 1, offset: 1, sortBy: "createdAt", sortOrder: "asc" },
 			fetchOptions: { headers },
 		});
 

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2400,12 +2400,12 @@ describe("listInvitations filters with limit & offset", async () => {
 		);
 
 		const first = await client.organization.listInvitations({
-			query: { limit: 1, offset: 0, sortBy: "createdAt", sortOrder: "asc" },
+			query: { limit: 1, offset: 0, sortBy: "createdAt", sortDirection: "asc" },
 			fetchOptions: { headers },
 		});
 
 		const second = await client.organization.listInvitations({
-			query: { limit: 1, offset: 1, sortBy: "createdAt", sortOrder: "asc" },
+			query: { limit: 1, offset: 1, sortBy: "createdAt", sortDirection: "asc" },
 			fetchOptions: { headers },
 		});
 

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2005,6 +2005,534 @@ describe("resend invitation should reuse existing", async () => {
 	});
 });
 
+describe("listInvitations filters with role", async () => {
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				async sendInvitationEmail(data, request) {},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "test",
+			slug: "test",
+		},
+		{
+			headers,
+		},
+	);
+
+	it("filters by role", async () => {
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "test10@test.com",
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "test11@test.com",
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+
+		const listInvitations = await client.organization.listInvitations({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const listInvitationsWithMemberFilter =
+			await client.organization.listInvitations({
+				query: {
+					role: ["member"],
+				},
+				fetchOptions: {
+					headers,
+				},
+			});
+
+		expect(listInvitations?.data).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ email: "test10@test.com" }),
+				expect.objectContaining({ email: "test11@test.com" }),
+			]),
+		);
+		expect(listInvitations?.data?.length).toBe(2);
+
+		expect(listInvitationsWithMemberFilter?.data).toEqual(
+			expect.arrayContaining([expect.objectContaining({ role: "member" })]),
+		);
+		expect(listInvitationsWithMemberFilter?.data?.length).toBe(2);
+	});
+});
+
+describe("listInvitations filters with email", async () => {
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				async sendInvitationEmail(data, request) {},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "test",
+			slug: "test",
+		},
+		{
+			headers,
+		},
+	);
+
+	it("filters by email", async () => {
+		const invite = await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "test10@test.com",
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+		expect(invite.data?.status).toBe("pending");
+
+		const invite2 = await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "test11@test.com",
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+		expect(invite2.data?.status).toBe("pending");
+
+		const listInvitations = await client.organization.listInvitations({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const listInvitationsWithEmail = await client.organization.listInvitations({
+			query: {
+				email: "test11@test.com",
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const listInvitationsWithIncorrectEmail =
+			await client.organization.listInvitations({
+				query: {
+					email: "thisdontexists@test.com",
+				},
+				fetchOptions: {
+					headers,
+				},
+			});
+
+		expect(listInvitations?.data).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ email: "test10@test.com" }),
+				expect.objectContaining({ email: "test11@test.com" }),
+			]),
+		);
+		expect(listInvitations?.data?.length).toBe(2);
+
+		expect(listInvitationsWithEmail?.data).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ email: "test11@test.com" }),
+			]),
+		);
+		expect(listInvitationsWithEmail?.data?.length).toBe(1);
+
+		expect(listInvitationsWithIncorrectEmail.data).toEqual([]);
+	});
+});
+
+describe("listInvitations filters with status", async () => {
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				async sendInvitationEmail(data, request) {},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "test",
+			slug: "test",
+		},
+		{
+			headers,
+		},
+	);
+
+	it("filters by status", async () => {
+		const invite1 = await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "status1@test.com",
+				role: "member",
+			},
+			{ headers },
+		);
+
+		const invite2 = await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "status2@test.com",
+				role: "member",
+			},
+			{ headers },
+		);
+
+		expect(invite1.data?.status).toBe("pending");
+		expect(invite2.data?.status).toBe("pending");
+
+		const result = await client.organization.listInvitations({
+			query: { status: "pending" },
+			fetchOptions: { headers },
+		});
+
+		expect(result.data?.length).toBe(2);
+		expect(result.data).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ email: "status1@test.com" }),
+				expect.objectContaining({ email: "status2@test.com" }),
+			]),
+		);
+	});
+});
+
+describe("listInvitations filters by inviterId", async () => {
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				async sendInvitationEmail(data, request) {},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "test",
+			slug: "test",
+		},
+		{
+			headers,
+		},
+	);
+
+	it("filters by inviterId", async () => {
+		const invite = await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "inviter@test.com",
+				role: "member",
+			},
+			{ headers },
+		);
+
+		const inviterId = invite.data?.inviterId;
+
+		const result = await client.organization.listInvitations({
+			query: { inviterId },
+			fetchOptions: { headers },
+		});
+
+		expect(result.data?.length).toBe(1);
+		expect(result.data?.[0]?.inviterId).toBe(inviterId);
+	});
+});
+
+describe("listInvitations filters with multiple roles", async () => {
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				async sendInvitationEmail(data, request) {},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "test",
+			slug: "test",
+		},
+		{
+			headers,
+		},
+	);
+
+	it("filters by multiple roles", async () => {
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "multi1@test.com",
+				role: "member",
+			},
+			{ headers },
+		);
+
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "multi2@test.com",
+				role: "owner",
+			},
+			{ headers },
+		);
+
+		const result = await client.organization.listInvitations({
+			query: {
+				role: ["member", "owner"],
+			},
+			fetchOptions: { headers },
+		});
+
+		expect(result.data?.length).toBe(2);
+	});
+});
+
+describe("listInvitations filters with limit & offset", async () => {
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				async sendInvitationEmail(data, request) {},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "test",
+			slug: "test",
+		},
+		{
+			headers,
+		},
+	);
+
+	it("supports limit and offset", async () => {
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "p1@test.com",
+				role: "member",
+			},
+			{ headers },
+		);
+
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "p2@test.com",
+				role: "member",
+			},
+			{ headers },
+		);
+
+		const first = await client.organization.listInvitations({
+			query: { limit: 1, offset: 0 },
+			fetchOptions: { headers },
+		});
+
+		const second = await client.organization.listInvitations({
+			query: { limit: 1, offset: 1 },
+			fetchOptions: { headers },
+		});
+
+		expect(first.data?.length).toBe(1);
+		expect(second.data?.length).toBe(1);
+
+		expect(first.data?.[0]?.email).not.toBe(second.data?.[0]?.email);
+	});
+});
+
+describe("listInvitations filters with sorting", async () => {
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				async sendInvitationEmail(data, request) {},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "test",
+			slug: "test",
+		},
+		{
+			headers,
+		},
+	);
+
+	it("supports sorting", async () => {
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "a@test.com",
+				role: "member",
+			},
+			{ headers },
+		);
+
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "z@test.com",
+				role: "member",
+			},
+			{ headers },
+		);
+
+		const asc = await client.organization.listInvitations({
+			query: {
+				sortBy: "email",
+				sortDirection: "asc",
+			},
+			fetchOptions: { headers },
+		});
+
+		const desc = await client.organization.listInvitations({
+			query: {
+				sortBy: "email",
+				sortDirection: "desc",
+			},
+			fetchOptions: { headers },
+		});
+
+		expect(asc.data?.[0]?.email).toBe("a@test.com");
+		expect(desc.data?.[0]?.email).toBe("z@test.com");
+	});
+});
+
+describe("listInvitations filters with multiple filters", async () => {
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				async sendInvitationEmail(data, request) {},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "test",
+			slug: "test",
+		},
+		{
+			headers,
+		},
+	);
+
+	it("combines multiple filters correctly", async () => {
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "combo@test.com",
+				role: "member",
+			},
+			{ headers },
+		);
+
+		await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "combo2@test.com",
+				role: "owner",
+			},
+			{ headers },
+		);
+
+		const result = await client.organization.listInvitations({
+			query: {
+				role: ["member"],
+				email: "combo@test.com",
+			},
+			fetchOptions: { headers },
+		});
+
+		expect(result.data?.length).toBe(1);
+		expect(result.data?.[0]?.email).toBe("combo@test.com");
+	});
+});
+
 describe("owner can update roles", async () => {
 	const statement = {
 		custom: ["custom"],

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -1079,6 +1079,56 @@ const listInvitationQuerySchema = z
 				description: "The ID of the organization to list invitations for",
 			})
 			.optional(),
+		email: z
+			.string()
+			.meta({
+				description: "The Email address of the invitation",
+			})
+			.optional(),
+		role: z
+			.union([z.string(), z.array(z.string())])
+			.transform((val) => (Array.isArray(val) ? val : [val]))
+			.meta({
+				description: "Array of roles to filter invitation for",
+			})
+			.optional(),
+		status: z
+			.union([
+				z.enum(["pending", "accepted", "rejected", "canceled"]),
+				z.array(z.enum(["pending", "accepted", "rejected", "canceled"])),
+			])
+			.transform((val) => (Array.isArray(val) ? val : [val]))
+			.optional(),
+		inviterId: z
+			.string()
+			.meta({
+				description: "Id of the user who sent the invitation",
+			})
+			.optional(),
+		limit: z.coerce
+			.number()
+			.meta({
+				description: "The number of users to return",
+			})
+			.optional(),
+		offset: z.coerce
+			.number()
+			.meta({
+				description: "The offset to start from",
+			})
+			.optional(),
+		sortBy: z
+			.string()
+			.meta({
+				description: "The field to sort by",
+			})
+			.optional(),
+		sortDirection: z
+			.enum(["asc", "desc"])
+			.meta({
+				description: "The direction to sort by",
+			})
+			.optional(),
 	})
 	.optional();
 
@@ -1117,6 +1167,14 @@ export const listInvitations = <O extends OrganizationOptions>(options: O) =>
 			}
 			const invitations = await adapter.listInvitations({
 				organizationId: orgId,
+				email: ctx?.query?.email,
+				role: ctx?.query?.role,
+				status: ctx?.query?.status,
+				inviterId: ctx?.query?.inviterId,
+				limit: ctx?.query?.limit,
+				offset: ctx?.query?.offset,
+				sortBy: ctx?.query?.sortBy,
+				sortOrder: ctx?.query?.sortDirection,
 			});
 			return ctx.json(invitations);
 		},

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -1098,6 +1098,9 @@ const listInvitationQuerySchema = z
 				z.array(z.enum(["pending", "accepted", "rejected", "canceled"])),
 			])
 			.transform((val) => (Array.isArray(val) ? val : [val]))
+			.meta({
+				description: "Array of status to filter invitation for",
+			})
 			.optional(),
 		inviterId: z
 			.string()


### PR DESCRIPTION
Closes: https://github.com/better-auth/better-auth/issues/8829

added filters on `organization.listInvitations` of organization plugin
for filtering added
- email
- role
- status
- inviterId

for pagination added
- limit
- offset

for sorting added
- sortBy
- sortOrder

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends `organization.listInvitations` with flexible filters, pagination, and sorting for precise queries. Also makes email filtering case-insensitive, fixes pagination, and updates docs.

- **New Features**
  - Filters: `email`, `role` (single or array), `status` (single or array), `inviterId`
  - Pagination: `limit`, `offset`
  - Sorting: `sortBy` + `sortDirection` (`asc` | `desc`, replaces `sortOrder`)

- **Bug Fixes**
  - Email filter is now case-insensitive.
  - Pagination correctly applies `limit` and `offset`.

<sup>Written for commit 5d864a74a112ed7ed40a84f2675f0bb7f9483a95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

