### PR TITLE
fix(cimd): use ipaddr.js to better cover edge cases

### DIFF
--- a/.changeset/cimd-plugin.md
+++ b/.changeset/cimd-plugin.md
@@ -26,7 +26,7 @@ betterAuth({
 
 Ships with §3/§4.1 validation, SSRF protection for private/reserved IPs and cloud metadata endpoints, a 5-second fetch timeout, a 5 KB response size limit (UTF-8 byte-counted), origin binding for redirect URIs, and lifecycle hooks (`onClientCreated`, `onClientRefreshed`). Advertises `client_id_metadata_document_supported` in OAuth/OIDC discovery metadata.
 
-The `allowFetch` pre-fetch gate lets operators add origin allowlists, per-host rate limits, or DNS-level defenses beyond the built-in IP-literal check.
+The `allowFetch` pre-fetch gate lets operators add origin allowlists, per-host rate limits, or DNS-level defenses beyond the built-in IP-literal check. Currently, allowed IP-literals are "unicast" ranges as defined by ipaddr.js but can be additionally configured in the plugin's configuration options via `allowedIpRanges`.
 
 Admin-controlled fields (`disabled`, `skipConsent`, `enableEndSession`) are preserved across refreshes so admin decisions survive document updates.
 

--- a/packages/cimd/package.json
+++ b/packages/cimd/package.json
@@ -66,5 +66,8 @@
     "@better-auth/oauth-provider": "workspace:^",
     "better-auth": "workspace:^",
     "better-call": "catalog:"
+  },
+  "dependencies": {
+    "ipaddr.js": "^2.3.0"
   }
 }

