### PR TITLE
feat(generic-oauth,sso): support IDP-initiated flows via secure bounce

### DIFF
--- a/.changeset/oauth-idp-initiated-bounce.md
+++ b/.changeset/oauth-idp-initiated-bounce.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+"@better-auth/sso": patch
+---
+
+Add `allowIdpInitiated` to `GenericOAuthConfig` and SSO `OIDCConfig` to support providers that initiate OAuth without a `state` parameter (e.g. Clever). When enabled, stateless callbacks restart the OAuth flow server-side with fresh state and PKCE, preserving CSRF protection. Also hardens `parseState` against undefined request bodies on GET callbacks.

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -457,7 +457,7 @@ export const auth = betterAuth({
 });
 ```
 
-When a stateless callback hits `/callback/:providerId`, Better Auth discards the provider-issued code and restarts the flow server-side: a fresh `state` and PKCE verifier are generated, and the user is redirected to the provider's authorize endpoint. The provider recognises the user's live session and completes the flow automatically. CSRF protection and PKCE are preserved throughout.
+When a stateless callback hits `/callback/:providerId`, Better Auth discards the provider-issued code and restarts the flow server-side: a fresh `state` and PKCE verifier are generated, and the user is redirected to the provider's authorize endpoint. The provider recognizes the user's live session and completes the flow automatically. CSRF protection and PKCE are preserved throughout.
 
 Leave `allowIdpInitiated` off (the default) for any provider that always initiates the flow from your side — stateless callbacks to those providers indicate malformed or malicious requests and should be rejected.
 

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -430,6 +430,37 @@ getUserInfo: async (tokens) => {
 }
 ```
 
