### PR TITLE
chore: add all packages to changesets fixed group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,30 @@
     { "repo": "better-auth/better-auth" }
   ],
   "commit": false,
-  "fixed": [["better-auth", "@better-auth/core"]],
+  "fixed": [
+    [
+      "better-auth",
+      "@better-auth/core",
+      "auth",
+      "@better-auth/api-key",
+      "@better-auth/drizzle-adapter",
+      "@better-auth/electron",
+      "@better-auth/expo",
+      "@better-auth/i18n",
+      "@better-auth/kysely-adapter",
+      "@better-auth/memory-adapter",
+      "@better-auth/mongo-adapter",
+      "@better-auth/oauth-provider",
+      "@better-auth/passkey",
+      "@better-auth/prisma-adapter",
+      "@better-auth/redis-storage",
+      "@better-auth/scim",
+      "@better-auth/sso",
+      "@better-auth/stripe",
+      "@better-auth/telemetry",
+      "@better-auth/test-utils"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary

Add all 20 published packages to the changesets `fixed` group so they always share the same version number.

Previously only `better-auth` and `@better-auth/core` were locked together. This caused version drift where some packages would be at `1.6.0-beta.0` and others at `1.5.7-beta.0` in the same release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add all 20 published packages to the `changesets` `fixed` group so they always share the same version number. This prevents version drift and ensures releasing any package bumps the version for all.

<sup>Written for commit 54aa1c58cb2be04be7ed6675d64779bc9c7ad2f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

