### PR TITLE
chore(ci): harden GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
       - main
   merge_group:
 
+permissions: {}
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
@@ -18,6 +20,8 @@ env:
 jobs:
   lint:
     runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: read
     concurrency:
       group: ${{ github.workflow }}-lint-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -25,6 +29,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache turbo build setup
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
@@ -86,6 +91,8 @@ jobs:
 
   typecheck:
     runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: read
     concurrency:
       group: ${{ github.workflow }}-typecheck-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -93,6 +100,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache turbo build setup
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
@@ -124,6 +132,8 @@ jobs:
 
   test:
     runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: read
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-test-${{ matrix.node-version }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
@@ -141,6 +151,7 @@ jobs:
         if: github.event_name != 'merge_group'
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache turbo build setup
         if: github.event_name != 'merge_group'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |
@@ -31,6 +33,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
@@ -16,6 +18,8 @@ env:
 jobs:
   demo:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.demo }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -27,6 +31,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache turbo build setup
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,8 @@ env:
   TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
   BETTER_AUTH_TELEMETRY_ENDPOINT: ${{ vars.BETTER_AUTH_TELEMETRY_ENDPOINT }}
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -19,10 +21,13 @@ jobs:
     name: Smoke test
     timeout-minutes: 30
     runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache turbo build setup
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
@@ -49,7 +54,7 @@ jobs:
       - name: Start Docker Containers
         run: docker compose up -d --wait --wait-timeout 60
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
@@ -64,6 +69,8 @@ jobs:
     name: Integration test
     timeout-minutes: 60
     runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Skip integration tests in merge queue
         if: github.event_name == 'merge_group'
@@ -73,6 +80,7 @@ jobs:
         if: github.event_name != 'merge_group'
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache turbo build setup
         if: github.event_name != 'merge_group'
@@ -115,6 +123,8 @@ jobs:
   adapter-integration:
     name: ${{ matrix.packages }} Integration Test
     runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +138,7 @@ jobs:
         if: github.event_name != 'merge_group'
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache turbo build setup
         if: github.event_name != 'merge_group'

--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -17,8 +17,7 @@ on:
         type: string
         default: 'latest'
 
-permissions:
-  id-token: write
+permissions: {}
 
 jobs:
   dist-tag:
@@ -30,6 +29,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Add dist-tag
-        run: npm dist-tag add "${{ inputs.package }}@${{ inputs.version }}" "${{ inputs.tag }}"
+        run: npm dist-tag add "${PACKAGE}@${VERSION}" "${TAG}"
         env:
+          PACKAGE: ${{ inputs.package }}
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ inputs.tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,6 +1,8 @@
 name: Publish Any Commit
 on: [pull_request]
 
+permissions: {}
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
@@ -13,11 +15,14 @@ concurrency:
 jobs:
   build:
     runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cache turbo build setup
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,7 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -19,10 +17,14 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
@@ -73,7 +75,8 @@ jobs:
           echo "Using npm tag: $NPM_TAG"
 
       - name: Publish to npm
-        run: pnpm -r publish --access public --no-git-checks --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
+        run: pnpm -r publish --access public --no-git-checks --tag "${NPM_TAG}"
         env:
+          NPM_TAG: ${{ steps.determine_npm_tag.outputs.npm_tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -8,13 +8,14 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   validate:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Check PR title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,6 +15,7 @@ permissions: {}
 
 jobs:
   zizmor:
+    if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/zizmor.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/zizmor.yml'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      # Intentional: this workflow only reads PR title metadata via GitHub API,
+      # never checks out fork code. The pull_request_target trigger is required
+      # for the action to post/delete PR comments.
+      - semantic-pull-request.yml
+  cache-poisoning:
+    ignore:
+      # False positive: neither setup-node call has caching enabled (no `cache:` param).
+      # The workflow only triggers on tag push, with no shared cache surface.
+      - release.yml


### PR DESCRIPTION
## Summary

Every workflow now follows a deny-all default: `permissions: {}` at the top level forces each job to declare only the permissions it actually needs. This eliminates the risk of compromised actions inheriting broad token access from repository defaults.

The changes fall into 3 categories: access control, supply chain hardening, and injection prevention.

### Access control

- **`permissions: {}` on all 9 workflows** (lock-threads already had it). Each job now declares its own minimal grant: `contents: read` for CI jobs, `contents: write` + `id-token: write` for the release job, `pull-requests: write` for the semantic PR validator.
- **`persist-credentials: false` on all `actions/checkout` steps** (10 total). Prevents the GITHUB_TOKEN from persisting in `.git/config`, where subsequent steps could use it for unintended git operations.
- **Removed unused `id-token: write`** from `npm-dist-tag.yml`, which authenticates via `NPM_TOKEN` secret, not OIDC.
- **Moved top-level permissions to job-level** in `release.yml` and `semantic-pull-request.yml`, so each job's token scope is visible alongside its steps.

### Supply chain hardening

- **SHA-pinned `oven-sh/setup-bun`** (`@v2` to `@0c5077e...`, v2.2.0), the only action still using a mutable tag. All actions across all workflows are now pinned to full commit SHAs.
- **Added zizmor security analysis workflow** that runs on workflow file changes and uploads SARIF findings to the Security tab.
- **Added `.github/zizmor.yml` config** to suppress 2 intentional findings: `pull_request_target` in `semantic-pull-request.yml` (no fork code is checked out) and `cache-poisoning` in `release.yml` (no caching is configured).

### Injection prevention

- **Fixed template injection in `npm-dist-tag.yml`**: `inputs.package`, `inputs.version`, and `inputs.tag` were interpolated directly in `run:`, which allows command injection if the input contains shell metacharacters. Moved all 3 to environment variables.
- **Fixed template injection in `release.yml`**: `steps.determine_npm_tag.outputs.npm_tag` was interpolated in `run:`. Moved to an environment variable.

### Validated locally

```
$ zizmor --gh-token="$(gh auth token)" --config .github/zizmor.yml .github/workflows/
34 findings (3 ignored, 21 suppressed): 1 informational, 0 low, 9 medium, 0 high
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened all GitHub Actions by defaulting to deny-all `permissions: {}` and granting minimal per‑job scopes. Also added zizmor security analysis, pinned the remaining floating action, fixed shell template injection in publish workflows, and made zizmor skip fork PRs to avoid SARIF upload failures.

- **Refactors**
  - Default `permissions: {}` for every workflow; jobs now request only what they need (e.g., `contents: read`; release uses `contents: write` + `id-token: write`; semantic PR uses `pull-requests: write`).
  - Set `persist-credentials: false` on all `actions/checkout`; moved permissions to job-level in `release.yml` and `semantic-pull-request.yml`; removed unused `id-token: write` from `npm-dist-tag.yml`.
  - SHA-pinned `oven-sh/setup-bun`; all actions are now pinned to commit SHAs.

- **New Features**
  - Added zizmor security analysis workflow that runs on workflow file changes, skips on fork PRs, and uploads SARIF to the Security tab.
  - Added `.github/zizmor.yml` to silence two intentional findings for `pull_request_target` and a cache false-positive.

<sup>Written for commit ef57065e47d828e3bab1c17a7d9448b93cfec059. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



