### PR TITLE
feat(generic-oauth,sso): support IDP-initiated flows via secure bounce

### DIFF
--- a/.changeset/oauth-idp-initiated-bounce.md
+++ b/.changeset/oauth-idp-initiated-bounce.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/sso": patch
+---
+
+Add `allowIdpInitiated` to `GenericOAuthConfig` and SSO `OIDCConfig` to support providers that initiate OAuth without a `state` parameter (e.g. Clever). When enabled, stateless callbacks restart the OAuth flow server-side with fresh state and PKCE, preserving CSRF protection. Also hardens `parseState` against undefined request bodies on GET callbacks.

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -513,6 +513,37 @@ getUserInfo: async (tokens) => {
 }
 ```
 
+### IDP-Initiated Flows
+
+Some OAuth providers (e.g., [Clever](https://dev.clever.com/docs/oauth-implementation#initiating-logins)) let the identity provider redirect users to your callback URL without first having the user click a "sign in" button in your app. These callbacks arrive with a `code` parameter but no `state`, which would normally be rejected because the missing `state` breaks the standard CSRF check.
+
+Set `allowIdpInitiated: true` on the provider to accept these flows safely:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { genericOAuth } from "better-auth/plugins";
+
+export const auth = betterAuth({
+    plugins: [
+        genericOAuth({
+            config: [
+                {
+                    providerId: "clever",
+                    discoveryUrl: "https://clever.com/.well-known/openid-configuration",
+                    clientId: process.env.CLEVER_CLIENT_ID,
+                    clientSecret: process.env.CLEVER_CLIENT_SECRET,
+                    allowIdpInitiated: true,
+                },
+            ],
+        }),
+    ],
+});
+```
+
+When a stateless callback hits `/oauth2/callback/:providerId`, Better Auth discards the provider-issued code and restarts the flow server-side: a fresh `state` and PKCE verifier are generated, and the user is redirected to the provider's authorize endpoint. The provider recognises the user's live session and completes the flow automatically. CSRF protection and PKCE are preserved throughout.
+
+Leave `allowIdpInitiated` off (the default) for any provider that always initiates the flow from your side — stateless callbacks to those providers indicate malformed or malicious requests and should be rejected.
+
 ### Error Handling
 
 The plugin includes built-in error handling for common OAuth issues. Errors are typically redirected to your application's error page with an appropriate error message in the URL parameters. If the callback URL is not provided, the user will be redirected to Better Auth's default error page.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -445,6 +445,8 @@ To register a SAML provider, use the `registerSSOProvider` endpoint with SAML co
 
 ### IdP-Initiated SSO
 
+For OIDC providers that initiate logins without sending a `state` parameter, set `allowIdpInitiated: true` on the provider's `oidcConfig`. When a stateless callback arrives at `/sso/callback/:providerId`, the IdP-issued code is discarded and a new OAuth flow is started server-side with a fresh `state` and PKCE verifier. CSRF protection remains in effect. This flag defaults to `false`.
+
 For IdP-initiated flows (e.g., via Okta dashboard), your framework may require an explicit route handler to manage the redirect if the default handler doesn't support the `GET` request following the SAML POST.
 
 <Tabs items={["next-js-app-router"]}>

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -47,7 +47,7 @@ export async function generateState(
 }
 
 export async function parseState(c: GenericEndpointContext) {
-	const state = c.query.state || c.body.state;
+	const state = c.query.state || c.body?.state;
 	const errorURL =
 		c.context.options.onAPIError?.errorURL || `${c.context.baseURL}/error`;
 

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2331,4 +2331,95 @@ describe("oauth2", async () => {
 			expect(callbackURL).toBe("http://localhost:3000/dashboard");
 		});
 	});
