### PR TITLE
feat(generic-oauth): support additionalData in oauth link flow

### DIFF
--- a/.changeset/long-seals-burn.md
+++ b/.changeset/long-seals-burn.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Add additionalData support to generic OAuth account linking.

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -94,6 +94,10 @@ To start the OAuth sign-in process:
        * Explicitly request sign-up. Useful when disableImplicitSignUp is true for this provider. 
        */
       requestSignUp?: boolean = false
+      /**
+       * Any additional data to pass through the oauth flow.
+       */
+      additionalData?: Record<string, any> = {}
   }
   ```
 </APIMethod>
@@ -113,6 +117,10 @@ To link an OAuth account to an existing user:
        * The URL to redirect to once the account linking was complete. 
        */
       callbackURL: string = "/successful-link"
+      /**
+       * Any additional data to pass through the oauth flow.
+       */
+      additionalData?: Record<string, any> = {}
   }
   ```
 </APIMethod>
@@ -122,6 +130,14 @@ To link an OAuth account to an existing user:
 The plugin mounts a route to handle the OAuth callback `/oauth2/callback/:providerId`. This means by default `${baseURL}/api/auth/oauth2/callback/:providerId` will be used as the callback URL. Make sure your OAuth provider is configured to use this URL.
 
 Unlike built-in providers, the `:providerId` parameter is required and must match your configured provider ID.
+
+### Passing Additional Data Through OAuth Flow
+
+You can pass additional data through the OAuth flow without storing it in the database. This is useful for scenarios like tracking referral codes, analytics sources, or other temporary data that should be processed during authentication but not persisted.
+
+#### Accessing Additional Data in Hooks
+
+The additional data is available in your hooks during the OAuth callback through `getOAuthState`.
 
 ## Pre-configured Provider Helpers
 

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1,8 +1,10 @@
 import type { GenericEndpointContext } from "@better-auth/core";
+import { createAuthMiddleware } from "@better-auth/core/api";
 import { runWithEndpointContext } from "@better-auth/core/context";
 import { betterFetch } from "@better-fetch/fetch";
 import { OAuth2Server } from "oauth2-mock-server";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { getOAuthState } from "../../api";
 import { createAuthClient } from "../../client";
 import { getAwaitableValue } from "../../context/helpers";
 import { parseSetCookieHeader } from "../../cookies";
@@ -1086,6 +1088,153 @@ describe("oauth2", async () => {
 		});
 
 		expect(result?.user).toHaveProperty("customField", "async-custom-data");
+	});
+
+	it("should pass additional data through oauth sign in", async () => {
+		const providerId = "test-additional-data-sign-in";
+
+		let oauthState: Awaited<ReturnType<typeof getOAuthState>> = null;
+		const headers = new Headers();
+
+		const { customFetchImpl } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId,
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId,
+							clientSecret,
+						},
+					],
+				}),
+			],
+			hooks: {
+				after: createAuthMiddleware(async (ctx) => {
+					if (
+						ctx.path === "/oauth2/callback/:providerId" &&
+						ctx.params.providerId === providerId
+					) {
+						oauthState = await getOAuthState();
+					}
+				}),
+			},
+		});
+
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+
+		const signUpRes = await authClient.signIn.oauth2({
+			providerId,
+			callbackURL: "http://localhost:3000/callback",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+			additionalData: {
+				source: "SIGNUP_PAGE",
+			},
+		});
+		const simulation = await simulateOAuthFlow(
+			signUpRes.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		expect(simulation.callbackURL).toBe("http://localhost:3000/new_user");
+		expect(oauthState).not.toBeNull();
+		expect(oauthState).toMatchObject({
+			source: "SIGNUP_PAGE",
+		});
+	});
+
+	it("should pass additional data through oauth account linking", async () => {
+		const providerId = "test-additional-data-link";
+
+		let oauthState: Awaited<ReturnType<typeof getOAuthState>> = null;
+		let headers = new Headers();
+
+		const { customFetchImpl } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId,
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId,
+							clientSecret,
+						},
+					],
+				}),
+			],
+			hooks: {
+				after: createAuthMiddleware(async (ctx) => {
+					if (
+						ctx.path === "/oauth2/callback/:providerId" &&
+						ctx.params.providerId === providerId
+					) {
+						oauthState = await getOAuthState();
+					}
+				}),
+			},
+		});
+
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+
+		const loginRes = await authClient.signIn.oauth2({
+			providerId,
+			callbackURL: "http://localhost:3000/callback",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+			additionalData: {
+				source: "LOGIN_PAGE",
+			},
+		});
+		const loginSimulation = await simulateOAuthFlow(
+			loginRes.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		expect(loginSimulation.callbackURL).toBe("http://localhost:3000/new_user");
+
+		oauthState = null;
+		headers = loginSimulation.headers;
+
+		const linkRes = await authClient.linkSocial({
+			provider: providerId,
+			callbackURL: "http://localhost:3000/link/callback",
+			fetchOptions: {
+				headers,
+				onSuccess: cookieSetter(headers),
+			},
+			additionalData: {
+				source: "LINK_ACCOUNT_PAGE",
+			},
+		});
+		const linkSimulation = await simulateOAuthFlow(
+			linkRes.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		expect(linkSimulation.callbackURL).toBe(
+			"http://localhost:3000/link/callback",
+		);
+		expect(oauthState).not.toBeNull();
+		expect(oauthState).toMatchObject({
+			source: "LINK_ACCOUNT_PAGE",
+		});
 	});
 
 	describe("Okta Provider Helper", () => {

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -573,6 +573,10 @@ const OAuth2LinkAccountBodySchema = z.object({
 				"The URL to redirect to if there is an error during the link process",
 		})
 		.optional(),
+	/**
+	 * Any additional data to pass through the oauth flow.
+	 */
+	additionalData: z.record(z.string(), z.any()).optional(),
 });
 /**
  * ### Endpoint
@@ -696,7 +700,7 @@ export const oAuth2LinkAccount = (options: GenericOAuthOptions) =>
 					userId: session.user.id,
 					email: session.user.email,
 				},
-				undefined,
+				c.body.additionalData,
 			);
 
 			const additionalParams =


### PR DESCRIPTION
## Summary

Adds `additionalData` support to the Generic OAuth account linking flow.

Previously, the Generic OAuth `/oauth2/link` flow did not forward `additionalData` into OAuth state, even though the sign-in flow already supported it. This change makes the link flow behave consistently.

## Changes

- add `additionalData` to the Generic OAuth `/oauth2/link` request body
- pass `additionalData` into `generateState(...)` for the link flow
- add tests for Generic OAuth sign-in and link state handling
- update Generic OAuth docs to document `additionalData`

## Why

This allows temporary metadata like referral codes or source information to be passed through Generic OAuth account linking and accessed during the callback with `getOAuthState`.

This makes Generic OAuth behave consistently with the standard OAuth flows.

## Testing

- `pnpm vitest packages/better-auth/src/plugins/generic-oauth --run`
- `pnpm typecheck`

Related discussion: https://github.com/better-auth/better-auth/discussions/9252


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `additionalData` to the Generic OAuth `/oauth2/link` flow so apps can pass temporary metadata through account linking and read it during the callback via `getOAuthState`. This aligns the link flow with the existing sign-in behavior.

- **New Features**
  - Extends the link request schema to accept `additionalData` and forwards it to `generateState(...)`.
  - Adds tests for sign-in and link state handling and updates docs with examples of accessing additional data.

<sup>Written for commit d1711c15c12c78276a3c0cb9be43826421dd8831. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

