### PR TITLE
fix(ci): surface new packages in release notes

### DIFF
--- a/.github/prompts/release-notes-rewrite.md
+++ b/.github/prompts/release-notes-rewrite.md
@@ -64,10 +64,10 @@ Breaking changes:
 
 - Do NOT add or remove entries
 - Do NOT modify PR links `([#NNNN](url))`
-- Do NOT modify `## \`package-name\`` headings or their order
+- Do NOT modify package headings (including any new-package markers like `✨`) or their order
 - Do NOT modify `### ❗ Breaking Changes`, `### Features`, or
   `### Bug Fixes` sub-headings or their order
-- Do NOT modify the `CHANGELOG` links at the end of each package section
+- Do NOT modify the reference links at the end of each package section
 - Do NOT add author attributions (`by @username`)
 - Do NOT use em dashes (—); use commas, colons, or parentheses
   (exception: the " — " separator after breaking change titles is allowed)

--- a/.github/scripts/lib/pr-analyzer.ts
+++ b/.github/scripts/lib/pr-analyzer.ts
@@ -50,6 +50,7 @@ const SCOPE_TO_DOMAIN: Record<string, string> = {
 	"oidc-provider": "identity",
 	mcp: "identity",
 	"device-authorization": "identity",
+	cimd: "identity",
 
 	// organization
 	organization: "organization",
@@ -100,6 +101,7 @@ const PATH_TO_DOMAIN: [string, string][] = [
 	["packages/better-auth/src/plugins/oidc-provider/", "identity"],
 	["packages/better-auth/src/plugins/mcp/", "identity"],
 	["packages/better-auth/src/plugins/device-authorization/", "identity"],
+	["packages/cimd/", "identity"],
 	["packages/better-auth/src/plugins/magic-link/", "credentials"],
 	["packages/better-auth/src/plugins/email-otp/", "credentials"],
 	["packages/better-auth/src/plugins/phone-number/", "credentials"],
@@ -252,6 +254,7 @@ export const FILTERED_DOMAINS = new Set(["docs", "devops"]);
  * Used by release-notes.ts to group entries by the package users install.
  */
 const SCOPE_TO_PACKAGE: Record<string, string> = {
+	cimd: "@better-auth/cimd",
 	sso: "@better-auth/sso",
 	scim: "@better-auth/scim",
 	passkey: "@better-auth/passkey",
@@ -276,6 +279,7 @@ const SCOPE_TO_PACKAGE: Record<string, string> = {
  * Order matters: more specific paths must come before catch-alls.
  */
 const PATH_TO_PACKAGE: [string, string][] = [
+	["packages/cimd/", "@better-auth/cimd"],
 	["packages/sso/", "@better-auth/sso"],
 	["packages/scim/", "@better-auth/scim"],
 	["packages/passkey/", "@better-auth/passkey"],

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -121,6 +121,17 @@ function readFileFromRef(path: string, branch: string): string {
 	return readFileSync(path, "utf-8");
 }
 
+function refHasPath(ref: string, path: string): boolean {
+	try {
+		execFileSync("git", ["cat-file", "-e", `${ref}:${path}`], {
+			stdio: "ignore",
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function listTags(): string[] {
 	const output = execFileSync(
 		"git",
@@ -451,8 +462,33 @@ function packageToDir(name: string): string {
 	return `packages/${name.replace(/^@better-auth\//, "")}`;
 }
 
+function packageToReadmeUrl(name: string, ref: string): string {
+	return `https://github.com/${REPO}/blob/${ref}/${packageToDir(name)}/README.md`;
+}
+
 function packageToChangelogUrl(name: string, ref: string): string {
 	return `https://github.com/${REPO}/blob/${ref}/${packageToDir(name)}/CHANGELOG.md`;
+}
+
+function isNewPackageSinceTag(name: string, previousTag: string): boolean {
+	return !refHasPath(previousTag, `${packageToDir(name)}/package.json`);
+}
+
+function packageReferenceLink(
+	name: string,
+	ref: string,
+): { label: "CHANGELOG" | "README"; url: string } {
+	if (refHasPath(ref, `${packageToDir(name)}/CHANGELOG.md`)) {
+		return {
+			label: "CHANGELOG",
+			url: packageToChangelogUrl(name, ref),
+		};
+	}
+
+	return {
+		label: "README",
+		url: packageToReadmeUrl(name, ref),
+	};
 }
 
 /** Load changeset IDs from the previous beta's pre.json to exclude from orphans. */
@@ -670,17 +706,24 @@ function collectEntries(version: string, branch: string): ReleaseEntry[] {
 					: resolvePackage(parsed.scope || undefined, []);
 		}
 
-		entries.push({
-			id: changeset ? `pr-${prNumber}` : `git-${prNumber}`,
-			title,
-			changesetDescription,
-			prNumber,
-			author,
-			domain,
-			packageName,
-			changeType: classifyChangeType(parsed.type, breaking),
-			breaking,
-		});
+		const releasePackages =
+			changeset?.packageNames.length && changeset.packageNames.length > 0
+				? [...new Set(changeset.packageNames)]
+				: [packageName];
+
+		for (const releasePackage of releasePackages) {
+			entries.push({
+				id: `${changeset ? `pr-${prNumber}` : `git-${prNumber}`}:${releasePackage}`,
+				title,
+				changesetDescription,
+				prNumber,
+				author,
+				domain,
+				packageName: releasePackage,
+				changeType: classifyChangeType(parsed.type, breaking),
+				breaking,
+			});
+		}
 	}
 
 	const previousBetaChangesets = loadPreviousPrereleaseChangesets(version);
@@ -783,10 +826,14 @@ function formatReleaseBody(opts: FormatOptions): string {
 		return a.localeCompare(b);
 	});
 
+	const newPackages = new Set(
+		packageOrder.filter((pkg) => isNewPackageSinceTag(pkg, previousTag)),
+	);
+
 	for (const pkg of packageOrder) {
 		const pkgEntries = grouped.get(pkg)!;
 
-		lines.push(`## \`${pkg}\``);
+		lines.push(newPackages.has(pkg) ? `## ✨ \`${pkg}\` ✨` : `## \`${pkg}\``);
 		lines.push("");
 
 		for (const changeType of CHANGE_TYPE_ORDER) {
@@ -816,8 +863,12 @@ function formatReleaseBody(opts: FormatOptions): string {
 			lines.push("");
 		}
 
-		const changelogUrl = packageToChangelogUrl(pkg, commitRef);
-		lines.push(`For detailed changes, see [\`CHANGELOG\`](${changelogUrl})`);
+		const referenceLink = packageReferenceLink(pkg, commitRef);
+		lines.push(
+			referenceLink.label === "CHANGELOG"
+				? `For detailed changes, see [\`${referenceLink.label}\`](${referenceLink.url})`
+				: `For package details, see [\`${referenceLink.label}\`](${referenceLink.url})`,
+		);
 		lines.push("");
 	}
 

--- a/.github/scripts/release-notes.ts
+++ b/.github/scripts/release-notes.ts
@@ -833,7 +833,7 @@ function formatReleaseBody(opts: FormatOptions): string {
 	for (const pkg of packageOrder) {
 		const pkgEntries = grouped.get(pkg)!;
 
-		lines.push(newPackages.has(pkg) ? `## ✨ \`${pkg}\` ✨` : `## \`${pkg}\``);
+		lines.push(newPackages.has(pkg) ? `## \`${pkg}\` ✨` : `## \`${pkg}\``);
 		lines.push("");
 
 		for (const changeType of CHANGE_TYPE_ORDER) {


### PR DESCRIPTION
## Summary
Fix the release-note pipeline so new packages like `@better-auth/cimd` get their own package section instead of being folded into another package.

## What changed
- add `cimd` package/domain mappings to the release-note analyzer
- duplicate multi-package changeset entries across each affected package section instead of collapsing them to one package
- mark packages that are new since the previous tag with `✨`
- fall back to `README` links when a newly added package does not have a generated `CHANGELOG.md` yet
- update the AI rewrite prompt so it preserves the new-package heading markers and generic reference links

## Root cause
The `@better-auth/cimd` PR carried a multi-package changeset, but the analyzer did not recognize `cimd` as its own package. That caused the release notes to group the PR under `@better-auth/oauth-provider`. For brand-new packages, the formatter also assumed a `CHANGELOG.md` already existed, which is not true for `@better-auth/cimd` in `v1.7.0-beta.1`.

## Impact
Future release notes will surface newly added packages as first-class sections, with a visible marker and a valid reference link, instead of burying them under adjacent packages.

## Validation
- `node .github/scripts/release-notes.ts --version 1.7.0-beta.1 --branch HEAD --dry-run`
- pre-commit hooks on commit: `spell`, `biome`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release-notes pipeline so new packages get their own section with clear markers and valid links. Prevents mis-grouping like `@better-auth/cimd` being folded under another package.

- **Bug Fixes**
  - Added `cimd` scope/path mappings and resolved to `@better-auth/cimd`.
  - Duplicated multi-package changesets into each affected package section; generate per-package entry IDs to prevent collapsing.
  - Marked packages added since the previous tag with ✨ in headings.
  - Used `README` links when no `CHANGELOG.md` exists; preferred `CHANGELOG` when available.
  - Updated the rewrite prompt to never alter package headings (including ✨) or the final reference links.

<sup>Written for commit 56307ba6749d511fd22ad446615595acf9e9874c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

