### PR TITLE
feat(oauth-provider): add `customTokenResponseFields` and harden authorization code validation

### DIFF
--- a/.changeset/oauth-provider-token-refactor.md
+++ b/.changeset/oauth-provider-token-refactor.md
@@ -1,5 +1,5 @@
 ---
-"@better-auth/oauth-provider": minor
+"@better-auth/oauth-provider": patch
 ---
 
 feat(oauth-provider): add `customTokenResponseFields` callback and Zod validation for authorization codes

--- a/.changeset/oauth-provider-token-refactor.md
+++ b/.changeset/oauth-provider-token-refactor.md
@@ -1,0 +1,9 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+feat(oauth-provider): add `customTokenResponseFields` callback and Zod validation for authorization codes
+
+Add `customTokenResponseFields` callback to `OAuthOptions` for injecting custom fields into token endpoint responses across all grant types. Standard OAuth fields (`access_token`, `token_type`, etc.) cannot be overridden. Follows the same pattern as `customAccessTokenClaims` and `customIdTokenClaims`.
+
+Authorization code verification values are now validated with a Zod schema at deserialization, consistently returning `invalid_verification` errors for malformed or corrupted values instead of potential 500s.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1029,6 +1029,24 @@ oauthProvider({
 })
 ```
 
+#### Custom Token Response Fields
+
+Unlike the claim callbacks above (which add data *inside* JWT payloads), `customTokenResponseFields` adds fields to the **token endpoint JSON response** alongside `access_token`, `token_type`, etc. Standard OAuth fields cannot be overridden.
+
+```ts title="auth.ts"
+oauthProvider({
+  customTokenResponseFields: ({ grantType, user, scopes, metadata, verificationValue }) => {
+    // Add tenant context for authorization_code grants
+    if (grantType === "authorization_code" && verificationValue?.referenceId) {
+      return { tenant_id: verificationValue.referenceId };
+    }
+    return {};
+  },
+})
+```
+
+The callback receives the grant type, user (undefined for `client_credentials`), scopes, parsed client metadata, and the verification value (only for `authorization_code` grants). It is called before any tokens are created, so throwing an error will not leave partially-applied state.
+
 ### Expirations
 
 Each token type and grant type can independently can set a default expiration.

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -14,8 +14,9 @@ import { createLocalJWKSet, decodeJwt, jwtVerify } from "jose";
 import { beforeAll, describe, expect, it } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
-import type { OAuthOptions, Scope } from "./types";
+import type { OAuthOptions, Scope, VerificationValue } from "./types";
 import type { OAuthClient } from "./types/oauth";
+import { verificationValueSchema } from "./types/zod";
 
 type MakeRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
@@ -1490,7 +1491,6 @@ describe("oauth token - config", async () => {
 		const refreshedTokens = await client.oauth2.token(
 			{
 				resource: validAudience,
-				// @ts-expect-error refresh token is sent
 				refresh_token: tokens.data?.refresh_token,
 				grant_type: "refresh_token",
 				client_id: oauthClient?.client_id,
@@ -1600,7 +1600,6 @@ describe("oauth token - config", async () => {
 		// Refresh token
 		const refreshedTokens = await client.oauth2.token(
 			{
-				// @ts-expect-error refresh token is sent
 				refresh_token: tokens.data?.refresh_token,
 				grant_type: "refresh_token",
 				client_id: oauthClient?.client_id,
@@ -2233,5 +2232,306 @@ describe("scope preservation through authorization code flow", async () => {
 			headers: reqHeaders,
 		});
 		expect(tokens.data?.scope).toBe(requestedScopes.join(" "));
+	});
+});
+
+describe("customTokenResponseFields", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({
+				jwt: {
+					issuer: authServerBaseUrl,
+				},
+			}),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+				customTokenResponseFields: ({ grantType, verificationValue }) => {
+					if (
+						grantType === "authorization_code" &&
+						verificationValue?.referenceId
+					) {
+						return { org_id: verificationValue.referenceId };
+					}
+					return { server_time: "2024-01-01" };
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient(), jwtClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const state = "custom-fields-test";
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		oauthClient = response;
+	});
+
+	it("should include custom fields in authorization_code token response", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const codeVerifier = generateRandomString(32);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes: ["openid"],
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		const url = new URL(callbackRedirectUrl);
+		const code = url.searchParams.get("code")!;
+
+		const { body, headers: tokenHeaders } = createAuthorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			server_time?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.server_time).toBe("2024-01-01");
+	});
+
+	it("should not allow custom fields to override standard OAuth fields", async () => {
+		const authServerBaseUrl2 = "http://localhost:3000";
+		const {
+			auth: auth2,
+			signInWithTestUser: signIn2,
+			customFetchImpl: fetch2,
+		} = await getTestInstance({
+			baseURL: authServerBaseUrl2,
+			plugins: [
+				jwt({ jwt: { issuer: authServerBaseUrl2 } }),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+					customTokenResponseFields: () => ({
+						access_token: "should-be-ignored",
+						token_type: "should-be-ignored",
+						custom_field: "should-be-present",
+					}),
+				}),
+			],
+		});
+
+		const { headers: headers2 } = await signIn2();
+		const client2 = createAuthClient({
+			plugins: [oauthProviderClient(), jwtClient()],
+			baseURL: authServerBaseUrl2,
+			fetchOptions: { customFetchImpl: fetch2, headers: headers2 },
+		});
+
+		const response = await auth2.api.adminCreateOAuthClient({
+			headers: headers2,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+
+		const codeVerifier = generateRandomString(32);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: response!.client_id!,
+				clientSecret: response!.client_secret!,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl2}/api/auth/oauth2/authorize`,
+			state,
+			scopes: ["openid"],
+			codeVerifier,
+		});
+
+		let callbackUrl = "";
+		await client2.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		const code = new URL(callbackUrl).searchParams.get("code")!;
+		const { body, headers: tokenHeaders } = createAuthorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: response!.client_id!,
+				clientSecret: response!.client_secret!,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client2.$fetch<{
+			access_token?: string;
+			token_type?: string;
+			custom_field?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+
+		expect(tokens.data?.access_token).not.toBe("should-be-ignored");
+		expect(tokens.data?.token_type).toBe("Bearer");
+		expect(tokens.data?.custom_field).toBe("should-be-present");
+	});
+
+	it("should include custom fields in client_credentials token response", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { body, headers: tokenHeaders } = createClientCredentialsTokenRequest(
+			{
+				options: {
+					clientId: oauthClient.client_id,
+					clientSecret: oauthClient.client_secret,
+					redirectURI: redirectUri,
+				},
+			},
+		);
+
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			server_time?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.server_time).toBe("2024-01-01");
+	});
+});
+
+describe("verificationValueSchema", () => {
+	it("should validate a well-formed verification value", () => {
+		const value: VerificationValue = {
+			type: "authorization_code",
+			query: {
+				response_type: "code",
+				client_id: "test-client",
+				redirect_uri: "https://example.com/callback",
+				scope: "openid",
+				state: "abc123",
+			},
+			userId: "user-1",
+			sessionId: "session-1",
+		};
+
+		const result = verificationValueSchema.safeParse(value);
+		expect(result.success).toBe(true);
+	});
+
+	it("should reject a verification value with wrong type", () => {
+		const result = verificationValueSchema.safeParse({
+			type: "password_reset",
+			query: {
+				client_id: "test",
+				redirect_uri: "https://example.com",
+				state: "abc",
+			},
+			userId: "u1",
+			sessionId: "s1",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("should reject a verification value missing required fields", () => {
+		const result = verificationValueSchema.safeParse({
+			type: "authorization_code",
+			query: {
+				client_id: "test",
+				redirect_uri: "https://example.com",
+				state: "abc",
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("should pass through unknown fields for extensibility", () => {
+		const value = {
+			type: "authorization_code",
+			query: {
+				client_id: "test",
+				redirect_uri: "https://example.com",
+				state: "abc",
+			},
+			userId: "u1",
+			sessionId: "s1",
+			futureField: "should-pass-through",
+		};
+
+		const result = verificationValueSchema.safeParse(value);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect((result.data as Record<string, unknown>).futureField).toBe(
+				"should-pass-through",
+			);
+		}
 	});
 });

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -422,6 +422,17 @@ async function createUserTokens(
 	const isJwtAccessToken = audience && !opts.disableJwtPlugin;
 	const isIdToken = user && scopes.includes("openid");
 
+	// Resolve custom fields before any token side effects (refresh rotation, DB writes)
+	const customFields = opts.customTokenResponseFields
+		? await opts.customTokenResponseFields({
+				grantType,
+				user,
+				scopes,
+				metadata: parseClientMetadata(client.metadata),
+				verificationValue,
+			})
+		: undefined;
+
 	// Refresh token may need to be created beforehand for id field
 	const earlyRefreshToken =
 		isRefreshToken && user && !isJwtAccessToken
@@ -505,16 +516,6 @@ async function createUserTokens(
 				)
 			: undefined,
 	]);
-
-	const customFields = opts.customTokenResponseFields
-		? await opts.customTokenResponseFields({
-				grantType,
-				user,
-				scopes,
-				metadata: parseClientMetadata(client.metadata),
-				verificationValue,
-			})
-		: undefined;
 
 	return ctx.json(
 		{

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -14,6 +14,7 @@ import type {
 	VerificationValue,
 } from "./types";
 import type { GrantType } from "./types/oauth";
+import { verificationValueSchema } from "./types/zod";
 import { userNormalClaims } from "./userinfo";
 import {
 	basicToClientCredentials,
@@ -71,7 +72,7 @@ export async function tokenEndpoint(
 async function createJwtAccessToken(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
-	user: User,
+	user: User | undefined,
 	client: SchemaClient<Scope[]>,
 	audience: string | string[],
 	scopes: string[],
@@ -101,7 +102,7 @@ async function createJwtAccessToken(
 		options: jwtPluginOptions,
 		payload: {
 			...customClaims,
-			sub: user.id,
+			sub: user?.id,
 			aud:
 				typeof audience === "string"
 					? audience
@@ -364,22 +365,42 @@ async function checkResource(
 	return audience?.length === 1 ? audience.at(0) : audience;
 }
 
+interface CreateUserTokensParams {
+	client: SchemaClient<Scope[]>;
+	scopes: string[];
+	grantType: GrantType;
+	user?: User;
+	referenceId?: string;
+	sessionId?: string;
+	nonce?: string;
+	refreshToken?: OAuthRefreshToken<Scope[]> & { id: string };
+	authTime?: Date;
+	verificationValue?: VerificationValue;
+}
+
 async function createUserTokens(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
-	client: SchemaClient<Scope[]>,
-	scopes: string[],
-	user: User,
-	referenceId?: string,
-	sessionId?: string,
-	nonce?: string,
-	additional?: {
-		refreshToken?: OAuthRefreshToken<Scope[]> & { id: string };
-	},
-	authTime?: Date,
+	params: CreateUserTokensParams,
 ) {
+	const {
+		client,
+		scopes,
+		user,
+		grantType,
+		referenceId,
+		sessionId,
+		nonce,
+		refreshToken: existingRefreshToken,
+		authTime,
+		verificationValue,
+	} = params;
+
 	const iat = Math.floor(Date.now() / 1000);
-	const defaultExp = iat + (opts.accessTokenExpiresIn ?? 3600);
+	const baseExpiry = user
+		? (opts.accessTokenExpiresIn ?? 3600)
+		: (opts.m2mAccessTokenExpiresIn ?? 3600);
+	const defaultExp = iat + baseExpiry;
 	const exp = opts.scopeExpirations
 		? scopes
 				.map((sc) =>
@@ -395,14 +416,15 @@ async function createUserTokens(
 	// Check requested audience if sent as the resource parameter
 	const audience = await checkResource(ctx, opts, scopes);
 	const isRefreshToken =
-		additional?.refreshToken?.scopes?.includes("offline_access") ||
-		scopes.includes("offline_access");
+		user &&
+		(existingRefreshToken?.scopes?.includes("offline_access") ||
+			scopes.includes("offline_access"));
 	const isJwtAccessToken = audience && !opts.disableJwtPlugin;
-	const isIdToken = scopes.includes("openid");
+	const isIdToken = user && scopes.includes("openid");
 
 	// Refresh token may need to be created beforehand for id field
 	const earlyRefreshToken =
-		isRefreshToken && !isJwtAccessToken
+		isRefreshToken && user && !isJwtAccessToken
 			? await createRefreshToken(
 					ctx,
 					opts,
@@ -415,7 +437,7 @@ async function createUserTokens(
 						exp: iat + (opts.refreshTokenExpiresIn ?? 2592000),
 						sid: sessionId,
 					},
-					additional?.refreshToken,
+					existingRefreshToken,
 					authTime,
 				)
 			: undefined;
@@ -453,7 +475,7 @@ async function createUserTokens(
 				),
 		earlyRefreshToken
 			? earlyRefreshToken
-			: isRefreshToken
+			: isRefreshToken && user
 				? createRefreshToken(
 						ctx,
 						opts,
@@ -466,11 +488,11 @@ async function createUserTokens(
 							exp: iat + (opts.refreshTokenExpiresIn ?? 2592000),
 							sid: sessionId,
 						},
-						additional?.refreshToken,
+						existingRefreshToken,
 						authTime,
 					)
 				: undefined,
-		isIdToken
+		isIdToken && user
 			? createIdToken(
 					ctx,
 					opts,
@@ -484,12 +506,23 @@ async function createUserTokens(
 			: undefined,
 	]);
 
+	const customFields = opts.customTokenResponseFields
+		? await opts.customTokenResponseFields({
+				grantType,
+				user,
+				scopes,
+				metadata: parseClientMetadata(client.metadata),
+				verificationValue,
+			})
+		: undefined;
+
 	return ctx.json(
 		{
+			...customFields,
 			access_token: accessToken,
 			expires_in: exp - iat,
 			expires_at: exp,
-			token_type: "Bearer",
+			token_type: "Bearer" as const,
 			refresh_token: refreshToken?.token,
 			scope: scopes.join(" "),
 			id_token: idToken,
@@ -514,9 +547,6 @@ async function checkVerificationValue(
 	const verification = await ctx.context.internalAdapter.findVerificationValue(
 		await storeToken(opts.storeTokens, code, "authorization_code"),
 	);
-	const verificationValue: VerificationValue = verification
-		? JSON.parse(verification?.value)
-		: undefined;
 
 	if (!verification) {
 		throw new APIError("UNAUTHORIZED", {
@@ -525,12 +555,11 @@ async function checkVerificationValue(
 		});
 	}
 
-	// Delete used code
+	// Delete used code (single-use per RFC 6749 §4.1.2)
 	await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 		await storeToken(opts.storeTokens, code, "authorization_code"),
 	);
 
-	// Check verification
 	if (!verification.expiresAt || verification.expiresAt < new Date()) {
 		throw new APIError("UNAUTHORIZED", {
 			error_description: "code expired",
@@ -538,29 +567,29 @@ async function checkVerificationValue(
 		});
 	}
 
-	// Check verification value
-	if (!verificationValue) {
+	let rawValue: unknown;
+	try {
+		rawValue = JSON.parse(verification.value);
+	} catch {
 		throw new APIError("UNAUTHORIZED", {
-			error_description: "missing verification value content",
+			error_description: "malformed verification value",
 			error: "invalid_verification",
 		});
 	}
-	if (verificationValue.type !== "authorization_code") {
+	const parsed = verificationValueSchema.safeParse(rawValue);
+	if (!parsed.success) {
 		throw new APIError("UNAUTHORIZED", {
-			error_description: "incorrect verification type",
+			error_description: "malformed verification value",
 			error: "invalid_verification",
 		});
 	}
+	// Zod's passthrough adds index signature; the schema already validates the structure
+	const verificationValue = parsed.data as VerificationValue;
+
 	if (verificationValue.query.client_id !== client_id) {
 		throw new APIError("UNAUTHORIZED", {
 			error_description: "invalid client_id",
 			error: "invalid_client",
-		});
-	}
-	if (!verificationValue.userId) {
-		throw new APIError("BAD_REQUEST", {
-			error_description: "missing user_id on challenge",
-			error: "invalid_user",
 		});
 	}
 	if (
@@ -764,18 +793,17 @@ async function handleAuthorizationCodeGrant(
 			? normalizeTimestampValue(verificationValue.authTime)
 			: resolveSessionAuthTime(session);
 
-	return createUserTokens(
-		ctx,
-		opts,
+	return createUserTokens(ctx, opts, {
 		client,
-		verificationValue.query.scope?.split(" ") ?? [],
+		scopes: verificationValue.query.scope?.split(" ") ?? [],
 		user,
-		verificationValue.referenceId,
-		session.id,
-		verificationValue.query?.nonce,
-		undefined,
+		grantType: "authorization_code",
+		referenceId: verificationValue.referenceId,
+		sessionId: session.id,
+		nonce: verificationValue.query?.nonce,
 		authTime,
-	);
+		verificationValue,
+	});
 }
 
 /**
@@ -856,76 +884,11 @@ async function handleClientCredentialsGrant(
 			[];
 	}
 
-	// Check requested audience if sent as the resource parameter
-	const jwtPluginOptions = opts.disableJwtPlugin
-		? undefined
-		: getJwtPlugin(ctx.context).options;
-	const audience = await checkResource(ctx, opts, requestedScopes);
-
-	const iat = Math.floor(Date.now() / 1000);
-	const defaultExp = iat + (opts.m2mAccessTokenExpiresIn ?? 3600);
-	const exp =
-		opts.scopeExpirations && requestedScopes
-			? requestedScopes
-					.map((sc) =>
-						opts.scopeExpirations?.[sc]
-							? toExpJWT(opts.scopeExpirations[sc], iat)
-							: defaultExp,
-					)
-					.reduce((prev, curr) => {
-						return prev < curr ? prev : curr;
-					}, defaultExp)
-			: defaultExp;
-
-	const customClaims = opts.customAccessTokenClaims
-		? await opts.customAccessTokenClaims({
-				scopes: requestedScopes,
-				resource: ctx.body.resource,
-				metadata: parseClientMetadata(client.metadata),
-			})
-		: {};
-
-	const accessToken =
-		audience && !opts.disableJwtPlugin
-			? await signJWT(ctx, {
-					options: jwtPluginOptions,
-					payload: {
-						...customClaims,
-						aud: audience,
-						azp: client.clientId,
-						scope: requestedScopes.join(" "),
-						iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
-						iat,
-						exp,
-					},
-				})
-			: await createOpaqueAccessToken(
-					ctx,
-					opts,
-					undefined,
-					client,
-					requestedScopes,
-					{
-						iat,
-						exp,
-					},
-				);
-
-	return ctx.json(
-		{
-			access_token: accessToken,
-			expires_in: exp - iat,
-			expires_at: exp,
-			token_type: "Bearer",
-			scope: requestedScopes.join(" "),
-		},
-		{
-			headers: {
-				"Cache-Control": "no-store",
-				Pragma: "no-cache",
-			},
-		},
-	);
+	return createUserTokens(ctx, opts, {
+		client,
+		scopes: requestedScopes,
+		grantType: "client_credentials",
+	});
 }
 
 /**
@@ -1070,18 +1033,14 @@ async function handleRefreshTokenGrant(
 			: undefined;
 
 	// Generate new tokens
-	return createUserTokens(
-		ctx,
-		opts,
+	return createUserTokens(ctx, opts, {
 		client,
-		requestedScopes ?? scopes,
+		scopes: requestedScopes ?? scopes,
 		user,
-		refreshToken.referenceId,
-		refreshToken.sessionId,
-		undefined,
-		{
-			refreshToken,
-		},
+		grantType: "refresh_token",
+		referenceId: refreshToken.referenceId,
+		sessionId: refreshToken.sessionId,
+		refreshToken,
 		authTime,
-	);
+	});
 }

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -496,6 +496,37 @@ export interface OAuthOptions<
 		metadata?: Record<string, any>;
 	}) => Awaitable<Record<string, any>>;
 	/**
+	 * Custom fields to include in the token response body.
+	 *
+	 * Unlike `customAccessTokenClaims` (which adds claims inside the JWT payload),
+	 * this adds fields to the JSON response envelope alongside `access_token`,
+	 * `token_type`, etc. Standard OAuth fields (`access_token`, `token_type`,
+	 * `expires_in`, `expires_at`, `refresh_token`, `scope`, `id_token`) cannot
+	 * be overridden.
+	 *
+	 * @param info - context that may be useful when creating custom fields
+	 */
+	customTokenResponseFields?: (info: {
+		/** The grant type being processed */
+		grantType: GrantType;
+		/**
+		 * The user, if applicable.
+		 * Undefined for `client_credentials` (M2M, no user).
+		 * Always present for `authorization_code` and `refresh_token`.
+		 */
+		user?: (User & Record<string, unknown>) | null;
+		/** Scopes granted for this token */
+		scopes: Scopes;
+		/** oAuthClient metadata */
+		metadata?: Record<string, any>;
+		/**
+		 * The authorization code verification value.
+		 * Only present for `authorization_code` grant. Contains the original
+		 * authorization request parameters (`query`), `referenceId`, `sessionId`, etc.
+		 */
+		verificationValue?: VerificationValue;
+	}) => Awaitable<Record<string, unknown>>;
+	/**
 	 * Overwrite specific /.well-known/openid-configuration
 	 * values so they are not available publically.
 	 * This may be important if not all clients need specific scopes.

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -12,6 +12,47 @@ function isLocalhost(hostname: string): boolean {
 }
 
 /**
+ * Runtime schema for OAuthAuthorizationQuery.
+ * Uses passthrough to tolerate fields added by future extensions (PAR, FPA, etc.)
+ */
+export const oauthAuthorizationQuerySchema = z
+	.object({
+		response_type: z.literal("code").optional(),
+		request_uri: z.string().optional(),
+		redirect_uri: z.string(),
+		scope: z.string().optional(),
+		state: z.string(),
+		client_id: z.string(),
+		prompt: z.string().optional(),
+		display: z.string().optional(),
+		ui_locales: z.string().optional(),
+		max_age: z.coerce.number().optional(),
+		acr_values: z.string().optional(),
+		login_hint: z.string().optional(),
+		id_token_hint: z.string().optional(),
+		code_challenge: z.string().optional(),
+		code_challenge_method: z.literal("S256").optional(),
+		nonce: z.string().optional(),
+	})
+	.passthrough();
+
+/**
+ * Runtime schema for the authorization code verification value.
+ * Validates structure on deserialization from the JSON blob stored in the DB.
+ * Uses passthrough so future fields (e.g. from authorization challenge) don't break parsing.
+ */
+export const verificationValueSchema = z
+	.object({
+		type: z.literal("authorization_code"),
+		query: oauthAuthorizationQuerySchema,
+		sessionId: z.string(),
+		userId: z.string(),
+		referenceId: z.string().optional(),
+		authTime: z.number().optional(),
+	})
+	.passthrough();
+
+/**
  * Reusable URL validation for OAuth redirect URIs.
  * - Blocks dangerous schemes (javascript:, data:, vbscript:)
  * - For http/https: requires HTTPS (HTTP allowed only for localhost)

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -15,7 +15,7 @@ function isLocalhost(hostname: string): boolean {
  * Runtime schema for OAuthAuthorizationQuery.
  * Uses passthrough to tolerate fields added by future extensions (PAR, FPA, etc.)
  */
-export const oauthAuthorizationQuerySchema = z
+const oauthAuthorizationQuerySchema = z
 	.object({
 		response_type: z.literal("code").optional(),
 		request_uri: z.string().optional(),


### PR DESCRIPTION
## Summary

Closes #8635 (auth_session passthrough for first-party app step-up).

Instead of hardcoding `auth_session` into the verification value and threading it through positional parameters, this PR builds the proper foundation:

- Add `customTokenResponseFields` callback to `OAuthOptions` for injecting custom fields into token endpoint responses across all grant types. Standard OAuth fields cannot be overridden. Follows the same pattern as `customAccessTokenClaims` and `customIdTokenClaims`.
- Refactor `createUserTokens` from 10 positional params to a typed `CreateUserTokensParams` options object. Make `user` optional to unify `handleClientCredentialsGrant` through the same code path (eliminating 75 lines of duplicated token response construction).
- Replace raw `JSON.parse` + type cast in `checkVerificationValue` with Zod runtime validation. Invalid JSON and malformed verification values now consistently return `invalid_verification` errors instead of 500s.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `customTokenResponseFields` to `OAuthOptions` to inject custom fields into token responses for all grant types; the callback runs before any token creation/rotation to avoid partial state. Authorization code verification now uses Zod validation, and token creation is refactored to a typed options object that also handles `client_credentials`.

- **New Features**
  - `customTokenResponseFields` adds fields to token responses for all grant types; standard fields cannot be overridden.
  - Callback runs before token creation/rotation to prevent partial state on error.

- **Refactors**
  - Replaced positional params with `CreateUserTokensParams`; `user` is optional so `client_credentials` uses the same builder.
  - Zod-based `verificationValueSchema` for authorization code values; malformed data returns `invalid_verification` instead of 500.
  - Token logic adapts to context: uses `m2mAccessTokenExpiresIn` for M2M; only issues ID/refresh tokens when a user is present and scopes allow.
  - Made `oauthAuthorizationQuerySchema` internal (non-exported).

<sup>Written for commit 8bbe7406b34b7e256fd59132fbdcb8c859e2fff6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



