### PR TITLE
fix(types): guard type utilities against any poisoning

### DIFF
--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -6,6 +6,7 @@ import type { BetterFetchResponse } from "@better-fetch/fetch";
 import type { Endpoint, InputContext, StandardSchemaV1 } from "better-call";
 import type {
 	HasRequiredKeys,
+	IsAny,
 	Prettify,
 	UnionToIntersection,
 } from "../types/helper";
@@ -108,30 +109,35 @@ export type InferUserUpdateCtx<
 	UnionToIntersection<InferAdditionalFromClient<ClientOpts, "user", "input">>
 >;
 
+type InferCtxQuery<
+	C extends InputContext<any, any>,
+	FetchOptions extends ClientFetchOption,
+> =
+	C["query"] extends Record<string, any>
+		? {
+				query: C["query"];
+				fetchOptions?: FetchOptions | undefined;
+			}
+		: C["query"] extends Record<string, any> | undefined
+			? {
+					query?: C["query"] | undefined;
+					fetchOptions?: FetchOptions | undefined;
+				}
+			: {
+					fetchOptions?: FetchOptions | undefined;
+				};
+
 export type InferCtx<
 	C extends InputContext<any, any>,
 	FetchOptions extends ClientFetchOption,
-> = 0 extends 1 & C["body"]
-	? {
-			fetchOptions?: FetchOptions | undefined;
-		}
-	: C["body"] extends Record<string, any>
-		? C["body"] & {
-				fetchOptions?: FetchOptions | undefined;
-			}
-		: C["query"] extends Record<string, any>
-			? {
-					query: C["query"];
+> =
+	IsAny<C["body"]> extends true
+		? InferCtxQuery<C, FetchOptions>
+		: C["body"] extends Record<string, any>
+			? C["body"] & {
 					fetchOptions?: FetchOptions | undefined;
 				}
-			: C["query"] extends Record<string, any> | undefined
-				? {
-						query?: C["query"] | undefined;
-						fetchOptions?: FetchOptions | undefined;
-					}
-				: {
-						fetchOptions?: FetchOptions | undefined;
-					};
+			: InferCtxQuery<C, FetchOptions>;
 
 export type MergeRoutes<T> = UnionToIntersection<T>;
 

--- a/packages/better-auth/src/types/helper.ts
+++ b/packages/better-auth/src/types/helper.ts
@@ -1,3 +1,5 @@
+export type IsAny<T> = 0 extends 1 & T ? true : false;
+
 export type Prettify<T> = Omit<T, never>;
 
 export type PrettifyDeep<T> = {
@@ -29,12 +31,13 @@ export type RequiredKeysOf<BaseType extends object> = Exclude<
 	undefined
 >;
 
-export type HasRequiredKeys<BaseType> = 0 extends 1 & BaseType
-	? false
-	: [BaseType] extends [object]
-		? RequiredKeysOf<BaseType & object> extends never
-			? false
-			: true
-		: false;
+export type HasRequiredKeys<BaseType> =
+	IsAny<BaseType> extends true
+		? false
+		: [BaseType] extends [object]
+			? RequiredKeysOf<BaseType & object> extends never
+				? false
+				: true
+			: false;
 
 export type StripEmptyObjects<T extends object> = { [K in keyof T]: T[K] };

--- a/packages/better-auth/src/types/models.ts
+++ b/packages/better-auth/src/types/models.ts
@@ -3,7 +3,7 @@ import type {
 	InferDBFieldsFromOptionsInput,
 	InferDBFieldsFromPluginsInput,
 } from "@better-auth/core/db";
-import type { UnionToIntersection } from "./helper";
+import type { IsAny, UnionToIntersection } from "./helper";
 
 export type AdditionalUserFieldsInput<Options extends BetterAuthOptions> =
 	InferDBFieldsFromPluginsInput<"user", Options["plugins"]> &
@@ -16,11 +16,13 @@ export type AdditionalSessionFieldsInput<Options extends BetterAuthOptions> =
 export type InferPluginTypes<O extends BetterAuthOptions> =
 	O["plugins"] extends Array<infer P>
 		? UnionToIntersection<
-				P extends BetterAuthPlugin
-					? P["$Infer"] extends Record<string, any>
-						? P["$Infer"]
+				IsAny<P> extends true
+					? {}
+					: P extends BetterAuthPlugin
+						? P["$Infer"] extends Record<string, any>
+							? P["$Infer"]
+							: {}
 						: {}
-					: {}
 			>
 		: {};
 

--- a/packages/better-auth/src/types/plugins.ts
+++ b/packages/better-auth/src/types/plugins.ts
@@ -5,7 +5,7 @@ import type {
 } from "@better-auth/core";
 
 import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
-import type { UnionToIntersection } from "./helper";
+import type { IsAny, UnionToIntersection } from "./helper";
 
 export type InferOptionSchema<S extends BetterAuthPluginDBSchema> =
 	S extends Record<string, { fields: infer Fields }>
@@ -24,11 +24,13 @@ export type InferOptionSchema<S extends BetterAuthPluginDBSchema> =
 export type InferPluginErrorCodes<O extends BetterAuthOptions> =
 	O["plugins"] extends Array<infer P>
 		? UnionToIntersection<
-				P extends BetterAuthPlugin
-					? P["$ERROR_CODES"] extends Record<string, any>
-						? P["$ERROR_CODES"]
+				IsAny<P> extends true
+					? {}
+					: P extends BetterAuthPlugin
+						? P["$ERROR_CODES"] extends Record<string, any>
+							? P["$ERROR_CODES"]
+							: {}
 						: {}
-					: {}
 			>
 		: {};
 

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -247,4 +247,66 @@ describe("InferCtx", () => {
 		type Keys = keyof Result;
 		expectTypeOf<Keys>().toEqualTypeOf<"fetchOptions">();
 	});
+
+	it("should preserve query when body is any", () => {
+		type Result = InferCtx<
+			{ body: any; query: { page: number }; method: "GET" },
+			{}
+		>;
+		type HasQuery = "query" extends keyof Result ? true : false;
+		expectTypeOf<HasQuery>().toEqualTypeOf<true>();
+	});
+});
+
+describe("any-poisoning guards", () => {
+	/**
+	 * PrettifyDeep is used in InferSessionAPI return types.
+	 * Verify auth.$Infer.Session preserves structure and doesn't collapse.
+	 */
+	it("auth.$Infer.Session should have typed user/session fields", async () => {
+		const { auth } = await getTestInstance();
+		type Session = typeof auth.$Infer.Session;
+		expectTypeOf<Session>().toHaveProperty("user");
+		expectTypeOf<Session>().toHaveProperty("session");
+		type User = Session["user"];
+		expectTypeOf<User>().toHaveProperty("id");
+		expectTypeOf<User>().toHaveProperty("email");
+	});
+
+	/**
+	 * InferPluginTypes extracts $Infer from each plugin. When a plugin in
+	 * the array is `any`, the entire $Infer type should not collapse.
+	 */
+	it("auth.$Infer should not collapse with untyped plugin", async () => {
+		const untypedPlugin = {} as any;
+		const { auth } = await getTestInstance({
+			plugins: [organization(), untypedPlugin],
+		});
+		type Infer = typeof auth.$Infer;
+		expectTypeOf<Infer>().not.toBeAny();
+		expectTypeOf<Infer>().toHaveProperty("Session");
+	});
+
+	/**
+	 * InferPluginErrorCodes extracts $ERROR_CODES from each plugin.
+	 * Same any guard as InferPluginTypes.
+	 */
+	it("auth.$ERROR_CODES should not collapse with untyped plugin", async () => {
+		const untypedPlugin = {} as any;
+		const { auth } = await getTestInstance({
+			plugins: [organization(), untypedPlugin],
+		});
+		type Codes = (typeof auth)["$ERROR_CODES"];
+		expectTypeOf<Codes>().not.toBeAny();
+	});
+
+	/**
+	 * InferResolvedHooks transforms plugin atoms to hook methods (useSession, etc.).
+	 * Built-in hooks should remain typed regardless of plugin composition.
+	 */
+	it("client hooks should not collapse with untyped plugin", async () => {
+		const { client } = await getTestInstance();
+		type UseSession = typeof client.useSession;
+		expectTypeOf<UseSession>().not.toBeAny();
+	});
 });


### PR DESCRIPTION
Improves type safety when `any` is involved. Previously, mixing in an `any` plugin would poison the other client response types. After this change, valid plugin types are preserved even if an `any` plugin is present.