### PR TITLE
chore(docs): ignore `next-env.d.ts`

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .source
 .env
 .DS_Store
+next-env.d.ts

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
> Good to know:
> 
> We recommend adding next-env.d.ts to your .gitignore file.
> The file must be in your tsconfig.json include array (create-next-app does this automatically).

https://nextjs.org/docs/app/api-reference/config/typescript#next-envdts