### PR TITLE
fix(core): expose plugin init-contributed options via getPlugin()

### DIFF
--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -1757,6 +1757,31 @@ describe("base context creation", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/8908
 		 */
+		it("should deep-merge nested options between plugin and init in getPlugin()", async () => {
+			const ctx = await initBase({
+				plugins: [
+					{
+						id: "my-plugin",
+						options: { emailAndPassword: { enabled: true } },
+						init: () => ({
+							options: {
+								emailAndPassword: { maxPasswordLength: 256 },
+							},
+						}),
+					} as any,
+				],
+			});
+
+			const plugin = ctx.getPlugin("my-plugin");
+			expect(plugin).not.toBeNull();
+			// Both plugin-defined and init-contributed nested keys are preserved
+			expect(plugin?.options?.emailAndPassword?.enabled).toBe(true);
+			expect(plugin?.options?.emailAndPassword?.maxPasswordLength).toBe(256);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/8908
+		 */
 		it("should prefer plugin-defined options over init-contributed options in getPlugin()", async () => {
 			const ctx = await initBase({
 				plugins: [

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -1730,6 +1730,55 @@ describe("base context creation", () => {
 
 			expect(ctx.internalAdapter).toBeDefined();
 		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/8908
+		 */
+		it("should expose init-contributed options via getPlugin()", async () => {
+			const ctx = await initBase({
+				plugins: [
+					{
+						id: "my-plugin",
+						init: () => ({
+							options: {
+								appName: "from-init",
+							},
+						}),
+					},
+				],
+			});
+
+			const plugin = ctx.getPlugin("my-plugin");
+			expect(plugin).not.toBeNull();
+			// Options contributed via init() should be accessible through getPlugin()
+			expect(plugin?.options?.appName).toBe("from-init");
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/8908
+		 */
+		it("should prefer plugin-defined options over init-contributed options in getPlugin()", async () => {
+			const ctx = await initBase({
+				plugins: [
+					{
+						id: "my-plugin",
+						options: { custom: "original", appName: "plugin-defined" },
+						init: () => ({
+							options: {
+								appName: "from-init",
+							},
+						}),
+					} as any,
+				],
+			});
+
+			const plugin = ctx.getPlugin("my-plugin");
+			expect(plugin).not.toBeNull();
+			// Plugin-defined options take precedence over init-contributed ones
+			expect(plugin?.options?.appName).toBe("plugin-defined");
+			// Both plugin options and init options are accessible
+			expect(plugin?.options?.custom).toBe("original");
+		});
 	});
 
 	describe("additional edge cases", () => {

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -48,7 +48,7 @@ export async function runPluginInit(context: AuthContext) {
 					 * Plugin-defined options take precedence over init-merged ones.
 					 */
 					if (Object.keys(restOpts).length > 0) {
-						plugin.options = { ...restOpts, ...(plugin.options ?? {}) };
+						plugin.options = defu(plugin.options ?? {}, restOpts);
 					}
 				}
 				if (result.context) {

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -42,6 +42,14 @@ export async function runPluginInit(context: AuthContext) {
 						pluginTrustedOrigins.push(trustedOrigins);
 					}
 					options = defu(options, restOpts);
+					/**
+					 * Merge init-contributed options back onto the plugin object so that
+					 * `getPlugin(id)?.options` reflects the effective configuration.
+					 * Plugin-defined options take precedence over init-merged ones.
+					 */
+					if (Object.keys(restOpts).length > 0) {
+						plugin.options = { ...restOpts, ...(plugin.options ?? {}) };
+					}
 				}
 				if (result.context) {
 					// Use Object.assign to keep the reference to the original context

--- a/packages/core/src/error/index.ts
+++ b/packages/core/src/error/index.ts
@@ -11,7 +11,15 @@ export class BetterAuthError extends Error {
 
 export { type APIErrorCode, BASE_ERROR_CODES } from "./codes";
 
+type BaseAPIErrorInstance = InstanceType<typeof BaseAPIError>;
+
 export class APIError extends BaseAPIError {
+	declare status: BaseAPIErrorInstance["status"];
+	declare body: BaseAPIErrorInstance["body"];
+	declare headers: BaseAPIErrorInstance["headers"];
+	declare statusCode: BaseAPIErrorInstance["statusCode"];
+	declare message: string;
+
 	constructor(...args: ConstructorParameters<typeof BaseAPIError>) {
 		super(...args);
 	}


### PR DESCRIPTION
  ## Summary

  - `getPlugin(id)` previously returned the original plugin definition object, causing `plugin.options` to be `undefined` for plugins that contribute options via `init()`
  rather than setting them directly on the definition
  - In `runPluginInit`, after merging `init()`-returned options into `context.options` via `defu`, they are now also merged back onto `plugin.options`
  - Plugin-defined `options` take precedence over `init()`-contributed ones (`{ ...restOpts, ...plugin.options }`)

  ## Test plan

  - [ ] New tests in `create-context.test.ts` verify that `getPlugin(id)?.options` reflects values contributed via `init()`
  - [ ] Existing tests verify that plugin-defined options still take precedence
  - [ ] Run `vitest packages/better-auth/src/context/create-context.test.ts` to confirm

  Fixes #8908 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose init-contributed plugin options via `getPlugin(id)?.options` so consumers see the effective configuration. Also fix `APIError` typings to surface inherited fields in TypeScript. Fixes #8908.

- **Bug Fixes**
  - In `better-auth`, deep-merge `init()`-returned options back into `plugin.options` with `defu` in `runPluginInit`; preserves nested keys and keeps plugin-defined options as the source of truth. Tests cover `getPlugin()` access, nested merge, and precedence.
  - In `core`, declare inherited `APIError` properties (`status`, `body`, `headers`, `statusCode`, `message`) to fix TypeScript type resolution.

<sup>Written for commit 243cfea09622719385cba121bde2c7ad4d46c7f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

