### PR TITLE
fix(ci): mark test packages as private and remove duplicate beta title suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,8 @@ jobs:
         with:
           version: pnpm ci:version
           publish: pnpm ci:release
-          title: "chore: version packages${{ github.ref_name == 'next' && ' (beta)' || '' }}"
-          commit: "chore: version packages${{ github.ref_name == 'next' && ' (beta)' || '' }}"
+          title: "chore: version packages"
+          commit: "chore: version packages"
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}

--- a/e2e/integration/package.json
+++ b/e2e/integration/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@better-auth-test/integration",
+  "private": true,
   "scripts": {
     "e2e:integration": "playwright test"
   },

--- a/e2e/smoke/package.json
+++ b/e2e/smoke/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@better-auth-test/smoke",
+  "private": true,
   "type": "module",
   "dependencies": {
     "@better-auth/passkey": "workspace:*",


### PR DESCRIPTION
## Summary

- Mark `@better-auth-test/integration` and `@better-auth-test/smoke` as `private: true` — fixes the `ERR_PNPM_PACKAGE_VERSION_NOT_FOUND` error during publish
- Remove conditional `(beta)` suffix from Version Packages PR title — `changesets/action` already appends the pre-release tag, causing double `(beta) (beta)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release workflow by preventing test packages from being published and removing duplicate "(beta)" in Version Packages PR title/commit.

- **Bug Fixes**
  - Set `private: true` in `@better-auth-test/integration` and `@better-auth-test/smoke` to avoid `ERR_PNPM_PACKAGE_VERSION_NOT_FOUND` during publish.
  - Make `changesets/action` title/commit static (`"chore: version packages"`) since it already adds the pre-release tag, preventing `(beta) (beta)`.

<sup>Written for commit 3b66db9f547668d938cea289ea69713c4dc5f15d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

