### PR TITLE
docs: add @pinklemon8/better-auth-siws to community plugins

### DIFF
--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -30,3 +30,4 @@ ejirocodes
 0-Sandy
 qamarq
 C-W-D-Harshit
+ysrdevs

--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -237,4 +237,15 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/C-W-D-Harshit.png",
 		},
 	},
+	{
+		name: "@pinklemon8/better-auth-siws",
+		url: "https://github.com/ysrdevs/better-auth-siws",
+		description:
+			"Sign In With Solana (SIWS) — wallet authentication, linking, and ready-made React components.",
+		author: {
+			name: "ysrdevs",
+			github: "ysrdevs",
+			avatar: "https://github.com/ysrdevs.png",
+		},
+	},
 ];


### PR DESCRIPTION
Adds @pinklemon8/better-auth-siws to the community plugins table.

Sign In With Solana (SIWS) plugin for Better Auth — wallet authentication, wallet linking, and ready-made React components.

- npm: https://www.npmjs.com/package/@pinklemon8/better-auth-siws
- GitHub: https://github.com/ysrdevs/better-auth-siws

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@pinklemon8/better-auth-siws` to the Community Plugins docs, covering SIWS wallet auth, wallet linking, and React components. Also adds "ysrdevs" to `.cspell` to avoid false positives.

<sup>Written for commit af683376a77a716841d67f459c10e991db2f6536. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

