### PR TITLE
fix(api-key): coerce referenceId to string before strict comparison in list route

### DIFF
--- a/.changeset/fix-api-key-list-string-coerce-referenceid.md
+++ b/.changeset/fix-api-key-list-string-coerce-referenceid.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/api-key": patch
+---
+
+Fix `apiKey.list` silently returning empty when the storage adapter returns `referenceId` as a non-string type (e.g. Postgres integer columns, MongoDB ObjectId). The list route's post-filter used strict `===` to compare `key.referenceId` against the stringified `session.user.id`, which dropped every row when the adapter returned a type other than `string`. Values are now coerced with `String()` on both sides before comparison.

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -4641,3 +4641,77 @@ describe("api-key", async () => {
 		});
 	});
 });
+
+// Regression for https://github.com/better-auth/better-auth/issues/9336
+//
+// listApiKeys post-filters the adapter results with strict `===`:
+//
+//   key.referenceId === referenceId
+//
+// `referenceId` on the right is derived from `session.user.id`, which the core
+// adapter factory always stringifies on output. `key.referenceId` on the left
+// is whatever the adapter returned — the api-key schema declares it as a plain
+// `string` field with no `references` entry, so the factory's output transform
+// never coerces it. Adapters that store/return `referenceId` as a non-string
+// (e.g. Postgres integer columns, MongoDB ObjectId) therefore made the strict
+// equality silently fail for every row.
+describe("api-key (regression #9336) — list tolerates non-string referenceId", async () => {
+	// Secondary-storage mode exercises the list endpoint's post-filter
+	// directly: keys are returned from the KV as-is, without any pre-filter
+	// strict-equality gating. This mirrors how real SQL/BSON adapters behave —
+	// their findMany tolerates int-vs-string via implicit coercion, so the
+	// mismatched types only bite at the JS-level post-filter inside the route.
+	const store = new Map<string, string>();
+	const secondaryStorage: SecondaryStorage = {
+		set(key, value) {
+			store.set(key, value as string);
+		},
+		get(key) {
+			return store.get(key) || null;
+		},
+		delete(key) {
+			store.delete(key);
+		},
+	};
+
+	const { auth, signInWithTestUser } = await getTestInstance(
+		{
+			secondaryStorage,
+			plugins: [apiKey({ storage: "secondary-storage" })],
+			advanced: {
+				// SERIAL ids — user.id is numeric in the DB. The core factory
+				// still stringifies it on output, so session.user.id is the
+				// string "1" at the plugin boundary. This mirrors the original
+				// report's Postgres setup.
+				database: { generateId: "serial" },
+			},
+		},
+		{
+			clientOptions: { plugins: [apiKeyClient()] },
+		},
+	);
+	const { headers, user } = await signInWithTestUser();
+
+	it("returns API keys whose stored referenceId is a Number (e.g. Postgres integer column)", async () => {
+		const created = await auth.api.createApiKey({ body: {}, headers });
+
+		// Rewrite the stored key so referenceId is a JS Number that String()-
+		// equals session.user.id. The list route's post-filter runs
+		// `key.referenceId === referenceId` and `referenceId` is always a
+		// string because the core factory stringifies id outputs. Without the
+		// fix, `1 === "1"` is false and the row is silently dropped.
+		const storageKey = `api-key:by-id:${created.id}`;
+		const raw = store.get(storageKey);
+		expect(raw).toBeDefined();
+		const stored = JSON.parse(raw!);
+		const numericReferenceId = Number(user.id);
+		expect(Number.isFinite(numericReferenceId)).toBe(true);
+		stored.referenceId = numericReferenceId;
+		store.set(storageKey, JSON.stringify(stored));
+
+		const result = await auth.api.listApiKeys({ headers });
+
+		expect(result.total).toBeGreaterThan(0);
+		expect(result.apiKeys.find((k) => k.id === created.id)).toBeDefined();
+	});
+});

--- a/packages/api-key/src/routes/list-api-keys.ts
+++ b/packages/api-key/src/routes/list-api-keys.ts
@@ -342,9 +342,16 @@ export function listApiKeys({
 					return c.configId === key.configId;
 				});
 				const referencesType = keyConfig?.references ?? "user";
+				// Coerce both sides to string before comparison. `referenceId` is derived
+				// from `session.user.id`, which the core adapter factory always stringifies
+				// on output. `key.referenceId` is not stringified by the factory because the
+				// api-key schema declares it as a plain `string` field with no `references`
+				// entry, so adapters that store it as a non-string type (e.g. Postgres
+				// integer columns, MongoDB ObjectId) would otherwise cause strict `===` to
+				// silently drop every matching row. See #9336.
 				return (
 					referencesType === expectedReferencesType &&
-					key.referenceId === referenceId
+					String(key.referenceId) === String(referenceId)
 				);
 			});
 


### PR DESCRIPTION
## Summary

Fix `apiKey.list` silently returning `{ apiKeys: [], total: 0 }` when the storage adapter returns `referenceId` as a non-string type.

`packages/api-key/src/routes/list-api-keys.ts` post-filters the adapter results with strict `===`:

```ts
key.referenceId === referenceId
```

- `referenceId` (right) is `session.user.id`, which the core adapter factory always stringifies on output (`originalKey === "id" || field.references?.field === "id"` → `String(newValue)`).
- `key.referenceId` (left) is whatever the adapter returned. The api-key schema declares `referenceId: { type: "string" }` with **no `references` entry**, so the factory's output transform never coerces it. Adapters that store/return `referenceId` as a non-string (Postgres integer columns, MongoDB ObjectId, etc.) make the strict `===` evaluate false and the row is silently filtered out.

Values are now coerced with `String()` on both sides before comparison. Purely additive — same-type comparisons remain equivalent, and no storage representation changes.

## Why not fix the schema instead?

Adding `references: { model: "user", field: "id" }` to the api-key schema would let the core factory stringify `referenceId` on output symmetrically, but that would break the plugin's dual user/organization reference design (confirmed in the triage on #9336) — `referenceId` can point at either a user or an organization, not strictly `user.id`. String coercion at the comparison site is the safe, targeted fix.

## Changes

- `packages/api-key/src/routes/list-api-keys.ts`: `String(key.referenceId) === String(referenceId)` at the post-filter, with a comment pointing to this issue.
- `packages/api-key/src/api-key.test.ts`: regression test that uses the secondary-storage path (which exercises the post-filter directly, since KV keys aren't pre-filtered by any adapter `findMany`). The test stores a key with a `Number` `referenceId` whose `String()` matches `session.user.id` and asserts `listApiKeys` still returns it. Confirmed to fail without the fix and pass with it.
- `.changeset/…`: patch bump for `@better-auth/api-key`.

## Test plan

- [x] `pnpm vitest run` in `packages/api-key` — **177/177 pass**
- [x] `pnpm typecheck` in `packages/api-key` — clean
- [x] `pnpm biome check packages/api-key/src/routes/list-api-keys.ts packages/api-key/src/api-key.test.ts` — clean
- [x] Regression test fails on unpatched `main`, passes with fix

Closes #9336


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `apiKey.list` returning empty results when adapters store `referenceId` as non-strings (e.g., Postgres ints, MongoDB ObjectIds). The post-filter now compares stringified IDs so keys are returned consistently.

- **Bug Fixes**
  - Added a regression test covering numeric `referenceId` via secondary storage.
  - Patch bump for `@better-auth/api-key`.

<sup>Written for commit 85f9f5f8da1f97e085ad45d158ef97b2760bbb67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

