### PR TITLE
docs: add @pinklemon8/better-auth-webhooks to community plugins

### DIFF
--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -30,3 +30,4 @@ ejirocodes
 0-Sandy
 qamarq
 C-W-D-Harshit
+ysrdevs

--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -237,4 +237,15 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/C-W-D-Harshit.png",
 		},
 	},
+	{
+		name: "@pinklemon8/better-auth-webhooks",
+		url: "https://github.com/ysrdevs/better-auth-webhooks",
+		description:
+			"Webhook plugin — fire HTTP webhooks on auth events (user/session/account CRUD) with HMAC-SHA256 signing and automatic retries.",
+		author: {
+			name: "ysrdevs",
+			github: "ysrdevs",
+			avatar: "https://github.com/ysrdevs.png",
+		},
+	},
 ];


### PR DESCRIPTION
Adds @pinklemon8/better-auth-webhooks to the community plugins table.

Webhook plugin for Better Auth — fire HTTP webhooks on auth events (user/session/account CRUD) with HMAC-SHA256 signing, automatic retries with exponential backoff, and sensitive field stripping.

- npm: https://www.npmjs.com/package/@pinklemon8/better-auth-webhooks
- GitHub: https://github.com/ysrdevs/better-auth-webhooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@pinklemon8/better-auth-webhooks` to the community plugins table; it sends webhooks on auth CRUD events, signs payloads with HMAC-SHA256, and retries with exponential backoff. Also add `ysrdevs` to cspell names.

<sup>Written for commit 22d6a43d8ef793b33bc630972859b3513bd55513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