+
+	describe("IDP-initiated bounce (allowIdpInitiated)", () => {
+		it("should bounce a stateless callback to the provider's authorize endpoint when the provider opts in", async () => {
+			const { customFetchImpl } = await getTestInstance({
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "idp-initiated",
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId,
+								clientSecret,
+								allowIdpInitiated: true,
+							},
+						],
+					}),
+				],
+			});
+
+			const res = await customFetchImpl(
+				"http://localhost:3000/api/auth/oauth2/callback/idp-initiated?code=idp-issued-code",
+				{ method: "GET", redirect: "manual" },
+			);
+
+			expect(res.status).toBe(302);
+			const location = res.headers.get("location") || "";
+			expect(location).toContain(`http://localhost:${port}/authorize`);
+			const url = new URL(location);
+			expect(url.searchParams.get("state")).toBeTruthy();
+			expect(url.searchParams.get("client_id")).toBe(clientId);
+			expect(url.searchParams.get("redirect_uri")).toBe(
+				"http://localhost:3000/api/auth/oauth2/callback/idp-initiated",
+			);
+			expect(url.searchParams.get("code")).toBeNull();
+		});
+
+		it("should redirect to the error page when a stateless callback arrives for a provider without the flag", async () => {
+			const { customFetchImpl } = await getTestInstance({
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "strict",
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId,
+								clientSecret,
+							},
+						],
+					}),
+				],
+			});
+
+			const res = await customFetchImpl(
+				"http://localhost:3000/api/auth/oauth2/callback/strict?code=idp-issued-code",
+				{ method: "GET", redirect: "manual" },
+			);
+
+			expect(res.status).toBe(302);
+			expect(res.headers.get("location")).toContain(
+				"please_restart_the_process",
+			);
+		});
+
+		it("should not bounce when state is present even if allowIdpInitiated is on", async () => {
+			const { customFetchImpl } = await getTestInstance({
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "idp-initiated-with-state",
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId,
+								clientSecret,
+								allowIdpInitiated: true,
+							},
+						],
+					}),
+				],
+			});
+
+			const res = await customFetchImpl(
+				"http://localhost:3000/api/auth/oauth2/callback/idp-initiated-with-state?code=abc&state=unknown-state",
+				{ method: "GET", redirect: "manual" },
+			);
+
+			expect(res.status).toBe(302);
+			const location = res.headers.get("location") || "";
+			expect(location).not.toContain(`http://localhost:${port}/authorize`);
+			expect(location).toContain("please_restart_the_process");
+		});
+	});
 });

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -304,6 +304,54 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 				});
 			}
 
+			// TODO: on sync to the next branch, relocate this bounce branch
+			// into the shared callback at
+			// packages/better-auth/src/api/routes/callback.ts; generic-oauth's
+			// own /oauth2/callback/:providerId route no longer exists there.
+			if (!ctx.query.state && providerConfig.allowIdpInitiated) {
+				let finalAuthUrl = providerConfig.authorizationUrl;
+				if (providerConfig.discoveryUrl) {
+					const discovery = await betterFetch<{
+						authorization_endpoint: string;
+					}>(providerConfig.discoveryUrl, {
+						method: "GET",
+						headers: providerConfig.discoveryHeaders,
+					});
+					if (discovery.data?.authorization_endpoint) {
+						finalAuthUrl = discovery.data.authorization_endpoint;
+					}
+				}
+				if (!finalAuthUrl) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						GENERIC_OAUTH_ERROR_CODES.INVALID_OAUTH_CONFIGURATION,
+					);
+				}
+				const { state, codeVerifier } = await generateState(
+					ctx,
+					undefined,
+					undefined,
+				);
+				const authUrl = await createAuthorizationURL({
+					id: providerId,
+					options: {
+						clientId: providerConfig.clientId,
+						clientSecret: providerConfig.clientSecret,
+						redirectURI: providerConfig.redirectURI,
+					},
+					authorizationEndpoint: finalAuthUrl,
+					state,
+					codeVerifier: providerConfig.pkce ? codeVerifier : undefined,
+					scopes: providerConfig.scopes || [],
+					redirectURI: `${ctx.context.baseURL}/oauth2/callback/${providerId}`,
+					prompt: providerConfig.prompt,
+					accessType: providerConfig.accessType,
+					responseType: providerConfig.responseType,
+					responseMode: providerConfig.responseMode,
+				});
+				throw ctx.redirect(authUrl.toString());
+			}
+
 			let tokens: OAuth2Tokens | undefined = undefined;
 			const parsedState = await parseState(ctx);
 			const {

--- a/packages/better-auth/src/plugins/generic-oauth/types.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/types.ts
@@ -182,4 +182,13 @@ export interface GenericOAuthConfig {
 	 * @default false
 	 */
 	overrideUserInfo?: boolean | undefined;
+	/**
+	 * Accept callbacks from providers that initiate the OAuth flow without
+	 * sending a `state` parameter (e.g. Clever). When enabled, stateless
+	 * callbacks restart the OAuth flow server-side with a fresh `state` and
+	 * PKCE verifier. See the generic-oauth docs for details.
+	 *
+	 * @default false
+	 */
+	allowIdpInitiated?: boolean | undefined;
 }

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1528,3 +1528,74 @@ describe("SSO OIDC UserInfo endpoint sub claim mapping", async () => {
 		expect(session.data?.user.email).toBe("userinfo-only@test.com");
 	});
 });
