### PR TITLE
fix(stripe)!: remove optional marker from onSubscriptionCancel `event`

### DIFF
--- a/.changeset/cool-lights-burn.md
+++ b/.changeset/cool-lights-burn.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/stripe": minor
+---
+
+`onSubscriptionCancel` callback `event` is no longer marked optional, consistent with all other subscription lifecycle callbacks. The only call site always provides an event, so the optional marker was inaccurate.

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -306,7 +306,7 @@ export type SubscriptionOptions = {
 	 */
 	onSubscriptionCancel?:
 		| ((data: {
-				event?: Stripe.Event;
+				event: Stripe.Event;
 				subscription: Subscription;
 				stripeSubscription: Stripe.Subscription;
 				cancellationDetails?: Stripe.Subscription.CancellationDetails | null;


### PR DESCRIPTION
> [!NOTE]
> It looks like it wasn't actually optional in the docs, and was more of a code mismatch. Since the type changes, I've targeted it to the beta track.