### PR TITLE
fix(next-js): replace cookie probe with header-based RSC detection in nextCookies

### DIFF
--- a/.changeset/fix-nextcookies-router-refresh.md
+++ b/.changeset/fix-nextcookies-router-refresh.md
@@ -1,0 +1,13 @@
+---
+"better-auth": patch
+---
+
+fix(next-js): replace cookie probe with header-based RSC detection in `nextCookies()` to prevent infinite router refresh loops
+
+The `nextCookies()` before hook previously used `cookies().set()` to detect whether it was running in a Server Component context. In Next.js, `cookies().set()` unconditionally triggers router cache invalidation, causing infinite re-render loops when `getSession` was called from Server Actions.
+
+The fix detects RSC context by inspecting the `RSC` and `next-action` request headers instead, which has zero side effects. This also eliminates the leaked `__better-auth-cookie-store` probe cookie.
+
+Additionally, the two-factor `verifyTOTP` and `verifyOTP` enrollment flows now set the new session cookie before deleting the old session, preventing a brief window where `getSession` could return null.
+
+Closes #8464, #8828, #6077

--- a/.changeset/fix-nextcookies-router-refresh.md
+++ b/.changeset/fix-nextcookies-router-refresh.md
@@ -2,12 +2,4 @@
 "better-auth": patch
 ---
 
-fix(next-js): replace cookie probe with header-based RSC detection in `nextCookies()` to prevent infinite router refresh loops
-
-The `nextCookies()` before hook previously used `cookies().set()` to detect whether it was running in a Server Component context. In Next.js, `cookies().set()` unconditionally triggers router cache invalidation, causing infinite re-render loops when `getSession` was called from Server Actions.
-
-The fix detects RSC context by inspecting the `RSC` and `next-action` request headers instead, which has zero side effects. This also eliminates the leaked `__better-auth-cookie-store` probe cookie.
-
-Additionally, the two-factor `verifyTOTP` and `verifyOTP` enrollment flows now set the new session cookie before deleting the old session, preventing a brief window where `getSession` could return null.
-
-Closes #8464, #8828, #6077
+fix(next-js): replace cookie probe with header-based RSC detection in `nextCookies()` to prevent infinite router refresh loops and eliminate leaked `__better-auth-cookie-store` cookie. Also fix two-factor enrollment flows to set the new session cookie before deleting the old session.

