### PR TITLE
fix: cookie store strategy should verify oauth state

### DIFF
--- a/.changeset/famous-banks-open.md
+++ b/.changeset/famous-banks-open.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-fix: on cookie-backed state the OAuth callback’s state parameter should match the nonce stored
+security: verify OAuth state parameter against cookie-stored nonce to prevent CSRF on cookie-backed flows

--- a/.changeset/famous-banks-open.md
+++ b/.changeset/famous-banks-open.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+ensures the OAuth callback’s state parameter matches the nonce stored with the flow so cookie-backed state cannot be replayed with an attacker’s authorization code.

--- a/.changeset/famous-banks-open.md
+++ b/.changeset/famous-banks-open.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-ensures the OAuth callback’s state parameter matches the nonce stored with the flow so cookie-backed state cannot be replayed with an attacker’s authorization code.
+fix: on cookie-backed state the OAuth callback’s state parameter should match the nonce stored

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -990,17 +990,6 @@ describe("oauth2", async () => {
 	});
 
 	it("should reject cookie-backed OAuth when callback state does not match the issued state", async () => {
-		server.service.once("beforeUserinfo", (userInfoResponse) => {
-			userInfoResponse.body = {
-				email: "oauth2-csrf@test.com",
-				name: "OAuth2 CSRF",
-				sub: "oauth2-csrf",
-				picture: "https://test.com/picture.png",
-				email_verified: true,
-			};
-			userInfoResponse.statusCode = 200;
-		});
-
 		const { customFetchImpl, cookieSetter } = await getTestInstance({
 			plugins: [
 				genericOAuth({
@@ -1037,52 +1026,18 @@ describe("oauth2", async () => {
 				onSuccess: cookieSetter(victimHeaders),
 			},
 		});
-		const authUrl = signInRes.data?.url;
-		expect(authUrl).toBeTruthy();
+		expect(signInRes.data?.url).toBeTruthy();
 
-		let providerLocation: string | null = null;
-		await betterFetch(authUrl!, {
-			method: "GET",
-			customFetchImpl,
-			redirect: "manual",
-			onError(context) {
-				providerLocation = context.response.headers.get("location");
+		const res = await customFetchImpl(
+			"http://localhost:3000/api/auth/oauth2/callback/test-cookie-csrf?code=dummy&state=attacker-controlled-state",
+			{
+				headers: victimHeaders,
+				redirect: "manual",
 			},
-		});
-		expect(providerLocation).toBeTruthy();
+		);
 
-		let callbackLocation: string | null = null;
-		await betterFetch(providerLocation!, {
-			method: "GET",
-			customFetchImpl,
-			headers: victimHeaders,
-			redirect: "manual",
-			onError(context) {
-				callbackLocation = context.response.headers.get("location");
-			},
-		});
-		expect(callbackLocation).toBeTruthy();
-		expect(callbackLocation).toContain("code=");
-		expect(callbackLocation).toContain("state=");
-
-		const callbackUrl = new URL(callbackLocation!);
-		const code = callbackUrl.searchParams.get("code");
-		expect(code).toBeTruthy();
-		callbackUrl.searchParams.set("state", "attacker-controlled-state");
-
-		let finalRedirect: string | null = null;
-		await betterFetch(callbackUrl.toString(), {
-			method: "GET",
-			customFetchImpl,
-			headers: victimHeaders,
-			redirect: "manual",
-			onError(context) {
-				finalRedirect = context.response.headers.get("location");
-			},
-		});
-
-		expect(finalRedirect).toBeTruthy();
-		expect(finalRedirect).toContain("error=state_mismatch");
+		expect(res.status).toBe(302);
+		expect(res.headers.get("location")).toContain("state_mismatch");
 
 		const session = await authClient.getSession({
 			fetchOptions: {

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -989,6 +989,109 @@ describe("oauth2", async () => {
 		expect(session.data?.user.name).toBe("OAuth2 Cookie State");
 	});
 
+	it("should reject cookie-backed OAuth when callback state does not match the issued state", async () => {
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				email: "oauth2-csrf@test.com",
+				name: "OAuth2 CSRF",
+				sub: "oauth2-csrf",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const { customFetchImpl, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "test-cookie-csrf",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: false,
+						},
+					],
+				}),
+			],
+			account: {
+				storeStateStrategy: "cookie",
+			},
+		});
+
+		const victimHeaders = new Headers();
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				onSuccess: cookieSetter(victimHeaders),
+			},
+		});
+
+		const signInRes = await authClient.signIn.oauth2({
+			providerId: "test-cookie-csrf",
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: {
+				onSuccess: cookieSetter(victimHeaders),
+			},
+		});
+		const authUrl = signInRes.data?.url;
+		expect(authUrl).toBeTruthy();
+
+		let providerLocation: string | null = null;
+		await betterFetch(authUrl!, {
+			method: "GET",
+			customFetchImpl,
+			redirect: "manual",
+			onError(context) {
+				providerLocation = context.response.headers.get("location");
+			},
+		});
+		expect(providerLocation).toBeTruthy();
+
+		let callbackLocation: string | null = null;
+		await betterFetch(providerLocation!, {
+			method: "GET",
+			customFetchImpl,
+			headers: victimHeaders,
+			redirect: "manual",
+			onError(context) {
+				callbackLocation = context.response.headers.get("location");
+			},
+		});
+		expect(callbackLocation).toBeTruthy();
+		expect(callbackLocation).toContain("code=");
+		expect(callbackLocation).toContain("state=");
+
+		const callbackUrl = new URL(callbackLocation!);
+		const code = callbackUrl.searchParams.get("code");
+		expect(code).toBeTruthy();
+		callbackUrl.searchParams.set("state", "attacker-controlled-state");
+
+		let finalRedirect: string | null = null;
+		await betterFetch(callbackUrl.toString(), {
+			method: "GET",
+			customFetchImpl,
+			headers: victimHeaders,
+			redirect: "manual",
+			onError(context) {
+				finalRedirect = context.response.headers.get("location");
+			},
+		});
+
+		expect(finalRedirect).toBeTruthy();
+		expect(finalRedirect).toContain("error=state_mismatch");
+
+		const session = await authClient.getSession({
+			fetchOptions: {
+				headers: victimHeaders,
+			},
+		});
+		expect(session.data).toBeNull();
+	});
+
 	it("should await async mapProfileToUser", async () => {
 		const { auth } = await getTestInstance({
 			plugins: [

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -371,18 +371,19 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							return;
 						}
 
+						const errorURL =
+							stateData.errorURL ||
+							ctx.context.options.onAPIError?.errorURL ||
+							`${ctx.context.baseURL}/error`;
+
 						if (
 							stateData.oauthState !== undefined &&
 							stateData.oauthState !== statePackage.state
 						) {
 							ctx.context.logger.error("OAuth proxy state binding mismatch");
-							return;
+							throw redirectOnError(ctx, errorURL, "state_mismatch");
 						}
 
-						const errorURL =
-							stateData.errorURL ||
-							ctx.context.options.onAPIError?.errorURL ||
-							`${ctx.context.baseURL}/error`;
 						if (error) {
 							throw redirectOnError(ctx, errorURL, error);
 						}

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -375,9 +375,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							stateData.oauthState !== undefined &&
 							stateData.oauthState !== statePackage.state
 						) {
-							ctx.context.logger.error(
-								"OAuth proxy state binding mismatch",
-							);
+							ctx.context.logger.error("OAuth proxy state binding mismatch");
 							return;
 						}
 

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -371,6 +371,16 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							return;
 						}
 
+						if (
+							stateData.oauthState !== undefined &&
+							stateData.oauthState !== statePackage.state
+						) {
+							ctx.context.logger.error(
+								"OAuth proxy state binding mismatch",
+							);
+							return;
+						}
+
 						const errorURL =
 							stateData.errorURL ||
 							ctx.context.options.onAPIError?.errorURL ||

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -823,6 +823,7 @@ describe("signin", async () => {
 			expiresAt: expect.any(Number),
 			invitedBy: "user-123",
 			errorURL: "http://localhost:3000/api/auth/error",
+			oauthState: expect.any(String),
 		});
 	});
 

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -823,7 +823,7 @@ describe("signin", async () => {
 			expiresAt: expect.any(Number),
 			invitedBy: "user-123",
 			errorURL: "http://localhost:3000/api/auth/error",
-			oauthState: expect.any(String),
+			oauthState: state,
 		});
 	});
 

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -805,6 +805,7 @@ describe("signin", async () => {
 			redirect: true,
 		});
 		state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		expect(state).toBeTruthy();
 
 		await client.$fetch("/callback/google", {
 			query: {

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -109,7 +109,10 @@ export async function generateGenericState(
 	expiresAt.setMinutes(expiresAt.getMinutes() + 10);
 
 	const verification = await c.context.internalAdapter.createVerificationValue({
-		value: JSON.stringify({ ...stateData, oauthState: state } satisfies StateData),
+		value: JSON.stringify({
+			...stateData,
+			oauthState: state,
+		} satisfies StateData),
 		identifier: state,
 		expiresAt,
 	});

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -14,6 +14,11 @@ const stateDataSchema = z.looseObject({
 	errorURL: z.string().optional(),
 	newUserURL: z.string().optional(),
 	expiresAt: z.number(),
+	/**
+	 * CSRF nonce returned to the OAuth provider. When using cookie state storage,
+	 * this must match the callback `state` query parameter.
+	 */
+	oauthState: z.string().optional(),
 	link: z
 		.object({
 			email: z.string(),
@@ -61,9 +66,10 @@ export async function generateGenericState(
 	// State data is encrypted into the cookie
 	// no verification record created
 	if (storeStateStrategy === "cookie") {
+		const payload: StateData = { ...stateData, oauthState: state };
 		const encryptedData = await symmetricEncrypt({
 			key: c.context.secretConfig,
-			data: JSON.stringify(stateData),
+			data: JSON.stringify(payload),
 		});
 
 		const stateCookie = c.context.createAuthCookie(
@@ -103,7 +109,7 @@ export async function generateGenericState(
 	expiresAt.setMinutes(expiresAt.getMinutes() + 10);
 
 	const verification = await c.context.internalAdapter.createVerificationValue({
-		value: JSON.stringify(stateData),
+		value: JSON.stringify({ ...stateData, oauthState: state } satisfies StateData),
 		identifier: state,
 		expiresAt,
 	});
@@ -166,6 +172,16 @@ export async function parseGenericState(
 			);
 		}
 
+		if (!parsedData.oauthState || parsedData.oauthState !== state) {
+			throw new StateError(
+				"State mismatch: OAuth state parameter does not match stored state",
+				{
+					code: "state_security_mismatch",
+					details: { state },
+				},
+			);
+		}
+
 		// Clear the cookie after successful parsing
 		expireCookie(c, stateCookie);
 	} else {
@@ -179,6 +195,19 @@ export async function parseGenericState(
 		}
 
 		parsedData = stateDataSchema.parse(JSON.parse(data.value));
+
+		if (
+			parsedData.oauthState !== undefined &&
+			parsedData.oauthState !== state
+		) {
+			throw new StateError(
+				"State mismatch: OAuth state parameter does not match stored state",
+				{
+					code: "state_security_mismatch",
+					details: { state },
+				},
+			);
+		}
 
 		const stateCookie = c.context.createAuthCookie(
 			settings?.cookieName ?? "state",


### PR DESCRIPTION

### Summary
When `account.storeStateStrategy` is `"cookie"`, the OAuth callback only decrypted the `oauth_state` cookie and checked expiry. It did **not** verify that the `state` query parameter matched the nonce issued at sign-in, which broke CSRF binding for the authorization response.
This change stores the issued state (`oauthState`) inside the persisted payload (encrypted cookie and, for the database strategy, the verification record value) and rejects the callback unless the incoming `state` matches. The OAuth proxy path that decrypts the passthrough cookie now also checks `oauthState` against the inner state when present.
