### PR TITLE
fix(api-key): allow server-side org key creation without userId

### DIFF
--- a/.changeset/fix-api-key-org-no-userid.md
+++ b/.changeset/fix-api-key-org-no-userid.md
@@ -1,0 +1,12 @@
+---
+"@better-auth/api-key": patch
+---
+
+fix(api-key): allow server-side org key creation without userId
+
+Server-side trusted callers can now create organization-owned API keys without
+specifying a `userId`. Previously, `auth.api.createApiKey` with
+`references: "organization"` threw UNAUTHORIZED when called without `userId`.
+
+The org authorization path is now split into client (membership + permission
+check) vs server-side (org existence only).

--- a/packages/api-key/src/error-codes.ts
+++ b/packages/api-key/src/error-codes.ts
@@ -44,4 +44,5 @@ export const API_KEY_ERROR_CODES = defineErrorCodes({
 		"No default api-key configuration found.",
 	ORGANIZATION_PLUGIN_REQUIRED:
 		"Organization plugin is required for organization-owned API keys. Please install and configure the organization plugin.",
+	ORGANIZATION_NOT_FOUND: "Organization not found.",
 });

--- a/packages/api-key/src/org-api-key.test.ts
+++ b/packages/api-key/src/org-api-key.test.ts
@@ -614,5 +614,111 @@ describe("organization API keys", async () => {
 			expect(getResult.error).toBeDefined();
 			expect(getResult.error?.status).toBe(404);
 		});
+
+		it("should return ORGANIZATION_NOT_FOUND when organizationId does not exist", async () => {
+			const { client, signInWithTestUser } = await getTestInstance(
+				{
+					plugins: [
+						organization({
+							async sendInvitationEmail() {},
+						}),
+						apiKey([
+							{
+								configId: "org-keys",
+								defaultPrefix: "org_",
+								references: "organization",
+							},
+						]),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [apiKeyClient()],
+					},
+				},
+			);
+
+			const { headers } = await signInWithTestUser();
+
+			const result = await client.apiKey.create(
+				{ configId: "org-keys", organizationId: "non-existent-org-id" },
+				{ headers },
+			);
+
+			expect(result.error).toBeDefined();
+			expect(result.error?.status).toBe(403);
+			expect(result.error?.code).toBe(
+				ERROR_CODES.USER_NOT_MEMBER_OF_ORGANIZATION.code,
+			);
+		});
+
+		it("should allow server-side org key creation without userId (trusted server call)", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance(
+				{
+					plugins: [
+						organization({
+							async sendInvitationEmail() {},
+						}),
+						apiKey([
+							{
+								configId: "org-keys",
+								defaultPrefix: "org_",
+								references: "organization",
+							},
+						]),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [apiKeyClient()],
+					},
+				},
+			);
+
+			const { headers } = await signInWithTestUser();
+			const org = await auth.api.createOrganization({
+				body: { name: "Server Key Org", slug: `server-key-${Date.now()}` },
+				headers,
+			});
+
+			// Server-side call: no session headers, just organizationId
+			const result = await auth.api.createApiKey({
+				body: { configId: "org-keys", organizationId: org.id },
+			});
+
+			expect(result.key).toBeDefined();
+			expect(result.referenceId).toBe(org.id);
+			expect(result.configId).toBe("org-keys");
+		});
+
+		it("should return ORGANIZATION_NOT_FOUND on server-side call with non-existent orgId", async () => {
+			const { auth } = await getTestInstance(
+				{
+					plugins: [
+						organization({
+							async sendInvitationEmail() {},
+						}),
+						apiKey([
+							{
+								configId: "org-keys",
+								defaultPrefix: "org_",
+								references: "organization",
+							},
+						]),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [apiKeyClient()],
+					},
+				},
+			);
+
+			await expect(
+				auth.api.createApiKey({
+					body: { configId: "org-keys", organizationId: "non-existent-org-id" },
+				}),
+			).rejects.toThrow();
+		});
 	});
 });

--- a/packages/api-key/src/org-authorization.ts
+++ b/packages/api-key/src/org-authorization.ts
@@ -25,6 +25,15 @@ interface Member {
 	createdAt: Date;
 }
 
