### PR TITLE
fix(oauth-provider): honor `prompt=login` across consent continuation

### DIFF
--- a/.changeset/fix-oauth-provider-consent-postlogin-retrigger.md
+++ b/.changeset/fix-oauth-provider-consent-postlogin-retrigger.md
@@ -2,13 +2,15 @@
 "@better-auth/oauth-provider": patch
 ---
 
-fix(oauth-provider): gate consent-accept postLogin skip on signed query marker
+fix(oauth-provider): bind consent-accept postLogin skip to the signing session
 
 When `authorize` emits a signed redirect past the postLogin gate it now
-records a `ba_pl=1` marker in the signed authorization query. On consent
+records `ba_pl=<sessionId>` in the signed authorization query. On consent
 accept, `authorizeEndpoint` is called with `{ postLogin: true }` only when
-the incoming signed query carries that marker; otherwise it re-enters
-`authorize` with `postLogin.shouldRedirect` still enforced. Resolves the
-post-consent bounce back to the postLogin page for `setActive`-driven
-flows, and prevents a direct POST to `/oauth2/consent` with a pre-postLogin
-signed query from skipping `shouldRedirect` to issue an authorization code.
+the incoming signed query's marker matches the current session's id;
+otherwise it re-enters `authorize` with `postLogin.shouldRedirect` still
+enforced. Resolves the post-consent bounce back to the postLogin page for
+`setActive`-driven flows, blocks a direct POST to `/oauth2/consent` with
+a pre-postLogin signed query from skipping `shouldRedirect`, and prevents
+a different or newly logged-in session from re-using another session's
+marker to skip `shouldRedirect`.

--- a/.changeset/fix-oauth-provider-consent-postlogin-retrigger.md
+++ b/.changeset/fix-oauth-provider-consent-postlogin-retrigger.md
@@ -2,12 +2,13 @@
 "@better-auth/oauth-provider": patch
 ---
 
-fix(oauth-provider): skip postLogin re-check when consent is accepted
+fix(oauth-provider): gate consent-accept postLogin skip on signed query marker
 
-Consent accept now passes `{ postLogin: true }` to the authorize endpoint so
-the post-consent pass does not re-evaluate `postLogin.shouldRedirect`. Prior
-behavior could bounce the user back to the postLogin page after accepting
-consent whenever `shouldRedirect` returned true at that point (for example,
-when session state that `setActive` wrote is not visible to the consent
-request, or when the integration's `shouldRedirect` logic depends on a flag
-that is not session-persistent).
+When `authorize` emits a signed redirect past the postLogin gate it now
+records a `ba_pl=1` marker in the signed authorization query. On consent
+accept, `authorizeEndpoint` is called with `{ postLogin: true }` only when
+the incoming signed query carries that marker; otherwise it re-enters
+`authorize` with `postLogin.shouldRedirect` still enforced. Resolves the
+post-consent bounce back to the postLogin page for `setActive`-driven
+flows, and prevents a direct POST to `/oauth2/consent` with a pre-postLogin
+signed query from skipping `shouldRedirect` to issue an authorization code.

--- a/.changeset/fix-oauth-provider-consent-postlogin-retrigger.md
+++ b/.changeset/fix-oauth-provider-consent-postlogin-retrigger.md
@@ -1,0 +1,13 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+fix(oauth-provider): skip postLogin re-check when consent is accepted
+
+Consent accept now passes `{ postLogin: true }` to the authorize endpoint so
+the post-consent pass does not re-evaluate `postLogin.shouldRedirect`. Prior
+behavior could bounce the user back to the postLogin page after accepting
+consent whenever `shouldRedirect` returned true at that point (for example,
+when session state that `setActive` wrote is not visible to the consent
+request, or when the integration's `shouldRedirect` logic depends on a flag
+that is not session-persistent).

