### PR TITLE
fix(oauth-provider)!: return RFC-compliant error envelopes from validation failures

### DIFF
--- a/.changeset/fix-oauth-provider-rfc-error-envelope.md
+++ b/.changeset/fix-oauth-provider-rfc-error-envelope.md
@@ -6,8 +6,8 @@ fix(oauth-provider): return RFC-compliant `{ error, error_description }` envelop
 
 An internal `createOAuthEndpoint` wrapper now translates zod validation failures into the envelope required by RFC 6749 §5.2, 7009 §2.2.1, 7662 §2.3, and 7591 §3.2.2. Failing issues are routed per field:
 
-- an absent required value maps to `fieldErrors[name].missing` or the endpoint's `defaultError`.
-- an unsupported value (unknown enum member) maps to `fieldErrors[name].invalid` or `defaultError`.
+- an absent required value maps to `errorCodesByField[name].missing` or the endpoint's `defaultError`.
+- an unsupported value (unknown enum member) maps to `errorCodesByField[name].invalid` or `defaultError`.
 - any other failure (wrong type, duplicated query params, invalid format, refinement) maps to `defaultError`, so RFC 6749 §3.1 malformed requests emit the endpoint's default code regardless of field.
 
 All six OAuth endpoints (`/oauth2/token`, `/oauth2/authorize`, `/oauth2/revoke`, `/oauth2/introspect`, `/oauth2/register`, `/oauth2/end-session`) now return RFC-compliant errors for malformed requests. `/oauth2/authorize` validation failures redirect to the relying party with `error`, `error_description`, echoed `state`, and `iss` whenever `client_id` and `redirect_uri` resolve against the registered client; requests without a trusted RP fall back to the server error page.

--- a/.changeset/fix-oauth-provider-rfc-error-envelope.md
+++ b/.changeset/fix-oauth-provider-rfc-error-envelope.md
@@ -11,3 +11,8 @@ An internal `createOAuthEndpoint` wrapper now translates zod validation failures
 - any other failure (wrong type, duplicated query params, invalid format, refinement) maps to `defaultError`, so RFC 6749 §3.1 malformed requests emit the endpoint's default code regardless of field.
 
 All six OAuth endpoints (`/oauth2/token`, `/oauth2/authorize`, `/oauth2/revoke`, `/oauth2/introspect`, `/oauth2/register`, `/oauth2/end-session`) now return RFC-compliant errors for malformed requests. `/oauth2/authorize` validation failures redirect to the relying party with `error`, `error_description`, echoed `state`, and `iss` whenever `client_id` and `redirect_uri` resolve against the registered client; requests without a trusted RP fall back to the server error page.
+
+Additional RFC compliance fixes on the same endpoints:
+
+- `/oauth2/revoke` and `/oauth2/introspect` now ignore an unknown `token_type_hint` instead of rejecting it. RFC 7009 §2.2.1 and RFC 7662 §2.1 reserve `unsupported_token_type` for the token itself, not the hint value; servers MAY ignore unrecognized hints and search across supported token types.
+- `/oauth2/authorize` error redirects now respect OIDC Core 1.0 §5 response modes. Errors for `response_type=token` or `id_token` are delivered in the URL fragment per RFC 6749 §4.2.2.1; an explicit `response_mode=query` overrides the default.