+### IDP-Initiated Flows
+
+Some OAuth providers (e.g., [Clever](https://dev.clever.com/docs/oauth-implementation#initiating-logins)) let the identity provider redirect users to your callback URL without first having the user click a "sign in" button in your app. These callbacks arrive with a `code` parameter but no `state`, which would normally be rejected because the missing `state` breaks the standard CSRF check.
+
+Set `allowIdpInitiated: true` on the provider to accept these flows safely:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { genericOAuth } from "better-auth/plugins";
+
+export const auth = betterAuth({
+    plugins: [
+        genericOAuth({
+            config: [
+                {
+                    providerId: "clever",
+                    discoveryUrl: "https://clever.com/.well-known/openid-configuration",
+                    clientId: process.env.CLEVER_CLIENT_ID,
+                    clientSecret: process.env.CLEVER_CLIENT_SECRET,
+                    allowIdpInitiated: true,
+                },
+            ],
+        }),
+    ],
+});
+```
+
+When a stateless callback hits `/callback/:providerId`, Better Auth discards the provider-issued code and restarts the flow server-side: a fresh `state` and PKCE verifier are generated, and the user is redirected to the provider's authorize endpoint. The provider recognises the user's live session and completes the flow automatically. CSRF protection and PKCE are preserved throughout.
+
+Leave `allowIdpInitiated` off (the default) for any provider that always initiates the flow from your side — stateless callbacks to those providers indicate malformed or malicious requests and should be rejected.
+
 ### Error Handling
 
 The plugin includes built-in error handling for common OAuth issues. Errors are typically redirected to your application's error page with an appropriate error message in the URL parameters. If the callback URL is not provided, the user will be redirected to Better Auth's default error page.

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -461,6 +461,10 @@ When a stateless callback hits `/callback/:providerId`, Better Auth discards the
 
 Leave `allowIdpInitiated` off (the default) for any provider that always initiates the flow from your side — stateless callbacks to those providers indicate malformed or malicious requests and should be rejected.
 
+<Callout type="warn">
+  Set the global `baseURL` option when enabling `allowIdpInitiated`. IDP-initiated callbacks carry no initiating request body, so the bounce uses `baseURL` as the post-login destination. If `baseURL` is unset, the bounce fails with `CALLBACK_URL_REQUIRED`.
+</Callout>
+
 ### Error Handling
 
 The plugin includes built-in error handling for common OAuth issues. Errors are typically redirected to your application's error page with an appropriate error message in the URL parameters. If the callback URL is not provided, the user will be redirected to Better Auth's default error page.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -447,6 +447,10 @@ To register a SAML provider, use the `registerSSOProvider` endpoint with SAML co
 
 For OIDC providers that initiate logins without sending a `state` parameter, set `allowIdpInitiated: true` on the provider's `oidcConfig`. When a stateless callback arrives at `/sso/callback/:providerId`, the IdP-issued code is discarded and a new OAuth flow is started server-side with a fresh `state` and PKCE verifier. CSRF protection remains in effect. This flag defaults to `false`.
 
+<Callout type="warn">
+  Set the global `baseURL` option when enabling `allowIdpInitiated` on an OIDC provider. IdP-initiated callbacks carry no initiating request body, so the bounce uses `baseURL` as the post-login destination. If `baseURL` is unset, the bounce fails with `CALLBACK_URL_REQUIRED`.
+</Callout>
+
 For IdP-initiated flows (e.g., via Okta dashboard), your framework may require an explicit route handler to manage the redirect if the default handler doesn't support the `GET` request following the SAML POST.
 
 <Tabs items={["next-js-app-router"]}>

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -445,6 +445,8 @@ To register a SAML provider, use the `registerSSOProvider` endpoint with SAML co
 
 ### IdP-Initiated SSO
 
+For OIDC providers that initiate logins without sending a `state` parameter, set `allowIdpInitiated: true` on the provider's `oidcConfig`. When a stateless callback arrives at `/sso/callback/:providerId`, the IdP-issued code is discarded and a new OAuth flow is started server-side with a fresh `state` and PKCE verifier. CSRF protection remains in effect. This flag defaults to `false`.
+
 For IdP-initiated flows (e.g., via Okta dashboard), your framework may require an explicit route handler to manage the redirect if the default handler doesn't support the `GET` request following the SAML POST.
 
 <Tabs items={["next-js-app-router"]}>

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -6,7 +6,7 @@ import { getAwaitableValue } from "../../context/helpers";
 import { setSessionCookie } from "../../cookies";
 import { OAUTH_CALLBACK_ERROR_CODES } from "../../oauth2/error-codes";
 import { handleOAuthUserInfo } from "../../oauth2/link-account";
-import { parseState } from "../../oauth2/state";
+import { generateState, parseState } from "../../oauth2/state";
 import { setTokenUtil } from "../../oauth2/utils";
 import { HIDE_METADATA } from "../../utils/hide-metadata";
 
@@ -82,6 +82,22 @@ export const callbackOAuth = createAuthEndpoint(
 		} = queryOrBody;
 
 		if (!state) {
+			const provider = await getAwaitableValue(c.context.socialProviders, {
+				value: c.params.id,
+			});
+			if (provider?.allowIdpInitiated && code) {
+				const { state: freshState, codeVerifier } = await generateState(
+					c,
+					undefined,
+					undefined,
+				);
+				const authUrl = await provider.createAuthorizationURL({
+					state: freshState,
+					codeVerifier,
+					redirectURI: `${c.context.baseURL}/callback/${provider.id}`,
+				});
+				throw c.redirect(authUrl.toString());
+			}
 			c.context.logger.error("State not found", error);
 			const sep = defaultErrorURL.includes("?") ? "&" : "?";
 			const url = `${defaultErrorURL}${sep}state=state_not_found`;

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -81,11 +81,11 @@ export const callbackOAuth = createAuthEndpoint(
 			iss,
 		} = queryOrBody;
 
-		if (!state) {
+		if (state === undefined && code) {
 			const provider = await getAwaitableValue(c.context.socialProviders, {
 				value: c.params.id,
 			});
-			if (provider?.allowIdpInitiated && code) {
+			if (provider?.allowIdpInitiated) {
 				const { state: freshState, codeVerifier } = await generateState(
 					c,
 					undefined,
@@ -98,6 +98,9 @@ export const callbackOAuth = createAuthEndpoint(
 				});
 				throw c.redirect(authUrl.toString());
 			}
+		}
+
+		if (!state) {
 			c.context.logger.error("State not found", error);
 			const sep = defaultErrorURL.includes("?") ? "&" : "?";
 			const url = `${defaultErrorURL}${sep}state=state_not_found`;

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2087,4 +2087,93 @@ describe("oauth2", async () => {
 		expect(provider).toBeDefined();
 		expect(provider?.name).toBe("My Custom Provider");
 	});
+
+	describe("IDP-initiated bounce (allowIdpInitiated)", () => {
+		it("should bounce a stateless callback to the provider's authorize endpoint when the provider opts in", async () => {
+			const { customFetchImpl } = await getTestInstance({
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "idp-initiated",
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId,
+								clientSecret,
+								allowIdpInitiated: true,
+							},
+						],
+					}),
+				],
+			});
+
+			const res = await customFetchImpl(
+				"http://localhost:3000/api/auth/callback/idp-initiated?code=idp-issued-code",
+				{ method: "GET", redirect: "manual" },
+			);
+
+			expect(res.status).toBe(302);
+			const location = res.headers.get("location") || "";
+			expect(location).toContain(`http://localhost:${port}/authorize`);
+			const url = new URL(location);
+			expect(url.searchParams.get("state")).toBeTruthy();
+			expect(url.searchParams.get("client_id")).toBe(clientId);
+			expect(url.searchParams.get("redirect_uri")).toBe(
+				"http://localhost:3000/api/auth/callback/idp-initiated",
+			);
+			expect(url.searchParams.get("code")).toBeNull();
+		});
+
+		it("should redirect to the error page when a stateless callback arrives for a provider without the flag", async () => {
+			const { customFetchImpl } = await getTestInstance({
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "strict",
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId,
+								clientSecret,
+							},
+						],
+					}),
+				],
+			});
+
+			const res = await customFetchImpl(
+				"http://localhost:3000/api/auth/callback/strict?code=idp-issued-code",
+				{ method: "GET", redirect: "manual" },
+			);
+
+			expect(res.status).toBe(302);
+			expect(res.headers.get("location")).toContain("state=state_not_found");
+		});
+
+		it("should not bounce when state is present even if allowIdpInitiated is on", async () => {
+			const { customFetchImpl } = await getTestInstance({
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "idp-initiated-with-state",
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId,
+								clientSecret,
+								allowIdpInitiated: true,
+							},
+						],
+					}),
+				],
+			});
+
+			const res = await customFetchImpl(
+				"http://localhost:3000/api/auth/callback/idp-initiated-with-state?code=abc&state=unknown-state",
+				{ method: "GET", redirect: "manual" },
+			);
+
+			expect(res.status).toBe(302);
+			const location = res.headers.get("location") || "";
+			expect(location).not.toContain(`http://localhost:${port}/authorize`);
+			expect(location).toContain("please_restart_the_process");
+		});
+	});
 });

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2148,6 +2148,34 @@ describe("oauth2", async () => {
 			expect(res.headers.get("location")).toContain("state=state_not_found");
 		});
 
