### PR TITLE
docs(2fa): add OAuth provider integration example for 2FA flow

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -176,7 +176,7 @@ This is different from the OAuth provider callback URL.
 ```ts title="sign-in.ts"
 import { authClient } from "@/lib/auth-client"
 
-await authClient.signIn.social({ provider: 'google', callbackURL: '/verify-2fa' });
+await authClient.signIn.social({ provider: "google", callbackURL: "/verify-2fa" });
 ```
 ```ts title="verify-2fa.ts"
 import { authClient } from "@/lib/auth-client"

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -169,6 +169,20 @@ const authClient = createAuthClient({
 });
 ```
 
+Using an OAuth provider:
+
+You need to manually set the callback url and redirect to your 2fa verify page.
+```ts title="sign-in.ts"
+import { authClient } from "@/lib/auth-client"
+
+await authClient.signIn.social({ 'google', callbackURL: ' /verify-2fa' });
+```
+```ts title="verify-2fa.ts"
+import { authClient } from "@/lib/auth-client"
+
+await authClient.twoFactor.verifyTotp({ code: code.trim() })
+```
+
 <Callout type="warn">
   Using the `twoFactorPage` option will cause a full page reload when redirecting users to the two-factor authentication page. If you want to avoid page reloads, consider using the `onTwoFactorRedirect` callback instead to handle the redirect programmatically within your application.
 </Callout>

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -171,16 +171,17 @@ const authClient = createAuthClient({
 
 Using an OAuth provider:
 
-You need to manually set the callback url and redirect to your 2fa verify page.
+You need to manually set Better Auth’s `callbackURL` option to your 2FA verification page.
+This is different from the OAuth provider callback URL.
 ```ts title="sign-in.ts"
 import { authClient } from "@/lib/auth-client"
 
-await authClient.signIn.social({ 'google', callbackURL: ' /verify-2fa' });
+await authClient.signIn.social({ provider: 'google', callbackURL: '/verify-2fa' });
 ```
 ```ts title="verify-2fa.ts"
 import { authClient } from "@/lib/auth-client"
 
-await authClient.twoFactor.verifyTotp({ code: code.trim() })
+await authClient.twoFactor.verifyTotp({ code: "120842" })
 ```
 
 <Callout type="warn">


### PR DESCRIPTION
I added a simple code example to show how to use 2fa with OAuth. since 1.6.3 all session creating endpoints enforce 2fa.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 2FA-with-OAuth docs example for 1.6.3, which enforces 2FA on all session-creating endpoints. Clarifies setting Better Auth’s `callbackURL` to `/verify-2fa` in `authClient.signIn.social` (not the provider callback), verifies with `authClient.twoFactor.verifyTotp`, and standardizes quotes in the snippet.

<sup>Written for commit 725a886f14215bb1781874dc03083ab9ca43fd7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

