### PR TITLE
feat(scim): connect scim user active to org member active flag

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1216,9 +1216,59 @@ To leave organization you can use `organization.leave` function. This function w
 ```ts
 type leaveOrganization = {
     /**
-     * The organization ID for the member to leave. 
+     * The organization ID for the member to leave.
      */
     organizationId: string = "organization-id"
+}
+```
+</APIMethod>
+
+### Activate Member
+
+To activate a previously deactivated member, you can use `organization.activateMember`. This requires the `member: ["update"]` permission.
+
+<APIMethod
+  path="/organization/activate-member"
+  method="POST"
+  requireSession
+>
+```ts
+type activateMember = {
+    /**
+     * The member id to activate.
+     */
+    memberId: string = "member-id"
+    /**
+     * An optional organization ID. If not provided, will default to the user's active organization.
+     */
+    organizationId?: string = "org-id"
+}
+```
+</APIMethod>
+
+### Deactivate Member
+
+To deactivate a member without removing them from the organization, you can use `organization.deactivateMember`. Deactivated members are blocked from performing any organization actions, including setting the organization as active and passing any permission checks. This requires the `member: ["update"]` permission.
+
+<Callout>
+  You cannot deactivate the last active owner of an organization.
+</Callout>
+
+<APIMethod
+  path="/organization/deactivate-member"
+  method="POST"
+  requireSession
+>
+```ts
+type deactivateMember = {
+    /**
+     * The member id to deactivate.
+     */
+    memberId: string = "member-id"
+    /**
+     * An optional organization ID. If not provided, will default to the user's active organization.
+     */
+    organizationId?: string = "org-id"
 }
 ```
 </APIMethod>
@@ -2218,6 +2268,11 @@ Table Name: `member`
       name: "role",
       type: "string",
       description: "The role of the user in the organization",
+    },
+    {
+      name: "active",
+      type: "boolean",
+      description: "Whether the member is active in the organization. Defaults to true. Inactive members are blocked from performing any organization actions.",
     },
     {
       name: "createdAt",

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -303,7 +303,10 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			});
 			return member;
 		},
-		updateMember: async (memberId: string, role: string) => {
+		updateMember: async (
+			memberId: string,
+			data: { role?: string; active?: boolean },
+		) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
 			const member = await adapter.update<InferMember<O, false>>({
 				model: "member",
@@ -314,7 +317,8 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					},
 				],
 				update: {
-					role,
+					...(data.role !== undefined ? { role: data.role } : {}),
+					...(data.active !== undefined ? { active: data.active } : {}),
 				},
 			});
 			return member;

