### PR TITLE
feat(ci): add release automation scripts

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -7,7 +7,9 @@
 	"tags": ["-lintignore"],
 	"ignore": [
 		// test utilities only imported by test files — invisible to --production
-		"packages/better-auth/src/client/test-plugin.ts"
+		"packages/better-auth/src/client/test-plugin.ts",
+		// CI scripts invoked by GitHub Actions, not part of any workspace
+		"scripts/**"
 	],
 	"ignoreBinaries": ["playwright", "changelogithub", "open", "remark"],
 	// exports used only by tests — invisible to --production mode

--- a/scripts/auto-changeset.ts
+++ b/scripts/auto-changeset.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * Auto-generates .changeset/*.md files from PR metadata.
+ *
+ * Modes:
+ *   default:        Generate changeset + apply c-* label + commit (team PRs)
+ *   --comment-only: Apply c-* label + post comment with changeset (fork PRs)
+ *   --label-only:   Only apply the c-* label
+ *
+ * Environment:
+ *   PR_NUMBER  - Pull request number
+ *   PR_TITLE   - Pull request title (conventional commit format)
+ *   BASE_REF   - Base branch name (main, next, release/*)
+ *   GH_TOKEN   - GitHub token for API calls
+ *
+ * Usage:
+ *   PR_NUMBER=8895 PR_TITLE="fix(stripe): ..." BASE_REF=main \
+ *   npx tsx scripts/auto-changeset.ts
+ */
+
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+	detectAffectedPackages,
+	mapTypeToBump,
+	parseConventionalCommit,
+	resolveDomain,
+} from "./lib/pr-analyzer.ts";
+
+function exec(cmd: string): string {
+	return execSync(cmd, { encoding: "utf-8" }).trim();
+}
+
+function getEnv(name: string): string {
+	const val = process.env[name];
+	if (!val) {
+		console.error(`Missing required env var: ${name}`);
+		process.exit(1);
+	}
+	return val;
+}
+
+function getChangedFiles(prNumber: string): string[] {
+	try {
+		return exec(`gh pr diff ${prNumber} --name-only`)
+			.split("\n")
+			.filter(Boolean);
+	} catch {
+		console.error("Failed to get PR diff");
+		return [];
+	}
+}
+
+function applyLabel(prNumber: string, domain: string): void {
+	try {
+		exec(`gh pr edit ${prNumber} --add-label ${domain}`);
+		console.log(`Applied label: ${domain}`);
+	} catch (err) {
+		console.error(`Failed to apply label ${domain}:`, err);
+	}
+}
+
+function hasExistingChangeset(prNumber: string): boolean {
+	try {
+		const diff = exec(`gh pr diff ${prNumber} --name-only`);
+		return diff
+			.split("\n")
+			.some((f) => f.startsWith(".changeset/") && f.endsWith(".md"));
+	} catch {
+		return false;
+	}
+}
+
+function hasSkipLabel(prNumber: string): boolean {
+	try {
+		const labels = exec(
+			`gh pr view ${prNumber} --json labels --jq '.labels[].name'`,
+		);
+		return labels.split("\n").includes("skip-changeset");
+	} catch {
+		return false;
+	}
+}
+
+function generateChangesetContent(
+	packages: string[],
+	bump: "patch" | "minor" | "major",
+	subject: string,
+): string {
+	const header = packages.map((pkg) => `"${pkg}": ${bump}`).join("\n");
+	return `---\n${header}\n---\n\n${subject}\n`;
+}
+
+function enforceBasePolicy(
+	baseRef: string,
+	bump: "patch" | "minor" | "major",
+): "patch" | "minor" | "major" {
+	if (baseRef === "main" && bump !== "patch") {
+		console.log(
+			`Base is main, downgrading ${bump} to patch (main is patch-only).`,
+		);
+		return "patch";
+	}
+	return bump;
+}
+
+function postStickyComment(prNumber: string, content: string): void {
+	const marker = "<!-- auto-changeset -->";
+	const body = `${marker}\n\n**Auto-generated changeset:**\n\n\`\`\`markdown\n${content}\`\`\`\n\nCopy this into a \`.changeset/*.md\` file to include it in the release.`;
+
+	try {
+		const comments = exec(
+			`gh api repos/{owner}/{repo}/issues/${prNumber}/comments --jq '.[].body'`,
+		);
+		if (comments.includes(marker)) {
+			const commentId = exec(
+				`gh api repos/{owner}/{repo}/issues/${prNumber}/comments --jq '.[] | select(.body | contains("${marker}")) | .id'`,
+			);
+			if (commentId) {
+				exec(
+					`gh api repos/{owner}/{repo}/issues/comments/${commentId} -X PATCH -f body='${body.replace(/'/g, "'\\''")}'`,
+				);
+				console.log("Updated existing changeset comment.");
+				return;
+			}
+		}
+		exec(`gh pr comment ${prNumber} --body '${body.replace(/'/g, "'\\''")}'`);
+		console.log("Posted changeset comment.");
+	} catch (err) {
+		console.error("Failed to post comment:", err);
+	}
+}
+
+function main(): void {
+	const prNumber = getEnv("PR_NUMBER");
+	const prTitle = getEnv("PR_TITLE");
+	const baseRef = getEnv("BASE_REF");
+
+	const mode = process.argv.includes("--comment-only")
+		? "comment-only"
+		: process.argv.includes("--label-only")
+			? "label-only"
+			: "default";
+
+	const parsed = parseConventionalCommit(prTitle);
+	const changedFiles = getChangedFiles(prNumber);
+	const domain = resolveDomain(parsed.scope, changedFiles);
+
+	applyLabel(prNumber, domain);
+
+	if (mode === "label-only") {
+		console.log("Label-only mode, done.");
+		return;
+	}
+
+	let bump = mapTypeToBump(parsed.type, parsed.breaking);
+	if (bump === "skip") {
+		console.log(`Type "${parsed.type}" does not require a changeset.`);
+		return;
+	}
+
+	if (hasSkipLabel(prNumber)) {
+		console.log("skip-changeset label found, skipping.");
+		return;
+	}
+
+	if (hasExistingChangeset(prNumber)) {
+		console.log("PR already contains a changeset, skipping.");
+		return;
+	}
+
+	bump = enforceBasePolicy(baseRef, bump);
+	const packages = detectAffectedPackages(changedFiles);
+
+	if (packages.length === 0) {
+		console.log("No publishable packages affected, skipping changeset.");
+		return;
+	}
+
+	const content = generateChangesetContent(packages, bump, parsed.subject);
+
+	if (mode === "comment-only") {
+		postStickyComment(prNumber, content);
+		return;
+	}
+
+	// Default mode: write file, commit, push
+	const changesetDir = path.resolve(".changeset");
+	if (!fs.existsSync(changesetDir)) {
+		fs.mkdirSync(changesetDir, { recursive: true });
+	}
+
+	const filename = `pr-${prNumber}.md`;
+	const filepath = path.join(changesetDir, filename);
+	fs.writeFileSync(filepath, content);
+	console.log(`Wrote ${filepath}`);
+
+	try {
+		exec(`git add ${filepath}`);
+		exec(`git commit -m "chore: add changeset for PR #${prNumber}"`);
+		exec("git push");
+		console.log("Changeset committed and pushed.");
+	} catch (err) {
+		console.error("Failed to commit changeset:", err);
+	}
+}
+
+try {
+	main();
+} catch (err) {
+	console.error("auto-changeset failed:", err);
+	process.exit(1);
+}

