### PR TITLE
chore: remove duplicate export for linkedin

### DIFF
--- a/packages/core/src/social-providers/index.ts
+++ b/packages/core/src/social-providers/index.ts
@@ -106,7 +106,6 @@ export * from "./google";
 export * from "./huggingface";
 export * from "./kakao";
 export * from "./kick";
-export * from "./kick";
 export * from "./line";
 export * from "./linear";
 export * from "./linkedin";

--- a/packages/core/src/social-providers/index.ts
+++ b/packages/core/src/social-providers/index.ts
@@ -110,7 +110,6 @@ export * from "./kick";
 export * from "./line";
 export * from "./linear";
 export * from "./linkedin";
-export * from "./linkedin";
 export * from "./microsoft-entra-id";
 export * from "./naver";
 export * from "./notion";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed duplicate exports for the `kick` and `linkedin` providers in `packages/core/src/social-providers/index.ts` to clean up the barrel and prevent lint/build warnings.

<sup>Written for commit ab2e12e68e13a633195b68bb3ee9c724e18a0b93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

