### PR TITLE
feat(drizzle-adapter): optional supportsUUIDs override for PostgreSQL

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -32,6 +32,25 @@ export const auth = betterAuth({
 });
 ```
 
+## PostgreSQL: explicit user IDs (`supportsUUIDs`)
+
+For PostgreSQL, the Drizzle adapter defaults `supportsUUIDs` to `true` so UUID primary keys are treated as database-generated. If you use **`databaseHooks`** (or similar) to insert a related row first and must pass the **same UUID** as `user.id` on the next insert, set `supportsUUIDs` to `false` so explicit ids are not stripped during adapter input transforms:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { db } from "./database.ts";
+
+export const auth = betterAuth({
+  database: drizzleAdapter(db, {
+    provider: "pg",
+    supportsUUIDs: false,
+  }),
+});
+```
+
+For MySQL and SQLite the default remains `supportsUUIDs: false`; you only need this override when using PostgreSQL with the default `true` and explicit ids from hooks.
+
 ## Schema generation & migration
 
 The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import { drizzleAdapter } from "./drizzle-adapter";
 
 describe("drizzle-adapter", () => {
+	const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+
 	it("should create drizzle adapter", () => {
 		const db = {
 			_: {
@@ -26,8 +28,6 @@ describe("drizzle-adapter", () => {
 				}),
 			} as any;
 		}
-
-		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
 
 		it("should pass when drizzle schema has all required fields with default camelCase names", async () => {
 			const userTable = {
@@ -129,6 +129,61 @@ describe("drizzle-adapter", () => {
 					data: { name: "Test", email: "test@example.com" },
 				}),
 			).rejects.toThrow(/Schema not found/);
+		});
+	});
+
+	describe("supportsUUIDs override (PostgreSQL)", () => {
+		const explicitId = "550e8400-e29b-41d4-a716-446655440000";
+
+		it("passes explicit id through to Drizzle when supportsUUIDs is false with forceAllowId", async () => {
+			const captured: Record<string, unknown>[] = [];
+			const userTable = {
+				id: { name: "id" },
+				name: { name: "name" },
+				email: { name: "email" },
+				emailVerified: { name: "emailVerified" },
+				image: { name: "image" },
+				createdAt: { name: "createdAt" },
+				updatedAt: { name: "updatedAt" },
+			};
+			const db = {
+				_: { fullSchema: { user: userTable } },
+				insert: vi.fn().mockImplementation(() => ({
+					values: (v: Record<string, unknown>) => {
+						captured.push(v);
+						return {
+							returning: vi.fn().mockResolvedValue([v]),
+						};
+					},
+				})),
+			} as any;
+
+			const factory = drizzleAdapter(db, {
+				provider: "pg",
+				supportsUUIDs: false,
+			});
+			const adapter = factory({
+				secret: defaultSecret,
+				advanced: { database: { generateId: "uuid" } },
+			});
+
+			await adapter.create({
+				model: "user",
+				data: {
+					id: explicitId,
+					name: "Hooked",
+					email: "hooked@example.com",
+				},
+				forceAllowId: true,
+			});
+
+			expect(captured[0]).toEqual(
+				expect.objectContaining({
+					id: explicitId,
+					name: "Hooked",
+					email: "hooked@example.com",
+				}),
+			);
 		});
 	});
 });

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -77,6 +77,16 @@ export interface DrizzleAdapterConfig {
 	 * @default false
 	 */
 	transaction?: boolean | undefined;
+	/**
+	 * Passed to the adapter factory as `supportsUUIDs`. When `true` (the default for PostgreSQL),
+	 * UUID primary keys are treated as database-generated and explicit `id` values may be
+	 * omitted during input transforms. Set to `false` if you must supply explicit UUIDs on
+	 * insert (for example, `databaseHooks.user.create.before` after inserting a related row
+	 * that shares the same primary key).
+	 *
+	 * @default `true` for `provider: "pg"`, otherwise `false`.
+	 */
+	supportsUUIDs?: boolean | undefined;
 }
 
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
@@ -846,7 +856,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 			adapterName: "Drizzle Adapter",
 			usePlural: config.usePlural ?? false,
 			debugLogs: config.debugLogs ?? false,
-			supportsUUIDs: config.provider === "pg" ? true : false,
+			supportsUUIDs:
+				config.supportsUUIDs ?? (config.provider === "pg" ? true : false),
 			supportsJSON:
 				config.provider === "pg" // even though mysql also supports it, mysql requires to pass stringified json anyway.
 					? true


### PR DESCRIPTION
## Summary
- Add optional `supportsUUIDs` to `drizzleAdapter` config (defaults unchanged).
- Document PostgreSQL + explicit ids from hooks use case.
- Unit test: explicit id preserved when `supportsUUIDs: false`, `generateId: "uuid"`, `forceAllowId: true`.

Closes #9091


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional `supportsUUIDs` to `drizzleAdapter` so PostgreSQL apps can pass explicit UUID `id` values when needed (e.g., with database hooks). Defaults are unchanged; no breaking changes.

- **New Features**
  - Added `supportsUUIDs` config: defaults to `true` for `provider: "pg"`, `false` otherwise. Set `supportsUUIDs: false` to keep provided `id` values, including with `generateId: "uuid"` and `forceAllowId: true`.
  - Updated docs with a PostgreSQL + hooks example and added a unit test to confirm explicit UUIDs pass through.

<sup>Written for commit 0079d8823098786e0a6e4adaddc190175cb5d295. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