+interface Organization {
+	id: string;
+	name: string;
+	slug: string;
+	logo: string | null | undefined;
+	metadata?: Record<string, unknown> | string;
+	createdAt: Date;
+}
+
 /**
  * Gets the organization plugin options from the context.
  * Returns null if the organization plugin is not installed.
@@ -43,6 +52,34 @@ function getOrgOptions(
 	}
 
 	return null;
+}
+
+/**
+ * Validates that an organization exists and that the organization plugin is installed.
+ * Use this for server-side trusted calls where no user context is available.
+ *
+ * @param ctx - The endpoint context
+ * @param organizationId - The ID of the organization to validate
+ * @throws APIError if the organization plugin is not installed or the organization does not exist
+ */
+export async function checkOrgExists(
+	ctx: GenericEndpointContext,
+	organizationId: string,
+): Promise<void> {
+	const orgOptions = getOrgOptions(ctx);
+	if (!orgOptions) {
+		throw APIError.from(
+			"INTERNAL_SERVER_ERROR",
+			ERROR_CODES.ORGANIZATION_PLUGIN_REQUIRED,
+		);
+	}
+	const org = await ctx.context.adapter.findOne<Organization>({
+		model: "organization",
+		where: [{ field: "id", value: organizationId }],
+	});
+	if (!org) {
+		throw APIError.from("BAD_REQUEST", ERROR_CODES.ORGANIZATION_NOT_FOUND);
+	}
 }
 
 /**

--- a/packages/api-key/src/routes/create-api-key.ts
+++ b/packages/api-key/src/routes/create-api-key.ts
@@ -8,7 +8,7 @@ import * as z from "zod";
 import { API_KEY_TABLE_NAME, API_KEY_ERROR_CODES as ERROR_CODES } from "..";
 import { defaultKeyHasher } from "../";
 import { setApiKey } from "../adapter";
-import { checkOrgApiKeyPermission } from "../org-authorization";
+import { checkOrgApiKeyPermission, checkOrgExists } from "../org-authorization";
 import type { apiKeySchema } from "../schema";
 import type { ApiKey } from "../types";
 import { getDate } from "../utils";
@@ -328,14 +328,21 @@ export function createApiKey({
 					throw APIError.from("BAD_REQUEST", msg);
 				}
 
-				// Get user ID from session or body
-				const userId = session?.user.id || ctx.body.userId;
-				if (!userId) {
-					throw APIError.from("UNAUTHORIZED", ERROR_CODES.UNAUTHORIZED_SESSION);
+				if (isClientRequest) {
+					// Get user ID from session
+					const userId = session?.user.id;
+					if (!userId) {
+						throw APIError.from(
+							"UNAUTHORIZED",
+							ERROR_CODES.UNAUTHORIZED_SESSION,
+						);
+					}
+					// Verify membership and permission
+					await checkOrgApiKeyPermission(ctx, userId, orgId, "create");
+				} else {
+					// Verify Organization Existence
+					await checkOrgExists(ctx, orgId);
 				}
-
-				// Verify membership and permission
-				await checkOrgApiKeyPermission(ctx, userId, orgId, "create");
 
 				referenceId = orgId;
 			} else {


### PR DESCRIPTION
## Summary

`auth.api.createApiKey` with `references: "organization"` threw UNAUTHORIZED when called without
`userId`. Server-side trusted callers should be able to create org keys without specifying a user —
only org existence needs validation.

## What changed

- Split org auth path into client (membership + permission check) vs server-side (org existence only)
- Add `checkOrgExists()` for org plugin + org existence validation
- Add tests for server-side org key creation and non-existent org validation

---

Side note: `update`, `delete`, `get`, `list` have similar inconsistencies around `sessionMiddleware`
and server-side org key support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow trusted server calls to create organization API keys without a `userId` by verifying only that the organization exists. Fixes UNAUTHORIZED errors for backend jobs creating org-owned keys without a session.

- **Bug Fixes**
  - Split org auth: client requests require session user + membership/permission; server-side checks only org existence.
  - Added `checkOrgExists()` and `ORGANIZATION_NOT_FOUND`; updated create route and tests for server-side creation and missing org cases.

<sup>Written for commit 00bea8cffca67e2470f2be553f8de5292ec97d22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