--- a/packages/cimd/src/client-store.ts
+++ b/packages/cimd/src/client-store.ts
@@ -272,7 +272,10 @@ async function fetchAndValidateMetadataDocument(
 	cimdOptions: CimdOptions,
 ): Promise<Record<string, unknown>> {
 	// §3: validate the URL structure before fetching
-	const urlError = validateClientIdUrl(clientIdUrl);
+	const urlError = validateClientIdUrl(
+		clientIdUrl,
+		cimdOptions.allowedIpRanges,
+	);
 	if (urlError) {
 		throw new APIError("BAD_REQUEST", {
 			error: "invalid_client",
@@ -361,6 +364,7 @@ async function fetchAndValidateMetadataDocument(
 		clientIdUrl,
 		data,
 		cimdOptions.originBoundFields,
+		cimdOptions.allowedIpRanges,
 	);
 
 	if (!validation.valid) {

--- a/packages/cimd/src/types.ts
+++ b/packages/cimd/src/types.ts
@@ -1,5 +1,6 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import type { SchemaClient, Scope } from "@better-auth/oauth-provider";
+import type ipaddr from "ipaddr.js";
 
 /**
  * Options for the Client ID Metadata Document plugin.
@@ -28,6 +29,24 @@ export interface CimdOptions {
 	 * @default ["redirect_uris", "post_logout_redirect_uris", "client_uri"]
 	 */
 	originBoundFields?: string[];
+	/**
+	 * The set of ipaddr.js range names that are considered publicly routable
+	 * and therefore allowed as `client_id` URL hosts.
+	 *
+	 * Any resolved IP address whose range is **not** in this set is rejected
+	 * as a potential SSRF target. ipaddr.js range names include `"unicast"`,
+	 * `"private"`, `"loopback"`, `"linkLocal"`, `"multicast"`, etc.
+	 *
+	 * Override this only if you operate an internal deployment where
+	 * clients are expected to live on RFC 1918 addresses.
+	 *
+	 * For custom IPs and CIDR ranges, use `allowFetch`.
+	 *
+	 * @default new Set(["unicast"])
+	 */
+	allowedIpRanges?: Set<
+		ReturnType<ipaddr.IPv4["range"]> | ReturnType<ipaddr.IPv6["range"]>
+	>;
 	/**
 	 * Pre-fetch gate called before a metadata document is requested. Return
 	 * `false` to reject the `client_id` URL.

--- a/packages/cimd/src/types.ts
+++ b/packages/cimd/src/types.ts
@@ -33,14 +33,16 @@ export interface CimdOptions {
 	 * The set of ipaddr.js range names that are considered publicly routable
 	 * and therefore allowed as `client_id` URL hosts.
 	 *
-	 * Any resolved IP address whose range is **not** in this set is rejected
-	 * as a potential SSRF target. ipaddr.js range names include `"unicast"`,
-	 * `"private"`, `"loopback"`, `"linkLocal"`, `"multicast"`, etc.
+	 * If the `client_id` URL host is an IP literal, its range must be in this
+	 * set or the URL is rejected as a potential SSRF target. ipaddr.js range
+	 * names include `"unicast"`, `"private"`, `"loopback"`, `"linkLocal"`,
+	 * `"multicast"`, etc.
 	 *
 	 * Override this only if you operate an internal deployment where
 	 * clients are expected to live on RFC 1918 addresses.
 	 *
-	 * For custom IPs and CIDR ranges, use `allowFetch`.
+	 * For custom IPs and CIDR ranges, or for DNS-level hostname checks, use
+	 * `allowFetch`.
 	 *
 	 * @default new Set(["unicast"])
 	 */

--- a/packages/cimd/src/validate-metadata-document.test.ts
+++ b/packages/cimd/src/validate-metadata-document.test.ts
@@ -499,3 +499,90 @@ describe("validateCimdMetadata", () => {
 		expect(result.error).toContain("logo_uri");
 	});
 });
+
+describe("allowedIpRanges override", () => {
+	// validateClientIdUrl
+
+	it("allows https://10.0.0.1/... when 'private' is in allowedIpRanges", () => {
+		const allowed = new Set(["unicast", "private"]);
+		expect(
+			validateClientIdUrl("https://10.0.0.1/client-metadata.json", allowed),
+		).toBeNull();
+	});
+
+	it("allows https://192.168.1.1/... when 'private' is in allowedIpRanges", () => {
+		const allowed = new Set(["unicast", "private"]);
+		expect(
+			validateClientIdUrl("https://192.168.1.1/client-metadata.json", allowed),
+		).toBeNull();
+	});
+
+	it("allows https://172.16.0.1/... when 'private' is in allowedIpRanges", () => {
+		const allowed = new Set(["unicast", "private"]);
+		expect(
+			validateClientIdUrl("https://172.16.0.1/client-metadata.json", allowed),
+		).toBeNull();
+	});
+
+	it("blocks metadata.google.internal even when 'private' is in allowedIpRanges", () => {
+		/**
+		 * Cloud metadata hostnames are blocked at the name level, before any
+		 * IP-range check, so no allowedIpRanges override can unblock them.
+		 */
+		const allowed = new Set(["unicast", "private", "loopback", "linkLocal"]);
+		expect(
+			validateClientIdUrl(
+				"https://metadata.google.internal/computeMetadata/v1/",
+				allowed,
+			),
+		).toContain("private");
+	});
+
+	it("still blocks 169.254.169.254 (link-local) when only 'private' is added", () => {
+		// link-local range is not covered by 'private'; only adding 'linkLocal'
+		// would allow it. Verify the default unicast+private set still rejects it.
+		const allowed = new Set(["unicast", "private"]);
+		expect(
+			validateClientIdUrl("https://169.254.169.254/latest/meta-data/", allowed),
+		).toContain("private");
+	});
+
+	// validateCimdMetadata (4th argument) — controls SSRF checks on embedded
+	// URI fields such as client_uri and logo_uri, not on the fetchUrl itself.
+
+	it("allows client_uri with private IP in validateCimdMetadata when 'private' is in allowedIpRanges", () => {
+		const fetchUrl = "https://example.com/client-metadata.json";
+		const allowed = new Set(["unicast", "private"]);
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				client_uri: "https://10.0.0.1/about",
+			}),
+			// Pass [] so the origin-bound check ignores client_uri; we only
+			// want to exercise the SSRF / allowedIpRanges path.
+			[],
+			allowed,
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	it("blocks metadata.google.internal in client_uri even with broad allowedIpRanges", () => {
+		/**
+		 * The name-level block for cloud metadata hostnames in isPrivateHost()
+		 * fires before any allowedRanges lookup, so no allowedIpRanges
+		 * configuration can unblock metadata.google.internal.
+		 */
+		const fetchUrl = "https://example.com/client-metadata.json";
+		const allowed = new Set(["unicast", "private", "loopback", "linkLocal"]);
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				client_uri: "https://metadata.google.internal/",
+			}),
+			[],
+			allowed,
+		);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("private");
+	});
+});

