### PR TITLE
fix(sso): scope session to authenticated org after SSO login

### DIFF
--- a/.changeset/pr-9024.md
+++ b/.changeset/pr-9024.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+scope session to authenticated org after SSO login

--- a/packages/sso/src/constants.ts
+++ b/packages/sso/src/constants.ts
@@ -20,6 +20,21 @@ export const SAML_SESSION_KEY_PREFIX = "saml-session:";
 /** Prefix for reverse lookup of SAML session by Better Auth session ID */
 export const SAML_SESSION_BY_ID_PREFIX = "saml-session-by-id:";
 
+/**
+ * Prefix for storing which SSO provider authenticated a given session.
+ * Used to enforce org-scoped sessions: a session created via one org's SSO
+ * cannot switch to a different SSO-protected org.
+ *
+ * Stored as verification value: `sso-session:{sessionId}` -> providerId
+ *
+ * NOTE: This uses the verification table to avoid requiring a schema migration.
+ * The trade-off is an extra DB lookup on setActiveOrganization and the
+ * possibility of silent enforcement loss if verification values are purged.
+ * TODO: In a future major/minor release, migrate to a `ssoProviderId` field
+ * on the session schema for atomic writes and zero-cost lookups.
+ */
+export const SSO_SESSION_PROVIDER_PREFIX = "sso-session:";
+
 /** Prefix for LogoutRequest IDs used in SP-initiated SLO validation */
 export const LOGOUT_REQUEST_KEY_PREFIX = "saml-logout-request:";
 

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -1,8 +1,15 @@
 import type { BetterAuthPlugin } from "better-auth";
-import { createAuthMiddleware, getSessionFromCtx } from "better-auth/api";
+import {
+	APIError,
+	createAuthMiddleware,
+	getSessionFromCtx,
+} from "better-auth/api";
 import { XMLValidator } from "fast-xml-parser";
 import * as saml from "samlify";
-import { SAML_SESSION_BY_ID_PREFIX } from "./constants";
+import {
+	SAML_SESSION_BY_ID_PREFIX,
+	SSO_SESSION_PROVIDER_PREFIX,
+} from "./constants";
 import { assignOrganizationByDomain } from "./linking";
 import {
 	requestDomainVerification,
@@ -229,6 +236,66 @@ export function sso<O extends SSOOptions>(
 							await ctx.context.internalAdapter
 								.deleteVerificationByIdentifier(sessionLookupKey)
 								.catch(() => {});
+						}
+					}),
+				},
+				{
+					matcher(context) {
+						return context.path === "/organization/set-active";
+					},
+					/**
+					 * Prevent an SSO-authenticated session from switching to a
+					 * different org that also has SSO configured. The SSO provider
+					 * used during login is stored as a verification value (see
+					 * SSO_SESSION_PROVIDER_PREFIX) and looked up here.
+					 *
+					 * NOTE: Uses verification table, not a session field, to avoid
+					 * schema migrations. See constants.ts for trade-off notes.
+					 * TODO: Migrate to session field `ssoProviderId` in a future release.
+					 */
+					handler: createAuthMiddleware(async (ctx: any) => {
+						if (!ctx.context.hasPlugin("organization")) return;
+
+						const session = await getSessionFromCtx(ctx);
+						if (!session) return;
+
+						const verification =
+							await ctx.context.internalAdapter.findVerificationValue(
+								`${SSO_SESSION_PROVIDER_PREFIX}${session.session.id}`,
+							);
+						if (!verification?.value) return;
+
+						const ssoProviderId = verification.value;
+
+						let organizationId = ctx.body?.organizationId;
+						const organizationSlug = ctx.body?.organizationSlug;
+
+						if (organizationId === null || organizationId === undefined) {
+							if (!organizationSlug) return;
+							const org = (await ctx.context.adapter.findOne({
+								model: "organization",
+								where: [{ field: "slug", value: organizationSlug }],
+							})) as { id: string } | null;
+							if (!org) return;
+							organizationId = org.id;
+						}
+
+						const orgSSOProviders = (await ctx.context.adapter.findMany({
+							model: "ssoProvider",
+							where: [{ field: "organizationId", value: organizationId }],
+						})) as { providerId: string }[];
+
+						if (!orgSSOProviders.length) return;
+
+						const matchesProvider = orgSSOProviders.some(
+							(p: { providerId: string }) => p.providerId === ssoProviderId,
+						);
+
+						if (!matchesProvider) {
+							throw new APIError("FORBIDDEN", {
+								message:
+									"This organization requires authentication through its SSO provider",
+							});
 						}
 					}),
 				},

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1,5 +1,6 @@
 import { betterFetch } from "@better-fetch/fetch";
 import { createAuthClient } from "better-auth/client";
