### PR TITLE
fix(cli): better handling of wildcards in tsconfig paths

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -78,6 +78,7 @@ async function generateAction(opts: any) {
 		.object({
 			cwd: z.string(),
 			config: z.string().optional(),
+			tsconfig: z.string().optional(),
 			output: z.string().optional(),
 			adapter: z.string().optional(),
 			dialect: z.string().optional(),
@@ -94,6 +95,7 @@ async function generateAction(opts: any) {
 	const config = await getConfig({
 		cwd,
 		configPath: options.config,
+		tsconfig: options.tsconfig,
 	});
 	if (!config) {
 		console.error(
@@ -273,6 +275,10 @@ export const generate = new Command("generate")
 	.option(
 		"--config <config>",
 		"the path to the configuration file. defaults to the first configuration file found.",
+	)
+	.option(
+		"--tsconfig <tsconfig>",
+		"the tsconfig file to use for path aliases. defaults to tsconfig.json or jsconfig.json.",
 	)
 	.option("--output <output>", "the file to output to the generated schema")
 	.option(

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -310,6 +310,7 @@ function sanitizeBetterAuthConfig(config: any): any {
 async function getBetterAuthInfo(
 	projectRoot: string,
 	configPath?: string,
+	tsconfigName?: string,
 	suppressLogs = false,
 ) {
 	try {
@@ -328,6 +329,7 @@ async function getBetterAuthInfo(
 			const config = await getConfig({
 				cwd: projectRoot,
 				configPath,
+				tsconfig: tsconfigName,
 				shouldThrowOnError: true,
 			});
 			const packageInfo = await getPackageInfo();
@@ -411,6 +413,10 @@ export const info = new Command("info")
 	.description("Display system and Better Auth configuration information")
 	.option("--cwd <cwd>", "The working directory", process.cwd())
 	.option("--config <config>", "Path to the Better Auth configuration file")
+	.option(
+		"--tsconfig <tsconfig>",
+		"The tsconfig file to use for path aliases. Defaults to tsconfig.json or jsconfig.json.",
+	)
 	.option("-j, --json", "Output as JSON")
 	.option("-c, --copy", "Copy output to clipboard (requires pbcopy/xclip)")
 	.action(async (options) => {
@@ -425,6 +431,7 @@ export const info = new Command("info")
 		const betterAuthInfo = await getBetterAuthInfo(
 			projectRoot,
 			options.config,
+			options.tsconfig,
 			options.json,
 		);
 

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -19,6 +19,7 @@ export async function migrateAction(opts: any) {
 		.object({
 			cwd: z.string(),
 			config: z.string().optional(),
+			tsconfig: z.string().optional(),
 			y: z.boolean().optional(),
 			yes: z.boolean().optional(),
 		})
@@ -33,6 +34,7 @@ export async function migrateAction(opts: any) {
 	const config = await getConfig({
 		cwd,
 		configPath: options.config,
+		tsconfig: options.tsconfig,
 	});
 	if (!config) {
 		console.error(
@@ -190,6 +192,10 @@ export const migrate = new Command("migrate")
 	.option(
 		"--config <config>",
 		"the path to the configuration file. defaults to the first configuration file found.",
+	)
+	.option(
+		"--tsconfig <tsconfig>",
+		"the tsconfig file to use for path aliases. defaults to tsconfig.json or jsconfig.json.",
 	)
 	.option(
 		"-y, --yes",

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -64,11 +64,40 @@ function extractAliases(tsconfig: TsConfigResult): Record<string, string> {
 
 	for (const [alias, aliasPaths = []] of Object.entries(paths)) {
 		for (const aliasedPath of aliasPaths) {
-			const finalAlias = alias.slice(-1) === "*" ? alias.slice(0, -1) : alias;
-			const finalAliasedPath =
-				aliasedPath.slice(-1) === "*" ? aliasedPath.slice(0, -1) : aliasedPath;
+			const aliasStarIdx = alias.indexOf("*");
+			const pathStarIdx = aliasedPath.indexOf("*");
 
-			result[finalAlias || ""] = path.join(resolvedBaseUrl, finalAliasedPath);
+			if (aliasStarIdx === -1 && pathStarIdx === -1) {
+				// Exact alias, no wildcards
+				result[alias] = path.join(resolvedBaseUrl, aliasedPath);
+			} else if (pathStarIdx === aliasedPath.length - 1) {
+				// Trailing wildcard in path — prefix-based alias
+				const finalAlias =
+					aliasStarIdx !== -1 ? alias.slice(0, aliasStarIdx) : alias;
+				const finalAliasedPath = aliasedPath.slice(0, pathStarIdx);
+				result[finalAlias || ""] = path.join(resolvedBaseUrl, finalAliasedPath);
+			} else if (pathStarIdx !== -1 && aliasStarIdx !== -1) {
+				// Mid-path wildcard — expand by scanning the filesystem
+				const aliasPrefix = alias.slice(0, aliasStarIdx);
+				const aliasSuffix = alias.slice(aliasStarIdx + 1);
+				const pathPrefix = aliasedPath.slice(0, pathStarIdx);
+				const pathSuffix = aliasedPath.slice(pathStarIdx + 1);
+				const scanDir = path.join(resolvedBaseUrl, pathPrefix);
+
+				try {
+					const entries = fs.readdirSync(scanDir, { withFileTypes: true });
+					for (const entry of entries) {
+						if (!entry.isDirectory()) continue;
+						const candidate = path.join(scanDir, entry.name, pathSuffix);
+						if (fs.existsSync(candidate)) {
+							const concreteAlias = aliasPrefix + entry.name + aliasSuffix;
+							result[concreteAlias] = candidate;
+						}
+					}
+				} catch {
+					// Directory doesn't exist, skip
+				}
+			}
 		}
 	}
 	return result;
@@ -130,10 +159,15 @@ function collectReferencesAliases(
 	return result;
 }
 
-function getPathAliases(cwd: string): Record<string, string> | null {
-	const configName = fs.existsSync(path.join(cwd, "tsconfig.json"))
-		? "tsconfig.json"
-		: "jsconfig.json";
+function getPathAliases(
+	cwd: string,
+	tsconfigName?: string,
+): Record<string, string> | null {
+	const configName =
+		tsconfigName ??
+		(fs.existsSync(path.join(cwd, "tsconfig.json"))
+			? "tsconfig.json"
+			: "jsconfig.json");
 	const tsconfig = getTsconfig(cwd, configName);
 	if (!tsconfig) {
 		return null;
@@ -152,8 +186,8 @@ function getPathAliases(cwd: string): Record<string, string> | null {
 /**
  * .tsx files are not supported by Jiti.
  */
-const jitiOptions = (cwd: string): JitiOptions => {
-	const alias = getPathAliases(cwd) || {};
+const jitiOptions = (cwd: string, tsconfigName?: string): JitiOptions => {
+	const alias = getPathAliases(cwd, tsconfigName) || {};
 	return {
 		transformOptions: {
 			babel: {
@@ -188,10 +222,12 @@ const isDefaultExport = (
 export async function getConfig({
 	cwd,
 	configPath,
+	tsconfig,
 	shouldThrowOnError = false,
 }: {
 	cwd: string;
 	configPath?: string;
+	tsconfig?: string;
 	shouldThrowOnError?: boolean;
 }) {
 	try {
@@ -213,7 +249,7 @@ export async function getConfig({
 				dotenv: {
 					fileName: [".env", ".env.local"],
 				},
-				jitiOptions: jitiOptions(cwd),
+				jitiOptions: jitiOptions(cwd, tsconfig),
 				cwd,
 			});
 			if (!("auth" in config) && !isDefaultExport(config)) {
@@ -245,7 +281,7 @@ export async function getConfig({
 						dotenv: {
 							fileName: [".env", ".env.local"],
 						},
-						jitiOptions: jitiOptions(cwd),
+						jitiOptions: jitiOptions(cwd, tsconfig),
 						cwd,
 					});
 					const hasConfig = Object.keys(config).length > 0;

--- a/packages/cli/test/get-config.test.ts
+++ b/packages/cli/test/get-config.test.ts
@@ -1110,4 +1110,59 @@ describe("getConfig", async () => {
 			emailAndPassword: { enabled: true },
 		});
 	});
+
+	it("should resolve mid-path wildcard aliases", async () => {
+		const authPath = path.join(tmpDir, "src", "auth");
+		const dbPath = path.join(tmpDir, "libs", "db-sdk", "src");
+		await fs.mkdir(authPath, { recursive: true });
+		await fs.mkdir(dbPath, { recursive: true });
+
+		// Create tsconfig with mid-path wildcard: * is not trailing
+		await fs.writeFile(
+			path.join(tmpDir, "tsconfig.json"),
+			`{
+				"compilerOptions": {
+					"paths": {
+						"@backstage/*": ["./libs/*/src/index.ts"]
+					}
+				}
+			}`,
+		);
+
+		// Create the module that the wildcard should resolve to
+		await fs.writeFile(
+			path.join(dbPath, "index.ts"),
+			`class PrismaClient {
+				constructor() {}
+			}
+			export const db = new PrismaClient()`,
+		);
+
+		// Create auth.ts importing via the wildcard alias
+		await fs.writeFile(
+			path.join(authPath, "auth.ts"),
+			`import {betterAuth} from "better-auth";
+			 import {prismaAdapter} from "better-auth/adapters/prisma";
+			 import {db} from "@backstage/db-sdk";
+
+			 export const auth = betterAuth({
+					database: prismaAdapter(db, {
+							provider: 'sqlite'
+					}),
+					emailAndPassword: {
+						enabled: true,
+					}
+			 })`,
+		);
+
+		const config = await getConfig({
+			cwd: tmpDir,
+			configPath: "src/auth/auth.ts",
+		});
+
+		expect(config).not.toBe(null);
+		expect(config).toMatchObject({
+			emailAndPassword: { enabled: true },
+		});
+	});
 });


### PR DESCRIPTION
Improves the handling of wildcards in the middle of the path alias in tsconfig files, for example `"@web/*": ["./libs/web/*/src/index.ts"],`

Previously the CLI would simply ignore those wildcards and try to find directories matching the character literally thus leading to a module not found error. Now it expands the inner directories as to better reflect how typescript's module resolution works.

Also added a new `--tsconfig` option to the CLI, allowing us to specify which config should be used instead of a hardcoded `tsconfig.json`. This can be useful when the repo uses `tsconfig.base.json` or `tsconfig.app.json` for their path aliases.

Possibly fixes https://github.com/better-auth/better-auth/issues/8933 and https://github.com/better-auth/better-auth/issues/7033

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI resolution of `tsconfig` path aliases with mid-path wildcards and adds a `--tsconfig` flag to pick the config file. This matches TypeScript behavior and prevents “module not found” errors.

- **Bug Fixes**
  - Expands mid-path wildcards by scanning directories and creating concrete aliases (e.g., `./libs/*/src/index.ts`).
  - Preserves exact and trailing-wildcard alias handling.

- **New Features**
  - Adds `--tsconfig` to `generate`, `info`, and `migrate` to choose the config; defaults to `tsconfig.json` or `jsconfig.json`.
  - Passes the resolved alias map to the config loader so path aliases work during `getConfig`.

<sup>Written for commit 6b7b8aaac6f88616430d0b7df12c4be0446fab4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

