### PR TITLE
fix(ci): skip changeset verification on sync PRs (main → next)

### DIFF
--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -19,6 +19,7 @@ jobs:
     if: >
       !startsWith(github.head_ref, 'changeset-release/') &&
       !(github.head_ref == 'next' && github.base_ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository) &&
+      !(github.head_ref == 'main' && github.base_ref == 'next' && github.event.pull_request.head.repo.full_name == github.repository) &&
       github.actor != 'github-actions[bot]' &&
       github.actor != 'better-release[bot]'
     permissions:


### PR DESCRIPTION
## Summary
- The sync PR (`main → next`) carries package changes but no changeset — this is correct since it's a structural sync, not a feature.
- `verify-changesets.yml` already excluded promote PRs (`next → main`) but not the reverse direction.
- The workflow was triggered by `cubic-dev-ai[bot]` (label sync), bypassing the actor-based exclusion for `better-release[bot]`.
- Fix: add structural exclusion for `head=main && base=next` (same pattern as the promote PR exclusion).

## Context
Sync PR #8976 failed: https://github.com/better-auth/better-auth/actions/runs/24012825893/job/70027096985

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip changeset verification for structural sync PRs from `main` to `next`. This mirrors the existing `next → main` exclusion and prevents false failures on bot-triggered syncs (e.g., `cubic-dev-ai[bot]`, `github-actions[bot]`, `better-release[bot]`).

<sup>Written for commit 812f93d900a15bf8d2f0c5e22881fa384d3ca742. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

