### PR TITLE
fix: incorrect `operationId` in password reset callback endpoint

### DIFF
--- a/.changeset/fix-password-reset-callback-operation-id.md
+++ b/.changeset/fix-password-reset-callback-operation-id.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix(api): align top-level `operationId` on `requestPasswordResetCallback` with the OpenAPI `resetPasswordCallback`

--- a/demo/expo/src/app/forgot-password.tsx
+++ b/demo/expo/src/app/forgot-password.tsx
@@ -14,12 +14,12 @@ import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
 import { authClient } from "@/lib/auth-client";
 
-export default function ForgetPassword() {
+export default function ForgotPassword() {
 	const [email, setEmail] = useState("");
 	return (
 		<Card className="w-10/12 ">
 			<CardHeader>
-				<CardTitle>Forget Password</CardTitle>
+				<CardTitle>Forgot Password</CardTitle>
 				<CardDescription>
 					Enter your email to reset your password
 				</CardDescription>
@@ -36,7 +36,7 @@ export default function ForgetPassword() {
 				<View className="w-full gap-2">
 					<Button
 						onPress={() => {
-							authClient.forgetPassword({
+							authClient.requestPasswordReset({
 								email,
 								redirectTo: "/reset-password",
 							});

--- a/demo/expo/src/app/index.tsx
+++ b/demo/expo/src/app/index.tsx
@@ -93,10 +93,10 @@ export default function Index() {
 						variant="link"
 						className="w-full"
 						onPress={() => {
-							router.push("/forget-password");
+							router.push("/forgot-password");
 						}}
 					>
-						<Text className="underline text-center">Forget Password?</Text>
+						<Text className="underline text-center">Forgot Password?</Text>
 					</Button>
 					<Button
 						onPress={() => {

--- a/demo/nextjs/app/(auth)/forgot-password/page.tsx
+++ b/demo/nextjs/app/(auth)/forgot-password/page.tsx
@@ -3,7 +3,7 @@
 import { ArrowLeft, CheckCircle2 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import { ForgetPasswordForm } from "@/components/forms/forget-password-form";
+import { ForgotPasswordForm } from "@/components/forms/forgot-password-form";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -59,7 +59,7 @@ export default function Page() {
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
-					<ForgetPasswordForm onSuccess={() => setIsSubmitted(true)} />
+					<ForgotPasswordForm onSuccess={() => setIsSubmitted(true)} />
 				</CardContent>
 				<CardFooter className="flex justify-center">
 					<Link href="/sign-in">

--- a/demo/nextjs/components/forms/forgot-password-form.tsx
+++ b/demo/nextjs/components/forms/forgot-password-form.tsx
@@ -15,33 +15,33 @@ import {
 import { Input } from "@/components/ui/input";
 import { authClient } from "@/lib/auth-client";
 
-const forgetPasswordSchema = z.object({
+const forgotPasswordSchema = z.object({
 	email: z.email("Please enter a valid email address."),
 });
 
-type ForgetPasswordFormValues = z.infer<typeof forgetPasswordSchema>;
+type ForgotPasswordFormValues = z.infer<typeof forgotPasswordSchema>;
 
-interface ForgetPasswordFormProps {
+interface ForgotPasswordFormProps {
 	onSuccess?: () => void;
 	onError?: (error: string) => void;
 	redirectTo?: string;
 }
 
-export function ForgetPasswordForm({
+export function ForgotPasswordForm({
 	onSuccess,
 	onError,
 	redirectTo = "/reset-password",
-}: ForgetPasswordFormProps) {
+}: ForgotPasswordFormProps) {
 	const [loading, startTransition] = useTransition();
 
-	const form = useForm<ForgetPasswordFormValues>({
-		resolver: zodResolver(forgetPasswordSchema),
+	const form = useForm<ForgotPasswordFormValues>({
+		resolver: zodResolver(forgotPasswordSchema),
 		defaultValues: {
 			email: "",
 		},
 	});
 
-	const onSubmit = (data: ForgetPasswordFormValues) => {
+	const onSubmit = (data: ForgotPasswordFormValues) => {
 		startTransition(async () => {
 			try {
 				await authClient.requestPasswordReset({
@@ -63,10 +63,10 @@ export function ForgetPasswordForm({
 					control={form.control}
 					render={({ field, fieldState }) => (
 						<Field data-invalid={fieldState.invalid}>
-							<FieldLabel htmlFor="forget-email">Email</FieldLabel>
+							<FieldLabel htmlFor="forgot-email">Email</FieldLabel>
 							<Input
 								{...field}
-								id="forget-email"
+								id="forgot-email"
 								type="email"
 								placeholder="Enter your email"
 								aria-invalid={fieldState.invalid}

--- a/demo/nextjs/components/forms/sign-in-form.tsx
+++ b/demo/nextjs/components/forms/sign-in-form.tsx
@@ -109,7 +109,7 @@ export function SignInForm({
 							<div className="flex items-center">
 								<FieldLabel htmlFor="sign-in-password">Password</FieldLabel>
 								<Link
-									href="/forget-password"
+									href="/forgot-password"
 									className="ml-auto inline-block text-sm underline text-foreground"
 								>
 									Forgot your password?

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils";
 import type { Account } from "../../types";
 
-describe("forget password", async () => {
+describe("forgot password", async () => {
 	const mockSendEmail = vi.fn();
 	const mockOnPasswordReset = vi.fn();
 	let token = "";

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -153,7 +153,7 @@ export const requestPasswordResetCallback = createAuthEndpoint(
 	"/reset-password/:token",
 	{
 		method: "GET",
-		operationId: "forgetPasswordCallback",
+		operationId: "resetPasswordCallback",
 		query: z.object({
 			callbackURL: z.string().meta({
 				description: "The URL to redirect the user to reset their password",


### PR DESCRIPTION
Fixes an incorrect top-level `operationId` on `requestPasswordResetCallback`. The top-level field feeds the OpenTelemetry span attribute `ATTR_OPERATION_ID` (via `getOperationId` in `api/to-auth-endpoints.ts`), while the OpenAPI generator reads `metadata.openapi.operationId`. On this route they were out of sync: OpenAPI said `resetPasswordCallback` but OTel was tagged `forgetPasswordCallback`, a leftover from the old `/forget-password` route name. Every other endpoint that sets both fields (e.g. `email-verification.ts:82+96`, `oauth-proxy/index.ts:138+143`) keeps them matching; this route was the only outlier.

Bundled a `forget` to `forgot` cleanup pass on places unrelated to the deprecated `/forget-password/email-otp` flow:

- `packages/better-auth/src/api/routes/password.ts:156`: top-level `operationId` to `resetPasswordCallback`
- `packages/better-auth/src/api/routes/password.test.ts:6`: `describe("forget password")` to `describe("forgot password")`
- `demo/nextjs`: `(auth)/forget-password/` directory, `forget-password-form.tsx`, `Forget*` identifiers, `sign-in-form.tsx` href
- `demo/expo`: `forget-password.tsx` file, `index.tsx` route push and button text. Also fixes a broken `authClient.forgetPassword(...)` call (method does not exist on the current client) by switching to `authClient.requestPasswordReset(...)`

Untouched on purpose: the deprecated `/forget-password/email-otp` endpoint, its `"forget-password"` OTP type literal, the `forget-password-otp-` identifier prefix, the `forgetPasswordEmailOTP` export, the rate-limiter matcher, the email-otp docs that describe those literals, and the `1-4.mdx` / `1-5.mdx` blog history. Renaming any of those would invalidate stored OTPs and break consumers still on the deprecated path.
