### PR TITLE
feat(core): add `mapConcurrent` bounded-concurrency utility

### DIFF
--- a/.changeset/bounded-map-concurrent.md
+++ b/.changeset/bounded-map-concurrent.md
@@ -2,4 +2,4 @@
 "@better-auth/core": patch
 ---
 
-chore(core): add `mapConcurrent` bounded-concurrency utility at `@better-auth/core/utils/async`
+feat(core): add `mapConcurrent` bounded-concurrency utility at `@better-auth/core/utils/async`

--- a/.changeset/bounded-map-concurrent.md
+++ b/.changeset/bounded-map-concurrent.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+chore(core): add `mapConcurrent` bounded-concurrency utility at `@better-auth/core/utils/async`

--- a/packages/api-key/src/adapter.ts
+++ b/packages/api-key/src/adapter.ts
@@ -1,34 +1,11 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import type { SecondaryStorage } from "@better-auth/core/db";
+import { mapConcurrent } from "@better-auth/core/utils/async";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import type { PredefinedApiKeyOptions } from "./routes";
 import type { ApiKey } from "./types";
 
 const STORAGE_CONCURRENCY = 10;
-
-/**
- * Run an async mapper over items with bounded concurrency (worker-pool pattern).
- */
-async function mapConcurrent<T, R>(
-	items: T[],
-	fn: (item: T) => Promise<R>,
-	concurrency: number = STORAGE_CONCURRENCY,
-): Promise<R[]> {
-	const results: R[] = new Array(items.length);
-	let idx = 0;
-
-	async function worker() {
-		while (idx < items.length) {
-			const i = idx++;
-			results[i] = await fn(items[i] as T);
-		}
-	}
-
-	await Promise.all(
-		Array.from({ length: Math.min(concurrency, items.length) }, () => worker()),
-	);
-	return results;
-}
 
 /**
  * Parses double-stringified metadata synchronously without updating the database.
@@ -659,8 +636,10 @@ export async function listApiKeys(
 			}
 
 			if (keyIds.length > 0) {
-				const results = await mapConcurrent(keyIds, (id) =>
-					getApiKeyByIdFromStorage(ctx, id, storage),
+				const results = await mapConcurrent(
+					keyIds,
+					(id) => getApiKeyByIdFromStorage(ctx, id, storage),
+					{ concurrency: STORAGE_CONCURRENCY },
 				);
 				const apiKeys = results.filter(
 					(key): key is ApiKey => key !== null && key !== undefined,
@@ -707,8 +686,11 @@ export async function listApiKeys(
 		// per-key entries fan out,
 		// ref list is written last with the full id set.
 		if (storage && dbKeys.length > 0) {
-			await mapConcurrent(dbKeys, (apiKey) =>
-				setApiKeyInStorage(ctx, apiKey, storage, calculateTTL(apiKey), opts),
+			await mapConcurrent(
+				dbKeys,
+				(apiKey) =>
+					setApiKeyInStorage(ctx, apiKey, storage, calculateTTL(apiKey), opts),
+				{ concurrency: STORAGE_CONCURRENCY },
 			);
 			const keyIds = dbKeys.map((apiKey) => apiKey.id);
 			await storage.set(refKey, JSON.stringify(keyIds));
@@ -739,8 +721,10 @@ export async function listApiKeys(
 			return { apiKeys: [], total: 0 };
 		}
 
-		const results = await mapConcurrent(keyIds, (id) =>
-			getApiKeyByIdFromStorage(ctx, id, storage),
+		const results = await mapConcurrent(
+			keyIds,
+			(id) => getApiKeyByIdFromStorage(ctx, id, storage),
+			{ concurrency: STORAGE_CONCURRENCY },
 		);
 		const apiKeys = results.filter(
 			(key): key is ApiKey => key !== null && key !== undefined,

--- a/packages/core/src/utils/async.test.ts
+++ b/packages/core/src/utils/async.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import { mapConcurrent } from "./async";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("mapConcurrent", () => {
+	it("returns [] for an empty input without invoking the mapper", async () => {
+		const fn = vi.fn(async (x: number) => x);
+		const result = await mapConcurrent([], fn, { concurrency: 4 });
+		expect(result).toEqual([]);
+		expect(fn).not.toHaveBeenCalled();
+	});
+
+	it("preserves input order regardless of completion order", async () => {
+		const result = await mapConcurrent(
+			[1, 2, 3, 4, 5],
+			async (x) => {
+				await wait(x === 1 ? 30 : 0);
+				return x * 10;
+			},
+			{ concurrency: 3 },
+		);
+		expect(result).toEqual([10, 20, 30, 40, 50]);
+	});
+
+	it("passes (item, index) to the mapper", async () => {
+		const seen: Array<[string, number]> = [];
+		await mapConcurrent(
+			["a", "b", "c"],
+			async (item, index) => {
+				seen.push([item, index]);
+				return item;
+			},
+			{ concurrency: 2 },
+		);
+		seen.sort((a, b) => a[1] - b[1]);
+		expect(seen).toEqual([
+			["a", 0],
+			["b", 1],
+			["c", 2],
+		]);
+	});
+
+	it("caps simultaneous in-flight mappers at concurrency", async () => {
+		let inflight = 0;
+		let peak = 0;
+		await mapConcurrent(
+			Array.from({ length: 20 }, (_, i) => i),
+			async () => {
+				inflight++;
+				peak = Math.max(peak, inflight);
+				await wait(5);
+				inflight--;
+			},
+			{ concurrency: 4 },
+		);
+		expect(peak).toBe(4);
+	});
+
+	it("clamps concurrency to items.length when larger", async () => {
+		let inflight = 0;
+		let peak = 0;
+		await mapConcurrent(
+			[1, 2, 3],
+			async () => {
+				inflight++;
+				peak = Math.max(peak, inflight);
+				await wait(5);
+				inflight--;
+			},
+			{ concurrency: 100 },
+		);
+		expect(peak).toBe(3);
+	});
+
+	it("clamps sub-1 concurrency to 1 (zero, negative, NaN, 0 < x < 1)", async () => {
+		for (const bad of [0, -1, -10, Number.NaN, 0.4]) {
+			const result = await mapConcurrent([1, 2, 3], async (x) => x * 2, {
+				concurrency: bad,
+			});
+			expect(result).toEqual([2, 4, 6]);
+		}
+	});
+
+	it("floors non-integer concurrency (2.5 runs at most 2 in flight)", async () => {
+		let inflight = 0;
+		let peak = 0;
+		await mapConcurrent(
+			Array.from({ length: 10 }, (_, i) => i),
+			async () => {
+				inflight++;
+				peak = Math.max(peak, inflight);
+				await wait(5);
+				inflight--;
+			},
+			{ concurrency: 2.5 },
+		);
+		expect(peak).toBe(2);
+	});
+
+	it("fails fast on the first mapper rejection", async () => {
+		const calls: number[] = [];
+		await expect(
+			mapConcurrent(
+				[1, 2, 3, 4, 5],
+				async (x) => {
+					calls.push(x);
+					if (x === 2) throw new Error("boom");
+					await wait(20);
+					return x;
+				},
+				{ concurrency: 2 },
+			),
+		).rejects.toThrow("boom");
+		expect(calls).toContain(2);
+	});
+
+	it("rejects immediately when the signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort(new Error("pre-aborted"));
+		const fn = vi.fn(async (x: number) => x);
+		await expect(
+			mapConcurrent([1, 2, 3], fn, {
+				concurrency: 2,
+				signal: controller.signal,
+			}),
+		).rejects.toThrow("pre-aborted");
+		expect(fn).not.toHaveBeenCalled();
+	});
+
+	it("aborts at the next iteration boundary when signal fires mid-run", async () => {
+		const controller = new AbortController();
+		const processed: number[] = [];
+		const run = mapConcurrent(
+			Array.from({ length: 20 }, (_, i) => i),
+			async (x) => {
+				processed.push(x);
+				await wait(10);
+				return x;
+			},
+			{ concurrency: 2, signal: controller.signal },
+		);
+		await wait(15);
+		controller.abort(new Error("cancel"));
+		await expect(run).rejects.toThrow("cancel");
+		expect(processed.length).toBeLessThan(20);
+	});
+});

--- a/packages/core/src/utils/async.test.ts
+++ b/packages/core/src/utils/async.test.ts
@@ -115,6 +115,31 @@ describe("mapConcurrent", () => {
 		expect(calls).toContain(2);
 	});
 
+	it("stops scheduling new mappers after the first rejection", async () => {
+		let scheduled = 0;
+		await expect(
+			mapConcurrent(
+				Array.from({ length: 50 }, (_, i) => i),
+				async (x) => {
+					scheduled++;
+					if (x === 2) throw new Error("boom");
+					await wait(20);
+					return x;
+				},
+				{ concurrency: 4 },
+			),
+		).rejects.toThrow("boom");
+		await wait(100);
+		expect(scheduled).toBeLessThan(50);
+	});
+
+	it("accepts sync mappers (Awaitable)", async () => {
+		const result = await mapConcurrent([1, 2, 3], (x) => x * 2, {
+			concurrency: 2,
+		});
+		expect(result).toEqual([2, 4, 6]);
+	});
+
 	it("rejects immediately when the signal is already aborted", async () => {
 		const controller = new AbortController();
 		controller.abort(new Error("pre-aborted"));

--- a/packages/core/src/utils/async.ts
+++ b/packages/core/src/utils/async.ts
@@ -1,3 +1,5 @@
+import type { Awaitable } from "../types/helper";
+
 export interface MapConcurrentOptions {
 	/**
 	 * Max in-flight mappers. Non-integer values are floored, then clamped
@@ -5,8 +7,8 @@ export interface MapConcurrentOptions {
 	 */
 	concurrency: number;
 	/**
-	 * Aborts the run at the next iteration boundary. In-flight mappers
-	 * finish but their results are discarded.
+	 * Rejects with `signal.reason` when aborted. In-flight mappers keep
+	 * running but their results are not returned.
 	 */
 	signal?: AbortSignal;
 }
