### PR TITLE
docs: add subsection for advanced database configuration options

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -649,7 +649,7 @@ export const auth = betterAuth({
 * `skipTrailingSlashes`: Skip trailing slash validation in route matching. (default: `false`)
 * OAuth state configuration options (`storeStateStrategy`, `skipStateCookieCheck`) are now part of the `account` option
 
-### `database`
+<h3 id="advanced-database"><code>database</code></h3>
 
 Set custom strategies for ID generation and findMany queries.
 

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -649,6 +649,36 @@ export const auth = betterAuth({
 * `skipTrailingSlashes`: Skip trailing slash validation in route matching. (default: `false`)
 * OAuth state configuration options (`storeStateStrategy`, `skipStateCookieCheck`) are now part of the `account` option
 
+### `database`
+
+Set custom strategies for ID generation and findMany queries.
+
+* `generateId`: Controls how record IDs are generated. Accepts a custom function, `false`, `"serial"`, or `"uuid"` (default: random nanoid-style string).
+* `defaultFindManyLimit`: The default maximum number of records returned by the `findMany` adapter method. (default: `100`)
+
+#### `generateId`
+
+| Value | Behavior |
+| --- | --- |
+| Custom function | Called with `{ model, size }` — the returned string is used as the ID |
+| `false` | Defers to the database's own auto-generated ID (e.g. auto-increment) |
+| `"serial"` | Same as `false` — the ID column type becomes `number` and no JS-side value is generated; uses `GENERATED ALWAYS AS IDENTITY` in PostgreSQL |
+| `"uuid"` | Uses the database's native `gen_random_uuid()` / `uuid()` where supported, otherwise falls back to `crypto.randomUUID()` |
+| _(unset)_ | Generates a random base-62 string |
+
+```ts
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+	advanced: {
+		database: {
+			generateId: "uuid",
+			defaultFindManyLimit: 50,
+		},
+	},
+});
+```
+
 ### `backgroundTasks`
 
 Configure background task handling for deferred operations. Background tasks allow non-critical operations (like cleanup, analytics, timing-attack mitigation, or rate limit counter updates) to run after the response is sent. This can significantly improve response times on serverless platforms.

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -653,18 +653,8 @@ export const auth = betterAuth({
 
 Set custom strategies for ID generation and findMany queries.
 
-* `generateId`: Controls how record IDs are generated. Accepts a custom function, `false`, `"serial"`, or `"uuid"` (default: random nanoid-style string).
+* `generateId`: Controls how record IDs are generated. Accepts a custom function, `false`, `"serial"`, or `"uuid"` (default: random nanoid-style string). See the [Database documentation](/docs/concepts/database#id-generation) for more info.
 * `defaultFindManyLimit`: The default maximum number of records returned by the `findMany` adapter method. (default: `100`)
-
-#### `generateId`
-
-| Value | Behavior |
-| --- | --- |
-| Custom function | Called with `{ model, size }` — the returned string is used as the ID |
-| `false` | Defers to the database's own auto-generated ID (e.g. auto-increment) |
-| `"serial"` | Same as `false` — the ID column type becomes `number` and no JS-side value is generated; uses `GENERATED ALWAYS AS IDENTITY` in PostgreSQL |
-| `"uuid"` | Uses the database's native `gen_random_uuid()` / `uuid()` where supported, otherwise falls back to `crypto.randomUUID()` |
-| _(unset)_ | Generates a random base-62 string |
 
 ```ts
 import { betterAuth } from "better-auth";

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -653,7 +653,7 @@ export const auth = betterAuth({
 
 Set custom strategies for ID generation and findMany queries.
 
-* `generateId`: Controls how record IDs are generated. Accepts a custom function, `false`, `"serial"`, or `"uuid"` (default: random nanoid-style string). See the [Database documentation](/docs/concepts/database#id-generation) for more info.
+* `generateId`: Controls how record IDs are generated. Accepts a custom function, `false`, `"serial"`, or `"uuid"` (default: [random base62 string](https://github.com/better-auth/better-auth/blob/main/packages/core/src/utils/id.ts)). See the [Database documentation](/docs/concepts/database#id-generation) for more info.
 * `defaultFindManyLimit`: The default maximum number of records returned by the `findMany` adapter method. (default: `100`)
 
 ```ts


### PR DESCRIPTION
Add a subsection to the options reference to document the `advanced.database` config options.

Fixes #9148 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `advanced.database` subsection to the options reference for configuring ID generation and default `findMany` limits.

Documents `generateId` (custom function, `false`, `"serial"`, or `"uuid"`; default random base62 string) and `defaultFindManyLimit` (default `100`), links to ID generation docs, includes a `"uuid"` + limit `50` example, and sets the header anchor to `advanced-database` to avoid conflicts.

<sup>Written for commit 4e079c6e8adb870492fd83944aeff408e3f9c87c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



