### PR TITLE
chore(ci): rename bot identity to better-release

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           MARKER="<!-- auto-changeset -->"
           gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq ".[] | select((.body | startswith(\"${MARKER}\")) and (.user.login == \"better-auth-releases[bot]\" or .user.login == \"github-actions[bot]\")) | .id" \
+            --jq ".[] | select((.body | startswith(\"${MARKER}\")) and (.user.login == \"better-release[bot]\" or .user.login == \"github-actions[bot]\")) | .id" \
             | xargs -r -I{} gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/{}" 2>/dev/null || true
 
       - name: Post skip explanation

--- a/.github/workflows/auto-retarget.yml
+++ b/.github/workflows/auto-retarget.yml
@@ -14,7 +14,7 @@ jobs:
       !startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
       github.event.pull_request.head.ref != 'next' &&
       github.actor != 'github-actions[bot]' &&
-      github.actor != 'better-auth-releases[bot]'
+      github.actor != 'better-release[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -59,8 +59,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          git config user.name "better-auth-releases[bot]"
-          git config user.email "273320539+better-auth-releases[bot]@users.noreply.github.com"
+          git config user.name "better-release[bot]"
+          git config user.email "273320539+better-release[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git add -A
           if git diff --cached --quiet; then

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -20,7 +20,7 @@ jobs:
       !startsWith(github.head_ref, 'changeset-release/') &&
       !(github.head_ref == 'next' && github.base_ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository) &&
       github.actor != 'github-actions[bot]' &&
-      github.actor != 'better-auth-releases[bot]'
+      github.actor != 'better-release[bot]'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary
- Renamed GitHub App from `better-auth-releases` to `better-release`
- Updated all workflow references: git identity, actor exclusions, and comment filters

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the GitHub App/bot identity from `better-auth-releases` to `better-release` across CI workflows. Updated actor exclusions, comment cleanup filters, and git commit user.name/email to use the new bot.

<sup>Written for commit afafd0c9fcf5d622ae469ae5a6c6e4e3af17c9a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

