### PR TITLE
chore(cimd): add to fixed version group and align at 1.7.0-beta.1

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,7 @@
       "@better-auth/core",
       "auth",
       "@better-auth/api-key",
+      "@better-auth/cimd",
       "@better-auth/drizzle-adapter",
       "@better-auth/electron",
       "@better-auth/expo",

--- a/packages/cimd/package.json
+++ b/packages/cimd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/cimd",
-  "version": "1.7.0-beta.0",
+  "version": "1.7.0-beta.1",
   "description": "Client ID Metadata Document plugin for Better Auth",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
The v1.7.0-beta.1 release failed to publish `@better-auth/cimd` because the package was created on `next` (#9159) without being added to the `fixed` group in `.changeset/config.json`. Every other package bumped from `beta.0` to `beta.1` as a group; CIMD stayed at `beta.0` and hit a second issue: it had never been published to npm before, so OIDC trusted publishing could not bootstrap the package name.

`@better-auth/cimd@1.7.0-beta.0` was published manually to create the npm entry, and a trusted publisher config has been set for the package. This PR:

- Adds `@better-auth/cimd` to the fixed version group so future releases keep it in lockstep with the rest of the workspace.
- Bumps `packages/cimd/package.json` to `1.7.0-beta.1` so `changeset publish` detects the out-of-sync state and publishes `CIMD@1.7.0-beta.1` via OIDC on merge.

On merge, the changesets publish step will also trigger the release-notes generation and GitHub Release creation that were skipped when the original v1.7.0-beta.1 run failed on CIMD. The release-notes script diffs the current `.changeset/pre.json` against `v1.7.0-beta.0`'s pre.json, so the recovered notes will cover all 12 changesets consumed in the beta.1 cycle (not just CIMD).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@better-auth/cimd` to the fixed version group and bumps it to `1.7.0-beta.1`. Fixes the beta.1 publish gap and keeps CIMD in lockstep with the workspace.

- **Bug Fixes**
  - Add `@better-auth/cimd` to `.changeset/config.json` fixed group to align versions with other packages.
  - Set `packages/cimd/package.json` to `1.7.0-beta.1` so `changeset publish` releases via OIDC and generates the beta.1 release notes.

<sup>Written for commit 364184a1b7e1af41ca34095ea428ea655c616775. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

