### PR TITLE
chore(oidc-provider): deprecate plugin in favor of @better-auth/oauth-provider

### DIFF
--- a/.changeset/deprecate-oidc-provider.md
+++ b/.changeset/deprecate-oidc-provider.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+deprecate `oidc-provider` plugin in favor of `@better-auth/oauth-provider`
+
+The `oidc-provider` plugin now emits a one-time runtime deprecation warning when instantiated and is marked as `@deprecated` in TypeScript. It will be removed in the next major version. Migrate to `@better-auth/oauth-provider`.

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -190,7 +190,7 @@ export const mcp = (options: MCPOptions) => {
 		oauthAccessToken: "oauthAccessToken",
 		oauthConsent: "oauthConsent",
 	};
-	const provider = oidcProvider(opts);
+	const provider = oidcProvider({ ...opts, __skipDeprecationWarning: true });
 	return {
 		id: "mcp",
 		version: PACKAGE_VERSION,

--- a/packages/better-auth/src/plugins/oidc-provider/client.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/client.ts
@@ -2,6 +2,10 @@ import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
 import type { oidcProvider } from ".";
 
+/**
+ * @deprecated Use `@better-auth/oauth-provider` instead. This plugin will be removed in the next major version.
+ * @see https://www.better-auth.com/docs/plugins/oauth-provider
+ */
 export const oidcClient = () => {
 	return {
 		id: "oidc-client",

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -7,6 +7,7 @@ import {
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import { getCurrentAuthContext } from "@better-auth/core/context";
+import { deprecate } from "@better-auth/core/utils/deprecate";
 import { base64 } from "@better-auth/utils/base64";
 import { createHash } from "@better-auth/utils/hash";
 import type { OpenAPIParameter } from "better-call";
@@ -274,15 +275,28 @@ const DEFAULT_CODE_EXPIRES_IN = 600;
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN = 3600;
 const DEFAULT_REFRESH_TOKEN_EXPIRES_IN = 604800;
 
+const warnOidcDeprecation = deprecate(
+	() => {},
+	'The "oidc-provider" plugin is deprecated and will be removed in the next major version. ' +
+		"Migrate to @better-auth/oauth-provider. " +
+		"See: https://www.better-auth.com/docs/plugins/oauth-provider",
+);
+
 /**
  * OpenID Connect (OIDC) plugin for Better Auth. This plugin implements the
  * authorization code flow and the token exchange flow. It also implements the
  * userinfo endpoint.
  *
+ * @deprecated Use `@better-auth/oauth-provider` instead. This plugin will be removed in the next major version.
+ * @see https://www.better-auth.com/docs/plugins/oauth-provider
+ *
  * @param options - The options for the OIDC plugin.
  * @returns A Better Auth plugin.
  */
 export const oidcProvider = (options: OIDCOptions) => {
+	if (!options.__skipDeprecationWarning) {
+		warnOidcDeprecation();
+	}
 	const modelName = {
 		oauthClient: "oauthApplication",
 		oauthAccessToken: "oauthAccessToken",

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -2,6 +2,8 @@ import type { InferOptionSchema, User } from "../../types";
 import type { OAuthApplication, schema } from "./schema";
 
 export interface OIDCOptions {
+	/** @internal */
+	__skipDeprecationWarning?: boolean | undefined;
 	/**
 	 * The amount of time in seconds that the access token is valid for.
 	 *


### PR DESCRIPTION
Adds a one-time runtime deprecation warning to `oidcProvider()` using the existing `deprecate()` utility from `@better-auth/core`, and marks both `oidcProvider` and `oidcClient` as `@deprecated` in JSDoc.

Internal MCP usage bypasses the warning via a `__skipDeprecationWarning` flag on `OIDCOptions`, so only direct consumers see the notice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates the `oidc-provider` plugin in favor of `@better-auth/oauth-provider`. Adds a one-time runtime deprecation warning (via `@better-auth/core`’s `deprecate()`), marks `oidcProvider` and `oidcClient` as `@deprecated`, and allows internal MCP usage to bypass the warning with `__skipDeprecationWarning`.

- **Migration**
  - Switch to `@better-auth/oauth-provider`: https://www.better-auth.com/docs/plugins/oauth-provider

<sup>Written for commit ed69f1112c7955b689a6a1f0a085bf447c67b4cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

