### PR TITLE
test(organization): add regression for owner-to-owner invites

### DIFF
--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -720,6 +720,49 @@ describe("organization", async () => {
 		expect(invite.data?.role).toBe("owner");
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8826
+	 */
+	it("should allow owner to invite with owner role when allowInviteByRole is configured", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			user: {
+				modelName: "users",
+			},
+			plugins: [
+				organization({
+					allowInviteByRole: ["owner", "admin"],
+					async sendInvitationEmail(data, request) {},
+				}),
+			],
+			logger: {
+				level: "error",
+			},
+		});
+		const { headers } = await signInWithTestUser();
+		const scopedClient = createAuthClient({
+			plugins: [organizationClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				customFetchImpl: async (url, init) => {
+					return auth.handler(new Request(url, init));
+				},
+			},
+		});
+		const org = await scopedClient.organization.create({
+			name: "allow-invite-by-role-owner",
+			slug: "allow-invite-by-role-owner",
+			fetchOptions: { headers },
+		});
+		const invite = await scopedClient.organization.inviteMember({
+			organizationId: org.data!.id,
+			email: "allow-invite-by-role-owner@test.com",
+			role: "owner",
+			fetchOptions: { headers },
+		});
+		expect(invite.error).toBeNull();
+		expect(invite.data?.role).toBe("owner");
+	});
+
 	it("should allow leaving organization", async () => {
 		const newUser = {
 			email: "leave@org.com",


### PR DESCRIPTION
Resolves #8826.

### Summary
- Adds an organization regression test for the reported configuration: `allowInviteByRole: ["owner", "admin"]`.
- Verifies that an organization owner can invite another user with `role: "owner"`.
- Keeps coverage close to the reported reproduction to prevent regressions.

### Validation
- `pnpm --filter better-auth exec vitest src/plugins/organization/organization.test.ts -t "allow owner to invite with owner role when allowInviteByRole is configured"`
- `pnpm --filter better-auth test`