### PR TITLE
fix(sso): unify SAML response processing and fix bugs

### DIFF
--- a/.changeset/sso-saml-hardening.md
+++ b/.changeset/sso-saml-hardening.md
@@ -1,0 +1,12 @@
+---
+"@better-auth/sso": patch
+---
+
+fix(sso): unify SAML response processing and fix provider/config bugs
+
+- Fix SP metadata endpoint using internal row ID instead of `providerId` in ACS URL
+- Fix `acsEndpoint` skipping DB provider lookup when `defaultSSO` is configured
+- Fix `acsEndpoint` missing encryption fields (`isAssertionEncrypted`, `encPrivateKey`), which caused silent decryption failures
+- Add registration-time validation: reject SAML configs with no usable IdP entry point
+- Extract shared `processSAMLResponse` pipeline to eliminate ~500 lines of duplicated logic between `callbackSSOSAML` and `acsEndpoint`
+- Complete `createSP`/`createIdP` helpers with all encryption and signing fields

--- a/.changeset/sso-saml-hardening.md
+++ b/.changeset/sso-saml-hardening.md
@@ -4,9 +4,22 @@
 
 fix(sso): unify SAML response processing and fix provider/config bugs
 
+**Bug fixes:**
+
 - Fix SP metadata endpoint using internal row ID instead of `providerId` in ACS URL
 - Fix `acsEndpoint` skipping DB provider lookup when `defaultSSO` is configured
 - Fix `acsEndpoint` missing encryption fields (`isAssertionEncrypted`, `encPrivateKey`), which caused silent decryption failures
-- Add registration-time validation: reject SAML configs with no usable IdP entry point
-- Extract shared `processSAMLResponse` pipeline to eliminate ~500 lines of duplicated logic between `callbackSSOSAML` and `acsEndpoint`
+- Fix `defaultSSO` config parsing in callback path (`safeJsonParse` on already-parsed objects)
+- Fix `createSP` missing `callbackUrl` fallback to auto-generated ACS URL
 - Complete `createSP`/`createIdP` helpers with all encryption and signing fields
+
+**Behavioral changes:**
+
+- ACS error redirect query parameters now use uppercase error codes (e.g. `error=SAML_MULTIPLE_ASSERTIONS` instead of `error=multiple_assertions`). If your application parses these error codes from the redirect URL, update the expected values.
+- SAML provider registration now rejects configs with no usable IdP entry point (no valid `entryPoint` URL, no `idpMetadata.metadata`, and no `idpMetadata.singleSignOnService`). Previously these would register successfully but fail at sign-in.
+- `entryPoint` validation tightened from `startsWith("http")` to `new URL()` parsing, rejecting malformed URLs like `http:evil` or `http//missing-colon`.
+
+**Refactoring (no API changes):**
+
+- Extract shared `processSAMLResponse` pipeline to eliminate ~500 lines of duplicated logic between `callbackSSOSAML` and `acsEndpoint`
+- Move `validateSAMLTimestamp` to `saml/timestamp.ts` (re-exported from original location for compatibility)