--- a/packages/better-auth/src/integrations/next-js.test.ts
+++ b/packages/better-auth/src/integrations/next-js.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("next-js integration", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.clearAllMocks();
+		vi.resetModules();
+		vi.doUnmock("next/headers.js");
+	});
+
+	async function getSessionWithNextHeaders(
+		nextHeaders: HeadersInit | "unavailable",
+	) {
+		const cookiesMock = vi.fn(async () => ({
+			set: vi.fn(),
+			delete: vi.fn(),
+			get: vi.fn(),
+		}));
+		const headersMock =
+			nextHeaders === "unavailable"
+				? vi.fn(async () => {
+						throw new Error("`headers` was called outside a request scope.");
+					})
+				: vi.fn(async () => new Headers(nextHeaders));
+
+		vi.doMock("next/headers.js", () => ({
+			cookies:
+				nextHeaders === "unavailable"
+					? vi.fn(async () => {
+							throw new Error("`cookies` was called outside a request scope.");
+						})
+					: cookiesMock,
+			headers: headersMock,
+		}));
+
+		const [{ getTestInstance }, { nextCookies }] = await Promise.all([
+			import("../test-utils/test-instance"),
+			import("./next-js"),
+		]);
+
+		const { auth, testUser } = await getTestInstance({
+			plugins: [nextCookies()],
+			session: {
+				deferSessionRefresh: true,
+				updateAge: 0,
+			},
+		});
+
+		const signInRes = await auth.api.signInEmail({
+			body: {
+				email: testUser.email,
+				password: testUser.password,
+			},
+			returnHeaders: true,
+		});
+		const requestHeaders = new Headers();
+		requestHeaders.set("cookie", signInRes.headers.getSetCookie()[0]!);
+
+		cookiesMock.mockClear();
+		headersMock.mockClear();
+
+		vi.useFakeTimers();
+		await vi.advanceTimersByTimeAsync(1000);
+
+		const session = await auth.api.getSession({
+			headers: requestHeaders,
+		});
+
+		return {
+			cookiesMock,
+			headersMock,
+			session: session as { needsRefresh?: boolean } | null,
+		};
+	}
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8464
+	 */
+	it("should not probe cookies in server action context", async () => {
+		const { cookiesMock, headersMock, session } =
+			await getSessionWithNextHeaders({
+				RSC: "1",
+				"next-action": "abc123",
+			});
+
+		expect(headersMock).toHaveBeenCalledTimes(1);
+		expect(cookiesMock).not.toHaveBeenCalled();
+		expect(session).not.toBeNull();
+		expect(session?.needsRefresh).toBe(true);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8464
+	 */
+	it("should skip refresh in server component context", async () => {
+		const { cookiesMock, headersMock, session } =
+			await getSessionWithNextHeaders({ RSC: "1" });
+
+		expect(headersMock).toHaveBeenCalledTimes(1);
+		expect(cookiesMock).not.toHaveBeenCalled();
+		expect(session).not.toBeNull();
+		expect(session?.needsRefresh).toBe(false);
+	});
+
+	it("should allow refresh in route handler context", async () => {
+		const { cookiesMock, session } = await getSessionWithNextHeaders({});
+
+		expect(cookiesMock).not.toHaveBeenCalled();
+		expect(session).not.toBeNull();
+		expect(session?.needsRefresh).toBe(true);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8828
+	 */
+	it("should not leak __better-auth-cookie-store cookie", async () => {
+		vi.doMock("next/headers.js", () => ({
+			cookies: vi.fn(async () => ({
+				set: vi.fn(),
+				delete: vi.fn(),
+				get: vi.fn(),
+			})),
+			headers: vi.fn(async () => new Headers({ RSC: "1" })),
+		}));
+
+		const [{ getTestInstance }, { nextCookies }] = await Promise.all([
+			import("../test-utils/test-instance"),
+			import("./next-js"),
+		]);
+
+		const { auth, testUser } = await getTestInstance({
+			plugins: [nextCookies()],
+		});
+
+		const signInRes = await auth.api.signInEmail({
+			body: {
+				email: testUser.email,
+				password: testUser.password,
+			},
+			returnHeaders: true,
+		});
+		const requestHeaders = new Headers();
+		requestHeaders.set("cookie", signInRes.headers.getSetCookie()[0]!);
+
+		const res = await auth.handler(
+			new Request("http://localhost:3000/api/auth/get-session", {
+				headers: requestHeaders,
+			}),
+		);
+
+		const setCookies = res.headers.getSetCookie();
+		const hasProbeCookie = setCookies.some((c) =>
+			c.includes("__better-auth-cookie-store"),
+		);
+		expect(hasProbeCookie).toBe(false);
+	});
+
+	it("should handle unavailable headers gracefully", async () => {
+		const { cookiesMock, session } =
+			await getSessionWithNextHeaders("unavailable");
+
+		expect(cookiesMock).not.toHaveBeenCalled();
+		expect(session).not.toBeNull();
+	});
+});

--- a/packages/better-auth/src/integrations/next-js.test.ts
+++ b/packages/better-auth/src/integrations/next-js.test.ts
@@ -156,10 +156,8 @@ describe("next-js integration", () => {
 	});
 
 	it("should handle unavailable headers gracefully", async () => {
-		const { cookiesMock, session } =
-			await getSessionWithNextHeaders("unavailable");
+		const { session } = await getSessionWithNextHeaders("unavailable");
 
-		expect(cookiesMock).not.toHaveBeenCalled();
 		expect(session).not.toBeNull();
 	});
 });

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -48,14 +48,17 @@ export const nextCookies = () => {
 						} catch {
 							return;
 						}
