### PR TITLE
feat(oauth): add Yandex social provider

### DIFF
--- a/.changeset/true-news-rule.md
+++ b/.changeset/true-news-rule.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+feat(oauth): add Yandex social provider

--- a/.changeset/true-news-rule.md
+++ b/.changeset/true-news-rule.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": minor
+"better-auth": patch
 ---
 
-feat(oauth): add Yandex social provider
+Add a pre-configured Yandex provider helper for the generic OAuth plugin.

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -137,6 +137,7 @@ Better Auth provides pre-configured helper functions for popular OAuth providers
 * **Okta** - `okta(options)`
 * **Slack** - `slack(options)`
 * **Patreon** - `patreon(options)`
+* **Yandex** - `yandex(options)`
 
 ### Example: Using Pre-configured Providers
 
@@ -155,6 +156,7 @@ import {
 	okta,
 	slack,
 	patreon,
+	yandex,
 } from 'better-auth/plugins';
 
 export const auth = betterAuth({
@@ -209,6 +211,10 @@ export const auth = betterAuth({
 					clientId: process.env.PATREON_CLIENT_ID,
 					clientSecret: process.env.PATREON_CLIENT_SECRET,
 				}),
+				yandex({
+					clientId: process.env.YANDEX_CLIENT_ID,
+					clientSecret: process.env.YANDEX_CLIENT_SECRET,
+				}),
 			],
 		}),
 	],
@@ -225,6 +231,7 @@ Each provider helper accepts common OAuth options (extending `BaseOAuthProviderO
 * **Okta**: Requires `issuer` (e.g., `https://dev-xxxxx.okta.com/oauth2/default`)
 * **Slack**: No additional required fields
 * **Patreon**: No additional required fields
+* **Yandex**: No additional required fields
 
 All providers support the same optional fields:
 

--- a/packages/better-auth/src/plugins/generic-oauth/providers/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/index.ts
@@ -17,6 +17,7 @@
  *  okta,
  *  slack,
  *  patreon,
+ *  yandex,
  * } from 'better-auth/plugins';
  *
  * export const auth = betterAuth({
@@ -48,3 +49,4 @@ export {
 export { type OktaOptions, okta } from "./okta";
 export { type PatreonOptions, patreon } from "./patreon";
 export { type SlackOptions, slack } from "./slack";
+export { type YandexOptions, yandex } from "./yandex";

--- a/packages/better-auth/src/plugins/generic-oauth/providers/yandex.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/yandex.ts
@@ -1,0 +1,97 @@
+import type { OAuth2Tokens, OAuth2UserInfo } from "@better-auth/core/oauth2";
+import { betterFetch } from "@better-fetch/fetch";
+import type { BaseOAuthProviderOptions, GenericOAuthConfig } from "../index";
+
+export interface YandexOptions extends BaseOAuthProviderOptions {}
+
+interface YandexProfile {
+	login: string;
+	id: string;
+	client_id: string;
+	/* cspell:disable-next-line */
+	psuid: string;
+	emails?: string[];
+	default_email?: string;
+	is_avatar_empty?: boolean;
+	default_avatar_id?: string;
+	birthday?: string | null;
+	first_name?: string;
+	last_name?: string;
+	display_name?: string;
+	real_name?: string;
+	sex?: "male" | "female" | null;
+	default_phone?: { id: number; number: string };
+}
+
+/**
+ * Yandex OAuth provider helper
+ *
+ * @example
+ * ```ts
+ * import { genericOAuth, yandex } from "better-auth/plugins/generic-oauth";
+ *
+ * export const auth = betterAuth({
+ *   plugins: [
+ *     genericOAuth({
+ *       config: [
+ *         yandex({
+ *           clientId: process.env.YANDEX_CLIENT_ID,
+ *           clientSecret: process.env.YANDEX_CLIENT_SECRET,
+ *         }),
+ *       ],
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function yandex(options: YandexOptions): GenericOAuthConfig {
+	const defaultScopes = ["login:info", "login:email", "login:avatar"];
+
+	const getUserInfo = async (
+		tokens: OAuth2Tokens,
+	): Promise<OAuth2UserInfo | null> => {
+		const { data: profile, error } = await betterFetch<YandexProfile>(
+			"https://login.yandex.ru/info?format=json",
+			{
+				method: "GET",
+				headers: {
+					Authorization: `OAuth ${tokens.accessToken}`,
+				},
+			},
+		);
+
+		if (error || !profile) {
+			return null;
+		}
+
+		return {
+			id: profile.id,
+			name:
+				profile.display_name ??
+				profile.real_name ??
+				profile.first_name ??
+				profile.login,
+			email: profile.default_email,
+			emailVerified: !!profile.default_email,
+			image:
+				!profile.is_avatar_empty && profile.default_avatar_id
+					? `https://avatars.yandex.net/get-yapic/${profile.default_avatar_id}/islands-200`
+					: undefined,
+		};
+	};
+
+	return {
+		providerId: "yandex",
+		authorizationUrl: "https://oauth.yandex.com/authorize",
+		tokenUrl: "https://oauth.yandex.com/token",
+		clientId: options.clientId,
+		clientSecret: options.clientSecret,
+		scopes: options.scopes ?? defaultScopes,
+		redirectURI: options.redirectURI,
+		pkce: options.pkce,
+		disableImplicitSignUp: options.disableImplicitSignUp,
+		disableSignUp: options.disableSignUp,
+		overrideUserInfo: options.overrideUserInfo,
+		getUserInfo,
+	};
+}

--- a/packages/better-auth/src/plugins/generic-oauth/providers/yandex.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/yandex.ts
@@ -71,8 +71,8 @@ export function yandex(options: YandexOptions): GenericOAuthConfig {
 				profile.real_name ??
 				profile.first_name ??
 				profile.login,
-			email: profile.default_email,
-			emailVerified: !!profile.default_email,
+			email: profile.default_email ?? profile.emails?.[0],
+			emailVerified: false,
 			image:
 				!profile.is_avatar_empty && profile.default_avatar_id
 					? `https://avatars.yandex.net/get-yapic/${profile.default_avatar_id}/islands-200`


### PR DESCRIPTION
Updated https://github.com/better-auth/better-auth/pull/7028

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Yandex OAuth provider to `generic-oauth` for easy Yandex sign-in. Updates docs and exports.

- **New Features**
  - Added `yandex(options)` with Yandex endpoints, default scopes (`login:info`, `login:email`, `login:avatar`), and aligned `getUserInfo` (id, name fallbacks, `default_email`/`emails[0]`, avatar when present).
  - Exported `yandex` and `YandexOptions` from `better-auth/plugins`; docs show import, `YANDEX_CLIENT_ID`/`YANDEX_CLIENT_SECRET` usage, and list Yandex with no extra required fields.

<sup>Written for commit 308b26e2dd5df0a30d5e9eff94790951f98aafdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

