### PR TITLE
fix(core): resolve instrumentation via package self-reference in adapter factory

### DIFF
--- a/.changeset/factory-instrumentation-self-reference.md
+++ b/.changeset/factory-instrumentation-self-reference.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+fix(core): self-reference `./instrumentation` in the adapter factory so the `exports` map routes edge/browser to the pure variant

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -1,10 +1,10 @@
-import { createLogger, getColorDepth, TTY_COLORS } from "../../env";
-import { BetterAuthError } from "../../error";
 import {
 	ATTR_DB_COLLECTION_NAME,
 	ATTR_DB_OPERATION_NAME,
 	withSpan,
-} from "../../instrumentation";
+} from "@better-auth/core/instrumentation";
+import { createLogger, getColorDepth, TTY_COLORS } from "../../env";
+import { BetterAuthError } from "../../error";
 import type { BetterAuthOptions } from "../../types";
 import { safeJSONParse } from "../../utils/json";
 import { getAuthTables } from "../get-tables";


### PR DESCRIPTION
The adapter factory imports `./instrumentation` via the relative path, so `exports` can't route browser/edge to `pure.index.mjs`. Swap to the package self-reference like the rest of `packages/core`.

Verified against Convex, where the current relative import 500s every `/api/auth/*` request on the dynamic `@opentelemetry/api` load.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the adapter factory to import instrumentation via the package self-reference `@better-auth/core/instrumentation` instead of a relative path. This lets the `exports` map route edge/browser to the pure build and prevents runtime failures.

- **Bug Fixes**
  - Avoids dynamic `@opentelemetry/api` loading in edge/browser, preventing 500s (e.g., Convex `/api/auth/*`).
  - No change for Node; same API and behavior.

<sup>Written for commit 6475ed514051a706b748135cd98c82674330a911. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

