### PR TITLE
fix: resolve dynamic baseURL for direct `auth.api` calls

### DIFF
--- a/.changeset/lovely-toes-swim.md
+++ b/.changeset/lovely-toes-swim.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+resolve dynamic `baseURL` from request headers on direct `auth.api` calls

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -982,7 +982,7 @@ describe("dynamic baseURL resolution", () => {
 	it("should reject Node IncomingMessage-shaped objects when duck typing", async () => {
 		// A Node http.IncomingMessage has url/method/headers but also socket,
 		// and its headers are a plain object (not Web Headers). Accepting it
-		// as a Fetch Request would crash inside getHostFromRequest.
+		// as a Fetch Request would crash inside getHostFromSource.
 		const authContext = init({
 			baseURL: {
 				allowedHosts: ["example.com"],

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -936,6 +936,99 @@ describe("debug mode stack trace", () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9105
+ */
+describe("dynamic baseURL resolution", () => {
+	const endpoints = {
+		readBaseURL: createAuthEndpoint(
+			"/read-base-url",
+			{
+				method: "GET",
+			},
+			async (c) => {
+				return { baseURL: c.context.baseURL };
+			},
+		),
+	};
+
+	it("should resolve dynamic baseURL from headers for direct auth.api calls", async () => {
+		const authContext = init({
+			baseURL: {
+				allowedHosts: ["example.com"],
+				protocol: "https",
+			},
+		});
+		const authEndpoints = toAuthEndpoints(endpoints, authContext);
+
+		const res = await authEndpoints.readBaseURL({
+			headers: new Headers({ host: "example.com" }),
+		});
+		expect(res.baseURL).toBe("https://example.com/api/auth");
+	});
+
+	it("should leave baseURL untouched for static string config", async () => {
+		const authContext = init({
+			baseURL: "https://static.example.com",
+		});
+		const authEndpoints = toAuthEndpoints(endpoints, authContext);
+
+		const res = await authEndpoints.readBaseURL({
+			headers: new Headers({ host: "other.example.com" }),
+		});
+		expect(res.baseURL).toBe("https://static.example.com/api/auth");
+	});
+
+	it("should reject Node IncomingMessage-shaped objects when duck typing", async () => {
+		// A Node http.IncomingMessage has url/method/headers but also socket,
+		// and its headers are a plain object (not Web Headers). Accepting it
+		// as a Fetch Request would crash inside getHostFromRequest.
+		const authContext = init({
+			baseURL: {
+				allowedHosts: ["example.com"],
+				protocol: "https",
+			},
+		});
+		const authEndpoints = toAuthEndpoints(endpoints, authContext);
+
+		const fakeIncomingMessage = {
+			url: "/read-base-url",
+			method: "GET",
+			headers: { host: "example.com" },
+			socket: {},
+		};
+		const res = await authEndpoints.readBaseURL({
+			request: fakeIncomingMessage as unknown as Request,
+			headers: new Headers({ host: "example.com" }),
+		});
+		expect(res.baseURL).toBe("https://example.com/api/auth");
+	});
+
+	it("should not mutate the shared authContext across calls", async () => {
+		const authContext = init({
+			baseURL: {
+				allowedHosts: ["tenant-a.example.com", "tenant-b.example.com"],
+				protocol: "https",
+			},
+		});
+		const authEndpoints = toAuthEndpoints(endpoints, authContext);
+
+		const [resA, resB] = await Promise.all([
+			authEndpoints.readBaseURL({
+				headers: new Headers({ host: "tenant-a.example.com" }),
+			}),
+			authEndpoints.readBaseURL({
+				headers: new Headers({ host: "tenant-b.example.com" }),
+			}),
+		]);
+		expect(resA.baseURL).toBe("https://tenant-a.example.com/api/auth");
+		expect(resB.baseURL).toBe("https://tenant-b.example.com/api/auth");
+
+		const sharedCtx = await authContext;
+		expect(sharedCtx.baseURL).toBe("");
+	});
+});
+
 describe("custom response code", () => {
 	const endpoints = {
 		responseWithStatus: createAuthEndpoint(

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -71,7 +71,7 @@ type UserInputContext = Partial<
 function pickSource(
 	input: UserInputContext | undefined,
 ): Request | Headers | undefined {
-	if (isRequestLike(input?.request)) return input.request as Request;
+	if (isRequestLike(input?.request)) return input.request;
 	if (!input?.headers) return undefined;
 
 	const headers = new Headers(input.headers);

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -69,8 +69,7 @@ type UserInputContext = Partial<
 >;
 
 /**
- * Cross-realm-safe Request detection:
- * Plain `instanceof Request` misses polyfilled or cross-realm Requests.
+ * `instanceof Request` misses polyfilled / cross-realm instances.
  */
 function isRequestLike(value: unknown): value is Request {
 	if (value == null || typeof value !== "object") return false;
@@ -79,24 +78,34 @@ function isRequestLike(value: unknown): value is Request {
 	return value[Symbol.toStringTag] === "Request";
 }
 
+function pickRequest(input: UserInputContext | undefined): Request | undefined {
+	if (isRequestLike(input?.request)) return input.request as Request;
+	if (!input?.headers) return undefined;
+
+	const headers = new Headers(input.headers);
+	const hasHost = headers.has("host") || headers.has("x-forwarded-host");
+	if (!hasHost) return undefined;
+
+	// `https://` keeps `protocol: "auto"` from downgrading
+	// `.invalid` marks the URL unused (RFC 2606)
+	return new Request("https://placeholder.invalid", { headers });
+}
+
 /**
- * Cold-path helper:
- * only invoked when the dynamic config branch is taken,
- * so the static path pays zero async wrapping cost.
+ * Direct `auth.api.*()` calls bypass the HTTP handler's per-request resolution.
  */
 async function resolveDynamicContext(
 	rawCtx: AuthContext,
 	input: UserInputContext | undefined,
 ): Promise<AuthContext> {
-	if (isRequestLike(input?.request)) {
-		return resolveRequestContext(rawCtx, input.request as Request);
-	}
-	if (!input?.headers) return rawCtx;
-	const headers = new Headers(input.headers);
-	if (!headers.has("host") && !headers.has("x-forwarded-host")) {
-		return rawCtx;
-	}
-	const request = new Request("http://placeholder.invalid", { headers });
+	const request = pickRequest(input);
+	const config = rawCtx.options.baseURL;
+	const hasFallback =
+		isDynamicBaseURLConfig(config) && Boolean(config.fallback);
+
+	const canResolve = request !== undefined || hasFallback;
+	if (!canResolve) return rawCtx;
+
 	return resolveRequestContext(rawCtx, request);
 }
 

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -22,7 +22,9 @@ import type {
 } from "better-call";
 import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
 import { createDefu } from "defu";
+import { resolveRequestContext } from "../context/helpers";
 import { isAPIError } from "../utils/is-api-error";
+import { isDynamicBaseURLConfig } from "../utils/url";
 
 type InternalContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
@@ -66,6 +68,38 @@ type UserInputContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
 >;
 
+/**
+ * Cross-realm-safe Request detection:
+ * Plain `instanceof Request` misses polyfilled or cross-realm Requests.
+ */
+function isRequestLike(value: unknown): value is Request {
+	if (value == null || typeof value !== "object") return false;
+	if (value instanceof Request) return true;
+	if (!(Symbol.toStringTag in value)) return false;
+	return value[Symbol.toStringTag] === "Request";
+}
+
+/**
+ * Cold-path helper:
+ * only invoked when the dynamic config branch is taken,
+ * so the static path pays zero async wrapping cost.
+ */
+async function resolveDynamicContext(
+	rawCtx: AuthContext,
+	input: UserInputContext | undefined,
+): Promise<AuthContext> {
+	if (isRequestLike(input?.request)) {
+		return resolveRequestContext(rawCtx, input.request as Request);
+	}
+	if (!input?.headers) return rawCtx;
+	const headers = new Headers(input.headers);
+	if (!headers.has("host") && !headers.has("x-forwarded-host")) {
+		return rawCtx;
+	}
+	const request = new Request("http://placeholder.invalid", { headers });
+	return resolveRequestContext(rawCtx, request);
+}
+
 export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 	endpoints: E,
 	ctx: AuthContext | Promise<AuthContext>,
@@ -89,10 +123,16 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 				: endpointMethod;
 
 			const run = async () => {
-				const authContext = await ctx;
+				const rawContext = await ctx;
 				const methodName =
 					context?.method ?? context?.request?.method ?? defaultMethod ?? "?";
 				const route = endpoint.path ?? "/:virtual";
+
+				// Direct API calls bypass the handler's per-request resolution.
+				// Rehydrate only when the dynamic branch actually applies so the static path stays zero-overhead.
+				const authContext = isDynamicBaseURLConfig(rawContext.options.baseURL)
+					? await resolveDynamicContext(rawContext, context)
+					: rawContext;
 
 				let internalContext: InternalContext = {
 					...context,

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -24,7 +24,7 @@ import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
 import { createDefu } from "defu";
 import { resolveRequestContext } from "../context/helpers";
 import { isAPIError } from "../utils/is-api-error";
-import { isDynamicBaseURLConfig } from "../utils/url";
+import { isDynamicBaseURLConfig, isRequestLike } from "../utils/url";
 
 type InternalContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
@@ -68,17 +68,9 @@ type UserInputContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
 >;
 
-/**
- * `instanceof Request` misses polyfilled / cross-realm instances.
- */
-function isRequestLike(value: unknown): value is Request {
-	if (value == null || typeof value !== "object") return false;
-	if (value instanceof Request) return true;
-	if (!(Symbol.toStringTag in value)) return false;
-	return value[Symbol.toStringTag] === "Request";
-}
-
-function pickRequest(input: UserInputContext | undefined): Request | undefined {
+function pickSource(
+	input: UserInputContext | undefined,
+): Request | Headers | undefined {
 	if (isRequestLike(input?.request)) return input.request as Request;
 	if (!input?.headers) return undefined;
 
@@ -86,27 +78,23 @@ function pickRequest(input: UserInputContext | undefined): Request | undefined {
 	const hasHost = headers.has("host") || headers.has("x-forwarded-host");
 	if (!hasHost) return undefined;
 
-	// `https://` keeps `protocol: "auto"` from downgrading
-	// `.invalid` marks the URL unused (RFC 2606)
-	return new Request("https://placeholder.invalid", { headers });
+	return headers;
 }
 
-/**
- * Direct `auth.api.*()` calls bypass the HTTP handler's per-request resolution.
- */
+// Direct `auth.api` calls bypass the HTTP handler's per-request resolution.
 async function resolveDynamicContext(
 	rawCtx: AuthContext,
 	input: UserInputContext | undefined,
 ): Promise<AuthContext> {
-	const request = pickRequest(input);
+	const source = pickSource(input);
 	const config = rawCtx.options.baseURL;
 	const hasFallback =
 		isDynamicBaseURLConfig(config) && Boolean(config.fallback);
 
-	const canResolve = request !== undefined || hasFallback;
+	const canResolve = source !== undefined || hasFallback;
 	if (!canResolve) return rawCtx;
 
-	return resolveRequestContext(rawCtx, request);
+	return resolveRequestContext(rawCtx, source);
 }
 
 export function toAuthEndpoints<const E extends Record<string, Endpoint>>(

--- a/packages/better-auth/src/auth/base.ts
+++ b/packages/better-auth/src/auth/base.ts
@@ -2,15 +2,13 @@ import type { AuthContext, BetterAuthOptions } from "@better-auth/core";
 import { runWithAdapter } from "@better-auth/core/context";
 import { BASE_ERROR_CODES, BetterAuthError } from "@better-auth/core/error";
 import { getEndpoints, router } from "../api";
-import { getTrustedOrigins, getTrustedProviders } from "../context/helpers";
-import { createCookieGetter, getCookies } from "../cookies";
-import type { Auth } from "../types";
 import {
-	getBaseURL,
-	getOrigin,
-	isDynamicBaseURLConfig,
-	resolveBaseURL,
-} from "../utils/url";
+	getTrustedOrigins,
+	getTrustedProviders,
+	resolveRequestContext,
+} from "../context/helpers";
+import type { Auth } from "../types";
+import { getBaseURL, getOrigin, isDynamicBaseURLConfig } from "../utils/url";
 
 export const createBetterAuth = <Options extends BetterAuthOptions>(
 	options: Options,
@@ -35,40 +33,9 @@ export const createBetterAuth = <Options extends BetterAuthOptions>(
 			let handlerCtx: AuthContext;
 
 			if (isDynamicBaseURLConfig(options.baseURL)) {
-				// Create per-request context to avoid concurrent request race conditions.
-				// Each request may resolve to a different host, so we must not mutate the shared ctx.
-				handlerCtx = Object.create(
-					Object.getPrototypeOf(ctx),
-					Object.getOwnPropertyDescriptors(ctx),
-				) as AuthContext;
-				const baseURL = resolveBaseURL(options.baseURL, basePath, request);
-				if (baseURL) {
-					handlerCtx.baseURL = baseURL;
-					handlerCtx.options = {
-						...ctx.options,
-						baseURL: getOrigin(baseURL) || undefined,
-					};
-				} else {
-					throw new BetterAuthError(
-						"Could not resolve base URL from request. Check your allowedHosts config.",
-					);
-				}
-				// Use a typed variable so the baseURL override doesn't need
-				// an unsafe cast — the spread is structurally BetterAuthOptions.
-				const trustedOriginOptions: BetterAuthOptions = {
-					...handlerCtx.options,
-					baseURL: options.baseURL,
-				};
-				handlerCtx.trustedOrigins = await getTrustedOrigins(
-					trustedOriginOptions,
-					request,
-				);
-				// When crossSubDomainCookies is enabled, recompute cookies
-				// per-request so the domain matches the resolved host.
-				if (options.advanced?.crossSubDomainCookies?.enabled) {
-					handlerCtx.authCookies = getCookies(handlerCtx.options);
-					handlerCtx.createAuthCookie = createCookieGetter(handlerCtx.options);
-				}
+				// Per-request clone avoids mutating shared ctx under concurrent
+				// requests that may resolve to different hosts.
+				handlerCtx = await resolveRequestContext(ctx, request);
 			} else {
 				handlerCtx = ctx;
 				// Static config: resolve once from the first request when no

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -14,6 +14,7 @@ import {
 	getBaseURL,
 	getOrigin,
 	isDynamicBaseURLConfig,
+	isRequestLike,
 	resolveBaseURL,
 } from "../utils/url";
 
@@ -159,11 +160,11 @@ export async function getTrustedOrigins(
  */
 export async function resolveRequestContext(
 	ctx: AuthContext,
-	request?: Request,
+	source?: Request | Headers,
 ): Promise<AuthContext> {
 	const dynamicBaseURLConfig = ctx.options.baseURL;
 	const basePath = ctx.options.basePath || "/api/auth";
-	const baseURL = resolveBaseURL(dynamicBaseURLConfig, basePath, request);
+	const baseURL = resolveBaseURL(dynamicBaseURLConfig, basePath, source);
 	if (!baseURL) {
 		throw new BetterAuthError(
 			"Could not resolve base URL from request. Check your allowedHosts config.",
@@ -185,6 +186,8 @@ export async function resolveRequestContext(
 		...resolved.options,
 		baseURL: dynamicBaseURLConfig,
 	};
+	// getTrustedOrigins user callback expects Request|undefined (public API).
+	const request = isRequestLike(source) ? source : undefined;
 	resolved.trustedOrigins = await getTrustedOrigins(
 		trustedOriginOptions,
 		request,

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -154,16 +154,12 @@ export async function getTrustedOrigins(
 }
 
 /**
- * Produce a per-request clone of an AuthContext configured with a dynamic baseURL.
- * Resolves the host against `allowedHosts` and rehydrates `trustedOrigins` and cookie helpers
- * so downstream code sees values matching the resolved host.
- *
- * Throws when the host cannot be resolved (unknown host, no fallback, etc.).
- * Caller is expected to only invoke this when `isDynamicBaseURLConfig` holds.
+ * Per-request clone with `baseURL`, `trustedOrigins` and cookies rehydrated
+ * for the resolved host. Throws when the URL cannot be resolved.
  */
 export async function resolveRequestContext(
 	ctx: AuthContext,
-	request: Request,
+	request?: Request,
 ): Promise<AuthContext> {
 	const dynamicBaseURLConfig = ctx.options.baseURL;
 	const basePath = ctx.options.basePath || "/api/auth";
@@ -184,8 +180,7 @@ export async function resolveRequestContext(
 		baseURL: getOrigin(baseURL) || undefined,
 	};
 
-	// getTrustedOrigins expands allowedHosts when passed the dynamic config,
-	// so feed it the original object rather than the resolved origin string.
+	// Pass the dynamic config so getTrustedOrigins can expand `allowedHosts`.
 	const trustedOriginOptions: BetterAuthOptions = {
 		...resolved.options,
 		baseURL: dynamicBaseURLConfig,

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -5,10 +5,17 @@ import type {
 	BetterAuthPlugin,
 } from "@better-auth/core";
 import { env } from "@better-auth/core/env";
+import { BetterAuthError } from "@better-auth/core/error";
 import { defu } from "defu";
+import { createCookieGetter, getCookies } from "../cookies";
 import { createInternalAdapter } from "../db";
 import { isPromise } from "../utils/is-promise";
-import { getBaseURL, isDynamicBaseURLConfig } from "../utils/url";
+import {
+	getBaseURL,
+	getOrigin,
+	isDynamicBaseURLConfig,
+	resolveBaseURL,
+} from "../utils/url";
 
 export async function runPluginInit(context: AuthContext) {
 	let options = context.options;
@@ -144,6 +151,56 @@ export async function getTrustedOrigins(
 		trustedOrigins.push(...envTrustedOrigins.split(","));
 	}
 	return trustedOrigins.filter((v): v is string => Boolean(v));
+}
+
+/**
+ * Produce a per-request clone of an AuthContext configured with a dynamic baseURL.
+ * Resolves the host against `allowedHosts` and rehydrates `trustedOrigins` and cookie helpers
+ * so downstream code sees values matching the resolved host.
+ *
+ * Throws when the host cannot be resolved (unknown host, no fallback, etc.).
+ * Caller is expected to only invoke this when `isDynamicBaseURLConfig` holds.
+ */
+export async function resolveRequestContext(
+	ctx: AuthContext,
+	request: Request,
+): Promise<AuthContext> {
+	const dynamicBaseURLConfig = ctx.options.baseURL;
+	const basePath = ctx.options.basePath || "/api/auth";
+	const baseURL = resolveBaseURL(dynamicBaseURLConfig, basePath, request);
+	if (!baseURL) {
+		throw new BetterAuthError(
+			"Could not resolve base URL from request. Check your allowedHosts config.",
+		);
+	}
+
+	const resolved = Object.create(
+		Object.getPrototypeOf(ctx),
+		Object.getOwnPropertyDescriptors(ctx),
+	) as AuthContext;
+	resolved.baseURL = baseURL;
+	resolved.options = {
+		...ctx.options,
+		baseURL: getOrigin(baseURL) || undefined,
+	};
+
+	// getTrustedOrigins expands allowedHosts when passed the dynamic config,
+	// so feed it the original object rather than the resolved origin string.
+	const trustedOriginOptions: BetterAuthOptions = {
+		...resolved.options,
+		baseURL: dynamicBaseURLConfig,
+	};
+	resolved.trustedOrigins = await getTrustedOrigins(
+		trustedOriginOptions,
+		request,
+	);
+
+	if (ctx.options.advanced?.crossSubDomainCookies?.enabled) {
+		resolved.authCookies = getCookies(resolved.options);
+		resolved.createAuthCookie = createCookieGetter(resolved.options);
+	}
+
+	return resolved;
 }
 
 export async function getAwaitableValue<T extends Record<string, any>>(

--- a/packages/better-auth/src/utils/url.test.ts
+++ b/packages/better-auth/src/utils/url.test.ts
@@ -2,8 +2,8 @@ import type { DynamicBaseURLConfig } from "@better-auth/core";
 import { describe, expect, it } from "vitest";
 import {
 	getBaseURL,
-	getHostFromRequest,
-	getProtocolFromRequest,
+	getHostFromSource,
+	getProtocolFromSource,
 	isDynamicBaseURLConfig,
 	matchesHostPattern,
 	resolveBaseURL,
@@ -361,7 +361,7 @@ describe("matchesHostPattern", () => {
 	});
 });
 
-describe("getHostFromRequest", () => {
+describe("getHostFromSource", () => {
 	it("should prefer x-forwarded-host over host header", () => {
 		const request = new Request("http://localhost:3000/test", {
 			headers: {
@@ -370,7 +370,7 @@ describe("getHostFromRequest", () => {
 			},
 		});
 
-		expect(getHostFromRequest(request)).toBe("myapp.vercel.app");
+		expect(getHostFromSource(request)).toBe("myapp.vercel.app");
 	});
 
 	it("should fall back to host header if x-forwarded-host is not set", () => {
@@ -380,13 +380,13 @@ describe("getHostFromRequest", () => {
 			},
 		});
 
-		expect(getHostFromRequest(request)).toBe("localhost:3000");
+		expect(getHostFromSource(request)).toBe("localhost:3000");
 	});
 
 	it("should fall back to request URL if no headers", () => {
 		const request = new Request("http://example.com:8080/test");
 
-		expect(getHostFromRequest(request)).toBe("example.com:8080");
+		expect(getHostFromSource(request)).toBe("example.com:8080");
 	});
 
 	it("should reject malicious x-forwarded-host and fall back", () => {
@@ -397,16 +397,16 @@ describe("getHostFromRequest", () => {
 			},
 		});
 
-		expect(getHostFromRequest(request)).toBe("localhost:3000");
+		expect(getHostFromSource(request)).toBe("localhost:3000");
 	});
 });
 
-describe("getProtocolFromRequest", () => {
+describe("getProtocolFromSource", () => {
 	it("should use explicit protocol config", () => {
 		const request = new Request("http://localhost:3000/test");
 
-		expect(getProtocolFromRequest(request, "https")).toBe("https");
-		expect(getProtocolFromRequest(request, "http")).toBe("http");
+		expect(getProtocolFromSource(request, "https")).toBe("https");
+		expect(getProtocolFromSource(request, "http")).toBe("http");
 	});
 
 	it("should use x-forwarded-proto when set to auto", () => {
@@ -416,19 +416,19 @@ describe("getProtocolFromRequest", () => {
 			},
 		});
 
-		expect(getProtocolFromRequest(request, "auto")).toBe("https");
+		expect(getProtocolFromSource(request, "auto")).toBe("https");
 	});
 
 	it("should fall back to request URL protocol", () => {
 		const request = new Request("https://example.com/test");
 
-		expect(getProtocolFromRequest(request, "auto")).toBe("https");
+		expect(getProtocolFromSource(request, "auto")).toBe("https");
 	});
 
 	it("should use request URL protocol as fallback", () => {
 		const request = new Request("http://localhost:3000/test");
 
-		expect(getProtocolFromRequest(request, "auto")).toBe("http");
+		expect(getProtocolFromSource(request, "auto")).toBe("http");
 	});
 });
 

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -202,6 +202,15 @@ export function isDynamicBaseURLConfig(
 	);
 }
 
+// `instanceof Request` misses polyfilled or cross-realm instances.
+export function isRequestLike(value: unknown): value is Request {
+	if (value == null || typeof value !== "object") return false;
+	if (value instanceof Request) return true;
+
+	if (!(Symbol.toStringTag in value)) return false;
+	return value[Symbol.toStringTag] === "Request";
+}
+
 /**
  * Extracts the host from the request headers.
  * Tries x-forwarded-host first (for proxy setups), then falls back to host header.
@@ -209,23 +218,30 @@ export function isDynamicBaseURLConfig(
  * @param request The incoming request
  * @returns The host string or null if not found
  */
-export function getHostFromRequest(request: Request): string | null {
-	const forwardedHost = request.headers.get("x-forwarded-host");
+export function getHostFromRequest(source: Request | Headers): string | null {
+	const headers = isRequestLike(source) ? source.headers : source;
+
+	const forwardedHost = headers.get("x-forwarded-host");
 	if (forwardedHost && validateProxyHeader(forwardedHost, "host")) {
 		return forwardedHost;
 	}
 
-	const host = request.headers.get("host");
+	const host = headers.get("host");
 	if (host && validateProxyHeader(host, "host")) {
 		return host;
 	}
 
-	try {
-		const url = new URL(request.url);
-		return url.host;
-	} catch {
-		return null;
+	// URL fallback only when a full Request is available.
+	if (isRequestLike(source)) {
+		try {
+			const url = new URL(source.url);
+			return url.host;
+		} catch {
+			return null;
+		}
 	}
+
+	return null;
 }
 
 /**
@@ -237,24 +253,28 @@ export function getHostFromRequest(request: Request): string | null {
  * @returns The protocol ("http" or "https")
  */
 export function getProtocolFromRequest(
-	request: Request,
+	source: Request | Headers,
 	configProtocol?: "http" | "https" | "auto" | undefined,
 ): "http" | "https" {
 	if (configProtocol === "http" || configProtocol === "https") {
 		return configProtocol;
 	}
 
-	const forwardedProto = request.headers.get("x-forwarded-proto");
+	const headers = isRequestLike(source) ? source.headers : source;
+	const forwardedProto = headers.get("x-forwarded-proto");
 	if (forwardedProto && validateProxyHeader(forwardedProto, "proto")) {
 		return forwardedProto as "http" | "https";
 	}
 
-	try {
-		const url = new URL(request.url);
-		if (url.protocol === "http:" || url.protocol === "https:") {
-			return url.protocol.slice(0, -1) as "http" | "https";
-		}
-	} catch {}
+	// URL fallback only when a full Request is available.
+	if (isRequestLike(source)) {
+		try {
+			const url = new URL(source.url);
+			if (url.protocol === "http:" || url.protocol === "https:") {
+				return url.protocol.slice(0, -1) as "http" | "https";
+			}
+		} catch {}
+	}
 
 	return "https";
 }
@@ -314,10 +334,10 @@ export const matchesHostPattern = (host: string, pattern: string): boolean => {
  */
 export function resolveDynamicBaseURL(
 	config: DynamicBaseURLConfig,
-	request: Request,
+	source: Request | Headers,
 	basePath: string,
 ): string {
-	const host = getHostFromRequest(request);
+	const host = getHostFromRequest(source);
 
 	if (!host) {
 		if (config.fallback) {
@@ -334,7 +354,7 @@ export function resolveDynamicBaseURL(
 	);
 
 	if (isAllowed) {
-		const protocol = getProtocolFromRequest(request, config.protocol);
+		const protocol = getProtocolFromRequest(source, config.protocol);
 		return withPath(`${protocol}://${host}`, basePath);
 	}
 
@@ -363,13 +383,13 @@ export function resolveDynamicBaseURL(
 export function resolveBaseURL(
 	config: BaseURLConfig | undefined,
 	basePath: string,
-	request?: Request,
+	source?: Request | Headers,
 	loadEnv?: boolean,
 	trustedProxyHeaders?: boolean,
 ): string | undefined {
 	if (isDynamicBaseURLConfig(config)) {
-		if (request) {
-			return resolveDynamicBaseURL(config, request, basePath);
+		if (source) {
+			return resolveDynamicBaseURL(config, source, basePath);
 		}
 		if (config.fallback) {
 			return withPath(config.fallback, basePath);
@@ -377,12 +397,14 @@ export function resolveBaseURL(
 		return getBaseURL(
 			undefined,
 			basePath,
-			request,
+			undefined,
 			loadEnv,
 			trustedProxyHeaders,
 		);
 	}
 
+	// Static config path -> getBaseURL needs a full Request for URL parsing.
+	const request = isRequestLike(source) ? source : undefined;
 	if (typeof config === "string") {
 		return getBaseURL(config, basePath, request, loadEnv, trustedProxyHeaders);
 	}

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -202,13 +202,19 @@ export function isDynamicBaseURLConfig(
 	);
 }
 
-// `instanceof Request` misses polyfilled or cross-realm instances.
+/**
+ * Check if a value is a `Request`
+ * - `instanceof`: works for native Request instances
+ * - `toString`: handles where instanceof check fails but the object is still a valid Request
+ *
+ * @param value The value to check
+ * @returns `true` if the value is a Request instance
+ */
 export function isRequestLike(value: unknown): value is Request {
-	if (value == null || typeof value !== "object") return false;
-	if (value instanceof Request) return true;
-
-	if (!(Symbol.toStringTag in value)) return false;
-	return value[Symbol.toStringTag] === "Request";
+	return (
+		value instanceof Request ||
+		Object.prototype.toString.call(value) === "[object Request]"
+	);
 }
 
 /**

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -224,7 +224,7 @@ export function isRequestLike(value: unknown): value is Request {
  * @param request The incoming request
  * @returns The host string or null if not found
  */
-export function getHostFromRequest(source: Request | Headers): string | null {
+export function getHostFromSource(source: Request | Headers): string | null {
 	const headers = isRequestLike(source) ? source.headers : source;
 
 	const forwardedHost = headers.get("x-forwarded-host");
@@ -258,7 +258,7 @@ export function getHostFromRequest(source: Request | Headers): string | null {
  * @param configProtocol Protocol override from config
  * @returns The protocol ("http" or "https")
  */
-export function getProtocolFromRequest(
+export function getProtocolFromSource(
 	source: Request | Headers,
 	configProtocol?: "http" | "https" | "auto" | undefined,
 ): "http" | "https" {
@@ -343,7 +343,7 @@ export function resolveDynamicBaseURL(
 	source: Request | Headers,
 	basePath: string,
 ): string {
-	const host = getHostFromRequest(source);
+	const host = getHostFromSource(source);
 
 	if (!host) {
 		if (config.fallback) {
@@ -360,7 +360,7 @@ export function resolveDynamicBaseURL(
 	);
 
 	if (isAllowed) {
-		const protocol = getProtocolFromRequest(source, config.protocol);
+		const protocol = getProtocolFromSource(source, config.protocol);
 		return withPath(`${protocol}://${host}`, basePath);
 	}
 


### PR DESCRIPTION
> [!NOTE]
> Functions like `getProtocolFromRequest` previously assumed a `Request` was always present. However, when using `better-call` without `requireRequest`, calls can be made with headers only. This PR fixes that assumption. 

- Closes #9105