### PR TITLE
fix(ci): fix `grep -c` fallback producing invalid integer in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,8 +177,8 @@ jobs:
           fi
 
           # Count PR links in both files
-          RAW_COUNT=$(grep -coP '\[#\d+\]' "$RAW_PATH" || echo 0)
-          FINAL_COUNT=$(grep -coP '\[#\d+\]' "$FINAL" || echo 0)
+          RAW_COUNT=$(grep -coP '\[#\d+\]' "$RAW_PATH" || true)
+          FINAL_COUNT=$(grep -coP '\[#\d+\]' "$FINAL" || true)
 
           if [ "$FINAL_COUNT" -lt "$RAW_COUNT" ]; then
             echo "::warning::AI output has fewer PR links ($FINAL_COUNT) than raw ($RAW_COUNT). Falling back to raw notes."


### PR DESCRIPTION
## Summary

- `grep -coP` outputs `0` to stdout on no matches but exits 1, causing the `|| echo 0` fallback to append a second `0`
- The resulting multi-line value fails the `-lt` integer comparison in release note validation
- Fix: use `|| true` instead, since `grep -c` already outputs the correct count

Cherry-picked from chore/sync-main-to-next (2e0ad3036).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release validation workflow by replacing the `grep -coP` fallback from `|| echo 0` to `|| true`, so zero matches remain a single `0`.
This prevents multi-line counts like `0\n0` that broke the `-lt` comparison when checking PR link counts.

<sup>Written for commit 72ce3b21cc0125a45351645a6aa25e4716c37873. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

