### PR TITLE
docs: add discord username example

### DIFF
--- a/docs/content/docs/authentication/discord.mdx
+++ b/docs/content/docs/authentication/discord.mdx
@@ -74,3 +74,35 @@ export const auth = betterAuth({
 ```
 
 **Note:** The `permissions` parameter only works when the `bot` scope is included in your OAuth2 scopes. Read more about [Discord bot permissions](https://discord.com/developers/docs/topics/permissions).
+
+### Usernames (Optional)
+
+To include the Discord username in your user model, add it to `additionalFields` and map it from the provider profile.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+
+export const auth = betterAuth({
+    socialProviders: {
+        discord: {
+            clientId: process.env.DISCORD_CLIENT_ID as string,
+            clientSecret: process.env.DISCORD_CLIENT_SECRET as string,
+            mapProfileToUser: (profile) => {
+                return {
+                    username: profile.username,
+                };
+            },
+        },
+    },
+    user: {
+        additionalFields: {
+            username: {
+                type: "string",
+                input: false,
+            },
+        },
+    },
+})
+```
+
+**Note:** To make custom fields available in client-side types, infer the additional fields in your `auth-client.ts`. See [Inferring Additional Fields on Client](/docs/concepts/typescript#inferring-additional-fields-on-client).


### PR DESCRIPTION
I updated the Discord auth docs to add an optional username flow: it explains that if you want to store the Discord username you should map it from the provider profile with `mapProfileToUser`, add username to `user.additionalFields`, and infer additional fields in `auth-client.ts` so the field is typed on the client, with a link to the TypeScript docs for that inference step.

Currently, the needed steps are spread across different docs, and this example puts the server mapping and additional fields in one clear snippet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an optional Discord username example in the auth docs to make storing usernames straightforward. It shows mapping `profile.username` via `mapProfileToUser`, defining `user.additionalFields.username`, and how to infer the field on the client in `auth-client.ts` (with a link to the TypeScript docs).

<sup>Written for commit b7b42cc923b6cd00a7b447fdf1fefa3d7bcce3ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