--- a/.changeset/fix-oauth-provider-rfc-error-envelope.md
+++ b/.changeset/fix-oauth-provider-rfc-error-envelope.md
@@ -1,0 +1,13 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+fix(oauth-provider): return RFC-compliant `{ error, error_description }` envelopes from validation failures
+
+An internal `createOAuthEndpoint` wrapper now translates zod validation failures into the envelope required by RFC 6749 §5.2, 7009 §2.2.1, 7662 §2.3, and 7591 §3.2.2. Failing issues are routed per field:
+
+- an absent required value maps to `fieldErrors[name].missing` or the endpoint's `defaultError`.
+- an unsupported value (unknown enum member) maps to `fieldErrors[name].invalid` or `defaultError`.
+- any other failure (wrong type, duplicated query params, invalid format, refinement) maps to `defaultError`, so RFC 6749 §3.1 malformed requests emit the endpoint's default code regardless of field.
+
+All six OAuth endpoints (`/oauth2/token`, `/oauth2/authorize`, `/oauth2/revoke`, `/oauth2/introspect`, `/oauth2/register`, `/oauth2/end-session`) now return RFC-compliant errors for malformed requests. `/oauth2/authorize` validation failures redirect to the relying party with `error`, `error_description`, echoed `state`, and `iss` whenever `client_id` and `redirect_uri` resolve against the registered client; requests without a trusted RP fall back to the server error page.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -16,6 +16,7 @@
 	"ignoreIssues": {
 		"packages/cli/src/commands/init/index.ts": ["exports"],
 		"packages/cli/src/commands/init/utility/imports.ts": ["exports"],
+		"packages/oauth-provider/src/oauth-endpoint.ts": ["exports"],
 		"packages/sso/src/saml/assertions.ts": ["exports"]
 	},
 	"ignoreDependencies": ["@changesets/cli", "@vitest/coverage-istanbul"],

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -137,7 +137,7 @@ export function getIssuer(
  * Error page url if redirect_uri has not been verified yet
  * Generates Url for custom error page
  */
-function getErrorURL(
+export function getErrorURL(
 	ctx: GenericEndpointContext,
 	error: string,
 	description: string,
@@ -146,6 +146,59 @@ function getErrorURL(
 		ctx.context.options.onAPIError?.errorURL || `${ctx.context.baseURL}/error`;
 	const formattedURL = formatErrorURL(baseURL, error, description);
 	return formattedURL;
+}
+
+/**
+ * Finds the matching entry in a client's registered redirect_uris for a
+ * requested redirect_uri. Honors RFC 8252 §7.3 loopback port variance for
+ * 127.0.0.1 and [::1], matching on scheme+host+path+query and ignoring
+ * port. DNS names like "localhost" are excluded per §8.3.
+ */
+export function findRegisteredRedirectUri(
+	registered: readonly string[] | undefined,
+	requested: string | undefined,
+): string | undefined {
+	if (!registered || !requested) return undefined;
+	return registered.find((url) => {
+		if (url === requested) return true;
+		try {
+			const reg = new URL(url);
+			const req = new URL(requested);
+			return (
+				(reg.hostname === "127.0.0.1" || reg.hostname === "[::1]") &&
+				reg.hostname === req.hostname &&
+				reg.pathname === req.pathname &&
+				reg.protocol === req.protocol &&
+				reg.search === req.search
+			);
+		} catch {
+			return false;
+		}
+	});
+}
+
+/**
+ * Loads the client, verifies it's enabled, and returns the requested
+ * redirect_uri when it matches a registered entry. Returns null whenever the
+ * RP cannot be safely reached, so callers can fall back to the server error
+ * page (avoiding open-redirect risk on validation failures).
+ */
+export async function resolveTrustedRedirectUri(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	clientId: string | undefined,
+	redirectUri: string | undefined,
+): Promise<string | null> {
+	if (!clientId || !redirectUri) return null;
+	let client: Awaited<ReturnType<typeof getClient>> | undefined;
+	try {
+		client = await getClient(ctx, opts, clientId);
+	} catch {
+		return null;
+	}
+	if (!client || client.disabled) return null;
+	const matched = findRegisteredRedirectUri(client.redirectUris, redirectUri);
+	return matched ? redirectUri : null;
 }
 
 export async function authorizeEndpoint(
@@ -260,24 +313,10 @@ export async function authorizeEndpoint(
 		);
 	}
 
-	const redirectUri = client.redirectUris?.find((url) => {
-		if (url === query.redirect_uri) return true;
-		try {
-			const registered = new URL(url);
-			const requested = new URL(query.redirect_uri);
-			// RFC 8252 §7.3: loopback IPs match on scheme+host+path+query, ignoring port
-			if (
-				(registered.hostname === "127.0.0.1" ||
-					registered.hostname === "[::1]") &&
-				registered.hostname === requested.hostname &&
-				registered.pathname === requested.pathname &&
-				registered.protocol === requested.protocol &&
-				registered.search === requested.search
-			)
-				return true;
-		} catch {}
-		return false;
-	});
+	const redirectUri = findRegisteredRedirectUri(
+		client.redirectUris,
+		query.redirect_uri,
+	);
 	if (!redirectUri || !query.redirect_uri) {
 		return handleRedirect(
 			ctx,

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -5,6 +5,7 @@ import { generateRandomString, makeSignature } from "better-auth/crypto";
 import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
 import { oAuthState } from "./oauth";
+import type { OAuthErrorCode } from "./oauth-endpoint";
 import type {
 	OAuthAuthorizationQuery,
 	OAuthConsent,
@@ -22,21 +23,11 @@ import {
 } from "./utils";
 
 /**
- * OIDC Error Codes
- * @see https://openid.net/specs/openid-connect-core-1_0.html#AuthError
- */
-type OIDCAuthError =
-	| "login_required"
-	| "consent_required"
-	| "interaction_required"
-	| "account_selection_required";
-
-/**
  * Formats an error url
  */
 export function formatErrorURL(
 	url: string,
-	error: string,
+	error: OAuthErrorCode,
 	description: string,
 	state?: string,
 	iss?: string,
@@ -67,7 +58,7 @@ function redirectWithPromptNoneError(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 	query: OAuthAuthorizationQuery,
-	error: OIDCAuthError,
+	error: OAuthErrorCode,
 	description: string,
 ) {
 	return handleRedirect(
@@ -139,7 +130,7 @@ export function getIssuer(
  */
 export function getErrorURL(
 	ctx: GenericEndpointContext,
-	error: string,
+	error: OAuthErrorCode,
 	description: string,
 ) {
 	const baseURL =
@@ -164,6 +155,8 @@ export function findRegisteredRedirectUri(
 		try {
 			const reg = new URL(url);
 			const req = new URL(requested);
+			// TODO: swap to @better-auth/core/utils/host#isLoopbackIP once the
+			// main→next sync lands to cover the full 127.0.0.0/8 range (RFC 8252 §7.3).
 			return (
 				(reg.hostname === "127.0.0.1" || reg.hostname === "[::1]") &&
 				reg.hostname === req.hostname &&

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -237,10 +237,14 @@ async function resolveTrustedRedirectUri(
 }
 
 /**
- * Builds the `redirectOnError` callback for `/oauth2/authorize`: redirects
- * back to the RP with the RFC 6749 error query params when the already-parsed
- * query maps to a trusted registered redirect_uri, otherwise falls back to
- * the server error page (to avoid open-redirect risk on validation failures).
+ * `redirectOnError` callback for `/oauth2/authorize`. Per RFC 6749 §4.1.2.1,
+ * authorize errors MUST be delivered to the client's `redirect_uri` with
+ * `error`, `error_description`, `state`, and (RFC 9207) `iss`. The clause
+ * carves out one case: a missing/invalid `redirect_uri` or `client_id` MUST
+ * NOT redirect to the requested URI. We implement the carve-out via
+ * `resolveTrustedRedirectUri`, falling back to the server error page.
+ *
+ * Channel (query vs fragment) follows OIDC Core §5 via `deriveResponseMode`.
  */
 export function authorizeRedirectOnError(
 	opts: OAuthOptions<Scope[]>,

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -145,7 +145,7 @@ export function getErrorURL(
  * 127.0.0.1 and [::1], matching on scheme+host+path+query and ignoring
  * port. DNS names like "localhost" are excluded per §8.3.
  */
-export function findRegisteredRedirectUri(
+function findRegisteredRedirectUri(
 	registered: readonly string[] | undefined,
 	requested: string | undefined,
 ): string | undefined {

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -5,7 +5,7 @@ import { generateRandomString, makeSignature } from "better-auth/crypto";
 import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
 import { oAuthState } from "./oauth";
-import type { OAuthErrorCode } from "./oauth-endpoint";
+import type { OAuthErrorCode, OAuthRedirectOnError } from "./oauth-endpoint";
 import type {
 	OAuthAuthorizationQuery,
 	OAuthConsent,
@@ -128,7 +128,7 @@ export function getIssuer(
  * Error page url if redirect_uri has not been verified yet
  * Generates Url for custom error page
  */
-export function getErrorURL(
+function getErrorURL(
 	ctx: GenericEndpointContext,
 	error: OAuthErrorCode,
 	description: string,
@@ -150,19 +150,31 @@ function findRegisteredRedirectUri(
 	requested: string | undefined,
 ): string | undefined {
 	if (!registered || !requested) return undefined;
+
+	let req: URL | undefined;
+	try {
+		req = new URL(requested);
+	} catch {
+		// malformed requested — only exact-match branch can succeed below
+	}
+
+	// TODO(sync-from-main-9226): swap for isLoopbackIP(req.hostname) once the
+	// helper lands here, to cover the full 127.0.0.0/8 range per RFC 8252 §7.3.
+	const loopbackReq =
+		req?.hostname === "127.0.0.1" || req?.hostname === "[::1]"
+			? req
+			: undefined;
+
 	return registered.find((url) => {
 		if (url === requested) return true;
+		if (!loopbackReq) return false;
 		try {
 			const reg = new URL(url);
-			const req = new URL(requested);
-			// TODO: swap to @better-auth/core/utils/host#isLoopbackIP once the
-			// main→next sync lands to cover the full 127.0.0.0/8 range (RFC 8252 §7.3).
 			return (
-				(reg.hostname === "127.0.0.1" || reg.hostname === "[::1]") &&
-				reg.hostname === req.hostname &&
-				reg.pathname === req.pathname &&
-				reg.protocol === req.protocol &&
-				reg.search === req.search
+				reg.hostname === loopbackReq.hostname &&
+				reg.pathname === loopbackReq.pathname &&
+				reg.protocol === loopbackReq.protocol &&
+				reg.search === loopbackReq.search
 			);
 		} catch {
 			return false;
@@ -176,7 +188,7 @@ function findRegisteredRedirectUri(
  * RP cannot be safely reached, so callers can fall back to the server error
  * page (avoiding open-redirect risk on validation failures).
  */
-export async function resolveTrustedRedirectUri(
+async function resolveTrustedRedirectUri(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 	clientId: string | undefined,
@@ -192,6 +204,43 @@ export async function resolveTrustedRedirectUri(
 	if (!client || client.disabled) return null;
 	const matched = findRegisteredRedirectUri(client.redirectUris, redirectUri);
 	return matched ? redirectUri : null;
+}
+
+/**
+ * Builds the `redirectOnError` callback for `/oauth2/authorize`: redirects
+ * back to the RP with the RFC 6749 error query params when the already-parsed
+ * query maps to a trusted registered redirect_uri, otherwise falls back to
+ * the server error page (to avoid open-redirect risk on validation failures).
+ */
+export function authorizeRedirectOnError(
+	opts: OAuthOptions<Scope[]>,
+): OAuthRedirectOnError<GenericEndpointContext> {
+	return async ({ error, error_description, ctx }) => {
+		const raw = (ctx.query ?? {}) as Record<string, unknown>;
+		const clientId =
+			typeof raw.client_id === "string" ? raw.client_id : undefined;
+		const redirectUriRaw =
+			typeof raw.redirect_uri === "string" ? raw.redirect_uri : undefined;
+		const trusted = await resolveTrustedRedirectUri(
+			ctx,
+			opts,
+			clientId,
+			redirectUriRaw,
+		);
+		if (trusted) {
+			return handleRedirect(
+				ctx,
+				formatErrorURL(
+					trusted,
+					error,
+					error_description,
+					typeof raw.state === "string" ? raw.state : undefined,
+					getIssuer(ctx, opts),
+				),
+			);
+		}
+		return handleRedirect(ctx, getErrorURL(ctx, error, error_description));
+	};
 }
 
 export async function authorizeEndpoint(

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -23,7 +23,9 @@ import {
 } from "./utils";
 
 /**
- * Formats an error url
+ * Formats an error url. Per OIDC Core 1.0 §5 / RFC 6749 §4.2.2.1, errors on
+ * implicit and hybrid flows are delivered in the URL fragment, not the query.
+ * Callers on the code flow (default) omit `mode` and get query delivery.
  */
 export function formatErrorURL(
 	url: string,
@@ -31,6 +33,7 @@ export function formatErrorURL(
 	description: string,
 	state?: string,
 	iss?: string,
+	mode: "query" | "fragment" = "query",
 ) {
 	const searchParams = new URLSearchParams({
 		error,
@@ -38,7 +41,34 @@ export function formatErrorURL(
 	});
 	state && searchParams.append("state", state);
 	iss && searchParams.append("iss", iss);
+	if (mode === "fragment") {
+		return `${url}#${searchParams.toString()}`;
+	}
 	return `${url}${url.includes("?") ? "&" : "?"}${searchParams.toString()}`;
+}
+
+/**
+ * Selects the response mode for an error redirect to the RP. OIDC Core 1.0 §5
+ * defines defaults based on response_type: `code` → query, types containing
+ * `token` / `id_token` → fragment. An explicit `response_mode` overrides.
+ *
+ * When `response_type` is duplicated (array) or absent, we can't trust the
+ * caller's intent, so we default to query — the safer channel for
+ * unrecognized shapes.
+ */
+function deriveResponseMode(
+	raw: Record<string, unknown>,
+): "query" | "fragment" {
+	const responseMode =
+		typeof raw.response_mode === "string" ? raw.response_mode : undefined;
+	if (responseMode === "fragment") return "fragment";
+	if (responseMode === "query") return "query";
+	const responseType =
+		typeof raw.response_type === "string" ? raw.response_type : undefined;
+	if (responseType && /\b(token|id_token)\b/.test(responseType)) {
+		return "fragment";
+	}
+	return "query";
 }
 
 export const handleRedirect = (ctx: GenericEndpointContext, uri: string) => {
@@ -236,6 +266,7 @@ export function authorizeRedirectOnError(
 					error_description,
 					typeof raw.state === "string" ? raw.state : undefined,
 					getIssuer(ctx, opts),
+					deriveResponseMode(raw),
 				),
 			);
 		}

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -6,5 +6,14 @@ export {
 	oidcServerMetadata,
 } from "./metadata";
 export { getOAuthProviderState, oauthProvider } from "./oauth";
+export type {
+	OAuthEndpointErrorResult,
+	OAuthEndpointRedirectContext,
+	OAuthErrorCode,
+	OAuthErrorDelivery,
+	OAuthFieldError,
+	OAuthFieldErrorMap,
+	OAuthRedirectOnError,
+} from "./oauth-endpoint";
 export { checkOAuthClient, oauthToSchema } from "./register";
 export type * from "./types";

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -10,7 +10,6 @@ export type {
 	OAuthEndpointErrorResult,
 	OAuthEndpointRedirectContext,
 	OAuthErrorCode,
-	OAuthErrorDelivery,
 	OAuthFieldError,
 	OAuthFieldErrorMap,
 	OAuthRedirectOnError,

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -10,8 +10,8 @@ export type {
 	OAuthEndpointErrorResult,
 	OAuthEndpointRedirectContext,
 	OAuthErrorCode,
-	OAuthFieldError,
-	OAuthFieldErrorMap,
+	OAuthFieldErrorCode,
+	OAuthFieldErrorCodeMap,
 	OAuthRedirectOnError,
 } from "./oauth-endpoint";
 export { checkOAuthClient, oauthToSchema } from "./register";

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -400,8 +400,17 @@ export async function introspectEndpoint(
 ) {
 	let { token, token_type_hint } = ctx.body as {
 		token: string;
-		token_type_hint?: "access_token" | "refresh_token";
+		token_type_hint?: string;
 	};
+
+	// RFC 7662 §2.1: unknown hints are ignored and detection falls back to
+	// trying both supported token types.
+	if (
+		token_type_hint !== "access_token" &&
+		token_type_hint !== "refresh_token"
+	) {
+		token_type_hint = undefined;
+	}
 
 	const credentials = await extractClientCredentials(
 		ctx,

--- a/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
@@ -122,13 +122,15 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 	});
 
 	describe("oauth2Revoke (JSON delivery)", () => {
-		it("unknown token_type_hint → unsupported_token_type", async () => {
-			const { status, body } = await postForm("/oauth2/revoke", {
+		it("unknown token_type_hint is ignored at schema level (RFC 7009 §2.2.1)", async () => {
+			const { body } = await postForm("/oauth2/revoke", {
 				token: "placeholder",
 				token_type_hint: "id_token",
 			});
-			expect(status).toBe(400);
-			expect(body?.error).toBe("unsupported_token_type");
+			// The schema used to reject unknown hints with unsupported_token_type.
+			// RFC 7009 §2.2.1 says servers MAY ignore the hint; that error code is
+			// reserved for the token type itself being unsupported, not the hint.
+			expect(body?.error).not.toBe("unsupported_token_type");
 		});
 
 		it("missing token → invalid_request with envelope", async () => {
@@ -159,7 +161,7 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 	});
 
 	describe("oauth2Authorize (redirect delivery)", () => {
-		it("unsupported response_type → RP redirect with state and iss", async () => {
+		it("unsupported response_type=token → error in fragment (OIDC §5)", async () => {
 			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
 			const state = "opaque-state-abc";
 			const qs = new URLSearchParams({
@@ -175,15 +177,33 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 			expect(status).toBeLessThan(400);
 			expect(location).toBeTruthy();
 			const errorUrl = new URL(location!);
-			// RP receives the error: Location starts with the registered redirect_uri,
-			// echoes state, and carries iss per RFC 9207.
+			// Implicit flow: errors MUST be in the fragment, not query.
 			expect(location!.startsWith(redirectUri)).toBe(true);
+			expect(errorUrl.hash).toBeTruthy();
+			const params = new URLSearchParams(errorUrl.hash.slice(1));
+			expect(params.get("error")).toBe("unsupported_response_type");
+			expect(params.get("error_description")).toBeTruthy();
+			expect(params.get("state")).toBe(state);
+			expect(params.get("iss")).toBeTruthy();
+		});
+
+		it("response_mode=query overrides implicit default", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				response_type: "token",
+				response_mode: "query",
+				state: "s",
+			}).toString();
+			const { location } = await captureRedirect(`/oauth2/authorize?${qs}`);
+			expect(location).toBeTruthy();
+			const errorUrl = new URL(location!);
+			// Explicit response_mode wins over the response_type-derived default.
+			expect(errorUrl.hash).toBe("");
 			expect(errorUrl.searchParams.get("error")).toBe(
 				"unsupported_response_type",
 			);
-			expect(errorUrl.searchParams.get("error_description")).toBeTruthy();
-			expect(errorUrl.searchParams.get("state")).toBe(state);
-			expect(errorUrl.searchParams.get("iss")).toBeTruthy();
 		});
 
 		it("duplicated response_type → invalid_request (RFC 6749 §3.1)", async () => {

--- a/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
@@ -1,0 +1,275 @@
+import { createAuthClient } from "better-auth/client";
+import { jwt } from "better-auth/plugins/jwt";
+import { getTestInstance } from "better-auth/test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { oauthProviderClient } from "./client";
+import { oauthProvider } from "./oauth";
+import type { OAuthClient } from "./types/oauth";
+
+const authServerBaseUrl = "http://localhost:3000";
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9250
+ */
+describe("RFC envelope compliance across OAuth endpoints", async () => {
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({
+				jwt: {
+					issuer: authServerBaseUrl,
+				},
+			}),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null = null;
+	const redirectUri = "http://localhost:5000/api/auth/oauth2/callback/test";
+
+	beforeAll(async () => {
+		oauthClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+	});
+
+	type Envelope = { error?: string; error_description?: string };
+
+	async function captureJsonResponse(
+		path: string,
+		init: Parameters<typeof client.$fetch>[1],
+	): Promise<{ status: number; body: Envelope | null }> {
+		let status = 0;
+		let body: Envelope | null = null;
+		await client.$fetch(path, {
+			...init,
+			onResponse: async (context) => {
+				status = context.response.status;
+				try {
+					body = (await context.response.clone().json()) as Envelope;
+				} catch {
+					body = null;
+				}
+			},
+		});
+		return { status, body };
+	}
+
+	async function captureRedirect(path: string) {
+		let status = 0;
+		let location: string | null = null;
+		await client.$fetch(path, {
+			method: "GET",
+			redirect: "manual",
+			onResponse: async (context) => {
+				status = context.response.status;
+				location = context.response.headers.get("location");
+			},
+		});
+		return { status, location };
+	}
+
+	function postForm(path: string, body: Record<string, string>) {
+		return captureJsonResponse(path, {
+			method: "POST",
+			body,
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+		});
+	}
+
+	function postJson(path: string, body: Record<string, unknown>) {
+		return captureJsonResponse(path, { method: "POST", body });
+	}
+
+	describe("oauth2Token (JSON delivery)", () => {
+		it("missing grant_type → invalid_request", async () => {
+			const { status, body } = await postForm("/oauth2/token", {});
+			expect(status).toBe(400);
+			expect(body).toEqual({
+				error: "invalid_request",
+				error_description: "grant_type is required",
+			});
+		});
+
+		it("unsupported grant_type → unsupported_grant_type", async () => {
+			const { status, body } = await postForm("/oauth2/token", {
+				grant_type: "password",
+			});
+			expect(status).toBe(400);
+			expect(body?.error).toBe("unsupported_grant_type");
+		});
+	});
+
+	describe("oauth2Revoke (JSON delivery)", () => {
+		it("unknown token_type_hint → unsupported_token_type", async () => {
+			const { status, body } = await postForm("/oauth2/revoke", {
+				token: "placeholder",
+				token_type_hint: "id_token",
+			});
+			expect(status).toBe(400);
+			expect(body?.error).toBe("unsupported_token_type");
+		});
+
+		it("missing token → invalid_request with envelope", async () => {
+			const { status, body } = await postForm("/oauth2/revoke", {});
+			expect(status).toBe(400);
+			expect(body).toEqual({
+				error: "invalid_request",
+				error_description: "token is required",
+			});
+		});
+	});
+
+	describe("registerOAuthClient (JSON delivery)", () => {
+		it("missing redirect_uris → invalid_redirect_uri", async () => {
+			const { status, body } = await postJson("/oauth2/register", {});
+			expect(status).toBe(400);
+			expect(body?.error).toBe("invalid_redirect_uri");
+		});
+
+		it("unsupported token_endpoint_auth_method → invalid_client_metadata default", async () => {
+			const { status, body } = await postJson("/oauth2/register", {
+				redirect_uris: [redirectUri],
+				token_endpoint_auth_method: "not_a_real_method",
+			});
+			expect(status).toBe(400);
+			expect(body?.error).toBe("invalid_client_metadata");
+		});
+	});
+
+	describe("oauth2Authorize (redirect delivery)", () => {
+		it("unsupported response_type → RP redirect with state and iss", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const state = "opaque-state-abc";
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				response_type: "token",
+				state,
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			expect(location).toBeTruthy();
+			const errorUrl = new URL(location!);
+			// RP receives the error: Location starts with the registered redirect_uri,
+			// echoes state, and carries iss per RFC 9207.
+			expect(location!.startsWith(redirectUri)).toBe(true);
+			expect(errorUrl.searchParams.get("error")).toBe(
+				"unsupported_response_type",
+			);
+			expect(errorUrl.searchParams.get("error_description")).toBeTruthy();
+			expect(errorUrl.searchParams.get("state")).toBe(state);
+			expect(errorUrl.searchParams.get("iss")).toBeTruthy();
+		});
+
+		it("duplicated response_type → invalid_request (RFC 6749 §3.1)", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const qs = new URLSearchParams([
+				["client_id", oauthClient.client_id],
+				["redirect_uri", redirectUri],
+				["response_type", "code"],
+				["response_type", "token"],
+				["state", "s"],
+			]).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			expect(location).toBeTruthy();
+			const errorUrl = new URL(location!);
+			expect(errorUrl.searchParams.get("error")).toBe("invalid_request");
+			expect(errorUrl.searchParams.get("error_description")).toMatch(
+				/response_type/,
+			);
+		});
+
+		it("missing client_id → server error page with invalid_request (no RP to trust)", async () => {
+			const qs = new URLSearchParams({
+				redirect_uri: redirectUri,
+				response_type: "code",
+				state: "s",
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			expect(location).toBeTruthy();
+			// Without a trusted client_id we cannot redirect to the RP: fall back
+			// to the server error page.
+			expect(location!.startsWith(redirectUri)).toBe(false);
+			const errorUrl = new URL(location!);
+			expect(errorUrl.searchParams.get("error")).toBe("invalid_request");
+			expect(errorUrl.searchParams.get("error_description")).toBeTruthy();
+		});
+
+		it("invalid response_type with unregistered redirect_uri → server error page", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: "http://evil.example.com/callback",
+				response_type: "token",
+				state: "s",
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			expect(location).toBeTruthy();
+			// Open-redirect guard: unregistered redirect_uri means we cannot trust
+			// the RP, regardless of other validation failures.
+			expect(location!.startsWith("http://evil.example.com")).toBe(false);
+		});
+	});
+
+	describe("oauth2Introspect (JSON delivery)", () => {
+		it("missing token → invalid_request with envelope", async () => {
+			const { status, body } = await postForm("/oauth2/introspect", {});
+			expect(status).toBe(400);
+			expect(body).toEqual({
+				error: "invalid_request",
+				error_description: "token is required",
+			});
+		});
+	});
+
+	describe("oauth2EndSession (JSON delivery)", () => {
+		it("missing id_token_hint → invalid_request with envelope", async () => {
+			const { status, body } = await captureJsonResponse(
+				"/oauth2/end-session",
+				{ method: "GET" },
+			);
+			expect(status).toBe(400);
+			expect(body).toEqual({
+				error: "invalid_request",
+				error_description: "id_token_hint is required",
+			});
+		});
+	});
+});

--- a/packages/oauth-provider/src/oauth-endpoint.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import * as z from "zod";
-import {
-	createOAuthEndpoint,
-	isMissingValueIssue,
-	mapIssuesToOAuthError,
-} from "./oauth-endpoint";
+import { isMissingValueIssue, mapIssuesToOAuthError } from "./oauth-endpoint";
 
 /**
  * @see https://github.com/better-auth/better-auth/issues/9250
@@ -166,35 +162,5 @@ describe("zod v4 issue shape contract", () => {
 		expect(issue).toBeDefined();
 		expect(issue!.code).toBe("invalid_value");
 		expect(isMissingValueIssue(issue!)).toBe(false);
-	});
-});
-
-describe("createOAuthEndpoint factory guards", () => {
-	it("throws when errorDelivery is 'redirect' but redirectOnError is absent", () => {
-		expect(() =>
-			createOAuthEndpoint(
-				"/oauth2/authorize",
-				{
-					method: "GET",
-					query: z.object({ client_id: z.string() }),
-					errorDelivery: "redirect",
-				},
-				async () => ({}),
-			),
-		).toThrow(/requires redirectOnError/);
-	});
-
-	it("throws when redirectOnError is set without errorDelivery 'redirect'", () => {
-		expect(() =>
-			createOAuthEndpoint(
-				"/oauth2/token",
-				{
-					method: "POST",
-					body: z.object({ grant_type: z.string() }),
-					redirectOnError: async () => ({}),
-				},
-				async () => ({}),
-			),
-		).toThrow(/requires errorDelivery "redirect"/);
 	});
 });

--- a/packages/oauth-provider/src/oauth-endpoint.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.test.ts
@@ -183,4 +183,18 @@ describe("createOAuthEndpoint factory guards", () => {
 			),
 		).toThrow(/requires redirectOnError/);
 	});
+
+	it("throws when redirectOnError is set without errorDelivery 'redirect'", () => {
+		expect(() =>
+			createOAuthEndpoint(
+				"/oauth2/token",
+				{
+					method: "POST",
+					body: z.object({ grant_type: z.string() }),
+					redirectOnError: async () => ({}),
+				},
+				async () => ({}),
+			),
+		).toThrow(/requires errorDelivery "redirect"/);
+	});
 });

--- a/packages/oauth-provider/src/oauth-endpoint.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import * as z from "zod";
+import {
+	createOAuthEndpoint,
+	isMissingValueIssue,
+	mapIssuesToOAuthError,
+} from "./oauth-endpoint";
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9250
+ */
+describe("mapIssuesToOAuthError", () => {
+	it("returns defaultError when issue list is empty", () => {
+		expect(mapIssuesToOAuthError([])).toEqual({
+			error: "invalid_request",
+			error_description: "Invalid request.",
+		});
+	});
+
+	it("honors custom defaultError when no mapping matches", () => {
+		const issues =
+			z.object({ foo: z.string() }).safeParse({}).error?.issues ?? [];
+		expect(
+			mapIssuesToOAuthError(issues, undefined, "invalid_client_metadata"),
+		).toEqual({
+			error: "invalid_client_metadata",
+			error_description: "foo is required",
+		});
+	});
+
+	it("applies string field mapping to both missing and invalid cases", () => {
+		const schema = z.object({ redirect_uris: z.array(z.string()).min(1) });
+		const missing = schema.safeParse({}).error?.issues ?? [];
+		const invalid =
+			schema.safeParse({ redirect_uris: "nope" }).error?.issues ?? [];
+
+		expect(
+			mapIssuesToOAuthError(missing, { redirect_uris: "invalid_redirect_uri" }),
+		).toMatchObject({ error: "invalid_redirect_uri" });
+		expect(
+			mapIssuesToOAuthError(invalid, { redirect_uris: "invalid_redirect_uri" }),
+		).toMatchObject({ error: "invalid_redirect_uri" });
+	});
+
+	it("distinguishes missing from invalid when mapping uses object form", () => {
+		// Required enum fields must be wrapped in `z.string().pipe(z.enum([...]))`
+		// so that missing surfaces as invalid_type and invalid surfaces as invalid_value.
+		const schema = z.object({
+			grant_type: z
+				.string()
+				.pipe(
+					z.enum(["authorization_code", "client_credentials", "refresh_token"]),
+				),
+		});
+		const mapping = {
+			grant_type: {
+				missing: "invalid_request" as const,
+				invalid: "unsupported_grant_type" as const,
+			},
+		};
+
+		const missing = schema.safeParse({}).error?.issues ?? [];
+		expect(mapIssuesToOAuthError(missing, mapping)).toMatchObject({
+			error: "invalid_request",
+			error_description: "grant_type is required",
+		});
+
+		const invalid =
+			schema.safeParse({ grant_type: "password" }).error?.issues ?? [];
+		expect(mapIssuesToOAuthError(invalid, mapping)).toMatchObject({
+			error: "unsupported_grant_type",
+		});
+	});
+
+	it("falls back to the other object mapping half when only one is defined", () => {
+		const schema = z.object({
+			token_type_hint: z.enum(["access_token", "refresh_token"]).optional(),
+		});
+		const invalid =
+			schema.safeParse({ token_type_hint: "id_token" }).error?.issues ?? [];
+		expect(
+			mapIssuesToOAuthError(invalid, {
+				token_type_hint: { invalid: "unsupported_token_type" },
+			}),
+		).toMatchObject({ error: "unsupported_token_type" });
+	});
+
+	it("describes duplicated scalar fields as appearing more than once", () => {
+		const schema = z.object({ resource: z.string() });
+		const issues =
+			schema.safeParse({ resource: ["one", "two"] }).error?.issues ?? [];
+		expect(mapIssuesToOAuthError(issues)).toMatchObject({
+			error: "invalid_request",
+			error_description: "resource must not appear more than once",
+		});
+	});
+
+	it("routes duplicated fields to defaultError even when mapping.invalid is set", () => {
+		const schema = z.object({
+			response_type: z
+				.string()
+				.pipe(z.enum(["code"]))
+				.optional(),
+		});
+		const issues =
+			schema.safeParse({ response_type: ["code", "token"] }).error?.issues ??
+			[];
+		expect(
+			mapIssuesToOAuthError(issues, {
+				response_type: { invalid: "unsupported_response_type" },
+			}),
+		).toMatchObject({
+			error: "invalid_request",
+			error_description: "response_type must not appear more than once",
+		});
+	});
+
+	it("routes unsupported enum values through mapping.invalid", () => {
+		const schema = z.object({
+			response_type: z
+				.string()
+				.pipe(z.enum(["code"]))
+				.optional(),
+		});
+		const issues =
+			schema.safeParse({ response_type: "token" }).error?.issues ?? [];
+		const result = mapIssuesToOAuthError(issues, {
+			response_type: { invalid: "unsupported_response_type" },
+		});
+		expect(result.error).toBe("unsupported_response_type");
+		expect(result.error_description).toMatch(/response_type/);
+	});
+});
+
+/**
+ * Pins the zod v4 message suffixes that `isMissingValueIssue` and
+ * `describeIssue` rely on. A rephrase in a zod release would fail these
+ * assertions before it could silently reclassify missing or duplicated
+ * fields in production.
+ * @see https://github.com/better-auth/better-auth/issues/9250
+ */
+describe("zod v4 issue shape contract", () => {
+	it("reports missing required string as invalid_type + 'received undefined'", () => {
+		const schema = z.object({ grant_type: z.string() });
+		const issue = schema.safeParse({}).error?.issues[0];
+		expect(issue).toBeDefined();
+		expect(issue!.code).toBe("invalid_type");
+		expect(issue!.message.endsWith("received undefined")).toBe(true);
+		expect(isMissingValueIssue(issue!)).toBe(true);
+	});
+
+	it("reports duplicated string field as invalid_type + 'received array'", () => {
+		const schema = z.object({ resource: z.string() });
+		const issue = schema.safeParse({ resource: ["a", "b"] }).error?.issues[0];
+		expect(issue).toBeDefined();
+		expect(issue!.code).toBe("invalid_type");
+		expect(issue!.message.endsWith("received array")).toBe(true);
+		expect(isMissingValueIssue(issue!)).toBe(false);
+	});
+
+	it("reports unsupported enum value as invalid_value", () => {
+		const schema = z.object({
+			grant_type: z.string().pipe(z.enum(["authorization_code"])),
+		});
+		const issue = schema.safeParse({ grant_type: "password" }).error?.issues[0];
+		expect(issue).toBeDefined();
+		expect(issue!.code).toBe("invalid_value");
+		expect(isMissingValueIssue(issue!)).toBe(false);
+	});
+});
+
+describe("createOAuthEndpoint factory guards", () => {
+	it("throws when errorDelivery is 'redirect' but redirectOnError is absent", () => {
+		expect(() =>
+			createOAuthEndpoint(
+				"/oauth2/authorize",
+				{
+					method: "GET",
+					query: z.object({ client_id: z.string() }),
+					errorDelivery: "redirect",
+				},
+				async () => ({}),
+			),
+		).toThrow(/requires redirectOnError/);
+	});
+});

--- a/packages/oauth-provider/src/oauth-endpoint.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.ts
@@ -1,0 +1,334 @@
+import type { AuthContext } from "@better-auth/core";
+import { createAuthEndpoint } from "better-auth/api";
+import type {
+	EndpointContext,
+	EndpointOptions,
+	StrictEndpoint,
+} from "better-call";
+import { APIError } from "better-call";
+import type * as z from "zod";
+
+/**
+ * RFC 6749 §5.2, 7009 §2.2.1, 7662 §2.3, 7591 §3.2.2 require OAuth error
+ * responses in the shape `{ error, error_description }`. `createOAuthEndpoint`
+ * wraps `createAuthEndpoint` so zod schemas stay the single source of truth
+ * for body/query shape while validation failures serialize as the RFC envelope.
+ *
+ * A failing issue is routed using the field's entry in `fieldErrors`:
+ *
+ * - a missing required field (`invalid_type` with "received undefined") maps
+ *   to `fieldErrors[name].missing` or `defaultError`.
+ * - an unsupported value (`invalid_value`, e.g. unknown enum member) maps to
+ *   `fieldErrors[name].invalid` or `defaultError`.
+ * - any other failure (wrong type, duplicated query params materialized as
+ *   arrays, invalid format, failed refinement, out-of-range scalar) maps to
+ *   `defaultError`, so RFC 6749 §3.1 malformed requests surface as the
+ *   endpoint's default error regardless of field.
+ *
+ * String-form `fieldErrors` entries apply to every failure on the field; use
+ * the object form only when missing and unsupported need different codes.
+ * For enum fields that need this distinction, compose as
+ * `z.string().pipe(z.enum([...]))` so duplicated params fail the outer
+ * `z.string()` as `invalid_type` rather than masquerading as an unsupported
+ * enum value.
+ *
+ * Error delivery is either:
+ * - `"json"` (default): installs an `onValidationError` hook that throws an
+ *   `APIError` carrying the RFC envelope. The framework's generic throw never
+ *   fires because this hook throws first.
+ * - `"redirect"`: validates inside the handler wrapper so `redirectOnError`
+ *   can reach the request context (e.g. to compute an RP redirect URL from
+ *   already-parsed query params).
+ */
+
+export type OAuthErrorCode =
+	| "invalid_request"
+	| "invalid_client"
+	| "invalid_grant"
+	| "unauthorized_client"
+	| "unsupported_grant_type"
+	| "unsupported_response_type"
+	| "invalid_scope"
+	| "invalid_redirect_uri"
+	| "invalid_client_metadata"
+	| "access_denied"
+	| "server_error"
+	| "temporarily_unavailable"
+	| (string & {});
+
+export interface OAuthFieldErrorMap {
+	/**
+	 * RFC code when the field is absent (undefined input).
+	 * @default defaultError
+	 */
+	missing?: OAuthErrorCode;
+	/**
+	 * RFC code when the field is present but holds an unsupported value
+	 * (`invalid_value`, e.g. unknown enum member).
+	 * @default defaultError
+	 */
+	invalid?: OAuthErrorCode;
+}
+
+export type OAuthFieldError = OAuthErrorCode | OAuthFieldErrorMap;
+
+export type OAuthErrorDelivery = "json" | "redirect";
+
+export interface OAuthEndpointErrorResult {
+	error: OAuthErrorCode;
+	error_description: string;
+}
+
+export interface OAuthEndpointRedirectContext<Ctx = unknown> {
+	error: OAuthErrorCode;
+	error_description: string;
+	ctx: Ctx;
+}
+
+export type OAuthRedirectOnError<Ctx = any> = (
+	result: OAuthEndpointRedirectContext<Ctx>,
+) => unknown;
+
+type ValidationErrorHookArgs = {
+	message: string;
+	issues: readonly z.core.$ZodIssue[];
+};
+
+type ValidationErrorHook = (args: ValidationErrorHookArgs) => unknown;
+
+export interface OAuthEndpointExtras {
+	/**
+	 * How to deliver validation errors.
+	 * - `"json"`: throws `APIError` with the RFC envelope as body.
+	 * - `"redirect"`: invokes `redirectOnError` (required when this is set).
+	 * @default "json"
+	 */
+	errorDelivery?: OAuthErrorDelivery;
+	/**
+	 * Invoked by the wrapper when `errorDelivery === "redirect"` and validation
+	 * fails. The return value becomes the endpoint response.
+	 */
+	redirectOnError?: OAuthRedirectOnError;
+	/**
+	 * First-path-segment → RFC code mapping. Use the string form when any
+	 * failure on the field should emit the same RFC code, or the object form
+	 * to distinguish missing from unsupported.
+	 *
+	 * Keys match only the first path segment: nested failures like
+	 * `jwks.keys[0].n` collapse to `jwks`. Lift a nested schema to a
+	 * top-level field when per-sub-field codes are required.
+	 */
+	fieldErrors?: Record<string, OAuthFieldError>;
+	/**
+	 * RFC code returned when no `fieldErrors` entry matches or the failure is
+	 * structurally malformed (wrong type, duplicated params, invalid format,
+	 * failed refinement).
+	 * @default "invalid_request"
+	 */
+	defaultError?: OAuthErrorCode;
+}
+
+export function createOAuthEndpoint<
+	Path extends string,
+	Options extends EndpointOptions,
+	R,
+>(
+	path: Path,
+	options: Options & OAuthEndpointExtras,
+	handler: (ctx: EndpointContext<Path, Options, AuthContext>) => Promise<R>,
+): StrictEndpoint<Path, Options, R> {
+	const {
+		errorDelivery = "json",
+		redirectOnError,
+		fieldErrors,
+		defaultError = "invalid_request",
+		...rest
+	} = options;
+
+	if (errorDelivery === "redirect" && !redirectOnError) {
+		throw new Error(
+			`createOAuthEndpoint(${path}): errorDelivery "redirect" requires redirectOnError`,
+		);
+	}
+
+	if (errorDelivery === "json") {
+		const userHook = (rest as { onValidationError?: ValidationErrorHook })
+			.onValidationError;
+		const forwarded = {
+			...rest,
+			onValidationError: async (args: ValidationErrorHookArgs) => {
+				if (userHook) await userHook(args);
+				throw new APIError("BAD_REQUEST", {
+					...mapIssuesToOAuthError(args.issues, fieldErrors, defaultError),
+				});
+			},
+		} as unknown as Options;
+		return createAuthEndpoint(path, forwarded, handler);
+	}
+
+	const userHook = (rest as { onValidationError?: ValidationErrorHook })
+		.onValidationError;
+	const {
+		body: bodySchema,
+		query: querySchema,
+		onValidationError: _userHookForwarded,
+		...forwarded
+	} = rest as typeof rest & {
+		body?: z.ZodTypeAny;
+		query?: z.ZodTypeAny;
+		onValidationError?: ValidationErrorHook;
+	};
+
+	return createAuthEndpoint(
+		path,
+		forwarded as unknown as Options,
+		async (ctx) => {
+			if (bodySchema) {
+				const result = await bodySchema.safeParseAsync(ctx.body ?? {});
+				if (!result.success) {
+					if (userHook) {
+						await userHook({
+							message: result.error.message,
+							issues: result.error.issues,
+						});
+					}
+					return await redirectOnError!({
+						...mapIssuesToOAuthError(
+							result.error.issues,
+							fieldErrors,
+							defaultError,
+						),
+						ctx,
+					});
+				}
+				(ctx as { body: unknown }).body = result.data;
+			}
+			if (querySchema) {
+				const result = await querySchema.safeParseAsync(ctx.query ?? {});
+				if (!result.success) {
+					if (userHook) {
+						await userHook({
+							message: result.error.message,
+							issues: result.error.issues,
+						});
+					}
+					return await redirectOnError!({
+						...mapIssuesToOAuthError(
+							result.error.issues,
+							fieldErrors,
+							defaultError,
+						),
+						ctx,
+					});
+				}
+				(ctx as { query: unknown }).query = result.data;
+			}
+			return handler(ctx);
+		},
+	) as StrictEndpoint<Path, Options, R>;
+}
+
+export function mapIssuesToOAuthError(
+	issues: readonly z.core.$ZodIssue[],
+	fieldErrors?: Record<string, OAuthFieldError>,
+	defaultError: OAuthErrorCode = "invalid_request",
+): OAuthEndpointErrorResult {
+	const issue = issues[0];
+	if (!issue) {
+		return {
+			error: defaultError,
+			error_description: "Invalid request.",
+		};
+	}
+
+	const fieldName = firstPathSegment(issue);
+	const mapping =
+		typeof fieldName === "string" ? fieldErrors?.[fieldName] : undefined;
+
+	return {
+		error: resolveErrorCode(issue, mapping, defaultError),
+		error_description: describeIssue(issue),
+	};
+}
+
+function resolveErrorCode(
+	issue: z.core.$ZodIssue,
+	mapping: OAuthFieldError | undefined,
+	defaultError: OAuthErrorCode,
+): OAuthErrorCode {
+	if (typeof mapping === "string") return mapping;
+
+	if (isMissingValueIssue(issue)) {
+		return mapping?.missing ?? defaultError;
+	}
+	if (issue.code === "invalid_value") {
+		return mapping?.invalid ?? defaultError;
+	}
+	return defaultError;
+}
+
+/**
+ * Returns `true` for issues that represent an absent required value. Zod v4
+ * strips `input` from published issues, so the signal is the `invalid_type`
+ * code combined with a message suffix of "received undefined". The suffix is
+ * pinned by a regression test so a zod rephrase fails the test instead of
+ * silently reclassifying missing fields.
+ */
+export function isMissingValueIssue(issue: z.core.$ZodIssue): boolean {
+	return (
+		issue.code === "invalid_type" &&
+		issue.message.endsWith("received undefined")
+	);
+}
+
+function firstPathSegment(issue: z.core.$ZodIssue): string | undefined {
+	const segment = issue.path?.[0];
+	if (segment === undefined) return undefined;
+	if (typeof segment === "string") return segment;
+	if (typeof segment === "number") return String(segment);
+	if (typeof segment === "object" && segment !== null && "key" in segment) {
+		const key = (segment as { key: unknown }).key;
+		return typeof key === "string" ? key : String(key);
+	}
+	return String(segment);
+}
+
+function describeIssue(issue: z.core.$ZodIssue): string {
+	const field = fieldPath(issue);
+	if (!field) return issue.message;
+
+	if (issue.code === "invalid_type") {
+		if (issue.message.endsWith("received undefined")) {
+			return `${field} is required`;
+		}
+		if (issue.message.endsWith("received array")) {
+			return `${field} must not appear more than once`;
+		}
+		const expected = (issue as { expected?: string }).expected ?? "valid value";
+		return `${field} must be a ${expected}`;
+	}
+
+	if (issue.code === "invalid_value") {
+		const values = (issue as { values?: readonly unknown[] }).values;
+		if (Array.isArray(values) && values.length > 0) {
+			return `${field} must be one of: ${values.join(", ")}`;
+		}
+	}
+
+	return `${field}: ${issue.message}`;
+}
+
+function fieldPath(issue: z.core.$ZodIssue): string {
+	if (!issue.path?.length) return "";
+	return issue.path
+		.map((segment) => {
+			if (typeof segment === "string") return segment;
+			if (typeof segment === "number") return String(segment);
+			if (typeof segment === "object" && segment !== null && "key" in segment) {
+				const key = (segment as { key: unknown }).key;
+				return typeof key === "string" ? key : String(key);
+			}
+			return String(segment);
+		})
+		.join(".");
+}

--- a/packages/oauth-provider/src/oauth-endpoint.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.ts
@@ -41,7 +41,20 @@ import type * as z from "zod";
  *   already-parsed query params).
  */
 
+/**
+ * Canonical OAuth 2.0 / OpenID Connect error codes. The union is the single
+ * vocabulary for every error-emitting surface in this plugin: token, authorize,
+ * revoke, introspect, register, userinfo, logout, consent, and the redirect
+ * error channel. Entries are grouped by source RFC so the declaration doubles
+ * as a specification map.
+ *
+ * The trailing `(string & {})` keeps the type open for product-specific codes
+ * (e.g. `"invalid_verification"`, `"invalid_user"`) while preserving editor
+ * autocomplete for the listed standard codes. Prefer a standard code whenever
+ * one applies; fall back to a custom string only for states no RFC covers.
+ */
 export type OAuthErrorCode =
+	// RFC 6749 §4.1.2.1, §5.2 core authorization + token errors
 	| "invalid_request"
 	| "invalid_client"
 	| "invalid_grant"
@@ -49,11 +62,31 @@ export type OAuthErrorCode =
 	| "unsupported_grant_type"
 	| "unsupported_response_type"
 	| "invalid_scope"
-	| "invalid_redirect_uri"
-	| "invalid_client_metadata"
 	| "access_denied"
 	| "server_error"
 	| "temporarily_unavailable"
+	// RFC 6750 §3.1 bearer token / RFC 7662 introspection
+	| "invalid_token"
+	// RFC 7009 §2.2.1 token revocation
+	| "unsupported_token_type"
+	// RFC 7591 §3.2.2 dynamic client registration
+	| "invalid_redirect_uri"
+	| "invalid_client_metadata"
+	| "invalid_software_statement"
+	| "unapproved_software_statement"
+	// RFC 8707 §2 resource indicators
+	| "invalid_target"
+	// RFC 9101 §6 JWT-secured authorization requests (JAR)
+	| "invalid_request_object"
+	// OIDC Core 1.0 §3.1.2.6 authorization error response
+	| "login_required"
+	| "consent_required"
+	| "interaction_required"
+	| "account_selection_required"
+	| "invalid_request_uri"
+	| "request_not_supported"
+	| "request_uri_not_supported"
+	| "registration_not_supported"
 	| (string & {});
 
 export interface OAuthFieldErrorMap {
@@ -91,7 +124,7 @@ export type OAuthRedirectOnError<Ctx = any> = (
 
 type ValidationErrorHookArgs = {
 	message: string;
-	issues: readonly z.core.$ZodIssue[];
+	issues: readonly z.ZodIssue[];
 };
 
 type ValidationErrorHook = (args: ValidationErrorHookArgs) => unknown;
@@ -148,6 +181,11 @@ export function createOAuthEndpoint<
 	if (errorDelivery === "redirect" && !redirectOnError) {
 		throw new Error(
 			`createOAuthEndpoint(${path}): errorDelivery "redirect" requires redirectOnError`,
+		);
+	}
+	if (errorDelivery !== "redirect" && redirectOnError) {
+		throw new Error(
+			`createOAuthEndpoint(${path}): redirectOnError requires errorDelivery "redirect"`,
 		);
 	}
 
@@ -229,7 +267,7 @@ export function createOAuthEndpoint<
 }
 
 export function mapIssuesToOAuthError(
-	issues: readonly z.core.$ZodIssue[],
+	issues: readonly z.ZodIssue[],
 	fieldErrors?: Record<string, OAuthFieldError>,
 	defaultError: OAuthErrorCode = "invalid_request",
 ): OAuthEndpointErrorResult {
@@ -252,7 +290,7 @@ export function mapIssuesToOAuthError(
 }
 
 function resolveErrorCode(
-	issue: z.core.$ZodIssue,
+	issue: z.ZodIssue,
 	mapping: OAuthFieldError | undefined,
 	defaultError: OAuthErrorCode,
 ): OAuthErrorCode {
@@ -273,15 +311,19 @@ function resolveErrorCode(
  * code combined with a message suffix of "received undefined". The suffix is
  * pinned by a regression test so a zod rephrase fails the test instead of
  * silently reclassifying missing fields.
+ *
+ * Assumes the default zod error map. Consumers that install a localized map
+ * via `z.setErrorMap()` will break this check, collapsing missing-field
+ * failures to `defaultError`.
  */
-export function isMissingValueIssue(issue: z.core.$ZodIssue): boolean {
+export function isMissingValueIssue(issue: z.ZodIssue): boolean {
 	return (
 		issue.code === "invalid_type" &&
 		issue.message.endsWith("received undefined")
 	);
 }
 
-function firstPathSegment(issue: z.core.$ZodIssue): string | undefined {
+function firstPathSegment(issue: z.ZodIssue): string | undefined {
 	const segment = issue.path?.[0];
 	if (segment === undefined) return undefined;
 	if (typeof segment === "string") return segment;
@@ -293,7 +335,7 @@ function firstPathSegment(issue: z.core.$ZodIssue): string | undefined {
 	return String(segment);
 }
 
-function describeIssue(issue: z.core.$ZodIssue): string {
+function describeIssue(issue: z.ZodIssue): string {
 	const field = fieldPath(issue);
 	if (!field) return issue.message;
 
@@ -318,7 +360,7 @@ function describeIssue(issue: z.core.$ZodIssue): string {
 	return `${field}: ${issue.message}`;
 }
 
-function fieldPath(issue: z.core.$ZodIssue): string {
+function fieldPath(issue: z.ZodIssue): string {
 	if (!issue.path?.length) return "";
 	return issue.path
 		.map((segment) => {

--- a/packages/oauth-provider/src/oauth-endpoint.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.ts
@@ -56,12 +56,12 @@ export type OAuthErrorCode =
 	| "registration_not_supported"
 	| (string & {});
 
-export type OAuthFieldErrorMap = {
+export type OAuthFieldErrorCodeMap = {
 	missing?: OAuthErrorCode;
 	invalid?: OAuthErrorCode;
 };
 
-export type OAuthFieldError = OAuthErrorCode | OAuthFieldErrorMap;
+export type OAuthFieldErrorCode = OAuthErrorCode | OAuthFieldErrorCodeMap;
 
 export interface OAuthEndpointErrorResult {
 	error: OAuthErrorCode;
@@ -103,9 +103,9 @@ export interface OAuthEndpointExtras {
 	 * `jwks.keys[0].n` collapse to `jwks`; lift a nested schema to a
 	 * top-level field when per-sub-field codes are required.
 	 */
-	fieldErrors?: Record<string, OAuthFieldError>;
+	errorCodesByField?: Record<string, OAuthFieldErrorCode>;
 	/**
-	 * RFC code returned when no `fieldErrors` entry matches or the failure is
+	 * RFC code returned when no `errorCodesByField` entry matches or the failure is
 	 * structurally malformed (wrong type, duplicated params, bad format,
 	 * failed refinement).
 	 * @default "invalid_request"
@@ -118,7 +118,7 @@ export interface OAuthEndpointExtras {
  * for body/query shape while validation failures serialize as the RFC 6749
  * §5.2 error envelope `{ error, error_description }`.
  *
- * A failing issue is routed by its first path segment via `fieldErrors`:
+ * A failing issue is routed by its first path segment via `errorCodesByField`:
  * - missing required (`invalid_type` + "received undefined") → `.missing`
  * - unsupported value (`invalid_value`) → `.invalid`
  * - anything else (wrong type, duplicated params, bad format) → `defaultError`
@@ -140,7 +140,7 @@ export function createOAuthEndpoint<
 	const {
 		redirectOnError,
 		onValidationError: userHook,
-		fieldErrors,
+		errorCodesByField,
 		defaultError = "invalid_request",
 		...rest
 	} = options;
@@ -151,7 +151,11 @@ export function createOAuthEndpoint<
 			onValidationError: async (args: ValidationErrorHookArgs) => {
 				if (userHook) await userHook(args);
 				throw new APIError("BAD_REQUEST", {
-					...mapIssuesToOAuthError(args.issues, fieldErrors, defaultError),
+					...mapIssuesToOAuthError(
+						args.issues,
+						errorCodesByField,
+						defaultError,
+					),
 				});
 			},
 		} as unknown as Options;
@@ -192,7 +196,7 @@ export function createOAuthEndpoint<
 			response: redirect({
 				...mapIssuesToOAuthError(
 					result.error.issues,
-					fieldErrors,
+					errorCodesByField,
 					defaultError,
 				),
 				ctx,
@@ -215,7 +219,7 @@ export function createOAuthEndpoint<
 
 export function mapIssuesToOAuthError(
 	issues: readonly z.core.$ZodIssue[],
-	fieldErrors?: Record<string, OAuthFieldError>,
+	errorCodesByField?: Record<string, OAuthFieldErrorCode>,
 	defaultError: OAuthErrorCode = "invalid_request",
 ): OAuthEndpointErrorResult {
 	const issue = issues[0];
@@ -228,7 +232,7 @@ export function mapIssuesToOAuthError(
 
 	const first = issue.path?.[0];
 	const fieldKey = typeof first === "string" ? first : undefined;
-	const mapping = fieldKey ? fieldErrors?.[fieldKey] : undefined;
+	const mapping = fieldKey ? errorCodesByField?.[fieldKey] : undefined;
 	const field = issue.path?.length ? z.core.toDotPath(issue.path) : "";
 
 	return {
@@ -239,7 +243,7 @@ export function mapIssuesToOAuthError(
 
 function resolveErrorCode(
 	issue: z.core.$ZodIssue,
-	mapping: OAuthFieldError | undefined,
+	mapping: OAuthFieldErrorCode | undefined,
 	defaultError: OAuthErrorCode,
 ): OAuthErrorCode {
 	if (typeof mapping === "string") return mapping;

--- a/packages/oauth-provider/src/oauth-endpoint.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.ts
@@ -6,40 +6,7 @@ import type {
 	StrictEndpoint,
 } from "better-call";
 import { APIError } from "better-call";
-import type * as z from "zod";
-
-/**
- * RFC 6749 §5.2, 7009 §2.2.1, 7662 §2.3, 7591 §3.2.2 require OAuth error
- * responses in the shape `{ error, error_description }`. `createOAuthEndpoint`
- * wraps `createAuthEndpoint` so zod schemas stay the single source of truth
- * for body/query shape while validation failures serialize as the RFC envelope.
- *
- * A failing issue is routed using the field's entry in `fieldErrors`:
- *
- * - a missing required field (`invalid_type` with "received undefined") maps
- *   to `fieldErrors[name].missing` or `defaultError`.
- * - an unsupported value (`invalid_value`, e.g. unknown enum member) maps to
- *   `fieldErrors[name].invalid` or `defaultError`.
- * - any other failure (wrong type, duplicated query params materialized as
- *   arrays, invalid format, failed refinement, out-of-range scalar) maps to
- *   `defaultError`, so RFC 6749 §3.1 malformed requests surface as the
- *   endpoint's default error regardless of field.
- *
- * String-form `fieldErrors` entries apply to every failure on the field; use
- * the object form only when missing and unsupported need different codes.
- * For enum fields that need this distinction, compose as
- * `z.string().pipe(z.enum([...]))` so duplicated params fail the outer
- * `z.string()` as `invalid_type` rather than masquerading as an unsupported
- * enum value.
- *
- * Error delivery is either:
- * - `"json"` (default): installs an `onValidationError` hook that throws an
- *   `APIError` carrying the RFC envelope. The framework's generic throw never
- *   fires because this hook throws first.
- * - `"redirect"`: validates inside the handler wrapper so `redirectOnError`
- *   can reach the request context (e.g. to compute an RP redirect URL from
- *   already-parsed query params).
- */
+import * as z from "zod";
 
 /**
  * Canonical OAuth 2.0 / OpenID Connect error codes. The union is the single
@@ -89,23 +56,12 @@ export type OAuthErrorCode =
 	| "registration_not_supported"
 	| (string & {});
 
-export interface OAuthFieldErrorMap {
-	/**
-	 * RFC code when the field is absent (undefined input).
-	 * @default defaultError
-	 */
+export type OAuthFieldErrorMap = {
 	missing?: OAuthErrorCode;
-	/**
-	 * RFC code when the field is present but holds an unsupported value
-	 * (`invalid_value`, e.g. unknown enum member).
-	 * @default defaultError
-	 */
 	invalid?: OAuthErrorCode;
-}
+};
 
 export type OAuthFieldError = OAuthErrorCode | OAuthFieldErrorMap;
-
-export type OAuthErrorDelivery = "json" | "redirect";
 
 export interface OAuthEndpointErrorResult {
 	error: OAuthErrorCode;
@@ -124,43 +80,54 @@ export type OAuthRedirectOnError<Ctx = any> = (
 
 type ValidationErrorHookArgs = {
 	message: string;
-	issues: readonly z.ZodIssue[];
+	issues: readonly z.core.$ZodIssue[];
 };
 
 type ValidationErrorHook = (args: ValidationErrorHookArgs) => unknown;
 
 export interface OAuthEndpointExtras {
 	/**
-	 * How to deliver validation errors.
-	 * - `"json"`: throws `APIError` with the RFC envelope as body.
-	 * - `"redirect"`: invokes `redirectOnError` (required when this is set).
-	 * @default "json"
-	 */
-	errorDelivery?: OAuthErrorDelivery;
-	/**
-	 * Invoked by the wrapper when `errorDelivery === "redirect"` and validation
-	 * fails. The return value becomes the endpoint response.
+	 * Invoked when validation fails. Presence switches delivery from a JSON
+	 * `APIError` envelope to this callback, which receives the request
+	 * context so it can compute an RP redirect URL from already-parsed query
+	 * params.
 	 */
 	redirectOnError?: OAuthRedirectOnError;
 	/**
-	 * First-path-segment → RFC code mapping. Use the string form when any
-	 * failure on the field should emit the same RFC code, or the object form
-	 * to distinguish missing from unsupported.
-	 *
-	 * Keys match only the first path segment: nested failures like
-	 * `jwks.keys[0].n` collapse to `jwks`. Lift a nested schema to a
+	 * Forwarded to `better-call` and awaited before the RFC envelope is
+	 * synthesized, so callers can observe or transform issues.
+	 */
+	onValidationError?: ValidationErrorHook;
+	/**
+	 * First-path-segment → RFC code mapping. Nested failures like
+	 * `jwks.keys[0].n` collapse to `jwks`; lift a nested schema to a
 	 * top-level field when per-sub-field codes are required.
 	 */
 	fieldErrors?: Record<string, OAuthFieldError>;
 	/**
 	 * RFC code returned when no `fieldErrors` entry matches or the failure is
-	 * structurally malformed (wrong type, duplicated params, invalid format,
+	 * structurally malformed (wrong type, duplicated params, bad format,
 	 * failed refinement).
 	 * @default "invalid_request"
 	 */
 	defaultError?: OAuthErrorCode;
 }
 
+/**
+ * Wraps `createAuthEndpoint` so zod schemas stay the single source of truth
+ * for body/query shape while validation failures serialize as the RFC 6749
+ * §5.2 error envelope `{ error, error_description }`.
+ *
+ * A failing issue is routed by its first path segment via `fieldErrors`:
+ * - missing required (`invalid_type` + "received undefined") → `.missing`
+ * - unsupported value (`invalid_value`) → `.invalid`
+ * - anything else (wrong type, duplicated params, bad format) → `defaultError`
+ *
+ * For enum fields that need to distinguish missing from unsupported, compose
+ * as `z.string().pipe(z.enum([...]))` so duplicated params fail the outer
+ * `z.string()` as `invalid_type` instead of masquerading as an unsupported
+ * enum value.
+ */
 export function createOAuthEndpoint<
 	Path extends string,
 	Options extends EndpointOptions,
@@ -171,27 +138,14 @@ export function createOAuthEndpoint<
 	handler: (ctx: EndpointContext<Path, Options, AuthContext>) => Promise<R>,
 ): StrictEndpoint<Path, Options, R> {
 	const {
-		errorDelivery = "json",
 		redirectOnError,
+		onValidationError: userHook,
 		fieldErrors,
 		defaultError = "invalid_request",
 		...rest
 	} = options;
 
-	if (errorDelivery === "redirect" && !redirectOnError) {
-		throw new Error(
-			`createOAuthEndpoint(${path}): errorDelivery "redirect" requires redirectOnError`,
-		);
-	}
-	if (errorDelivery !== "redirect" && redirectOnError) {
-		throw new Error(
-			`createOAuthEndpoint(${path}): redirectOnError requires errorDelivery "redirect"`,
-		);
-	}
-
-	if (errorDelivery === "json") {
-		const userHook = (rest as { onValidationError?: ValidationErrorHook })
-			.onValidationError;
+	if (!redirectOnError) {
 		const forwarded = {
 			...rest,
 			onValidationError: async (args: ValidationErrorHookArgs) => {
@@ -204,70 +158,63 @@ export function createOAuthEndpoint<
 		return createAuthEndpoint(path, forwarded, handler);
 	}
 
-	const userHook = (rest as { onValidationError?: ValidationErrorHook })
-		.onValidationError;
+	// Bind so the non-null narrowing from the guard above survives into `validateSlot`;
+	// TS drops narrowing when crossing into a nested function declaration.
+	const redirect = redirectOnError;
 	const {
 		body: bodySchema,
 		query: querySchema,
-		onValidationError: _userHookForwarded,
 		...forwarded
 	} = rest as typeof rest & {
 		body?: z.ZodTypeAny;
 		query?: z.ZodTypeAny;
-		onValidationError?: ValidationErrorHook;
 	};
+
+	async function validateSlot(
+		ctx: EndpointContext<Path, Options, AuthContext>,
+		slot: "body" | "query",
+		schema: z.ZodTypeAny | undefined,
+	): Promise<{ ok: true } | { ok: false; response: unknown }> {
+		if (!schema) return { ok: true };
+		const result = await schema.safeParseAsync(ctx[slot] ?? {});
+		if (result.success) {
+			(ctx as Record<string, unknown>)[slot] = result.data;
+			return { ok: true };
+		}
+		if (userHook) {
+			await userHook({
+				message: result.error.message,
+				issues: result.error.issues,
+			});
+		}
+		return {
+			ok: false,
+			response: redirect({
+				...mapIssuesToOAuthError(
+					result.error.issues,
+					fieldErrors,
+					defaultError,
+				),
+				ctx,
+			}),
+		};
+	}
 
 	return createAuthEndpoint(
 		path,
 		forwarded as unknown as Options,
 		async (ctx) => {
-			if (bodySchema) {
-				const result = await bodySchema.safeParseAsync(ctx.body ?? {});
-				if (!result.success) {
-					if (userHook) {
-						await userHook({
-							message: result.error.message,
-							issues: result.error.issues,
-						});
-					}
-					return await redirectOnError!({
-						...mapIssuesToOAuthError(
-							result.error.issues,
-							fieldErrors,
-							defaultError,
-						),
-						ctx,
-					});
-				}
-				(ctx as { body: unknown }).body = result.data;
-			}
-			if (querySchema) {
-				const result = await querySchema.safeParseAsync(ctx.query ?? {});
-				if (!result.success) {
-					if (userHook) {
-						await userHook({
-							message: result.error.message,
-							issues: result.error.issues,
-						});
-					}
-					return await redirectOnError!({
-						...mapIssuesToOAuthError(
-							result.error.issues,
-							fieldErrors,
-							defaultError,
-						),
-						ctx,
-					});
-				}
-				(ctx as { query: unknown }).query = result.data;
-			}
+			const body = await validateSlot(ctx, "body", bodySchema);
+			if (!body.ok) return body.response;
+			const query = await validateSlot(ctx, "query", querySchema);
+			if (!query.ok) return query.response;
 			return handler(ctx);
 		},
 	) as StrictEndpoint<Path, Options, R>;
 }
 
 export function mapIssuesToOAuthError(
-	issues: readonly z.ZodIssue[],
+	issues: readonly z.core.$ZodIssue[],
 	fieldErrors?: Record<string, OAuthFieldError>,
 	defaultError: OAuthErrorCode = "invalid_request",
 ): OAuthEndpointErrorResult {
@@ -279,18 +226,19 @@ export function mapIssuesToOAuthError(
 		};
 	}
 
-	const fieldName = firstPathSegment(issue);
-	const mapping =
-		typeof fieldName === "string" ? fieldErrors?.[fieldName] : undefined;
+	const first = issue.path?.[0];
+	const fieldKey = typeof first === "string" ? first : undefined;
+	const mapping = fieldKey ? fieldErrors?.[fieldKey] : undefined;
+	const field = issue.path?.length ? z.core.toDotPath(issue.path) : "";
 
 	return {
 		error: resolveErrorCode(issue, mapping, defaultError),
-		error_description: describeIssue(issue),
+		error_description: describeIssue(issue, field),
 	};
 }
 
 function resolveErrorCode(
-	issue: z.ZodIssue,
+	issue: z.core.$ZodIssue,
 	mapping: OAuthFieldError | undefined,
 	defaultError: OAuthErrorCode,
 ): OAuthErrorCode {
@@ -316,27 +264,14 @@ function resolveErrorCode(
  * via `z.setErrorMap()` will break this check, collapsing missing-field
  * failures to `defaultError`.
  */
-export function isMissingValueIssue(issue: z.ZodIssue): boolean {
+export function isMissingValueIssue(issue: z.core.$ZodIssue): boolean {
 	return (
 		issue.code === "invalid_type" &&
 		issue.message.endsWith("received undefined")
 	);
 }
 
-function firstPathSegment(issue: z.ZodIssue): string | undefined {
-	const segment = issue.path?.[0];
-	if (segment === undefined) return undefined;
-	if (typeof segment === "string") return segment;
-	if (typeof segment === "number") return String(segment);
-	if (typeof segment === "object" && segment !== null && "key" in segment) {
-		const key = (segment as { key: unknown }).key;
-		return typeof key === "string" ? key : String(key);
-	}
-	return String(segment);
-}
-
-function describeIssue(issue: z.ZodIssue): string {
-	const field = fieldPath(issue);
+function describeIssue(issue: z.core.$ZodIssue, field: string): string {
 	if (!field) return issue.message;
 
 	if (issue.code === "invalid_type") {
@@ -358,19 +293,4 @@ function describeIssue(issue: z.ZodIssue): string {
 	}
 
 	return `${field}: ${issue.message}`;
-}
-
-function fieldPath(issue: z.ZodIssue): string {
-	if (!issue.path?.length) return "";
-	return issue.path
-		.map((segment) => {
-			if (typeof segment === "string") return segment;
-			if (typeof segment === "number") return String(segment);
-			if (typeof segment === "object" && segment !== null && "key" in segment) {
-				const key = (segment as { key: unknown }).key;
-				return typeof key === "string" ? key : String(key);
-			}
-			return String(segment);
-		})
-		.join(".");
 }

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -407,7 +407,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							.optional(),
 					}),
 					redirectOnError: authorizeRedirectOnError(opts),
-					fieldErrors: {
+					errorCodesByField: {
 						response_type: { invalid: "unsupported_response_type" },
 					},
 					metadata: {
@@ -646,7 +646,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						resource: z.string().optional(),
 						scope: z.string().optional(),
 					}),
-					fieldErrors: {
+					errorCodesByField: {
 						grant_type: {
 							missing: "invalid_request",
 							invalid: "unsupported_grant_type",
@@ -1231,7 +1231,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							})
 							.optional(),
 					}),
-					fieldErrors: {
+					errorCodesByField: {
 						redirect_uris: "invalid_redirect_uri",
 						post_logout_redirect_uris: "invalid_redirect_uri",
 						software_statement: "invalid_software_statement",

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -12,12 +12,20 @@ import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
 import type { BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
-import { authorizeEndpoint } from "./authorize";
+import {
+	authorizeEndpoint,
+	formatErrorURL,
+	getErrorURL,
+	getIssuer,
+	handleRedirect,
+	resolveTrustedRedirectUri,
+} from "./authorize";
 import { consentEndpoint } from "./consent";
 import { continueEndpoint } from "./continue";
 import { introspectEndpoint } from "./introspect";
 import { rpInitiatedLogoutEndpoint } from "./logout";
 import { authServerMetadata, oidcServerMetadata } from "./metadata";
+import { createOAuthEndpoint } from "./oauth-endpoint";
 import * as oauthClientEndpoints from "./oauthClient";
 import * as oauthConsentEndpoints from "./oauthConsent";
 import { registerEndpoint } from "./register";
@@ -370,32 +378,76 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					return metadata;
 				},
 			),
-			oauth2Authorize: createAuthEndpoint(
+			oauth2Authorize: createOAuthEndpoint(
 				"/oauth2/authorize",
 				{
 					method: "GET",
 					query: z.object({
-						response_type: z.enum(["code"]).optional(),
+						response_type: z
+							.string()
+							.pipe(z.enum(["code"]))
+							.optional(),
 						client_id: z.string(),
 						redirect_uri: SafeUrlSchema.optional(),
 						scope: z.string().optional(),
 						state: z.string().optional(),
 						request_uri: z.string().optional(),
 						code_challenge: z.string().optional(),
-						code_challenge_method: z.enum(["S256"]).optional(),
+						code_challenge_method: z
+							.string()
+							.pipe(z.enum(["S256"]))
+							.optional(),
 						nonce: z.string().optional(),
 						prompt: z
-							.enum([
-								"none",
-								"consent",
-								"login",
-								"create",
-								"select_account",
-								"login consent",
-								"select_account consent",
-							])
+							.string()
+							.pipe(
+								z.enum([
+									"none",
+									"consent",
+									"login",
+									"create",
+									"select_account",
+									"login consent",
+									"select_account consent",
+								]),
+							)
 							.optional(),
 					}),
+					errorDelivery: "redirect",
+					redirectOnError: async ({ error, error_description, ctx }) => {
+						const raw = (ctx.query ?? {}) as Record<string, unknown>;
+						const clientId =
+							typeof raw.client_id === "string" ? raw.client_id : undefined;
+						const redirectUriRaw =
+							typeof raw.redirect_uri === "string"
+								? raw.redirect_uri
+								: undefined;
+						const trusted = await resolveTrustedRedirectUri(
+							ctx,
+							opts,
+							clientId,
+							redirectUriRaw,
+						);
+						if (trusted) {
+							return handleRedirect(
+								ctx,
+								formatErrorURL(
+									trusted,
+									error,
+									error_description,
+									typeof raw.state === "string" ? raw.state : undefined,
+									getIssuer(ctx, opts),
+								),
+							);
+						}
+						return handleRedirect(
+							ctx,
+							getErrorURL(ctx, error, error_description),
+						);
+					},
+					fieldErrors: {
+						response_type: { invalid: "unsupported_response_type" },
+					},
 					metadata: {
 						openapi: {
 							description: "Authorize an OAuth2 request",
@@ -607,16 +659,20 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					return continueEndpoint(ctx, opts);
 				},
 			),
-			oauth2Token: createAuthEndpoint(
+			oauth2Token: createOAuthEndpoint(
 				"/oauth2/token",
 				{
 					method: "POST",
 					body: z.object({
-						grant_type: z.enum([
-							"authorization_code",
-							"client_credentials",
-							"refresh_token",
-						]),
+						grant_type: z
+							.string()
+							.pipe(
+								z.enum([
+									"authorization_code",
+									"client_credentials",
+									"refresh_token",
+								]),
+							),
 						client_id: z.string().optional(),
 						client_secret: z.string().optional(),
 						client_assertion: z.string().optional(),
@@ -628,6 +684,12 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						resource: z.string().optional(),
 						scope: z.string().optional(),
 					}),
+					fieldErrors: {
+						grant_type: {
+							missing: "invalid_request",
+							invalid: "unsupported_grant_type",
+						},
+					},
 					metadata: {
 						allowedMediaTypes: ["application/x-www-form-urlencoded"],
 						openapi: {
@@ -758,7 +820,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					return tokenEndpoint(ctx, opts);
 				},
 			),
-			oauth2Introspect: createAuthEndpoint(
+			oauth2Introspect: createOAuthEndpoint(
 				"/oauth2/introspect",
 				{
 					method: "POST",
@@ -901,7 +963,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					return introspectEndpoint(ctx, opts);
 				},
 			),
-			oauth2Revoke: createAuthEndpoint(
+			oauth2Revoke: createOAuthEndpoint(
 				"/oauth2/revoke",
 				{
 					method: "POST",
@@ -912,9 +974,13 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						client_assertion_type: z.string().optional(),
 						token: z.string(),
 						token_type_hint: z
-							.enum(["access_token", "refresh_token"])
+							.string()
+							.pipe(z.enum(["access_token", "refresh_token"]))
 							.optional(),
 					}),
+					fieldErrors: {
+						token_type_hint: { invalid: "unsupported_token_type" },
+					},
 					metadata: {
 						allowedMediaTypes: ["application/x-www-form-urlencoded"],
 						openapi: {
@@ -1103,7 +1169,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					return userInfoEndpoint(ctx, opts);
 				},
 			),
-			oauth2EndSession: createAuthEndpoint(
+			oauth2EndSession: createOAuthEndpoint(
 				"/oauth2/end-session",
 				{
 					method: "GET",
@@ -1149,7 +1215,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					return rpInitiatedLogoutEndpoint(ctx, opts);
 				},
 			),
-			registerOAuthClient: createAuthEndpoint(
+			registerOAuthClient: createOAuthEndpoint(
 				"/oauth2/register",
 				{
 					method: "POST",
@@ -1207,6 +1273,12 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							})
 							.optional(),
 					}),
+					fieldErrors: {
+						redirect_uris: "invalid_redirect_uri",
+						post_logout_redirect_uris: "invalid_redirect_uri",
+						software_statement: "invalid_software_statement",
+					},
+					defaultError: "invalid_client_metadata",
 					metadata: {
 						openapi: {
 							description: "Register an OAuth2 application",

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -792,9 +792,10 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						client_assertion: z.string().optional(),
 						client_assertion_type: z.string().optional(),
 						token: z.string(),
-						token_type_hint: z
-							.enum(["access_token", "refresh_token"])
-							.optional(),
+						// RFC 7662 §2.1: hint, server MAY ignore. Unknown values are
+						// coerced to undefined in introspectEndpoint so detection falls
+						// back to trying both token types.
+						token_type_hint: z.string().optional(),
 					}),
 					metadata: {
 						allowedMediaTypes: ["application/x-www-form-urlencoded"],
@@ -935,14 +936,11 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						client_assertion: z.string().optional(),
 						client_assertion_type: z.string().optional(),
 						token: z.string(),
-						token_type_hint: z
-							.string()
-							.pipe(z.enum(["access_token", "refresh_token"]))
-							.optional(),
+						// RFC 7009 §2.2.1: hint, server MAY ignore. Unknown values are
+						// coerced to undefined in revokeEndpoint; `unsupported_token_type`
+						// in RFC 7009 applies to the token itself, not the hint value.
+						token_type_hint: z.string().optional(),
 					}),
-					fieldErrors: {
-						token_type_hint: { invalid: "unsupported_token_type" },
-					},
 					metadata: {
 						allowedMediaTypes: ["application/x-www-form-urlencoded"],
 						openapi: {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -823,9 +823,8 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 												},
 												token_type_hint: {
 													type: "string",
-													enum: ["access_token", "refresh_token"],
 													description:
-														"Hint about the type of the token submitted for introspection",
+														"Hint about the token type. Recognized values: `access_token`, `refresh_token`.",
 												},
 												resource: {
 													type: "string",
@@ -967,9 +966,8 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 												},
 												token_type_hint: {
 													type: "string",
-													enum: ["access_token", "refresh_token"],
 													description:
-														"Hint about the type of the token submitted for revocation",
+														"Hint about the token type. Recognized values: `access_token`, `refresh_token`.",
 												},
 											},
 											required: ["token"],

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -12,14 +12,7 @@ import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
 import type { BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
-import {
-	authorizeEndpoint,
-	formatErrorURL,
-	getErrorURL,
-	getIssuer,
-	handleRedirect,
-	resolveTrustedRedirectUri,
-} from "./authorize";
+import { authorizeEndpoint, authorizeRedirectOnError } from "./authorize";
 import { consentEndpoint } from "./consent";
 import { continueEndpoint } from "./continue";
 import { introspectEndpoint } from "./introspect";
@@ -413,38 +406,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							)
 							.optional(),
 					}),
-					errorDelivery: "redirect",
-					redirectOnError: async ({ error, error_description, ctx }) => {
-						const raw = (ctx.query ?? {}) as Record<string, unknown>;
-						const clientId =
-							typeof raw.client_id === "string" ? raw.client_id : undefined;
-						const redirectUriRaw =
-							typeof raw.redirect_uri === "string"
-								? raw.redirect_uri
-								: undefined;
-						const trusted = await resolveTrustedRedirectUri(
-							ctx,
-							opts,
-							clientId,
-							redirectUriRaw,
-						);
-						if (trusted) {
-							return handleRedirect(
-								ctx,
-								formatErrorURL(
-									trusted,
-									error,
-									error_description,
-									typeof raw.state === "string" ? raw.state : undefined,
-									getIssuer(ctx, opts),
-								),
-							);
-						}
-						return handleRedirect(
-							ctx,
-							getErrorURL(ctx, error, error_description),
-						);
-					},
+					redirectOnError: authorizeRedirectOnError(opts),
 					fieldErrors: {
 						response_type: { invalid: "unsupported_response_type" },
 					},

--- a/packages/oauth-provider/src/revoke.ts
+++ b/packages/oauth-provider/src/revoke.ts
@@ -249,8 +249,17 @@ export async function revokeEndpoint(
 ) {
 	let { token, token_type_hint } = ctx.body as {
 		token: string;
-		token_type_hint?: "access_token" | "refresh_token";
+		token_type_hint?: string;
 	};
+
+	// RFC 7009 §2.2.1: unknown hints are ignored and the server extends its
+	// search across all supported token types.
+	if (
+		token_type_hint !== "access_token" &&
+		token_type_hint !== "refresh_token"
+	) {
+		token_type_hint = undefined;
+	}
 
 	const credentials = await extractClientCredentials(
 		ctx,

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -39,9 +39,9 @@ export async function tokenEndpoint(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 ) {
-	const grantType: GrantType | undefined = ctx.body?.grant_type;
+	const grantType: GrantType = ctx.body.grant_type;
 
-	if (opts.grantTypes && grantType && !opts.grantTypes.includes(grantType)) {
+	if (opts.grantTypes && !opts.grantTypes.includes(grantType)) {
 		throw new APIError("BAD_REQUEST", {
 			error_description: `unsupported grant_type ${grantType}`,
 			error: "unsupported_grant_type",
@@ -55,16 +55,6 @@ export async function tokenEndpoint(
 			return handleClientCredentialsGrant(ctx, opts);
 		case "refresh_token":
 			return handleRefreshTokenGrant(ctx, opts);
-		case undefined:
-			throw new APIError("BAD_REQUEST", {
-				error_description: "missing required grant_type",
-				error: "unsupported_grant_type",
-			});
-		default:
-			throw new APIError("BAD_REQUEST", {
-				error_description: `unsupported grant_type ${grantType}`,
-				error: "unsupported_grant_type",
-			});
 	}
 }
 


### PR DESCRIPTION
OAuth endpoints currently return Better Auth's generic `VALIDATION_ERROR` envelope for schema failures instead of the RFC 6749 §5.2 / 7009 §2.2.1 / 7662 §2.3 / 7591 §3.2.2 `{error, error_description}` form, breaking compliant clients that branch on `error`.

Introduces a plugin-local `createOAuthEndpoint` wrapper that maps zod issues to RFC codes through a per-field table:

```ts
errorCodesByField: {
  grant_type: { missing: "invalid_request", invalid: "unsupported_grant_type" },
  response_type: { invalid: "unsupported_response_type" },
  redirect_uris: "invalid_redirect_uri",
}
```

Issues route to one of three buckets: missing required field, unsupported value, or duplicated scalar (`invalid_request`). Required enums use `z.string().pipe(z.enum([...]))` so missing and unsupported-value cases remain distinguishable at the zod layer. All 6 OAuth endpoints migrated.

`/oauth2/authorize` opts into redirect-mode error delivery by providing a `redirectOnError` callback: failures redirect back to the RP with `error`, `error_description`, `state`, and `iss` (RFC 9207) when `client_id` + `redirect_uri` resolve against a registered client. Unregistered RPs fall back to the server error page, avoiding open-redirect risk.

Two additional RFC compliance fixes folded into the PR:

- `/oauth2/revoke` and `/oauth2/introspect` ignore unrecognized `token_type_hint` values and search across supported token types. RFC 7009 §2.2.1 and RFC 7662 §2.1 reserve `unsupported_token_type` for the token itself, not the hint; the previous schema incorrectly rejected unknown hints with that code.
- `/oauth2/authorize` error redirects select the delivery channel per OIDC Core 1.0 §5. `response_type=token` or `id_token` now delivers errors in the URL fragment (RFC 6749 §4.2.2.1); an explicit `response_mode=query` overrides.

Closes #9267
Closes #9250
Closes #9279 (introduces a regression and doesn't solve the problem holistically)
