### PR TITLE
fix(core): serve noop `./instrumentation` on browser and edge conditions

### DIFF
--- a/.changeset/fix-instrumentation-pure-entry.md
+++ b/.changeset/fix-instrumentation-pure-entry.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+fix(core): serve noop `./instrumentation` on `browser`/`edge` conditions, matching `./async_hooks`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -102,6 +102,12 @@
     "./instrumentation": {
       "dev-source": "./src/instrumentation/index.ts",
       "types": "./dist/instrumentation/index.d.mts",
+      "node": "./dist/instrumentation/index.mjs",
+      "deno": "./dist/instrumentation/index.mjs",
+      "bun": "./dist/instrumentation/index.mjs",
+      "edge": "./dist/instrumentation/pure.index.mjs",
+      "workerd": "./dist/instrumentation/index.mjs",
+      "browser": "./dist/instrumentation/pure.index.mjs",
       "default": "./dist/instrumentation/index.mjs"
     }
   },

--- a/packages/core/src/instrumentation/api.ts
+++ b/packages/core/src/instrumentation/api.ts
@@ -1,52 +1,5 @@
-import type { Span, Tracer } from "@opentelemetry/api";
-
-type OpenTelemetryAPI = Pick<
-	typeof import("@opentelemetry/api"),
-	"trace" | "SpanStatusCode"
->;
-
-function createNoopSpan(): Span {
-	return {
-		end(): void {},
-		setAttribute(_key: string, _value: unknown): void {},
-		setStatus(_status: unknown): void {},
-		recordException(_exception: unknown): void {},
-	} as Span;
-}
-
-function createNoopTracer(noopSpanInstance: Span): Tracer {
-	function startActiveSpan<F extends (span: Span) => unknown>(
-		_name: string,
-		_options: { attributes?: Record<string, string | number | boolean> },
-		fn: F,
-	): ReturnType<F> {
-		return fn(noopSpanInstance) as ReturnType<F>;
-	}
-
-	return { startActiveSpan } as Tracer;
-}
-
-function createNoopTraceAPI() {
-	const noopTracer = createNoopTracer(createNoopSpan());
-	return {
-		getTracer(_name?: string, _version?: string) {
-			return noopTracer;
-		},
-	};
-}
-
-function createNoopOpenTelemetryAPI(): OpenTelemetryAPI {
-	return {
-		SpanStatusCode: {
-			UNSET: 0,
-			OK: 1,
-			ERROR: 2,
-		},
-		trace: createNoopTraceAPI(),
-	} as OpenTelemetryAPI;
-}
-
-const noopOpenTelemetryAPI = createNoopOpenTelemetryAPI();
+import type { OpenTelemetryAPI } from "./noop";
+import { noopOpenTelemetryAPI } from "./noop";
 
 let openTelemetryAPIPromise: Promise<void> | undefined;
 let openTelemetryAPI: OpenTelemetryAPI | undefined;

--- a/packages/core/src/instrumentation/noop.test.ts
+++ b/packages/core/src/instrumentation/noop.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { noopOpenTelemetryAPI } from "./noop";
+
+// @see https://github.com/better-auth/better-auth/issues/8765
+describe("instrumentation noop", () => {
+	it("exposes a SpanStatusCode enum matching @opentelemetry/api", () => {
+		expect(noopOpenTelemetryAPI.SpanStatusCode).toMatchObject({
+			UNSET: 0,
+			OK: 1,
+			ERROR: 2,
+		});
+	});
+
+	it("exposes a trace API with getTracer and getActiveSpan", () => {
+		expect(typeof noopOpenTelemetryAPI.trace.getTracer).toBe("function");
+		expect(
+			(
+				noopOpenTelemetryAPI.trace as { getActiveSpan?: () => unknown }
+			).getActiveSpan?.(),
+		).toBeUndefined();
+	});
+
+	it("returns a span whose mutators are safe no-ops", () => {
+		const span = noopOpenTelemetryAPI.trace
+			.getTracer("t")
+			.startActiveSpan("noop", {}, (s) => s);
+		expect(() => span.end()).not.toThrow();
+		expect(() => span.setAttribute("k", "v")).not.toThrow();
+	});
+
+	it("honors all three startActiveSpan overloads", () => {
+		const tracer = noopOpenTelemetryAPI.trace.getTracer("t");
+
+		// (name, fn)
+		const r1 = tracer.startActiveSpan("two-arg", (s) => {
+			expect(s).toBeDefined();
+			return 1 as const;
+		});
+		expect(r1).toBe(1);
+
+		// (name, options, fn)
+		const r2 = tracer.startActiveSpan("three-arg", { attributes: {} }, (s) => {
+			expect(s).toBeDefined();
+			return 2 as const;
+		});
+		expect(r2).toBe(2);
+
+		// (name, options, context, fn)
+		const r3 = (
+			tracer.startActiveSpan as unknown as (
+				name: string,
+				options: unknown,
+				context: unknown,
+				fn: (span: unknown) => unknown,
+			) => unknown
+		)("four-arg", {}, {}, (s) => {
+			expect(s).toBeDefined();
+			return 3 as const;
+		});
+		expect(r3).toBe(3);
+	});
+});

