### PR TITLE
fix(security): remove ReDoS-prone regex from x-forwarded-host validation

### DIFF
--- a/.changeset/fix-redos-proxy-host-validation.md
+++ b/.changeset/fix-redos-proxy-host-validation.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+fix(security): remove ReDoS-prone regex from `x-forwarded-host` validation
+
+`validateProxyHeader` previously used a hostname regex with nested quantifiers (`([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?` repeated under an outer group). On JS engines without v8's regex hardening, a crafted `x-forwarded-host` value could trigger catastrophic backtracking and exhaust CPU. Replaced the hostname/IPv6 regex paths with a linear split-and-validate-per-label parser; behavior is unchanged for valid input. Reported by PatchPilots in #8898.

--- a/packages/better-auth/src/utils/url.test.ts
+++ b/packages/better-auth/src/utils/url.test.ts
@@ -268,6 +268,31 @@ describe("getBaseURL", () => {
 
 			expect(result).toBe("https://api.v1.staging.example.com/auth");
 		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/8898
+		 */
+		it("should reject malicious x-forwarded-host without catastrophic backtracking", () => {
+			// Crafted payload: many labels each ending in a hyphen, with an
+			// invalid trailing character. Against the previous nested-quantifier
+			// regex this triggered exponential backtracking on engines without
+			// the v8 hardening (e.g. JavaScriptCore in Bun).
+			const label = `a${"-".repeat(60)}`;
+			const malicious = `${Array(160).fill(label).join(".")}!`;
+			const request = new Request("http://localhost:3000/test", {
+				headers: {
+					"x-forwarded-host": malicious,
+					"x-forwarded-proto": "https",
+				},
+			});
+
+			const t0 = Date.now();
+			const result = getBaseURL(undefined, "/auth", request, false, true);
+			const elapsed = Date.now() - t0;
+
+			expect(result).toBe("http://localhost:3000/auth");
+			expect(elapsed).toBeLessThan(50);
+		});
 	});
 });
 

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -78,6 +78,41 @@ function withPath(url: string, path = "/api/auth") {
 	return `${trimmedUrl}${path}`;
 }
 
+/**
+ * Validates an RFC 1123 DNS label. Linear-time per character — no regex
+ * backtracking. Used by the host-header validator below.
+ */
+function isValidDnsLabel(label: string): boolean {
+	const len = label.length;
+	if (len === 0 || len > 63) return false;
+	for (let i = 0; i < len; i++) {
+		const c = label.charCodeAt(i);
+		const isDigit = c >= 48 && c <= 57;
+		const isUpper = c >= 65 && c <= 90;
+		const isLower = c >= 97 && c <= 122;
+		const isHyphen = c === 45;
+		if (!(isDigit || isUpper || isLower || isHyphen)) return false;
+		// Hyphen not allowed at start or end of a label.
+		if (isHyphen && (i === 0 || i === len - 1)) return false;
+	}
+	return true;
+}
+
+/**
+ * Validates a port substring (already split off the host). Empty string is
+ * treated as "no port" by the caller — this only sees a non-empty value.
+ */
+function isValidPort(port: string): boolean {
+	if (port.length === 0 || port.length > 5) return false;
+	let n = 0;
+	for (let i = 0; i < port.length; i++) {
+		const c = port.charCodeAt(i);
+		if (c < 48 || c > 57) return false;
+		n = n * 10 + (c - 48);
+	}
+	return n >= 1 && n <= 65535;
+}
+
 function validateProxyHeader(header: string, type: "host" | "proto"): boolean {
 	if (!header || header.trim() === "") {
 		return false;
@@ -104,26 +139,55 @@ function validateProxyHeader(header: string, type: "host" | "proto"): boolean {
 			return false;
 		}
 
-		// Basic hostname validation (allows localhost, IPs, and domains with ports)
-		// This is a simple check, not exhaustive RFC validation
-		const hostnameRegex =
-			/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(:[0-9]{1,5})?$/;
+		// Split off optional port. IPv6 literals are wrapped in `[...]`, so the
+		// port (if any) is the last `:`-segment after the closing bracket.
+		let host = header;
+		let port: string | undefined;
+		if (header.startsWith("[")) {
+			const close = header.indexOf("]");
+			if (close === -1) return false;
+			host = header.slice(0, close + 1);
+			const tail = header.slice(close + 1);
+			if (tail.length > 0) {
+				if (tail[0] !== ":") return false;
+				port = tail.slice(1);
+			}
+		} else {
+			const colon = header.lastIndexOf(":");
+			// Multiple colons in an unbracketed host means it's neither a valid
+			// hostname nor IPv4 — reject. Bracketed IPv6 already handled above.
+			if (colon !== -1 && header.indexOf(":") !== colon) return false;
+			if (colon !== -1) {
+				host = header.slice(0, colon);
+				port = header.slice(colon + 1);
+			}
+		}
 
-		// Also allow IPv4 addresses
-		const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}(:[0-9]{1,5})?$/;
+		if (port !== undefined && !isValidPort(port)) return false;
+		if (host.length === 0) return false;
 
-		// Also allow IPv6 addresses in brackets
-		const ipv6Regex = /^\[[0-9a-fA-F:]+\](:[0-9]{1,5})?$/;
+		// IPv6 literal in brackets: validate hex/colon contents. No nested
+		// quantifiers — this is a flat character class.
+		if (host.startsWith("[") && host.endsWith("]")) {
+			const inner = host.slice(1, -1);
+			if (inner.length === 0) return false;
+			for (let i = 0; i < inner.length; i++) {
+				const c = inner.charCodeAt(i);
+				const isHex =
+					(c >= 48 && c <= 57) || (c >= 65 && c <= 70) || (c >= 97 && c <= 102);
+				if (!isHex && c !== 58) return false; // 58 is ':'
+			}
+			return true;
+		}
 
-		// Allow localhost variations
-		const localhostRegex = /^localhost(:[0-9]{1,5})?$/i;
-
-		return (
-			hostnameRegex.test(header) ||
-			ipv4Regex.test(header) ||
-			ipv6Regex.test(header) ||
-			localhostRegex.test(header)
-		);
+		// Hostname (or dotted IPv4): validate each dot-separated label.
+		// Splitting first then per-label scanning is O(n) overall, with no
+		// nested quantifiers and therefore no ReDoS exposure.
+		const labels = host.split(".");
+		for (const label of labels) {
+			if (!isValidDnsLabel(label)) return false;
+		}
+		return true;
 	}
 
 	return false;


