### PR TITLE
fix: turbo caching, enforce lockfile integrity, expand pre-commit hooks

### DIFF
--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -51,3 +51,4 @@ whsec
 moonshotai
 kimi
 ilike
+nvmrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           cache: pnpm
 
       - name: Install
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         env:
@@ -119,7 +119,7 @@ jobs:
           cache: pnpm
 
       - name: Install
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
@@ -174,7 +174,7 @@ jobs:
 
       - name: Install
         if: github.event_name != 'merge_group'
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Start Docker Containers
         if: github.event_name != 'merge_group'

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,5 +5,15 @@ output:
 pre-commit:
   commands:
     biome:
-      run: pnpm biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      run: pnpm biome check --write --error-on-warnings --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
+    spell:
+      run: pnpm cspell --no-progress --no-summary {staged_files}
+    format:
+      glob: "docs/**/*.{md,mdx}"
+      root: "docs/"
+      run: node_modules/.bin/remark {staged_files} --output --quiet
+      stage_fixed: true
+    lockfile:
+      glob: "{package.json,pnpm-lock.yaml,pnpm-workspace.yaml,packages/*/package.json}"
+      run: pnpm install --frozen-lockfile --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git+https://github.com/better-auth/better-auth.git"
   },
   "scripts": {
+    "prepare": "lefthook install --reset-hooks-path",
     "build": "turbo build --filter=./packages/*",
     "dev": "turbo dev --filter=./packages/* --filter=!./packages/cli",
     "clean": "turbo clean --filter=./packages/* && rm -rf node_modules",
@@ -50,7 +51,7 @@
     "nyc": "^17.1.0",
     "publint": "^0.3.17",
     "tinyglobby": "^0.2.15",
-    "turbo": "^2.8.11",
+    "turbo": "^2.9.3",
     "typescript": "catalog:",
     "vitest": "catalog:vitest"
   }

--- a/packages/api-key/package.json
+++ b/packages/api-key/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -29,7 +29,7 @@
     "dev": "tsdown --watch",
     "test": "vitest",
     "coverage": "vitest run --coverage --coverage.provider=istanbul",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "test:adapters": "vitest run --config vitest.config.adapters.ts",
     "typecheck": "tsc --project tsconfig.json"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "build": "tsdown",
     "dev": "tsx ./src/index.ts",
     "start": "node ./dist/index.mjs",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/drizzle-adapter/package.json
+++ b/packages/drizzle-adapter/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --noEmit",
     "test": "vitest"

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/kysely-adapter/package.json
+++ b/packages/kysely-adapter/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --noEmit",
     "test": "vitest"

--- a/packages/memory-adapter/package.json
+++ b/packages/memory-adapter/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --noEmit",
     "test": "vitest"

--- a/packages/mongo-adapter/package.json
+++ b/packages/mongo-adapter/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --noEmit",
     "test": "vitest"

--- a/packages/oauth-provider/package.json
+++ b/packages/oauth-provider/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/passkey/package.json
+++ b/packages/passkey/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/prisma-adapter/package.json
+++ b/packages/prisma-adapter/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --noEmit",
     "test": "vitest"

--- a/packages/redis-storage/package.json
+++ b/packages/redis-storage/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --noEmit",
     "test": "vitest"

--- a/packages/scim/package.json
+++ b/packages/scim/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json",
     "test": "vitest",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "lint:package": "publint run --strict",
+    "lint:package": "publint run --strict --pack false",
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --project tsconfig.json"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^0.2.15
         version: 0.2.15
       turbo:
