### PR TITLE
chore(oauth-provider): correct optional typing for refreshToken sessionId field

### DIFF
--- a/.changeset/yellow-shirts-heal.md
+++ b/.changeset/yellow-shirts-heal.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Make `sessionId` optional in refresh token types to match the refresh token schema.

--- a/.changeset/yellow-shirts-heal.md
+++ b/.changeset/yellow-shirts-heal.md
@@ -2,4 +2,4 @@
 "@better-auth/oauth-provider": patch
 ---
 
-Make `sessionId` optional in refresh token types to match the refresh token schema.
+Make `sessionId` optional and nullable in refresh token types to match the refresh token schema.

--- a/.changeset/yellow-shirts-heal.md
+++ b/.changeset/yellow-shirts-heal.md
@@ -2,4 +2,4 @@
 "@better-auth/oauth-provider": patch
 ---
 
-Make `sessionId` optional and nullable in refresh token types to match the refresh token schema.
+Make `sessionId` optional in refresh token types to match the refresh token schema.

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -288,14 +288,14 @@ async function validateRefreshToken(
 		};
 	}
 
-	let sessionId: string | undefined = refreshToken.sessionId ?? undefined;
+	let sessionId = refreshToken.sessionId ?? undefined;
 	if (sessionId) {
 		const session = await ctx.context.adapter.findOne<Session>({
 			model: "session",
 			where: [
 				{
 					field: "id",
-					value: refreshToken.sessionId,
+					value: sessionId,
 				},
 			],
 		});

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -301,7 +301,9 @@ async function createRefreshToken(
 	}
 
 	// Issue new refresh token
-	const refreshToken = await ctx.context.adapter.create({
+	const refreshToken = await ctx.context.adapter.create<
+		OAuthRefreshToken<Scope[]> & { id: string }
+	>({
 		model: "oauthRefreshToken",
 		data: {
 			token: await storeToken(opts.storeTokens, token, "refresh_token"),

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1042,7 +1042,7 @@ async function handleRefreshTokenGrant(
 		user,
 		grantType: "refresh_token",
 		referenceId: refreshToken.referenceId,
-		sessionId: refreshToken.sessionId ?? undefined,
+		sessionId: refreshToken.sessionId,
 		refreshToken,
 		authTime,
 	});

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1042,7 +1042,7 @@ async function handleRefreshTokenGrant(
 		user,
 		grantType: "refresh_token",
 		referenceId: refreshToken.referenceId,
-		sessionId: refreshToken.sessionId,
+		sessionId: refreshToken.sessionId ?? undefined,
 		refreshToken,
 		authTime,
 	});

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1035,7 +1035,7 @@ export interface OAuthRefreshToken<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
 > {
 	token: string;
-	sessionId: string;
+	sessionId?: string;
 	userId: string;
 	referenceId?: string;
 	clientId?: string;

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1035,7 +1035,7 @@ export interface OAuthRefreshToken<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
 > {
 	token: string;
-	sessionId?: string;
+	sessionId?: string | null;
 	userId: string;
 	referenceId?: string;
 	clientId?: string;

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1035,7 +1035,7 @@ export interface OAuthRefreshToken<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
 > {
 	token: string;
-	sessionId?: string | null;
+	sessionId?: string;
 	userId: string;
 	referenceId?: string;
 	clientId?: string;


### PR DESCRIPTION
Improve internal type safety. Make `sessionId` type optional in refresh token types to match the refresh token schema.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `sessionId` optional in OAuth refresh token types to match the schema and avoid type errors when tokens have no session in `@better-auth/oauth-provider`.

- **Bug Fixes**
  - Type `OAuthRefreshToken.sessionId` as optional `string`; map `null` to `undefined` in introspection.
  - Narrow `adapter.create` to `OAuthRefreshToken<Scope[]> & { id: string }` when issuing refresh tokens.

<sup>Written for commit 857b7e1e5362da2a956980aa1010d7416f741308. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



