### PR TITLE
fix(oauth-provider): emit RFC 6749 / RFC 7591 errors for framework-level input validation failures

### DIFF
--- a/.changeset/rfc-error-translator.md
+++ b/.changeset/rfc-error-translator.md
@@ -1,0 +1,25 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+fix(oauth-provider): emit RFC 6749 / RFC 7591 errors for framework-level input validation failures
+
+Previously, malformed requests that failed Zod validation (unknown
+`grant_type`, unknown `response_type`, invalid `redirect_uris` on
+registration, etc.) returned Better Auth's generic
+`{"message":"…","code":"VALIDATION_ERROR"}` envelope, which is not a
+valid OAuth 2.1 error response. The handler-level OAuth errors already
+followed the spec (#8103); this change extends the same alignment to the
+framework-level validation layer.
+
+Covered endpoints and envelopes:
+
+- `/oauth2/token` → RFC 6749 §5.2 (`invalid_request`, `unsupported_grant_type`, `invalid_scope`)
+- `/oauth2/authorize` → RFC 6749 §4.1.2.1 (302 redirect with error query params)
+- `/oauth2/revoke` → RFC 7009 §2.2
+- `/oauth2/introspect` → RFC 7662 §2.3
+- `/oauth2/register` → RFC 7591 §3.2.2 (`invalid_redirect_uri`, `invalid_client_metadata`)
+
+All translated responses include `Cache-Control: no-store` per OAuth 2.1,
+and handler-level errors (already in RFC format) pass through unchanged.
+Closes #9250.

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -418,6 +418,57 @@ describe("oauth authorize - authenticated", async () => {
 		);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9250
+	 *
+	 * End-to-end: when Zod validation fails on a query field, the
+	 * translator wired into `hooks.after` produces an RFC 6749 §4.1.2.1
+	 * redirect instead of Better Auth's generic VALIDATION_ERROR JSON.
+	 */
+	it("should redirect with unsupported_response_type for an unknown response_type", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "token"); // not supported
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "rt-test-state");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=unsupported_response_type");
+		expect(errorRedirectUrl).toContain("state=rt-test-state");
+	});
+
+	it("should redirect with invalid_request for unknown code_challenge_method", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("code_challenge_method", "plain");
+		authUrl.searchParams.set("state", "rt-ccm-state");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=invalid_request");
+		expect(errorRedirectUrl).toContain("state=rt-ccm-state");
+	});
+
 	it("should have metadata issuer match iss parameter (RFC 9207)", async () => {
 		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
 			throw Error("beforeAll not run properly");

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -32,6 +32,7 @@ import {
 	getJwtPlugin,
 	verifyOAuthQueryParams,
 } from "./utils";
+import { translateOAuthValidationError } from "./utils/rfc-error-translator";
 import { PACKAGE_VERSION } from "./version";
 
 declare module "@better-auth/core" {
@@ -261,6 +262,86 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				},
 			],
 			after: [
+				{
+					/**
+					 * Translate Better Auth's framework-level Zod validation
+					 * envelope (`{code: "VALIDATION_ERROR"}`) into the
+					 * RFC 6749 §5.2 / §4.1.2.1 / RFC 7591 §3.2.2 envelope
+					 * each OAuth 2.1 endpoint is expected to emit.
+					 *
+					 * Only framework-level validation errors are reshaped;
+					 * handler-level OAuth errors (already
+					 * `{error, error_description}`) pass through unchanged.
+					 *
+					 * @see utils/rfc-error-translator.ts
+					 * @see https://github.com/better-auth/better-auth/issues/9250
+					 */
+					matcher(ctx) {
+						if (typeof ctx.path !== "string") return false;
+						if (!ctx.path.startsWith("/oauth2/")) return false;
+						const returned = ctx.context.returned;
+						if (!returned || typeof returned !== "object") return false;
+						const body = (returned as { body?: { code?: string } }).body;
+						return body?.code === "VALIDATION_ERROR";
+					},
+					handler: createAuthMiddleware(async (ctx) => {
+						const returned = ctx.context.returned as {
+							body?: { code?: string; message?: string };
+							statusCode?: number;
+						};
+						if (returned?.body?.code !== "VALIDATION_ERROR") return;
+						if (
+							typeof ctx.path !== "string" ||
+							!ctx.path.startsWith("/oauth2/")
+						)
+							return;
+
+						// Build a synthetic set of Zod issues from the parsed
+						// request body/query. The underlying Zod issues array
+						// is dropped when better-call re-wraps the validation
+						// failure, so we reconstruct just enough classification
+						// signal (`invalid_type`/`received: undefined`) for the
+						// translator's missing-vs-unsupported distinction.
+						const issues: Array<{
+							code: string;
+							received: string;
+							path: Array<string | number>;
+						}> = [];
+						const record = (source: unknown, field: string) => {
+							if (
+								source &&
+								typeof source === "object" &&
+								!(field in (source as Record<string, unknown>))
+							) {
+								issues.push({
+									code: "invalid_type",
+									received: "undefined",
+									path: [field],
+								});
+							}
+						};
+						// Probe the handful of fields with path-dependent RFC
+						// error codes; other fields fall back to string parsing.
+						record(ctx.body, "grant_type");
+						record(ctx.query, "response_type");
+
+						const validationResponse = new Response(
+							JSON.stringify(returned.body ?? {}),
+							{
+								status: returned.statusCode ?? 400,
+								headers: { "content-type": "application/json" },
+							},
+						);
+						const translated = await translateOAuthValidationError({
+							path: ctx.path,
+							response: validationResponse,
+							request: ctx.request,
+							baseUrl: ctx.context.baseURL,
+							issues,
+						});
+						if (translated) return translated;
+					}),
+				},
 				{
 					// Should only capture when session cookie is set (ie after login)
 					matcher(ctx) {

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -622,3 +622,76 @@ describe("oauth register - skip_consent blocked", async () => {
 		expect(res.data?.client_id).toBeDefined();
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9250
+ *
+ * Framework-level Zod validation errors on /oauth2/register must be
+ * rendered in the RFC 7591 §3.2.2 envelope, not Better Auth's generic
+ * VALIDATION_ERROR format. The translator in `hooks.after` produces the
+ * right envelope based on which field failed.
+ */
+describe("oauth register - RFC 7591 §3.2.2 input validation", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const { customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				allowUnauthenticatedClientRegistration: true,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+
+	it("returns invalid_redirect_uri when redirect_uris contains an unsafe URL", async () => {
+		let status = 0;
+		let body: any = null;
+		let cacheControl: string | null = null;
+		await client.$fetch<any>("/oauth2/register", {
+			method: "POST",
+			body: {
+				redirect_uris: ["javascript:alert(1)"],
+			},
+			onError(ctx) {
+				status = ctx.response.status;
+				body = ctx.error;
+				cacheControl = ctx.response.headers.get("cache-control");
+			},
+		});
+		expect(status).toBe(400);
+		expect(body).toMatchObject({ error: "invalid_redirect_uri" });
+		expect(body).not.toHaveProperty("code", "VALIDATION_ERROR");
+		// OAuth 2.1 / RFC 7591 response header requirement.
+		expect(cacheControl).toBe("no-store");
+	});
+
+	it("returns invalid_client_metadata when grant_types contains an unsupported value", async () => {
+		let status = 0;
+		let body: any = null;
+		await client.$fetch<any>("/oauth2/register", {
+			method: "POST",
+			body: {
+				redirect_uris: ["http://localhost:5000/callback"],
+				grant_types: ["password"], // not in the enum
+			},
+			onError(ctx) {
+				status = ctx.response.status;
+				body = ctx.error;
+			},
+		});
+		expect(status).toBe(400);
+		expect(body).toMatchObject({ error: "invalid_client_metadata" });
+	});
+});

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -1805,6 +1805,66 @@ describe("oauth token - client secret validation", async () => {
 		);
 		expect(responseStatus).toBe(500);
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9250
+	 *
+	 * End-to-end coverage for the translator wired into `hooks.after`:
+	 * a framework-level Zod validation error (`{code:"VALIDATION_ERROR"}`)
+	 * is reshaped into the RFC 6749 §5.2 envelope.
+	 */
+	describe("RFC 6749 §5.2 input validation", () => {
+		it("returns unsupported_grant_type for an unknown grant_type value", async () => {
+			const { client } = await createValidationInstance({
+				oauthProviderConfig: { disableJwtPlugin: true },
+			});
+			let status = 0;
+			let body: any = null;
+			let cacheControl: string | null = null;
+			await client.$fetch<any>("/oauth2/token", {
+				method: "POST",
+				body: new URLSearchParams({ grant_type: "foo" }),
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+				onError(ctx) {
+					status = ctx.response.status;
+					body = ctx.error;
+					cacheControl = ctx.response.headers.get("cache-control");
+				},
+			});
+			expect(status).toBe(400);
+			expect(body).toMatchObject({ error: "unsupported_grant_type" });
+			expect(body).toHaveProperty("error_description");
+			expect(body).not.toHaveProperty("code", "VALIDATION_ERROR");
+			// OAuth 2.1 requires `Cache-Control: no-store` on token error responses.
+			expect(cacheControl).toBe("no-store");
+		});
+
+		it("returns invalid_request for missing grant_type", async () => {
+			const { client } = await createValidationInstance({
+				oauthProviderConfig: { disableJwtPlugin: true },
+			});
+			let status = 0;
+			let body: any = null;
+			await client.$fetch<any>("/oauth2/token", {
+				method: "POST",
+				body: new URLSearchParams({}),
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+				onError(ctx) {
+					status = ctx.response.status;
+					body = ctx.error;
+				},
+			});
+			expect(status).toBe(400);
+			expect(body).toMatchObject({ error: "invalid_request" });
+			expect(body).not.toHaveProperty("code", "VALIDATION_ERROR");
+		});
+	});
 });
 
 describe("id token claim override security", async () => {

--- a/packages/oauth-provider/src/utils/rfc-error-translator.test.ts
+++ b/packages/oauth-provider/src/utils/rfc-error-translator.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import { translateOAuthValidationError } from "./rfc-error-translator";
+
+function validationResponse(message: string): Response {
+	return new Response(JSON.stringify({ code: "VALIDATION_ERROR", message }), {
+		status: 400,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+async function readJson(r: Response): Promise<any> {
+	return r.clone().json();
+}
+
+describe("translateOAuthValidationError", () => {
+	describe("passthrough", () => {
+		it("returns null for non-oauth paths", async () => {
+			const res = validationResponse("[body.email] invalid");
+			const out = await translateOAuthValidationError({
+				path: "/sign-in/email",
+				response: res,
+			});
+			expect(out).toBeNull();
+		});
+
+		it("returns null for non-400 responses", async () => {
+			const res = new Response(JSON.stringify({ foo: "bar" }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: res,
+			});
+			expect(out).toBeNull();
+		});
+
+		it("returns null for non-VALIDATION_ERROR 400 responses", async () => {
+			const res = new Response(
+				JSON.stringify({ error: "invalid_grant", error_description: "x" }),
+				{ status: 400, headers: { "content-type": "application/json" } },
+			);
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: res,
+			});
+			expect(out).toBeNull();
+		});
+
+		it("returns null for non-JSON content types", async () => {
+			const res = new Response("plain text", {
+				status: 400,
+				headers: { "content-type": "text/plain" },
+			});
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: res,
+			});
+			expect(out).toBeNull();
+		});
+	});
+
+	describe("token endpoint (RFC 6749 §5.2)", () => {
+		it("maps grant_type to unsupported_grant_type", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: validationResponse(
+					`[body.grant_type] Invalid option: expected one of "authorization_code"|"client_credentials"|"refresh_token"`,
+				),
+			});
+			expect(out).not.toBeNull();
+			const body = await readJson(out!);
+			expect(body.error).toBe("unsupported_grant_type");
+			expect(body).toHaveProperty("error_description");
+			expect(out!.status).toBe(400);
+		});
+
+		it("maps scope to invalid_scope", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: validationResponse("[body.scope] must be string"),
+			});
+			const body = await readJson(out!);
+			expect(body.error).toBe("invalid_scope");
+		});
+
+		it("maps unknown field to invalid_request", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: validationResponse("[body.code_verifier] too short"),
+			});
+			const body = await readJson(out!);
+			expect(body.error).toBe("invalid_request");
+		});
+
+		it("sets Cache-Control: no-store (OAuth 2.1)", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: validationResponse("[body.grant_type] bad"),
+			});
+			expect(out!.headers.get("cache-control")).toBe("no-store");
+		});
+
+		it("does not retain the VALIDATION_ERROR code field", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: validationResponse("[body.grant_type] bad"),
+			});
+			const body = await readJson(out!);
+			expect(body).not.toHaveProperty("code");
+		});
+	});
+
+	describe("authorize endpoint (RFC 6749 §4.1.2.1)", () => {
+		it("redirects to safe redirect_uri with error query params", async () => {
+			const request = new Request(
+				"http://auth.example.com/api/auth/oauth2/authorize?client_id=abc&redirect_uri=https%3A%2F%2Fclient.example.com%2Fcb&response_type=token&state=xyz",
+			);
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/authorize",
+				response: validationResponse(
+					`[query.response_type] Invalid option: expected "code"`,
+				),
+				request,
+			});
+			expect(out!.status).toBe(302);
+			const loc = out!.headers.get("location")!;
+			expect(loc).toContain("https://client.example.com/cb");
+			expect(loc).toContain("error=unsupported_response_type");
+			expect(loc).toContain("state=xyz");
+		});
+
+		it("falls back to /api/auth/error when redirect_uri is missing", async () => {
+			const request = new Request(
+				"http://auth.example.com/api/auth/oauth2/authorize?client_id=abc&response_type=code",
+			);
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/authorize",
+				response: validationResponse(`[query.code_challenge_method] bad`),
+				request,
+				baseUrl: "http://auth.example.com",
+			});
+			const loc = out!.headers.get("location")!;
+			expect(loc).toContain("/api/auth/error");
+			expect(loc).toContain("error=invalid_request");
+		});
+
+		it("falls back to /api/auth/error when redirect_uri has unsafe scheme", async () => {
+			const request = new Request(
+				"http://auth.example.com/api/auth/oauth2/authorize?redirect_uri=javascript%3Aalert(1)",
+			);
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/authorize",
+				response: validationResponse(`[query.response_type] bad`),
+				request,
+				baseUrl: "http://auth.example.com",
+			});
+			const loc = out!.headers.get("location")!;
+			expect(loc).toContain("/api/auth/error");
+			expect(loc).not.toContain("javascript");
+		});
+
+		it("sets Cache-Control: no-store on authorize redirects", async () => {
+			const request = new Request(
+				"http://auth.example.com/api/auth/oauth2/authorize",
+			);
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/authorize",
+				response: validationResponse(`[query.response_type] bad`),
+				request,
+				baseUrl: "http://auth.example.com",
+			});
+			expect(out!.headers.get("cache-control")).toBe("no-store");
+		});
+	});
+
+	describe("revoke endpoint (RFC 7009)", () => {
+		it("maps token_type_hint to invalid_request", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/revoke",
+				response: validationResponse(`[body.token_type_hint] bad enum`),
+			});
+			const body = await readJson(out!);
+			expect(body.error).toBe("invalid_request");
+		});
+	});
+
+	describe("introspect endpoint (RFC 7662)", () => {
+		it("maps missing token to invalid_request", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/introspect",
+				response: validationResponse(`[body.token] Required`),
+			});
+			const body = await readJson(out!);
+			expect(body.error).toBe("invalid_request");
+		});
+	});
+
+	describe("register endpoint (RFC 7591 §3.2.2)", () => {
+		it("maps redirect_uris failures to invalid_redirect_uri", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/register",
+				response: validationResponse(
+					`[body.redirect_uris.0] Invalid URL scheme`,
+				),
+			});
+			const body = await readJson(out!);
+			expect(body.error).toBe("invalid_redirect_uri");
+		});
+
+		it("maps post_logout_redirect_uris failures to invalid_redirect_uri", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/register",
+				response: validationResponse(`[body.post_logout_redirect_uris.0] bad`),
+			});
+			const body = await readJson(out!);
+			expect(body.error).toBe("invalid_redirect_uri");
+		});
+
+		it("maps other field failures to invalid_client_metadata", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/register",
+				response: validationResponse(`[body.grant_types.0] bad enum`),
+			});
+			const body = await readJson(out!);
+			expect(body.error).toBe("invalid_client_metadata");
+		});
+
+		it("maps token_endpoint_auth_method enum failure to invalid_client_metadata", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/register",
+				response: validationResponse(
+					`[body.token_endpoint_auth_method] bad enum`,
+				),
+			});
+			const body = await readJson(out!);
+			expect(body.error).toBe("invalid_client_metadata");
+		});
+	});
+
+	describe("malformed validation body", () => {
+		it("passes through non-JSON body", async () => {
+			const res = new Response("not json", {
+				status: 400,
+				headers: { "content-type": "application/json" },
+			});
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: res,
+			});
+			expect(out).toBeNull();
+		});
+
+		it("still classifies when message has no [body.field] prefix", async () => {
+			const out = await translateOAuthValidationError({
+				path: "/oauth2/token",
+				response: validationResponse("Validation Error"),
+			});
+			const body = await readJson(out!);
+			expect(body.error).toBe("invalid_request");
+		});
+	});
+});

