### PR TITLE
ci: add release notes pipeline with AI rewriting

### DIFF
--- a/.github/prompts/release-notes-rewrite.md
+++ b/.github/prompts/release-notes-rewrite.md
@@ -1,3 +1,6 @@
+<!-- Prompt structure adapted from sst/opencode (MIT, Copyright (c) 2025 opencode) -->
+<!-- https://github.com/anomalyco/opencode — .opencode/command/changelog.md -->
+
 You are rewriting release notes for better-auth, an open-source
 authentication framework for TypeScript.
 

--- a/.github/prompts/release-notes-rewrite.md
+++ b/.github/prompts/release-notes-rewrite.md
@@ -1,0 +1,38 @@
+You are rewriting release notes for better-auth, an open-source
+authentication framework for TypeScript.
+
+Read the raw changelog at: __RAW_CHANGELOG_PATH__
+
+This raw changelog was generated from git history and PR metadata.
+Each entry has a description, a PR link, and an author attribution.
+Entries are grouped by domain (Core, Database, Identity, etc.).
+
+Entries come from two sources:
+- Changeset descriptions (already user-focused, capitalized, clean)
+- Raw commit subjects (lower-case, terse, may include PR number
+  suffixes like "(#8289)" in the description text)
+
+Your job is to rewrite ALL descriptions to be user-focused and
+consistent. The changelog is for users who are at least slightly
+technical (they use the library and want to know what changed).
+
+For entries that are unclear or too terse, inspect the actual PR
+diff to understand what really changed:
+  gh pr diff <PR_NUMBER> --repo __GITHUB_REPOSITORY__ | head -200
+
+Rules:
+- Rewrite descriptions to focus on what changed for users, not internals
+- Start each bullet with a capital letter, use past tense
+- Avoid technical jargon unless it's necessary to explain the user impact
+- Do NOT use em dashes; use parentheses, commas, or colons instead
+- Be specific ("Fixed session cookie prefix casing" not "Fixed cookies")
+- Remove duplicate PR number suffixes from description text (the PR
+  link in parentheses after the description already provides this)
+- Do NOT add or remove entries; keep every entry from the raw changelog
+- Do NOT modify PR links, author attributions, or the **BREAKING:** prefix
+- Do NOT modify the ## domain headings or their order
+- Keep the install banner and full changelog link exactly as-is
+- Focus on writing the least words to get the point across
+- Keep total output concise (users skim release notes)
+
+Write the final release notes to: __RAW_CHANGELOG_PATH__.final

--- a/.github/prompts/release-notes-rewrite.md
+++ b/.github/prompts/release-notes-rewrite.md
@@ -34,12 +34,20 @@ Code references:
 - Do NOT wrap general concepts in backticks (e.g., "password hashing" stays plain)
 
 User focus:
+- The changelog is for users who are at least slightly technical (they
+  use the library and want to know what changed for them)
 - Describe the impact on users, not the internal code change
 - "Fixed a bug where sessions expired immediately after creation" is better
   than "Aligned session fresh age calculation with creation time"
 - "Password hashing no longer blocks the server during sign-up" is better
   than "Used non-blocking scrypt for password hashing"
 - If a change is behavioral (affects what users experience), lead with the behavior
+- Be thorough in understanding flow-on effects that may not be immediately
+  apparent: a package upgrade that looks internal may patch a user-facing
+  bug; a refactor may stabilize a race condition that caused intermittent
+  failures; a dependency bump may change minimum supported versions
+- When inspecting a diff, look at the PR title and body for the author's
+  context (the outcome they intended, not just the technical detail)
 
 Breaking changes:
 - Entries with `**BREAKING:**` prefix must clearly explain what changed

--- a/.github/prompts/release-notes-rewrite.md
+++ b/.github/prompts/release-notes-rewrite.md
@@ -16,9 +16,10 @@ Your job is to rewrite ALL descriptions to be user-focused and
 consistent. The changelog is for users who are at least slightly
 technical (they use the library and want to know what changed).
 
-For entries that are unclear or too terse, inspect the actual PR
+For the 3-5 most unclear or terse entries, inspect the actual PR
 diff to understand what really changed:
   gh pr diff <PR_NUMBER> --repo __GITHUB_REPOSITORY__ | head -200
+Do NOT inspect every entry; most descriptions are already clear enough.
 
 Rules:
 - Rewrite descriptions to focus on what changed for users, not internals

--- a/.github/prompts/release-notes-rewrite.md
+++ b/.github/prompts/release-notes-rewrite.md
@@ -8,32 +8,53 @@ Each entry has a description, a PR link, and an author attribution.
 Entries are grouped by domain (Core, Database, Identity, etc.).
 
 Entries come from two sources:
-- Changeset descriptions (already user-focused, capitalized, clean)
+- Changeset descriptions (may already look clean but often need tense
+  fixes, code formatting, and user-focus adjustments)
 - Raw commit subjects (lower-case, terse, may include PR number
   suffixes like "(#8289)" in the description text)
 
-Your job is to rewrite ALL descriptions to be user-focused and
-consistent. The changelog is for users who are at least slightly
-technical (they use the library and want to know what changed).
+Your job is to rewrite EVERY description so the changelog reads as a
+polished, consistent document written for end users.
 
-For the 3-5 most unclear or terse entries, inspect the actual PR
-diff to understand what really changed:
+For entries that are unclear or too terse, inspect the actual PR diff
+to understand what really changed:
   gh pr diff <PR_NUMBER> --repo __GITHUB_REPOSITORY__ | head -200
-Do NOT inspect every entry; most descriptions are already clear enough.
 
-Rules:
-- Rewrite descriptions to focus on what changed for users, not internals
-- Start each bullet with a capital letter, use past tense
-- Avoid technical jargon unless it's necessary to explain the user impact
-- Do NOT use em dashes; use parentheses, commas, or colons instead
-- Be specific ("Fixed session cookie prefix casing" not "Fixed cookies")
-- Remove duplicate PR number suffixes from description text (the PR
-  link in parentheses after the description already provides this)
+## Writing rules
+
+Tense and voice:
+- Use past tense consistently throughout ("Added", "Fixed", "Removed")
+- Never mix tenses ("Added X and improve Y" is wrong, use "Added X and improved Y")
+- Never use imperative/present ("Add", "Fix", "Remove")
+
+Code references:
+- Wrap code identifiers in backticks: function names, method names,
+  option names, config keys, field names, type names, package names
+  (e.g., `storeSessionInDatabase`, `provisionUserOnEveryLogin`, `auth_time`)
+- Do NOT wrap general concepts in backticks (e.g., "password hashing" stays plain)
+
+User focus:
+- Describe the impact on users, not the internal code change
+- "Fixed a bug where sessions expired immediately after creation" is better
+  than "Aligned session fresh age calculation with creation time"
+- "Password hashing no longer blocks the server during sign-up" is better
+  than "Used non-blocking scrypt for password hashing"
+- If a change is behavioral (affects what users experience), lead with the behavior
+
+Breaking changes:
+- Entries with `**BREAKING:**` prefix must clearly explain what changed
+  and what users need to do (migration steps if applicable)
+- Keep the `**BREAKING:**` prefix exactly as-is
+
+## Structural rules (do NOT violate)
+
 - Do NOT add or remove entries; keep every entry from the raw changelog
-- Do NOT modify PR links, author attributions, or the **BREAKING:** prefix
-- Do NOT modify the ## domain headings or their order
-- Keep the install banner and full changelog link exactly as-is
-- Focus on writing the least words to get the point across
-- Keep total output concise (users skim release notes)
+- Do NOT modify PR links `([#NNNN](url))` or author attributions `by @username`
+- Do NOT modify the `## Domain` headings or their order
+- Do NOT use em dashes; use parentheses, commas, or colons instead
+- Keep the install banner line and full changelog link exactly as-is
+- Remove duplicate PR number suffixes from description text (the PR
+  link in parentheses already provides this; e.g., change
+  "fixed foo (#8289)" to "Fixed foo")
 
 Write the final release notes to: __RAW_CHANGELOG_PATH__.final

--- a/.github/scripts/auto-changeset.ts
+++ b/.github/scripts/auto-changeset.ts
@@ -8,9 +8,8 @@
  * Usage: GITHUB_TOKEN=... PR_NUMBER=... npx tsx .github/scripts/auto-changeset.ts
  */
 
-import { execFileSync } from "node:child_process";
-import { randomBytes } from "node:crypto";
-import { appendFileSync } from "node:fs";
+import { gh, ghJSON, REPO, setOutput } from "./lib/github.ts";
+import { mapTypeToBump, parseConventionalCommit } from "./lib/pr-analyzer.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -25,81 +24,10 @@ interface PRData {
 	changedFiles: string[];
 }
 
-interface ConventionalCommit {
-	type: string;
-	scope: string;
-	subject: string;
-	breaking: boolean;
-}
-
 // ── Constants ──────────────────────────────────────────────────────────
-
-const REPO = process.env.GITHUB_REPOSITORY ?? "better-auth/better-auth";
 
 const CUBIC_OPEN = "<!-- This is an auto-generated description by cubic. -->";
 const CUBIC_CLOSE = "<!-- End of auto-generated description by cubic. -->";
-
-// ── Conventional commit helpers ────────────────────────────────────────
-
-function parseConventionalCommit(title: string): ConventionalCommit {
-	const typeMatch = title.match(/^([a-z]+)/);
-	const type = typeMatch?.[1] ?? "";
-	const scopeMatch = title.match(/^[a-z]+\(([^)]+)\)/);
-	const scope = scopeMatch?.[1] ?? "";
-	const breaking = /^[a-z]+(\([^)]+\))?!:/.test(title);
-	const subject = title.replace(/^[a-z]+(\([^)]+\))?!?:\s*/, "");
-	return { type, scope, subject, breaking };
-}
-
-function mapTypeToBump(
-	type: string,
-	breaking: boolean,
-): "patch" | "minor" | "major" | "skip" {
-	if (breaking) return "major";
-	switch (type) {
-		case "fix":
-		case "perf":
-		case "refactor":
-			return "patch";
-		case "feat":
-			return "minor";
-		case "chore":
-		case "docs":
-		case "ci":
-		case "test":
-		case "style":
-		case "build":
-			return "skip";
-		default:
-			return "patch";
-	}
-}
-
-// ── GitHub CLI helpers ─────────────────────────────────────────────────
-
-function gh(args: string[]): string {
-	return execFileSync("gh", args, {
-		encoding: "utf-8",
-		env: { ...process.env, GH_TOKEN: process.env.GITHUB_TOKEN },
-	}).trim();
-}
-
-function ghJSON<T>(args: string[]): T {
-	return JSON.parse(gh(args)) as T;
-}
-
-// ── GITHUB_OUTPUT helpers ──────────────────────────────────────────────
-
-function setOutput(key: string, value: string): void {
-	const outputFile = process.env.GITHUB_OUTPUT;
-	if (outputFile) {
-		const delim = `GHEOF_${randomBytes(8).toString("hex")}`;
-		appendFileSync(outputFile, `${key}<<${delim}\n${value}\n${delim}\n`);
-	}
-	console.log(
-		`  ${key}: ${value.length > 100 ? `${value.slice(0, 100)}...` : value}`,
-	);
-}
 
 // ── PR data fetching ───────────────────────────────────────────────────
 

--- a/.github/scripts/lib/github.ts
+++ b/.github/scripts/lib/github.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared GitHub CLI and CI output helpers.
+ *
+ * Used by: auto-changeset.ts, release-notes.ts
+ */
+
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { appendFileSync } from "node:fs";
+
+export const REPO = process.env.GITHUB_REPOSITORY ?? "better-auth/better-auth";
+
+export function gh(args: string[]): string {
+	return execFileSync("gh", args, {
+		encoding: "utf-8",
+		env: { ...process.env, GH_TOKEN: process.env.GITHUB_TOKEN },
+	}).trim();
+}
+
+export function ghJSON<T>(args: string[]): T {
+	return JSON.parse(gh(args)) as T;
+}
+
+export function setOutput(key: string, value: string): void {
+	const outputFile = process.env.GITHUB_OUTPUT;
+	if (outputFile) {
+		const delim = `GHEOF_${randomBytes(8).toString("hex")}`;
+		appendFileSync(outputFile, `${key}<<${delim}\n${value}\n${delim}\n`);
+	}
+	console.log(
+		`  ${key}: ${value.length > 100 ? `${value.slice(0, 100)}...` : value}`,
+	);
+}

--- a/.github/scripts/lib/github.ts
+++ b/.github/scripts/lib/github.ts
@@ -13,7 +13,10 @@ export const REPO = process.env.GITHUB_REPOSITORY ?? "better-auth/better-auth";
 export function gh(args: string[]): string {
 	return execFileSync("gh", args, {
 		encoding: "utf-8",
-		env: { ...process.env, GH_TOKEN: process.env.GITHUB_TOKEN },
+		env: {
+			...process.env,
+			GH_TOKEN: process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN,
+		},
 	}).trim();
 }
 

