### PR TITLE
chore: downgrade `better-call`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 1.1.21
       version: 1.1.21
     better-call:
-      specifier: 2.0.3
-      version: 2.0.3
+      specifier: 1.3.5
+      version: 1.3.5
     tsdown:
       specifier: 0.21.1
       version: 0.21.1
@@ -827,7 +827,7 @@ importers:
         version: 7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       better-sqlite3:
         specifier: ^12.0.0
         version: 12.6.2
@@ -1070,7 +1070,7 @@ importers:
         version: 1.30.1(@opentelemetry/api@1.9.0)
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       jose:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1112,7 +1112,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       conf:
         specifier: ^15.0.2
         version: 15.1.0
@@ -1146,7 +1146,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1252,7 +1252,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       jose:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1292,7 +1292,7 @@ importers:
         version: 13.2.3
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       nanostores:
         specifier: ^1.0.1
         version: 1.1.1
@@ -1363,7 +1363,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1416,7 +1416,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       body-parser:
         specifier: ^2.2.2
         version: 2.2.2
@@ -1447,7 +1447,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       stripe:
         specifier: ^20.4.0
         version: 20.4.0(@types/node@25.5.0)
@@ -7718,8 +7718,8 @@ packages:
     peerDependencies:
       better-auth: ^1.0.3
 
-  better-call@2.0.3:
-    resolution: {integrity: sha512-0ZrD4tszOwN+vn9pCiHahe6wPb7AL1U+LgaPMstyZelD0kuA7lW3WwyxGmh22WRApKiWy4epNCN5pf7dfl6Sdw==}
+  better-call@1.3.5:
+    resolution: {integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -22075,7 +22075,7 @@ snapshots:
       mailchecker: 6.0.19
       validator: 13.15.26
 
-  better-call@2.0.3(zod@4.3.6):
+  better-call@1.3.5(zod@4.3.6):
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ blockExoticSubdeps: true
 catalog:
   '@better-auth/utils': 0.4.0
   '@better-fetch/fetch': 1.1.21
-  better-call: 2.0.3
+  better-call: 1.3.5
   tsdown: 0.21.1
   typescript: ^5.9.3
 


### PR DESCRIPTION
kept `@better-auth/utils` up to date through backporting while avoiding breaking type shape changes in Endpoint and Middleware... so on

---

WIP