### PR TITLE
fix: apply `disableBody: true` on common no-body POST endpoints

### DIFF
--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -783,6 +783,7 @@ export const revokeSessions = createAuthEndpoint(
 	"/revoke-sessions",
 	{
 		method: "POST",
+		disableBody: true,
 		use: [sensitiveSessionMiddleware],
 		requireHeaders: true,
 		metadata: {
@@ -838,6 +839,7 @@ export const revokeOtherSessions = createAuthEndpoint(
 	"/revoke-other-sessions",
 	{
 		method: "POST",
+		disableBody: true,
 		requireHeaders: true,
 		use: [sensitiveSessionMiddleware],
 		metadata: {

--- a/packages/better-auth/src/api/routes/sign-out.ts
+++ b/packages/better-auth/src/api/routes/sign-out.ts
@@ -5,6 +5,7 @@ export const signOut = createAuthEndpoint(
 	"/sign-out",
 	{
 		method: "POST",
+		disableBody: true,
 		operationId: "signOut",
 		requireHeaders: true,
 		metadata: {

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -65,6 +65,7 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 				"/sign-in/anonymous",
 				{
 					method: "POST",
+					disableBody: true,
 					metadata: {
 						openapi: {
 							description: "Sign in anonymously",
@@ -145,6 +146,7 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 				"/delete-anonymous-user",
 				{
 					method: "POST",
+					disableBody: true,
 					use: [sensitiveSessionMiddleware],
 					metadata: {
 						openapi: {


### PR DESCRIPTION
## Summary

Closes #9295.

The 5 no-body POST endpoints currently return **HTTP 500** when a client sends `Content-Type: application/json` with an empty or malformed JSON body — the framework attempts `JSON.parse` before the handler runs, and the parse exception propagates unchecked.

Applying `disableBody: true` (already supported by better-call per `EndpointBaseOptions`) tells the framework to skip body parsing on endpoints whose contract accepts no payload. After this change, a request with `Content-Type: application/json` + empty/malformed body returns **HTTP 200** (the contractual no-op).

## Affected endpoints

- `/sign-out` — `packages/better-auth/src/api/routes/sign-out.ts`
- `/revoke-sessions` — `packages/better-auth/src/api/routes/session.ts`
- `/revoke-other-sessions` — `packages/better-auth/src/api/routes/session.ts`
- `/sign-in/anonymous` — `packages/better-auth/src/plugins/anonymous/index.ts`
- `/delete-anonymous-user` — `packages/better-auth/src/plugins/anonymous/index.ts`

## Why these five

Each is documented as taking no request body (their handlers never read `ctx.body` / their OpenAPI `requestBody` is absent). Picked from the set surfaced in #9295 + a grep across `packages/better-auth/src/` for POST endpoints with no body schema + no `ctx.body` access.

## Reproduction (pre-fix)

```bash
curl -X POST https://YOUR-HOST/api/auth/sign-out \
  -H 'Content-Type: application/json' \
  -H 'Origin: https://YOUR-HOST' \
  --data ''
# → HTTP 500
```

## After this change

```bash
# same request → HTTP 200 {"success":true}
```

Other shapes unchanged:
- no body + no `Content-Type` → same as today (framework no-ops)
- valid `{}` body → same as today (returned 200 already)

## Notes

- No test additions — happy to follow up with ones if maintainers prefer. The `disableBody` option path is exercised by other endpoints in the codebase already.
- Happy to split the anonymous-plugin changes out if you'd prefer a narrower PR scope.

Original bug report: #9295


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable body parsing for five POST endpoints that accept no payload to prevent 500s on empty/malformed JSON requests. Fixes #9295; these requests now return 200 (no-op).

- **Bug Fixes**
  - Set `disableBody: true` on:
    - POST /sign-out
    - POST /revoke-sessions
    - POST /revoke-other-sessions
    - POST /sign-in/anonymous
    - POST /delete-anonymous-user

<sup>Written for commit a8b4c38e5724987061951aa3c366c6391e0d1f64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

