### PR TITLE
feat(session): support JWKS-backed JWT session cookie cache

### DIFF
--- a/.changeset/pr-8931.md
+++ b/.changeset/pr-8931.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Add opt-in JWKS-backed asymmetric JWT support for `session_data` cookie cache tokens, so services can verify cookie-cache JWTs with public keys instead of shared secrets.

--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -3,7 +3,15 @@ title: Cookies
 description: Learn how Better Auth uses cookies, including cookie prefixes, custom cookie attributes, cross-subdomain sharing, secure cookies, and handling Safari ITP with proxies.
 ---
 
-Cookies are used to store data such as session tokens, session data, OAuth state, and more. All cookies are signed using the `secret` key provided in the auth options or the `BETTER_AUTH_SECRET` environment variable. If you use [versioned secrets](/docs/reference/options#secrets) for rotation, encrypted cookie data (such as JWE session caches) will automatically use the current key and remain decryptable with previous keys.
+Cookies are used to store data such as session tokens, session data, OAuth state, and more.
+
+- The primary `session_token` cookie remains an opaque, secret-signed session identifier.
+- The `session_data` cookie is only present when `session.cookieCache` is enabled, and its encoding depends on the configured strategy:
+  - `compact`: base64url + HMAC with your Better Auth secret
+  - `jwt`: HS256 by default, or asymmetric JWKS-backed signing when `session.cookieCache.jwt.keySource = "jwks"` and the `jwt()` plugin is installed
+  - `jwe`: encrypted with your Better Auth secret
+
+If you use [versioned secrets](/docs/reference/options#secrets) for rotation, secret-backed cookie data (including signed cookies and encrypted JWE session caches) will automatically use the current key and remain compatible with previous keys where supported.
 
 ### Cookie Prefix
 

--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -5,11 +5,11 @@ description: Learn how Better Auth uses cookies, including cookie prefixes, cust
 
 Cookies are used to store data such as session tokens, session data, OAuth state, and more.
 
-- The primary `session_token` cookie remains an opaque, secret-signed session identifier.
-- The `session_data` cookie is only present when `session.cookieCache` is enabled, and its encoding depends on the configured strategy:
-  - `compact`: base64url + HMAC with your Better Auth secret
-  - `jwt`: HS256 by default, or asymmetric JWKS-backed signing when `session.cookieCache.jwt.keySource = "jwks"` and the `jwt()` plugin is installed
-  - `jwe`: encrypted with your Better Auth secret
+* The primary `session_token` cookie remains an opaque, secret-signed session identifier.
+* The `session_data` cookie is only present when `session.cookieCache` is enabled, and its encoding depends on the configured strategy:
+  * `compact`: base64url + HMAC with your Better Auth secret
+  * `jwt`: HS256 by default, or asymmetric signing with the JWT plugin's JWKS when `session.cookieCache.jwt.signingKey = "jwt-plugin"` and the `jwt()` plugin is installed
+  * `jwe`: encrypted with your Better Auth secret
 
 If you use [versioned secrets](/docs/reference/options#secrets) for rotation, secret-backed cookie data (including signed cookies and encrypted JWE session caches) will automatically use the current key and remain compatible with previous keys where supported.
 

--- a/docs/content/docs/concepts/session-management.mdx
+++ b/docs/content/docs/concepts/session-management.mdx
@@ -5,6 +5,8 @@ description: Learn about session management in Better Auth, including session ex
 
 Better Auth manages session using a traditional cookie-based session management. The session is stored in a cookie and is sent to the server on every request. The server then verifies the session and returns the user data if the session is valid.
 
+The main `session_token` cookie is still the server-side session identifier. If you enable `session.cookieCache`, Better Auth also writes a separate `session_data` cookie for short-lived cached session data. This cache cookie is distinct from the JWT plugin's `/token` endpoint and `set-auth-jwt` header output.
+
 ## Session table
 
 The session table stores the session data. The session table has the following fields:
@@ -249,7 +251,7 @@ export const auth = betterAuth({
 Better Auth supports three different encoding strategies for cookie cache:
 
 * **`compact`** (default): Uses base64url encoding with HMAC-SHA256 signature. Most compact format with no JWT spec overhead. Best for performance and size.
-* **`jwt`**: Standard JWT with HMAC-SHA256 signature (HS256). Signed but not encrypted - readable by anyone but tamper-proof. Follows JWT spec for interoperability.
+* **`jwt`**: Standard JWT. By default this uses HMAC-SHA256 (HS256) with your Better Auth secret. Signed but not encrypted - readable by anyone but tamper-proof. If you need JWKS-verifiable session cache cookies, install the `jwt()` plugin and set `session.cookieCache.jwt.keySource = "jwks"` to use its asymmetric signing keys instead.
 * **`jwe`**: Uses JWE (JSON Web Encryption) with A256CBC-HS512 and HKDF key derivation. Fully encrypted tokens - neither readable nor tamperable. Most secure but largest size.
 
 **Comparison:**
@@ -277,8 +279,32 @@ export const auth = betterAuth({
 **When to use each:**
 
 * **Use `compact`** when you need maximum performance and smallest cookie size. Best for most applications where cookies are only used internally by Better Auth.
-* **Use `jwt`** when you need JWT compatibility for external systems, or when you want standard JWT tokens that can be verified by third-party tools. The tokens are readable (base64-encoded JSON) but tamper-proof.
+* **Use `jwt`** when you need JWT compatibility for external systems, or when you want standard JWT tokens that can be verified by third-party tools. The tokens are readable (base64-encoded JSON) but tamper-proof. Add `jwt: { keySource: "jwks" }` if you want the cookie-cache JWT to verify against Better Auth's JWKS instead of a shared secret.
 * **Use `jwe`** when you need maximum security and want to hide session data from the client. The tokens are fully encrypted and cannot be read without the secret key. Use this for sensitive data or compliance requirements.
+
+### JWKS-backed cookie-cache JWTs
+
+If you want the `session_data` cookie to be verifiable with the JWT plugin's JWKS endpoint instead of a shared secret, enable the JWT plugin and opt into JWKS-backed signing explicitly:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+import { jwt } from "better-auth/plugins"
+
+export const auth = betterAuth({
+    plugins: [jwt()],
+    session: {
+        cookieCache: {
+            enabled: true,
+            strategy: "jwt",
+            jwt: {
+                keySource: "jwks"
+            }
+        }
+    }
+})
+```
+
+This only affects the `session_data` cookie. The primary `session_token` cookie is still an opaque session identifier and is not exposed through JWKS.
 
 If you want to disable returning from the cookie cache when fetching the session, you can pass `disableCookieCache:true` this will force the server to fetch the session from the database and also refresh the cookie cache.
 

--- a/docs/content/docs/concepts/session-management.mdx
+++ b/docs/content/docs/concepts/session-management.mdx
@@ -251,7 +251,7 @@ export const auth = betterAuth({
 Better Auth supports three different encoding strategies for cookie cache:
 
 * **`compact`** (default): Uses base64url encoding with HMAC-SHA256 signature. Most compact format with no JWT spec overhead. Best for performance and size.
-* **`jwt`**: Standard JWT. By default this uses HMAC-SHA256 (HS256) with your Better Auth secret. Signed but not encrypted - readable by anyone but tamper-proof. If you need JWKS-verifiable session cache cookies, install the `jwt()` plugin and set `session.cookieCache.jwt.keySource = "jwks"` to use its asymmetric signing keys instead.
+* **`jwt`**: Standard JWT. By default this uses HMAC-SHA256 (HS256) with your Better Auth secret. Signed but not encrypted - readable by anyone but tamper-proof. If you need session cache cookies that verify against the JWT plugin's JWKS, install the `jwt()` plugin and set `session.cookieCache.jwt.signingKey = "jwt-plugin"` to use its asymmetric signing keys instead.
 * **`jwe`**: Uses JWE (JSON Web Encryption) with A256CBC-HS512 and HKDF key derivation. Fully encrypted tokens - neither readable nor tamperable. Most secure but largest size.
 
 **Comparison:**
@@ -279,7 +279,7 @@ export const auth = betterAuth({
 **When to use each:**
 
 * **Use `compact`** when you need maximum performance and smallest cookie size. Best for most applications where cookies are only used internally by Better Auth.
-* **Use `jwt`** when you need JWT compatibility for external systems, or when you want standard JWT tokens that can be verified by third-party tools. The tokens are readable (base64-encoded JSON) but tamper-proof. Add `jwt: { keySource: "jwks" }` if you want the cookie-cache JWT to verify against Better Auth's JWKS instead of a shared secret.
+* **Use `jwt`** when you need JWT compatibility for external systems, or when you want standard JWT tokens that can be verified by third-party tools. The tokens are readable (base64-encoded JSON) but tamper-proof. Add `jwt: { signingKey: "jwt-plugin" }` if you want the cookie-cache JWT to verify against the JWT plugin's JWKS instead of a shared secret.
 * **Use `jwe`** when you need maximum security and want to hide session data from the client. The tokens are fully encrypted and cannot be read without the secret key. Use this for sensitive data or compliance requirements.
 
 ### JWKS-backed cookie-cache JWTs
@@ -297,14 +297,14 @@ export const auth = betterAuth({
             enabled: true,
             strategy: "jwt",
             jwt: {
-                keySource: "jwks"
+                signingKey: "jwt-plugin"
             }
         }
     }
 })
 ```
 
-This only affects the `session_data` cookie. The primary `session_token` cookie is still an opaque session identifier and is not exposed through JWKS.
+This only affects the `session_data` cookie. The primary `session_token` cookie is still an opaque session identifier and is not exposed through JWKS. Cookie-cache JWTs also use a separate token profile from the JWT plugin's `/token` endpoint, so those tokens are not interchangeable.
 
 If you want to disable returning from the cookie cache when fetching the session, you can pass `disableCookieCache:true` this will force the server to fetch the session from the database and also refresh the cookie cache.
 

--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -9,6 +9,12 @@ The JWT plugin provides endpoints to retrieve a JWT token and a JWKS endpoint to
   This plugin is not meant as a replacement for the session. It's meant to be used for services that require JWT tokens. If you're looking to use JWT tokens for authentication, check out the [Bearer Plugin](/docs/plugins/bearer).
 </Callout>
 
+<Callout type="info">
+  The JWT plugin's `/token` endpoint and `set-auth-jwt` header produce JWKS-verifiable JWTs for external services. They are separate from Better Auth's primary `session_token` cookie.
+
+  If you enable `session.cookieCache.strategy = "jwt"`, the `session_data` cookie still uses HS256 with your Better Auth secret by default. To make that cookie-cache JWT verifiable with JWKS too, install `jwt()` and opt into `session.cookieCache.jwt.keySource = "jwks"`.
+</Callout>
+
 ## Installation
 
 <Steps>

--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -12,7 +12,7 @@ The JWT plugin provides endpoints to retrieve a JWT token and a JWKS endpoint to
 <Callout type="info">
   The JWT plugin's `/token` endpoint and `set-auth-jwt` header produce JWKS-verifiable JWTs for external services. They are separate from Better Auth's primary `session_token` cookie.
 
-  If you enable `session.cookieCache.strategy = "jwt"`, the `session_data` cookie still uses HS256 with your Better Auth secret by default. To make that cookie-cache JWT verifiable with JWKS too, install `jwt()` and opt into `session.cookieCache.jwt.keySource = "jwks"`.
+  If you enable `session.cookieCache.strategy = "jwt"`, the `session_data` cookie still uses HS256 with your Better Auth secret by default. To make that cookie-cache JWT verifiable with the JWT plugin's JWKS too, install `jwt()` and opt into `session.cookieCache.jwt.signingKey = "jwt-plugin"`.
 </Callout>
 
 ## Installation

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -448,7 +448,11 @@ export const auth = betterAuth({
 		preserveSessionInDatabase: false, // Preserve session records in database when deleted from secondary storage (default: `false`)
 		cookieCache: {
 			enabled: true, // Enable caching session in cookie (default: `false`)	
-			maxAge: 300 // 5 minutes
+			maxAge: 300, // 5 minutes
+			strategy: "jwt",
+			jwt: {
+				keySource: "jwks" // or "secret" (default for JWT strategy)
+			}
 		}
 	},
 })
@@ -462,6 +466,7 @@ export const auth = betterAuth({
 * `storeSessionInDatabase`: Store session in database when secondary storage is provided (default: `false`)
 * `preserveSessionInDatabase`: Preserve session records in database when deleted from secondary storage (default: `false`)
 * `cookieCache`: Enable caching session in cookie
+* `cookieCache.jwt.keySource`: For `strategy: "jwt"`, choose `"secret"` (HS256, default) or `"jwks"` (asymmetric JWTs backed by the `jwt()` plugin)
 
 ## `account`
 

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -448,13 +448,13 @@ export const auth = betterAuth({
 		preserveSessionInDatabase: false, // Preserve session records in database when deleted from secondary storage (default: `false`)
 		cookieCache: {
 			enabled: true, // Enable caching session in cookie (default: `false`)	
-			maxAge: 300, // 5 minutes
-			strategy: "jwt",
-			jwt: {
-				keySource: "jwks" // or "secret" (default for JWT strategy)
+				maxAge: 300, // 5 minutes
+				strategy: "jwt",
+				jwt: {
+					signingKey: "jwt-plugin" // or "secret" (default for JWT strategy)
+				}
 			}
-		}
-	},
+		},
 })
 ```
 
@@ -466,7 +466,7 @@ export const auth = betterAuth({
 * `storeSessionInDatabase`: Store session in database when secondary storage is provided (default: `false`)
 * `preserveSessionInDatabase`: Preserve session records in database when deleted from secondary storage (default: `false`)
 * `cookieCache`: Enable caching session in cookie
-* `cookieCache.jwt.keySource`: For `strategy: "jwt"`, choose `"secret"` (HS256, default) or `"jwks"` (asymmetric JWTs backed by the `jwt()` plugin)
+* `cookieCache.jwt.signingKey`: For `strategy: "jwt"`, choose `"secret"` (HS256, default) or `"jwt-plugin"` (asymmetric JWTs backed by the `jwt()` plugin)
 
 ## `account`
 

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -20,14 +20,13 @@ import { parseCookies, parseSetCookieHeader } from "../../cookies";
 import { signJWT, verifyJWT } from "../../crypto";
 import { jwt } from "../../plugins";
 import { admin } from "../../plugins/admin";
-import {
-	COOKIE_CACHE_JWT_AUDIENCE,
-	COOKIE_CACHE_JWT_TYPE,
-} from "../../plugins/jwt/cookie-cache";
 import { organization } from "../../plugins/organization";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { getDate } from "../../utils/date";
 import { freshSessionMiddleware, getSessionFromCtx } from "./session";
+
+const COOKIE_CACHE_JWT_TYPE = "better-auth.session-cache+jwt";
+const COOKIE_CACHE_JWT_AUDIENCE = "better-auth:session-cache";
 
 describe("session", async () => {
 	const { client, testUser, sessionSetter, cookieSetter, auth } =

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -20,6 +20,10 @@ import { parseCookies, parseSetCookieHeader } from "../../cookies";
 import { signJWT, verifyJWT } from "../../crypto";
 import { jwt } from "../../plugins";
 import { admin } from "../../plugins/admin";
+import {
+	COOKIE_CACHE_JWT_AUDIENCE,
+	COOKIE_CACHE_JWT_TYPE,
+} from "../../plugins/jwt/cookie-cache";
 import { organization } from "../../plugins/organization";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { getDate } from "../../utils/date";
@@ -889,7 +893,7 @@ describe("cookie cache with JWT strategy backed by JWKS", async () => {
 				strategy: "jwt",
 				refreshCache: false,
 				jwt: {
-					keySource: "jwks",
+					signingKey: "jwt-plugin",
 				},
 			},
 		},
@@ -932,15 +936,85 @@ describe("cookie cache with JWT strategy backed by JWKS", async () => {
 
 		const protectedHeader = decodeProtectedHeader(token);
 		expect(protectedHeader.kid).toEqual(expect.any(String));
+		expect(protectedHeader.typ).toBe(COOKIE_CACHE_JWT_TYPE);
 
 		const jwks = await auth.api.getJwks();
 		const localJwks = createLocalJWKSet(jwks);
-		const verified = await jwtVerify(token, localJwks);
+		const verified = await jwtVerify(token, localJwks, {
+			audience: COOKIE_CACHE_JWT_AUDIENCE,
+		});
 
 		expect(verified.payload.session).toBeDefined();
+		expect(verified.payload.iss).toEqual(expect.any(String));
+		expect(verified.payload.aud).toBe(COOKIE_CACHE_JWT_AUDIENCE);
+		expect(verified.payload.sub).toBe(session.data?.user.id);
+		expect(verified.payload.sid).toBe(session.data?.session.token);
 		expect(session.data?.session).not.toHaveProperty("sensitiveData");
 		expect(session.data).not.toBeNull();
 		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it("should ignore a JWKS cookie cache from a different session token", async () => {
+		const firstHeaders = new Headers();
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(firstHeaders),
+			},
+		);
+		const firstSession = await client.getSession({
+			fetchOptions: {
+				headers: firstHeaders,
+			},
+		});
+
+		const secondHeaders = new Headers();
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(secondHeaders),
+			},
+		);
+		const secondSession = await client.getSession({
+			fetchOptions: {
+				headers: secondHeaders,
+			},
+		});
+
+		const firstCookieCache = parseCookies(firstHeaders.get("cookie") || "").get(
+			"better-auth.session_data",
+		);
+		const secondSessionCookie = parseCookies(
+			secondHeaders.get("cookie") || "",
+		).get("better-auth.session_token");
+		if (!firstCookieCache || !secondSessionCookie || !secondSession.data) {
+			throw new Error("Expected both session cookies to be present");
+		}
+
+		const mixedHeaders = new Headers();
+		mixedHeaders.set(
+			"cookie",
+			`better-auth.session_data=${firstCookieCache}; better-auth.session_token=${secondSessionCookie}`,
+		);
+
+		const mixedSession = await client.getSession({
+			fetchOptions: {
+				headers: mixedHeaders,
+			},
+		});
+
+		expect(mixedSession.data?.session.token).toBe(
+			secondSession.data.session.token,
+		);
+		expect(mixedSession.data?.session.token).not.toBe(
+			firstSession.data?.session.token,
+		);
 	});
 
 	it("should not allow tampering with the cookie in JWKS mode", async () => {
@@ -965,7 +1039,9 @@ describe("cookie cache with JWT strategy backed by JWKS", async () => {
 
 		const jwks = await auth.api.getJwks();
 		const localJwks = createLocalJWKSet(jwks);
-		const verified = await jwtVerify(token, localJwks);
+		const verified = await jwtVerify(token, localJwks, {
+			audience: COOKIE_CACHE_JWT_AUDIENCE,
+		});
 		const verifiedPayload = verified.payload as {
 			session: Record<string, any>;
 			user: Record<string, any>;
@@ -989,8 +1065,10 @@ describe("cookie cache with JWT strategy backed by JWKS", async () => {
 			throw new Error("Session cookie not found");
 		}
 
-		headers.set("cookie", `better-auth.session_data=${tamperedToken}`);
-		headers.append("cookie", `better-auth.session_token=${sessionCookie}`);
+		headers.set(
+			"cookie",
+			`better-auth.session_data=${tamperedToken}; better-auth.session_token=${sessionCookie}`,
+		);
 		const res = await client.getSession({
 			fetchOptions: {
 				headers,
@@ -1008,7 +1086,7 @@ describe("cookie cache with JWT strategy backed by JWKS", async () => {
 					enabled: true,
 					strategy: "jwt",
 					jwt: {
-						keySource: "jwks",
+						signingKey: "jwt-plugin",
 					},
 				},
 			},
@@ -1053,7 +1131,9 @@ describe("cookie cache with JWT strategy backed by JWKS", async () => {
 		expect(jwks.keys.length).toBeGreaterThan(1);
 
 		const localJwks = createLocalJWKSet(jwks);
-		const verified = await jwtVerify(originalToken, localJwks);
+		const verified = await jwtVerify(originalToken, localJwks, {
+			audience: COOKIE_CACHE_JWT_AUDIENCE,
+		});
 		expect(verified.payload.session).toBeDefined();
 	});
 });

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@better-auth/core/context";
 import type { MemoryDB } from "@better-auth/memory-adapter";
 import { memoryAdapter } from "@better-auth/memory-adapter";
+import { createLocalJWKSet, decodeProtectedHeader, jwtVerify } from "jose";
 import {
 	afterEach,
 	beforeEach,
@@ -17,6 +18,7 @@ import {
 } from "vitest";
 import { parseCookies, parseSetCookieHeader } from "../../cookies";
 import { signJWT, verifyJWT } from "../../crypto";
+import { jwt } from "../../plugins";
 import { admin } from "../../plugins/admin";
 import { organization } from "../../plugins/organization";
 import { getTestInstance } from "../../test-utils/test-instance";
@@ -869,6 +871,190 @@ describe("cookie cache with JWT strategy", async () => {
 			expect(result.data).not.toBeNull();
 			expect(result.data?.user.email).toBe(testUser.email);
 		});
+	});
+});
+
+describe("cookie cache with JWT strategy backed by JWKS", async () => {
+	const { auth, client, testUser, cookieSetter } = await getTestInstance({
+		session: {
+			additionalFields: {
+				sensitiveData: {
+					type: "string",
+					returned: false,
+					defaultValue: "sensitive-data",
+				},
+			},
+			cookieCache: {
+				enabled: true,
+				strategy: "jwt",
+				refreshCache: false,
+				jwt: {
+					keySource: "jwks",
+				},
+			},
+		},
+		plugins: [jwt()],
+	});
+	const ctx = await auth.$context;
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	const fn = vi.spyOn(ctx.adapter, "findOne");
+
+	it("should cache cookies with JWKS-backed JWT strategy", async () => {
+		const headers = new Headers();
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(headers),
+			},
+		);
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const token = parseCookies(headers.get("cookie") || "").get(
+			"better-auth.session_data",
+		);
+		if (!token) {
+			throw new Error("JWT not found");
+		}
+
+		const protectedHeader = decodeProtectedHeader(token);
+		expect(protectedHeader.kid).toEqual(expect.any(String));
+
+		const jwks = await auth.api.getJwks();
+		const localJwks = createLocalJWKSet(jwks);
+		const verified = await jwtVerify(token, localJwks);
+
+		expect(verified.payload.session).toBeDefined();
+		expect(session.data?.session).not.toHaveProperty("sensitiveData");
+		expect(session.data).not.toBeNull();
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not allow tampering with the cookie in JWKS mode", async () => {
+		const headers = new Headers();
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(headers),
+			},
+		);
+
+		const token = parseCookies(headers.get("cookie") || "").get(
+			"better-auth.session_data",
+		);
+		if (!token) {
+			throw new Error("JWT not found");
+		}
+
+		const jwks = await auth.api.getJwks();
+		const localJwks = createLocalJWKSet(jwks);
+		const verified = await jwtVerify(token, localJwks);
+		const verifiedPayload = verified.payload as {
+			session: Record<string, any>;
+			user: Record<string, any>;
+		};
+
+		const tamperedToken = await signJWT(
+			{
+				session: verifiedPayload.session,
+				user: {
+					...verifiedPayload.user,
+					id: "tampered-id",
+				},
+			},
+			"tampered-secret",
+		);
+
+		const sessionCookie = parseCookies(headers.get("cookie") || "").get(
+			"better-auth.session_token",
+		);
+		if (!sessionCookie) {
+			throw new Error("Session cookie not found");
+		}
+
+		headers.set("cookie", `better-auth.session_data=${tamperedToken}`);
+		headers.append("cookie", `better-auth.session_token=${sessionCookie}`);
+		const res = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(res.data).toBeNull();
+	});
+
+	it("should verify existing cookie-cache JWTs across JWKS rotation grace period", async () => {
+		vi.useFakeTimers();
+
+		const { auth, client, testUser, cookieSetter } = await getTestInstance({
+			session: {
+				cookieCache: {
+					enabled: true,
+					strategy: "jwt",
+					jwt: {
+						keySource: "jwks",
+					},
+				},
+			},
+			plugins: [
+				jwt({
+					jwks: {
+						rotationInterval: 1,
+						gracePeriod: 60,
+					},
+				}),
+			],
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(headers),
+			},
+		);
+
+		const originalToken = parseCookies(headers.get("cookie") || "").get(
+			"better-auth.session_data",
+		);
+		if (!originalToken) {
+			throw new Error("JWT not found");
+		}
+
+		await vi.advanceTimersByTimeAsync(1_100);
+		await auth.api.signJWT({
+			body: {
+				payload: {
+					sub: "rotated-user",
+				},
+			},
+		});
+
+		const jwks = await auth.api.getJwks();
+		expect(jwks.keys.length).toBeGreaterThan(1);
+
+		const localJwks = createLocalJWKSet(jwks);
+		const verified = await jwtVerify(originalToken, localJwks);
+		expect(verified.payload.session).toBeDefined();
 	});
 });
 

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -25,7 +25,7 @@ import { getSessionQuerySchema } from "../../cookies/session-store";
 import { symmetricDecodeJWT, verifyJWT as verifySecretJWT } from "../../crypto";
 import { parseSessionOutput, parseUserOutput } from "../../db";
 import {
-	getCookieCacheJwtKeySource,
+	getCookieCacheJwtSigningKey,
 	verifyCookieCacheJWT,
 } from "../../plugins/jwt/cookie-cache";
 import type { Prettify, Session, User } from "../../types";
@@ -115,7 +115,9 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 				if (sessionDataCookie) {
 					const strategy =
 						ctx.context.options.session?.cookieCache?.strategy || "compact";
-					const jwtKeySource = getCookieCacheJwtKeySource(ctx.context.options);
+					const jwtSigningKey = getCookieCacheJwtSigningKey(
+						ctx.context.options,
+					);
 
 					if (strategy === "jwe") {
 						// Decode JWE (encrypted)
@@ -147,7 +149,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 						}
 					} else if (strategy === "jwt") {
 						const payload =
-							jwtKeySource === "jwks"
+							jwtSigningKey === "jwt-plugin"
 								? await verifyCookieCacheJWT<{
 										session: Session;
 										user: User;
@@ -227,131 +229,50 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 				) {
 					const session = sessionDataPayload.session;
 
-					const versionConfig =
-						ctx.context.options.session?.cookieCache?.version;
-					let expectedVersion = "1";
-					if (versionConfig) {
-						if (typeof versionConfig === "string") {
-							expectedVersion = versionConfig;
-						} else if (typeof versionConfig === "function") {
-							const result = versionConfig(session.session, session.user);
-							expectedVersion =
-								result instanceof Promise ? await result : result;
+					let shouldExpireCookieCache =
+						session.session.token !== sessionCookieToken;
+
+					if (!shouldExpireCookieCache) {
+						const versionConfig =
+							ctx.context.options.session?.cookieCache?.version;
+						let expectedVersion = "1";
+						if (versionConfig) {
+							if (typeof versionConfig === "string") {
+								expectedVersion = versionConfig;
+							} else if (typeof versionConfig === "function") {
+								const result = versionConfig(session.session, session.user);
+								expectedVersion =
+									result instanceof Promise ? await result : result;
+							}
 						}
+
+						const cookieVersion = session.version || "1";
+						shouldExpireCookieCache = cookieVersion !== expectedVersion;
 					}
 
-					const cookieVersion = session.version || "1";
-					if (cookieVersion !== expectedVersion) {
-						// Version mismatch - invalidate the cookie cache
-						expireCookie(ctx, ctx.context.authCookies.sessionData);
-					} else {
+					if (!shouldExpireCookieCache) {
+						const now = Date.now();
 						const cachedSessionExpiresAt = new Date(
 							session.session.expiresAt as unknown as string | number | Date,
-						);
-						const hasExpired =
-							sessionDataPayload.expiresAt < Date.now() ||
-							cachedSessionExpiresAt < new Date();
+						).getTime();
+						shouldExpireCookieCache =
+							sessionDataPayload.expiresAt < now ||
+							!Number.isFinite(cachedSessionExpiresAt) ||
+							cachedSessionExpiresAt < now;
+					}
 
-						if (hasExpired) {
-							// When the session data cookie has expired, delete it;
-							//  then we try to fetch from DB
-							expireCookie(ctx, ctx.context.authCookies.sessionData);
-						} else {
-							// Check if the cookie cache needs to be refreshed based on refreshCache
-							const cookieRefreshCache =
-								ctx.context.sessionConfig.cookieRefreshCache;
+					if (shouldExpireCookieCache) {
+						expireCookie(ctx, ctx.context.authCookies.sessionData);
+					} else {
+						// Check if the cookie cache needs to be refreshed based on refreshCache
+						const cookieRefreshCache =
+							ctx.context.sessionConfig.cookieRefreshCache;
 
-							if (cookieRefreshCache === false) {
-								// If refreshCache is disabled, return the session from cookie as-is
-								ctx.context.session = session;
-								// Parse session and user to ensure additionalFields are included
-								// Rehydrate date fields from JSON strings before parsing
-								const parsedSession = parseSessionOutput(ctx.context.options, {
-									...session.session,
-									expiresAt: new Date(session.session.expiresAt),
-									createdAt: new Date(session.session.createdAt),
-									updatedAt: new Date(session.session.updatedAt),
-								});
-								const parsedUser = parseUserOutput(ctx.context.options, {
-									...session.user,
-									createdAt: new Date(session.user.createdAt),
-									updatedAt: new Date(session.user.updatedAt),
-								});
-								return ctx.json({
-									session: parsedSession,
-									user: parsedUser,
-								} as {
-									session: Session<Option["session"], Option["plugins"]>;
-									user: User<Option["user"], Option["plugins"]>;
-								});
-							}
-
-							const timeUntilExpiry = sessionDataPayload.expiresAt - Date.now();
-							const updateAge = cookieRefreshCache.updateAge * 1000; // Convert to milliseconds
-							const shouldSkipSessionRefresh =
-								await getShouldSkipSessionRefresh();
-
-							if (timeUntilExpiry < updateAge && !shouldSkipSessionRefresh) {
-								const refreshedSession = {
-									session: {
-										...session.session,
-									},
-									user: session.user,
-									updatedAt: Date.now(),
-								};
-
-								// Set the refreshed cookie cache
-								await setCookieCache(ctx, refreshedSession, false);
-
-								// Also refresh the session_token cookie expiry
-								const sessionTokenOptions =
-									ctx.context.authCookies.sessionToken.attributes;
-								const sessionTokenMaxAge = dontRememberMe
-									? undefined
-									: ctx.context.sessionConfig.expiresIn;
-								await ctx.setSignedCookie(
-									ctx.context.authCookies.sessionToken.name,
-									session.session.token,
-									ctx.context.secret,
-									{
-										...sessionTokenOptions,
-										maxAge: sessionTokenMaxAge,
-									},
-								);
-
-								// Parse session and user to ensure additionalFields are included
-								// Rehydrate date fields from JSON strings before parsing
-								const parsedRefreshedSession = parseSessionOutput(
-									ctx.context.options,
-									{
-										...refreshedSession.session,
-										expiresAt: new Date(refreshedSession.session.expiresAt),
-										createdAt: new Date(refreshedSession.session.createdAt),
-										updatedAt: new Date(refreshedSession.session.updatedAt),
-									},
-								);
-								const parsedRefreshedUser = parseUserOutput(
-									ctx.context.options,
-									{
-										...refreshedSession.user,
-										createdAt: new Date(refreshedSession.user.createdAt),
-										updatedAt: new Date(refreshedSession.user.updatedAt),
-									},
-								);
-								ctx.context.session = {
-									session: parsedRefreshedSession,
-									user: parsedRefreshedUser,
-								};
-								return ctx.json({
-									session: parsedRefreshedSession,
-									user: parsedRefreshedUser,
-								} as {
-									session: Session<Option["session"], Option["plugins"]>;
-									user: User<Option["user"], Option["plugins"]>;
-								});
-							}
-
+						if (cookieRefreshCache === false) {
+							// If refreshCache is disabled, return the session from cookie as-is
+							ctx.context.session = session;
 							// Parse session and user to ensure additionalFields are included
+							// Rehydrate date fields from JSON strings before parsing
 							const parsedSession = parseSessionOutput(ctx.context.options, {
 								...session.session,
 								expiresAt: new Date(session.session.expiresAt),
@@ -363,10 +284,6 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 								createdAt: new Date(session.user.createdAt),
 								updatedAt: new Date(session.user.updatedAt),
 							});
-							ctx.context.session = {
-								session: parsedSession,
-								user: parsedUser,
-							};
 							return ctx.json({
 								session: parsedSession,
 								user: parsedUser,
@@ -375,6 +292,92 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 								user: User<Option["user"], Option["plugins"]>;
 							});
 						}
+
+						const timeUntilExpiry = sessionDataPayload.expiresAt - Date.now();
+						const updateAge = cookieRefreshCache.updateAge * 1000; // Convert to milliseconds
+						const shouldSkipSessionRefresh =
+							await getShouldSkipSessionRefresh();
+
+						if (timeUntilExpiry < updateAge && !shouldSkipSessionRefresh) {
+							const refreshedSession = {
+								session: {
+									...session.session,
+								},
+								user: session.user,
+								updatedAt: Date.now(),
+							};
+
+							// Set the refreshed cookie cache
+							await setCookieCache(ctx, refreshedSession, false);
+
+							// Also refresh the session_token cookie expiry
+							const sessionTokenOptions =
+								ctx.context.authCookies.sessionToken.attributes;
+							const sessionTokenMaxAge = dontRememberMe
+								? undefined
+								: ctx.context.sessionConfig.expiresIn;
+							await ctx.setSignedCookie(
+								ctx.context.authCookies.sessionToken.name,
+								session.session.token,
+								ctx.context.secret,
+								{
+									...sessionTokenOptions,
+									maxAge: sessionTokenMaxAge,
+								},
+							);
+
+							// Parse session and user to ensure additionalFields are included
+							// Rehydrate date fields from JSON strings before parsing
+							const parsedRefreshedSession = parseSessionOutput(
+								ctx.context.options,
+								{
+									...refreshedSession.session,
+									expiresAt: new Date(refreshedSession.session.expiresAt),
+									createdAt: new Date(refreshedSession.session.createdAt),
+									updatedAt: new Date(refreshedSession.session.updatedAt),
+								},
+							);
+							const parsedRefreshedUser = parseUserOutput(ctx.context.options, {
+								...refreshedSession.user,
+								createdAt: new Date(refreshedSession.user.createdAt),
+								updatedAt: new Date(refreshedSession.user.updatedAt),
+							});
+							ctx.context.session = {
+								session: parsedRefreshedSession,
+								user: parsedRefreshedUser,
+							};
+							return ctx.json({
+								session: parsedRefreshedSession,
+								user: parsedRefreshedUser,
+							} as {
+								session: Session<Option["session"], Option["plugins"]>;
+								user: User<Option["user"], Option["plugins"]>;
+							});
+						}
+
+						// Parse session and user to ensure additionalFields are included
+						const parsedSession = parseSessionOutput(ctx.context.options, {
+							...session.session,
+							expiresAt: new Date(session.session.expiresAt),
+							createdAt: new Date(session.session.createdAt),
+							updatedAt: new Date(session.session.updatedAt),
+						});
+						const parsedUser = parseUserOutput(ctx.context.options, {
+							...session.user,
+							createdAt: new Date(session.user.createdAt),
+							updatedAt: new Date(session.user.updatedAt),
+						});
+						ctx.context.session = {
+							session: parsedSession,
+							user: parsedUser,
+						};
+						return ctx.json({
+							session: parsedSession,
+							user: parsedUser,
+						} as {
+							session: Session<Option["session"], Option["plugins"]>;
+							user: User<Option["user"], Option["plugins"]>;
+						});
 					}
 				}
 

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -22,8 +22,12 @@ import {
 	setSessionCookie,
 } from "../../cookies";
 import { getSessionQuerySchema } from "../../cookies/session-store";
-import { symmetricDecodeJWT, verifyJWT } from "../../crypto";
+import { symmetricDecodeJWT, verifyJWT as verifySecretJWT } from "../../crypto";
 import { parseSessionOutput, parseUserOutput } from "../../db";
+import {
+	getCookieCacheJwtKeySource,
+	verifyCookieCacheJWT,
+} from "../../plugins/jwt/cookie-cache";
 import type { Prettify, Session, User } from "../../types";
 import { getDate } from "../../utils/date";
 import { isAPIError } from "../../utils/is-api-error";
@@ -111,6 +115,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 				if (sessionDataCookie) {
 					const strategy =
 						ctx.context.options.session?.cookieCache?.strategy || "compact";
+					const jwtKeySource = getCookieCacheJwtKeySource(ctx.context.options);
 
 					if (strategy === "jwe") {
 						// Decode JWE (encrypted)
@@ -141,14 +146,22 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 							return ctx.json(null);
 						}
 					} else if (strategy === "jwt") {
-						// Decode JWT (signed with HMAC, not encrypted)
-						const payload = await verifyJWT<{
-							session: Session;
-							user: User;
-							updatedAt: number;
-							version?: string;
-							exp?: number;
-						}>(sessionDataCookie, ctx.context.secret);
+						const payload =
+							jwtKeySource === "jwks"
+								? await verifyCookieCacheJWT<{
+										session: Session;
+										user: User;
+										updatedAt: number;
+										version?: string;
+										exp?: number;
+									}>(ctx, sessionDataCookie)
+								: await verifySecretJWT<{
+										session: Session;
+										user: User;
+										updatedAt: number;
+										version?: string;
+										exp?: number;
+									}>(sessionDataCookie, ctx.context.secret);
 
 						if (payload && payload.session && payload.user) {
 							sessionDataPayload = {

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -2,6 +2,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 import { createAuthEndpoint } from "../api";
 import { getAdapter } from "../db/adapter-kysely";
+import { jwt } from "../plugins";
 import { getTestInstance } from "../test-utils/test-instance";
 import type { BetterAuthOptions } from "../types";
 import { createAuthContext } from "./create-context";
@@ -413,6 +414,89 @@ describe("base context creation", () => {
 				enabled: true,
 				updateAge: 500,
 			});
+		});
+
+		it("should require the jwt plugin for cookie-cache JWKS mode", async () => {
+			await expect(
+				initBase({
+					session: {
+						cookieCache: {
+							enabled: true,
+							strategy: "jwt",
+							jwt: {
+								keySource: "jwks",
+							},
+						} as any,
+					},
+				}),
+			).rejects.toThrow(
+				'`session.cookieCache.jwt.keySource = "jwks"` requires the `jwt()` plugin to be installed.',
+			);
+		});
+
+		it("should reject remote signing for cookie-cache JWKS mode", async () => {
+			await expect(
+				initBase({
+					session: {
+						cookieCache: {
+							enabled: true,
+							strategy: "jwt",
+							jwt: {
+								keySource: "jwks",
+							},
+						} as any,
+					},
+					plugins: [
+						jwt({
+							jwks: {
+								remoteUrl: "https://example.com/jwks",
+								keyPairConfig: {
+									alg: "RS256",
+								},
+							},
+							jwt: {
+								sign: async () => "signed-remotely",
+							},
+						}),
+					],
+				}),
+			).rejects.toThrow(
+				"Cookie-cache JWT JWKS mode does not support `jwt({ jwt: { sign } })`.",
+			);
+		});
+
+		it("should warn when cookie-cache maxAge exceeds the JWKS grace period", async () => {
+			const log = vi.fn();
+			await initBase({
+				logger: {
+					level: "warn",
+					log,
+				} as any,
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwt",
+						maxAge: 301,
+						jwt: {
+							keySource: "jwks",
+						},
+					} as any,
+				},
+				plugins: [
+					jwt({
+						jwks: {
+							gracePeriod: 300,
+						},
+					}),
+				],
+			});
+
+			expect(log).toHaveBeenCalledWith(
+				"warn",
+				expect.stringContaining(
+					"`session.cookieCache.maxAge` (301s) exceeds the JWT plugin JWKS grace period (300s)",
+				),
+			);
 		});
 
 		it("should allow custom session timeouts", async () => {

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -424,13 +424,13 @@ describe("base context creation", () => {
 							enabled: true,
 							strategy: "jwt",
 							jwt: {
-								keySource: "jwks",
+								signingKey: "jwt-plugin",
 							},
 						} as any,
 					},
 				}),
 			).rejects.toThrow(
-				'`session.cookieCache.jwt.keySource = "jwks"` requires the `jwt()` plugin to be installed.',
+				'`session.cookieCache.jwt.signingKey = "jwt-plugin"` requires the `jwt()` plugin to be installed.',
 			);
 		});
 
@@ -442,7 +442,7 @@ describe("base context creation", () => {
 							enabled: true,
 							strategy: "jwt",
 							jwt: {
-								keySource: "jwks",
+								signingKey: "jwt-plugin",
 							},
 						} as any,
 					},
@@ -461,7 +461,7 @@ describe("base context creation", () => {
 					],
 				}),
 			).rejects.toThrow(
-				"Cookie-cache JWT JWKS mode does not support `jwt({ jwt: { sign } })`.",
+				'`session.cookieCache.jwt.signingKey = "jwt-plugin"` requires locally managed JWT plugin keys and does not support `jwt({ jwt: { sign } })`.',
 			);
 		});
 
@@ -478,7 +478,7 @@ describe("base context creation", () => {
 						strategy: "jwt",
 						maxAge: 301,
 						jwt: {
-							keySource: "jwks",
+							signingKey: "jwt-plugin",
 						},
 					} as any,
 				},

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -20,7 +20,7 @@ import { matchesOriginPattern } from "../auth/trusted-origins";
 import { createCookieGetter, getCookies } from "../cookies";
 import { hashPassword, verifyPassword } from "../crypto/password";
 import { createInternalAdapter } from "../db/internal-adapter";
-import { getCookieCacheJwtKeySource } from "../plugins/jwt/cookie-cache";
+import { getCookieCacheJwtSigningKey } from "../plugins/jwt/cookie-cache";
 import type { JwtOptions } from "../plugins/jwt/types";
 import { DEFAULT_SECRET } from "../utils/constants";
 import { isPromise } from "../utils/is-promise";
@@ -259,25 +259,25 @@ Most of the features of Better Auth will not work correctly.`,
 				: getDatabaseType(options.database),
 	});
 
-	const cookieCacheJwtKeySource = getCookieCacheJwtKeySource(options);
-	if (cookieCacheJwtKeySource === "jwks") {
+	const cookieCacheJwtSigningKey = getCookieCacheJwtSigningKey(options);
+	if (cookieCacheJwtSigningKey === "jwt-plugin") {
 		if (options.session?.cookieCache?.strategy !== "jwt") {
 			throw new BetterAuthError(
-				'`session.cookieCache.jwt.keySource = "jwks"` requires `session.cookieCache.strategy = "jwt"`.',
+				'`session.cookieCache.jwt.signingKey = "jwt-plugin"` requires `session.cookieCache.strategy = "jwt"`.',
 			);
 		}
 
 		const jwtPlugin = options.plugins?.find((plugin) => plugin.id === "jwt");
 		if (!jwtPlugin) {
 			throw new BetterAuthError(
-				'`session.cookieCache.jwt.keySource = "jwks"` requires the `jwt()` plugin to be installed.',
+				'`session.cookieCache.jwt.signingKey = "jwt-plugin"` requires the `jwt()` plugin to be installed.',
 			);
 		}
 
 		const jwtPluginOptions = (jwtPlugin.options ?? {}) as JwtOptions;
 		if (jwtPluginOptions.jwt?.sign) {
 			throw new BetterAuthError(
-				"Cookie-cache JWT JWKS mode does not support `jwt({ jwt: { sign } })`. Use locally managed JWKS keys instead.",
+				'`session.cookieCache.jwt.signingKey = "jwt-plugin"` requires locally managed JWT plugin keys and does not support `jwt({ jwt: { sign } })`.',
 			);
 		}
 

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -20,6 +20,8 @@ import { matchesOriginPattern } from "../auth/trusted-origins";
 import { createCookieGetter, getCookies } from "../cookies";
 import { hashPassword, verifyPassword } from "../crypto/password";
 import { createInternalAdapter } from "../db/internal-adapter";
+import { getCookieCacheJwtKeySource } from "../plugins/jwt/cookie-cache";
+import type { JwtOptions } from "../plugins/jwt/types";
 import { DEFAULT_SECRET } from "../utils/constants";
 import { isPromise } from "../utils/is-promise";
 import { checkPassword } from "../utils/password";
@@ -256,6 +258,37 @@ Most of the features of Better Auth will not work correctly.`,
 				? "adapter"
 				: getDatabaseType(options.database),
 	});
+
+	const cookieCacheJwtKeySource = getCookieCacheJwtKeySource(options);
+	if (cookieCacheJwtKeySource === "jwks") {
+		if (options.session?.cookieCache?.strategy !== "jwt") {
+			throw new BetterAuthError(
+				'`session.cookieCache.jwt.keySource = "jwks"` requires `session.cookieCache.strategy = "jwt"`.',
+			);
+		}
+
+		const jwtPlugin = options.plugins?.find((plugin) => plugin.id === "jwt");
+		if (!jwtPlugin) {
+			throw new BetterAuthError(
+				'`session.cookieCache.jwt.keySource = "jwks"` requires the `jwt()` plugin to be installed.',
+			);
+		}
+
+		const jwtPluginOptions = (jwtPlugin.options ?? {}) as JwtOptions;
+		if (jwtPluginOptions.jwt?.sign) {
+			throw new BetterAuthError(
+				"Cookie-cache JWT JWKS mode does not support `jwt({ jwt: { sign } })`. Use locally managed JWKS keys instead.",
+			);
+		}
+
+		const gracePeriod = jwtPluginOptions.jwks?.gracePeriod;
+		const cookieMaxAge = options.session?.cookieCache?.maxAge || 60 * 5;
+		if (gracePeriod !== undefined && cookieMaxAge > gracePeriod) {
+			logger.warn(
+				`[better-auth] \`session.cookieCache.maxAge\` (${cookieMaxAge}s) exceeds the JWT plugin JWKS grace period (${gracePeriod}s). Rotated keys may stop verifying cookie-cache JWTs before the cookie expires.`,
+			);
+		}
+	}
 
 	const pluginIds = new Set(options.plugins!.map((p) => p.id));
 

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -25,6 +25,10 @@ import {
 } from "../cookies";
 import { signJWT, symmetricDecodeJWT } from "../crypto";
 import { jwt } from "../plugins";
+import {
+	COOKIE_CACHE_JWT_AUDIENCE,
+	COOKIE_CACHE_JWT_TYPE,
+} from "../plugins/jwt/cookie-cache";
 import { getTestInstance } from "../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../utils/constants";
 import {
@@ -1176,7 +1180,7 @@ describe("Cookie Cache Field Filtering", () => {
 					enabled: true,
 					strategy: "jwt",
 					jwt: {
-						keySource: "jwks",
+						signingKey: "jwt-plugin",
 					},
 				},
 			},
@@ -1214,7 +1218,7 @@ describe("Cookie Cache Field Filtering", () => {
 		const cache = await getCookieCache(request, {
 			strategy: "jwt",
 			jwt: {
-				keySource: "jwks",
+				signingKey: "jwt-plugin",
 				jwks,
 			},
 		});
@@ -1222,9 +1226,16 @@ describe("Cookie Cache Field Filtering", () => {
 		expect(cache?.user?.email).toEqual(testUser.email);
 
 		const localJwks = createLocalJWKSet(jwks);
-		const verified = await jwtVerify(token, localJwks);
+		const verified = await jwtVerify(token, localJwks, {
+			audience: COOKIE_CACHE_JWT_AUDIENCE,
+		});
+		expect(header.typ).toBe(COOKIE_CACHE_JWT_TYPE);
 		expect(verified.payload.session).toBeDefined();
 		expect(verified.payload.user).toBeDefined();
+		expect(verified.payload.iss).toEqual(expect.any(String));
+		expect(verified.payload.aud).toBe(COOKIE_CACHE_JWT_AUDIENCE);
+		expect(verified.payload.sub).toBe(cache?.user?.id);
+		expect(verified.payload.sid).toBe(cache?.session?.token);
 	});
 
 	it("should work with compact strategy", async () => {
@@ -1291,12 +1302,42 @@ describe("Cookie Cache Field Filtering", () => {
 			getCookieCache(request, {
 				strategy: "jwt",
 				jwt: {
-					keySource: "jwks",
+					signingKey: "jwt-plugin",
 				},
 			}),
 		).rejects.toThrow(
-			"getCookieCache requires `jwt.jwks` when `jwt.keySource` is set to `jwks`.",
+			'getCookieCache requires `jwt.jwks` when `jwt.signingKey` is set to `"jwt-plugin"`.',
 		);
+	});
+
+	it("should reject JWT plugin tokens that are not cookie-cache JWTs", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [jwt()],
+		});
+		const token = await auth.api.signJWT({
+			body: {
+				payload: {
+					sub: "user-id",
+				},
+			},
+		});
+		const jwks = await auth.api.getJwks();
+
+		const headers = new Headers();
+		headers.set("cookie", `better-auth.session_data=${token.token}`);
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+
+		const cache = await getCookieCache(request, {
+			strategy: "jwt",
+			jwt: {
+				signingKey: "jwt-plugin",
+				jwks,
+			},
+		});
+
+		expect(cache).toBeNull();
 	});
 
 	it("should return null when JWKS verification uses the wrong key set", async () => {
@@ -1306,7 +1347,7 @@ describe("Cookie Cache Field Filtering", () => {
 					enabled: true,
 					strategy: "jwt",
 					jwt: {
-						keySource: "jwks",
+						signingKey: "jwt-plugin",
 					},
 				},
 			},
@@ -1333,7 +1374,7 @@ describe("Cookie Cache Field Filtering", () => {
 		const cache = await getCookieCache(request, {
 			strategy: "jwt",
 			jwt: {
-				keySource: "jwks",
+				signingKey: "jwt-plugin",
 				jwks: {
 					keys: [],
 				},
@@ -1481,7 +1522,7 @@ describe("Cookie Chunking", () => {
 					enabled: true,
 					strategy: "jwt",
 					jwt: {
-						keySource: "jwks",
+						signingKey: "jwt-plugin",
 					},
 				},
 			},
@@ -1527,7 +1568,7 @@ describe("Cookie Chunking", () => {
 		const cache = await getCookieCache(request, {
 			strategy: "jwt",
 			jwt: {
-				keySource: "jwks",
+				signingKey: "jwt-plugin",
 				jwks: await auth.api.getJwks(),
 			},
 		});

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -25,10 +25,6 @@ import {
 } from "../cookies";
 import { signJWT, symmetricDecodeJWT } from "../crypto";
 import { jwt } from "../plugins";
-import {
-	COOKIE_CACHE_JWT_AUDIENCE,
-	COOKIE_CACHE_JWT_TYPE,
-} from "../plugins/jwt/cookie-cache";
 import { getTestInstance } from "../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../utils/constants";
 import {
@@ -40,6 +36,9 @@ import {
 	stripSecureCookiePrefix,
 	toCookieOptions,
 } from "./cookie-utils";
+
+const COOKIE_CACHE_JWT_TYPE = "better-auth.session-cache+jwt";
+const COOKIE_CACHE_JWT_AUDIENCE = "better-auth:session-cache";
 
 describe("cookies", async () => {
 	const { client, testUser } = await getTestInstance();

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -3,6 +3,7 @@ import type { GoogleProfile } from "@better-auth/core/social-providers";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { base64Url } from "@better-auth/utils/base64";
 import { createHMAC } from "@better-auth/utils/hmac";
+import { createLocalJWKSet, decodeProtectedHeader, jwtVerify } from "jose";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import {
@@ -23,6 +24,7 @@ import {
 	parseCookies,
 } from "../cookies";
 import { signJWT, symmetricDecodeJWT } from "../crypto";
+import { jwt } from "../plugins";
 import { getTestInstance } from "../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../utils/constants";
 import {
@@ -1167,6 +1169,64 @@ describe("Cookie Cache Field Filtering", () => {
 		expect(cache?.session?.token).toEqual(expect.any(String));
 	});
 
+	it("should work with JWT strategy backed by JWKS keys", async () => {
+		const { auth, client, testUser, cookieSetter } = await getTestInstance({
+			session: {
+				cookieCache: {
+					enabled: true,
+					strategy: "jwt",
+					jwt: {
+						keySource: "jwks",
+					},
+				},
+			},
+			plugins: [jwt()],
+		});
+
+		const headers = new Headers();
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(headers),
+			},
+		);
+
+		const token = parseCookies(headers.get("cookie") || "").get(
+			"better-auth.session_data",
+		);
+		if (!token) {
+			throw new Error("Cookie-cache JWT not found");
+		}
+
+		const header = decodeProtectedHeader(token);
+		expect(header.alg).toBe("EdDSA");
+		expect(header.kid).toEqual(expect.any(String));
+
+		const jwks = await auth.api.getJwks();
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+
+		const cache = await getCookieCache(request, {
+			strategy: "jwt",
+			jwt: {
+				keySource: "jwks",
+				jwks,
+			},
+		});
+		expect(cache).not.toBeNull();
+		expect(cache?.user?.email).toEqual(testUser.email);
+
+		const localJwks = createLocalJWKSet(jwks);
+		const verified = await jwtVerify(token, localJwks);
+		expect(verified.payload.session).toBeDefined();
+		expect(verified.payload.user).toBeDefined();
+	});
+
 	it("should work with compact strategy", async () => {
 		const { client, testUser, cookieSetter } = await getTestInstance({
 			secret: "better-auth.secret",
@@ -1219,13 +1279,77 @@ describe("Cookie Cache Field Filtering", () => {
 		expect(cache).toBeNull();
 	});
 
-	it("should default to JWT strategy when not specified", async () => {
+	it("should require JWKS input for helper verification in JWKS mode", async () => {
+		const headers = new Headers();
+		headers.set("cookie", "better-auth.session_data=token");
+
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+
+		await expect(
+			getCookieCache(request, {
+				strategy: "jwt",
+				jwt: {
+					keySource: "jwks",
+				},
+			}),
+		).rejects.toThrow(
+			"getCookieCache requires `jwt.jwks` when `jwt.keySource` is set to `jwks`.",
+		);
+	});
+
+	it("should return null when JWKS verification uses the wrong key set", async () => {
+		const { auth, client, testUser, cookieSetter } = await getTestInstance({
+			session: {
+				cookieCache: {
+					enabled: true,
+					strategy: "jwt",
+					jwt: {
+						keySource: "jwks",
+					},
+				},
+			},
+			plugins: [jwt()],
+		});
+
+		const headers = new Headers();
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(headers),
+			},
+		);
+
+		expect((await auth.api.getJwks()).keys.length).toBeGreaterThan(0);
+
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+		const cache = await getCookieCache(request, {
+			strategy: "jwt",
+			jwt: {
+				keySource: "jwks",
+				jwks: {
+					keys: [],
+				},
+			},
+		});
+
+		expect(cache).toBeNull();
+	});
+
+	it("should default to compact strategy when not specified", async () => {
 		const { client, testUser, cookieSetter } = await getTestInstance({
 			secret: "better-auth.secret",
 			session: {
 				cookieCache: {
 					enabled: true,
-					// No strategy specified, should default to "jwt"
+					// No strategy specified, should default to "compact"
 				},
 			},
 		});
@@ -1248,7 +1372,7 @@ describe("Cookie Cache Field Filtering", () => {
 
 		const cache = await getCookieCache(request, {
 			secret: "better-auth.secret",
-			// No strategy specified, should default to "jwt"
+			// No strategy specified, should default to "compact"
 		});
 		expect(cache).not.toBeNull();
 		expect(cache?.user?.email).toEqual(testUser.email);
@@ -1333,6 +1457,83 @@ describe("Cookie Chunking", () => {
 
 		expect(cache).not.toBeNull();
 		expect(cache?.user?.email).toEqual("chunk-test@example.com");
+		expect(cache?.session?.token).toEqual(expect.any(String));
+	});
+
+	it("should chunk JWKS-backed JWT cookies when they exceed 4KB", async () => {
+		const largeString = "j".repeat(2000);
+
+		const { auth, client } = await getTestInstance({
+			user: {
+				additionalFields: {
+					field1: {
+						type: "string",
+						defaultValue: "",
+					},
+					field2: {
+						type: "string",
+						defaultValue: "",
+					},
+				},
+			},
+			session: {
+				cookieCache: {
+					enabled: true,
+					strategy: "jwt",
+					jwt: {
+						keySource: "jwks",
+					},
+				},
+			},
+			plugins: [jwt()],
+		});
+
+		const headers = new Headers();
+
+		await client.signUp.email(
+			{
+				name: "JWKS Chunk User",
+				email: "jwks-chunk-test@example.com",
+				password: "password123",
+				field1: largeString,
+				field2: largeString,
+			} as any,
+			{
+				onSuccess(context) {
+					const setCookie = context.response.headers.get("set-cookie");
+					expect(setCookie).toBeDefined();
+
+					const parsed = parseSetCookieHeader(setCookie!);
+					let hasChunks = false;
+
+					parsed.forEach((value, name) => {
+						if (
+							name.includes("session_data.0") ||
+							name.includes("session_data.1")
+						) {
+							hasChunks = true;
+						}
+						headers.append("cookie", `${name}=${value.value}`);
+					});
+
+					expect(hasChunks).toBe(true);
+				},
+			},
+		);
+
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+		const cache = await getCookieCache(request, {
+			strategy: "jwt",
+			jwt: {
+				keySource: "jwks",
+				jwks: await auth.api.getJwks(),
+			},
+		});
+
+		expect(cache).not.toBeNull();
+		expect(cache?.user?.email).toEqual("jwks-chunk-test@example.com");
 		expect(cache?.session?.token).toEqual(expect.any(String));
 	});
 

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -12,14 +12,20 @@ import { base64Url } from "@better-auth/utils/base64";
 import { binary } from "@better-auth/utils/binary";
 import { createHMAC } from "@better-auth/utils/hmac";
 import type { CookieOptions } from "better-call";
+import type { JSONWebKeySet } from "jose";
 import { shouldBindAccountCookieToSessionUser } from "../context/store-capabilities";
 import {
-	signJWT,
+	signJWT as signSecretJWT,
 	symmetricDecodeJWT,
 	symmetricEncodeJWT,
-	verifyJWT,
+	verifyJWT as verifySecretJWT,
 } from "../crypto/jwt";
 import { parseUserOutput } from "../db/schema";
+import {
+	getCookieCacheJwtKeySource,
+	signCookieCacheJWT,
+	verifyCookieCacheJWTWithJWKS,
+} from "../plugins/jwt/cookie-cache";
 import type { Session, User } from "../types";
 import { getDate } from "../utils/date";
 import { isPromise } from "../utils/is-promise";
@@ -196,6 +202,7 @@ export async function setCookieCache(
 	const expiresAtDate = getDate(options.maxAge || 60, "sec").getTime();
 	const strategy =
 		ctx.context.options.session?.cookieCache?.strategy || "compact";
+	const jwtKeySource = getCookieCacheJwtKeySource(ctx.context.options);
 
 	let data: string;
 
@@ -208,12 +215,14 @@ export async function setCookieCache(
 			options.maxAge || 60 * 5,
 		);
 	} else if (strategy === "jwt") {
-		// Use JWT strategy with HMAC-SHA256 signature (HS256), no encryption
-		data = await signJWT(
-			sessionData,
-			ctx.context.secret,
-			options.maxAge || 60 * 5,
-		);
+		data =
+			jwtKeySource === "jwks"
+				? await signCookieCacheJWT(ctx, sessionData, options.maxAge || 60 * 5)
+				: await signSecretJWT(
+						sessionData,
+						ctx.context.secret,
+						options.maxAge || 60 * 5,
+					);
 	} else {
 		// Use compact strategy (base64url + HMAC, no JWT spec overhead)
 		// Also handles legacy "base64-hmac" for backward compatibility
@@ -525,6 +534,12 @@ export const getCookieCache = async <
 				isSecure?: boolean;
 				secret?: string;
 				strategy?: "compact" | "jwt" | "jwe"; // base64-hmac for backward compatibility
+				jwt?:
+					| {
+							keySource?: "secret" | "jwks";
+							jwks?: JSONWebKeySet;
+					  }
+					| undefined;
 				version?:
 					| string
 					| ((
@@ -582,14 +597,8 @@ export const getCookieCache = async <
 	}
 
 	if (sessionData) {
-		const secret = config?.secret || env.BETTER_AUTH_SECRET;
-		if (!secret) {
-			throw new BetterAuthError(
-				"getCookieCache requires a secret to be provided. Either pass it as an option or set the BETTER_AUTH_SECRET environment variable",
-			);
-		}
-
 		const strategy = config?.strategy || "compact";
+		const jwtKeySource = config?.jwt?.keySource ?? "secret";
 
 		// A valid signature/encryption only proves integrity, not freshness. Mirror
 		// the in-route session reader and reject a snapshot whose embedded session
@@ -601,6 +610,12 @@ export const getCookieCache = async <
 		};
 
 		if (strategy === "jwe") {
+			const secret = config?.secret || env.BETTER_AUTH_SECRET;
+			if (!secret) {
+				throw new BetterAuthError(
+					"getCookieCache requires a secret to be provided. Either pass it as an option or set the BETTER_AUTH_SECRET environment variable",
+				);
+			}
 			// Use JWE strategy (encrypted)
 			const payload = await symmetricDecodeJWT<S>(
 				sessionData,
@@ -630,8 +645,26 @@ export const getCookieCache = async <
 			}
 			return null;
 		} else if (strategy === "jwt") {
-			// Use JWT strategy with HMAC signature (HS256), no encryption
-			const payload = await verifyJWT<S>(sessionData, secret);
+			const payload =
+				jwtKeySource === "jwks"
+					? await (() => {
+							const jwks = config?.jwt?.jwks;
+							if (!jwks) {
+								throw new BetterAuthError(
+									"getCookieCache requires `jwt.jwks` when `jwt.keySource` is set to `jwks`.",
+								);
+							}
+							return verifyCookieCacheJWTWithJWKS<S>(sessionData, jwks);
+						})()
+					: await (() => {
+							const secret = config?.secret || env.BETTER_AUTH_SECRET;
+							if (!secret) {
+								throw new BetterAuthError(
+									"getCookieCache requires a secret to be provided. Either pass it as an option or set the BETTER_AUTH_SECRET environment variable",
+								);
+							}
+							return verifySecretJWT<S>(sessionData, secret);
+						})();
 
 			if (payload && payload.session && payload.user) {
 				// Validate version if provided
@@ -655,6 +688,12 @@ export const getCookieCache = async <
 			}
 			return null;
 		} else {
+			const secret = config?.secret || env.BETTER_AUTH_SECRET;
+			if (!secret) {
+				throw new BetterAuthError(
+					"getCookieCache requires a secret to be provided. Either pass it as an option or set the BETTER_AUTH_SECRET environment variable",
+				);
+			}
 			// Use compact strategy (or legacy base64-hmac)
 			const sessionDataPayload = safeJSONParse<{
 				session: S;

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -22,7 +22,7 @@ import {
 } from "../crypto/jwt";
 import { parseUserOutput } from "../db/schema";
 import {
-	getCookieCacheJwtKeySource,
+	getCookieCacheJwtSigningKey,
 	signCookieCacheJWT,
 	verifyCookieCacheJWTWithJWKS,
 } from "../plugins/jwt/cookie-cache";
@@ -202,7 +202,7 @@ export async function setCookieCache(
 	const expiresAtDate = getDate(options.maxAge || 60, "sec").getTime();
 	const strategy =
 		ctx.context.options.session?.cookieCache?.strategy || "compact";
-	const jwtKeySource = getCookieCacheJwtKeySource(ctx.context.options);
+	const jwtSigningKey = getCookieCacheJwtSigningKey(ctx.context.options);
 
 	let data: string;
 
@@ -216,7 +216,7 @@ export async function setCookieCache(
 		);
 	} else if (strategy === "jwt") {
 		data =
-			jwtKeySource === "jwks"
+			jwtSigningKey === "jwt-plugin"
 				? await signCookieCacheJWT(ctx, sessionData, options.maxAge || 60 * 5)
 				: await signSecretJWT(
 						sessionData,
@@ -480,6 +480,19 @@ export function deleteSessionCookie(
 	}
 }
 
+function isEmbeddedSessionExpired(
+	session: { expiresAt?: unknown } | undefined,
+) {
+	if (!session?.expiresAt) {
+		return false;
+	}
+
+	const expiresAt = new Date(
+		session.expiresAt as string | number | Date,
+	).getTime();
+	return Number.isFinite(expiresAt) && expiresAt < Date.now();
+}
+
 export type EligibleCookies = (string & {}) | (keyof BetterAuthCookies & {});
 
 export const getSessionCookie = (
@@ -536,8 +549,10 @@ export const getCookieCache = async <
 				strategy?: "compact" | "jwt" | "jwe"; // base64-hmac for backward compatibility
 				jwt?:
 					| {
-							keySource?: "secret" | "jwks";
+							signingKey?: "secret" | "jwt-plugin";
 							jwks?: JSONWebKeySet;
+							issuer?: string;
+							audience?: string;
 					  }
 					| undefined;
 				version?:
@@ -598,16 +613,7 @@ export const getCookieCache = async <
 
 	if (sessionData) {
 		const strategy = config?.strategy || "compact";
-		const jwtKeySource = config?.jwt?.keySource ?? "secret";
-
-		// A valid signature/encryption only proves integrity, not freshness. Mirror
-		// the in-route session reader and reject a snapshot whose embedded session
-		// has already expired, so a caller using this helper as an auth gate cannot
-		// treat a stale-but-signed cookie as a live session.
-		const isEmbeddedSessionExpired = (payload: S): boolean => {
-			const expiresAt = payload.session?.expiresAt;
-			return !!expiresAt && new Date(expiresAt).getTime() < Date.now();
-		};
+		const jwtSigningKey = config?.jwt?.signingKey ?? "secret";
 
 		if (strategy === "jwe") {
 			const secret = config?.secret || env.BETTER_AUTH_SECRET;
@@ -638,7 +644,7 @@ export const getCookieCache = async <
 						return null;
 					}
 				}
-				if (isEmbeddedSessionExpired(payload)) {
+				if (isEmbeddedSessionExpired(payload.session)) {
 					return null;
 				}
 				return payload;
@@ -646,15 +652,18 @@ export const getCookieCache = async <
 			return null;
 		} else if (strategy === "jwt") {
 			const payload =
-				jwtKeySource === "jwks"
+				jwtSigningKey === "jwt-plugin"
 					? await (() => {
 							const jwks = config?.jwt?.jwks;
 							if (!jwks) {
 								throw new BetterAuthError(
-									"getCookieCache requires `jwt.jwks` when `jwt.keySource` is set to `jwks`.",
+									'getCookieCache requires `jwt.jwks` when `jwt.signingKey` is set to `"jwt-plugin"`.',
 								);
 							}
-							return verifyCookieCacheJWTWithJWKS<S>(sessionData, jwks);
+							return verifyCookieCacheJWTWithJWKS<S>(sessionData, jwks, {
+								issuer: config?.jwt?.issuer,
+								audience: config?.jwt?.audience,
+							});
 						})()
 					: await (() => {
 							const secret = config?.secret || env.BETTER_AUTH_SECRET;
@@ -681,7 +690,7 @@ export const getCookieCache = async <
 						return null;
 					}
 				}
-				if (isEmbeddedSessionExpired(payload)) {
+				if (isEmbeddedSessionExpired(payload.session)) {
 					return null;
 				}
 				return payload;
@@ -714,7 +723,6 @@ export const getCookieCache = async <
 			if (!isValid) {
 				return null;
 			}
-
 			// Validate version if provided
 			if (config?.version && sessionDataPayload.session) {
 				const cookieVersion = sessionDataPayload.session.version || "1";
@@ -742,7 +750,7 @@ export const getCookieCache = async <
 			) {
 				return null;
 			}
-			if (isEmbeddedSessionExpired(sessionDataPayload.session)) {
+			if (isEmbeddedSessionExpired(sessionDataPayload.session?.session)) {
 				return null;
 			}
 

--- a/packages/better-auth/src/plugins/jwt/cookie-cache.ts
+++ b/packages/better-auth/src/plugins/jwt/cookie-cache.ts
@@ -1,0 +1,193 @@
+import type {
+	BetterAuthOptions,
+	GenericEndpointContext,
+} from "@better-auth/core";
+import { BetterAuthError } from "@better-auth/core/error";
+import type { JSONWebKeySet, JWTPayload } from "jose";
+import { decodeProtectedHeader, importJWK, jwtVerify, SignJWT } from "jose";
+import { symmetricDecrypt } from "../../crypto";
+import { getJwksAdapter } from "./adapter";
+import type { JwtOptions } from "./types";
+import { createJwk } from "./utils";
+
+type CookieCacheKeySource = "secret" | "jwks";
+
+export function getCookieCacheJwtKeySource(
+	options:
+		| Pick<BetterAuthOptions, "session">
+		| {
+				session?:
+					| {
+							cookieCache?:
+								| {
+										jwt?:
+											| {
+													keySource?: CookieCacheKeySource;
+											  }
+											| undefined;
+								  }
+								| undefined;
+					  }
+					| undefined;
+		  }
+		| undefined,
+): CookieCacheKeySource {
+	const cookieCache = options?.session?.cookieCache as
+		| {
+				jwt?:
+					| {
+							keySource?: CookieCacheKeySource;
+					  }
+					| undefined;
+		  }
+		| undefined;
+	return cookieCache?.jwt?.keySource ?? "secret";
+}
+
+function getJwtPluginOptions(ctx: GenericEndpointContext): JwtOptions {
+	const plugin = ctx.context.getPlugin?.("jwt");
+	if (!plugin) {
+		throw new BetterAuthError(
+			'`session.cookieCache.jwt.keySource = "jwks"` requires the `jwt()` plugin to be installed.',
+		);
+	}
+	const options = (plugin.options ?? {}) as JwtOptions;
+	if (options.jwt?.sign) {
+		throw new BetterAuthError(
+			"Cookie-cache JWT JWKS mode does not support `jwt({ jwt: { sign } })`. Use locally managed JWKS keys instead.",
+		);
+	}
+	return options;
+}
+
+async function importLocalPublicKey(
+	ctx: GenericEndpointContext,
+	token: string,
+	options: JwtOptions,
+) {
+	const header = decodeProtectedHeader(token);
+	const kid = header.kid;
+	if (!kid) {
+		ctx.context.logger.debug("Cookie-cache JWT missing kid in header");
+		return null;
+	}
+
+	const adapter = getJwksAdapter(ctx.context.adapter, options);
+	const keys = await adapter.getAllKeys(ctx);
+	if (!keys?.length) {
+		ctx.context.logger.debug("No JWKS keys available for cookie-cache JWT");
+		return null;
+	}
+
+	const key = keys.find((entry) => entry.id === kid);
+	if (!key) {
+		ctx.context.logger.debug(
+			`No JWKS key found for cookie-cache JWT kid: ${kid}`,
+		);
+		return null;
+	}
+
+	const alg =
+		key.alg ??
+		options.jwks?.keyPairConfig?.alg ??
+		(header.alg as string | undefined);
+	if (!alg) {
+		ctx.context.logger.debug(
+			`No JWT algorithm available for cookie-cache JWT kid: ${kid}`,
+		);
+		return null;
+	}
+
+	return importJWK(JSON.parse(key.publicKey), alg);
+}
+
+export async function signCookieCacheJWT<T extends Record<string, any>>(
+	ctx: GenericEndpointContext,
+	payload: T,
+	expiresIn: number,
+): Promise<string> {
+	const options = getJwtPluginOptions(ctx);
+	const adapter = getJwksAdapter(ctx.context.adapter, options);
+	let key = await adapter.getLatestKey(ctx);
+	if (!key || (key.expiresAt && key.expiresAt < new Date())) {
+		key = await createJwk(ctx, options);
+	}
+
+	const privateKeyEncryptionEnabled =
+		!options.jwks?.disablePrivateKeyEncryption;
+	const privateWebKey = privateKeyEncryptionEnabled
+		? await symmetricDecrypt({
+				key: ctx.context.secretConfig,
+				data: JSON.parse(key.privateKey),
+			}).catch(() => {
+				throw new BetterAuthError(
+					"Failed to decrypt private key for cookie-cache JWT signing. Make sure the current secret can decrypt your JWKS private key material.",
+				);
+			})
+		: key.privateKey;
+
+	const alg = key.alg ?? options.jwks?.keyPairConfig?.alg ?? "EdDSA";
+	const privateKey = await importJWK(JSON.parse(privateWebKey), alg);
+
+	return await new SignJWT(payload)
+		.setProtectedHeader({
+			alg,
+			kid: key.id,
+		})
+		.setIssuedAt()
+		.setExpirationTime(Math.floor(Date.now() / 1000) + expiresIn)
+		.sign(privateKey);
+}
+
+export async function verifyCookieCacheJWT<T = JWTPayload>(
+	ctx: GenericEndpointContext,
+	token: string,
+): Promise<T | null> {
+	try {
+		const options = getJwtPluginOptions(ctx);
+		const publicKey = await importLocalPublicKey(ctx, token, options);
+		if (!publicKey) {
+			return null;
+		}
+
+		const { payload } = await jwtVerify(token, publicKey, {
+			clockTolerance: 15,
+		});
+
+		return payload as T;
+	} catch (error) {
+		ctx.context.logger.debug("Cookie-cache JWT verification failed", error);
+		return null;
+	}
+}
+
+export async function verifyCookieCacheJWTWithJWKS<T = JWTPayload>(
+	token: string,
+	jwks: JSONWebKeySet,
+): Promise<T | null> {
+	try {
+		const header = decodeProtectedHeader(token);
+		const kid = header.kid;
+		if (!kid) {
+			return null;
+		}
+
+		const key = jwks.keys.find((entry) => entry.kid === kid);
+		if (!key) {
+			return null;
+		}
+
+		const alg = key.alg ?? (header.alg as string | undefined);
+		if (!alg) {
+			return null;
+		}
+
+		const publicKey = await importJWK(key, alg);
+		const { payload } = await jwtVerify(token, publicKey, {
+			clockTolerance: 15,
+		});
+		return payload as T;
+	} catch {
+		return null;
+	}
+}

--- a/packages/better-auth/src/plugins/jwt/cookie-cache.ts
+++ b/packages/better-auth/src/plugins/jwt/cookie-cache.ts
@@ -13,35 +13,9 @@ import { createJwk } from "./utils";
 type CookieCacheKeySource = "secret" | "jwks";
 
 export function getCookieCacheJwtKeySource(
-	options:
-		| Pick<BetterAuthOptions, "session">
-		| {
-				session?:
-					| {
-							cookieCache?:
-								| {
-										jwt?:
-											| {
-													keySource?: CookieCacheKeySource;
-											  }
-											| undefined;
-								  }
-								| undefined;
-					  }
-					| undefined;
-		  }
-		| undefined,
+	options: Pick<BetterAuthOptions, "session"> | undefined,
 ): CookieCacheKeySource {
-	const cookieCache = options?.session?.cookieCache as
-		| {
-				jwt?:
-					| {
-							keySource?: CookieCacheKeySource;
-					  }
-					| undefined;
-		  }
-		| undefined;
-	return cookieCache?.jwt?.keySource ?? "secret";
+	return options?.session?.cookieCache?.jwt?.keySource ?? "secret";
 }
 
 function getJwtPluginOptions(ctx: GenericEndpointContext): JwtOptions {

--- a/packages/better-auth/src/plugins/jwt/cookie-cache.ts
+++ b/packages/better-auth/src/plugins/jwt/cookie-cache.ts
@@ -5,33 +5,105 @@ import type {
 import { BetterAuthError } from "@better-auth/core/error";
 import type { JSONWebKeySet, JWTPayload } from "jose";
 import { decodeProtectedHeader, importJWK, jwtVerify, SignJWT } from "jose";
-import { symmetricDecrypt } from "../../crypto";
+import type { Session, User } from "../../types";
 import { getJwksAdapter } from "./adapter";
+import { resolveSigningKey } from "./sign";
 import type { JwtOptions } from "./types";
-import { createJwk } from "./utils";
 
-type CookieCacheKeySource = "secret" | "jwks";
+export const COOKIE_CACHE_JWT_TYPE = "better-auth.session-cache+jwt";
+export const COOKIE_CACHE_JWT_AUDIENCE = "better-auth:session-cache";
+export const COOKIE_CACHE_JWT_ISSUER = "better-auth:session-cache";
 
-export function getCookieCacheJwtKeySource(
+type CookieCacheJwtSigningKey = "secret" | "jwt-plugin";
+
+type CookieCacheJwtPayload = {
+	session: Session & Record<string, unknown>;
+	user: User & Record<string, unknown>;
+	updatedAt: number;
+	version?: string;
+};
+
+export type VerifyCookieCacheJwtOptions = {
+	issuer?: string | undefined;
+	audience?: string | undefined;
+};
+
+export function getCookieCacheJwtSigningKey(
 	options: Pick<BetterAuthOptions, "session"> | undefined,
-): CookieCacheKeySource {
-	return options?.session?.cookieCache?.jwt?.keySource ?? "secret";
+): CookieCacheJwtSigningKey {
+	return options?.session?.cookieCache?.jwt?.signingKey ?? "secret";
 }
 
 function getJwtPluginOptions(ctx: GenericEndpointContext): JwtOptions {
 	const plugin = ctx.context.getPlugin?.("jwt");
 	if (!plugin) {
 		throw new BetterAuthError(
-			'`session.cookieCache.jwt.keySource = "jwks"` requires the `jwt()` plugin to be installed.',
+			'`session.cookieCache.jwt.signingKey = "jwt-plugin"` requires the `jwt()` plugin to be installed.',
 		);
 	}
 	const options = (plugin.options ?? {}) as JwtOptions;
 	if (options.jwt?.sign) {
 		throw new BetterAuthError(
-			"Cookie-cache JWT JWKS mode does not support `jwt({ jwt: { sign } })`. Use locally managed JWKS keys instead.",
+			'`session.cookieCache.jwt.signingKey = "jwt-plugin"` requires locally managed JWT plugin keys and does not support `jwt({ jwt: { sign } })`.',
 		);
 	}
 	return options;
+}
+
+function getCookieCacheJwtIssuer(ctx: GenericEndpointContext) {
+	const baseURL = ctx.context.options.baseURL;
+	return typeof baseURL === "string"
+		? baseURL || COOKIE_CACHE_JWT_ISSUER
+		: ctx.context.baseURL || COOKIE_CACHE_JWT_ISSUER;
+}
+
+function getCookieCacheJwtVerifyOptions(options?: VerifyCookieCacheJwtOptions) {
+	const verifyOptions: {
+		clockTolerance: number;
+		audience: string;
+		issuer?: string;
+	} = {
+		clockTolerance: 15,
+		audience: options?.audience ?? COOKIE_CACHE_JWT_AUDIENCE,
+	};
+
+	if (options?.issuer) {
+		verifyOptions.issuer = options.issuer;
+	}
+
+	return verifyOptions;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseCookieCacheJwtPayload<T extends CookieCacheJwtPayload>(
+	payload: JWTPayload,
+): (T & JWTPayload) | null {
+	if (
+		!isRecord(payload.session) ||
+		!isRecord(payload.user) ||
+		typeof payload.updatedAt !== "number"
+	) {
+		return null;
+	}
+
+	if (typeof payload.iss !== "string" || payload.iss.length === 0) {
+		return null;
+	}
+
+	const userId = payload.user.id;
+	const sessionToken = payload.session.token;
+	if (typeof userId !== "string" || typeof sessionToken !== "string") {
+		return null;
+	}
+
+	if (payload.sub !== userId || payload.sid !== sessionToken) {
+		return null;
+	}
+
+	return payload as T & JWTPayload;
 }
 
 async function importLocalPublicKey(
@@ -72,75 +144,88 @@ async function importLocalPublicKey(
 		return null;
 	}
 
-	return importJWK(JSON.parse(key.publicKey), alg);
+	return {
+		alg,
+		publicKey: await importJWK(JSON.parse(key.publicKey), alg),
+	};
 }
 
-export async function signCookieCacheJWT<T extends Record<string, any>>(
+export async function signCookieCacheJWT<T extends CookieCacheJwtPayload>(
 	ctx: GenericEndpointContext,
 	payload: T,
 	expiresIn: number,
 ): Promise<string> {
 	const options = getJwtPluginOptions(ctx);
-	const adapter = getJwksAdapter(ctx.context.adapter, options);
-	let key = await adapter.getLatestKey(ctx);
-	if (!key || (key.expiresAt && key.expiresAt < new Date())) {
-		key = await createJwk(ctx, options);
+	const resolvedKey = await resolveSigningKey(ctx, options);
+	if (!resolvedKey) {
+		throw new BetterAuthError(
+			'`session.cookieCache.jwt.signingKey = "jwt-plugin"` requires locally managed JWT plugin keys and does not support `jwt({ jwt: { sign } })`.',
+		);
 	}
 
-	const privateKeyEncryptionEnabled =
-		!options.jwks?.disablePrivateKeyEncryption;
-	const privateWebKey = privateKeyEncryptionEnabled
-		? await symmetricDecrypt({
-				key: ctx.context.secretConfig,
-				data: JSON.parse(key.privateKey),
-			}).catch(() => {
-				throw new BetterAuthError(
-					"Failed to decrypt private key for cookie-cache JWT signing. Make sure the current secret can decrypt your JWKS private key material.",
-				);
-			})
-		: key.privateKey;
-
-	const alg = key.alg ?? options.jwks?.keyPairConfig?.alg ?? "EdDSA";
-	const privateKey = await importJWK(JSON.parse(privateWebKey), alg);
-
-	return await new SignJWT(payload)
+	const jwt = new SignJWT({
+		...payload,
+		sid: payload.session.token,
+	})
 		.setProtectedHeader({
-			alg,
-			kid: key.id,
+			alg: resolvedKey.alg,
+			kid: resolvedKey.kid,
+			typ: COOKIE_CACHE_JWT_TYPE,
 		})
 		.setIssuedAt()
 		.setExpirationTime(Math.floor(Date.now() / 1000) + expiresIn)
-		.sign(privateKey);
+		.setIssuer(getCookieCacheJwtIssuer(ctx))
+		.setAudience(COOKIE_CACHE_JWT_AUDIENCE)
+		.setSubject(payload.user.id);
+
+	return await jwt.sign(resolvedKey.privateKey);
 }
 
-export async function verifyCookieCacheJWT<T = JWTPayload>(
+export async function verifyCookieCacheJWT<
+	T extends CookieCacheJwtPayload = CookieCacheJwtPayload,
+>(
 	ctx: GenericEndpointContext,
 	token: string,
-): Promise<T | null> {
+): Promise<(T & JWTPayload) | null> {
 	try {
-		const options = getJwtPluginOptions(ctx);
-		const publicKey = await importLocalPublicKey(ctx, token, options);
-		if (!publicKey) {
+		const header = decodeProtectedHeader(token);
+		if (header.typ !== COOKIE_CACHE_JWT_TYPE) {
 			return null;
 		}
 
-		const { payload } = await jwtVerify(token, publicKey, {
-			clockTolerance: 15,
+		const options = getJwtPluginOptions(ctx);
+		const key = await importLocalPublicKey(ctx, token, options);
+		if (!key) {
+			return null;
+		}
+
+		const { payload } = await jwtVerify(token, key.publicKey, {
+			...getCookieCacheJwtVerifyOptions({
+				issuer: getCookieCacheJwtIssuer(ctx),
+			}),
+			algorithms: [key.alg],
 		});
 
-		return payload as T;
+		return parseCookieCacheJwtPayload<T>(payload);
 	} catch (error) {
 		ctx.context.logger.debug("Cookie-cache JWT verification failed", error);
 		return null;
 	}
 }
 
-export async function verifyCookieCacheJWTWithJWKS<T = JWTPayload>(
+export async function verifyCookieCacheJWTWithJWKS<
+	T extends CookieCacheJwtPayload = CookieCacheJwtPayload,
+>(
 	token: string,
 	jwks: JSONWebKeySet,
-): Promise<T | null> {
+	options?: VerifyCookieCacheJwtOptions,
+): Promise<(T & JWTPayload) | null> {
 	try {
 		const header = decodeProtectedHeader(token);
+		if (header.typ !== COOKIE_CACHE_JWT_TYPE) {
+			return null;
+		}
+
 		const kid = header.kid;
 		if (!kid) {
 			return null;
@@ -158,9 +243,10 @@ export async function verifyCookieCacheJWTWithJWKS<T = JWTPayload>(
 
 		const publicKey = await importJWK(key, alg);
 		const { payload } = await jwtVerify(token, publicKey, {
-			clockTolerance: 15,
+			...getCookieCacheJwtVerifyOptions(options),
+			algorithms: [alg],
 		});
-		return payload as T;
+		return parseCookieCacheJwtPayload<T>(payload);
 	} catch {
 		return null;
 	}

--- a/packages/better-auth/src/plugins/jwt/cookie-cache.ts
+++ b/packages/better-auth/src/plugins/jwt/cookie-cache.ts
@@ -10,9 +10,9 @@ import { getJwksAdapter } from "./adapter";
 import { resolveSigningKey } from "./sign";
 import type { JwtOptions } from "./types";
 
-export const COOKIE_CACHE_JWT_TYPE = "better-auth.session-cache+jwt";
-export const COOKIE_CACHE_JWT_AUDIENCE = "better-auth:session-cache";
-export const COOKIE_CACHE_JWT_ISSUER = "better-auth:session-cache";
+const COOKIE_CACHE_JWT_TYPE = "better-auth.session-cache+jwt";
+const COOKIE_CACHE_JWT_AUDIENCE = "better-auth:session-cache";
+const COOKIE_CACHE_JWT_ISSUER = "better-auth:session-cache";
 
 type CookieCacheJwtSigningKey = "secret" | "jwt-plugin";
 

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1064,14 +1064,14 @@ export type BetterAuthOptions = {
 					 */
 					jwt?: {
 						/**
-						 * Which key source signs and verifies cookie-cache JWTs.
+						 * Which signing key is used for cookie-cache JWTs.
 						 *
 						 * - `"secret"`: uses the Better Auth secret with HS256.
-						 * - `"jwks"`: uses the installed `jwt()` plugin's asymmetric JWKS keys.
+						 * - `"jwt-plugin"`: uses the installed `jwt()` plugin's asymmetric signing keys.
 						 *
 						 * @default "secret"
 						 */
-						keySource?: "secret" | "jwks";
+						signingKey?: "secret" | "jwt-plugin";
 					};
 					/**
 					 * Controls stateless cookie cache refresh behavior.

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1060,6 +1060,20 @@ export type BetterAuthOptions = {
 					 */
 					strategy?: "compact" | "jwt" | "jwe";
 					/**
+					 * JWT-specific configuration for `strategy: "jwt"`.
+					 */
+					jwt?: {
+						/**
+						 * Which key source signs and verifies cookie-cache JWTs.
+						 *
+						 * - `"secret"`: uses the Better Auth secret with HS256.
+						 * - `"jwks"`: uses the installed `jwt()` plugin's asymmetric JWKS keys.
+						 *
+						 * @default "secret"
+						 */
+						keySource?: "secret" | "jwks";
+					};
+					/**
 					 * Controls stateless cookie cache refresh behavior.
 					 *
 					 * When enabled, the cookie cache will be automatically refreshed before expiry


### PR DESCRIPTION
## Summary

`session.cookieCache.strategy = "jwt"` can now use the JWT plugin's asymmetric signing keys, so `session_data` cookies can be verified through JWKS without changing the opaque `session_token` cookie.

Closes #8923

Better Auth already exposes JWKS-backed JWTs through the JWT plugin, but the cookie-cache JWT is a different token shape. This keeps that difference explicit: cookie-cache JWTs use their own token profile and are not interchangeable with OAuth access tokens, OIDC ID Tokens, or JWT plugin `/token` output.

## What changed

- Adds `session.cookieCache.jwt.signingKey`, with `"secret"` as the default and `"jwt-plugin"` as the opt-in asymmetric mode.
- Uses the installed `jwt()` plugin's locally managed signing keys for cookie-cache JWT signing.
- Verifies cookie-cache JWTs with explicit token type, audience, issuer, accepted algorithm, expiration, and session-token binding checks.
- Extends `getCookieCache()` so callers can verify JWKS-backed cookie-cache JWTs with explicit JWKS input.
- Adds guardrails for `jwt-plugin` signing mode: it requires `strategy: "jwt"`, the `jwt()` plugin, and locally managed JWT plugin keys.
- Updates docs, types, and tests for the cookie-cache JWT profile.

## Notes

- This does not change the primary `session_token` cookie.
- Cookie-cache JWTs are not OAuth access tokens or OIDC ID Tokens.
- JWT plugin `/token` output and cookie-cache JWTs are intentionally not interchangeable.
