### PR TITLE
fix: remove vitest from optional peer dependency

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -551,7 +551,6 @@
     "react-dom": "^18.0.0 || ^19.0.0",
     "solid-js": "^1.0.0",
     "svelte": "^4.0.0 || ^5.0.0",
-    "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "vue": "^3.0.0"
   },
   "peerDependenciesMeta": {
@@ -607,9 +606,6 @@
       "optional": true
     },
     "better-sqlite3": {
-      "optional": true
-    },
-    "vitest": {
       "optional": true
     }
   }


### PR DESCRIPTION
Fixes: #9083 

Changes
Dropped vitest from peerDependencies and peerDependenciesMeta in packages/better-auth/package.json.

Why 
npm v7+ automatically resolves peer dependencies. Because vitest was listed as an optional peer, running npm ci --omit=dev for a production build would still install it if the user already had it in their root devDependencies. This was dragging the testing framework in production deployments.


Testing
Verified locally. Packed the package , installed it in an isolated test repo with vitest as a dev dependency, and confirmed npm ci --omit=dev successfully ignores it now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `vitest` from `peerDependencies` and `peerDependenciesMeta` in `packages/better-auth` to prevent it from being installed in production. Resolves #9083 by avoiding npm v7+ peer auto-install during `npm ci --omit=dev`.

- **Bug Fixes**
  - Before: optional peer caused `vitest` to be installed if present in root devDependencies.
  - After: `npm ci --omit=dev` no longer pulls `vitest` with `better-auth`.

<sup>Written for commit e549f6b901acaf2025fcfc080972fd7bd17328b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

