### PR TITLE
fix(api): preserve current session on change-password with revokeOtherSessions

### DIFF
--- a/.changeset/change-password-preserve-current-session.md
+++ b/.changeset/change-password-preserve-current-session.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+---
+
+fix(api): preserve current session on `/change-password` when `revokeOtherSessions: true`

--- a/.changeset/change-password-preserve-current-session.md
+++ b/.changeset/change-password-preserve-current-session.md
@@ -3,4 +3,4 @@
 "@better-auth/core": patch
 ---
 
-fix(api): preserve current session on `/change-password` when `revokeOtherSessions: true`
+`changePassword({ revokeOtherSessions: true })` no longer signs the caller out; only other devices' sessions are revoked.

--- a/.changeset/change-password-preserve-current-session.md
+++ b/.changeset/change-password-preserve-current-session.md
@@ -3,4 +3,4 @@
 "@better-auth/core": patch
 ---
 
-fix(api): preserve current session on `/change-password` when `revokeOtherSessions: true`
+`changePassword({ revokeOtherSessions: true })` no longer signs the caller out. Only other devices' sessions are revoked.

--- a/docs/content/docs/concepts/session-management.mdx
+++ b/docs/content/docs/concepts/session-management.mdx
@@ -193,7 +193,7 @@ await auth.api.updateSession({
 
 ### Revoking Sessions on Password Change
 
-You can revoke all sessions when the user changes their password by passing `revokeOtherSessions` as true on `changePassword` function.
+You can revoke all sessions other than the current one when the user changes their password by passing `revokeOtherSessions` as true on `changePassword` function. The current session is preserved so the caller stays signed in after the change.
 
 ```ts title="auth.ts"
 import { authClient } from "@/lib/auth-client"

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -875,19 +875,9 @@ export const revokeOtherSessions = createAuthEndpoint(
 				code: "UNAUTHORIZED",
 			});
 		}
-		const sessions = await ctx.context.internalAdapter.listSessions(
+		await ctx.context.internalAdapter.deleteOtherSessions(
 			session.user.id,
-		);
-		const activeSessions = sessions.filter((session) => {
-			return session.expiresAt > new Date();
-		});
-		const otherSessions = activeSessions.filter(
-			(session) => session.token !== ctx.context.session.session.token,
-		);
-		await Promise.all(
-			otherSessions.map((session) =>
-				ctx.context.internalAdapter.deleteSession(session.token),
-			),
+			session.session.token,
 		);
 		return ctx.json({
 			status: true,

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -886,19 +886,9 @@ export const revokeOtherSessions = createAuthEndpoint(
 				code: "UNAUTHORIZED",
 			});
 		}
-		const sessions = await ctx.context.internalAdapter.listSessions(
+		await ctx.context.internalAdapter.deleteOtherSessions(
 			session.user.id,
-		);
-		const activeSessions = sessions.filter((session) => {
-			return session.expiresAt > new Date();
-		});
-		const otherSessions = activeSessions.filter(
-			(session) => session.token !== ctx.context.session.session.token,
-		);
-		await Promise.all(
-			otherSessions.map((session) =>
-				ctx.context.internalAdapter.deleteSession(session.token),
-			),
+			session.session.token,
 		);
 		return ctx.json({
 			status: true,

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -243,26 +243,79 @@ describe("updateUser", async () => {
 		expect(signInAttempt.data).toBeNull();
 	});
 
-	it("should revoke other sessions", async () => {
-		await globalRunWithClient(async (headers) => {
-			const newHeaders = new Headers();
-			await client.changePassword({
-				newPassword: "newPassword",
-				currentPassword: testUser.password,
-				revokeOtherSessions: true,
-				fetchOptions: {
-					onSuccess: sessionSetter(newHeaders),
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/6881
+	 */
+	it("should revoke other sessions while preserving the current session", async () => {
+		const { client: multiSessionClient, sessionSetter: multiSessionSetter } =
+			await getTestInstance(
+				{},
+				{
+					disableTestUser: true,
 				},
-			});
-			const cookie = newHeaders.get("cookie");
-			const oldCookie = headers.get("cookie");
-			expect(cookie).not.toBe(oldCookie);
-			// Try to use the old session - it should be revoked
-			const sessionAttempt = await client.getSession();
-			// The old session should still be invalidated even though we're using runWithClient
-			// because revokeOtherSessions should have invalidated it on the server
-			expect(sessionAttempt.data).toBeNull();
+			);
+
+		const email = `multi-session-${Date.now()}@test.com`;
+		const password = "testPassword123";
+		await multiSessionClient.signUp.email({
+			email,
+			password,
+			name: "Multi Session Test User",
 		});
+
+		const currentHeaders = new Headers();
+		await multiSessionClient.signIn.email({
+			email,
+			password,
+			fetchOptions: {
+				onSuccess: multiSessionSetter(currentHeaders),
+			},
+		});
+
+		const otherHeaders = new Headers();
+		await multiSessionClient.signIn.email({
+			email,
+			password,
+			fetchOptions: {
+				onSuccess: multiSessionSetter(otherHeaders),
+			},
+		});
+
+		const currentBefore = await multiSessionClient.getSession({
+			fetchOptions: {
+				headers: currentHeaders,
+			},
+		});
+		expect(currentBefore.data?.session.id).toBeDefined();
+
+		const result = await multiSessionClient.changePassword({
+			newPassword: "newSecurePassword123",
+			currentPassword: password,
+			revokeOtherSessions: true,
+			fetchOptions: {
+				headers: currentHeaders,
+			},
+		});
+		expect(result.data?.user.email).toBe(email);
+		expect(result.data?.token).toBeNull();
+
+		const currentAfter = await multiSessionClient.getSession({
+			fetchOptions: {
+				headers: currentHeaders,
+			},
+		});
+		expect(currentAfter.data?.user.email).toBe(email);
+		expect(currentAfter.data?.session.id).toBe(currentBefore.data?.session.id);
+		expect(currentAfter.data?.session.token).toBe(
+			currentBefore.data?.session.token,
+		);
+
+		const otherAfter = await multiSessionClient.getSession({
+			fetchOptions: {
+				headers: otherHeaders,
+			},
+		});
+		expect(otherAfter.data).toBeNull();
 	});
 
 	it("shouldn't pass defaults", async () => {
@@ -679,7 +732,19 @@ describe("delete user", async () => {
 			},
 		});
 
-		expect(sessionAfterPasswordChange.data).toBeNull();
+		expect(sessionAfterPasswordChange.data?.user.email).toBe(uniqueEmail);
+
+		const staleSignIn = await cacheClient.signIn.email({
+			email: uniqueEmail,
+			password: testPassword,
+		});
+		expect(staleSignIn.data).toBeNull();
+
+		const freshSignIn = await cacheClient.signIn.email({
+			email: uniqueEmail,
+			password: "newSecurePassword123",
+		});
+		expect(freshSignIn.data?.user.email).toBe(uniqueEmail);
 	});
 });
 

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -187,9 +187,8 @@ export const changePassword = createAuthEndpoint(
 									properties: {
 										token: {
 											type: "string",
-											nullable: true, // Only present if revokeOtherSessions is true
-											description:
-												"New session token if other sessions were revoked",
+											nullable: true,
+											description: "Always null; current session preserved.",
 										},
 										user: {
 											type: "object",
@@ -286,28 +285,15 @@ export const changePassword = createAuthEndpoint(
 		await ctx.context.internalAdapter.updateAccount(account.id, {
 			password: passwordHash,
 		});
-		let token = null;
 		if (revokeOtherSessions) {
-			await ctx.context.internalAdapter.deleteSessions(session.user.id);
-			const newSession = await ctx.context.internalAdapter.createSession(
+			await ctx.context.internalAdapter.deleteOtherSessions(
 				session.user.id,
+				session.session.token,
 			);
-			if (!newSession) {
-				throw APIError.from(
-					"INTERNAL_SERVER_ERROR",
-					BASE_ERROR_CODES.FAILED_TO_GET_SESSION,
-				);
-			}
-			// set the new session cookie
-			await setSessionCookie(ctx, {
-				session: newSession,
-				user: session.user,
-			});
-			token = newSession.token;
 		}
 
 		return ctx.json({
-			token,
+			token: null,
 			user: parseUserOutput(ctx.context.options, session.user),
 		});
 	},

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -186,8 +186,7 @@ export const changePassword = createAuthEndpoint(
 									type: "object",
 									properties: {
 										token: {
-											type: "string",
-											nullable: true,
+											type: "null",
 											description: "Always null; current session preserved.",
 										},
 										user: {

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -187,9 +187,8 @@ export const changePassword = createAuthEndpoint(
 									properties: {
 										token: {
 											type: "string",
-											nullable: true, // Only present if revokeOtherSessions is true
-											description:
-												"New session token if other sessions were revoked",
+											nullable: true,
+											description: "Always null; current session preserved.",
 										},
 										user: {
 											type: "object",
@@ -286,28 +285,15 @@ export const changePassword = createAuthEndpoint(
 		await ctx.context.internalAdapter.updateAccount(account.id, {
 			password: passwordHash,
 		});
-		let token = null;
 		if (revokeOtherSessions) {
-			await ctx.context.internalAdapter.deleteUserSessions(session.user.id);
-			const newSession = await ctx.context.internalAdapter.createSession(
+			await ctx.context.internalAdapter.deleteOtherSessions(
 				session.user.id,
+				session.session.token,
 			);
-			if (!newSession) {
-				throw APIError.from(
-					"INTERNAL_SERVER_ERROR",
-					BASE_ERROR_CODES.FAILED_TO_GET_SESSION,
-				);
-			}
-			// set the new session cookie
-			await setSessionCookie(ctx, {
-				session: newSession,
-				user: session.user,
-			});
-			token = newSession.token;
 		}
 
 		return ctx.json({
-			token,
+			token: null,
 			user: parseUserOutput(ctx.context.options, session.user),
 		});
 	},

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -981,6 +981,79 @@ describe("internal adapter test", async () => {
 		);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/6881
+	 */
+	it("deleteOtherSessions preserves the exceptToken survivor (db-only)", async () => {
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+		} satisfies BetterAuthOptions;
+
+		(await getMigrations(testOpts)).runMigrations();
+
+		const testCtx = await init(testOpts);
+		const testInternalAdapter = testCtx.internalAdapter;
+
+		const user = await testInternalAdapter.createUser({
+			name: "test-user-except-db",
+			email: "test-except-db@email.com",
+		});
+
+		const survivor = await testInternalAdapter.createSession(user.id);
+		await testInternalAdapter.createSession(user.id);
+
+		await testInternalAdapter.deleteOtherSessions(user.id, survivor.token);
+
+		const remaining = await testInternalAdapter.listSessions(user.id);
+		expect(remaining.length).toBe(1);
+		expect(remaining[0]!.token).toBe(survivor.token);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/6881
+	 */
+	it("deleteOtherSessions preserves the exceptToken survivor (secondary storage)", async () => {
+		const testMap = new Map<string, string>();
+
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				set(key: string, value: string) {
+					testMap.set(key, value);
+				},
+				get(key: string) {
+					return testMap.get(key) || null;
+				},
+				delete(key: string) {
+					testMap.delete(key);
+				},
+			},
+		} satisfies BetterAuthOptions;
+
+		(await getMigrations(testOpts)).runMigrations();
+
+		const testCtx = await init(testOpts);
+		const testInternalAdapter = testCtx.internalAdapter;
+
+		const user = await testInternalAdapter.createUser({
+			name: "test-user-except-secondary",
+			email: "test-except-secondary@email.com",
+		});
+
+		const survivor = await testInternalAdapter.createSession(user.id);
+		const sibling = await testInternalAdapter.createSession(user.id);
+
+		await testInternalAdapter.deleteOtherSessions(user.id, survivor.token);
+
+		expect(testMap.has(survivor.token)).toBe(true);
+		expect(testMap.has(sibling.token)).toBe(false);
+		expect(
+			safeJSONParse<{ token: string; expiresAt: number }[]>(
+				testMap.get(`active-sessions-${user.id}`)!,
+			),
+		).toEqual([{ token: survivor.token, expiresAt: expect.any(Number) }]);
+	});
+
 	it("should update session and active-sessions list in secondary storage", async () => {
 		const testMap = new Map<string, string>();
 		const testExpirationMap = new Map<string, number>();

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1054,6 +1054,103 @@ describe("internal adapter test", async () => {
 		).toEqual([{ token: survivor.token, expiresAt: expect.any(Number) }]);
 	});
 
+	it("deleteOtherSessions falls back to db cleanup when active-sessions json is corrupt", async () => {
+		const testMap = new Map<string, string>();
+
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				set(key: string, value: string) {
+					testMap.set(key, value);
+				},
+				get(key: string) {
+					return testMap.get(key) || null;
+				},
+				delete(key: string) {
+					testMap.delete(key);
+				},
+			},
+			session: { storeSessionInDatabase: true },
+		} satisfies BetterAuthOptions;
+
+		(await getMigrations(testOpts)).runMigrations();
+
+		const testCtx = await init(testOpts);
+		const testInternalAdapter = testCtx.internalAdapter;
+
+		const user = await testInternalAdapter.createUser({
+			name: "test-user-corrupt-list",
+			email: "test-corrupt-list@email.com",
+		});
+
+		const survivor = await testInternalAdapter.createSession(user.id);
+		await testInternalAdapter.createSession(user.id);
+
+		testMap.set(`active-sessions-${user.id}`, "{not json");
+
+		await testInternalAdapter.deleteOtherSessions(user.id, survivor.token);
+
+		expect(testMap.has(`active-sessions-${user.id}`)).toBe(false);
+		const remaining = await testCtx.adapter.findMany<Session>({
+			model: "session",
+			where: [{ field: "userId", value: user.id }],
+		});
+		expect(remaining.length).toBe(1);
+		expect(remaining[0]!.token).toBe(survivor.token);
+	});
+
+	it("deleteOtherSessions deletes the active-sessions key when survivor ttl floors to zero", async () => {
+		const testMap = new Map<string, string>();
+		const testExpirationMap = new Map<string, number>();
+
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				set(key: string, value: string, ttl?: number) {
+					testMap.set(key, value);
+					if (ttl !== undefined) testExpirationMap.set(key, ttl);
+				},
+				get(key: string) {
+					return testMap.get(key) || null;
+				},
+				delete(key: string) {
+					testMap.delete(key);
+					testExpirationMap.delete(key);
+				},
+			},
+		} satisfies BetterAuthOptions;
+
+		(await getMigrations(testOpts)).runMigrations();
+
+		const testCtx = await init(testOpts);
+		const testInternalAdapter = testCtx.internalAdapter;
+
+		const user = await testInternalAdapter.createUser({
+			name: "test-user-ttl-zero",
+			email: "test-ttl-zero@email.com",
+		});
+
+		const survivor = await testInternalAdapter.createSession(user.id);
+		const sibling = await testInternalAdapter.createSession(user.id);
+		const listKey = `active-sessions-${user.id}`;
+
+		const aboutToExpire = Date.now() + 999;
+		testMap.set(
+			listKey,
+			JSON.stringify([
+				{ token: survivor.token, expiresAt: aboutToExpire },
+				{ token: sibling.token, expiresAt: aboutToExpire },
+			]),
+		);
+
+		await testInternalAdapter.deleteOtherSessions(user.id, survivor.token);
+
+		expect(testMap.has(listKey)).toBe(false);
+		expect(testExpirationMap.has(listKey)).toBe(false);
+		expect(testMap.has(survivor.token)).toBe(true);
+		expect(testMap.has(sibling.token)).toBe(false);
+	});
+
 	it("should update session and active-sessions list in secondary storage", async () => {
 		const testMap = new Map<string, string>();
 		const testExpirationMap = new Map<string, number>();

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -987,6 +987,79 @@ describe("internal adapter test", async () => {
 		);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/6881
+	 */
+	it("deleteOtherSessions preserves the exceptToken survivor (db-only)", async () => {
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+		} satisfies BetterAuthOptions;
+
+		(await getMigrations(testOpts)).runMigrations();
+
+		const testCtx = await init(testOpts);
+		const testInternalAdapter = testCtx.internalAdapter;
+
+		const user = await testInternalAdapter.createUser({
+			name: "test-user-except-db",
+			email: "test-except-db@email.com",
+		});
+
+		const survivor = await testInternalAdapter.createSession(user.id);
+		await testInternalAdapter.createSession(user.id);
+
+		await testInternalAdapter.deleteOtherSessions(user.id, survivor.token);
+
+		const remaining = await testInternalAdapter.listSessions(user.id);
+		expect(remaining.length).toBe(1);
+		expect(remaining[0]!.token).toBe(survivor.token);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/6881
+	 */
+	it("deleteOtherSessions preserves the exceptToken survivor (secondary storage)", async () => {
+		const testMap = new Map<string, string>();
+
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				set(key: string, value: string) {
+					testMap.set(key, value);
+				},
+				get(key: string) {
+					return testMap.get(key) || null;
+				},
+				delete(key: string) {
+					testMap.delete(key);
+				},
+			},
+		} satisfies BetterAuthOptions;
+
+		(await getMigrations(testOpts)).runMigrations();
+
+		const testCtx = await init(testOpts);
+		const testInternalAdapter = testCtx.internalAdapter;
+
+		const user = await testInternalAdapter.createUser({
+			name: "test-user-except-secondary",
+			email: "test-except-secondary@email.com",
+		});
+
+		const survivor = await testInternalAdapter.createSession(user.id);
+		const sibling = await testInternalAdapter.createSession(user.id);
+
+		await testInternalAdapter.deleteOtherSessions(user.id, survivor.token);
+
+		expect(testMap.has(survivor.token)).toBe(true);
+		expect(testMap.has(sibling.token)).toBe(false);
+		expect(
+			safeJSONParse<{ token: string; expiresAt: number }[]>(
+				testMap.get(`active-sessions-${user.id}`)!,
+			),
+		).toEqual([{ token: survivor.token, expiresAt: expect.any(Number) }]);
+	});
+
 	it("should update session and active-sessions list in secondary storage", async () => {
 		const testMap = new Map<string, string>();
 		const testExpirationMap = new Map<string, number>();

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1060,6 +1060,103 @@ describe("internal adapter test", async () => {
 		).toEqual([{ token: survivor.token, expiresAt: expect.any(Number) }]);
 	});
 
+	it("deleteOtherSessions falls back to db cleanup when active-sessions json is corrupt", async () => {
+		const testMap = new Map<string, string>();
+
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				set(key: string, value: string) {
+					testMap.set(key, value);
+				},
+				get(key: string) {
+					return testMap.get(key) || null;
+				},
+				delete(key: string) {
+					testMap.delete(key);
+				},
+			},
+			session: { storeSessionInDatabase: true },
+		} satisfies BetterAuthOptions;
+
+		(await getMigrations(testOpts)).runMigrations();
+
+		const testCtx = await init(testOpts);
+		const testInternalAdapter = testCtx.internalAdapter;
+
+		const user = await testInternalAdapter.createUser({
+			name: "test-user-corrupt-list",
+			email: "test-corrupt-list@email.com",
+		});
+
+		const survivor = await testInternalAdapter.createSession(user.id);
+		await testInternalAdapter.createSession(user.id);
+
+		testMap.set(`active-sessions-${user.id}`, "{not json");
+
+		await testInternalAdapter.deleteOtherSessions(user.id, survivor.token);
+
+		expect(testMap.has(`active-sessions-${user.id}`)).toBe(false);
+		const remaining = await testCtx.adapter.findMany<Session>({
+			model: "session",
+			where: [{ field: "userId", value: user.id }],
+		});
+		expect(remaining.length).toBe(1);
+		expect(remaining[0]!.token).toBe(survivor.token);
+	});
+
+	it("deleteOtherSessions deletes the active-sessions key when survivor ttl floors to zero", async () => {
+		const testMap = new Map<string, string>();
+		const testExpirationMap = new Map<string, number>();
+
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				set(key: string, value: string, ttl?: number) {
+					testMap.set(key, value);
+					if (ttl !== undefined) testExpirationMap.set(key, ttl);
+				},
+				get(key: string) {
+					return testMap.get(key) || null;
+				},
+				delete(key: string) {
+					testMap.delete(key);
+					testExpirationMap.delete(key);
+				},
+			},
+		} satisfies BetterAuthOptions;
+
+		(await getMigrations(testOpts)).runMigrations();
+
+		const testCtx = await init(testOpts);
+		const testInternalAdapter = testCtx.internalAdapter;
+
+		const user = await testInternalAdapter.createUser({
+			name: "test-user-ttl-zero",
+			email: "test-ttl-zero@email.com",
+		});
+
+		const survivor = await testInternalAdapter.createSession(user.id);
+		const sibling = await testInternalAdapter.createSession(user.id);
+		const listKey = `active-sessions-${user.id}`;
+
+		const aboutToExpire = Date.now() + 999;
+		testMap.set(
+			listKey,
+			JSON.stringify([
+				{ token: survivor.token, expiresAt: aboutToExpire },
+				{ token: sibling.token, expiresAt: aboutToExpire },
+			]),
+		);
+
+		await testInternalAdapter.deleteOtherSessions(user.id, survivor.token);
+
+		expect(testMap.has(listKey)).toBe(false);
+		expect(testExpirationMap.has(listKey)).toBe(false);
+		expect(testMap.has(survivor.token)).toBe(true);
+		expect(testMap.has(sibling.token)).toBe(false);
+	});
+
 	it("should update session and active-sessions list in secondary storage", async () => {
 		const testMap = new Map<string, string>();
 		const testExpirationMap = new Map<string, number>();

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -790,10 +790,13 @@ export const createInternalAdapter = (
 				const activeSession = await secondaryStorage.get(
 					`active-sessions-${userId}`,
 				);
-				const sessions = activeSession
+				const parsed = activeSession
 					? safeJSONParse<{ token: string; expiresAt: number }[]>(activeSession)
-					: [];
-				if (!sessions) return;
+					: null;
+				if (activeSession && !parsed) {
+					await secondaryStorage.delete(`active-sessions-${userId}`);
+				}
+				const sessions = parsed ?? [];
 				const now = Date.now();
 				const survivor = sessions.find(
 					(s) => s.token === exceptToken && s.expiresAt > now,
@@ -803,11 +806,16 @@ export const createInternalAdapter = (
 					await secondaryStorage.delete(session.token);
 				}
 				if (survivor) {
-					await secondaryStorage.set(
-						`active-sessions-${userId}`,
-						JSON.stringify([survivor]),
-						getTTLSeconds(survivor.expiresAt, now),
-					);
+					const ttl = getTTLSeconds(survivor.expiresAt, now);
+					if (ttl > 0) {
+						await secondaryStorage.set(
+							`active-sessions-${userId}`,
+							JSON.stringify([survivor]),
+							ttl,
+						);
+					} else {
+						await secondaryStorage.delete(`active-sessions-${userId}`);
+					}
 				} else {
 					await secondaryStorage.delete(`active-sessions-${userId}`);
 				}

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -785,6 +785,56 @@ export const createInternalAdapter = (
 				undefined,
 			);
 		},
+		deleteOtherSessions: async (userId: string, exceptToken: string) => {
+			if (secondaryStorage) {
+				const activeSession = await secondaryStorage.get(
+					`active-sessions-${userId}`,
+				);
+				const sessions = activeSession
+					? safeJSONParse<{ token: string; expiresAt: number }[]>(activeSession)
+					: [];
+				if (!sessions) return;
+				const now = Date.now();
+				const survivor = sessions.find(
+					(s) => s.token === exceptToken && s.expiresAt > now,
+				);
+				for (const session of sessions) {
+					if (session.token === exceptToken) continue;
+					await secondaryStorage.delete(session.token);
+				}
+				if (survivor) {
+					await secondaryStorage.set(
+						`active-sessions-${userId}`,
+						JSON.stringify([survivor]),
+						getTTLSeconds(survivor.expiresAt, now),
+					);
+				} else {
+					await secondaryStorage.delete(`active-sessions-${userId}`);
+				}
+
+				if (
+					!options.session?.storeSessionInDatabase ||
+					ctx.options.session?.preserveSessionInDatabase
+				) {
+					return;
+				}
+			}
+			await deleteManyWithHooks(
+				[
+					{
+						field: "userId",
+						value: userId,
+					},
+					{
+						field: "token",
+						value: exceptToken,
+						operator: "ne",
+					} satisfies Where,
+				],
+				"session",
+				undefined,
+			);
+		},
 		findOAuthUser: async (
 			email: string,
 			accountId: string,

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -836,6 +836,56 @@ export const createInternalAdapter = (
 				undefined,
 			);
 		},
+		deleteOtherSessions: async (userId: string, exceptToken: string) => {
+			if (secondaryStorage) {
+				const activeSession = await secondaryStorage.get(
+					`active-sessions-${userId}`,
+				);
+				const sessions = activeSession
+					? safeJSONParse<{ token: string; expiresAt: number }[]>(activeSession)
+					: [];
+				if (!sessions) return;
+				const now = Date.now();
+				const survivor = sessions.find(
+					(s) => s.token === exceptToken && s.expiresAt > now,
+				);
+				for (const session of sessions) {
+					if (session.token === exceptToken) continue;
+					await secondaryStorage.delete(session.token);
+				}
+				if (survivor) {
+					await secondaryStorage.set(
+						`active-sessions-${userId}`,
+						JSON.stringify([survivor]),
+						getTTLSeconds(survivor.expiresAt, now),
+					);
+				} else {
+					await secondaryStorage.delete(`active-sessions-${userId}`);
+				}
+
+				if (
+					!options.session?.storeSessionInDatabase ||
+					ctx.options.session?.preserveSessionInDatabase
+				) {
+					return;
+				}
+			}
+			await deleteManyWithHooks(
+				[
+					{
+						field: "userId",
+						value: userId,
+					},
+					{
+						field: "token",
+						value: exceptToken,
+						operator: "ne",
+					} satisfies Where,
+				],
+				"session",
+				undefined,
+			);
+		},
 		findOAuthUser: async (
 			email: string,
 			accountId: string,

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -841,10 +841,13 @@ export const createInternalAdapter = (
 				const activeSession = await secondaryStorage.get(
 					`active-sessions-${userId}`,
 				);
-				const sessions = activeSession
+				const parsed = activeSession
 					? safeJSONParse<{ token: string; expiresAt: number }[]>(activeSession)
-					: [];
-				if (!sessions) return;
+					: null;
+				if (activeSession && !parsed) {
+					await secondaryStorage.delete(`active-sessions-${userId}`);
+				}
+				const sessions = parsed ?? [];
 				const now = Date.now();
 				const survivor = sessions.find(
 					(s) => s.token === exceptToken && s.expiresAt > now,
@@ -854,11 +857,16 @@ export const createInternalAdapter = (
 					await secondaryStorage.delete(session.token);
 				}
 				if (survivor) {
-					await secondaryStorage.set(
-						`active-sessions-${userId}`,
-						JSON.stringify([survivor]),
-						getTTLSeconds(survivor.expiresAt, now),
-					);
+					const ttl = getTTLSeconds(survivor.expiresAt, now);
+					if (ttl > 0) {
+						await secondaryStorage.set(
+							`active-sessions-${userId}`,
+							JSON.stringify([survivor]),
+							ttl,
+						);
+					} else {
+						await secondaryStorage.delete(`active-sessions-${userId}`);
+					}
 				} else {
 					await secondaryStorage.delete(`active-sessions-${userId}`);
 				}

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -811,8 +811,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
                   "properties": {
                     "token": {
                       "description": "Always null; current session preserved.",
-                      "nullable": true,
-                      "type": "string",
+                      "type": "null",
                     },
                     "user": {
                       "properties": {

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -810,7 +810,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
                 "schema": {
                   "properties": {
                     "token": {
-                      "description": "New session token if other sessions were revoked",
+                      "description": "Always null; current session preserved.",
                       "nullable": true,
                       "type": "string",
                     },

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -155,6 +155,8 @@ export interface InternalAdapter<
 
 	deleteSessions(userIdOrSessionTokens: string | string[]): Promise<void>;
 
+	deleteOtherSessions(userId: string, exceptToken: string): Promise<void>;
+
 	findOAuthUser(
 		email: string,
 		accountId: string,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -168,6 +168,8 @@ export interface InternalAdapter<
 	 */
 	deleteSessions(sessionTokens: string[]): Promise<void>;
 
+	deleteOtherSessions(userId: string, exceptToken: string): Promise<void>;
+
 	findOAuthUser(
 		email: string,
 		accountId: string,


### PR DESCRIPTION
`auth.api.changePassword({ revokeOtherSessions: true, ... })` silently rotates the caller's own session, leaving any cached JWT (Convex queries, OIDC consumers) pointing at the deleted session id for ~500 to 1500 ms. The JSDoc on `revokeOtherSessions` reads "revoke all sessions that are not the current one logged in by the user", so the behavior contradicts its own contract.

This PR adds `internalAdapter.deleteOtherSessions(userId, exceptToken)` and routes both `/change-password`'s `revokeOtherSessions: true` branch and `/revoke-other-sessions` through it. `deleteSessions` is unchanged.

# Test plan

- `pnpm typecheck` clean
- `pnpm vitest internal-adapter.test.ts -t deleteOtherSessions`: 4/4 pass
- `pnpm vitest update-user.test.ts -t "revoke other sessions while preserving"`: 1/1 pass

Refs #6881
