### PR TITLE
test: remove dead stripe option from fixture

### DIFF
--- a/e2e/smoke/test/fixtures/tsconfig-declaration/src/demo.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/src/demo.ts
@@ -48,7 +48,6 @@ export const auth = betterAuth({
 			stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
 			subscription: {
 				enabled: true,
-				allowReTrialsForDifferentPlans: true,
 				plans: () => {
 					const PRO_PRICE_ID = {
 						default:


### PR DESCRIPTION
`allowReTrialsForDifferentPlans` is not a valid option.