--- a/.changeset/fix-oauth-provider-login-consent-prompt.md
+++ b/.changeset/fix-oauth-provider-login-consent-prompt.md
@@ -1,0 +1,10 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+fix(oauth-provider): complete stale `prompt=login consent` continuations after forced login
+
+Consent continuations now carry the signed authorization request issue time and
+only clear a lingering `login` prompt when the active session was created for
+that request. This preserves forced reauthentication semantics while avoiding
+the loop where a completed reauthentication is sent back to `/login`.

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -8,6 +8,7 @@ import { validateIssuerUrl } from "./authorize";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import type { OAuthClient } from "./types/oauth";
+import { postLoginClearedParam } from "./utils";
 
 describe("validateIssuerUrl (RFC 9207)", () => {
 	it("should allow HTTPS URLs unchanged", () => {
@@ -187,6 +188,7 @@ describe("oauth authorize - request_uri resolution", async () => {
 	const providerId = "test";
 	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
 	const requestUri = "urn:better-auth:par:test";
+	const requestUriWithPostLoginMarker = "urn:better-auth:par:post-login";
 
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: authServerBaseUrl,
@@ -195,11 +197,7 @@ describe("oauth authorize - request_uri resolution", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				requestUriResolver: async ({ requestUri: receivedRequestUri }) => {
-					if (receivedRequestUri !== requestUri) {
-						return null;
-					}
-
-					return {
+					const resolvedParams = {
 						response_type: "code",
 						redirect_uri: redirectUri,
 						scope: "openid",
@@ -207,6 +205,19 @@ describe("oauth authorize - request_uri resolution", async () => {
 						code_challenge: "a".repeat(43),
 						code_challenge_method: "S256",
 					};
+
+					if (receivedRequestUri === requestUri) {
+						return resolvedParams;
+					}
+
+					if (receivedRequestUri === requestUriWithPostLoginMarker) {
+						return {
+							...resolvedParams,
+							[postLoginClearedParam]: "attacker-session",
+						};
+					}
+
+					return null;
 				},
 				silenceWarnings: {
 					oauthAuthServerConfig: true,
@@ -263,6 +274,27 @@ describe("oauth authorize - request_uri resolution", async () => {
 		);
 		expect(loginRedirectUrl).toContain("state=par-state");
 		expect(loginRedirectUrl).not.toContain("request_uri=");
+	});
+
+	it("should drop reserved post-login markers from resolved PAR parameters", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("request_uri", requestUriWithPostLoginMarker);
+
+		let loginRedirectUrl = "";
+		await unauthenticatedClient.$fetch(authUrl.toString(), {
+			onError(context) {
+				loginRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		const loginRedirect = new URL(loginRedirectUrl, authServerBaseUrl);
+		expect(loginRedirect.pathname).toBe("/login");
+		expect(loginRedirect.searchParams.get(postLoginClearedParam)).toBeNull();
 	});
 
 	/**

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -640,6 +640,8 @@ async function signParams(
 	);
 	params.set("exp", String(exp));
 	params.set(signedQueryIssuedAtParam, String(issuedAt));
+	// Reserved marker: only server-issued consent redirects may sign this.
+	params.delete(postLoginClearedParam);
 	if (flags?.postLoginClearedForSession) {
 		params.set(postLoginClearedParam, flags.postLoginClearedForSession);
 	}

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -19,6 +19,7 @@ import {
 	getJwtPlugin,
 	isPKCERequired,
 	parsePrompt,
+	postLoginClearedParam,
 	signedQueryIssuedAtParam,
 	storeToken,
 } from "./utils";
@@ -598,7 +599,11 @@ async function redirectWithPromptCode(
 	type: "login" | "create" | "consent" | "select_account" | "post_login",
 	page?: string,
 ) {
-	const queryParams = await signParams(ctx, opts);
+	// `consent` is the only type reachable past the postLogin gate in
+	// authorize, so its signed query attests that postLogin is cleared.
+	const queryParams = await signParams(ctx, opts, {
+		postLoginCleared: type === "consent",
+	});
 	let path = opts.loginPage;
 	if (type === "select_account") {
 		path = opts.selectAccount?.page ?? opts.loginPage;
@@ -619,6 +624,7 @@ async function redirectWithPromptCode(
 async function signParams(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
+	flags?: { postLoginCleared?: boolean },
 ) {
 	// Add expiration to query parameters
 	const issuedAt = Date.now();
@@ -629,6 +635,9 @@ async function signParams(
 	);
 	params.set("exp", String(exp));
 	params.set(signedQueryIssuedAtParam, String(issuedAt));
+	if (flags?.postLoginCleared) {
+		params.set(postLoginClearedParam, "1");
+	}
 
 	const signature = await makeSignature(params.toString(), ctx.context.secret);
 	params.append("sig", signature);

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -19,6 +19,7 @@ import {
 	getJwtPlugin,
 	isPKCERequired,
 	parsePrompt,
+	signedQueryIssuedAtParam,
 	storeToken,
 } from "./utils";
 
@@ -620,12 +621,14 @@ async function signParams(
 	opts: OAuthOptions<Scope[]>,
 ) {
 	// Add expiration to query parameters
-	const iat = Math.floor(Date.now() / 1000);
+	const issuedAt = Date.now();
+	const iat = Math.floor(issuedAt / 1000);
 	const exp = iat + (opts.codeExpiresIn ?? 600);
 	const params = serializeAuthorizationQuery(
 		ctx.query as OAuthAuthorizationQuery,
 	);
 	params.set("exp", String(exp));
+	params.set(signedQueryIssuedAtParam, String(issuedAt));
 
 	const signature = await makeSignature(params.toString(), ctx.context.secret);
 	params.append("sig", signature);

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -601,11 +601,13 @@ async function redirectWithPromptCode(
 	options?: { page?: string; sessionId?: string },
 ) {
 	// `consent` is the only type reachable past the postLogin gate in
-	// authorize, so its signed query attests that postLogin is cleared
-	// for the specific session recorded in the marker.
+	// authorize, so when `opts.postLogin` is configured its signed query
+	// attests that postLogin is cleared for the specific session recorded
+	// in the marker. Skip the marker otherwise: there is no postLogin gate
+	// to clear, and an unused session id does not belong in the URL.
 	const queryParams = await signParams(ctx, opts, {
 		postLoginClearedForSession:
-			type === "consent" ? options?.sessionId : undefined,
+			type === "consent" && opts.postLogin ? options?.sessionId : undefined,
 	});
 	let path = opts.loginPage;
 	if (type === "select_account") {

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -431,12 +431,9 @@ export async function authorizeEndpoint(
 					"End-User interaction is required",
 				);
 			}
-			return redirectWithPromptCode(
-				ctx,
-				opts,
-				"create",
-				typeof signupRedirect === "string" ? signupRedirect : undefined,
-			);
+			return redirectWithPromptCode(ctx, opts, "create", {
+				page: typeof signupRedirect === "string" ? signupRedirect : undefined,
+			});
 		}
 	}
 
@@ -463,7 +460,9 @@ export async function authorizeEndpoint(
 
 	// Force consent screen
 	if (promptSet?.has("consent")) {
-		return redirectWithPromptCode(ctx, opts, "consent");
+		return redirectWithPromptCode(ctx, opts, "consent", {
+			sessionId: session.session.id,
+		});
 	}
 
 	const referenceId = await opts.postLogin?.consentReferenceId?.({
@@ -518,7 +517,9 @@ export async function authorizeEndpoint(
 				"End-User consent is required",
 			);
 		}
-		return redirectWithPromptCode(ctx, opts, "consent");
+		return redirectWithPromptCode(ctx, opts, "consent", {
+			sessionId: session.session.id,
+		});
 	}
 
 	return redirectWithAuthorizationCode(ctx, opts, {
@@ -597,12 +598,14 @@ async function redirectWithPromptCode(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 	type: "login" | "create" | "consent" | "select_account" | "post_login",
-	page?: string,
+	options?: { page?: string; sessionId?: string },
 ) {
 	// `consent` is the only type reachable past the postLogin gate in
-	// authorize, so its signed query attests that postLogin is cleared.
+	// authorize, so its signed query attests that postLogin is cleared
+	// for the specific session recorded in the marker.
 	const queryParams = await signParams(ctx, opts, {
-		postLoginCleared: type === "consent",
+		postLoginClearedForSession:
+			type === "consent" ? options?.sessionId : undefined,
 	});
 	let path = opts.loginPage;
 	if (type === "select_account") {
@@ -618,13 +621,13 @@ async function redirectWithPromptCode(
 	} else if (type === "create") {
 		path = opts.signup?.page ?? opts.loginPage;
 	}
-	return handleRedirect(ctx, `${page ?? path}?${queryParams}`);
+	return handleRedirect(ctx, `${options?.page ?? path}?${queryParams}`);
 }
 
 async function signParams(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
-	flags?: { postLoginCleared?: boolean },
+	flags?: { postLoginClearedForSession?: string },
 ) {
 	// Add expiration to query parameters
 	const issuedAt = Date.now();
@@ -635,8 +638,8 @@ async function signParams(
 	);
 	params.set("exp", String(exp));
 	params.set(signedQueryIssuedAtParam, String(issuedAt));
-	if (flags?.postLoginCleared) {
-		params.set(postLoginClearedParam, "1");
+	if (flags?.postLoginClearedForSession) {
+		params.set(postLoginClearedParam, flags.postLoginClearedForSession);
 	}
 
 	const signature = await makeSignature(params.toString(), ctx.context.secret);

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -147,8 +147,7 @@ export async function consentEndpoint(
 		authorizationQuery = removePromptFromQuery(authorizationQuery, "login");
 	}
 	ctx.query = searchParamsToQuery(authorizationQuery);
-	(ctx.context as Record<string, unknown>).postLogin = true;
-	const { url } = await authorizeEndpoint(ctx, opts);
+	const { url } = await authorizeEndpoint(ctx, opts, { postLogin: true });
 	return {
 		redirect: true,
 		url,

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -3,14 +3,19 @@ import { APIError, getSessionFromCtx } from "better-auth/api";
 import { authorizeEndpoint, formatErrorURL, getIssuer } from "./authorize";
 import { oAuthState } from "./oauth";
 import type { OAuthConsent, OAuthOptions, Scope } from "./types";
-import { deleteFromPrompt } from "./utils";
+import {
+	parsePrompt,
+	removePromptFromQuery,
+	searchParamsToQuery,
+} from "./utils";
 
 export async function consentEndpoint(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 ) {
 	// Obtain oauth query
-	const _query = (await oAuthState.get())?.query as string | undefined;
+	const oauthRequest = await oAuthState.get();
+	const _query = oauthRequest?.query as string | undefined;
 	if (!_query) {
 		throw new APIError("BAD_REQUEST", {
 			error_description: "missing oauth query",
@@ -55,6 +60,24 @@ export async function consentEndpoint(
 
 	// Consent accepted
 	const session = await getSessionFromCtx(ctx);
+	const promptSet = parsePrompt(query.get("prompt") ?? "");
+	const hasLoginPrompt = promptSet.has("login");
+	const hasSatisfiedLoginPrompt =
+		hasLoginPrompt &&
+		sessionSatisfiesLoginPrompt(
+			session?.session.createdAt,
+			oauthRequest?.signedQueryIssuedAt,
+		);
+	if (hasLoginPrompt && !hasSatisfiedLoginPrompt) {
+		ctx?.headers?.set("accept", "application/json");
+		ctx.query = searchParamsToQuery(query);
+		const { url } = await authorizeEndpoint(ctx, opts);
+		return {
+			redirect: true,
+			url,
+		};
+	}
+
 	const referenceId = await opts.postLogin?.consentReferenceId?.({
 		user: session?.user!,
 		session: session?.session!,
@@ -119,11 +142,27 @@ export async function consentEndpoint(
 		query.set("scope", consent.scopes.join(" "));
 	}
 	ctx?.headers?.set("accept", "application/json");
-	ctx.query = deleteFromPrompt(query, "consent");
+	let authorizationQuery = removePromptFromQuery(query, "consent");
+	if (hasSatisfiedLoginPrompt) {
+		authorizationQuery = removePromptFromQuery(authorizationQuery, "login");
+	}
+	ctx.query = searchParamsToQuery(authorizationQuery);
 	(ctx.context as Record<string, unknown>).postLogin = true;
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,
 		url,
 	};
+}
+
+// Relies on session.createdAt being immutable for the session's lifetime; a
+// refresh path that rewrites it would silently accept a pre-request session.
+function sessionSatisfiesLoginPrompt(
+	sessionCreatedAt: Date | string | undefined,
+	signedQueryIssuedAt: Date | undefined,
+) {
+	if (!sessionCreatedAt || !signedQueryIssuedAt) {
+		return false;
+	}
+	return new Date(sessionCreatedAt).getTime() >= signedQueryIssuedAt.getTime();
 }

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -4,6 +4,7 @@ import { authorizeEndpoint, formatErrorURL, getIssuer } from "./authorize";
 import { oAuthState } from "./oauth";
 import type { OAuthConsent, OAuthOptions, Scope } from "./types";
 import {
+	normalizeTimestampValue,
 	parsePrompt,
 	removePromptFromQuery,
 	searchParamsToQuery,
@@ -147,7 +148,9 @@ export async function consentEndpoint(
 		authorizationQuery = removePromptFromQuery(authorizationQuery, "login");
 	}
 	ctx.query = searchParamsToQuery(authorizationQuery);
-	const { url } = await authorizeEndpoint(ctx, opts, { postLogin: true });
+	const { url } = await authorizeEndpoint(ctx, opts, {
+		postLogin: oauthRequest?.postLoginCleared === true,
+	});
 	return {
 		redirect: true,
 		url,
@@ -160,8 +163,8 @@ function sessionSatisfiesLoginPrompt(
 	sessionCreatedAt: Date | string | undefined,
 	signedQueryIssuedAt: Date | undefined,
 ) {
-	if (!sessionCreatedAt || !signedQueryIssuedAt) {
-		return false;
-	}
-	return new Date(sessionCreatedAt).getTime() >= signedQueryIssuedAt.getTime();
+	if (!signedQueryIssuedAt) return false;
+	const normalized = normalizeTimestampValue(sessionCreatedAt);
+	if (!normalized) return false;
+	return normalized.getTime() >= signedQueryIssuedAt.getTime();
 }

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -148,8 +148,11 @@ export async function consentEndpoint(
 		authorizationQuery = removePromptFromQuery(authorizationQuery, "login");
 	}
 	ctx.query = searchParamsToQuery(authorizationQuery);
+	const postLoginClearedForThisSession =
+		oauthRequest?.postLoginClearedForSession !== undefined &&
+		oauthRequest.postLoginClearedForSession === session?.session.id;
 	const { url } = await authorizeEndpoint(ctx, opts, {
-		postLogin: oauthRequest?.postLoginCleared === true,
+		postLogin: postLoginClearedForThisSession,
 	});
 	return {
 		redirect: true,

--- a/packages/oauth-provider/src/continue.ts
+++ b/packages/oauth-provider/src/continue.ts
@@ -3,7 +3,7 @@ import { APIError } from "better-auth/api";
 import { authorizeEndpoint } from "./authorize";
 import { oAuthState } from "./oauth";
 import type { OAuthOptions, Scope } from "./types";
-import { deleteFromPrompt, searchParamsToQuery } from "./utils";
+import { removePromptFromQuery, searchParamsToQuery } from "./utils";
 
 export async function continueEndpoint(
 	ctx: GenericEndpointContext,
@@ -37,7 +37,9 @@ async function selected(
 	}
 	ctx.headers?.set("accept", "application/json");
 	const query = new URLSearchParams(_query);
-	ctx.query = deleteFromPrompt(query, "select_account");
+	ctx.query = searchParamsToQuery(
+		removePromptFromQuery(query, "select_account"),
+	);
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,
@@ -58,7 +60,7 @@ async function created(
 	}
 	const query = new URLSearchParams(_query);
 	ctx.headers?.set("accept", "application/json");
-	ctx.query = deleteFromPrompt(query, "create");
+	ctx.query = searchParamsToQuery(removePromptFromQuery(query, "create"));
 	const { url } = await authorizeEndpoint(ctx, opts);
 	return {
 		redirect: true,

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -2529,6 +2529,100 @@ describe("oauth - prompt", async () => {
 		expect(consentRes.url).toContain("/select-organization");
 		expect(consentRes.url).not.toContain("code=");
 	});
+
+	it("consent accept should not skip postLogin when the ba_pl marker is from another session", async ({
+		onTestFinished,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		enablePostLogin = true;
+		bypassReferenceIdCheck = true;
+		onTestFinished(() => {
+			enablePostLogin = false;
+			bypassReferenceIdCheck = false;
+		});
+
+		// Session A: sign in, complete setActive, capture the signed /consent URL (marker from A).
+		const headersA = new Headers();
+		await serverClient.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ throw: true, onSuccess: cookieSetter(headersA) },
+		);
+
+		const { customFetchImpl: customFetchImplRP, cookieSetter: rpCookieSetter } =
+			await createTestInstance({ prompt: "consent" });
+		const client = createAuthClient({
+			plugins: [genericOAuthClient(), organization()],
+			baseURL: rpBaseUrl,
+			fetchOptions: { customFetchImpl: customFetchImplRP },
+		});
+
+		const oauthHeadersA = new Headers();
+		const dataA = await client.signIn.oauth2(
+			{ providerId, callbackURL: "/success" },
+			{
+				headers: headersA,
+				throw: true,
+				onSuccess: rpCookieSetter(oauthHeadersA),
+			},
+		);
+		if (!dataA.url) {
+			throw new Error("missing authorization URL");
+		}
+
+		let selectOrgUriA = "";
+		await serverClient.$fetch(dataA.url, {
+			method: "GET",
+			headers: headersA,
+			onError(context) {
+				selectOrgUriA = context.response.headers.get("Location") || "";
+				cookieSetter(headersA)(context);
+			},
+		});
+		expect(selectOrgUriA).toContain("/select-organization");
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(selectOrgUriA, authServerBaseUrl).search,
+			},
+		});
+
+		const setActiveResponse = await serverClient.organization.setActive(
+			{ organizationId: org.id, organizationSlug: org.slug },
+			{ headers: headersA, throw: true, onSuccess: cookieSetter(headersA) },
+		);
+		if (!isRedirectResult(setActiveResponse)) {
+			expect.unreachable();
+		}
+		const consentUrlWithMarker = setActiveResponse.url;
+		expect(consentUrlWithMarker).toContain("/consent");
+
+		// Session B: a fresh sign-in for the same user. A new session row, no active org.
+		const headersB = new Headers();
+		await serverClient.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ throw: true, onSuccess: cookieSetter(headersB) },
+		);
+
+		// Session B posts to /consent using session A's marker.
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(consentUrlWithMarker, authServerBaseUrl).search,
+			},
+		});
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const consentRes = await serverClient.oauth2.consent(
+			{ accept: true },
+			{ headers: headersB, throw: true, onResponse: cookieSetter(headersB) },
+		);
+
+		// Session B must not be granted a code using session A's marker.
+		expect(consentRes.url).toContain("/select-organization");
+		expect(consentRes.url).not.toContain("code=");
+	});
 });
 
 describe("oauth - config", () => {

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -1199,6 +1199,9 @@ describe("oauth - prompt", async () => {
 			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
 		);
 		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
+		if (!data.url) {
+			throw new Error("missing authorization URL");
+		}
 
 		// Check for redirection to /login
 		let loginRedirectUri = "";
@@ -1936,6 +1939,9 @@ describe("oauth - prompt", async () => {
 			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
 		);
 		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
+		if (!data.url) {
+			throw new Error("missing authorization URL");
+		}
 
 		// Check for redirection to /login
 		let loginRedirectUri = "";
@@ -1952,9 +1958,11 @@ describe("oauth - prompt", async () => {
 		expect(loginRedirectUri).toContain(
 			`redirect_uri=${encodeURIComponent(oauthClient?.redirect_uris?.at(0)!)}`,
 		);
+		const loginRedirectSearch = new URL(loginRedirectUri, authServerBaseUrl)
+			.search;
 		vi.stubGlobal("window", {
 			location: {
-				search: new URL(loginRedirectUri, authServerBaseUrl).search,
+				search: loginRedirectSearch,
 			},
 		});
 		onTestFinished(() => {
@@ -1969,11 +1977,117 @@ describe("oauth - prompt", async () => {
 			},
 			{
 				throw: true,
+				onSuccess: cookieSetter(headers),
 			},
 		);
 		expect(signInResponse.redirect).toBe(true);
 		expect(signInResponse.url).toContain("/consent");
 		expect(signInResponse.url).toContain("prompt=consent");
+		expect(signInResponse.url).not.toContain("prompt=login");
+
+		vi.stubGlobal("window", {
+			location: {
+				search: loginRedirectSearch,
+			},
+		});
+
+		const consentRes = await serverClient.oauth2.consent(
+			{
+				accept: true,
+			},
+			{
+				headers,
+				throw: true,
+			},
+		);
+		expect(consentRes.redirect).toBe(true);
+		expect(consentRes.url).toContain(redirectUri);
+		expect(consentRes.url).toContain("code=");
+		expect(consentRes.url).not.toContain("/login");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/discussions/9261
+	 */
+	it("login+consent - should not accept stale login prompt without reauthentication", async ({
+		onTestFinished,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const authHeaders = new Headers();
+		const { user } = await serverClient.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(authHeaders),
+			},
+		);
+		expect(user.id).toBeDefined();
+
+		const { customFetchImpl: customFetchImplRP, cookieSetter: rpCookieSetter } =
+			await createTestInstance({
+				prompt: "login consent",
+			});
+		const client = createAuthClient({
+			baseURL: rpBaseUrl,
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+
+		const data = await client.signIn.social(
+			{
+				provider: providerId,
+				callbackURL: "/success",
+			},
+			{
+				headers: authHeaders,
+				throw: true,
+				onSuccess: rpCookieSetter(authHeaders),
+			},
+		);
+		if (!data.url) {
+			throw new Error("missing authorization URL");
+		}
+
+		let loginRedirectUri = "";
+		await serverClient.$fetch(data.url, {
+			method: "GET",
+			headers: authHeaders,
+			onError(context) {
+				loginRedirectUri = context.response.headers.get("Location") || "";
+				rpCookieSetter(authHeaders)(context);
+			},
+		});
+		expect(loginRedirectUri).toContain("/login");
+
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(loginRedirectUri, authServerBaseUrl).search,
+			},
+		});
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const consentRes = await serverClient.oauth2.consent(
+			{
+				accept: true,
+			},
+			{
+				headers: authHeaders,
+				throw: true,
+			},
+		);
+		expect(consentRes.redirect).toBe(true);
+		expect(consentRes.url).toContain("/login");
+		expect(consentRes.url).toContain("prompt=login");
+		expect(consentRes.url).not.toContain("code=");
 	});
 
 	it("select_account+consent - should always redirect to select_account and force consent (notice consent previously given)", async ({

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -2401,9 +2401,12 @@ describe("oauth - prompt", async () => {
 				onSuccess: rpCookieSetter(oauthHeaders),
 			},
 		);
+		if (!data.url) {
+			throw new Error("missing authorization URL");
+		}
 
 		let selectOrgRedirectUri = "";
-		await serverClient.$fetch(data.url!, {
+		await serverClient.$fetch(data.url, {
 			method: "GET",
 			headers: freshHeaders,
 			onError(context) {

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -981,6 +981,7 @@ describe("oauth - prompt", async () => {
 	let enablePostLogin = false;
 	let selectedPostLogin = false;
 	let forcePostLoginRedirect = false;
+	let bypassReferenceIdCheck = false;
 	let isUserRegistered = true;
 	const {
 		auth: authorizationServer,
@@ -1022,6 +1023,7 @@ describe("oauth - prompt", async () => {
 					consentReferenceId({ session }) {
 						if (!enablePostLogin) return undefined;
 						if (selectedPostLogin) return undefined;
+						if (bypassReferenceIdCheck) return undefined;
 						const activeOrganizationId = (session?.activeOrganizationId ??
 							undefined) as string | undefined;
 						if (!activeOrganizationId)
@@ -1197,13 +1199,13 @@ describe("oauth - prompt", async () => {
 				throw: true,
 			},
 		);
+		if (!data.url) {
+			throw new Error("missing authorization URL");
+		}
 		expect(data.url).toContain(
 			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
 		);
 		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
-		if (!data.url) {
-			throw new Error("missing authorization URL");
-		}
 
 		// Check for redirection to /login
 		let loginRedirectUri = "";
@@ -1937,13 +1939,13 @@ describe("oauth - prompt", async () => {
 				throw: true,
 			},
 		);
+		if (!data.url) {
+			throw new Error("missing authorization URL");
+		}
 		expect(data.url).toContain(
 			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
 		);
 		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
-		if (!data.url) {
-			throw new Error("missing authorization URL");
-		}
 
 		// Check for redirection to /login
 		let loginRedirectUri = "";
@@ -2451,6 +2453,78 @@ describe("oauth - prompt", async () => {
 		expect(consentRes.url).toContain(redirectUri);
 		expect(consentRes.url).toContain("code=");
 		expect(consentRes.url).not.toContain("/select-organization");
+	});
+
+	it("consent accept should not bypass postLogin when posted with a pre-postLogin signed query", async ({
+		onTestFinished,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		enablePostLogin = true;
+		bypassReferenceIdCheck = true;
+		onTestFinished(() => {
+			enablePostLogin = false;
+			bypassReferenceIdCheck = false;
+		});
+
+		const freshHeaders = new Headers();
+		await serverClient.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ throw: true, onSuccess: cookieSetter(freshHeaders) },
+		);
+
+		const { customFetchImpl: customFetchImplRP, cookieSetter: rpCookieSetter } =
+			await createTestInstance({ prompt: "consent" });
+		const client = createAuthClient({
+			plugins: [genericOAuthClient(), organization()],
+			baseURL: rpBaseUrl,
+			fetchOptions: { customFetchImpl: customFetchImplRP },
+		});
+
+		const oauthHeaders = new Headers();
+		const data = await client.signIn.oauth2(
+			{ providerId, callbackURL: "/success" },
+			{
+				headers: freshHeaders,
+				throw: true,
+				onSuccess: rpCookieSetter(oauthHeaders),
+			},
+		);
+		if (!data.url) {
+			throw new Error("missing authorization URL");
+		}
+
+		let selectOrgRedirectUri = "";
+		await serverClient.$fetch(data.url, {
+			method: "GET",
+			headers: freshHeaders,
+			onError(context) {
+				selectOrgRedirectUri = context.response.headers.get("Location") || "";
+				cookieSetter(freshHeaders)(context);
+			},
+		});
+		expect(selectOrgRedirectUri).toContain("/select-organization");
+
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(selectOrgRedirectUri, authServerBaseUrl).search,
+			},
+		});
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const consentRes = await serverClient.oauth2.consent(
+			{ accept: true },
+			{
+				headers: freshHeaders,
+				throw: true,
+				onResponse: cookieSetter(freshHeaders),
+			},
+		);
+		expect(consentRes.url).toContain("/select-organization");
+		expect(consentRes.url).not.toContain("code=");
 	});
 });
 

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -2016,7 +2016,7 @@ describe("oauth - prompt", async () => {
 			throw Error("beforeAll not run properly");
 		}
 
-		const authHeaders = new Headers();
+		const staleHeaders = new Headers();
 		const { user } = await serverClient.signIn.email(
 			{
 				email: testUser.email,
@@ -2024,7 +2024,7 @@ describe("oauth - prompt", async () => {
 			},
 			{
 				throw: true,
-				onSuccess: cookieSetter(authHeaders),
+				onSuccess: cookieSetter(staleHeaders),
 			},
 		);
 		expect(user.id).toBeDefined();
@@ -2034,21 +2034,22 @@ describe("oauth - prompt", async () => {
 				prompt: "login consent",
 			});
 		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
 			baseURL: rpBaseUrl,
 			fetchOptions: {
 				customFetchImpl: customFetchImplRP,
 			},
 		});
 
-		const data = await client.signIn.social(
+		const rpHeaders = new Headers();
+		const data = await client.signIn.oauth2(
 			{
-				provider: providerId,
+				providerId,
 				callbackURL: "/success",
 			},
 			{
-				headers: authHeaders,
+				headers: rpHeaders,
 				throw: true,
-				onSuccess: rpCookieSetter(authHeaders),
 			},
 		);
 		if (!data.url) {
@@ -2058,13 +2059,14 @@ describe("oauth - prompt", async () => {
 		let loginRedirectUri = "";
 		await serverClient.$fetch(data.url, {
 			method: "GET",
-			headers: authHeaders,
+			headers: rpHeaders,
 			onError(context) {
 				loginRedirectUri = context.response.headers.get("Location") || "";
-				rpCookieSetter(authHeaders)(context);
+				rpCookieSetter(rpHeaders)(context);
 			},
 		});
 		expect(loginRedirectUri).toContain("/login");
+		expect(loginRedirectUri).toContain("prompt=login");
 
 		vi.stubGlobal("window", {
 			location: {
@@ -2080,7 +2082,7 @@ describe("oauth - prompt", async () => {
 				accept: true,
 			},
 			{
-				headers: authHeaders,
+				headers: staleHeaders,
 				throw: true,
 			},
 		);

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -980,6 +980,7 @@ describe("oauth - prompt", async () => {
 	let enableSelectAccount = false;
 	let enablePostLogin = false;
 	let selectedPostLogin = false;
+	let forcePostLoginRedirect = false;
 	let isUserRegistered = true;
 	const {
 		auth: authorizationServer,
@@ -1015,6 +1016,7 @@ describe("oauth - prompt", async () => {
 					shouldRedirect({ session }) {
 						if (!enablePostLogin) return false;
 						if (selectedPostLogin) return false;
+						if (forcePostLoginRedirect) return true;
 						return !session?.activeOrganizationId;
 					},
 					consentReferenceId({ session }) {
@@ -2360,6 +2362,95 @@ describe("oauth - prompt", async () => {
 		expect(consentRes.url).toContain(`code=`);
 
 		enablePostLogin = false;
+	});
+
+	it("consent accept should not re-trigger postLogin redirect", async ({
+		onTestFinished,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		enablePostLogin = true;
+		onTestFinished(() => {
+			enablePostLogin = false;
+			forcePostLoginRedirect = false;
+		});
+
+		const freshHeaders = new Headers();
+		await serverClient.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ throw: true, onSuccess: cookieSetter(freshHeaders) },
+		);
+
+		const { customFetchImpl: customFetchImplRP, cookieSetter: rpCookieSetter } =
+			await createTestInstance({ prompt: "consent" });
+		const client = createAuthClient({
+			plugins: [genericOAuthClient(), organization()],
+			baseURL: rpBaseUrl,
+			fetchOptions: { customFetchImpl: customFetchImplRP },
+		});
+
+		const oauthHeaders = new Headers();
+		const data = await client.signIn.oauth2(
+			{ providerId, callbackURL: "/success" },
+			{
+				headers: freshHeaders,
+				throw: true,
+				onSuccess: rpCookieSetter(oauthHeaders),
+			},
+		);
+
+		let selectOrgRedirectUri = "";
+		await serverClient.$fetch(data.url!, {
+			method: "GET",
+			headers: freshHeaders,
+			onError(context) {
+				selectOrgRedirectUri = context.response.headers.get("Location") || "";
+				cookieSetter(freshHeaders)(context);
+			},
+		});
+		expect(selectOrgRedirectUri).toContain("/select-organization");
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(selectOrgRedirectUri, authServerBaseUrl).search,
+			},
+		});
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const setActiveResponse = await serverClient.organization.setActive(
+			{ organizationId: org.id, organizationSlug: org.slug },
+			{
+				headers: freshHeaders,
+				throw: true,
+				onSuccess: cookieSetter(freshHeaders),
+			},
+		);
+		if (!isRedirectResult(setActiveResponse)) {
+			expect.unreachable();
+		}
+		const consentRedirectUri = setActiveResponse.url;
+		expect(consentRedirectUri).toContain(`/consent`);
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(consentRedirectUri, authServerBaseUrl).search,
+			},
+		});
+
+		forcePostLoginRedirect = true;
+
+		const consentRes = await serverClient.oauth2.consent(
+			{ accept: true },
+			{
+				headers: freshHeaders,
+				throw: true,
+				onResponse: cookieSetter(freshHeaders),
+			},
+		);
+		expect(consentRes.url).toContain(redirectUri);
+		expect(consentRes.url).toContain("code=");
+		expect(consentRes.url).not.toContain("/select-organization");
 	});
 });
 

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -30,6 +30,7 @@ import { userInfoEndpoint } from "./userinfo";
 import {
 	getJwtPlugin,
 	getSignedQueryIssuedAt,
+	postLoginClearedParam,
 	removePromptFromQuery,
 	searchParamsToQuery,
 	signedQueryIssuedAtParam,
@@ -48,6 +49,7 @@ declare module "@better-auth/core" {
 export const oAuthState = defineRequestState<{
 	query?: string;
 	signedQueryIssuedAt?: Date;
+	postLoginCleared?: boolean;
 } | null>(() => null);
 export const getOAuthProviderState = oAuthState.get;
 
@@ -250,12 +252,16 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							opts.codeExpiresIn ?? 600,
 						);
 						const queryParams = new URLSearchParams(query);
+						const postLoginCleared =
+							queryParams.get(postLoginClearedParam) === "1";
 						queryParams.delete("sig");
 						queryParams.delete("exp");
 						queryParams.delete(signedQueryIssuedAtParam);
+						queryParams.delete(postLoginClearedParam);
 						await oAuthState.set({
 							query: queryParams.toString(),
 							signedQueryIssuedAt: signedQueryIssuedAt ?? undefined,
+							postLoginCleared,
 						});
 
 						// If path starts oauth2 authorize (ie /sign-in/social, /sign-in/oauth2), add to additional data body

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -28,8 +28,11 @@ import type { OAuthOptions, Scope } from "./types";
 import { SafeUrlSchema } from "./types/zod";
 import { userInfoEndpoint } from "./userinfo";
 import {
-	deleteFromPrompt,
 	getJwtPlugin,
+	getSignedQueryIssuedAt,
+	removePromptFromQuery,
+	searchParamsToQuery,
+	signedQueryIssuedAtParam,
 	verifyOAuthQueryParams,
 } from "./utils";
 import { PACKAGE_VERSION } from "./version";
@@ -42,9 +45,10 @@ declare module "@better-auth/core" {
 	}
 }
 
-export const oAuthState = defineRequestState<{ query?: string } | null>(
-	() => null,
-);
+export const oAuthState = defineRequestState<{
+	query?: string;
+	signedQueryIssuedAt?: Date;
+} | null>(() => null);
 export const getOAuthProviderState = oAuthState.get;
 
 /**
@@ -241,11 +245,17 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 								error: "invalid_signature",
 							});
 						}
+						const signedQueryIssuedAt = getSignedQueryIssuedAt(
+							query,
+							opts.codeExpiresIn ?? 600,
+						);
 						const queryParams = new URLSearchParams(query);
 						queryParams.delete("sig");
 						queryParams.delete("exp");
+						queryParams.delete(signedQueryIssuedAtParam);
 						await oAuthState.set({
 							query: queryParams.toString(),
+							signedQueryIssuedAt: signedQueryIssuedAt ?? undefined,
 						});
 
 						// If path starts oauth2 authorize (ie /sign-in/social, /sign-in/oauth2), add to additional data body
@@ -302,7 +312,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						if (!isNavigationRequest) {
 							ctx.headers?.set("accept", "application/json");
 						}
-						ctx.query = deleteFromPrompt(query, "login");
+						ctx.query = searchParamsToQuery(
+							removePromptFromQuery(query, "login"),
+						);
 						return await authorizeEndpoint(ctx, opts);
 					}),
 				},

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -247,10 +247,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 								error: "invalid_signature",
 							});
 						}
-						const signedQueryIssuedAt = getSignedQueryIssuedAt(
-							query,
-							opts.codeExpiresIn ?? 600,
-						);
+						const signedQueryIssuedAt = getSignedQueryIssuedAt(query);
 						const queryParams = new URLSearchParams(query);
 						const postLoginCleared =
 							queryParams.get(postLoginClearedParam) === "1";

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -49,7 +49,7 @@ declare module "@better-auth/core" {
 export const oAuthState = defineRequestState<{
 	query?: string;
 	signedQueryIssuedAt?: Date;
-	postLoginCleared?: boolean;
+	postLoginClearedForSession?: string;
 } | null>(() => null);
 export const getOAuthProviderState = oAuthState.get;
 
@@ -249,8 +249,8 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						}
 						const signedQueryIssuedAt = getSignedQueryIssuedAt(query);
 						const queryParams = new URLSearchParams(query);
-						const postLoginCleared =
-							queryParams.get(postLoginClearedParam) === "1";
+						const postLoginClearedForSession =
+							queryParams.get(postLoginClearedParam) ?? undefined;
 						queryParams.delete("sig");
 						queryParams.delete("exp");
 						queryParams.delete(signedQueryIssuedAtParam);
@@ -258,7 +258,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						await oAuthState.set({
 							query: queryParams.toString(),
 							signedQueryIssuedAt: signedQueryIssuedAt ?? undefined,
-							postLoginCleared,
+							postLoginClearedForSession,
 						});
 
 						// If path starts oauth2 authorize (ie /sign-in/social, /sign-in/oauth2), add to additional data body

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -575,28 +575,12 @@ export function searchParamsToQuery(
 export const signedQueryIssuedAtParam = "ba_iat";
 export const postLoginClearedParam = "ba_pl";
 
-export function getSignedQueryIssuedAt(
-	oauthQuery: string,
-	codeExpiresIn: number,
-) {
-	const params = new URLSearchParams(oauthQuery);
-	const issuedAtParam = params.get(signedQueryIssuedAtParam);
-	if (issuedAtParam) {
-		const issuedAt = Number(issuedAtParam);
-		if (Number.isFinite(issuedAt) && issuedAt > 0) {
-			return new Date(issuedAt);
-		}
-	}
-
-	const expiresAtParam = params.get("exp");
-	if (!expiresAtParam) {
-		return null;
-	}
-	const expiresAt = Number(expiresAtParam);
-	if (!Number.isFinite(expiresAt)) {
-		return null;
-	}
-	return new Date((expiresAt - codeExpiresIn) * 1000);
+export function getSignedQueryIssuedAt(oauthQuery: string): Date | null {
+	const raw = new URLSearchParams(oauthQuery).get(signedQueryIssuedAtParam);
+	if (!raw) return null;
+	const issuedAt = Number(raw);
+	if (!Number.isFinite(issuedAt) || issuedAt <= 0) return null;
+	return new Date(issuedAt);
 }
 
 export function removePromptFromQuery(query: URLSearchParams, prompt: Prompt) {

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -573,6 +573,7 @@ export function searchParamsToQuery(
 }
 
 export const signedQueryIssuedAtParam = "ba_iat";
+export const postLoginClearedParam = "ba_pl";
 
 export function getSignedQueryIssuedAt(
 	oauthQuery: string,
@@ -582,9 +583,9 @@ export function getSignedQueryIssuedAt(
 	const issuedAtParam = params.get(signedQueryIssuedAtParam);
 	if (issuedAtParam) {
 		const issuedAt = Number(issuedAtParam);
-		return Number.isFinite(issuedAt) && issuedAt > 0
-			? new Date(issuedAt)
-			: null;
+		if (Number.isFinite(issuedAt) && issuedAt > 0) {
+			return new Date(issuedAt);
+		}
 	}
 
 	const expiresAtParam = params.get("exp");

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -572,22 +572,43 @@ export function searchParamsToQuery(
 	return result;
 }
 
-/**
- * Deletes a prompt value
- *
- * @param ctx
- * @param prompt - the prompt value to delete
- */
-export function deleteFromPrompt(query: URLSearchParams, prompt: Prompt) {
-	const prompts = query.get("prompt")?.split(" ");
+export const signedQueryIssuedAtParam = "ba_iat";
+
+export function getSignedQueryIssuedAt(
+	oauthQuery: string,
+	codeExpiresIn: number,
+) {
+	const params = new URLSearchParams(oauthQuery);
+	const issuedAtParam = params.get(signedQueryIssuedAtParam);
+	if (issuedAtParam) {
+		const issuedAt = Number(issuedAtParam);
+		return Number.isFinite(issuedAt) && issuedAt > 0
+			? new Date(issuedAt)
+			: null;
+	}
+
+	const expiresAtParam = params.get("exp");
+	if (!expiresAtParam) {
+		return null;
+	}
+	const expiresAt = Number(expiresAtParam);
+	if (!Number.isFinite(expiresAt)) {
+		return null;
+	}
+	return new Date((expiresAt - codeExpiresIn) * 1000);
+}
+
+export function removePromptFromQuery(query: URLSearchParams, prompt: Prompt) {
+	const nextQuery = new URLSearchParams(query);
+	const prompts = nextQuery.get("prompt")?.split(" ");
 	const foundPrompt = prompts?.findIndex((v) => v === prompt) ?? -1;
 	if (foundPrompt >= 0) {
 		prompts?.splice(foundPrompt, 1);
 		prompts?.length
-			? query.set("prompt", prompts.join(" "))
-			: query.delete("prompt");
+			? nextQuery.set("prompt", prompts.join(" "))
+			: nextQuery.delete("prompt");
 	}
-	return searchParamsToQuery(query);
+	return nextQuery;
 }
 
 enum PKCERequirementErrors {

--- a/packages/oauth-provider/src/utils/query-serialization.test.ts
+++ b/packages/oauth-provider/src/utils/query-serialization.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { deleteFromPrompt, searchParamsToQuery } from "./index";
+import {
+	getSignedQueryIssuedAt,
+	removePromptFromQuery,
+	searchParamsToQuery,
+	signedQueryIssuedAtParam,
+} from "./index";
 
 describe("searchParamsToQuery", () => {
 	it("preserves single-valued params as strings", () => {
@@ -48,12 +53,12 @@ describe("searchParamsToQuery", () => {
 	});
 });
 
-describe("deleteFromPrompt", () => {
+describe("removePromptFromQuery", () => {
 	it("removes a prompt value and preserves other params", () => {
 		const params = new URLSearchParams(
 			"client_id=abc&prompt=login consent&scope=openid",
 		);
-		const result = deleteFromPrompt(params, "login");
+		const result = searchParamsToQuery(removePromptFromQuery(params, "login"));
 
 		expect(result.prompt).toBe("consent");
 		expect(result.client_id).toBe("abc");
@@ -64,7 +69,9 @@ describe("deleteFromPrompt", () => {
 		const params = new URLSearchParams(
 			"client_id=abc&prompt=consent&scope=openid",
 		);
-		const result = deleteFromPrompt(params, "consent");
+		const result = searchParamsToQuery(
+			removePromptFromQuery(params, "consent"),
+		);
 
 		expect(result.prompt).toBeUndefined();
 		expect(result.client_id).toBe("abc");
@@ -77,7 +84,7 @@ describe("deleteFromPrompt", () => {
 		params.append("resource", "https://api.example.com");
 		params.append("resource", "https://other.example.com");
 
-		const result = deleteFromPrompt(params, "login");
+		const result = searchParamsToQuery(removePromptFromQuery(params, "login"));
 
 		expect(result.prompt).toBe("consent");
 		expect(result.resource).toEqual([
@@ -88,8 +95,51 @@ describe("deleteFromPrompt", () => {
 
 	it("does nothing when the prompt value is not present", () => {
 		const params = new URLSearchParams("client_id=abc&prompt=consent");
-		const result = deleteFromPrompt(params, "login");
+		const result = searchParamsToQuery(removePromptFromQuery(params, "login"));
 
 		expect(result.prompt).toBe("consent");
+	});
+
+	it("does not mutate the original query", () => {
+		const params = new URLSearchParams(
+			"client_id=abc&prompt=login consent&scope=openid",
+		);
+		removePromptFromQuery(params, "login");
+
+		expect(params.get("prompt")).toBe("login consent");
+	});
+});
+
+describe("getSignedQueryIssuedAt", () => {
+	it("reads the signed query issue time when present", () => {
+		const issuedAt = 1777026004123;
+		const params = new URLSearchParams({
+			client_id: "abc",
+			exp: "1777026604",
+			[signedQueryIssuedAtParam]: String(issuedAt),
+		});
+
+		expect(getSignedQueryIssuedAt(params.toString(), 600)).toEqual(
+			new Date(issuedAt),
+		);
+	});
+
+	it("falls back to the expiration window for existing signed queries", () => {
+		const params = new URLSearchParams({
+			client_id: "abc",
+			exp: "1777026604",
+		});
+
+		expect(getSignedQueryIssuedAt(params.toString(), 600)).toEqual(
+			new Date(1777026004 * 1000),
+		);
+	});
+
+	it("returns null when no signed timing parameter is available", () => {
+		const params = new URLSearchParams({
+			client_id: "abc",
+		});
+
+		expect(getSignedQueryIssuedAt(params.toString(), 600)).toBeNull();
 	});
 });

--- a/packages/oauth-provider/src/utils/query-serialization.test.ts
+++ b/packages/oauth-provider/src/utils/query-serialization.test.ts
@@ -115,31 +115,29 @@ describe("getSignedQueryIssuedAt", () => {
 		const issuedAt = 1777026004123;
 		const params = new URLSearchParams({
 			client_id: "abc",
-			exp: "1777026604",
 			[signedQueryIssuedAtParam]: String(issuedAt),
 		});
 
-		expect(getSignedQueryIssuedAt(params.toString(), 600)).toEqual(
+		expect(getSignedQueryIssuedAt(params.toString())).toEqual(
 			new Date(issuedAt),
 		);
 	});
 
-	it("falls back to the expiration window for existing signed queries", () => {
+	it("returns null when ba_iat is absent", () => {
 		const params = new URLSearchParams({
 			client_id: "abc",
 			exp: "1777026604",
 		});
 
-		expect(getSignedQueryIssuedAt(params.toString(), 600)).toEqual(
-			new Date(1777026004 * 1000),
-		);
+		expect(getSignedQueryIssuedAt(params.toString())).toBeNull();
 	});
 
-	it("returns null when no signed timing parameter is available", () => {
+	it("returns null when ba_iat is not a positive finite number", () => {
 		const params = new URLSearchParams({
 			client_id: "abc",
+			[signedQueryIssuedAtParam]: "not-a-number",
 		});
 
-		expect(getSignedQueryIssuedAt(params.toString(), 600)).toBeNull();
+		expect(getSignedQueryIssuedAt(params.toString())).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

Two separate bugs on the consent accept path into `authorizeEndpoint`, both reachable from the #9261 thread's multi-tenant + forced-reauth setup.

### 1. `prompt=login` honored across consent continuation

Consent accept stripped `prompt=login` unconditionally, letting a pre-existing session satisfy a forced reauthentication request. Now threads the signed request issue time (`ba_iat`) through state and only clears `prompt=login` when the active session was created at or after that time; otherwise bounces back to `/authorize`.

### 2. `postLogin.shouldRedirect` no longer re-triggers after consent

Consent accept called `authorizeEndpoint` without signaling that `postLogin` had already been cleared, so the post-consent pass re-evaluated `postLogin.shouldRedirect`. Any `shouldRedirect` implementation that can return true after postLogin completed (typical of `setActive`-driven flows where the persisted session state is not visible to the consent request) bounced the user back to the postLogin page.

`authorize` now records a `ba_pl=1` marker in the signed query it emits past the postLogin gate. Consent accept bypasses `postLogin.shouldRedirect` only when the incoming signed query carries that marker; otherwise it re-enters `authorize` with the postLogin check intact. This preserves the legitimate `setActive` → consent → code flow and blocks a direct POST to `/oauth2/consent` with a pre-postLogin signed query from skipping `shouldRedirect` to issue a code.