### PR TITLE
docs: update requestPasswordResetEmailOTP typings

### DIFF
--- a/docs/content/docs/plugins/email-otp.mdx
+++ b/docs/content/docs/plugins/email-otp.mdx
@@ -186,7 +186,7 @@ To reset the user's password with OTP, use the `emailOtp.requestPasswordReset()`
 
 <APIMethod path="/email-otp/request-password-reset" method="POST">
   ```ts
-  type requestPasswordResetEmailOTP = {
+  type forgetPasswordEmailOTP = {
       /**
        * Email address to send the OTP.
        */


### PR DESCRIPTION
Update to the documentation to change 'requestPasswordResetEmailOTP' to 'forgetPasswordEmailOTP'.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Email OTP docs type from `requestPasswordResetEmailOTP` to `forgetPasswordEmailOTP` to match the current API and reduce confusion.

<sup>Written for commit 8548a0cb9c8f67dccccdf5131973ca90ff63b0a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

