### PR TITLE
refactor(ci): simplify release notes to one-line entries

### DIFF
--- a/.github/prompts/release-notes-rewrite.md
+++ b/.github/prompts/release-notes-rewrite.md
@@ -4,92 +4,76 @@
 You are rewriting release notes for better-auth, an open-source
 authentication framework for TypeScript.
 
-Read the raw changelog at: __RAW_CHANGELOG_PATH__
+## Input files
 
-This raw changelog was generated from git history and PR metadata.
-Each entry has a description and a PR link.
-Entries are grouped by npm package (`better-auth`, `@better-auth/sso`,
-etc.), then by change type (`Breaking Changes`, `Features`, `Bug Fixes`).
+**Raw changelog:** __RAW_CHANGELOG_PATH__
+Each entry is a one-line PR title followed by a PR link, grouped by npm
+package and change type (Breaking Changes, Features, Bug Fixes).
 
-Entries come from two sources:
-- Changeset descriptions (may already look clean but often need tense
-  fixes, code formatting, and user-focus adjustments)
-- Raw commit subjects (lower-case, terse, may include PR number
-  suffixes like "(#8289)" in the description text)
+**Changeset context (optional):** __CONTEXT_PATH__
+A JSON file mapping PR numbers to their full changeset descriptions.
+Use these descriptions as background context to write better titles —
+they explain the motivation and details behind each change. If the file
+path is "none" or does not exist, skip this step.
 
-Your job is to rewrite EVERY description so the changelog reads as a
-polished, consistent document written for end users.
+## Your job
 
-For entries that are unclear or too terse, inspect the actual PR diff
-to understand what really changed:
-  gh pr diff <PR_NUMBER> --repo __GITHUB_REPOSITORY__ | head -200
+Rewrite every entry title into a polished, user-focused one-liner.
+The raw titles are conventional commit messages (e.g.,
+`fix(next-js): replace cookie probe with header-based RSC detection`).
+Transform them into clean descriptions that tell users what changed
+for them.
 
 ## Writing rules
 
-Tense and voice:
-- Use past tense consistently throughout ("Added", "Fixed", "Removed")
-- Never mix tenses ("Added X and improve Y" is wrong, use "Added X and improved Y")
-- Never use imperative/present ("Add", "Fix", "Remove")
-
-Code references:
-- Wrap code identifiers in backticks: function names, method names,
-  option names, config keys, field names, type names, package names
-  (e.g., `storeSessionInDatabase`, `provisionUserOnEveryLogin`, `auth_time`)
-- Do NOT wrap general concepts in backticks (e.g., "password hashing" stays plain)
-
-User focus:
-- The changelog is for users who are at least slightly technical (they
-  use the library and want to know what changed for them)
-- Describe the impact on users, not the internal code change
-- "Fixed a bug where sessions expired immediately after creation" is better
-  than "Aligned session fresh age calculation with creation time"
-- "Password hashing no longer blocks the server during sign-up" is better
-  than "Used non-blocking scrypt for password hashing"
-- If a change is behavioral (affects what users experience), lead with the behavior
-- Be thorough in understanding flow-on effects that may not be immediately
-  apparent: a package upgrade that looks internal may patch a user-facing
-  bug; a refactor may stabilize a race condition that caused intermittent
-  failures; a dependency bump may change minimum supported versions
-- When inspecting a diff, look at the PR title and body for the author's
-  context (the outcome they intended, not just the technical detail)
+Rewriting titles:
+- Remove conventional commit prefixes (`fix(scope):`, `feat:`, etc.)
+- Replace with a past-tense verb describing the change type:
+  "Fixed …", "Added …", "Improved …", "Refactored …", "Removed …"
+- Keep it to one sentence — this is a summary, not a paragraph
+- Describe the user-visible impact, not the internal code change
+- Wrap code identifiers in backticks: function names, config keys,
+  field names, type names (e.g., `nextCookies()`, `twoFactorMethods`)
+- Do NOT wrap general concepts in backticks ("password hashing" stays plain)
+- If a title is unclear, read the changeset context for that PR number,
+  or inspect the diff: `gh pr diff <N> --repo __GITHUB_REPOSITORY__ | head -200`
+- Remove duplicate PR number suffixes from the title text (the PR
+  link in parentheses already provides this)
 
 Breaking changes:
-- Entries prefixed with `**BREAKING:**` must be transformed into a rich format:
-  1. Replace the `**BREAKING:**` prefix with a bold title extracted from the description
-  2. Add " — " after the title, followed by user-focused context
-  3. Keep the PR link at the end of the description line
-  4. Below the description, add a code block showing the migration action
-     (the opt-out config, the before/after import change, or the new required option)
-  5. Inspect the PR diff (`gh pr diff <N>`) to find the exact migration action
-- Example transformation:
+- Entries under `### ⚠️ Breaking Changes` need a migration note
+- Rewrite the title the same way (past-tense, user-focused)
+- The raw output may include indented changeset details below the title
+  line; replace them with a single concise blockquote:
+  `> **Migration:** <what changed and what users need to do>`
+- Inspect the PR diff (`gh pr diff <N>`) to find the exact migration action
+- If there is a config opt-out, show it in an inline code span
+- Keep migration notes concise (1-3 lines max)
+- Example:
   ```
   Before (raw):
-  **BREAKING:** enable InResponseTo validation by default for SAML flows ([#8736](url))
+  - feat(sso)!: enable InResponseTo validation by default for SAML flows ([#8736](url))
+    ...indented changeset description...
 
   After (rewritten):
-  **SAML InResponseTo validation enabled by default** — `enableInResponseToValidation` is now `true` for SP-initiated SAML flows ([#8736](url)). To restore the previous behavior:
-
-  ```ts
-  sso({ saml: { enableInResponseToValidation: false } })
-  ```
+  - Enabled InResponseTo validation by default for SP-initiated SAML flows ([#8736](url))
+  > **Migration:** Set `sso({ saml: { enableInResponseToValidation: false } })` to restore the previous behavior.
   ```
 
 ## Structural rules (do NOT violate)
 
-- Do NOT add or remove entries; keep every entry from the raw changelog
+- Do NOT add or remove entries
 - Do NOT modify PR links `([#NNNN](url))`
-- Do NOT modify the `## \`package-name\`` headings or their order
-- Do NOT modify the `### ⚠️ Breaking Changes`, `### Features`, or
-  `### Bug Fixes` sub-headings or their order within a package
-- Do NOT add author attributions (`by @username`) to entries
-- Do NOT use em dashes (—); use parentheses, commas, or colons instead
-  (exception: the " — " separator in breaking change titles is allowed)
+- Do NOT modify `## \`package-name\`` headings or their order
+- Do NOT modify `### ⚠️ Breaking Changes`, `### Features`, or
+  `### Bug Fixes` sub-headings or their order
+- Do NOT modify the `CHANGELOG` links at the end of each package section
+- Do NOT add author attributions (`by @username`)
+- Do NOT use em dashes (—); use commas, colons, or parentheses
+  (exception: the " — " separator after breaking change titles is allowed)
 - Keep the blog post link, contributors section, and full changelog
   link exactly as-is
-- Remove duplicate PR number suffixes from description text (the PR
-  link in parentheses already provides this; e.g., change
-  "fixed foo (#8289)" to "Fixed foo")
-- Do NOT duplicate an entry across multiple sub-sections; each entry
-  appears exactly once under the change type it was classified as
+- Each entry stays on one line (title + PR link), except breaking
+  changes which get an additional blockquote line for migration
 
 Write the final release notes to: __RAW_CHANGELOG_PATH__.final

--- a/.github/prompts/release-notes-rewrite.md
+++ b/.github/prompts/release-notes-rewrite.md
@@ -41,7 +41,7 @@ Rewriting titles:
   link in parentheses already provides this)
 
 Breaking changes:
