### PR TITLE
fix(two-factor): revert enforcement broadening from #9122

### DIFF
--- a/.changeset/fix-revert-2fa-broadening.md
+++ b/.changeset/fix-revert-2fa-broadening.md
@@ -1,0 +1,9 @@
+---
+"better-auth": patch
+---
+
+fix(two-factor): revert enforcement broadening from #9122
+
+Restores the pre-#9122 enforcement scope. 2FA is challenged only on `/sign-in/email`, `/sign-in/username`, and `/sign-in/phone-number`, matching the behavior that shipped through v1.6.2. Non-credential sign-in flows (magic link, email OTP, OAuth, SSO, passkey, SIWE, one-tap, phone-number OTP, device authorization, email-verification auto-sign-in) are no longer gated by a 2FA challenge by default.
+
+A broader enforcement scope with per-method opt-outs and alignment to NIST SP 800-63B-4 authenticator assurance levels is planned for a future minor release.

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -378,8 +378,9 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 				{
 					matcher(context) {
 						return (
-							context.context.newSession != null &&
-							!context.path?.startsWith("/two-factor/")
+							context.path === "/sign-in/email" ||
+							context.path === "/sign-in/username" ||
+							context.path === "/sign-in/phone-number"
 						);
 					},
 					handler: createAuthMiddleware(async (ctx) => {
@@ -389,12 +390,6 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 						}
 
 						if (!data?.user.twoFactorEnabled) {
-							return;
-						}
-
-						// Skip if the request already had an authenticated session
-						// (session refresh, updateUser, etc. are not sign-in flows)
-						if (ctx.context.session) {
 							return;
 						}
 

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -8,6 +8,7 @@ import { convertSetCookieToCookie } from "../../test-utils/headers";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../../utils/constants";
 import { anonymous } from "../anonymous";
+import { magicLink } from "../magic-link";
 import { TWO_FACTOR_ERROR_CODES, twoFactor, twoFactorClient } from ".";
 import type { TwoFactorTable, UserWithTwoFactor } from "./types";
 
@@ -2344,6 +2345,96 @@ describe("twoFactorMethods in sign-in response", () => {
 			expect((signInRes as any).twoFactorRedirect).toBe(true);
 			expect((signInRes as any).twoFactorMethods).toEqual(["otp"]);
 		});
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/pull/9205
+ *
+ * 2FA enforcement is intentionally scoped to credential sign-in paths
+ * only. These tests lock that scope in so a future refactor does not
+ * accidentally broaden enforcement to non-credential sign-in flows
+ * without a dedicated release.
+ */
+describe("2FA enforcement scope", async () => {
+	let magicLinkURL = "";
+	const { auth, signInWithTestUser, testUser } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [
+			twoFactor({
+				otpOptions: {
+					sendOTP() {},
+				},
+				skipVerificationOnEnable: true,
+			}),
+			magicLink({
+				sendMagicLink({ url }) {
+					magicLinkURL = url;
+				},
+			}),
+		],
+	});
+
+	it("should not challenge 2FA on magic-link sign-in", async () => {
+		const { headers } = await signInWithTestUser();
+		await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+
+		await auth.api.signInMagicLink({
+			body: { email: testUser.email },
+			headers: new Headers(),
+		});
+
+		const url = new URL(magicLinkURL);
+		const token = url.searchParams.get("token")!;
+
+		const verifyRes = await auth.api.magicLinkVerify({
+			query: { token },
+			headers: new Headers(),
+			asResponse: true,
+		});
+
+		const json = await verifyRes.json();
+		expect(json.twoFactorRedirect).toBeUndefined();
+	});
+
+	it("should not challenge 2FA on authenticated non-sign-in endpoints", async () => {
+		const {
+			auth: instance,
+			signInWithTestUser: signIn,
+			testUser: user,
+		} = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					otpOptions: { sendOTP() {} },
+					skipVerificationOnEnable: true,
+				}),
+			],
+		});
+		let { headers } = await signIn();
+		const enableRes = await instance.api.enableTwoFactor({
+			body: { password: user.password },
+			headers,
+			asResponse: true,
+		});
+		headers = convertSetCookieToCookie(enableRes.headers);
+
+		const session = await instance.api.getSession({ headers });
+		expect(session?.user.twoFactorEnabled).toBe(true);
+
+		const updateRes = await instance.api.updateUser({
+			body: { name: "updated-name" },
+			headers,
+			asResponse: true,
+		});
+
+		expect(updateRes.ok).toBe(true);
+		const json = await updateRes.json();
+		expect(json.twoFactorRedirect).toBeUndefined();
 	});
 });
 

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -8,7 +8,6 @@ import { convertSetCookieToCookie } from "../../test-utils/headers";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../../utils/constants";
 import { anonymous } from "../anonymous";
