### PR TITLE
fix(types): use const generic on betterAuth to preserve plugin tuple inference

### DIFF
--- a/.changeset/const-generic-preserve-plugin-tuple.md
+++ b/.changeset/const-generic-preserve-plugin-tuple.md
@@ -1,0 +1,9 @@
+---
+"better-auth": patch
+---
+
+fix(types): use `const` type parameter on `betterAuth` to preserve plugin tuple inference
+
+`betterAuth<Options>(options)` previously inferred `Options["plugins"]` as `BetterAuthPlugin[]` (and `any[]` whenever an untyped plugin was in the list), which collapsed per-element type information before the tuple-walk utilities introduced in #8981 could run. Each typed plugin's `$Infer` and `$ERROR_CODES` contributions were therefore silently dropped whenever an `any`-typed plugin was present alongside typed ones.
+
+Adding the `const` modifier to the generic on `betterAuth` (full and minimal entry points) and on `getTestInstance` preserves the literal tuple shape at the call site, so `InferPluginFieldFromTuple` walks each element through the existing `IsAny` guard — `any` elements contribute `{}`, typed elements preserve their contributions. No public API signatures change.

--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -6,6 +6,7 @@ import {
 import type { router } from "better-auth/api";
 import { describe, expect, expectTypeOf, test } from "vitest";
 import { createAuthClient } from "../client";
+import { organization } from "../plugins/organization";
 import { getTestInstance } from "../test-utils";
 import type { Auth } from "../types";
 import { betterAuth } from "./full";
@@ -37,6 +38,28 @@ describe("auth type", () => {
 			code: string;
 			message: string;
 		}>();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8986
+	 */
+	test("preserves typed plugin contributions when an untyped plugin is present", () => {
+		const auth = betterAuth({
+			plugins: [organization(), {} as any],
+		});
+
+		// Without the `const` modifier on Options, TS collapses `plugins` to
+		// `any[]`, the tuple walk (InferPluginFieldFromTuple) never fires, and
+		// the org plugin's `$ERROR_CODES` / `$Infer` contributions are lost.
+		// Accessing `$ERROR_CODES.ORGANIZATION_NOT_FOUND` or `$Infer.Organization`
+		// would be a compile error. With `const`, the literal tuple is preserved,
+		// the walk fires, and the contributions survive alongside the `any`.
+		expectTypeOf<
+			(typeof auth.$ERROR_CODES)["ORGANIZATION_NOT_FOUND"]["code"]
+		>().toEqualTypeOf<"ORGANIZATION_NOT_FOUND">();
+		expectTypeOf<
+			(typeof auth.$Infer)["Organization"]["id"]
+		>().toEqualTypeOf<string>();
 	});
 
 	test("plugin endpoints", () => {

--- a/packages/better-auth/src/auth/full.ts
+++ b/packages/better-auth/src/auth/full.ts
@@ -24,7 +24,7 @@ import { createBetterAuth } from "./base";
  *	  database: drizzleAdapter(db, { provider: "pg" }),
  * });
  */
-export const betterAuth = <Options extends BetterAuthOptions>(
+export const betterAuth = <const Options extends BetterAuthOptions>(
 	options: Options & {},
 ): Auth<Options> => {
 	return createBetterAuth(options, init);

--- a/packages/better-auth/src/auth/minimal.ts
+++ b/packages/better-auth/src/auth/minimal.ts
@@ -8,7 +8,7 @@ export type { BetterAuthOptions };
 /**
  * Better Auth initializer for minimal mode (without Kysely)
  */
-export const betterAuth = <Options extends BetterAuthOptions>(
+export const betterAuth = <const Options extends BetterAuthOptions>(
 	options: Options & {},
 ): Auth<Options> => {
 	return createBetterAuth(options, initMinimal);

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -31,7 +31,7 @@ afterAll(async () => {
 });
 
 export async function getTestInstance<
-	O extends Partial<BetterAuthOptions>,
+	const O extends Partial<BetterAuthOptions>,
 	C extends BetterAuthClientOptions,
 >(
 	options?: O | undefined,


### PR DESCRIPTION
## Summary

Closes #8986.

Adds the `const` modifier to the `Options` generic on `betterAuth` (full + minimal) and on `getTestInstance`, so TypeScript preserves the literal tuple shape of `options.plugins` at the call site. The tuple-walk utilities introduced in #8981 (`InferPluginFieldFromTuple`, `ExtractPluginField` with `IsAny` guard) then get a tuple to walk — each typed plugin contributes its `\$Infer` / `\$ERROR_CODES`, while `any`-typed elements fall through to `{}` via the existing `IsAny` check.

### Minimal change, empirically verified

I probed this carefully before committing (details in #8986 discussion):

- **`const` alone was sufficient** on `full.ts`. No change to `BetterAuthOptions.plugins` was required — TypeScript's mutable-vs-readonly constraint gotcha (which can force widening back) didn't bite here because the tuple elements are typed plugin objects that satisfy the `BetterAuthPlugin` constraint individually.
- **No widening of `InferDBFieldsFromPlugins[Input]` bounds** was needed either.
- `createBetterAuth` is internal (no external import path) and re-infers from the already-narrow `Options` passed in from `betterAuth`, so it doesn't need `const`.

Result: public API signatures are unchanged, and the workspace typecheck passes with no adjustments elsewhere.

### Regression test

`packages/better-auth/src/auth/full.test.ts` now asserts that the org plugin's contributions survive when an `any`-typed plugin is next to it:

```ts
const auth = betterAuth({
  plugins: [organization(), {} as any],
});

expectTypeOf<
  (typeof auth.\$ERROR_CODES)[\"ORGANIZATION_NOT_FOUND\"][\"code\"]
>().toEqualTypeOf<\"ORGANIZATION_NOT_FOUND\">();
expectTypeOf<
  (typeof auth.\$Infer)[\"Organization\"][\"id\"]
>().toEqualTypeOf<string>();
```

Without `const`, both assertions fail at compile time (the keys don't exist on the collapsed-to-`any[]` inference).

## Test plan

- [x] `pnpm typecheck` — clean across the entire workspace.
- [x] `pnpm vitest run src/auth/full.test.ts` (in `packages/better-auth`) — 16/16 pass, including the new regression test.
- [x] Verified the probe catches the regression by temporarily reverting `const`: compile fails, as expected.

## Note for reviewers

The `const` modifier narrows the whole `Options` type, not just `plugins` (e.g. string config values become literal types). This is intentional and harmless for downstream type consumers in this codebase — the full-workspace typecheck confirms nothing broke — but I called it out in the issue thread in case maintainers want to be aware.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves plugin tuple inference by using a const generic on `betterAuth`, so typed plugin contributions aren’t dropped when an `any` plugin is present. Fixes `$Infer` and `$ERROR_CODES` aggregation without changing the public API.

- **Bug Fixes**
  - Added `const` to `Options` in `betterAuth` (full and minimal) and `getTestInstance` to keep `options.plugins` as a literal tuple.
  - Tuple-walk utilities now combine each plugin’s `$Infer` and `$ERROR_CODES`; `any` elements fall back to `{}`.
  - Added a regression test to ensure `organization()` contributions persist alongside an `any` plugin.

<sup>Written for commit c7ab3c8a5dd1bee3365bb60b5d515ba301e45889. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

