### PR TITLE
docs(cimd): recommend removal of `allowUnauthenticatedClientRegistration` for client deduplication

### DIFF
--- a/.changeset/cimd-plugin.md
+++ b/.changeset/cimd-plugin.md
@@ -57,4 +57,4 @@ The `checkOAuthClient` and `oauthToSchema` helpers are now exported for plugins 
 
 `jwks_uri` validation now accepts a same-origin URL when the `client_id` itself is an HTTPS URL, since URL-based discovery flows verify the origin through the `client_id` itself.
 
-Docs recommendation to remove the oauth-provider configuration `allowUnauthenticatedClientRegistration` while using CIMD.
+Documentation now recommends removing the oauth-provider configuration `allowUnauthenticatedClientRegistration` when using CIMD.

--- a/.changeset/cimd-plugin.md
+++ b/.changeset/cimd-plugin.md
@@ -56,3 +56,5 @@ Plugins like `@better-auth/cimd` append an entry here at init time, so multiple 
 The `checkOAuthClient` and `oauthToSchema` helpers are now exported for plugins that create client records directly.
 
 `jwks_uri` validation now accepts a same-origin URL when the `client_id` itself is an HTTPS URL, since URL-based discovery flows verify the origin through the `client_id` itself.
+
+Docs recommendation to remove the oauth-provider configuration `allowUnauthenticatedClientRegistration` while using CIMD.

