### PR TITLE
chore: re-enter beta pre-release mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,28 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "docs": "0.1.0",
+    "@better-auth/api-key": "1.6.0",
+    "better-auth": "1.6.0",
+    "auth": "1.6.0",
+    "@better-auth/core": "1.6.0",
+    "@better-auth/drizzle-adapter": "1.6.0",
+    "@better-auth/electron": "1.6.0",
+    "@better-auth/expo": "1.6.0",
+    "@better-auth/i18n": "1.6.0",
+    "@better-auth/kysely-adapter": "1.6.0",
+    "@better-auth/memory-adapter": "1.6.0",
+    "@better-auth/mongo-adapter": "1.6.0",
+    "@better-auth/oauth-provider": "1.6.0",
+    "@better-auth/passkey": "1.6.0",
+    "@better-auth/prisma-adapter": "1.6.0",
+    "@better-auth/redis-storage": "1.6.0",
+    "@better-auth/scim": "1.6.0",
+    "@better-auth/sso": "1.6.0",
+    "@better-auth/stripe": "1.6.0",
+    "@better-auth/telemetry": "1.6.0",
+    "@better-auth/test-utils": "1.6.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
Re-enters changesets pre-release mode on next after the v1.6.0 promotion. Starts the 1.7.0-beta.0 cycle.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned on Changesets pre-release mode on `next` with `beta` to start the 1.7.0-beta.0 cycle. Adds .changeset/pre.json with initial versions set to 1.6.0 for all packages.

<sup>Written for commit d131de56537db9210d03de052d5d0ccf248265d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