### PR DESCRIPTION
## Summary

Closes #8898.

The `hostnameRegex` in `validateProxyHeader` (`packages/better-auth/src/utils/url.ts`) used nested quantifiers — `([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?` repeated under an outer `(...)*` — which can trigger catastrophic backtracking on crafted `x-forwarded-host` values. On engines without v8's regex hardening (e.g. JavaScriptCore in Bun), this enables a CPU-exhaustion DoS.

This PR replaces the regex paths with a linear split-and-validate parser:
- Peel off the optional port; reject ports outside `1..=65535` or longer than 5 digits.
- Bracketed IPv6 literals are validated against a flat hex/colon character class (no quantifier nesting).
- Hostnames (and dotted IPv4) are split on `.` and each label is validated per-character against RFC 1123 (`isValidDnsLabel` — A–Z, a–z, 0–9, hyphen not at start/end, length 1–63).

The suspicious-pattern blocklist (path traversal, null bytes, `<>'"`, `javascript:`, `file:`, `data:`) is preserved unchanged.

Behavior is unchanged for valid input — every existing test in `packages/better-auth/src/utils/url.test.ts` still passes.

## Test plan

- [x] `pnpm vitest run packages/better-auth/src/utils/url.test.ts` — 55/55 pass (54 existing + 1 new regression test)
- [x] `pnpm typecheck` — clean
- [x] New regression test asserts a crafted ~10 KB malicious `x-forwarded-host` (160 labels of `a` + 60 hyphens) is rejected and falls back to the request URL in <50 ms — see `should reject malicious x-forwarded-host without catastrophic backtracking` (with `@see #8898`).
- [x] Changeset added (`patch` for `better-auth`).

Reported by [PatchPilots](https://github.com/alavesa/patchpilots) security audit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a ReDoS-prone regex from `x-forwarded-host` validation in `better-auth`, replacing it with a linear-time parser to prevent CPU DoS on crafted headers. Behavior for valid hosts is unchanged; adds a fast-fail regression test. Fixes #8898.

- **Bug Fixes**
  - Replaced hostname/IPv6 regex with a split-and-validate parser: peel optional port (1–65535), validate bracketed IPv6 via hex/colon scan, and check dot-separated labels per RFC 1123 (1–63 chars, alnum, hyphen not at ends). Reject unbracketed hosts with multiple colons.
  - Kept the suspicious-pattern blocklist and URL fallback logic.
  - Added a regression test for a ~10 KB malicious `x-forwarded-host`; asserts fallback and <50 ms processing. All existing tests pass; patch changeset added.

<sup>Written for commit 28ab7ccaf5cb2605dc855bfeb72d5ca9e3a7b920. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

