### PR TITLE
docs: update Convex Labs link in documentation

### DIFF
--- a/docs/content/docs/integrations/convex.mdx
+++ b/docs/content/docs/integrations/convex.mdx
@@ -114,7 +114,7 @@ In this guide, we'll walk through the steps to integrate Better Auth with [Conve
   <Step>
     ## Create the Better Auth Convex Component
 
-    Convex components can be installed from NPM or a local folder. While the NPM version is available [here](https://www.convex.dev/components/better-auth), this guide uses a local folder setup to unlock the full potential of Better Auth.
+    Convex components can be installed from NPM or a local folder. While the NPM version is available [here](https://labs.convex.dev/better-auth), this guide uses a local folder setup to unlock the full potential of Better Auth.
 
     ### Create the component definition
 


### PR DESCRIPTION
It moved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Better Auth Convex component link in the integration guide to the new Convex Labs URL. Fixes an outdated link so readers reach the correct component page.

<sup>Written for commit f024fdf68d3555458296b469709c80eaf07e408f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

