### PR TITLE
fix(stripe): prevent prototype pollution via user-supplied metadata

### DIFF
--- a/.changeset/fix-stripe-defu-prototype-pollution.md
+++ b/.changeset/fix-stripe-defu-prototype-pollution.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/stripe": patch
+---
+
+fix(stripe): drop unsafe keys when merging user-supplied metadata
+
+The Stripe plugin previously merged `ctx.body.metadata` through `defu`, which was vulnerable to prototype pollution when attacker-controlled `__proto__` keys reached the second argument. Since Stripe metadata is a flat `Record<string, string>`, the deep-merge was never exercised on that path. The merge now ignores `__proto__`, `constructor`, and `prototype`, so the user-controlled surface no longer depends on `defu`. The remaining `defu` call sites (deep-merging developer-supplied `CustomerCreateParams`) also receive the patched range.

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -60,7 +60,7 @@
     }
   },
   "dependencies": {
-    "defu": "^6.1.4",
+    "defu": "^6.1.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/stripe/src/metadata.ts
+++ b/packages/stripe/src/metadata.ts
@@ -1,29 +1,40 @@
-import { defu } from "defu";
 import type Stripe from "stripe";
 
-/**
- * Internal metadata fields for Stripe Customer.
- */
 type CustomerInternalMetadata =
 	| { customerType: "user"; userId: string }
 	| { customerType: "organization"; organizationId: string };
 
-/**
- * Internal metadata fields for Stripe Subscription/Checkout.
- */
 type SubscriptionInternalMetadata = {
 	userId: string;
 	subscriptionId: string;
 	referenceId: string;
 };
 
+const UNSAFE_METADATA_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 /**
- * Customer metadata - set internal fields and extract typed fields.
+ * Merge flat Stripe metadata objects, giving `internalFields` final priority.
+ * Drops reserved keys that could mutate the target's prototype chain.
  */
+function mergeMetadata<Internal extends Record<string, string>>(
+	internalFields: Internal,
+	userMetadata: (Stripe.Emptyable<Stripe.MetadataParam> | undefined)[],
+): Stripe.MetadataParam {
+	const merged: Stripe.MetadataParam = {};
+	for (const source of userMetadata) {
+		if (!source) continue;
+		for (const [key, value] of Object.entries(source)) {
+			if (UNSAFE_METADATA_KEYS.has(key)) continue;
+			merged[key] = value;
+		}
+	}
+	for (const [key, value] of Object.entries(internalFields)) {
+		merged[key] = value;
+	}
+	return merged;
+}
+
 export const customerMetadata = {
-	/**
-	 * Internal metadata keys for type-safe access.
-	 */
 	keys: {
 		userId: "userId",
 		organizationId: "organizationId",
@@ -32,18 +43,16 @@ export const customerMetadata = {
 
 	/**
 	 * Create metadata with internal fields that cannot be overridden by user metadata.
-	 * Uses `defu` which prioritizes the first argument.
 	 */
 	set(
 		internalFields: CustomerInternalMetadata,
 		...userMetadata: (Stripe.Emptyable<Stripe.MetadataParam> | undefined)[]
 	): Stripe.MetadataParam {
-		return defu(internalFields, ...userMetadata.filter(Boolean));
+		return mergeMetadata(internalFields, userMetadata);
 	},
 
 	/**
 	 * Extract internal fields from Stripe metadata.
-	 * Provides type-safe access to internal metadata keys.
 	 */
 	get(metadata: Stripe.Metadata | null | undefined) {
 		return {
@@ -56,13 +65,7 @@ export const customerMetadata = {
 	},
 };
 
-/**
- * Subscription/Checkout metadata - set internal fields and extract typed fields.
- */
 export const subscriptionMetadata = {
-	/**
-	 * Internal metadata keys for type-safe access.
-	 */
 	keys: {
 		userId: "userId",
 		subscriptionId: "subscriptionId",
@@ -71,18 +74,16 @@ export const subscriptionMetadata = {
 
 	/**
 	 * Create metadata with internal fields that cannot be overridden by user metadata.
-	 * Uses `defu` which prioritizes the first argument.
 	 */
 	set(
 		internalFields: SubscriptionInternalMetadata,
 		...userMetadata: (Stripe.Emptyable<Stripe.MetadataParam> | undefined)[]
 	): Stripe.MetadataParam {
-		return defu(internalFields, ...userMetadata.filter(Boolean));
+		return mergeMetadata(internalFields, userMetadata);
 	},
 
 	/**
 	 * Extract internal fields from Stripe metadata.
-	 * Provides type-safe access to internal metadata keys.
 	 */
 	get(metadata: Stripe.Metadata | null | undefined) {
 		return {

--- a/packages/stripe/test/metadata.test.ts
+++ b/packages/stripe/test/metadata.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { customerMetadata, subscriptionMetadata } from "../src/metadata";
+
+const ROOT_PROBE_KEY = "polluted";
+
+/**
+ * @see https://github.com/advisories/GHSA-737v-mqg7-c878
+ */
+describe("stripe metadata prototype pollution guard", () => {
+	afterEach(() => {
+		Reflect.deleteProperty(Object.prototype, ROOT_PROBE_KEY);
+	});
+
+	it("drops __proto__ from user metadata on customerMetadata.set", () => {
+		const malicious = JSON.parse(
+			`{"__proto__":{"${ROOT_PROBE_KEY}":"yes"},"plan":"pro"}`,
+		);
+		const result = customerMetadata.set(
+			{ customerType: "user", userId: "u1" },
+			malicious,
+		);
+		expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+		expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+		expect(result.plan).toBe("pro");
+		expect(result.userId).toBe("u1");
+	});
+
+	it("drops constructor and prototype from user metadata on customerMetadata.set", () => {
+		const malicious = JSON.parse(
+			`{"constructor":{"prototype":{"${ROOT_PROBE_KEY}":"yes"}},"plan":"pro"}`,
+		);
+		const result = customerMetadata.set(
+			{ customerType: "user", userId: "u1" },
+			malicious,
+		);
+		expect(result.constructor).toBe(Object);
+		expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+		expect(result.plan).toBe("pro");
+	});
+
+	it("drops __proto__ from user metadata on subscriptionMetadata.set", () => {
+		const malicious = JSON.parse(
+			`{"__proto__":{"${ROOT_PROBE_KEY}":"yes"},"planName":"pro"}`,
+		);
+		const result = subscriptionMetadata.set(
+			{ userId: "u1", subscriptionId: "s1", referenceId: "ref1" },
+			malicious,
+		);
+		expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+		expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+		expect(result.planName).toBe("pro");
+		expect(result.subscriptionId).toBe("s1");
+	});
+
+	it("internal fields always take precedence over user metadata", () => {
+		const result = customerMetadata.set(
+			{ customerType: "user", userId: "real" },
+			{ userId: "spoofed", customerType: "organization" },
+		);
+		expect(result.userId).toBe("real");
+		expect(result.customerType).toBe("user");
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,8 +1449,8 @@ importers:
   packages/stripe:
     dependencies:
       defu:
-        specifier: ^6.1.4
-        version: 6.1.4
+        specifier: ^6.1.5
+        version: 6.1.7
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -8880,6 +8880,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
@@ -21850,7 +21853,7 @@ snapshots:
       citty: 0.1.6
       clipboardy: 4.0.0
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       get-port-please: 3.2.0
       h3: 1.15.10
       http-shutdown: 1.2.2
@@ -22723,7 +22726,7 @@ snapshots:
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.4
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       exsolve: 1.0.8
       giget: 2.0.0
@@ -22740,7 +22743,7 @@ snapshots:
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.4
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       exsolve: 1.0.8
       giget: 2.0.0
@@ -23668,6 +23671,8 @@ snapshots:
     optional: true
 
   defu@6.1.4: {}
+
+  defu@6.1.7: {}
 
   delaunator@5.0.1:
     dependencies:
@@ -24974,7 +24979,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.6.5
       pathe: 2.0.3
@@ -25092,7 +25097,7 @@ snapshots:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.5
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
       iron-webcrypto: 1.2.1
       node-mock-http: 1.0.4
@@ -27746,7 +27751,7 @@ snapshots:
       croner: 9.1.0
       crossws: 0.3.5
       db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(better-sqlite3@12.6.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260226.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@prisma/client@7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@upstash/redis@1.36.4)(better-sqlite3@12.6.2)(bun-types@1.3.9)(gel@2.2.0)(kysely@0.28.14)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(mysql2@3.18.2(@types/node@25.6.0))
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.1.0
       esbuild: 0.27.7
@@ -28727,7 +28732,7 @@ snapshots:
 
   rc9@2.1.2:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
 
   rc@1.2.8:
@@ -29813,7 +29818,7 @@ snapshots:
 
   serve-placeholder@2.0.2:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.7
 
   serve-static@1.16.3:
     dependencies:
@@ -30725,7 +30730,7 @@ snapshots:
   unenv@1.10.0:
     dependencies:
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       mime: 3.0.0
       node-fetch-native: 1.6.7
       pathe: 1.1.2
@@ -30932,7 +30937,7 @@ snapshots:
   untyped@2.0.0:
     dependencies:
       citty: 0.1.6
-      defu: 6.1.4
+      defu: 6.1.7
       jiti: 2.6.1
       knitwork: 1.3.0
       scule: 1.3.0


### PR DESCRIPTION
The Stripe plugin previously merged `ctx.body.metadata` through `defu`, which is vulnerable to prototype pollution when attacker-controlled `__proto__` keys reach the second argument (GHSA-737v-mqg7-c878).

Stripe metadata is a flat `Record<string, string>`, so `defu`'s deep-merge semantics were never exercised on that path. Replacing it with an inline merge that drops `__proto__`, `constructor`, and `prototype` keys eliminates the attack surface rather than tracking upstream patches, and also drops the need for `defu` on the user-input side.

The two remaining `defu` call sites in `index.ts` and `routes.ts` deep-merge developer-supplied `CustomerCreateParams` where inputs are trusted; they continue to use `defu` and receive the patched range via the bumped dependency.

The regression test covers three payload shapes (`__proto__`, `constructor.prototype`, and flat values) across both `customerMetadata.set` and `subscriptionMetadata.set`, asserts on the returned object's prototype chain (not just `Object.prototype`), and includes a precedence test to keep the internal-fields-win invariant under guard.