### PR TITLE
docs: change community plugin name

### DIFF
--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -291,8 +291,8 @@ export const communityPlugins: CommunityPlugin[] = [
 		},
 	},
 	{
-		name: "better-auth-invite-plugin",
-		url: "https://github.com/0-Sandy/better-auth-invite-plugin",
+		name: "better-invite",
+		url: "https://github.com/better-invite/better-invite",
 		description:
 			"Easily create and manage user invitations, allowing you to invite users with customizable settings and track usage.",
 		author: {


### PR DESCRIPTION
Change community plugin "better-auth-invite-plugin" name to "better-invite"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the community plugin `better-auth-invite-plugin` to `better-invite` and updated its GitHub URL in the Community Plugins table.

<sup>Written for commit 7fb8fab690357f19f8175becbe922ab21cb00b30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

