### PR TITLE
fix(sso): include RelayState in signed SAML AuthnRequests

### DIFF
--- a/.changeset/saml-relay-state-signing.md
+++ b/.changeset/saml-relay-state-signing.md
@@ -1,0 +1,8 @@
+---
+"better-auth": patch
+---
+
+fix(sso): include RelayState in signed SAML AuthnRequests per SAML 2.0 Bindings §3.4.4.1
+
+- RelayState is now passed to samlify's ServiceProvider constructor so it is included in the redirect binding signature. Previously it was appended after the signature, causing spec-compliant IdPs to reject signed AuthnRequests.
+- `authnRequestsSigned: true` without a private key now throws instead of silently sending unsigned requests.

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1326,11 +1326,17 @@ export const signInSSO = (options?: SSOOptions) => {
 					!parsedSamlConfig.spMetadata?.privateKey &&
 					!parsedSamlConfig.privateKey
 				) {
-					ctx.context.logger.warn(
-						"authnRequestsSigned is enabled but no privateKey provided - AuthnRequests will not be signed",
-						{ providerId: provider.providerId },
-					);
+					throw new APIError("BAD_REQUEST", {
+						message:
+							"authnRequestsSigned is enabled but no privateKey provided in spMetadata or samlConfig",
+					});
 				}
+
+				const { state: relayState } = await generateRelayState(
+					ctx,
+					undefined,
+					false,
+				);
 
 				let metadata = parsedSamlConfig.spMetadata.metadata;
 
@@ -1367,6 +1373,7 @@ export const signInSSO = (options?: SSOOptions) => {
 						parsedSamlConfig.spMetadata?.privateKey ||
 						parsedSamlConfig.privateKey,
 					privateKeyPass: parsedSamlConfig.spMetadata?.privateKeyPass,
+					relayState,
 				});
 
 				const idpData = parsedSamlConfig.idpMetadata;
@@ -1411,12 +1418,6 @@ export const signInSSO = (options?: SSOOptions) => {
 					});
 				}
 
-				const { state: relayState } = await generateRelayState(
-					ctx,
-					undefined,
-					false,
-				);
-
 				const shouldSaveRequest =
 					loginRequest.id &&
 					options?.saml?.enableInResponseToValidation !== false;
@@ -1437,7 +1438,7 @@ export const signInSSO = (options?: SSOOptions) => {
 				}
 
 				return ctx.json({
-					url: `${loginRequest.context}&RelayState=${encodeURIComponent(relayState)}`,
+					url: loginRequest.context,
 					redirect: true,
 				});
 			}

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -1,4 +1,9 @@
-import { randomUUID } from "node:crypto";
+import {
+	createPrivateKey,
+	createPublicKey,
+	createVerify,
+	randomUUID,
+} from "node:crypto";
 import type { createServer } from "node:http";
 import { betterFetch } from "@better-fetch/fetch";
 import { betterAuth } from "better-auth";
@@ -356,15 +361,62 @@ const createTemplateCallback =
 		};
 	};
 