@@ -17,7 +19,7 @@ export interface MapConcurrentOptions {
  */
 export async function mapConcurrent<T, R>(
 	items: readonly T[],
-	fn: (item: T, index: number) => Promise<R>,
+	fn: (item: T, index: number) => Awaitable<R>,
 	options: MapConcurrentOptions,
 ): Promise<R[]> {
 	const n = items.length;
@@ -31,12 +33,18 @@ export async function mapConcurrent<T, R>(
 
 	const results = new Array<R>(n);
 	let idx = 0;
+	let failed = false;
 
 	const worker = async (): Promise<void> => {
-		while (idx < n) {
+		while (!failed && idx < n) {
 			if (signal?.aborted) throw signal.reason;
 			const i = idx++;
-			results[i] = await fn(items[i] as T, i);
+			try {
+				results[i] = await fn(items[i] as T, i);
+			} catch (error) {
+				failed = true;
+				throw error;
+			}
 		}
 	};
 

--- a/packages/core/src/utils/async.ts
+++ b/packages/core/src/utils/async.ts
@@ -1,0 +1,45 @@
+export interface MapConcurrentOptions {
+	/**
+	 * Max in-flight mappers. Non-integer values are floored, then clamped
+	 * to the range `[1, items.length]`. `NaN` falls back to 1.
+	 */
+	concurrency: number;
+	/**
+	 * Aborts the run at the next iteration boundary. In-flight mappers
+	 * finish but their results are discarded.
+	 */
+	signal?: AbortSignal;
+}
+
+/**
+ * Run an async mapper over items with bounded concurrency.
+ * Preserves input order in the result. Fails fast on the first rejection.
+ */
+export async function mapConcurrent<T, R>(
+	items: readonly T[],
+	fn: (item: T, index: number) => Promise<R>,
+	options: MapConcurrentOptions,
+): Promise<R[]> {
+	const n = items.length;
+	if (n === 0) return [];
+
+	const { signal } = options;
+	if (signal?.aborted) throw signal.reason;
+
+	const raw = Math.floor(options.concurrency);
+	const width = Math.min(n, raw >= 1 ? raw : 1);
+
+	const results = new Array<R>(n);
+	let idx = 0;
+
+	const worker = async (): Promise<void> => {
+		while (idx < n) {
+			if (signal?.aborted) throw signal.reason;
+			const i = idx++;
+			results[i] = await fn(items[i] as T, i);
+		}
+	};
+
+	await Promise.all(Array.from({ length: width }, worker));
+	return results;
+}


### PR DESCRIPTION
## Follow-up candidates

Other unbounded fan-out sites that could adopt `mapConcurrent` later.
Not included here to keep this PR scoped to the utility introduction:

### Noteworthy (same shape as the api-key migration)
- https://github.com/better-auth/better-auth/blob/main/packages/core/src/db/adapter/factory.ts#L1225  
  — parallel `transformOutput` over `findMany` results

- https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/db/internal-adapter.ts#L68  
  — per-session secondary-storage reads

### Size-dependent
- https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/api/routes/session.ts#L887  
  — parallel session deletions on revoke-all

- https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/plugins/organization/adapter.ts#L360  
  — parallel `deleteMany` over teams

- https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/plugins/custom-session/index.ts#L82  
  — user callback per session