-import { magicLink } from "../magic-link";
 import { TWO_FACTOR_ERROR_CODES, twoFactor, twoFactorClient } from ".";
 import type { TwoFactorTable, UserWithTwoFactor } from "./types";
 
@@ -2345,91 +2344,6 @@ describe("twoFactorMethods in sign-in response", () => {
 			expect((signInRes as any).twoFactorRedirect).toBe(true);
 			expect((signInRes as any).twoFactorMethods).toEqual(["otp"]);
 		});
-	});
-});
-
-/**
- * @see https://github.com/better-auth/better-auth/issues/8627
- */
-describe("2FA enforcement on non-credential sign-in paths", async () => {
-	let magicLinkURL = "";
-	const { auth, signInWithTestUser, testUser } = await getTestInstance({
-		secret: DEFAULT_SECRET,
-		plugins: [
-			twoFactor({
-				otpOptions: {
-					sendOTP() {},
-				},
-				skipVerificationOnEnable: true,
-			}),
-			magicLink({
-				sendMagicLink({ url }) {
-					magicLinkURL = url;
-				},
-			}),
-		],
-	});
-
-	it("should enforce 2FA on magic-link sign-in", async () => {
-		const { headers } = await signInWithTestUser();
-		await auth.api.enableTwoFactor({
-			body: { password: testUser.password },
-			headers,
-			asResponse: true,
-		});
-
-		await auth.api.signInMagicLink({
-			body: { email: testUser.email },
-			headers: new Headers(),
-		});
-
-		const url = new URL(magicLinkURL);
-		const token = url.searchParams.get("token")!;
-
-		const verifyRes = await auth.api.magicLinkVerify({
-			query: { token },
-			headers: new Headers(),
-			asResponse: true,
-		});
-
-		const json = await verifyRes.json();
-		expect(json.twoFactorRedirect).toBe(true);
-	});
-
-	it("should not enforce 2FA on authenticated non-sign-in endpoints", async () => {
-		const {
-			auth: a,
-			signInWithTestUser: signIn,
-			testUser: tu,
-		} = await getTestInstance({
-			secret: DEFAULT_SECRET,
-			plugins: [
-				twoFactor({
-					otpOptions: { sendOTP() {} },
-					skipVerificationOnEnable: true,
-				}),
-			],
-		});
-		let { headers: h } = await signIn();
-		const enableRes = await a.api.enableTwoFactor({
-			body: { password: tu.password },
-			headers: h,
-			asResponse: true,
-		});
-		h = convertSetCookieToCookie(enableRes.headers);
-
-		const session = await a.api.getSession({ headers: h });
-		expect(session?.user.twoFactorEnabled).toBe(true);
-
-		const updateRes = await a.api.updateUser({
-			body: { name: "updated-name" },
-			headers: h,
-			asResponse: true,
-		});
-
-		expect(updateRes.ok).toBe(true);
-		const json = await updateRes.json();
-		expect(json.twoFactorRedirect).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
Reverts #9122

## Why

The broadening shipped in #9122 caused unintended 2FA prompts on non-credential sign-in paths (magic link, email OTP, OAuth, SSO, passkey, SIWE, one-tap, phone-number OTP, device authorization, email-verification auto-sign-in) for users who had 2FA enabled. Apps that had not wired up 2FA handling on those surfaces reported that users were locked out.

## What this PR does

Restores the pre-#9122 enforcement scope. 2FA is challenged only on `/sign-in/email`, `/sign-in/username`, and `/sign-in/phone-number`, matching v1.6.2 behavior.

## What happens next

The broader enforcement, with per-method opt-outs and alignment to NIST SP 800-63B-4 authenticator assurance levels, is planned for a future minor release with migration guidance in #9203.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the broadened 2FA enforcement in `better-auth`. Restores v1.6.2 behavior by challenging 2FA only on `/sign-in/email`, `/sign-in/username`, and `/sign-in/phone-number`; non-credential sign-ins are no longer prompted.

- **Bug Fixes**
  - Restricts the two-factor middleware matcher to the three credential paths and removes the now-redundant session check.
  - Adds regression tests to lock the scope: no 2FA on magic-link sign-in and no 2FA on authenticated non-sign-in endpoints.

<sup>Written for commit 3255fa1521c1bdeadd3aa83bf2a6cbb596f984d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



