### PR TITLE
fix(core): use package imports map for internal async_hooks reference

### DIFF
--- a/.changeset/internal-imports-async-hooks.md
+++ b/.changeset/internal-imports-async-hooks.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/core": patch
+---
+
+fix(core): use package imports map for internal async_hooks reference
+
+Four internal modules under `packages/core/src/context/` imported the package's own subpath via `@better-auth/core/async_hooks`. Self-referential subpath resolution breaks under content-addressed install layouts (notably Bun's production install mode, used by Vercel's native Bun runtime), surfacing as `TypeError: Requested module is not instantiated yet` on Vercel or `Cannot find module '@better-auth/core/async_hooks'` on a plain Bun prod install. Switched those four imports to `#async_hooks` and added a matching `imports` map to `packages/core/package.json` that mirrors the conditions of the public `./async_hooks` export. No change for downstream consumers.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,19 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "imports": {
+    "#async_hooks": {
+      "dev-source": "./src/async_hooks/index.ts",
+      "types": "./dist/async_hooks/index.d.mts",
+      "node": "./dist/async_hooks/index.mjs",
+      "deno": "./dist/async_hooks/index.mjs",
+      "bun": "./dist/async_hooks/index.mjs",
+      "edge": "./dist/async_hooks/pure.index.mjs",
+      "workerd": "./dist/async_hooks/index.mjs",
+      "browser": "./dist/async_hooks/pure.index.mjs",
+      "default": "./dist/async_hooks/index.mjs"
+    }
+  },
   "exports": {
     ".": {
       "dev-source": "./src/index.ts",

--- a/packages/core/src/context/endpoint-context.ts
+++ b/packages/core/src/context/endpoint-context.ts
@@ -1,6 +1,6 @@
-import type { AsyncLocalStorage } from "@better-auth/core/async_hooks";
-import { getAsyncLocalStorage } from "@better-auth/core/async_hooks";
 import type { EndpointContext, InputContext } from "better-call";
+import type { AsyncLocalStorage } from "#async_hooks";
+import { getAsyncLocalStorage } from "#async_hooks";
 import type { AuthContext } from "../types";
 import { __getBetterAuthGlobal } from "./global";
 

--- a/packages/core/src/context/global.ts
+++ b/packages/core/src/context/global.ts
@@ -1,4 +1,4 @@
-import type { AsyncLocalStorage } from "@better-auth/core/async_hooks";
+import type { AsyncLocalStorage } from "#async_hooks";
 
 interface BetterAuthGlobal {
 	/**

--- a/packages/core/src/context/request-state.ts
+++ b/packages/core/src/context/request-state.ts
@@ -1,5 +1,5 @@
-import type { AsyncLocalStorage } from "@better-auth/core/async_hooks";
-import { getAsyncLocalStorage } from "@better-auth/core/async_hooks";
+import type { AsyncLocalStorage } from "#async_hooks";
+import { getAsyncLocalStorage } from "#async_hooks";
 import { __getBetterAuthGlobal } from "./global";
 
 export type RequestStateWeakMap = WeakMap<object, any>;

--- a/packages/core/src/context/transaction.ts
+++ b/packages/core/src/context/transaction.ts
@@ -1,5 +1,5 @@
 import type { AsyncLocalStorage } from "node:async_hooks";
-import { getAsyncLocalStorage } from "@better-auth/core/async_hooks";
+import { getAsyncLocalStorage } from "#async_hooks";
 import type { DBAdapter, DBTransactionAdapter } from "../db/adapter";
 import { __getBetterAuthGlobal } from "./global";
 


### PR DESCRIPTION
Internal modules under `packages/core/src/context/` imported the package's own subpath via `@better-auth/core/async_hooks`. Self- referential subpath imports fail to resolve under some install layouts (e.g. Bun's content-addressed cache in production install mode used by Vercel's Bun runtime), surfacing as

    TypeError: Requested module is not instantiated yet

or

    Cannot find module '@better-auth/core/async_hooks'

Switch the internal references to `#async_hooks` and add a matching `imports` map to `packages/core/package.json`. The map preserves the existing edge/browser/default condition split, so published consumers (still resolving the public `./async_hooks` subpath) are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch internal async hooks imports to `#async_hooks` and add an `imports` map in `@better-auth/core`. This fixes self-referential subpath errors in Bun production installs (e.g., Vercel) without changing the public `./async_hooks` export.

- **Bug Fixes**
  - Updated `endpoint-context.ts`, `request-state.ts`, `transaction.ts`, and `global.ts` to import from `#async_hooks`.
  - Added `imports.#async_hooks` to `packages/core/package.json` mirroring edge/browser/default conditions (incl. types and `dev-source`); public `./async_hooks` remains unchanged.

<sup>Written for commit 0c072d3852d5d8f5590f712e65a355f1e898c3d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

