### PR TITLE
fix: cleanup sessions when deleting users

### DIFF
--- a/.changeset/chatty-streets-play.md
+++ b/.changeset/chatty-streets-play.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix: cleanup sessions when deleting users

--- a/.changeset/chatty-streets-play.md
+++ b/.changeset/chatty-streets-play.md
@@ -3,4 +3,4 @@
 "@better-auth/scim": patch
 ---
 
-fix: cleanup sessions when deleting users
+fix: cleanup sessions when admin, anonymous, or SCIM deletes a user

--- a/.changeset/chatty-streets-play.md
+++ b/.changeset/chatty-streets-play.md
@@ -1,5 +1,6 @@
 ---
 "better-auth": patch
+"@better-auth/scim": patch
 ---
 
 fix: cleanup sessions when deleting users

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -1,5 +1,7 @@
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { beforeEach, describe, expect, it } from "vitest";
+import { admin } from "../plugins/admin/admin";
+import { adminClient } from "../plugins/admin/client";
 import { getTestInstance } from "../test-utils/test-instance";
 
 describe("secondary storage - get returns JSON string", async () => {
@@ -226,5 +228,88 @@ describe("secondary storage - storeSessionInDatabase", () => {
 			const after = await client.getSession({ fetchOptions: { headers } });
 			expect(after.data).toBeNull();
 		});
+	});
+});
+
+describe("secondary storage - admin removeUser cleans up sessions", async () => {
+	const store = new Map<string, string>();
+
+	const { client, signInWithUser, customFetchImpl } = await getTestInstance({
+		plugins: [admin()],
+		secondaryStorage: {
+			set(key, value, ttl) {
+				store.set(key, value);
+			},
+			get(key) {
+				return store.get(key) || null;
+			},
+			delete(key) {
+				store.delete(key);
+			},
+		},
+		databaseHooks: {
+			user: {
+				create: {
+					before: async (user) => {
+						if (user.email === "admin@test.com") {
+							return { data: { ...user, role: "admin" } };
+						}
+					},
+				},
+			},
+		},
+		rateLimit: {
+			enabled: false,
+		},
+	});
+
+	const { createAuthClient } = await import("../client");
+	const adminAuthClient = createAuthClient({
+		fetchOptions: { customFetchImpl },
+		plugins: [adminClient()],
+		baseURL: "http://localhost:3000",
+	});
+
+	it("should clear secondary storage sessions when removing a user via admin", async () => {
+		await client.signUp.email({
+			email: "admin@test.com",
+			password: "password",
+			name: "Admin",
+		});
+		const { headers: adminHeaders } = await signInWithUser(
+			"admin@test.com",
+			"password",
+		);
+
+		await client.signUp.email({
+			email: "victim@test.com",
+			password: "password",
+			name: "Victim",
+		});
+		const { headers: victimHeaders } = await signInWithUser(
+			"victim@test.com",
+			"password",
+		);
+
+		const victimSession = await client.getSession({
+			fetchOptions: { headers: victimHeaders },
+		});
+		expect(victimSession.data).not.toBeNull();
+
+		const victimId = victimSession.data!.user.id;
+		const victimToken = victimSession.data!.session.token;
+		expect(store.has(victimToken)).toBe(true);
+
+		await adminAuthClient.admin.removeUser(
+			{ userId: victimId },
+			{ headers: adminHeaders },
+		);
+
+		expect(store.has(victimToken)).toBe(false);
+
+		const after = await client.getSession({
+			fetchOptions: { headers: victimHeaders },
+		});
+		expect(after.data).toBeNull();
 	});
 });

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -2,6 +2,8 @@ import { safeJSONParse } from "@better-auth/core/utils/json";
 import { beforeEach, describe, expect, it } from "vitest";
 import { admin } from "../plugins/admin/admin";
 import { adminClient } from "../plugins/admin/client";
