### PR TITLE
fix(two-factor): enforce 2FA on all sign-in paths

### DIFF
--- a/.changeset/fix-2fa-bypass.md
+++ b/.changeset/fix-2fa-bypass.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+fix(two-factor): enforce 2FA on all sign-in paths
+
+The 2FA after-hook now triggers on any endpoint that creates a new session, covering magic-link, OAuth, passkey, email-OTP, SIWE, and all future sign-in methods. Authenticated requests (session refreshes, profile updates) are excluded.

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -378,9 +378,8 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 				{
 					matcher(context) {
 						return (
-							context.path === "/sign-in/email" ||
-							context.path === "/sign-in/username" ||
-							context.path === "/sign-in/phone-number"
+							context.context.newSession != null &&
+							!context.path?.startsWith("/two-factor/")
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {
@@ -390,6 +389,12 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 						}
 
 						if (!data?.user.twoFactorEnabled) {
+							return;
+						}
+
+						// Skip if the request already had an authenticated session
+						// (session refresh, updateUser, etc. are not sign-in flows)
+						if (ctx.context.session) {
 							return;
 						}
 

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -8,6 +8,7 @@ import { convertSetCookieToCookie } from "../../test-utils/headers";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../../utils/constants";
 import { anonymous } from "../anonymous";
+import { magicLink } from "../magic-link";
 import { TWO_FACTOR_ERROR_CODES, twoFactor, twoFactorClient } from ".";
 import type { TwoFactorTable, UserWithTwoFactor } from "./types";
 
@@ -2344,5 +2345,91 @@ describe("twoFactorMethods in sign-in response", () => {
 			expect((signInRes as any).twoFactorRedirect).toBe(true);
 			expect((signInRes as any).twoFactorMethods).toEqual(["otp"]);
 		});
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8627
+ */
+describe("2FA enforcement on non-credential sign-in paths", async () => {
+	let magicLinkURL = "";
+	const { auth, signInWithTestUser, testUser } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [
+			twoFactor({
+				otpOptions: {
+					sendOTP() {},
+				},
+				skipVerificationOnEnable: true,
+			}),
+			magicLink({
+				sendMagicLink({ url }) {
+					magicLinkURL = url;
+				},
+			}),
+		],
+	});
+
+	it("should enforce 2FA on magic-link sign-in", async () => {
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		await auth.api.signInMagicLink({
+			body: { email: testUser.email },
+			headers: new Headers(),
+		});
+
+		const url = new URL(magicLinkURL);
+		const token = url.searchParams.get("token")!;
+		const callbackURL = url.searchParams.get("callbackURL")!;
+
+		const verifyRes = await auth.api.magicLinkVerify({
+			query: { token, callbackURL },
+			headers: new Headers(),
+			asResponse: true,
+		});
+
+		const json = await verifyRes.json();
+		expect(json.twoFactorRedirect).toBe(true);
+	});
+
+	it("should not enforce 2FA on authenticated non-sign-in endpoints", async () => {
+		const {
+			auth: a,
+			signInWithTestUser: signIn,
+			testUser: tu,
+		} = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+				}),
+			],
+		});
+		let { headers: h } = await signIn();
+		const enableRes = await a.api.enableTwoFactor({
+			body: { password: tu.password },
+			headers: h,
+			asResponse: true,
+		});
+		h = convertSetCookieToCookie(enableRes.headers);
+
+		const session = await a.api.getSession({ headers: h });
+		expect(session?.user.twoFactorEnabled).toBe(true);
+
+		const updateRes = await a.api.updateUser({
+			body: { name: "updated-name" },
+			headers: h,
+			asResponse: true,
+		});
+
+		expect(updateRes.ok).toBe(true);
+		const json = await updateRes.json();
+		expect(json.twoFactorRedirect).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

- Replace the hardcoded 3-path matcher in the 2FA sign-in hook with a session-based matcher
- The hook now triggers on any endpoint that creates a new session, excluding two-factor endpoints themselves
- Covers magic-link, OAuth, passkey, email-OTP, SIWE, and all future sign-in methods

Closes #8627

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce 2FA on all sign-in methods by triggering the 2FA hook whenever a new session is created. Blocks bypasses (magic link, OAuth, passkeys, email OTP, SIWE, etc.) and avoids false positives on authenticated non-sign-in requests.

- **Bug Fixes**
  - Switch from path allowlist to a session-based matcher (`context.context.newSession != null`); exclude `/two-factor/` routes and skip requests with an existing session.
  - Add tests for magic-link enforcement and for not enforcing 2FA on authenticated non-sign-in endpoints (e.g., `updateUser`).
  - Add changeset to publish a patch for `better-auth`.

<sup>Written for commit 96756f8e24740fcf380383f4b8e7c7f3545e4e3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

