### PR TITLE
fix(ci): exclude promotion PRs from auto-retarget

### DIFF
--- a/.github/workflows/auto-retarget.yml
+++ b/.github/workflows/auto-retarget.yml
@@ -12,6 +12,7 @@ jobs:
     if: >
       github.repository_owner == 'better-auth' &&
       !startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
+      github.event.pull_request.head.ref != 'next' &&
       github.actor != 'github-actions[bot]' &&
       github.actor != 'better-auth-releases[bot]'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Promotion PRs (`next → main`) contain minor/major changesets by design. Without this exclusion, auto-retarget would move them back to `next`, breaking the promotion flow.
- Adds `github.event.pull_request.head.ref != 'next'` to the job condition.

## Context
Caught by Cubic review on #8957 (merged before this could be included).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude promotion PRs (`next` → `main`) from auto-retarget so they aren’t moved back to `next`. Adds `github.event.pull_request.head.ref != 'next'` to `.github/workflows/auto-retarget.yml` to preserve the promotion flow.

<sup>Written for commit 6982273b281c98aab87e5a3f3b3f168a54ae6cf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

