### PR TITLE
fix(oauth-provider): graceful DCR override for unauthenticated confidential clients

### DIFF
--- a/.changeset/dcr-graceful-override-confidential.md
+++ b/.changeset/dcr-graceful-override-confidential.md
@@ -4,22 +4,4 @@
 
 fix(oauth-provider): override confidential auth methods to public in unauthenticated DCR
 
-When `allowUnauthenticatedClientRegistration` is enabled, unauthenticated DCR
-requests that specify `client_secret_post`, `client_secret_basic`, or omit
-`token_endpoint_auth_method` (which defaults to `client_secret_basic` per
-[RFC 7591 §2](https://datatracker.ietf.org/doc/html/rfc7591#section-2)) are
-now silently overridden to `token_endpoint_auth_method: "none"` (public client)
-instead of being rejected with HTTP 401.
-
-This follows [RFC 7591 §3.2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1),
-which allows the server to "reject or replace any of the client's requested
-metadata values submitted during the registration and substitute them with
-suitable values." The registration response communicates the actual method
-back to the client, allowing compliant clients to adjust.
-
-This fixes interoperability with real-world MCP clients (Claude, Codex, Factory
-Droid, and others) that send `token_endpoint_auth_method: "client_secret_post"`
-in their DCR payload because the server metadata advertises it in
-`token_endpoint_auth_methods_supported`.
-
-Closes #8588
+When `allowUnauthenticatedClientRegistration` is enabled, unauthenticated DCR requests that specify `client_secret_post`, `client_secret_basic`, or omit `token_endpoint_auth_method` (which defaults to `client_secret_basic` per [RFC 7591 Section 2](https://datatracker.ietf.org/doc/html/rfc7591#section-2)) are now overridden to `token_endpoint_auth_method: "none"` (public client) instead of being rejected with HTTP 401.

--- a/.changeset/dcr-graceful-override-confidential.md
+++ b/.changeset/dcr-graceful-override-confidential.md
@@ -1,0 +1,25 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+fix(oauth-provider): override confidential auth methods to public in unauthenticated DCR
+
+When `allowUnauthenticatedClientRegistration` is enabled, unauthenticated DCR
+requests that specify `client_secret_post`, `client_secret_basic`, or omit
+`token_endpoint_auth_method` (which defaults to `client_secret_basic` per
+[RFC 7591 §2](https://datatracker.ietf.org/doc/html/rfc7591#section-2)) are
+now silently overridden to `token_endpoint_auth_method: "none"` (public client)
+instead of being rejected with HTTP 401.
+
+This follows [RFC 7591 §3.2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1),
+which allows the server to "reject or replace any of the client's requested
+metadata values submitted during the registration and substitute them with
+suitable values." The registration response communicates the actual method
+back to the client, allowing compliant clients to adjust.
+
+This fixes interoperability with real-world MCP clients (Claude, Codex, Factory
+Droid, and others) that send `token_endpoint_auth_method: "client_secret_post"`
+in their DCR payload because the server metadata advertises it in
+`token_endpoint_auth_methods_supported`.
+
+Closes #8588

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -370,6 +370,7 @@ describe("oauth register - unauthenticated", async () => {
 		expect(response.data?.client_id).toBeDefined();
 		expect(response.data?.client_secret).toBeUndefined();
 		expect(response.data?.token_endpoint_auth_method).toBe("none");
+		expect(response.data?.type).toBeUndefined();
 	});
 
 	/**

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -287,11 +287,73 @@ describe("oauth register - unauthenticated", async () => {
 		expect(response.data?.client_secret).toBeUndefined();
 	});
 
-	it("should not create confidential clients without authentication", async () => {
+	/**
+	 * RFC 7591 §2: when token_endpoint_auth_method is omitted, the default
+	 * is "client_secret_basic". Unauthenticated DCR overrides this to "none"
+	 * per RFC 7591 §3.2.1 ("the server MAY reject or replace any of the
+	 * client's requested metadata values").
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/8588
+	 */
+	it("should override omitted auth method (RFC 7591 default) to public", async () => {
 		const response = await unauthenticatedClient.oauth2.register({
 			redirect_uris: [redirectUri],
 		});
-		expect(response.error?.status).toBe(401);
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.client_secret).toBeUndefined();
+		expect(response.data?.token_endpoint_auth_method).toBe("none");
+		expect(response.data?.public).toBe(true);
+	});
+
+	/**
+	 * Real-world MCP clients (Claude, Codex, Factory Droid) send
+	 * token_endpoint_auth_method: "client_secret_post" in their DCR payload.
+	 * The server overrides this to "none" and communicates the actual method
+	 * in the registration response so compliant clients can adjust.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/8588
+	 */
+	it("should override client_secret_post to public for unauthenticated DCR", async () => {
+		const response = await unauthenticatedClient.oauth2.register({
+			token_endpoint_auth_method: "client_secret_post",
+			redirect_uris: [redirectUri],
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.client_secret).toBeUndefined();
+		expect(response.data?.token_endpoint_auth_method).toBe("none");
+		expect(response.data?.public).toBe(true);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8588
+	 */
+	it("should override client_secret_basic to public for unauthenticated DCR", async () => {
+		const response = await unauthenticatedClient.oauth2.register({
+			token_endpoint_auth_method: "client_secret_basic",
+			redirect_uris: [redirectUri],
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.client_secret).toBeUndefined();
+		expect(response.data?.token_endpoint_auth_method).toBe("none");
+		expect(response.data?.public).toBe(true);
+	});
+
+	/**
+	 * When a client sends type: "web" with a confidential method, the
+	 * override should also clear the type to avoid a validation error
+	 * (type "web" is only valid for confidential clients).
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/8588
+	 */
+	it("should clear type 'web' when overriding confidential to public", async () => {
+		const response = await unauthenticatedClient.oauth2.register({
+			token_endpoint_auth_method: "client_secret_post",
+			type: "web",
+			redirect_uris: [redirectUri],
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.client_secret).toBeUndefined();
+		expect(response.data?.token_endpoint_auth_method).toBe("none");
 	});
 });
 

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -1,10 +1,15 @@
 import { createAuthClient } from "better-auth/client";
 import { organizationClient } from "better-auth/client/plugins";
+import { generateRandomString } from "better-auth/crypto";
+import {
+	createAuthorizationCodeRequest,
+	createAuthorizationURL,
+} from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import type { Organization } from "better-auth/plugins/organization";
 import { organization } from "better-auth/plugins/organization";
 import { getTestInstance } from "better-auth/test";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, onTestFinished, vi } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import type { OAuthClient } from "./types/oauth";
@@ -211,6 +216,21 @@ describe("oauth register", async () => {
 		expect(response.data?.disabled).toBeFalsy();
 	});
 
+	it("should preserve confidential method and type for authenticated registration", async () => {
+		const response = await serverClient.oauth2.register({
+			token_endpoint_auth_method: "client_secret_post",
+			type: "web",
+			redirect_uris: [redirectUri],
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.client_secret).toBeDefined();
+		expect(response.data?.token_endpoint_auth_method).toBe(
+			"client_secret_post",
+		);
+		expect(response.data?.type).toBe("web");
+		expect(response.data?.public).toBeFalsy();
+	});
+
 	it("should register client with metadata field", async () => {
 		const response = await auth.api.adminCreateOAuthClient({
 			headers,
@@ -339,10 +359,6 @@ describe("oauth register - unauthenticated", async () => {
 	});
 
 	/**
-	 * When a client sends type: "web" with a confidential method, the
-	 * override should also clear the type to avoid a validation error
-	 * (type "web" is only valid for confidential clients).
-	 *
 	 * @see https://github.com/better-auth/better-auth/issues/8588
 	 */
 	it("should clear type 'web' when overriding confidential to public", async () => {
@@ -354,6 +370,145 @@ describe("oauth register - unauthenticated", async () => {
 		expect(response.data?.client_id).toBeDefined();
 		expect(response.data?.client_secret).toBeUndefined();
 		expect(response.data?.token_endpoint_auth_method).toBe("none");
+	});
+
+	/**
+	 * client_credentials requires a secret, which public clients never get.
+	 * Reject the combination at registration rather than creating an unusable client.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/8588
+	 */
+	it("should reject client_credentials grant for unauthenticated DCR", async () => {
+		const response = await unauthenticatedClient.oauth2.register({
+			grant_types: ["client_credentials"],
+			redirect_uris: [redirectUri],
+		});
+		expect(response.error?.status).toBe(400);
+	});
+});
+
+/**
+ * Verifies the overridden public client is actually usable end-to-end:
+ * DCR with client_secret_post (overridden to "none") -> authorize -> PKCE token exchange.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/8588
+ */
+describe("oauth register - unauthenticated DCR full flow", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const { signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				allowUnauthenticatedClientRegistration: true,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const authenticatedClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: { customFetchImpl, headers },
+	});
+	const unauthenticatedClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const state = "e2e-test-state";
+
+	it("should complete authorize + PKCE token exchange after override from client_secret_post", async () => {
+		// 1. Register via unauthenticated DCR with client_secret_post (gets overridden to "none")
+		const reg = await unauthenticatedClient.oauth2.register({
+			token_endpoint_auth_method: "client_secret_post",
+			redirect_uris: [redirectUri],
+		});
+		expect(reg.data?.client_id).toBeDefined();
+		expect(reg.data?.client_secret).toBeUndefined();
+		expect(reg.data?.token_endpoint_auth_method).toBe("none");
+
+		const clientId = reg.data!.client_id;
+
+		// 2. Build authorization URL with PKCE (no client secret)
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes: ["openid"],
+			codeVerifier,
+		});
+
+		// 3. Hit authorize endpoint (with user session) -> consent redirect
+		let consentRedirectUrl = "";
+		await authenticatedClient.$fetch(authUrl.toString(), {
+			onError(ctx) {
+				consentRedirectUrl = ctx.response.headers.get("Location") || "";
+			},
+		});
+		expect(consentRedirectUrl).toContain("/consent");
+
+		// 4. Accept consent -> get authorization code
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(consentRedirectUrl, authServerBaseUrl).search,
+			},
+		});
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const consentRes = await authenticatedClient.oauth2.consent(
+			{ accept: true },
+			{ headers, throw: true },
+		);
+		expect(consentRes.url).toContain("code=");
+
+		const code = new URL(consentRes.url).searchParams.get("code")!;
+
+		// 5. Exchange code at token endpoint with PKCE (no client_secret)
+		const { body: tokenBody, headers: tokenHeaders } =
+			createAuthorizationCodeRequest({
+				code,
+				codeVerifier,
+				redirectURI: redirectUri,
+				options: {
+					clientId,
+					redirectURI: redirectUri,
+				},
+			});
+
+		const tokenRes = await customFetchImpl(
+			`${authServerBaseUrl}/api/auth/oauth2/token`,
+			{
+				method: "POST",
+				body: tokenBody.toString(),
+				headers: tokenHeaders,
+			},
+		);
+		const tokens = await tokenRes.json();
+
+		expect(tokens.access_token).toBeDefined();
+		expect(tokens.id_token).toBeDefined();
+		expect(tokens.token_type.toLowerCase()).toBe("bearer");
+		expect(tokens.scope).toBe("openid");
 	});
 });
 

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -29,17 +29,31 @@ export async function registerEndpoint(
 		});
 	}
 
-	// Determine whether registration request for public client
-	// https://datatracker.ietf.org/doc/html/rfc7591#section-2
-	const isPublic = body.token_endpoint_auth_method === "none";
-
-	// Check unauthenticated user is requesting a confidential client
-	if (!session && !isPublic) {
-		throw new APIError("UNAUTHORIZED", {
-			error: "invalid_request",
-			error_description:
-				"Authentication required for confidential client registration",
-		});
+	// Unauthenticated DCR: override confidential methods to public.
+	//
+	// RFC 7591 §3.2.1 allows the server to "reject or replace any of the
+	// client's requested metadata values submitted during the registration
+	// and substitute them with suitable values."
+	//
+	// When no session is present, a client_secret provides no meaningful
+	// trust: anyone can register and receive one, so PKCE (always required
+	// for registered clients) is the actual security boundary.  Silently
+	// downgrading to "none" keeps real-world MCP clients (Claude, Codex,
+	// etc.) working while the response communicates the actual method back
+	// to the client per RFC 7591 §3.2.1.
+	//
+	// If token_endpoint_auth_method is omitted, RFC 7591 §2 defaults it to
+	// "client_secret_basic", which also triggers this override.
+	if (!session) {
+		const requestedMethod = body.token_endpoint_auth_method;
+		if (requestedMethod !== "none") {
+			body.token_endpoint_auth_method = "none";
+			// Clear type so checkOAuthClient does not reject the now-public
+			// client for having type "web" (confidential-only).
+			if (body.type === "web") {
+				body.type = undefined;
+			}
+		}
 	}
 
 	// Ensure dynamically registered clients shall have a scope

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -3,14 +3,34 @@ import { APIError, getSessionFromCtx } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
 import { toExpJWT } from "better-auth/plugins";
 import type { OAuthOptions, SchemaClient, Scope } from "./types";
-import type { OAuthClient } from "./types/oauth";
+import type { OAuthClient, TokenEndpointAuthMethod } from "./types/oauth";
 import { parseClientMetadata, storeClientSecret } from "./utils";
+
+/**
+ * Resolves the auth method and type for unauthenticated DCR.
+ * Overrides confidential methods to "none" per RFC 7591 Section 3.2.1.
+ * Clears type "web" since it is only valid for confidential clients.
+ */
+function resolveUnauthenticatedAuth(body: OAuthClient): {
+	tokenEndpointAuthMethod: TokenEndpointAuthMethod;
+	type: OAuthClient["type"];
+} {
+	if (body.token_endpoint_auth_method === "none") {
+		return {
+			tokenEndpointAuthMethod: "none",
+			type: body.type,
+		};
+	}
+	return {
+		tokenEndpointAuthMethod: "none",
+		type: body.type === "web" ? undefined : body.type,
+	};
+}
 
 export async function registerEndpoint(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 ) {
-	// Check if registration endpoint is enabled
 	if (!opts.allowDynamicClientRegistration) {
 		throw new APIError("FORBIDDEN", {
 			error: "access_denied",
@@ -21,7 +41,6 @@ export async function registerEndpoint(
 	const body = ctx.body as OAuthClient;
 	const session = await getSessionFromCtx(ctx);
 
-	// Check authorization
 	if (!(session || opts.allowUnauthenticatedClientRegistration)) {
 		throw new APIError("UNAUTHORIZED", {
 			error: "invalid_token",
@@ -29,38 +48,24 @@ export async function registerEndpoint(
 		});
 	}
 
-	// Unauthenticated DCR: override confidential methods to public.
-	//
-	// RFC 7591 §3.2.1 allows the server to "reject or replace any of the
-	// client's requested metadata values submitted during the registration
-	// and substitute them with suitable values."
-	//
-	// When no session is present, a client_secret provides no meaningful
-	// trust: anyone can register and receive one, so PKCE (always required
-	// for registered clients) is the actual security boundary.  Silently
-	// downgrading to "none" keeps real-world MCP clients (Claude, Codex,
-	// etc.) working while the response communicates the actual method back
-	// to the client per RFC 7591 §3.2.1.
-	//
-	// If token_endpoint_auth_method is omitted, RFC 7591 §2 defaults it to
-	// "client_secret_basic", which also triggers this override.
 	if (!session) {
-		const requestedMethod = body.token_endpoint_auth_method;
-		if (requestedMethod !== "none") {
-			body.token_endpoint_auth_method = "none";
-			// Clear type so checkOAuthClient does not reject the now-public
-			// client for having type "web" (confidential-only).
-			if (body.type === "web") {
-				body.type = undefined;
-			}
+		if (body.grant_types?.includes("client_credentials")) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description:
+					"client_credentials grant requires authenticated registration",
+			});
 		}
+
+		const resolved = resolveUnauthenticatedAuth(body);
+		body.token_endpoint_auth_method = resolved.tokenEndpointAuthMethod;
+		body.type = resolved.type;
 	}
 
-	// Ensure dynamically registered clients shall have a scope
-	if (!ctx.body.scope) {
-		ctx.body.scope = (
-			opts.clientRegistrationDefaultScopes ?? opts.scopes
-		)?.join(" ");
+	if (!body.scope) {
+		body.scope = (opts.clientRegistrationDefaultScopes ?? opts.scopes)?.join(
+			" ",
+		);
 	}
 
 	return createOAuthClientEndpoint(ctx, opts, {

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -9,7 +9,7 @@ import { parseClientMetadata, storeClientSecret } from "./utils";
 /**
  * Resolves the auth method and type for unauthenticated DCR.
  * Overrides confidential methods to "none" per RFC 7591 Section 3.2.1.
- * Clears type "web" since it is only valid for confidential clients.
+ * When overriding, clears type "web" since it is only valid for confidential clients.
  */
 function resolveUnauthenticatedAuth(body: OAuthClient): {
 	tokenEndpointAuthMethod: TokenEndpointAuthMethod;


### PR DESCRIPTION
## Summary

When `allowUnauthenticatedClientRegistration` is enabled, unauthenticated DCR requests that specify `client_secret_post`, `client_secret_basic`, or omit `token_endpoint_auth_method` entirely are now overridden to `"none"` (public client) instead of being rejected with HTTP 401.

[RFC 7591 Section 3.2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1) explicitly allows this: the server MAY replace requested metadata values with suitable values. The registration response communicates the actual method back so compliant clients can adjust.

Closes #8588

## What changed

- Override confidential auth methods to `"none"` for unauthenticated DCR via a pure `resolveUnauthenticatedAuth` resolver (no direct body mutation)
- Reject `client_credentials` grant in unauthenticated DCR; public clients have no secret, so the grant would always fail at the token endpoint
- Clear `type: "web"` during override since it is only valid for confidential clients
- End-to-end test: unauthenticated DCR with `client_secret_post` -> authorize -> PKCE token exchange