### PR TITLE
feat(organization): cache dynamic role permissions

### DIFF
--- a/.changeset/fuzzy-radios-glow.md
+++ b/.changeset/fuzzy-radios-glow.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Add organization permission caching through `secondaryStorage` and expose `auth.api.hasPermissionForRoles(...)` for evaluating org permissions with caller-provided roles.

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1401,6 +1401,35 @@ const canCreateProjectAndCreateSale =
   });
 ```
 
+**Has Permission For Roles**:
+
+If your app already knows the member roles for an organization, you can skip the membership lookup and evaluate permissions directly with `hasPermissionForRoles`.
+
+```ts title="has-permission-for-roles.ts"
+import { auth } from "@/lib/auth"
+
+await auth.api.hasPermissionForRoles({
+  body: {
+    organizationId: "org-id",
+    roles: ["admin", "member"],
+    permissions: {
+      project: ["create"],
+    },
+  },
+});
+
+await auth.api.hasPermissionForRoles({
+  body: {
+    organizationId: "org-id",
+    roles: "admin,member",
+    permissions: {
+      project: ["create"],
+      sale: ["create"],
+    },
+  },
+});
+```
+
 **Check Role Permission**:
 
 Once you have defined the roles and permissions to avoid checking the permission from the server you can use the `checkRolePermission` function provided by the client.
@@ -1485,6 +1514,37 @@ export const authClient = createAuthClient({
   The `authClient.organization.checkRolePermission` function will not include any dynamic roles as everything is ran synchronously on the client side.
   Please use the [hasPermission](#access-control-usage) APIs to include checks for any dynamic roles.
 </Callout>
+
+### Dynamic Role Permission Cache
+
+If you already configured a global [secondary storage](/docs/concepts/database#secondary-storage), you can enable `permissionCache` on the organization plugin to cache dynamic role definitions per organization.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { organization } from "better-auth/plugins";
+import { redisStorage } from "@better-auth/redis-storage";
+import { ac } from "@/auth/permissions";
+
+export const auth = betterAuth({
+  secondaryStorage: redisStorage({
+    url: process.env.REDIS_URL!,
+  }),
+  plugins: [
+    organization({
+      ac,
+      dynamicAccessControl: {
+        enabled: true,
+      },
+      permissionCache: {
+        enabled: true,
+        ttl: 60,
+      },
+    }),
+  ],
+});
+```
+
+When enabled, Better Auth checks secondary storage before loading dynamic organization roles from the primary database. If no global `secondaryStorage` is configured, Better Auth logs a warning and falls back to database reads.
 
 ### Creating a role
 

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1407,8 +1407,10 @@ If your app already knows the member roles for an organization, you can skip the
 
 ```ts title="has-permission-for-roles.ts"
 import { auth } from "@/lib/auth"
+import { headers } from "next/headers"
 
 await auth.api.hasPermissionForRoles({
+  headers: await headers(),
   body: {
     organizationId: "org-id",
     roles: ["admin", "member"],
@@ -1419,6 +1421,7 @@ await auth.api.hasPermissionForRoles({
 });
 
 await auth.api.hasPermissionForRoles({
+  headers: await headers(),
   body: {
     organizationId: "org-id",
     roles: "admin,member",
@@ -1429,6 +1432,8 @@ await auth.api.hasPermissionForRoles({
   },
 });
 ```
+
+`hasPermissionForRoles` is a server-side `auth.api` helper and still requires an authenticated session. It skips the membership lookup, but it does not expose organization permission evaluation as a public unauthenticated endpoint.
 
 **Check Role Permission**:
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -11,7 +11,14 @@
 		// CI scripts used by GitHub Actions workflows, not by packages
 		".github/scripts/**"
 	],
-	"ignoreBinaries": ["playwright", "changeset", "open", "remark", "tsx"],
+	"ignoreBinaries": [
+		"playwright",
+		"changeset",
+		"open",
+		"remark",
+		"tsx",
+		"tsdown"
+	],
 	// exports used only by tests — invisible to --production mode
 	"ignoreIssues": {
 		"packages/cli/src/commands/init/index.ts": ["exports"],

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -426,6 +426,17 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					},
 				],
 			});
