### PR TITLE
chore: update CODEOWNERS with domain-based team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,58 @@
-# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Last matching pattern takes precedence.
+# Only lines that CHANGE the owner from the default need to exist.
+# Everything not listed here falls to the global fallback.
+# Teams must have Write access to the repo.
 
-* @Bekacru @himself65
+# ── Global fallback (covers: core, devtools, infra, and anything unlisted) ──
+* @better-auth/core
+
+# ── Database ──
+/packages/better-auth/src/db/                      @better-auth/data
+/packages/better-auth/src/adapters/                @better-auth/data
+/packages/drizzle-adapter/                         @better-auth/data
+/packages/prisma-adapter/                          @better-auth/data
+/packages/mongo-adapter/                           @better-auth/data
+/packages/kysely-adapter/                          @better-auth/data
+/packages/memory-adapter/                          @better-auth/data
+
+# ── Identity & Auth ──
+/packages/oauth-provider/                          @better-auth/identity
+/packages/better-auth/src/plugins/oidc-provider/   @better-auth/identity
+/packages/better-auth/src/plugins/mcp/             @better-auth/identity
+/packages/better-auth/src/plugins/device-authorization/ @better-auth/identity
+/packages/sso/                                     @better-auth/identity
+/packages/scim/                                    @better-auth/identity
+/packages/core/src/oauth2/                         @better-auth/identity
+/packages/better-auth/src/oauth2/                  @better-auth/identity
+/packages/passkey/                                 @better-auth/identity
+/packages/better-auth/src/plugins/two-factor/      @better-auth/identity
+/packages/better-auth/src/plugins/magic-link/      @better-auth/identity
+/packages/better-auth/src/plugins/email-otp/       @better-auth/identity
+/packages/better-auth/src/plugins/phone-number/    @better-auth/identity
+/packages/better-auth/src/plugins/username/        @better-auth/identity
+/packages/better-auth/src/plugins/anonymous/       @better-auth/identity
+/packages/better-auth/src/plugins/siwe/            @better-auth/identity
+/packages/better-auth/src/plugins/captcha/         @better-auth/identity
+/packages/better-auth/src/plugins/haveibeenpwned/  @better-auth/identity
+/packages/better-auth/src/plugins/generic-oauth/   @better-auth/identity
+/packages/better-auth/src/plugins/oauth-proxy/     @better-auth/identity
+/packages/better-auth/src/plugins/one-tap/         @better-auth/identity
+/packages/core/src/social-providers/               @better-auth/identity
+
+# ── Plugins (non-auth) ──
+/packages/better-auth/src/plugins/organization/    @better-auth/plugins
+/packages/better-auth/src/plugins/admin/           @better-auth/plugins
+/packages/better-auth/src/plugins/access/          @better-auth/plugins
+/packages/stripe/                                  @better-auth/plugins
+/packages/api-key/                                 @better-auth/plugins
+
+# ── Platform ──
+/packages/expo/                                    @better-auth/platform
+/packages/electron/                                @better-auth/platform
+/packages/better-auth/src/integrations/            @better-auth/platform
+
+# ── Documentation ──
+/docs/                                             @better-auth/docs
+/demo/                                             @better-auth/docs


### PR DESCRIPTION
## Summary

Replace the flat `* @Bekacru @himself65` rule with granular path-based ownership mapped to domain teams.

### Team updates applied
- All domain teams granted Write access to the repo (required for CODEOWNERS)
- Removed `dan-better-auth` from domain teams (separate hierarchy)
- Added `ping-maxwell` to `@better-auth/core`
- Added `jonathansamines` to `@better-auth/platform`

### How it works
- `* @better-auth/core` is the global fallback — covers core, devtools, infra, and anything unlisted
- Only paths that need a DIFFERENT team have explicit lines
- Last matching pattern wins (broadest first, most specific last)
- Using informational mode (no "Require review from Code Owners" in branch protection)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CODEOWNERS to domain-based, path-scoped ownership so reviews go to the right teams, with `@better-auth/core` as the default fallback. Keeps code owner checks informational only.

- **Refactors**
  - Replaced `*` catch-all with domain-based path rules (database, identity/auth, plugins, platform, docs); last match wins.
  - Global fallback is `@better-auth/core`; only overrides are listed; code owner reviews not required.
  - Team updates: granted Write to domain teams; removed `dan-better-auth`; added `ping-maxwell` to `@better-auth/core`; added `jonathansamines` to `@better-auth/platform`.

<sup>Written for commit cd6f9d2c31cc70ae562669014a1fd518c1be4140. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

