### PR TITLE
fix: skip getAccessToken updateAccount in stateless mode

### DIFF
--- a/.changeset/fix-stateless-getaccesstoken-skip-update.md
+++ b/.changeset/fix-stateless-getaccesstoken-skip-update.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix: skip `internalAdapter.updateAccount` during `getAccessToken` auto-refresh when no `database` is configured. Previously, refreshed tokens triggered a redundant call to the in-memory fallback adapter; with no real DB to update, the call is now skipped and the refreshed tokens are still returned and persisted in the account cookie when `storeAccountCookie` is enabled. Fixes #7703.

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -1,5 +1,6 @@
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import type { GoogleProfile } from "@better-auth/core/social-providers";
+import type { ErrorContext } from "@better-fetch/fetch";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import type { MockInstance } from "vitest";
@@ -993,6 +994,111 @@ describe("account", async () => {
 		expect(secondAccessToken.error).toBeFalsy();
 		expect(secondAccessToken.data?.idToken).toBe(newIdToken);
 		expect(refreshTokenCalls).toBeGreaterThan(0);
+	});
+
+	it("should skip internalAdapter.updateAccount during getAccessToken auto-refresh when no database is configured", async () => {
+		const { auth, client, cookieSetter } = await getTestInstance({
+			database: undefined,
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				storeAccountCookie: true,
+			},
+		});
+		const ctx = await auth.$context;
+		const updateAccountSpy = vi.spyOn(ctx.internalAdapter, "updateAccount");
+
+		const headers = new Headers();
+		email = "skip-update-no-db@test.com";
+
+		const now = Math.floor(Date.now() / 1000);
+		const idToken = await signJWT(
+			{
+				email,
+				email_verified: true,
+				name: "First Last",
+				picture: "https://lh3.googleusercontent.com/a-/AOh14GjQ4Z7Vw",
+				exp: now + 3600,
+				sub: "skip-update-no-db",
+				iat: now,
+				aud: "test",
+				azp: "test",
+				nbf: now,
+				iss: "test",
+				locale: "en",
+				jti: "skip-update-no-db-id-token",
+				given_name: "First",
+				family_name: "Last",
+			} satisfies GoogleProfile,
+			DEFAULT_SECRET,
+		);
+
+		let refreshTokenCalls = 0;
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async ({ request }) => {
+				const body = await request.text();
+				const grantType = new URLSearchParams(body).get("grant_type");
+
+				if (grantType === "refresh_token") {
+					refreshTokenCalls += 1;
+					return HttpResponse.json({
+						access_token: "refreshed-access-token",
+						refresh_token: "refreshed-refresh-token",
+						expires_in: 3600,
+						id_token: idToken,
+					});
+				}
+
+				return HttpResponse.json({
+					access_token: "initial-access-token",
+					refresh_token: "initial-refresh-token",
+					expires_in: 1,
+					id_token: idToken,
+				});
+			}),
+		);
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const state =
+			signInRes.data && "url" in signInRes.data && signInRes.data.url
+				? new URL(signInRes.data.url).searchParams.get("state") || ""
+				: "";
+
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test" },
+			headers,
+			method: "GET",
+			onError: (context: ErrorContext) => {
+				expect(context.response.status).toBe(302);
+				cookieSetter(headers)({ response: context.response });
+			},
+		});
+
+		updateAccountSpy.mockClear();
+
+		const accessToken = await client.getAccessToken(
+			{ providerId: "google" },
+			{ headers, onSuccess: cookieSetter(headers) },
+		);
+
+		expect(accessToken.error).toBeFalsy();
+		expect(accessToken.data?.accessToken).toBe("refreshed-access-token");
+		expect(refreshTokenCalls).toBe(1);
+		expect(updateAccountSpy).not.toHaveBeenCalled();
+
+		updateAccountSpy.mockRestore();
 	});
 
 	it("should NOT chunk account data cookies when exceeding 4KB", async () => {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -571,7 +571,7 @@ export const getAccessToken = createAuthEndpoint(
 					idToken: newTokens?.idToken || account.idToken,
 				};
 				let updatedAccount: Record<string, any> | null = null;
-				if (account.id) {
+				if (account.id && ctx.context.options.database) {
 					updatedAccount = await ctx.context.internalAdapter.updateAccount(
 						account.id,
 						updatedData,


### PR DESCRIPTION
## Summary

Fixes #7703. Supersedes #7705 (inactive since Jan 30, 2026).

In stateless setups (no `database` configured), `getAccessToken` unconditionally calls `internalAdapter.updateAccount` against the in-memory fallback adapter. This is wasted work and, in multi-instance deployments where the cookie-resolved `account.id` does not exist in the current instance's memory, can mask the refreshed tokens behind a generic `BAD_REQUEST`.

This PR adopts the form @bytaesu suggested in their review on #7705 — \`if (account.id && ctx.context.options.database)\` — instead of the try/catch in the original PR. It does **not** include the \`accessTokenExpiresAt\`-missing change from #7705 (per @bytaesu's request, that belongs in a separate PR).

Co-authored with @biniam0 to acknowledge the original work on #7705.

## Changes

- \`packages/better-auth/src/api/routes/account.ts\`: skip \`internalAdapter.updateAccount\` in \`getAccessToken\` when \`options.database\` is undefined. The account cookie is still refreshed via \`setAccountCookie\` when \`storeAccountCookie\` is enabled.
- \`packages/better-auth/src/api/routes/account.test.ts\`: add \`should skip internalAdapter.updateAccount during getAccessToken auto-refresh when no database is configured\` — verifies the spy on \`updateAccount\` is not called and refreshed tokens are still returned.
- \`.changeset/fix-stateless-getaccesstoken-skip-update.md\`: \`patch\` changeset.

## Verification

- On \`main\` without this fix: new test fails (\`updateAccount\` called once)
- With this fix: new test passes; full \`account.test.ts\` 24/24 passing
- No \`any\`, no implicit-\`any\`, no TS errors in the new test (verified with \`tsc --noEmit -p .\`)

## Out of scope

- The \`accessTokenExpiresAt\`-missing case from #7705. Per @bytaesu's review comment, that change is better handled in a separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `internalAdapter.updateAccount` in `getAccessToken` when no `database` is configured to avoid stateless multi-instance `BAD_REQUEST`s; tokens still return and the account cookie is refreshed when `storeAccountCookie` is enabled.

- **Bug Fixes**
  - Gate update behind `account.id && ctx.context.options.database`.
  - Add test to ensure no update call and successful token refresh in stateless mode.

<sup>Written for commit 4d9638c22eb1a144ac5d98719bdffec98733465a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

