### PR TITLE
chore: optimize pre-commit hooks for faster commits

### DIFF
--- a/.cspell.jsonc
+++ b/.cspell.jsonc
@@ -98,6 +98,7 @@
 		"e2e/smoke/test/fixtures/cloudflare/worker-configuration.d.ts",
 		"*.config.js",
 		"*.config.ts",
-		"*.json"
+		"*.json",
+		".gitignore"
 	]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,10 @@ web_modules/
 
 .eslintcache
 
+# CSpell cache
+
+.cspellcache
+
 # Optional stylelint cache
 
 .stylelintcache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,18 +152,9 @@ See [SECURITY.md](/SECURITY.md) for details.
 
 ### Code Formatting and Linting
 
-[Lefthook](https://lefthook.dev/) runs the following checks in parallel on every
-commit:
-
-| Hook | What it does | Runs on |
-| --- | --- | --- |
-| **biome** | Linting, formatting, and import sorting (auto-fixes and re-stages) | All staged files |
-| **spell** | Spell checking with cspell | All staged files |
-| **format** | Markdown formatting with remark | Staged `docs/**/*.{md,mdx}` only |
-| **lockfile** | Verifies `pnpm-lock.yaml` is in sync | Only when `package.json` or lockfile changes |
-
-Additional checks like dependency linting (knip), type checking, and tests run
-in CI on every pull request.
+[Lefthook](https://lefthook.dev/) runs linting, formatting, and spell checking
+in parallel on every commit. Additional checks like dependency linting (knip),
+type checking, and tests run in CI.
 
 To skip a specific hook by command name, use `LEFTHOOK_EXCLUDE`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,8 +152,24 @@ See [SECURITY.md](/SECURITY.md) for details.
 
 ### Code Formatting and Linting
 
-A pre-commit hook automatically checks and fixes staged files when you commit
-using [Biome](https://biomejs.dev/).
+[Lefthook](https://lefthook.dev/) runs the following checks in parallel on every
+commit:
+
+| Hook | What it does | Runs on |
+| --- | --- | --- |
+| **biome** | Linting, formatting, and import sorting (auto-fixes and re-stages) | All staged files |
+| **spell** | Spell checking with cspell | All staged files |
+| **format** | Markdown formatting with remark | Staged `docs/**/*.{md,mdx}` only |
+| **lockfile** | Verifies `pnpm-lock.yaml` is in sync | Only when `package.json` or lockfile changes |
+
+Additional checks like dependency linting (knip), type checking, and tests run
+in CI on every pull request.
+
+To skip a specific hook by command name, use `LEFTHOOK_EXCLUDE`:
+
+```bash
+LEFTHOOK_EXCLUDE=spell git commit -m "your message"
+```
 
 Run `pnpm typecheck` and make sure it passes before opening your PR.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,12 +3,13 @@ output:
   - failure
 
 pre-commit:
+  parallel: true
   commands:
     biome:
       run: pnpm biome check --write --error-on-warnings --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
     spell:
-      run: pnpm cspell --no-progress --no-summary --no-must-find-files {staged_files}
+      run: pnpm cspell --cache --no-progress --no-summary --no-must-find-files {staged_files}
     format:
       glob: "docs/**/*.{md,mdx}"
       root: "docs/"
@@ -17,5 +18,3 @@ pre-commit:
     lockfile:
       glob: "{package.json,pnpm-lock.yaml,pnpm-workspace.yaml,packages/*/package.json}"
       run: pnpm install --frozen-lockfile --ignore-scripts
-    dependencies:
-      run: pnpm lint:dependencies


### PR DESCRIPTION
## Summary

- Add `parallel: true` to lefthook — hooks now run concurrently instead of sequentially
- Remove knip (`lint:dependencies`) from pre-commit — it has no incremental mode and always scans the full repo (~11s). Already runs in CI
- Add `--cache` to cspell for faster repeated spell checks
- Add `.cspellcache` and `lefthook-local.yml` to `.gitignore`
- Ignore `.gitignore` in cspell config (standard boilerplate template words)
- Document pre-commit hooks and contributor escape hatches in `CONTRIBUTING.md`

**Before:** ~16.8s sequential (biome + cspell + knip two passes)
**After:** ~4-5s parallel (bottlenecked on biome, which does real work)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up pre-commit by running hooks in parallel and caching spell checks. Commit time drops from ~16.8s to ~4–5s.

- **Refactors**
  - Enabled concurrent hooks via `lefthook` (`parallel: true`).
  - Added `--cache` to `cspell`; ignore `.gitignore`; added `.cspellcache` to `.gitignore`.
  - Removed `knip` from pre-commit (CI-only).
  - Simplified and documented pre-commit behavior in CONTRIBUTING, including `LEFTHOOK_EXCLUDE`.

<sup>Written for commit a4253e2878d4eb3b80fdca75861399fdcd3b04e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