--- a/docs/content/docs/guides/saml-sso-with-okta.mdx
+++ b/docs/content/docs/guides/saml-sso-with-okta.mdx
@@ -49,8 +49,7 @@ const ssoConfig = {
       // SP Configuration
       issuer: "http://localhost:3000/api/auth/sso/saml2/sp/metadata",
       entryPoint: "https://trial-1076874.okta.com/app/trial-1076874_samltest_1/exktofb0a62hqLAUL697/sso/saml",
-      callbackUrl: "/dashboard", // Redirect after successful authentication
-      
+      callbackUrl: "http://localhost:3000/dashboard",
       // IdP Configuration
       idpMetadata: {
         entityID: "https://trial-1076874.okta.com/app/exktofb0a62hqLAUL697/sso/saml/metadata",
@@ -157,7 +156,7 @@ await authClient.signIn.sso({
 * Never use these certificates in production
 * The example uses `localhost:3000` - adjust URLs for your environment
 * For production, always use proper IdP providers like Okta, Azure AD, or OneLogin
-* The `callbackUrl` in your SAML config should point to your app's destination (e.g., `/dashboard`), not the callback route itself
+* Set `callbackUrl` in your SAML config to your app's post-login page (e.g., `/dashboard`). For SP-initiated flows, the `callbackURL` in `signIn.sso()` takes priority
 
 ### Step 5: Dynamically Registering SAML Providers
 

--- a/docs/content/docs/guides/saml-sso-with-okta.mdx
+++ b/docs/content/docs/guides/saml-sso-with-okta.mdx
@@ -49,7 +49,7 @@ const ssoConfig = {
       // SP Configuration
       issuer: "http://localhost:3000/api/auth/sso/saml2/sp/metadata",
       entryPoint: "https://trial-1076874.okta.com/app/trial-1076874_samltest_1/exktofb0a62hqLAUL697/sso/saml",
-      callbackUrl: "http://localhost:3000/dashboard",
+      callbackUrl: "http://localhost:3000/api/auth/sso/saml2/sp/acs/sso",
       // IdP Configuration
       idpMetadata: {
         entityID: "https://trial-1076874.okta.com/app/exktofb0a62hqLAUL697/sso/saml/metadata",
@@ -156,7 +156,7 @@ await authClient.signIn.sso({
 * Never use these certificates in production
 * The example uses `localhost:3000` - adjust URLs for your environment
 * For production, always use proper IdP providers like Okta, Azure AD, or OneLogin
-* Set `callbackUrl` in your SAML config to your app's post-login page (e.g., `/dashboard`). For SP-initiated flows, the `callbackURL` in `signIn.sso()` takes priority
+* `callbackUrl` is the SAML ACS endpoint URL. If omitted, it defaults to `{baseURL}/sso/saml2/sp/acs/{providerId}`. The post-login destination is controlled by `callbackURL` in `signIn.sso()`
 
 ### Step 5: Dynamically Registering SAML Providers
 

--- a/docs/content/docs/guides/supabase-migration-guide.mdx
+++ b/docs/content/docs/guides/supabase-migration-guide.mdx
@@ -1103,10 +1103,11 @@ If you're using Supabase's Enterprise SSO (SAML), follow these additional steps 
     List and export your existing SSO providers from Supabase using the CLI:
 
     ```bash title="Terminal"
-    # List all SSO providers
+    # List all SSO providers (note: this does NOT include metadata XML)
     supabase sso list --project-ref <your-project-ref>
 
-    # Export each provider's details to a JSON file
+    # Export each provider's full details (including metadata XML) to a JSON file
+    # You MUST use `sso show`, not `sso list`, to get the metadata_xml field
     supabase sso show <provider-id> --project-ref <your-project-ref> -o json > sso-provider.json
     ```
 
@@ -1118,6 +1119,7 @@ If you're using Supabase's Enterprise SSO (SAML), follow these additional steps 
       "saml": {
         "entity_id": "https://idp.example.com/saml",
         "metadata_url": "https://idp.example.com/saml/metadata",
+        "metadata_xml": "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://idp.example.com/saml\">...</md:EntityDescriptor>",
         "attribute_mapping": {
           "keys": {
             "email": { "name": "mail" },
@@ -1154,11 +1156,16 @@ If you're using Supabase's Enterprise SSO (SAML), follow these additional steps 
         metadata_url?: string;
         metadata_xml?: string;
         attribute_mapping?: {
-          keys: Record<string, { name: string }>;
+          keys: Record<string, {
+            name?: string;
+            names?: string[];
+            default?: unknown;
+            array?: boolean;
+          }>;
         };
         name_id_format?: string;
       };
-      domains: Array<{ id: string; domain: string }>;
+      domains: Array<{ id?: string; domain: string }>;
     };
 
     type SSOProviderInsertData = {
@@ -1204,23 +1211,41 @@ If you're using Supabase's Enterprise SSO (SAML), follow these additional steps 
         // Combine all domains into a comma-separated string
         const domains = provider.domains.map(d => d.domain).join(',');
         
-        // Transform Supabase attribute mapping to Better Auth format
+        // Transform Supabase attribute mapping to Better Auth format.
+        // Supabase supports both { name: "attr" } and { names: ["attr1", "attr2"] };
+        // Better Auth only uses a single attribute name, so take the first match.
         const mapping = provider.saml.attribute_mapping?.keys || {};
+        const attrName = (key: string) => mapping[key]?.name || mapping[key]?.names?.[0];
         
+        // If Supabase provided a metadata URL, fetch the XML first.
+        // Better Auth requires inline metadata XML, not a URL.
+        let idpMetadataXml = provider.saml.metadata_xml;
+        if (!idpMetadataXml && provider.saml.metadata_url) {
+          const res = await fetch(provider.saml.metadata_url);
+          if (!res.ok) {
+            console.error(`[SSO] Failed to fetch IdP metadata from ${provider.saml.metadata_url}`);
+            continue;
+          }
+          idpMetadataXml = await res.text();
+        }
+
+        if (!idpMetadataXml) {
+          console.error(`[SSO] No IdP metadata available for provider ${providerId}`);
+          continue;
+        }
+
         const samlConfig = {
           issuer: provider.saml.entity_id,
-          // These will be auto-populated from metadata
           entryPoint: '',
           cert: '',
-          // Callback URL for SAML responses
-          callbackUrl: `${betterAuthUrl}/api/auth/sso/saml2/callback/${providerId}`,
-          // IdP metadata - Better Auth will fetch and parse this
-          idpMetadata: provider.saml.metadata_url 
-            ? { metadataUrl: provider.saml.metadata_url }
-            : { metadata: provider.saml.metadata_xml },
-          // SP metadata configuration
+          // Inline IdP metadata XML (required).
+          // When metadata is present, entryPoint/cert are ignored;
+          // samlify extracts them from the XML.
+          idpMetadata: {
+            metadata: idpMetadataXml,
+          },
           spMetadata: {
-            entityID: `${betterAuthUrl}/api/auth/sso/saml2/sp/metadata`,
+            entityID: `${betterAuthUrl}/api/auth/sso/saml2/sp/metadata?providerId=${providerId}`,
           },
           // Name ID format from Supabase config
           identifierFormat: provider.saml.name_id_format || 
@@ -1228,10 +1253,10 @@ If you're using Supabase's Enterprise SSO (SAML), follow these additional steps 
           // Map Supabase attribute names to Better Auth fields
           mapping: {
             id: 'nameID',
-            email: mapping.email?.name || 'email',
-            name: mapping.name?.name || 'displayName',
-            firstName: mapping.first_name?.name || 'givenName',
-            lastName: mapping.last_name?.name || 'surname',
+            email: attrName('email') || 'email',
+            name: attrName('name') || 'displayName',
+            firstName: attrName('first_name') || 'givenName',
+            lastName: attrName('last_name') || 'surname',
           },
         };
 
@@ -1359,7 +1384,7 @@ If you're using Supabase's Enterprise SSO (SAML), follow these additional steps 
 
     | Setting              | Old Value (Supabase)                                      | New Value (Better Auth)                                                      |
     | -------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------- |
-    | ACS URL / Reply URL  | `https://<project>.supabase.co/auth/v1/sso/saml/acs`      | `https://yourapp.com/api/auth/sso/saml2/callback/<providerId>`               |
+    | ACS URL / Reply URL  | `https://<project>.supabase.co/auth/v1/sso/saml/acs`      | `https://yourapp.com/api/auth/sso/saml2/sp/acs/<providerId>`                 |
     | Entity ID / Audience | `https://<project>.supabase.co/auth/v1/sso/saml/metadata` | `https://yourapp.com/api/auth/sso/saml2/sp/metadata?providerId=<providerId>` |
 
     Replace `<providerId>` with your migrated provider ID (e.g., `sso-550e8400-e29b-41d4-a716-446655440000`).

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -345,7 +345,7 @@ To register a SAML provider, use the `registerSSOProvider` endpoint with SAML co
         samlConfig: {
             entryPoint: "https://idp.example.com/sso",
             cert: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-            callbackUrl: "https://yourapp.com/dashboard",
+            callbackUrl: "https://yourapp.com/api/auth/sso/saml2/sp/acs/saml-provider",
             audience: "https://yourapp.com",
             wantAssertionsSigned: true,
             signatureAlgorithm: "sha256",
@@ -396,7 +396,7 @@ To register a SAML provider, use the `registerSSOProvider` endpoint with SAML co
             samlConfig: {
                 entryPoint: "https://idp.example.com/sso",
                 cert: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-                callbackUrl: "https://yourapp.com/dashboard",
+                callbackUrl: "https://yourapp.com/api/auth/sso/saml2/sp/acs/saml-provider",
                 audience: "https://yourapp.com",
                 wantAssertionsSigned: true,
                 signatureAlgorithm: "sha256",
@@ -905,7 +905,7 @@ const auth = betterAuth({
                         issuer: "https://your-app.com",
                         entryPoint: "https://idp.example.com/sso",
                         cert: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-                        callbackUrl: "http://localhost:3000/dashboard",
+                        callbackUrl: "http://localhost:3000/api/auth/sso/saml2/sp/acs/default-saml",
                         spMetadata: {
                             entityID: "http://localhost:3000/api/auth/sso/saml2/sp/metadata",
                             metadata: "<!-- Your SP Metadata XML -->",
@@ -1412,7 +1412,9 @@ The SAML callback endpoint (`/api/auth/sso/saml2/callback/{providerId}`) handles
 * **SP-initiated**: User clicks "Sign in with SSO" in your app → redirects to IdP → IdP POSTs SAMLResponse to callback
 * **IdP-initiated**: User clicks app icon in IdP dashboard (Okta, Azure AD, etc.) → IdP POSTs SAMLResponse to callback
 
-**Important**: Set `callbackUrl` in your SAML configuration to your application's post-login destination (e.g., `https://yourapp.com/dashboard`). For SP-initiated flows, the post-login redirect is controlled by the `callbackURL` parameter in the client-side `signIn.sso()` call, which takes priority over the configured `callbackUrl`:
+**Important**: `callbackUrl` in your SAML configuration is used as the Assertion Consumer Service (ACS) URL. Set it to the SAML callback route for your provider (e.g., `https://yourapp.com/api/auth/sso/saml2/sp/acs/my-provider`). If omitted, Better Auth derives it automatically from your `baseURL` and `providerId`.
+
+The post-login redirect destination is controlled by the `callbackURL` parameter in the client-side `signIn.sso()` call:
 
 ```ts
 await authClient.signIn.sso({
@@ -1429,16 +1431,16 @@ The plugin requires additional fields in the `ssoProvider` table to store the pr
 
 <DatabaseTable
   fields={[
-  {
-      name: "id", type: "string", description: "A database identifier", isPrimaryKey: true,
-  },
-  { name: "issuer", type: "string", description: "The issuer identifier" },
-  { name: "domain", type: "string", description: "The domain of the provider" },
-  { name: "oidcConfig", type: "string", description: "The OIDC configuration (JSON string)", isOptional: true },
-  { name: "samlConfig", type: "string", description: "The SAML configuration (JSON string)", isOptional: true },
-  { name: "userId", type: "string", description: "The user ID", isForeignKey: true },
-  { name: "providerId", type: "string", description: "The provider ID. Used to identify a provider and to generate a redirect URL.", isUnique: true },
-  { name: "organizationId", type: "string", description: "The organization Id. If provider is linked to an organization.", isOptional: true }
+{
+    name: "id", type: "string", description: "A database identifier", isPrimaryKey: true,
+},
+{ name: "issuer", type: "string", description: "The issuer identifier" },
+{ name: "domain", type: "string", description: "The domain of the provider" },
+{ name: "oidcConfig", type: "string", description: "The OIDC configuration (JSON string)", isOptional: true },
+{ name: "samlConfig", type: "string", description: "The SAML configuration (JSON string)", isOptional: true },
+{ name: "userId", type: "string", description: "The user ID", isForeignKey: true },
+{ name: "providerId", type: "string", description: "The provider ID. Used to identify a provider and to generate a redirect URL.", isUnique: true },
+{ name: "organizationId", type: "string", description: "The organization Id. If provider is linked to an organization.", isOptional: true }
 ]}
 />
 
@@ -1448,7 +1450,7 @@ The `ssoProvider` schema is extended as follows:
 
 <DatabaseTable
   fields={[
-  { name: "domainVerified", type: "boolean", description: "A flag indicating whether the provider domain has been verified.", isOptional: true },
+{ name: "domainVerified", type: "boolean", description: "A flag indicating whether the provider domain has been verified.", isOptional: true },
 ]}
 />
 
@@ -1466,7 +1468,7 @@ Better Auth supports **IdP-initiated SSO flows**, where users access your applic
 **No additional configuration required** - the callback route automatically handles both GET and POST requests.
 
 <Callout type="warn">
-  IdP-initiated flows do not carry a RelayState. After authentication, Better Auth redirects to your configured `callbackUrl` if set, or falls back to the application's base URL. Set `callbackUrl` to your desired landing page (e.g., `https://yourapp.com/dashboard`) to control where IdP-initiated users arrive.
+  IdP-initiated flows do not carry a RelayState, so the post-login redirect falls back to your application's base URL. To control where users land after SP-initiated SSO, pass the destination via `callbackURL` in the `signIn.sso()` call.
 </Callout>
 
 <Callout type="info">
@@ -1498,195 +1500,195 @@ If you want to allow account linking for specific trusted providers, enable the 
 <TypeTable
   type={{
 provisionUser: {
-  description: "A custom function to provision a user when they sign in with an SSO provider.",
-  type: "function",
+description: "A custom function to provision a user when they sign in with an SSO provider.",
+type: "function",
 },
 provisionUserOnEveryLogin: {
-  description: "If true, the provisionUser callback will be called on every login, not just when a new user is registered.",
-  type: "boolean",
-  default: false,
+description: "If true, the provisionUser callback will be called on every login, not just when a new user is registered.",
+type: "boolean",
+default: false,
 },
 organizationProvisioning: {
-  description: "Options for provisioning users to an organization.",
-  type: "object",
-  properties: {
-      disabled: {
-          description: "Disable organization provisioning.",
-          type: "boolean",
-          default: false,
-      },
-      defaultRole: {
-          description: "The default role for new users.",
-          type: "string",
-          enum: ["member", "admin"],
-          default: "member",
-      },
-      getRole: {
-          description: "A custom function to determine the role for new users.",
-          type: "function",
-      },
-  },
+description: "Options for provisioning users to an organization.",
+type: "object",
+properties: {
+    disabled: {
+        description: "Disable organization provisioning.",
+        type: "boolean",
+        default: false,
+    },
+    defaultRole: {
+        description: "The default role for new users.",
+        type: "string",
+        enum: ["member", "admin"],
+        default: "member",
+    },
+    getRole: {
+        description: "A custom function to determine the role for new users.",
+        type: "function",
+    },
+},
 },
 defaultOverrideUserInfo: {
-  description: "Override user info with the provider info by default.",
-  type: "boolean",
-  default: false,
+description: "Override user info with the provider info by default.",
+type: "boolean",
+default: false,
 },
 disableImplicitSignUp: {
-  description: "Disable implicit sign up for new users. When set to true, sign-in needs to be called with requestSignUp as true to create new users.",
-  type: "boolean",
-  default: false,
+description: "Disable implicit sign up for new users. When set to true, sign-in needs to be called with requestSignUp as true to create new users.",
+type: "boolean",
+default: false,
 },
 providersLimit: {
-  description: "Configure the maximum number of SSO providers a user can register. Set to 0 to disable SSO provider registration.",
-  type: "number | function",
-  default: 10,
+description: "Configure the maximum number of SSO providers a user can register. Set to 0 to disable SSO provider registration.",
+type: "number | function",
+default: 10,
 },
 redirectURI: {
-  description: "Custom redirect URI for OIDC SSO callbacks. When set, all OIDC providers share this single callback URL instead of per-provider URLs. The provider ID is stored in the OAuth state. Can be a relative path (e.g., '/sso/callback') or a full URL.",
-  type: "string",
-  required: false,
+description: "Custom redirect URI for OIDC SSO callbacks. When set, all OIDC providers share this single callback URL instead of per-provider URLs. The provider ID is stored in the OAuth state. Can be a relative path (e.g., '/sso/callback') or a full URL.",
+type: "string",
+required: false,
 },
 domainVerification: {
-  description: "Configure the domain verification feature",
-  type: "object",
-  properties: {
-      enabled: {
-          description: "Enables or disables the domain verification feature",
-          type: "boolean",
-          required: false
-      },
-      tokenPrefix: {
-          description: "Prefix used to generate the domain verification identifier. An underscore is automatically prepended.",
-          type: "string",
-          required: false,
-          default: "better-auth-token"
-      },
-  },
+description: "Configure the domain verification feature",
+type: "object",
+properties: {
+    enabled: {
+        description: "Enables or disables the domain verification feature",
+        type: "boolean",
+        required: false
+    },
+    tokenPrefix: {
+        description: "Prefix used to generate the domain verification identifier. An underscore is automatically prepended.",
+        type: "string",
+        required: false,
+        default: "better-auth-token"
+    },
+},
 },
 defaultSSO: {
-  description: "Configure a default SSO provider for testing and development. This provider will be used when no matching provider is found in the database.",
-  type: "array",
-  items: {
-      type: "object",
-      properties: {
-          domain: {
-              description: "The domain to match for this default provider.",
-              type: "string",
-              required: true,
-          },
-          providerId: {
-              description: "The provider ID to use for the default provider.",
-              type: "string",
-              required: true,
-          },
-          samlConfig: {
-              description: "SAML configuration for the default provider.",
-              type: "SAMLConfig",
-              required: false,
-          },
-          oidcConfig: {
-              description: "OIDC configuration for the default provider.",
-              type: "OIDCConfig",
-              required: false,
-          },
-      }
-  },
+description: "Configure a default SSO provider for testing and development. This provider will be used when no matching provider is found in the database.",
+type: "array",
+items: {
+    type: "object",
+    properties: {
+        domain: {
+            description: "The domain to match for this default provider.",
+            type: "string",
+            required: true,
+        },
+        providerId: {
+            description: "The provider ID to use for the default provider.",
+            type: "string",
+            required: true,
+        },
+        samlConfig: {
+            description: "SAML configuration for the default provider.",
+            type: "SAMLConfig",
+            required: false,
+        },
+        oidcConfig: {
+            description: "OIDC configuration for the default provider.",
+            type: "OIDCConfig",
+            required: false,
+        },
+    }
+},
 },
 saml: {
-  description: "SAML security options for AuthnRequest/InResponseTo validation, replay protection, and timestamp handling.",
-  type: "object",
-  properties: {
-      enableInResponseToValidation: {
-          description: "Enable InResponseTo validation for SP-initiated SAML flows.",
-          type: "boolean",
-          default: true,
-      },
-      allowIdpInitiated: {
-          description: "Allow IdP-initiated SSO (unsolicited SAML responses). Set to false for stricter security. Only applies when validation is enabled.",
-          type: "boolean",
-          default: true,
-      },
-      requestTTL: {
-          description: "TTL for AuthnRequest records in milliseconds. Only applies when validation is enabled.",
-          type: "number",
-          default: 300000,
-      },
-      clockSkew: {
-          description: "Clock skew tolerance for SAML assertion timestamp validation (NotBefore/NotOnOrAfter) in milliseconds. Allows for minor time differences between IdP and SP servers.",
-          type: "number",
-          default: 300000,
-      },
-      requireTimestamps: {
-          description: "Require timestamp conditions (NotBefore/NotOnOrAfter) in SAML assertions. When enabled, assertions without timestamps are rejected. When disabled, they are accepted with a warning logged.",
-          type: "boolean",
-          default: false,
-      },
-      algorithms: {
-          description: "Algorithm validation options.",
-          type: "object",
-          properties: {
-              onDeprecated: {
-                  description: "Behavior for deprecated algorithms (SHA-1, RSA 1.5, 3DES).",
-                  type: "string",
-                  enum: ["reject", "warn", "allow"],
-                  default: "warn",
-              },
-          },
-      },
-      maxResponseSize: {
-          description: "Maximum allowed size for SAML responses in bytes.",
-          type: "number",
-          default: 262144,
-      },
-      maxMetadataSize: {
-          description: "Maximum allowed size for IdP metadata XML in bytes.",
-          type: "number",
-          default: 102400,
-      },
-  },
+description: "SAML security options for AuthnRequest/InResponseTo validation, replay protection, and timestamp handling.",
+type: "object",
+properties: {
+    enableInResponseToValidation: {
+        description: "Enable InResponseTo validation for SP-initiated SAML flows.",
+        type: "boolean",
+        default: true,
+    },
+    allowIdpInitiated: {
+        description: "Allow IdP-initiated SSO (unsolicited SAML responses). Set to false for stricter security. Only applies when validation is enabled.",
+        type: "boolean",
+        default: true,
+    },
+    requestTTL: {
+        description: "TTL for AuthnRequest records in milliseconds. Only applies when validation is enabled.",
+        type: "number",
+        default: 300000,
+    },
+    clockSkew: {
+        description: "Clock skew tolerance for SAML assertion timestamp validation (NotBefore/NotOnOrAfter) in milliseconds. Allows for minor time differences between IdP and SP servers.",
+        type: "number",
+        default: 300000,
+    },
+    requireTimestamps: {
+        description: "Require timestamp conditions (NotBefore/NotOnOrAfter) in SAML assertions. When enabled, assertions without timestamps are rejected. When disabled, they are accepted with a warning logged.",
+        type: "boolean",
+        default: false,
+    },
+    algorithms: {
+        description: "Algorithm validation options.",
+        type: "object",
+        properties: {
+            onDeprecated: {
+                description: "Behavior for deprecated algorithms (SHA-1, RSA 1.5, 3DES).",
+                type: "string",
+                enum: ["reject", "warn", "allow"],
+                default: "warn",
+            },
+        },
+    },
+    maxResponseSize: {
+        description: "Maximum allowed size for SAML responses in bytes.",
+        type: "number",
+        default: 262144,
+    },
+    maxMetadataSize: {
+        description: "Maximum allowed size for IdP metadata XML in bytes.",
+        type: "number",
+        default: 102400,
+    },
+},
 },
 modelName: {
-  description: "The model name for the SSO provider table",
-  type: "string",
-  default: "ssoProvider"
+description: "The model name for the SSO provider table",
+type: "string",
+default: "ssoProvider"
 },
 fields: {
-  issuer: {
-      description: "Custom name for the issuer column",
-      type: "string",
-      default: "issuer",
-  },
-  oidcConfig: {
-      description: "Custom name for the oidcConfig column",
-      type: "string",
-      default: "oidcConfig",
-  },
-  samlConfig: {
-      description: "Custom name for the samlConfig column",
-      type: "string",
-      default: "samlConfig",
-  },
-  userId: {
-      description: "Custom name for the userId column",
-      type: "string",
-      default: "userId",
-  },
-  providerId: {
-      description: "Custom name for the providerId column",
-      type: "string",
-      default: "providerId",
-  },
-  organizationId: {
-      description: "Custom name for the organizationId column",
-      type: "string",
-      default: "organizationId",
-  },
-  domain: {
-      description: "Custom name for the domain column",
-      type: "string",
-      default: "domain",
-  }
+issuer: {
+    description: "Custom name for the issuer column",
+    type: "string",
+    default: "issuer",
+},
+oidcConfig: {
+    description: "Custom name for the oidcConfig column",
+    type: "string",
+    default: "oidcConfig",
+},
+samlConfig: {
+    description: "Custom name for the samlConfig column",
+    type: "string",
+    default: "samlConfig",
+},
+userId: {
+    description: "Custom name for the userId column",
+    type: "string",
+    default: "userId",
+},
+providerId: {
+    description: "Custom name for the providerId column",
+    type: "string",
+    default: "providerId",
+},
+organizationId: {
+    description: "Custom name for the organizationId column",
+    type: "string",
+    default: "organizationId",
+},
+domain: {
+    description: "Custom name for the domain column",
+    type: "string",
+    default: "domain",
+}
 }
 }}
 />

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -1429,16 +1429,16 @@ The plugin requires additional fields in the `ssoProvider` table to store the pr
 
 <DatabaseTable
   fields={[
-    {
-        name: "id", type: "string", description: "A database identifier", isPrimaryKey: true,
-    },
-    { name: "issuer", type: "string", description: "The issuer identifier" },
-    { name: "domain", type: "string", description: "The domain of the provider" },
-    { name: "oidcConfig", type: "string", description: "The OIDC configuration (JSON string)", isOptional: true },
-    { name: "samlConfig", type: "string", description: "The SAML configuration (JSON string)", isOptional: true },
-    { name: "userId", type: "string", description: "The user ID", isForeignKey: true },
-    { name: "providerId", type: "string", description: "The provider ID. Used to identify a provider and to generate a redirect URL.", isUnique: true },
-    { name: "organizationId", type: "string", description: "The organization Id. If provider is linked to an organization.", isOptional: true }
+  {
+      name: "id", type: "string", description: "A database identifier", isPrimaryKey: true,
+  },
+  { name: "issuer", type: "string", description: "The issuer identifier" },
+  { name: "domain", type: "string", description: "The domain of the provider" },
+  { name: "oidcConfig", type: "string", description: "The OIDC configuration (JSON string)", isOptional: true },
+  { name: "samlConfig", type: "string", description: "The SAML configuration (JSON string)", isOptional: true },
+  { name: "userId", type: "string", description: "The user ID", isForeignKey: true },
+  { name: "providerId", type: "string", description: "The provider ID. Used to identify a provider and to generate a redirect URL.", isUnique: true },
+  { name: "organizationId", type: "string", description: "The organization Id. If provider is linked to an organization.", isOptional: true }
 ]}
 />
 
@@ -1448,7 +1448,7 @@ The `ssoProvider` schema is extended as follows:
 
 <DatabaseTable
   fields={[
-    { name: "domainVerified", type: "boolean", description: "A flag indicating whether the provider domain has been verified.", isOptional: true },
+  { name: "domainVerified", type: "boolean", description: "A flag indicating whether the provider domain has been verified.", isOptional: true },
 ]}
 />
 
@@ -1466,7 +1466,7 @@ Better Auth supports **IdP-initiated SSO flows**, where users access your applic
 **No additional configuration required** - the callback route automatically handles both GET and POST requests.
 
 <Callout type="warn">
-  IdP-initiated flows do not carry a RelayState, so Better Auth redirects to your application's base URL after authentication. If you need users to land on a specific page (e.g., `/dashboard`), handle this in your application's root route by checking for an active session and redirecting accordingly.
+  IdP-initiated flows do not carry a RelayState. After authentication, Better Auth redirects to your configured `callbackUrl` if set, or falls back to the application's base URL. Set `callbackUrl` to your desired landing page (e.g., `https://yourapp.com/dashboard`) to control where IdP-initiated users arrive.
 </Callout>
 
 <Callout type="info">
@@ -1498,195 +1498,195 @@ If you want to allow account linking for specific trusted providers, enable the 
 <TypeTable
   type={{
 provisionUser: {
-    description: "A custom function to provision a user when they sign in with an SSO provider.",
-    type: "function",
+  description: "A custom function to provision a user when they sign in with an SSO provider.",
+  type: "function",
 },
 provisionUserOnEveryLogin: {
-    description: "If true, the provisionUser callback will be called on every login, not just when a new user is registered.",
-    type: "boolean",
-    default: false,
+  description: "If true, the provisionUser callback will be called on every login, not just when a new user is registered.",
+  type: "boolean",
+  default: false,
 },
 organizationProvisioning: {
-    description: "Options for provisioning users to an organization.",
-    type: "object",
-    properties: {
-        disabled: {
-            description: "Disable organization provisioning.",
-            type: "boolean",
-            default: false,
-        },
-        defaultRole: {
-            description: "The default role for new users.",
-            type: "string",
-            enum: ["member", "admin"],
-            default: "member",
-        },
-        getRole: {
-            description: "A custom function to determine the role for new users.",
-            type: "function",
-        },
-    },
+  description: "Options for provisioning users to an organization.",
+  type: "object",
+  properties: {
+      disabled: {
+          description: "Disable organization provisioning.",
+          type: "boolean",
+          default: false,
+      },
+      defaultRole: {
+          description: "The default role for new users.",
+          type: "string",
+          enum: ["member", "admin"],
+          default: "member",
+      },
+      getRole: {
+          description: "A custom function to determine the role for new users.",
+          type: "function",
+      },
+  },
 },
 defaultOverrideUserInfo: {
-    description: "Override user info with the provider info by default.",
-    type: "boolean",
-    default: false,
+  description: "Override user info with the provider info by default.",
+  type: "boolean",
+  default: false,
 },
 disableImplicitSignUp: {
-    description: "Disable implicit sign up for new users. When set to true, sign-in needs to be called with requestSignUp as true to create new users.",
-    type: "boolean",
-    default: false,
+  description: "Disable implicit sign up for new users. When set to true, sign-in needs to be called with requestSignUp as true to create new users.",
+  type: "boolean",
+  default: false,
 },
 providersLimit: {
-    description: "Configure the maximum number of SSO providers a user can register. Set to 0 to disable SSO provider registration.",
-    type: "number | function",
-    default: 10,
+  description: "Configure the maximum number of SSO providers a user can register. Set to 0 to disable SSO provider registration.",
+  type: "number | function",
+  default: 10,
 },
 redirectURI: {
-    description: "Custom redirect URI for OIDC SSO callbacks. When set, all OIDC providers share this single callback URL instead of per-provider URLs. The provider ID is stored in the OAuth state. Can be a relative path (e.g., '/sso/callback') or a full URL.",
-    type: "string",
-    required: false,
+  description: "Custom redirect URI for OIDC SSO callbacks. When set, all OIDC providers share this single callback URL instead of per-provider URLs. The provider ID is stored in the OAuth state. Can be a relative path (e.g., '/sso/callback') or a full URL.",
+  type: "string",
+  required: false,
 },
 domainVerification: {
-    description: "Configure the domain verification feature",
-    type: "object",
-    properties: {
-        enabled: {
-            description: "Enables or disables the domain verification feature",
-            type: "boolean",
-            required: false
-        },
-        tokenPrefix: {
-            description: "Prefix used to generate the domain verification identifier. An underscore is automatically prepended.",
-            type: "string",
-            required: false,
-            default: "better-auth-token"
-        },
-    },
+  description: "Configure the domain verification feature",
+  type: "object",
+  properties: {
+      enabled: {
+          description: "Enables or disables the domain verification feature",
+          type: "boolean",
+          required: false
+      },
+      tokenPrefix: {
+          description: "Prefix used to generate the domain verification identifier. An underscore is automatically prepended.",
+          type: "string",
+          required: false,
+          default: "better-auth-token"
+      },
+  },
 },
 defaultSSO: {
-    description: "Configure a default SSO provider for testing and development. This provider will be used when no matching provider is found in the database.",
-    type: "array",
-    items: {
-        type: "object",
-        properties: {
-            domain: {
-                description: "The domain to match for this default provider.",
-                type: "string",
-                required: true,
-            },
-            providerId: {
-                description: "The provider ID to use for the default provider.",
-                type: "string",
-                required: true,
-            },
-            samlConfig: {
-                description: "SAML configuration for the default provider.",
-                type: "SAMLConfig",
-                required: false,
-            },
-            oidcConfig: {
-                description: "OIDC configuration for the default provider.",
-                type: "OIDCConfig",
-                required: false,
-            },
-        }
-    },
+  description: "Configure a default SSO provider for testing and development. This provider will be used when no matching provider is found in the database.",
+  type: "array",
+  items: {
+      type: "object",
+      properties: {
+          domain: {
+              description: "The domain to match for this default provider.",
+              type: "string",
+              required: true,
+          },
+          providerId: {
+              description: "The provider ID to use for the default provider.",
+              type: "string",
+              required: true,
+          },
+          samlConfig: {
+              description: "SAML configuration for the default provider.",
+              type: "SAMLConfig",
+              required: false,
+          },
+          oidcConfig: {
+              description: "OIDC configuration for the default provider.",
+              type: "OIDCConfig",
+              required: false,
+          },
+      }
+  },
 },
 saml: {
-    description: "SAML security options for AuthnRequest/InResponseTo validation, replay protection, and timestamp handling.",
-    type: "object",
-    properties: {
-        enableInResponseToValidation: {
-            description: "Enable InResponseTo validation for SP-initiated SAML flows.",
-            type: "boolean",
-            default: true,
-        },
-        allowIdpInitiated: {
-            description: "Allow IdP-initiated SSO (unsolicited SAML responses). Set to false for stricter security. Only applies when validation is enabled.",
-            type: "boolean",
-            default: true,
-        },
-        requestTTL: {
-            description: "TTL for AuthnRequest records in milliseconds. Only applies when validation is enabled.",
-            type: "number",
-            default: 300000,
-        },
-        clockSkew: {
-            description: "Clock skew tolerance for SAML assertion timestamp validation (NotBefore/NotOnOrAfter) in milliseconds. Allows for minor time differences between IdP and SP servers.",
-            type: "number",
-            default: 300000,
-        },
-        requireTimestamps: {
-            description: "Require timestamp conditions (NotBefore/NotOnOrAfter) in SAML assertions. When enabled, assertions without timestamps are rejected. When disabled, they are accepted with a warning logged.",
-            type: "boolean",
-            default: false,
-        },
-        algorithms: {
-            description: "Algorithm validation options.",
-            type: "object",
-            properties: {
-                onDeprecated: {
-                    description: "Behavior for deprecated algorithms (SHA-1, RSA 1.5, 3DES).",
-                    type: "string",
-                    enum: ["reject", "warn", "allow"],
-                    default: "warn",
-                },
-            },
-        },
-        maxResponseSize: {
-            description: "Maximum allowed size for SAML responses in bytes.",
-            type: "number",
-            default: 262144,
-        },
-        maxMetadataSize: {
-            description: "Maximum allowed size for IdP metadata XML in bytes.",
-            type: "number",
-            default: 102400,
-        },
-    },
+  description: "SAML security options for AuthnRequest/InResponseTo validation, replay protection, and timestamp handling.",
+  type: "object",
+  properties: {
+      enableInResponseToValidation: {
+          description: "Enable InResponseTo validation for SP-initiated SAML flows.",
+          type: "boolean",
+          default: true,
+      },
+      allowIdpInitiated: {
+          description: "Allow IdP-initiated SSO (unsolicited SAML responses). Set to false for stricter security. Only applies when validation is enabled.",
+          type: "boolean",
+          default: true,
+      },
+      requestTTL: {
+          description: "TTL for AuthnRequest records in milliseconds. Only applies when validation is enabled.",
+          type: "number",
+          default: 300000,
+      },
+      clockSkew: {
+          description: "Clock skew tolerance for SAML assertion timestamp validation (NotBefore/NotOnOrAfter) in milliseconds. Allows for minor time differences between IdP and SP servers.",
+          type: "number",
+          default: 300000,
+      },
+      requireTimestamps: {
+          description: "Require timestamp conditions (NotBefore/NotOnOrAfter) in SAML assertions. When enabled, assertions without timestamps are rejected. When disabled, they are accepted with a warning logged.",
+          type: "boolean",
+          default: false,
+      },
+      algorithms: {
+          description: "Algorithm validation options.",
+          type: "object",
+          properties: {
+              onDeprecated: {
+                  description: "Behavior for deprecated algorithms (SHA-1, RSA 1.5, 3DES).",
+                  type: "string",
+                  enum: ["reject", "warn", "allow"],
+                  default: "warn",
+              },
+          },
+      },
+      maxResponseSize: {
+          description: "Maximum allowed size for SAML responses in bytes.",
+          type: "number",
+          default: 262144,
+      },
+      maxMetadataSize: {
+          description: "Maximum allowed size for IdP metadata XML in bytes.",
+          type: "number",
+          default: 102400,
+      },
+  },
 },
 modelName: {
-    description: "The model name for the SSO provider table",
-    type: "string",
-    default: "ssoProvider"
+  description: "The model name for the SSO provider table",
+  type: "string",
+  default: "ssoProvider"
 },
 fields: {
-    issuer: {
-        description: "Custom name for the issuer column",
-        type: "string",
-        default: "issuer",
-    },
-	oidcConfig: {
-        description: "Custom name for the oidcConfig column",
-        type: "string",
-        default: "oidcConfig",
-    },
-	samlConfig: {
-        description: "Custom name for the samlConfig column",
-        type: "string",
-        default: "samlConfig",
-    },
-	userId: {
-        description: "Custom name for the userId column",
-        type: "string",
-        default: "userId",
-    },
-	providerId: {
-        description: "Custom name for the providerId column",
-        type: "string",
-        default: "providerId",
-    },
-	organizationId: {
-        description: "Custom name for the organizationId column",
-        type: "string",
-        default: "organizationId",
-    },
-	domain: {
-        description: "Custom name for the domain column",
-        type: "string",
-        default: "domain",
-    }
+  issuer: {
+      description: "Custom name for the issuer column",
+      type: "string",
+      default: "issuer",
+  },
+  oidcConfig: {
+      description: "Custom name for the oidcConfig column",
+      type: "string",
+      default: "oidcConfig",
+  },
+  samlConfig: {
+      description: "Custom name for the samlConfig column",
+      type: "string",
+      default: "samlConfig",
+  },
+  userId: {
+      description: "Custom name for the userId column",
+      type: "string",
+      default: "userId",
+  },
+  providerId: {
+      description: "Custom name for the providerId column",
+      type: "string",
+      default: "providerId",
+  },
+  organizationId: {
+      description: "Custom name for the organizationId column",
+      type: "string",
+      default: "organizationId",
+  },
+  domain: {
+      description: "Custom name for the domain column",
+      type: "string",
+      default: "domain",
+  }
 }
 }}
 />

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -345,7 +345,7 @@ To register a SAML provider, use the `registerSSOProvider` endpoint with SAML co
         samlConfig: {
             entryPoint: "https://idp.example.com/sso",
             cert: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-            callbackUrl: "https://yourapp.com/api/auth/sso/saml2/callback/saml-provider",
+            callbackUrl: "https://yourapp.com/dashboard",
             audience: "https://yourapp.com",
             wantAssertionsSigned: true,
             signatureAlgorithm: "sha256",
@@ -396,7 +396,7 @@ To register a SAML provider, use the `registerSSOProvider` endpoint with SAML co
             samlConfig: {
                 entryPoint: "https://idp.example.com/sso",
                 cert: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-                callbackUrl: "https://yourapp.com/api/auth/sso/saml2/callback/saml-provider",
+                callbackUrl: "https://yourapp.com/dashboard",
                 audience: "https://yourapp.com",
                 wantAssertionsSigned: true,
                 signatureAlgorithm: "sha256",
@@ -905,7 +905,7 @@ const auth = betterAuth({
                         issuer: "https://your-app.com",
                         entryPoint: "https://idp.example.com/sso",
                         cert: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-                        callbackUrl: "http://localhost:3000/api/auth/sso/saml2/sp/acs",
+                        callbackUrl: "http://localhost:3000/dashboard",
                         spMetadata: {
                             entityID: "http://localhost:3000/api/auth/sso/saml2/sp/metadata",
                             metadata: "<!-- Your SP Metadata XML -->",
@@ -1264,7 +1264,7 @@ The provider ID is stored in the OAuth state so the callback can identify which 
 </Callout>
 
 <Callout type="info">
-  This option only affects OIDC providers. SAML providers already support custom callback URLs via `callbackUrl` in `samlConfig`.
+  This option only affects OIDC providers. SAML providers use a separate ACS endpoint that is configured automatically.
 </Callout>
 
 <Callout type="info">
@@ -1412,13 +1412,13 @@ The SAML callback endpoint (`/api/auth/sso/saml2/callback/{providerId}`) handles
 * **SP-initiated**: User clicks "Sign in with SSO" in your app → redirects to IdP → IdP POSTs SAMLResponse to callback
 * **IdP-initiated**: User clicks app icon in IdP dashboard (Okta, Azure AD, etc.) → IdP POSTs SAMLResponse to callback
 
-**Important**: The `callbackUrl` in your SAML configuration should point to your application's destination URL (e.g., `/dashboard`), **not** the callback route itself. Better Auth automatically handles the callback route and redirects users to your specified `callbackUrl` after successful authentication.
+**Important**: Set `callbackUrl` in your SAML configuration to your application's post-login destination (e.g., `https://yourapp.com/dashboard`). For SP-initiated flows, the post-login redirect is controlled by the `callbackURL` parameter in the client-side `signIn.sso()` call, which takes priority over the configured `callbackUrl`:
 
 ```ts
-samlConfig: {
-  callbackUrl: "/dashboard", // Correct - points to your app destination
-  // callbackUrl: "/api/auth/sso/saml2/callback/my-provider" // Incorrect - don't point to callback route
-}
+await authClient.signIn.sso({
+  providerId: "my-provider",
+  callbackURL: "/dashboard", // Where the user lands after SSO
+});
 ```
 
 The callback route supports both GET and POST methods automatically, so you don't need to create any additional route handlers in your framework.
@@ -1427,66 +1427,30 @@ The callback route supports both GET and POST methods automatically, so you don'
 
 The plugin requires additional fields in the `ssoProvider` table to store the provider's configuration.
 
-export const ssoProviderTableFields = [
-	{
-		name: "id",
-		type: "string",
-		description: "A database identifier",
-		isPrimaryKey: true,
-	},
-	{ name: "issuer", type: "string", description: "The issuer identifier" },
-	{ name: "domain", type: "string", description: "The domain of the provider" },
-	{
-		name: "oidcConfig",
-		type: "string",
-		description: "The OIDC configuration (JSON string)",
-		isOptional: true,
-	},
-	{
-		name: "samlConfig",
-		type: "string",
-		description: "The SAML configuration (JSON string)",
-		isOptional: true,
-	},
-	{
-		name: "userId",
-		type: "string",
-		description: "The user ID",
-		isForeignKey: true,
-	},
-	{
-		name: "providerId",
-		type: "string",
-		description:
-			"The provider ID. Used to identify a provider and to generate a redirect URL.",
-		isUnique: true,
-	},
-	{
-		name: "organizationId",
-		type: "string",
-		description:
-			"The organization Id. If provider is linked to an organization.",
-		isOptional: true,
-	},
-];
-
-<DatabaseTable name="ssoProvider" fields={ssoProviderTableFields} />
+<DatabaseTable
+  fields={[
+    {
+        name: "id", type: "string", description: "A database identifier", isPrimaryKey: true,
+    },
+    { name: "issuer", type: "string", description: "The issuer identifier" },
+    { name: "domain", type: "string", description: "The domain of the provider" },
+    { name: "oidcConfig", type: "string", description: "The OIDC configuration (JSON string)", isOptional: true },
+    { name: "samlConfig", type: "string", description: "The SAML configuration (JSON string)", isOptional: true },
+    { name: "userId", type: "string", description: "The user ID", isForeignKey: true },
+    { name: "providerId", type: "string", description: "The provider ID. Used to identify a provider and to generate a redirect URL.", isUnique: true },
+    { name: "organizationId", type: "string", description: "The organization Id. If provider is linked to an organization.", isOptional: true }
+]}
+/>
 
 ### If you have enabled domain verification:
 
 The `ssoProvider` schema is extended as follows:
 
-export const ssoProviderDomainVerificationFields = [
-	{
-		name: "domainVerified",
-		type: "boolean",
-		description:
-			"A flag indicating whether the provider domain has been verified.",
-		isOptional: true,
-	},
-];
-
-<DatabaseTable name="ssoProvider" fields={ssoProviderDomainVerificationFields} />
+<DatabaseTable
+  fields={[
+    { name: "domainVerified", type: "boolean", description: "A flag indicating whether the provider domain has been verified.", isOptional: true },
+]}
+/>
 
 ### IdP-Initiated SAML SSO
 
@@ -1496,10 +1460,14 @@ Better Auth supports **IdP-initiated SSO flows**, where users access your applic
 
 1. User clicks your app icon in the IdP dashboard
 2. IdP POSTs SAMLResponse to `/api/auth/sso/saml2/callback/{providerId}`
-3. Better Auth processes the assertion, creates a session, and redirects to your `callbackUrl`
+3. Better Auth processes the assertion, creates a session, and redirects to your application
 4. Browser follows the redirect with a GET request (handled automatically)
 
 **No additional configuration required** - the callback route automatically handles both GET and POST requests.
+
+<Callout type="warn">
+  IdP-initiated flows do not carry a RelayState, so Better Auth redirects to your application's base URL after authentication. If you need users to land on a specific page (e.g., `/dashboard`), handle this in your application's root route by checking for an active session and redirecting accordingly.
+</Callout>
 
 <Callout type="info">
   If you previously created a manual GET handler for the SAML callback route as a workaround, you can remove it after upgrading. Better Auth now handles GET requests automatically.
@@ -1527,207 +1495,198 @@ For a detailed guide on setting up SAML SSO with examples for Okta and testing w
 
 If you want to allow account linking for specific trusted providers, enable the `accountLinking` option in your auth config and specify those providers in the `trustedProviders` list.
 
-export const ssoTypeTable = {
-    provisionUser: {
-        description: "A custom function to provision a user when they sign in with an SSO provider.",
-        type: "function",
-    },
-    provisionUserOnEveryLogin: {
-        description:
-            "If true, the provisionUser callback will be called on every login, not just when a new user is registered.",
-        type: "boolean",
-        default: false,
-    },
-    organizationProvisioning: {
-        description: "Options for provisioning users to an organization.",
-        type: "object",
-        properties: {
-            disabled: {
-                description: "Disable organization provisioning.",
-                type: "boolean",
-                default: false,
-            },
-            defaultRole: {
-                description: "The default role for new users.",
-                type: "string",
-                enum: ["member", "admin"],
-                default: "member",
-            },
-            getRole: {
-                description: "A custom function to determine the role for new users.",
-                type: "function",
-            },
+<TypeTable
+  type={{
+provisionUser: {
+    description: "A custom function to provision a user when they sign in with an SSO provider.",
+    type: "function",
+},
+provisionUserOnEveryLogin: {
+    description: "If true, the provisionUser callback will be called on every login, not just when a new user is registered.",
+    type: "boolean",
+    default: false,
+},
+organizationProvisioning: {
+    description: "Options for provisioning users to an organization.",
+    type: "object",
+    properties: {
+        disabled: {
+            description: "Disable organization provisioning.",
+            type: "boolean",
+            default: false,
+        },
+        defaultRole: {
+            description: "The default role for new users.",
+            type: "string",
+            enum: ["member", "admin"],
+            default: "member",
+        },
+        getRole: {
+            description: "A custom function to determine the role for new users.",
+            type: "function",
         },
     },
-    defaultOverrideUserInfo: {
-        description: "Override user info with the provider info by default.",
-        type: "boolean",
-        default: false,
-    },
-    disableImplicitSignUp: {
-        description:
-            "Disable implicit sign up for new users. When set to true, sign-in needs to be called with requestSignUp as true to create new users.",
-        type: "boolean",
-        default: false,
-    },
-    providersLimit: {
-        description:
-            "Configure the maximum number of SSO providers a user can register. Set to 0 to disable SSO provider registration.",
-        type: "number | function",
-        default: 10,
-    },
-    redirectURI: {
-        description:
-            "Custom redirect URI for OIDC SSO callbacks. When set, all OIDC providers share this single callback URL instead of per-provider URLs. The provider ID is stored in the OAuth state. Can be a relative path (e.g., '/sso/callback') or a full URL.",
-        type: "string",
-        required: false,
-    },
-    domainVerification: {
-        description: "Configure the domain verification feature",
-        type: "object",
-        properties: {
-            enabled: {
-                description: "Enables or disables the domain verification feature",
-                type: "boolean",
-                required: false,
-            },
-            tokenPrefix: {
-                description: "Prefix used to generate the domain verification identifier. An underscore is automatically prepended.",
-                type: "string",
-                required: false,
-                default: "better-auth-token",
-            },
+},
+defaultOverrideUserInfo: {
+    description: "Override user info with the provider info by default.",
+    type: "boolean",
+    default: false,
+},
+disableImplicitSignUp: {
+    description: "Disable implicit sign up for new users. When set to true, sign-in needs to be called with requestSignUp as true to create new users.",
+    type: "boolean",
+    default: false,
+},
+providersLimit: {
+    description: "Configure the maximum number of SSO providers a user can register. Set to 0 to disable SSO provider registration.",
+    type: "number | function",
+    default: 10,
+},
+redirectURI: {
+    description: "Custom redirect URI for OIDC SSO callbacks. When set, all OIDC providers share this single callback URL instead of per-provider URLs. The provider ID is stored in the OAuth state. Can be a relative path (e.g., '/sso/callback') or a full URL.",
+    type: "string",
+    required: false,
+},
+domainVerification: {
+    description: "Configure the domain verification feature",
+    type: "object",
+    properties: {
+        enabled: {
+            description: "Enables or disables the domain verification feature",
+            type: "boolean",
+            required: false
+        },
+        tokenPrefix: {
+            description: "Prefix used to generate the domain verification identifier. An underscore is automatically prepended.",
+            type: "string",
+            required: false,
+            default: "better-auth-token"
         },
     },
-    defaultSSO: {
-        description:
-            "Configure a default SSO provider for testing and development. This provider will be used when no matching provider is found in the database.",
-        type: "array",
-        items: {
+},
+defaultSSO: {
+    description: "Configure a default SSO provider for testing and development. This provider will be used when no matching provider is found in the database.",
+    type: "array",
+    items: {
+        type: "object",
+        properties: {
+            domain: {
+                description: "The domain to match for this default provider.",
+                type: "string",
+                required: true,
+            },
+            providerId: {
+                description: "The provider ID to use for the default provider.",
+                type: "string",
+                required: true,
+            },
+            samlConfig: {
+                description: "SAML configuration for the default provider.",
+                type: "SAMLConfig",
+                required: false,
+            },
+            oidcConfig: {
+                description: "OIDC configuration for the default provider.",
+                type: "OIDCConfig",
+                required: false,
+            },
+        }
+    },
+},
+saml: {
+    description: "SAML security options for AuthnRequest/InResponseTo validation, replay protection, and timestamp handling.",
+    type: "object",
+    properties: {
+        enableInResponseToValidation: {
+            description: "Enable InResponseTo validation for SP-initiated SAML flows.",
+            type: "boolean",
+            default: true,
+        },
+        allowIdpInitiated: {
+            description: "Allow IdP-initiated SSO (unsolicited SAML responses). Set to false for stricter security. Only applies when validation is enabled.",
+            type: "boolean",
+            default: true,
+        },
+        requestTTL: {
+            description: "TTL for AuthnRequest records in milliseconds. Only applies when validation is enabled.",
+            type: "number",
+            default: 300000,
+        },
+        clockSkew: {
+            description: "Clock skew tolerance for SAML assertion timestamp validation (NotBefore/NotOnOrAfter) in milliseconds. Allows for minor time differences between IdP and SP servers.",
+            type: "number",
+            default: 300000,
+        },
+        requireTimestamps: {
+            description: "Require timestamp conditions (NotBefore/NotOnOrAfter) in SAML assertions. When enabled, assertions without timestamps are rejected. When disabled, they are accepted with a warning logged.",
+            type: "boolean",
+            default: false,
+        },
+        algorithms: {
+            description: "Algorithm validation options.",
             type: "object",
             properties: {
-                domain: {
-                    description: "The domain to match for this default provider.",
+                onDeprecated: {
+                    description: "Behavior for deprecated algorithms (SHA-1, RSA 1.5, 3DES).",
                     type: "string",
-                    required: true,
-                },
-                providerId: {
-                    description: "The provider ID to use for the default provider.",
-                    type: "string",
-                    required: true,
-                },
-                samlConfig: {
-                    description: "SAML configuration for the default provider.",
-                    type: "SAMLConfig",
-                    required: false,
-                },
-                oidcConfig: {
-                    description: "OIDC configuration for the default provider.",
-                    type: "OIDCConfig",
-                    required: false,
+                    enum: ["reject", "warn", "allow"],
+                    default: "warn",
                 },
             },
         },
-    },
-    saml: {
-        description:
-            "SAML security options for AuthnRequest/InResponseTo validation, replay protection, and timestamp handling.",
-        type: "object",
-        properties: {
-            enableInResponseToValidation: {
-                description: "Enable InResponseTo validation for SP-initiated SAML flows.",
-                type: "boolean",
-                default: true,
-            },
-            allowIdpInitiated: {
-                description:
-                    "Allow IdP-initiated SSO (unsolicited SAML responses). Set to false for stricter security. Only applies when validation is enabled.",
-                type: "boolean",
-                default: true,
-            },
-            requestTTL: {
-                description: "TTL for AuthnRequest records in milliseconds. Only applies when validation is enabled.",
-                type: "number",
-                default: 300000,
-            },
-            clockSkew: {
-                description:
-                    "Clock skew tolerance for SAML assertion timestamp validation (NotBefore/NotOnOrAfter) in milliseconds. Allows for minor time differences between IdP and SP servers.",
-                type: "number",
-                default: 300000,
-            },
-            requireTimestamps: {
-                description:
-                    "Require timestamp conditions (NotBefore/NotOnOrAfter) in SAML assertions. When enabled, assertions without timestamps are rejected. When disabled, they are accepted with a warning logged.",
-                type: "boolean",
-                default: false,
-            },
-            algorithms: {
-                description: "Algorithm validation options.",
-                type: "object",
-                properties: {
-                    onDeprecated: {
-                        description: "Behavior for deprecated algorithms (SHA-1, RSA 1.5, 3DES).",
-                        type: "string",
-                        enum: ["reject", "warn", "allow"],
-                        default: "warn",
-                    },
-                },
-            },
-            maxResponseSize: {
-                description: "Maximum allowed size for SAML responses in bytes.",
-                type: "number",
-                default: 262144,
-            },
-            maxMetadataSize: {
-                description: "Maximum allowed size for IdP metadata XML in bytes.",
-                type: "number",
-                default: 102400,
-            },
+        maxResponseSize: {
+            description: "Maximum allowed size for SAML responses in bytes.",
+            type: "number",
+            default: 262144,
+        },
+        maxMetadataSize: {
+            description: "Maximum allowed size for IdP metadata XML in bytes.",
+            type: "number",
+            default: 102400,
         },
     },
-    modelName: {
-        description: "The model name for the SSO provider table",
+},
+modelName: {
+    description: "The model name for the SSO provider table",
+    type: "string",
+    default: "ssoProvider"
+},
+fields: {
+    issuer: {
+        description: "Custom name for the issuer column",
         type: "string",
-        default: "ssoProvider",
+        default: "issuer",
     },
-    fields: {
-        issuer: {
-            description: "Custom name for the issuer column",
-            type: "string",
-            default: "issuer",
-        },
-        oidcConfig: {
-            description: "Custom name for the oidcConfig column",
-            type: "string",
-            default: "oidcConfig",
-        },
-        samlConfig: {
-            description: "Custom name for the samlConfig column",
-            type: "string",
-            default: "samlConfig",
-        },
-        userId: {
-            description: "Custom name for the userId column",
-            type: "string",
-            default: "userId",
-        },
-        providerId: {
-            description: "Custom name for the providerId column",
-            type: "string",
-            default: "providerId",
-        },
-        organizationId: {
-            description: "Custom name for the organizationId column",
-            type: "string",
-            default: "organizationId",
-        },
-        domain: {
-            description: "Custom name for the domain column",
-            type: "string",
-            default: "domain",
-        },
+	oidcConfig: {
+        description: "Custom name for the oidcConfig column",
+        type: "string",
+        default: "oidcConfig",
     },
+	samlConfig: {
+        description: "Custom name for the samlConfig column",
+        type: "string",
+        default: "samlConfig",
+    },
+	userId: {
+        description: "Custom name for the userId column",
+        type: "string",
+        default: "userId",
+    },
+	providerId: {
+        description: "Custom name for the providerId column",
+        type: "string",
+        default: "providerId",
+    },
+	organizationId: {
+        description: "Custom name for the organizationId column",
+        type: "string",
+        default: "organizationId",
+    },
+	domain: {
+        description: "Custom name for the domain column",
+        type: "string",
+        default: "domain",
+    }
 }
-
-<TypeTable type={ssoTypeTable} />
+}}
+/>

--- a/packages/sso/src/routes/helpers.ts
+++ b/packages/sso/src/routes/helpers.ts
@@ -42,21 +42,32 @@ export function createSP(
 	config: SAMLConfig,
 	baseURL: string,
 	providerId: string,
-	sloOptions?: {
-		wantLogoutRequestSigned?: boolean;
-		wantLogoutResponseSigned?: boolean;
+	opts?: {
+		relayState?: string;
+		sloOptions?: {
+			wantLogoutRequestSigned?: boolean;
+			wantLogoutResponseSigned?: boolean;
+		};
 	},
 ) {
+	const spData = config.spMetadata;
 	const sloLocation = `${baseURL}/sso/saml2/sp/slo/${providerId}`;
+	// TODO: derive ACS URL exclusively from baseURL + providerId.
+	// callbackUrl doubles as both ACS and post-auth redirect, which breaks
+	// when it points to an app destination (e.g., /dashboard).
+	const acsUrl =
+		config.callbackUrl || `${baseURL}/sso/saml2/sp/acs/${providerId}`;
+
 	return saml.ServiceProvider({
-		entityID: config.spMetadata?.entityID || config.issuer,
-		assertionConsumerService: [
-			{
-				Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-				Location:
-					config.callbackUrl || `${baseURL}/sso/saml2/sp/acs/${providerId}`,
-			},
-		],
+		entityID: spData?.entityID || config.issuer,
+		assertionConsumerService: spData?.metadata
+			? undefined
+			: [
+					{
+						Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+						Location: acsUrl,
+					},
+				],
 		singleLogoutService: [
 			{
 				Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
@@ -68,11 +79,19 @@ export function createSP(
 			},
 		],
 		wantMessageSigned: config.wantAssertionsSigned || false,
-		wantLogoutRequestSigned: sloOptions?.wantLogoutRequestSigned ?? false,
-		wantLogoutResponseSigned: sloOptions?.wantLogoutResponseSigned ?? false,
-		metadata: config.spMetadata?.metadata,
-		privateKey: config.spMetadata?.privateKey || config.privateKey,
-		privateKeyPass: config.spMetadata?.privateKeyPass,
+		wantLogoutRequestSigned: opts?.sloOptions?.wantLogoutRequestSigned ?? false,
+		wantLogoutResponseSigned:
+			opts?.sloOptions?.wantLogoutResponseSigned ?? false,
+		metadata: spData?.metadata,
+		privateKey: spData?.privateKey || config.privateKey,
+		privateKeyPass: spData?.privateKeyPass,
+		isAssertionEncrypted: spData?.isAssertionEncrypted || false,
+		encPrivateKey: spData?.encPrivateKey,
+		encPrivateKeyPass: spData?.encPrivateKeyPass,
+		nameIDFormat: config.identifierFormat
+			? [config.identifierFormat]
+			: undefined,
+		relayState: opts?.relayState,
 	});
 }
 
@@ -83,6 +102,7 @@ export function createIdP(config: SAMLConfig) {
 			metadata: idpData.metadata,
 			privateKey: idpData.privateKey,
 			privateKeyPass: idpData.privateKeyPass,
+			isAssertionEncrypted: idpData.isAssertionEncrypted,
 			encPrivateKey: idpData.encPrivateKey,
 			encPrivateKeyPass: idpData.encPrivateKeyPass,
 		});
@@ -97,6 +117,10 @@ export function createIdP(config: SAMLConfig) {
 		],
 		singleLogoutService: idpData?.singleLogoutService,
 		signingCert: idpData?.cert || config.cert,
+		wantAuthnRequestsSigned: config.authnRequestsSigned || false,
+		isAssertionEncrypted: idpData?.isAssertionEncrypted || false,
+		encPrivateKey: idpData?.encPrivateKey,
+		encPrivateKeyPass: idpData?.encPrivateKeyPass,
 	});
 }
 

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -190,10 +190,13 @@ export async function processSAMLResponse(
 	const sp = createSP(parsedSamlConfig, ctx.context.baseURL, providerId);
 	const idp = createIdP(parsedSamlConfig);
 
-	const samlRedirectUrl =
-		relayState?.callbackURL ||
-		parsedSamlConfig.callbackUrl ||
-		ctx.context.baseURL;
+	const samlRedirectUrl = getSafeRedirectUrl(
+		relayState?.callbackURL || parsedSamlConfig.callbackUrl,
+		params.currentCallbackPath,
+		appOrigin,
+		(url: string, settings?: { allowRelativePaths: boolean }) =>
+			ctx.context.isTrustedOrigin(url, settings),
+	);
 
 	// 8. Single assertion validation
 	// Throws APIError directly (not redirect) since this is a structural issue

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -1,0 +1,526 @@
+import type { User } from "better-auth";
+import { APIError } from "better-auth/api";
+import { setSessionCookie } from "better-auth/cookies";
+import { handleOAuthUserInfo } from "better-auth/oauth2";
+import { XMLParser } from "fast-xml-parser";
+import type { FlowResult } from "samlify/types/src/flow";
+
+import * as constants from "../constants";
+import { assignOrganizationFromProvider } from "../linking";
+import { validateSAMLAlgorithms, validateSingleAssertion } from "../saml";
+import { parseRelayState } from "../saml-state";
+import type {
+	AuthnRequestRecord,
+	SAMLAssertionExtract,
+	SAMLConfig,
+	SAMLSessionRecord,
+	SSOOptions,
+	SSOProvider,
+} from "../types";
+import { safeJsonParse, validateEmailDomain } from "../utils";
+import { createIdP, createSP, findSAMLProvider } from "./helpers";
+import type { SAMLConditions } from "./sso";
+import { validateSAMLTimestamp } from "./sso";
+
+type RelayState = Awaited<ReturnType<typeof parseRelayState>>;
+
+/**
+ * Validates and returns a safe redirect URL.
+ * - Prevents open redirect attacks by validating against trusted origins
+ * - Prevents redirect loops by checking if URL points to callback route
+ * - Falls back to appOrigin if URL is invalid or unsafe
+ */
+export function getSafeRedirectUrl(
+	url: string | undefined,
+	callbackPath: string,
+	appOrigin: string,
+	isTrustedOrigin: (
+		url: string,
+		settings?: { allowRelativePaths: boolean },
+	) => boolean,
+): string {
+	if (!url) {
+		return appOrigin;
+	}
+
+	if (url.startsWith("/") && !url.startsWith("//")) {
+		try {
+			const absoluteUrl = new URL(url, appOrigin);
+			if (absoluteUrl.origin !== appOrigin) {
+				return appOrigin;
+			}
+			const callbackPathname = new URL(callbackPath).pathname;
+			if (absoluteUrl.pathname === callbackPathname) {
+				return appOrigin;
+			}
+		} catch {
+			return appOrigin;
+		}
+		return url;
+	}
+
+	if (!isTrustedOrigin(url, { allowRelativePaths: false })) {
+		return appOrigin;
+	}
+
+	try {
+		const callbackPathname = new URL(callbackPath).pathname;
+		const urlPathname = new URL(url).pathname;
+		if (urlPathname === callbackPathname) {
+			return appOrigin;
+		}
+	} catch {
+		if (url === callbackPath || url.startsWith(`${callbackPath}?`)) {
+			return appOrigin;
+		}
+	}
+
+	return url;
+}
+
+/**
+ * Extracts the Assertion ID from a SAML response XML.
+ * Used for replay protection per SAML 2.0 Core section 2.3.3.
+ */
+export function extractAssertionId(samlContent: string): string | null {
+	try {
+		const parser = new XMLParser({
+			ignoreAttributes: false,
+			attributeNamePrefix: "@_",
+			removeNSPrefix: true,
+		});
+		const parsed = parser.parse(samlContent);
+
+		const response = parsed.Response || parsed["samlp:Response"];
+		if (!response) return null;
+
+		const rawAssertion = response.Assertion || response["saml:Assertion"];
+		const assertion = Array.isArray(rawAssertion)
+			? rawAssertion[0]
+			: rawAssertion;
+		if (!assertion) return null;
+
+		return assertion["@_ID"] || null;
+	} catch {
+		return null;
+	}
+}
+
+export interface SAMLResponseParams {
+	SAMLResponse: string;
+	RelayState?: string;
+	providerId: string;
+	currentCallbackPath: string;
+}
+
+/**
+ * Unified SAML response processing pipeline.
+ *
+ * Both `/sso/saml2/callback/:providerId` (POST) and `/sso/saml2/sp/acs/:providerId`
+ * delegate to this function. It handles the full lifecycle: provider lookup,
+ * SP/IdP construction, response validation, session creation, and redirect
+ * URL computation.
+ */
+export async function processSAMLResponse(
+	ctx: any,
+	params: SAMLResponseParams,
+	options?: SSOOptions,
+): Promise<string> {
+	const { providerId, currentCallbackPath } = params;
+	const appOrigin = new URL(ctx.context.baseURL).origin;
+
+	// 1. Size validation
+	const maxResponseSize =
+		options?.saml?.maxResponseSize ?? constants.DEFAULT_MAX_SAML_RESPONSE_SIZE;
+	if (new TextEncoder().encode(params.SAMLResponse).length > maxResponseSize) {
+		throw new APIError("BAD_REQUEST", {
+			message: `SAML response exceeds maximum allowed size (${maxResponseSize} bytes)`,
+		});
+	}
+
+	// 2. Whitespace normalization
+	const SAMLResponse = params.SAMLResponse.replace(/\s+/g, "");
+
+	// 3. RelayState parsing
+	let relayState: RelayState | null = null;
+	if (params.RelayState) {
+		try {
+			relayState = await parseRelayState(ctx);
+		} catch {
+			relayState = null;
+		}
+	}
+
+	// 4. Provider lookup (unified: defaultSSO by providerId, then DB fallback)
+	const provider: SSOProvider<SSOOptions> | null = await findSAMLProvider(
+		providerId,
+		options,
+		ctx.context.adapter,
+	);
+
+	if (!provider?.samlConfig) {
+		throw new APIError("NOT_FOUND", {
+			message: "No SAML provider found",
+		});
+	}
+
+	// 5. Domain verification
+	if (
+		options?.domainVerification?.enabled &&
+		!("domainVerified" in provider && provider.domainVerified)
+	) {
+		throw new APIError("UNAUTHORIZED", {
+			message: "Provider domain has not been verified",
+		});
+	}
+
+	// 6. Config parsing
+	const parsedSamlConfig =
+		typeof provider.samlConfig === "object"
+			? provider.samlConfig
+			: safeJsonParse<SAMLConfig>(provider.samlConfig as unknown as string);
+
+	if (!parsedSamlConfig) {
+		throw new APIError("BAD_REQUEST", {
+			message: "Invalid SAML configuration",
+		});
+	}
+
+	// 7. SP/IdP construction via helpers
+	const sp = createSP(parsedSamlConfig, ctx.context.baseURL, providerId);
+	const idp = createIdP(parsedSamlConfig);
+
+	const samlRedirectUrl =
+		relayState?.callbackURL ||
+		parsedSamlConfig.callbackUrl ||
+		ctx.context.baseURL;
+
+	// 8. Single assertion validation
+	// Throws APIError directly (not redirect) since this is a structural issue
+	// with the SAMLResponse, not a flow-level error.
+	validateSingleAssertion(SAMLResponse);
+
+	// 9. Response parsing
+	let parsedResponse: FlowResult;
+	try {
+		parsedResponse = await sp.parseLoginResponse(idp, "post", {
+			body: {
+				SAMLResponse,
+				RelayState: params.RelayState || undefined,
+			},
+		});
+
+		if (!parsedResponse?.extract) {
+			throw new Error("Invalid SAML response structure");
+		}
+	} catch (error) {
+		ctx.context.logger.error("SAML response validation failed", {
+			error,
+			samlResponsePreview: SAMLResponse.slice(0, 200),
+		});
+		throw new APIError("BAD_REQUEST", {
+			message: "Invalid SAML response",
+			details: error instanceof Error ? error.message : String(error),
+		});
+	}
+
+	const { extract } = parsedResponse!;
+
+	// 10. Algorithm validation
+	validateSAMLAlgorithms(parsedResponse, options?.saml?.algorithms);
+
+	// 11. Timestamp validation
+	validateSAMLTimestamp((extract as SAMLAssertionExtract).conditions, {
+		clockSkew: options?.saml?.clockSkew,
+		requireTimestamps: options?.saml?.requireTimestamps,
+		logger: ctx.context.logger,
+	});
+
+	// 12. InResponseTo validation
+	const inResponseTo = (extract as SAMLAssertionExtract).inResponseTo as
+		| string
+		| undefined;
+	const shouldValidateInResponseTo =
+		options?.saml?.enableInResponseToValidation !== false;
+
+	if (shouldValidateInResponseTo) {
+		const allowIdpInitiated = options?.saml?.allowIdpInitiated !== false;
+
+		if (inResponseTo) {
+			let storedRequest: AuthnRequestRecord | null = null;
+
+			const verification =
+				await ctx.context.internalAdapter.findVerificationValue(
+					`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
+				);
+			if (verification) {
+				try {
+					storedRequest = JSON.parse(verification.value) as AuthnRequestRecord;
+					if (storedRequest && storedRequest.expiresAt < Date.now()) {
+						storedRequest = null;
+					}
+				} catch {
+					storedRequest = null;
+				}
+			}
+
+			if (!storedRequest) {
+				ctx.context.logger.error(
+					"SAML InResponseTo validation failed: unknown or expired request ID",
+					{ inResponseTo, providerId },
+				);
+				throw ctx.redirect(
+					`${samlRedirectUrl}?error=invalid_saml_response&error_description=Unknown+or+expired+request+ID`,
+				);
+			}
+
+			if (storedRequest.providerId !== providerId) {
+				ctx.context.logger.error(
+					"SAML InResponseTo validation failed: provider mismatch",
+					{
+						inResponseTo,
+						expectedProvider: storedRequest.providerId,
+						actualProvider: providerId,
+					},
+				);
+				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+					`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
+				);
+				throw ctx.redirect(
+					`${samlRedirectUrl}?error=invalid_saml_response&error_description=Provider+mismatch`,
+				);
+			}
+
+			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+				`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
+			);
+		} else if (!allowIdpInitiated) {
+			ctx.context.logger.error(
+				"SAML IdP-initiated SSO rejected: InResponseTo missing and allowIdpInitiated is false",
+				{ providerId },
+			);
+			throw ctx.redirect(
+				`${samlRedirectUrl}?error=unsolicited_response&error_description=IdP-initiated+SSO+not+allowed`,
+			);
+		}
+	}
+
+	// 13. Replay protection
+	const samlContent = (parsedResponse as any).samlContent as string | undefined;
+	const assertionId = samlContent ? extractAssertionId(samlContent) : null;
+
+	if (assertionId) {
+		const issuer = idp.entityMeta.getEntityID();
+		const conditions = (extract as SAMLAssertionExtract).conditions as
+			| SAMLConditions
+			| undefined;
+		const clockSkew =
+			options?.saml?.clockSkew ?? constants.DEFAULT_CLOCK_SKEW_MS;
+		const expiresAt = conditions?.notOnOrAfter
+			? new Date(conditions.notOnOrAfter).getTime() + clockSkew
+			: Date.now() + constants.DEFAULT_ASSERTION_TTL_MS;
+
+		const existingAssertion =
+			await ctx.context.internalAdapter.findVerificationValue(
+				`${constants.USED_ASSERTION_KEY_PREFIX}${assertionId}`,
+			);
+
+		let isReplay = false;
+		if (existingAssertion) {
+			try {
+				const stored = JSON.parse(existingAssertion.value);
+				if (stored.expiresAt >= Date.now()) {
+					isReplay = true;
+				}
+			} catch (error) {
+				ctx.context.logger.warn("Failed to parse stored assertion record", {
+					assertionId,
+					error,
+				});
+			}
+		}
+
+		if (isReplay) {
+			ctx.context.logger.error(
+				"SAML assertion replay detected: assertion ID already used",
+				{ assertionId, issuer, providerId },
+			);
+			throw ctx.redirect(
+				`${samlRedirectUrl}?error=replay_detected&error_description=SAML+assertion+has+already+been+used`,
+			);
+		}
+
+		await ctx.context.internalAdapter.createVerificationValue({
+			identifier: `${constants.USED_ASSERTION_KEY_PREFIX}${assertionId}`,
+			value: JSON.stringify({
+				assertionId,
+				issuer,
+				providerId,
+				usedAt: Date.now(),
+				expiresAt,
+			}),
+			expiresAt: new Date(expiresAt),
+		});
+	} else {
+		ctx.context.logger.warn(
+			"Could not extract assertion ID for replay protection",
+			{ providerId },
+		);
+	}
+
+	// 14. User attribute extraction
+	const attributes = extract.attributes || {};
+	const mapping = parsedSamlConfig.mapping ?? {};
+
+	const userInfo = {
+		...Object.fromEntries(
+			Object.entries(mapping.extraFields || {}).map(([key, value]) => [
+				key,
+				attributes[value as string],
+			]),
+		),
+		id: attributes[mapping.id || "nameID"] || extract.nameID,
+		email: (
+			attributes[mapping.email || "email"] || extract.nameID
+		).toLowerCase(),
+		name:
+			[
+				attributes[mapping.firstName || "givenName"],
+				attributes[mapping.lastName || "surname"],
+			]
+				.filter(Boolean)
+				.join(" ") ||
+			attributes[mapping.name || "displayName"] ||
+			extract.nameID,
+		emailVerified:
+			options?.trustEmailVerified && mapping.emailVerified
+				? ((attributes[mapping.emailVerified] || false) as boolean)
+				: false,
+	};
+	if (!userInfo.id || !userInfo.email) {
+		ctx.context.logger.error("Missing essential user info from SAML response", {
+			attributes: Object.keys(attributes),
+			mapping,
+			extractedId: userInfo.id,
+			extractedEmail: userInfo.email,
+		});
+		throw new APIError("BAD_REQUEST", {
+			message: "Unable to extract user ID or email from SAML response",
+		});
+	}
+
+	// 15. Session creation
+	const isTrustedProvider: boolean =
+		ctx.context.trustedProviders.includes(providerId) ||
+		("domainVerified" in provider &&
+			!!(provider as { domainVerified?: boolean }).domainVerified &&
+			validateEmailDomain(userInfo.email as string, provider.domain));
+
+	// TODO: split callbackUrl into separate ACS URL and post-auth redirect
+	// fields. Currently callbackUrl serves both purposes, which means
+	// IdP-initiated flows (no RelayState) fall back to either a URL that may be
+	// the ACS endpoint (blocked by loop protection) or baseURL.
+	const callbackUrl =
+		relayState?.callbackURL ||
+		parsedSamlConfig.callbackUrl ||
+		ctx.context.baseURL;
+
+	const result = await handleOAuthUserInfo(ctx, {
+		userInfo: {
+			email: userInfo.email as string,
+			name: (userInfo.name || userInfo.email) as string,
+			id: userInfo.id as string,
+			emailVerified: Boolean(userInfo.emailVerified),
+		},
+		account: {
+			providerId,
+			accountId: userInfo.id as string,
+			accessToken: "",
+			refreshToken: "",
+		},
+		callbackURL: callbackUrl,
+		disableSignUp: options?.disableImplicitSignUp,
+		isTrustedProvider,
+	});
+
+	if (result.error) {
+		throw ctx.redirect(
+			`${callbackUrl}?error=${result.error.split(" ").join("_")}`,
+		);
+	}
+
+	const { session, user } = result.data!;
+
+	// 16. Provision user
+	if (
+		options?.provisionUser &&
+		(result.isRegister || options.provisionUserOnEveryLogin)
+	) {
+		await options.provisionUser({
+			user: user as User & Record<string, any>,
+			userInfo,
+			provider,
+		});
+	}
+
+	// 17. Organization assignment
+	await assignOrganizationFromProvider(ctx as any, {
+		user,
+		profile: {
+			providerType: "saml",
+			providerId,
+			accountId: userInfo.id as string,
+			email: userInfo.email as string,
+			emailVerified: Boolean(userInfo.emailVerified),
+			rawAttributes: attributes,
+		},
+		provider,
+		provisioningOptions: options?.organizationProvisioning,
+	});
+
+	// 18. Set session cookie
+	await setSessionCookie(ctx, { session, user });
+
+	// 19. SLO session record
+	if (options?.saml?.enableSingleLogout && extract.nameID) {
+		const samlSessionKey = `${constants.SAML_SESSION_KEY_PREFIX}${providerId}:${extract.nameID}`;
+		const samlSessionData: SAMLSessionRecord = {
+			sessionId: session.id,
+			providerId,
+			nameID: extract.nameID,
+			sessionIndex: (extract as SAMLAssertionExtract).sessionIndex,
+		};
+		await ctx.context.internalAdapter
+			.createVerificationValue({
+				identifier: samlSessionKey,
+				value: JSON.stringify(samlSessionData),
+				expiresAt: session.expiresAt,
+			})
+			.catch((e: unknown) =>
+				ctx.context.logger.warn("Failed to create SAML session record", {
+					error: e,
+				}),
+			);
+		await ctx.context.internalAdapter
+			.createVerificationValue({
+				identifier: `${constants.SAML_SESSION_BY_ID_PREFIX}${session.id}`,
+				value: samlSessionKey,
+				expiresAt: session.expiresAt,
+			})
+			.catch((e: unknown) =>
+				ctx.context.logger.warn(
+					"Failed to create SAML session lookup record",
+					e,
+				),
+			);
+	}
+
+	// 20. Compute safe redirect URL
+	return getSafeRedirectUrl(
+		relayState?.callbackURL || parsedSamlConfig.callbackUrl,
+		currentCallbackPath,
+		appOrigin,
+		(url: string, settings?: { allowRelativePaths: boolean }) =>
+			ctx.context.isTrustedOrigin(url, settings),
+	);
+}

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -8,6 +8,8 @@ import type { FlowResult } from "samlify/types/src/flow";
 import * as constants from "../constants";
 import { assignOrganizationFromProvider } from "../linking";
 import { validateSAMLAlgorithms, validateSingleAssertion } from "../saml";
+import type { SAMLConditions } from "../saml/timestamp";
+import { validateSAMLTimestamp } from "../saml/timestamp";
 import { parseRelayState } from "../saml-state";
 import type {
 	AuthnRequestRecord,
@@ -19,8 +21,6 @@ import type {
 } from "../types";
 import { safeJsonParse, validateEmailDomain } from "../utils";
 import { createIdP, createSP, findSAMLProvider } from "./helpers";
-import type { SAMLConditions } from "./sso";
-import { validateSAMLTimestamp } from "./sso";
 
 type RelayState = Awaited<ReturnType<typeof parseRelayState>>;
 
@@ -82,7 +82,7 @@ export function getSafeRedirectUrl(
  * Extracts the Assertion ID from a SAML response XML.
  * Used for replay protection per SAML 2.0 Core section 2.3.3.
  */
-export function extractAssertionId(samlContent: string): string | null {
+function extractAssertionId(samlContent: string): string | null {
 	try {
 		const parser = new XMLParser({
 			ignoreAttributes: false,

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1911,18 +1911,48 @@ export const acsEndpoint = (options?: SSOOptions) => {
 		async (ctx) => {
 			const { providerId } = ctx.params;
 			const currentCallbackPath = `${ctx.context.baseURL}/sso/saml2/sp/acs/${providerId}`;
+			const appOrigin = new URL(ctx.context.baseURL).origin;
 
-			const safeRedirectUrl = await processSAMLResponse(
-				ctx,
-				{
-					SAMLResponse: ctx.body.SAMLResponse,
-					RelayState: ctx.body.RelayState,
-					providerId,
-					currentCallbackPath,
-				},
-				options,
-			);
-			throw ctx.redirect(safeRedirectUrl);
+			try {
+				const safeRedirectUrl = await processSAMLResponse(
+					ctx,
+					{
+						SAMLResponse: ctx.body.SAMLResponse,
+						RelayState: ctx.body.RelayState,
+						providerId,
+						currentCallbackPath,
+					},
+					options,
+				);
+				throw ctx.redirect(safeRedirectUrl);
+			} catch (error) {
+				// Re-throw redirects (they use throw for control flow)
+				if (
+					error instanceof Response ||
+					(error &&
+						typeof error === "object" &&
+						"status" in error &&
+						(error as any).status === 302)
+				) {
+					throw error;
+				}
+				// Translate structural SAML errors (400) into browser-friendly redirects
+				// so the user returns to the app instead of seeing raw JSON.
+				// Non-400 errors (404 provider not found, 401 unauthorized) propagate as-is.
+				if (error instanceof APIError && error.statusCode === 400) {
+					const errorCode = error.body?.code || "saml_error";
+					const redirectUrl = getSafeRedirectUrl(
+						ctx.body.RelayState || undefined,
+						currentCallbackPath,
+						appOrigin,
+						(url, settings) => ctx.context.isTrustedOrigin(url, settings),
+					);
+					throw ctx.redirect(
+						`${redirectUrl}?error=${encodeURIComponent(errorCode)}&error_description=${encodeURIComponent(error.message)}`,
+					);
+				}
+				throw error;
+			}
 		},
 	);
 };

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1,5 +1,4 @@
 import { BetterFetchError, betterFetch } from "@better-fetch/fetch";
-import type { User } from "better-auth";
 import {
 	createAuthorizationURL,
 	generateState,
@@ -17,22 +16,11 @@ import {
 import { deleteSessionCookie, setSessionCookie } from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
 import { handleOAuthUserInfo } from "better-auth/oauth2";
-import { XMLParser } from "fast-xml-parser";
 import { decodeJwt } from "jose";
 import * as saml from "samlify";
 import type { BindingContext } from "samlify/types/src/entity";
 import type { IdentityProvider } from "samlify/types/src/entity-idp";
-import type { FlowResult } from "samlify/types/src/flow";
 import * as z from "zod";
-import { getVerificationIdentifier } from "./domain-verification";
-
-interface AuthnRequestRecord {
-	id: string;
-	providerId: string;
-	createdAt: number;
-	expiresAt: number;
-}
-
 import * as constants from "../constants";
 import { assignOrganizationFromProvider } from "../linking";
 import type { HydratedOIDCConfig } from "../oidc";
@@ -42,14 +30,11 @@ import {
 	ensureRuntimeDiscovery,
 	mapDiscoveryErrorToAPIError,
 } from "../oidc";
-import {
-	validateConfigAlgorithms,
-	validateSAMLAlgorithms,
-	validateSingleAssertion,
-} from "../saml";
+import { validateConfigAlgorithms } from "../saml";
 import { SAML_ERROR_CODES } from "../saml/error-codes";
-import { generateRelayState, parseRelayState } from "../saml-state";
+import { generateRelayState } from "../saml-state";
 import type {
+	AuthnRequestRecord,
 	OIDCConfig,
 	SAMLAssertionExtract,
 	SAMLConfig,
@@ -58,12 +43,14 @@ import type {
 	SSOProvider,
 } from "../types";
 import { domainMatches, safeJsonParse, validateEmailDomain } from "../utils";
+import { getVerificationIdentifier } from "./domain-verification";
 import {
 	createIdP,
 	createSAMLPostForm,
 	createSP,
 	findSAMLProvider,
 } from "./helpers";
+import { getSafeRedirectUrl, processSAMLResponse } from "./saml-pipeline";
 
 /**
  * Builds the OIDC redirect URI. Uses the shared `redirectURI` option
@@ -167,40 +154,10 @@ export function validateSAMLTimestamp(
 	}
 }
 
-/**
- * Extracts the Assertion ID from a SAML response XML.
- * Returns null if the assertion ID cannot be found.
- */
-function extractAssertionId(samlContent: string): string | null {
-	try {
-		const parser = new XMLParser({
-			ignoreAttributes: false,
-			attributeNamePrefix: "@_",
-			removeNSPrefix: true,
-		});
-		const parsed = parser.parse(samlContent);
-
-		const response = parsed.Response || parsed["samlp:Response"];
-		if (!response) return null;
-
-		const rawAssertion = response.Assertion || response["saml:Assertion"];
-		const assertion = Array.isArray(rawAssertion)
-			? rawAssertion[0]
-			: rawAssertion;
-		if (!assertion) return null;
-
-		return assertion["@_ID"] || null;
-	} catch {
-		return null;
-	}
-}
-
 const spMetadataQuerySchema = z.object({
 	providerId: z.string(),
 	format: z.enum(["xml", "json"]).default("xml"),
 });
-
-type RelayState = Awaited<ReturnType<typeof parseRelayState>>;
 
 export const spMetadata = (options?: SSOOptions) => {
 	return createAuthEndpoint(
@@ -273,7 +230,7 @@ export const spMetadata = (options?: SSOOptions) => {
 								Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
 								Location:
 									parsedSamlConfig.callbackUrl ||
-									`${ctx.context.baseURL}/sso/saml2/sp/acs/${provider.id}`,
+									`${ctx.context.baseURL}/sso/saml2/sp/acs/${ctx.query.providerId}`,
 							},
 						],
 						singleLogoutService,
@@ -865,6 +822,20 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 					},
 					options?.saml?.algorithms,
 				);
+
+				// Validate that the config has a usable IdP entry point
+				const hasIdpMetadata = body.samlConfig.idpMetadata?.metadata;
+				const hasEntryPoint =
+					body.samlConfig.entryPoint &&
+					body.samlConfig.entryPoint.startsWith("http");
+				const hasSingleSignOnService =
+					body.samlConfig.idpMetadata?.singleSignOnService?.length;
+				if (!hasIdpMetadata && !hasEntryPoint && !hasSingleSignOnService) {
+					throw new APIError("BAD_REQUEST", {
+						message:
+							"SAML configuration requires either idpMetadata.metadata (IdP metadata XML), idpMetadata.singleSignOnService, or a valid entryPoint URL",
+					});
+				}
 			}
 
 			const provider = await ctx.context.adapter.create<
@@ -1885,60 +1856,6 @@ const callbackSSOSAMLBodySchema = z.object({
 	RelayState: z.string().optional(),
 });
 
-/**
- * Validates and returns a safe redirect URL.
- * - Prevents open redirect attacks by validating against trusted origins
- * - Prevents redirect loops by checking if URL points to callback route
- * - Falls back to appOrigin if URL is invalid or unsafe
- */
-const getSafeRedirectUrl = (
-	url: string | undefined,
-	callbackPath: string,
-	appOrigin: string,
-	isTrustedOrigin: (
-		url: string,
-		settings?: { allowRelativePaths: boolean },
-	) => boolean,
-): string => {
-	if (!url) {
-		return appOrigin;
-	}
-
-	if (url.startsWith("/") && !url.startsWith("//")) {
-		try {
-			const absoluteUrl = new URL(url, appOrigin);
-			if (absoluteUrl.origin !== appOrigin) {
-				return appOrigin;
-			}
-			const callbackPathname = new URL(callbackPath).pathname;
-			if (absoluteUrl.pathname === callbackPathname) {
-				return appOrigin;
-			}
-		} catch {
-			return appOrigin;
-		}
-		return url;
-	}
-
-	if (!isTrustedOrigin(url, { allowRelativePaths: false })) {
-		return appOrigin;
-	}
-
-	try {
-		const callbackPathname = new URL(callbackPath).pathname;
-		const urlPathname = new URL(url).pathname;
-		if (urlPathname === callbackPathname) {
-			return appOrigin;
-		}
-	} catch {
-		if (url === callbackPath || url.startsWith(`${callbackPath}?`)) {
-			return appOrigin;
-		}
-	}
-
-	return url;
-};
-
 export const callbackSSOSAML = (options?: SSOOptions) => {
 	return createAuthEndpoint(
 		"/sso/saml2/callback/:providerId",
@@ -2010,478 +1927,15 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 				});
 			}
 
-			const maxResponseSize =
-				options?.saml?.maxResponseSize ??
-				constants.DEFAULT_MAX_SAML_RESPONSE_SIZE;
-			if (
-				new TextEncoder().encode(ctx.body.SAMLResponse).length > maxResponseSize
-			) {
-				throw new APIError("BAD_REQUEST", {
-					message: `SAML response exceeds maximum allowed size (${maxResponseSize} bytes)`,
-				});
-			}
-
-			const SAMLResponse = ctx.body.SAMLResponse.replace(/\s+/g, "");
-
-			let relayState: RelayState | null = null;
-			if (ctx.body.RelayState) {
-				try {
-					relayState = await parseRelayState(ctx);
-				} catch {
-					relayState = null;
-				}
-			}
-			let provider: SSOProvider<SSOOptions> | null = null;
-			if (options?.defaultSSO?.length) {
-				const matchingDefault = options.defaultSSO.find(
-					(defaultProvider) => defaultProvider.providerId === providerId,
-				);
-				if (matchingDefault) {
-					provider = {
-						...matchingDefault,
-						userId: "default",
-						issuer: matchingDefault.samlConfig?.issuer || "",
-						...(options.domainVerification?.enabled
-							? { domainVerified: true }
-							: {}),
-					} as SSOProvider<SSOOptions>;
-				}
-			}
-			if (!provider) {
-				provider = await ctx.context.adapter
-					.findOne<SSOProvider<SSOOptions>>({
-						model: "ssoProvider",
-						where: [{ field: "providerId", value: providerId }],
-					})
-					.then((res) => {
-						if (!res) return null;
-						return {
-							...res,
-							samlConfig: res.samlConfig
-								? safeJsonParse<SAMLConfig>(
-										res.samlConfig as unknown as string,
-									) || undefined
-								: undefined,
-						};
-					});
-			}
-
-			if (!provider) {
-				throw new APIError("NOT_FOUND", {
-					message: "No provider found for the given providerId",
-				});
-			}
-
-			if (
-				options?.domainVerification?.enabled &&
-				!("domainVerified" in provider && provider.domainVerified)
-			) {
-				throw new APIError("UNAUTHORIZED", {
-					message: "Provider domain has not been verified",
-				});
-			}
-
-			const parsedSamlConfig = safeJsonParse<SAMLConfig>(
-				provider.samlConfig as unknown as string,
-			);
-			if (!parsedSamlConfig) {
-				throw new APIError("BAD_REQUEST", {
-					message: "Invalid SAML configuration",
-				});
-			}
-			const idpData = parsedSamlConfig.idpMetadata;
-			let idp: IdentityProvider | null = null;
-
-			// Construct IDP with fallback to manual configuration
-			if (!idpData?.metadata) {
-				idp = saml.IdentityProvider({
-					entityID: idpData?.entityID || parsedSamlConfig.issuer,
-					singleSignOnService: idpData?.singleSignOnService || [
-						{
-							Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-							Location: parsedSamlConfig.entryPoint,
-						},
-					],
-					signingCert: idpData?.cert || parsedSamlConfig.cert,
-					wantAuthnRequestsSigned:
-						parsedSamlConfig.authnRequestsSigned || false,
-					isAssertionEncrypted: idpData?.isAssertionEncrypted || false,
-					encPrivateKey: idpData?.encPrivateKey,
-					encPrivateKeyPass: idpData?.encPrivateKeyPass,
-				});
-			} else {
-				idp = saml.IdentityProvider({
-					metadata: idpData.metadata,
-					privateKey: idpData.privateKey,
-					privateKeyPass: idpData.privateKeyPass,
-					isAssertionEncrypted: idpData.isAssertionEncrypted,
-					encPrivateKey: idpData.encPrivateKey,
-					encPrivateKeyPass: idpData.encPrivateKeyPass,
-				});
-			}
-
-			// Construct SP with fallback to manual configuration
-			const spData = parsedSamlConfig.spMetadata;
-			const sp = saml.ServiceProvider({
-				metadata: spData?.metadata,
-				entityID: spData?.entityID || parsedSamlConfig.issuer,
-				assertionConsumerService: spData?.metadata
-					? undefined
-					: [
-							{
-								Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-								Location: parsedSamlConfig.callbackUrl,
-							},
-						],
-				privateKey: spData?.privateKey || parsedSamlConfig.privateKey,
-				privateKeyPass: spData?.privateKeyPass,
-				isAssertionEncrypted: spData?.isAssertionEncrypted || false,
-				encPrivateKey: spData?.encPrivateKey,
-				encPrivateKeyPass: spData?.encPrivateKeyPass,
-				wantMessageSigned: parsedSamlConfig.wantAssertionsSigned || false,
-				nameIDFormat: parsedSamlConfig.identifierFormat
-					? [parsedSamlConfig.identifierFormat]
-					: undefined,
-			});
-
-			validateSingleAssertion(SAMLResponse);
-
-			let parsedResponse: FlowResult;
-			try {
-				parsedResponse = await sp.parseLoginResponse(idp, "post", {
-					body: {
-						SAMLResponse,
-						RelayState: ctx.body.RelayState || undefined,
-					},
-				});
-
-				if (!parsedResponse?.extract) {
-					throw new Error("Invalid SAML response structure");
-				}
-			} catch (error) {
-				ctx.context.logger.error("SAML response validation failed", {
-					error,
-					decodedResponse: Buffer.from(SAMLResponse, "base64").toString(
-						"utf-8",
-					),
-				});
-				throw new APIError("BAD_REQUEST", {
-					message: "Invalid SAML response",
-					details: error instanceof Error ? error.message : String(error),
-				});
-			}
-
-			const { extract } = parsedResponse!;
-
-			validateSAMLAlgorithms(parsedResponse, options?.saml?.algorithms);
-
-			validateSAMLTimestamp((extract as SAMLAssertionExtract).conditions, {
-				clockSkew: options?.saml?.clockSkew,
-				requireTimestamps: options?.saml?.requireTimestamps,
-				logger: ctx.context.logger,
-			});
-
-			const inResponseTo = (extract as SAMLAssertionExtract).inResponseTo as
-				| string
-				| undefined;
-			const shouldValidateInResponseTo =
-				options?.saml?.enableInResponseToValidation !== false;
-
-			if (shouldValidateInResponseTo) {
-				const allowIdpInitiated = options?.saml?.allowIdpInitiated !== false;
-
-				if (inResponseTo) {
-					let storedRequest: AuthnRequestRecord | null = null;
-
-					const verification =
-						await ctx.context.internalAdapter.findVerificationValue(
-							`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
-						);
-					if (verification) {
-						try {
-							storedRequest = JSON.parse(
-								verification.value,
-							) as AuthnRequestRecord;
-							if (storedRequest && storedRequest.expiresAt < Date.now()) {
-								storedRequest = null;
-							}
-						} catch {
-							storedRequest = null;
-						}
-					}
-
-					if (!storedRequest) {
-						ctx.context.logger.error(
-							"SAML InResponseTo validation failed: unknown or expired request ID",
-							{ inResponseTo, providerId: provider.providerId },
-						);
-						const redirectUrl =
-							relayState?.callbackURL ||
-							parsedSamlConfig.callbackUrl ||
-							ctx.context.baseURL;
-						throw ctx.redirect(
-							`${redirectUrl}?error=invalid_saml_response&error_description=Unknown+or+expired+request+ID`,
-						);
-					}
-
-					if (storedRequest.providerId !== provider.providerId) {
-						ctx.context.logger.error(
-							"SAML InResponseTo validation failed: provider mismatch",
-							{
-								inResponseTo,
-								expectedProvider: storedRequest.providerId,
-								actualProvider: provider.providerId,
-							},
-						);
-
-						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
-						);
-						const redirectUrl =
-							relayState?.callbackURL ||
-							parsedSamlConfig.callbackUrl ||
-							ctx.context.baseURL;
-						throw ctx.redirect(
-							`${redirectUrl}?error=invalid_saml_response&error_description=Provider+mismatch`,
-						);
-					}
-
-					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
-					);
-				} else if (!allowIdpInitiated) {
-					ctx.context.logger.error(
-						"SAML IdP-initiated SSO rejected: InResponseTo missing and allowIdpInitiated is false",
-						{ providerId: provider.providerId },
-					);
-					const redirectUrl =
-						relayState?.callbackURL ||
-						parsedSamlConfig.callbackUrl ||
-						ctx.context.baseURL;
-					throw ctx.redirect(
-						`${redirectUrl}?error=unsolicited_response&error_description=IdP-initiated+SSO+not+allowed`,
-					);
-				}
-			}
-
-			// Assertion Replay Protection
-			const samlContent = (parsedResponse as any).samlContent as
-				| string
-				| undefined;
-			const assertionId = samlContent ? extractAssertionId(samlContent) : null;
-
-			if (assertionId) {
-				const issuer = idp.entityMeta.getEntityID();
-				const conditions = (extract as SAMLAssertionExtract).conditions as
-					| SAMLConditions
-					| undefined;
-				const clockSkew =
-					options?.saml?.clockSkew ?? constants.DEFAULT_CLOCK_SKEW_MS;
-				const expiresAt = conditions?.notOnOrAfter
-					? new Date(conditions.notOnOrAfter).getTime() + clockSkew
-					: Date.now() + constants.DEFAULT_ASSERTION_TTL_MS;
-
-				const existingAssertion =
-					await ctx.context.internalAdapter.findVerificationValue(
-						`${constants.USED_ASSERTION_KEY_PREFIX}${assertionId}`,
-					);
-
-				let isReplay = false;
-				if (existingAssertion) {
-					try {
-						const stored = JSON.parse(existingAssertion.value);
-						if (stored.expiresAt >= Date.now()) {
-							isReplay = true;
-						}
-					} catch (error) {
-						ctx.context.logger.warn("Failed to parse stored assertion record", {
-							assertionId,
-							error,
-						});
-					}
-				}
-
-				if (isReplay) {
-					ctx.context.logger.error(
-						"SAML assertion replay detected: assertion ID already used",
-						{
-							assertionId,
-							issuer,
-							providerId: provider.providerId,
-						},
-					);
-					const redirectUrl =
-						relayState?.callbackURL ||
-						parsedSamlConfig.callbackUrl ||
-						ctx.context.baseURL;
-					throw ctx.redirect(
-						`${redirectUrl}?error=replay_detected&error_description=SAML+assertion+has+already+been+used`,
-					);
-				}
-
-				await ctx.context.internalAdapter.createVerificationValue({
-					identifier: `${constants.USED_ASSERTION_KEY_PREFIX}${assertionId}`,
-					value: JSON.stringify({
-						assertionId,
-						issuer,
-						providerId: provider.providerId,
-						usedAt: Date.now(),
-						expiresAt,
-					}),
-					expiresAt: new Date(expiresAt),
-				});
-			} else {
-				ctx.context.logger.warn(
-					"Could not extract assertion ID for replay protection",
-					{ providerId: provider.providerId },
-				);
-			}
-
-			const attributes = extract.attributes || {};
-			const mapping = parsedSamlConfig.mapping ?? {};
-
-			const userInfo = {
-				...Object.fromEntries(
-					Object.entries(mapping.extraFields || {}).map(([key, value]) => [
-						key,
-						attributes[value as string],
-					]),
-				),
-				id: attributes[mapping.id || "nameID"] || extract.nameID,
-				email: (
-					attributes[mapping.email || "email"] || extract.nameID
-				).toLowerCase(),
-				name:
-					[
-						attributes[mapping.firstName || "givenName"],
-						attributes[mapping.lastName || "surname"],
-					]
-						.filter(Boolean)
-						.join(" ") ||
-					attributes[mapping.name || "displayName"] ||
-					extract.nameID,
-				emailVerified:
-					options?.trustEmailVerified && mapping.emailVerified
-						? ((attributes[mapping.emailVerified] || false) as boolean)
-						: false,
-			};
-			if (!userInfo.id || !userInfo.email) {
-				ctx.context.logger.error(
-					"Missing essential user info from SAML response",
-					{
-						attributes: Object.keys(attributes),
-						mapping,
-						extractedId: userInfo.id,
-						extractedEmail: userInfo.email,
-					},
-				);
-				throw new APIError("BAD_REQUEST", {
-					message: "Unable to extract user ID or email from SAML response",
-				});
-			}
-
-			const isTrustedProvider: boolean =
-				ctx.context.trustedProviders.includes(provider.providerId) ||
-				("domainVerified" in provider &&
-					!!(provider as { domainVerified?: boolean }).domainVerified &&
-					validateEmailDomain(userInfo.email as string, provider.domain));
-
-			const callbackUrl =
-				relayState?.callbackURL ||
-				parsedSamlConfig.callbackUrl ||
-				ctx.context.baseURL;
-
-			const result = await handleOAuthUserInfo(ctx, {
-				userInfo: {
-					email: userInfo.email as string,
-					name: (userInfo.name || userInfo.email) as string,
-					id: userInfo.id as string,
-					emailVerified: Boolean(userInfo.emailVerified),
+			const safeRedirectUrl = await processSAMLResponse(
+				ctx,
+				{
+					SAMLResponse: ctx.body.SAMLResponse,
+					RelayState: ctx.body.RelayState,
+					providerId,
+					currentCallbackPath,
 				},
-				account: {
-					providerId: provider.providerId,
-					accountId: userInfo.id as string,
-					accessToken: "",
-					refreshToken: "",
-				},
-				callbackURL: callbackUrl,
-				disableSignUp: options?.disableImplicitSignUp,
-				isTrustedProvider,
-			});
-
-			if (result.error) {
-				throw ctx.redirect(
-					`${callbackUrl}?error=${result.error.split(" ").join("_")}`,
-				);
-			}
-
-			const { session, user } = result.data!;
-
-			if (
-				options?.provisionUser &&
-				(result.isRegister || options.provisionUserOnEveryLogin)
-			) {
-				await options.provisionUser({
-					user: user as User & Record<string, any>,
-					userInfo,
-					provider,
-				});
-			}
-
-			await assignOrganizationFromProvider(ctx as any, {
-				user,
-				profile: {
-					providerType: "saml",
-					providerId: provider.providerId,
-					accountId: userInfo.id as string,
-					email: userInfo.email as string,
-					emailVerified: Boolean(userInfo.emailVerified),
-					rawAttributes: attributes,
-				},
-				provider,
-				provisioningOptions: options?.organizationProvisioning,
-			});
-
-			await setSessionCookie(ctx, { session, user });
-
-			if (options?.saml?.enableSingleLogout && extract.nameID) {
-				const samlSessionKey = `${constants.SAML_SESSION_KEY_PREFIX}${provider.providerId}:${extract.nameID}`;
-				const samlSessionData: SAMLSessionRecord = {
-					sessionId: session.id,
-					providerId: provider.providerId,
-					nameID: extract.nameID,
-					sessionIndex: (extract as SAMLAssertionExtract).sessionIndex,
-				};
-				await ctx.context.internalAdapter
-					.createVerificationValue({
-						identifier: samlSessionKey,
-						value: JSON.stringify(samlSessionData),
-						expiresAt: session.expiresAt,
-					})
-					.catch((e) =>
-						ctx.context.logger.warn("Failed to create SAML session record", {
-							error: e,
-						}),
-					);
-				await ctx.context.internalAdapter
-					.createVerificationValue({
-						identifier: `${constants.SAML_SESSION_BY_ID_PREFIX}${session.id}`,
-						value: samlSessionKey,
-						expiresAt: session.expiresAt,
-					})
-					.catch((e) =>
-						ctx.context.logger.warn(
-							"Failed to create SAML session lookup record",
-							e,
-						),
-					);
-			}
-
-			const safeRedirectUrl = getSafeRedirectUrl(
-				relayState?.callbackURL || parsedSamlConfig.callbackUrl,
-				currentCallbackPath,
-				appOrigin,
-				(url, settings) => ctx.context.isTrustedOrigin(url, settings),
+				options,
 			);
 			throw ctx.redirect(safeRedirectUrl);
 		},
@@ -2522,487 +1976,16 @@ export const acsEndpoint = (options?: SSOOptions) => {
 		async (ctx) => {
 			const { providerId } = ctx.params;
 			const currentCallbackPath = `${ctx.context.baseURL}/sso/saml2/sp/acs/${providerId}`;
-			const appOrigin = new URL(ctx.context.baseURL).origin;
 
-			const maxResponseSize =
-				options?.saml?.maxResponseSize ??
-				constants.DEFAULT_MAX_SAML_RESPONSE_SIZE;
-			if (
-				new TextEncoder().encode(ctx.body.SAMLResponse).length > maxResponseSize
-			) {
-				throw new APIError("BAD_REQUEST", {
-					message: `SAML response exceeds maximum allowed size (${maxResponseSize} bytes)`,
-				});
-			}
-
-			const SAMLResponse = ctx.body.SAMLResponse.replace(/\s+/g, "");
-			let relayState: RelayState | null = null;
-			if (ctx.body.RelayState) {
-				try {
-					relayState = await parseRelayState(ctx);
-				} catch {
-					relayState = null;
-				}
-			}
-
-			// If defaultSSO is configured, use it as the provider
-			let provider: SSOProvider<SSOOptions> | null = null;
-
-			if (options?.defaultSSO?.length) {
-				// For ACS endpoint, we can use the first default provider or try to match by providerId
-				const matchingDefault = providerId
-					? options.defaultSSO.find(
-							(defaultProvider) => defaultProvider.providerId === providerId,
-						)
-					: options.defaultSSO[0]; // Use first default provider if no specific providerId
-
-				if (matchingDefault) {
-					provider = {
-						issuer: matchingDefault.samlConfig?.issuer || "",
-						providerId: matchingDefault.providerId,
-						userId: "default",
-						samlConfig: matchingDefault.samlConfig,
-						domain: matchingDefault.domain,
-						...(options.domainVerification?.enabled
-							? { domainVerified: true }
-							: {}),
-					};
-				}
-			} else {
-				provider = await ctx.context.adapter
-					.findOne<SSOProvider<SSOOptions>>({
-						model: "ssoProvider",
-						where: [
-							{
-								field: "providerId",
-								value: providerId,
-							},
-						],
-					})
-					.then((res) => {
-						if (!res) return null;
-						return {
-							...res,
-							samlConfig: res.samlConfig
-								? safeJsonParse<SAMLConfig>(
-										res.samlConfig as unknown as string,
-									) || undefined
-								: undefined,
-						};
-					});
-			}
-
-			if (!provider?.samlConfig) {
-				throw new APIError("NOT_FOUND", {
-					message: "No SAML provider found",
-				});
-			}
-
-			if (
-				options?.domainVerification?.enabled &&
-				!("domainVerified" in provider && provider.domainVerified)
-			) {
-				throw new APIError("UNAUTHORIZED", {
-					message: "Provider domain has not been verified",
-				});
-			}
-
-			const parsedSamlConfig = provider.samlConfig;
-			// Configure SP and IdP
-			const sp = saml.ServiceProvider({
-				entityID:
-					parsedSamlConfig.spMetadata?.entityID || parsedSamlConfig.issuer,
-				assertionConsumerService: [
-					{
-						Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-						Location:
-							parsedSamlConfig.callbackUrl ||
-							`${ctx.context.baseURL}/sso/saml2/sp/acs/${providerId}`,
-					},
-				],
-				wantMessageSigned: parsedSamlConfig.wantAssertionsSigned || false,
-				metadata: parsedSamlConfig.spMetadata?.metadata,
-				privateKey:
-					parsedSamlConfig.spMetadata?.privateKey ||
-					parsedSamlConfig.privateKey,
-				privateKeyPass: parsedSamlConfig.spMetadata?.privateKeyPass,
-				nameIDFormat: parsedSamlConfig.identifierFormat
-					? [parsedSamlConfig.identifierFormat]
-					: undefined,
-			});
-
-			// Update where we construct the IdP
-			const idpData = parsedSamlConfig.idpMetadata;
-			const idp = !idpData?.metadata
-				? saml.IdentityProvider({
-						entityID: idpData?.entityID || parsedSamlConfig.issuer,
-						singleSignOnService: idpData?.singleSignOnService || [
-							{
-								Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-								Location: parsedSamlConfig.entryPoint,
-							},
-						],
-						signingCert: idpData?.cert || parsedSamlConfig.cert,
-					})
-				: saml.IdentityProvider({
-						metadata: idpData.metadata,
-					});
-
-			try {
-				validateSingleAssertion(SAMLResponse);
-			} catch (error) {
-				if (error instanceof APIError) {
-					const redirectUrl =
-						relayState?.callbackURL ||
-						parsedSamlConfig.callbackUrl ||
-						ctx.context.baseURL;
-					const errorCode =
-						error.body?.code === "SAML_MULTIPLE_ASSERTIONS"
-							? "multiple_assertions"
-							: "no_assertion";
-					throw ctx.redirect(
-						`${redirectUrl}?error=${errorCode}&error_description=${encodeURIComponent(error.message)}`,
-					);
-				}
-				throw error;
-			}
-
-			// Parse and validate SAML response
-			let parsedResponse: FlowResult;
-			try {
-				parsedResponse = await sp.parseLoginResponse(idp, "post", {
-					body: {
-						SAMLResponse,
-						RelayState: ctx.body.RelayState || undefined,
-					},
-				});
-
-				if (!parsedResponse?.extract) {
-					throw new Error("Invalid SAML response structure");
-				}
-			} catch (error) {
-				ctx.context.logger.error("SAML response validation failed", {
-					error,
-					decodedResponse: Buffer.from(SAMLResponse, "base64").toString(
-						"utf-8",
-					),
-				});
-				throw new APIError("BAD_REQUEST", {
-					message: "Invalid SAML response",
-					details: error instanceof Error ? error.message : String(error),
-				});
-			}
-
-			const { extract } = parsedResponse!;
-
-			validateSAMLAlgorithms(parsedResponse, options?.saml?.algorithms);
-
-			validateSAMLTimestamp((extract as SAMLAssertionExtract).conditions, {
-				clockSkew: options?.saml?.clockSkew,
-				requireTimestamps: options?.saml?.requireTimestamps,
-				logger: ctx.context.logger,
-			});
-
-			const inResponseToAcs = (extract as SAMLAssertionExtract).inResponseTo as
-				| string
-				| undefined;
-			const shouldValidateInResponseToAcs =
-				options?.saml?.enableInResponseToValidation !== false;
-
-			if (shouldValidateInResponseToAcs) {
-				const allowIdpInitiated = options?.saml?.allowIdpInitiated !== false;
-
-				if (inResponseToAcs) {
-					let storedRequest: AuthnRequestRecord | null = null;
-
-					const verification =
-						await ctx.context.internalAdapter.findVerificationValue(
-							`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseToAcs}`,
-						);
-					if (verification) {
-						try {
-							storedRequest = JSON.parse(
-								verification.value,
-							) as AuthnRequestRecord;
-							if (storedRequest && storedRequest.expiresAt < Date.now()) {
-								storedRequest = null;
-							}
-						} catch {
-							storedRequest = null;
-						}
-					}
-
-					if (!storedRequest) {
-						ctx.context.logger.error(
-							"SAML InResponseTo validation failed: unknown or expired request ID",
-							{ inResponseTo: inResponseToAcs, providerId },
-						);
-						const redirectUrl =
-							relayState?.callbackURL ||
-							parsedSamlConfig.callbackUrl ||
-							ctx.context.baseURL;
-						throw ctx.redirect(
-							`${redirectUrl}?error=invalid_saml_response&error_description=Unknown+or+expired+request+ID`,
-						);
-					}
-
-					if (storedRequest.providerId !== providerId) {
-						ctx.context.logger.error(
-							"SAML InResponseTo validation failed: provider mismatch",
-							{
-								inResponseTo: inResponseToAcs,
-								expectedProvider: storedRequest.providerId,
-								actualProvider: providerId,
-							},
-						);
-						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseToAcs}`,
-						);
-						const redirectUrl =
-							relayState?.callbackURL ||
-							parsedSamlConfig.callbackUrl ||
-							ctx.context.baseURL;
-						throw ctx.redirect(
-							`${redirectUrl}?error=invalid_saml_response&error_description=Provider+mismatch`,
-						);
-					}
-
-					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseToAcs}`,
-					);
-				} else if (!allowIdpInitiated) {
-					ctx.context.logger.error(
-						"SAML IdP-initiated SSO rejected: InResponseTo missing and allowIdpInitiated is false",
-						{ providerId },
-					);
-					const redirectUrl =
-						relayState?.callbackURL ||
-						parsedSamlConfig.callbackUrl ||
-						ctx.context.baseURL;
-					throw ctx.redirect(
-						`${redirectUrl}?error=unsolicited_response&error_description=IdP-initiated+SSO+not+allowed`,
-					);
-				}
-			}
-
-			// Assertion Replay Protection
-			const samlContentAcs = Buffer.from(SAMLResponse, "base64").toString(
-				"utf-8",
-			);
-			const assertionIdAcs = extractAssertionId(samlContentAcs);
-
-			if (assertionIdAcs) {
-				const issuer = idp.entityMeta.getEntityID();
-				const conditions = (extract as SAMLAssertionExtract).conditions as
-					| SAMLConditions
-					| undefined;
-				const clockSkew =
-					options?.saml?.clockSkew ?? constants.DEFAULT_CLOCK_SKEW_MS;
-				const expiresAt = conditions?.notOnOrAfter
-					? new Date(conditions.notOnOrAfter).getTime() + clockSkew
-					: Date.now() + constants.DEFAULT_ASSERTION_TTL_MS;
-
-				const existingAssertion =
-					await ctx.context.internalAdapter.findVerificationValue(
-						`${constants.USED_ASSERTION_KEY_PREFIX}${assertionIdAcs}`,
-					);
-
-				let isReplay = false;
-				if (existingAssertion) {
-					try {
-						const stored = JSON.parse(existingAssertion.value);
-						if (stored.expiresAt >= Date.now()) {
-							isReplay = true;
-						}
-					} catch (error) {
-						ctx.context.logger.warn("Failed to parse stored assertion record", {
-							assertionId: assertionIdAcs,
-							error,
-						});
-					}
-				}
-
-				if (isReplay) {
-					ctx.context.logger.error(
-						"SAML assertion replay detected: assertion ID already used",
-						{
-							assertionId: assertionIdAcs,
-							issuer,
-							providerId,
-						},
-					);
-					const redirectUrl =
-						relayState?.callbackURL ||
-						parsedSamlConfig.callbackUrl ||
-						ctx.context.baseURL;
-					throw ctx.redirect(
-						`${redirectUrl}?error=replay_detected&error_description=SAML+assertion+has+already+been+used`,
-					);
-				}
-
-				await ctx.context.internalAdapter.createVerificationValue({
-					identifier: `${constants.USED_ASSERTION_KEY_PREFIX}${assertionIdAcs}`,
-					value: JSON.stringify({
-						assertionId: assertionIdAcs,
-						issuer,
-						providerId,
-						usedAt: Date.now(),
-						expiresAt,
-					}),
-					expiresAt: new Date(expiresAt),
-				});
-			} else {
-				ctx.context.logger.warn(
-					"Could not extract assertion ID for replay protection",
-					{ providerId },
-				);
-			}
-
-			const attributes = extract.attributes || {};
-			const mapping = parsedSamlConfig.mapping ?? {};
-
-			const userInfo = {
-				...Object.fromEntries(
-					Object.entries(mapping.extraFields || {}).map(([key, value]) => [
-						key,
-						attributes[value as string],
-					]),
-				),
-				id: attributes[mapping.id || "nameID"] || extract.nameID,
-				email: (
-					attributes[mapping.email || "email"] || extract.nameID
-				).toLowerCase(),
-				name:
-					[
-						attributes[mapping.firstName || "givenName"],
-						attributes[mapping.lastName || "surname"],
-					]
-						.filter(Boolean)
-						.join(" ") ||
-					attributes[mapping.name || "displayName"] ||
-					extract.nameID,
-				emailVerified:
-					options?.trustEmailVerified && mapping.emailVerified
-						? ((attributes[mapping.emailVerified] || false) as boolean)
-						: false,
-			};
-
-			if (!userInfo.id || !userInfo.email) {
-				ctx.context.logger.error(
-					"Missing essential user info from SAML response",
-					{
-						attributes: Object.keys(attributes),
-						mapping,
-						extractedId: userInfo.id,
-						extractedEmail: userInfo.email,
-					},
-				);
-				throw new APIError("BAD_REQUEST", {
-					message: "Unable to extract user ID or email from SAML response",
-				});
-			}
-
-			const isTrustedProvider: boolean =
-				ctx.context.trustedProviders.includes(provider.providerId) ||
-				("domainVerified" in provider &&
-					!!(provider as { domainVerified?: boolean }).domainVerified &&
-					validateEmailDomain(userInfo.email as string, provider.domain));
-
-			const callbackUrl =
-				relayState?.callbackURL ||
-				parsedSamlConfig.callbackUrl ||
-				ctx.context.baseURL;
-
-			const result = await handleOAuthUserInfo(ctx, {
-				userInfo: {
-					email: userInfo.email as string,
-					name: (userInfo.name || userInfo.email) as string,
-					id: userInfo.id as string,
-					emailVerified: Boolean(userInfo.emailVerified),
-				},
-				account: {
-					providerId: provider.providerId,
-					accountId: userInfo.id as string,
-					accessToken: "",
-					refreshToken: "",
-				},
-				callbackURL: callbackUrl,
-				disableSignUp: options?.disableImplicitSignUp,
-				isTrustedProvider,
-			});
-
-			if (result.error) {
-				throw ctx.redirect(
-					`${callbackUrl}?error=${result.error.split(" ").join("_")}`,
-				);
-			}
-
-			const { session, user } = result.data!;
-
-			if (
-				options?.provisionUser &&
-				(result.isRegister || options.provisionUserOnEveryLogin)
-			) {
-				await options.provisionUser({
-					user: user as User & Record<string, any>,
-					userInfo,
-					provider,
-				});
-			}
-
-			await assignOrganizationFromProvider(ctx as any, {
-				user,
-				profile: {
-					providerType: "saml",
-					providerId: provider.providerId,
-					accountId: userInfo.id as string,
-					email: userInfo.email as string,
-					emailVerified: Boolean(userInfo.emailVerified),
-					rawAttributes: attributes,
-				},
-				provider,
-				provisioningOptions: options?.organizationProvisioning,
-			});
-
-			await setSessionCookie(ctx, { session, user });
-			if (options?.saml?.enableSingleLogout && extract.nameID) {
-				const samlSessionKey = `${constants.SAML_SESSION_KEY_PREFIX}${providerId}:${extract.nameID}`;
-				const samlSessionData: SAMLSessionRecord = {
-					sessionId: session.id,
+			const safeRedirectUrl = await processSAMLResponse(
+				ctx,
+				{
+					SAMLResponse: ctx.body.SAMLResponse,
+					RelayState: ctx.body.RelayState,
 					providerId,
-					nameID: extract.nameID,
-					sessionIndex: (extract as SAMLAssertionExtract).sessionIndex,
-				};
-				await ctx.context.internalAdapter
-					.createVerificationValue({
-						identifier: samlSessionKey,
-						value: JSON.stringify(samlSessionData),
-						expiresAt: session.expiresAt,
-					})
-					.catch((e) =>
-						ctx.context.logger.warn("Failed to create SAML session record", {
-							error: e,
-						}),
-					);
-				await ctx.context.internalAdapter
-					.createVerificationValue({
-						identifier: `${constants.SAML_SESSION_BY_ID_PREFIX}${session.id}`,
-						value: samlSessionKey,
-						expiresAt: session.expiresAt,
-					})
-					.catch((e) =>
-						ctx.context.logger.warn(
-							"Failed to create SAML session lookup record",
-							e,
-						),
-					);
-			}
-
-			const safeRedirectUrl = getSafeRedirectUrl(
-				relayState?.callbackURL || parsedSamlConfig.callbackUrl,
-				currentCallbackPath,
-				appOrigin,
-				(url, settings) => ctx.context.isTrustedOrigin(url, settings),
+					currentCallbackPath,
+				},
+				options,
 			);
 			throw ctx.redirect(safeRedirectUrl);
 		},
@@ -3073,8 +2056,10 @@ export const sloEndpoint = (options?: SSOOptions) => {
 
 			const config = provider.samlConfig as SAMLConfig;
 			const sp = createSP(config, ctx.context.baseURL, providerId, {
-				wantLogoutRequestSigned: options?.saml?.wantLogoutRequestSigned,
-				wantLogoutResponseSigned: options?.saml?.wantLogoutResponseSigned,
+				sloOptions: {
+					wantLogoutRequestSigned: options?.saml?.wantLogoutRequestSigned,
+					wantLogoutResponseSigned: options?.saml?.wantLogoutResponseSigned,
+				},
 			});
 			const idp = createIdP(config);
 
@@ -3315,8 +2300,10 @@ export const initiateSLO = (options?: SSOOptions) => {
 			}
 
 			const sp = createSP(config, ctx.context.baseURL, providerId, {
-				wantLogoutRequestSigned: options?.saml?.wantLogoutRequestSigned,
-				wantLogoutResponseSigned: options?.saml?.wantLogoutResponseSigned,
+				sloOptions: {
+					wantLogoutRequestSigned: options?.saml?.wantLogoutRequestSigned,
+					wantLogoutResponseSigned: options?.saml?.wantLogoutResponseSigned,
+				},
 			});
 			const idp = createIdP(config);
 

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -77,82 +77,11 @@ function getOIDCRedirectURI(
 	return `${baseURL}/sso/callback/${providerId}`;
 }
 
-export interface TimestampValidationOptions {
-	clockSkew?: number;
-	requireTimestamps?: boolean;
-	logger?: {
-		warn: (message: string, data?: Record<string, unknown>) => void;
-	};
-}
-
-/** Conditions extracted from SAML assertion */
-export interface SAMLConditions {
-	notBefore?: string;
-	notOnOrAfter?: string;
-}
-
-/**
- * Validates SAML assertion timestamp conditions (NotBefore/NotOnOrAfter).
- * Prevents acceptance of expired or future-dated assertions.
- * @throws {APIError} If timestamps are invalid, expired, or not yet valid
- */
-export function validateSAMLTimestamp(
-	conditions: SAMLConditions | undefined,
-	options: TimestampValidationOptions = {},
-): void {
-	const clockSkew = options.clockSkew ?? constants.DEFAULT_CLOCK_SKEW_MS;
-	const hasTimestamps = conditions?.notBefore || conditions?.notOnOrAfter;
-
-	if (!hasTimestamps) {
-		if (options.requireTimestamps) {
-			throw new APIError("BAD_REQUEST", {
-				message: "SAML assertion missing required timestamp conditions",
-				details:
-					"Assertions must include NotBefore and/or NotOnOrAfter conditions",
-			});
-		}
-		// Log warning for missing timestamps when not required
-		options.logger?.warn(
-			"SAML assertion accepted without timestamp conditions",
-			{ hasConditions: !!conditions },
-		);
-		return;
-	}
-
-	const now = Date.now();
-
-	if (conditions?.notBefore) {
-		const notBeforeTime = new Date(conditions.notBefore).getTime();
-		if (Number.isNaN(notBeforeTime)) {
-			throw new APIError("BAD_REQUEST", {
-				message: "SAML assertion has invalid NotBefore timestamp",
-				details: `Unable to parse NotBefore value: ${conditions.notBefore}`,
-			});
-		}
-		if (now < notBeforeTime - clockSkew) {
-			throw new APIError("BAD_REQUEST", {
-				message: "SAML assertion is not yet valid",
-				details: `Current time is before NotBefore (with ${clockSkew}ms clock skew tolerance)`,
-			});
-		}
-	}
-
-	if (conditions?.notOnOrAfter) {
-		const notOnOrAfterTime = new Date(conditions.notOnOrAfter).getTime();
-		if (Number.isNaN(notOnOrAfterTime)) {
-			throw new APIError("BAD_REQUEST", {
-				message: "SAML assertion has invalid NotOnOrAfter timestamp",
-				details: `Unable to parse NotOnOrAfter value: ${conditions.notOnOrAfter}`,
-			});
-		}
-		if (now > notOnOrAfterTime + clockSkew) {
-			throw new APIError("BAD_REQUEST", {
-				message: "SAML assertion has expired",
-				details: `Current time is after NotOnOrAfter (with ${clockSkew}ms clock skew tolerance)`,
-			});
-		}
-	}
-}
+export {
+	type SAMLConditions,
+	type TimestampValidationOptions,
+	validateSAMLTimestamp,
+} from "../saml/timestamp";
 
 const spMetadataQuerySchema = z.object({
 	providerId: z.string(),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1948,7 +1948,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 						(url, settings) => ctx.context.isTrustedOrigin(url, settings),
 					);
 					throw ctx.redirect(
-						`${redirectUrl}?error=${encodeURIComponent(errorCode)}&error_description=${encodeURIComponent(error.message)}`,
+						`${redirectUrl}${redirectUrl.includes("?") ? "&" : "?"}error=${encodeURIComponent(errorCode)}&error_description=${encodeURIComponent(error.message)}`,
 					);
 				}
 				throw error;

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1940,7 +1940,15 @@ export const acsEndpoint = (options?: SSOOptions) => {
 				// so the user returns to the app instead of seeing raw JSON.
 				// Non-400 errors (404 provider not found, 401 unauthorized) propagate as-is.
 				if (error instanceof APIError && error.statusCode === 400) {
-					const errorCode = error.body?.code || "saml_error";
+					// TODO: unify error codes across endpoints (callbackSSOSAML uses
+					// the raw APIError code, ACS uses lowercase snake_case for backward compat)
+					const internalCode = error.body?.code || "";
+					const errorCode =
+						internalCode === "SAML_MULTIPLE_ASSERTIONS"
+							? "multiple_assertions"
+							: internalCode === "SAML_NO_ASSERTION"
+								? "no_assertion"
+								: internalCode.toLowerCase() || "saml_error";
 					const redirectUrl = getSafeRedirectUrl(
 						ctx.body.RelayState || undefined,
 						currentCallbackPath,

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -754,9 +754,15 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 
 				// Validate that the config has a usable IdP entry point
 				const hasIdpMetadata = body.samlConfig.idpMetadata?.metadata;
-				const hasEntryPoint =
-					body.samlConfig.entryPoint &&
-					body.samlConfig.entryPoint.startsWith("http");
+				let hasEntryPoint = false;
+				if (body.samlConfig.entryPoint) {
+					try {
+						new URL(body.samlConfig.entryPoint);
+						hasEntryPoint = true;
+					} catch {
+						// not a valid URL
+					}
+				}
 				const hasSingleSignOnService =
 					body.samlConfig.idpMetadata?.singleSignOnService?.length;
 				if (!hasIdpMetadata && !hasEntryPoint && !hasSingleSignOnService) {

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -4600,9 +4600,11 @@ describe("SAML SSO - Single Assertion Validation", () => {
 			),
 		);
 
-		expect(response.status).toBe(302);
-		const location = response.headers.get("location") || "";
-		expect(location).toContain("error=multiple_assertions");
+		// Both endpoints throw APIError for structural SAMLResponse issues
+		// (multiple assertions, no assertions, XSW injection)
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.code).toBe("SAML_MULTIPLE_ASSERTIONS");
 	});
 
 	it("should reject SAML response with no assertions", async () => {
@@ -5761,5 +5763,325 @@ describe("SAML provisionUserOnEveryLogin should call provisionUser on every sign
 		});
 
 		expect(provisionUserFn).toHaveBeenCalledTimes(1);
+	});
+});
+
+/**
+ * SAML SSO Hardening Tests (TDD Red Phase)
+ *
+ * These tests encode requirements from SAML 2.0 Core, Profiles, and Bindings,
+ * plus better-auth-specific behaviors. They are written to fail against the
+ * current codebase, exposing bugs that the refactor will fix.
+ *
+ * @see https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
+ * @see https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf
+ */
+describe("SAML SSO Hardening", () => {
+	/**
+	 * RFC: SAML 2.0 Core §2.3.3 - ACS URL in SP metadata MUST match the ACS URL
+	 * in AuthnRequests. When callbackUrl is omitted, both should derive the same
+	 * ACS from baseURL + providerId.
+	 */
+	describe("ACS URL consistency (provider.id vs providerId)", () => {
+		// When callbackUrl is split from ACS URL, SP metadata should
+		// always derive the ACS from baseURL + providerId regardless of callbackUrl.
+		it.todo("should use providerId (not internal row ID) in SP metadata ACS URL when callbackUrl is an app destination", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [sso()],
+			});
+			const { headers } = await signInWithTestUser();
+
+			// Register with callbackUrl pointing to app destination (not an ACS route).
+			// When spMetadata.metadata is absent, the SP metadata endpoint should
+			// generate an ACS URL from baseURL + providerId, not from provider.id (row UUID).
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "acs-consistency-test",
+					issuer: "http://localhost:8081",
+					domain: "acs-test.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl: "http://localhost:3000/dashboard",
+						spMetadata: {},
+					},
+				},
+				headers,
+			});
+
+			const spMetadataRes = await auth.api.spMetadata({
+				query: { providerId: "acs-consistency-test" },
+			});
+			const xml = await spMetadataRes.text();
+
+			// When callbackUrl is an app destination (not an ACS URL), the SP metadata
+			// generator should still use a proper ACS URL with the providerId.
+			// The generated metadata should contain the providerId, not the row UUID.
+			expect(xml).toContain("acs-consistency-test");
+		});
+
+		// When callbackUrl is split from ACS URL, both SP metadata
+		// and AuthnRequest should derive ACS from the same source.
+		it.todo("should produce matching ACS URLs in SP metadata and AuthnRequest", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [sso()],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "acs-match-test",
+					issuer: "http://localhost:8081",
+					domain: "acs-match.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl: "http://localhost:3000/dashboard",
+						idpMetadata: {
+							metadata: idpMetadata,
+						},
+						spMetadata: {},
+					},
+				},
+				headers,
+			});
+
+			// Get ACS URL from SP metadata
+			const spMetadataRes = await auth.api.spMetadata({
+				query: { providerId: "acs-match-test" },
+			});
+			const metadataXml = await spMetadataRes.text();
+			const metadataAcsMatch = metadataXml.match(
+				/Location="([^"]*\/sso\/saml2\/sp\/acs[^"]*)"/,
+			);
+			expect(metadataAcsMatch).not.toBeNull();
+			const metadataAcsUrl = metadataAcsMatch![1];
+
+			// Get ACS URL from AuthnRequest
+			const signInResponse = await auth.api.signInSSO({
+				body: {
+					providerId: "acs-match-test",
+					callbackURL: "/dashboard",
+				},
+			});
+			// The redirect URL's SAMLRequest contains the ACS URL; we verify
+			// they both derive from the same providerId
+			expect(metadataAcsUrl).toContain("acs-match-test");
+			expect(signInResponse.url).toBeDefined();
+		});
+	});
+
+	/**
+	 * Better-auth specific: acsEndpoint provider lookup MUST fall back to the
+	 * database when defaultSSO is configured but no entry matches the providerId.
+	 */
+	describe("Provider lookup fallback", () => {
+		it("should find DB provider even when defaultSSO is configured with different providers", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						defaultSSO: [
+							{
+								providerId: "default-provider",
+								domain: "default.example.com",
+								samlConfig: {
+									issuer: "http://localhost:8081",
+									entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+									cert: certificate,
+									callbackUrl: "http://localhost:3000/dashboard",
+									spMetadata: { metadata: spMetadata },
+								},
+							},
+						],
+					}),
+				],
+			});
+
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "db-provider",
+					issuer: "http://localhost:8081",
+					domain: "db.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl: "http://localhost:3000/dashboard",
+						spMetadata: { metadata: spMetadata },
+						idpMetadata: { metadata: idpMetadata },
+					},
+				},
+				headers,
+			});
+
+			// POST a SAMLResponse to ACS for the DB provider
+			// The endpoint MUST find "db-provider" in the database, not fall back to defaultSSO[0]
+			const response = await auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/db-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: "invalid-but-tests-provider-lookup",
+						}),
+					},
+				),
+			);
+
+			// Should NOT return 404 (which would mean it didn't find the provider)
+			// It will return 400 because the SAMLResponse is invalid, but the
+			// provider lookup itself should succeed
+			expect(response.status).not.toBe(404);
+		});
+
+		it("should return 404 for nonexistent providerId even when defaultSSO is configured", async () => {
+			const { auth } = await getTestInstance({
+				plugins: [
+					sso({
+						defaultSSO: [
+							{
+								providerId: "default-provider",
+								domain: "default.example.com",
+								samlConfig: {
+									issuer: "http://localhost:8081",
+									entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+									cert: certificate,
+									callbackUrl: "http://localhost:3000/dashboard",
+									spMetadata: { metadata: spMetadata },
+								},
+							},
+						],
+					}),
+				],
+			});
+
+			// POST to ACS for a provider that doesn't exist anywhere
+			const response = await auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/nonexistent-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: "irrelevant",
+						}),
+					},
+				),
+			);
+
+			// MUST be 404 — should NOT fall back to defaultSSO[0]
+			expect(response.status).toBe(404);
+		});
+	});
+
+	/**
+	 * Better-auth specific: registration-time validation should catch config
+	 * errors early rather than failing silently at sign-in time.
+	 */
+	describe("Registration-time config validation", () => {
+		it("should reject registration with empty entryPoint and no idpMetadata.metadata", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [sso()],
+			});
+			const { headers } = await signInWithTestUser();
+
+			// This config has no way to reach the IdP: entryPoint is empty and
+			// there's no idpMetadata.metadata to extract it from. The registration
+			// should fail instead of creating a broken provider that silently fails
+			// at sign-in time.
+			await expect(
+				auth.api.registerSSOProvider({
+					body: {
+						providerId: "broken-config",
+						issuer: "http://localhost:8081",
+						domain: "broken.example.com",
+						samlConfig: {
+							entryPoint: "not-a-url",
+							cert: "placeholder",
+							callbackUrl: "http://localhost:3000/dashboard",
+							spMetadata: {},
+						},
+					},
+					headers,
+				}),
+			).rejects.toMatchObject({
+				body: expect.objectContaining({
+					message: expect.stringContaining("entryPoint"),
+				}),
+			});
+		});
+	});
+
+	/**
+	 * SAML 2.0 Bindings §3.5.3 - RelayState is an opaque reference to state
+	 * maintained at the SP. The SP MUST use it to determine where to redirect
+	 * the user after authentication. Config-level callbackUrl is a fallback.
+	 */
+	describe("RelayState priority over callbackUrl", () => {
+		it("should redirect to RelayState callbackURL, not config callbackUrl", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [sso()],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "relay-priority-test",
+					issuer: "http://localhost:8081",
+					domain: "relay.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl: "http://localhost:3000/from-config",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			// Sign in with a specific callbackURL
+			const signInResponse = await auth.api.signInSSO({
+				body: {
+					providerId: "relay-priority-test",
+					callbackURL: "/from-relay-state",
+				},
+			});
+
+			// Get SAMLResponse from mock IdP
+			let samlResponse: any;
+			await betterFetch(signInResponse.url as string, {
+				onSuccess: async (context) => {
+					samlResponse = await context.data;
+				},
+			});
+
+			// Extract RelayState from the sign-in redirect URL
+			const signInUrl = new URL(signInResponse.url as string);
+			const relayState = signInUrl.searchParams.get("RelayState") ?? "";
+
+			// POST to callback with RelayState
+			const callbackResponse = (await auth.api.callbackSSOSAML({
+				method: "POST",
+				body: {
+					SAMLResponse: samlResponse.samlResponse,
+					RelayState: relayState,
+				},
+				params: { providerId: "relay-priority-test" },
+				asResponse: true,
+			})) as unknown as Response;
+
+			const location = callbackResponse.headers.get("location") || "";
+
+			// MUST redirect to the RelayState callbackURL, not config's callbackUrl
+			expect(location).toContain("/from-relay-state");
+			expect(location).not.toContain("/from-config");
+		});
 	});
 });

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -5766,12 +5766,6 @@ describe("SAML provisionUserOnEveryLogin should call provisionUser on every sign
 });
 
 /**
- * SAML SSO Hardening Tests (TDD Red Phase)
- *
- * These tests encode requirements from SAML 2.0 Core, Profiles, and Bindings,
- * plus better-auth-specific behaviors. They are written to fail against the
- * current codebase, exposing bugs that the refactor will fix.
- *
  * @see https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
  * @see https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf
  */

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -4603,7 +4603,7 @@ describe("SAML SSO - Single Assertion Validation", () => {
 		// ACS endpoint translates structural errors into browser-friendly redirects
 		expect(response.status).toBe(302);
 		const location = response.headers.get("location") || "";
-		expect(location).toContain("error=SAML_MULTIPLE_ASSERTIONS");
+		expect(location).toContain("error=multiple_assertions");
 	});
 
 	it("should reject SAML response with no assertions", async () => {

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -4600,11 +4600,10 @@ describe("SAML SSO - Single Assertion Validation", () => {
 			),
 		);
 
-		// Both endpoints throw APIError for structural SAMLResponse issues
-		// (multiple assertions, no assertions, XSW injection)
-		expect(response.status).toBe(400);
-		const body = await response.json();
-		expect(body.code).toBe("SAML_MULTIPLE_ASSERTIONS");
+		// ACS endpoint translates structural errors into browser-friendly redirects
+		expect(response.status).toBe(302);
+		const location = response.headers.get("location") || "";
+		expect(location).toContain("error=SAML_MULTIPLE_ASSERTIONS");
 	});
 
 	it("should reject SAML response with no assertions", async () => {

--- a/packages/sso/src/saml/timestamp.ts
+++ b/packages/sso/src/saml/timestamp.ts
@@ -1,0 +1,78 @@
+import { APIError } from "better-auth/api";
+import * as constants from "../constants";
+
+export interface TimestampValidationOptions {
+	clockSkew?: number;
+	requireTimestamps?: boolean;
+	logger?: {
+		warn: (message: string, data?: Record<string, unknown>) => void;
+	};
+}
+
+/** Conditions extracted from SAML assertion */
+export interface SAMLConditions {
+	notBefore?: string;
+	notOnOrAfter?: string;
+}
+
+/**
+ * Validates SAML assertion timestamp conditions (NotBefore/NotOnOrAfter).
+ * Prevents acceptance of expired or future-dated assertions.
+ * @throws {APIError} If timestamps are invalid, expired, or not yet valid
+ */
+export function validateSAMLTimestamp(
+	conditions: SAMLConditions | undefined,
+	options: TimestampValidationOptions = {},
+): void {
+	const clockSkew = options.clockSkew ?? constants.DEFAULT_CLOCK_SKEW_MS;
+	const hasTimestamps = conditions?.notBefore || conditions?.notOnOrAfter;
+
+	if (!hasTimestamps) {
+		if (options.requireTimestamps) {
+			throw new APIError("BAD_REQUEST", {
+				message: "SAML assertion missing required timestamp conditions",
+				details:
+					"Assertions must include NotBefore and/or NotOnOrAfter conditions",
+			});
+		}
+		options.logger?.warn(
+			"SAML assertion accepted without timestamp conditions",
+			{ hasConditions: !!conditions },
+		);
+		return;
+	}
+
+	const now = Date.now();
+
+	if (conditions?.notBefore) {
+		const notBeforeTime = new Date(conditions.notBefore).getTime();
+		if (Number.isNaN(notBeforeTime)) {
+			throw new APIError("BAD_REQUEST", {
+				message: "SAML assertion has invalid NotBefore timestamp",
+				details: `Unable to parse NotBefore value: ${conditions.notBefore}`,
+			});
+		}
+		if (now < notBeforeTime - clockSkew) {
+			throw new APIError("BAD_REQUEST", {
+				message: "SAML assertion is not yet valid",
+				details: `Current time is before NotBefore (with ${clockSkew}ms clock skew tolerance)`,
+			});
+		}
+	}
+
+	if (conditions?.notOnOrAfter) {
+		const notOnOrAfterTime = new Date(conditions.notOnOrAfter).getTime();
+		if (Number.isNaN(notOnOrAfterTime)) {
+			throw new APIError("BAD_REQUEST", {
+				message: "SAML assertion has invalid NotOnOrAfter timestamp",
+				details: `Unable to parse NotOnOrAfter value: ${conditions.notOnOrAfter}`,
+			});
+		}
+		if (now > notOnOrAfterTime + clockSkew) {
+			throw new APIError("BAD_REQUEST", {
+				message: "SAML assertion has expired",
+				details: `Current time is after NotOnOrAfter (with ${clockSkew}ms clock skew tolerance)`,
+			});
+		}
+	}
+}

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -87,6 +87,14 @@ export interface SAMLConfig {
 	mapping?: SAMLMapping | undefined;
 }
 
+/** Stored AuthnRequest record for InResponseTo validation */
+export interface AuthnRequestRecord {
+	id: string;
+	providerId: string;
+	createdAt: number;
+	expiresAt: number;
+}
+
 /** Session data stored during SAML login for Single Logout */
 export interface SAMLSessionRecord {
 	sessionId: string;


### PR DESCRIPTION
## Summary

- Extract duplicated SAML response handling from `callbackSSOSAML` and `acsEndpoint` into a shared `processSAMLResponse` pipeline
- Complete `createSP`/`createIdP` helpers with all encryption and signing fields so both endpoints produce identical SP/IdP objects
- Fix SP metadata endpoint using internal row ID instead of `providerId` in ACS URL fallback
- Fix `acsEndpoint` skipping DB lookup when `defaultSSO` was configured, and falling back to `defaultSSO[0]` for unmatched providerIds
- Fix `acsEndpoint` missing encryption fields (`isAssertionEncrypted`, `encPrivateKey`) causing silent decryption failures
- Add registration-time validation: reject configs with no usable IdP entry point
- Fix Supabase migration guide generating unsupported `metadataUrl` field; fetch IdP metadata XML inline instead
- Fix contradictory `callbackUrl` guidance across SSO docs
- Add TDD tests for provider lookup fallback, registration validation, and RelayState priority


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies SAML response handling in `@better-auth/sso`, restores browser-friendly ACS redirects with sanitized, query-safe URLs, and aligns docs to treat `callbackUrl` as the ACS URL. Keeps ACS error codes in backward‑compatible lowercase.

- **Refactors**
  - Added shared `processSAMLResponse` for ACS and callback, removing duplicate logic.
  - Completed `createSP`/`createIdP` with full signing/encryption, `nameIDFormat`, SLO, RelayState; `createSP` now falls back to a generated ACS URL when `callbackUrl` is missing.
  - Extracted `validateSAMLTimestamp` to `saml/timestamp.ts` (re-exported) and made `extractAssertionId` internal.

- **Bug Fixes**
  - Corrected ACS URL/provider lookup: SP metadata uses public `providerId`; ACS always queries the DB and never falls back to `defaultSSO[0]`; fixed `defaultSSO` parsing in the callback path.
  - Added missing encryption fields (`isAssertionEncrypted`, `encPrivateKey`) to prevent silent decryption failures.
  - Registration now requires IdP metadata XML, `singleSignOnService`, and a valid `entryPoint` (validated via `new URL()`).
  - Restored browser-friendly ACS error redirects, sanitized redirect targets, preserved existing query params, and kept error codes in lowercase snake_case (e.g., `error=multiple_assertions`) for compatibility.

<sup>Written for commit 4546e4d09b11af11d42d9a112e16d2390060f076. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



