### PR TITLE
docs: improve select dropdown contrast on enterprise form

### DIFF
--- a/docs/app/enterprise/enterprise-client.tsx
+++ b/docs/app/enterprise/enterprise-client.tsx
@@ -278,14 +278,49 @@ export function EnterprisePageClient() {
 												<select
 													id="enterprise-size"
 													name="companySize"
-													className="w-full px-3 py-2 bg-transparent border border-foreground/[0.15] text-foreground/85 dark:text-foreground/75 text-sm focus:outline-none focus:border-foreground/40 transition-colors appearance-none cursor-pointer font-mono"
+													className="w-full px-3 py-2 bg-background text-foreground border border-foreground/[0.15] text-sm focus:outline-none focus:border-foreground/40 transition-colors appearance-none cursor-pointer font-mono"
 												>
-													<option value="">Select</option>
-													<option value="1-10">1-10</option>
-													<option value="11-50">11-50</option>
-													<option value="51-200">51-200</option>
-													<option value="201-500">201-500</option>
-													<option value="501+">501+</option>
+													<option
+														value=""
+														className="bg-background text-foreground"
+													>
+														Select
+													</option>
+
+													<option
+														value="1-10"
+														className="bg-background text-foreground"
+													>
+														1-10
+													</option>
+
+													<option
+														value="11-50"
+														className="bg-background text-foreground"
+													>
+														11-50
+													</option>
+
+													<option
+														value="51-200"
+														className="bg-background text-foreground"
+													>
+														51-200
+													</option>
+
+													<option
+														value="201-500"
+														className="bg-background text-foreground"
+													>
+														201-500
+													</option>
+
+													<option
+														value="501+"
+														className="bg-background text-foreground"
+													>
+														501+
+													</option>
 												</select>
 											</div>
 


### PR DESCRIPTION
### Fix: Improve dropdown contrast in Enterprise form

#### Before (Current behavior)
<img width="1919" height="960" alt="Screenshot 2026-04-02 010729" src="https://github.com/user-attachments/assets/d8e1163f-23a1-4742-b152-7fc1bb5abff7" />



#### After (Fixed behavior)
<img width="1919" height="908" alt="Screenshot 2026-04-02 005452" src="https://github.com/user-attachments/assets/49647a8b-22bf-43a1-a883-acfdb0b7fd80" />

---

### Changes
- Replaced `bg-transparent` with `bg-background`
- Added background and text color to `<option>` elements
- Improves readability in dark mode

---

### Note
Native `<select>` elements are OS-controlled, so styling may still vary across browsers.

Happy to implement a custom select component if needed.

fixes #8774
