### PR TITLE
fix(ci): prevent label explosion on PRs targeting the next branch

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -9,7 +9,13 @@ permissions: {}
 jobs:
   label:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'better-auth'
+    # Skip PRs targeting next (retargeted or direct) to avoid label explosion
+    # from the large diff between next and feature branches.
+    # Skip bot sync PRs (main→next) which touch many files but are purely devops.
+    if: >
+      github.repository_owner == 'better-auth' &&
+      github.event.pull_request.base.ref != 'next' &&
+      github.actor != 'better-release[bot]'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,7 @@ jobs:
           EXISTING=$(gh pr list --base next --head "${GITHUB_REPOSITORY_OWNER}:main" --state open --repo "$GITHUB_REPOSITORY" --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             echo "Sync PR #$EXISTING already exists ($AHEAD commits pending)"
+            gh pr edit "$EXISTING" --repo "$GITHUB_REPOSITORY" --add-label devops || true
           else
             SYNC_BODY="Brings stable fixes from main into the next branch."
             SYNC_BODY="$SYNC_BODY\n\n**This PR must be merged by a maintainer using 'Create a merge commit'** (not squash, not rebase). This preserves individual fix commits and their verified signatures."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,7 @@ jobs:
               --head main \
               --repo "$GITHUB_REPOSITORY" \
               --title "chore: sync main to next" \
+              --label devops \
               --body "$(echo -e "$SYNC_BODY")" || true
 
             EXISTING=$(gh pr list --base next --head "${GITHUB_REPOSITORY_OWNER}:main" --state open --repo "$GITHUB_REPOSITORY" --json number --jq '.[0].number // empty')


### PR DESCRIPTION
## Summary

The auto-labeler computes its diff against the PR's base branch. Three scenarios cause it to apply nearly every label in the repo:

1. **Retargeted PRs** — `auto-retarget.yml` moves the base from `main` to `next` when a changeset declares a minor/major bump. Because `next` has diverged from `main`, the diff now includes hundreds of files the author never touched, triggering most label rules.
2. **Direct-to-next PRs** — Same large diff problem for any PR opened directly against `next`.
3. **Bot sync PRs** — The `chore: sync main to next` PR created by `better-release[bot]` carries every file that diverged between the two branches.

Since `sync-labels: false` means labels only accumulate (never removed), the incorrect labels persist permanently.

## Changes

- **`auto-label.yml`**: skip the labeler when `base.ref == next` or when the actor is `better-release[bot]`
- **`release.yml`**: tag sync PRs with the `devops` label at creation time, since the labeler will no longer run for them

Retargeted PRs keep their correct labels from the initial `opened` event (when base was still `main`). No labels are lost.

## Test plan

- [ ] Open a PR with a minor changeset → verify it gets retargeted to `next` and keeps only the labels from the initial run
- [ ] Push a new commit to a retargeted PR → verify no new labels are added
- [ ] Merge to `main` to trigger a sync PR → verify it gets only the `devops` label

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent label explosion on PRs targeting the next branch and on sync PRs by `better-release[bot]`. We skip the auto-labeler in those cases and always tag sync PRs with the `devops` label, including existing sync PRs.

- **Bug Fixes**
  - In `.github/workflows/auto-label.yml`, skip the label job when base is `next` or actor is `better-release[bot]`.
  - In `.github/workflows/release.yml`, ensure sync PRs have `devops`: add `--label devops` on create and `gh pr edit ... --add-label devops` when a sync PR already exists.

<sup>Written for commit 6f69b41cd8eacb23cfd5af347308427b4420c64a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

