### PR TITLE
chore: pin `axios` below 1.14.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ catalogs:
       specifier: ^4.0.18
       version: 4.0.18
 
+overrides:
+  axios: <1.14.0
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,9 @@ packages:
 
 blockExoticSubdeps: true
 
+overrides:
+  axios: <1.14.0
+
 catalog:
   '@better-auth/utils': 0.4.0
   '@better-fetch/fetch': 1.1.21


### PR DESCRIPTION
> [!NOTE]
> Remove this changes later. Actually It's not useful right now, but I added it just in case.

That version isn't installed for us. However, since the Typesense SDK uses axios internally, it might be pulled in there. It likely won’t have actual impact, but adding it just in case.