### PR TITLE
docs: correct wording for invocable endpoints in integration guides

### DIFF
--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -51,7 +51,7 @@ The client also uses [better-fetch](https://github.com/bekacru/better-fetch) to 
 
 ## RSC and Server actions
 
-The `api` object exported from the auth instance contains all the actions that you can perform on the server. Every endpoint made inside Better Auth is a invocable as a function. Including plugins endpoints.
+The `api` object exported from the auth instance contains all the actions that you can perform on the server. Every endpoint made inside Better Auth is invocable as a function. Including plugins endpoints.
 
 **Example: Getting Session on a server action**
 

--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -63,7 +63,7 @@ const session = authClient.useSession()
 
 ### Server Usage
 
-The `api` object exported from the auth instance contains all the actions that you can perform on the server. Every endpoint made inside Better Auth is a invocable as a function. Including plugins endpoints.
+The `api` object exported from the auth instance contains all the actions that you can perform on the server. Every endpoint made inside Better Auth is invocable as a function. Including plugins endpoints.
 
 **Example: Getting Session on a server API route**
 

--- a/docs/content/docs/integrations/waku.mdx
+++ b/docs/content/docs/integrations/waku.mdx
@@ -65,7 +65,7 @@ The client also uses [better-fetch](https://github.com/bekacru/better-fetch) to 
 
 ## RSC and Server actions
 
-The `api` object exported from the auth instance contains all the actions that you can perform on the server. Every endpoint made inside Better Auth is a invocable as a function. Including plugins endpoints.
+The `api` object exported from the auth instance contains all the actions that you can perform on the server. Every endpoint made inside Better Auth is invocable as a function. Including plugins endpoints.
 
 **Example: Getting Session on a server action**
 


### PR DESCRIPTION
Fixed a repeated grammatical error across three documentation pages. "a invocable" has been corrected to "is invocable" in each instance, as "invocable" requires "is" rather than the indefinite article "a."
No breaking changes. No related issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a grammatical error in the `Next`, `Nuxt`, and `Waku` integration docs by replacing “a invocable” with “is invocable” in the endpoint description.

<sup>Written for commit f76d427475d9d68d2003e553d015b14563b1f3d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

