### PR TITLE
fix: recover sessions from DB when secondary storage TTL expires

### DIFF
--- a/docs/content/docs/concepts/session-management.mdx
+++ b/docs/content/docs/concepts/session-management.mdx
@@ -316,11 +316,11 @@ betterAuth({
 
 ### Storing Sessions in the Database
 
-By default, Better Auth already stores sessions in the database, however if you provide a secondary storage,
-Better Auth will store sessions in the secondary storage instead of the database.
+If you provide a database and secondary storage together, sessions are stored in **both** by default (`storeSessionInDatabase` defaults to `true`). That way, if the secondary storage entry expires (for example, KV TTL) before the session does, Better Auth can still resolve the session from the database.
 
-You can choose to store sessions in the database instead of secondary storage by passing
-`storeSessionInDatabase: true` in the session configuration.
+If you use secondary storage **without** a database, sessions live only in secondary storage.
+
+If you use secondary storage with a database but want sessions only in secondary storage (not in the database), set `storeSessionInDatabase: false`.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
@@ -328,7 +328,7 @@ import { betterAuth } from "better-auth";
 export const auth = betterAuth({
     secondaryStorage: { /** your secondary storage implementation here */ },
     session: { // [!code highlight]
-        storeSessionInDatabase: true, // [!code highlight]
+        storeSessionInDatabase: false, // opt out of DB persistence when using secondary storage + database // [!code highlight]
     } // [!code highlight]
 });
 ```

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -405,7 +405,7 @@ export const auth = betterAuth({
 				type: "string",
 			}
 		},
-		storeSessionInDatabase: true, // Store session in database when secondary storage is provided (default: `false`)
+		storeSessionInDatabase: true, // When using secondary storage: defaults to `true` if `database` is also set, otherwise `false`
 		preserveSessionInDatabase: false, // Preserve session records in database when deleted from secondary storage (default: `false`)
 		cookieCache: {
 			enabled: true, // Enable caching session in cookie (default: `false`)	
@@ -420,7 +420,7 @@ export const auth = betterAuth({
 - `expiresIn`: Expiration time for the session token in seconds (default: `604800` - 7 days)
 - `updateAge`: How often the session should be refreshed in seconds (default: `86400` - 1 day)
 - `additionalFields`: Additional fields for the session table
-- `storeSessionInDatabase`: Store session in database when secondary storage is provided (default: `false`)
+- `storeSessionInDatabase`: Store session in database when secondary storage is provided. Defaults to `true` when both `database` and `secondaryStorage` are configured (so sessions stay valid if secondary storage TTL expires first); otherwise defaults to `false`.
 - `preserveSessionInDatabase`: Preserve session records in database when deleted from secondary storage (default: `false`)
 - `cookieCache`: Enable caching session in cookie
 

--- a/e2e/smoke/test/redis.spec.ts
+++ b/e2e/smoke/test/redis.spec.ts
@@ -67,7 +67,7 @@ test("Redis secondary storage integration", async (t) => {
 	});
 
 	await t.test(
-		"should store session data in Redis after email signup",
+		"should store session data in Redis after email signup (default: DB + secondary storage)",
 		async (t: TestContext) => {
 			const auth = betterAuth({
 				database: new DatabaseSync(":memory:"),
@@ -78,48 +78,6 @@ test("Redis secondary storage integration", async (t) => {
 					client: redisClient,
 					keyPrefix: `${id}|`,
 				}),
-			});
-
-			const { runMigrations } = await getMigrations(auth.options);
-			await runMigrations();
-
-			const { token } = await auth.api.signUpEmail({
-				body: {
-					email: "himself65@outlook.com",
-					password: "123456789",
-					name: "Alex Yang",
-				},
-			});
-
-			t.assert.ok(token);
-
-			const storage = auth.options.secondaryStorage;
-			const keys = await storage.listKeys();
-			t.assert.equal(keys.length, 2);
-			const key = keys.find((key) => !key.startsWith("active-sessions"))!;
-			const sessionDataString = await storage.get(key);
-			t.assert.ok(sessionDataString);
-			const sessionData = JSON.parse(sessionDataString);
-			t.assert.ok(sessionData.user.id);
-			t.assert.ok(sessionData.session.id === undefined);
-		},
-	);
-
-	await t.test(
-		"should have session id in Redis when `storeSessionInDatabase` is true",
-		async (t: TestContext) => {
-			const auth = betterAuth({
-				database: new DatabaseSync(":memory:"),
-				emailAndPassword: {
-					enabled: true,
-				},
-				secondaryStorage: redisStorage({
-					client: redisClient,
-					keyPrefix: `${id}|`,
-				}),
-				session: {
-					storeSessionInDatabase: true,
-				},
 			});
 
 			const { runMigrations } = await getMigrations(auth.options);
@@ -144,6 +102,48 @@ test("Redis secondary storage integration", async (t) => {
 			const sessionData = JSON.parse(sessionDataString);
 			t.assert.ok(sessionData.user.id);
 			t.assert.ok(sessionData.session.id);
+		},
+	);
+
+	await t.test(
+		"should omit session id in Redis when `storeSessionInDatabase` is false",
+		async (t: TestContext) => {
+			const auth = betterAuth({
+				database: new DatabaseSync(":memory:"),
+				emailAndPassword: {
+					enabled: true,
+				},
+				secondaryStorage: redisStorage({
+					client: redisClient,
+					keyPrefix: `${id}|`,
+				}),
+				session: {
+					storeSessionInDatabase: false,
+				},
+			});
+
+			const { runMigrations } = await getMigrations(auth.options);
+			await runMigrations();
+
+			const { token } = await auth.api.signUpEmail({
+				body: {
+					email: "himself65@outlook.com",
+					password: "123456789",
+					name: "Alex Yang",
+				},
+			});
+
+			t.assert.ok(token);
+
+			const storage = auth.options.secondaryStorage;
+			const keys = await storage.listKeys();
+			t.assert.equal(keys.length, 2);
+			const key = keys.find((key) => !key.startsWith("active-sessions"))!;
+			const sessionDataString = await storage.get(key);
+			t.assert.ok(sessionDataString);
+			const sessionData = JSON.parse(sessionDataString);
+			t.assert.ok(sessionData.user.id);
+			t.assert.ok(sessionData.session.id === undefined);
 		},
 	);
 

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -462,6 +462,7 @@ describe("base context creation", () => {
 
 		it("should not override explicit storeSessionInDatabase: false", async () => {
 			const res = await initBase({
+				database: new DatabaseSync(":memory:"),
 				secondaryStorage: {
 					get: vi.fn(),
 					set: vi.fn(),

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -5,7 +5,10 @@ import { getAdapter } from "../db/adapter-kysely";
 import { getTestInstance } from "../test-utils/test-instance";
 import type { BetterAuthOptions } from "../types";
 import { createAuthContext } from "./create-context";
-import { getAwaitableValue } from "./helpers";
+import {
+	applySecondaryStorageSessionDefaults,
+	getAwaitableValue,
+} from "./helpers";
 
 describe("base context creation", () => {
 	const initBase = async (options: Partial<BetterAuthOptions> = {}) => {
@@ -13,6 +16,7 @@ describe("base context creation", () => {
 			baseURL: "http://localhost:3000",
 			...options,
 		};
+		applySecondaryStorageSessionDefaults(opts);
 		const adapter = await getAdapter(opts);
 		const getDatabaseType = () => "memory";
 		return createAuthContext(adapter, opts, getDatabaseType);
@@ -442,6 +446,32 @@ describe("base context creation", () => {
 				},
 			});
 			expect(res.rateLimit.storage).toBe("secondary-storage");
+		});
+
+		it("should default storeSessionInDatabase to true when database and secondaryStorage are set", async () => {
+			const res = await initBase({
+				database: new DatabaseSync(":memory:"),
+				secondaryStorage: {
+					get: vi.fn(),
+					set: vi.fn(),
+					delete: vi.fn(),
+				},
+			});
+			expect(res.options.session?.storeSessionInDatabase).toBe(true);
+		});
+
+		it("should not override explicit storeSessionInDatabase: false", async () => {
+			const res = await initBase({
+				secondaryStorage: {
+					get: vi.fn(),
+					set: vi.fn(),
+					delete: vi.fn(),
+				},
+				session: {
+					storeSessionInDatabase: false,
+				},
+			});
+			expect(res.options.session?.storeSessionInDatabase).toBe(false);
 		});
 
 		it("should use default window and max values", async () => {

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -10,6 +10,33 @@ import { createInternalAdapter } from "../db";
 import { isPromise } from "../utils/is-promise";
 import { getBaseURL, isDynamicBaseURLConfig } from "../utils/url";
 
+/**
+ * When both a database and secondary storage are configured, persist sessions in
+ * the database by default so valid sessions can be recovered when secondary
+ * storage TTL expires or the entry is evicted before the session expires.
+ *
+ * Must run before `getAdapter` / `getBaseAdapter` so the session table is
+ * included in the schema when appropriate.
+ *
+ * Mutates `options` in place so the same object referenced by `betterAuth({...})`
+ * (e.g. `auth.options`) stays aligned with the adapter schema.
+ */
+export function applySecondaryStorageSessionDefaults(
+	options: BetterAuthOptions,
+): BetterAuthOptions {
+	if (
+		options.database &&
+		options.secondaryStorage &&
+		options.session?.storeSessionInDatabase === undefined
+	) {
+		options.session = {
+			...options.session,
+			storeSessionInDatabase: true,
+		};
+	}
+	return options;
+}
+
 export async function runPluginInit(context: AuthContext) {
 	let options = context.options;
 	const plugins = options.plugins || [];

--- a/packages/better-auth/src/context/init-minimal.ts
+++ b/packages/better-auth/src/context/init-minimal.ts
@@ -2,8 +2,10 @@ import type { BetterAuthOptions } from "@better-auth/core";
 import { BetterAuthError } from "@better-auth/core/error";
 import { getBaseAdapter } from "../db/adapter-base";
 import { createAuthContext } from "./create-context";
+import { applySecondaryStorageSessionDefaults } from "./helpers";
 
 export const initMinimal = async (options: BetterAuthOptions) => {
+	applySecondaryStorageSessionDefaults(options);
 	const adapter = await getBaseAdapter(options, async () => {
 		throw new BetterAuthError(
 			"Direct database connection requires Kysely. Please use `better-auth` instead of `better-auth/minimal`, or provide an adapter (drizzleAdapter, prismaAdapter, etc.)",

--- a/packages/better-auth/src/context/init.ts
+++ b/packages/better-auth/src/context/init.ts
@@ -4,8 +4,10 @@ import { getAdapter } from "../db/adapter-kysely";
 import { getMigrations } from "../db/get-migration";
 import type { BetterAuthOptions } from "../types";
 import { createAuthContext } from "./create-context";
+import { applySecondaryStorageSessionDefaults } from "./helpers";
 
 export const init = async (options: BetterAuthOptions) => {
+	applySecondaryStorageSessionDefaults(options);
 	const adapter = await getAdapter(options);
 
 	// Get database type using Kysely's dialect detection

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -121,6 +121,55 @@ describe("secondary storage - get returns already-parsed object", async () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/4203
+ */
+describe("secondary storage - database fallback when KV entry expires", () => {
+	it("should recover the session from the database after secondary storage loses the session key", async () => {
+		const store = new Map<string, string>();
+
+		const { client, signInWithTestUser } = await getTestInstance({
+			secondaryStorage: {
+				set(key, value, _ttl) {
+					store.set(key, value);
+				},
+				get(key) {
+					return store.get(key) ?? null;
+				},
+				delete(key) {
+					store.delete(key);
+				},
+			},
+			session: {
+				cookieCache: {
+					enabled: true,
+				},
+			},
+			rateLimit: {
+				enabled: false,
+			},
+		});
+
+		const { headers } = await signInWithTestUser();
+		const s1 = await client.getSession({
+			fetchOptions: { headers },
+		});
+		expect(s1.data).not.toBeNull();
+		const token = s1.data!.session.token;
+		expect(store.has(token)).toBe(true);
+
+		store.delete(token);
+		store.delete(`active-sessions-${s1.data!.session.userId}`);
+
+		const afterKvLoss = await client.getSession({
+			query: { disableCookieCache: true },
+			fetchOptions: { headers },
+		});
+		expect(afterKvLoss.data).not.toBeNull();
+		expect(afterKvLoss.data?.session.token).toBe(token);
+	});
+});
+
 describe("secondary storage - storeSessionInDatabase", () => {
 	describe("preserveSessionInDatabase: false", async () => {
 		const store = new Map<string, string>();

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -886,9 +886,14 @@ export type BetterAuthOptions = {
 				 * Set this to true to store the session in the database
 				 * as well.
 				 *
-				 * Reads are always done from the secondary storage.
+				 * Reads are always done from the secondary storage first, then the
+				 * database when `storeSessionInDatabase` is true.
 				 *
-				 * @default false
+				 * When both `database` and `secondaryStorage` are configured,
+				 * this defaults to `true` so sessions remain valid if secondary
+				 * storage TTL expires before the session does.
+				 *
+				 * @default false (or `true` when both `database` and `secondaryStorage` are set)
 				 */
 				storeSessionInDatabase?: boolean;
 				/**


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/4203#issuecomment-4162526389

## Problem
With `database` and `secondaryStorage` (e.g. Redis / Cloudflare KV) and cookie cache enabled, users could be forced to sign in again after the secondary storage entry expired, even though the session was still valid (e.g. cookie + DB expectations).

By default, `session.storeSessionInDatabase` was `false` when using secondary storage, so session rows were not written to the database. `findSession` reads secondary storage first; on a KV miss it only falls back to the database when `storeSessionInDatabase` is `true`. After TTL eviction there was no DB row, so the session resolved to null.

## Solution
- Introduce `applySecondaryStorageSessionDefaults` (packages/better-auth/src/context/helpers.ts): when both database and `secondaryStorage` are set and `storeSessionInDatabase` is omitted, set `storeSessionInDatabase: true` so sessions are stored in both places and `findSession` can fall back to the DB after a KV miss.
- Apply this before `getAdapter` / `getBaseAdapter` in `init.ts` and `init-minimal.ts` so the adapter schema (and migrations) include the session table when appropriate.
- Mutate options in place so the same object used as `betterAuth({ ... })` / `auth.options` stays consistent with what the adapter was built with.

## Is it a breaking change?
Not a semver-major / API break: no removed or renamed public APIs; TypeScript types are unchanged.

Behavior / default change (call out in changelog): apps that use both a database and secondary storage and relied on the old default (sessions only in secondary storage, not in the DB) will now persist sessions in the database unless they set:

```ts
session: { storeSessionInDatabase: false }
```

That can affect storage, migrations (session table must exist), and anyone who intentionally avoided DB session persistence. Recommend labeling the release note as a notable default change with an explicit opt-out rather than a breaking change in the strict sense.