+			if (options?.dynamicAccessControl?.enabled) {
+				await adapter.deleteMany({
+					model: "organizationRole",
+					where: [
+						{
+							field: "organizationId",
+							value: organizationId,
+						},
+					],
+				});
+			}
 			await adapter.delete<InferOrganization<O, false>>({
 				model: "organization",
 				where: [

--- a/packages/better-auth/src/plugins/organization/has-permission.ts
+++ b/packages/better-auth/src/plugins/organization/has-permission.ts
@@ -26,11 +26,15 @@ type DynamicRoleStatements = z.infer<typeof dynamicRoleStatementsSchema>;
 type PermissionStatements = z.infer<typeof permissionStatementsSchema>;
 
 const getPermissionCacheTTL = (options: OrganizationOptions) => {
-	const ttl = options.permissionCache?.ttl ?? DEFAULT_PERMISSION_CACHE_TTL;
-	return Math.max(Math.floor(ttl), 0);
+	const ttl = options.permissionCache?.ttl;
+	const normalizedTTL =
+		typeof ttl === "number" && Number.isFinite(ttl)
+			? ttl
+			: DEFAULT_PERMISSION_CACHE_TTL;
+	return Math.max(Math.floor(normalizedTTL), 0);
 };
 
-export const getPermissionCacheKey = (organizationId: string) =>
+const getPermissionCacheKey = (organizationId: string) =>
 	`organization-role-permissions:${organizationId}`;
 
 const getDefaultAccessControlRoles = (
@@ -53,8 +57,19 @@ const setMemoryRoleCache = (
 	roles: AccessControlRoleMap,
 	options: OrganizationOptions,
 ) => {
+	const ttl = getPermissionCacheTTL(options);
+	const now = Date.now();
+	for (const [cachedOrganizationId, cacheEntry] of cacheAllRoles) {
+		if (cacheEntry.expiresAt <= now) {
+			cacheAllRoles.delete(cachedOrganizationId);
+		}
+	}
+	if (ttl === 0) {
+		cacheAllRoles.delete(organizationId);
+		return;
+	}
 	cacheAllRoles.set(organizationId, {
-		expiresAt: Date.now() + getPermissionCacheTTL(options) * 1000,
+		expiresAt: now + ttl * 1000,
 		roles,
 	});
 };
@@ -164,7 +179,7 @@ const getSecondaryStorageRoleCache = async (
 	return buildAccessControlRoles(options, parsedPayload.data.roles);
 };
 
-export const resolveAccessControlRoles = async (
+const resolveAccessControlRoles = async (
 	input: {
 		organizationId: string;
 		options: OrganizationOptions;
@@ -173,11 +188,12 @@ export const resolveAccessControlRoles = async (
 	ctx: GenericEndpointContext,
 ) => {
 	const defaultRolesMap = getDefaultAccessControlRoles(input.options);
+	const shouldUseMemoryCache = input.useMemoryCache === true;
 	if (!input.organizationId) {
 		return defaultRolesMap;
 	}
 
-	if (input.useMemoryCache) {
+	if (shouldUseMemoryCache) {
 		const cachedRoles = getMemoryRoleCache(input.organizationId);
 		if (cachedRoles) {
 			return cachedRoles;
@@ -185,7 +201,9 @@ export const resolveAccessControlRoles = async (
 	}
 
 	if (!input.options.dynamicAccessControl?.enabled || !input.options.ac) {
-		setMemoryRoleCache(input.organizationId, defaultRolesMap, input.options);
+		if (shouldUseMemoryCache) {
+			setMemoryRoleCache(input.organizationId, defaultRolesMap, input.options);
+		}
 		return defaultRolesMap;
 	}
 
@@ -205,7 +223,9 @@ export const resolveAccessControlRoles = async (
 		ctx,
 	);
 	if (cachedRoles) {
-		setMemoryRoleCache(input.organizationId, cachedRoles, input.options);
+		if (shouldUseMemoryCache) {
+			setMemoryRoleCache(input.organizationId, cachedRoles, input.options);
+		}
 		return cachedRoles;
 	}
 
@@ -214,7 +234,9 @@ export const resolveAccessControlRoles = async (
 		ctx,
 	);
 	const acRoles = buildAccessControlRoles(input.options, dynamicRoleStatements);
-	setMemoryRoleCache(input.organizationId, acRoles, input.options);
+	if (shouldUseMemoryCache) {
+		setMemoryRoleCache(input.organizationId, acRoles, input.options);
+	}
 
 	if (input.options.permissionCache?.enabled && secondaryStorage) {
 		await secondaryStorage.set(

--- a/packages/better-auth/src/plugins/organization/has-permission.ts
+++ b/packages/better-auth/src/plugins/organization/has-permission.ts
@@ -254,9 +254,19 @@ export const invalidatePermissionCache = async (
 	ctx: GenericEndpointContext,
 ) => {
 	cacheAllRoles.delete(organizationId);
-	await ctx.context.secondaryStorage?.delete(
-		getPermissionCacheKey(organizationId),
-	);
+	try {
+		await ctx.context.secondaryStorage?.delete(
+			getPermissionCacheKey(organizationId),
+		);
+	} catch (error) {
+		ctx.context.logger.warn(
+			"[organization] Failed to invalidate permission cache after an organization write. Continuing without blocking the request.",
+			{
+				error,
+				organizationId,
+			},
+		);
+	}
 };
 
 export const hasPermission = async (

--- a/packages/better-auth/src/plugins/organization/has-permission.ts
+++ b/packages/better-auth/src/plugins/organization/has-permission.ts
@@ -1,11 +1,241 @@
 import type { GenericEndpointContext } from "@better-auth/core";
+import { safeJSONParse } from "@better-auth/core/utils/json";
 import * as z from "zod";
 import { APIError } from "../../api";
-import type { Role } from "../access";
 import { defaultRoles } from "./access";
-import type { HasPermissionBaseInput } from "./permission";
+import type {
+	AccessControlRoleMap,
+	HasPermissionBaseInput,
+} from "./permission";
 import { cacheAllRoles, hasPermissionFn } from "./permission";
 import type { OrganizationRole } from "./schema";
+import type { OrganizationOptions } from "./types";
+
+const DEFAULT_PERMISSION_CACHE_TTL = 60;
+const permissionStatementsSchema = z.record(z.string(), z.array(z.string()));
+const dynamicRoleStatementsSchema = z.record(
+	z.string(),
+	permissionStatementsSchema,
+);
+const permissionCachePayloadSchema = z.object({
+	roles: dynamicRoleStatementsSchema,
+});
+const warnedPermissionCacheWithoutStorage = new WeakSet<OrganizationOptions>();
+
+type DynamicRoleStatements = z.infer<typeof dynamicRoleStatementsSchema>;
+type PermissionStatements = z.infer<typeof permissionStatementsSchema>;
+
+const getPermissionCacheTTL = (options: OrganizationOptions) => {
+	const ttl = options.permissionCache?.ttl ?? DEFAULT_PERMISSION_CACHE_TTL;
+	return Math.max(Math.floor(ttl), 0);
+};
+
+export const getPermissionCacheKey = (organizationId: string) =>
+	`organization-role-permissions:${organizationId}`;
+
+const getDefaultAccessControlRoles = (
+	options: OrganizationOptions,
+): AccessControlRoleMap => ({ ...(options.roles || defaultRoles) });
+
+const mergePermissionStatements = (
+	existing: PermissionStatements = {},
+	incoming: PermissionStatements,
+): PermissionStatements => {
+	const merged: PermissionStatements = { ...existing };
+	for (const [key, actions] of Object.entries(incoming)) {
+		merged[key] = [...new Set([...(merged[key] ?? []), ...actions])];
+	}
+	return merged;
+};
+
+const setMemoryRoleCache = (
+	organizationId: string,
+	roles: AccessControlRoleMap,
+	options: OrganizationOptions,
+) => {
+	cacheAllRoles.set(organizationId, {
+		expiresAt: Date.now() + getPermissionCacheTTL(options) * 1000,
+		roles,
+	});
+};
+
+const getMemoryRoleCache = (organizationId: string) => {
+	const cacheEntry = cacheAllRoles.get(organizationId);
+	if (!cacheEntry) return null;
+	if (cacheEntry.expiresAt <= Date.now()) {
+		cacheAllRoles.delete(organizationId);
+		return null;
+	}
+	return cacheEntry.roles;
+};
+
+const parsePermissionStatements = (
+	role: string,
+	rawPermission: unknown,
+	ctx: GenericEndpointContext,
+) => {
+	const parsedPermission = safeJSONParse<unknown>(rawPermission);
+	const result = permissionStatementsSchema.safeParse(parsedPermission);
+	if (!result.success) {
+		ctx.context.logger.error(
+			"[hasPermission] Invalid permissions for role " + role,
+			{
+				permissions: parsedPermission,
+			},
+		);
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			message: "Invalid permissions for role " + role,
+		});
+	}
+	return result.data;
+};
+
+const buildAccessControlRoles = (
+	options: OrganizationOptions,
+	dynamicRoleStatements: DynamicRoleStatements,
+) => {
+	const acRoles = getDefaultAccessControlRoles(options);
+	if (!options.ac) {
+		return acRoles;
+	}
+
+	for (const [role, statements] of Object.entries(dynamicRoleStatements)) {
+		acRoles[role] = options.ac.newRole(
+			mergePermissionStatements(acRoles[role]?.statements, statements),
+		);
+	}
+
+	return acRoles;
+};
+
+const getDynamicRoleStatementsFromDatabase = async (
+	organizationId: string,
+	ctx: GenericEndpointContext,
+) => {
+	const roles = await ctx.context.adapter.findMany<
+		OrganizationRole & { permission: string }
+	>({
+		model: "organizationRole",
+		where: [
+			{
+				field: "organizationId",
+				value: organizationId,
+			},
+		],
+	});
+
+	const dynamicRoleStatements: DynamicRoleStatements = {};
+	for (const { role, permission } of roles) {
+		const statements = parsePermissionStatements(role, permission, ctx);
+		dynamicRoleStatements[role] = mergePermissionStatements(
+			dynamicRoleStatements[role],
+			statements,
+		);
+	}
+
+	return dynamicRoleStatements;
+};
+
+const getSecondaryStorageRoleCache = async (
+	organizationId: string,
+	options: OrganizationOptions,
+	ctx: GenericEndpointContext,
+) => {
+	const secondaryStorage = ctx.context.secondaryStorage;
+	if (!options.permissionCache?.enabled || !secondaryStorage) {
+		return null;
+	}
+
+	const rawCachedRoles = await secondaryStorage.get(
+		getPermissionCacheKey(organizationId),
+	);
+	if (!rawCachedRoles) {
+		return null;
+	}
+
+	const parsedPayload = permissionCachePayloadSchema.safeParse(
+		safeJSONParse(rawCachedRoles),
+	);
+	if (!parsedPayload.success) {
+		await secondaryStorage.delete(getPermissionCacheKey(organizationId));
+		return null;
+	}
+
+	return buildAccessControlRoles(options, parsedPayload.data.roles);
+};
+
+export const resolveAccessControlRoles = async (
+	input: {
+		organizationId: string;
+		options: OrganizationOptions;
+		useMemoryCache?: boolean | undefined;
+	},
+	ctx: GenericEndpointContext,
+) => {
+	const defaultRolesMap = getDefaultAccessControlRoles(input.options);
+	if (!input.organizationId) {
+		return defaultRolesMap;
+	}
+
+	if (input.useMemoryCache) {
+		const cachedRoles = getMemoryRoleCache(input.organizationId);
+		if (cachedRoles) {
+			return cachedRoles;
+		}
+	}
+
+	if (!input.options.dynamicAccessControl?.enabled || !input.options.ac) {
+		setMemoryRoleCache(input.organizationId, defaultRolesMap, input.options);
+		return defaultRolesMap;
+	}
+
+	const secondaryStorage = ctx.context.secondaryStorage;
+	if (input.options.permissionCache?.enabled && !secondaryStorage) {
+		if (!warnedPermissionCacheWithoutStorage.has(input.options)) {
+			ctx.context.logger.warn(
+				"[organization] `permissionCache.enabled` requires a global `secondaryStorage` configuration. Falling back to database reads for organization permissions.",
+			);
+			warnedPermissionCacheWithoutStorage.add(input.options);
+		}
+	}
+
+	const cachedRoles = await getSecondaryStorageRoleCache(
+		input.organizationId,
+		input.options,
+		ctx,
+	);
+	if (cachedRoles) {
+		setMemoryRoleCache(input.organizationId, cachedRoles, input.options);
+		return cachedRoles;
+	}
+
+	const dynamicRoleStatements = await getDynamicRoleStatementsFromDatabase(
+		input.organizationId,
+		ctx,
+	);
+	const acRoles = buildAccessControlRoles(input.options, dynamicRoleStatements);
+	setMemoryRoleCache(input.organizationId, acRoles, input.options);
+
+	if (input.options.permissionCache?.enabled && secondaryStorage) {
+		await secondaryStorage.set(
+			getPermissionCacheKey(input.organizationId),
+			JSON.stringify({ roles: dynamicRoleStatements }),
+			getPermissionCacheTTL(input.options),
+		);
+	}
+
+	return acRoles;
+};
+
+export const invalidatePermissionCache = async (
+	organizationId: string,
+	ctx: GenericEndpointContext,
+) => {
+	cacheAllRoles.delete(organizationId);
+	await ctx.context.secondaryStorage?.delete(
+		getPermissionCacheKey(organizationId),
+	);
+};
 
 export const hasPermission = async (
 	input: {
@@ -21,59 +251,14 @@ export const hasPermission = async (
 	} & HasPermissionBaseInput,
 	ctx: GenericEndpointContext,
 ) => {
-	let acRoles: {
-		[x: string]: Role<any> | undefined;
-	} = { ...(input.options.roles || defaultRoles) };
-
-	if (
-		ctx &&
-		input.organizationId &&
-		input.options.dynamicAccessControl?.enabled &&
-		input.options.ac &&
-		!input.useMemoryCache
-	) {
-		// Load roles from database
-		const roles = await ctx.context.adapter.findMany<
-			OrganizationRole & { permission: string }
-		>({
-			model: "organizationRole",
-			where: [
-				{
-					field: "organizationId",
-					value: input.organizationId,
-				},
-			],
-		});
-
-		for (const { role, permission: permissionsString } of roles) {
-			const result = z
-				.record(z.string(), z.array(z.string()))
-				.safeParse(JSON.parse(permissionsString));
-
-			if (!result.success) {
-				ctx.context.logger.error(
-					"[hasPermission] Invalid permissions for role " + role,
-					{
-						permissions: JSON.parse(permissionsString),
-					},
-				);
-				throw new APIError("INTERNAL_SERVER_ERROR", {
-					message: "Invalid permissions for role " + role,
-				});
-			}
-
-			const merged: Record<string, string[]> = { ...acRoles[role]?.statements };
-			for (const [key, actions] of Object.entries(result.data)) {
-				merged[key] = [...new Set([...(merged[key] ?? []), ...actions])];
-			}
-			acRoles[role] = input.options.ac.newRole(merged);
-		}
-	}
-
-	if (input.useMemoryCache) {
-		acRoles = cacheAllRoles.get(input.organizationId) || acRoles;
-	}
-	cacheAllRoles.set(input.organizationId, acRoles);
+	const acRoles = await resolveAccessControlRoles(
+		{
+			organizationId: input.organizationId,
+			options: input.options,
+			useMemoryCache: input.useMemoryCache,
+		},
+		ctx,
+	);
 
 	return hasPermissionFn(input, acRoles);
 };

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -18,11 +18,9 @@ import { admin } from "../admin";
 import { adminAc, defaultStatements, memberAc, ownerAc } from "./access";
 import { inferOrgAdditionalFields, organizationClient } from "./client";
 import { ORGANIZATION_ERROR_CODES } from "./error-codes";
-import {
-	getPermissionCacheKey,
-	hasPermission as hasPermissionHelper,
-} from "./has-permission";
+import { hasPermission as hasPermissionHelper } from "./has-permission";
 import { organization } from "./organization";
+import { cacheAllRoles } from "./permission";
 import type {
 	InferInvitation,
 	InferMember,
@@ -30,6 +28,9 @@ import type {
 	InvitationStatus,
 } from "./schema";
 import type { OrganizationOptions } from "./types";
+
+const getPermissionCacheKey = (organizationId: string) =>
+	`organization-role-permissions:${organizationId}`;
 
 describe("organization type", () => {
 	it("empty org type should works", () => {
@@ -1984,6 +1985,62 @@ describe("organization permission cache ttl", async () => {
 	});
 	if (!org) throw new Error("Organization not created");
 
+	it("falls back to the default ttl when permissionCache.ttl is non-finite", async () => {
+		const invalidTtlOrg = await auth.api.createOrganization({
+			body: {
+				name: "permission-cache-invalid-ttl-org",
+				slug: `permission-cache-invalid-ttl-org-${crypto.randomUUID()}`,
+			},
+			headers,
+		});
+		if (!invalidTtlOrg) throw new Error("Organization not created");
+
+		await db.create({
+			model: "organizationRole",
+			data: {
+				organizationId: invalidTtlOrg.id,
+				role: "custom-invalid-ttl",
+				permission: JSON.stringify({
+					project: ["create"],
+				}),
+				createdAt: new Date(),
+			},
+		});
+
+		const context = await auth.$context;
+		const invalidTtlOptions = {
+			ac,
+			dynamicAccessControl: {
+				enabled: true,
+			},
+			permissionCache: {
+				enabled: true,
+				ttl: Number.NaN,
+			},
+		} satisfies OrganizationOptions;
+
+		secondaryStorage.set.mockClear();
+
+		const result = await hasPermissionHelper(
+			{
+				role: "custom-invalid-ttl",
+				options: invalidTtlOptions,
+				organizationId: invalidTtlOrg.id,
+				permissions: {
+					project: ["create"],
+				},
+			},
+			{ context } as any,
+		);
+
+		expect(result).toBe(true);
+		expect(secondaryStorage.set).toHaveBeenCalledWith(
+			getPermissionCacheKey(invalidTtlOrg.id),
+			expect.any(String),
+			60,
+		);
+	});
+
 	it("expires the in-memory role cache based on ttl", async () => {
 		await db.create({
 			model: "organizationRole",
@@ -2072,6 +2129,52 @@ describe("organization permission cache ttl", async () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("only stores in-memory cache entries when useMemoryCache is enabled", async () => {
+		onTestFinished(() => {
+			cacheAllRoles.clear();
+		});
+		const { headers: freshHeaders } = await signInWithTestUser();
+
+		const memoryCacheOrg = await auth.api.createOrganization({
+			body: {
+				name: "permission-cache-memory-write-org",
+				slug: `permission-cache-memory-write-org-${crypto.randomUUID()}`,
+			},
+			headers: freshHeaders,
+		});
+		if (!memoryCacheOrg) throw new Error("Organization not created");
+
+		await db.create({
+			model: "organizationRole",
+			data: {
+				organizationId: memoryCacheOrg.id,
+				role: "custom-memory-cache",
+				permission: JSON.stringify({
+					project: ["create"],
+				}),
+				createdAt: new Date(),
+			},
+		});
+
+		const context = await auth.$context;
+		cacheAllRoles.clear();
+
+		const result = await hasPermissionHelper(
+			{
+				role: "custom-memory-cache",
+				options: organizationOptions,
+				organizationId: memoryCacheOrg.id,
+				permissions: {
+					project: ["create"],
+				},
+			},
+			{ context } as any,
+		);
+
+		expect(result).toBe(true);
+		expect(cacheAllRoles.has(memoryCacheOrg.id)).toBe(false);
 	});
 });
 

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1,4 +1,4 @@
-import type { APIError } from "@better-auth/core/error";
+import { APIError } from "@better-auth/core/error";
 import { memoryAdapter } from "@better-auth/memory-adapter";
 import type { Prettify } from "better-call";
 import { describe, expect, expectTypeOf, it, onTestFinished, vi } from "vitest";
@@ -2115,6 +2115,27 @@ describe("hasPermissionForRoles", async () => {
 	});
 	if (!org) throw new Error("Organization not created");
 
+	it("requires an authenticated session even when roles are provided", async () => {
+		try {
+			await auth.api.hasPermissionForRoles({
+				headers: new Headers(),
+				body: {
+					organizationId: org.id,
+					roles: ["owner"],
+					permissions: {
+						project: ["create"],
+					},
+				},
+			});
+			expect.fail("Should have thrown an error");
+		} catch (error) {
+			expect(error).toBeInstanceOf(APIError);
+			if (error instanceof APIError) {
+				expect(error.status).toBe("UNAUTHORIZED");
+			}
+		}
+	});
+
 	it("skips membership lookup and invalidates cached roles after role updates and deletes", async () => {
 		const permissionKey = getPermissionCacheKey(org.id);
 
@@ -2160,6 +2181,7 @@ describe("hasPermissionForRoles", async () => {
 		secondaryStorage.delete.mockClear();
 
 		const firstCheck = await auth.api.hasPermissionForRoles({
+			headers,
 			body: {
 				organizationId: org.id,
 				roles: ["custom-cache"],
@@ -2189,6 +2211,7 @@ describe("hasPermissionForRoles", async () => {
 		expect(secondaryStorage.delete).toHaveBeenCalledWith(permissionKey);
 
 		const createAfterUpdate = await auth.api.hasPermissionForRoles({
+			headers,
 			body: {
 				organizationId: org.id,
 				roles: "custom-cache",
@@ -2198,6 +2221,7 @@ describe("hasPermissionForRoles", async () => {
 			},
 		});
 		const deleteAfterUpdate = await auth.api.hasPermissionForRoles({
+			headers,
 			body: {
 				organizationId: org.id,
 				roles: "custom-cache",
@@ -2223,6 +2247,7 @@ describe("hasPermissionForRoles", async () => {
 		expect(secondaryStorage.delete).toHaveBeenCalledWith(permissionKey);
 
 		const afterDelete = await auth.api.hasPermissionForRoles({
+			headers,
 			body: {
 				organizationId: org.id,
 				roles: ["custom-cache"],
@@ -2291,6 +2316,7 @@ describe("organization permission cache invalidation on delete", async () => {
 
 		const permissionKey = getPermissionCacheKey(org.id);
 		const warmCache = await auth.api.hasPermissionForRoles({
+			headers,
 			body: {
 				organizationId: org.id,
 				roles: ["custom-delete"],
@@ -2324,6 +2350,7 @@ describe("organization permission cache invalidation on delete", async () => {
 		expect(remainingRoles).toHaveLength(0);
 
 		const afterDelete = await auth.api.hasPermissionForRoles({
+			headers,
 			body: {
 				organizationId: org.id,
 				roles: ["custom-delete"],

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1,7 +1,7 @@
 import type { APIError } from "@better-auth/core/error";
 import { memoryAdapter } from "@better-auth/memory-adapter";
 import type { Prettify } from "better-call";
-import { describe, expect, expectTypeOf, it, onTestFinished } from "vitest";
+import { describe, expect, expectTypeOf, it, onTestFinished, vi } from "vitest";
 import type {
 	BetterFetchError,
 	PreinitializedWritableAtom,
@@ -18,6 +18,10 @@ import { admin } from "../admin";
 import { adminAc, defaultStatements, memberAc, ownerAc } from "./access";
 import { inferOrgAdditionalFields, organizationClient } from "./client";
 import { ORGANIZATION_ERROR_CODES } from "./error-codes";
+import {
+	getPermissionCacheKey,
+	hasPermission as hasPermissionHelper,
+} from "./has-permission";
 import { organization } from "./organization";
 import type {
 	InferInvitation,
@@ -1783,6 +1787,634 @@ describe("dynamic access control should merge DB permissions with built-in roles
 			},
 		});
 		expect(orgDelete.success).toBe(true);
+	});
+});
+
+describe("organization permission cache", async () => {
+	const storage = new Map<string, string>();
+	const storageTTLs = new Map<string, number | undefined>();
+	const secondaryStorage = {
+		get: vi.fn((key: string) => storage.get(key)),
+		set: vi.fn((key: string, value: string, ttl?: number) => {
+			storage.set(key, value);
+			storageTTLs.set(key, ttl);
+		}),
+		delete: vi.fn((key: string) => {
+			storage.delete(key);
+			storageTTLs.delete(key);
+		}),
+	};
+	const ac = createAccessControl({
+		...defaultStatements,
+		project: ["create", "delete"],
+	});
+	const { auth, signInWithTestUser, db } = await getTestInstance({
+		secondaryStorage,
+		plugins: [
+			organization({
+				ac,
+				dynamicAccessControl: {
+					enabled: true,
+				},
+				permissionCache: {
+					enabled: true,
+					ttl: 60,
+				},
+			}),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await auth.api.createOrganization({
+		body: {
+			name: "permission-cache-org",
+			slug: "permission-cache-org",
+		},
+		headers,
+	});
+	if (!org) throw new Error("Organization not created");
+
+	it("warms secondary storage and reuses it on later hasPermission calls", async () => {
+		await db.create({
+			model: "organizationRole",
+			data: {
+				organizationId: org.id,
+				role: "owner",
+				permission: JSON.stringify({
+					project: ["create", "delete"],
+				}),
+				createdAt: new Date(),
+			},
+		});
+
+		const context = await auth.$context;
+		const findManySpy = vi.spyOn(context.adapter, "findMany");
+		findManySpy.mockClear();
+		secondaryStorage.get.mockClear();
+		secondaryStorage.set.mockClear();
+
+		const permissionKey = getPermissionCacheKey(org.id);
+		const firstCheck = await auth.api.hasPermission({
+			headers,
+			body: {
+				organizationId: org.id,
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+
+		expect(firstCheck.success).toBe(true);
+		expect(
+			findManySpy.mock.calls.filter(
+				([args]) => args.model === "organizationRole",
+			),
+		).toHaveLength(1);
+		expect(secondaryStorage.set).toHaveBeenCalledWith(
+			permissionKey,
+			expect.any(String),
+			60,
+		);
+		expect(storageTTLs.get(permissionKey)).toBe(60);
+
+		findManySpy.mockClear();
+		secondaryStorage.get.mockClear();
+
+		const secondCheck = await auth.api.hasPermission({
+			headers,
+			body: {
+				organizationId: org.id,
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+
+		expect(secondCheck.success).toBe(true);
+		expect(secondaryStorage.get).toHaveBeenCalledWith(permissionKey);
+		expect(
+			findManySpy.mock.calls.filter(
+				([args]) => args.model === "organizationRole",
+			),
+		).toHaveLength(0);
+	});
+
+	it("deletes corrupt secondary storage payloads and repopulates from the database", async () => {
+		const corruptOrg = await auth.api.createOrganization({
+			body: {
+				name: "permission-cache-corrupt-org",
+				slug: `permission-cache-corrupt-org-${crypto.randomUUID()}`,
+			},
+			headers,
+		});
+		if (!corruptOrg) throw new Error("Organization not created");
+
+		await db.create({
+			model: "organizationRole",
+			data: {
+				organizationId: corruptOrg.id,
+				role: "owner",
+				permission: JSON.stringify({
+					project: ["create"],
+				}),
+				createdAt: new Date(),
+			},
+		});
+
+		const permissionKey = getPermissionCacheKey(corruptOrg.id);
+		storage.set(permissionKey, JSON.stringify({ roles: "broken" }));
+		secondaryStorage.delete.mockClear();
+		secondaryStorage.set.mockClear();
+
+		const permissionRes = await auth.api.hasPermission({
+			headers,
+			body: {
+				organizationId: corruptOrg.id,
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+
+		expect(permissionRes.success).toBe(true);
+		expect(secondaryStorage.delete).toHaveBeenCalledWith(permissionKey);
+		expect(secondaryStorage.set).toHaveBeenCalledWith(
+			permissionKey,
+			expect.any(String),
+			60,
+		);
+	});
+});
+
+describe("organization permission cache ttl", async () => {
+	const storage = new Map<string, string>();
+	const secondaryStorage = {
+		get: vi.fn((key: string) => storage.get(key)),
+		set: vi.fn((key: string, value: string) => {
+			storage.set(key, value);
+		}),
+		delete: vi.fn((key: string) => {
+			storage.delete(key);
+		}),
+	};
+	const ac = createAccessControl({
+		...defaultStatements,
+		project: ["create"],
+	});
+	const organizationOptions = {
+		ac,
+		dynamicAccessControl: {
+			enabled: true,
+		},
+		permissionCache: {
+			enabled: true,
+			ttl: 1,
+		},
+	} satisfies OrganizationOptions;
+	const { auth, signInWithTestUser, db } = await getTestInstance({
+		secondaryStorage,
+		plugins: [organization(organizationOptions)],
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await auth.api.createOrganization({
+		body: {
+			name: "permission-cache-ttl-org",
+			slug: "permission-cache-ttl-org",
+		},
+		headers,
+	});
+	if (!org) throw new Error("Organization not created");
+
+	it("expires the in-memory role cache based on ttl", async () => {
+		await db.create({
+			model: "organizationRole",
+			data: {
+				organizationId: org.id,
+				role: "owner",
+				permission: JSON.stringify({
+					project: ["create"],
+				}),
+				createdAt: new Date(),
+			},
+		});
+
+		const context = await auth.$context;
+		const findManySpy = vi.spyOn(context.adapter, "findMany");
+		findManySpy.mockClear();
+
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-04-17T00:00:00.000Z"));
+
+			const warmResult = await hasPermissionHelper(
+				{
+					role: "owner",
+					options: organizationOptions,
+					organizationId: org.id,
+					permissions: {
+						project: ["create"],
+					},
+					useMemoryCache: true,
+				},
+				{ context } as any,
+			);
+
+			expect(warmResult).toBe(true);
+			expect(
+				findManySpy.mock.calls.filter(
+					([args]) => args.model === "organizationRole",
+				),
+			).toHaveLength(1);
+
+			storage.clear();
+			findManySpy.mockClear();
+
+			const beforeExpiry = await hasPermissionHelper(
+				{
+					role: "owner",
+					options: organizationOptions,
+					organizationId: org.id,
+					permissions: {
+						project: ["create"],
+					},
+					useMemoryCache: true,
+				},
+				{ context } as any,
+			);
+
+			expect(beforeExpiry).toBe(true);
+			expect(
+				findManySpy.mock.calls.filter(
+					([args]) => args.model === "organizationRole",
+				),
+			).toHaveLength(0);
+
+			vi.setSystemTime(new Date("2026-04-17T00:00:02.000Z"));
+
+			const afterExpiry = await hasPermissionHelper(
+				{
+					role: "owner",
+					options: organizationOptions,
+					organizationId: org.id,
+					permissions: {
+						project: ["create"],
+					},
+					useMemoryCache: true,
+				},
+				{ context } as any,
+			);
+
+			expect(afterExpiry).toBe(true);
+			expect(
+				findManySpy.mock.calls.filter(
+					([args]) => args.model === "organizationRole",
+				),
+			).toHaveLength(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+describe("hasPermissionForRoles", async () => {
+	const storage = new Map<string, string>();
+	const secondaryStorage = {
+		get: vi.fn((key: string) => storage.get(key)),
+		set: vi.fn((key: string, value: string) => {
+			storage.set(key, value);
+		}),
+		delete: vi.fn((key: string) => {
+			storage.delete(key);
+		}),
+	};
+	const ac = createAccessControl({
+		...defaultStatements,
+		project: ["create", "delete"],
+	});
+	const { auth, signInWithTestUser, db } = await getTestInstance({
+		secondaryStorage,
+		plugins: [
+			organization({
+				ac,
+				dynamicAccessControl: {
+					enabled: true,
+				},
+				permissionCache: {
+					enabled: true,
+					ttl: 60,
+				},
+			}),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await auth.api.createOrganization({
+		body: {
+			name: "permission-cache-custom-role-org",
+			slug: "permission-cache-custom-role-org",
+		},
+		headers,
+	});
+	if (!org) throw new Error("Organization not created");
+
+	it("skips membership lookup and invalidates cached roles after role updates and deletes", async () => {
+		const permissionKey = getPermissionCacheKey(org.id);
+
+		await db.create({
+			model: "organizationRole",
+			data: {
+				organizationId: org.id,
+				role: "owner",
+				permission: JSON.stringify({
+					project: ["create", "delete"],
+				}),
+				createdAt: new Date(),
+			},
+		});
+
+		await auth.api.hasPermission({
+			headers,
+			body: {
+				organizationId: org.id,
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+
+		secondaryStorage.delete.mockClear();
+
+		await auth.api.createOrgRole({
+			headers,
+			body: {
+				organizationId: org.id,
+				role: "custom-cache",
+				permission: {
+					project: ["create"],
+				},
+			},
+		});
+		expect(secondaryStorage.delete).toHaveBeenCalledWith(permissionKey);
+
+		const context = await auth.$context;
+		const findOneSpy = vi.spyOn(context.adapter, "findOne");
+		findOneSpy.mockClear();
+		secondaryStorage.delete.mockClear();
+
+		const firstCheck = await auth.api.hasPermissionForRoles({
+			body: {
+				organizationId: org.id,
+				roles: ["custom-cache"],
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+
+		expect(firstCheck.success).toBe(true);
+		expect(findOneSpy).not.toHaveBeenCalled();
+		expect(storage.has(permissionKey)).toBe(true);
+
+		await auth.api.updateOrgRole({
+			headers,
+			body: {
+				organizationId: org.id,
+				roleName: "custom-cache",
+				data: {
+					permission: {
+						project: ["delete"],
+					},
+				},
+			},
+		});
+
+		expect(secondaryStorage.delete).toHaveBeenCalledWith(permissionKey);
+
+		const createAfterUpdate = await auth.api.hasPermissionForRoles({
+			body: {
+				organizationId: org.id,
+				roles: "custom-cache",
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+		const deleteAfterUpdate = await auth.api.hasPermissionForRoles({
+			body: {
+				organizationId: org.id,
+				roles: "custom-cache",
+				permissions: {
+					project: ["delete"],
+				},
+			},
+		});
+
+		expect(createAfterUpdate.success).toBe(false);
+		expect(deleteAfterUpdate.success).toBe(true);
+
+		secondaryStorage.delete.mockClear();
+
+		await auth.api.deleteOrgRole({
+			headers,
+			body: {
+				organizationId: org.id,
+				roleName: "custom-cache",
+			},
+		});
+
+		expect(secondaryStorage.delete).toHaveBeenCalledWith(permissionKey);
+
+		const afterDelete = await auth.api.hasPermissionForRoles({
+			body: {
+				organizationId: org.id,
+				roles: ["custom-cache"],
+				permissions: {
+					project: ["delete"],
+				},
+			},
+		});
+
+		expect(afterDelete.success).toBe(false);
+	});
+});
+
+describe("organization permission cache invalidation on delete", async () => {
+	const storage = new Map<string, string>();
+	const secondaryStorage = {
+		get: vi.fn((key: string) => storage.get(key)),
+		set: vi.fn((key: string, value: string) => {
+			storage.set(key, value);
+		}),
+		delete: vi.fn((key: string) => {
+			storage.delete(key);
+		}),
+	};
+	const ac = createAccessControl({
+		...defaultStatements,
+		project: ["create"],
+	});
+	const { auth, signInWithTestUser, db } = await getTestInstance({
+		secondaryStorage,
+		plugins: [
+			organization({
+				ac,
+				dynamicAccessControl: {
+					enabled: true,
+				},
+				permissionCache: {
+					enabled: true,
+					ttl: 60,
+				},
+			}),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await auth.api.createOrganization({
+		body: {
+			name: "permission-cache-delete-org",
+			slug: "permission-cache-delete-org",
+		},
+		headers,
+	});
+	if (!org) throw new Error("Organization not created");
+
+	it("clears cached data and removes dynamic org roles when an organization is deleted", async () => {
+		await db.create({
+			model: "organizationRole",
+			data: {
+				organizationId: org.id,
+				role: "custom-delete",
+				permission: JSON.stringify({
+					project: ["create"],
+				}),
+				createdAt: new Date(),
+			},
+		});
+
+		const permissionKey = getPermissionCacheKey(org.id);
+		const warmCache = await auth.api.hasPermissionForRoles({
+			body: {
+				organizationId: org.id,
+				roles: ["custom-delete"],
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+
+		expect(warmCache.success).toBe(true);
+		expect(storage.has(permissionKey)).toBe(true);
+
+		await auth.api.deleteOrganization({
+			headers,
+			body: {
+				organizationId: org.id,
+			},
+		});
+
+		expect(storage.has(permissionKey)).toBe(false);
+
+		const remainingRoles = await db.findMany({
+			model: "organizationRole",
+			where: [
+				{
+					field: "organizationId",
+					value: org.id,
+				},
+			],
+		});
+		expect(remainingRoles).toHaveLength(0);
+
+		const afterDelete = await auth.api.hasPermissionForRoles({
+			body: {
+				organizationId: org.id,
+				roles: ["custom-delete"],
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+
+		expect(afterDelete.success).toBe(false);
+	});
+});
+
+describe("organization permission cache without secondary storage", async () => {
+	const ac = createAccessControl({
+		...defaultStatements,
+		project: ["create"],
+	});
+	const { auth, signInWithTestUser, db } = await getTestInstance({
+		plugins: [
+			organization({
+				ac,
+				dynamicAccessControl: {
+					enabled: true,
+				},
+				permissionCache: {
+					enabled: true,
+					ttl: 60,
+				},
+			}),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await auth.api.createOrganization({
+		body: {
+			name: "permission-cache-no-secondary-storage",
+			slug: "permission-cache-no-secondary-storage",
+		},
+		headers,
+	});
+	if (!org) throw new Error("Organization not created");
+
+	it("falls back to database reads when permissionCache is enabled without secondary storage", async () => {
+		await db.create({
+			model: "organizationRole",
+			data: {
+				organizationId: org.id,
+				role: "owner",
+				permission: JSON.stringify({
+					project: ["create"],
+				}),
+				createdAt: new Date(),
+			},
+		});
+
+		const context = await auth.$context;
+		const findManySpy = vi.spyOn(context.adapter, "findMany");
+		const warnSpy = vi.spyOn(context.logger, "warn");
+		findManySpy.mockClear();
+		warnSpy.mockClear();
+
+		const firstCheck = await auth.api.hasPermission({
+			headers,
+			body: {
+				organizationId: org.id,
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+		const secondCheck = await auth.api.hasPermission({
+			headers,
+			body: {
+				organizationId: org.id,
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+
+		expect(firstCheck.success).toBe(true);
+		expect(secondCheck.success).toBe(true);
+		expect(
+			findManySpy.mock.calls.filter(
+				([args]) => args.model === "organizationRole",
+			),
+		).toHaveLength(2);
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("permissionCache.enabled"),
+		);
 	});
 });
 

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2465,6 +2465,74 @@ describe("organization permission cache invalidation on delete", async () => {
 
 		expect(afterDelete.success).toBe(false);
 	});
+
+	it("still deletes the organization when secondary storage invalidation fails", async () => {
+		const failingOrg = await auth.api.createOrganization({
+			body: {
+				name: "permission-cache-delete-org-with-storage-error",
+				slug: `permission-cache-delete-org-with-storage-error-${crypto.randomUUID()}`,
+			},
+			headers,
+		});
+		if (!failingOrg) throw new Error("Organization not created");
+
+		await db.create({
+			model: "organizationRole",
+			data: {
+				organizationId: failingOrg.id,
+				role: "custom-delete-failure",
+				permission: JSON.stringify({
+					project: ["create"],
+				}),
+				createdAt: new Date(),
+			},
+		});
+
+		const permissionKey = getPermissionCacheKey(failingOrg.id);
+		await auth.api.hasPermissionForRoles({
+			headers,
+			body: {
+				organizationId: failingOrg.id,
+				roles: ["custom-delete-failure"],
+				permissions: {
+					project: ["create"],
+				},
+			},
+		});
+
+		const context = await auth.$context;
+		const warnSpy = vi.spyOn(context.logger, "warn");
+		secondaryStorage.delete.mockImplementationOnce(() => {
+			throw new Error("secondary storage unavailable");
+		});
+
+		const deletedOrganization = await auth.api.deleteOrganization({
+			headers,
+			body: {
+				organizationId: failingOrg.id,
+			},
+		});
+
+		expect(deletedOrganization.id).toBe(failingOrg.id);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Failed to invalidate permission cache"),
+			expect.objectContaining({
+				organizationId: failingOrg.id,
+			}),
+		);
+		expect(storage.has(permissionKey)).toBe(true);
+
+		const remainingOrganizations = await db.findMany({
+			model: "organization",
+			where: [
+				{
+					field: "id",
+					value: failingOrg.id,
+				},
+			],
+		});
+		expect(remainingOrganizations).toHaveLength(0);
+	});
 });
 
 describe("organization permission cache without secondary storage", async () => {

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -113,7 +113,13 @@ export interface OrganizationCreator {
 }
 
 export function parseRoles(roles: string | string[]): string {
-	return Array.isArray(roles) ? roles.join(",") : roles;
+	if (Array.isArray(roles)) {
+		return roles
+			.map((role) => role.trim())
+			.filter(Boolean)
+			.join(",");
+	}
+	return roles;
 }
 
 export type DynamicAccessControlEndpoints<O extends OrganizationOptions> = {
@@ -159,22 +165,35 @@ export type OrganizationEndpoints<O extends OrganizationOptions> = {
 	listMembers: ReturnType<typeof listMembers<O>>;
 	getActiveMemberRole: ReturnType<typeof getActiveMemberRole<O>>;
 	hasPermission: ReturnType<typeof createHasPermission<O>>;
+	hasPermissionForRoles: ReturnType<typeof createHasPermissionForRoles<O>>;
 };
+
+const permissionBodySchema = z.xor([
+	z.object({
+		permission: z.record(z.string(), z.array(z.string())),
+	}),
+	z.object({
+		permissions: z.record(z.string(), z.array(z.string())),
+	}),
+]);
 
 const createHasPermissionBodySchema = z
 	.object({
 		organizationId: z.string().optional(),
 	})
-	.and(
-		z.xor([
-			z.object({
-				permission: z.record(z.string(), z.array(z.string())),
-			}),
-			z.object({
-				permissions: z.record(z.string(), z.array(z.string())),
-			}),
-		]),
-	);
+	.and(permissionBodySchema);
+
+const createHasPermissionForRolesBodySchema = z
+	.object({
+		organizationId: z.string(),
+		roles: z.string().or(z.array(z.string())),
+	})
+	.and(permissionBodySchema);
+
+const getPermissionsFromBody = (body: {
+	permission?: Record<string, unknown>;
+	permissions?: Record<string, unknown>;
+}) => body.permissions ?? body.permission ?? {};
 
 const createHasPermission = <O extends OrganizationOptions>(options: O) => {
 	type DefaultStatements = typeof defaultStatements;
@@ -276,8 +295,119 @@ const createHasPermission = <O extends OrganizationOptions>(options: O) => {
 				{
 					role: member.role,
 					options: options,
-					permissions: ctx.body.permissions as any,
+					permissions: getPermissionsFromBody(ctx.body) as any,
 					organizationId: activeOrganizationId,
+				},
+				ctx,
+			);
+
+			return ctx.json({
+				error: null,
+				success: result,
+			});
+		},
+	);
+};
+
+const createHasPermissionForRoles = <O extends OrganizationOptions>(
+	options: O,
+) => {
+	type DefaultStatements = typeof defaultStatements;
+	type Statements =
+		O["ac"] extends AccessControl<infer S> ? S : DefaultStatements;
+	type PermissionType = {
+		[key in keyof Statements]?: Array<
+			Statements[key] extends readonly unknown[]
+				? ArrayElement<Statements[key]>
+				: never
+		>;
+	};
+	type PermissionExclusive = {
+		permissions: PermissionType;
+	};
+
+	return createAuthEndpoint(
+		"/organization/has-permission-for-roles",
+		{
+			method: "POST",
+			body: createHasPermissionForRolesBodySchema,
+			metadata: {
+				$Infer: {
+					body: {} as PermissionExclusive & {
+						organizationId: string;
+						roles: string | string[];
+					},
+				},
+				openapi: {
+					description:
+						"Check if the provided organization roles have permission",
+					requestBody: {
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										organizationId: {
+											type: "string",
+											description:
+												"The organization to resolve dynamic roles from",
+										},
+										roles: {
+											oneOf: [
+												{ type: "string" },
+												{
+													type: "array",
+													items: { type: "string" },
+												},
+											],
+											description: "The caller-provided member roles",
+										},
+										permission: {
+											type: "object",
+											description: "The permission to check",
+											deprecated: true,
+										},
+										permissions: {
+											type: "object",
+											description: "The permission to check",
+										},
+									},
+									required: ["organizationId", "roles", "permissions"],
+								},
+							},
+						},
+					},
+					responses: {
+						"200": {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											error: {
+												type: "string",
+											},
+											success: {
+												type: "boolean",
+											},
+										},
+										required: ["success"],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const result = await hasPermission(
+				{
+					role: parseRoles(ctx.body.roles),
+					options,
+					permissions: getPermissionsFromBody(ctx.body) as any,
+					organizationId: ctx.body.organizationId,
 				},
 				ctx,
 			);
@@ -1212,6 +1342,7 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 		endpoints: {
 			...(api as OrganizationEndpoints<O>),
 			hasPermission: createHasPermission(opts),
+			hasPermissionForRoles: createHasPermissionForRoles(opts),
 		},
 		schema: {
 			...(schema as BetterAuthPluginDBSchema),

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -330,8 +330,11 @@ const createHasPermissionForRoles = <O extends OrganizationOptions>(
 		"/organization/has-permission-for-roles",
 		{
 			method: "POST",
+			requireHeaders: true,
 			body: createHasPermissionForRolesBodySchema,
+			use: [orgSessionMiddleware],
 			metadata: {
+				scope: "server",
 				$Infer: {
 					body: {} as PermissionExclusive & {
 						organizationId: string;

--- a/packages/better-auth/src/plugins/organization/permission.ts
+++ b/packages/better-auth/src/plugins/organization/permission.ts
@@ -1,15 +1,20 @@
 import type { Role } from "../access";
 import type { OrganizationOptions } from "./types";
 
+export type AccessControlRoleMap = {
+	[x: string]: Role<any> | undefined;
+};
+
 export const hasPermissionFn = (
 	input: HasPermissionBaseInput,
-	acRoles: {
-		[x: string]: Role<any> | undefined;
-	},
+	acRoles: AccessControlRoleMap,
 ) => {
 	if (!input.permissions) return false;
 
-	const roles = input.role.split(",");
+	const roles = input.role
+		.split(",")
+		.map((role) => role.trim())
+		.filter(Boolean);
 	const creatorRole = input.options.creatorRole || "owner";
 	const isCreator = roles.includes(creatorRole);
 
@@ -30,12 +35,12 @@ export type PermissionExclusive = {
 	permissions: { [key: string]: string[] };
 };
 
-export const cacheAllRoles = new Map<
-	string,
-	{
-		[x: string]: Role<any> | undefined;
-	}
->();
+export type InMemoryRoleCacheEntry = {
+	expiresAt: number;
+	roles: AccessControlRoleMap;
+};
+
+export const cacheAllRoles = new Map<string, InMemoryRoleCacheEntry>();
 
 export type HasPermissionBaseInput = {
 	role: string;

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -9,7 +9,7 @@ import type { User } from "../../../types";
 import type { AccessControl } from "../../access";
 import { orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
-import { hasPermission } from "../has-permission";
+import { hasPermission, invalidatePermissionCache } from "../has-permission";
 import type { Member, OrganizationRole } from "../schema";
 import type { OrganizationOptions } from "../types";
 
@@ -266,6 +266,7 @@ export const createOrgRole = <O extends OrganizationOptions>(options: O) => {
 					...additionalFields,
 				},
 			});
+			await invalidatePermissionCache(organizationId, ctx);
 
 			const data = {
 				...newRoleInDB,
@@ -520,6 +521,7 @@ export const deleteOrgRole = <O extends OrganizationOptions>(options: O) => {
 					condition,
 				],
 			});
+			await invalidatePermissionCache(organizationId, ctx);
 
 			return ctx.json({
 				success: true,
@@ -1084,6 +1086,7 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 				],
 				update,
 			});
+			await invalidatePermissionCache(organizationId, ctx);
 
 			// -----
 			// Return the updated role

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -8,7 +8,7 @@ import { toZodSchema } from "../../../db";
 import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
-import { hasPermission } from "../has-permission";
+import { hasPermission, invalidatePermissionCache } from "../has-permission";
 import type {
 	InferInvitation,
 	InferMember,
@@ -611,6 +611,7 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 				});
 			}
 			await adapter.deleteOrganization(organizationId);
+			await invalidatePermissionCache(organizationId, ctx);
 			if (options?.organizationHooks?.afterDeleteOrganization) {
 				await options.organizationHooks.afterDeleteOrganization({
 					organization: org,

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -103,6 +103,28 @@ export interface OrganizationOptions {
 		  }
 		| undefined;
 	/**
+	 * Cache configuration for organization permission checks.
+	 *
+	 * When enabled, Better Auth will use the global `secondaryStorage`
+	 * to cache dynamic role definitions for each organization.
+	 */
+	permissionCache?:
+		| {
+				/**
+				 * Whether to enable permission caching for dynamic organization roles.
+				 *
+				 * @default false
+				 */
+				enabled?: boolean;
+				/**
+				 * Cache TTL in seconds.
+				 *
+				 * @default 60
+				 */
+				ttl?: number;
+		  }
+		| undefined;
+	/**
 	 * Support for team.
 	 */
 	teams?: {


### PR DESCRIPTION
## Summary

This PR adds first-class caching for dynamic organization role permissions and introduces a lower-level permission API for callers that already know a member's org roles.

## Closes: #9213 

## What changed

- Added `organization({ permissionCache: { enabled, ttl } })`
- Reused global `secondaryStorage` as the cache layer for dynamic organization role definitions
- Added `auth.api.hasPermissionForRoles(...)` to evaluate permissions from caller-provided roles without a membership lookup
- Refactored organization permission resolution so `hasPermission` and `hasPermissionForRoles` share the same role-loading and caching path
- Added route-level cache invalidation for:
  - org role create
  - org role update
  - org role delete
  - organization delete
- Updated org deletion to explicitly remove `organizationRole` rows before deleting the org
- Documented the new cache option and `hasPermissionForRoles` API
- Added a changeset for a `minor` release

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds caching for dynamic organization role permissions via global `secondaryStorage` with a default 60s TTL and an optional in-memory TTL cache. Introduces `auth.api.hasPermissionForRoles` to check permissions when roles are already known, and enforces auth on all role permission checks. Closes #9213.

- **New Features**
  - `organization({ permissionCache: { enabled, ttl } })` caches dynamic role definitions in `secondaryStorage` (default 60s) and optionally in-memory; validates cache payloads and self-heals if corrupt.
  - In-memory role cache uses TTL and only populates when `useMemoryCache: true`.
  - Warns once and falls back to DB if `permissionCache.enabled` is set without global `secondaryStorage`.
  - `auth.api.hasPermissionForRoles(...)` server endpoint; accepts roles as array or comma string; skips membership lookup.
  - Automatic cache invalidation on org role create/update/delete and organization delete; best-effort and non-blocking if secondary storage invalidation fails.

- **Bug Fixes**
  - Role permission checks now require an authenticated session (including `hasPermissionForRoles`).
  - Organization deletion now removes `organizationRole` rows before deleting the org to prevent leftovers.

<sup>Written for commit f590cec3442fca3fbb36de27b8f60e2c5756e0d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