--- a/docs/content/docs/plugins/cimd.mdx
+++ b/docs/content/docs/plugins/cimd.mdx
@@ -87,7 +87,7 @@ cimd({
 ```
 
 <Callout type="info">
-  In most cases, it is recommended to remove the oauth-provider configuration `allowUnauthenticatedClientRegistration` when using the CIMD plugin. CIMD provides additional identity behavior and deduplication of client ids for the same URL (eg. client).
+  In most cases, it is recommended to remove the oauth-provider configuration `allowUnauthenticatedClientRegistration` when using the CIMD plugin. CIMD provides additional identity behavior and deduplicates multiple registrations for the same `client_id` URL.
 </Callout>
 
 ### Options

--- a/docs/content/docs/plugins/cimd.mdx
+++ b/docs/content/docs/plugins/cimd.mdx
@@ -87,7 +87,7 @@ cimd({
 ```
 
 <Callout type="info">
-  In most cases, it is recommended to remove the oauth-provider configuration `allowUnauthenticatedClientRegistration` when using the CIMD plugin. CIMD provides additional identity behavior and deduplicates multiple registrations for the same `client_id` URL.
+  For [MCP auth](https://modelcontextprotocol.io/specification/draft/basic/authorization#client-registration-approaches) only deployments, we recommend disabling the `allowUnauthenticatedClientRegistration` option in `oauth-provider`. CIMD handles client identity and prevents duplicate registrations for the same `client_id` URL. Keep `allowUnauthenticatedClientRegistration` only if you need registration fallback — be aware this can create duplicate client records.
 </Callout>
 
 ### Options

--- a/docs/content/docs/plugins/cimd.mdx
+++ b/docs/content/docs/plugins/cimd.mdx
@@ -86,40 +86,44 @@ cimd({
 });
 ```
 
+<Callout type="info">
+  In most cases, it is recommended to remove the oauth-provider configuration `allowUnauthenticatedClientRegistration` when using the CIMD plugin. CIMD provides additional identity behavior and deduplication of client ids for the same URL (eg. client).
+</Callout>
+
 ### Options
 
-<TypeTable
-  type={{
-refreshRate: {
-  type: "number | string",
-  default: '"60m"',
-  description:
-    "How frequently to re-fetch a client's metadata document. Number values are seconds; strings are duration expressions (e.g. `\"60m\"`, `\"1d\"`). A value of `0` makes every request stale (useful for tests).",
-},
-originBoundFields: {
-  type: "string[]",
-  default: '["redirect_uris", "post_logout_redirect_uris", "client_uri"]',
-  description:
-    "Metadata fields whose URL values must share the same origin as the `client_id` URL. Localhost is accepted for redirect URI fields (for native and desktop flows) but never for `client_uri` or custom fields. Pass an empty array to disable origin binding.",
-},
-allowFetch: {
-  type: "(url, ctx) => boolean | Promise<boolean>",
-  default: "always allow",
-  description:
-    "Pre-fetch gate: return `false` to reject a `client_id` URL before the metadata document is requested. Use this for origin allowlists, per-host rate limiting, or DNS-level defenses beyond the built-in IP-literal SSRF check.",
-},
-onClientCreated: {
-  type: "(data: { client, metadata, ctx }) => void | Promise<void>",
-  description:
-    "Called once, after a new client has been persisted. The `metadata` argument is the raw JSON body of the metadata document.",
-},
-onClientRefreshed: {
-  type: "(data: { client, metadata, ctx }) => void | Promise<void>",
-  description:
-    "Called each time an existing client record is re-fetched and updated. Admin-controlled fields (`disabled`, `skipConsent`, `enableEndSession`) are preserved across refreshes; use this hook to detect document changes or sync derived data.",
-},
-}}
-/>
+export const cimdOptionsType = {
+	refreshRate: {
+		type: "number | string",
+		default: '"60m"',
+		description:
+			"How frequently to re-fetch a client's metadata document. Number values are seconds; strings are duration expressions (e.g. `\"60m\"`, `\"1d\"`). A value of `0` makes every request stale (useful for tests).",
+	},
+	originBoundFields: {
+		type: "string[]",
+		default: '["redirect_uris", "post_logout_redirect_uris", "client_uri"]',
+		description:
+			"Metadata fields whose URL values must share the same origin as the `client_id` URL. Localhost is accepted for redirect URI fields (for native and desktop flows) but never for `client_uri` or custom fields. Pass an empty array to disable origin binding.",
+	},
+	allowFetch: {
+		type: "(url, ctx) => boolean | Promise<boolean>",
+		default: "always allow",
+		description:
+			"Pre-fetch gate: return `false` to reject a `client_id` URL before the metadata document is requested. Use this for origin allowlists, per-host rate limiting, or DNS-level defenses beyond the built-in IP-literal SSRF check.",
+	},
+	onClientCreated: {
+		type: "(data: { client, metadata, ctx }) => void | Promise<void>",
+		description:
+			"Called once, after a new client has been persisted. The `metadata` argument is the raw JSON body of the metadata document.",
+	},
+	onClientRefreshed: {
+		type: "(data: { client, metadata, ctx }) => void | Promise<void>",
+		description:
+			"Called each time an existing client record is re-fetched and updated. Admin-controlled fields (`disabled`, `skipConsent`, `enableEndSession`) are preserved across refreshes; use this hook to detect document changes or sync derived data.",
+	},
+};
+
+<TypeTable type={cimdOptionsType} />
 
 ## Metadata document requirements
 

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1146,7 +1146,7 @@ oauthProvider({
 })
 ```
 
-Unauthenticated client registration additionally allows for public clients (never confidential) to register without an authorization header (i.e. without a session). This is especially useful for an MCP to dynamically register themselves as a public client without an active session. For MCP support, the recommended approach is via the [CIMD plugin](/docs/plugins/cimd) which maintains the identity of the public client.
+Unauthenticated client registration additionally allows for public clients (never confidential) to register without an authorization header. This is especially useful for an MCP to dynamically register themselves as a public client without an active session. For MCP auth support, the recommended approach is via the [CIMD plugin](/docs/plugins/cimd) which maintains the identity of the public client.
 
 ```ts title="auth.ts"
 oauthProvider({

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -421,7 +421,7 @@ oauthProvider({
 To enable unauthenticated client registration which allows for dynamically registered public clients, additionally set `allowUnauthenticatedClientRegistration: true` in your auth config.
 
 <Callout type="info">
-  For MCP, [Client ID Metadata Documents](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/991) is [available](/docs/plugins/cimd). [`software_statement` and `jwks_uri`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1032) may be added as an alternative for public client identification in the future.
+  For MCP, [Client ID Metadata Documents](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/991) are [available](/docs/plugins/cimd). [`software_statement` and `jwks_uri`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1032) may be added as an alternative for public client identification in the future.
 </Callout>
 
 ```ts title="auth.ts"
@@ -1146,7 +1146,7 @@ oauthProvider({
 })
 ```
 
-Unauthenticated client registration additionally allows for public clients (never confidential) to register without an authorization header (ie without a session). This is especially useful for an MCP to dynamically register themselves as a public client without an active session. For MCP support, the recommended approach is via the [CIMD plugin](/docs/plugins/cimd) which maintains the identity of the public client.
+Unauthenticated client registration additionally allows for public clients (never confidential) to register without an authorization header (i.e. without a session). This is especially useful for an MCP to dynamically register themselves as a public client without an active session. For MCP support, the recommended approach is via the [CIMD plugin](/docs/plugins/cimd) which maintains the identity of the public client.
 
 ```ts title="auth.ts"
 oauthProvider({

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -420,8 +420,8 @@ oauthProvider({
 
 To enable unauthenticated client registration which allows for dynamically registered public clients, additionally set `allowUnauthenticatedClientRegistration: true` in your auth config.
 
-<Callout type="warn">
-  Support for `allowUnauthenticatedClientRegistration` **will be deprecated** when the MCP protocol standardizes unauthenticated dynamic client registration. As of writing, both [Client ID Metadata Documents](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/991) and [`software_statement` and `jwks_uri`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1032) are under debate.
+<Callout type="info">
+  For MCP, [Client ID Metadata Documents](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/991) is [available](/docs/plugins/cimd). [`software_statement` and `jwks_uri`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1032) may be added as an alternative for public client identification in the future.
 </Callout>
 
 ```ts title="auth.ts"
@@ -1146,7 +1146,7 @@ oauthProvider({
 })
 ```
 
-Unauthenticated client registration additionally allows for public clients (never confidential) to register without an authorization header. This is especially useful for an MCP to dynamically register themselves as a public client.
+Unauthenticated client registration additionally allows for public clients (never confidential) to register without an authorization header (ie without a session). This is especially useful for an MCP to dynamically register themselves as a public client without an active session. For MCP support, the recommended approach is via the [CIMD plugin](/docs/plugins/cimd) which maintains the identity of the public client.
 
 ```ts title="auth.ts"
 oauthProvider({
@@ -1155,8 +1155,8 @@ oauthProvider({
 })
 ```
 
-<Callout type="warn">
-  Support for `allowUnauthenticatedClientRegistration` **will be deprecated** when the MCP protocol standardizes unauthenticated dynamic client registration. As of writing, both [Client ID Metadata Documents](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/991) and [`software_statement` and `jwks_uri`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1032) are under debate.
+<Callout type="info">
+  For MCP, [`software_statement` and `jwks_uri`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1032) may be added as an alternative for public client identification in the future.
 </Callout>
 
 #### Dynamic Client Registration Expiration


### PR DESCRIPTION
Add a recommendation to remove `allowUnauthenticatedClientRegistration` in most cases (eg MCP cases) which provides URL identification and deduplication of client ids for the same client.

Format fix for TypeTable to match other mdx files (`lint fix` formats it better this way).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recommend disabling `allowUnauthenticatedClientRegistration` when using `@better-auth/cimd` (especially for MCP-only auth) so clients are identified by the `client_id` URL and duplicate registrations are avoided; keep it only if you need a fallback.

Docs: added a CIMD info callout, clarified that “unauthenticated” means “without an active session,” directed MCP users to CIMD, switched related callouts to info, and standardized the CIMD Options `TypeTable` in MDX.

<sup>Written for commit c3e1ef5e089864c9c921b1db1b58c7bc4197d66e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