--- a/.github/scripts/lib/pr-analyzer.ts
+++ b/.github/scripts/lib/pr-analyzer.ts
@@ -96,7 +96,6 @@ const SCOPE_TO_DOMAIN: Record<string, string> = {
 };
 
 const PATH_TO_DOMAIN: [string, string][] = [
-	// Most specific paths first
 	["packages/oauth-provider/", "identity"],
 	["packages/better-auth/src/plugins/oidc-provider/", "identity"],
 	["packages/better-auth/src/plugins/mcp/", "identity"],
@@ -173,10 +172,6 @@ export function parseConventionalCommit(title: string): ConventionalCommit {
 	return { type, scope, subject, breaking };
 }
 
-function scopeToDomain(scope: string): string | undefined {
-	return SCOPE_TO_DOMAIN[scope];
-}
-
 function classifyDomain(filePath: string): string | undefined {
 	for (const [prefix, domain] of PATH_TO_DOMAIN) {
 		if (filePath.startsWith(prefix)) return domain;
@@ -189,7 +184,7 @@ export function resolveDomain(
 	changedFiles: string[],
 ): string {
 	if (scope) {
-		const domain = scopeToDomain(scope);
+		const domain = SCOPE_TO_DOMAIN[scope];
 		if (domain) return domain;
 	}
 

--- a/.github/scripts/lib/pr-analyzer.ts
+++ b/.github/scripts/lib/pr-analyzer.ts
@@ -1,0 +1,251 @@
+/**
+ * PR Analyzer — shared classification module
+ *
+ * Pure functions for mapping conventional commit scopes and file paths
+ * to domain labels. No side effects, no network calls.
+ *
+ * Used by: auto-changeset.ts, release-notes.ts
+ */
+
+const SCOPE_TO_DOMAIN: Record<string, string> = {
+	// core
+	core: "core",
+	api: "core",
+	client: "core",
+	cookies: "core",
+	crypto: "core",
+	account: "core",
+	session: "core",
+	instrumentation: "core",
+	"last-login-method": "core",
+	"redis-storage": "core",
+
+	// database
+	db: "database",
+	adapters: "database",
+	"drizzle-adapter": "database",
+	"prisma-adapter": "database",
+	"kysely-adapter": "database",
+	"mongo-adapter": "database",
+	"memory-adapter": "database",
+
+	// oauth
+	"oauth-proxy": "oauth",
+	"one-tap": "oauth",
+	"generic-oauth": "oauth",
+	"social-provider": "oauth",
+
+	// credentials
+	"magic-link": "credentials",
+	"email-otp": "credentials",
+	"phone-number": "credentials",
+	phone: "credentials",
+	username: "credentials",
+	anonymous: "credentials",
+	siwe: "credentials",
+	passkey: "credentials",
+
+	// identity
+	"oauth-provider": "identity",
+	"oidc-provider": "identity",
+	mcp: "identity",
+	"device-authorization": "identity",
+
+	// organization
+	organization: "organization",
+	admin: "organization",
+	access: "organization",
+
+	// security
+	"two-factor": "security",
+	"2fa": "security",
+	captcha: "security",
+	haveibeenpwned: "security",
+	"rate-limiter": "security",
+
+	// enterprise
+	sso: "enterprise",
+	scim: "enterprise",
+
+	// payments
+	stripe: "payments",
+	"api-key": "payments",
+
+	// platform
+	expo: "platform",
+	electron: "platform",
+
+	// devtools
+	cli: "devtools",
+	telemetry: "devtools",
+	i18n: "devtools",
+	"test-utils": "devtools",
+	"open-api": "devtools",
+
+	// devops (filtered from release notes)
+	build: "devops",
+	ci: "devops",
+	deps: "devops",
+	"deps-dev": "devops",
+	knip: "devops",
+
+	// docs (filtered from release notes)
+	docs: "docs",
+	blog: "docs",
+	landing: "docs",
+};
+
+const PATH_TO_DOMAIN: [string, string][] = [
+	// Most specific paths first
+	["packages/oauth-provider/", "identity"],
+	["packages/better-auth/src/plugins/oidc-provider/", "identity"],
+	["packages/better-auth/src/plugins/mcp/", "identity"],
+	["packages/better-auth/src/plugins/device-authorization/", "identity"],
+	["packages/better-auth/src/plugins/magic-link/", "credentials"],
+	["packages/better-auth/src/plugins/email-otp/", "credentials"],
+	["packages/better-auth/src/plugins/phone-number/", "credentials"],
+	["packages/better-auth/src/plugins/username/", "credentials"],
+	["packages/better-auth/src/plugins/anonymous/", "credentials"],
+	["packages/better-auth/src/plugins/siwe/", "credentials"],
+	["packages/passkey/", "credentials"],
+	["packages/better-auth/src/plugins/two-factor/", "security"],
+	["packages/better-auth/src/api/rate-limiter/", "security"],
+	["packages/better-auth/src/plugins/captcha/", "security"],
+	["packages/better-auth/src/plugins/haveibeenpwned/", "security"],
+	["packages/better-auth/src/plugins/organization/", "organization"],
+	["packages/better-auth/src/plugins/admin/", "organization"],
+	["packages/better-auth/src/plugins/access/", "organization"],
+	["packages/better-auth/src/plugins/generic-oauth/", "oauth"],
+	["packages/better-auth/src/plugins/oauth-proxy/", "oauth"],
+	["packages/better-auth/src/plugins/one-tap/", "oauth"],
+	["packages/better-auth/src/oauth2/", "oauth"],
+	["packages/core/src/social-providers/", "oauth"],
+	["packages/core/src/oauth2/", "oauth"],
+	["packages/sso/", "enterprise"],
+	["packages/scim/", "enterprise"],
+	["packages/stripe/", "payments"],
+	["packages/api-key/", "payments"],
+	["packages/better-auth/src/db/", "database"],
+	["packages/better-auth/src/adapters/", "database"],
+	["packages/drizzle-adapter/", "database"],
+	["packages/prisma-adapter/", "database"],
+	["packages/mongo-adapter/", "database"],
+	["packages/kysely-adapter/", "database"],
+	["packages/memory-adapter/", "database"],
+	["packages/expo/", "platform"],
+	["packages/electron/", "platform"],
+	["packages/better-auth/src/integrations/", "platform"],
+	["packages/cli/", "devtools"],
+	["packages/better-auth/src/plugins/open-api/", "devtools"],
+	["packages/telemetry/", "devtools"],
+	["packages/i18n/", "devtools"],
+	["packages/test-utils/", "devtools"],
+	// Session-related plugins → core
+	["packages/better-auth/src/plugins/jwt/", "core"],
+	["packages/better-auth/src/plugins/bearer/", "core"],
+	["packages/better-auth/src/plugins/multi-session/", "core"],
+	["packages/better-auth/src/plugins/custom-session/", "core"],
+	["packages/redis-storage/", "core"],
+	// Catch-all for better-auth and core packages
+	["packages/better-auth/", "core"],
+	["packages/core/", "core"],
+	// Non-user-facing
+	["docs/", "docs"],
+	["demo/", "docs"],
+	[".github/", "devops"],
+	["e2e/", "devops"],
+];
+
+export interface ConventionalCommit {
+	type: string;
+	scope: string;
+	subject: string;
+	breaking: boolean;
+}
+
+export function parseConventionalCommit(title: string): ConventionalCommit {
+	const typeMatch = title.match(/^([a-z]+)/);
+	const type = typeMatch?.[1] ?? "";
+	const scopeMatch = title.match(/^[a-z]+\(([^)]+)\)/);
+	const scope = scopeMatch?.[1] ?? "";
+	const breaking = /^[a-z]+(\([^)]+\))?!:/.test(title);
+	const subject = title.replace(/^[a-z]+(\([^)]+\))?!?:\s*/, "");
+	return { type, scope, subject, breaking };
+}
+
+function scopeToDomain(scope: string): string | undefined {
+	return SCOPE_TO_DOMAIN[scope];
+}
+
+function classifyDomain(filePath: string): string | undefined {
+	for (const [prefix, domain] of PATH_TO_DOMAIN) {
+		if (filePath.startsWith(prefix)) return domain;
+	}
+	return undefined;
+}
+
+export function resolveDomain(
+	scope: string | undefined,
+	changedFiles: string[],
+): string {
+	if (scope) {
+		const domain = scopeToDomain(scope);
+		if (domain) return domain;
+	}
+
+	const counts: Record<string, number> = {};
+	for (const file of changedFiles) {
+		const domain = classifyDomain(file);
+		if (domain) {
+			counts[domain] = (counts[domain] ?? 0) + 1;
+		}
+	}
+
+	const domains = Object.keys(counts);
+	if (domains.length === 0) return "devops";
+	if (domains.length >= 3) return "core";
+
+	return domains.sort((a, b) => (counts[b] ?? 0) - (counts[a] ?? 0))[0]!;
+}
+
+export function mapTypeToBump(
+	type: string,
+	breaking: boolean,
+): "patch" | "minor" | "major" | "skip" {
+	if (breaking) return "major";
+	switch (type) {
+		case "fix":
+		case "perf":
+		case "refactor":
+			return "patch";
+		case "feat":
+			return "minor";
+		case "chore":
+		case "docs":
+		case "ci":
+		case "test":
+		case "style":
+		case "build":
+			return "skip";
+		default:
+			return "patch";
+	}
+}
+
+/** Domains in display order for release notes */
+export const DOMAIN_ORDER = [
+	"core",
+	"database",
+	"oauth",
+	"credentials",
+	"identity",
+	"organization",
+	"security",
+	"enterprise",
+	"payments",
+	"platform",
+	"devtools",
+] as const;
+
+/** Domains excluded from release notes */
+export const FILTERED_DOMAINS = new Set(["docs", "devops"]);

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -64,13 +64,6 @@ const DOMAIN_DISPLAY_NAMES: Record<string, string> = {
 	devtools: "Devtools",
 };
 
-// Package name → directory mapping for packages that don't follow
-// the @better-auth/<dir> convention.
-const PACKAGE_DIR_OVERRIDES: Record<string, string> = {
-	auth: "cli",
-	"better-auth": "better-auth",
-};
-
 // ── CLI argument parsing ───────────────────────────────────────────────
 
 function parseArgs(): {
@@ -152,7 +145,7 @@ function listTags(): string[] {
 
 /** Parse "1.2.3" into [1, 2, 3]. Returns null on invalid input. */
 function parseVersionTuple(ver: string): [number, number, number] | null {
-	const base = ver.replace(/-.*$/, ""); // strip pre-release suffix
+	const base = ver.replace(/-.*$/, "");
 	const m = base.match(/^(\d+)\.(\d+)\.(\d+)$/);
 	if (!m) return null;
 	return [Number(m[1]), Number(m[2]), Number(m[3])];
@@ -177,7 +170,7 @@ function findPreviousTag(currentVersion: string, isBeta: boolean): string {
 		const preMatch = currentVersion.match(/^(.+)-(beta|alpha|rc)\.(\d+)$/);
 		if (preMatch && Number(preMatch[3]) > 0) {
 			const prevN = Number(preMatch[3]) - 1;
-			const channel = preMatch[2]; // preserve the actual channel
+			const channel = preMatch[2];
 			const prevVersion = `${preMatch[1]}-${channel}.${prevN}`;
 			const prevTag = `v${prevVersion}`;
 			if (tags.includes(prevTag)) return prevTag;
@@ -185,29 +178,19 @@ function findPreviousTag(currentVersion: string, isBeta: boolean): string {
 	}
 
 	const currentTag = `v${currentVersion}`;
-
-	// Extract the major.minor prefix to scope to the current release line.
 	const majorMinorMatch = currentVersion.match(/^(\d+\.\d+)\./);
 	const majorMinor = majorMinorMatch?.[1];
 
+	// First prefer the same major.minor line, then fall back to any stable tag
+	let fallback: string | undefined;
 	for (const tag of tags) {
 		if (tag === currentTag) continue;
 		const ver = tag.replace(/^v/, "");
-		if (ver.includes("-")) continue;
-		if (majorMinor && !ver.startsWith(`${majorMinor}.`)) continue;
-		// Only return tags strictly older than the current version
-		if (!isOlderVersion(ver, currentVersion)) continue;
-		return tag;
+		if (ver.includes("-") || !isOlderVersion(ver, currentVersion)) continue;
+		if (majorMinor && ver.startsWith(`${majorMinor}.`)) return tag;
+		fallback ??= tag;
 	}
-
-	// Fallback: any stable tag older than the current version
-	for (const tag of tags) {
-		if (tag === currentTag) continue;
-		const ver = tag.replace(/^v/, "");
-		if (ver.includes("-")) continue;
-		if (!isOlderVersion(ver, currentVersion)) continue;
-		return tag;
-	}
+	if (fallback) return fallback;
 
 	throw new Error("No previous stable tag found");
 }
@@ -298,11 +281,7 @@ interface ChangesetEntry {
 	packageNames: string[];
 }
 
-/**
- * Build a map of PR number → changeset description by scanning .changeset/ for
- * pr-*.md and commit-*.md files directly. Does not rely on pre.json.changesets
- * which can be empty on freshly entered pre-release branches or absent on main.
- */
+/** Build a map of PR number to changeset description from .changeset/ files and pre.json. */
 function buildChangesetIndex(branch: string): {
 	byPR: Map<number, ChangesetEntry>;
 	orphans: ChangesetEntry[];
@@ -310,12 +289,8 @@ function buildChangesetIndex(branch: string): {
 } {
 	const byPR = new Map<number, ChangesetEntry>();
 	const orphans: ChangesetEntry[] = [];
-	// Index by first line of description for matching manual changesets to PRs
 	const byDescription = new Map<string, ChangesetEntry>();
 
-	// Collect changeset IDs from two sources:
-	// 1. pre.json.changesets (consumed changesets, always present in pre-release mode)
-	// 2. Directory listing (uncovered changesets not yet versioned)
 	const ids = new Set<string>();
 
 	try {
@@ -323,48 +298,48 @@ function buildChangesetIndex(branch: string): {
 		const preJSON = JSON.parse(raw) as { changesets: string[] };
 		for (const id of preJSON.changesets) ids.add(id);
 	} catch {
-		// No pre.json — that's fine, we'll scan the directory
+		// No pre.json — scan the directory instead
 	}
 
-	// Scan .changeset/ for pr-* and commit-* files. Try the target ref first;
-	// Search for a commit that still has changeset files.
-	// On main after promotion, `changeset version` deletes them. The files
-	// may be on: (1) an ancestor on the first-parent chain, or (2) the
-	// merged next branch side (HEAD^2) from the promote merge commit.
+	// Walk recent ancestors (including merge parents via rev-list's full graph
+	// traversal) to find a commit that still has changeset files. On main after
+	// promotion, `changeset version` deletes them, so we may need to look at
+	// the merged next branch side.
+	const skipFiles = new Set(["README", "config"]);
 	const baseRef = branch || "HEAD";
 	let effectiveBranch = branch;
-	const refsToTry = [baseRef];
-	for (let i = 1; i <= 5; i++) refsToTry.push(`${baseRef}~${i}`);
-	// Also check the second parent of merge commits and its ancestors.
-	// In the promote flow, `changeset version` runs on next BEFORE the merge,
-	// so HEAD^2 itself has the files deleted. We need HEAD^2~1, HEAD^2~2, etc.
-	for (let i = 0; i <= 3; i++) {
-		const mergeRef = i === 0 ? baseRef : `${baseRef}~${i}`;
-		refsToTry.push(`${mergeRef}^2`);
-		for (let j = 1; j <= 3; j++) refsToTry.push(`${mergeRef}^2~${j}`);
-	}
-	for (const ref of refsToTry) {
-		try {
-			const listing = execFileSync(
-				"git",
-				["ls-tree", "-r", "--name-only", ref, ".changeset/"],
-				{ encoding: "utf-8" },
-			);
-			const SKIP_FILES = new Set(["README", "config"]);
-			let foundAny = false;
-			for (const file of listing.split("\n")) {
-				const name = file.replace(/^\.changeset\//, "").replace(/\.md$/, "");
-				if (!name || SKIP_FILES.has(name) || !file.endsWith(".md")) continue;
-				ids.add(name);
-				foundAny = true;
+	try {
+		const revs = execFileSync("git", ["rev-list", "--max-count=15", baseRef], {
+			encoding: "utf-8",
+		})
+			.trim()
+			.split("\n")
+			.filter(Boolean);
+
+		for (const rev of revs) {
+			try {
+				const listing = execFileSync(
+					"git",
+					["ls-tree", "-r", "--name-only", rev, ".changeset/"],
+					{ encoding: "utf-8" },
+				);
+				let foundAny = false;
+				for (const file of listing.split("\n")) {
+					const name = file.replace(/^\.changeset\//, "").replace(/\.md$/, "");
+					if (!name || skipFiles.has(name) || !file.endsWith(".md")) continue;
+					ids.add(name);
+					foundAny = true;
+				}
+				if (foundAny) {
+					effectiveBranch = rev;
+					break;
+				}
+			} catch {
+				// listing failed — try next
 			}
-			if (foundAny) {
-				effectiveBranch = ref;
-				break;
-			}
-		} catch {
-			// ref doesn't exist or listing failed — try next
 		}
+	} catch {
+		// rev-list failed — proceed with whatever pre.json gave us
 	}
 
 	for (const id of ids) {
@@ -386,7 +361,6 @@ function buildChangesetIndex(branch: string): {
 				byPR.set(Number(prMatch[1]), entry);
 			} else {
 				orphans.push(entry);
-				// Index by first line for matching to PRs via commit subject
 				const firstLine = description.split("\n")[0]!.trim().toLowerCase();
 				if (firstLine) byDescription.set(firstLine, entry);
 			}
@@ -398,11 +372,24 @@ function buildChangesetIndex(branch: string): {
 	return { byPR, orphans, byDescription };
 }
 
-/** Map a changeset package name to its directory under packages/ */
 function packageNameToPath(name: string): string {
-	const stripped = name.replace(/^@better-auth\//, "");
-	const dir = PACKAGE_DIR_OVERRIDES[stripped] ?? stripped;
-	return `packages/${dir}/`;
+	return `packages/${name.replace(/^@better-auth\//, "")}/`;
+}
+
+/** Load changeset IDs from the previous beta's pre.json to exclude from orphans. */
+function loadPreviousBetaChangesets(version: string): Set<string> {
+	const betaMatch = version.match(/^(.+)-beta\.(\d+)$/);
+	if (!betaMatch || Number(betaMatch[2]) === 0) return new Set();
+
+	const prevTag = `v${betaMatch[1]}-beta.${Number(betaMatch[2]) - 1}`;
+	try {
+		const prevPre = JSON.parse(gitShow(prevTag, ".changeset/pre.json")) as {
+			changesets: string[];
+		};
+		return new Set(prevPre.changesets);
+	} catch {
+		return new Set();
+	}
 }
 
 // ── Entry collection ───────────────────────────────────────────────────
@@ -421,7 +408,6 @@ function collectEntries(
 ): { entries: ReleaseEntry[]; targetRef: string } {
 	const previousTag = findPreviousTag(version, version.includes("-"));
 
-	// Determine the target ref: tag > branch arg > HEAD
 	const currentTag = `v${version}`;
 	let targetRef: string;
 	try {
@@ -448,7 +434,7 @@ function collectEntries(
 		);
 		isDirectAncestor = true;
 	} catch {
-		// Not a direct ancestor — cherry-pick model
+		// Not a direct ancestor
 	}
 
 	let log: string;
@@ -469,8 +455,6 @@ function collectEntries(
 
 		console.log(`  Cherry-pick mode: common ancestor ${mergeBase.slice(0, 7)}`);
 
-		// Collect PR numbers between merge-base and the previous tag
-		// (scoped range avoids reading the entire tag history)
 		const tagLog = execFileSync(
 			"git",
 			["log", `${mergeBase}..${previousTag}`, "--oneline"],
@@ -489,7 +473,6 @@ function collectEntries(
 
 	let lines = log.trim().split("\n").filter(Boolean);
 
-	// In cherry-pick mode, filter out commits whose PR was already released
 	if (alreadyReleasedPRs.size > 0) {
 		const before = lines.length;
 		lines = lines.filter((line) => {
@@ -500,7 +483,7 @@ function collectEntries(
 		console.log(`  Filtered ${before - lines.length} already-released PRs`);
 	}
 
-	// Revert chain cancellation
+	// Cancel out revert/original pairs
 	const seen = new Map<string, { hash: string; msg: string }>();
 	for (const line of lines) {
 		const spaceIdx = line.indexOf(" ");
@@ -526,9 +509,8 @@ function collectEntries(
 		seen.set(msg, { hash, msg });
 	}
 
-	// Build changeset index from the same ref used for the commit range.
-	// On reruns where the tag already exists, this prevents reading newer
-	// changesets from a branch that has advanced past the tagged release.
+	// Use the tag ref when it exists to avoid reading newer changesets from
+	// a branch that has advanced past the tagged release.
 	const changesetRef = targetRef === currentTag ? targetRef : branch;
 	const {
 		byPR: changesetByPR,
@@ -548,18 +530,14 @@ function collectEntries(
 	for (const { msg } of seen.values()) {
 		const parsed = parseConventionalCommit(msg);
 
-		// Only include commits with a PR number — direct commits without PRs
-		// are infra changes, version bumps, or blog edits that aren't user-facing.
+		// Direct commits without PRs are infra/version bumps, not user-facing
 		const prMatch = msg.match(/\(#(\d+)\)$/);
 		if (!prMatch) continue;
 		const prNumber = Number(prMatch[1]);
 
 		if (seenPRs.has(prNumber)) continue;
 
-		// Check for a changeset BEFORE filtering by commit type — a PR with
-		// a manual changeset should appear in release notes even if its
-		// merge title starts with docs:/chore:/etc.
-		// Try PR-keyed index first, then match by commit subject for manual names.
+		// A PR with a changeset should appear even if its type is docs:/chore:/etc.
 		const descMatch = changesetByDesc.get(parsed.subject.toLowerCase().trim());
 		const changeset = changesetByPR.get(prNumber) ?? descMatch;
 		if (descMatch) consumedOrphans.add(descMatch);
@@ -600,38 +578,19 @@ function collectEntries(
 		});
 	}
 
-	// Add orphan changesets (commit-HASH or manually named, no PR).
-	// Filter against the git range: for commit-HASH, verify the commit is
-	// in range. For manually named, check it wasn't in a previous beta's pre.json.
-	let previousBetaChangesets = new Set<string>();
-	if (version.includes("-")) {
-		const betaMatch = version.match(/^(.+)-beta\.(\d+)$/);
-		if (betaMatch && Number(betaMatch[2]) > 0) {
-			const prevTag = `v${betaMatch[1]}-beta.${Number(betaMatch[2]) - 1}`;
-			try {
-				const prevPre = JSON.parse(gitShow(prevTag, ".changeset/pre.json")) as {
-					changesets: string[];
-				};
-				previousBetaChangesets = new Set(prevPre.changesets);
-			} catch {
-				// No previous beta — include all orphans
-			}
-		}
-	}
+	const previousBetaChangesets = loadPreviousBetaChangesets(version);
+	const commitHashes = new Set([...seen.values()].map(({ hash }) => hash));
 
 	for (const changeset of changesetOrphans) {
-		// Skip orphans already matched to a PR via description
 		if (consumedOrphans.has(changeset)) continue;
-		// Skip orphans that were already in a previous beta
 		if (previousBetaChangesets.has(changeset.id)) continue;
 
-		// For commit-HASH, verify the commit is in the git range
 		const commitMatch = changeset.id.match(/^commit-([a-f0-9]+)$/);
-		if (commitMatch) {
-			const inRange = [...seen.values()].some(({ hash }) =>
-				hash.startsWith(commitMatch[1]!),
-			);
-			if (!inRange) continue;
+		if (
+			commitMatch &&
+			![...commitHashes].some((h) => h.startsWith(commitMatch[1]!))
+		) {
+			continue;
 		}
 
 		const pkgPaths = changeset.packageNames.map(packageNameToPath);
@@ -653,18 +612,19 @@ function collectEntries(
 
 // ── Formatting ─────────────────────────────────────────────────────────
 
-function formatReleaseBody(
-	version: string,
-	isBeta: boolean,
-	entries: ReleaseEntry[],
-	previousTag: string,
-	distTag: string,
-	targetRef: string,
-): string {
+interface FormatOptions {
+	version: string;
+	entries: ReleaseEntry[];
+	previousTag: string;
+	distTag: string;
+	targetRef: string;
+}
+
+function formatReleaseBody(opts: FormatOptions): string {
+	const { version, entries, previousTag, distTag, targetRef } = opts;
 	const lines: string[] = [];
 
-	// Determine the install tag: explicit dist-tag > infer from version
-	const installTag = distTag || (isBeta ? "beta" : "latest");
+	const installTag = distTag || (version.includes("-") ? "beta" : "latest");
 	lines.push(`> Install: \`npm i better-auth@${installTag}\``);
 	lines.push("");
 
@@ -701,8 +661,6 @@ function formatReleaseBody(
 		lines.push("");
 	}
 
-	// Use the tag if it already exists (targetRef will be v<version>),
-	// otherwise use the branch ref so preview compare links don't 404.
 	const currentTag = `v${version}`;
 	const compareTarget =
 		targetRef === currentTag ? currentTag : targetRef.replace(/^origin\//, "");
@@ -731,27 +689,22 @@ const { entries, targetRef } = collectEntries(version, branch);
 console.log(`  Found ${entries.length} entries`);
 console.log("");
 
-const body = formatReleaseBody(
+const body = formatReleaseBody({
 	version,
-	isBeta,
 	entries,
 	previousTag,
 	distTag,
 	targetRef,
-);
+});
 
 if (dryRun) {
 	console.log("=== DRY RUN — Raw changelog ===\n");
 	console.log(body);
 } else {
-	// Write raw changelog to temp file for the AI stage
-	// Write inside the repo working directory so claude-code-action can read it
-	// (it restricts file access to the checkout directory)
+	// Write inside the repo directory so claude-code-action can read it
 	const rawFile = join(process.cwd(), `.release-notes-raw-${version}.md`);
 	writeFileSync(rawFile, body);
 	console.log(`Wrote raw changelog to ${rawFile}`);
-
-	// Set outputs for the workflow
 	setOutput("version", version);
 	setOutput("previous_tag", previousTag);
 	setOutput("is_beta", String(isBeta));

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -304,9 +304,12 @@ interface ChangesetEntry {
 function buildChangesetIndex(branch: string): {
 	byPR: Map<number, ChangesetEntry>;
 	orphans: ChangesetEntry[];
+	byDescription: Map<string, ChangesetEntry>;
 } {
 	const byPR = new Map<number, ChangesetEntry>();
 	const orphans: ChangesetEntry[] = [];
+	// Index by first line of description for matching manual changesets to PRs
+	const byDescription = new Map<string, ChangesetEntry>();
 
 	// Collect changeset IDs from two sources:
 	// 1. pre.json.changesets (consumed changesets, always present in pre-release mode)
@@ -380,13 +383,16 @@ function buildChangesetIndex(branch: string): {
 				byPR.set(Number(prMatch[1]), entry);
 			} else {
 				orphans.push(entry);
+				// Index by first line for matching to PRs via commit subject
+				const firstLine = description.split("\n")[0]!.trim().toLowerCase();
+				if (firstLine) byDescription.set(firstLine, entry);
 			}
 		} catch {
 			// File not found — skip
 		}
 	}
 
-	return { byPR, orphans };
+	return { byPR, orphans, byDescription };
 }
 
 /** Map a changeset package name to its directory under packages/ */
@@ -518,8 +524,11 @@ function collectEntries(
 	}
 
 	// Build changeset index for description enrichment
-	const { byPR: changesetByPR, orphans: changesetOrphans } =
-		buildChangesetIndex(branch);
+	const {
+		byPR: changesetByPR,
+		orphans: changesetOrphans,
+		byDescription: changesetByDesc,
+	} = buildChangesetIndex(branch);
 	if (changesetByPR.size > 0 || changesetOrphans.length > 0) {
 		console.log(
 			`  Loaded ${changesetByPR.size} changeset descriptions, ${changesetOrphans.length} orphans`,
@@ -543,7 +552,10 @@ function collectEntries(
 		// Check for a changeset BEFORE filtering by commit type — a PR with
 		// a manual changeset should appear in release notes even if its
 		// merge title starts with docs:/chore:/etc.
-		const changeset = changesetByPR.get(prNumber);
+		// Try PR-keyed index first, then match by commit subject for manual names.
+		const changeset =
+			changesetByPR.get(prNumber) ??
+			changesetByDesc.get(parsed.subject.toLowerCase().trim());
 
 		if (
 			!changeset &&
@@ -609,7 +621,6 @@ function formatReleaseBody(
 	previousTag: string,
 	distTag: string,
 	targetRef: string,
-	dryRun: boolean,
 ): string {
 	const lines: string[] = [];
 
@@ -651,14 +662,11 @@ function formatReleaseBody(
 		lines.push("");
 	}
 
-	// In CI (non-dry-run), the tag will be created after these notes are
-	// generated, so always use v<version> for a stable compare link.
-	// In preview/dry-run mode, use the branch ref since the tag doesn't exist.
+	// Use the tag if it already exists (targetRef will be v<version>),
+	// otherwise use the branch ref so preview compare links don't 404.
 	const currentTag = `v${version}`;
 	const compareTarget =
-		targetRef === currentTag || !dryRun
-			? currentTag
-			: targetRef.replace(/^origin\//, "");
+		targetRef === currentTag ? currentTag : targetRef.replace(/^origin\//, "");
 	lines.push(
 		`**Full changelog**: [\`${previousTag}...${compareTarget}\`](https://github.com/${REPO}/compare/${previousTag}...${compareTarget})`,
 	);
@@ -691,7 +699,6 @@ const body = formatReleaseBody(
 	previousTag,
 	distTag,
 	targetRef,
-	dryRun,
 );
 
 if (dryRun) {

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -392,7 +392,10 @@ function packageNameToPath(name: string): string {
  * a direct ancestor) using PR-number deduplication, same as
  * release-previews.sh.
  */
-function collectEntries(version: string, branch: string): ReleaseEntry[] {
+function collectEntries(
+	version: string,
+	branch: string,
+): { entries: ReleaseEntry[]; targetRef: string } {
 	const previousTag = findPreviousTag(version, version.includes("-"));
 
 	// Determine the target ref: tag > branch arg > HEAD
@@ -580,7 +583,7 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 		});
 	}
 
-	return entries;
+	return { entries, targetRef };
 }
 
 // ── Formatting ─────────────────────────────────────────────────────────
@@ -591,6 +594,7 @@ function formatReleaseBody(
 	entries: ReleaseEntry[],
 	previousTag: string,
 	distTag: string,
+	targetRef: string,
 ): string {
 	const lines: string[] = [];
 
@@ -632,9 +636,12 @@ function formatReleaseBody(
 		lines.push("");
 	}
 
+	// Use the tag if it exists, otherwise the branch ref (for preview mode)
 	const currentTag = `v${version}`;
+	const compareTarget =
+		targetRef === currentTag ? currentTag : targetRef.replace(/^origin\//, "");
 	lines.push(
-		`**Full changelog**: [\`${previousTag}...${currentTag}\`](https://github.com/${REPO}/compare/${previousTag}...${currentTag})`,
+		`**Full changelog**: [\`${previousTag}...${compareTarget}\`](https://github.com/${REPO}/compare/${previousTag}...${compareTarget})`,
 	);
 
 	return lines.join("\n");
@@ -654,11 +661,18 @@ if (distTag) console.log(`  Dist tag: ${distTag}`);
 console.log("");
 
 console.log("Collecting entries...");
-const entries = collectEntries(version, branch);
+const { entries, targetRef } = collectEntries(version, branch);
 console.log(`  Found ${entries.length} entries`);
 console.log("");
 
-const body = formatReleaseBody(version, isBeta, entries, previousTag, distTag);
+const body = formatReleaseBody(
+	version,
+	isBeta,
+	entries,
+	previousTag,
+	distTag,
+	targetRef,
+);
 
 if (dryRun) {
 	console.log("=== DRY RUN — Raw changelog ===\n");

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -1,0 +1,708 @@
+/**
+ * Release Notes — deterministic stage of release note generation.
+ *
+ * Reads changeset files and pre.json to collect entries, resolves PR metadata
+ * via `gh` CLI for correct attribution and domain classification, then outputs
+ * a raw structured changelog for the AI rewriting stage.
+ *
+ * This is stage 1 of a 2-stage pipeline:
+ *   Stage 1 (this script): deterministic data extraction + domain classification
+ *   Stage 2 (Claude in CI): rewrite descriptions to be user-focused
+ *
+ * CI:    PUBLISHED_PACKAGES='[...]' node .github/scripts/release-notes.ts
+ * Local: node --experimental-strip-types .github/scripts/release-notes.ts \
+ *          --version 1.6.0-beta.0 --branch origin/next --dry-run
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ghJSON, REPO, setOutput } from "./lib/github.ts";
+import {
+	DOMAIN_ORDER,
+	FILTERED_DOMAINS,
+	parseConventionalCommit,
+	resolveDomain,
+} from "./lib/pr-analyzer.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface ReleaseEntry {
+	id: string;
+	description: string;
+	prNumber: number | null;
+	author: string;
+	domain: string;
+	breaking: boolean;
+}
+
+interface PRInfo {
+	author: string;
+	title: string;
+	labels: string[];
+	files: string[];
+}
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const DOMAIN_DISPLAY_NAMES: Record<string, string> = {
+	core: "Core",
+	database: "Database",
+	oauth: "OAuth",
+	credentials: "Credentials",
+	identity: "Identity",
+	organization: "Organization",
+	security: "Security",
+	enterprise: "Enterprise",
+	payments: "Payments",
+	platform: "Platform",
+	devtools: "Devtools",
+};
+
+// Package name → directory mapping for packages that don't follow
+// the @better-auth/<dir> convention.
+const PACKAGE_DIR_OVERRIDES: Record<string, string> = {
+	auth: "cli",
+	"better-auth": "better-auth",
+};
+
+// ── CLI argument parsing ───────────────────────────────────────────────
+
+function parseArgs(): {
+	version: string;
+	branch: string;
+	distTag: string;
+	dryRun: boolean;
+} {
+	const args = process.argv.slice(2);
+	let version = "";
+	let branch = "";
+	let distTag = "";
+	let dryRun = false;
+
+	for (let i = 0; i < args.length; i++) {
+		switch (args[i]) {
+			case "--version":
+				version = args[++i] ?? "";
+				break;
+			case "--branch":
+				branch = args[++i] ?? "";
+				break;
+			case "--dist-tag":
+				distTag = args[++i] ?? "";
+				break;
+			case "--dry-run":
+				dryRun = true;
+				break;
+		}
+	}
+
+	if (!version) {
+		const pkgs = process.env.PUBLISHED_PACKAGES;
+		if (pkgs) {
+			const parsed = JSON.parse(pkgs) as { name: string; version: string }[];
+			version = parsed[0]?.version ?? "";
+		}
+	}
+
+	if (!distTag) {
+		distTag = process.env.NPM_DIST_TAG ?? "";
+	}
+
+	if (!version) {
+		console.error(
+			"Usage: release-notes.ts --version <ver> [--branch <ref>] [--dist-tag <tag>] [--dry-run]",
+		);
+		process.exit(1);
+	}
+
+	return { version, branch, distTag, dryRun };
+}
+
+// ── Git helpers ────────────────────────────────────────────────────────
+
+function gitShow(ref: string, path: string): string {
+	return execFileSync("git", ["show", `${ref}:${path}`], {
+		encoding: "utf-8",
+	});
+}
+
+function readFileFromRef(path: string, branch: string): string {
+	if (branch) {
+		return gitShow(branch, path);
+	}
+	return readFileSync(path, "utf-8");
+}
+
+function listTags(): string[] {
+	const output = execFileSync(
+		"git",
+		["tag", "--sort=-version:refname", "--list", "v*"],
+		{ encoding: "utf-8" },
+	);
+	return output.trim().split("\n").filter(Boolean);
+}
+
+// ── Previous tag resolution ────────────────────────────────────────────
+
+/** Parse "1.2.3" into [1, 2, 3]. Returns null on invalid input. */
+function parseVersionTuple(ver: string): [number, number, number] | null {
+	const base = ver.replace(/-.*$/, ""); // strip pre-release suffix
+	const m = base.match(/^(\d+)\.(\d+)\.(\d+)$/);
+	if (!m) return null;
+	return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** True if a < b by major.minor.patch comparison. */
+function isOlderVersion(a: string, b: string): boolean {
+	const ta = parseVersionTuple(a);
+	const tb = parseVersionTuple(b);
+	if (!ta || !tb) return false;
+	for (let i = 0; i < 3; i++) {
+		if (ta[i]! < tb[i]!) return true;
+		if (ta[i]! > tb[i]!) return false;
+	}
+	return false;
+}
+
+function findPreviousTag(currentVersion: string, isBeta: boolean): string {
+	const tags = listTags();
+
+	if (isBeta) {
+		const betaMatch = currentVersion.match(/^(.+)-(?:beta|alpha|rc)\.(\d+)$/);
+		if (betaMatch && Number(betaMatch[2]) > 0) {
+			const prevN = Number(betaMatch[2]) - 1;
+			const prevVersion = `${betaMatch[1]}-beta.${prevN}`;
+			const prevTag = `v${prevVersion}`;
+			if (tags.includes(prevTag)) return prevTag;
+		}
+	}
+
+	const currentTag = `v${currentVersion}`;
+
+	// Extract the major.minor prefix to scope to the current release line.
+	const majorMinorMatch = currentVersion.match(/^(\d+\.\d+)\./);
+	const majorMinor = majorMinorMatch?.[1];
+
+	for (const tag of tags) {
+		if (tag === currentTag) continue;
+		const ver = tag.replace(/^v/, "");
+		if (ver.includes("-")) continue;
+		if (majorMinor && !ver.startsWith(`${majorMinor}.`)) continue;
+		// Only return tags strictly older than the current version
+		if (!isOlderVersion(ver, currentVersion)) continue;
+		return tag;
+	}
+
+	// Fallback: any stable tag older than the current version
+	for (const tag of tags) {
+		if (tag === currentTag) continue;
+		const ver = tag.replace(/^v/, "");
+		if (ver.includes("-")) continue;
+		if (!isOlderVersion(ver, currentVersion)) continue;
+		return tag;
+	}
+
+	throw new Error("No previous stable tag found");
+}
+
+// ── Changeset file parsing ─────────────────────────────────────────────
+
+function parseChangesetFile(content: string): {
+	packages: Record<string, string>;
+	description: string;
+} {
+	const parts = content.split("---");
+	if (parts.length < 3) {
+		return { packages: {}, description: content.trim() };
+	}
+
+	const frontmatter = parts[1]!;
+	const description = parts.slice(2).join("---").trim();
+
+	const packages: Record<string, string> = {};
+	for (const line of frontmatter.split("\n")) {
+		const match = line.match(/^"?([^"]+)"?\s*:\s*(.+)$/);
+		if (match) {
+			packages[match[1]!.trim()] = match[2]!.trim();
+		}
+	}
+
+	return { packages, description };
+}
+
+// ── PR metadata resolution ─────────────────────────────────────────────
+
+const prCache = new Map<number, PRInfo>();
+
+function fetchPR(prNumber: number): PRInfo {
+	const cached = prCache.get(prNumber);
+	if (cached) return cached;
+
+	const data = ghJSON<{
+		author: { login: string };
+		title: string;
+		labels: { name: string }[];
+		files: { path: string }[];
+	}>([
+		"pr",
+		"view",
+		String(prNumber),
+		"--repo",
+		REPO,
+		"--json",
+		"author,title,labels,files",
+	]);
+
+	const info: PRInfo = {
+		author: data.author.login,
+		title: data.title,
+		labels: data.labels.map((l) => l.name),
+		files: data.files.map((f) => f.path),
+	};
+
+	prCache.set(prNumber, info);
+	return info;
+}
+
+// ── Domain classification ──────────────────────────────────────────────
+
+function classifyEntry(
+	prInfo: PRInfo | null,
+	scope: string | undefined,
+	files: string[],
+): string {
+	if (prInfo) {
+		for (const label of prInfo.labels) {
+			if (DOMAIN_ORDER.includes(label as (typeof DOMAIN_ORDER)[number])) {
+				return label;
+			}
+		}
+	}
+
+	return resolveDomain(scope, files);
+}
+
+// ── Changeset description index ────────────────────────────────────────
+
+interface ChangesetEntry {
+	description: string;
+	breaking: boolean;
+	packageNames: string[];
+}
+
+/**
+ * Build a map of PR number → changeset description by scanning .changeset/ for
+ * pr-*.md and commit-*.md files directly. Does not rely on pre.json.changesets
+ * which can be empty on freshly entered pre-release branches or absent on main.
+ */
+function buildChangesetIndex(branch: string): {
+	byPR: Map<number, ChangesetEntry>;
+	orphans: ChangesetEntry[];
+} {
+	const byPR = new Map<number, ChangesetEntry>();
+	const orphans: ChangesetEntry[] = [];
+
+	// Collect changeset IDs from two sources:
+	// 1. pre.json.changesets (consumed changesets, always present in pre-release mode)
+	// 2. Directory listing (uncovered changesets not yet versioned)
+	const ids = new Set<string>();
+
+	try {
+		const raw = readFileFromRef(".changeset/pre.json", branch);
+		const preJSON = JSON.parse(raw) as { changesets: string[] };
+		for (const id of preJSON.changesets) ids.add(id);
+	} catch {
+		// No pre.json — that's fine, we'll scan the directory
+	}
+
+	// Scan .changeset/ for pr-* and commit-* files. Try the target ref first;
+	// if empty, try HEAD~1 — on main/release/*, `changeset version` deletes
+	// the files before publish runs, but the parent commit still has them.
+	let effectiveBranch = branch;
+	for (const ref of [branch, branch ? undefined : "HEAD~1"]) {
+		if (ref === undefined) continue;
+		try {
+			const listing = execFileSync(
+				"git",
+				["ls-tree", "--name-only", ref || "HEAD", ".changeset/"],
+				{ encoding: "utf-8" },
+			);
+			let foundAny = false;
+			for (const file of listing.split("\n")) {
+				const name = file.replace(/^\.changeset\//, "").replace(/\.md$/, "");
+				if (name.startsWith("pr-") || name.startsWith("commit-")) {
+					ids.add(name);
+					foundAny = true;
+				}
+			}
+			if (foundAny) {
+				effectiveBranch = ref;
+				break;
+			}
+		} catch {
+			// ref doesn't exist or listing failed — try next
+		}
+	}
+
+	for (const id of ids) {
+		try {
+			const content = readFileFromRef(`.changeset/${id}.md`, effectiveBranch);
+			const { packages, description } = parseChangesetFile(content);
+			if (!description) continue;
+
+			const breaking = Object.values(packages).some((b) => b === "major");
+			const entry: ChangesetEntry = {
+				description,
+				breaking,
+				packageNames: Object.keys(packages),
+			};
+
+			const prMatch = id.match(/^pr-(\d+)$/);
+			if (prMatch) {
+				byPR.set(Number(prMatch[1]), entry);
+			} else {
+				orphans.push(entry);
+			}
+		} catch {
+			// File not found — skip
+		}
+	}
+
+	return { byPR, orphans };
+}
+
+/** Map a changeset package name to its directory under packages/ */
+function packageNameToPath(name: string): string {
+	const stripped = name.replace(/^@better-auth\//, "");
+	const dir = PACKAGE_DIR_OVERRIDES[stripped] ?? stripped;
+	return `packages/${dir}/`;
+}
+
+// ── Entry collection ───────────────────────────────────────────────────
+
+/**
+ * Collects release entries using git history as the ground truth,
+ * enriched with changeset descriptions where available.
+ *
+ * Handles the cherry-pick history gap (where the previous tag is not
+ * a direct ancestor) using PR-number deduplication, same as
+ * release-previews.sh.
+ */
+function collectEntries(version: string, branch: string): ReleaseEntry[] {
+	const previousTag = findPreviousTag(version, version.includes("-"));
+
+	// Determine the target ref: tag > branch arg > HEAD
+	const currentTag = `v${version}`;
+	let targetRef: string;
+	try {
+		execFileSync("git", ["rev-parse", `${currentTag}^{}`], {
+			encoding: "utf-8",
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		targetRef = currentTag;
+	} catch {
+		targetRef = branch || "HEAD";
+	}
+
+	// Handle cherry-pick history gap: if the previous tag is NOT a direct
+	// ancestor, use merge-base + PR deduplication to avoid double-counting
+	// commits already released via cherry-pick.
+	let isDirectAncestor = false;
+	try {
+		execFileSync(
+			"git",
+			["merge-base", "--is-ancestor", previousTag, targetRef],
+			{
+				encoding: "utf-8",
+			},
+		);
+		isDirectAncestor = true;
+	} catch {
+		// Not a direct ancestor — cherry-pick model
+	}
+
+	let log: string;
+	const alreadyReleasedPRs = new Set<string>();
+
+	if (isDirectAncestor) {
+		log = execFileSync(
+			"git",
+			["log", `${previousTag}..${targetRef}`, "--no-merges", "--oneline"],
+			{ encoding: "utf-8" },
+		);
+	} else {
+		const mergeBase = execFileSync(
+			"git",
+			["merge-base", previousTag, targetRef],
+			{ encoding: "utf-8" },
+		).trim();
+
+		console.log(`  Cherry-pick mode: common ancestor ${mergeBase.slice(0, 7)}`);
+
+		// Collect PR numbers between merge-base and the previous tag
+		// (scoped range avoids reading the entire tag history)
+		const tagLog = execFileSync(
+			"git",
+			["log", `${mergeBase}..${previousTag}`, "--oneline"],
+			{ encoding: "utf-8" },
+		);
+		for (const match of tagLog.matchAll(/\(#(\d+)\)/g)) {
+			alreadyReleasedPRs.add(match[1]!);
+		}
+
+		log = execFileSync(
+			"git",
+			["log", `${mergeBase}..${targetRef}`, "--no-merges", "--oneline"],
+			{ encoding: "utf-8" },
+		);
+	}
+
+	let lines = log.trim().split("\n").filter(Boolean);
+
+	// In cherry-pick mode, filter out commits whose PR was already released
+	if (alreadyReleasedPRs.size > 0) {
+		const before = lines.length;
+		lines = lines.filter((line) => {
+			const prMatch = line.match(/\(#(\d+)\)/);
+			if (!prMatch) return true;
+			return !alreadyReleasedPRs.has(prMatch[1]!);
+		});
+		console.log(`  Filtered ${before - lines.length} already-released PRs`);
+	}
+
+	// Revert chain cancellation
+	const seen = new Map<string, { hash: string; msg: string }>();
+	for (const line of lines) {
+		const spaceIdx = line.indexOf(" ");
+		const hash = line.slice(0, spaceIdx);
+		const msg = line.slice(spaceIdx + 1);
+
+		const revertMatch = msg.match(/^Revert "(.+)"$/);
+		if (revertMatch) {
+			if (seen.has(revertMatch[1]!)) {
+				seen.delete(revertMatch[1]!);
+			} else {
+				seen.set(msg, { hash, msg });
+			}
+			continue;
+		}
+
+		const revertKey = `Revert "${msg}"`;
+		if (seen.has(revertKey)) {
+			seen.delete(revertKey);
+			continue;
+		}
+
+		seen.set(msg, { hash, msg });
+	}
+
+	// Build changeset index for description enrichment
+	const { byPR: changesetByPR, orphans: changesetOrphans } =
+		buildChangesetIndex(branch);
+	if (changesetByPR.size > 0 || changesetOrphans.length > 0) {
+		console.log(
+			`  Loaded ${changesetByPR.size} changeset descriptions, ${changesetOrphans.length} orphans`,
+		);
+	}
+
+	const entries: ReleaseEntry[] = [];
+	const seenPRs = new Set<number>();
+
+	for (const { msg } of seen.values()) {
+		const parsed = parseConventionalCommit(msg);
+
+		// Only include commits with a PR number — direct commits without PRs
+		// are infra changes, version bumps, or blog edits that aren't user-facing.
+		const prMatch = msg.match(/\(#(\d+)\)$/);
+		if (!prMatch) continue;
+		const prNumber = Number(prMatch[1]);
+
+		if (seenPRs.has(prNumber)) continue;
+
+		// Check for a changeset BEFORE filtering by commit type — a PR with
+		// a manual changeset should appear in release notes even if its
+		// merge title starts with docs:/chore:/etc.
+		const changeset = changesetByPR.get(prNumber);
+
+		if (
+			!changeset &&
+			["chore", "docs", "ci", "test", "style", "build"].includes(parsed.type)
+		) {
+			continue;
+		}
+
+		seenPRs.add(prNumber);
+
+		let author = "unknown";
+		let domain = "core";
+		let breaking = parsed.breaking;
+
+		const description = changeset?.description ?? parsed.subject;
+		if (changeset?.breaking) breaking = true;
+
+		try {
+			const prInfo = fetchPR(prNumber);
+			author = prInfo.author;
+			domain = classifyEntry(prInfo, parsed.scope || undefined, prInfo.files);
+			if (prInfo.labels.includes("breaking")) breaking = true;
+		} catch {
+			domain = resolveDomain(parsed.scope || undefined, []);
+		}
+
+		entries.push({
+			id: changeset ? `pr-${prNumber}` : `git-${prNumber}`,
+			description,
+			prNumber,
+			author,
+			domain,
+			breaking,
+		});
+	}
+
+	// Add PR-keyed changeset entries not found in git history
+	for (const [prNum, changeset] of changesetByPR) {
+		if (seenPRs.has(prNum)) continue;
+		seenPRs.add(prNum);
+
+		let author = "unknown";
+		let domain = "core";
+		try {
+			const prInfo = fetchPR(prNum);
+			author = prInfo.author;
+			const parsed = parseConventionalCommit(prInfo.title);
+			domain = classifyEntry(prInfo, parsed.scope || undefined, prInfo.files);
+		} catch {
+			// skip
+		}
+
+		entries.push({
+			id: `pr-${prNum}`,
+			description: changeset.description,
+			prNumber: prNum,
+			author,
+			domain,
+			breaking: changeset.breaking,
+		});
+	}
+
+	// Add orphan changesets (commit-HASH pattern, no PR)
+	for (const changeset of changesetOrphans) {
+		const pkgPaths = changeset.packageNames.map(packageNameToPath);
+		const domain = resolveDomain(undefined, pkgPaths);
+		if (FILTERED_DOMAINS.has(domain)) continue;
+
+		entries.push({
+			id: `changeset-orphan`,
+			description: changeset.description,
+			prNumber: null,
+			author: "unknown",
+			domain,
+			breaking: changeset.breaking,
+		});
+	}
+
+	return entries;
+}
+
+// ── Formatting ─────────────────────────────────────────────────────────
+
+function formatReleaseBody(
+	version: string,
+	isBeta: boolean,
+	entries: ReleaseEntry[],
+	previousTag: string,
+	distTag: string,
+): string {
+	const lines: string[] = [];
+
+	// Determine the install tag: explicit dist-tag > infer from version
+	const installTag = distTag || (isBeta ? "beta" : "latest");
+	lines.push(`> Install: \`npm i better-auth@${installTag}\``);
+	lines.push("");
+
+	const grouped = new Map<string, ReleaseEntry[]>();
+	for (const entry of entries) {
+		if (FILTERED_DOMAINS.has(entry.domain)) continue;
+		const list = grouped.get(entry.domain) ?? [];
+		list.push(entry);
+		grouped.set(entry.domain, list);
+	}
+
+	for (const domain of DOMAIN_ORDER) {
+		const domainEntries = grouped.get(domain);
+		if (!domainEntries?.length) continue;
+
+		const displayName = DOMAIN_DISPLAY_NAMES[domain] ?? domain;
+		lines.push(`## ${displayName}`);
+		lines.push("");
+
+		domainEntries.sort((a, b) => {
+			if (a.breaking !== b.breaking) return a.breaking ? -1 : 1;
+			return a.description.localeCompare(b.description);
+		});
+
+		for (const entry of domainEntries) {
+			const prefix = entry.breaking ? "**BREAKING:** " : "";
+			const prLink = entry.prNumber
+				? ` ([#${entry.prNumber}](https://github.com/${REPO}/pull/${entry.prNumber}))`
+				: "";
+			const authorAttr =
+				entry.author !== "unknown" ? ` by @${entry.author}` : "";
+			lines.push(`- ${prefix}${entry.description}${prLink}${authorAttr}`);
+		}
+		lines.push("");
+	}
+
+	const currentTag = `v${version}`;
+	lines.push(
+		`**Full changelog**: [\`${previousTag}...${currentTag}\`](https://github.com/${REPO}/compare/${previousTag}...${currentTag})`,
+	);
+
+	return lines.join("\n");
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+const { version, branch, distTag, dryRun } = parseArgs();
+const isBeta = version.includes("-");
+const previousTag = findPreviousTag(version, isBeta);
+
+console.log(`Generating release notes for v${version}`);
+console.log(`  Previous tag: ${previousTag}`);
+console.log(`  Release type: ${isBeta ? "pre-release" : "stable"}`);
+console.log(`  Branch: ${branch || "HEAD"}`);
+if (distTag) console.log(`  Dist tag: ${distTag}`);
+console.log("");
+
+console.log("Collecting entries...");
+const entries = collectEntries(version, branch);
+console.log(`  Found ${entries.length} entries`);
+console.log("");
+
+const body = formatReleaseBody(version, isBeta, entries, previousTag, distTag);
+
+if (dryRun) {
+	console.log("=== DRY RUN — Raw changelog ===\n");
+	console.log(body);
+} else {
+	// Write raw changelog to temp file for the AI stage
+	const outDir = process.env.RUNNER_TEMP ?? tmpdir();
+	const rawFile = join(outDir, `release-notes-raw-${version}.md`);
+	writeFileSync(rawFile, body);
+	console.log(`Wrote raw changelog to ${rawFile}`);
+
+	// Set outputs for the workflow
+	setOutput("version", version);
+	setOutput("previous_tag", previousTag);
+	setOutput("is_beta", String(isBeta));
+	setOutput("raw_changelog_path", rawFile);
+	setOutput(
+		"pr_numbers",
+		entries
+			.filter((e) => e.prNumber)
+			.map((e) => e.prNumber)
+			.join(","),
+	);
+}

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -403,10 +403,7 @@ function loadPreviousPrereleaseChangesets(version: string): Set<string> {
  * a direct ancestor) using PR-number deduplication, same as
  * release-previews.sh.
  */
-function collectEntries(
-	version: string,
-	branch: string,
-): { entries: ReleaseEntry[]; targetRef: string } {
+function collectEntries(version: string, branch: string): ReleaseEntry[] {
 	const previousTag = findPreviousTag(version, version.includes("-"));
 
 	const currentTag = `v${version}`;
@@ -608,7 +605,7 @@ function collectEntries(
 		});
 	}
 
-	return { entries, targetRef };
+	return entries;
 }
 
 // ── Formatting ─────────────────────────────────────────────────────────
@@ -618,14 +615,14 @@ interface FormatOptions {
 	entries: ReleaseEntry[];
 	previousTag: string;
 	distTag: string;
-	targetRef: string;
 }
 
 function formatReleaseBody(opts: FormatOptions): string {
-	const { version, entries, previousTag, distTag, targetRef } = opts;
+	const { version, entries, previousTag, distTag } = opts;
 	const lines: string[] = [];
 
-	const installTag = distTag || (version.includes("-") ? "beta" : "latest");
+	const channelMatch = version.match(/-(beta|alpha|rc)\./);
+	const installTag = distTag || channelMatch?.[1] || "latest";
 	lines.push(`> Install: \`npm i better-auth@${installTag}\``);
 	lines.push("");
 
@@ -663,10 +660,8 @@ function formatReleaseBody(opts: FormatOptions): string {
 	}
 
 	const currentTag = `v${version}`;
-	const compareTarget =
-		targetRef === currentTag ? currentTag : targetRef.replace(/^origin\//, "");
 	lines.push(
-		`**Full changelog**: [\`${previousTag}...${compareTarget}\`](https://github.com/${REPO}/compare/${previousTag}...${compareTarget})`,
+		`**Full changelog**: [\`${previousTag}...${currentTag}\`](https://github.com/${REPO}/compare/${previousTag}...${currentTag})`,
 	);
 
 	return lines.join("\n");
@@ -686,7 +681,7 @@ if (distTag) console.log(`  Dist tag: ${distTag}`);
 console.log("");
 
 console.log("Collecting entries...");
-const { entries, targetRef } = collectEntries(version, branch);
+const entries = collectEntries(version, branch);
 console.log(`  Found ${entries.length} entries`);
 console.log("");
 
@@ -695,7 +690,6 @@ const body = formatReleaseBody({
 	entries,
 	previousTag,
 	distTag,
-	targetRef,
 });
 
 if (dryRun) {

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -317,13 +317,14 @@ function buildChangesetIndex(branch: string): {
 	}
 
 	// Scan .changeset/ for pr-* and commit-* files. Try the target ref first;
-	// if empty, try HEAD~1 — on main/release/*, `changeset version` deletes
-	// the files before publish runs, but the parent commit still has them.
-	// Try the target ref first, then its parent — on main/release/*,
-	// `changeset version` deletes the files, but the parent still has them.
+	// Search backwards from the target ref to find a commit that still has
+	// changeset files. On main after promotion, `changeset version` ran on
+	// next before the merge, so both HEAD and HEAD~1 may have them deleted.
 	const baseRef = branch || "HEAD";
 	let effectiveBranch = branch;
-	for (const ref of [baseRef, `${baseRef}~1`]) {
+	const refsToTry = [baseRef];
+	for (let i = 1; i <= 5; i++) refsToTry.push(`${baseRef}~${i}`);
+	for (const ref of refsToTry) {
 		try {
 			const listing = execFileSync(
 				"git",

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -291,6 +291,7 @@ function classifyEntry(
 // ── Changeset description index ────────────────────────────────────────
 
 interface ChangesetEntry {
+	id: string;
 	description: string;
 	breaking: boolean;
 	packageNames: string[];
@@ -373,6 +374,7 @@ function buildChangesetIndex(branch: string): {
 
 			const breaking = Object.values(packages).some((b) => b === "major");
 			const entry: ChangesetEntry = {
+				id,
 				description,
 				breaking,
 				packageNames: Object.keys(packages),
@@ -593,14 +595,44 @@ function collectEntries(
 		});
 	}
 
-	// Add orphan changesets (commit-HASH pattern, no PR)
+	// Add orphan changesets (commit-HASH or manually named, no PR).
+	// Filter against the git range: for commit-HASH, verify the commit is
+	// in range. For manually named, check it wasn't in a previous beta's pre.json.
+	let previousBetaChangesets = new Set<string>();
+	if (version.includes("-")) {
+		const betaMatch = version.match(/^(.+)-beta\.(\d+)$/);
+		if (betaMatch && Number(betaMatch[2]) > 0) {
+			const prevTag = `v${betaMatch[1]}-beta.${Number(betaMatch[2]) - 1}`;
+			try {
+				const prevPre = JSON.parse(gitShow(prevTag, ".changeset/pre.json")) as {
+					changesets: string[];
+				};
+				previousBetaChangesets = new Set(prevPre.changesets);
+			} catch {
+				// No previous beta — include all orphans
+			}
+		}
+	}
+
 	for (const changeset of changesetOrphans) {
+		// Skip orphans that were already in a previous beta
+		if (previousBetaChangesets.has(changeset.id)) continue;
+
+		// For commit-HASH, verify the commit is in the git range
+		const commitMatch = changeset.id.match(/^commit-([a-f0-9]+)$/);
+		if (commitMatch) {
+			const inRange = [...seen.values()].some(({ hash }) =>
+				hash.startsWith(commitMatch[1]!),
+			);
+			if (!inRange) continue;
+		}
+
 		const pkgPaths = changeset.packageNames.map(packageNameToPath);
 		const domain = resolveDomain(undefined, pkgPaths);
 		if (FILTERED_DOMAINS.has(domain)) continue;
 
 		entries.push({
-			id: `changeset-orphan`,
+			id: changeset.id,
 			description: changeset.description,
 			prNumber: null,
 			author: "unknown",

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -541,7 +541,7 @@ function collectEntries(
 		seenPRs.add(prNumber);
 
 		let author = "unknown";
-		let domain = "core";
+		let domain: string;
 		let breaking = parsed.breaking;
 
 		const description =

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -377,11 +377,12 @@ function packageNameToPath(name: string): string {
 }
 
 /** Load changeset IDs from the previous beta's pre.json to exclude from orphans. */
-function loadPreviousBetaChangesets(version: string): Set<string> {
-	const betaMatch = version.match(/^(.+)-beta\.(\d+)$/);
-	if (!betaMatch || Number(betaMatch[2]) === 0) return new Set();
+function loadPreviousPrereleaseChangesets(version: string): Set<string> {
+	const preMatch = version.match(/^(.+)-(beta|alpha|rc)\.(\d+)$/);
+	if (!preMatch || Number(preMatch[3]) === 0) return new Set();
 
-	const prevTag = `v${betaMatch[1]}-beta.${Number(betaMatch[2]) - 1}`;
+	const channel = preMatch[2];
+	const prevTag = `v${preMatch[1]}-${channel}.${Number(preMatch[3]) - 1}`;
 	try {
 		const prevPre = JSON.parse(gitShow(prevTag, ".changeset/pre.json")) as {
 			changesets: string[];
@@ -578,7 +579,7 @@ function collectEntries(
 		});
 	}
 
-	const previousBetaChangesets = loadPreviousBetaChangesets(version);
+	const previousBetaChangesets = loadPreviousPrereleaseChangesets(version);
 	const commitHashes = new Set([...seen.values()].map(({ hash }) => hash));
 
 	for (const changeset of changesetOrphans) {

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -331,13 +331,13 @@ function buildChangesetIndex(branch: string): {
 				["ls-tree", "--name-only", ref, ".changeset/"],
 				{ encoding: "utf-8" },
 			);
+			const SKIP_FILES = new Set(["README", "config"]);
 			let foundAny = false;
 			for (const file of listing.split("\n")) {
 				const name = file.replace(/^\.changeset\//, "").replace(/\.md$/, "");
-				if (name.startsWith("pr-") || name.startsWith("commit-")) {
-					ids.add(name);
-					foundAny = true;
-				}
+				if (!name || SKIP_FILES.has(name) || !file.endsWith(".md")) continue;
+				ids.add(name);
+				foundAny = true;
 			}
 			if (foundAny) {
 				effectiveBranch = ref;

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -317,13 +317,19 @@ function buildChangesetIndex(branch: string): {
 	}
 
 	// Scan .changeset/ for pr-* and commit-* files. Try the target ref first;
-	// Search backwards from the target ref to find a commit that still has
-	// changeset files. On main after promotion, `changeset version` ran on
-	// next before the merge, so both HEAD and HEAD~1 may have them deleted.
+	// Search for a commit that still has changeset files.
+	// On main after promotion, `changeset version` deletes them. The files
+	// may be on: (1) an ancestor on the first-parent chain, or (2) the
+	// merged next branch side (HEAD^2) from the promote merge commit.
 	const baseRef = branch || "HEAD";
 	let effectiveBranch = branch;
 	const refsToTry = [baseRef];
 	for (let i = 1; i <= 5; i++) refsToTry.push(`${baseRef}~${i}`);
+	// Also check the second parent of merge commits (promote flow: next → main)
+	for (let i = 0; i <= 3; i++) {
+		const mergeRef = i === 0 ? baseRef : `${baseRef}~${i}`;
+		refsToTry.push(`${mergeRef}^2`);
+	}
 	for (const ref of refsToTry) {
 		try {
 			const listing = execFileSync(
@@ -595,6 +601,7 @@ function formatReleaseBody(
 	previousTag: string,
 	distTag: string,
 	targetRef: string,
+	dryRun: boolean,
 ): string {
 	const lines: string[] = [];
 
@@ -636,10 +643,14 @@ function formatReleaseBody(
 		lines.push("");
 	}
 
-	// Use the tag if it exists, otherwise the branch ref (for preview mode)
+	// In CI (non-dry-run), the tag will be created after these notes are
+	// generated, so always use v<version> for a stable compare link.
+	// In preview/dry-run mode, use the branch ref since the tag doesn't exist.
 	const currentTag = `v${version}`;
 	const compareTarget =
-		targetRef === currentTag ? currentTag : targetRef.replace(/^origin\//, "");
+		targetRef === currentTag || !dryRun
+			? currentTag
+			: targetRef.replace(/^origin\//, "");
 	lines.push(
 		`**Full changelog**: [\`${previousTag}...${compareTarget}\`](https://github.com/${REPO}/compare/${previousTag}...${compareTarget})`,
 	);
@@ -672,6 +683,7 @@ const body = formatReleaseBody(
 	previousTag,
 	distTag,
 	targetRef,
+	dryRun,
 );
 
 if (dryRun) {

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -320,13 +320,15 @@ function buildChangesetIndex(branch: string): {
 	// Scan .changeset/ for pr-* and commit-* files. Try the target ref first;
 	// if empty, try HEAD~1 — on main/release/*, `changeset version` deletes
 	// the files before publish runs, but the parent commit still has them.
+	// Try the target ref first, then its parent — on main/release/*,
+	// `changeset version` deletes the files, but the parent still has them.
+	const baseRef = branch || "HEAD";
 	let effectiveBranch = branch;
-	for (const ref of [branch, branch ? undefined : "HEAD~1"]) {
-		if (ref === undefined) continue;
+	for (const ref of [baseRef, `${baseRef}~1`]) {
 		try {
 			const listing = execFileSync(
 				"git",
-				["ls-tree", "--name-only", ref || "HEAD", ".changeset/"],
+				["ls-tree", "--name-only", ref, ".changeset/"],
 				{ encoding: "utf-8" },
 			);
 			let foundAny = false;
@@ -558,32 +560,6 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 			author,
 			domain,
 			breaking,
-		});
-	}
-
-	// Add PR-keyed changeset entries not found in git history
-	for (const [prNum, changeset] of changesetByPR) {
-		if (seenPRs.has(prNum)) continue;
-		seenPRs.add(prNum);
-
-		let author = "unknown";
-		let domain = "core";
-		try {
-			const prInfo = fetchPR(prNum);
-			author = prInfo.author;
-			const parsed = parseConventionalCommit(prInfo.title);
-			domain = classifyEntry(prInfo, parsed.scope || undefined, prInfo.files);
-		} catch {
-			// skip
-		}
-
-		entries.push({
-			id: `pr-${prNum}`,
-			description: changeset.description,
-			prNumber: prNum,
-			author,
-			domain,
-			breaking: changeset.breaking,
 		});
 	}
 

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -328,7 +328,7 @@ function buildChangesetIndex(branch: string): {
 		try {
 			const listing = execFileSync(
 				"git",
-				["ls-tree", "--name-only", ref, ".changeset/"],
+				["ls-tree", "-r", "--name-only", ref, ".changeset/"],
 				{ encoding: "utf-8" },
 			);
 			const SKIP_FILES = new Set(["README", "config"]);
@@ -541,7 +541,8 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 		let domain = "core";
 		let breaking = parsed.breaking;
 
-		const description = changeset?.description ?? parsed.subject;
+		const description =
+			changeset?.description ?? parsed.subject.replace(/\s*\(#\d+\)$/, "");
 		if (changeset?.breaking) breaking = true;
 
 		try {

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -12,6 +12,11 @@
  * CI:    PUBLISHED_PACKAGES='[...]' node .github/scripts/release-notes.ts
  * Local: node --experimental-strip-types .github/scripts/release-notes.ts \
  *          --version 1.6.0-beta.0 --branch origin/next --dry-run
+ *
+ * Revert-cancellation algorithm and two-stage AI pipeline adapted from
+ * sst/opencode (MIT License, Copyright (c) 2025 opencode):
+ *   https://github.com/anomalyco/opencode
+ *   script/raw-changelog.ts, script/changelog.ts, script/version.ts
  */
 
 import { execFileSync } from "node:child_process";

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -174,10 +174,11 @@ function findPreviousTag(currentVersion: string, isBeta: boolean): string {
 	const tags = listTags();
 
 	if (isBeta) {
-		const betaMatch = currentVersion.match(/^(.+)-(?:beta|alpha|rc)\.(\d+)$/);
-		if (betaMatch && Number(betaMatch[2]) > 0) {
-			const prevN = Number(betaMatch[2]) - 1;
-			const prevVersion = `${betaMatch[1]}-beta.${prevN}`;
+		const preMatch = currentVersion.match(/^(.+)-(beta|alpha|rc)\.(\d+)$/);
+		if (preMatch && Number(preMatch[3]) > 0) {
+			const prevN = Number(preMatch[3]) - 1;
+			const channel = preMatch[2]; // preserve the actual channel
+			const prevVersion = `${preMatch[1]}-${channel}.${prevN}`;
 			const prevTag = `v${prevVersion}`;
 			if (tags.includes(prevTag)) return prevTag;
 		}
@@ -525,12 +526,15 @@ function collectEntries(
 		seen.set(msg, { hash, msg });
 	}
 
-	// Build changeset index for description enrichment
+	// Build changeset index from the same ref used for the commit range.
+	// On reruns where the tag already exists, this prevents reading newer
+	// changesets from a branch that has advanced past the tagged release.
+	const changesetRef = targetRef === currentTag ? targetRef : branch;
 	const {
 		byPR: changesetByPR,
 		orphans: changesetOrphans,
 		byDescription: changesetByDesc,
-	} = buildChangesetIndex(branch);
+	} = buildChangesetIndex(changesetRef);
 	if (changesetByPR.size > 0 || changesetOrphans.length > 0) {
 		console.log(
 			`  Loaded ${changesetByPR.size} changeset descriptions, ${changesetOrphans.length} orphans`,
@@ -539,6 +543,7 @@ function collectEntries(
 
 	const entries: ReleaseEntry[] = [];
 	const seenPRs = new Set<number>();
+	const consumedOrphans = new Set<ChangesetEntry>();
 
 	for (const { msg } of seen.values()) {
 		const parsed = parseConventionalCommit(msg);
@@ -555,9 +560,9 @@ function collectEntries(
 		// a manual changeset should appear in release notes even if its
 		// merge title starts with docs:/chore:/etc.
 		// Try PR-keyed index first, then match by commit subject for manual names.
-		const changeset =
-			changesetByPR.get(prNumber) ??
-			changesetByDesc.get(parsed.subject.toLowerCase().trim());
+		const descMatch = changesetByDesc.get(parsed.subject.toLowerCase().trim());
+		const changeset = changesetByPR.get(prNumber) ?? descMatch;
+		if (descMatch) consumedOrphans.add(descMatch);
 
 		if (
 			!changeset &&
@@ -615,6 +620,8 @@ function collectEntries(
 	}
 
 	for (const changeset of changesetOrphans) {
+		// Skip orphans already matched to a PR via description
+		if (consumedOrphans.has(changeset)) continue;
 		// Skip orphans that were already in a previous beta
 		if (previousBetaChangesets.has(changeset.id)) continue;
 

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -330,10 +330,13 @@ function buildChangesetIndex(branch: string): {
 	let effectiveBranch = branch;
 	const refsToTry = [baseRef];
 	for (let i = 1; i <= 5; i++) refsToTry.push(`${baseRef}~${i}`);
-	// Also check the second parent of merge commits (promote flow: next → main)
+	// Also check the second parent of merge commits and its ancestors.
+	// In the promote flow, `changeset version` runs on next BEFORE the merge,
+	// so HEAD^2 itself has the files deleted. We need HEAD^2~1, HEAD^2~2, etc.
 	for (let i = 0; i <= 3; i++) {
 		const mergeRef = i === 0 ? baseRef : `${baseRef}~${i}`;
 		refsToTry.push(`${mergeRef}^2`);
+		for (let j = 1; j <= 3; j++) refsToTry.push(`${mergeRef}^2~${j}`);
 	}
 	for (const ref of refsToTry) {
 		try {

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -16,7 +16,6 @@
 
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ghJSON, REPO, setOutput } from "./lib/github.ts";
 import {
@@ -664,8 +663,9 @@ if (dryRun) {
 	console.log(body);
 } else {
 	// Write raw changelog to temp file for the AI stage
-	const outDir = process.env.RUNNER_TEMP ?? tmpdir();
-	const rawFile = join(outDir, `release-notes-raw-${version}.md`);
+	// Write inside the repo working directory so claude-code-action can read it
+	// (it restricts file access to the checkout directory)
+	const rawFile = join(process.cwd(), `.release-notes-raw-${version}.md`);
 	writeFileSync(rawFile, body);
 	console.log(`Wrote raw changelog to ${rawFile}`);
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 6 --allowedTools "Read Write Bash(gh:*)"
+          claude_args: --max-turns 15 --allowedTools "Read Write Bash(gh:*)"
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
@@ -390,7 +390,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 6 --allowedTools "Read Write Bash(gh:*)"
+          claude_args: --max-turns 15 --allowedTools "Read Write Bash(gh:*)"
 
       - name: Post results to job summary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,7 @@ jobs:
     environment: Release
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Generate App Token
         id: app-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,10 +363,15 @@ jobs:
             DIST_TAG="latest"
           fi
 
+          DIST_TAG_ARGS=""
+          if [ -n "$DIST_TAG" ]; then
+            DIST_TAG_ARGS="--dist-tag $DIST_TAG"
+          fi
+
           node .github/scripts/release-notes.ts \
             --version "$INPUT_VERSION" \
             --branch "origin/$INPUT_BRANCH" \
-            ${DIST_TAG:+--dist-tag "$DIST_TAG"}
+            $DIST_TAG_ARGS
 
       - name: Build AI prompt from template
         id: ai-prompt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
           NPM_DIST_TAG: ${{ steps.npm-tag.outputs.tag }}
-        run: node .github/scripts/release-notes.ts
+        run: node .github/scripts/release-notes.ts --branch "$GITHUB_REF_NAME"
 
       - name: Build AI prompt from template
         id: ai-prompt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# cSpell:words anthropics
 name: Release
 
 on:
@@ -12,6 +13,16 @@ on:
         description: 'Snapshot tag (e.g. "snapshot"). Leave empty for normal release.'
         required: false
         default: ''
+        type: string
+      preview_version:
+        description: 'Preview release notes for a version (e.g. "1.6.0-beta.0"). Leave empty for normal release.'
+        required: false
+        default: ''
+        type: string
+      preview_branch:
+        description: 'Branch to read changeset data from (for preview mode).'
+        required: false
+        default: 'next'
         type: string
 
 permissions: {}
@@ -29,7 +40,7 @@ env:
 jobs:
   release:
     if: >
-      (github.event_name != 'workflow_dispatch' || inputs.snapshot == '') &&
+      (github.event_name != 'workflow_dispatch' || (inputs.snapshot == '' && inputs.preview_version == '')) &&
       github.repository_owner == 'better-auth' &&
       (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || startsWith(github.ref, 'refs/heads/release/'))
     runs-on: ubuntu-latest
@@ -98,10 +109,102 @@ jobs:
           publish: pnpm ci:release
           title: "chore: version packages"
           commit: "chore: version packages"
-          createGithubReleases: true
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           NPM_CONFIG_TAG: ${{ steps.npm-tag.outputs.tag }}
+
+      - name: Generate raw release notes
+        id: raw-notes
+        if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          NPM_DIST_TAG: ${{ steps.npm-tag.outputs.tag }}
+        run: node .github/scripts/release-notes.ts
+
+      - name: Build AI prompt from template
+        id: ai-prompt
+        if: steps.raw-notes.outcome == 'success'
+        env:
+          RAW_PATH: ${{ steps.raw-notes.outputs.raw_changelog_path }}
+        run: |
+          PROMPT=$(sed \
+            -e "s|__RAW_CHANGELOG_PATH__|${RAW_PATH}|g" \
+            -e "s|__GITHUB_REPOSITORY__|${GITHUB_REPOSITORY}|g" \
+            .github/prompts/release-notes-rewrite.md)
+          EOF_DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
+          echo "prompt<<${EOF_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$PROMPT" >> "$GITHUB_OUTPUT"
+          echo "${EOF_DELIM}" >> "$GITHUB_OUTPUT"
+
+      - name: Rewrite release notes with AI
+        id: ai-notes
+        if: steps.raw-notes.outcome == 'success'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.ai-prompt.outputs.prompt }}
+          claude_args: --max-turns 3
+
+      - name: Create GitHub Release
+        if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.raw-notes.outputs.version }}
+          IS_BETA: ${{ steps.raw-notes.outputs.is_beta }}
+          RAW_PATH: ${{ steps.raw-notes.outputs.raw_changelog_path }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          # Determine version: from raw-notes output, or parse from publishedPackages
+          if [ -z "$VERSION" ]; then
+            VERSION=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[0].version // empty')
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::warning::Could not determine version, skipping release creation"
+            exit 0
+          fi
+
+          TAG="v${VERSION}"
+
+          # Use AI-rewritten notes > raw notes > minimal fallback
+          if [ -n "$RAW_PATH" ] && [ -f "${RAW_PATH}.final" ]; then
+            NOTES_FILE="${RAW_PATH}.final"
+            echo "Using AI-rewritten release notes"
+          elif [ -n "$RAW_PATH" ] && [ -f "${RAW_PATH}" ]; then
+            NOTES_FILE="${RAW_PATH}"
+            echo "Using raw release notes (AI step skipped or failed)"
+          else
+            NOTES_FILE=$(mktemp)
+            echo "Release ${TAG}" > "$NOTES_FILE"
+            echo "Using minimal fallback (note generation failed)"
+          fi
+
+          # Create tag via GitHub API (git push has no credentials with persist-credentials: false)
+          COMMIT_SHA="${GITHUB_SHA}"
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${TAG}" -f sha="$COMMIT_SHA" 2>/dev/null \
+            || echo "Tag $TAG already exists"
+
+          # Create or update release, targeting the exact commit
+          PRERELEASE_FLAG=""
+          if [ "$IS_BETA" = "true" ] || echo "$VERSION" | grep -q '-'; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$NOTES_FILE" $PRERELEASE_FLAG
+            echo "Updated release $TAG"
+          else
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes-file "$NOTES_FILE" --target "$COMMIT_SHA" $PRERELEASE_FLAG
+            echo "Created release $TAG"
+          fi
 
       - name: Sync main to next via PR
         if: github.ref_name == 'main'
@@ -196,3 +299,113 @@ jobs:
         env:
           SNAPSHOT_TAG: ${{ inputs.snapshot }}
         run: pnpm changeset publish --no-git-tag --tag "$SNAPSHOT_TAG"
+
+  preview-notes:
+    if: github.event_name == 'workflow_dispatch' && inputs.preview_version != '' && github.repository_owner == 'better-auth'
+    runs-on: ubuntu-latest
+    environment: Release
+    permissions:
+      contents: read
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        if: vars.RELEASE_APP_ID != ''
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      # TODO: restore ref: main before merging — pinned to current branch for testing
+      # Always check out main for trusted scripts — the preview_branch
+      # input controls which ref changeset files are read from (via --branch),
+      # not which code is executed.
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # ref: main
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Validate inputs
+        env:
+          INPUT_VERSION: ${{ inputs.preview_version }}
+          INPUT_BRANCH: ${{ inputs.preview_branch }}
+        run: |
+          git fetch origin "$INPUT_BRANCH" || { echo "::error::Branch '$INPUT_BRANCH' not found"; exit 1; }
+          if echo "$INPUT_VERSION" | grep -q '-'; then
+            if ! git show "origin/${INPUT_BRANCH}:.changeset/pre.json" >/dev/null 2>&1; then
+              echo "::error::Version '$INPUT_VERSION' is a pre-release but branch '$INPUT_BRANCH' has no .changeset/pre.json"
+              exit 1
+            fi
+          fi
+
+      - name: Generate raw release notes
+        id: raw-notes
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.preview_version }}
+          INPUT_BRANCH: ${{ inputs.preview_branch }}
+        run: |
+          # Infer dist-tag from the branch (matches the npm-tag step in the release job)
+          DIST_TAG=""
+          if [[ "$INPUT_BRANCH" =~ ^release/ ]]; then
+            DIST_TAG="release-${INPUT_BRANCH#release/}"
+          elif [[ "$INPUT_BRANCH" == "main" ]]; then
+            DIST_TAG="latest"
+          fi
+
+          node .github/scripts/release-notes.ts \
+            --version "$INPUT_VERSION" \
+            --branch "origin/$INPUT_BRANCH" \
+            ${DIST_TAG:+--dist-tag "$DIST_TAG"}
+
+      - name: Build AI prompt from template
+        id: ai-prompt
+        env:
+          RAW_PATH: ${{ steps.raw-notes.outputs.raw_changelog_path }}
+        run: |
+          PROMPT=$(sed \
+            -e "s|__RAW_CHANGELOG_PATH__|${RAW_PATH}|g" \
+            -e "s|__GITHUB_REPOSITORY__|${GITHUB_REPOSITORY}|g" \
+            .github/prompts/release-notes-rewrite.md)
+          EOF_DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
+          echo "prompt<<${EOF_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$PROMPT" >> "$GITHUB_OUTPUT"
+          echo "${EOF_DELIM}" >> "$GITHUB_OUTPUT"
+
+      - name: Rewrite release notes with AI
+        id: ai-notes
+        continue-on-error: true
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.ai-prompt.outputs.prompt }}
+          claude_args: --max-turns 3
+
+      - name: Post results to job summary
+        env:
+          RAW_PATH: ${{ steps.raw-notes.outputs.raw_changelog_path }}
+          VERSION: ${{ steps.raw-notes.outputs.version }}
+        run: |
+          {
+            echo "# Release Notes Preview: v${VERSION}"
+            echo ""
+            if [ -f "${RAW_PATH}.final" ]; then
+              echo "## AI-Rewritten (final)"
+              echo ""
+              cat "${RAW_PATH}.final"
+              echo ""
+              echo "---"
+              echo ""
+            fi
+            echo "## Raw (deterministic)"
+            echo ""
+            cat "${RAW_PATH}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 100 --allowedTools "Read Write Bash(gh:*)"
+          claude_args: --max-turns 100 --allowedTools "Read Write Bash(gh pr diff*) Bash(gh pr view*)"
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
@@ -187,8 +187,14 @@ jobs:
             echo "Using minimal fallback (note generation failed)"
           fi
 
-          # Create tag via GitHub API (git push has no credentials with persist-credentials: false)
+          # Resolve the actual branch HEAD (changesets/action may have pushed a new commit)
           COMMIT_SHA="${GITHUB_SHA}"
+          RESOLVED=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${GITHUB_REF_NAME}" --jq '.object.sha' 2>/dev/null || true)
+          if [ -n "$RESOLVED" ]; then
+            COMMIT_SHA="$RESOLVED"
+          fi
+
+          # Create tag via GitHub API (git push has no credentials with persist-credentials: false)
           gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
             -f ref="refs/tags/${TAG}" -f sha="$COMMIT_SHA" 2>/dev/null \
             || echo "Tag $TAG already exists"
@@ -307,7 +313,7 @@ jobs:
     environment: Release
     permissions:
       contents: read
-      id-token: write
+      pull-requests: read
     steps:
       - name: Generate App Token
         id: app-token
@@ -389,7 +395,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 100 --allowedTools "Read Write Bash(gh:*)"
+          claude_args: --max-turns 100 --allowedTools "Read Write Bash(gh pr diff*) Bash(gh pr view*)"
 
       - name: Post results to job summary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,13 +317,12 @@ jobs:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      # TODO: restore ref: main before merging — pinned to current branch for testing
       # Always check out main for trusted scripts — the preview_branch
       # input controls which ref changeset files are read from (via --branch),
       # not which code is executed.
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # ref: main
+          ref: main
           fetch-depth: 0
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Build AI prompt from template
         id: ai-prompt
         if: steps.raw-notes.outcome == 'success'
+        continue-on-error: true
         env:
           RAW_PATH: ${{ steps.raw-notes.outputs.raw_changelog_path }}
         run: |
@@ -373,6 +374,7 @@ jobs:
 
       - name: Build AI prompt from template
         id: ai-prompt
+        continue-on-error: true
         env:
           RAW_PATH: ${{ steps.raw-notes.outputs.raw_changelog_path }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 15 --allowedTools "Read Write Bash(gh:*)"
+          claude_args: --max-turns 25 --allowedTools "Read Write Bash(gh:*)"
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
@@ -390,7 +390,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 15 --allowedTools "Read Write Bash(gh:*)"
+          claude_args: --max-turns 25 --allowedTools "Read Write Bash(gh:*)"
 
       - name: Post results to job summary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 3
+          claude_args: --max-turns 6 --allowedTools "Read Write Bash(gh:*)"
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
@@ -390,7 +390,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 3
+          claude_args: --max-turns 6 --allowedTools "Read Write Bash(gh:*)"
 
       - name: Post results to job summary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 25 --allowedTools "Read Write Bash(gh:*)"
+          claude_args: --max-turns 100 --allowedTools "Read Write Bash(gh:*)"
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
@@ -390,7 +390,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
-          claude_args: --max-turns 25 --allowedTools "Read Write Bash(gh:*)"
+          claude_args: --max-turns 100 --allowedTools "Read Write Bash(gh:*)"
 
       - name: Post results to job summary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,12 +188,8 @@ jobs:
             echo "Using minimal fallback (note generation failed)"
           fi
 
-          # Resolve the actual branch HEAD (changesets/action may have pushed a new commit)
+          # Tag the exact commit that triggered this workflow run
           COMMIT_SHA="${GITHUB_SHA}"
-          RESOLVED=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${GITHUB_REF_NAME}" --jq '.object.sha' 2>/dev/null || true)
-          if [ -n "$RESOLVED" ]; then
-            COMMIT_SHA="$RESOLVED"
-          fi
 
           # Create tag via GitHub API (git push has no credentials with persist-credentials: false)
           gh api "repos/${GITHUB_REPOSITORY}/git/refs" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
           claude_args: --max-turns 3
 
@@ -387,6 +388,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
           claude_args: --max-turns 3
 


### PR DESCRIPTION
## Summary

The `changesets/action` creates one GitHub Release per published package (20 releases for a lockstep monorepo), each with wrong attribution because all changeset files share a single batch commit. This PR replaces that with a single consolidated release produced by a two-stage pipeline: deterministic data extraction followed by AI rewriting.

## Two-Stage Pipeline

The release notes flow through two stages that serve different purposes but produce a single output.

**Stage 1** (`release-notes.ts`) is deterministic. It uses git history as the ground truth (not changesets alone, which can miss PRs merged without changeset files), resolves actual PR authors via `gh pr view`, classifies each entry into a domain using the same scope and file-path mappings that drive `actions/labeler`, and handles the cherry-pick history gap between `main` and `next` through PR-number deduplication.

**Stage 2** (`claude-code-action`) rewrites the raw descriptions to be user-focused. It inspects PR diffs for unclear entries, normalizes tense and formatting, wraps code identifiers in backticks, and surfaces flow-on effects that commit messages obscure. If this step fails, the raw deterministic output is used as-is.

## Architecture Decisions

| Decision | Rationale |
|----------|-----------|
| `createGithubReleases: false` | Prevents 20 per-package releases; our pipeline creates 1 |
| `v<version>` tag format | Matches existing tag convention (`v1.5.6`), not changesets' `<pkg>@<version>` |
| Git history as ground truth | Changesets miss PRs merged without `.changeset/*.md` files; git log catches everything |
| Cherry-pick deduplication | `v1.5.6` is not a direct ancestor of `next`; PR-number filtering prevents double-counting |
| Tag creation via GitHub API | `persist-credentials: false` means `git push` has no auth; `gh api` uses `GH_TOKEN` |
| `continue-on-error: true` on all post-publish steps | npm publish is the critical path; release notes are best-effort |
| `preview-notes` pinned to `ref: main` | Prevents feature branches from injecting code that runs with release secrets |

## References

Patterns and algorithms adapted from:
- [sst/opencode](https://github.com/anomalyco/opencode) (MIT License): revert-cancellation algorithm (`script/raw-changelog.ts`), two-stage AI pipeline architecture (`script/version.ts`, `script/changelog.ts`), and changelog prompt structure (`.opencode/command/changelog.md`)
- [#8862](https://github.com/better-auth/better-auth/pull/8862): initial release automation setup (changesets migration, OIDC publishing, branch strategy)
