### PR TITLE
fix(oauth-provider): enforce DB-backed sessions with secondary storage

### DIFF
--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -44,6 +44,14 @@ function isRedirectResult(
 }
 
 describe("oauth - init", () => {
+	const createSecondaryStorage = () => ({
+		set(key: string, value: string, ttl?: number) {},
+		get(key: string) {
+			return null;
+		},
+		delete(key: string) {},
+	});
+
 	it("should fail without the jwt plugin", async () => {
 		await expect(
 			getTestInstance({
@@ -84,6 +92,73 @@ describe("oauth - init", () => {
 	it("should pass with correct plugins", async () => {
 		await expect(
 			getTestInstance({
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).resolves.not.toThrowError();
+	});
+
+	it("should fail with secondaryStorage when session config is omitted", async () => {
+		await expect(
+			getTestInstance({
+				secondaryStorage: createSecondaryStorage(),
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).rejects.toThrowError(
+			"OAuth Provider requires `session.storeSessionInDatabase: true` when using secondaryStorage",
+		);
+	});
+
+	it("should fail with secondaryStorage when storeSessionInDatabase is false", async () => {
+		await expect(
+			getTestInstance({
+				secondaryStorage: createSecondaryStorage(),
+				session: {
+					storeSessionInDatabase: false,
+				},
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).rejects.toThrowError(
+			"OAuth Provider requires `session.storeSessionInDatabase: true` when using secondaryStorage",
+		);
+	});
+
+	it("should pass with secondaryStorage when storeSessionInDatabase is true", async () => {
+		await expect(
+			getTestInstance({
+				secondaryStorage: createSecondaryStorage(),
+				session: {
+					storeSessionInDatabase: true,
+				},
 				plugins: [
 					jwt(),
 					oauthProvider({

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -168,8 +168,12 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		version: PACKAGE_VERSION,
 		options: opts as NoInfer<O>,
 		init: (ctx) => {
-			// Require session id storage on database (secondary-storage only solution not yet supported)
-			if (ctx.options.session && !ctx.options.session.storeSessionInDatabase) {
+			// OAuth provider performs adapter-level session lookups by id, so it
+			// currently requires DB-backed sessions whenever secondary storage is enabled.
+			if (
+				ctx.options.secondaryStorage &&
+				ctx.options.session?.storeSessionInDatabase !== true
+			) {
 				throw new BetterAuthError(
 					"OAuth Provider requires `session.storeSessionInDatabase: true` when using secondaryStorage",
 				);


### PR DESCRIPTION
## Summary

This change makes `oauth-provider` fail fast when it is used with `secondaryStorage` without also enabling database-backed sessions.

`oauth-provider` performs adapter-level session lookups by session id, so `session.storeSessionInDatabase` must be explicitly set to `true` when `secondaryStorage` is enabled. Previously, that requirement was only enforced when a `session` config object was present, which allowed unsupported configs to slip through initialization and fail later at runtime.

## Closes #8893 

## Changes

- enforce the existing `session.storeSessionInDatabase: true` requirement whenever `secondaryStorage` is enabled
- keep `getAuthTables()` behavior unchanged
- add regression tests for:
  - `secondaryStorage` with no `session` config
  - `secondaryStorage` with `storeSessionInDatabase: false`
  - `secondaryStorage` with `storeSessionInDatabase: true`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces DB-backed sessions when `secondaryStorage` is enabled in `oauth-provider` to prevent unsupported configs from failing at runtime. Adds an init-time error and regression tests to cover the key scenarios.

- **Bug Fixes**
  - Fail fast if `secondaryStorage` is set and `session.storeSessionInDatabase` is not true.
  - Added tests for omitted session config, `storeSessionInDatabase: false`, and `true`.

- **Migration**
  - If you use `secondaryStorage`, set `session.storeSessionInDatabase: true`.

<sup>Written for commit 6fee32c142102809a8b99c2ee4bbaa421204e94a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

