### PR TITLE
ci(verify-changesets): always run and report pass/fail

### DIFF
--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -28,20 +28,22 @@ jobs:
           exempt=false
           reason=""
 
-          case "$HEAD_REF" in
-            changeset-release/*)
-              exempt=true
-              reason="release PR from changeset-release/* branch"
-              ;;
-          esac
+          if [ "$HEAD_REPO" = "$UPSTREAM_REPO" ]; then
+            case "$HEAD_REF" in
+              changeset-release/*)
+                exempt=true
+                reason="release PR from changeset-release/* branch"
+                ;;
+            esac
 
-          if [ "$exempt" = "false" ] && [ "$HEAD_REPO" = "$UPSTREAM_REPO" ]; then
-            if [ "$HEAD_REF" = "next" ] && [ "$BASE_REF" = "main" ]; then
-              exempt=true
-              reason="next -> main promotion PR"
-            elif [ "$HEAD_REF" = "main" ] && [ "$BASE_REF" = "next" ]; then
-              exempt=true
-              reason="main -> next sync PR"
+            if [ "$exempt" = "false" ]; then
+              if [ "$HEAD_REF" = "next" ] && [ "$BASE_REF" = "main" ]; then
+                exempt=true
+                reason="next -> main promotion PR"
+              elif [ "$HEAD_REF" = "main" ] && [ "$BASE_REF" = "next" ]; then
+                exempt=true
+                reason="main -> next sync PR"
+              fi
             fi
           fi
 

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -7,32 +7,62 @@ on:
       - main
       - next
       - 'release/**'
-    paths:
-      - '.changeset/**'
-      - 'packages/**'
 
 permissions: {}
 
 jobs:
   verify:
     runs-on: ubuntu-latest
-    if: >
-      !startsWith(github.head_ref, 'changeset-release/') &&
-      !(github.head_ref == 'next' && github.base_ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository) &&
-      !(github.head_ref == 'main' && github.base_ref == 'next' && github.event.pull_request.head.repo.full_name == github.repository) &&
-      github.actor != 'github-actions[bot]' &&
-      github.actor != 'better-release[bot]'
     permissions:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Evaluate exemptions
+        id: gate
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          UPSTREAM_REPO: ${{ github.repository }}
+        run: |
+          exempt=false
+          reason=""
+
+          case "$HEAD_REF" in
+            changeset-release/*)
+              exempt=true
+              reason="release PR from changeset-release/* branch"
+              ;;
+          esac
+
+          if [ "$exempt" = "false" ] && [ "$HEAD_REPO" = "$UPSTREAM_REPO" ]; then
+            if [ "$HEAD_REF" = "next" ] && [ "$BASE_REF" = "main" ]; then
+              exempt=true
+              reason="next -> main promotion PR"
+            elif [ "$HEAD_REF" = "main" ] && [ "$BASE_REF" = "next" ]; then
+              exempt=true
+              reason="main -> next sync PR"
+            fi
+          fi
+
+          {
+            echo "exempt=$exempt"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$exempt" = "true" ]; then
+            echo "Verification exempt: $reason"
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.exempt == 'false'
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Block pre.json on main
-        if: github.base_ref == 'main'
+        if: steps.gate.outputs.exempt == 'false' && github.base_ref == 'main'
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -43,6 +73,7 @@ jobs:
 
       - name: Get changed changeset files
         id: changed
+        if: steps.gate.outputs.exempt == 'false'
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -57,7 +88,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Check package changes require changeset
-        if: steps.changed.outputs.has_changesets == 'false'
+        if: steps.gate.outputs.exempt == 'false' && steps.changed.outputs.has_changesets == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -65,13 +96,13 @@ jobs:
         run: |
           LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
           if echo "$LABELS" | grep -q "skip-changeset"; then
-            echo "Skipping changeset requirement (skip-changeset label found)"
+            echo "Changeset not required (skip-changeset label present)"
             exit 0
           fi
 
           PKG_CHANGES=$(git diff --name-only "origin/$BASE_REF"...HEAD -- 'packages/' | grep -c '.' || true)
           if [ "$PKG_CHANGES" -eq 0 ]; then
-            echo "No package changes detected, changeset not required"
+            echo "Changeset not required (no package changes)"
             exit 0
           fi
 
@@ -79,7 +110,7 @@ jobs:
           exit 1
 
       - name: Validate changeset files
-        if: steps.changed.outputs.has_changesets == 'true'
+        if: steps.gate.outputs.exempt == 'false' && steps.changed.outputs.has_changesets == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -116,7 +147,7 @@ jobs:
             while IFS= read -r line; do
               [ -z "$line" ] && continue
               if ! echo "$line" | grep -qE '^"[^"]+"\s*:\s*(major|minor|patch|none)\s*$'; then
-                echo "::error::Changeset $f has invalid entry: $line — expected '\"package-name\": patch|minor|major|none'"
+                echo "::error::Changeset $f has invalid entry: $line (expected '\"package-name\": patch|minor|major|none')"
                 HAS_ERROR=1
               fi
             done <<< "$BODY"

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -7,6 +7,7 @@ on:
       - main
       - next
       - 'release/**'
+  merge_group:
 
 permissions: {}
 
@@ -28,7 +29,10 @@ jobs:
           exempt=false
           reason=""
 
-          if [ "$HEAD_REPO" = "$UPSTREAM_REPO" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
+            exempt=true
+            reason="merge_group event (verification ran on the source PR)"
+          elif [ "$HEAD_REPO" = "$UPSTREAM_REPO" ]; then
             case "$HEAD_REF" in
               changeset-release/*)
                 exempt=true


### PR DESCRIPTION
## Problem

PR #9219 merged green despite missing a changeset. Verify Changesets actually failed on the first run, but a subsequent bot-triggered run marked the check `skipped`, which visually replaced the failure in the PR checks UI.

### Root cause

The job-level ``if:`` excluded ``github.actor == 'better-release[bot]'``. The workflow triggers on ``labeled, unlabeled, edited``. When ``auto-label`` added content-area labels within seconds of the PR opening, the ``labeled`` event re-ran verify as the release bot, matched the exclusion, and concluded ``skipped``.

Three independent defects combined:

1. Job-level ``if:`` producing ``skipped`` on exempt paths, which GitHub's branch protection treats as success.
2. ``paths:`` filter meant PRs outside ``.changeset/**``/``packages/**`` produced no run at all, so the check could not be required.
3. Bot actor exclusions were redundant with the ``head_ref``-based exclusions for ``changeset-release/*`` and ``next``↔``main`` sync PRs.

## Fix

- Move exemption logic into a first ``Evaluate exemptions`` step that sets an output. Subsequent steps gate on that output. Exempt PRs now report ``success`` (all downstream steps skipped within a successful job), not ``skipped``.
- Drop the ``paths:`` filter. Every PR to ``main``/``next``/``release/**`` now produces a deterministic ``verify`` result, so the check can be added to required status checks.
- Remove redundant actor exclusions; the ``changeset-release/*`` head filter and ``next``↔``main`` sync filters already cover every legitimate bot-authored PR.

Trigger types (``labeled``, ``unlabeled``, ``edited``) are preserved: ``skip-changeset`` label additions should re-run verify, and auto-retarget's base change (``edited``) must re-evaluate the patch-only policy (#8979, cb4fc531).

## Follow-up for maintainers

After merge, add ``Verify Changesets / verify`` to required status checks on ``main`` and ``next`` rulesets:

``````
gh api --method PUT repos/better-auth/better-auth/rulesets/8529262 ...  # add 'verify' to required_status_checks
gh api --method PUT repos/better-auth/better-auth/rulesets/14707771 ... # same for next
``````

Currently only ``ci`` and ``e2e`` are required; this fix is advisory until the ruleset is updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Verify Changesets always runs and reports a clear pass/fail, including merge queue runs, so re-runs can’t hide failures. Exemptions only apply to upstream PRs to avoid skips on forks.

- **Bug Fixes**
  - Added `merge_group` trigger (short-circuits with success) and kept `labeled`/`unlabeled`/`edited` so checks re-run on label/base changes.
  - Moved exemptions to a first “Evaluate exemptions” step; exempt PRs now end with a successful job (not job-level “skipped”).
  - Scoped exemptions to upstream PRs only; forks never bypass verification.
  - Removed `paths:` filter so every PR to `main`/`next`/`release/**` gets a deterministic `verify` result.
  - Dropped bot actor exclusions; existing `head_ref` rules cover `changeset-release/*` and internal `next`↔`main` syncs.

- **Migration**
  - After merge, add “Verify Changesets / verify” to required status checks on the `main` and `next` rulesets.

<sup>Written for commit d50733d3308d66009bf6190f9d603788c7c65313. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

