### PR TITLE
fix(sso): require org admin role to register SSO providers

### DIFF
--- a/.changeset/fix-sso-register-role-check.md
+++ b/.changeset/fix-sso-register-role-check.md
@@ -1,0 +1,14 @@
+---
+"@better-auth/sso": patch
+---
+
+fix(sso): require org admin role to register SSO providers
+
+`POST /sso/register` previously allowed any organization member to register an
+SSO provider for the organization when `organizationId` was supplied, only
+checking membership and not role. This brings it in line with the other
+provider endpoints (`get`/`update`/`delete`), which go through
+`checkProviderAccess` → `isOrgAdmin` and restrict access to `owner` or `admin`
+roles.
+
+Closes #9133.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -755,6 +755,10 @@ const auth = betterAuth({
 
 When registering an SSO provider, you can link it to a specific organization:
 
+<Callout type="info">
+  When the `organization` plugin is enabled and `organizationId` is supplied, the caller must be an organization `owner` or `admin`. Regular members receive a `403 FORBIDDEN`. SSO deployments without the `organization` plugin keep the prior behavior (membership lookup only).
+</Callout>
+
 ```ts title="register-org-provider.ts"
 import { auth } from "@/lib/auth"
 

--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -1317,4 +1317,104 @@ describe("SSO provider read endpoints", () => {
 			expect(data.account.length).toBe(accountCountBefore);
 		});
 	});
+
+	describe("POST /sso/register", () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/9133
+		 */
+		it("should reject registration from non-admin org members", async () => {
+			const { auth, getAuthHeaders, createOrganization, addMember, data } =
+				createTestAuth(true);
+
+			const ownerHeaders = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			const org = await createOrganization("test-org", ownerHeaders);
+
+			const memberHeaders = await getAuthHeaders({
+				email: "member@example.com",
+				password: "password123",
+				name: "Member",
+			});
+
+			const memberUser = (data.user as { id: string; email: string }[]).find(
+				(u) => u.email === "member@example.com",
+			);
+
+			await addMember(memberUser!.id, org!.id, "member", ownerHeaders);
+
+			const response = await auth.api.registerSSOProvider({
+				body: {
+					providerId: "org-saml-provider",
+					issuer: "https://idp.example.com",
+					domain: "example.com",
+					samlConfig: {
+						entryPoint: "https://idp.example.com/sso",
+						cert: TEST_CERT,
+						callbackUrl: "http://localhost:3000/api/sso/callback",
+						audience: "my-audience",
+						wantAssertionsSigned: true,
+						spMetadata: {},
+					},
+					organizationId: org!.id,
+				},
+				headers: memberHeaders,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(403);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/9133
+		 */
+		it("should allow registration from org admins", async () => {
+			const { auth, getAuthHeaders, createOrganization, addMember, data } =
+				createTestAuth(true);
+
+			const ownerHeaders = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			const org = await createOrganization("test-org", ownerHeaders);
+
+			const adminHeaders = await getAuthHeaders({
+				email: "admin@example.com",
+				password: "password123",
+				name: "Admin",
+			});
+
+			const adminUser = (data.user as { id: string; email: string }[]).find(
+				(u) => u.email === "admin@example.com",
+			);
+
+			await addMember(adminUser!.id, org!.id, "admin", ownerHeaders);
+
+			const response = await auth.api.registerSSOProvider({
+				body: {
+					providerId: "org-saml-provider",
+					issuer: "https://idp.example.com",
+					domain: "example.com",
+					samlConfig: {
+						entryPoint: "https://idp.example.com/sso",
+						cert: TEST_CERT,
+						callbackUrl: "http://localhost:3000/api/sso/callback",
+						audience: "my-audience",
+						wantAssertionsSigned: true,
+						spMetadata: {},
+					},
+					organizationId: org!.id,
+				},
+				headers: adminHeaders,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(200);
+		});
+	});
 });

--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -1416,5 +1416,47 @@ describe("SSO provider read endpoints", () => {
 
 			expect(response.status).toBe(200);
 		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/9133
+		 */
+		it("should reject registration when user is not a member of the organization", async () => {
+			const { auth, getAuthHeaders, createOrganization } = createTestAuth(true);
+
+			const ownerHeaders = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			const org = await createOrganization("test-org", ownerHeaders);
+
+			const outsiderHeaders = await getAuthHeaders({
+				email: "outsider@example.com",
+				password: "password123",
+				name: "Outsider",
+			});
+
+			const response = await auth.api.registerSSOProvider({
+				body: {
+					providerId: "org-saml-provider",
+					issuer: "https://idp.example.com",
+					domain: "example.com",
+					samlConfig: {
+						entryPoint: "https://idp.example.com/sso",
+						cert: TEST_CERT,
+						callbackUrl: "http://localhost:3000/api/sso/callback",
+						audience: "my-audience",
+						wantAssertionsSigned: true,
+						spMetadata: {},
+					},
+					organizationId: org!.id,
+				},
+				headers: outsiderHeaders,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(400);
+		});
 	});
 });

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -29,7 +29,7 @@ export function hasOrgAdminRole(member: Pick<Member, "role">): boolean {
 	return member.role.split(",").some((r) => ADMIN_ROLES.includes(r.trim()));
 }
 
-export async function isOrgAdmin(
+async function isOrgAdmin(
 	ctx: {
 		context: {
 			adapter: {

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -25,7 +25,7 @@ interface SSOProviderRecord {
 
 const ADMIN_ROLES = ["owner", "admin"];
 
-async function isOrgAdmin(
+export async function isOrgAdmin(
 	ctx: {
 		context: {
 			adapter: {

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -25,6 +25,10 @@ interface SSOProviderRecord {
 
 const ADMIN_ROLES = ["owner", "admin"];
 
+export function hasOrgAdminRole(member: Pick<Member, "role">): boolean {
+	return member.role.split(",").some((r) => ADMIN_ROLES.includes(r.trim()));
+}
+
 export async function isOrgAdmin(
 	ctx: {
 		context: {
@@ -46,9 +50,7 @@ export async function isOrgAdmin(
 			{ field: "organizationId", value: organizationId },
 		],
 	});
-	if (!member) return false;
-	const roles = member.role.split(",");
-	return roles.some((r) => ADMIN_ROLES.includes(r.trim()));
+	return member ? hasOrgAdminRole(member) : false;
 }
 
 async function batchCheckOrgAdmin(
@@ -72,8 +74,7 @@ async function batchCheckOrgAdmin(
 
 	const adminOrgIds = new Set<string>();
 	for (const member of members) {
-		const roles = member.role.split(",");
-		if (roles.some((r: string) => ADMIN_ROLES.includes(r.trim()))) {
+		if (hasOrgAdminRole(member)) {
 			adminOrgIds.add(member.organizationId);
 		}
 	}

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -35,6 +35,7 @@ import { SAML_ERROR_CODES } from "../saml/error-codes";
 import { generateRelayState } from "../saml-state";
 import type {
 	AuthnRequestRecord,
+	Member,
 	OIDCConfig,
 	SAMLAssertionExtract,
 	SAMLConfig,
@@ -50,7 +51,7 @@ import {
 	createSP,
 	findSAMLProvider,
 } from "./helpers";
-import { isOrgAdmin } from "./providers";
+import { hasOrgAdminRole } from "./providers";
 import { getSafeRedirectUrl, processSAMLResponse } from "./saml-pipeline";
 
 /**
@@ -630,7 +631,7 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 			}
 
 			if (ctx.body.organizationId) {
-				const organization = await ctx.context.adapter.findOne({
+				const member = await ctx.context.adapter.findOne<Member>({
 					model: "member",
 					where: [
 						{
@@ -643,23 +644,16 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 						},
 					],
 				});
-				if (!organization) {
+				if (!member) {
 					throw new APIError("BAD_REQUEST", {
 						message: "You are not a member of the organization",
 					});
 				}
-				if (ctx.context.hasPlugin("organization")) {
-					const hasAdminAccess = await isOrgAdmin(
-						ctx,
-						user.id,
-						ctx.body.organizationId,
-					);
-					if (!hasAdminAccess) {
-						throw new APIError("FORBIDDEN", {
-							message:
-								"You must be an organization owner or admin to register SSO providers",
-						});
-					}
+				if (ctx.context.hasPlugin("organization") && !hasOrgAdminRole(member)) {
+					throw new APIError("FORBIDDEN", {
+						message:
+							"You must be an organization owner or admin to register SSO providers",
+					});
 				}
 			}
 

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -50,6 +50,7 @@ import {
 	createSP,
 	findSAMLProvider,
 } from "./helpers";
+import { isOrgAdmin } from "./providers";
 import { getSafeRedirectUrl, processSAMLResponse } from "./saml-pipeline";
 
 /**
@@ -646,6 +647,19 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 					throw new APIError("BAD_REQUEST", {
 						message: "You are not a member of the organization",
 					});
+				}
+				if (ctx.context.hasPlugin("organization")) {
+					const hasAdminAccess = await isOrgAdmin(
+						ctx,
+						user.id,
+						ctx.body.organizationId,
+					);
+					if (!hasAdminAccess) {
+						throw new APIError("FORBIDDEN", {
+							message:
+								"You must be an organization owner or admin to register SSO providers",
+						});
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

- `POST /sso/register` only verified organization membership; any regular member could register an SSO provider for an organization when passing `organizationId`. This now also requires the caller to be `owner` or `admin`, matching `get`/`update`/`delete` (which go through `checkProviderAccess`).
- A shared `hasOrgAdminRole(member)` helper is extracted from `routes/providers.ts` and reused in `routes/sso.ts`. `registerSSOProvider` keeps its own membership lookup so it can return 400 for non-members and 403 for member-but-non-admin.
- The role check is gated on `hasPlugin("organization")`, matching the pattern in `checkProviderAccess`.

Closes #9133.

> Note: #9133 was filed as a public issue (with the `security` label). Since disclosure is already public, a normal PR is appropriate rather than private coordination.

## Test plan

- [x] `pnpm vitest packages/sso --run` — 350 tests pass
- [x] `tsc --noEmit` on `@better-auth/sso` — clean
- [x] Two new regression tests under `POST /sso/register` in `providers.test.ts`:
  - `should reject registration from non-admin org members` — confirms the fix (403)
  - `should allow registration from org admins` — confirms admins still work (200)
- [x] Both tests carry `@see https://github.com/better-auth/better-auth/issues/9133` per CONTRIBUTING
- [x] Changeset included (`@better-auth/sso: patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require org owner/admin role to register SSO providers in `@better-auth/sso`. Blocks non-admin members from POST /sso/register with organizationId, matching protections on get/update/delete; docs now note this when the `organization` plugin is enabled. Closes #9133.

- **Bug Fixes**
  - Gate POST /sso/register on organization membership and owner/admin role when the `organization` plugin is enabled; return 403 for non-admin members and 400 for non-members.
  - Tests: 403 for non-admin member, 200 for admin, 400 for non-member.

- **Refactors**
  - Deduplicate member lookup and use `hasOrgAdminRole` for role checks.
  - Drop unused `isOrgAdmin` export; keep it internal and export only `hasOrgAdminRole` for reuse.

<sup>Written for commit eccbb904a88df8c802ae94712473bda76cf3469b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
