### PR TITLE
docs(test): cross-reference #8897 on cookie-strategy OAuth state CSRF test

### DIFF
--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1042,7 +1042,6 @@ describe("oauth2", async () => {
 
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/8897
-	 * @see https://github.com/better-auth/better-auth/pull/8949
 	 */
 	it("should reject cookie-backed OAuth when callback state does not match the issued state", async () => {
 		const { customFetchImpl, cookieSetter } = await getTestInstance({

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1040,6 +1040,10 @@ describe("oauth2", async () => {
 		expect(session.data?.user.name).toBe("OAuth2 Cookie State");
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8897
+	 * @see https://github.com/better-auth/better-auth/pull/8949
+	 */
 	it("should reject cookie-backed OAuth when callback state does not match the issued state", async () => {
 		const { customFetchImpl, cookieSetter } = await getTestInstance({
 			plugins: [


### PR DESCRIPTION
## Summary

Closes #8897.

The OAuth cookie-strategy state-verification gap reported in #8897 was already fixed in #8949 (`9deb7936a`, merged 2026-04-09), and there's an existing regression test in `packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts` (`should reject cookie-backed OAuth when callback state does not match the issued state`) that exercises the patched path.

This PR is purely a docs touch: it adds `@see` links to the advisory (#8897) and the fix PR (#8949) above that test so future greps for the issue number land at the coverage. No behavior change, no new test, no changeset needed.

## Test plan

- [x] `pnpm vitest run packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts -t "should reject cookie-backed OAuth when callback state does not match"` — passes (1/1), logged error confirms `state_security_mismatch` is thrown from the cookie branch of `parseGenericState`.

Original advisory reported by [PatchPilots](https://github.com/alavesa/patchpilots).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an @see link to advisory #8897 above the regression test in `packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts` that rejects cookie-backed OAuth when the callback state doesn't match. Traceability only; no behavior or test changes.

<sup>Written for commit 8cbc1320b8afc874fa6f2d78e0ace1066a520350. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

