### PR TITLE
fix(oauth2): prevent cross-provider account collision in link-social callback

### DIFF
--- a/.changeset/fix-link-social-provider-scope.md
+++ b/.changeset/fix-link-social-provider-scope.md
@@ -1,0 +1,9 @@
+---
+"better-auth": patch
+---
+
+fix(oauth2): prevent cross-provider account collision in link-social callback
+
+The link-social callback used `findAccount(accountId)` which matched by account ID across all providers. When two providers return the same numeric ID (e.g. both Google and GitHub assign `99999`), the lookup could match the wrong provider's account, causing a spurious `account_already_linked_to_different_user` error or silently updating the wrong account's tokens.
+
+Replaced with `findAccountByProviderId(accountId, providerId)` to scope the lookup to the correct provider, matching the pattern already used in the generic OAuth plugin.

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -193,9 +193,11 @@ export const callbackOAuth = createAuthEndpoint(
 				return redirectOnError("email_doesn't_match");
 			}
 
-			const existingAccount = await c.context.internalAdapter.findAccount(
-				String(userInfo.id),
-			);
+			const existingAccount =
+				await c.context.internalAdapter.findAccountByProviderId(
+					String(userInfo.id),
+					provider.id,
+				);
 
 			if (existingAccount) {
 				if (existingAccount.userId.toString() !== link.userId.toString()) {

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -882,3 +882,179 @@ describe("oauth2 - override user info on sign-in", async () => {
 		expect(session.data?.user.name).toBe("Updated Name");
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8906
+ *
+ * Regression: linkSocial callback used findAccount(accountId) without
+ * filtering by providerId. When two different providers share the same
+ * numeric account ID, the wrong account could be matched, causing a
+ * spurious "account_already_linked_to_different_user" error or silently
+ * updating the wrong account record.
+ */
+describe("oauth2 - link-social uses provider-scoped account lookup", async () => {
+	// Shared numeric ID used by both Google and GitHub to trigger the bug
+	const SHARED_ACCOUNT_ID = "99999";
+
+	const { auth, client, cookieSetter } = await getTestInstance({
+		socialProviders: {
+			google: {
+				clientId: "test",
+				clientSecret: "test",
+				enabled: true,
+			},
+			github: {
+				clientId: "test",
+				clientSecret: "test",
+				enabled: true,
+			},
+		},
+		emailAndPassword: {
+			enabled: true,
+		},
+		account: {
+			accountLinking: {
+				enabled: true,
+				trustedProviders: ["google", "github"],
+			},
+		},
+	});
+
+	const ctx = await auth.$context;
+
+	function mockGoogleToken(email: string, sub: string) {
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				const profile = {
+					sub,
+					email,
+					email_verified: true,
+					name: "Test User",
+					iat: 0,
+					exp: 9999999999,
+					aud: "test",
+					iss: "https://accounts.google.com",
+				};
+				const idToken = await signJWT(profile, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: "google-access-token",
+					id_token: idToken,
+				});
+			}),
+		);
+	}
+
+	function mockGithubToken(login: string, id: number, email: string) {
+		server.use(
+			http.post("https://github.com/login/oauth/access_token", async () => {
+				return HttpResponse.json({ access_token: "github-access-token" });
+			}),
+			http.get("https://api.github.com/user", async () => {
+				return HttpResponse.json({ id, login, name: login, email });
+			}),
+			http.get("https://api.github.com/user/emails", async () => {
+				return HttpResponse.json([{ email, primary: true, verified: true }]);
+			}),
+		);
+	}
+
+	it("should not match a different provider's account when the accountId is the same", async () => {
+		// User A: signed up via Google with accountId = SHARED_ACCOUNT_ID
+		const userAEmail = "user-a@example.com";
+		mockGoogleToken(userAEmail, SHARED_ACCOUNT_ID);
+
+		const userAHeaders = new Headers();
+		const googleSignIn = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/",
+			fetchOptions: { onSuccess: cookieSetter(userAHeaders) },
+		});
+		const stateA =
+			new URL(googleSignIn.data!.url!).searchParams.get("state") || "";
+		await client.$fetch("/callback/google", {
+			query: { state: stateA, code: "test_code" },
+			method: "GET",
+			headers: userAHeaders,
+			onError(ctx) {
+				cookieSetter(userAHeaders)(ctx as any);
+			},
+		});
+
+		const sessionA = await client.getSession({
+			fetchOptions: { headers: userAHeaders },
+		});
+		expect(sessionA.data?.user.email).toBe(userAEmail);
+		const userAId = sessionA.data!.user.id;
+
+		// User B: separate email/password account
+		const userBEmail = "user-b@example.com";
+		const userBHeaders = new Headers();
+		await client.signUp.email(
+			{
+				email: userBEmail,
+				password: "password123",
+				name: "User B",
+			},
+			{ onSuccess: cookieSetter(userBHeaders) },
+		);
+
+		// User B tries to link GitHub — GitHub returns the SAME accountId
+		// as User A's Google account. Without the fix, findAccount(SHARED_ACCOUNT_ID)
+		// would find User A's Google account and return "account_already_linked_to_different_user".
+		mockGithubToken("user-b-gh", Number(SHARED_ACCOUNT_ID), userBEmail);
+
+		const linkRes = await client.linkSocial(
+			{ provider: "github", callbackURL: "/settings" },
+			{ headers: userBHeaders, onSuccess: cookieSetter(userBHeaders) },
+		);
+		expect(linkRes.error).toBeNull();
+
+		const stateB = new URL(linkRes.data!.url!).searchParams.get("state") || "";
+		let redirectLocation = "";
+		await client.$fetch("/callback/github", {
+			query: { state: stateB, code: "test_code" },
+			method: "GET",
+			headers: userBHeaders,
+			onError(ctx) {
+				redirectLocation = ctx.response.headers.get("location") || "";
+				cookieSetter(userBHeaders)(ctx as any);
+			},
+		});
+
+		// Should redirect to /settings without error
+		expect(redirectLocation).not.toContain("error");
+		expect(redirectLocation).toContain("/settings");
+
+		// User B should have a GitHub account linked
+		const sessionB = await client.getSession({
+			fetchOptions: { headers: userBHeaders },
+		});
+		const userBId = sessionB.data!.user.id;
+
+		const accountsB = await ctx.adapter.findMany<{
+			providerId: string;
+			accountId: string;
+			userId: string;
+		}>({
+			model: "account",
+			where: [{ field: "userId", value: userBId }],
+		});
+
+		const githubAccount = accountsB.find((a) => a.providerId === "github");
+		expect(githubAccount).toBeTruthy();
+		expect(githubAccount?.accountId).toBe(SHARED_ACCOUNT_ID);
+		expect(githubAccount?.userId).toBe(userBId);
+
+		// User A's Google account must remain untouched
+		const accountsA = await ctx.adapter.findMany<{
+			providerId: string;
+			userId: string;
+		}>({
+			model: "account",
+			where: [{ field: "userId", value: userAId }],
+		});
+		const googleAccount = accountsA.find((a) => a.providerId === "google");
+		expect(googleAccount).toBeTruthy();
+		expect(googleAccount?.userId).toBe(userAId);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #8906

The `link-social` callback at `packages/better-auth/src/api/routes/callback.ts:196` used `findAccount(String(userInfo.id))` which searches by `accountId` across **all providers**. When two different providers return the same numeric user ID (e.g. both GitHub and Google happen to return `id = 99999`), the lookup could match an account belonging to a completely different provider and a different user, causing a spurious `account_already_linked_to_different_user` error or — worse — silently updating the wrong account's tokens.

The generic OAuth plugin already does this correctly using `findAccountByProviderId`. This PR applies the same provider-scoped lookup to the main social callback link path.

## Change

```diff
- const existingAccount = await c.context.internalAdapter.findAccount(
-     String(userInfo.id),
- );
+ const existingAccount =
+     await c.context.internalAdapter.findAccountByProviderId(
+         String(userInfo.id),
+         provider.id,
+     );
```

## Test

Added a regression test in `link-account.test.ts` that:
1. Creates User A with a Google account (accountId = `"99999"`)
2. Creates User B (email/password) and links GitHub — also returning accountId `"99999"`
3. Verifies User B's GitHub link succeeds without error (old code would return `account_already_linked_to_different_user`)
4. Verifies User A's Google account is untouched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes account lookup by provider in the OAuth2 link-social callback to prevent collisions when different providers return the same account ID. This avoids false `account_already_linked_to_different_user` errors and accidental token updates.

- **Bug Fixes**
  - Use `findAccountByProviderId(accountId, provider.id)` instead of `findAccount(accountId)` in the link-social path.
  - Add regression test to ensure linking `github` does not collide with an existing `google` account sharing the same numeric ID, and that the original account remains unchanged.
  - Add changeset entry for a patch release.

<sup>Written for commit 9c9fb5bbbf0573d06adfa9f0d37f33be0144e6b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

