### PR TITLE
chore: reset package versions to 1.5.6

### DIFF
--- a/packages/api-key/package.json
+++ b/packages/api-key/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/api-key",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "API Key plugin for Better Auth.",
   "type": "module",
   "license": "MIT",

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-auth",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "The most comprehensive authentication framework for TypeScript.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "The CLI for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/core",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "The most comprehensive authentication framework for TypeScript.",
   "type": "module",
   "license": "MIT",

--- a/packages/drizzle-adapter/package.json
+++ b/packages/drizzle-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/drizzle-adapter",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Drizzle adapter for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/electron",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Better Auth integration for Electron applications.",
   "type": "module",
   "license": "MIT",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/expo",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Better Auth integration for Expo and React Native applications.",
   "type": "module",
   "license": "MIT",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/i18n",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "i18n plugin for Better Auth - translate error messages",
   "type": "module",
   "license": "MIT",

--- a/packages/kysely-adapter/package.json
+++ b/packages/kysely-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/kysely-adapter",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Kysely adapter for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/memory-adapter/package.json
+++ b/packages/memory-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/memory-adapter",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Memory adapter for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/mongo-adapter/package.json
+++ b/packages/mongo-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/mongo-adapter",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Mongo adapter for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/oauth-provider/package.json
+++ b/packages/oauth-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/oauth-provider",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "An oauth provider plugin for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/passkey/package.json
+++ b/packages/passkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/passkey",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Passkey plugin for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/prisma-adapter/package.json
+++ b/packages/prisma-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/prisma-adapter",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Prisma adapter for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/redis-storage/package.json
+++ b/packages/redis-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/redis-storage",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Redis storage for Better Auth secondary storage",
   "type": "module",
   "license": "MIT",

--- a/packages/scim/package.json
+++ b/packages/scim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/scim",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "SCIM plugin for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/sso",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "SSO plugin for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/stripe",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Stripe plugin for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/telemetry",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Telemetry package for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/test-utils",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.6",
   "description": "Testing utilities for Better Auth adapter development",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Reset all 20 package versions from `1.5.7-beta.1` to `1.5.6` to match npm `latest`
- Prepares for the changesets migration in #8903

No code changes — version metadata only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset versions for 20 packages from 1.5.7-beta.1 to 1.5.6 to match npm `latest` and prepare for the upcoming changesets migration. No code changes; only package.json version fields updated.

<sup>Written for commit c2bdb575a0a5eee332ad4fbf9a27efbb4c003ad9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