-						// Detect RSC via headers, NOT by probing cookies().set().
-						// In Next.js, cookies().set() unconditionally triggers router
-						// cache invalidation -- even if the value is unchanged.
-						// See: next.js/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
-						//
-						// RSC sends `RSC: 1` without `next-action`. Only in that
-						// context cookies cannot be written -- skip session refresh
-						// to avoid DB/cookie mismatch.
+						/**
+						 * Detect RSC via headers, NOT by probing cookies().set().
+						 * In Next.js, cookies().set() unconditionally triggers router
+						 * cache invalidation -- even if the value is unchanged.
+						 *
+						 * RSC sends `RSC: 1` without `next-action`. Only in that
+						 * context cookies cannot be written -- skip session refresh
+						 * to avoid DB/cookie mismatch.
+						 *
+						 * @see https://github.com/vercel/next.js/blob/8c5af211d580/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts#L112-L157
+						 */
 						const isRSC = headersStore.get("RSC") === "1";
 						const isServerAction = !!headersStore.get("next-action");
 						if (isRSC && !isServerAction) {

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -33,25 +33,32 @@ export const nextCookies = () => {
 					matcher(ctx) {
 						return ctx.path === "/get-session";
 					},
-					handler: createAuthMiddleware(async () => {
-						// Detect Server Component by testing if cookies can be modified.
-						// In Server Components, `cookies().set()` throws an error.
-						// In Server Actions or Route Handlers, it succeeds.
-						let cookieStore: Awaited<
-							ReturnType<typeof import("next/headers.js").cookies>
-						>;
-						try {
-							const { cookies } = await import("next/headers.js");
-							cookieStore = await cookies();
-						} catch {
-							// import failed or not in request context
+					handler: createAuthMiddleware(async (ctx) => {
+						// Real HTTP requests (via router) set cookies through
+						// response headers -- no need to skip refresh.
+						if ("_flag" in ctx && ctx._flag === "router") {
 							return;
 						}
+						let headersStore: Awaited<
+							ReturnType<typeof import("next/headers.js").headers>
+						>;
 						try {
-							cookieStore.set("__better-auth-cookie-store", "1", { maxAge: 0 });
-							// If cookie was set successfully, we should clean up.
-							cookieStore.delete("__better-auth-cookie-store");
+							const { headers } = await import("next/headers.js");
+							headersStore = await headers();
 						} catch {
+							return;
+						}
+						// Detect RSC via headers, NOT by probing cookies().set().
+						// In Next.js, cookies().set() unconditionally triggers router
+						// cache invalidation -- even if the value is unchanged.
+						// See: next.js/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+						//
+						// RSC sends `RSC: 1` without `next-action`. Only in that
+						// context cookies cannot be written -- skip session refresh
+						// to avoid DB/cookie mismatch.
+						const isRSC = headersStore.get("RSC") === "1";
+						const isServerAction = !!headersStore.get("next-action");
+						if (isRSC && !isServerAction) {
 							await setShouldSkipSessionRefresh(true);
 						}
 					}),
@@ -71,24 +78,22 @@ export const nextCookies = () => {
 							const setCookies = returned?.get("set-cookie");
 							if (!setCookies) return;
 							const parsed = parseSetCookieHeader(setCookies);
-							const { cookies } = await import("next/headers.js");
-							let cookieHelper: Awaited<ReturnType<typeof cookies>>;
+							let cookieHelper: Awaited<
+								ReturnType<typeof import("next/headers.js").cookies>
+							>;
 							try {
+								const { cookies } = await import("next/headers.js");
 								cookieHelper = await cookies();
 							} catch (error) {
 								if (
 									error instanceof Error &&
-									error.message.startsWith(
+									(error.message.startsWith(
 										"`cookies` was called outside a request scope.",
-									)
+									) ||
+										error.message.includes("Cannot find module"))
 								) {
-									// If error it means the `cookies` was called outside request scope.
-									// NextJS docs on this: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context
-									// This often gets called in a monorepo workspace (outside of NextJS),
-									// so we will try to catch this suppress it, and ignore using next-cookies.
 									return;
 								}
-								// If it's an unexpected error, throw it.
 								throw error;
 							}
 							parsed.forEach((value, key) => {

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -95,6 +95,8 @@ export const nextCookies = () => {
 									) ||
 										error.message.includes("Cannot find module"))
 								) {
+									// Monorepo workspaces outside of Next.js hit this path.
+									// @see https://nextjs.org/docs/messages/next-dynamic-api-wrong-context
 									return;
 								}
 								throw error;

--- a/packages/better-auth/src/plugins/two-factor/otp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/otp/index.ts
@@ -360,13 +360,13 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 						false,
 						session.session,
 					);
-					await ctx.context.internalAdapter.deleteSession(
-						session.session.token,
-					);
 					await setSessionCookie(ctx, {
 						session: newSession,
 						user: updatedUser,
 					});
+					await ctx.context.internalAdapter.deleteSession(
+						session.session.token,
+					);
 					return ctx.json({
 						token: newSession.token,
 						user: parseUserOutput(ctx.context.options, updatedUser),

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -314,11 +314,11 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 						activeSession,
 					);
 
-					await ctx.context.internalAdapter.deleteSession(activeSession.token);
 					await setSessionCookie(ctx, {
 						session: newSession,
 						user: updatedUser,
 					});
+					await ctx.context.internalAdapter.deleteSession(activeSession.token);
 				}
 				// Mark verified only after all session operations succeed.
 				// This keeps the gate on twoFactorEnabled (retry-safe) and ensures


### PR DESCRIPTION
## Problem

PR #7763 changed the `nextCookies()` before hook from header-based RSC detection to a cookie probe: it called `cookies().set()` then `cookies().delete()` on every `/get-session` request to test whether it was running in a Server Component.

In Next.js, **`cookies().set()` unconditionally triggers router cache invalidation** -- even if the value hasn't changed and even if `maxAge` is `0`. Every `.set()` call marks `pathWasRevalidated = ActionDidRevalidateStaticAndDynamic`, invalidating the entire prefetch cache on the client ([source: `request-cookies.ts` L112-L157](https://github.com/vercel/next.js/blob/8c5af211d580/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts#L112-L157)).

This caused:
- **Infinite router refresh loops** from Server Actions (#8464)
- **Leaked `__better-auth-cookie-store` probe cookie** (#8828)
- Combined with two-factor **delete-then-set ordering**, a brief null-session window during TOTP/OTP enrollment (#6077)

## Solution

### Replace cookie probe with header inspection

Detect RSC context by reading `RSC` and `next-action` headers from `next/headers` instead of probing `cookies().set()`. Zero cookie mutations, zero side effects.

Three layers:
- **`_flag === "router"`**: HTTP requests through the router handle cookies via response headers. No skip needed.
- **`RSC: 1` without `next-action`**: RSC flight requests where cookies cannot be written. Skip session refresh.
- **Everything else** (Server Actions, Route Handlers, direct API calls): Allow refresh normally.

### Reorder two-factor session operations

`verifyTOTP` and `verifyOTP` enrollment paths now set the new session cookie *before* deleting the old session, matching the order already used by `enableTwoFactor` and `disableTwoFactor`.

## Known trade-off

`RSC: 1` is present during client-side RSC flight requests but absent during **initial page loads** (first visit, hard refresh). During initial SSR, Server Components still cannot write cookies, yet our check does not skip refresh. The after hook's `cookies().set()` fails silently (existing try/catch), and the DB session gets extended while the cookie stays stale.

This is a **temporary, self-correcting mismatch**: the cookie cache expires within `maxAge` (default 5 min), and the next request resolves via DB lookup. This same gap existed when PR #7625's header-based detection was live before #7763 replaced it, with no issues reported.

The alternative (`!next-action` alone) covers initial SSR but incorrectly skips refresh for Route Handler `auth.api.*` calls—a worse trade-off.

## Testing

5 new regression tests in `next-js.test.ts`

## Closes

Closes #8464
Closes #8828
Closes #6077

Supersedes:
Closes #6107
Closes #8462.