### PR TITLE
fix(utils): add input validation for validatePassword

### DIFF
--- a/packages/better-auth/src/utils/password.ts
+++ b/packages/better-auth/src/utils/password.ts
@@ -8,7 +8,7 @@ export async function validatePassword(
 		userId: string;
 	},
 ) {
-	if (!data.password || typeof data.password !== "string") {
+	if (!data.password) {
 		return false;
 	}
 

--- a/packages/better-auth/src/utils/password.ts
+++ b/packages/better-auth/src/utils/password.ts
@@ -8,6 +8,12 @@ export async function validatePassword(
 		userId: string;
 	},
 ) {
+	if (!data.password || typeof data.password !== "string") {
+		return false;
+	}
+
+	const password = data.password.trim();
+	if (!password) return false;
 	const accounts = await ctx.context.internalAdapter.findAccounts(data.userId);
 	const credentialAccount = accounts?.find(
 		(account) => account.providerId === "credential",
@@ -18,7 +24,7 @@ export async function validatePassword(
 	}
 	const compare = await ctx.context.password.verify({
 		hash: currentPassword,
-		password: data.password,
+		password,
 	});
 	return compare;
 }


### PR DESCRIPTION
## Summary
Adds input validation to prevent empty or invalid password values from being processed.

## Changes
- Added guard clause for missing passwords
- Trimmed password input before verification

## Result
Prevents unnecessary processing and improves safety of password validation

This is a non-breaking change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add input validation to validatePassword to return false when the password is missing or whitespace-only. Trim the input before verification to prevent unnecessary account lookups and hash checks.

<sup>Written for commit 1667fb74a4c477005c93bcf9dabec84c4529bdab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

