### PR TITLE
docs: add 'better-auth-audit-logs' plugin to community table

### DIFF
--- a/docs/components/community-plugins-table.tsx
+++ b/docs/components/community-plugins-table.tsx
@@ -323,6 +323,17 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/C-W-D-Harshit.png",
 		},
 	},
+	{
+		name: "better-auth-audit-logs",
+		url: "https://github.com/ejirocodes/better-auth-audit-logs",
+		description:
+			"Audit log plugin for Better Auth. Auto-captures auth events with severity inference, PII redaction, custom storage backends, and retention policies.",
+		author: {
+			name: "ejirocodes",
+			github: "ejirocodes",
+			avatar: "https://github.com/ejirocodes.png",
+		},
+	},
 ];
 export function CommunityPluginsTable() {
 	const [sorting, setSorting] = useState<SortingState>([]);


### PR DESCRIPTION
## Summary
- Added the "better-auth-audit-logs" community plugin to the docs table

Re-submission of #8172 (cherry-picked in #8182, which was merged but never made it to prod).

## Test plan
- [ ] Verify the community plugins table renders correctly with the new entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the `better-auth-audit-logs` community plugin to the Community Plugins table in docs so it’s easy to discover with its link, description, and author details.

<sup>Written for commit 24f2d8c2192743b6cd00aa0473e493e6cee43742. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

