### PR TITLE
fix(ci): run tests in merge queue, add summary gate jobs, cover next branch

### DIFF
--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -55,3 +55,6 @@ nvmrc
 retarget
 retargeted
 GHEOF
+denoland
+zizmor
+zizmorcore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,13 +180,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test]
-    if: ${{ !cancelled() }}
+    if: always()
     steps:
-      - name: Check required jobs
-        run: |
-          results='${{ toJSON(needs.*.result) }}'
-          if echo "$results" | jq -e 'any(. == "failure")' > /dev/null; then
-            echo "::error::One or more required jobs failed"
-            exit 1
-          fi
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}
              

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,18 +144,12 @@ jobs:
       matrix:
         node-version: [22.x, 24.x]
     steps:
-      - name: Skip tests in merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping tests in merge queue"
-
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        if: github.event_name != 'merge_group'
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Cache turbo build setup
-        if: github.event_name != 'merge_group'
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: .turbo
@@ -164,28 +158,35 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        if: github.event_name != 'merge_group'
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        if: github.event_name != 'merge_group'
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
       - name: Install
-        if: github.event_name != 'merge_group'
         run: pnpm install --frozen-lockfile
 
       - name: Start Docker Containers
-        if: github.event_name != 'merge_group'
         run: docker compose up -d --wait --wait-timeout 60
 
       - name: Test
-        if: github.event_name != 'merge_group'
         run: pnpm coverage
 
       - name: Stop Docker Containers
-        if: github.event_name != 'merge_group'
         run: docker compose down
+
+  ci:
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Check required jobs
+        run: |
+          results='${{ toJSON(needs.*.result) }}'
+          if echo "$results" | jq -e 'any(. == "failure")' > /dev/null; then
+            echo "::error::One or more required jobs failed"
+            exit 1
+          fi
              

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -155,12 +155,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: [smoke, integration, adapter-integration]
-    if: ${{ !cancelled() }}
+    if: always()
     steps:
-      - name: Check required jobs
-        run: |
-          results='${{ toJSON(needs.*.result) }}'
-          if echo "$results" | jq -e 'any(. == "failure")' > /dev/null; then
-            echo "::error::One or more required jobs failed"
-            exit 1
-          fi
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,7 @@
 name: E2E
 on:
   push:
-    branches: [ main ]
+    branches: [ main, next ]
   merge_group:
   pull_request:
 
@@ -72,18 +72,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Skip integration tests in merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping integration tests in merge queue"
-
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        if: github.event_name != 'merge_group'
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Cache turbo build setup
-        if: github.event_name != 'merge_group'
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: .turbo
@@ -92,33 +86,26 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        if: github.event_name != 'merge_group'
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        if: github.event_name != 'merge_group'
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
       - name: Install
-        if: github.event_name != 'merge_group'
         run: pnpm install
 
       - name: Install Playwright Browsers
-        if: github.event_name != 'merge_group'
         uses: ./.github/actions/setup-playwright
 
       - name: Start Docker Containers
-        if: github.event_name != 'merge_group'
         run: docker compose up -d --wait --wait-timeout 60
 
       - name: Integration
-        if: github.event_name != 'merge_group'
         run: pnpm e2e:integration --filter=./e2e/integration
 
       - name: Stop Docker Containers
-        if: github.event_name != 'merge_group'
         run: docker compose down
   adapter-integration:
     name: ${{ matrix.packages }} Integration Test
@@ -130,18 +117,12 @@ jobs:
       matrix:
         packages: [ "@better-auth-test/adapter-factory", "@better-auth-test/drizzle-adapter", "@better-auth-test/kysely-prisma-adapter", "@better-auth-test/memory-adapter", "@better-auth-test/mongo-adapter", "@better-auth-test/prisma-adapter" ]
     steps:
-      - name: Skip integration tests in merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping integration tests in merge queue"
-
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        if: github.event_name != 'merge_group'
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Cache turbo build setup
-        if: github.event_name != 'merge_group'
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: .turbo
@@ -150,29 +131,36 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        if: github.event_name != 'merge_group'
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        if: github.event_name != 'merge_group'
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
       - name: Install
-        if: github.event_name != 'merge_group'
         run: pnpm install
 
       - name: Start Docker Containers
-        if: github.event_name != 'merge_group'
         run: docker compose up -d --wait --wait-timeout 60
 
       - name: Adapter Integration
-        if: github.event_name != 'merge_group'
         env:
           FILTER: ${{ matrix.packages }}
         run: pnpm e2e:integration --filter="$FILTER"
 
       - name: Stop Docker Containers
-        if: github.event_name != 'merge_group'
         run: docker compose down
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [smoke, integration, adapter-integration]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Check required jobs
+        run: |
+          results='${{ toJSON(needs.*.result) }}'
+          if echo "$results" | jq -e 'any(. == "failure")' > /dev/null; then
+            echo "::error::One or more required jobs failed"
+            exit 1
+          fi

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: GitHub Actions Security Analysis
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
     paths:
       - '.github/workflows/**'
       - '.github/zizmor.yml'


### PR DESCRIPTION
## Summary

- **Run tests in merge queue.** Removes `merge_group` skip conditions from `test`, `integration`, and `adapter-integration` jobs. The merge queue was only running lint/typecheck/smoke — defeating its purpose of catching combined-PR breakage.
- **Add summary gate jobs.** `ci` and `e2e` jobs aggregate all matrix results. Required status checks now reference these stable names instead of individual matrix jobs (`test (22.x)`, `@better-auth-test/memory-adapter Integration Test`, etc.). Matrix changes (add Node versions, adapters) no longer require ruleset updates.
- **Cover `next` branch.** Adds `next` to `e2e.yml` and `zizmor.yml` push triggers so post-merge validation runs on both branches.

## Ruleset changes (applied via API, not in this diff)

Both "Protect main" and "Protect next" rulesets updated:

| Change | Before | After |
|--------|--------|-------|
| Required checks | `lint`, `test (22.x)`, `Smoke test`, `memory-adapter Integration Test`, `typecheck` | `ci`, `e2e`, `Validate PR title` |
| `check_response_timeout_minutes` | 60 | 15 |
| `min_entries_to_merge_wait_minutes` | 5 | 0 |

## Test plan

- [ ] Open a PR and verify `ci` and `e2e` gate jobs appear as required checks
- [ ] Verify `Validate PR title` blocks non-conventional titles
- [ ] Verify merge queue runs the full test suite (not just lint/typecheck)
- [ ] Push to `next` and verify e2e and zizmor workflows trigger

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the full test suite in the merge queue and add stable gate jobs (`ci`, `e2e`) powered by `re-actors/alls-green` for consistent required checks. Also run post-merge validation on the `next` branch.

- **Refactors**
  - Removed merge queue skips so `test`, `integration`, and `adapter-integration` run in `merge_group`.
  - Added `ci` and `e2e` summary jobs using `re-actors/alls-green`; required checks use these stable names, so matrix changes don’t need ruleset updates.
  - Triggered `e2e` and `zizmor` on pushes to `next` as well as `main`.
  - Added `denoland`, `zizmor`, and `zizmorcore` to `.cspell`.

<sup>Written for commit 9975cf3cc0644509750a1c217673f963c83c29a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

