### PR TITLE
docs: improve descriptions for appName, trustedOrigins, useSecureCookies

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -9,7 +9,7 @@ List of all the available options for configuring Better Auth. See [Better Auth 
 
 The name of your application. Defaults to `"Better Auth"`.
 
-It's used as a display name in contexts where your app needs to be identified — for example, when users set up two-factor authentication with an authenticator app (like Google Authenticator or Authy), `appName` appears as the issuer name in the TOTP entry. This can be overridden per-plugin (e.g. the [2FA plugin's `issuer` option](/docs/plugins/2fa#issuer)).
+It's used as a display name in contexts where your app needs to be identified — for example, when users set up two-factor authentication with an authenticator app (like Google Authenticator), `appName` appears as the issuer name in the TOTP entry. This can be overridden per-plugin (e.g. the [2FA plugin's `issuer` option](/docs/plugins/2fa#issuer)).
 
 ```ts
 import { betterAuth } from "better-auth";
@@ -601,7 +601,7 @@ export const auth = betterAuth({
 ```
 
 - `ipAddress`: IP address configuration for rate limiting and session tracking
-- `useSecureCookies`: By default, cookies are set as secure only when the server is running in production mode. Set this to `true` to force cookies to always use the `Secure` attribute, regardless of environment.
+- `useSecureCookies`: By default, cookies are secure in production environments. Set this to `true` to force the `Secure` cookie attribute in all environments.
 - `disableCSRFCheck`: Disable all CSRF protection including origin header validation and Fetch Metadata checks (⚠️ security risk)
 - `disableOriginCheck`: Disable URL validation for `callbackURL`, `redirectTo`, and other redirect URLs (⚠️ security risk)
 - `crossSubDomainCookies`: Configure cookies to be shared across subdomains

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -7,7 +7,9 @@ List of all the available options for configuring Better Auth. See [Better Auth 
 
 ## `appName`
 
-The name of the application.
+The name of your application. Defaults to `"Better Auth"`.
+
+It's used as a display name in contexts where your app needs to be identified — for example, when users set up two-factor authentication with an authenticator app (like Google Authenticator or Authy), `appName` appears as the issuer name in the TOTP entry. This can be overridden per-plugin (e.g. the [2FA plugin's `issuer` option](/docs/plugins/2fa#issuer)).
 
 ```ts
 import { betterAuth } from "better-auth";

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -601,7 +601,7 @@ export const auth = betterAuth({
 ```
 
 - `ipAddress`: IP address configuration for rate limiting and session tracking
-- `useSecureCookies`: Use secure cookies (default: `false`)
+- `useSecureCookies`: By default, cookies are set as secure only when the server is running in production mode. Set this to `true` to force cookies to always use the `Secure` attribute, regardless of environment.
 - `disableCSRFCheck`: Disable all CSRF protection including origin header validation and Fetch Metadata checks (⚠️ security risk)
 - `disableOriginCheck`: Disable URL validation for `callbackURL`, `redirectTo`, and other redirect URLs (⚠️ security risk)
 - `crossSubDomainCookies`: Configure cookies to be shared across subdomains

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -50,7 +50,7 @@ Default: `/api/auth`
 
 ## `trustedOrigins`
 
-List of trusted origins. You can provide a static array of origins, a function that returns origins dynamically, or use wildcard patterns to match multiple domains.
+By default, Better Auth trusts the base URL of your app (i.e. [`baseURL`](#baseurl)). You can specify additional trusted origins via this option. Values can be a static array of origins, a function that returns origins dynamically, or wildcard patterns to match multiple domains.
 
 ### Static Origins
 

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -216,7 +216,10 @@ export type BetterAuthAdvancedOptions = {
 		  }
 		| undefined;
 	/**
-	 * Use secure cookies
+	 * Force cookies to always use the `Secure` attribute. By default,
+	 * cookies are only secure when the server is running in production
+	 * mode. Set this to `true` to enforce secure cookies in all
+	 * environments.
 	 *
 	 * @default false
 	 */
@@ -384,9 +387,11 @@ export type BetterAuthAdvancedOptions = {
 
 export type BetterAuthOptions = {
 	/**
-	 * The name of the application
+	 * The name of your application. Used as a display name in contexts
+	 * where your app needs to be identified — for example, as the default
+	 * issuer name in authenticator apps when users set up 2FA/TOTP.
 	 *
-	 * process.env.APP_NAME
+	 * Can also be set via the `APP_NAME` environment variable.
 	 *
 	 * @default "Better Auth"
 	 */
@@ -1145,7 +1150,12 @@ export type BetterAuthOptions = {
 		  })
 		| undefined;
 	/**
-	 * List of trusted origins.
+	 * Additional trusted origins. By default, Better Auth trusts your
+	 * app's {@link baseURL}. Use this option to allow additional origins
+	 * (e.g. a separate frontend domain).
+	 *
+	 * Can be a static array, a function that returns origins dynamically,
+	 * or use wildcard patterns (e.g. `"https://*.example.com"`).
 	 *
 	 * @param request - The request object.
 	 * It'll be undefined if no request was

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -217,9 +217,8 @@ export type BetterAuthAdvancedOptions = {
 		| undefined;
 	/**
 	 * Force cookies to always use the `Secure` attribute. By default,
-	 * cookies are only secure when the server is running in production
-	 * mode. Set this to `true` to enforce secure cookies in all
-	 * environments.
+	 * cookies are secure in production environments. Set this to `true`
+	 * to enforce secure cookies in all environments.
 	 *
 	 * @default false
 	 */


### PR DESCRIPTION
## Summary

Some parts of the docs/intellisense tripped me up - trying to make them clearer.

- **`appName`**: Explain that it's used as the default issuer name in authenticator apps for 2FA/TOTP, not just "the name of the application"
- **`trustedOrigins`**: Clarify that `baseURL` is trusted by default and this option specifies *additional* origins
- **`useSecureCookies`**: Clarify that cookies are already secure in production by default — this option forces the `Secure` attribute in all environments

Updates both the docs reference page (`docs/content/docs/reference/options.mdx`) and the TypeScript JSDoc comments (`packages/core/src/types/init-options.ts`) so the improved descriptions also show on hover in editors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarify `appName`, `trustedOrigins`, and `useSecureCookies` in docs and JSDoc, and fix a spell-check issue, so usage and defaults are accurate.

`appName` is the default issuer for 2FA/TOTP; `trustedOrigins` adds to `baseURL`; `useSecureCookies` forces Secure cookies in all environments (cookies are already secure in production).

<sup>Written for commit ee8af2beabbc58056534c69cda0a9cf6a7989587. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