-- Entries under `### ⚠️ Breaking Changes` need a migration note
+- Entries under `### ❗ Breaking Changes` need a migration note
 - Rewrite the title the same way (past-tense, user-focused)
 - The raw output may include indented changeset details below the title
   line; replace them with a single concise blockquote:
@@ -65,7 +65,7 @@ Breaking changes:
 - Do NOT add or remove entries
 - Do NOT modify PR links `([#NNNN](url))`
 - Do NOT modify `## \`package-name\`` headings or their order
-- Do NOT modify `### ⚠️ Breaking Changes`, `### Features`, or
+- Do NOT modify `### ❗ Breaking Changes`, `### Features`, or
   `### Bug Fixes` sub-headings or their order
 - Do NOT modify the `CHANGELOG` links at the end of each package section
 - Do NOT add author attributions (`by @username`)

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -802,11 +802,21 @@ function formatReleaseBody(opts: FormatOptions): string {
 					? ` ([#${entry.prNumber}](https://github.com/${REPO}/pull/${entry.prNumber}))`
 					: "";
 
+				const descLines = entry.description.split("\n");
+				const firstLine = descLines[0]!;
+				// Indent continuation lines so markdown keeps them inside the list item
+				const rest = descLines
+					.slice(1)
+					.map((l) => (l ? `  ${l}` : l))
+					.join("\n");
+
 				if (changeType === "breaking") {
 					// Breaking changes get bold description for the AI to expand
-					lines.push(`**BREAKING:** ${entry.description}${prLink}`);
+					const body = rest ? `\n${rest}` : "";
+					lines.push(`**BREAKING:** ${firstLine}${prLink}${body}`);
 				} else {
-					lines.push(`- ${entry.description}${prLink}`);
+					const body = rest ? `\n${rest}` : "";
+					lines.push(`- ${firstLine}${prLink}${body}`);
 				}
 			}
 			lines.push("");

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -728,7 +728,7 @@ interface FormatOptions {
 }
 
 const CHANGE_TYPE_HEADINGS: Record<string, string> = {
-	breaking: "### ⚠️ Breaking Changes",
+	breaking: "### ❗ Breaking Changes",
 	feat: "### Features",
 	fix: "### Bug Fixes",
 };

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -36,7 +36,10 @@ import {
 
 interface ReleaseEntry {
 	id: string;
-	description: string;
+	/** PR title (preferred for display) or changeset first-line fallback */
+	title: string;
+	/** Full changeset description (kept for AI context, not displayed directly) */
+	changesetDescription: string | null;
 	prNumber: number | null;
 	author: string;
 	domain: string;
@@ -64,13 +67,11 @@ interface ChangesetSnapshot {
 function parseArgs(): {
 	version: string;
 	branch: string;
-	distTag: string;
 	dryRun: boolean;
 } {
 	const args = process.argv.slice(2);
 	let version = "";
 	let branch = "";
-	let distTag = "";
 	let dryRun = false;
 
 	for (let i = 0; i < args.length; i++) {
@@ -80,9 +81,6 @@ function parseArgs(): {
 				break;
 			case "--branch":
 				branch = args[++i] ?? "";
-				break;
-			case "--dist-tag":
-				distTag = args[++i] ?? "";
 				break;
 			case "--dry-run":
 				dryRun = true;
@@ -98,18 +96,14 @@ function parseArgs(): {
 		}
 	}
 
-	if (!distTag) {
-		distTag = process.env.NPM_DIST_TAG ?? "";
-	}
-
 	if (!version) {
 		console.error(
-			"Usage: release-notes.ts --version <ver> [--branch <ref>] [--dist-tag <tag>] [--dry-run]",
+			"Usage: release-notes.ts --version <ver> [--branch <ref>] [--dry-run]",
 		);
 		process.exit(1);
 	}
 
-	return { version, branch, distTag, dryRun };
+	return { version, branch, dryRun };
 }
 
 // ── Git helpers ────────────────────────────────────────────────────────
@@ -451,8 +445,14 @@ function buildChangesetIndex(branch: string): {
 	return { byPR, orphans, byDescription };
 }
 
-function packageNameToPath(name: string): string {
-	return `packages/${name.replace(/^@better-auth\//, "")}/`;
+function packageToDir(name: string): string {
+	if (name === "auth") return "packages/cli";
+	if (name === "better-auth") return "packages/better-auth";
+	return `packages/${name.replace(/^@better-auth\//, "")}`;
+}
+
+function packageToChangelogUrl(name: string, ref: string): string {
+	return `https://github.com/${REPO}/blob/${ref}/${packageToDir(name)}/CHANGELOG.md`;
 }
 
 /** Load changeset IDs from the previous beta's pre.json to exclude from orphans. */
@@ -643,17 +643,18 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 		seenPRs.add(prNumber);
 
 		let author = "unknown";
+		let title: string;
 		let domain: string;
 		let packageName: string;
 		let breaking = parsed.breaking;
 
-		const description =
-			changeset?.description ?? parsed.subject.replace(/\s*\(#\d+\)$/, "");
+		const changesetDescription = changeset?.description ?? null;
 		if (changeset?.breaking) breaking = true;
 
 		try {
 			const prInfo = fetchPR(prNumber);
 			author = prInfo.author;
+			title = prInfo.title;
 			domain = classifyEntry(prInfo, parsed.scope || undefined, prInfo.files);
 			packageName =
 				changeset?.packageNames.length === 1
@@ -661,6 +662,7 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 					: resolvePackage(parsed.scope || undefined, prInfo.files);
 			if (prInfo.labels.includes("breaking")) breaking = true;
 		} catch {
+			title = parsed.subject.replace(/\s*\(#\d+\)$/, "");
 			domain = resolveDomain(parsed.scope || undefined, []);
 			packageName =
 				changeset?.packageNames.length === 1
@@ -670,7 +672,8 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 
 		entries.push({
 			id: changeset ? `pr-${prNumber}` : `git-${prNumber}`,
-			description,
+			title,
+			changesetDescription,
 			prNumber,
 			author,
 			domain,
@@ -695,13 +698,14 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 			continue;
 		}
 
-		const pkgPaths = changeset.packageNames.map(packageNameToPath);
+		const pkgPaths = changeset.packageNames.map((n) => `${packageToDir(n)}/`);
 		const domain = resolveDomain(undefined, pkgPaths);
 		if (FILTERED_DOMAINS.has(domain)) continue;
 
 		entries.push({
 			id: changeset.id,
-			description: changeset.description,
+			title: changeset.description.split("\n")[0]!,
+			changesetDescription: changeset.description,
 			prNumber: null,
 			author: "unknown",
 			domain,
@@ -718,6 +722,7 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 
 interface FormatOptions {
 	version: string;
+	commitRef: string;
 	entries: ReleaseEntry[];
 	previousTag: string;
 }
@@ -735,20 +740,17 @@ const CHANGE_TYPE_ORDER: ("breaking" | "feat" | "fix")[] = [
 ];
 
 function formatReleaseBody(opts: FormatOptions): string {
-	const { version, entries, previousTag } = opts;
+	const { version, commitRef, entries, previousTag } = opts;
 	const lines: string[] = [];
-	const isBeta = version.includes("-");
 
-	// Blog post link for stable releases
-	if (!isBeta) {
-		const majorMinor = version.match(/^(\d+)\.(\d+)/);
-		if (majorMinor) {
-			const blogSlug = `${majorMinor[1]}-${majorMinor[2]}`;
-			lines.push(
-				`**Blog post:** [Better Auth ${majorMinor[1]}.${majorMinor[2]}](https://better-auth.com/blog/${blogSlug})`,
-			);
-			lines.push("");
-		}
+	// Blog post link for minor releases (x.y.0) only
+	const minorMatch = version.match(/^(\d+)\.(\d+)\.0$/);
+	if (minorMatch) {
+		const blogSlug = `${minorMatch[1]}-${minorMatch[2]}`;
+		lines.push(
+			`**Blog post:** [Better Auth ${minorMatch[1]}.${minorMatch[2]}](https://better-auth.com/blog/${blogSlug})`,
+		);
+		lines.push("");
 	}
 
 	// Group entries by package
@@ -787,12 +789,11 @@ function formatReleaseBody(opts: FormatOptions): string {
 		lines.push(`## \`${pkg}\``);
 		lines.push("");
 
-		// Group by change type within this package
 		for (const changeType of CHANGE_TYPE_ORDER) {
 			const typeEntries = pkgEntries.filter((e) => e.changeType === changeType);
 			if (typeEntries.length === 0) continue;
 
-			typeEntries.sort((a, b) => a.description.localeCompare(b.description));
+			typeEntries.sort((a, b) => a.title.localeCompare(b.title));
 
 			lines.push(CHANGE_TYPE_HEADINGS[changeType]!);
 			lines.push("");
@@ -802,27 +803,21 @@ function formatReleaseBody(opts: FormatOptions): string {
 					? ` ([#${entry.prNumber}](https://github.com/${REPO}/pull/${entry.prNumber}))`
 					: "";
 
-				const descLines = entry.description.split("\n");
-				const firstLine = descLines[0]!;
-				// Indent continuation lines so markdown keeps them inside the list item
-				const rest = descLines
-					.slice(1)
-					.map((l) => (l ? `  ${l}` : l))
-					.join("\n");
+				lines.push(`- ${entry.title}${prLink}`);
 
-				if (changeType === "breaking") {
-					// Breaking changes get bold description for the AI to expand
-					const body = rest ? `\n${rest}` : "";
-					lines.push(`**BREAKING:** ${firstLine}${prLink}${body}`);
-				} else {
-					const body = rest ? `\n${rest}` : "";
-					lines.push(`- ${firstLine}${prLink}${body}`);
+				if (changeType === "breaking" && entry.changesetDescription) {
+					// Include changeset description so the raw fallback still
+					// carries migration guidance when AI is skipped.
+					for (const line of entry.changesetDescription.split("\n").slice(1)) {
+						lines.push(line ? `  ${line}` : "");
+					}
 				}
 			}
 			lines.push("");
 		}
 
-		lines.push("---");
+		const changelogUrl = packageToChangelogUrl(pkg, commitRef);
+		lines.push(`For detailed changes, see [\`CHANGELOG\`](${changelogUrl})`);
 		lines.push("");
 	}
 
@@ -849,15 +844,19 @@ function formatReleaseBody(opts: FormatOptions): string {
 
 // ── Main ───────────────────────────────────────────────────────────────
 
-const { version, branch, distTag, dryRun } = parseArgs();
+const { version, branch, dryRun } = parseArgs();
 const isBeta = version.includes("-");
 const previousTag = findPreviousTag(version, isBeta);
+
+const commitRef =
+	process.env.GITHUB_SHA ??
+	execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
 
 console.log(`Generating release notes for v${version}`);
 console.log(`  Previous tag: ${previousTag}`);
 console.log(`  Release type: ${isBeta ? "pre-release" : "stable"}`);
 console.log(`  Branch: ${branch || "HEAD"}`);
-if (distTag) console.log(`  Dist tag: ${distTag}`);
+console.log(`  Commit: ${commitRef.slice(0, 12)}`);
 console.log("");
 
 console.log("Collecting entries...");
@@ -867,27 +866,51 @@ console.log("");
 
 const body = formatReleaseBody({
 	version,
+	commitRef,
 	entries,
 	previousTag,
 });
 
+// Build changeset context file for the AI rewriting stage.
+// Maps each PR to its full changeset description so the AI can use it
+// as background when rewriting the one-line titles.
+const changesetContext: Record<number, string> = {};
+for (const entry of entries) {
+	if (entry.prNumber && entry.changesetDescription) {
+		changesetContext[entry.prNumber] = entry.changesetDescription;
+	}
+}
+
 if (dryRun) {
 	console.log("=== DRY RUN — Raw changelog ===\n");
 	console.log(body);
+	if (Object.keys(changesetContext).length > 0) {
+		console.log("\n=== Changeset context (for AI) ===\n");
+		console.log(JSON.stringify(changesetContext, null, 2));
+	}
 } else {
 	// Write inside the repo directory so claude-code-action can read it
 	const rawFile = join(process.cwd(), `.release-notes-raw-${version}.md`);
 	writeFileSync(rawFile, body);
 	console.log(`Wrote raw changelog to ${rawFile}`);
+
+	// Write changeset descriptions as AI context
+	if (Object.keys(changesetContext).length > 0) {
+		const contextFile = join(
+			process.cwd(),
+			`.release-notes-context-${version}.json`,
+		);
+		writeFileSync(contextFile, JSON.stringify(changesetContext, null, 2));
+		console.log(`Wrote changeset context to ${contextFile}`);
+		setOutput("context_path", contextFile);
+	} else {
+		console.log(
+			"No changeset context available (AI enrichment will be skipped)",
+		);
+	}
+
 	setOutput("version", version);
 	setOutput("previous_tag", previousTag);
 	setOutput("is_beta", String(isBeta));
 	setOutput("raw_changelog_path", rawFile);
-	setOutput(
-		"pr_numbers",
-		entries
-			.filter((e) => e.prNumber)
-			.map((e) => e.prNumber)
-			.join(","),
-	);
 }

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -655,11 +655,17 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 			const prInfo = fetchPR(prNumber);
 			author = prInfo.author;
 			domain = classifyEntry(prInfo, parsed.scope || undefined, prInfo.files);
-			packageName = resolvePackage(parsed.scope || undefined, prInfo.files);
+			packageName =
+				changeset?.packageNames.length === 1
+					? changeset.packageNames[0]!
+					: resolvePackage(parsed.scope || undefined, prInfo.files);
 			if (prInfo.labels.includes("breaking")) breaking = true;
 		} catch {
 			domain = resolveDomain(parsed.scope || undefined, []);
-			packageName = resolvePackage(parsed.scope || undefined, []);
+			packageName =
+				changeset?.packageNames.length === 1
+					? changeset.packageNames[0]!
+					: resolvePackage(parsed.scope || undefined, []);
 		}
 
 		entries.push({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,6 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-          NPM_DIST_TAG: ${{ steps.npm-tag.outputs.tag }}
         run: node .github/scripts/release-notes.ts --branch "$GITHUB_REF_NAME"
 
       - name: Build AI prompt from template
@@ -131,9 +130,11 @@ jobs:
         continue-on-error: true
         env:
           RAW_PATH: ${{ steps.raw-notes.outputs.raw_changelog_path }}
+          CONTEXT_PATH: ${{ steps.raw-notes.outputs.context_path }}
         run: |
           PROMPT=$(sed \
             -e "s|__RAW_CHANGELOG_PATH__|${RAW_PATH}|g" \
+            -e "s|__CONTEXT_PATH__|${CONTEXT_PATH:-none}|g" \
             -e "s|__GITHUB_REPOSITORY__|${GITHUB_REPOSITORY}|g" \
             .github/prompts/release-notes-rewrite.md)
           EOF_DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
@@ -143,7 +144,7 @@ jobs:
 
       - name: Rewrite release notes with AI
         id: ai-notes
-        if: steps.raw-notes.outcome == 'success'
+        if: steps.ai-prompt.outcome == 'success'
         continue-on-error: true
         uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         env:
@@ -154,6 +155,42 @@ jobs:
           prompt: ${{ steps.ai-prompt.outputs.prompt }}
           claude_args: --max-turns 100 --allowedTools "Read Write Bash(gh pr diff*) Bash(gh pr view*)"
           allowed_bots: "github-merge-queue"
+
+      - name: Validate AI output
+        if: steps.ai-notes.outcome == 'success'
+        continue-on-error: true
+        env:
+          RAW_PATH: ${{ steps.raw-notes.outputs.raw_changelog_path }}
+        run: |
+          FINAL="${RAW_PATH}.final"
+          if [ ! -f "$FINAL" ]; then
+            echo "AI did not produce output file"
+            exit 0
+          fi
+
+          # Count PR links in both files
+          RAW_COUNT=$(grep -coP '\[#\d+\]' "$RAW_PATH" || echo 0)
+          FINAL_COUNT=$(grep -coP '\[#\d+\]' "$FINAL" || echo 0)
+
+          if [ "$FINAL_COUNT" -lt "$RAW_COUNT" ]; then
+            echo "::warning::AI output has fewer PR links ($FINAL_COUNT) than raw ($RAW_COUNT). Falling back to raw notes."
+            rm -f "$FINAL"
+            exit 0
+          fi
+
+          # Verify all package headings from raw are present in final
+          MISSING=0
+          while IFS= read -r heading; do
+            if ! grep -qF "$heading" "$FINAL"; then
+              echo "::warning::Missing package heading: $heading"
+              MISSING=$((MISSING + 1))
+            fi
+          done < <(grep -oP '## `[^`]+`' "$RAW_PATH")
+
+          if [ "$MISSING" -gt 0 ]; then
+            echo "::warning::AI output is missing $MISSING package heading(s). Falling back to raw notes."
+            rm -f "$FINAL"
+          fi
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
@@ -356,32 +393,20 @@ jobs:
           INPUT_VERSION: ${{ inputs.preview_version }}
           INPUT_BRANCH: ${{ inputs.preview_branch }}
         run: |
-          # Infer dist-tag from the branch (matches the npm-tag step in the release job)
-          DIST_TAG=""
-          if [[ "$INPUT_BRANCH" =~ ^release/ ]]; then
-            DIST_TAG="release-${INPUT_BRANCH#release/}"
-          elif [[ "$INPUT_BRANCH" == "main" ]]; then
-            DIST_TAG="latest"
-          fi
-
-          DIST_TAG_ARGS=""
-          if [ -n "$DIST_TAG" ]; then
-            DIST_TAG_ARGS="--dist-tag $DIST_TAG"
-          fi
-
           node .github/scripts/release-notes.ts \
             --version "$INPUT_VERSION" \
-            --branch "origin/$INPUT_BRANCH" \
-            $DIST_TAG_ARGS
+            --branch "origin/$INPUT_BRANCH"
 
       - name: Build AI prompt from template
         id: ai-prompt
         continue-on-error: true
         env:
           RAW_PATH: ${{ steps.raw-notes.outputs.raw_changelog_path }}
+          CONTEXT_PATH: ${{ steps.raw-notes.outputs.context_path }}
         run: |
           PROMPT=$(sed \
             -e "s|__RAW_CHANGELOG_PATH__|${RAW_PATH}|g" \
+            -e "s|__CONTEXT_PATH__|${CONTEXT_PATH:-none}|g" \
             -e "s|__GITHUB_REPOSITORY__|${GITHUB_REPOSITORY}|g" \
             .github/prompts/release-notes-rewrite.md)
           EOF_DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
@@ -391,6 +416,7 @@ jobs:
 
       - name: Rewrite release notes with AI
         id: ai-notes
+        if: steps.ai-prompt.outcome == 'success'
         continue-on-error: true
         uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         env:


### PR DESCRIPTION
## Summary

Rewrites the release notes pipeline so each entry is a single-line PR title instead of the full changeset description. The AI stage now polishes titles (removes scopes, past tense, user-focused) rather than expanding multi-paragraph descriptions.

- Use PR titles as entry content; changeset descriptions passed as a JSON sidecar for AI context
- Per-package `CHANGELOG` link at the end of each section (uses `GITHUB_SHA` for always-valid URLs)
- Consolidate `packageNameToPath` into `packageToDir` (fixes silent drop of CLI orphan changesets)
- Add post-AI validation step: checks PR link count and package headings, falls back to raw if mismatched
- Guard `ai-notes` on `ai-prompt` outcome to prevent running with an empty prompt
- Remove dead code: `distTag` parsing, `has_breaking`/`pr_numbers` outputs
- Blog post link only on minor releases (`x.y.0`)