--- a/packages/better-auth/src/plugins/organization/error-codes.ts
+++ b/packages/better-auth/src/plugins/organization/error-codes.ts
@@ -90,4 +90,5 @@ export const ORGANIZATION_ERROR_CODES = defineErrorCodes({
 	CANNOT_DELETE_A_PRE_DEFINED_ROLE: "Cannot delete a pre-defined role",
 	ROLE_IS_ASSIGNED_TO_MEMBERS:
 		"Cannot delete a role that is assigned to members. Please reassign the members to a different role first",
+	MEMBER_IS_NOT_ACTIVE: "Member is not active in this organization",
 });

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2527,6 +2527,7 @@ describe("Additional Fields", async () => {
 				id: string;
 				organizationId: string;
 				role: "member" | "admin" | "owner";
+				active: boolean;
 				createdAt: Date;
 				userId: string;
 				teamId?: string | undefined;
@@ -2773,6 +2774,7 @@ describe("Additional Fields", async () => {
 			id: string;
 			organizationId: string;
 			role: "member" | "admin" | "owner";
+			active: boolean;
 			createdAt: Date;
 			userId: string;
 			teamId?: string | undefined;
@@ -2893,6 +2895,7 @@ describe("Additional Fields", async () => {
 				id: string;
 				organizationId: string;
 				role: "member" | "admin" | "owner";
+				active: boolean;
 				createdAt: Date;
 				userId: string;
 				teamId?: string | undefined;
@@ -3131,6 +3134,7 @@ describe("Additional Fields", async () => {
 				organizationId: string;
 				userId: string;
 				role: string;
+				active: boolean;
 				createdAt: Date;
 				memberRequiredField: string;
 				memberOptionalField?: string | undefined;

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -30,7 +30,9 @@ import {
 	rejectInvitation,
 } from "./routes/crud-invites";
 import {
+	activateMember,
 	addMember,
+	deactivateMember,
 	getActiveMember,
 	getActiveMemberRole,
 	leaveOrganization,
@@ -158,6 +160,8 @@ export type OrganizationEndpoints<O extends OrganizationOptions> = {
 	listUserInvitations: ReturnType<typeof listUserInvitations<O>>;
 	listMembers: ReturnType<typeof listMembers<O>>;
 	getActiveMemberRole: ReturnType<typeof getActiveMemberRole<O>>;
+	activateMember: ReturnType<typeof activateMember<O>>;
+	deactivateMember: ReturnType<typeof deactivateMember<O>>;
 	hasPermission: ReturnType<typeof createHasPermission<O>>;
 };
 
@@ -277,6 +281,7 @@ const createHasPermission = <O extends OrganizationOptions>(options: O) => {
 			const result = await hasPermission(
 				{
 					role: member.role,
+					memberActive: member.active,
 					options: options,
 					permissions: ctx.body.permissions as any,
 					organizationId: activeOrganizationId,
@@ -718,6 +723,38 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 		/**
 		 * ### Endpoint
 		 *
+		 * POST `/organization/activate-member`
+		 *
+		 * ### API Methods
+		 *
+		 * **server:**
+		 * `auth.api.activateMember`
+		 *
+		 * **client:**
+		 * `authClient.organization.activateMember`
+		 *
+		 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/organization#activate-member)
+		 */
+		activateMember: activateMember(opts),
+		/**
+		 * ### Endpoint
+		 *
+		 * POST `/organization/deactivate-member`
+		 *
+		 * ### API Methods
+		 *
+		 * **server:**
+		 * `auth.api.deactivateMember`
+		 *
+		 * **client:**
+		 * `authClient.organization.deactivateMember`
+		 *
+		 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/organization#deactivate-member)
+		 */
+		deactivateMember: deactivateMember(opts),
+		/**
+		 * ### Endpoint
+		 *
 		 * POST `/organization/leave`
 		 *
 		 * ### API Methods
@@ -1117,6 +1154,12 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 						sortable: true,
 						defaultValue: "member",
 						fieldName: opts.schema?.member?.fields?.role,
+					},
+					active: {
+						type: "boolean",
+						required: false,
+						defaultValue: true,
+						fieldName: opts.schema?.member?.fields?.active,
 					},
 					createdAt: {
 						type: "date",

--- a/packages/better-auth/src/plugins/organization/permission.ts
+++ b/packages/better-auth/src/plugins/organization/permission.ts
@@ -7,6 +7,7 @@ export const hasPermissionFn = (
 		[x: string]: Role<any> | undefined;
 	},
 ) => {
+	if (input.memberActive === false) return false;
 	if (!input.permissions) return false;
 
 	const roles = input.role.split(",");
@@ -41,4 +42,5 @@ export type HasPermissionBaseInput = {
 	role: string;
 	options: OrganizationOptions;
 	allowCreatorAllPermissions?: boolean | undefined;
+	memberActive?: boolean | undefined;
 } & PermissionExclusive;

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -182,6 +182,7 @@ export const createOrgRole = <O extends OrganizationOptions>(options: O) => {
 						ac: ["create"],
 					},
 					role: member.role,
+					memberActive: member.active,
 				},
 				ctx,
 			);
@@ -374,6 +375,7 @@ export const deleteOrgRole = <O extends OrganizationOptions>(options: O) => {
 						ac: ["delete"],
 					},
 					role: member.role,
+					memberActive: member.active,
 				},
 				ctx,
 			);
@@ -603,6 +605,7 @@ export const listOrgRoles = <O extends OrganizationOptions>(options: O) => {
 						ac: ["read"],
 					},
 					role: member.role,
+					memberActive: member.active,
 				},
 				ctx,
 			);
@@ -742,6 +745,7 @@ export const getOrgRole = <O extends OrganizationOptions>(options: O) => {
 						ac: ["read"],
 					},
 					role: member.role,
+					memberActive: member.active,
 				},
 				ctx,
 			);
@@ -943,6 +947,7 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 					options,
 					organizationId,
 					role: member.role,
+					memberActive: member.active,
 					permissions: {
 						ac: ["update"],
 					},
@@ -1161,6 +1166,7 @@ async function checkIfMemberHasPermission({
 						permissions: { [resource]: [perm] },
 						useMemoryCache: true,
 						role: member.role,
+						memberActive: member.active,
 					},
 					ctx,
 				),

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -204,6 +204,7 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 			const canInvite = await hasPermission(
 				{
 					role: member.role,
+					memberActive: member.active,
 					options: ctx.context.orgOptions,
 					permissions: {
 						invitation: ["create"],
@@ -889,6 +890,7 @@ export const cancelInvitation = <O extends OrganizationOptions>(options: O) =>
 			const canCancel = await hasPermission(
 				{
 					role: member.role,
+					memberActive: member.active,
 					options: ctx.context.orgOptions,
 					permissions: {
 						invitation: ["cancel"],

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
@@ -577,3 +577,199 @@ describe("inviteMember role validation", async () => {
 		expect(data).toBeDefined();
 	});
 });
+
+describe("activateMember / deactivateMember", async () => {
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		plugins: [organization()],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	const org = await client.organization.create({
+		name: "active-test",
+		slug: "active-test",
+		fetchOptions: { headers },
+	});
+
+	const newUser = await auth.api.signUpEmail({
+		body: {
+			email: "active-test-user@test.com",
+			name: "active-test",
+			password: "password",
+		},
+	});
+
+	const member = await auth.api.addMember({
+		body: {
+			organizationId: org.data?.id as string,
+			userId: newUser.user.id,
+			role: "admin",
+		},
+	});
+
+	it("should default new members to active", () => {
+		expect(member?.active).toBe(true);
+	});
+
+	it("should deactivate a member", async () => {
+		const result = await auth.api.deactivateMember({
+			body: {
+				memberId: member!.id,
+				organizationId: org.data?.id as string,
+			},
+			headers,
+		});
+		expect(result?.active).toBe(false);
+	});
+
+	it("inactive members should still appear in listMembers", async () => {
+		await client.organization.setActive({
+			organizationId: org.data?.id as string,
+			fetchOptions: { headers },
+		});
+		const { data } = await client.organization.listMembers({
+			fetchOptions: { headers },
+		});
+		const deactivated = data?.members.find((m) => m.id === member!.id);
+		expect(deactivated).toBeDefined();
+		expect(deactivated?.active).toBe(false);
+	});
+
+	it("inactive member cannot set active organization", async () => {
+		const memberHeaders = new Headers();
+		await client.signIn.email({
+			email: "active-test-user@test.com",
+			password: "password",
+			fetchOptions: {
+				onSuccess(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					if (setCookie) memberHeaders.set("cookie", setCookie);
+				},
+			},
+		});
+		const result = await client.organization.setActive({
+			organizationId: org.data?.id as string,
+			fetchOptions: { headers: memberHeaders },
+		});
+		expect(result.error).toBeTruthy();
+		expect(result.error?.message).toBe(
+			ORGANIZATION_ERROR_CODES.MEMBER_IS_NOT_ACTIVE.message,
+		);
+	});
+
+	it("should activate a member", async () => {
+		const result = await auth.api.activateMember({
+			body: {
+				memberId: member!.id,
+				organizationId: org.data?.id as string,
+			},
+			headers,
+		});
+		expect(result?.active).toBe(true);
+	});
+
+	it("activated member can set active organization again", async () => {
+		const memberHeaders = new Headers();
+		await client.signIn.email({
+			email: "active-test-user@test.com",
+			password: "password",
+			fetchOptions: {
+				onSuccess(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					if (setCookie) memberHeaders.set("cookie", setCookie);
+				},
+			},
+		});
+		const result = await client.organization.setActive({
+			organizationId: org.data?.id as string,
+			fetchOptions: { headers: memberHeaders },
+		});
+		expect(result.error).toBeNull();
+	});
+
+	it("should not deactivate the last active owner", async () => {
+		const ownerMember = org.data?.members[0];
+		const result = await auth.api
+			.deactivateMember({
+				body: {
+					memberId: ownerMember!.id,
+					organizationId: org.data?.id as string,
+				},
+				headers,
+			})
+			.catch((e) => e);
+		expect(result.message || result.error?.message).toContain(
+			ORGANIZATION_ERROR_CODES
+				.YOU_CANNOT_LEAVE_THE_ORGANIZATION_AS_THE_ONLY_OWNER.message,
+		);
+	});
+
+	it("inactive member should fail permission checks", async () => {
+		const organizationId = org.data?.id as string;
+
+		// Deactivate the admin member again
+		await auth.api.deactivateMember({
+			body: {
+				memberId: member!.id,
+				organizationId,
+			},
+			headers,
+		});
+
+		// Create a third user to test with
+		const thirdUser = await auth.api.signUpEmail({
+			body: {
+				email: "active-test-user3@test.com",
+				name: "active-test3",
+				password: "password",
+			},
+		});
+		const thirdUserMember = await auth.api.addMember({
+			body: {
+				organizationId,
+				userId: thirdUser.user.id,
+				role: "member",
+			},
+			headers,
+		});
+
+		// Sign in as the inactive admin
+		const memberHeaders = new Headers();
+		await client.signIn.email({
+			email: "active-test-user@test.com",
+			password: "password",
+			fetchOptions: {
+				onSuccess(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					if (setCookie) memberHeaders.set("cookie", setCookie);
+				},
+			},
+		});
+
+		// Try to update a member's role — should fail
+		const updateResult = await client.organization.updateMemberRole(
+			{
+				organizationId: organizationId,
+				memberId: thirdUserMember.id,
+				role: "admin",
+			},
+			{ headers: memberHeaders },
+		);
+		expect(updateResult.error).toBeTruthy();
+
+		// Re-activate for cleanup
+		await auth.api.activateMember({
+			body: {
+				memberId: member!.id,
+				organizationId,
+			},
+			headers,
+		});
+	});
+});

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -348,14 +348,12 @@ export const removeMember = <O extends OrganizationOptions>(options: O) =>
 						ORGANIZATION_ERROR_CODES.YOU_CANNOT_LEAVE_THE_ORGANIZATION_AS_THE_ONLY_OWNER,
 					);
 				}
-				const { members } = await adapter.listMembers({
-					organizationId: organizationId,
-				});
-				const owners = members.filter((member) => {
-					const roles = member.role.split(",");
-					return roles.includes(creatorRole);
-				});
-				if (owners.length <= 1) {
+        const { members } = await adapter.listMembers({
+          organizationId: organizationId,
+					limit: 2,
+					filter: { field: "role", operator: "contains", value: creatorRole },
+        });
+				if (members.length <= 1) {
 					throw APIError.from(
 						"BAD_REQUEST",
 						ORGANIZATION_ERROR_CODES.YOU_CANNOT_LEAVE_THE_ORGANIZATION_AS_THE_ONLY_OWNER,
@@ -821,19 +819,13 @@ export const leaveOrganization = <O extends OrganizationOptions>(options: O) =>
 			const creatorRole = ctx.context.orgOptions?.creatorRole || "owner";
 			const isOwnerLeaving = member.role.split(",").includes(creatorRole);
 			if (isOwnerLeaving) {
-				const members = await ctx.context.adapter.findMany<Member>({
-					model: "member",
-					where: [
-						{
-							field: "organizationId",
-							value: ctx.body.organizationId,
-						},
-					],
-				});
-				const owners = members.filter((member) =>
-					member.role.split(",").includes(creatorRole),
-				);
-				if (owners.length <= 1) {
+        const { members } = await adapter.listMembers({
+          organizationId: ctx.body.organizationId,
+          limit: 2,
+          filter: { field: "role", operator: "contains", value: creatorRole },
+        });
+
+				if (members.length <= 1) {
 					throw APIError.from(
 						"BAD_REQUEST",
 						ORGANIZATION_ERROR_CODES.YOU_CANNOT_LEAVE_THE_ORGANIZATION_AS_THE_ONLY_OWNER,
@@ -1223,12 +1215,14 @@ export const deactivateMember = <O extends OrganizationOptions>(option: O) =>
 			const creatorRole = ctx.context.orgOptions?.creatorRole || "owner";
 			const roles = toBeDeactivatedMember.role.split(",");
 			if (roles.includes(creatorRole)) {
-				const { members } = await adapter.listMembers({
-					organizationId,
-				});
-				const activeOwners = members.filter((m) => {
-					const memberRoles = m.role.split(",");
-					return memberRoles.includes(creatorRole) && m.active !== false;
+				const activeOwners = await ctx.context.adapter.findMany<Member>({
+					model: "member",
+					where: [
+						{ field: "organizationId", value: organizationId },
+						{ field: "role", operator: "contains", value: creatorRole },
+						{ field: "active", operator: "ne", value: false },
+					],
+					limit: 2,
 				});
 				if (activeOwners.length <= 1) {
 					throw APIError.from(

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -348,11 +348,11 @@ export const removeMember = <O extends OrganizationOptions>(options: O) =>
 						ORGANIZATION_ERROR_CODES.YOU_CANNOT_LEAVE_THE_ORGANIZATION_AS_THE_ONLY_OWNER,
 					);
 				}
-        const { members } = await adapter.listMembers({
-          organizationId: organizationId,
+				const { members } = await adapter.listMembers({
+					organizationId: organizationId,
 					limit: 2,
 					filter: { field: "role", operator: "contains", value: creatorRole },
-        });
+				});
 				if (members.length <= 1) {
 					throw APIError.from(
 						"BAD_REQUEST",
@@ -819,11 +819,11 @@ export const leaveOrganization = <O extends OrganizationOptions>(options: O) =>
 			const creatorRole = ctx.context.orgOptions?.creatorRole || "owner";
 			const isOwnerLeaving = member.role.split(",").includes(creatorRole);
 			if (isOwnerLeaving) {
-        const { members } = await adapter.listMembers({
-          organizationId: ctx.body.organizationId,
-          limit: 2,
-          filter: { field: "role", operator: "contains", value: creatorRole },
-        });
+				const { members } = await adapter.listMembers({
+					organizationId: ctx.body.organizationId,
+					limit: 2,
+					filter: { field: "role", operator: "contains", value: creatorRole },
+				});
 
 				if (members.length <= 1) {
 					throw APIError.from(

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -18,6 +18,19 @@ import type {
 } from "../schema";
 import type { OrganizationOptions } from "../types";
 
+const activateDeactivateBodySchema = z.object({
+	memberId: z.string().meta({
+		description: 'The member id to activate or deactivate. Eg: "member-id"',
+	}),
+	organizationId: z
+		.string()
+		.meta({
+			description:
+				'An optional organization ID. If not provided, will default to the user\'s active organization. Eg: "org-id"',
+		})
+		.optional(),
+});
+
 const baseMemberSchema = z.object({
 	userId: z.coerce.string().meta({
 		description:
@@ -352,6 +365,7 @@ export const removeMember = <O extends OrganizationOptions>(options: O) =>
 			const canDeleteMember = await hasPermission(
 				{
 					role: member.role,
+					memberActive: member.active,
 					options: ctx.context.orgOptions,
 					permissions: {
 						member: ["delete"],
@@ -612,6 +626,7 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 			const canUpdateMember = await hasPermission(
 				{
 					role: member.role,
+					memberActive: member.active,
 					options: ctx.context.orgOptions,
 					permissions: {
 						member: ["update"],
@@ -661,10 +676,9 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 				);
 				if (response && typeof response === "object" && "data" in response) {
 					// Allow the hook to modify the role
-					const updatedMember = await adapter.updateMember(
-						ctx.body.memberId,
-						response.data.role || newRole,
-					);
+					const updatedMember = await adapter.updateMember(ctx.body.memberId, {
+						role: response.data.role || newRole,
+					});
 					if (!updatedMember) {
 						throw APIError.from(
 							"BAD_REQUEST",
@@ -686,10 +700,9 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 				}
 			}
 
-			const updatedMember = await adapter.updateMember(
-				ctx.body.memberId,
-				newRole,
-			);
+			const updatedMember = await adapter.updateMember(ctx.body.memberId, {
+				role: newRole,
+			});
 			if (!updatedMember) {
 				throw APIError.from(
 					"BAD_REQUEST",
@@ -1058,5 +1071,181 @@ export const getActiveMemberRole = <O extends OrganizationOptions>(
 			return ctx.json({
 				role: member?.role,
 			});
+		},
+	);
+
+export const activateMember = <O extends OrganizationOptions>(option: O) =>
+	createAuthEndpoint(
+		"/organization/activate-member",
+		{
+			method: "POST",
+			body: activateDeactivateBodySchema,
+			use: [orgMiddleware, orgSessionMiddleware],
+			requireHeaders: true,
+			metadata: {
+				openapi: {
+					operationId: "activateOrganizationMember",
+					description: "Activate a member in an organization",
+				},
+			},
+		},
+		async (ctx) => {
+			const session = ctx.context.session;
+			const organizationId =
+				ctx.body.organizationId || session.session.activeOrganizationId;
+			if (!organizationId) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.NO_ACTIVE_ORGANIZATION,
+				);
+			}
+			const adapter = getOrgAdapter<O>(ctx.context, option);
+			const member = await adapter.findMemberByOrgId({
+				userId: session.user.id,
+				organizationId,
+			});
+			if (!member) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.MEMBER_NOT_FOUND,
+				);
+			}
+			const canUpdateMember = await hasPermission(
+				{
+					role: member.role,
+					memberActive: member.active,
+					options: ctx.context.orgOptions,
+					permissions: {
+						member: ["update"],
+					},
+					organizationId,
+				},
+				ctx,
+			);
+			if (!canUpdateMember) {
+				throw APIError.from(
+					"FORBIDDEN",
+					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_MEMBER,
+				);
+			}
+			const toBeActivatedMember = await adapter.findMemberById(
+				ctx.body.memberId,
+			);
+			if (
+				!toBeActivatedMember ||
+				toBeActivatedMember.organizationId !== organizationId
+			) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.MEMBER_NOT_FOUND,
+				);
+			}
+			const updatedMember = await adapter.updateMember(ctx.body.memberId, {
+				active: true,
+			});
+			if (!updatedMember) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.MEMBER_NOT_FOUND,
+				);
+			}
+			return ctx.json(updatedMember);
+		},
+	);
+
+export const deactivateMember = <O extends OrganizationOptions>(option: O) =>
+	createAuthEndpoint(
+		"/organization/deactivate-member",
+		{
+			method: "POST",
+			body: activateDeactivateBodySchema,
+			use: [orgMiddleware, orgSessionMiddleware],
+			requireHeaders: true,
+			metadata: {
+				openapi: {
+					operationId: "deactivateOrganizationMember",
+					description: "Deactivate a member in an organization",
+				},
+			},
+		},
+		async (ctx) => {
+			const session = ctx.context.session;
+			const organizationId =
+				ctx.body.organizationId || session.session.activeOrganizationId;
+			if (!organizationId) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.NO_ACTIVE_ORGANIZATION,
+				);
+			}
+			const adapter = getOrgAdapter<O>(ctx.context, option);
+			const member = await adapter.findMemberByOrgId({
+				userId: session.user.id,
+				organizationId,
+			});
+			if (!member) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.MEMBER_NOT_FOUND,
+				);
+			}
+			const canUpdateMember = await hasPermission(
+				{
+					role: member.role,
+					memberActive: member.active,
+					options: ctx.context.orgOptions,
+					permissions: {
+						member: ["update"],
+					},
+					organizationId,
+				},
+				ctx,
+			);
+			if (!canUpdateMember) {
+				throw APIError.from(
+					"FORBIDDEN",
+					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_MEMBER,
+				);
+			}
+			const toBeDeactivatedMember = await adapter.findMemberById(
+				ctx.body.memberId,
+			);
+			if (
+				!toBeDeactivatedMember ||
+				toBeDeactivatedMember.organizationId !== organizationId
+			) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.MEMBER_NOT_FOUND,
+				);
+			}
+			// Prevent deactivating the last active owner
+			const creatorRole = ctx.context.orgOptions?.creatorRole || "owner";
+			const roles = toBeDeactivatedMember.role.split(",");
+			if (roles.includes(creatorRole)) {
+				const { members } = await adapter.listMembers({
+					organizationId,
+				});
+				const activeOwners = members.filter((m) => {
+					const memberRoles = m.role.split(",");
+					return memberRoles.includes(creatorRole) && m.active !== false;
+				});
+				if (activeOwners.length <= 1) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.YOU_CANNOT_LEAVE_THE_ORGANIZATION_AS_THE_ONLY_OWNER,
+					);
+				}
+			}
+			const updatedMember = await adapter.updateMember(ctx.body.memberId, {
+				active: false,
+			});
+			if (!updatedMember) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.MEMBER_NOT_FOUND,
+				);
+			}
+			return ctx.json(updatedMember);
 		},
 	);

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -453,6 +453,7 @@ export const updateOrganization = <O extends OrganizationOptions>(
 						organization: ["update"],
 					},
 					role: member.role,
+					memberActive: member.active,
 					options: ctx.context.orgOptions,
 					organizationId,
 				},
@@ -579,6 +580,7 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 			const canDeleteOrg = await hasPermission(
 				{
 					role: member.role,
+					memberActive: member.active,
 					permissions: {
 						organization: ["delete"],
 					},
@@ -837,6 +839,13 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 				throw APIError.from(
 					"FORBIDDEN",
 					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
+				);
+			}
+			if (!isMember.active) {
+				await adapter.setActiveOrganization(session.session.token, null, ctx);
+				throw APIError.from(
+					"FORBIDDEN",
+					ORGANIZATION_ERROR_CODES.MEMBER_IS_NOT_ACTIVE,
 				);
 			}
 

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -123,6 +123,7 @@ export const createTeam = <O extends OrganizationOptions>(options: O) => {
 				const canCreate = await hasPermission(
 					{
 						role: member.role,
+						memberActive: member.active,
 						options: ctx.context.orgOptions,
 						permissions: {
 							team: ["create"],
@@ -288,6 +289,7 @@ export const removeTeam = <O extends OrganizationOptions>(options: O) =>
 				const canRemove = await hasPermission(
 					{
 						role: member.role,
+						memberActive: member.active,
 						options: ctx.context.orgOptions,
 						permissions: {
 							team: ["delete"],
@@ -467,6 +469,7 @@ export const updateTeam = <O extends OrganizationOptions>(options: O) => {
 			const canUpdate = await hasPermission(
 				{
 					role: member.role,
+					memberActive: member.active,
 					options: ctx.context.orgOptions,
 					permissions: {
 						team: ["update"],
@@ -1000,6 +1003,7 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 			const canUpdateMember = await hasPermission(
 				{
 					role: currentMember.role,
+					memberActive: currentMember.active,
 					options: ctx.context.orgOptions,
 					permissions: {
 						member: ["update"],
@@ -1174,6 +1178,7 @@ export const removeTeamMember = <O extends OrganizationOptions>(options: O) =>
 			const canDeleteMember = await hasPermission(
 				{
 					role: currentMember.role,
+					memberActive: currentMember.active,
 					options: ctx.context.orgOptions,
 					permissions: {
 						member: ["delete"],

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -145,6 +145,11 @@ interface MemberDefaultFields {
 		required: true;
 		defaultValue: "member";
 	};
+	active: {
+		type: "boolean";
+		required: false;
+		defaultValue: true;
+	};
 	createdAt: {
 		type: "date";
 		required: true;
@@ -306,6 +311,7 @@ export const memberSchema = z.object({
 	organizationId: z.string(),
 	userId: z.coerce.string(),
 	role: roleSchema,
+	active: z.boolean().default(true),
 	createdAt: z.date().default(() => new Date()),
 });
 
@@ -408,6 +414,7 @@ export type InferMember<
 				id: string;
 				organizationId: string;
 				role: InferOrganizationRolesFromOption<O>;
+				active: boolean;
 				createdAt: Date;
 				userId: string;
 				teamId?: string | undefined;
@@ -422,6 +429,7 @@ export type InferMember<
 				id: string;
 				organizationId: string;
 				role: InferOrganizationRolesFromOption<O>;
+				active: boolean;
 				createdAt: Date;
 				userId: string;
 				user: {

--- a/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
+++ b/packages/cli/test/__snapshots__/schema-mysql-custom.prisma
@@ -112,6 +112,7 @@ model Member {
   userId         String
   user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   role           String    @db.Text
+  active         Boolean?  @default(true)
   createdAt      DateTime
 
   @@index([organizationId(length: 191)])

--- a/packages/scim/src/patch-operations.ts
+++ b/packages/scim/src/patch-operations.ts
@@ -9,13 +9,14 @@ type Operation = {
 
 type Mapping = {
 	target: string;
-	resource: "user" | "account";
+	resource: "user" | "account" | "member";
 	map: (user: User, op: Operation, resources: Resources) => any;
 };
 
 type Resources = {
 	user: Record<string, any>;
 	account: Record<string, any>;
+	member: Record<string, any>;
 };
 
 const identity = (user: User, op: Operation, resources: Resources) => {
@@ -63,6 +64,7 @@ const userPatchMappings: Record<string, Mapping> = {
 		map: identity,
 	},
 	"/userName": { resource: "user", target: "email", map: lowerCase },
+	"/active": { resource: "member", target: "active", map: identity },
 };
 
 const normalizePath = (path: string): string => {
@@ -128,7 +130,12 @@ const applyPatchValue = (
 export const buildUserPatch = (user: User, operations: Operation[]) => {
 	const userPatch: Record<string, any> = {};
 	const accountPatch: Record<string, any> = {};
-	const resources: Resources = { user: userPatch, account: accountPatch };
+	const memberPatch: Record<string, any> = {};
+	const resources: Resources = {
+		user: userPatch,
+		account: accountPatch,
+		member: memberPatch,
+	};
 
 	for (const operation of operations) {
 		if (operation.op !== "add" && operation.op !== "replace") {

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -524,8 +524,8 @@ export const createSCIMUser = (authMiddleware: AuthMiddleware) =>
 							data: {
 								userId: userId,
 								role: "member",
-								createdAt: new Date(),
 								active: true,
+								createdAt: new Date(),
 								organizationId,
 							},
 						});
@@ -535,22 +535,25 @@ export const createSCIMUser = (authMiddleware: AuthMiddleware) =>
 
 			let user: User;
 			let account: Account;
+			let member: Member | null | undefined = null;
 
 			if (existingUser) {
 				user = existingUser;
-				account = await ctx.context.adapter.transaction<Account>(async () => {
+				[account, member] = await ctx.context.adapter.transaction<
+					[Account, Member | null | undefined]
+				>(async () => {
 					const account = await createAccount(user.id);
-					await createOrgMembership(user.id);
-					return account;
+					const member = await createOrgMembership(user.id);
+					return [account, member];
 				});
 			} else {
-				[user, account] = await ctx.context.adapter.transaction<
-					[User, Account]
+				[user, account, member] = await ctx.context.adapter.transaction<
+					[User, Account, Member | null | undefined]
 				>(async () => {
 					const user = await createUser();
 					const account = await createAccount(user.id);
-					await createOrgMembership(user.id);
-					return [user, account];
+					const member = await createOrgMembership(user.id);
+					return [user, account, member];
 				});
 			}
 
@@ -558,6 +561,7 @@ export const createSCIMUser = (authMiddleware: AuthMiddleware) =>
 				ctx.context.baseURL,
 				user,
 				account,
+				member,
 			);
 
 			ctx.setStatus(201);
@@ -600,11 +604,14 @@ export const updateSCIMUser = (authMiddleware: AuthMiddleware) =>
 			const { organizationId, providerId } = ctx.context.scimProvider;
 			const accountId = getAccountId(body.userName, body.externalId);
 
-			const { user, account } = await findUserById(ctx.context.adapter, {
-				userId,
-				providerId,
-				organizationId,
-			});
+			const { user, account, member } = await findUserById(
+				ctx.context.adapter,
+				{
+					userId,
+					providerId,
+					organizationId,
+				},
+			);
 
 			if (!user) {
 				throw new SCIMAPIError("NOT_FOUND", {
@@ -641,6 +648,7 @@ export const updateSCIMUser = (authMiddleware: AuthMiddleware) =>
 				ctx.context.baseURL,
 				updatedUser!,
 				updatedAccount,
+				member,
 			);
 
 			return ctx.json(userResource);
@@ -724,6 +732,7 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 			];
 
 			const organizationId = ctx.context.scimProvider.organizationId;
+			let memberMap: Map<string, Member> | null = null;
 			if (organizationId) {
 				const members = await ctx.context.adapter.findMany<Member>({
 					model: "member",
@@ -741,6 +750,7 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 					return ctx.json(emptyListResponse);
 				}
 
+				memberMap = new Map(members.map((m) => [m.userId, m]));
 				userFilters = [{ field: "id", value: memberUserIds, operator: "in" }];
 			}
 
@@ -756,7 +766,12 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 				itemsPerPage: users.length,
 				Resources: users.map((user) => {
 					const account = accounts.find((a) => a.userId === user.id);
-					return createUserResource(ctx.context.baseURL, user, account);
+					return createUserResource(
+						ctx.context.baseURL,
+						user,
+						account,
+						memberMap?.get(user.id),
+					);
 				}),
 			});
 		},
@@ -794,11 +809,14 @@ export const getSCIMUser = (authMiddleware: AuthMiddleware) =>
 			const providerId = ctx.context.scimProvider.providerId;
 			const organizationId = ctx.context.scimProvider.organizationId;
 
-			const { user, account } = await findUserById(ctx.context.adapter, {
-				userId,
-				providerId,
-				organizationId,
-			});
+			const { user, account, member } = await findUserById(
+				ctx.context.adapter,
+				{
+					userId,
+					providerId,
+					organizationId,
+				},
+			);
 
 			if (!user) {
 				throw new SCIMAPIError("NOT_FOUND", {
@@ -806,7 +824,9 @@ export const getSCIMUser = (authMiddleware: AuthMiddleware) =>
 				});
 			}
 
-			return ctx.json(createUserResource(ctx.context.baseURL, user, account));
+			return ctx.json(
+				createUserResource(ctx.context.baseURL, user, account, member),
+			);
 		},
 	);
 
@@ -859,11 +879,14 @@ export const patchSCIMUser = (authMiddleware: AuthMiddleware) =>
 			const organizationId = ctx.context.scimProvider.organizationId;
 			const providerId = ctx.context.scimProvider.providerId;
 
-			const { user, account } = await findUserById(ctx.context.adapter, {
-				userId,
-				providerId,
-				organizationId,
-			});
+			const { user, account, member } = await findUserById(
+				ctx.context.adapter,
+				{
+					userId,
+					providerId,
+					organizationId,
+				},
+			);
 
 			if (!user) {
 				throw new SCIMAPIError("NOT_FOUND", {
@@ -871,14 +894,16 @@ export const patchSCIMUser = (authMiddleware: AuthMiddleware) =>
 				});
 			}
 
-			const { user: userPatch, account: accountPatch } = buildUserPatch(
-				user,
-				ctx.body.Operations,
-			);
+			const {
+				user: userPatch,
+				account: accountPatch,
+				member: memberPatch,
+			} = buildUserPatch(user, ctx.body.Operations);
 
 			if (
 				Object.keys(userPatch).length === 0 &&
-				Object.keys(accountPatch).length === 0
+				Object.keys(accountPatch).length === 0 &&
+				Object.keys(memberPatch).length === 0
 			) {
 				throw new SCIMAPIError("BAD_REQUEST", {
 					detail: "No valid fields to update",
@@ -896,6 +921,13 @@ export const patchSCIMUser = (authMiddleware: AuthMiddleware) =>
 					? ctx.context.internalAdapter.updateAccount(account.id, {
 							...accountPatch,
 							updatedAt: new Date(),
+						})
+					: Promise.resolve(),
+				Object.keys(memberPatch).length > 0 && member
+					? ctx.context.adapter.update({
+							model: "member",
+							where: [{ field: "id", value: member.id }],
+							update: memberPatch,
 						})
 					: Promise.resolve(),
 			]);
@@ -1219,7 +1251,7 @@ const findUserById = async (
 	// Account is not associated to the provider
 
 	if (!account) {
-		return { user: null, account: null };
+		return { user: null, account: null, member: null };
 	}
 
 	let member: Member | null = null;
@@ -1237,7 +1269,7 @@ const findUserById = async (
 	// Token is restricted to an org and the member is not part of it
 
 	if (organizationId && !member) {
-		return { user: null, account: null };
+		return { user: null, account: null, member: null };
 	}
 
 	const user = await adapter.findOne<User>({
@@ -1246,10 +1278,10 @@ const findUserById = async (
 	});
 
 	if (!user) {
-		return { user: null, account: null };
+		return { user: null, account: null, member: null };
 	}
 
-	return { user, account };
+	return { user, account, member };
 };
 
 const parseSCIMAPIUserFilter = (filter?: string) => {

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -525,6 +525,7 @@ export const createSCIMUser = (authMiddleware: AuthMiddleware) =>
 								userId: userId,
 								role: "member",
 								createdAt: new Date(),
+								active: true,
 								organizationId,
 							},
 						});

--- a/packages/scim/src/scim-patch.test.ts
+++ b/packages/scim/src/scim-patch.test.ts
@@ -3,6 +3,7 @@ import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { createAuthClient } from "better-auth/client";
 import { setCookieToHeader } from "better-auth/cookies";
+import type { Member } from "better-auth/plugins";
 import { bearer, organization } from "better-auth/plugins";
 import { describe, expect, it } from "vitest";
 import { scim } from ".";
@@ -716,6 +717,73 @@ describe("SCIM", () => {
 					},
 				}),
 			);
+		});
+
+		it("should update the member active state via PATCH active", async () => {
+			const { auth, getSCIMToken, registerOrganization } = createTestInstance();
+			const org = await registerOrganization("patch-active-org");
+			const scimToken = await getSCIMToken("patch-active-provider", org.id);
+
+			const user = await auth.api.createSCIMUser({
+				body: {
+					userName: "patch-active-user@test.com",
+					name: { formatted: "Patch Active User" },
+				},
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			// Verify user starts as active
+			const initialUser = await auth.api.getSCIMUser({
+				params: { userId: user.id },
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+			expect(initialUser.active).toBe(true);
+
+			// PATCH active to false
+			await auth.api.patchSCIMUser({
+				params: { userId: user.id },
+				body: {
+					schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+					Operations: [{ op: "replace", path: "active", value: false }],
+				},
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			// Verify user is now inactive via SCIM GET
+			const deactivatedUser = await auth.api.getSCIMUser({
+				params: { userId: user.id },
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+			expect(deactivatedUser.active).toBe(false);
+
+			// Verify the member record in DB is also inactive
+			const ctx = await auth.$context;
+			const member = await ctx.adapter.findOne<Member>({
+				model: "member",
+				where: [
+					{ field: "organizationId", value: org.id },
+					{ field: "userId", value: user.id },
+				],
+			});
+			expect(member?.active).toBe(false);
+
+			// PATCH active back to true
+			await auth.api.patchSCIMUser({
+				params: { userId: user.id },
+				body: {
+					schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+					Operations: [{ op: "replace", path: "active", value: true }],
+				},
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			const reactivatedUser = await auth.api.getSCIMUser({
+				params: { userId: user.id },
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+			expect(reactivatedUser.active).toBe(true);
 		});
 	});
 });

--- a/packages/scim/src/scim-resources.ts
+++ b/packages/scim/src/scim-resources.ts
@@ -6,6 +6,7 @@ export const createUserResource = (
 	baseURL: string,
 	user: User,
 	account?: Account | null,
+	member?: { active?: boolean } | null,
 ) => {
 	return {
 		// Common attributes
@@ -28,7 +29,7 @@ export const createUserResource = (
 			formatted: user.name,
 		},
 		displayName: user.name,
-		active: true,
+		active: member ? member.active !== false : true,
 		emails: [{ primary: true, value: user.email }],
 		schemas: [SCIMUserResourceSchema.id],
 	};

--- a/packages/scim/src/scim.test.ts
+++ b/packages/scim/src/scim.test.ts
@@ -246,7 +246,7 @@ describe("SCIM", () => {
 				        {
 				          "description": "A Boolean value indicating the User's administrative status.",
 				          "multiValued": false,
-				          "mutability": "readOnly",
+				          "mutability": "readWrite",
 				          "name": "active",
 				          "required": false,
 				          "returned": "default",
@@ -396,7 +396,7 @@ describe("SCIM", () => {
 				    {
 				      "description": "A Boolean value indicating the User's administrative status.",
 				      "multiValued": false,
-				      "mutability": "readOnly",
+				      "mutability": "readWrite",
 				      "name": "active",
 				      "required": false,
 				      "returned": "default",

--- a/packages/scim/src/user-schemas.ts
+++ b/packages/scim/src/user-schemas.ts
@@ -109,7 +109,7 @@ export const SCIMUserResourceSchema = {
 			description:
 				"A Boolean value indicating the User's administrative status.",
 			required: false,
-			mutability: "readOnly",
+			mutability: "readWrite",
 			returned: "default",
 		},
 		{

--- a/packages/test-utils/src/adapter/suites/basic.ts
+++ b/packages/test-utils/src/adapter/suites/basic.ts
@@ -2579,6 +2579,7 @@ export const getNormalTestSuiteTests = (
 						organizationId: organizationData.id,
 						userId: user.id,
 						role: "owner",
+						active: true,
 						createdAt: new Date(),
 					},
 					forceAllowId: true,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                       
                                                        
  Connect the SCIM `active` attribute to the organization `member.active` flag instead of hard-coding it to `true`.                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                   
  ## Motivation                                                                                                                                                                                                                                                                                                    
                                                        
  Previously, the SCIM `active` attribute on user resources was hard-coded to `true` and had no effect on the system. Identity providers (Okta, Entra ID, etc.) use SCIM PATCH `active: false` to suspend users, but Better Auth silently ignored it.                                                              
   
  By mapping SCIM `active` to `member.active` (introduced in the organization plugin https://github.com/better-auth/better-auth/pull/8840):                                                                                                                                                                                                                             
                                                        
  1. **Single source of truth** — one column drives both the SCIM representation and the authorization layer                                                                                                                                                                                                       
  2. **Consistent behavior** — deactivating a user via SCIM has the same effect as deactivating them through the organization API
  3. **No orphaned state** — no separate "SCIM suspended" boolean that can drift out of sync                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                   
  ## Changes
                                                                                                                                                                                                                                                                                                                   
  - `findUserById` now returns the `member` record alongside `user` and `account`
  - `createUserResource` derives `active` from `member.active` instead of hard-coding `true`
  - `buildUserPatch` maps `/active` operations to a new `member` resource bucket                                                                                                                                                                                                                                   
  - `patchSCIMUser` applies `memberPatch` to the member row
  - `listSCIMUsers` builds a member map to pass into resource serialization                                                                                                                                                                                                                                        
  - `createSCIMUser` sets `active: true` on the initial membership                                                                                                                                                                                                                                                 
   
  ## Test plan                                                                                                                                                                                                                                                                                                     
                                                        
  - [x] New SCIM patch test: `PATCH /active` updates `member.active` and is reflected in subsequent `GET`                                                                                                                                                                                                          
  - [x] Existing SCIM test suite passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects SCIM `User.active` to organization `member.active` so IdP PATCH requests can suspend or reactivate users. Adds member activation APIs and blocks inactive members across org actions.

- **New Features**
  - Map SCIM `PATCH /active` to `member.active`; SCIM user schema `active` is now `readWrite`. SCIM user resources read `active` from membership, `createSCIMUser` creates membership with `active: true`, and SCIM user lists include inactive users.
  - New endpoints: `POST /organization/activate-member` and `POST /organization/deactivate-member` (cannot deactivate the last active owner).
  - Enforce `member.active` in permission checks and `setActiveOrganization`; inactive members are blocked and return `MEMBER_IS_NOT_ACTIVE`.
  - Adapter `updateMember` now accepts `{ role?: string, active?: boolean }`.

- **Migration**
  - Add `active boolean DEFAULT true` to the `member` table.
  - If you provide a custom organization adapter, update `updateMember(memberId, data)` to accept `{ role?, active? }`.

<sup>Written for commit 034d8a7c355887ba8bd04a9b76fd715d2aa98716. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

