### PR TITLE
fix: skip stateless defaults when secondaryStorage is configured

### DIFF
--- a/.changeset/shaggy-actors-walk.md
+++ b/.changeset/shaggy-actors-walk.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fixes a spurious refreshCache warning emitted when secondaryStorage is configured with cookieCache: { enabled: false }.

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -353,6 +353,37 @@ describe("base context creation", () => {
 			);
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/9297
+		 */
+		it("should not warn about refreshCache when secondaryStorage is configured with cookieCache disabled", async () => {
+			const log = vi.fn();
+			const res = await initBase({
+				logger: {
+					level: "warn",
+					log,
+				} as any,
+				secondaryStorage: {
+					get: vi.fn(),
+					set: vi.fn(),
+					delete: vi.fn(),
+				},
+				session: {
+					cookieCache: {
+						enabled: false,
+					},
+				},
+			});
+
+			expect(res.sessionConfig.cookieRefreshCache).toBe(false);
+			expect(log).not.toHaveBeenCalledWith(
+				"warn",
+				expect.stringContaining(
+					"`session.cookieCache.refreshCache` is enabled while `database` or `secondaryStorage` is configured",
+				),
+			);
+		});
+
 		it("should disable cookieRefreshCache and warn when secondaryStorage is configured with refreshCache=true", async () => {
 			const log = vi.fn();
 			const res = await initBase({

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -95,7 +95,7 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 	getDatabaseType: (database: Options["database"]) => string,
 ): Promise<AuthContext<Options>> {
 	//set default options for stateless mode
-	if (!options.database) {
+	if (!options.database && !options.secondaryStorage) {
 		options = defu(options, {
 			session: {
 				cookieCache: {


### PR DESCRIPTION
Fixes a spurious refreshCache warning emitted when secondaryStorage is configured with cookieCache: { enabled: false }.