### PR TITLE
chore(sso): fix samlify ESM/CJS loading compat issue

### DIFF
--- a/.changeset/pretty-tables-cover.md
+++ b/.changeset/pretty-tables-cover.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+Fix ESM/CJS compat issue when loading samlify

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,9 +18,13 @@ concurrency:
 
 jobs:
   smoke:
-    name: Smoke test
+    name: Smoke test (${{ matrix.node-version }})
     timeout-minutes: 30
     runs-on: starsling-ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
     permissions:
       contents: read
     steps:
@@ -41,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version-file: '.nvmrc'
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -1,7 +1,6 @@
 import type { BetterAuthPlugin } from "better-auth";
 import { createAuthMiddleware, getSessionFromCtx } from "better-auth/api";
 import { XMLValidator } from "fast-xml-parser";
-import * as saml from "samlify";
 import { SAML_SESSION_BY_ID_PREFIX } from "./constants";
 import { assignOrganizationByDomain } from "./linking";
 import {
@@ -25,6 +24,7 @@ import {
 	sloEndpoint,
 	spMetadata,
 } from "./routes/sso";
+import { saml } from "./samlify";
 
 export {
 	DEFAULT_CLOCK_SKEW_MS,

--- a/packages/sso/src/routes/helpers.ts
+++ b/packages/sso/src/routes/helpers.ts
@@ -1,5 +1,5 @@
 import type { DBAdapter } from "@better-auth/core/db/adapter";
-import * as saml from "samlify";
+import { saml } from "../samlify";
 import type { SAMLConfig, SSOOptions, SSOProvider } from "../types";
 import { safeJsonParse } from "../utils";
 

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -17,7 +17,6 @@ import { deleteSessionCookie, setSessionCookie } from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
 import { handleOAuthUserInfo } from "better-auth/oauth2";
 import { decodeJwt } from "jose";
-import * as saml from "samlify";
 import type { BindingContext } from "samlify/types/src/entity";
 import type { IdentityProvider } from "samlify/types/src/entity-idp";
 import * as z from "zod";
@@ -33,6 +32,7 @@ import {
 import { validateConfigAlgorithms } from "../saml";
 import { SAML_ERROR_CODES } from "../saml/error-codes";
 import { generateRelayState } from "../saml-state";
+import { saml } from "../samlify";
 import type {
 	AuthnRequestRecord,
 	OIDCConfig,

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -20,7 +20,6 @@ import type {
 	Response as ExpressResponse,
 } from "express";
 import express from "express";
-import * as saml from "samlify";
 import {
 	afterAll,
 	afterEach,
@@ -34,6 +33,7 @@ import {
 import { sso, validateSAMLTimestamp } from ".";
 import { ssoClient } from "./client";
 import { DEFAULT_CLOCK_SKEW_MS } from "./constants";
+import { saml } from "./samlify";
 
 const spMetadata = `
     <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://localhost:3001/api/sso/saml2/sp/metadata">

--- a/packages/sso/src/samlify.ts
+++ b/packages/sso/src/samlify.ts
@@ -1,0 +1,13 @@
+import samlifyDefault, * as samlifyNamespace from "samlify";
+
+/**
+ * CJS `samlify` default is sometimes undefined under ESM due to interop issues (#8697)
+ * So we prefer the namespace when it looks complete, else the default binding, else the namespace as fallback.
+ */
+const namespaceLooksComplete =
+	typeof samlifyNamespace.SPMetadata === "function" &&
+	typeof samlifyNamespace.setSchemaValidator === "function";
+
+export const saml: typeof samlifyDefault = namespaceLooksComplete
+	? (samlifyNamespace as unknown as typeof samlifyDefault)
+	: (samlifyDefault ?? (samlifyNamespace as unknown as typeof samlifyDefault));


### PR DESCRIPTION
**What is changing?**
Fixes regression of https://github.com/better-auth/better-auth/issues/7993 on recent releases.

This scenario is already covered by our smoke tests, but because this regression only affects Node.js 22 and Node.js < 24.14.0, we were not able to catch it. Adding Node.js 22 to the smoke test matrix to avoid this sort of issue going forward.