### PR TITLE
fix: skip identical cookie writes in `nextCookies` after-hook

### DIFF
--- a/.changeset/fix-nextcookies-idempotent-writes.md
+++ b/.changeset/fix-nextcookies-idempotent-writes.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Skip identical cookie writes in `nextCookies()` after-hook to avoid router cache invalidation when the session token value is unchanged

--- a/packages/better-auth/src/integrations/next-js.test.ts
+++ b/packages/better-auth/src/integrations/next-js.test.ts
@@ -160,4 +160,62 @@ describe("next-js integration", () => {
 
 		expect(session).not.toBeNull();
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8464
+	 */
+	it("should skip writing session_token when value is unchanged", async () => {
+		const store: Record<string, string> = {};
+		const setSpy = vi.fn((name: string, value: string) => {
+			store[name] = value;
+		});
+
+		vi.doMock("next/headers.js", () => ({
+			cookies: vi.fn(async () => ({
+				set: setSpy,
+				delete: vi.fn(),
+				get: vi.fn((name: string) =>
+					store[name] !== undefined ? { value: store[name] } : undefined,
+				),
+			})),
+			headers: vi.fn(async () => new Headers()),
+		}));
+
+		const [{ getTestInstance }, { nextCookies }] = await Promise.all([
+			import("../test-utils/test-instance"),
+			import("./next-js"),
+		]);
+
+		const { auth, testUser } = await getTestInstance({
+			plugins: [nextCookies()],
+			session: {
+				updateAge: 0,
+			},
+		});
+
+		const signInRes = await auth.api.signInEmail({
+			body: {
+				email: testUser.email,
+				password: testUser.password,
+			},
+			returnHeaders: true,
+		});
+		const requestHeaders = new Headers();
+		requestHeaders.set("cookie", signInRes.headers.getSetCookie()[0]!);
+
+		await auth.api.getSession({ headers: requestHeaders });
+		expect(Object.keys(store).length).toBeGreaterThan(0);
+
+		setSpy.mockClear();
+
+		await auth.api.getSession({ headers: requestHeaders });
+
+		const sessionTokenWrites = setSpy.mock.calls.filter(
+			([key]) =>
+				typeof key === "string" &&
+				key.includes("session_token") &&
+				!key.includes("session_token_multi"),
+		);
+		expect(sessionTokenWrites).toHaveLength(0);
+	});
 });

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -103,6 +103,8 @@ export const nextCookies = () => {
 							}
 							parsed.forEach((value, key) => {
 								if (!key) return;
+								// Skip identical writes to avoid router cache invalidation.
+								if (cookieHelper.get(key)?.value === value.value) return;
 								try {
 									cookieHelper.set(key, value.value, toCookieOptions(value));
 								} catch {


### PR DESCRIPTION
#9059 closed #8464 by removing the cookie probe, but the same `cookies().set()` invalidation still fires from the after-hook on session refresh.

## Limitation

The `session_data` cookie used by `cookieCache.enabled: true` embeds timestamps in its signed value, so its raw bytes differ on every refresh and the idempotency check cannot catch it.

## Path to root fix
- **Upstream**: vercel/next.js#84313 adds `cookies().set(name, value, { revalidate: false })`. Once shipped, this patch becomes a small replacement that drops the idempotency check entirely and applies uniformly to `session_token` and `session_data`. Authored by @cramforce, currently an inactive draft.