### PR TITLE
docs: fix PostgreSQL Prisma native type typo

### DIFF
--- a/docs/lib/copy-schema/adapter/prisma.ts
+++ b/docs/lib/copy-schema/adapter/prisma.ts
@@ -67,7 +67,7 @@ export const prismaResolver = (options: PrismaResolverOptions): Resolver => {
 				let newLine = `${field.fieldName} ${type}`;
 				let additionalLine = "";
 				if (field.type === "date" && provider === "postgresql") {
-					newLine += " @db.Timestampz(3)";
+					newLine += " @db.Timestamptz(3)";
 				}
 				if (field.unique) {
 					newLine += " @unique";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the PostgreSQL timestamptz annotation in the docs schema copy helper: use `@db.Timestamptz(3)` instead of `@db.Timestampz(3)` for date fields. Ensures the generated Prisma schema is valid for PostgreSQL.

<sup>Written for commit 80b09f23428718ae620a153c477f85bc809485b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

