### PR TITLE
fix(client): use basePath as fallback when resolving client baseURL

### DIFF
--- a/.changeset/moody-shrimps-agree.md
+++ b/.changeset/moody-shrimps-agree.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+When basePath was configured but baseURL couldn't be resolved via

--- a/packages/better-auth/src/client/client.test.ts
+++ b/packages/better-auth/src/client/client.test.ts
@@ -659,6 +659,34 @@ describe("type", () => {
 	});
 });
 
+describe("client config", () => {
+	it("should use basePath as baseURL fallback when only basePath is set", async () => {
+		const originalWindow = globalThis.window;
+		// Simulate SSR environment where window.location is not available
+		// @ts-expect-error - intentionally removing window for test
+		globalThis.window = undefined;
+		try {
+			const client = createVueClient({
+				basePath: "/custom/auth",
+				fetchOptions: {
+					customFetchImpl: async () => new Response(),
+				},
+			});
+
+			let capturedUrl = "";
+			const mockUseFetch = async (url: string, _opts: any) => {
+				capturedUrl = url;
+				return { data: null, error: null };
+			};
+
+			await client.useSession(mockUseFetch);
+			expect(capturedUrl).toBe("/custom/auth/get-session");
+		} finally {
+			globalThis.window = originalWindow;
+		}
+	});
+});
+
 describe("plugin actions deep merge", () => {
 	it("should merge actions from multiple plugins with same top-level key", async () => {
 		const client = createVanillaClient({

--- a/packages/better-auth/src/client/config.ts
+++ b/packages/better-auth/src/client/config.ts
@@ -47,6 +47,7 @@ export const getClientConfig = (
 	const baseURL =
 		getBaseURL(options?.baseURL, options?.basePath, undefined, loadEnv) ??
 		resolvePublicAuthUrl(options?.basePath) ??
+		options?.basePath ??
 		"/api/auth";
 	const pluginsFetchPlugins =
 		options?.plugins


### PR DESCRIPTION
   When basePath was configured but baseURL couldn't be resolved via
   getBaseURL or resolvePublicAuthUrl, the client would fall back to
   "/api/auth" instead of using the configured basePath. This caused
   framework-specific fetch wrappers (e.g. Vue's useFetch) to make
   requests to the wrong path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix client baseURL resolution to fall back to the configured basePath when neither baseURL nor the public auth URL can be resolved, so SSR and framework fetch wrappers hit the correct path instead of `/api/auth`.

Adds a Vue `useFetch` test asserting `/custom/auth/get-session` (from `basePath`) is used, plus a changeset for a `better-auth` patch release.

<sup>Written for commit a87c7ec89aacf4c4def3ddee1a11072780369729. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

