### PR TITLE
chore: remove pending `pr-8927` changeset

### DIFF
--- a/.changeset/pr-8927.md
+++ b/.changeset/pr-8927.md
@@ -1,5 +1,0 @@
----
-"better-auth": patch
----
-
-generate session id when using secondary storage without database


### PR DESCRIPTION
## Summary
- remove `.changeset/pr-8927.md` from `next`
- keep the `#8927` code changes already synced from `main`
- preserve the current `1.6.0` promotion path without introducing an extra patch bump

## Why
After `main` was synced back into `next`, the code from `#8927` and its patch changeset were both present on `next`. The code is fine to keep, but the changeset would cause a fresh promote/version run to schedule another patch release.

This PR removes only the pending changeset so the existing `1.6.0` promotion PR can stay on the exact intended version.

## Validation
- confirmed the diff is only the deletion of `.changeset/pr-8927.md`
- confirmed package versions on `next` remain at `1.6.0`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `.changeset/pr-8927.md` from `next` to prevent an unnecessary patch release. Keeps the #8927 code and preserves the existing `1.6.0` promotion.

<sup>Written for commit 4c4aa89d9a519a00b6ac63fc255e4a585e7b576d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