--- a/scripts/lib/pr-analyzer.ts
+++ b/scripts/lib/pr-analyzer.ts
@@ -1,0 +1,375 @@
+/**
+ * Shared module for PR analysis and domain classification.
+ * Used by auto-changeset (PR time) and release-notes (publish time).
+ *
+ * Classification algorithm (tested against 97 real commits):
+ * 1. Scope from PR title takes priority (conventional commit scope -> c-* label)
+ * 2. File-path majority vote (count files per domain, pick highest)
+ * 3. Cross-cutting fallback (3+ domains touched -> c-core)
+ */
+
+export interface ConventionalCommit {
+	type: string;
+	scope: string | undefined;
+	subject: string;
+	breaking: boolean;
+}
+
+export interface Commit {
+	hash: string;
+	message: string;
+	author?: string;
+}
+
+const SCOPE_TO_DOMAIN: Record<string, string> = {
+	core: "c-core",
+	api: "c-core",
+	client: "c-core",
+	cookies: "c-core",
+	crypto: "c-core",
+	account: "c-core",
+	session: "c-core",
+	instrumentation: "c-core",
+	"last-login-method": "c-core",
+	"redis-storage": "c-core",
+
+	db: "c-database",
+	adapters: "c-database",
+	"drizzle-adapter": "c-database",
+	"prisma-adapter": "c-database",
+	"kysely-adapter": "c-database",
+	"mongo-adapter": "c-database",
+	"memory-adapter": "c-database",
+
+	"oauth-proxy": "c-oauth",
+	"one-tap": "c-oauth",
+	"generic-oauth": "c-oauth",
+	"social-provider": "c-oauth",
+
+	"magic-link": "c-credentials",
+	"email-otp": "c-credentials",
+	"phone-number": "c-credentials",
+	phone: "c-credentials",
+	username: "c-credentials",
+	anonymous: "c-credentials",
+	siwe: "c-credentials",
+	passkey: "c-credentials",
+
+	"oauth-provider": "c-identity",
+	"oidc-provider": "c-identity",
+	mcp: "c-identity",
+	"device-authorization": "c-identity",
+
+	organization: "c-organization",
+	admin: "c-organization",
+	access: "c-organization",
+
+	"two-factor": "c-security",
+	"2fa": "c-security",
+	captcha: "c-security",
+	haveibeenpwned: "c-security",
+	"rate-limiter": "c-security",
+
+	sso: "c-enterprise",
+	scim: "c-enterprise",
+
+	stripe: "c-payments",
+	"api-key": "c-payments",
+
+	expo: "c-platform",
+	electron: "c-platform",
+
+	cli: "c-devtools",
+	telemetry: "c-devtools",
+	i18n: "c-devtools",
+	"test-utils": "c-devtools",
+	"open-api": "c-devtools",
+
+	build: "c-infra",
+	ci: "c-infra",
+	deps: "c-infra",
+	"deps-dev": "c-infra",
+	knip: "c-infra",
+
+	docs: "c-docs",
+	blog: "c-docs",
+	landing: "c-docs",
+};
+
+const PATH_TO_DOMAIN: [string, string][] = [
+	// Identity
+	["packages/oauth-provider/", "c-identity"],
+	["packages/better-auth/src/plugins/oidc-provider/", "c-identity"],
+	["packages/better-auth/src/plugins/mcp/", "c-identity"],
+	["packages/better-auth/src/plugins/device-authorization/", "c-identity"],
+
+	// Credentials
+	["packages/better-auth/src/plugins/magic-link/", "c-credentials"],
+	["packages/better-auth/src/plugins/email-otp/", "c-credentials"],
+	["packages/better-auth/src/plugins/phone-number/", "c-credentials"],
+	["packages/better-auth/src/plugins/username/", "c-credentials"],
+	["packages/better-auth/src/plugins/anonymous/", "c-credentials"],
+	["packages/better-auth/src/plugins/siwe/", "c-credentials"],
+	["packages/passkey/", "c-credentials"],
+
+	// Security
+	["packages/better-auth/src/plugins/two-factor/", "c-security"],
+	["packages/better-auth/src/api/rate-limiter/", "c-security"],
+	["packages/better-auth/src/plugins/captcha/", "c-security"],
+	["packages/better-auth/src/plugins/haveibeenpwned/", "c-security"],
+
+	// Organization
+	["packages/better-auth/src/plugins/organization/", "c-organization"],
+	["packages/better-auth/src/plugins/admin/", "c-organization"],
+	["packages/better-auth/src/plugins/access/", "c-organization"],
+
+	// OAuth
+	["packages/better-auth/src/plugins/generic-oauth/", "c-oauth"],
+	["packages/better-auth/src/plugins/oauth-proxy/", "c-oauth"],
+	["packages/better-auth/src/plugins/one-tap/", "c-oauth"],
+	["packages/better-auth/src/oauth2/", "c-oauth"],
+	["packages/core/src/social-providers/", "c-oauth"],
+	["packages/core/src/oauth2/", "c-oauth"],
+
+	// Enterprise
+	["packages/sso/", "c-enterprise"],
+	["packages/scim/", "c-enterprise"],
+
+	// Payments
+	["packages/stripe/", "c-payments"],
+	["packages/api-key/", "c-payments"],
+
+	// Database
+	["packages/better-auth/src/db/", "c-database"],
+	["packages/better-auth/src/adapters/", "c-database"],
+	["packages/drizzle-adapter/", "c-database"],
+	["packages/prisma-adapter/", "c-database"],
+	["packages/mongo-adapter/", "c-database"],
+	["packages/kysely-adapter/", "c-database"],
+	["packages/memory-adapter/", "c-database"],
+
+	// Platform
+	["packages/expo/", "c-platform"],
+	["packages/electron/", "c-platform"],
+	["packages/better-auth/src/integrations/", "c-platform"],
+
+	// Devtools
+	["packages/cli/", "c-devtools"],
+	["packages/better-auth/src/plugins/open-api/", "c-devtools"],
+	["packages/telemetry/", "c-devtools"],
+	["packages/i18n/", "c-devtools"],
+	["packages/test-utils/", "c-devtools"],
+
+	// Core (specific plugins before catch-all)
+	["packages/better-auth/src/plugins/jwt/", "c-core"],
+	["packages/better-auth/src/plugins/bearer/", "c-core"],
+	["packages/better-auth/src/plugins/multi-session/", "c-core"],
+	["packages/better-auth/src/plugins/custom-session/", "c-core"],
+	["packages/redis-storage/", "c-core"],
+
+	// Catch-alls
+	["packages/better-auth/", "c-core"],
+	["packages/core/", "c-core"],
+	["docs/", "c-docs"],
+	["demo/", "c-docs"],
+	[".github/", "c-infra"],
+	["e2e/", "c-infra"],
+];
+
+const DIR_TO_PACKAGE: Record<string, string> = {
+	"better-auth": "better-auth",
+	core: "@better-auth/core",
+	cli: "auth",
+	"api-key": "@better-auth/api-key",
+	"drizzle-adapter": "@better-auth/drizzle-adapter",
+	electron: "@better-auth/electron",
+	expo: "@better-auth/expo",
+	i18n: "@better-auth/i18n",
+	"kysely-adapter": "@better-auth/kysely-adapter",
+	"memory-adapter": "@better-auth/memory-adapter",
+	"mongo-adapter": "@better-auth/mongo-adapter",
+	"oauth-provider": "@better-auth/oauth-provider",
+	passkey: "@better-auth/passkey",
+	"prisma-adapter": "@better-auth/prisma-adapter",
+	"redis-storage": "@better-auth/redis-storage",
+	scim: "@better-auth/scim",
+	sso: "@better-auth/sso",
+	stripe: "@better-auth/stripe",
+	telemetry: "@better-auth/telemetry",
+	"test-utils": "@better-auth/test-utils",
+};
+
+/** Domain display order matching architecture layers */
+export const DOMAIN_ORDER = [
+	"c-core",
+	"c-database",
+	"c-oauth",
+	"c-credentials",
+	"c-identity",
+	"c-organization",
+	"c-security",
+	"c-enterprise",
+	"c-payments",
+	"c-platform",
+	"c-devtools",
+] as const;
+
+/** Human-readable domain labels */
+export const DOMAIN_LABELS: Record<string, string> = {
+	"c-core": "Core",
+	"c-database": "Database",
+	"c-oauth": "OAuth",
+	"c-credentials": "Credentials",
+	"c-identity": "Identity",
+	"c-organization": "Organization",
+	"c-security": "Security",
+	"c-enterprise": "Enterprise",
+	"c-payments": "Payments",
+	"c-platform": "Platform",
+	"c-devtools": "Devtools",
+};
+
+/** Parse a conventional commit title into its components */
+export function parseConventionalCommit(title: string): ConventionalCommit {
+	const match = title.match(/^(\w+)(?:\(([^)]*)\))?(!)?\s*:\s*(.+)$/);
+	if (!match) {
+		return {
+			type: "unknown",
+			scope: undefined,
+			subject: title,
+			breaking: false,
+		};
+	}
+	const [, type, scope, bang, subject] = match;
+	return {
+		type: type!,
+		scope: scope || undefined,
+		subject: subject!.trim(),
+		breaking: bang === "!",
+	};
+}
+
+/** Map a conventional commit scope to its c-* domain label */
+export function scopeToDomain(scope: string): string | undefined {
+	return SCOPE_TO_DOMAIN[scope];
+}
+
+/** Classify a file path to its c-* domain label (first match wins) */
+export function classifyDomain(filePath: string): string | undefined {
+	for (const [prefix, domain] of PATH_TO_DOMAIN) {
+		if (filePath.startsWith(prefix)) {
+			return domain;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Resolve the domain for a PR/commit given its scope and changed files.
+ *
+ * Priority: scope lookup -> cross-cutting fallback (3+ domains) -> majority vote.
+ */
+export function resolveDomain(
+	scope: string | undefined,
+	changedFiles: string[],
+): string {
+	if (scope) {
+		const domain = scopeToDomain(scope);
+		if (domain) return domain;
+	}
+
+	const counts = new Map<string, number>();
+	for (const file of changedFiles) {
+		const domain = classifyDomain(file);
+		if (domain) {
+			counts.set(domain, (counts.get(domain) ?? 0) + 1);
+		}
+	}
+
+	if (counts.size >= 3) return "c-core";
+
+	let best = "c-core";
+	let bestCount = 0;
+	for (const [domain, count] of counts) {
+		if (count > bestCount) {
+			best = domain;
+			bestCount = count;
+		}
+	}
+	return best;
+}
+
+/** Map conventional commit type + breaking flag to a changeset bump level */
+export function mapTypeToBump(
+	type: string,
+	breaking: boolean,
+): "patch" | "minor" | "major" | "skip" {
+	if (breaking) return "major";
+	switch (type) {
+		case "fix":
+		case "perf":
+		case "refactor":
+			return "patch";
+		case "feat":
+			return "minor";
+		default:
+			return "skip";
+	}
+}
+
+/**
+ * Extract affected npm package names from changed file paths.
+ *
+ * Handles the fixed group: if the only package is @better-auth/core,
+ * it is replaced with better-auth (they are released together).
+ */
+export function detectAffectedPackages(changedFiles: string[]): string[] {
+	const dirs = new Set<string>();
+	for (const file of changedFiles) {
+		const match = file.match(/^packages\/([^/]+)\//);
+		if (match) {
+			dirs.add(match[1]!);
+		}
+	}
+
+	const packages: string[] = [];
+	for (const dir of dirs) {
+		const pkg = DIR_TO_PACKAGE[dir];
+		if (pkg) {
+			packages.push(pkg);
+		}
+	}
+
+	// Fixed group: core alone -> better-auth
+	if (packages.length === 1 && packages[0] === "@better-auth/core") {
+		return ["better-auth"];
+	}
+
+	return packages.sort();
+}
+
+/**
+ * Cancel revert chains: if commit A says 'Revert "X"' and commit B
+ * has message X, remove both from the list.
+ */
+export function cancelReverts(commits: Commit[]): Commit[] {
+	const revertPattern = /^Revert "(.+)"$/;
+	const reverted = new Set<string>();
+	const revertHashes = new Set<string>();
+
+	// First pass: find all revert commits and their targets
+	for (const commit of commits) {
+		const match = commit.message.match(revertPattern);
+		if (match) {
+			reverted.add(match[1]!);
+			revertHashes.add(commit.hash);
+		}
+	}
+
+	// Second pass: remove both the revert and the reverted commit
+	return commits.filter((commit) => {
+		if (revertHashes.has(commit.hash)) return false;
+		if (reverted.has(commit.message)) return false;
+		return true;
+	});
+}

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * Rewrites GitHub Release body with domain-categorized notes.
+ *
+ * Runs as a post-publish step in release.yml.
+ * Reads PUBLISHED_PACKAGES env var from changesets/action output.
+ *
+ * Usage:
+ *   PUBLISHED_PACKAGES='[{"name":"better-auth","version":"1.6.0"}]' \
+ *   GH_TOKEN=... \
+ *   npx tsx scripts/release-notes.ts
+ */
+
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Commit, ConventionalCommit } from "./lib/pr-analyzer.ts";
+import {
+	cancelReverts,
+	DOMAIN_LABELS,
+	DOMAIN_ORDER,
+	mapTypeToBump,
+	parseConventionalCommit,
+	resolveDomain,
+} from "./lib/pr-analyzer.ts";
+
+interface PublishedPackage {
+	name: string;
+	version: string;
+}
+
+function exec(cmd: string): string {
+	return execSync(cmd, { encoding: "utf-8" }).trim();
+}
+
+function getChangedFiles(hash: string): string[] {
+	try {
+		return exec(`git diff-tree --no-commit-id --name-only -r ${hash}`)
+			.split("\n")
+			.filter(Boolean);
+	} catch {
+		return [];
+	}
+}
+
+interface ClassifiedCommit {
+	parsed: ConventionalCommit;
+	domain: string;
+	hash: string;
+	prNumber: string | undefined;
+}
+
+function extractPrNumber(subject: string): string | undefined {
+	const match = subject.match(/\(#(\d+)\)$/);
+	return match ? match[1] : undefined;
+}
+
+function isUserFacing(type: string): boolean {
+	return mapTypeToBump(type, false) !== "skip";
+}
+
+function classifyCommits(range: string): ClassifiedCommit[] {
+	const raw = exec(`git log --no-merges --oneline ${range}`);
+	if (!raw) return [];
+
+	const commits: Commit[] = raw
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => {
+			const spaceIdx = line.indexOf(" ");
+			return {
+				hash: line.slice(0, spaceIdx),
+				message: line.slice(spaceIdx + 1),
+			};
+		});
+
+	const surviving = cancelReverts(commits);
+
+	const classified: ClassifiedCommit[] = [];
+	for (const commit of surviving) {
+		const parsed = parseConventionalCommit(commit.message);
+		if (!isUserFacing(parsed.type)) continue;
+
+		const files = getChangedFiles(commit.hash);
+		const domain = resolveDomain(parsed.scope, files);
+		const prNumber = extractPrNumber(parsed.subject);
+
+		classified.push({ parsed, domain, hash: commit.hash, prNumber });
+	}
+
+	return classified;
+}
+
+interface ContributorInfo {
+	login: string;
+	prNumber: string;
+}
+
+function getCommunityContributors(
+	classified: ClassifiedCommit[],
+): ContributorInfo[] {
+	const contributors: ContributorInfo[] = [];
+	const seen = new Set<string>();
+
+	for (const commit of classified) {
+		if (!commit.prNumber) continue;
+
+		try {
+			const json = exec(
+				`gh api repos/{owner}/{repo}/pulls/${commit.prNumber} --jq '.author_association + " " + .user.login'`,
+			);
+			const [association, login] = json.split(" ");
+			if (
+				association !== "MEMBER" &&
+				association !== "OWNER" &&
+				login &&
+				!seen.has(login)
+			) {
+				seen.add(login);
+				contributors.push({ login, prNumber: commit.prNumber });
+			}
+		} catch {
+			// Non-critical, skip
+		}
+	}
+
+	return contributors;
+}
+
+function formatReleaseNotes(
+	classified: ClassifiedCommit[],
+	contributors: ContributorInfo[],
+): string {
+	const grouped = new Map<string, ClassifiedCommit[]>();
+	for (const commit of classified) {
+		const list = grouped.get(commit.domain) ?? [];
+		list.push(commit);
+		grouped.set(commit.domain, list);
+	}
+
+	const lines: string[] = [];
+
+	for (const domain of DOMAIN_ORDER) {
+		const commits = grouped.get(domain);
+		if (!commits?.length) continue;
+
+		const label = DOMAIN_LABELS[domain] ?? domain;
+		lines.push(`### ${label}`);
+		lines.push("");
+
+		for (const commit of commits) {
+			const pr = commit.prNumber ? ` (#${commit.prNumber})` : "";
+			const prefix = commit.parsed.breaking ? "**BREAKING** " : "";
+			lines.push(`- ${prefix}${commit.parsed.subject}${pr}`);
+		}
+		lines.push("");
+	}
+
+	if (contributors.length > 0) {
+		lines.push("### New Contributors");
+		lines.push("");
+		for (const c of contributors) {
+			lines.push(
+				`- @${c.login} made their first contribution in #${c.prNumber}`,
+			);
+		}
+		lines.push("");
+	}
+
+	return lines.join("\n");
+}
+
+function main(): void {
+	const publishedRaw = process.env.PUBLISHED_PACKAGES;
+	if (!publishedRaw) {
+		console.log("No PUBLISHED_PACKAGES env var, skipping release notes.");
+		return;
+	}
+
+	let packages: PublishedPackage[];
+	try {
+		packages = JSON.parse(publishedRaw) as PublishedPackage[];
+	} catch {
+		console.error("Failed to parse PUBLISHED_PACKAGES");
+		return;
+	}
+
+	const betterAuth = packages.find((p) => p.name === "better-auth");
+	if (!betterAuth) {
+		console.log("better-auth not in published packages, skipping.");
+		return;
+	}
+
+	const tag = `better-auth@${betterAuth.version}`;
+	console.log(`Generating release notes for ${tag}`);
+
+	// Find previous tag
+	let prevTag: string;
+	try {
+		const tags = exec("git tag --sort=-version:refname --list 'better-auth@*'")
+			.split("\n")
+			.filter(Boolean);
+		const currentIdx = tags.indexOf(tag);
+		if (currentIdx === -1 || currentIdx + 1 >= tags.length) {
+			console.log("Could not find previous tag, skipping.");
+			return;
+		}
+		prevTag = tags[currentIdx + 1]!;
+	} catch {
+		console.log("Failed to list tags, skipping.");
+		return;
+	}
+
+	console.log(`Comparing ${prevTag}..${tag}`);
+
+	const classified = classifyCommits(`${prevTag}..${tag}`);
+	if (classified.length === 0) {
+		console.log("No user-facing commits found.");
+		return;
+	}
+
+	const contributors = getCommunityContributors(classified);
+	const body = formatReleaseNotes(classified, contributors);
+
+	const tmpFile = path.join(os.tmpdir(), `release-notes-${Date.now()}.md`);
+	fs.writeFileSync(tmpFile, body);
+
+	try {
+		exec(`gh release edit ${tag} --notes-file ${tmpFile}`);
+		console.log("Release notes updated.");
+	} catch (err) {
+		console.error("Failed to update release notes:", err);
+	} finally {
+		fs.unlinkSync(tmpFile);
+	}
+}
+
+try {
+	main();
+} catch (err) {
+	console.error("release-notes failed:", err);
+	// Exit 0 to not block CI
+}


### PR DESCRIPTION
## Summary

Adds 3 scripts for automated release notes and changeset generation:

- `scripts/lib/pr-analyzer.ts` — shared domain classification module
- `scripts/auto-changeset.ts` — auto-generates changeset files from PR metadata
- `scripts/release-notes.ts` — rewrites GitHub Release body with domain-categorized notes

### How it works

**Auto-changeset (PR time):**
- Parses PR title (conventional commit format)
- Detects affected packages from changed files
- Classifies domain from scope + file paths → applies `c-*` label
- Team PRs: commits `.changeset/pr-{N}.md` directly
- Fork PRs: posts comment with changeset content

**Release notes (publish time):**
- Reads commits between previous and current tag
- Classifies each by domain (scope priority → file-path majority → cross-cutting fallback)
- Cancels revert chains
- Formats categorized markdown with community contributor section
- Updates GitHub Release body via `gh release edit`

### Classification

Uses the `c-*` label system (13 domains matching CODEOWNERS):
`c-core`, `c-database`, `c-oauth`, `c-credentials`, `c-identity`, `c-organization`, `c-security`, `c-enterprise`, `c-payments`, `c-platform`, `c-devtools`, `c-docs`, `c-infra`

Tested against 97 real commits (v1.5.6..HEAD) with 0 misclassifications for scoped commits.

### Integration points

- `auto-changeset.yml` (new workflow) — triggers on PR open/synchronize
- `release.yml` (existing) — post-publish step for release notes rewrite
- No new dependencies (uses Node 24 built-in + `gh` CLI)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CI scripts to auto-generate changesets and rewrite GitHub Release notes using domain-based classification. This reduces manual release work and keeps `c-*` labels and release notes consistent.

- **New Features**
  - `scripts/auto-changeset.ts`: generates `.changeset` from PR title + files, applies `c-*` label; supports `--comment-only` (forks) and `--label-only`.
  - `scripts/release-notes.ts`: groups commits by domain, removes revert chains, and updates releases via `gh release edit`.
  - `scripts/lib/pr-analyzer.ts`: shared parser and domain resolver (scope > file-path majority > fallback), package detection, and bump mapping.
  - CI: adds `auto-changeset.yml` (on PR open/sync) and hooks into `release.yml` (post-publish). `knip.jsonc` ignores `scripts/**`. No new deps (Node 24 + `gh`).

<sup>Written for commit d0b831627ca5d20feb60acbbd50726c30e8f1c3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