+
+describe("SSO OIDC IDP-initiated bounce", async () => {
+	const { customFetchImpl } = await getTestInstance({
+		trustedOrigins: ["http://localhost:8080"],
+		plugins: [
+			sso({
+				defaultSSO: [
+					{
+						domain: "idp-initiated.com",
+						providerId: "idp-initiated",
+						oidcConfig: {
+							issuer: "http://localhost:8080",
+							clientId: "idp-initiated-client",
+							clientSecret: "idp-initiated-secret",
+							pkce: true,
+							discoveryEndpoint:
+								"http://localhost:8080/.well-known/openid-configuration",
+							allowIdpInitiated: true,
+						},
+					},
+					{
+						domain: "strict-oidc.com",
+						providerId: "strict-oidc",
+						oidcConfig: {
+							issuer: "http://localhost:8080",
+							clientId: "strict-client",
+							clientSecret: "strict-secret",
+							pkce: true,
+							discoveryEndpoint:
+								"http://localhost:8080/.well-known/openid-configuration",
+						},
+					},
+				],
+			}),
+		],
+	});
+
+	beforeAll(async () => {
+		await server.issuer.keys.generate("RS256");
+		await server.start(8080, "localhost");
+	});
+
+	afterAll(async () => {
+		await server.stop().catch(() => {});
+	});
+
+	it("should bounce a stateless OIDC callback to the provider's authorize endpoint when allowIdpInitiated is true", async () => {
+		const res = await customFetchImpl(
+			"http://localhost:3000/api/auth/sso/callback/idp-initiated?code=idp-issued-code",
+			{ method: "GET", redirect: "manual" },
+		);
+
+		expect(res.status).toBe(302);
+		const location = res.headers.get("location") || "";
+		expect(location).toContain("http://localhost:8080/authorize");
+		const url = new URL(location);
+		expect(url.searchParams.get("state")).toBeTruthy();
+		expect(url.searchParams.get("client_id")).toBe("idp-initiated-client");
+		expect(url.searchParams.get("code")).toBeNull();
+	});
+
+	it("should redirect to the error page for providers without the flag", async () => {
+		const res = await customFetchImpl(
+			"http://localhost:3000/api/auth/sso/callback/strict-oidc?code=idp-issued-code",
+			{ method: "GET", redirect: "manual" },
+		);
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get("location")).toContain("please_restart_the_process");
+	});
+});

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1357,7 +1357,7 @@ export const signInSSO = (options?: SSOOptions) => {
 
 const callbackSSOQuerySchema = z.object({
 	code: z.string().optional(),
-	state: z.string(),
+	state: z.string().optional(),
 	error: z.string().optional(),
 	error_description: z.string().optional(),
 });
@@ -1394,43 +1394,7 @@ async function handleOIDCCallback(
 			}?error=${error}&error_description=${error_description}`,
 		);
 	}
-	let provider: SSOProvider<SSOOptions> | null = null;
-	if (options?.defaultSSO?.length) {
-		const matchingDefault = options.defaultSSO.find(
-			(defaultProvider) => defaultProvider.providerId === providerId,
-		);
-		if (matchingDefault) {
-			provider = {
-				...matchingDefault,
-				issuer: matchingDefault.oidcConfig?.issuer || "",
-				userId: "default",
-				...(options.domainVerification?.enabled
-					? { domainVerified: true }
-					: {}),
-			} as SSOProvider<SSOOptions>;
-		}
-	}
-	if (!provider) {
-		provider = await ctx.context.adapter
-			.findOne({
-				model: "ssoProvider",
-				where: [
-					{
-						field: "providerId",
-						value: providerId,
-					},
-				],
-			})
-			.then((res: { oidcConfig: string } | null) => {
-				if (!res) {
-					return null;
-				}
-				return {
-					...res,
-					oidcConfig: safeJsonParse<OIDCConfig>(res.oidcConfig) || undefined,
-				} as SSOProvider<SSOOptions>;
-			});
-	}
+	const provider = await resolveOIDCProvider(ctx, options, providerId);
 	if (!provider) {
 		throw ctx.redirect(
 			`${
@@ -1733,12 +1697,95 @@ const callbackSSOEndpointConfig = {
 	},
 };
 
+/**
+ * Resolves an SSO provider by `providerId`, first checking `options.defaultSSO`
+ * and falling back to the `ssoProvider` table. Returns `null` when no match is
+ * found so the caller can decide how to react (redirect, silently skip, etc.).
+ */
+async function resolveOIDCProvider(
+	ctx: any,
+	options: SSOOptions | undefined,
+	providerId: string,
+): Promise<SSOProvider<SSOOptions> | null> {
+	const matchingDefault = options?.defaultSSO?.find(
+		(defaultProvider) => defaultProvider.providerId === providerId,
+	);
+	if (matchingDefault) {
+		return {
+			...matchingDefault,
+			issuer: matchingDefault.oidcConfig?.issuer || "",
+			userId: "default",
+			...(options?.domainVerification?.enabled ? { domainVerified: true } : {}),
+		} as SSOProvider<SSOOptions>;
+	}
+	return ctx.context.adapter
+		.findOne({
+			model: "ssoProvider",
+			where: [{ field: "providerId", value: providerId }],
+		})
+		.then((res: { oidcConfig: string } | null) => {
+			if (!res) return null;
+			return {
+				...res,
+				oidcConfig: safeJsonParse<OIDCConfig>(res.oidcConfig) || undefined,
+			} as SSOProvider<SSOOptions>;
+		});
+}
+
+/**
+ * Restarts the OAuth flow server-side when a stateless callback arrives for
+ * an OIDC provider that opted into IDP-initiated flows. Silently returns
+ * otherwise, letting the normal handler produce its error redirect.
+ */
+async function bounceIfIdpInitiated(
+	ctx: any,
+	options: SSOOptions | undefined,
+	providerId: string,
+) {
+	const provider = await resolveOIDCProvider(ctx, options, providerId);
+	if (!provider?.oidcConfig?.allowIdpInitiated) return;
+
+	let config = provider.oidcConfig;
+	try {
+		config = await ensureRuntimeDiscovery(config, provider.issuer, (url) =>
+			ctx.context.isTrustedOrigin(url),
+		);
+	} catch {
+		return;
+	}
+	if (!config.authorizationEndpoint) return;
+
+	const state = await generateState(ctx, undefined, false);
+	const redirectURI = getOIDCRedirectURI(
+		ctx.context.baseURL,
+		provider.providerId,
+		options,
+	);
+	const authorizationURL = await createAuthorizationURL({
+		id: provider.issuer,
+		options: {
+			clientId: config.clientId,
+			clientSecret: config.clientSecret,
+		},
+		redirectURI,
+		state: state.state,
+		codeVerifier: config.pkce ? state.codeVerifier : undefined,
+		scopes: config.scopes || ["openid", "email", "profile", "offline_access"],
+		authorizationEndpoint: config.authorizationEndpoint,
+	});
+	throw ctx.redirect(authorizationURL.toString());
+}
+
 export const callbackSSO = (options?: SSOOptions) => {
 	return createAuthEndpoint(
 		"/sso/callback/:providerId",
 		callbackSSOEndpointConfig,
 		async (ctx) => {
-			return handleOIDCCallback(ctx, options, ctx.params.providerId);
+			const providerId = ctx.params.providerId;
+			if (!ctx.query.state) {
+				await bounceIfIdpInitiated(ctx, options, providerId);
+			}
+			return handleOIDCCallback(ctx, options, providerId);
 		},
 	);
 };

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -36,6 +36,15 @@ export interface OIDCConfig {
 		| undefined;
 	jwksEndpoint?: string | undefined;
 	mapping?: OIDCMapping | undefined;
+	/**
+	 * Accept callbacks from OIDC providers that initiate the OAuth flow
+	 * without sending a `state` parameter. When enabled, stateless callbacks
+	 * restart the OAuth flow server-side with a fresh `state` and PKCE
+	 * verifier. See the SSO docs for details.
+	 *
+	 * @default false
+	 */
+	allowIdpInitiated?: boolean | undefined;
 }
 
 export interface SAMLConfig {


### PR DESCRIPTION
Adds `allowIdpInitiated` to `GenericOAuthConfig` and the SSO `OIDCConfig`. When a stateless callback arrives at `/oauth2/callback/:providerId` or `/sso/callback/:providerId` and the resolved provider has `allowIdpInitiated: true`, the IDP-issued code is discarded and the OAuth flow is restarted server-side: a fresh `state` and PKCE verifier are generated, and the user is redirected to the provider's authorize endpoint. The provider's live IDP session completes the second hop automatically, so CSRF protection and PKCE stay in effect throughout.

The flag matches the existing `allowIdpInitiated` on the SAML SSO config for naming parity. Defaults to `false`.

Also guards `parseState` against `c.body` being undefined on GET callbacks, which previously crashed with a TypeError before the existing `please_restart_the_process` redirect could run.

This supersedes and implements the use case in PR #4951 without weakening CSRF or nullifying PKCE. The original approach there bypassed state validation entirely and introduced a silent PKCE downgrade; the bounce keeps both protections intact. Clever's own documentation recommends this pattern: "ignore the incoming Clever-initiated login and restart the authentication flow from your own site so you can include `state` yourself" (https://dev.clever.com/docs/oauth-implementation#initiating-logins).

Original work and motivation by @mhornbacher.

Closes #4951
Closes #9293

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for IdP‑initiated OAuth/OIDC via a secure “bounce” in `better-auth` and `@better-auth/sso`. Stateless callbacks are now supported without weakening CSRF or PKCE.

- **New Features**
  - Add `allowIdpInitiated` to `GenericOAuthConfig` and SSO `OIDCConfig` (default: false; matches SAML). On stateless callbacks to `/oauth2/callback/:providerId` or `/sso/callback/:providerId`, ignore the IdP code and restart server‑side with fresh `state` and PKCE, then redirect to the provider’s authorize endpoint (resolved via discovery when available).
  - Providers without the flag still redirect to the existing error. If `state` is present, normal validation runs (no bounce).
  - Updated docs and tests for bounce and strict paths.

- **Bug Fixes**
  - Guard `parseState` against undefined request bodies on GET callbacks to prevent a TypeError.

<sup>Written for commit dbbf039ccb647fab8c6be43341c2d50a5a08e20d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

