### PR TITLE
fix(stripe): expose `stripeSubscription` in `onSubscriptionUpdate` and fix stale snapshot

### DIFF
--- a/.changeset/tidy-clouds-train.md
+++ b/.changeset/tidy-clouds-train.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/stripe": patch
+---
+
+`onSubscriptionUpdate` now receives `stripeSubscription` (the raw Stripe object), matching the shape of all other subscription callbacks. `onSubscriptionCancel` now also receives the post-update subscription row instead of the pre-update snapshot.

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -620,8 +620,8 @@ subscription: {
         // Called when a subscription is created outside the checkout flow (e.g. Stripe dashboard)
         await sendSubscriptionCreatedEmail(subscription.referenceId, plan.name);
     },
-    onSubscriptionUpdate: async ({ event, subscription }) => {
-        // Called when a subscription is updated
+    onSubscriptionUpdate: async ({ event, subscription, stripeSubscription }) => {
+        // Called when a subscription is updated. Use `stripeSubscription` for raw Stripe fields like `cancellation_details`.
         console.log(`Subscription ${subscription.id} updated`);
     },
     onSubscriptionCancel: async ({ event, subscription, stripeSubscription, cancellationDetails }) => {
@@ -847,18 +847,18 @@ stripe({
 
 ### Subscription Options
 
-| Option                     | Type                         | Description                                                                                                                   |
-| -------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`                  | `boolean`                    | Whether to enable subscription functionality. **Required.**                                                                   |
-| `plans`                    | `StripePlan[]` or `function` | An array of subscription plans or an async function that returns plans. **Required** if enabled.                              |
-| `requireEmailVerification` | `boolean`                    | Whether to require email verification before allowing subscription upgrades. Default: `false`.                                |
-| `authorizeReference`       | `function`                   | Authorize reference IDs. Receives `{ user, session, referenceId, action }` and context.                                       |
-| `getCheckoutSessionParams` | `function`                   | Customize Stripe Checkout session parameters. Receives `{ user, session, plan, subscription }`, request, and context.         |
-| `onSubscriptionComplete`   | `function`                   | Called when a subscription is created via checkout. Receives `{ event, stripeSubscription, subscription, plan }` and context. |
-| `onSubscriptionCreated`    | `function`                   | Called when a subscription is created outside checkout. Receives `{ event, stripeSubscription, subscription, plan }`.         |
-| `onSubscriptionUpdate`     | `function`                   | Called when a subscription is updated. Receives `{ event, subscription }`.                                                    |
-| `onSubscriptionCancel`     | `function`                   | Called when a subscription is canceled. Receives `{ event, subscription, stripeSubscription, cancellationDetails }`.          |
-| `onSubscriptionDeleted`    | `function`                   | Called when a subscription is deleted. Receives `{ event, stripeSubscription, subscription }`.                                |
+| Option                     | Type                         | Description                                                                                                                                                                |
+| -------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                  | `boolean`                    | Whether to enable subscription functionality. **Required.**                                                                                                                |
+| `plans`                    | `StripePlan[]` or `function` | An array of subscription plans or an async function that returns plans. **Required** if enabled.                                                                           |
+| `requireEmailVerification` | `boolean`                    | Whether to require email verification before allowing subscription upgrades. Default: `false`.                                                                             |
+| `authorizeReference`       | `function`                   | Authorize reference IDs. Receives `{ user, session, referenceId, action }` and context.                                                                                    |
+| `getCheckoutSessionParams` | `function`                   | Customize Stripe Checkout session parameters. Receives `{ user, session, plan, subscription }`, request, and context.                                                      |
+| `onSubscriptionComplete`   | `function`                   | Called when a subscription is created via checkout. Receives `{ event, stripeSubscription, subscription, plan }` and context.                                              |
+| `onSubscriptionCreated`    | `function`                   | Called when a subscription is created outside checkout. Receives `{ event, stripeSubscription, subscription, plan }`.                                                      |
+| `onSubscriptionUpdate`     | `function`                   | Called when a subscription is updated. Receives `{ event, subscription, stripeSubscription }`. Use `stripeSubscription` for raw Stripe fields like `cancellation_details`. |
+| `onSubscriptionCancel`     | `function`                   | Called when a subscription is canceled. Receives `{ event, subscription, stripeSubscription, cancellationDetails }`.                                                       |
+| `onSubscriptionDeleted`    | `function`                   | Called when a subscription is deleted. Receives `{ event, stripeSubscription, subscription }`.                                                                             |
 
 #### Plan Configuration
 

--- a/packages/stripe/src/hooks.ts
+++ b/packages/stripe/src/hooks.ts
@@ -372,22 +372,31 @@ export async function onSubscriptionUpdated(
 				},
 			],
 		});
+		// Practically unreachable. A null here means the row was deleted between the read above and this update.
+		if (!updatedSubscription) {
+			ctx.context.logger.warn(
+				`Stripe webhook warning: Subscription ${subscription.id} update returned no row (likely deleted concurrently), skipping callbacks`,
+			);
+			return;
+		}
+
 		const isNewCancellation =
 			subscriptionUpdated.status === "active" &&
 			isStripePendingCancel(subscriptionUpdated) &&
 			!isPendingCancel(subscription);
 		if (isNewCancellation) {
 			await options.subscription.onSubscriptionCancel?.({
-				subscription,
+				event,
+				subscription: updatedSubscription,
+				stripeSubscription: subscriptionUpdated,
 				cancellationDetails:
 					subscriptionUpdated.cancellation_details || undefined,
-				stripeSubscription: subscriptionUpdated,
-				event,
 			});
 		}
 		await options.subscription.onSubscriptionUpdate?.({
 			event,
-			subscription: updatedSubscription || subscription,
+			subscription: updatedSubscription,
+			stripeSubscription: subscriptionUpdated,
 		});
 		if (plan) {
 			if (

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -291,24 +291,27 @@ export type SubscriptionOptions = {
 		  ) => Promise<void>)
 		| undefined;
 	/**
-	 * A callback to run after a user is about to cancel their subscription
+	 * A callback to run on every subscription update webhook. Use `stripeSubscription`
+	 * to read fields that are not persisted in the local subscription row.
 	 * @returns
 	 */
 	onSubscriptionUpdate?:
 		| ((data: {
 				event: Stripe.Event;
+				stripeSubscription: Stripe.Subscription;
 				subscription: Subscription;
 		  }) => Promise<void>)
 		| undefined;
 	/**
-	 * A callback to run after a user is about to cancel their subscription
+	 * A callback to run once when a subscription transitions into a pending-cancel state
+	 * (e.g. `cancel_at_period_end` or a scheduled `cancel_at`).
 	 * @returns
 	 */
 	onSubscriptionCancel?:
 		| ((data: {
 				event?: Stripe.Event;
-				subscription: Subscription;
 				stripeSubscription: Stripe.Subscription;
+				subscription: Subscription;
 				cancellationDetails?: Stripe.Subscription.CancellationDetails | null;
 		  }) => Promise<void>)
 		| undefined;

--- a/packages/stripe/test/stripe.test.ts
+++ b/packages/stripe/test/stripe.test.ts
@@ -4933,6 +4933,190 @@ describe("stripe", () => {
 			// Verify the cancelAt date is correct
 			expect(updatedSub!.cancelAt!.getTime()).toBe(cancelAt * 1000);
 		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/9321
+		 */
+		it("should pass stripeSubscription to onSubscriptionUpdate", async () => {
+			const onSubscriptionUpdate = vi.fn();
+
+			const now = Math.floor(Date.now() / 1000);
+			const cancelAt = now + 15 * 24 * 60 * 60;
+
+			const webhookEvent = {
+				type: "customer.subscription.updated",
+				data: {
+					object: {
+						id: "sub_9321",
+						customer: "cus_9321",
+						status: "active",
+						cancel_at_period_end: true,
+						cancel_at: cancelAt,
+						canceled_at: now,
+						ended_at: null,
+						items: {
+							data: [
+								{
+									price: { id: "price_starter_123", lookup_key: null },
+									quantity: 1,
+									current_period_start: now,
+									current_period_end: now + 30 * 24 * 60 * 60,
+								},
+							],
+						},
+					},
+				},
+			};
+
+			const constructEventAsync = vi.fn().mockResolvedValue(webhookEvent);
+			const stripeForTest = {
+				...stripeOptions.stripeClient,
+				webhooks: { constructEventAsync },
+			};
+
+			const testOptions = {
+				...stripeOptions,
+				stripeClient: stripeForTest as unknown as Stripe,
+				stripeWebhookSecret: "test_secret",
+				subscription: {
+					...stripeOptions.subscription,
+					onSubscriptionUpdate,
+				},
+			} as unknown as StripeOptions;
+
+			const { auth: webhookAuth } = await getTestInstance(
+				{ database: memory, plugins: [stripe(testOptions)] },
+				{ disableTestUser: true },
+			);
+			const webhookCtx = await webhookAuth.$context;
+
+			const { id: userId } = await webhookCtx.adapter.create({
+				model: "user",
+				data: { email: "9321@test.com" },
+			});
+			await webhookCtx.adapter.create({
+				model: "subscription",
+				data: {
+					referenceId: userId,
+					stripeCustomerId: "cus_9321",
+					stripeSubscriptionId: "sub_9321",
+					status: "active",
+					plan: "starter",
+				},
+			});
+
+			await webhookAuth.handler(
+				new Request("http://localhost:3000/api/auth/stripe/webhook", {
+					method: "POST",
+					headers: { "stripe-signature": "test_signature" },
+					body: JSON.stringify(webhookEvent),
+				}),
+			);
+
+			expect(onSubscriptionUpdate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					stripeSubscription: expect.any(Object),
+				}),
+			);
+		});
+
+		it("should pass the post-update subscription row to onSubscriptionCancel (symmetry with onSubscriptionUpdate)", async () => {
+			const onSubscriptionCancel = vi.fn();
+
+			const now = Math.floor(Date.now() / 1000);
+			const periodEnd = now + 30 * 24 * 60 * 60;
+			const cancelAt = now + 15 * 24 * 60 * 60;
+
+			const cancelEvent = {
+				type: "customer.subscription.updated",
+				data: {
+					object: {
+						id: "sub_cancel_timing",
+						customer: "cus_cancel_timing",
+						status: "active",
+						cancel_at_period_end: true,
+						cancel_at: cancelAt,
+						canceled_at: now,
+						ended_at: null,
+						items: {
+							data: [
+								{
+									price: { id: "price_starter_123", lookup_key: null },
+									quantity: 1,
+									current_period_start: now,
+									current_period_end: periodEnd,
+								},
+							],
+						},
+						cancellation_details: {
+							reason: "cancellation_requested",
+							feedback: null,
+							comment: null,
+						},
+					},
+				},
+			};
+
+			const constructEventAsync = vi.fn().mockResolvedValue(cancelEvent);
+			const stripeForTest = {
+				...stripeOptions.stripeClient,
+				webhooks: { constructEventAsync },
+			};
+
+			const testOptions = {
+				...stripeOptions,
+				stripeClient: stripeForTest as unknown as Stripe,
+				stripeWebhookSecret: "test_secret",
+				subscription: {
+					...stripeOptions.subscription,
+					onSubscriptionCancel,
+				},
+			} as unknown as StripeOptions;
+
+			const { auth: webhookAuth } = await getTestInstance(
+				{
+					database: memory,
+					plugins: [stripe(testOptions)],
+				},
+				{ disableTestUser: true },
+			);
+			const webhookCtx = await webhookAuth.$context;
+
+			const { id: userId } = await webhookCtx.adapter.create({
+				model: "user",
+				data: { email: "cancel-timing@test.com" },
+			});
+
+			await webhookCtx.adapter.create({
+				model: "subscription",
+				data: {
+					referenceId: userId,
+					stripeCustomerId: "cus_cancel_timing",
+					stripeSubscriptionId: "sub_cancel_timing",
+					status: "active",
+					plan: "starter",
+					cancelAtPeriodEnd: false,
+					cancelAt: null,
+					canceledAt: null,
+				},
+			});
+
+			await webhookAuth.handler(
+				new Request("http://localhost:3000/api/auth/stripe/webhook", {
+					method: "POST",
+					headers: { "stripe-signature": "test_signature" },
+					body: JSON.stringify(cancelEvent),
+				}),
+			);
+
+			expect(onSubscriptionCancel).toHaveBeenCalledTimes(1);
+			const arg = onSubscriptionCancel.mock.calls[0]?.[0];
+			expect(arg.subscription).toMatchObject({
+				cancelAtPeriodEnd: true,
+				cancelAt: expect.any(Date),
+				canceledAt: expect.any(Date),
+			});
+		});
 	});
 
 	describe("webhook: immediate cancellation (subscription deleted)", () => {


### PR DESCRIPTION
> [!NOTE]
>  
> This PR includes a small behavior change. It fixes the callback to return updated data instead of stale data. This was previously treated as a bug fix, and is considered a fix rather than a breaking change, so it will be released as a patch.
> - See:  #5819

Closes #9321