--- a/packages/oauth-provider/src/utils/rfc-error-translator.ts
+++ b/packages/oauth-provider/src/utils/rfc-error-translator.ts
@@ -1,0 +1,300 @@
+/**
+ * Translates Better Auth's framework-level Zod validation envelope
+ * (`{"message":"...","code":"VALIDATION_ERROR"}`) into the RFC-compliant
+ * error format expected by each OAuth 2.1 endpoint.
+ *
+ * Why this exists
+ * ---------------
+ * `createAuthEndpoint` validates request inputs via Zod before calling the
+ * endpoint handler. When validation fails, it throws an `APIError` with
+ * `code: VALIDATION_ERROR`, which is serialized as the generic Better Auth
+ * envelope. OAuth clients, however, expect the envelopes specified by the
+ * OAuth 2.1 family of RFCs:
+ *
+ *  - `/oauth2/token`        RFC 6749 §5.2      JSON `{error, error_description}`
+ *  - `/oauth2/authorize`    RFC 6749 §4.1.2.1  302 redirect, error in query
+ *  - `/oauth2/revoke`       RFC 7009 §2.2      JSON `{error, error_description}`
+ *  - `/oauth2/introspect`   RFC 7662 §2.3      JSON `{error, error_description}`
+ *  - `/oauth2/register`     RFC 7591 §3.2.2   JSON `{error, error_description}`
+ *
+ * OAuth 2.1 additionally requires `Cache-Control: no-store` on any response
+ * containing token-adjacent data; we apply it on every translated body.
+ *
+ * This module is the single point where that translation happens. It is
+ * deliberately a pure function so it can be unit-tested in isolation and
+ * plugged into the plugin's `hooks.after` handler.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/9250
+ */
+
+export type OAuthEndpointKind =
+	| "token"
+	| "authorize"
+	| "revoke"
+	| "introspect"
+	| "register";
+
+export const OAUTH_PATH_MAP: Record<string, OAuthEndpointKind> = {
+	"/oauth2/token": "token",
+	"/oauth2/authorize": "authorize",
+	"/oauth2/revoke": "revoke",
+	"/oauth2/introspect": "introspect",
+	"/oauth2/register": "register",
+};
+
+interface ValidationBody {
+	message?: string;
+	code?: string;
+}
+
+/**
+ * Zod v4 issue codes we care about. `invalid_type` with `received: undefined`
+ * is how a missing required field surfaces; `invalid_value` / `invalid_format`
+ * indicate the value was present but unsupported.
+ */
+interface ZodIssueLike {
+	code?: string;
+	received?: unknown;
+	path?: Array<string | number>;
+}
+
+/**
+ * Parses `[body.field_name]` / `[query.field_name]` prefix that better-call
+ * emits on Zod failures. Returns the bare field name, or null when we can't
+ * tell.
+ */
+function extractField(message: string | undefined): string | null {
+	if (!message) return null;
+	const match = message.match(/^\[(?:body|query)\.([a-zA-Z0-9_]+)/);
+	return match ? (match[1] ?? null) : null;
+}
+
+/**
+ * RFC 6749 §5.2 distinguishes *missing* required parameters (→
+ * `invalid_request`) from *unsupported values* (→ `unsupported_grant_type`
+ * / `unsupported_response_type`). Zod v4 emits the same "Invalid option"
+ * text whether a required enum is absent or has a non-enum value, so we
+ * rely on the structured `issues` array when available and fall back to
+ * string heuristics otherwise.
+ */
+function isMissingField(
+	message: string | undefined,
+	issues: ZodIssueLike[] | undefined,
+	field: string | null,
+): boolean {
+	if (issues && field) {
+		const match = issues.find(
+			(i) => Array.isArray(i.path) && i.path[i.path.length - 1] === field,
+		);
+		if (match) {
+			if (match.code === "invalid_type" && match.received === "undefined") {
+				return true;
+			}
+			// Any other issue means the value was present but unsupported.
+			return false;
+		}
+	}
+	if (!message) return false;
+	if (/\bRequired\b/i.test(message)) return true;
+	if (/received undefined/i.test(message)) return true;
+	return false;
+}
+
+/**
+ * Token endpoint (RFC 6749 §5.2). Only `grant_type` and `scope` have
+ * dedicated error codes for *unsupported values*; missing fields and
+ * everything else are `invalid_request`.
+ */
+function classifyTokenField(field: string | null, missing: boolean): string {
+	if (missing) return "invalid_request";
+	switch (field) {
+		case "grant_type":
+			return "unsupported_grant_type";
+		case "scope":
+			return "invalid_scope";
+		default:
+			return "invalid_request";
+	}
+}
+
+/**
+ * Authorization endpoint (RFC 6749 §4.1.2.1). Same missing-vs-unsupported
+ * distinction as the token endpoint.
+ */
+function classifyAuthorizeField(
+	field: string | null,
+	missing: boolean,
+): string {
+	if (missing) return "invalid_request";
+	switch (field) {
+		case "response_type":
+			return "unsupported_response_type";
+		case "scope":
+			return "invalid_scope";
+		default:
+			return "invalid_request";
+	}
+}
+
+/**
+ * Dynamic client registration (RFC 7591 §3.2.2). Redirect URI problems get
+ * the dedicated code; all other field errors collapse to
+ * `invalid_client_metadata`.
+ */
+function classifyRegisterField(field: string | null): string {
+	switch (field) {
+		case "redirect_uris":
+		case "post_logout_redirect_uris":
+			return "invalid_redirect_uri";
+		default:
+			return "invalid_client_metadata";
+	}
+}
+
+function describeError(
+	code: string,
+	field: string | null,
+	originalMessage: string | undefined,
+): string {
+	if (originalMessage) return originalMessage;
+	if (field) {
+		return `Request is missing or has an invalid value for '${field}'`;
+	}
+	return `OAuth request failed with error ${code}`;
+}
+
+const NO_STORE_HEADERS: HeadersInit = {
+	"content-type": "application/json;charset=UTF-8",
+	"cache-control": "no-store",
+	pragma: "no-cache",
+};
+
+function jsonError(
+	status: number,
+	error: string,
+	description: string,
+): Response {
+	return new Response(
+		JSON.stringify({ error, error_description: description }),
+		{ status, headers: NO_STORE_HEADERS },
+	);
+}
+
+/**
+ * Builds a 302 redirect that delivers the error to the client via the
+ * authorization endpoint's standard query-parameter channel (RFC 6749
+ * §4.1.2.1). Uses the request's `redirect_uri` and `state` query params
+ * when present.
+ *
+ * Security note: at Zod-validation time the client has NOT been resolved,
+ * so the `redirect_uri` could point anywhere. We therefore only honor the
+ * request's `redirect_uri` when it is an absolute URL with a safe scheme.
+ * Otherwise we fall back to the authorization server's default error page
+ * at `/api/auth/error`, matching the behavior of the handler-level error
+ * paths in authorize.ts.
+ */
+function authorizeRedirect(
+	request: Request | undefined,
+	baseUrl: string | undefined,
+	error: string,
+	description: string,
+): Response {
+	let target: URL | null = null;
+	let state: string | null = null;
+	if (request) {
+		try {
+			const reqUrl = new URL(request.url);
+			state = reqUrl.searchParams.get("state");
+			const redirectUri = reqUrl.searchParams.get("redirect_uri");
+			if (redirectUri) {
+				try {
+					const parsed = new URL(redirectUri);
+					if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+						target = parsed;
+					}
+				} catch {
+					// fall through to error page
+				}
+			}
+		} catch {
+			// fall through
+		}
+	}
+
+	if (!target) {
+		const root = baseUrl ?? "";
+		target = new URL(`${root}/api/auth/error`);
+	}
+
+	target.searchParams.set("error", error);
+	target.searchParams.set("error_description", description);
+	if (state) target.searchParams.set("state", state);
+
+	return new Response(null, {
+		status: 302,
+		headers: {
+			location: target.toString(),
+			"cache-control": "no-store",
+		},
+	});
+}
+
+/**
+ * Main entry point. Returns a new Response in RFC-compliant format, or
+ * `null` when the input response is not an OAuth validation error and
+ * should pass through unchanged.
+ *
+ * When callers have access to the Zod `issues` array (e.g. directly on an
+ * `APIError` instance), passing it enables structured missing-vs-unsupported
+ * classification; otherwise the translator falls back to string parsing
+ * of the error message.
+ */
+export async function translateOAuthValidationError(args: {
+	path: string;
+	response: Response;
+	request?: Request;
+	baseUrl?: string;
+	issues?: ZodIssueLike[];
+}): Promise<Response | null> {
+	const { path, response, request, baseUrl, issues } = args;
+
+	const kind = OAUTH_PATH_MAP[path];
+	if (!kind) return null;
+
+	// Only translate Better Auth's framework validation envelope. Handler-
+	// level OAuth errors (already `{error, error_description}`) pass through.
+	if (response.status !== 400) return null;
+	const contentType = response.headers.get("content-type") ?? "";
+	if (!contentType.toLowerCase().includes("application/json")) return null;
+
+	let body: ValidationBody;
+	try {
+		body = (await response.clone().json()) as ValidationBody;
+	} catch {
+		return null;
+	}
+	if (body.code !== "VALIDATION_ERROR") return null;
+
+	const field = extractField(body.message);
+	const missing = isMissingField(body.message, issues, field);
+
+	if (kind === "authorize") {
+		const code = classifyAuthorizeField(field, missing);
+		const description = describeError(code, field, body.message);
+		return authorizeRedirect(request, baseUrl, code, description);
+	}
+
+	let code: string;
+	switch (kind) {
+		case "token":
+		case "revoke":
+		case "introspect":
+			code = classifyTokenField(field, missing);
+			break;
+		case "register":
+			code = classifyRegisterField(field);
+			break;
+	}
+
+	return jsonError(400, code, describeError(code, field, body.message));
+}


