### PR TITLE
fix(ci): make `lint:dependencies` script cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format:md": "pnpm --filter docs format:md",
     "format:check": "pnpm --filter docs format:check",
     "lint": "biome check . --error-on-warnings",
-    "lint:dependencies": "knip; c1=$?; knip --production; c2=$?; [ $c1 -eq 0 ] && [ $c2 -eq 0 ]",
+    "lint:dependencies": "knip && knip --production",
     "lint:fix": "biome check . --fix --unsafe",
     "lint:spell": "cspell . --color",
     "lint:types": "turbo lint:types --filter=./packages/*",


### PR DESCRIPTION
## Summary
- Replace POSIX-only shell constructs (`$?`, `[ -eq ]`, `;`) in the `lint:dependencies` script with `&&` chaining
- The previous script used bash-specific syntax that breaks on Windows (`cmd.exe` / PowerShell)
- `&&` works identically across bash, zsh, cmd.exe, and PowerShell

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `lint:dependencies` script cross‑platform by replacing POSIX-only exit-code checks with `&&` chaining. Fixes failures on Windows (cmd/PowerShell) while keeping the same behavior on Unix shells.

<sup>Written for commit 10bcb3a8a9b7f096df647988342e6ee5bcc525e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

