### PR TITLE
fix(sso): normalize SAMLResponse whitespace at request boundary

### DIFF
--- a/.changeset/saml-whitespace-decoding.md
+++ b/.changeset/saml-whitespace-decoding.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/sso": patch
+---
+
+fix(sso): strip whitespace from SAMLResponse before base64 decoding
+
+Some SAML IDPs send SAMLResponse with line-wrapped base64 (per RFC 2045), which caused decoding failures. Whitespace is now stripped at the request boundary before any processing.

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -2009,16 +2009,18 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 				});
 			}
 
-			const { SAMLResponse } = ctx.body;
-
 			const maxResponseSize =
 				options?.saml?.maxResponseSize ??
 				constants.DEFAULT_MAX_SAML_RESPONSE_SIZE;
-			if (new TextEncoder().encode(SAMLResponse).length > maxResponseSize) {
+			if (
+				new TextEncoder().encode(ctx.body.SAMLResponse).length > maxResponseSize
+			) {
 				throw new APIError("BAD_REQUEST", {
 					message: `SAML response exceeds maximum allowed size (${maxResponseSize} bytes)`,
 				});
 			}
+
+			const SAMLResponse = ctx.body.SAMLResponse.replace(/\s+/g, "");
 
 			let relayState: RelayState | null = null;
 			if (ctx.body.RelayState) {
@@ -2517,7 +2519,6 @@ export const acsEndpoint = (options?: SSOOptions) => {
 			},
 		},
 		async (ctx) => {
-			const { SAMLResponse } = ctx.body;
 			const { providerId } = ctx.params;
 			const currentCallbackPath = `${ctx.context.baseURL}/sso/saml2/sp/acs/${providerId}`;
 			const appOrigin = new URL(ctx.context.baseURL).origin;
@@ -2525,11 +2526,15 @@ export const acsEndpoint = (options?: SSOOptions) => {
 			const maxResponseSize =
 				options?.saml?.maxResponseSize ??
 				constants.DEFAULT_MAX_SAML_RESPONSE_SIZE;
-			if (new TextEncoder().encode(SAMLResponse).length > maxResponseSize) {
+			if (
+				new TextEncoder().encode(ctx.body.SAMLResponse).length > maxResponseSize
+			) {
 				throw new APIError("BAD_REQUEST", {
 					message: `SAML response exceeds maximum allowed size (${maxResponseSize} bytes)`,
 				});
 			}
+
+			const SAMLResponse = ctx.body.SAMLResponse.replace(/\s+/g, "");
 			let relayState: RelayState | null = null;
 			if (ctx.body.RelayState) {
 				try {

--- a/packages/sso/src/saml/assertions.test.ts
+++ b/packages/sso/src/saml/assertions.test.ts
@@ -40,10 +40,19 @@ describe("validateSingleAssertion", () => {
 					</saml:Assertion>
 				</samlp:Response>
 			`;
-			const b64 = Buffer.from(xml).toString("base64");
-			const wrapped = b64.replace(/.{76}/g, "$&\n");
-			expect(wrapped).toContain("\n");
-			expect(() => validateSingleAssertion(wrapped)).not.toThrow();
+			const b64 = encode(xml);
+
+			const wrappedLf = b64.replace(/.{76}/g, "$&\n");
+			const wrappedCrLf = b64.replace(/.{76}/g, "$&\r\n");
+			const wrappedSpacesAndTabs = b64.replace(/.{20}/g, "$& \t ");
+
+			expect(wrappedLf).toContain("\n");
+			expect(wrappedCrLf).toContain("\r\n");
+			expect(wrappedSpacesAndTabs).toContain(" \t ");
+
+			expect(() => validateSingleAssertion(wrappedLf)).not.toThrow();
+			expect(() => validateSingleAssertion(wrappedCrLf)).not.toThrow();
+			expect(() => validateSingleAssertion(wrappedSpacesAndTabs)).not.toThrow();
 		});
 	});
 

--- a/packages/sso/src/saml/assertions.test.ts
+++ b/packages/sso/src/saml/assertions.test.ts
@@ -28,6 +28,25 @@ describe("validateSingleAssertion", () => {
 		});
 	});
 
+	describe("base64 whitespace handling", () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/8921
+		 */
+		it("should accept base64 with embedded whitespace from line-wrapping IDPs", () => {
+			const xml = `
+				<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+					<saml:Assertion ID="123">
+						<saml:Subject><saml:NameID>user@example.com</saml:NameID></saml:Subject>
+					</saml:Assertion>
+				</samlp:Response>
+			`;
+			const b64 = Buffer.from(xml).toString("base64");
+			const wrapped = b64.replace(/.{76}/g, "$&\n");
+			expect(wrapped).toContain("\n");
+			expect(() => validateSingleAssertion(wrapped)).not.toThrow();
+		});
+	});
+
 	describe("no assertions", () => {
 		it("should reject response with no assertions", () => {
 			const xml = `

--- a/packages/sso/src/saml/assertions.ts
+++ b/packages/sso/src/saml/assertions.ts
@@ -32,7 +32,9 @@ export function countAssertions(xml: string): AssertionCounts {
 export function validateSingleAssertion(samlResponse: string): void {
 	let xml: string;
 	try {
-		xml = new TextDecoder().decode(base64.decode(samlResponse.replace(/\s+/g, "")));
+		xml = new TextDecoder().decode(
+			base64.decode(samlResponse.replace(/\s+/g, "")),
+		);
 		if (!xml.includes("<")) {
 			throw new Error("Not XML");
 		}

--- a/packages/sso/src/saml/assertions.ts
+++ b/packages/sso/src/saml/assertions.ts
@@ -32,7 +32,7 @@ export function countAssertions(xml: string): AssertionCounts {
 export function validateSingleAssertion(samlResponse: string): void {
 	let xml: string;
 	try {
-		xml = new TextDecoder().decode(base64.decode(samlResponse));
+		xml = new TextDecoder().decode(base64.decode(samlResponse.replace(/\s+/g, "")));
 		if (!xml.includes("<")) {
 			throw new Error("Not XML");
 		}


### PR DESCRIPTION
## Summary

Some SAML IDPs send SAMLResponse with line-wrapped base64 (per RFC 2045), which caused decoding failures with `SAML_INVALID_ENCODING`.

Whitespace is now stripped at the route extraction point so all downstream consumers (size check, assertion validation, signature verification, replay protection) operate on clean base64. The size limit check runs on the raw payload before stripping to prevent whitespace-padding bypass.

Fixes #8921

## Test plan

- Added unit test for RFC 2045 line-wrapped base64 input in `assertions.test.ts`