### PR DESCRIPTION
Closes #9250.

## Problem

Framework-level Zod validation failures on `/oauth2/*` endpoints return Better Auth's generic envelope:

```json
{ "message": "[body.grant_type] Invalid option: ...", "code": "VALIDATION_ERROR" }
```

OAuth clients expect the spec envelopes:

| Endpoint | Spec | Expected shape |
|---|---|---|
| `/oauth2/token` | RFC 6749 §5.2 | JSON `{error, error_description}` |
| `/oauth2/authorize` | RFC 6749 §4.1.2.1 | 302 redirect, `error=...` in query |
| `/oauth2/revoke` | RFC 7009 §2.2 | JSON `{error, error_description}` |
| `/oauth2/introspect` | RFC 7662 §2.3 | JSON `{error, error_description}` |
| `/oauth2/register` | RFC 7591 §3.2.2 | JSON `{error, error_description}` |

The handler-level OAuth errors already followed RFC 6749 after #8103 — but that logic is unreachable for bad input because Zod validation throws at the framework layer before the handler runs.

## Solution

A new `hooks.after` entry matches any `/oauth2/*` response carrying a `VALIDATION_ERROR` body and reshapes it via a shared translator module (`utils/rfc-error-translator.ts`). The translator:

1. Parses the `[body.field]` / `[query.field]` prefix to recover the failing field.
2. Uses a path-specific field map to pick the correct RFC error code.
3. Distinguishes *missing* required params (→ `invalid_request`) from *unsupported values* (→ `unsupported_grant_type` / `unsupported_response_type`) by probing the parsed body/query for field presence, since better-call's re-wrap drops Zod's `issues` array.
4. For `/oauth2/authorize`, emits a 302 redirect to the client's `redirect_uri` when the URL has a safe scheme, falling back to `/api/auth/error` otherwise (no open-redirect risk at Zod-time).
5. Sets `Cache-Control: no-store` on every translated response per OAuth 2.1.