+		it("should not bounce on an empty `state=` parameter, only on truly stateless callbacks", async () => {
+			const { customFetchImpl } = await getTestInstance({
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "idp-initiated-empty-state",
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId,
+								clientSecret,
+								allowIdpInitiated: true,
+							},
+						],
+					}),
+				],
+			});
+
+			const res = await customFetchImpl(
+				"http://localhost:3000/api/auth/callback/idp-initiated-empty-state?code=idp-issued-code&state=",
+				{ method: "GET", redirect: "manual" },
+			);
+
+			expect(res.status).toBe(302);
+			const location = res.headers.get("location") || "";
+			expect(location).not.toContain(`http://localhost:${port}/authorize`);
+			expect(location).toContain("state=state_not_found");
+		});
+
 		it("should not bounce when state is present even if allowIdpInitiated is on", async () => {
 			const { customFetchImpl } = await getTestInstance({
 				plugins: [

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -230,6 +230,7 @@ export const genericOAuth = <const ID extends string>(
 					id: c.providerId,
 					name: c.name ?? c.providerId,
 					issuer,
+					allowIdpInitiated: c.allowIdpInitiated,
 					createAuthorizationURL(data) {
 						if (!authorizationUrl) {
 							throw APIError.from(

--- a/packages/better-auth/src/plugins/generic-oauth/types.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/types.ts
@@ -174,4 +174,13 @@ export interface GenericOAuthConfig<ID extends string = string> {
 	 * @default false
 	 */
 	overrideUserInfo?: boolean | undefined;
+	/**
+	 * Accept callbacks from providers that initiate the OAuth flow without
+	 * sending a `state` parameter (e.g. Clever). When enabled, stateless
+	 * callbacks restart the OAuth flow server-side with a fresh `state` and
+	 * PKCE verifier. See the generic-oauth docs for details.
+	 *
+	 * @default false
+	 */
+	allowIdpInitiated?: boolean | undefined;
 }

--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -95,6 +95,17 @@ export interface OAuthProvider<
 	 */
 	disableSignUp?: boolean | undefined;
 	/**
+	 * Accept callbacks that arrive without a `state` parameter. When true,
+	 * the shared OAuth callback handler restarts the flow server-side with
+	 * fresh `state` and PKCE instead of rejecting the request. Intended for
+	 * providers that initiate OAuth without RP-side flow kickoff (e.g.
+	 * Clever). Leave unset for any provider that always initiates from the
+	 * RP.
+	 *
+	 * @default false
+	 */
+	allowIdpInitiated?: boolean | undefined;
+	/**
 	 * Options for the provider
 	 */
 	options?: O | undefined;

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1724,3 +1724,74 @@ describe("SSO OIDC UserInfo endpoint sub claim mapping", async () => {
 		expect(session.data?.user.email).toBe("userinfo-only@test.com");
 	});
 });
+
+describe("SSO OIDC IDP-initiated bounce", async () => {
+	const { customFetchImpl } = await getTestInstance({
+		trustedOrigins: ["http://localhost:8080"],
+		plugins: [
+			sso({
+				defaultSSO: [
+					{
+						domain: "idp-initiated.com",
+						providerId: "idp-initiated",
+						oidcConfig: {
+							issuer: "http://localhost:8080",
+							clientId: "idp-initiated-client",
+							clientSecret: "idp-initiated-secret",
+							pkce: true,
+							discoveryEndpoint:
+								"http://localhost:8080/.well-known/openid-configuration",
+							allowIdpInitiated: true,
+						},
+					},
+					{
+						domain: "strict-oidc.com",
+						providerId: "strict-oidc",
+						oidcConfig: {
+							issuer: "http://localhost:8080",
+							clientId: "strict-client",
+							clientSecret: "strict-secret",
+							pkce: true,
+							discoveryEndpoint:
+								"http://localhost:8080/.well-known/openid-configuration",
+						},
+					},
+				],
+			}),
+		],
+	});
+
+	beforeAll(async () => {
+		await server.issuer.keys.generate("RS256");
+		await server.start(8080, "localhost");
+	});
+
+	afterAll(async () => {
+		await server.stop().catch(() => {});
+	});
+
+	it("should bounce a stateless OIDC callback to the provider's authorize endpoint when allowIdpInitiated is true", async () => {
+		const res = await customFetchImpl(
+			"http://localhost:3000/api/auth/sso/callback/idp-initiated?code=idp-issued-code",
+			{ method: "GET", redirect: "manual" },
+		);
+
+		expect(res.status).toBe(302);
+		const location = res.headers.get("location") || "";
+		expect(location).toContain("http://localhost:8080/authorize");
+		const url = new URL(location);
+		expect(url.searchParams.get("state")).toBeTruthy();
+		expect(url.searchParams.get("client_id")).toBe("idp-initiated-client");
+		expect(url.searchParams.get("code")).toBeNull();
+	});
+
+	it("should redirect to the error page for providers without the flag", async () => {
+		const res = await customFetchImpl(
+			"http://localhost:3000/api/auth/sso/callback/strict-oidc?code=idp-issued-code",
+			{ method: "GET", redirect: "manual" },
+		);
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get("location")).toContain("please_restart_the_process");
+	});
+});

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1797,6 +1797,46 @@ describe("SSO OIDC IDP-initiated bounce", async () => {
 		expect(location).toContain("please_restart_the_process");
 	});
 
+	it("should carry ssoProviderId in the bounced state when options.redirectURI is configured", async () => {
+		const { customFetchImpl: sharedRedirectFetch } = await getTestInstance({
+			trustedOrigins: ["http://localhost:8080"],
+			plugins: [
+				sso({
+					redirectURI: "/sso/callback",
+					defaultSSO: [
+						{
+							domain: "idp-initiated-shared.com",
+							providerId: "idp-initiated-shared",
+							oidcConfig: {
+								issuer: "http://localhost:8080",
+								clientId: "idp-initiated-shared-client",
+								clientSecret: "idp-initiated-shared-secret",
+								pkce: true,
+								discoveryEndpoint:
+									"http://localhost:8080/.well-known/openid-configuration",
+								allowIdpInitiated: true,
+							},
+						},
+					],
+				}),
+			],
+		});
+
+		const res = await sharedRedirectFetch(
+			"http://localhost:3000/api/auth/sso/callback/idp-initiated-shared?code=idp-issued-code",
+			{ method: "GET", redirect: "manual" },
+		);
+
+		expect(res.status).toBe(302);
+		const location = res.headers.get("location") || "";
+		expect(location).toContain("http://localhost:8080/authorize");
+		const url = new URL(location);
+		expect(url.searchParams.get("redirect_uri")).toBe(
+			"http://localhost:3000/api/auth/sso/callback",
+		);
+		expect(url.searchParams.get("state")).toBeTruthy();
+	});
+
 	it("should redirect to the error page for providers without the flag", async () => {
 		const res = await customFetchImpl(
 			"http://localhost:3000/api/auth/sso/callback/strict-oidc?code=idp-issued-code",

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1785,6 +1785,18 @@ describe("SSO OIDC IDP-initiated bounce", async () => {
 		expect(url.searchParams.get("code")).toBeNull();
 	});
 
+	it("should not bounce on an empty `state=` parameter, only on truly stateless callbacks", async () => {
+		const res = await customFetchImpl(
+			"http://localhost:3000/api/auth/sso/callback/idp-initiated?code=idp-issued-code&state=",
+			{ method: "GET", redirect: "manual" },
+		);
+
+		expect(res.status).toBe(302);
+		const location = res.headers.get("location") || "";
+		expect(location).not.toContain("http://localhost:8080/authorize");
+		expect(location).toContain("please_restart_the_process");
+	});
+
 	it("should redirect to the error page for providers without the flag", async () => {
 		const res = await customFetchImpl(
 			"http://localhost:3000/api/auth/sso/callback/strict-oidc?code=idp-issued-code",

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1785,6 +1785,17 @@ describe("SSO OIDC IDP-initiated bounce", async () => {
 		expect(url.searchParams.get("code")).toBeNull();
 	});
 
+	it("should not bounce when the `code` parameter is empty", async () => {
+		const res = await customFetchImpl(
+			"http://localhost:3000/api/auth/sso/callback/idp-initiated?code=",
+			{ method: "GET", redirect: "manual" },
+		);
+
+		expect(res.status).toBe(302);
+		const location = res.headers.get("location") || "";
+		expect(location).not.toContain("http://localhost:8080/authorize");
+	});
+
 	it("should not bounce on an empty `state=` parameter, only on truly stateless callbacks", async () => {
 		const res = await customFetchImpl(
 			"http://localhost:3000/api/auth/sso/callback/idp-initiated?code=idp-issued-code&state=",

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1793,7 +1793,7 @@ export const callbackSSO = (options?: SSOOptions) => {
 		callbackSSOEndpointConfig,
 		async (ctx) => {
 			const providerId = ctx.params.providerId;
-			if (ctx.query.state === undefined && ctx.query.code !== undefined) {
+			if (ctx.query.state === undefined && ctx.query.code) {
 				await bounceIfIdpInitiated(ctx, options, providerId);
 			}
 			return handleOIDCCallback(ctx, options, providerId);

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1305,7 +1305,7 @@ export const signInSSO = (options?: SSOOptions) => {
 
 const callbackSSOQuerySchema = z.object({
 	code: z.string().optional(),
-	state: z.string(),
+	state: z.string().optional(),
 	error: z.string().optional(),
 	error_description: z.string().optional(),
 });
@@ -1342,43 +1342,7 @@ async function handleOIDCCallback(
 			}?error=${error}&error_description=${error_description}`,
 		);
 	}
-	let provider: SSOProvider<SSOOptions> | null = null;
-	if (options?.defaultSSO?.length) {
-		const matchingDefault = options.defaultSSO.find(
-			(defaultProvider) => defaultProvider.providerId === providerId,
-		);
-		if (matchingDefault) {
-			provider = {
-				...matchingDefault,
-				issuer: matchingDefault.oidcConfig?.issuer || "",
-				userId: "default",
-				...(options.domainVerification?.enabled
-					? { domainVerified: true }
-					: {}),
-			} as SSOProvider<SSOOptions>;
-		}
-	}
-	if (!provider) {
-		provider = await ctx.context.adapter
-			.findOne({
-				model: "ssoProvider",
-				where: [
-					{
-						field: "providerId",
-						value: providerId,
-					},
-				],
-			})
-			.then((res: { oidcConfig: string } | null) => {
-				if (!res) {
-					return null;
-				}
-				return {
-					...res,
-					oidcConfig: safeJsonParse<OIDCConfig>(res.oidcConfig) || undefined,
-				} as SSOProvider<SSOOptions>;
-			});
-	}
+	const provider = await resolveOIDCProvider(ctx, options, providerId);
 	if (!provider) {
 		throw ctx.redirect(
 			`${
@@ -1738,12 +1702,95 @@ const callbackSSOEndpointConfig = {
 	},
 };
 
+/**
+ * Resolves an SSO provider by `providerId`, first checking `options.defaultSSO`
+ * and falling back to the `ssoProvider` table. Returns `null` when no match is
+ * found so the caller can decide how to react (redirect, silently skip, etc.).
+ */
+async function resolveOIDCProvider(
+	ctx: any,
+	options: SSOOptions | undefined,
+	providerId: string,
+): Promise<SSOProvider<SSOOptions> | null> {
+	const matchingDefault = options?.defaultSSO?.find(
+		(defaultProvider) => defaultProvider.providerId === providerId,
+	);
+	if (matchingDefault) {
+		return {
+			...matchingDefault,
+			issuer: matchingDefault.oidcConfig?.issuer || "",
+			userId: "default",
+			...(options?.domainVerification?.enabled ? { domainVerified: true } : {}),
+		} as SSOProvider<SSOOptions>;
+	}
+	return ctx.context.adapter
+		.findOne({
+			model: "ssoProvider",
+			where: [{ field: "providerId", value: providerId }],
+		})
+		.then((res: { oidcConfig: string } | null) => {
+			if (!res) return null;
+			return {
+				...res,
+				oidcConfig: safeJsonParse<OIDCConfig>(res.oidcConfig) || undefined,
+			} as SSOProvider<SSOOptions>;
+		});
+}
+
+/**
+ * Restarts the OAuth flow server-side when a stateless callback arrives for
+ * an OIDC provider that opted into IDP-initiated flows. Silently returns
+ * otherwise, letting the normal handler produce its error redirect.
+ */
+async function bounceIfIdpInitiated(
+	ctx: any,
+	options: SSOOptions | undefined,
+	providerId: string,
+) {
+	const provider = await resolveOIDCProvider(ctx, options, providerId);
+	if (!provider?.oidcConfig?.allowIdpInitiated) return;
+
+	let config = provider.oidcConfig;
+	try {
+		config = await ensureRuntimeDiscovery(config, provider.issuer, (url) =>
+			ctx.context.isTrustedOrigin(url),
+		);
+	} catch {
+		return;
+	}
+	if (!config.authorizationEndpoint) return;
+
+	const state = await generateState(ctx, undefined, false);
+	const redirectURI = getOIDCRedirectURI(
+		ctx.context.baseURL,
+		provider.providerId,
+		options,
+	);
+	const authorizationURL = await createAuthorizationURL({
+		id: provider.issuer,
+		options: {
+			clientId: config.clientId,
+			clientSecret: config.clientSecret,
+		},
+		redirectURI,
+		state: state.state,
+		codeVerifier: config.pkce ? state.codeVerifier : undefined,
+		scopes: config.scopes || ["openid", "email", "profile", "offline_access"],
+		authorizationEndpoint: config.authorizationEndpoint,
+	});
+	throw ctx.redirect(authorizationURL.toString());
+}
+
 export const callbackSSO = (options?: SSOOptions) => {
 	return createAuthEndpoint(
 		"/sso/callback/:providerId",
 		callbackSSOEndpointConfig,
 		async (ctx) => {
-			return handleOIDCCallback(ctx, options, ctx.params.providerId);
+			const providerId = ctx.params.providerId;
+			if (!ctx.query.state) {
+				await bounceIfIdpInitiated(ctx, options, providerId);
+			}
+			return handleOIDCCallback(ctx, options, providerId);
 		},
 	);
 };

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1755,10 +1755,20 @@ async function bounceIfIdpInitiated(
 		config = await ensureRuntimeDiscovery(config, provider.issuer, (url) =>
 			ctx.context.isTrustedOrigin(url),
 		);
-	} catch {
+	} catch (error) {
+		ctx.context.logger.error(
+			"IDP-initiated bounce skipped: OIDC discovery failed",
+			{ providerId: provider.providerId, issuer: provider.issuer, error },
+		);
 		return;
 	}
-	if (!config.authorizationEndpoint) return;
+	if (!config.authorizationEndpoint) {
+		ctx.context.logger.error(
+			"IDP-initiated bounce skipped: authorizationEndpoint missing after discovery",
+			{ providerId: provider.providerId, issuer: provider.issuer },
+		);
+		return;
+	}
 
 	const state = await generateState(
 		ctx,

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1760,7 +1760,13 @@ async function bounceIfIdpInitiated(
 	}
 	if (!config.authorizationEndpoint) return;
 
-	const state = await generateState(ctx, undefined, false);
+	const state = await generateState(
+		ctx,
+		undefined,
+		options?.redirectURI?.trim()
+			? { ssoProviderId: provider.providerId }
+			: false,
+	);
 	const redirectURI = getOIDCRedirectURI(
 		ctx.context.baseURL,
 		provider.providerId,

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1787,7 +1787,7 @@ export const callbackSSO = (options?: SSOOptions) => {
 		callbackSSOEndpointConfig,
 		async (ctx) => {
 			const providerId = ctx.params.providerId;
-			if (!ctx.query.state) {
+			if (ctx.query.state === undefined && ctx.query.code !== undefined) {
 				await bounceIfIdpInitiated(ctx, options, providerId);
 			}
 			return handleOIDCCallback(ctx, options, providerId);

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -41,6 +41,15 @@ export interface OIDCConfig {
 	privateKeyAlgorithm?: string | undefined;
 	jwksEndpoint?: string | undefined;
 	mapping?: OIDCMapping | undefined;
+	/**
+	 * Accept callbacks from OIDC providers that initiate the OAuth flow
+	 * without sending a `state` parameter. When enabled, stateless callbacks
+	 * restart the OAuth flow server-side with a fresh `state` and PKCE
+	 * verifier. See the SSO docs for details.
+	 *
+	 * @default false
+	 */
+	allowIdpInitiated?: boolean | undefined;
 }
 
 export interface SAMLConfig {


### PR DESCRIPTION
Adds `allowIdpInitiated` to the core `OAuthProvider` interface, to `GenericOAuthConfig`, and to the SSO `OIDCConfig`. When a stateless callback arrives at `/callback/:id` (shared OAuth callback) or `/sso/callback/:providerId` (SSO OIDC callback) and the resolved provider has `allowIdpInitiated: true`, the IDP-issued code is discarded and the OAuth flow is restarted server-side: a fresh `state` and PKCE verifier are generated, and the user is redirected to the provider's authorize endpoint. The provider's live IDP session completes the second hop automatically, so CSRF protection and PKCE stay in effect throughout.

The flag matches the existing `allowIdpInitiated` on the SAML SSO config for naming parity. Defaults to `false`.

In SSO, extracts a shared `resolveOIDCProvider` helper used by both the new `bounceIfIdpInitiated` preflight and the existing `handleOIDCCallback`, removing the duplicated `defaultSSO`-then-adapter lookup.

Also guards `parseState` against `c.body` being undefined on GET callbacks (mirrors #9293 on main, carried here since the sync hasn't run yet).

This is the `next`-targeted version of #9299 (main-targeted). #9299 will be closed as superseded. Clever's own guidance recommends this bounce pattern: "ignore the incoming Clever-initiated login and restart the authentication flow from your own site" (https://dev.clever.com/docs/oauth-implementation#initiating-logins).

Original work and motivation by @mhornbacher.

Closes #4951

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in support for IdP-initiated OAuth/OIDC via a secure server-side bounce. Stateless callbacks now restart the flow with fresh state and PKCE when `allowIdpInitiated` is enabled, preserving CSRF.

- **New Features**
  - Added `allowIdpInitiated` to `OAuthProvider`, `GenericOAuthConfig`, and SSO `OIDCConfig` (default: false).
  - For callbacks to `/callback/:id` or `/sso/callback/:providerId` with a `code` and no `state`, discard the code and restart the flow with new `state` and PKCE, redirecting to the provider’s authorize endpoint.
  - Documented that the bounce uses global `baseURL` for the post-login destination; if `baseURL` is unset, the flow fails with `CALLBACK_URL_REQUIRED`.

- **Bug Fixes**
  - Bounce only triggers for truly stateless callbacks (`state === undefined`) with a non-empty `code`; empty `state`/`code` keep existing error redirects.
  - For SSO with `options.redirectURI`, the bounced state carries `ssoProviderId` to avoid `missing_provider_id` on the shared `/sso/callback`.
  - Extracted a shared OIDC provider resolver for SSO, used by both the bounce preflight and the callback handler, removing duplicated lookup logic.
  - Added error logs when SSO bounce is skipped due to discovery failures or a missing `authorizationEndpoint`; also guarded `parseState` against undefined request bodies on GET callbacks.

<sup>Written for commit 0f42575318af40194008b4d7b71369dbee0e365c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

