### PR TITLE
fix(two-factor): require TOTP or backup code to disable 2FA instead of password

### DIFF
--- a/.changeset/fix-disable-2fa-totp.md
+++ b/.changeset/fix-disable-2fa-totp.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+Require TOTP or backup code to disable 2FA
+
+The `disableTwoFactor` endpoint now accepts a `code` parameter (TOTP code or backup code) instead of `password`. This applies to TOTP-enabled accounts. OTP-only accounts without a TOTP secret continue to require password verification.

--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -478,7 +478,8 @@ Below is an example of how to add two factor authentication using two factor plu
 
     const disableTwoFactor = async() => {
         const data = await authClient.twoFactor.disable({
-            password // the user password is required
+            code, // a valid TOTP code or backup code (for TOTP accounts)
+            // password: userPassword // fallback for OTP-only accounts
         }) // this will disable two factor
     }
 

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -203,13 +203,19 @@ const authClient = createAuthClient({
 
 ### Disabling 2FA
 
-To disable two-factor authentication, call `twoFactor.disable` with the user's password (required for credential accounts). If you enable `allowPasswordless`, the password can be omitted for users without a credential account.
+To disable two-factor authentication, call `twoFactor.disable` with a valid TOTP code or backup code. For TOTP-enabled accounts, a `code` is required — providing only a `password` will be rejected. For OTP-only accounts without a TOTP secret, the user's password is used as a fallback.
 
 <APIMethod path="/two-factor/disable" method="POST" requireSession>
   ```ts
   type disableTwoFactor = {
       /**
-       * The user's password (required for credential accounts)
+       * A valid TOTP code or backup code.
+       * Required if the user has TOTP enabled.
+       */
+      code?: string
+      /**
+       * User password. Only used as a fallback for
+       * OTP-only accounts without a TOTP secret.
        */
       password?: string
   }

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -312,7 +312,7 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 						}).verify(code);
 						const backupCodeResult = await verifyBackupCode(
 							{
-								backupCodes: twoFactor?.backupCodes,
+								backupCodes: twoFactor.backupCodes,
 								code,
 							},
 							ctx.context.secretConfig,

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -13,13 +13,17 @@ import {
 	expireCookie,
 	setSessionCookie,
 } from "../../cookies";
-import { symmetricEncrypt } from "../../crypto";
+import { symmetricDecrypt, symmetricEncrypt } from "../../crypto";
 import { generateRandomString } from "../../crypto/random";
 import { mergeSchema } from "../../db/schema";
 import { shouldRequirePassword, validatePassword } from "../../utils/password";
 import { PACKAGE_VERSION } from "../../version";
 import type { BackupCodeOptions } from "./backup-codes";
-import { backupCode2fa, generateBackupCodes } from "./backup-codes";
+import {
+	backupCode2fa,
+	generateBackupCodes,
+	verifyBackupCode,
+} from "./backup-codes";
 import {
 	TRUST_DEVICE_COOKIE_MAX_AGE,
 	TRUST_DEVICE_COOKIE_NAME,
@@ -88,13 +92,11 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 					})
 					.optional(),
 			});
-	const disableTwoFactorBodySchema = allowPasswordless
-		? z.object({
-				password: passwordSchema.optional(),
-			})
-		: z.object({
-				password: passwordSchema,
-			});
+
+	const disableTwoFactorBodySchema = z.object({
+		code: z.string().optional(),
+		password: passwordSchema.optional(),
+	});
 
 	return {
 		id: "two-factor",
@@ -294,30 +296,66 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 				},
 				async (ctx) => {
 					const user = ctx.context.session.user as UserWithTwoFactor;
-					const { password } = ctx.body;
-					const requirePassword = await shouldRequirePassword(
-						ctx,
-						user.id,
-						allowPasswordless,
-					);
-					if (requirePassword) {
-						if (!password) {
+					const { code, password } = ctx.body;
+					const twoFactor = await ctx.context.adapter.findOne<TwoFactorTable>({
+						model: "twoFactor",
+						where: [{ field: "userId", value: user.id }],
+					});
+					if (code && twoFactor) {
+						const decryptedSecret = await symmetricDecrypt({
+							key: ctx.context.secretConfig,
+							data: twoFactor.secret,
+						});
+						const isValidTOTP = await createOTP(decryptedSecret, {
+							period: 30,
+							digits: 6,
+						}).verify(code);
+						const backupCodeResult = await verifyBackupCode(
+							{
+								backupCodes: twoFactor?.backupCodes,
+								code,
+							},
+							ctx.context.secretConfig,
+							backupCodeOptions,
+						);
+						const isValidBackupCode = backupCodeResult.status;
+						if (!isValidBackupCode && !isValidTOTP) {
 							throw APIError.from(
 								"BAD_REQUEST",
-								BASE_ERROR_CODES.INVALID_PASSWORD,
+								TWO_FACTOR_ERROR_CODES.INVALID_CODE,
 							);
 						}
-						const isPasswordValid = await validatePassword(ctx, {
-							password,
-							userId: user.id,
-						});
-						if (!isPasswordValid) {
-							throw APIError.from(
-								"BAD_REQUEST",
-								BASE_ERROR_CODES.INVALID_PASSWORD,
-							);
+					} else if (twoFactor) {
+						throw APIError.from(
+							"BAD_REQUEST",
+							TWO_FACTOR_ERROR_CODES.INVALID_CODE,
+						);
+					} else {
+						const requirePassword = await shouldRequirePassword(
+							ctx,
+							user.id,
+							allowPasswordless,
+						);
+						if (requirePassword) {
+							if (!password) {
+								throw APIError.from(
+									"BAD_REQUEST",
+									BASE_ERROR_CODES.INVALID_PASSWORD,
+								);
+							}
+							const isPasswordValid = await validatePassword(ctx, {
+								password,
+								userId: user.id,
+							});
+							if (!isPasswordValid) {
+								throw APIError.from(
+									"BAD_REQUEST",
+									BASE_ERROR_CODES.INVALID_PASSWORD,
+								);
+							}
 						}
 					}
+
 					const updatedUser = await ctx.context.internalAdapter.updateUser(
 						user.id,
 						{

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -307,8 +307,8 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							data: twoFactor.secret,
 						});
 						const isValidTOTP = await createOTP(decryptedSecret, {
-							period: 30,
-							digits: 6,
+							digits: options?.totpOptions?.digits || 6,
+							period: options?.totpOptions?.period,
 						}).verify(code);
 						const backupCodeResult = await verifyBackupCode(
 							{

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -307,8 +307,8 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							data: twoFactor.secret,
 						});
 						const isValidTOTP = await createOTP(decryptedSecret, {
-							digits: options?.totpOptions?.digits || 6,
-							period: options?.totpOptions?.period,
+							period: options?.totpOptions?.period ?? 30,
+							digits: options?.totpOptions?.digits ?? 6,
 						}).verify(code);
 						const backupCodeResult = await verifyBackupCode(
 							{

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -509,7 +509,7 @@ describe("two factor", async () => {
 
 	it("should disable two factor", async () => {
 		const res = await client.twoFactor.disable({
-			password: testUser.password,
+			code: backupCodes[1]!,
 			fetchOptions: {
 				headers,
 			},
@@ -538,7 +538,7 @@ describe("two factor", async () => {
 describe("two factor auth API", async () => {
 	let OTP = "";
 	const sendOTP = vi.fn();
-	const { auth, signInWithTestUser, testUser } = await getTestInstance({
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
 		secret: DEFAULT_SECRET,
 		plugins: [
 			twoFactor({
@@ -634,19 +634,31 @@ describe("two factor auth API", async () => {
 	});
 
 	it("should disable two factor", async () => {
+		const session = await auth.api.getSession({
+			headers,
+		});
+		const twoFactor = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: session?.user.id as string }],
+		});
+		const decrypted = await symmetricDecrypt({
+			key: DEFAULT_SECRET,
+			data: twoFactor!.secret,
+		});
+		const code = await createOTP(decrypted).totp();
 		const res = await auth.api.disableTwoFactor({
 			headers,
 			body: {
-				password: testUser.password,
+				code,
 			},
 			asResponse: true,
 		});
 		headers = convertSetCookieToCookie(res.headers);
 		expect(res.status).toBe(200);
-		const session = await auth.api.getSession({
+		const sessionAfter = await auth.api.getSession({
 			headers,
 		});
-		expect(session?.user.twoFactorEnabled).toBe(false);
+		expect(sessionAfter?.user.twoFactorEnabled).toBe(false);
 	});
 });
 
@@ -1128,11 +1140,25 @@ describe("trust device server-side validation", async () => {
 		});
 		expect(verificationBefore).toBeDefined();
 
+		// Get valid TOTP code to disable 2FA
+		const session = await auth.api.getSession({
+			headers: sessionHeaders,
+		});
+		const twoFactor = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: session?.user.id as string }],
+		});
+		const decrypted = await symmetricDecrypt({
+			key: DEFAULT_SECRET,
+			data: twoFactor!.secret,
+		});
+		const code = await createOTP(decrypted).totp();
+
 		// Disable 2FA
 		const disableRes = await auth.api.disableTwoFactor({
 			headers: sessionHeaders,
 			body: {
-				password: testUser.password,
+				code,
 			},
 			asResponse: true,
 		});
@@ -2016,8 +2042,18 @@ describe("two factor passwordless", async () => {
 	});
 
 	it("allows disabling without password", async () => {
+		const twoFactor = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: userId }],
+		});
+		const decrypted = await symmetricDecrypt({
+			key: DEFAULT_SECRET,
+			data: twoFactor!.secret,
+		});
+		const code = await createOTP(decrypted).totp();
+
 		const res = await auth.api.disableTwoFactor({
-			body: {},
+			body: { code },
 			headers,
 			asResponse: true,
 		});
@@ -2557,4 +2593,104 @@ describe("backup codes storage configurations", () => {
 			);
 		});
 	}
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9248
+ */
+describe("disable two factor requires code when TOTP is enabled", async () => {
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [
+			twoFactor({
+				skipVerificationOnEnable: true,
+			}),
+		],
+	});
+	let { headers } = await signInWithTestUser();
+
+	it("should reject disable with only password when TOTP is enabled", async () => {
+		const enableRes = await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+		headers = convertSetCookieToCookie(enableRes.headers);
+
+		const res = await auth.api.disableTwoFactor({
+			headers,
+			body: {
+				password: testUser.password,
+			},
+			asResponse: true,
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("should allow disable with valid TOTP code", async () => {
+		const session = await auth.api.getSession({ headers });
+		const twoFactor = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: session?.user.id as string }],
+		});
+		const decrypted = await symmetricDecrypt({
+			key: DEFAULT_SECRET,
+			data: twoFactor!.secret,
+		});
+		const code = await createOTP(decrypted).totp();
+
+		const res = await auth.api.disableTwoFactor({
+			headers,
+			body: { code },
+			asResponse: true,
+		});
+		expect(res.status).toBe(200);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9248
+ */
+describe("disable two factor with OTP-only account (no TOTP row)", async () => {
+	let OTP = "";
+	const { auth, signInWithTestUser, testUser } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [
+			twoFactor({
+				otpOptions: {
+					sendOTP({ otp }) {
+						OTP = otp;
+					},
+				},
+			}),
+		],
+	});
+	let { headers } = await signInWithTestUser();
+
+	it("should disable two factor with password when user has OTP-only enrollment", async () => {
+		await auth.api.sendTwoFactorOTP({ headers, body: {} });
+		const otpEnrollRes = await auth.api.verifyTwoFactorOTP({
+			headers,
+			body: { code: OTP },
+			asResponse: true,
+		});
+		expect(otpEnrollRes.status).toBe(200);
+		headers = convertSetCookieToCookie(otpEnrollRes.headers);
+
+		const session = await auth.api.getSession({ headers });
+		expect(session?.user.twoFactorEnabled).toBe(true);
+
+		const res = await auth.api.disableTwoFactor({
+			headers,
+			body: {
+				password: testUser.password,
+			},
+			asResponse: true,
+		});
+		expect(res.status).toBe(200);
+		const sessionAfter = await auth.api.getSession({
+			headers: convertSetCookieToCookie(res.headers),
+		});
+		expect(sessionAfter?.user.twoFactorEnabled).toBe(false);
+	});
 });

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -2666,7 +2666,7 @@ describe("disable two factor respects custom TOTP config", async () => {
 	});
 	let { headers } = await signInWithTestUser();
 
-	it("should reject default 6-digit code when TOTP is configured with 8 digits", async () => {
+	it("should disable with a valid code generated from custom TOTP config", async () => {
 		const enableRes = await auth.api.enableTwoFactor({
 			body: { password: testUser.password },
 			headers,

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -2649,6 +2649,57 @@ describe("disable two factor requires code when TOTP is enabled", async () => {
 });
 
 /**
+ * @see https://github.com/better-auth/better-auth/pull/9256
+ */
+describe("disable two factor respects custom TOTP config", async () => {
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [
+			twoFactor({
+				skipVerificationOnEnable: true,
+				totpOptions: {
+					digits: 8,
+					period: 60,
+				},
+			}),
+		],
+	});
+	let { headers } = await signInWithTestUser();
+
+	it("should reject default 6-digit code when TOTP is configured with 8 digits", async () => {
+		const enableRes = await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+		expect(enableRes.status).toBe(200);
+		headers = convertSetCookieToCookie(enableRes.headers);
+
+		const session = await auth.api.getSession({ headers });
+		const twoFactor = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: session?.user.id as string }],
+		});
+		const decrypted = await symmetricDecrypt({
+			key: DEFAULT_SECRET,
+			data: twoFactor!.secret,
+		});
+		const code = await createOTP(decrypted, {
+			digits: 8,
+			period: 60,
+		}).totp();
+		expect(code.length).toBe(8);
+
+		const res = await auth.api.disableTwoFactor({
+			headers,
+			body: { code },
+			asResponse: true,
+		});
+		expect(res.status).toBe(200);
+	});
+});
+
+/**
  * @see https://github.com/better-auth/better-auth/issues/9248
  */
 describe("disable two factor with OTP-only account (no TOTP row)", async () => {


### PR DESCRIPTION
## Summary

Changes the `disableTwoFactor` endpoint to require TOTP code or backup code when TOTP is enabled, while maintaining password fallback for OTP-only accounts.

Requiring the first factor (password) to disable the second factor defeats the purpose of 2FA. This PR makes `code` the required verification method for TOTP-enabled accounts, while keeping `password` as a fallback for OTP-only accounts that don't have a TOTP secret.

Closes #9248

## Changes

### Server (`packages/better-auth/src/plugins/two-factor/index.ts`)
- Updated `disableTwoFactorBodySchema` to accept both `code` (optional) and `password` (optional)
- Validation logic:
  - `code` provided + user has `twoFactor` row → verify TOTP or backup code
  - No `code` + user has `twoFactor` row → **reject** (INVALID_CODE) — closes bypass loophole
  - No `twoFactor` row (OTP-only) → fall back to password validation
- Renamed `isBackupCode` → `backupCodeResult` for naming consistency

### Tests (`two-factor.test.ts`)
- 4 existing tests updated to use TOTP/backup code instead of password
- **New**: TOTP-enabled user cannot disable with only password (rejected with INVALID_CODE)
- **New**: TOTP-enabled user can disable with valid TOTP code
- **New**: OTP-only account can disable with password fallback
- Removed backward-compat test that allowed TOTP users to bypass code requirement

### Documentation
- Updated `docs/content/docs/plugins/2fa.mdx` API reference
- Updated `docs/content/docs/basic-usage.mdx` code example

## Backward Compatibility

| Call | Behavior |
|------|----------|
| `disableTwoFactor({ code: "123456" })` | TOTP/backup code verified |
| `disableTwoFactor({ password: "xxx" })` | **Rejected for TOTP users** (must use code). Accepted for OTP-only users (if they have a credential provider) |
| `disableTwoFactor({ code: "123456", password: "xxx" })` | Code takes precedence |
| `disableTwoFactor({})` | **Rejected for TOTP users**. For OTP-only users: rejected by default (password required); accepted only when `allowPasswordless: true` and user has no credential provider |

## Security

The previous version allowed TOTP-enabled passwordless users to disable 2FA with zero verification by submitting an empty body. This is now closed — if a `twoFactor` row exists, a valid `code` is mandatory.