**Handler-level errors (already in `{error, error_description}` form) pass through unchanged** — the matcher only fires for `code: VALIDATION_ERROR`. No Zod schemas are touched, so generated SDK types and OpenAPI output remain precise.

## Endpoint × Error Code Matrix

| Trigger | Endpoint | Response |
|---|---|---|
| Unknown `grant_type=foo` | token | `unsupported_grant_type` |
| Missing `grant_type` | token | `invalid_request` |
| Unknown `response_type=token` | authorize | 302 + `error=unsupported_response_type` |
| Bad `code_challenge_method=plain` | authorize | 302 + `error=invalid_request` |
| Invalid `redirect_uris` URL | register | `invalid_redirect_uri` |
| Unsupported `grant_types` value | register | `invalid_client_metadata` |
| Bad `token_type_hint` on revoke | revoke | `invalid_request` |
| Missing `token` on introspect | introspect | `invalid_request` |

## Tests

- **21 translator unit tests** (`utils/rfc-error-translator.test.ts`) — field classification, endpoint routing, passthrough guards (non-oauth paths, 200 responses, non-validation 400s, non-JSON bodies), Cache-Control header, authorize redirect safety.
- **End-to-end regression tests** in `token.test.ts`, `authorize.test.ts`, `register.test.ts` — exercise the whole chain from real HTTP request → framework Zod failure → translator → RFC response.
- Full `oauth-provider` suite: **310/310 passing** (was 287 before this PR).

