### PR TITLE
fix(core): use pure instrumentation entry for workerd

### DIFF
--- a/.changeset/warm-workers-sleep.md
+++ b/.changeset/warm-workers-sleep.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Route Cloudflare Workers instrumentation imports to the pure no-op entry when OpenTelemetry is not installed.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,7 +106,7 @@
       "deno": "./dist/instrumentation/index.mjs",
       "bun": "./dist/instrumentation/index.mjs",
       "edge": "./dist/instrumentation/pure.index.mjs",
-      "workerd": "./dist/instrumentation/index.mjs",
+      "workerd": "./dist/instrumentation/pure.index.mjs",
       "browser": "./dist/instrumentation/pure.index.mjs",
       "default": "./dist/instrumentation/index.mjs"
     }

--- a/packages/core/src/instrumentation/pure.test.ts
+++ b/packages/core/src/instrumentation/pure.test.ts
@@ -1,5 +1,15 @@
+// cspell:ignore workerd
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { withSpan } from "./pure.index";
+
+type CorePackageJSON = {
+	exports: {
+		"./instrumentation": {
+			workerd: string;
+		};
+	};
+};
 
 // @see https://github.com/better-auth/better-auth/issues/8765
 describe("instrumentation (pure entry)", () => {
@@ -41,5 +51,18 @@ describe("instrumentation (pure entry)", () => {
 		const pure = await import("./pure.index");
 		const main = await import("./index");
 		expect(Object.keys(pure).sort()).toEqual(Object.keys(main).sort());
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9365
+	 */
+	it("routes workerd package imports to the pure instrumentation entry", () => {
+		const pkg = JSON.parse(
+			readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+		) as CorePackageJSON;
+
+		expect(pkg.exports["./instrumentation"].workerd).toBe(
+			"./dist/instrumentation/pure.index.mjs",
+		);
 	});
 });


### PR DESCRIPTION
## Summary
Fixes #9365.

- Route the `workerd` condition for `@better-auth/core/instrumentation` to the pure no-op instrumentation entry, matching other edge/browser-style runtimes that cannot rely on the optional OpenTelemetry peer at runtime.
- Add regression coverage that keeps the package export condition pinned to the pure entry.
- Add a patch changeset for `@better-auth/core`.

## Test plan
- `pnpm vitest packages/core/src/instrumentation/pure.test.ts --run --reporter verbose`
- `pnpm biome check packages/core/src/instrumentation/pure.test.ts packages/core/package.json .changeset/warm-workers-sleep.md`
- `pnpm --filter @better-auth/core typecheck`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `workerd` instrumentation export in `@better-auth/core` to use the pure no-op entry. Prevents runtime failures in Cloudflare Workers when OpenTelemetry isn’t installed.

- **Bug Fixes**
  - Route `workerd` to `./dist/instrumentation/pure.index.mjs` instead of the OTEL-backed entry.
  - Add a regression test to pin the `workerd` export to the pure entry.

<sup>Written for commit 0e1bfcf8c75cdc992c104507dd012ed41c7b602b. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9395?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

