### PR TITLE
feat: warn when cookie integration plugins are not last in plugins[]

### DIFF
--- a/.changeset/cookie-plugin-guardrail.md
+++ b/.changeset/cookie-plugin-guardrail.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+warn when cookie integration plugins are not last in plugins[]

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -1938,10 +1938,7 @@ describe("cookie integration plugin order guardrail", () => {
 		const log = vi.fn();
 		await initBase({
 			logger: { level: "warn", log } as any,
-			plugins: [
-				{ id: "next-cookies" },
-				{ id: "some-other-plugin" },
-			],
+			plugins: [{ id: "next-cookies" }, { id: "some-other-plugin" }],
 		});
 		expect(log).toHaveBeenCalledWith(
 			"warn",
@@ -1955,10 +1952,7 @@ describe("cookie integration plugin order guardrail", () => {
 		const log = vi.fn();
 		await initBase({
 			logger: { level: "warn", log } as any,
-			plugins: [
-				{ id: "some-other-plugin" },
-				{ id: "next-cookies" },
-			],
+			plugins: [{ id: "some-other-plugin" }, { id: "next-cookies" }],
 		});
 		expect(log).not.toHaveBeenCalledWith(
 			"warn",

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -1922,3 +1922,100 @@ describe("base context creation", () => {
 		});
 	});
 });
+
+describe("cookie integration plugin order guardrail", () => {
+	const initBase = async (options: Partial<BetterAuthOptions> = {}) => {
+		const opts: BetterAuthOptions = {
+			baseURL: "http://localhost:3000",
+			...options,
+		};
+		const adapter = await getAdapter(opts);
+		const getDatabaseType = () => "memory";
+		return createAuthContext(adapter, opts, getDatabaseType);
+	};
+
+	it("should warn when a cookie integration plugin is not the last plugin", async () => {
+		const log = vi.fn();
+		await initBase({
+			logger: { level: "warn", log } as any,
+			plugins: [
+				{ id: "next-cookies" },
+				{ id: "some-other-plugin" },
+			],
+		});
+		expect(log).toHaveBeenCalledWith(
+			"warn",
+			expect.stringContaining(
+				'cookie integration plugin(s) "next-cookies" must be placed last in the plugins[] array',
+			),
+		);
+	});
+
+	it("should NOT warn when a cookie integration plugin is the last plugin", async () => {
+		const log = vi.fn();
+		await initBase({
+			logger: { level: "warn", log } as any,
+			plugins: [
+				{ id: "some-other-plugin" },
+				{ id: "next-cookies" },
+			],
+		});
+		expect(log).not.toHaveBeenCalledWith(
+			"warn",
+			expect.stringContaining("cookie integration plugin"),
+		);
+	});
+
+	it("should NOT warn when there is only one plugin which is a cookie integration plugin", async () => {
+		const log = vi.fn();
+		await initBase({
+			logger: { level: "warn", log } as any,
+			plugins: [{ id: "next-cookies" }],
+		});
+		expect(log).not.toHaveBeenCalledWith(
+			"warn",
+			expect.stringContaining("cookie integration plugin"),
+		);
+	});
+
+	it("should warn for all known cookie integration plugin IDs when misplaced", async () => {
+		const cookiePluginIds = [
+			"next-cookies",
+			"tanstack-start-cookies",
+			"tanstack-start-cookies-solid",
+			"sveltekit-cookies",
+		];
+
+		for (const id of cookiePluginIds) {
+			const log = vi.fn();
+			await initBase({
+				logger: { level: "warn", log } as any,
+				plugins: [{ id }, { id: "trailing-plugin" }],
+			});
+			expect(log).toHaveBeenCalledWith(
+				"warn",
+				expect.stringContaining(`"${id}"`),
+			);
+		}
+	});
+
+	it("should warn mentioning all misplaced cookie integration plugins", async () => {
+		const log = vi.fn();
+		await initBase({
+			logger: { level: "warn", log } as any,
+			plugins: [
+				{ id: "next-cookies" },
+				{ id: "tanstack-start-cookies" },
+				{ id: "trailing-plugin" },
+			],
+		});
+		expect(log).toHaveBeenCalledWith(
+			"warn",
+			expect.stringContaining('"next-cookies"'),
+		);
+		expect(log).toHaveBeenCalledWith(
+			"warn",
+			expect.stringContaining('"tanstack-start-cookies"'),
+		);
+	});
+});

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -132,12 +132,12 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 	]);
 
 	if (plugins.length > 1) {
-		const misorderedPlugins = plugins
+		const outOfOrderPlugins = plugins
 			.slice(0, -1)
 			.filter((p) => COOKIE_INTEGRATION_PLUGIN_IDS.has(p.id));
 
-		if (misorderedPlugins.length > 0) {
-			const ids = misorderedPlugins.map((p) => `"${p.id}"`).join(", ");
+		if (outOfOrderPlugins.length > 0) {
+			const ids = outOfOrderPlugins.map((p) => `"${p.id}"`).join(", ");
 			logger.warn(
 				`[better-auth] Misconfiguration detected: cookie integration plugin(s) ${ids} must be placed last in the plugins[] array. ` +
 					`Any plugin that runs after a cookie integration plugin will have its Set-Cookie headers silently dropped by the framework, ` +

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -115,6 +115,38 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 	const internalPlugins = getInternalPlugins(options);
 	const logger = createLogger(options.logger);
 
+	/**
+	 * Cookie integration plugins must be placed **last** in the plugins array.
+	 * When a cookie plugin runs its `after` hooks, it reads the current response
+	 * `Set-Cookie` headers and forwards them to the framework's cookie store
+	 * (Next.js, TanStack Start, SvelteKit, …). Any plugin that runs *after*
+	 * the cookie integration plugin and adds its own cookies will not have
+	 * those cookies forwarded, resulting in silent auth failures (missing
+	 * session, broken 2FA, redirect loops, etc.).
+	 */
+	const COOKIE_INTEGRATION_PLUGIN_IDS = new Set([
+		"next-cookies",
+		"tanstack-start-cookies",
+		"tanstack-start-cookies-solid",
+		"sveltekit-cookies",
+	]);
+
+	if (plugins.length > 1) {
+		const misorderedPlugins = plugins
+			.slice(0, -1)
+			.filter((p) => COOKIE_INTEGRATION_PLUGIN_IDS.has(p.id));
+
+		if (misorderedPlugins.length > 0) {
+			const ids = misorderedPlugins.map((p) => `"${p.id}"`).join(", ");
+			logger.warn(
+				`[better-auth] Misconfiguration detected: cookie integration plugin(s) ${ids} must be placed last in the plugins[] array. ` +
+					`Any plugin that runs after a cookie integration plugin will have its Set-Cookie headers silently dropped by the framework, ` +
+					`which can cause missing sessions, broken 2FA (INVALID_*_COOKIES), null sessions, or redirect loops. ` +
+					`Move the cookie integration plugin to the end of the plugins[] array to fix this.`,
+			);
+		}
+	}
+
 	const isDynamicConfig = isDynamicBaseURLConfig(options.baseURL);
 
 	if (isDynamicBaseURLConfig(options.baseURL)) {


### PR DESCRIPTION
Problem: Cookie integration plugins (nextCookies, tanstackStartCookies, sveltekitCookies) must be last in plugins[]. If they're not, cookies from subsequent plugins are silently dropped — causing missing sessions, broken 2FA, and redirect loops with no error shown.

Fix: Added a logger.warn() in createAuthContext that detects when a cookie integration plugin is not in the final position and prints a clear message with the fix.

Closes #8911


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a guardrail that warns when cookie integration plugins aren’t last in `plugins[]`. This prevents silent cookie drops that cause missing sessions, broken 2FA, or redirect loops.

- **Bug Fixes**
  - In `createAuthContext`, log a `logger.warn` if any of `next-cookies`, `tanstack-start-cookies`, `tanstack-start-cookies-solid`, or `sveltekit-cookies` appear before the last plugin. The warning lists all misplaced IDs and explains the fix.
  - Added tests for misordered vs. correct order, single-plugin setups, and cases where one or multiple known cookie plugins are misplaced.

<sup>Written for commit 432ca87eebbfa87608015bb60f6798b747d11fce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

