### PR TITLE
fix(oauth-provider): accept authorization flows without state

### DIFF
--- a/.changeset/oauth-provider-optional-state.md
+++ b/.changeset/oauth-provider-optional-state.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+fix(oauth-provider): accept authorization-code flows without `state`
+
+Align authorization-code verification with the authorize endpoint and OAuth/OIDC semantics by treating `state` as optional for the authorization server. The provider still echoes `state` when present, and Better Auth client helpers continue to generate and validate it.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -466,9 +466,11 @@ Important notes:
 
 **State**
 
-We require sending a state to mitigate cross-site request forgery (CSRF) attacks. This works by ensuring your client only responds to requests that your client initially requested.
+Clients should send a state value to mitigate cross-site request forgery (CSRF) attacks. This works by ensuring your client only responds to requests that your client initially requested.
 
 Generate a state value from your client and store on your client such as in a secure, HTTP-only cookie or database.
+
+The authorization server accepts requests without `state` for compatibility with OAuth and OpenID Connect, and echoes `state` back when it is provided. Better Auth's client helpers generate and validate `state` for you.
 
 **Code Challenge**
 

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -190,6 +190,35 @@ describe("oauth token - authorization_code", async () => {
 		expect(idToken.payload.email).toBeUndefined();
 	});
 
+	it("should exchange a PKCE authorization code when state is omitted", async () => {
+		const scopes = ["openid"];
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+		});
+		authUrl.searchParams.delete("state");
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain("code=");
+		expect(callbackRedirectUrl).not.toContain("state=");
+		const url = new URL(callbackRedirectUrl);
+
+		const tokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+		});
+
+		expect(tokens.error).toBeNull();
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.id_token).toBeDefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+	});
+
 	it("scope openid+profile should provide access_token and id_token", async ({
 		expect,
 	}) => {
@@ -2478,6 +2507,23 @@ describe("verificationValueSchema", () => {
 				redirect_uri: "https://example.com/callback",
 				scope: "openid",
 				state: "abc123",
+			},
+			userId: "user-1",
+			sessionId: "session-1",
+		};
+
+		const result = verificationValueSchema.safeParse(value);
+		expect(result.success).toBe(true);
+	});
+
+	it("should validate a verification value without state", () => {
+		const value: VerificationValue = {
+			type: "authorization_code",
+			query: {
+				response_type: "code",
+				client_id: "test-client",
+				redirect_uri: "https://example.com/callback",
+				scope: "openid",
 			},
 			userId: "user-1",
 			sessionId: "session-1",

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -752,10 +752,12 @@ export interface OAuthAuthorizationQuery {
 	 * Cross-Site Request Forgery (CSRF, XSRF) mitigation is done by cryptographically binding the
 	 * value of this parameter with a browser cookie.
 	 *
+	 * Recommended for clients, but optional for the authorization server.
+	 *
 	 * Note: Better Auth stores the state in a database instead of a cookie. - This is to minimize
 	 * the complication with native apps and other clients that may not have access to cookies.
 	 */
-	state: string;
+	state?: string;
 	/**
 	 * The client ID. Must be the ID of a registered client.
 	 */

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -13,7 +13,7 @@ const oauthAuthorizationQuerySchema = z
 		request_uri: z.string().optional(),
 		redirect_uri: z.string(),
 		scope: z.string().optional(),
-		state: z.string(),
+		state: z.string().optional(),
 		client_id: z.string(),
 		prompt: z.string().optional(),
 		display: z.string().optional(),


### PR DESCRIPTION
## Summary

Fixes #9320. Refs #9318.

This aligns the OAuth provider authorization-code verification path with the authorize endpoint contract and OAuth/OIDC semantics: `state` remains recommended for clients, but optional for the authorization server. The provider still echoes `state` when present, and Better Auth client/RP helpers keep generating and validating `state`.

## Root Cause

PR #9118 hardened stored authorization-code verification values with Zod validation. That validation accidentally required `query.state`, so flows that omitted `state` could receive an authorization code but fail at `/oauth2/token` with `invalid_verification` / `malformed verification value`.

## Changes

- Make provider-side `OAuthAuthorizationQuery.state` optional in TypeScript and runtime validation.
- Add regression coverage for a PKCE authorization-code flow with omitted `state`.
- Add schema coverage for stored verification values without `state`.
- Update oauth-provider docs to distinguish client guidance from authorization-server compatibility.
- Add a patch changeset.
