### PR TITLE
docs: update requestPasswordResetEmailOTP typings

### DIFF
--- a/docs/content/docs/plugins/email-otp.mdx
+++ b/docs/content/docs/plugins/email-otp.mdx
@@ -186,7 +186,7 @@ To reset the user's password with OTP, use the `emailOtp.requestPasswordReset()`
 
 <APIMethod path="/email-otp/request-password-reset" method="POST">
   ```ts
-  type requestPasswordResetEmailOTP = {
+  type forgetPasswordEmailOTP = {
       /**
        * Email address to send the OTP.
        */


### PR DESCRIPTION
Update to the documentation to change 'requestPasswordResetEmailOTP' to 'forgetPasswordEmailOTP'.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Email OTP docs to use the correct request type name `forgetPasswordEmailOTP` (replacing `requestPasswordResetEmailOTP`) for the `/email-otp/request-password-reset` endpoint.

<sup>Written for commit 877246fd2237c8659aba8396cb4b9d7a171943e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

