### PR TITLE
chore: revert `better-call` v2 migration, downgrade to v1.3.5

### DIFF
--- a/packages/better-auth/src/api/index.test.ts
+++ b/packages/better-auth/src/api/index.test.ts
@@ -10,10 +10,10 @@ import { getEndpoints } from "./index";
 
 describe("getEndpoints", () => {
 	it("should await promise-based context before passing to middleware", async () => {
-		const mockContext = {
+		const mockContext: AuthContext = {
 			baseURL: "http://localhost:3000",
 			options: {},
-		} as AuthContext;
+		} as any;
 
 		const middlewareFn = vi.fn().mockResolvedValue({});
 
@@ -45,7 +45,6 @@ describe("getEndpoints", () => {
 			context: { customProp: "value" },
 		};
 
-		// @ts-expect-error testCtx is a partial mock
 		await middlewares[0]!.middleware(testCtx);
 
 		expect(middlewareFn).toHaveBeenCalled();

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -181,7 +181,7 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 			body: socialSignInBodySchema,
 			metadata: {
 				$Infer: {
-					body: socialSignInBodySchema,
+					body: {} as z.infer<typeof socialSignInBodySchema>,
 					returned: {} as {
 						redirect: boolean;
 						token?: string | undefined;

--- a/packages/better-auth/src/api/routes/sign-up.test.ts
+++ b/packages/better-auth/src/api/routes/sign-up.test.ts
@@ -158,7 +158,7 @@ describe("sign-up with custom fields", async () => {
 					email: "input-false@test.com",
 					password: "password",
 					name: "Input False Test",
-					// @ts-expect-error role has input: false
+					//@ts-expect-error
 					role: "admin",
 				},
 			}),

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -442,7 +442,7 @@ describe("updateUser", async () => {
 		const { headers } = await signInWithTestUser();
 		const res = await client.updateUser(
 			{
-				// @ts-expect-error newField has input: false
+				//@ts-expect-error - newField is not available in the user input
 				newField: "new",
 			},
 			{

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -490,7 +490,7 @@ export const deleteUser = createAuthEndpoint(
 		}
 
 		if (ctx.body.token) {
-			// @ts-expect-error
+			//@ts-expect-error
 			await deleteUserCallback({
 				...ctx,
 				query: {

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -111,7 +111,7 @@ describe("before hook", async () => {
 			const res = await authEndpoints.body();
 			expect(res?.name).toBe("body");
 			const res2 = await authEndpoints.body({
-				// @ts-expect-error body not typed on this endpoint
+				//@ts-expect-error
 				body: {
 					key: "value",
 				},

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -17,7 +17,7 @@ import {
 import type {
 	Endpoint,
 	EndpointContext,
-	EndpointRuntimeOptions,
+	EndpointOptions,
 	InputContext,
 } from "better-call";
 import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
@@ -25,20 +25,7 @@ import { createDefu } from "defu";
 import { isAPIError } from "../utils/is-api-error";
 
 type InternalContext = Partial<
-	InputContext<string, any, any, any, any, any> &
-		EndpointContext<
-			string,
-			any,
-			any,
-			any,
-			any,
-			any,
-			any,
-			AuthContext & {
-				returned?: unknown | undefined;
-				responseHeaders?: Headers | undefined;
-			}
-		>
+	InputContext<string, any> & EndpointContext<string, any>
 > & {
 	path: string;
 	asResponse?: boolean | undefined;
@@ -76,8 +63,7 @@ function getOperationId(endpoint: Endpoint | undefined, key: string): string {
 }
 
 type UserInputContext = Partial<
-	InputContext<string, any, any, any, any, any> &
-		EndpointContext<string, any, any, any, any, any, any, any>
+	InputContext<string, any> & EndpointContext<string, any>
 >;
 
 export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
@@ -87,11 +73,10 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 	const api: Record<
 		string,
 		((
-			context: EndpointContext<string, any, any, any, any, any, any, any> &
-				InputContext<string, any, any, any, any, any>,
+			context: EndpointContext<string, any> & InputContext<string, any>,
 		) => Promise<any>) & {
 			path?: string | undefined;
-			options?: EndpointRuntimeOptions | undefined;
+			options?: EndpointOptions | undefined;
 		}
 	> = {};
 

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -3,7 +3,7 @@ import type {
 	ClientFetchOption,
 } from "@better-auth/core";
 import type { BetterFetchResponse } from "@better-fetch/fetch";
-import type { Endpoint, InputContext } from "better-call";
+import type { Endpoint, InputContext, StandardSchemaV1 } from "better-call";
 import type {
 	HasRequiredKeys,
 	Prettify,
@@ -108,55 +108,34 @@ export type InferUserUpdateCtx<
 	UnionToIntersection<InferAdditionalFromClient<ClientOpts, "user", "input">>
 >;
 
-type InferCtxQuery<
-	C extends InputContext<any, any, any, any, any, any>,
-	FetchOptions extends ClientFetchOption,
-> = 0 extends 1 & C["query"]
-	? {
-			query?: Record<string, any> | undefined;
-			fetchOptions?: FetchOptions | undefined;
-		}
-	: [C["query"]] extends [Record<string, any>]
-		? {
-				query: C["query"];
-				fetchOptions?: FetchOptions | undefined;
-			}
-		: [C["query"]] extends [Record<string, any> | undefined]
-			? {
-					query?: C["query"] | undefined;
-					fetchOptions?: FetchOptions | undefined;
-				}
-			: {
-					fetchOptions?: FetchOptions | undefined;
-				};
-
 export type InferCtx<
-	C extends InputContext<any, any, any, any, any, any>,
+	C extends InputContext<any, any>,
 	FetchOptions extends ClientFetchOption,
-> = 0 extends 1 & C["body"]
-	? // body is `any` — skip body intersection so fetchOptions stays typed
-		InferCtxQuery<C, FetchOptions>
-	: [C["body"]] extends [Record<string, any>]
+> =
+	C["body"] extends Record<string, any>
 		? C["body"] & {
 				fetchOptions?: FetchOptions | undefined;
 			}
-		: InferCtxQuery<C, FetchOptions>;
+		: C["query"] extends Record<string, any>
+			? {
+					query: C["query"];
+					fetchOptions?: FetchOptions | undefined;
+				}
+			: C["query"] extends Record<string, any> | undefined
+				? {
+						query?: C["query"] | undefined;
+						fetchOptions?: FetchOptions | undefined;
+					}
+				: {
+						fetchOptions?: FetchOptions | undefined;
+					};
 
 export type MergeRoutes<T> = UnionToIntersection<T>;
 
 export type InferRoute<API, COpts extends BetterAuthClientOptions> =
 	API extends Record<string, infer T>
-		? T extends Endpoint<
-				any,
-				any,
-				any,
-				any,
-				any,
-				infer R,
-				infer Meta,
-				infer ErrorSchema
-			>
-			? [Meta] extends [
+		? T extends Endpoint
+			? T["options"]["metadata"] extends
 					| {
 							isAction: false;
 					  }
@@ -168,23 +147,12 @@ export type InferRoute<API, COpts extends BetterAuthClientOptions> =
 					  }
 					| {
 							scope: "server";
-					  },
-				]
+					  }
 				? {}
 				: PathToObject<
 						T["path"],
-						T extends (ctx: infer _C) => any
-							? Extract<
-									_C,
-									InputContext<any, any, any, any, any, any>
-								> extends infer C extends InputContext<
-									any,
-									any,
-									any,
-									any,
-									any,
-									any
-								>
+						T extends (ctx: infer C) => infer R
+							? C extends InputContext<any, any>
 								? <
 										FetchOptions extends ClientFetchOption<
 											Partial<C["body"]> & Record<string, any>,
@@ -213,7 +181,7 @@ export type InferRoute<API, COpts extends BetterAuthClientOptions> =
 												]
 									) => Promise<
 										BetterFetchResponse<
-											Meta extends {
+											T["options"]["metadata"] extends {
 												CUSTOM_SESSION: boolean;
 											}
 												? MergeCustomSessionWithInferred<
@@ -226,17 +194,15 @@ export type InferRoute<API, COpts extends BetterAuthClientOptions> =
 															session: InferSessionFromClient<COpts>;
 														} | null
 													: RefineAuthResponse<NonNullable<Awaited<R>>, COpts>,
-											0 extends 1 & ErrorSchema
-												? {
+											T["options"]["error"] extends StandardSchemaV1
+												? // InferOutput
+													NonNullable<
+														T["options"]["error"]["~standard"]["types"]
+													>["output"]
+												: {
 														code?: string | undefined;
 														message?: string | undefined;
-													}
-												: [ErrorSchema] extends [Record<string, any>]
-													? ErrorSchema
-													: {
-															code?: string | undefined;
-															message?: string | undefined;
-														},
+													},
 											FetchOptions["throw"] extends true
 												? true
 												: COpts["fetchOptions"] extends { throw: true }

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -111,8 +111,11 @@ export type InferUserUpdateCtx<
 export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends ClientFetchOption,
-> =
-	C["body"] extends Record<string, any>
+> = 0 extends 1 & C["body"]
+	? {
+			fetchOptions?: FetchOptions | undefined;
+		}
+	: C["body"] extends Record<string, any>
 		? C["body"] & {
 				fetchOptions?: FetchOptions | undefined;
 			}

--- a/packages/better-auth/src/plugins/anonymous/types.ts
+++ b/packages/better-auth/src/plugins/anonymous/types.ts
@@ -52,12 +52,9 @@ export interface AnonymousOptions {
 		| ((
 				ctx: EndpointContext<
 					"/sign-in/anonymous",
-					"POST",
-					any,
-					any,
-					any,
-					any,
-					any,
+					{
+						method: "POST";
+					},
 					AuthContext
 				>,
 		  ) => Awaitable<string>)

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -6,7 +6,7 @@ import type {
 } from "@better-auth/core/db";
 import type {
 	Endpoint,
-	EndpointRuntimeOptions,
+	EndpointOptions,
 	OpenAPIParameter,
 	OpenAPISchemaType,
 } from "better-call";
@@ -123,7 +123,7 @@ function getFieldSchema(field: DBFieldAttribute) {
 	return schema;
 }
 
-function getParameters(options: EndpointRuntimeOptions) {
+function getParameters(options: EndpointOptions) {
 	const parameters: OpenAPIParameter[] = [];
 	if (options.metadata?.openapi?.parameters) {
 		parameters.push(...options.metadata.openapi.parameters);
@@ -150,7 +150,7 @@ function getParameters(options: EndpointRuntimeOptions) {
 	return parameters;
 }
 
-function getRequestBody(options: EndpointRuntimeOptions): any {
+function getRequestBody(options: EndpointOptions): any {
 	if (options.metadata?.openapi?.requestBody) {
 		return options.metadata.openapi.requestBody;
 	}
@@ -422,7 +422,7 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 
 	Object.entries(baseEndpoints.api).forEach(([_, value]) => {
 		if (!value.path || ctx.options.disabledPaths?.includes(value.path)) return;
-		const options = value.options as EndpointRuntimeOptions;
+		const options = value.options as EndpointOptions;
 		if (options.metadata?.SERVER_ONLY) return;
 		const path = toOpenApiPath(value.path);
 		const methods = Array.isArray(options.method)
@@ -503,7 +503,7 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 		Object.entries(api).forEach(([key, value]) => {
 			if (!value.path || ctx.options.disabledPaths?.includes(value.path))
 				return;
-			const options = value.options as EndpointRuntimeOptions;
+			const options = value.options as EndpointOptions;
 			if (options.metadata?.SERVER_ONLY) return;
 			const path = toOpenApiPath(value.path);
 			const methods = Array.isArray(options.method)

--- a/packages/better-auth/src/plugins/organization/client.test.ts
+++ b/packages/better-auth/src/plugins/organization/client.test.ts
@@ -36,7 +36,7 @@ describe("organization", () => {
 			name: "Test",
 			slug: "test",
 			newField: "123", //this should be allowed
-			// @ts-expect-error unavailableField is not in the schema
+			//@ts-expect-error - this field is not available
 			unavailableField: "123", //this should be not allowed
 		});
 	});
@@ -65,7 +65,7 @@ describe("organization", () => {
 			name: "Test",
 			slug: "test",
 			newField: "123", //this should be allowed
-			// @ts-expect-error unavailableField is not in the schema
+			//@ts-expect-error - this field is not available
 			unavailableField: "123", //this should be not allowed
 		});
 	});

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -313,9 +313,9 @@ export const inferOrgAdditionalFields = <
 	// if we don't remove all other properties we may see assignability issues
 
 	type ExtractClientOnlyFields<T> = {
-		[K in keyof T]: T[K] extends { additionalFields: infer _AF }
-			? T[K]
-			: undefined;
+		[K in keyof T as T[K] extends { additionalFields: unknown }
+			? K
+			: never]: T[K];
 	};
 
 	type Schema = O extends Object

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -313,7 +313,9 @@ export const inferOrgAdditionalFields = <
 	// if we don't remove all other properties we may see assignability issues
 
 	type ExtractClientOnlyFields<T> = {
-		[K in keyof T as T[K] extends { additionalFields: any } ? K : never]: T[K];
+		[K in keyof T]: T[K] extends { additionalFields: infer _AF }
+			? T[K]
+			: undefined;
 	};
 
 	type Schema = O extends Object

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -3430,6 +3430,30 @@ describe("organization additionalFields with returned: false", async () => {
 
 	const { headers } = await signInWithTestUser();
 
+	it("inferOrgAdditionalFields should filter out schema keys without additionalFields", async () => {
+		const { auth: authWithSession } = await getTestInstance({
+			plugins: [
+				organization({
+					schema: {
+						organization: {
+							additionalFields: {
+								logo: { type: "string", required: false },
+							},
+						},
+						session: {
+							fields: { activeOrganizationId: "orgId" },
+						},
+					},
+				}),
+			],
+		});
+		const inferred = inferOrgAdditionalFields<typeof authWithSession>();
+		type Schema = NonNullable<typeof inferred>;
+		// session has no additionalFields, should not be in inferred schema keys
+		type HasSession = "session" extends keyof Schema ? true : false;
+		expectTypeOf<HasSession>().toEqualTypeOf<false>();
+	});
+
 	const client = createAuthClient({
 		plugins: [
 			organizationClient({

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -3454,9 +3454,11 @@ describe("organization additionalFields with returned: false", async () => {
 		});
 
 		expect(org.data).toBeDefined();
-		expect(org.data?.publicField).toBe("public-value");
-		// @ts-expect-error secretField has returned: false
-		expect(org.data?.secretField).toBeUndefined();
+		// Note: publicField and secretField use `as any` because endpoint response types
+		// are inferred from adapter return values which include all fields.
+		// The runtime correctly filters returned: false fields.
+		expect((org.data as any).publicField).toBe("public-value");
+		expect((org.data as any).secretField).toBeUndefined();
 
 		const dbOrg = db.organization.find((o) => o.id === org.data?.id);
 		expect(dbOrg).toBeDefined();
@@ -3489,9 +3491,8 @@ describe("organization additionalFields with returned: false", async () => {
 		expect(orgs.data!.length).toBeGreaterThan(0);
 
 		for (const org of orgs.data!) {
-			// @ts-expect-error secretField has returned: false
-			expect(org.secretField).toBeUndefined();
-			expect(org.publicField).toBeDefined();
+			expect((org as any).secretField).toBeUndefined();
+			expect((org as any).publicField).toBeDefined();
 		}
 	});
 
@@ -3595,9 +3596,8 @@ describe("organization additionalFields with returned: false", async () => {
 		});
 
 		expect(updated.data).toBeDefined();
-		expect(updated.data?.publicField).toBe("updated-public");
-		// @ts-expect-error secretField has returned: false
-		expect(updated.data?.secretField).toBeUndefined();
+		expect((updated.data as any).publicField).toBe("updated-public");
+		expect((updated.data as any).secretField).toBeUndefined();
 
 		const dbOrg = db.organization.find((o) => o.id === org.data?.id);
 		expect(dbOrg?.secretField).toBe("updated-secret");

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -169,10 +169,10 @@ const createHasPermissionBodySchema = z
 		z.union([
 			z.object({
 				permission: z.record(z.string(), z.array(z.string())),
-				permissions: z.record(z.string(), z.array(z.string())).optional(),
+				permissions: z.undefined(),
 			}),
 			z.object({
-				permission: z.record(z.string(), z.array(z.string())).optional(),
+				permission: z.undefined(),
 				permissions: z.record(z.string(), z.array(z.string())),
 			}),
 		]),

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
@@ -531,7 +531,7 @@ describe("inviteMember role validation", async () => {
 		// Attempt to invite with a fake role
 		const { error } = await client.organization.inviteMember({
 			email: "fake-role@test.com",
-			// @ts-expect-error invalid role not in base type
+			// @ts-expect-error - testing invalid role validation
 			role: "super-invalid-role-123",
 			organizationId: org.data?.id as string,
 			fetchOptions: {

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -1,11 +1,11 @@
 import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import { generateId } from "@better-auth/core/utils/id";
+import type { Prettify } from "better-call";
 import * as z from "zod";
 import type {
 	FieldAttributeToObject,
 	RemoveFieldsWithReturnedFalse,
 } from "../../db";
-import type { Prettify } from "../../types/helper";
 import type { OrganizationOptions } from "./types";
 
 type InferSchema<

--- a/packages/better-auth/src/plugins/username/username.test.ts
+++ b/packages/better-auth/src/plugins/username/username.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { USERNAME_ERROR_CODES, username } from ".";
 import { usernameClient } from "./client";
@@ -550,14 +550,6 @@ describe("isUsernameAvailable with custom validator", async () => {
 			username: "invalid_user",
 			password: "password1234",
 		});
-
-		type Error = Exclude<typeof signInRes.error, null>;
-		expectTypeOf<Error>().toEqualTypeOf<{
-			message?: string | undefined;
-			code?: string;
-			statusText: string;
-			status: number;
-		}>();
 
 		expect(signInRes.error).toBeDefined();
 		expect(signInRes.error?.code).toBe(

--- a/packages/better-auth/src/types/api.ts
+++ b/packages/better-auth/src/types/api.ts
@@ -7,10 +7,10 @@ export type FilteredAPI<API> = Omit<
 		? K extends string
 			? K extends "getSession"
 				? never
-				: API[K] extends Endpoint<any, any, any, any, any, any, infer Meta>
-					? [Meta] extends [{ isAction: false } | { scope: "http" }]
-						? K
-						: never
+				: API[K]["options"]["metadata"] extends
+							| { isAction: false }
+							| { scope: "http" }
+					? K
 					: never
 			: never
 		: never

--- a/packages/better-auth/src/types/helper.ts
+++ b/packages/better-auth/src/types/helper.ts
@@ -29,7 +29,12 @@ export type RequiredKeysOf<BaseType extends object> = Exclude<
 	undefined
 >;
 
-export type HasRequiredKeys<BaseType extends object> =
-	RequiredKeysOf<BaseType> extends never ? false : true;
+export type HasRequiredKeys<BaseType> = 0 extends 1 & BaseType
+	? false
+	: [BaseType] extends [object]
+		? RequiredKeysOf<BaseType & object> extends never
+			? false
+			: true
+		: false;
 
 export type StripEmptyObjects<T extends object> = { [K in keyof T]: T[K] };

--- a/packages/better-auth/src/types/helper.ts
+++ b/packages/better-auth/src/types/helper.ts
@@ -29,12 +29,7 @@ export type RequiredKeysOf<BaseType extends object> = Exclude<
 	undefined
 >;
 
-export type HasRequiredKeys<BaseType> = 0 extends 1 & BaseType
-	? false
-	: [BaseType] extends [object]
-		? RequiredKeysOf<BaseType & object> extends never
-			? false
-			: true
-		: false;
+export type HasRequiredKeys<BaseType extends object> =
+	RequiredKeysOf<BaseType> extends never ? false : true;
 
 export type StripEmptyObjects<T extends object> = { [K in keyof T]: T[K] };

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAuthEndpoint } from "../api";
 import { organization, twoFactor } from "../plugins";
 import { getTestInstance } from "../test-utils/test-instance";
+import type { HasRequiredKeys } from "./helper";
 
 type TestTypeOptions = {
 	test: boolean;
@@ -221,5 +222,19 @@ describe("general types", async () => {
 		type SessionWithoutPlugins = typeof authWithoutPlugins.$Infer;
 
 		expectTypeOf<SessionWithEmptyPlugins>().toEqualTypeOf<SessionWithoutPlugins>();
+	});
+});
+
+describe("HasRequiredKeys", () => {
+	it("should return false for any", () => {
+		expectTypeOf<HasRequiredKeys<any>>().toEqualTypeOf<false>();
+	});
+
+	it("should return true for objects with required keys", () => {
+		expectTypeOf<HasRequiredKeys<{ name: string }>>().toEqualTypeOf<true>();
+	});
+
+	it("should return false for objects with only optional keys", () => {
+		expectTypeOf<HasRequiredKeys<{ name?: string }>>().toEqualTypeOf<false>();
 	});
 });

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -1,6 +1,8 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
+import type { InputContext } from "better-call";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAuthEndpoint } from "../api";
+import type { InferCtx } from "../client/path-to-object";
 import { organization, twoFactor } from "../plugins";
 import { getTestInstance } from "../test-utils/test-instance";
 import type { HasRequiredKeys } from "./helper";
@@ -236,5 +238,13 @@ describe("HasRequiredKeys", () => {
 
 	it("should return false for objects with only optional keys", () => {
 		expectTypeOf<HasRequiredKeys<{ name?: string }>>().toEqualTypeOf<false>();
+	});
+});
+
+describe("InferCtx", () => {
+	it("should preserve fetchOptions when body is any", () => {
+		type Result = InferCtx<InputContext<any, any> & { body: any }, {}>;
+		type Keys = keyof Result;
+		expectTypeOf<Keys>().toEqualTypeOf<"fetchOptions">();
 	});
 });

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,15 +1,7 @@
 import type {
-	Endpoint,
 	EndpointContext,
-	EndpointMetadata,
-	EndpointRuntimeOptions,
-	HTTPMethod,
-	Middleware,
-	ResolveBodyInput,
-	ResolveErrorInput,
-	ResolveMetaInput,
-	ResolveQueryInput,
-	StandardSchemaV1,
+	EndpointOptions,
+	StrictEndpoint,
 } from "better-call";
 import { createEndpoint, createMiddleware } from "better-call";
 import { runWithEndpointContext } from "../context";
@@ -41,145 +33,47 @@ export const createAuthMiddleware = createMiddleware.create({
 
 const use = [optionsMiddleware];
 
-type BodyOption<M, B extends object | undefined = undefined> = M extends
-	| "GET"
-	| "HEAD"
-	| ("GET" | "HEAD")[]
-	? { body?: never }
-	: { body?: B };
+type EndpointHandler<
+	Path extends string,
+	Options extends EndpointOptions,
+	R,
+> = (context: EndpointContext<Path, Options, AuthContext>) => Promise<R>;
 
-type AuthEndpointOptions<
-	Method extends HTTPMethod | HTTPMethod[] | "*",
-	BodySchema extends object | undefined,
-	QuerySchema extends object | undefined,
-	Use extends Middleware[],
-	ReqHeaders extends boolean,
-	ReqRequest extends boolean,
-	Meta extends EndpointMetadata | undefined,
-	ErrorSchema extends StandardSchemaV1 | undefined = undefined,
-> = { method: Method } & BodyOption<Method, BodySchema> & {
-		query?: QuerySchema;
-		use?: [...Use];
-		requireHeaders?: ReqHeaders;
-		requireRequest?: ReqRequest;
-		error?: ErrorSchema;
-		cloneRequest?: boolean;
-		disableBody?: boolean;
-		metadata?: Meta;
-		[key: string]: any;
-	};
-
-/**
- * Normalize readonly tuples produced by `const` type parameters
- * into mutable arrays so downstream `M extends Array<any>` checks work.
- */
-type NormalizeMethod<M> = M extends readonly (infer E)[] ? E[] : M;
-
-// Path + options + handler overload
 export function createAuthEndpoint<
 	Path extends string,
-	const Method extends HTTPMethod | HTTPMethod[] | "*",
-	BodySchema extends object | undefined = undefined,
-	QuerySchema extends object | undefined = undefined,
-	Use extends Middleware[] = [],
-	ReqHeaders extends boolean = false,
-	ReqRequest extends boolean = false,
-	R = unknown,
-	Meta extends EndpointMetadata | undefined = undefined,
-	ErrorSchema extends StandardSchemaV1 | undefined = undefined,
+	Options extends EndpointOptions,
+	R,
 >(
 	path: Path,
-	options: AuthEndpointOptions<
-		Method,
-		BodySchema,
-		QuerySchema,
-		Use,
-		ReqHeaders,
-		ReqRequest,
-		Meta,
-		ErrorSchema
-	>,
-	handler: (
-		ctx: EndpointContext<
-			Path,
-			Method,
-			BodySchema,
-			QuerySchema,
-			Use,
-			ReqHeaders,
-			ReqRequest,
-			AuthContext,
-			Meta
-		>,
-	) => Promise<R>,
-): Endpoint<
-	Path,
-	NormalizeMethod<Method>,
-	ResolveBodyInput<BodySchema, Meta>,
-	ResolveQueryInput<QuerySchema, Meta>,
-	Use,
-	R,
-	ResolveMetaInput<Meta>,
-	ResolveErrorInput<ErrorSchema, Meta>
->;
+	options: Options,
+	handler: EndpointHandler<Path, Options, R>,
+): StrictEndpoint<Path, Options, R>;
 
-// Options-only (virtual/path-less) overload
 export function createAuthEndpoint<
-	const Method extends HTTPMethod | HTTPMethod[] | "*",
-	BodySchema extends object | undefined = undefined,
-	QuerySchema extends object | undefined = undefined,
-	Use extends Middleware[] = [],
-	ReqHeaders extends boolean = false,
-	ReqRequest extends boolean = false,
-	R = unknown,
-	Meta extends EndpointMetadata | undefined = undefined,
-	ErrorSchema extends StandardSchemaV1 | undefined = undefined,
->(
-	options: AuthEndpointOptions<
-		Method,
-		BodySchema,
-		QuerySchema,
-		Use,
-		ReqHeaders,
-		ReqRequest,
-		Meta,
-		ErrorSchema
-	>,
-	handler: (
-		ctx: EndpointContext<
-			string,
-			Method,
-			BodySchema,
-			QuerySchema,
-			Use,
-			ReqHeaders,
-			ReqRequest,
-			AuthContext,
-			Meta
-		>,
-	) => Promise<R>,
-): Endpoint<
-	string,
-	NormalizeMethod<Method>,
-	ResolveBodyInput<BodySchema, Meta>,
-	ResolveQueryInput<QuerySchema, Meta>,
-	Use,
+	Path extends string,
+	Options extends EndpointOptions,
 	R,
-	ResolveMetaInput<Meta>,
-	ResolveErrorInput<ErrorSchema, Meta>
->;
+>(
+	options: Options,
+	handler: EndpointHandler<Path, Options, R>,
+): StrictEndpoint<Path, Options, R>;
 
-// Implementation
-export function createAuthEndpoint(
-	pathOrOptions: any,
-	handlerOrOptions: any,
+export function createAuthEndpoint<
+	Path extends string,
+	Opts extends EndpointOptions,
+	R,
+>(
+	pathOrOptions: Path | Opts,
+	handlerOrOptions: EndpointHandler<Path, Opts, R> | Opts,
 	handlerOrNever?: any,
 ) {
-	const path: string | undefined =
+	const path: Path | undefined =
 		typeof pathOrOptions === "string" ? pathOrOptions : undefined;
-	const options: EndpointRuntimeOptions =
-		typeof handlerOrOptions === "object" ? handlerOrOptions : pathOrOptions;
-	const handler =
+	const options: Opts =
+		typeof handlerOrOptions === "object"
+			? handlerOrOptions
+			: (pathOrOptions as Opts);
+	const handler: EndpointHandler<Path, Opts, R> =
 		typeof handlerOrOptions === "function" ? handlerOrOptions : handlerOrNever;
 
 	if (path) {
@@ -188,9 +82,9 @@ export function createAuthEndpoint(
 			{
 				...options,
 				use: [...(options?.use || []), ...use],
-			} as any,
+			},
 			// todo: prettify the code, we want to call `runWithEndpointContext` to top level
-			async (ctx: any) => runWithEndpointContext(ctx, () => handler(ctx)),
+			async (ctx) => runWithEndpointContext(ctx as any, () => handler(ctx)),
 		);
 	}
 
@@ -198,19 +92,15 @@ export function createAuthEndpoint(
 		{
 			...options,
 			use: [...(options?.use || []), ...use],
-		} as any,
+		},
 		// todo: prettify the code, we want to call `runWithEndpointContext` to top level
-		async (ctx: any) => runWithEndpointContext(ctx, () => handler(ctx)),
+		async (ctx) => runWithEndpointContext(ctx as any, () => handler(ctx)),
 	);
 }
 
-export type AuthEndpoint = ReturnType<typeof createAuthEndpoint>;
-/**
- * The handler type for plugin hooks.
- *
- * Accepts both `Middleware` instances (from `createAuthMiddleware`)
- * and plain async functions for better-call v1/v2 compatibility.
- */
-export type AuthMiddleware = (
-	inputContext: Record<string, any>,
-) => Promise<unknown>;
+export type AuthEndpoint<
+	Path extends string,
+	Opts extends EndpointOptions,
+	R,
+> = ReturnType<typeof createAuthEndpoint<Path, Opts, R>>;
+export type AuthMiddleware = ReturnType<typeof createAuthMiddleware>;

--- a/packages/core/src/context/endpoint-context.ts
+++ b/packages/core/src/context/endpoint-context.ts
@@ -5,8 +5,7 @@ import type { AuthContext } from "../types";
 import { __getBetterAuthGlobal } from "./global";
 
 export type AuthEndpointContext = Partial<
-	InputContext<string, any, any, any, any, any> &
-		EndpointContext<string, any, any, any, any, any, any, AuthContext>
+	InputContext<string, any> & EndpointContext<string, any>
 > & {
 	context: AuthContext;
 };

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -80,7 +80,9 @@ export type BetterAuthPluginRegistryIdentifier = keyof BetterAuthPluginRegistry<
 
 export type GenericEndpointContext<
 	Options extends BetterAuthOptions = BetterAuthOptions,
-> = EndpointContext<string, any, any, any, any, any, any, AuthContext<Options>>;
+> = EndpointContext<string, any> & {
+	context: AuthContext<Options>;
+};
 
 export interface InternalAdapter<
 	_Options extends BetterAuthOptions = BetterAuthOptions,

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -19,20 +19,7 @@ type DeepPartial<T> = T extends Function
 		: T;
 
 export type HookEndpointContext = Partial<
-	EndpointContext<
-		string,
-		any,
-		any,
-		any,
-		any,
-		any,
-		any,
-		AuthContext & {
-			returned?: unknown | undefined;
-			responseHeaders?: Headers | undefined;
-		}
-	> &
-		Omit<InputContext<string, any, any, any, any, any>, "method">
+	EndpointContext<string, any> & Omit<InputContext<string, any>, "method">
 > & {
 	path?: string;
 	context: AuthContext & {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 1.1.21
       version: 1.1.21
     better-call:
-      specifier: 2.0.3
-      version: 2.0.3
+      specifier: 1.3.5
+      version: 1.3.5
     tsdown:
       specifier: 0.21.1
       version: 0.21.1
@@ -832,7 +832,7 @@ importers:
         version: 7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       better-sqlite3:
         specifier: ^12.0.0
         version: 12.6.2
@@ -1075,7 +1075,7 @@ importers:
         version: 1.30.1(@opentelemetry/api@1.9.0)
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       jose:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1117,7 +1117,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       conf:
         specifier: ^15.0.2
         version: 15.1.0
@@ -1151,7 +1151,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1257,7 +1257,7 @@ importers:
         version: 1.1.21
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       jose:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1297,7 +1297,7 @@ importers:
         version: 13.2.3
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       nanostores:
         specifier: ^1.0.1
         version: 1.1.1
@@ -1368,7 +1368,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1421,7 +1421,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       body-parser:
         specifier: ^2.2.2
         version: 2.2.2
@@ -1452,7 +1452,7 @@ importers:
         version: link:../better-auth
       better-call:
         specifier: 'catalog:'
-        version: 2.0.3(zod@4.3.6)
+        version: 1.3.5(zod@4.3.6)
       stripe:
         specifier: ^20.4.0
         version: 20.4.0(@types/node@25.5.0)
@@ -7723,8 +7723,8 @@ packages:
     peerDependencies:
       better-auth: ^1.0.3
 
-  better-call@2.0.3:
-    resolution: {integrity: sha512-0ZrD4tszOwN+vn9pCiHahe6wPb7AL1U+LgaPMstyZelD0kuA7lW3WwyxGmh22WRApKiWy4epNCN5pf7dfl6Sdw==}
+  better-call@1.3.5:
+    resolution: {integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -22080,7 +22080,7 @@ snapshots:
       mailchecker: 6.0.19
       validator: 13.15.26
 
-  better-call@2.0.3(zod@4.3.6):
+  better-call@1.3.5(zod@4.3.6):
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ blockExoticSubdeps: true
 catalog:
   '@better-auth/utils': 0.4.0
   '@better-fetch/fetch': 1.1.21
-  better-call: 2.0.3
+  better-call: 1.3.5
   tsdown: 0.21.1
   typescript: ^5.9.3
 


### PR DESCRIPTION
Reverts #8021 (better-call v2 migration), downgrading to v1.3.5

- The following post-#8021 commits conflicted with the revert and were manually reconciled:
    - #8027 - to-auth-endpoints.ts: added getOperationId(endpoint: Endpoint) using v2's Endpoint type. Changed parameter to v1's Endpoint which has the same options/path shape.
    - #7521 - to-auth-endpoints.ts: added shouldReturnResponse logic around v2's InputContext<6 args>. Reverted to v1's InputContext<2 args> while keeping the logic.
    - #8466 - path-to-object.ts: changed InferRoutes to Record<string, unknown>, kept as-is. core/api/index.ts: added NormalizeMethod and const Method for v2 flat generics, dropped since v1 uses EndpointOptions instead of individual Method generic.
    - #8448 - path-to-object.ts: added MergeCustomSessionWithInferred using v2's Endpoint<8 args> for Meta inference. Changed to use v1's T["options"]["metadata"] access pattern.
    - #8750 - plugin.ts, context.ts, organization/client.ts, organization.ts: added version field. No conflict with v2 types, kept as-is.