### PR TITLE
fix(oauth): prevent double-hashing of state when storeIdentifier is hashed

### DIFF
--- a/.changeset/pr-8980.md
+++ b/.changeset/pr-8980.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix oauth state double-hashing when verification storeIdentifier is set to hashed

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2212,4 +2212,65 @@ describe("oauth2", async () => {
 			expect(callbackURL).toBe("http://localhost:3000/new_user");
 		});
 	});
+
+	describe("storeIdentifier: hashed", () => {
+		it("should complete oauth flow when verification identifiers are hashed", async () => {
+			server.service.once("beforeUserinfo", (userInfoResponse) => {
+				userInfoResponse.body = {
+					email: "hashed-oauth@test.com",
+					name: "Hashed OAuth Test",
+					sub: "hashed-oauth",
+					picture: "https://test.com/picture.png",
+					email_verified: true,
+				};
+				userInfoResponse.statusCode = 200;
+			});
+
+			const { customFetchImpl, cookieSetter } = await getTestInstance({
+				verification: {
+					storeIdentifier: "hashed" as const,
+				},
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "test-hashed",
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId: clientId,
+								clientSecret: clientSecret,
+								pkce: true,
+							},
+						],
+					}),
+				],
+			});
+
+			const authClient = createAuthClient({
+				plugins: [genericOAuthClient()],
+				baseURL: "http://localhost:3000",
+				fetchOptions: {
+					customFetchImpl,
+				},
+			});
+
+			const headers = new Headers();
+			const res = await authClient.signIn.oauth2({
+				providerId: "test-hashed",
+				callbackURL: "http://localhost:3000/dashboard",
+				fetchOptions: {
+					onSuccess: cookieSetter(headers),
+				},
+			});
+
+			expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
+
+			const { callbackURL } = await simulateOAuthFlow(
+				res.data?.url || "",
+				headers,
+				customFetchImpl,
+			);
+
+			expect(callbackURL).toBe("http://localhost:3000/dashboard");
+		});
+	});
 });

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -114,7 +114,7 @@ export async function generateGenericState(
 	}
 
 	return {
-		state: verification.identifier,
+		state,
 		codeVerifier: stateData.codeVerifier,
 	};
 }

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -118,8 +118,8 @@ export async function generateGenericState(
 	}
 
 	// Return the plain state, not verification.identifier.
-	// The adapter already hashed it for DB storage.
-	// Returning the hashed value would cause double-hashing on lookup.
+	// The adapter hashes it for DB storage when storeIdentifier is "hashed",
+	// so returning verification.identifier would cause double-hashing on lookup.
 	return {
 		state,
 		codeVerifier: stateData.codeVerifier,

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -56,9 +56,11 @@ export async function generateGenericState(
 	const state = generateRandomString(32);
 	const storeStateStrategy = c.context.oauthConfig.storeStateStrategy;
 
+	// Cookie strategy:
+	//
+	// State data is encrypted into the cookie
+	// no verification record created
 	if (storeStateStrategy === "cookie") {
-		// Store state data in an encrypted cookie
-
 		const encryptedData = await symmetricEncrypt({
 			key: c.context.secretConfig,
 			data: JSON.stringify(stateData),
@@ -79,8 +81,10 @@ export async function generateGenericState(
 		};
 	}
 
-	// Default: database strategy
-
+	// Database strategy:
+	//
+	// state is stored in a signed cookie and sent via OAuth URL
+	// the adapter hashes it at rest when storeIdentifier is set
 	const stateCookie = c.context.createAuthCookie(
 		settings?.cookieName ?? "state",
 		{
@@ -113,6 +117,9 @@ export async function generateGenericState(
 		);
 	}
 
+	// Return the plain state, not verification.identifier.
+	// The adapter already hashed it for DB storage.
+	// Returning the hashed value would cause double-hashing on lookup.
 	return {
 		state,
 		codeVerifier: stateData.codeVerifier,


### PR DESCRIPTION
https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/db/verification-token-storage.ts#L16-L18

This issue didn't surface before, because in the default plain mode, `verification.identifier` is the same as `state`.