### PR TITLE
fix(oauth-provider): align token and authorize input errors with RFC 6749

### DIFF
--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -418,6 +418,34 @@ describe("oauth authorize - authenticated", async () => {
 		);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9250
+	 */
+	it("should redirect with invalid_request for unsupported code_challenge_method", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "ccm-test-state");
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "plain");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain(redirectUri);
+		expect(errorRedirectUrl).toContain("error=invalid_request");
+		expect(errorRedirectUrl).toContain("state=ccm-test-state");
+	});
+
 	it("should have metadata issuer match iss parameter (RFC 9207)", async () => {
 		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
 			throw Error("beforeAll not run properly");

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -421,6 +421,29 @@ describe("oauth authorize - authenticated", async () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9250
 	 */
+	it("should redirect with unsupported_response_type for an unknown response_type", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "token");
+		authUrl.searchParams.set("scope", "openid");
+
+		let errorRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirectUrl).toContain("error=unsupported_response_type");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9250
+	 */
 	it("should redirect with invalid_request for unsupported code_challenge_method", async () => {
 		if (!oauthClient?.client_id) {
 			throw Error("beforeAll not run properly");

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -372,7 +372,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				{
 					method: "GET",
 					query: z.object({
-						response_type: z.enum(["code"]).optional(),
+						response_type: z.string().optional(),
 						client_id: z.string(),
 						redirect_uri: SafeUrlSchema.optional(),
 						scope: z.string().optional(),

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -379,7 +379,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						state: z.string().optional(),
 						request_uri: z.string().optional(),
 						code_challenge: z.string().optional(),
-						code_challenge_method: z.enum(["S256"]).optional(),
+						code_challenge_method: z.string().optional(),
 						nonce: z.string().optional(),
 						prompt: z
 							.enum([
@@ -609,11 +609,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				{
 					method: "POST",
 					body: z.object({
-						grant_type: z.enum([
-							"authorization_code",
-							"client_credentials",
-							"refresh_token",
-						]),
+						grant_type: z.string().optional(),
 						client_id: z.string().optional(),
 						client_secret: z.string().optional(),
 						code: z.string().optional(),

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -2468,6 +2468,75 @@ describe("customTokenResponseFields", async () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9250
+ */
+describe("oauth token - RFC 6749 §5.2 input validation", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const { customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				disableJwtPlugin: true,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+
+	type OAuthErrorBody = {
+		error?: string;
+		error_description?: string;
+		code?: string;
+		message?: string;
+	};
+
+	async function postTokenForm(
+		body: URLSearchParams,
+	): Promise<{ status: number; error: OAuthErrorBody | null }> {
+		let status = 0;
+		let error: OAuthErrorBody | null = null;
+		await client.$fetch<unknown>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: {
+				accept: "application/json",
+				"content-type": "application/x-www-form-urlencoded",
+			},
+			onError(ctx) {
+				status = ctx.response.status;
+				error = ctx.error as OAuthErrorBody;
+			},
+		});
+		return { status, error };
+	}
+
+	it("returns unsupported_grant_type for an unknown grant_type value", async () => {
+		const { status, error } = await postTokenForm(
+			new URLSearchParams({ grant_type: "foo" }),
+		);
+		expect(status).toBe(400);
+		expect(error).toMatchObject({ error: "unsupported_grant_type" });
+		expect(error).not.toHaveProperty("code", "VALIDATION_ERROR");
+	});
+
+	it("returns invalid_request when grant_type is missing", async () => {
+		const { status, error } = await postTokenForm(new URLSearchParams({}));
+		expect(status).toBe(400);
+		expect(error).toMatchObject({ error: "invalid_request" });
+		expect(error).not.toHaveProperty("code", "VALIDATION_ERROR");
+	});
+});
+
 describe("verificationValueSchema", () => {
 	it("should validate a well-formed verification value", () => {
 		const value: VerificationValue = {

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -55,9 +55,10 @@ export async function tokenEndpoint(
 		case "refresh_token":
 			return handleRefreshTokenGrant(ctx, opts);
 		case undefined:
+			// RFC 6749 §5.2: missing required parameter is invalid_request.
 			throw new APIError("BAD_REQUEST", {
 				error_description: "missing required grant_type",
-				error: "unsupported_grant_type",
+				error: "invalid_request",
 			});
 		default:
 			throw new APIError("BAD_REQUEST", {

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -825,7 +825,7 @@ export interface OAuthAuthorizationQuery {
 	/**
 	 * Code challenge method used
 	 */
-	code_challenge_method?: "S256";
+	code_challenge_method?: string;
 	/**
 	 * String value used to associate a Client session with an ID Token, and to mitigate replay
 	 * attacks. The value is passed through unmodified from the Authentication Request to the ID Token.

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -729,7 +729,7 @@ export interface OAuthAuthorizationQuery {
 	 * Optional in the query when using request_uri (PAR) — resolved from stored params.
 	 */
 	// NEVER SUPPORT "token" or "id_token" - depreciated in oAuth2.1
-	response_type?: "code";
+	response_type?: string;
 	/**
 	 * PAR request_uri. When present, other params are resolved from the stored request.
 	 */


### PR DESCRIPTION
- Closes #9250
- Replaces #9265