--- a/packages/cimd/src/validate-metadata-document.ts
+++ b/packages/cimd/src/validate-metadata-document.ts
@@ -2,8 +2,7 @@
 // Implements draft-ietf-oauth-client-id-metadata-document §3 and §4.1.
 import ipaddr from "ipaddr.js";
 
-const DOT_SEGMENT_RE =
-	/\/\.\.?(?:\/|$|#|\?)/; /** IP ranges considered publicly routable by default. */
+const DOT_SEGMENT_RE = /\/\.\.?(?:\/|$|#|\?)/;
 export const DEFAULT_ALLOWED_IP_RANGES: ReadonlySet<string> = new Set([
 	"unicast",
 ]);
@@ -54,12 +53,26 @@ function isPrivateHost(
 	if (lower === "metadata.google.internal") {
 		return true;
 	}
-	const host =
-		lower.startsWith("[") && lower.endsWith("]") ? lower.slice(1, -1) : lower;
+	const wasBracketed = lower.startsWith("[") && lower.endsWith("]");
+	// Strip brackets from IPv6 literals (e.g. "[::1]" → "::1").
+	let host = wasBracketed ? lower.slice(1, -1) : lower;
+	// Strip IPv6 zone identifiers before range-checking. Zone IDs appear as
+	// "%" or "%25" (percent-encoded) in URL hostnames, e.g. "fe80::1%25eth0".
+	// ipaddr.js cannot parse them, so we strip the suffix first.
+	const zoneIdx = host.indexOf("%");
+	if (zoneIdx !== -1) {
+		host = host.slice(0, zoneIdx);
+	}
 	try {
 		// process() converts IPv4-mapped IPv6 → IPv4 before range-checking.
 		return !allowedRanges.has(ipaddr.process(host).range());
 	} catch {
+		// If the hostname looked like an IP literal (was bracket-enclosed or
+		// contains a colon), reject it rather than letting a malformed address
+		// slip through as a "domain name".
+		if (wasBracketed || host.includes(":")) {
+			return true;
+		}
 		// Not a parseable IP address (e.g. a regular domain name). Domain
 		// names are not blocked here; use `allowFetch` for DNS-level checks.
 		return false;

--- a/packages/cimd/src/validate-metadata-document.ts
+++ b/packages/cimd/src/validate-metadata-document.ts
@@ -2,8 +2,11 @@
 // Implements draft-ietf-oauth-client-id-metadata-document §3 and §4.1.
 import ipaddr from "ipaddr.js";
 
-const DOT_SEGMENT_RE = /\/\.\.?(?:\/|$|#|\?)/;
-
+const DOT_SEGMENT_RE =
+	/\/\.\.?(?:\/|$|#|\?)/; /** IP ranges considered publicly routable by default. */
+export const DEFAULT_ALLOWED_IP_RANGES: ReadonlySet<string> = new Set([
+	"unicast",
+]);
 const PROHIBITED_FIELDS = new Set([
 	"client_secret",
 	"client_secret_expires_at",
@@ -37,14 +40,16 @@ export function isLocalhost(hostname: string): boolean {
 }
 
 /**
- * Check whether a hostname is private/reserved per RFC 6890.
+ * Check whether a hostname falls outside the allowed IP ranges.
  *
- * Uses ipaddr.js to parse IP addresses and check their range.
- * `ipaddr.process()` automatically converts IPv4-mapped IPv6 addresses
- * to IPv4. Any range other than `'unicast'` is considered non-public.
- * Cloud metadata hostnames are also blocked by name.
+ * Uses ipaddr.js to parse IP literals; `process()` converts IPv4-mapped
+ * IPv6 addresses to IPv4 before range-checking. Cloud metadata hostnames
+ * are blocked by name regardless of `allowedRanges`.
  */
-function isPrivateHost(hostname: string): boolean {
+function isPrivateHost(
+	hostname: string,
+	allowedRanges: ReadonlySet<string>,
+): boolean {
 	const lower = hostname.toLowerCase();
 	if (lower === "metadata.google.internal") {
 		return true;
@@ -53,9 +58,10 @@ function isPrivateHost(hostname: string): boolean {
 		lower.startsWith("[") && lower.endsWith("]") ? lower.slice(1, -1) : lower;
 	try {
 		// process() converts IPv4-mapped IPv6 → IPv4 before range-checking.
-		return ipaddr.process(host).range() !== "unicast";
+		return !allowedRanges.has(ipaddr.process(host).range());
 	} catch {
-		// Not a parseable IP address (e.g. a regular domain name).
+		// Not a parseable IP address (e.g. a regular domain name). Domain
+		// names are not blocked here; use `allowFetch` for DNS-level checks.
 		return false;
 	}
 }
@@ -82,8 +88,14 @@ export function isUrlClientId(clientId: string): boolean {
 /**
  * Validate a client_id URL per IETF draft §3.
  * Returns null on success, error string on failure.
+ *
+ * @param allowedIpRanges - ipaddr.js range names that are considered
+ *   publicly routable. Defaults to `DEFAULT_ALLOWED_IP_RANGES`.
  */
-export function validateClientIdUrl(url: string): string | null {
+export function validateClientIdUrl(
+	url: string,
+	allowedIpRanges: ReadonlySet<string> = DEFAULT_ALLOWED_IP_RANGES,
+): string | null {
 	// §3: check the raw URL for dot segments before the URL class normalizes them
 	if (DOT_SEGMENT_RE.test(url)) {
 		return "client_id URL MUST NOT contain dot segments";
@@ -120,7 +132,10 @@ export function validateClientIdUrl(url: string): string | null {
 	}
 
 	// SSRF: block private/reserved hosts
-	if (!isLocalhost(parsed.hostname) && isPrivateHost(parsed.hostname)) {
+	if (
+		!isLocalhost(parsed.hostname) &&
+		isPrivateHost(parsed.hostname, allowedIpRanges)
+	) {
 		return "client_id URL must not resolve to a private or reserved address";
 	}
 
@@ -160,6 +175,7 @@ export function validateCimdMetadata(
 	fetchUrl: string,
 	raw: unknown,
 	originBoundFields?: string[],
+	allowedIpRanges: ReadonlySet<string> = DEFAULT_ALLOWED_IP_RANGES,
 ): ClientIdMetadataDocumentResult {
 	if (!raw || typeof raw !== "object") {
 		return { valid: false, error: "metadata document is not a JSON object" };
@@ -281,7 +297,10 @@ export function validateCimdMetadata(
 				if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
 					return { valid: false, error: `${field} must use HTTP(S)` };
 				}
-				if (!isLocalhost(parsed.hostname) && isPrivateHost(parsed.hostname)) {
+				if (
+					!isLocalhost(parsed.hostname) &&
+					isPrivateHost(parsed.hostname, allowedIpRanges)
+				) {
 					return {
 						valid: false,
 						error: `${field} must not point to a private or reserved address`,

--- a/packages/cimd/src/validate-metadata-document.ts
+++ b/packages/cimd/src/validate-metadata-document.ts
@@ -1,6 +1,6 @@
 // Pure validation for Client ID Metadata Documents.
 // Implements draft-ietf-oauth-client-id-metadata-document §3 and §4.1.
-// Zero side-effect imports: testable without building the monorepo.
+import ipaddr from "ipaddr.js";
 
 const DOT_SEGMENT_RE = /\/\.\.?(?:\/|$|#|\?)/;
 
@@ -37,108 +37,27 @@ export function isLocalhost(hostname: string): boolean {
 }
 
 /**
- * Check whether a dotted-decimal IPv4 address is private, reserved, or
- * otherwise non-routable for a public SSRF target. Covers the subset of
- * RFC 6890 special-purpose ranges that an adversarial `client_id` URL
- * could point at to reach internal infrastructure or disrupt fetches.
- */
-function isPrivateIpv4(host: string): boolean {
-	const parts = host.split(".");
-	if (parts.length !== 4 || parts.some((p) => !/^\d{1,3}$/.test(p))) {
-		return false;
-	}
-	const a = Number(parts[0]);
-	const b = Number(parts[1]);
-	const c = Number(parts[2]);
-	return (
-		// Loopback (127.0.0.0/8), private (RFC 1918), "this network"
-		// (0.0.0.0/8), link-local (169.254.0.0/16), shared address space
-		// (100.64.0.0/10).
-		a === 127 ||
-		a === 10 ||
-		a === 0 ||
-		(a === 172 && b >= 16 && b <= 31) ||
-		(a === 192 && b === 168) ||
-		(a === 169 && b === 254) ||
-		(a === 100 && b >= 64 && b <= 127) ||
-		// Benchmarking (RFC 2544): 198.18.0.0/15.
-		(a === 198 && (b === 18 || b === 19)) ||
-		// Documentation (RFC 5737).
-		(a === 192 && b === 0 && c === 2) ||
-		(a === 198 && b === 51 && c === 100) ||
-		(a === 203 && b === 0 && c === 113) ||
-		// 6to4 anycast relay (RFC 7526 deprecated): 192.88.99.0/24.
-		(a === 192 && b === 88 && c === 99) ||
-		// Multicast (RFC 5771): 224.0.0.0/4.
-		(a >= 224 && a <= 239) ||
-		// Reserved / future use (RFC 1112 + broadcast 255.255.255.255):
-		// 240.0.0.0/4.
-		a >= 240
-	);
-}
-
-// Matches ::ffff:a.b.c.d (dotted-decimal, as written by humans)
-const V4_MAPPED_DOTTED_RE =
-	/^(?:0{0,4}:){0,4}:?(?:0{0,4}:)?ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/;
-
-// Matches hex-pair form (e.g. ::ffff:a9fe:a9fe), as normalized by the URL parser
-const V4_MAPPED_HEX_RE =
-	/^(?:0{0,4}:){0,4}:?(?:0{0,4}:)?ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
-
-/**
- * Convert two hex groups from an IPv4-mapped IPv6 address to dotted-decimal IPv4.
- * e.g. "a9fe" "a9fe" -> "169.254.169.254"
- */
-function hexGroupsToIpv4(hi: string, lo: string): string {
-	const h = Number.parseInt(hi, 16);
-	const l = Number.parseInt(lo, 16);
-	return `${(h >> 8) & 0xff}.${h & 0xff}.${(l >> 8) & 0xff}.${l & 0xff}`;
-}
-
-/**
  * Check whether a hostname is private/reserved per RFC 6890.
  *
- * Handles bracketed IPv6 (as returned by URL.hostname), IPv4-mapped
- * IPv6 in both dotted-decimal and hex-normalized forms, and cloud
- * metadata hostnames. No DNS resolution, so it runs identically on
- * Node, Bun, Deno, and Workers.
+ * Uses ipaddr.js to parse IP addresses and check their range.
+ * `ipaddr.process()` automatically converts IPv4-mapped IPv6 addresses
+ * to IPv4. Any range other than `'unicast'` is considered non-public.
+ * Cloud metadata hostnames are also blocked by name.
  */
 function isPrivateHost(hostname: string): boolean {
 	const lower = hostname.toLowerCase();
+	if (lower === "metadata.google.internal") {
+		return true;
+	}
 	const host =
 		lower.startsWith("[") && lower.endsWith("]") ? lower.slice(1, -1) : lower;
-
-	if (host === "::1") {
-		return true;
+	try {
+		// process() converts IPv4-mapped IPv6 → IPv4 before range-checking.
+		return ipaddr.process(host).range() !== "unicast";
+	} catch {
+		// Not a parseable IP address (e.g. a regular domain name).
+		return false;
 	}
-	if (isPrivateIpv4(host)) {
-		return true;
-	}
-	if (host.includes(":")) {
-		const dottedMatch = host.match(V4_MAPPED_DOTTED_RE);
-		if (dottedMatch && isPrivateIpv4(dottedMatch[1]!)) {
-			return true;
-		}
-		const hexMatch = host.match(V4_MAPPED_HEX_RE);
-		if (hexMatch) {
-			const ipv4 = hexGroupsToIpv4(hexMatch[1]!, hexMatch[2]!);
-			if (isPrivateIpv4(ipv4)) {
-				return true;
-			}
-		}
-		// Link-local (fe80::/10)
-		if (/^fe[89ab]/.test(host)) {
-			return true;
-		}
-		// Unique-local (fc00::/7)
-		if (host.startsWith("fc") || host.startsWith("fd")) {
-			return true;
-		}
-	}
-	if (host === "metadata.google.internal") {
-		return true;
-	}
-	return false;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -974,6 +974,9 @@ importers:
       better-call:
         specifier: 'catalog:'
         version: 1.3.5(zod@4.3.6)
+      ipaddr.js:
+        specifier: ^2.3.0
+        version: 2.3.0
     devDependencies:
       '@better-auth/core':
         specifier: workspace:*
@@ -10578,6 +10581,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -25542,6 +25549,8 @@ snapshots:
     optional: true
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.3.0: {}
 
   iron-webcrypto@1.2.1: {}
 


### PR DESCRIPTION
Use `ipaddr.js` package to better cover IP address ranges. For example, not all [special ranges](https://github.com/whitequark/ipaddr.js/blob/1915d222d66c1a9bfc7578fe7464f9bed4ccaac9/lib/ipaddr.js#L562) were covered and overall reduces maintained code/edge-cases.

Adds `allowedIpRanges` to allow users to further restrict/open ranges in advanced scenarios. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces custom IP checks with `ipaddr.js` to validate IP‑literal hosts in `client_id` URLs and embedded fields. Adds `allowedIpRanges` to configure permitted ipaddr.js ranges (default `unicast`).

- **Bug Fixes**
  - Use `ipaddr.js` for IPv4/IPv6 parsing, including IPv4‑mapped IPv6 and stripping IPv6 zone IDs; reject malformed IP‑literals.
  - Enforce range allowlist; keep `metadata.google.internal` blocked by name and allow `localhost`.

- **New Features**
  - Add `allowedIpRanges?: Set<...>` in `CimdOptions` to narrow/expand allowed ranges (default `new Set(["unicast"])`).
  - Apply the option in `validateClientIdUrl`, `validateCimdMetadata`, and the client-store fetch path.

<sup>Written for commit 6d3e51d614775baab4d7647565a4f275aaec4c2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