-const createMockSAMLIdP = (port: number) => {
+/**
+ * Verifies a SAML HTTP-Redirect binding signature per SAML 2.0 Bindings §3.4.4.1.
+ * The signed string is reconstructed from the raw query string (everything before &Signature=).
+ */
+function verifyRedirectSignature(
+	rawUrl: string,
+	spSigningKey: string,
+	spSigningKeyPass?: string,
+): boolean {
+	const queryStart = rawUrl.indexOf("?");
+	if (queryStart === -1) return false;
+	const queryString = rawUrl.substring(queryStart + 1);
+
+	const signatureParam = "&Signature=";
+	const signatureIndex = queryString.indexOf(signatureParam);
+	if (signatureIndex === -1) return false;
+
+	const signedData = queryString.substring(0, signatureIndex);
+	const signatureValue = decodeURIComponent(
+		queryString.substring(signatureIndex + signatureParam.length),
+	);
+
+	const cleanKey = spSigningKey
+		.split("\n")
+		.map((line) => line.trim())
+		.join("\n");
+	const privateKey = createPrivateKey({
+		key: cleanKey,
+		format: "pem",
+		...(spSigningKeyPass ? { passphrase: spSigningKeyPass } : {}),
+	});
+	const publicKey = createPublicKey(privateKey);
+
+	const verifier = createVerify("RSA-SHA256");
+	verifier.update(signedData);
+	return verifier.verify(publicKey, signatureValue, "base64");
+}
+
+interface MockIdPOptions {
+	idpMetadataXml?: string;
+	wantAuthnRequestsSigned?: boolean;
+	spSigningKey?: string;
+	spSigningKeyPass?: string;
+}
+
+const createMockSAMLIdP = (port: number, options: MockIdPOptions = {}) => {
 	const app: ExpressApp = express();
 	let server: ReturnType<typeof createServer> | undefined;
 
 	app.use(bodyParser.urlencoded({ extended: true }));
 	app.use(bodyParser.json());
 
+	const idpMetadataXml = options.idpMetadataXml || idpMetadata;
+
 	const idp = saml.IdentityProvider({
-		metadata: idpMetadata,
+		metadata: idpMetadataXml,
 		privateKey: idPk,
 		isAssertionEncrypted: false,
 		privateKeyPass: "jXmKf9By6ruLnUdRo90G",
@@ -396,9 +448,43 @@ const createMockSAMLIdP = (port: number) => {
 	const sp = saml.ServiceProvider({
 		metadata: spMetadata,
 	});
-	app.get(
-		"/api/sso/saml2/idp/post",
-		async (req: ExpressRequest, res: ExpressResponse) => {
+
+	const handleIdPRequest = async (
+		req: ExpressRequest,
+		res: ExpressResponse,
+	) => {
+		try {
+			if (options.wantAuthnRequestsSigned) {
+				const { SAMLRequest, SigAlg, Signature } = req.query;
+				if (!SAMLRequest || !SigAlg || !Signature) {
+					return res
+						.status(400)
+						.json({ error: "Missing required signature parameters" });
+				}
+				if (!options.spSigningKey) {
+					return res
+						.status(500)
+						.json({ error: "Mock IdP not configured with SP signing key" });
+				}
+				const expectedSigAlg =
+					"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+				if (String(SigAlg) !== expectedSigAlg) {
+					return res.status(400).json({
+						error: `Unsupported signature algorithm: ${String(SigAlg)}`,
+					});
+				}
+				const isValid = verifyRedirectSignature(
+					req.originalUrl,
+					options.spSigningKey,
+					options.spSigningKeyPass,
+				);
+				if (!isValid) {
+					return res
+						.status(400)
+						.json({ error: "Invalid AuthnRequest signature" });
+				}
+			}
+
 			const emailCase = req.query.emailCase as string;
 			const emailValue =
 				emailCase === "mixed" ? "TestUser@Example.com" : "test@email.com";
@@ -414,30 +500,16 @@ const createMockSAMLIdP = (port: number) => {
 				user,
 				createTemplateCallback(idp, sp, user.emailAddress),
 			);
-			res.status(200).send({ samlResponse: context, entityEndpoint });
-		},
-	);
-	app.get(
-		"/api/sso/saml2/idp/redirect",
-		async (req: ExpressRequest, res: ExpressResponse) => {
-			const emailCase = req.query.emailCase as string;
-			const emailValue =
-				emailCase === "mixed" ? "TestUser@Example.com" : "test@email.com";
-			const user = {
-				email: emailValue,
-				emailAddress: emailValue,
-				famName: "hello world",
-			};
-			const { context, entityEndpoint } = await idp.createLoginResponse(
-				sp,
-				{} as any,
-				saml.Constants.wording.binding.post,
-				user,
-				createTemplateCallback(idp, sp, user.emailAddress),
-			);
-			res.status(200).send({ samlResponse: context, entityEndpoint });
-		},
-	);
+			res.status(200).json({ samlResponse: context, entityEndpoint });
+		} catch (error) {
+			res.status(500).json({
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	};
+
+	app.get("/api/sso/saml2/idp/post", handleIdPRequest);
+	app.get("/api/sso/saml2/idp/redirect", handleIdPRequest);
 	app.post("/api/sso/saml2/sp/acs", async (req: any, res: any) => {
 		try {
 			const parseResult = await sp.parseLoginResponse(
@@ -480,7 +552,7 @@ const createMockSAMLIdP = (port: number) => {
 		"/api/sso/saml2/idp/metadata",
 		(req: ExpressRequest, res: ExpressResponse) => {
 			res.type("application/xml");
-			res.send(idpMetadata);
+			res.send(idpMetadataXml);
 		},
 	);
 	const start = () =>
@@ -589,9 +661,8 @@ describe("SAML SSO with defaultSSO array", async () => {
 });
 
 describe("SAML SSO with signed AuthnRequests", async () => {
-	// IdP metadata with WantAuthnRequestsSigned="true" for testing signed requests
 	const idpMetadataWithSignedRequests = `
-    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://localhost:8081/api/sso/saml2/idp/metadata">
+    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://localhost:8082/api/sso/saml2/idp/metadata">
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:KeyDescriptor use="signing">
         <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
@@ -600,11 +671,18 @@ describe("SAML SSO with signed AuthnRequests", async () => {
             </ds:X509Data>
         </ds:KeyInfo>
         </md:KeyDescriptor>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:8081/api/sso/saml2/idp/redirect"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8081/api/sso/saml2/idp/post"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:8082/api/sso/saml2/idp/redirect"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8082/api/sso/saml2/idp/post"/>
         </md:IDPSSODescriptor>
     </md:EntityDescriptor>
     `;
+
+	const signedMockIdP = createMockSAMLIdP(8082, {
+		idpMetadataXml: idpMetadataWithSignedRequests,
+		wantAuthnRequestsSigned: true,
+		spSigningKey: idPk,
+		spSigningKeyPass: "jXmKf9By6ruLnUdRo90G",
+	});
 
 	const data = {
 		user: [],
@@ -619,13 +697,13 @@ describe("SAML SSO with signed AuthnRequests", async () => {
 	const ssoOptions = {
 		defaultSSO: [
 			{
-				domain: "localhost:8081",
+				domain: "localhost:8082",
 				providerId: "signed-saml",
 				samlConfig: {
-					issuer: "http://localhost:8081",
-					entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+					issuer: "http://localhost:8082",
+					entryPoint: "http://localhost:8082/api/sso/saml2/idp/redirect",
 					cert: certificate,
-					callbackUrl: "http://localhost:8081/dashboard",
+					callbackUrl: "http://localhost:8082/dashboard",
 					wantAssertionsSigned: false,
 					authnRequestsSigned: true,
 					signatureAlgorithm: "sha256",
@@ -653,7 +731,15 @@ describe("SAML SSO with signed AuthnRequests", async () => {
 		plugins: [sso(ssoOptions)],
 	});
 
-	it("should generate signed AuthnRequest when authnRequestsSigned is true", async () => {
+	beforeAll(async () => {
+		await signedMockIdP.start();
+	});
+
+	afterAll(async () => {
+		await signedMockIdP.stop();
+	});
+
+	it("should generate signed AuthnRequest with Signature and SigAlg", async () => {
 		const signInResponse = await auth.api.signInSSO({
 			body: {
 				providerId: "signed-saml",
@@ -662,13 +748,89 @@ describe("SAML SSO with signed AuthnRequests", async () => {
 		});
 
 		expect(signInResponse).toEqual({
-			url: expect.stringContaining("http://localhost:8081"),
+			url: expect.stringContaining("http://localhost:8082"),
 			redirect: true,
 		});
-		// When authnRequestsSigned is true and privateKey is provided,
-		// samlify adds Signature and SigAlg parameters to the redirect URL
 		expect(signInResponse.url).toContain("Signature=");
 		expect(signInResponse.url).toContain("SigAlg=");
+	});
+
+	it("should include RelayState in the signed URL", async () => {
+		const signInResponse = await auth.api.signInSSO({
+			body: {
+				providerId: "signed-saml",
+				callbackURL: "http://localhost:3000/dashboard",
+			},
+		});
+
+		expect(signInResponse.url).toContain("RelayState=");
+		// RelayState must appear before Signature (it's part of the signed data)
+		const relayStateIdx = signInResponse.url.indexOf("RelayState=");
+		const signatureIdx = signInResponse.url.indexOf("Signature=");
+		expect(relayStateIdx).toBeLessThan(signatureIdx);
+	});
+
+	it("should produce a signature the IdP can verify", async () => {
+		const signInResponse = await auth.api.signInSSO({
+			body: {
+				providerId: "signed-saml",
+				callbackURL: "http://localhost:3000/dashboard",
+			},
+		});
+
+		// The mock IdP at port 8082 verifies the AuthnRequest signature.
+		// If the signature is invalid, it returns 400.
+		const res = await fetch(signInResponse.url);
+		const body = await res.json();
+		expect({ status: res.status, body }).toMatchObject({
+			status: 200,
+			body: expect.objectContaining({ samlResponse: expect.any(String) }),
+		});
+	});
+
+	it("should throw when authnRequestsSigned is true but no privateKey is provided", async () => {
+		const noKeyAuth = betterAuth({
+			database: memoryAdapter({
+				user: [],
+				session: [],
+				verification: [],
+				account: [],
+				ssoProvider: [],
+			}),
+			baseURL: "http://localhost:3000",
+			emailAndPassword: { enabled: true },
+			plugins: [
+				sso({
+					defaultSSO: [
+						{
+							domain: "localhost:8082",
+							providerId: "no-key-saml",
+							samlConfig: {
+								issuer: "http://localhost:8082",
+								entryPoint: "http://localhost:8082/api/sso/saml2/idp/redirect",
+								cert: certificate,
+								callbackUrl: "http://localhost:8082/dashboard",
+								authnRequestsSigned: true,
+								idpMetadata: {
+									metadata: idpMetadataWithSignedRequests,
+								},
+								identifierFormat:
+									"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+							},
+						},
+					],
+				}),
+			],
+		});
+
+		await expect(
+			noKeyAuth.api.signInSSO({
+				body: {
+					providerId: "no-key-saml",
+					callbackURL: "http://localhost:3000/dashboard",
+				},
+			}),
+		).rejects.toThrow(/privateKey/);
 	});
 });
 

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -811,6 +811,7 @@ describe("SAML SSO with signed AuthnRequests", async () => {
 								cert: certificate,
 								callbackUrl: "http://localhost:8082/dashboard",
 								authnRequestsSigned: true,
+								spMetadata: {},
 								idpMetadata: {
 									metadata: idpMetadataWithSignedRequests,
 								},


### PR DESCRIPTION
RelayState was appended after the AuthnRequest signature was computed, so it was not covered by the signed octet string per SAML 2.0 Bindings §3.4.4.1. Spec-compliant IdPs rejected these requests.

- Move `generateRelayState()` before SP construction and pass the token via `relayState` so samlify includes it in the signature
- Make `authnRequestsSigned: true` without a private key a hard error instead of a silent warning
- Add signature-verifying mock IdP to tests (port 8082) that rejects invalid signatures
- Document that a private key is required when signing is enabled

Closes #6048 — superseded by this PR, which applies the fix on current `main` architecture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes signed SAML AuthnRequests so RelayState is included in the HTTP-Redirect signature, making requests compliant with SAML 2.0 Bindings §3.4.4.1 and accepted by strict IdPs.

- **Bug Fixes**
  - Generate RelayState before SP construction and pass it as `relayState` to `samlify` so it’s included in the signed octet string.
  - Throw when `authnRequestsSigned: true` is set without an SP private key (no more silent unsigned requests).
  - Use `samlify`’s signed redirect URL (no manual `&RelayState=...`).
  - Tests: add a signature-verifying mock IdP (port 8082) for HTTP-Redirect; assert `RelayState` precedes `Signature` and verify `SigAlg`; add missing `spMetadata` in the no-key test to satisfy `SAMLConfig` typing.

- **Migration**
  - If `authnRequestsSigned` is enabled, set a private key in `samlConfig.spMetadata.privateKey` or `samlConfig.privateKey`; otherwise sign-in will fail.

<sup>Written for commit 3f11df95adb2715c6d9af622ae649e9909a4889b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

