### PR TITLE
chore: minor review followups on recent main commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,8 +177,10 @@ jobs:
           fi
 
           # Count PR links in both files
-          RAW_COUNT=$(grep -coP '\[#\d+\]' "$RAW_PATH" || true)
-          FINAL_COUNT=$(grep -coP '\[#\d+\]' "$FINAL" || true)
+          RAW_COUNT=$(grep -coP '\[#\d+\]' "$RAW_PATH" 2>/dev/null || true)
+          RAW_COUNT=${RAW_COUNT:-0}
+          FINAL_COUNT=$(grep -coP '\[#\d+\]' "$FINAL" 2>/dev/null || true)
+          FINAL_COUNT=${FINAL_COUNT:-0}
 
           if [ "$FINAL_COUNT" -lt "$RAW_COUNT" ]; then
             echo "::warning::AI output has fewer PR links ($FINAL_COUNT) than raw ($RAW_COUNT). Falling back to raw notes."

--- a/docs/app/api/enterprise/contact/route.ts
+++ b/docs/app/api/enterprise/contact/route.ts
@@ -23,7 +23,10 @@ export async function POST(request: Request) {
 
 	try {
 		// honeypot - bots fill hidden fields
-		const raw = body as Record<string, unknown>;
+		const raw =
+			typeof body === "object" && body !== null
+				? (body as Record<string, unknown>)
+				: {};
 		if (typeof raw._hp === "string" && raw._hp) {
 			return NextResponse.json({});
 		}

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -2385,10 +2385,9 @@ describe("2FA enforcement on non-credential sign-in paths", async () => {
 
 		const url = new URL(magicLinkURL);
 		const token = url.searchParams.get("token")!;
-		const callbackURL = url.searchParams.get("callbackURL")!;
 
 		const verifyRes = await auth.api.magicLinkVerify({
-			query: { token, callbackURL },
+			query: { token },
 			headers: new Headers(),
 			asResponse: true,
 		});


### PR DESCRIPTION
Three correctness followups on recent `main` commits:

- `release.yml`: handle all three `grep -c` exit paths (match, no-match, error) with `|| true` + `${VAR:-0}`. Neither `|| echo 0` (produces `0\n0` on the no-match case) nor `|| true` alone (leaves the var empty on the missing-file case) covers every path; the commit message spells out the full reasoning.
- `two-factor.test.ts`: drop `callbackURL` from magic-link verify so the assertion reads the JSON body, not a redirect.
- `contact/route.ts`: guard non-object JSON body before reading `_hp` so a `null` payload doesn't 500.