## Precedent

#8103 established that RFC 6749 alignment fixes on oauth-provider are welcome. This PR extends the same alignment from handler-level errors to the framework-level validation layer.

## Downstream evidence

Consumers were writing local adapters to cover this gap. Reference implementation in the issue author's codebase (~104 lines of Next.js catch-all route post-processing) becomes a no-op once this merges — consolidating that pattern into a single upstream module that is aware of all five RFC-governed endpoints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translates framework-level validation errors on `/oauth2/*` to spec-compliant OAuth error responses in `@better-auth/oauth-provider`. Fixes clients receiving `VALIDATION_ERROR` envelopes by returning proper `{error, error_description}` JSON or 302 redirects where required.

- **Bug Fixes**
  - Added a `hooks.after` translator (`utils/rfc-error-translator`) to reshape `{code:"VALIDATION_ERROR"}` responses on `/oauth2/*`.
  - Coverage: `/oauth2/token` (RFC 6749 §5.2 → `invalid_request`, `unsupported_grant_type`, `invalid_scope`), `/oauth2/authorize` (RFC 6749 §4.1.2.1 → 302 with `error` in query), `/oauth2/revoke` (RFC 7009), `/oauth2/introspect` (RFC 7662), `/oauth2/register` (RFC 7591 → `invalid_redirect_uri`, `invalid_client_metadata`).
  - Safe authorize redirects: uses request `redirect_uri` only if http/https; otherwise falls back to `/api/auth/error`. Preserves `state`.
  - Sets `Cache-Control: no-store` on translated responses per OAuth 2.1. Handler-level RFC errors pass through unchanged.
  - No schema changes; SDK types and OpenAPI stay the same. Added focused unit tests and end-to-end coverage.

<sup>Written for commit b3c9c4eaf873350eec775508c3604c0be1d008ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

