### PR TITLE
fix: patch changesets to fix pre-release peer dep version escalation

### DIFF
--- a/patches/@changesets__assemble-release-plan.patch
+++ b/patches/@changesets__assemble-release-plan.patch
@@ -1,0 +1,44 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index e07ba6e793021b6cfdec898afca517e293386ddb..c3c7c78be51bbc4bf25da83d634f8899afc68bf9 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -216,7 +216,7 @@ function determineDependents({
+             onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
+           })) {
+             type = "major";
+-          } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange))) {
++          } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange, preInfo ? { includePrerelease: true } : undefined))) {
+             switch (depType) {
+               case "dependencies":
+               case "optionalDependencies":
+@@ -321,7 +321,7 @@ function shouldBumpMajor({
+   return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
+   // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+   // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
+-  !onlyUpdatePeerDependentsWhenOutOfRange || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange)) && (
++  !onlyUpdatePeerDependentsWhenOutOfRange || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange, preInfo ? { includePrerelease: true } : undefined)) && (
+   // bump major only if the dependent doesn't already has a major release.
+   !releases.has(dependent) || releases.has(dependent) && releases.get(dependent).type !== "major");
+ }
+diff --git a/dist/changesets-assemble-release-plan.esm.js b/dist/changesets-assemble-release-plan.esm.js
+index ea2be567403c4ef94a65f3218ccb683cf5cb4bc1..0994493ff553b1ed856cb54a0db1648f56d550bc 100644
+--- a/dist/changesets-assemble-release-plan.esm.js
++++ b/dist/changesets-assemble-release-plan.esm.js
+@@ -205,7 +205,7 @@ function determineDependents({
+             onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
+           })) {
+             type = "major";
+-          } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange))) {
++          } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange, preInfo ? { includePrerelease: true } : undefined))) {
+             switch (depType) {
+               case "dependencies":
+               case "optionalDependencies":
+@@ -310,7 +310,7 @@ function shouldBumpMajor({
+   return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
+   // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+   // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
+-  !onlyUpdatePeerDependentsWhenOutOfRange || !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange)) && (
++  !onlyUpdatePeerDependentsWhenOutOfRange || !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange, preInfo ? { includePrerelease: true } : undefined)) && (
+   // bump major only if the dependent doesn't already has a major release.
+   !releases.has(dependent) || releases.has(dependent) && releases.get(dependent).type !== "major");
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,11 @@ catalogs:
 overrides:
   axios: <1.14.0
 
+patchedDependencies:
+  '@changesets/assemble-release-plan':
+    hash: 0599486e3d3f68b6f30d0f55a524ccac93e7fe24b273f0f5691b59685498605f
+    path: patches/@changesets__assemble-release-plan.patch
+
 importers:
 
   .:
@@ -16045,7 +16050,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.4
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@6.0.9(patch_hash=0599486e3d3f68b6f30d0f55a524ccac93e7fe24b273f0f5691b59685498605f)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -16069,7 +16074,7 @@ snapshots:
   '@changesets/cli@2.30.0(@types/node@25.3.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=0599486e3d3f68b6f30d0f55a524ccac93e7fe24b273f0f5691b59685498605f)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.3
       '@changesets/errors': 0.2.0
@@ -16128,7 +16133,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.15':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=0599486e3d3f68b6f30d0f55a524ccac93e7fe24b273f0f5691b59685498605f)
       '@changesets/config': 3.1.3
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,9 @@ onlyBuiltDependencies:
 overrides:
   axios: <1.14.0
 
+patchedDependencies:
+  '@changesets/assemble-release-plan': patches/@changesets__assemble-release-plan.patch
+
 trustPolicy: no-downgrade
 
 trustPolicyIgnoreAfter: 43200


### PR DESCRIPTION
## Summary

Patches `@changesets/assemble-release-plan` to pass `{ includePrerelease: true }` to `semver.satisfies()` when in pre-release mode.

Without this patch, pre-release versions like `1.6.0-beta.0` are incorrectly considered "out of range" for `^1.5.6` by the semver spec (pre-releases only match ranges for the same major.minor.patch tuple). This causes all peer dependents to escalate to major versions (`2.0.0-beta.0` instead of remaining at `1.5.x-beta.0`).

Upstream bug: changesets/changesets#960 (open since 2022, confirmed by maintainer).

### Tested

Verified locally: with the patch, a minor changeset for `better-auth` in pre-release mode produces `1.6.0-beta.0` for core and patch bumps for dependents — no major escalation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pre-release peer dependency version escalation by patching `@changesets/assemble-release-plan` so pre-releases count as in-range during pre mode. This keeps dependents on minor/patch betas instead of jumping to major betas.

- Bug Fixes
  - Passes `{ includePrerelease: true }` to `semver.satisfies()` when in pre-release mode to correctly evaluate ranges.

- Dependencies
  - Adds a `pnpm` patch for `@changesets/assemble-release-plan`; updates `pnpm-lock.yaml` and `pnpm-workspace.yaml` to apply it automatically.

<sup>Written for commit d5f4e5cc72f99ac6dc5d9b8ceccd07dc1b2cdf03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