+import { organizationClient } from "better-auth/client/plugins";
 import { organization } from "better-auth/plugins";
 import { getTestInstance } from "better-auth/test";
 import { OAuth2Server } from "oauth2-mock-server";
@@ -1526,5 +1527,202 @@ describe("SSO OIDC UserInfo endpoint sub claim mapping", async () => {
 			fetchOptions: { headers: sessionHeaders },
 		});
 		expect(session.data?.user.email).toBe("userinfo-only@test.com");
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9013
+ */
+describe("SSO org-scoped session: user logged in via one org SSO should not access another org", async () => {
+	const { auth, signInWithTestUser, customFetchImpl, cookieSetter } =
+		await getTestInstance({
+			trustedOrigins: ["http://localhost:8080"],
+			plugins: [sso(), organization()],
+		});
+
+	const authClient = createAuthClient({
+		plugins: [ssoClient(), organizationClient()],
+		baseURL: "http://localhost:3000",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	const userinfoHandler = (userInfoResponse: any) => {
+		userInfoResponse.body = {
+			email: "shared-user@org-scoped.com",
+			name: "Shared User",
+			sub: "shared-user-sub",
+			picture: "https://test.com/shared.png",
+			email_verified: true,
+		};
+		userInfoResponse.statusCode = 200;
+	};
+
+	const tokenHandler = (token: any) => {
+		token.payload.email = "shared-user@org-scoped.com";
+		token.payload.email_verified = true;
+		token.payload.name = "Shared User";
+		token.payload.sub = "shared-user-sub";
+	};
+
+	beforeAll(async () => {
+		await server.issuer.keys.generate("RS256");
+		server.service.removeAllListeners("beforeUserinfo");
+		server.service.removeAllListeners("beforeTokenSigning");
+		server.service.on("beforeUserinfo", userinfoHandler);
+		server.service.on("beforeTokenSigning", tokenHandler);
+		await server.start(8080, "localhost");
+	});
+
+	afterAll(async () => {
+		server.service.removeListener("beforeUserinfo", userinfoHandler);
+		server.service.removeListener("beforeTokenSigning", tokenHandler);
+		await server.stop().catch(() => {});
+	});
+
+	async function simulateOAuthFlow(authUrl: string, headers: Headers) {
+		let location: string | null = null;
+		await betterFetch(authUrl, {
+			method: "GET",
+			redirect: "manual",
+			onError(context) {
+				location = context.response.headers.get("location");
+			},
+		});
+
+		if (!location) throw new Error("No redirect location found");
+		const newHeaders = new Headers();
+		let callbackURL = "";
+		await betterFetch(location, {
+			method: "GET",
+			customFetchImpl,
+			headers,
+			onError(context) {
+				callbackURL = context.response.headers.get("location") || "";
+				cookieSetter(newHeaders)(context);
+			},
+		});
+
+		return { callbackURL, headers: newHeaders };
+	}
+
+	it("should scope session to the SSO-authenticated org and prevent access to another SSO-protected org", async () => {
+		const { headers: adminHeaders } = await signInWithTestUser();
+
+		const orgA = await auth.api.createOrganization({
+			body: { name: "Org A", slug: "org-a" },
+			headers: adminHeaders,
+		});
+
+		const orgB = await auth.api.createOrganization({
+			body: { name: "Org B", slug: "org-b" },
+			headers: adminHeaders,
+		});
+
+		await auth.api.registerSSOProvider({
+			body: {
+				issuer: server.issuer.url!,
+				domain: "org-scoped.com",
+				providerId: "org-a-sso",
+				organizationId: orgA!.id,
+				oidcConfig: {
+					clientId: "org-a-client",
+					clientSecret: "org-a-secret",
+					authorizationEndpoint: `${server.issuer.url}/authorize`,
+					tokenEndpoint: `${server.issuer.url}/token`,
+					jwksEndpoint: `${server.issuer.url}/jwks`,
+					discoveryEndpoint: `${server.issuer.url}/.well-known/openid-configuration`,
+					mapping: {
+						id: "sub",
+						email: "email",
+						emailVerified: "email_verified",
+						name: "name",
+						image: "picture",
+					},
+				},
+			},
+			headers: adminHeaders,
+		});
+
+		await auth.api.registerSSOProvider({
+			body: {
+				issuer: server.issuer.url!,
+				domain: "org-scoped-b.com",
+				providerId: "org-b-sso",
+				organizationId: orgB!.id,
+				oidcConfig: {
+					clientId: "org-b-client",
+					clientSecret: "org-b-secret",
+					authorizationEndpoint: `${server.issuer.url}/authorize`,
+					tokenEndpoint: `${server.issuer.url}/token`,
+					jwksEndpoint: `${server.issuer.url}/jwks`,
+					discoveryEndpoint: `${server.issuer.url}/.well-known/openid-configuration`,
+					mapping: {
+						id: "sub",
+						email: "email",
+						emailVerified: "email_verified",
+						name: "name",
+						image: "picture",
+					},
+				},
+			},
+			headers: adminHeaders,
+		});
+
+		// SSO sign-in via Org A's provider
+		const signInHeaders = new Headers();
+		const res = await authClient.signIn.sso({
+			providerId: "org-a-sso",
+			callbackURL: "/dashboard",
+			fetchOptions: {
+				throw: true,
+				onSuccess: cookieSetter(signInHeaders),
+			},
+		});
+		expect(res.url).toContain("http://localhost:8080/authorize");
+
+		const { callbackURL, headers: ssoSessionHeaders } = await simulateOAuthFlow(
+			res.url,
+			signInHeaders,
+		);
+		expect(callbackURL).toContain("/dashboard");
+
+		// User is now provisioned as a member of Org A via SSO
+		const orgAData = await auth.api.getFullOrganization({
+			query: { organizationId: orgA!.id },
+			headers: ssoSessionHeaders,
+		});
+		const memberInOrgA = orgAData?.members.find(
+			(m: any) => m.user.email === "shared-user@org-scoped.com",
+		);
+		expect(memberInOrgA).toBeDefined();
+
+		// Manually add the same user to Org B (simulating pre-existing membership)
+		await auth.api.addMember({
+			body: {
+				organizationId: orgB!.id,
+				userId: memberInOrgA!.userId,
+				role: "member",
+			},
+			headers: adminHeaders,
+		});
+
+		// After SSO via Org A, the session should have activeOrganizationId set to Org A
+		const session = await authClient.getSession({
+			fetchOptions: { headers: ssoSessionHeaders },
+		});
+		expect(session.data?.session.activeOrganizationId).toBe(orgA!.id);
+
+		// User should NOT be able to switch to Org B (which has its own SSO provider)
+		// since they did not authenticate via Org B's SSO
+		const setActiveResult = await authClient.organization.setActive({
+			organizationId: orgB!.id,
+			fetchOptions: {
+				headers: ssoSessionHeaders,
+				throw: false,
+			},
+		});
+		expect(setActiveResult.error).toBeDefined();
 	});
 });

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1607,16 +1607,28 @@ describe("SSO org-scoped session: user logged in via one org SSO should not acce
 		return { callbackURL, headers: newHeaders };
 	}
 
-	it("should scope session to the SSO-authenticated org and prevent access to another SSO-protected org", async () => {
-		const { headers: adminHeaders } = await signInWithTestUser();
+	let adminHeaders: Headers;
+	let orgA: any;
+	let orgB: any;
+	let orgC: any;
+	let ssoSessionHeaders: Headers;
+	let ssoUserId: string;
 
-		const orgA = await auth.api.createOrganization({
+	it("setup: create orgs, SSO providers, and perform SSO login", async () => {
+		({ headers: adminHeaders } = await signInWithTestUser());
+
+		orgA = await auth.api.createOrganization({
 			body: { name: "Org A", slug: "org-a" },
 			headers: adminHeaders,
 		});
 
-		const orgB = await auth.api.createOrganization({
+		orgB = await auth.api.createOrganization({
 			body: { name: "Org B", slug: "org-b" },
+			headers: adminHeaders,
+		});
+
+		orgC = await auth.api.createOrganization({
+			body: { name: "Org C (no SSO)", slug: "org-c" },
 			headers: adminHeaders,
 		});
 
@@ -1682,10 +1694,11 @@ describe("SSO org-scoped session: user logged in via one org SSO should not acce
 		});
 		expect(res.url).toContain("http://localhost:8080/authorize");
 
-		const { callbackURL, headers: ssoSessionHeaders } = await simulateOAuthFlow(
+		const { callbackURL, headers: sessionHeaders } = await simulateOAuthFlow(
 			res.url,
 			signInHeaders,
 		);
+		ssoSessionHeaders = sessionHeaders;
 		expect(callbackURL).toContain("/dashboard");
 
 		// User is now provisioned as a member of Org A via SSO
@@ -1697,32 +1710,77 @@ describe("SSO org-scoped session: user logged in via one org SSO should not acce
 			(m: any) => m.user.email === "shared-user@org-scoped.com",
 		);
 		expect(memberInOrgA).toBeDefined();
+		ssoUserId = memberInOrgA!.userId;
 
-		// Manually add the same user to Org B (simulating pre-existing membership)
+		// Add the SSO user as a member of Org B and Org C
 		await auth.api.addMember({
 			body: {
 				organizationId: orgB!.id,
-				userId: memberInOrgA!.userId,
+				userId: ssoUserId,
 				role: "member",
 			},
 			headers: adminHeaders,
 		});
+		await auth.api.addMember({
+			body: {
+				organizationId: orgC!.id,
+				userId: ssoUserId,
+				role: "member",
+			},
+			headers: adminHeaders,
+		});
+	});
 
-		// After SSO via Org A, the session should have activeOrganizationId set to Org A
+	it("should set activeOrganizationId to the SSO-authenticated org after login", async () => {
 		const session = await authClient.getSession({
 			fetchOptions: { headers: ssoSessionHeaders },
 		});
 		expect(session.data?.session.activeOrganizationId).toBe(orgA!.id);
+	});
 
-		// User should NOT be able to switch to Org B (which has its own SSO provider)
-		// since they did not authenticate via Org B's SSO
-		const setActiveResult = await authClient.organization.setActive({
+	it("should allow re-setting active org to the SSO-authenticated org", async () => {
+		const result = await authClient.organization.setActive({
+			organizationId: orgA!.id,
+			fetchOptions: {
+				headers: ssoSessionHeaders,
+				throw: false,
+			},
+		});
+		expect(result.error).toBeNull();
+	});
+
+	it("should block switching to another SSO-protected org via organizationId", async () => {
+		const result = await authClient.organization.setActive({
 			organizationId: orgB!.id,
 			fetchOptions: {
 				headers: ssoSessionHeaders,
 				throw: false,
 			},
 		});
-		expect(setActiveResult.error).toBeDefined();
+		expect(result.error).toBeDefined();
+		expect(result.error!.status).toBe(403);
+	});
+
+	it("should block switching to another SSO-protected org via organizationSlug", async () => {
+		const result = await authClient.organization.setActive({
+			organizationSlug: "org-b",
+			fetchOptions: {
+				headers: ssoSessionHeaders,
+				throw: false,
+			},
+		});
+		expect(result.error).toBeDefined();
+		expect(result.error!.status).toBe(403);
+	});
+
+	it("should allow switching to an org that has no SSO configured", async () => {
+		const result = await authClient.organization.setActive({
+			organizationId: orgC!.id,
+			fetchOptions: {
+				headers: ssoSessionHeaders,
+				throw: false,
+			},
+		});
+		expect(result.error).toBeNull();
 	});
 });

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -90,6 +90,70 @@ function getOIDCRedirectURI(
 	return `${baseURL}/sso/callback/${providerId}`;
 }
 
+/**
+ * After SSO authentication, set the active organization on the session (if the
+ * provider is org-linked) and record which SSO provider was used.
+ *
+ * The SSO provider ID is stored in the verification table (not a session field)
+ * to avoid requiring a schema migration. The `before` hook on
+ * `/organization/set-active` reads this value to prevent cross-org access.
+ *
+ * Trade-offs of verification-table approach vs. session field:
+ *  + No schema migration required
+ *  + Follows existing SAML SLO pattern in this plugin
+ *  - Extra DB read when checking setActiveOrganization
+ *  - Fails open if verification values are purged unexpectedly
+ *
+ * TODO: In a future release, migrate to a `ssoProviderId` session field for
+ * atomic writes and zero-cost lookups during enforcement.
+ */
+async function setSSOSessionContext(
+	ctx: {
+		context: {
+			internalAdapter: {
+				updateSession: (
+					token: string,
+					data: Record<string, any>,
+				) => Promise<any>;
+				createVerificationValue: (data: {
+					identifier: string;
+					value: string;
+					expiresAt: Date;
+				}) => Promise<any>;
+			};
+			hasPlugin: (name: string) => boolean;
+		};
+	},
+	session: { token: string; id: string; expiresAt: Date } & Record<string, any>,
+	provider: { providerId: string; organizationId?: string | null },
+) {
+	let updatedSession: any = session;
+
+	if (provider.organizationId && ctx.context.hasPlugin("organization")) {
+		try {
+			const result = await ctx.context.internalAdapter.updateSession(
+				session.token,
+				{ activeOrganizationId: provider.organizationId },
+			);
+			updatedSession = result || session;
+		} catch {
+			// best-effort
+		}
+	}
+
+	try {
+		await ctx.context.internalAdapter.createVerificationValue({
+			identifier: `${constants.SSO_SESSION_PROVIDER_PREFIX}${session.id}`,
+			value: provider.providerId,
+			expiresAt: session.expiresAt,
+		});
+	} catch {
+		// best-effort
+	}
+
+	return updatedSession;
+}
+
 export interface TimestampValidationOptions {
 	clockSkew?: number;
 	requireTimestamps?: boolean;
@@ -1789,8 +1853,10 @@ async function handleOIDCCallback(
 		provisioningOptions: options?.organizationProvisioning,
 	});
 
+	const updatedSession = await setSSOSessionContext(ctx, session, provider);
+
 	await setSessionCookie(ctx, {
-		session,
+		session: updatedSession,
 		user,
 	});
 	let toRedirectTo: string;
@@ -2439,7 +2505,9 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 				provisioningOptions: options?.organizationProvisioning,
 			});
 
-			await setSessionCookie(ctx, { session, user });
+			const updatedSession = await setSSOSessionContext(ctx, session, provider);
+
+			await setSessionCookie(ctx, { session: updatedSession, user });
 
 			if (options?.saml?.enableSingleLogout && extract.nameID) {
 				const samlSessionKey = `${constants.SAML_SESSION_KEY_PREFIX}${provider.providerId}:${extract.nameID}`;
@@ -2958,7 +3026,9 @@ export const acsEndpoint = (options?: SSOOptions) => {
 				provisioningOptions: options?.organizationProvisioning,
 			});
 
-			await setSessionCookie(ctx, { session, user });
+			const updatedSession = await setSSOSessionContext(ctx, session, provider);
+
+			await setSessionCookie(ctx, { session: updatedSession, user });
 			if (options?.saml?.enableSingleLogout && extract.nameID) {
 				const samlSessionKey = `${constants.SAML_SESSION_KEY_PREFIX}${providerId}:${extract.nameID}`;
 				const samlSessionData: SAMLSessionRecord = {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -122,6 +122,9 @@ async function setSSOSessionContext(
 				}) => Promise<any>;
 			};
 			hasPlugin: (name: string) => boolean;
+			logger: {
+				warn: (message: string, data?: Record<string, unknown>) => void;
+			};
 		};
 	},
 	session: { token: string; id: string; expiresAt: Date } & Record<string, any>,
@@ -137,19 +140,22 @@ async function setSSOSessionContext(
 			);
 			updatedSession = result || session;
 		} catch {
-			// best-effort
+			// best-effort: activeOrganizationId is a UX convenience, not a security boundary
 		}
 	}
 
-	try {
-		await ctx.context.internalAdapter.createVerificationValue({
+	await ctx.context.internalAdapter
+		.createVerificationValue({
 			identifier: `${constants.SSO_SESSION_PROVIDER_PREFIX}${session.id}`,
 			value: provider.providerId,
 			expiresAt: session.expiresAt,
-		});
-	} catch {
-		// best-effort
-	}
+		})
+		.catch((e: unknown) =>
+			ctx.context.logger.warn(
+				"Failed to create SSO session provider record. Cross-org session enforcement will not apply to this session.",
+				{ error: e },
+			),
+		);
 
 	return updatedSession;
 }


### PR DESCRIPTION
Closes #9013

## Summary

- Fix SSO org-scoped session security issue where a user authenticated via one org's SSO could access a different org that has its own SSO configured (#9013)
- After SSO login (OIDC or SAML), automatically set `activeOrganizationId` on the session to the SSO provider's org
- Store the authenticating SSO provider ID in the verification table per session, and add a `before` hook on `setActiveOrganization` that prevents switching to an SSO-protected org the session didn't authenticate through

## Migration considerations
This fix uses the verification table to track which SSO provider authenticated each session, rather than adding a `ssoProviderId` field to the session schema. This was a deliberate choice to avoid requiring users to run a database migration for a patch-level security fix.

The trade-off is that enforcement relies on ephemeral verification values: an extra DB lookup occurs on every `setActiveOrganization` call for SSO sessions, and if verification records are purged or expire unexpectedly, the restriction silently falls back to unrestricted access (fails open).

In a future minor release, we should migrate this to a proper `ssoProviderId` field on the session schema. That approach provides atomic writes (the SSO context is set in the same `updateSession` call), zero-cost lookups (the field is already loaded with the session), and guaranteed enforcement for the lifetime of the session. It will require a schema migration.
