### PR TITLE
fix(two-factor): identity-aware session guard with passkey UV exemption

### DIFF
--- a/.changeset/fix-2fa-identity-guard.md
+++ b/.changeset/fix-2fa-identity-guard.md
@@ -1,0 +1,14 @@
+---
+"better-auth": patch
+"@better-auth/passkey": patch
+---
+
+fix(two-factor): identity-aware session guard, passkey user-verification exemption, and `shouldEnforce` option
+
+The 2FA after-hook previously skipped the challenge whenever `ctx.context.session` was set, regardless of whose session it was. A before-hook that populated `ctx.context.session` with a session for a different user than the one being authenticated could suppress the challenge. The guard now compares the user on `ctx.context.session` against the user on `ctx.context.newSession` and only exits on same-user rewrites, preserving session-refresh and `updateUser` behavior.
+
+The after-hook no longer matches `/admin/impersonate-user`, `/admin/stop-impersonating`, or `/multi-session/*`. Those endpoints operate on already-authenticated identities, not sign-in events, and were being challenged with 2FA that the operator could not produce.
+
+The passkey plugin now signals user verification on `ctx.context.passkeyUserVerified` when the assertion confirmed UV, and the 2FA hook skips the challenge for those sign-ins. Passkey assertions without user verification are still challenged. A UV-verified passkey is a complete MFA event on its own, so a second factor is not required.
+
+A new `TwoFactorOptions.shouldEnforce(ctx) => boolean | Promise<boolean>` option overrides the built-in decision. Return `true` to challenge, `false` to skip. Setting this option replaces the default logic, including the passkey-UV exemption; same-user session rewrites and session-transition endpoints remain non-negotiable. Use it to trust upstream provider MFA on OAuth and SSO callbacks, force a challenge on every sign-in, or branch on request context.

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -517,7 +517,7 @@ export const twoFactorTableFields = [
 
 When a user has 2FA enabled, the plugin challenges the second factor on every sign-in that creates a new session. One exception applies: passkey sign-ins whose assertion confirmed user verification (UV) are not challenged. Passkey sign-ins without UV are still challenged.
 
-A password, magic link, or email OTP is a single primary authenticator and establishes AAL1 per [NIST SP 800-63B-4](https://pages.nist.gov/800-63-4/sp800-63b/). Challenging a second factor raises the session to AAL2.
+A password, magic link, or email OTP is a single primary authenticator and establishes AAL1 per [NIST SP 800-63B-4](https://csrc.nist.gov/pubs/sp/800/63/b/4/final). Challenging a second factor raises the session to AAL2.
 
 A UV-verified passkey already qualifies as AAL2 phishing-resistant authentication under NIST SP 800-63B-4 and the [FIDO Alliance](https://fidoalliance.org/passkeys/). It proves possession of the authenticator plus inherence (biometric) or knowledge (on-device PIN) in one step. Requiring a manually-entered second factor would reintroduce a phishable step.
 

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -511,6 +511,83 @@ export const twoFactorTableFields = [
 
 **Issuer**: The issuer is the name of your application. It's used to generate TOTP codes. It'll be displayed in the authenticator apps.
 
+**shouldEnforce**: Decides whether to challenge 2FA on a given sign-in. Return `true` to challenge, `false` to skip. Setting this option replaces the built-in enforcement decision, including the passkey user-verification exemption. See [Enforcement scope](#enforcement-scope) below.
+
+### Enforcement scope
+
+When a user has 2FA enabled, the plugin challenges the second factor on every sign-in that creates a new session. One exception applies: passkey sign-ins whose assertion confirmed user verification (UV) are not challenged. Passkey sign-ins without UV are still challenged.
+
+A password, magic link, or email OTP is a single primary authenticator and establishes AAL1 per [NIST SP 800-63B-4](https://pages.nist.gov/800-63-4/sp800-63b/). Challenging a second factor raises the session to AAL2.
+
+A UV-verified passkey already qualifies as AAL2 phishing-resistant authentication under NIST SP 800-63B-4 and the [FIDO Alliance](https://fidoalliance.org/passkeys/). It proves possession of the authenticator plus inherence (biometric) or knowledge (on-device PIN) in one step. Requiring a manually-entered second factor would reintroduce a phishable step.
+
+Federated sign-ins (OAuth, SSO) are challenged by default because the plugin does not yet read the provider's `amr` or `acr` claims. Without those signals, the plugin cannot tell which federated sessions already carry provider MFA. Applications that trust their provider opt out via `shouldEnforce`.
+
+Two guards run before `shouldEnforce` and cannot be overridden:
+
+* **Same-user session rewrites** (session refresh, `updateUser`, and similar) are never challenged; those are not sign-in events.
+* **Session-transition endpoints** (admin impersonation, multi-session switching) are never matched, because they operate on already-authenticated identities rather than establishing a new one.
+
+A pre-existing `ctx.context.session` for a different user does not suppress the challenge.
+
+Applications override the default by providing `shouldEnforce`. The callback receives the endpoint context and returns `true` to challenge or `false` to skip.
+
+Trust the upstream provider on OAuth and SSO (skip the challenge on those callbacks) while keeping the passkey-UV exemption in place:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+import { twoFactor } from "better-auth/plugins"
+
+export const auth = betterAuth({
+    plugins: [
+        twoFactor({
+            shouldEnforce: (ctx) => {
+                if (ctx.path?.startsWith("/callback/")) return false
+                if (ctx.path?.startsWith("/sso/callback/")) return false
+                if (ctx.path?.startsWith("/sso/saml2/sp/acs/")) return false
+                if (
+                    ctx.path === "/passkey/verify-authentication" &&
+                    (ctx.context as { passkeyUserVerified?: boolean })
+                        .passkeyUserVerified === true
+                ) {
+                    return false
+                }
+                return true
+            },
+        }),
+    ],
+})
+```
+
+Trust the upstream provider without preserving the passkey-UV exemption (simpler, but a UV-verified passkey will still be challenged):
+
+```ts title="auth.ts"
+twoFactor({
+    shouldEnforce: (ctx) =>
+        !ctx.path?.startsWith("/callback/") &&
+        !ctx.path?.startsWith("/sso/callback/") &&
+        !ctx.path?.startsWith("/sso/saml2/sp/acs/"),
+})
+```
+
+Challenge every sign-in unconditionally (including UV-verified passkey):
+
+```ts title="auth.ts"
+twoFactor({
+    shouldEnforce: () => true,
+})
+```
+
+Skip 2FA entirely (not recommended outside specific testing or migration scenarios):
+
+```ts title="auth.ts"
+twoFactor({
+    shouldEnforce: () => false,
+})
+```
+
+The callback receives the endpoint context, so predicates can branch on the request path, headers, or the session being minted (`ctx.context.newSession`).
+
 **TOTP options**
 
 these are options for TOTP.

--- a/packages/better-auth/src/plugins/two-factor/constant.ts
+++ b/packages/better-auth/src/plugins/two-factor/constant.ts
@@ -1,3 +1,14 @@
 export const TWO_FACTOR_COOKIE_NAME = "two_factor";
 export const TRUST_DEVICE_COOKIE_NAME = "trust_device";
 export const TRUST_DEVICE_COOKIE_MAX_AGE = 30 * 24 * 60 * 60; // 30 days
+
+/**
+ * Endpoints that mint a session as an authenticated transition rather
+ * than a sign-in. The 2FA hook skips these because the operator driving
+ * the transition cannot produce the target's second factor.
+ */
+export const SESSION_TRANSITION_PATH_PREFIXES: readonly string[] = [
+	"/admin/impersonate-user",
+	"/admin/stop-impersonating",
+	"/multi-session/",
+];

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -21,6 +21,7 @@ import { PACKAGE_VERSION } from "../../version";
 import type { BackupCodeOptions } from "./backup-codes";
 import { backupCode2fa, generateBackupCodes } from "./backup-codes";
 import {
+	SESSION_TRANSITION_PATH_PREFIXES,
 	TRUST_DEVICE_COOKIE_MAX_AGE,
 	TRUST_DEVICE_COOKIE_NAME,
 	TWO_FACTOR_COOKIE_NAME,
@@ -377,10 +378,18 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 			after: [
 				{
 					matcher(context) {
-						return (
-							context.context.newSession != null &&
-							!context.path?.startsWith("/two-factor/")
-						);
+						if (context.context.newSession == null) return false;
+						const path = context.path;
+						if (!path) return false;
+						if (path.startsWith("/two-factor/")) return false;
+						if (
+							SESSION_TRANSITION_PATH_PREFIXES.some((prefix) =>
+								path.startsWith(prefix),
+							)
+						) {
+							return false;
+						}
+						return true;
 					},
 					handler: createAuthMiddleware(async (ctx) => {
 						const data = ctx.context.newSession;
@@ -392,9 +401,30 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							return;
 						}
 
-						// Skip if the request already had an authenticated session
-						// (session refresh, updateUser, etc. are not sign-in flows)
-						if (ctx.context.session) {
+						// A different user's pre-existing session must not suppress
+						// enforcement; only same-user rewrites (session refresh,
+						// updateUser) are safe to skip.
+						if (
+							ctx.context.session &&
+							ctx.context.session.user?.id === data.user.id
+						) {
+							return;
+						}
+
+						// UV-verified passkey already proves possession + inherence.
+						// The flag is request-scoped and cannot be set by a client.
+						//
+						// TODO: extend this carve-out to federated sign-ins (OAuth,
+						// SSO) once the plugin reads `amr` / `acr` claims from the
+						// upstream provider.
+						const passkeyCompletedMfa =
+							(ctx.context as { passkeyUserVerified?: boolean })
+								.passkeyUserVerified === true;
+
+						const enforce = options?.shouldEnforce
+							? await options.shouldEnforce(ctx)
+							: !passkeyCompletedMfa;
+						if (!enforce) {
 							return;
 						}
 

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -380,14 +380,15 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 					matcher(context) {
 						if (context.context.newSession == null) return false;
 						const path = context.path;
-						if (!path) return false;
-						if (path.startsWith("/two-factor/")) return false;
-						if (
-							SESSION_TRANSITION_PATH_PREFIXES.some((prefix) =>
-								path.startsWith(prefix),
-							)
-						) {
-							return false;
+						if (path) {
+							if (path.startsWith("/two-factor/")) return false;
+							if (
+								SESSION_TRANSITION_PATH_PREFIXES.some((prefix) =>
+									path.startsWith(prefix),
+								)
+							) {
+								return false;
+							}
 						}
 						return true;
 					},

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -1,12 +1,16 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import { createOTP } from "@better-auth/utils/otp";
 import { describe, expect, it, vi } from "vitest";
+import * as z from "zod";
+import { createAuthEndpoint, createAuthMiddleware } from "../../api";
 import { createAuthClient } from "../../client";
-import { parseSetCookieHeader } from "../../cookies";
+import { parseSetCookieHeader, setSessionCookie } from "../../cookies";
 import { symmetricDecrypt } from "../../crypto";
 import { convertSetCookieToCookie } from "../../test-utils/headers";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../../utils/constants";
+import { admin } from "../admin";
 import { anonymous } from "../anonymous";
 import { magicLink } from "../magic-link";
 import { TWO_FACTOR_ERROR_CODES, twoFactor, twoFactorClient } from ".";
@@ -2350,8 +2354,15 @@ describe("twoFactorMethods in sign-in response", () => {
 
 /**
  * @see https://github.com/better-auth/better-auth/issues/8627
+ * @see https://github.com/better-auth/better-auth/pull/9122
+ *
+ * 2FA is challenged on every sign-in that creates a new session for a
+ * 2FA-enabled user. The built-in logic has one exception: passkey
+ * sign-ins whose assertion confirmed user verification are skipped
+ * (covered in a dedicated block below). Applications override the
+ * default via the `shouldEnforce` option.
  */
-describe("2FA enforcement on non-credential sign-in paths", async () => {
+describe("2FA default enforcement scope", async () => {
 	let magicLinkURL = "";
 	const { auth, signInWithTestUser, testUser } = await getTestInstance({
 		secret: DEFAULT_SECRET,
@@ -2370,7 +2381,7 @@ describe("2FA enforcement on non-credential sign-in paths", async () => {
 		],
 	});
 
-	it("should enforce 2FA on magic-link sign-in", async () => {
+	it("should challenge 2FA on magic-link sign-in by default", async () => {
 		const { headers } = await signInWithTestUser();
 		await auth.api.enableTwoFactor({
 			body: { password: testUser.password },
@@ -2396,11 +2407,14 @@ describe("2FA enforcement on non-credential sign-in paths", async () => {
 		expect(json.twoFactorRedirect).toBe(true);
 	});
 
-	it("should not enforce 2FA on authenticated non-sign-in endpoints", async () => {
+	it("should not challenge 2FA when same-user session rewrites itself (updateUser)", async () => {
+		// Uses a dedicated instance because the preceding test enables 2FA
+		// on the shared testUser, which would otherwise gate the sign-in
+		// with a 2FA challenge.
 		const {
-			auth: a,
+			auth: instance,
 			signInWithTestUser: signIn,
-			testUser: tu,
+			testUser: user,
 		} = await getTestInstance({
 			secret: DEFAULT_SECRET,
 			plugins: [
@@ -2410,25 +2424,461 @@ describe("2FA enforcement on non-credential sign-in paths", async () => {
 				}),
 			],
 		});
-		let { headers: h } = await signIn();
-		const enableRes = await a.api.enableTwoFactor({
-			body: { password: tu.password },
-			headers: h,
+		let { headers } = await signIn();
+		const enableRes = await instance.api.enableTwoFactor({
+			body: { password: user.password },
+			headers,
 			asResponse: true,
 		});
-		h = convertSetCookieToCookie(enableRes.headers);
+		headers = convertSetCookieToCookie(enableRes.headers);
 
-		const session = await a.api.getSession({ headers: h });
+		const session = await instance.api.getSession({ headers });
 		expect(session?.user.twoFactorEnabled).toBe(true);
 
-		const updateRes = await a.api.updateUser({
+		const updateRes = await instance.api.updateUser({
 			body: { name: "updated-name" },
-			headers: h,
+			headers,
 			asResponse: true,
 		});
 
 		expect(updateRes.ok).toBe(true);
 		const json = await updateRes.json();
+		expect(json.twoFactorRedirect).toBeUndefined();
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/pull/9122
+ *
+ * When `autoSignInAfterVerification` is enabled and the verified user
+ * has 2FA enabled, the resulting session creation must go through the
+ * 2FA challenge before the session cookie becomes usable.
+ */
+describe("2FA enforcement on email-verification auto-sign-in", async () => {
+	let verificationToken = "";
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		emailVerification: {
+			async sendVerificationEmail({ token }) {
+				verificationToken = token;
+			},
+			autoSignInAfterVerification: true,
+		},
+		plugins: [
+			twoFactor({
+				otpOptions: { sendOTP() {} },
+				skipVerificationOnEnable: true,
+			}),
+		],
+	});
+
+	it("should challenge 2FA when /verify-email auto-signs-in a 2FA-enabled user", async () => {
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		// Mark the user unverified so sendVerificationEmail issues a fresh
+		// token, mirroring the change-email / re-verification flow.
+		await db.update({
+			model: "user",
+			where: [{ field: "email", value: testUser.email }],
+			update: { emailVerified: false },
+		});
+
+		await auth.api.sendVerificationEmail({
+			body: { email: testUser.email },
+		});
+		expect(verificationToken).toBeTruthy();
+
+		// autoSignInAfterVerification mints a new session without any
+		// existing cookies; the 2FA challenge must fire before that
+		// session is usable.
+		const verifyRes = await auth.api.verifyEmail({
+			query: { token: verificationToken },
+			headers: new Headers(),
+			asResponse: true,
+		});
+		const json = await verifyRes.json();
+		expect(json.twoFactorRedirect).toBe(true);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/pull/9122
+ *
+ * The 2FA challenge must fire when a before-hook populates
+ * `ctx.context.session` with a session that belongs to a different
+ * user than the one being authenticated. Only same-user rewrites
+ * (session refresh, `updateUser`) skip the challenge.
+ */
+describe("2FA identity-aware session guard", async () => {
+	const injectedUserId = "injected-user-id";
+
+	const sessionInjector: BetterAuthPlugin = {
+		id: "test-session-injector",
+		hooks: {
+			before: [
+				{
+					matcher: (ctx) => ctx.headers?.get?.("x-inject-session") === "1",
+					handler: createAuthMiddleware(async (ctx) => {
+						ctx.context.session = {
+							user: { id: injectedUserId } as never,
+							session: { userId: injectedUserId } as never,
+						};
+					}),
+				},
+			],
+		},
+	};
+
+	it("should still challenge 2FA when a cross-user session is injected before the sign-in handler", async () => {
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+				}),
+				sessionInjector,
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		const injectedHeaders = new Headers({ "x-inject-session": "1" });
+		const res = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			headers: injectedHeaders,
+			asResponse: true,
+		});
+		const json = await res.json();
+		expect(json.twoFactorRedirect).toBe(true);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/pull/9122
+ *
+ * A user-verified passkey assertion satisfies MFA on its own, so the 2FA
+ * challenge must skip when the passkey plugin reports
+ * `passkeyUserVerified: true` on `ctx.context`. Assertions without UV
+ * still trigger the challenge.
+ *
+ * These tests use a minimal test plugin that registers the same path as
+ * the passkey plugin (`/passkey/verify-authentication`) and sets the same
+ * context flag, so the 2FA hook sees the exact shape it would see in a
+ * real passkey sign-in.
+ */
+describe("2FA passkey user-verified carve-out", async () => {
+	// Faithful simulator of the real passkey plugin's signal: it registers
+	// the same path and writes `passkeyUserVerified` on `ctx.context`.
+	// The real plugin lives at packages/passkey/src/routes.ts; keep this
+	// in sync with that handler.
+	const passkeyPathPlugin = (opts: { userVerified: boolean }) =>
+		({
+			id: "test-passkey-path",
+			endpoints: {
+				testPasskeyVerify: createAuthEndpoint(
+					"/passkey/verify-authentication",
+					{
+						method: "POST",
+						body: z.object({ email: z.string() }),
+					},
+					async (ctx) => {
+						const user = await ctx.context.internalAdapter.findUserByEmail(
+							ctx.body.email,
+						);
+						if (!user) throw new Error("user not found");
+						const session = await ctx.context.internalAdapter.createSession(
+							user.user.id,
+						);
+						(
+							ctx.context as { passkeyUserVerified?: boolean }
+						).passkeyUserVerified = opts.userVerified;
+						await setSessionCookie(ctx, {
+							session,
+							user: user.user,
+						});
+						return ctx.json({ ok: true });
+					},
+				),
+			},
+		}) satisfies BetterAuthPlugin;
+
+	it("should skip 2FA when passkey assertion had user verification", async () => {
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+				}),
+				passkeyPathPlugin({ userVerified: true }),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		const res = await auth.api.testPasskeyVerify({
+			body: { email: testUser.email },
+			headers: new Headers(),
+			asResponse: true,
+		});
+		const json = await res.json();
+		expect(json.twoFactorRedirect).toBeUndefined();
+		expect(json.ok).toBe(true);
+	});
+
+	it("should challenge 2FA when passkey assertion did not perform user verification", async () => {
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+				}),
+				passkeyPathPlugin({ userVerified: false }),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		const res = await auth.api.testPasskeyVerify({
+			body: { email: testUser.email },
+			headers: new Headers(),
+			asResponse: true,
+		});
+		const json = await res.json();
+		expect(json.twoFactorRedirect).toBe(true);
+	});
+
+	it("should honor shouldEnforce even when passkey assertion was user-verified", async () => {
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+					shouldEnforce: () => true,
+				}),
+				passkeyPathPlugin({ userVerified: true }),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		const res = await auth.api.testPasskeyVerify({
+			body: { email: testUser.email },
+			headers: new Headers(),
+			asResponse: true,
+		});
+		const json = await res.json();
+		expect(json.twoFactorRedirect).toBe(true);
+	});
+});
+
+/**
+ * Session-transition endpoints (admin impersonation, multi-session
+ * switching) mint a session for an identity that was already
+ * authenticated elsewhere. Challenging 2FA on those transitions is a
+ * regression: the operator driving the transition cannot produce the
+ * target's second factor.
+ */
+describe("2FA skips session-transition endpoints", async () => {
+	it("should not challenge 2FA on admin impersonation of a 2FA-enabled user", async () => {
+		const { auth, db } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+				}),
+				admin(),
+			],
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => {
+							if (user.email === "admin@test.com") {
+								return { data: { ...user, role: "admin" } };
+							}
+						},
+					},
+				},
+			},
+		});
+
+		const adminUser = await auth.api.signUpEmail({
+			body: {
+				email: "admin@test.com",
+				password: "admin-password",
+				name: "Admin",
+			},
+			asResponse: true,
+		});
+		const adminHeaders = convertSetCookieToCookie(adminUser.headers);
+
+		const target = await auth.api.signUpEmail({
+			body: {
+				email: "target@test.com",
+				password: "target-password",
+				name: "Target",
+			},
+			asResponse: true,
+		});
+		let targetHeaders = convertSetCookieToCookie(target.headers);
+		const enableRes = await auth.api.enableTwoFactor({
+			body: { password: "target-password" },
+			headers: targetHeaders,
+			asResponse: true,
+		});
+		targetHeaders = convertSetCookieToCookie(enableRes.headers);
+
+		const targetSession = await auth.api.getSession({ headers: targetHeaders });
+		const targetUserId = targetSession?.user.id;
+		expect(targetUserId).toBeDefined();
+		expect(targetSession?.user.twoFactorEnabled).toBe(true);
+
+		const impersonateRes = await auth.api.impersonateUser({
+			body: { userId: targetUserId! },
+			headers: adminHeaders,
+			asResponse: true,
+		});
+		expect(impersonateRes.ok).toBe(true);
+		const json = await impersonateRes.json();
+		expect(json.twoFactorRedirect).toBeUndefined();
+		expect(json.session).toBeDefined();
+		expect(json.user?.id).toBe(targetUserId);
+
+		// Confirm the impersonation session exists and was not torn down.
+		const sessions = await db.findMany<{ id: string; userId: string }>({
+			model: "session",
+			where: [{ field: "userId", value: targetUserId! }],
+		});
+		expect(sessions.length).toBeGreaterThan(0);
+	});
+});
+
+describe("2FA shouldEnforce option", async () => {
+	it("should skip 2FA when shouldEnforce returns false", async () => {
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+					shouldEnforce: () => false,
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		const res = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		const json = await res.json();
+		expect(json.twoFactorRedirect).toBeUndefined();
+		expect(json.token).toBeDefined();
+	});
+
+	it("should skip 2FA selectively when shouldEnforce returns false for a path", async () => {
+		let magicLinkURL = "";
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+					shouldEnforce: (ctx) => ctx.path !== "/magic-link/verify",
+				}),
+				magicLink({
+					sendMagicLink({ url }) {
+						magicLinkURL = url;
+					},
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		await auth.api.signInMagicLink({
+			body: { email: testUser.email },
+			headers: new Headers(),
+		});
+		const token = new URL(magicLinkURL).searchParams.get("token")!;
+
+		const verifyRes = await auth.api.magicLinkVerify({
+			query: { token },
+			headers: new Headers(),
+			asResponse: true,
+		});
+		const json = await verifyRes.json();
+		expect(json.twoFactorRedirect).toBeUndefined();
+		expect(json.session?.token).toBeDefined();
+	});
+
+	it("should accept an async shouldEnforce predicate", async () => {
+		const { auth, signInWithTestUser, testUser } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+					shouldEnforce: async () => {
+						await new Promise((resolve) => setTimeout(resolve, 1));
+						return false;
+					},
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		const res = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		const json = await res.json();
 		expect(json.twoFactorRedirect).toBeUndefined();
 	});
 });

--- a/packages/better-auth/src/plugins/two-factor/types.ts
+++ b/packages/better-auth/src/plugins/two-factor/types.ts
@@ -1,4 +1,8 @@
-import type { BetterAuthPlugin, LiteralString } from "@better-auth/core";
+import type {
+	BetterAuthPlugin,
+	GenericEndpointContext,
+	LiteralString,
+} from "@better-auth/core";
 import type { InferOptionSchema, User } from "../../types";
 import type { BackupCodeOptions } from "./backup-codes";
 import type { OTPOptions } from "./otp";
@@ -61,6 +65,34 @@ export interface TwoFactorOptions {
 	 * @default 2592000 (30 days)
 	 */
 	trustDeviceMaxAge?: number | undefined;
+	/**
+	 * Decides whether to challenge 2FA on a given sign-in.
+	 *
+	 * Return `true` to challenge 2FA for this request; return `false` to
+	 * skip. Setting this option replaces the built-in enforcement
+	 * decision (including the passkey user-verification exemption).
+	 *
+	 * When omitted, 2FA is challenged on every sign-in that creates a
+	 * new session, with one built-in exception: passkey sign-ins whose
+	 * assertion confirmed user verification (UV) are not challenged,
+	 * since a UV-verified passkey already satisfies MFA.
+	 *
+	 * Two guards run before this callback and cannot be overridden:
+	 * same-user session rewrites (session refresh, `updateUser`) are
+	 * never challenged, and session-transition endpoints (admin
+	 * impersonation, multi-session switching) are never matched.
+	 *
+	 * The callback receives the endpoint context. The authenticating
+	 * user is available at `ctx.context.newSession.user`.
+	 *
+	 * Use this option to skip 2FA on flows where the upstream provider
+	 * is trusted to enforce it (for example, OAuth callbacks where the
+	 * provider already required MFA), or to force a challenge on flows
+	 * that the built-in logic would otherwise skip.
+	 */
+	shouldEnforce?:
+		| ((ctx: GenericEndpointContext) => boolean | Promise<boolean>)
+		| undefined;
 }
 
 export interface UserWithTwoFactor extends User {

--- a/packages/better-auth/src/plugins/two-factor/types.ts
+++ b/packages/better-auth/src/plugins/two-factor/types.ts
@@ -66,29 +66,17 @@ export interface TwoFactorOptions {
 	 */
 	trustDeviceMaxAge?: number | undefined;
 	/**
-	 * Decides whether to challenge 2FA on a given sign-in.
+	 * Decides whether to challenge 2FA on a given sign-in. Return `true`
+	 * to challenge, `false` to skip. Setting this option replaces the
+	 * built-in decision, including the passkey UV exemption.
 	 *
-	 * Return `true` to challenge 2FA for this request; return `false` to
-	 * skip. Setting this option replaces the built-in enforcement
-	 * decision (including the passkey user-verification exemption).
+	 * Same-user session rewrites (session refresh, `updateUser`) and
+	 * session-transition endpoints (admin impersonation, multi-session
+	 * switching) are never matched and cannot be overridden.
 	 *
-	 * When omitted, 2FA is challenged on every sign-in that creates a
-	 * new session, with one built-in exception: passkey sign-ins whose
-	 * assertion confirmed user verification (UV) are not challenged,
-	 * since a UV-verified passkey already satisfies MFA.
+	 * The authenticating user is available at `ctx.context.newSession.user`.
 	 *
-	 * Two guards run before this callback and cannot be overridden:
-	 * same-user session rewrites (session refresh, `updateUser`) are
-	 * never challenged, and session-transition endpoints (admin
-	 * impersonation, multi-session switching) are never matched.
-	 *
-	 * The callback receives the endpoint context. The authenticating
-	 * user is available at `ctx.context.newSession.user`.
-	 *
-	 * Use this option to skip 2FA on flows where the upstream provider
-	 * is trusted to enforce it (for example, OAuth callbacks where the
-	 * provider already required MFA), or to force a challenge on flows
-	 * that the built-in logic would otherwise skip.
+	 * @see {@link https://better-auth.com/docs/plugins/2fa#enforcement-scope}
 	 */
 	shouldEnforce?:
 		| ((ctx: GenericEndpointContext) => boolean | Promise<boolean>)

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -827,6 +827,11 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 						message: "User not found",
 					});
 				}
+				// Expose UV to downstream hooks via request-scoped context, not
+				// the session object, so it cannot leak into the response body
+				// or the session cookie cache.
+				(ctx.context as { passkeyUserVerified?: boolean }).passkeyUserVerified =
+					verification.authenticationInfo.userVerified === true;
 				await setSessionCookie(ctx, {
 					session: s,
 					user,


### PR DESCRIPTION
## Summary

The 2FA after-hook shipped in v1.6.3 had three behaviors that required a follow-up patch.

**Cross-account bypass via identity-blind session guard.** The hook exited whenever `ctx.context.session` was set, regardless of whose session it was. A before-hook that populated `ctx.context.session` with a session for a different user suppressed the challenge for the authenticated user. The guard now compares user IDs and only exits on same-user rewrites (session refresh, `updateUser`).

**Admin impersonation and multi-session switching regression.** `/admin/impersonate-user`, `/admin/stop-impersonating`, and `/multi-session/*` mint sessions as authenticated transitions, not sign-in events. The hook was challenging 2FA against the target user's enrolment, which the operator cannot satisfy. The matcher now skips these path prefixes.

**Passkey UX regression.** A user-verified passkey already proves possession plus inherence and qualifies as AAL2 under NIST SP 800-63B-4 and FIDO Alliance guidance. Requiring a separate TOTP after UV weakens phishing resistance by reintroducing a manually-entered factor. The passkey plugin now sets `ctx.context.passkeyUserVerified` when the assertion confirms UV, and the 2FA hook skips the challenge for those sign-ins. The flag lives in a request-scoped context, so it cannot leak into the response body or the session cookie cache.

A new `TwoFactorOptions.shouldEnforce(ctx) => boolean | Promise<boolean>` option overrides the built-in decision for applications that trust upstream provider MFA on OAuth and SSO callbacks, or that want stricter enforcement. The same-user guard and the session-transition exclusions run before `shouldEnforce` and cannot be overridden.

Follow-up to #9122.