--- a/packages/core/src/instrumentation/noop.ts
+++ b/packages/core/src/instrumentation/noop.ts
@@ -59,7 +59,7 @@ function createNoopTraceAPI() {
 	};
 }
 
-export function createNoopOpenTelemetryAPI(): OpenTelemetryAPI {
+function createNoopOpenTelemetryAPI(): OpenTelemetryAPI {
 	return {
 		SpanStatusCode: {
 			UNSET: 0,

--- a/packages/core/src/instrumentation/noop.ts
+++ b/packages/core/src/instrumentation/noop.ts
@@ -19,12 +19,30 @@ function createNoopSpan(): Span {
 }
 
 function createNoopTracer(noopSpan: Span): Tracer {
+	// OpenTelemetry `Tracer.startActiveSpan` has three overloads:
+	//   (name, fn)
+	//   (name, options, fn)
+	//   (name, options, context, fn)
+	// The callback is always the last argument; fish it out by arity so a
+	// 2-arg call (options omitted) doesn't try to invoke `undefined`.
+	function startActiveSpan<F extends (span: Span) => unknown>(
+		_name: string,
+		fn: F,
+	): ReturnType<F>;
 	function startActiveSpan<F extends (span: Span) => unknown>(
 		_name: string,
 		_options: { attributes?: Record<string, string | number | boolean> },
 		fn: F,
-	): ReturnType<F> {
-		return fn(noopSpan) as ReturnType<F>;
+	): ReturnType<F>;
+	function startActiveSpan<F extends (span: Span) => unknown>(
+		_name: string,
+		_options: { attributes?: Record<string, string | number | boolean> },
+		_context: unknown,
+		fn: F,
+	): ReturnType<F>;
+	function startActiveSpan(_name: string, ...rest: Array<unknown>): unknown {
+		const fn = rest[rest.length - 1] as (span: Span) => unknown;
+		return fn(noopSpan);
 	}
 	return { startActiveSpan } as Tracer;
 }

--- a/packages/core/src/instrumentation/noop.ts
+++ b/packages/core/src/instrumentation/noop.ts
@@ -1,0 +1,56 @@
+import type { Span, Tracer } from "@opentelemetry/api";
+
+export type OpenTelemetryAPI = Pick<
+	typeof import("@opentelemetry/api"),
+	"trace" | "SpanStatusCode"
+>;
+
+function createNoopSpan(): Span {
+	const span = {
+		end(): void {},
+		setAttribute(_key: string, _value: unknown): void {},
+		setStatus(_status: unknown): void {},
+		recordException(_exception: unknown): void {},
+		updateName(_name: string) {
+			return span;
+		},
+	} as unknown as Span;
+	return span;
+}
+
+function createNoopTracer(noopSpan: Span): Tracer {
+	function startActiveSpan<F extends (span: Span) => unknown>(
+		_name: string,
+		_options: { attributes?: Record<string, string | number | boolean> },
+		fn: F,
+	): ReturnType<F> {
+		return fn(noopSpan) as ReturnType<F>;
+	}
+	return { startActiveSpan } as Tracer;
+}
+
+function createNoopTraceAPI() {
+	const noopTracer = createNoopTracer(createNoopSpan());
+	return {
+		getTracer(_name?: string, _version?: string) {
+			return noopTracer;
+		},
+		getActiveSpan(): Span | undefined {
+			return undefined;
+		},
+	};
+}
+
+export function createNoopOpenTelemetryAPI(): OpenTelemetryAPI {
+	return {
+		SpanStatusCode: {
+			UNSET: 0,
+			OK: 1,
+			ERROR: 2,
+		},
+		trace: createNoopTraceAPI(),
+	} as OpenTelemetryAPI;
+}
+
+export const noopOpenTelemetryAPI: OpenTelemetryAPI =
+	createNoopOpenTelemetryAPI();

--- a/packages/core/src/instrumentation/pure.index.ts
+++ b/packages/core/src/instrumentation/pure.index.ts
@@ -1,30 +1,16 @@
-import type { OpenTelemetryAPI } from "./noop";
-import { noopOpenTelemetryAPI } from "./noop";
-
 /**
  * Noop variant of `./instrumentation` for runtimes where the dynamic
- * `import("@opentelemetry/api")` in `./api` can't resolve via the normal
- * ECMAScript dynamic-import semantics.
+ * `import("@opentelemetry/api")` in `./api` throws synchronously instead of
+ * rejecting its returned promise. Convex's V8 isolate is the reproducer: bare
+ * specifiers are rejected at resolve time in `get-convex/convex-backend`
+ * `crates/isolate/src/request_scope.rs`, so the `.catch()` in
+ * `getOpenTelemetryAPI` never runs and every `withSpan` call surfaces an
+ * uncaught error.
  *
- * Convex's V8 isolate rejects bare specifiers at resolve time and throws
- * synchronously from the `import()` expression itself rather than rejecting
- * the returned promise (see `get-convex/convex-backend`
- * `crates/isolate/src/request_scope.rs` `dynamic_import_callback`, which
- * returns `None` on resolver error; V8 treats that as a pending exception).
- * The `.catch()` in `getOpenTelemetryAPI` never runs and every `withSpan`
- * call surfaces an uncaught error.
- *
- * This module is wired through `package.json` conditional exports on the
- * `./instrumentation` subpath, matching the existing `./async_hooks` pattern.
- * The noop primitives live in `./noop` and are shared with `./api` so the
- * two entries can't drift.
+ * Public surface must stay identical to `./index` (enforced by `pure.test.ts`).
  */
 
 export * from "./attributes";
-
-export function getOpenTelemetryAPI(): OpenTelemetryAPI {
-	return noopOpenTelemetryAPI;
-}
 
 export function withSpan<T>(
 	name: string,

--- a/packages/core/src/instrumentation/pure.index.ts
+++ b/packages/core/src/instrumentation/pure.index.ts
@@ -1,73 +1,26 @@
-import type { Span, Tracer } from "@opentelemetry/api";
+import type { OpenTelemetryAPI } from "./noop";
+import { noopOpenTelemetryAPI } from "./noop";
 
 /**
  * Noop variant of `./instrumentation` for runtimes where the dynamic
- * `import("@opentelemetry/api")` in `./api` can't be relied on.
+ * `import("@opentelemetry/api")` in `./api` can't resolve via the normal
+ * ECMAScript dynamic-import semantics.
  *
- * Browsers and edge bundlers (`browser`, `edge` package.json conditions)
- * don't typically run a global `TracerProvider`, and some isolate runtimes
- * reject bare specifiers at resolve time and throw synchronously from the
- * `import()` expression itself rather than rejecting the returned promise.
- * In those cases the `.catch()` in `getOpenTelemetryAPI` never runs and
- * every call through `withSpan` surfaces an uncaught error.
+ * Convex's V8 isolate rejects bare specifiers at resolve time and throws
+ * synchronously from the `import()` expression itself rather than rejecting
+ * the returned promise (see `get-convex/convex-backend`
+ * `crates/isolate/src/request_scope.rs` `dynamic_import_callback`, which
+ * returns `None` on resolver error; V8 treats that as a pending exception).
+ * The `.catch()` in `getOpenTelemetryAPI` never runs and every `withSpan`
+ * call surfaces an uncaught error.
  *
- * This module mirrors the public shape of `./index` without touching
- * `@opentelemetry/api` at all. Wired through `package.json` conditional
- * exports on the `./instrumentation` subpath, matching the existing
- * `./async_hooks` pattern.
+ * This module is wired through `package.json` conditional exports on the
+ * `./instrumentation` subpath, matching the existing `./async_hooks` pattern.
+ * The noop primitives live in `./noop` and are shared with `./api` so the
+ * two entries can't drift.
  */
 
 export * from "./attributes";
-
-type OpenTelemetryAPI = Pick<
-	typeof import("@opentelemetry/api"),
-	"trace" | "SpanStatusCode"
->;
-
-function createNoopSpan(): Span {
-	const span = {
-		end(): void {},
-		setAttribute(_key: string, _value: unknown): void {},
-		setStatus(_status: unknown): void {},
-		recordException(_exception: unknown): void {},
-		updateName(_name: string) {
-			return span;
-		},
-	} as unknown as Span;
-	return span;
-}
-
-function createNoopTracer(noopSpan: Span): Tracer {
-	function startActiveSpan<F extends (span: Span) => unknown>(
-		_name: string,
-		_options: { attributes?: Record<string, string | number | boolean> },
-		fn: F,
-	): ReturnType<F> {
-		return fn(noopSpan) as ReturnType<F>;
-	}
-	return { startActiveSpan } as Tracer;
-}
-
-function createNoopTraceAPI() {
-	const noopTracer = createNoopTracer(createNoopSpan());
-	return {
-		getTracer(_name?: string, _version?: string) {
-			return noopTracer;
-		},
-		getActiveSpan(): Span | undefined {
-			return undefined;
-		},
-	};
-}
-
-const noopOpenTelemetryAPI: OpenTelemetryAPI = {
-	SpanStatusCode: {
-		UNSET: 0,
-		OK: 1,
-		ERROR: 2,
-	},
-	trace: createNoopTraceAPI(),
-} as OpenTelemetryAPI;
 
 export function getOpenTelemetryAPI(): OpenTelemetryAPI {
 	return noopOpenTelemetryAPI;

--- a/packages/core/src/instrumentation/pure.index.ts
+++ b/packages/core/src/instrumentation/pure.index.ts
@@ -1,0 +1,92 @@
+import type { Span, Tracer } from "@opentelemetry/api";
+
+/**
+ * Noop variant of `./instrumentation` for runtimes where the dynamic
+ * `import("@opentelemetry/api")` in `./api` can't be relied on.
+ *
+ * Browsers and edge bundlers (`browser`, `edge` package.json conditions)
+ * don't typically run a global `TracerProvider`, and some isolate runtimes
+ * reject bare specifiers at resolve time and throw synchronously from the
+ * `import()` expression itself rather than rejecting the returned promise.
+ * In those cases the `.catch()` in `getOpenTelemetryAPI` never runs and
+ * every call through `withSpan` surfaces an uncaught error.
+ *
+ * This module mirrors the public shape of `./index` without touching
+ * `@opentelemetry/api` at all. Wired through `package.json` conditional
+ * exports on the `./instrumentation` subpath, matching the existing
+ * `./async_hooks` pattern.
+ */
+
+export * from "./attributes";
+
+type OpenTelemetryAPI = Pick<
+	typeof import("@opentelemetry/api"),
+	"trace" | "SpanStatusCode"
+>;
+
+function createNoopSpan(): Span {
+	const span = {
+		end(): void {},
+		setAttribute(_key: string, _value: unknown): void {},
+		setStatus(_status: unknown): void {},
+		recordException(_exception: unknown): void {},
+		updateName(_name: string) {
+			return span;
+		},
+	} as unknown as Span;
+	return span;
+}
+
+function createNoopTracer(noopSpan: Span): Tracer {
+	function startActiveSpan<F extends (span: Span) => unknown>(
+		_name: string,
+		_options: { attributes?: Record<string, string | number | boolean> },
+		fn: F,
+	): ReturnType<F> {
+		return fn(noopSpan) as ReturnType<F>;
+	}
+	return { startActiveSpan } as Tracer;
+}
+
+function createNoopTraceAPI() {
+	const noopTracer = createNoopTracer(createNoopSpan());
+	return {
+		getTracer(_name?: string, _version?: string) {
+			return noopTracer;
+		},
+		getActiveSpan(): Span | undefined {
+			return undefined;
+		},
+	};
+}
+
+const noopOpenTelemetryAPI: OpenTelemetryAPI = {
+	SpanStatusCode: {
+		UNSET: 0,
+		OK: 1,
+		ERROR: 2,
+	},
+	trace: createNoopTraceAPI(),
+} as OpenTelemetryAPI;
+
+export function getOpenTelemetryAPI(): OpenTelemetryAPI {
+	return noopOpenTelemetryAPI;
+}
+
+export function withSpan<T>(
+	name: string,
+	attributes: Record<string, string | number | boolean>,
+	fn: () => T,
+): T;
+export function withSpan<T>(
+	name: string,
+	attributes: Record<string, string | number | boolean>,
+	fn: () => Promise<T>,
+): Promise<T>;
+export function withSpan<T>(
+	_name: string,
+	_attributes: Record<string, string | number | boolean>,
+	fn: () => T | Promise<T>,
+): T | Promise<T> {
+	return fn();
+}

--- a/packages/core/src/instrumentation/pure.test.ts
+++ b/packages/core/src/instrumentation/pure.test.ts
@@ -52,6 +52,38 @@ describe("instrumentation (pure entry)", () => {
 		expect(() => span.setAttribute("k", "v")).not.toThrow();
 	});
 
+	it("noop tracer.startActiveSpan honors all three OpenTelemetry overloads", () => {
+		const tracer = getOpenTelemetryAPI().trace.getTracer("t");
+
+		// (name, fn)
+		const r1 = tracer.startActiveSpan("two-arg", (s) => {
+			expect(s).toBeDefined();
+			return 1 as const;
+		});
+		expect(r1).toBe(1);
+
+		// (name, options, fn)
+		const r2 = tracer.startActiveSpan("three-arg", { attributes: {} }, (s) => {
+			expect(s).toBeDefined();
+			return 2 as const;
+		});
+		expect(r2).toBe(2);
+
+		// (name, options, context, fn)
+		const r3 = (
+			tracer.startActiveSpan as unknown as (
+				name: string,
+				options: unknown,
+				context: unknown,
+				fn: (span: unknown) => unknown,
+			) => unknown
+		)("four-arg", {}, {}, (s) => {
+			expect(s).toBeDefined();
+			return 3 as const;
+		});
+		expect(r3).toBe(3);
+	});
+
 	it("does not reference `@opentelemetry/api` at runtime", async () => {
 		const mod = await import("./pure.index");
 		expect(mod.withSpan.toString()).not.toContain("opentelemetry");

--- a/packages/core/src/instrumentation/pure.test.ts
+++ b/packages/core/src/instrumentation/pure.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { getOpenTelemetryAPI, withSpan } from "./pure.index";
+
+// Covers the conditional-export variant served to `browser`/`edge` bundlers,
+// mirroring the `./async_hooks` split. The real entry is covered by
+// `./instrumentation.test.ts`. This suite asserts that the noop path mirrors
+// the public shape of `./index` without loading `@opentelemetry/api`, and
+// that `withSpan` still honors its contract: return the fn result, propagate
+// sync throws, propagate async rejections.
+//
+// @see https://github.com/better-auth/better-auth/issues/8765
+describe("instrumentation (pure entry)", () => {
+	it("returns the result of a sync fn", () => {
+		expect(withSpan("test.sync", { k: 1 }, () => 42)).toBe(42);
+	});
+
+	it("returns the result of an async fn", async () => {
+		await expect(
+			withSpan("test.async", { k: 1 }, async () => {
+				await Promise.resolve();
+				return "ok";
+			}),
+		).resolves.toBe("ok");
+	});
+
+	it("propagates sync throws", () => {
+		expect(() =>
+			withSpan("test.sync.err", {}, () => {
+				throw new Error("boom");
+			}),
+		).toThrow("boom");
+	});
+
+	it("propagates async rejections", async () => {
+		await expect(
+			withSpan("test.async.err", {}, async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+	});
+
+	it("getOpenTelemetryAPI returns a noop shape", () => {
+		const api = getOpenTelemetryAPI();
+		expect(api.SpanStatusCode).toMatchObject({ UNSET: 0, OK: 1, ERROR: 2 });
+		expect(typeof api.trace.getTracer).toBe("function");
+		expect(
+			(api.trace as { getActiveSpan?: () => unknown }).getActiveSpan?.(),
+		).toBeUndefined();
+
+		const span = api.trace.getTracer("t").startActiveSpan("noop", {}, (s) => s);
+		expect(() => span.end()).not.toThrow();
+		expect(() => span.setAttribute("k", "v")).not.toThrow();
+	});
+
+	it("does not reference `@opentelemetry/api` at runtime", async () => {
+		const mod = await import("./pure.index");
+		expect(mod.withSpan.toString()).not.toContain("opentelemetry");
+		expect(mod.getOpenTelemetryAPI.toString()).not.toContain("opentelemetry");
+	});
+});

--- a/packages/core/src/instrumentation/pure.test.ts
+++ b/packages/core/src/instrumentation/pure.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { getOpenTelemetryAPI, withSpan } from "./pure.index";
+import { withSpan } from "./pure.index";
 
-// Covers the conditional-export variant served to `browser`/`edge` bundlers,
-// mirroring the `./async_hooks` split. The real entry is covered by
-// `./instrumentation.test.ts`. This suite asserts that the noop path mirrors
-// the public shape of `./index` without loading `@opentelemetry/api`, and
-// that `withSpan` still honors its contract: return the fn result, propagate
-// sync throws, propagate async rejections.
-//
 // @see https://github.com/better-auth/better-auth/issues/8765
 describe("instrumentation (pure entry)", () => {
 	it("returns the result of a sync fn", () => {
@@ -39,54 +32,14 @@ describe("instrumentation (pure entry)", () => {
 		).rejects.toThrow("boom");
 	});
 
-	it("getOpenTelemetryAPI returns a noop shape", () => {
-		const api = getOpenTelemetryAPI();
-		expect(api.SpanStatusCode).toMatchObject({ UNSET: 0, OK: 1, ERROR: 2 });
-		expect(typeof api.trace.getTracer).toBe("function");
-		expect(
-			(api.trace as { getActiveSpan?: () => unknown }).getActiveSpan?.(),
-		).toBeUndefined();
-
-		const span = api.trace.getTracer("t").startActiveSpan("noop", {}, (s) => s);
-		expect(() => span.end()).not.toThrow();
-		expect(() => span.setAttribute("k", "v")).not.toThrow();
-	});
-
-	it("noop tracer.startActiveSpan honors all three OpenTelemetry overloads", () => {
-		const tracer = getOpenTelemetryAPI().trace.getTracer("t");
-
-		// (name, fn)
-		const r1 = tracer.startActiveSpan("two-arg", (s) => {
-			expect(s).toBeDefined();
-			return 1 as const;
-		});
-		expect(r1).toBe(1);
-
-		// (name, options, fn)
-		const r2 = tracer.startActiveSpan("three-arg", { attributes: {} }, (s) => {
-			expect(s).toBeDefined();
-			return 2 as const;
-		});
-		expect(r2).toBe(2);
-
-		// (name, options, context, fn)
-		const r3 = (
-			tracer.startActiveSpan as unknown as (
-				name: string,
-				options: unknown,
-				context: unknown,
-				fn: (span: unknown) => unknown,
-			) => unknown
-		)("four-arg", {}, {}, (s) => {
-			expect(s).toBeDefined();
-			return 3 as const;
-		});
-		expect(r3).toBe(3);
-	});
-
 	it("does not reference `@opentelemetry/api` at runtime", async () => {
 		const mod = await import("./pure.index");
 		expect(mod.withSpan.toString()).not.toContain("opentelemetry");
-		expect(mod.getOpenTelemetryAPI.toString()).not.toContain("opentelemetry");
+	});
+
+	it("does not export symbols beyond the public surface of ./index", async () => {
+		const pure = await import("./pure.index");
+		const main = await import("./index");
+		expect(Object.keys(pure).sort()).toEqual(Object.keys(main).sort());
 	});
 });

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
 		"!./src/utils/*.test.ts",
 		"./src/error/index.ts",
 		"./src/instrumentation/index.ts",
+		"./src/instrumentation/pure.index.ts",
 	],
 	deps: {
 		neverBundle: ["@better-auth/core/async_hooks"],


### PR DESCRIPTION
Apply the `./async_hooks` conditional-export shape to `./instrumentation` so runtimes where the dynamic `import("@opentelemetry/api")` in `packages/core/src/instrumentation/api.ts` can't resolve via standard ECMAScript dynamic-import semantics get a noop entry that doesn't depend on runtime import resolution at all.

Convex is the reproducer. Its V8 isolate rejects bare specifiers at resolve time via `deno_core::resolve_import` and throws synchronously from the `import()` expression instead of rejecting the returned promise. `dynamic_import_callback` in `get-convex/convex-backend` `crates/isolate/src/request_scope.rs` returns `None` on resolver error, which V8 treats as a pending exception. The `.catch()` in `getOpenTelemetryAPI` never runs, and every `withSpan` call through `packages/better-auth/src/api/to-auth-endpoints.ts` and `packages/better-auth/src/db/with-hooks.ts` surfaces an uncaught error:

```
[Better Auth]: Error: Relative import path "@opentelemetry/api" not prefixed
with / or ./ or ../ from "convex:/_deps/ZJDHZ5TX.js"
```

Reproducible whenever `@convex-dev/better-auth` resolves `better-auth` to 1.6.x, which happens today for any user upgrading past the currently-published `>=1.5.0 <1.6.0` peer range or adopting the pending 1.6 migration at get-convex/better-auth#323. The breaking pattern landed in #9111, which shipped in v1.6.6. `@opentelemetry/api` itself is runtime-agnostic and ships a noop proxy when no SDK is registered, so the issue isn't about OTel support in the browser or at the edge. The issue is that the dynamic-import-with-catch pattern in `./api` isn't portable to runtimes that throw synchronously from unresolvable bare specifiers.

The fix is the same shape already used for `./async_hooks`: conditional exports that hand strict-bundler runtimes a module with no runtime import probe. Convex's esbuild bundler activates the `browser` condition automatically because it runs with `platform: "browser"` (`get-convex/convex-js` `src/cli/lib/config.ts:637`), so matching on `browser` covers Convex without a vendor-specific condition key. The `browser` route also gives pure-browser bundles an eager noop, which matches the noop-by-default behavior `@opentelemetry/api` already has when no SDK is registered.

```diff
   "./instrumentation": {
     "dev-source": "./src/instrumentation/index.ts",
     "types": "./dist/instrumentation/index.d.mts",
+    "node": "./dist/instrumentation/index.mjs",
+    "deno": "./dist/instrumentation/index.mjs",
+    "bun": "./dist/instrumentation/index.mjs",
+    "edge": "./dist/instrumentation/pure.index.mjs",
+    "workerd": "./dist/instrumentation/index.mjs",
+    "browser": "./dist/instrumentation/pure.index.mjs",
     "default": "./dist/instrumentation/index.mjs"
   }
```

- `packages/core/src/instrumentation/noop.ts`: extracted the noop OpenTelemetry API factories and the `noopOpenTelemetryAPI` singleton so `./api`'s in-process fallback has a single source of truth
- `packages/core/src/instrumentation/api.ts`: imports `noopOpenTelemetryAPI` from `./noop`, keeps the dynamic-import-with-catch logic
- `packages/core/src/instrumentation/pure.index.ts`: passthrough `withSpan` plus the `./attributes` re-export. Public surface is identical to `./index` so consumers see the same shape on every export condition
- `packages/core/package.json`: six conditions added on `./instrumentation` mirroring `./async_hooks`
- `packages/core/tsdown.config.ts`: new entry wired into the build
- `packages/core/src/instrumentation/pure.test.ts`: sync/async return, throw/reject propagation, absence of `@opentelemetry/api` at runtime, surface-equality against `./index`; `@see` tagged to #8765
- `packages/core/src/instrumentation/noop.test.ts`: `SpanStatusCode` enum, `trace.getTracer`/`getActiveSpan` shape, span-mutator safety, 3-arity `startActiveSpan` overload regression; `@see` tagged to #8765

Forward-compatible with #9274: the shared noop already includes `getActiveSpan`/`updateName` on its noop shapes so this PR and #9274 rebase cleanly on each other regardless of merge order.

Reproduced on a real app. Before, every `/api/auth/*` request returned 500 with the error above. After, the Convex function bundle resolves `./instrumentation` to `pure.index.mjs` through the `browser` condition, the noop `withSpan` passes `fn()` through, and requests round-trip normally.

`pnpm build`, `pnpm lint`, `pnpm lint:dependencies`, `pnpm lint:packages`, `pnpm lint:spell`, `pnpm format:check`, `pnpm lint:types`, `pnpm typecheck`, `pnpm typecheck:dist` all clean. `pnpm -C packages/core test` 199/199 across 14 files, with `pure.test.ts` (6 tests) and `noop.test.ts` (4 tests) alongside the 11 existing `instrumentation.test.ts` tests. `pnpm --filter better-auth exec vitest run src/instrumentation.db.test.ts src/instrumentation.endpoint.test.ts` 15/15. `grep opentelemetry packages/core/dist/instrumentation/pure.index.mjs` returns 0.

Related: #8765 (optional peer dep declaration, fix via #9111 in 1.6.6), #5314 (Convex bundling class of issues), #8458 (prior `use conditional exports to replace dynamic import hacks` in telemetry).