+import { anonymous } from "../plugins/anonymous";
+import { anonymousClient } from "../plugins/anonymous/client";
 import { getTestInstance } from "../test-utils/test-instance";
 
 describe("secondary storage - get returns JSON string", async () => {
@@ -310,6 +312,55 @@ describe("secondary storage - admin removeUser cleans up sessions", async () => 
 		const after = await client.getSession({
 			fetchOptions: { headers: victimHeaders },
 		});
+		expect(after.data).toBeNull();
+	});
+});
+
+describe("secondary storage - /delete-anonymous-user cleans up sessions", async () => {
+	const store = new Map<string, string>();
+
+	const { client, auth, sessionSetter } = await getTestInstance(
+		{
+			plugins: [anonymous()],
+			secondaryStorage: {
+				set(key, value, ttl) {
+					store.set(key, value);
+				},
+				get(key) {
+					return store.get(key) || null;
+				},
+				delete(key) {
+					store.delete(key);
+				},
+			},
+			rateLimit: {
+				enabled: false,
+			},
+		},
+		{
+			clientOptions: {
+				plugins: [anonymousClient()],
+			},
+		},
+	);
+
+	it("should clear secondary storage sessions when an anonymous user calls /delete-anonymous-user", async () => {
+		const headers = new Headers();
+		await client.signIn.anonymous({
+			fetchOptions: { onSuccess: sessionSetter(headers) },
+		});
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		expect(session.data).not.toBeNull();
+
+		const sessionToken = session.data!.session.token;
+		expect(store.has(sessionToken)).toBe(true);
+
+		await auth.api.deleteAnonymousUser({ headers });
+
+		expect(store.has(sessionToken)).toBe(false);
+
+		const after = await client.getSession({ fetchOptions: { headers } });
 		expect(after.data).toBeNull();
 	});
 });

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -233,8 +233,15 @@ describe("secondary storage - storeSessionInDatabase", () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-2vg6-77g8-24mp
+ */
 describe("secondary storage - admin removeUser cleans up sessions", async () => {
 	const store = new Map<string, string>();
+
+	beforeEach(() => {
+		store.clear();
+	});
 
 	const { client, signInWithUser, customFetchImpl } = await getTestInstance({
 		plugins: [admin()],
@@ -316,8 +323,15 @@ describe("secondary storage - admin removeUser cleans up sessions", async () => 
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-2vg6-77g8-24mp
+ */
 describe("secondary storage - /delete-anonymous-user cleans up sessions", async () => {
 	const store = new Map<string, string>();
+
+	beforeEach(() => {
+		store.clear();
+	});
 
 	const { client, auth, sessionSetter } = await getTestInstance(
 		{

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1460,6 +1460,7 @@ export const removeUser = (opts: AdminOptions) =>
 				throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
 			}
 
+			await ctx.context.internalAdapter.deleteSessions(ctx.body.userId);
 			await ctx.context.internalAdapter.deleteUser(ctx.body.userId);
 			return ctx.json({
 				success: true,

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1460,7 +1460,9 @@ export const removeUser = (opts: AdminOptions) =>
 				throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
 			}
 
-			await ctx.context.internalAdapter.deleteSessions(ctx.body.userId);
+			if (ctx.context.options.secondaryStorage) {
+				await ctx.context.internalAdapter.deleteSessions(ctx.body.userId);
+			}
 			await ctx.context.internalAdapter.deleteUser(ctx.body.userId);
 			return ctx.json({
 				success: true,

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1460,9 +1460,7 @@ export const removeUser = (opts: AdminOptions) =>
 				throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
 			}
 
-			if (ctx.context.options.secondaryStorage) {
-				await ctx.context.internalAdapter.deleteSessions(ctx.body.userId);
-			}
+			await ctx.context.internalAdapter.deleteSessions(ctx.body.userId);
 			await ctx.context.internalAdapter.deleteUser(ctx.body.userId);
 			return ctx.json({
 				success: true,

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -378,9 +378,11 @@ describe("anonymous", async () => {
 		function createMiddlewareContext({
 			newSessionUser,
 			deleteUser,
+			deleteSessions,
 		}: {
 			newSessionUser: Record<string, any>;
 			deleteUser: ReturnType<typeof vi.fn>;
+			deleteSessions?: ReturnType<typeof vi.fn>;
 		}) {
 			return {
 				path: "/sign-in/anonymous",
@@ -411,6 +413,7 @@ describe("anonymous", async () => {
 					},
 					internalAdapter: {
 						deleteUser,
+						deleteSessions: deleteSessions ?? vi.fn(),
 					},
 					options: {},
 					secret: "secret",
@@ -457,12 +460,14 @@ describe("anonymous", async () => {
 			const plugin = anonymous();
 			const handler = plugin.hooks?.after?.[0]?.handler;
 			const deleteUser = vi.fn();
+			const deleteSessions = vi.fn();
 			const ctx = createMiddlewareContext({
 				newSessionUser: {
 					id: "linked-user",
 					isAnonymous: false,
 				},
 				deleteUser,
+				deleteSessions,
 			});
 
 			vi.spyOn(apiModule, "getSessionFromCtx").mockResolvedValue({
@@ -477,6 +482,7 @@ describe("anonymous", async () => {
 
 			await handler?.(ctx);
 
+			expect(deleteSessions).toHaveBeenCalledWith("anon-user");
 			expect(deleteUser).toHaveBeenCalledWith("anon-user");
 		});
 	});

--- a/packages/better-auth/src/plugins/anonymous/error-codes.ts
+++ b/packages/better-auth/src/plugins/anonymous/error-codes.ts
@@ -7,6 +7,8 @@ export const ANONYMOUS_ERROR_CODES = defineErrorCodes({
 	ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY:
 		"Anonymous users cannot sign in again anonymously",
 	FAILED_TO_DELETE_ANONYMOUS_USER: "Failed to delete anonymous user",
+	FAILED_TO_DELETE_ANONYMOUS_USER_SESSIONS:
+		"Failed to delete anonymous user sessions",
 	USER_IS_NOT_ANONYMOUS: "User is not anonymous",
 	DELETE_ANONYMOUS_USER_DISABLED: "Deleting anonymous users is disabled",
 });

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -219,6 +219,19 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 					}
 
 					try {
+						await ctx.context.internalAdapter.deleteSessions(session.user.id);
+					} catch (error) {
+						ctx.context.logger.error(
+							"Failed to delete anonymous user sessions",
+							error,
+						);
+						throw APIError.from(
+							"INTERNAL_SERVER_ERROR",
+							ANONYMOUS_ERROR_CODES.FAILED_TO_DELETE_ANONYMOUS_USER_SESSIONS,
+						);
+					}
+
+					try {
 						await ctx.context.internalAdapter.deleteUser(session.user.id);
 					} catch (error) {
 						ctx.context.logger.error("Failed to delete anonymous user", error);
@@ -322,6 +335,7 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 						) {
 							return;
 						}
+						await ctx.context.internalAdapter.deleteSessions(session.user.id);
 						await ctx.context.internalAdapter.deleteUser(session.user.id);
 					}),
 				},

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -339,9 +339,12 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 							await ctx.context.internalAdapter.deleteSessions(session.user.id);
 							await ctx.context.internalAdapter.deleteUser(session.user.id);
 						} catch (error) {
+							// TODO: collapse session+user cleanup into `internalAdapter.deleteUser`
+							// to remove the partial-state window where sessions are deleted but
+							// the user row remains.
 							ctx.context.logger.error(
 								"Failed to clean up anonymous user during post-link cleanup",
-								error,
+								{ anonymousUserId: session.user.id, error },
 							);
 						}
 					}),

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -335,8 +335,15 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 						) {
 							return;
 						}
-						await ctx.context.internalAdapter.deleteSessions(session.user.id);
-						await ctx.context.internalAdapter.deleteUser(session.user.id);
+						try {
+							await ctx.context.internalAdapter.deleteSessions(session.user.id);
+							await ctx.context.internalAdapter.deleteUser(session.user.id);
+						} catch (error) {
+							ctx.context.logger.error(
+								"Failed to clean up anonymous user during post-link cleanup",
+								error,
+							);
+						}
 					}),
 				},
 			],

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -1016,6 +1016,7 @@ export const deleteSCIMUser = (authMiddleware: AuthMiddleware) =>
 				});
 			}
 
+			await ctx.context.internalAdapter.deleteSessions(userId);
 			await ctx.context.internalAdapter.deleteUser(userId);
 
 			ctx.setStatus(204);

--- a/packages/scim/src/scim-users.test.ts
+++ b/packages/scim/src/scim-users.test.ts
@@ -655,6 +655,98 @@ describe("SCIM", () => {
 				}),
 			);
 		});
+
+		it("should clear secondary storage sessions when deleting a user via SCIM", async () => {
+			const store = new Map<string, string>();
+			const adminUser = {
+				email: "scim-admin@test.com",
+				password: "password",
+				name: "SCIM Admin",
+			};
+			const victimUser = {
+				email: "scim-victim@test.com",
+				password: "password",
+				name: "SCIM Victim",
+			};
+
+			const data = {
+				user: [],
+				session: [],
+				verification: [],
+				account: [],
+				ssoProvider: [],
+				scimProvider: [],
+				organization: [],
+				member: [],
+			};
+			const memory = memoryAdapter(data);
+
+			const auth = betterAuth({
+				database: memory,
+				baseURL: "http://localhost:3000",
+				emailAndPassword: { enabled: true },
+				plugins: [scim(), organization()],
+				secondaryStorage: {
+					set(key, value) {
+						store.set(key, value);
+					},
+					get(key) {
+						return store.get(key) || null;
+					},
+					delete(key) {
+						store.delete(key);
+					},
+				},
+			});
+
+			const authClient = createAuthClient({
+				baseURL: "http://localhost:3000",
+				plugins: [bearer(), scimClient()],
+				fetchOptions: {
+					customFetchImpl: async (url, init) =>
+						auth.handler(new Request(url, init)),
+				},
+			});
+
+			await authClient.signUp.email(adminUser);
+			const adminHeaders = new Headers();
+			await authClient.signIn.email(adminUser, {
+				throw: true,
+				onSuccess: setCookieToHeader(adminHeaders),
+			});
+
+			const { scimToken } = await auth.api.generateSCIMToken({
+				body: { providerId: "the-saml-provider-1" },
+				headers: adminHeaders,
+			});
+
+			await authClient.signUp.email(victimUser);
+			await auth.api.createSCIMUser({
+				body: { userName: victimUser.email },
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			const victimHeaders = new Headers();
+			await authClient.signIn.email(victimUser, {
+				throw: true,
+				onSuccess: setCookieToHeader(victimHeaders),
+			});
+
+			const { data: victimSession } = await authClient.getSession({
+				fetchOptions: { headers: victimHeaders },
+			});
+			expect(victimSession).not.toBeNull();
+			const victimToken = victimSession!.session.token;
+			const victimId = victimSession!.user.id;
+			expect(store.has(victimToken)).toBe(true);
+
+			await auth.api.deleteSCIMUser({
+				params: { userId: victimId },
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			expect(store.has(victimToken)).toBe(false);
+		});
 	});
 
 	describe("Default SCIM provider", () => {

--- a/packages/scim/src/scim-users.test.ts
+++ b/packages/scim/src/scim-users.test.ts
@@ -656,6 +656,9 @@ describe("SCIM", () => {
 			);
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-2vg6-77g8-24mp
+		 */
 		it("should clear secondary storage sessions when deleting a user via SCIM", async () => {
 			const store = new Map<string, string>();
 			const adminUser = {


### PR DESCRIPTION
the `admin` & `anonymous` plugins have routes which will delete users, but the internal adapter doesn't delete the sessions along with the user like it used to due to a previous fix.
This PR manually calls the internalAdapter to clean the session before deleting the user in each of those missing endpoints.

- [x] regression unit test