### PR TITLE
docs: fix fastify integration docs to avoid race conditions

### DIFF
--- a/docs/content/docs/integrations/fastify.mdx
+++ b/docs/content/docs/integrations/fastify.mdx
@@ -60,11 +60,10 @@ fastify.route({
       // Forward response to client
       reply.status(response.status);
       response.headers.forEach((value, key) => reply.header(key, value));
-      reply.send(response.body ? await response.text() : null);
-
+      return reply.send(response.body ? await response.text() : null);
     } catch (error) {
       fastify.log.error("Authentication Error:", error);
-      reply.status(500).send({ 
+      return reply.status(500).send({ 
         error: "Internal authentication error",
         code: "AUTH_FAILURE"
       });


### PR DESCRIPTION
Fixing integration guide to avoid subtle race conditions when async/await is used.

From [fastify docs](https://fastify.dev/docs/latest/Reference/Routes/#async-await):
> If needed, you can also send data back with `reply.send()`. In this case, do not forget to return reply or await reply in your async handler to avoid race conditions.