### PR TITLE
fix(generic-oauth): encode error params to prevent crash with non-ASCII chars

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -282,9 +282,11 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 				`${ctx.context.baseURL}/error`;
 			if (ctx.query.error || !ctx.query.code) {
 				throw ctx.redirect(
-					`${defaultErrorURL}?error=${
-						ctx.query.error || "oAuth_code_missing"
-					}&error_description=${ctx.query.error_description}`,
+					`${defaultErrorURL}?error=${encodeURIComponent(
+						ctx.query.error || "oAuth_code_missing",
+					)}&error_description=${encodeURIComponent(
+						ctx.query.error_description || "",
+					)}`,
 				);
 			}
 			const providerId = ctx.params?.providerId;


### PR DESCRIPTION
## Description

When OAuth providers return error_description containing non-ASCII characters (e.g., Cyrillic text from Yandex OAuth), the generic-oauth callback handler crashes with a TypeError because the description is interpolated directly into the redirect URL without encoding.

## Error

```
TypeError: Header 'location' has invalid value:
'https://example.com/auth/error?error=unauthorized_client&error_description=Запрещено получать токены...'
```

Non-ASCII characters in HTTP Location header are invalid per RFC 7230.

## Fix

Wrap query parameters with `encodeURIComponent()` when building the error redirect URL.

## Related Issue

Fixes #8954

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encode OAuth error query params in the `generic-oauth` callback to prevent crashes when providers return non-ASCII characters. Ensures valid Location headers and reliable redirects to the error page.

- **Bug Fixes**
  - URL-encode `error` and `error_description` with `encodeURIComponent`, and default to `oAuth_code_missing`/empty when missing, preventing invalid Location headers with non-ASCII text (e.g., Yandex OAuth).

<sup>Written for commit cf70cec909ca32a32c3230f5d873751738283e9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

