### PR TITLE
chore: fix release-blocking Changesets `null` versions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -31,6 +31,7 @@
   ],
   "linked": [],
   "access": "public",
+  "privatePackages": false,
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,

--- a/e2e/adapter/package.json
+++ b/e2e/adapter/package.json
@@ -17,6 +17,5 @@
   "dependencies": {
     "deepmerge": "^4.3.1",
     "kysely": "^0.28.14"
-  },
-  "version": null
+  }
 }

--- a/e2e/integration/test-utils/package.json
+++ b/e2e/integration/test-utils/package.json
@@ -7,6 +7,5 @@
   "private": true,
   "devDependencies": {
     "terminate": "^2.8.0"
-  },
-  "version": null
+  }
 }


### PR DESCRIPTION
## Summary
- stop Changesets from versioning private packages on `next`
- remove the invalid `"version": null` fields written into the two private e2e packages
- unblock `ci` and `e2e` on the release promotion flow

## Root Cause
The promote workflow on `next` exits pre-release mode and versions packages in one pass. Because `.changeset/config.json` did not set `privatePackages`, Changesets defaulted to versioning private packages. Two private e2e packages had no original `version` field, and the pre-exit/version flow wrote `"version": null` into their `package.json` files.

Turbo then failed very early while parsing workspace package manifests, so the branch-level `ci` and `e2e` checks both failed before real test execution.

## Impact
This unblocks the stuck release path by repairing the current `next` line and preventing the same private-package versioning issue from being reintroduced on future promote runs.

## Validation
- `pnpm build`
- confirmed `origin/next` failures were caused by `package_json_parse_error` on the two `version: null` entries


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops versioning of private e2e packages on `next` and removes invalid version fields. Restores CI and e2e checks in the release promotion flow.

- **Bug Fixes**
  - Set `"privatePackages": false` in `.changeset/config.json` to ignore private packages during promote.
  - Removed `"version": null` from `e2e/adapter/package.json` and `e2e/integration/test-utils/package.json` to fix workspace manifest parsing and allow CI to run.

<sup>Written for commit 25419428c5cd3e915f3991a5e54d17950ab7cf98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

