### PR TITLE
feat(google): add option to disable granted scopes

### DIFF
--- a/.changeset/google-include-granted-scopes.md
+++ b/.changeset/google-include-granted-scopes.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Add a Google provider option to omit `include_granted_scopes` from authorization requests.

--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -187,6 +187,20 @@ This will trigger a new OAuth flow that requests the additional scopes. After co
   provider.
 </Callout>
 
+### Disable Previously Granted Scopes
+
+By default, Google authorization requests include `include_granted_scopes=true`, which can return previously granted scopes along with newly requested scopes. Set `includeGrantedScopes` to `false` when you want each OAuth request to include only the scopes requested for that flow.
+
+```ts title="auth.ts"
+socialProviders: {
+    google: {
+        clientId: process.env.GOOGLE_CLIENT_ID as string,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+        includeGrantedScopes: false, // [!code highlight]
+    },
+}
+```
+
 ### Always get refresh token
 
 Google only issues a refresh token the first time a user consents to your app.

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -997,7 +997,7 @@ describe("updateAccountOnSignIn", async () => {
 /**
  * @see https://github.com/better-auth/better-auth/issues/4498
  */
-describe("Google Provider — multiple client IDs", async () => {
+describe("Google Provider", async () => {
 	const googleKeyPair = await generateKeyPair("RS256");
 	const googleJwk = await exportJWK(googleKeyPair.publicKey);
 	const googleKid = "test-google-kid";
@@ -1031,148 +1031,154 @@ describe("Google Provider — multiple client IDs", async () => {
 		);
 	});
 
-	it.each([
-		["web", webClientId],
-		["iOS", iosClientId],
-		["Android", androidClientId],
-	])("accepts an id token issued for the %s client", async (_, audience) => {
-		const idToken = await signIdToken(audience);
-		const { client } = await getTestInstance(
-			{
-				socialProviders: {
-					google: {
-						clientId: [webClientId, iosClientId, androidClientId],
-						clientSecret: "test-secret",
+	describe("multiple client IDs", () => {
+		it.each([
+			["web", webClientId],
+			["iOS", iosClientId],
+			["Android", androidClientId],
+		])("accepts an id token issued for the %s client", async (_, audience) => {
+			const idToken = await signIdToken(audience);
+			const { client } = await getTestInstance(
+				{
+					socialProviders: {
+						google: {
+							clientId: [webClientId, iosClientId, androidClientId],
+							clientSecret: "test-secret",
+						},
 					},
 				},
-			},
-			{ disableTestUser: true },
-		);
+				{ disableTestUser: true },
+			);
 
-		const res = await client.signIn.social({
-			provider: "google",
-			idToken: { token: idToken },
+			const res = await client.signIn.social({
+				provider: "google",
+				idToken: { token: idToken },
+			});
+
+			expect(res.data).toBeDefined();
+			expect(res.data!.redirect).toBe(false);
+			const data = res.data as { user: { email: string } };
+			expect(data.user.email).toBe("mobile-user@example.com");
 		});
 
-		expect(res.data).toBeDefined();
-		expect(res.data!.redirect).toBe(false);
-		const data = res.data as { user: { email: string } };
-		expect(data.user.email).toBe("mobile-user@example.com");
+		it("rejects an id token whose audience is not configured", async () => {
+			const idToken = await signIdToken("999-unknown.googleusercontent.com");
+			const { client } = await getTestInstance(
+				{
+					socialProviders: {
+						google: {
+							clientId: [webClientId, iosClientId],
+							clientSecret: "test-secret",
+						},
+					},
+				},
+				{ disableTestUser: true },
+			);
+
+			const res = await client.signIn.social({
+				provider: "google",
+				idToken: { token: idToken },
+			});
+
+			expect(res.error?.status).toBe(401);
+		});
+
+		it("uses the first configured client id when building the authorization URL", async () => {
+			const { client } = await getTestInstance(
+				{
+					socialProviders: {
+						google: {
+							clientId: [webClientId, iosClientId, androidClientId],
+							clientSecret: "test-secret",
+						},
+					},
+				},
+				{ disableTestUser: true },
+			);
+
+			const signInRes = await client.signIn.social({
+				provider: "google",
+				callbackURL: "/callback",
+			});
+
+			expect(signInRes.data?.url).toContain(encodeURIComponent(webClientId));
+			expect(signInRes.data?.url).not.toContain(
+				encodeURIComponent(iosClientId),
+			);
+		});
+
+		it("rejects an empty clientId array at sign-in time", async () => {
+			const { client } = await getTestInstance(
+				{
+					socialProviders: {
+						google: {
+							clientId: [],
+							clientSecret: "test-secret",
+						},
+					},
+				},
+				{ disableTestUser: true },
+			);
+
+			const res = await client.signIn.social({
+				provider: "google",
+				callbackURL: "/callback",
+			});
+
+			expect(res.error?.status).toBe(500);
+		});
 	});
 
-	it("rejects an id token whose audience is not configured", async () => {
-		const idToken = await signIdToken("999-unknown.googleusercontent.com");
-		const { client } = await getTestInstance(
-			{
-				socialProviders: {
-					google: {
-						clientId: [webClientId, iosClientId],
-						clientSecret: "test-secret",
+	describe("includeGrantedScopes", () => {
+		it("includes granted scopes in the authorization URL by default", async () => {
+			const { client } = await getTestInstance(
+				{
+					socialProviders: {
+						google: {
+							clientId: webClientId,
+							clientSecret: "test-secret",
+						},
 					},
 				},
-			},
-			{ disableTestUser: true },
-		);
+				{ disableTestUser: true },
+			);
 
-		const res = await client.signIn.social({
-			provider: "google",
-			idToken: { token: idToken },
+			const signInRes = await client.signIn.social({
+				provider: "google",
+				callbackURL: "/callback",
+			});
+
+			const authUrl = new URL(signInRes.data!.url!);
+			expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
 		});
 
-		expect(res.error?.status).toBe(401);
-	});
-
-	it("uses the first configured client id when building the authorization URL", async () => {
-		const { client } = await getTestInstance(
-			{
-				socialProviders: {
-					google: {
-						clientId: [webClientId, iosClientId, androidClientId],
-						clientSecret: "test-secret",
+		it("omits granted scopes from the authorization URL when disabled", async () => {
+			const { client } = await getTestInstance(
+				{
+					socialProviders: {
+						google: {
+							clientId: webClientId,
+							clientSecret: "test-secret",
+							includeGrantedScopes: false,
+						},
 					},
 				},
-			},
-			{ disableTestUser: true },
-		);
+				{ disableTestUser: true },
+			);
 
-		const signInRes = await client.signIn.social({
-			provider: "google",
-			callbackURL: "/callback",
+			const signInRes = await client.signIn.social({
+				provider: "google",
+				callbackURL: "/callback",
+				scopes: ["https://www.googleapis.com/auth/drive.file"],
+			});
+
+			const authUrl = new URL(signInRes.data!.url!);
+			expect(authUrl.searchParams.has("include_granted_scopes")).toBe(false);
+			expect(authUrl.searchParams.get("scope")).toContain("openid");
+			expect(authUrl.searchParams.get("scope")).toContain(
+				"https://www.googleapis.com/auth/drive.file",
+			);
 		});
-
-		expect(signInRes.data?.url).toContain(encodeURIComponent(webClientId));
-		expect(signInRes.data?.url).not.toContain(encodeURIComponent(iosClientId));
-	});
-
-	it("includes granted scopes in the authorization URL by default", async () => {
-		const { client } = await getTestInstance(
-			{
-				socialProviders: {
-					google: {
-						clientId: webClientId,
-						clientSecret: "test-secret",
-					},
-				},
-			},
-			{ disableTestUser: true },
-		);
-
-		const signInRes = await client.signIn.social({
-			provider: "google",
-			callbackURL: "/callback",
-		});
-
-		const authUrl = new URL(signInRes.data!.url!);
-		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
-	});
-
-	it("omits granted scopes from the authorization URL when disabled", async () => {
-		const { client } = await getTestInstance(
-			{
-				socialProviders: {
-					google: {
-						clientId: webClientId,
-						clientSecret: "test-secret",
-						includeGrantedScopes: false,
-					},
-				},
-			},
-			{ disableTestUser: true },
-		);
-
-		const signInRes = await client.signIn.social({
-			provider: "google",
-			callbackURL: "/callback",
-			scopes: ["https://www.googleapis.com/auth/drive.file"],
-		});
-
-		const authUrl = new URL(signInRes.data!.url!);
-		expect(authUrl.searchParams.has("include_granted_scopes")).toBe(false);
-		expect(authUrl.searchParams.get("scope")).toContain("openid");
-		expect(authUrl.searchParams.get("scope")).toContain(
-			"https://www.googleapis.com/auth/drive.file",
-		);
-	});
-
-	it("rejects an empty clientId array at sign-in time", async () => {
-		const { client } = await getTestInstance(
-			{
-				socialProviders: {
-					google: {
-						clientId: [],
-						clientSecret: "test-secret",
-					},
-				},
-			},
-			{ disableTestUser: true },
-		);
-
-		const res = await client.signIn.social({
-			provider: "google",
-			callbackURL: "/callback",
-		});
-
-		expect(res.error?.status).toBe(500);
 	});
 });
 

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -1104,6 +1104,56 @@ describe("Google Provider — multiple client IDs", async () => {
 		expect(signInRes.data?.url).not.toContain(encodeURIComponent(iosClientId));
 	});
 
+	it("includes granted scopes in the authorization URL by default", async () => {
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: webClientId,
+						clientSecret: "test-secret",
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+		});
+
+		const authUrl = new URL(signInRes.data!.url!);
+		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
+	});
+
+	it("omits granted scopes from the authorization URL when disabled", async () => {
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: webClientId,
+						clientSecret: "test-secret",
+						includeGrantedScopes: false,
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			scopes: ["https://www.googleapis.com/auth/drive.file"],
+		});
+
+		const authUrl = new URL(signInRes.data!.url!);
+		expect(authUrl.searchParams.has("include_granted_scopes")).toBe(false);
+		expect(authUrl.searchParams.get("scope")).toContain("openid");
+		expect(authUrl.searchParams.get("scope")).toContain(
+			"https://www.googleapis.com/auth/drive.file",
+		);
+	});
+
 	it("rejects an empty clientId array at sign-in time", async () => {
 		const { client } = await getTestInstance(
 			{

--- a/packages/core/src/social-providers/google.ts
+++ b/packages/core/src/social-providers/google.ts
@@ -51,6 +51,11 @@ export interface GoogleOptions extends ProviderOptions<GoogleProfile> {
 	 * The hosted domain of the user
 	 */
 	hd?: string | undefined;
+	/**
+	 * Include previously granted scopes in the authorization request.
+	 * Defaults to true.
+	 */
+	includeGrantedScopes?: boolean | undefined;
 }
 
 export const google = (options: GoogleOptions) => {
@@ -92,9 +97,12 @@ export const google = (options: GoogleOptions) => {
 				display: display || options.display,
 				loginHint,
 				hd: options.hd,
-				additionalParams: {
-					include_granted_scopes: "true",
-				},
+				additionalParams:
+					options.includeGrantedScopes === false
+						? undefined
+						: {
+								include_granted_scopes: "true",
+							},
 			});
 			return url;
 		},


### PR DESCRIPTION
## Summary

Adds a Google provider option, `includeGrantedScopes`, to control whether Better Auth sends `include_granted_scopes=true` in Google authorization requests.

By default, behavior is unchanged. Users can now set `includeGrantedScopes: false` to omit the parameter when they want each OAuth flow to request only the scopes explicitly provided for that flow.

## Closes: #9326 

## Changes

- Add `includeGrantedScopes?: boolean` to `GoogleOptions`
- Keep `include_granted_scopes=true` by default
- Omit `include_granted_scopes` when `includeGrantedScopes` is `false`
- Add Google provider tests for default and disabled behavior
- Document the new option
- Add a patch changeset

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `includeGrantedScopes` option to the Google provider to control Google’s `include_granted_scopes` behavior during OAuth. Default stays the same; set `includeGrantedScopes: false` to request only the scopes you pass for that flow.

- New Features
  - Added `includeGrantedScopes?: boolean` to `GoogleOptions` (defaults to true).
  - Omits `include_granted_scopes` in the auth URL when disabled; only sends the requested scope(s).
  - Updated docs, added tests for both modes, and included a patch changeset in `better-auth`.

<sup>Written for commit 66bb590e302b01387d6b959fad2a1d364125e17e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

