### PR TITLE
fix(oauth2): guard against undefined body when parsing state

### DIFF
--- a/.changeset/parse-state-body-nullsafe.md
+++ b/.changeset/parse-state-body-nullsafe.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Guard against `c.body` being undefined in `parseState`. Callback requests that arrive as GET leave `c.body` unset in some runtimes, which caused `c.body.state` to throw a `TypeError` before the existing error redirect could run. The state lookup now short-circuits on the query parameter and falls back to `c.body?.state` safely, so a callback without a state parameter redirects to the error page instead of crashing.

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -47,7 +47,7 @@ export async function generateState(
 }
 
 export async function parseState(c: GenericEndpointContext) {
-	const state = c.query.state || c.body.state;
+	const state = c.query.state || c.body?.state;
 	const errorURL =
 		c.context.options.onAPIError?.errorURL || `${c.context.baseURL}/error`;
 

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1047,6 +1047,22 @@ describe("oauth2", async () => {
 		expect(session.data).toBeNull();
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/4951
+	 */
+	it("should redirect to the error page when a GET callback arrives without state", async () => {
+		const res = await customFetchImpl(
+			`http://localhost:3000/api/auth/oauth2/callback/${providerId}?code=dummy`,
+			{
+				method: "GET",
+				redirect: "manual",
+			},
+		);
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get("location")).toContain("please_restart_the_process");
+	});
+
 	it("should await async mapProfileToUser", async () => {
 		const { auth } = await getTestInstance({
 			plugins: [


### PR DESCRIPTION
Guards against `c.body` being undefined when parsing OAuth state. Callback requests that arrive as GET leave `c.body` unset in some runtimes, so `c.query.state || c.body.state` threw a `TypeError` before the existing `please_restart_the_process` redirect in `parseState` could run.

Adds a regression test covering a GET callback to `/oauth2/callback/:id` with no state parameter: the endpoint now returns a 302 to the error page rather than crashing.

Supersedes #4951, which bundled this fix with a larger `stateOptional` / IDP-initiated feature. That feature is being tracked separately for the `next` branch, where the generic-oauth rewrite (#9069) changes the implementation shape.

Closes #4951 

Original patch by @mhornbacher.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in OAuth2 callbacks when the request is GET and has no body. `parseState` now safely reads state and redirects to the error page instead of throwing a TypeError.

- **Bug Fixes**
  - `parseState` checks `c.query.state` then `c.body?.state` to avoid undefined access.
  - Regression test for GET callback without state (expects 302 to the error page).

<sup>Written for commit 85bb9119b347068c75c5be7e7e37d25ccff7e790. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