-        specifier: ^2.8.11
-        version: 2.8.11
+        specifier: ^2.9.3
+        version: 2.9.3
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -6732,6 +6732,36 @@ packages:
 
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
+
+  '@turbo/darwin-64@2.9.3':
+    resolution: {integrity: sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.3':
+    resolution: {integrity: sha512-SIzEkvtNdzdI50FJDaIQ6kQGqgSSdFPcdn0wqmmONN6iGKjy6hsT+EH99GP65FsfV7DLZTh2NmtTIRl2kdoz5Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.3':
+    resolution: {integrity: sha512-pLRwFmcHHNBvsCySLS6OFabr/07kDT2pxEt/k6eBf/3asiVQZKJ7Rk88AafQx2aYA641qek4RsXvYO3JYpiBug==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.3':
+    resolution: {integrity: sha512-gy6ApUroC2Nzv+qjGtE/uPNkhHAFU4c8God+zd5Aiv9L9uBgHlxVJpHT3XWl5xwlJZ2KWuMrlHTaS5kmNB+q1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.3':
+    resolution: {integrity: sha512-d0YelTX6hAsB7kIEtGB3PzIzSfAg3yDoUlHwuwJc3adBXUsyUIs0YLG+1NNtuhcDOUGnWQeKUoJ2pGWvbpRj7w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.3':
+    resolution: {integrity: sha512-/08CwpKJl3oRY8nOlh2YgilZVJDHsr60XTNxRhuDeuFXONpUZ5X+Nv65izbG/xBew9qxcJFbDX9/sAmAX+ITcQ==}
+    cpu: [arm64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -13883,41 +13913,11 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo-darwin-64@2.8.11:
-    resolution: {integrity: sha512-XKaCWaz4OCt77oYYvGCIRpvYD4c/aNaKjRkUpv+e8rN3RZb+5Xsyew4yRO+gaHdMIUhQznXNXfHlhs+/p7lIhA==}
-    cpu: [x64]
-    os: [darwin]
-
-  turbo-darwin-arm64@2.8.11:
-    resolution: {integrity: sha512-VvynLHGUNvQ9k7GZjRPSsRcK4VkioTfFb7O7liAk4nHKjEcMdls7GqxzjVWgJiKz3hWmQGaP9hRa9UUnhVWCxA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  turbo-linux-64@2.8.11:
-    resolution: {integrity: sha512-cbSn37dcm+EmkQ7DD0euy7xV7o2el4GAOr1XujvkAyKjjNvQ+6QIUeDgQcwAx3D17zPpDvfDMJY2dLQadWnkmQ==}
-    cpu: [x64]
-    os: [linux]
-
-  turbo-linux-arm64@2.8.11:
-    resolution: {integrity: sha512-+trymp2s2aBrhS04l6qFxcExzZ8ffndevuUB9c5RCeqsVpZeiWuGQlWNm5XjOmzoMayxRARZ5ma7yiWbGMiLqQ==}
-    cpu: [arm64]
-    os: [linux]
-
   turbo-stream@2.4.1:
     resolution: {integrity: sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw==}
 
-  turbo-windows-64@2.8.11:
-    resolution: {integrity: sha512-3kJjFSM4yw1n9Uzmi+XkAUgCae19l/bH6RJ442xo7mnZm0tpOjo33F+FYHoSVpIWVMd0HG0LDccyafPSdylQbA==}
-    cpu: [x64]
-    os: [win32]
-
-  turbo-windows-arm64@2.8.11:
-    resolution: {integrity: sha512-JOM4uF2vuLsJUvibdR6X9QqdZr6BhC6Nhlrw4LKFPsXZZI/9HHLoqAiYRpE4MuzIwldCH/jVySnWXrI1SKto0g==}
-    cpu: [arm64]
-    os: [win32]
-
-  turbo@2.8.11:
-    resolution: {integrity: sha512-H+rwSHHPLoyPOSoHdmI1zY0zy0GGj1Dmr7SeJW+nZiWLz2nex8EJ+fkdVabxXFMNEux+aywI4Sae8EqhmnOv4A==}
+  turbo@2.9.3:
+    resolution: {integrity: sha512-J/VUvsGRykPb9R8Kh8dHVBOqioDexLk9BhLCU/ZybRR+HN9UR3cURdazFvNgMDt9zPP8TF6K73Z+tplfmi0PqQ==}
     hasBin: true
 
   tw-animate-css@1.4.0:
@@ -20652,6 +20652,24 @@ snapshots:
       minimatch: 10.2.4
       path-browserify: 1.0.1
       tinyglobby: 0.2.15
+
+  '@turbo/darwin-64@2.9.3':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.3':
+    optional: true
+
+  '@turbo/linux-64@2.9.3':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.3':
+    optional: true
+
+  '@turbo/windows-64@2.9.3':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.3':
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -29705,35 +29723,17 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo-darwin-64@2.8.11:
-    optional: true
-
-  turbo-darwin-arm64@2.8.11:
-    optional: true
-
-  turbo-linux-64@2.8.11:
-    optional: true
-
-  turbo-linux-arm64@2.8.11:
-    optional: true
-
   turbo-stream@2.4.1:
     optional: true
 
-  turbo-windows-64@2.8.11:
-    optional: true
-
-  turbo-windows-arm64@2.8.11:
-    optional: true
-
-  turbo@2.8.11:
+  turbo@2.9.3:
     optionalDependencies:
-      turbo-darwin-64: 2.8.11
-      turbo-darwin-arm64: 2.8.11
-      turbo-linux-64: 2.8.11
-      turbo-linux-arm64: 2.8.11
-      turbo-windows-64: 2.8.11
-      turbo-windows-arm64: 2.8.11
+      '@turbo/darwin-64': 2.9.3
+      '@turbo/darwin-arm64': 2.9.3
+      '@turbo/linux-64': 2.9.3
+      '@turbo/linux-arm64': 2.9.3
+      '@turbo/windows-64': 2.9.3
+      '@turbo/windows-arm64': 2.9.3
 
   tw-animate-css@1.4.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,11 +1,12 @@
 {
   "$schema": "./node_modules/turbo/schema.json",
-  "globalDependencies": [
-    "package.json",
-    "tsconfig.json",
-    "pnpm-lock.yaml",
-    "pnpm-workspace.yaml"
-  ],
+  "futureFlags": {
+    "globalConfiguration": true,
+    "affectedUsingTaskInputs": true
+  },
+  "global": {
+    "inputs": ["tsconfig.json", "tsconfig.base.json", "pnpm-workspace.yaml"]
+  },
   "tasks": {
     "dev": {
       "cache": false,
@@ -13,8 +14,8 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "inputs": ["$TURBO_DEFAULT$", "tsconfig.json", "tsdown.config.*"],
+      "outputs": ["dist/**", "node_modules/.cache/ts/**"]
     },
     "docs#build": {
       "dependsOn": ["^build"],
@@ -28,17 +29,28 @@
         "UPSTASH_REDIS_REST_TOKEN"
       ]
     },
-    "clean": {},
-    "format": {
-      "dependsOn": ["//#format"]
+    "clean": {
+      "cache": false
     },
-    "//#format": {},
-    "lint": {},
+    "format": {
+      "dependsOn": ["//#format"],
+      "cache": false
+    },
+    "//#format": {
+      "cache": false
+    },
+    "lint": {
+      "outputs": []
+    },
     "lint:types": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": ["^build", "build"],
+      "inputs": ["dist/**", "package.json"],
+      "outputs": []
     },
     "lint:package": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": ["^build", "build"],
+      "inputs": ["dist/**", "package.json"],
+      "outputs": []
     },
     "test": {
       "dependsOn": ["^build", "build"],
@@ -83,7 +95,7 @@
         "package.json"
       ],
       "outputs": ["test-results/**", "playwright-report/**"],
-      "cache": true
+      "cache": false
     },
     "e2e:integration": {
       "dependsOn": ["^build"],
@@ -105,7 +117,7 @@
         "test-results/**",
         "playwright-report/**"
       ],
-      "cache": true
+      "cache": false
     },
     "deploy": {
       "cache": false


### PR DESCRIPTION
## Summary

The build and lint infrastructure had structural problems: turbo caching was misconfigured (wrong inputs/outputs, redundant global dependencies, missing tsconfig.base.json), publint ran unnecessary pnpm pack subprocesses, lefthook only ran biome without --error-on-warnings, hooks were never auto-installed, and CI accepted mismatched lockfiles.

## Changes

**Turbo 2.8.11 → 2.9.3** with future flags:
- `globalConfiguration`: `globalDependencies` becomes `global.inputs`, prepended to each task's inputs instead of a single global hash
- `affectedUsingTaskInputs`: `turbo --affected` filters at the task level using `inputs` globs

**turbo.json fixes:**

| Issue | Before | After |
|---|---|---|
| lint:types, lint:package | no inputs/outputs (hashes source files, tools only read dist) | `inputs: ["dist/**", "package.json"]`, `outputs: []` |
| globalDependencies | `package.json, tsconfig.json, pnpm-lock.yaml, pnpm-workspace.yaml` (2 redundant) | `tsconfig.json, tsconfig.base.json, pnpm-workspace.yaml` (moved to `global.inputs`) |
| build outputs | `dist/**, .next/**` (library packages don't use .next) | `dist/**, node_modules/.cache/ts/**` (caches tsbuildinfo for incremental builds) |
| build inputs | `$TURBO_DEFAULT$, .env*` (env not used by libraries) | `$TURBO_DEFAULT$, tsconfig.json, tsdown.config.*` |
| clean, format | cacheable (default) | `cache: false` |
| e2e:smoke, e2e:integration | `cache: true` | `cache: false` (external deps make caching unreliable) |

**publint:** `--pack false` added to all 19 packages (every package has `"files": ["dist"]`, making the pnpm pack subprocess redundant)

**lefthook pre-commit** (all run in parallel, ~3s total):

| Check | Behavior |
|---|---|
| biome (with `--error-on-warnings`) | auto-fixes staged files, re-stages |
| cspell | spell-checks staged files |
| remark | auto-fixes staged markdown in `docs/`, re-stages |
| lockfile validation | runs `pnpm install --frozen-lockfile` when package.json or lockfile staged |

**CI:** `--frozen-lockfile` added to all install steps (3 jobs)

**Other:** `"prepare": "lefthook install --reset-hooks-path"` auto-installs hooks on `pnpm install`