### PR TITLE
fix(sso): use findSAMLProvider in spMetadata so defaultSSO works

### DIFF
--- a/.changeset/sso-default-metadata.md
+++ b/.changeset/sso-default-metadata.md
@@ -1,0 +1,11 @@
+---
+"@better-auth/sso": patch
+---
+
+fix(sso): use findSAMLProvider in spMetadata so defaultSSO providers resolve
+
+`/sso/saml2/sp/metadata` was the only SAML endpoint that called `adapter.findOne`
+directly, so providers configured via `defaultSSO` (which are not persisted to the
+database) caused it to throw `NOT_FOUND`. The endpoint now uses the shared
+`findSAMLProvider` helper, matching `signInSSO`, the SAML callback handler, and
+`signOut`.

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -108,25 +108,18 @@ export const spMetadata = (options?: SSOOptions) => {
 			},
 		},
 		async (ctx) => {
-			const provider = await ctx.context.adapter.findOne<{
-				id: string;
-				samlConfig: string;
-			}>({
-				model: "ssoProvider",
-				where: [
-					{
-						field: "providerId",
-						value: ctx.query.providerId,
-					},
-				],
-			});
+			const provider = await findSAMLProvider(
+				ctx.query.providerId,
+				options,
+				ctx.context.adapter,
+			);
 			if (!provider) {
 				throw new APIError("NOT_FOUND", {
 					message: "No provider found for the given providerId",
 				});
 			}
 
-			const parsedSamlConfig = safeJsonParse<SAMLConfig>(provider.samlConfig);
+			const parsedSamlConfig = provider.samlConfig;
 			if (!parsedSamlConfig) {
 				throw new APIError("BAD_REQUEST", {
 					message: "Invalid SAML configuration",

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -658,6 +658,17 @@ describe("SAML SSO with defaultSSO array", async () => {
 			redirect: true,
 		});
 	});
+
+	it("should fetch sp metadata for a defaultSSO provider", async () => {
+		const spMetadataRes = await auth.api.spMetadata({
+			query: {
+				providerId: "default-saml",
+			},
+		});
+		const spMetadataResValue = await spMetadataRes.text();
+		expect(spMetadataRes.status).toBe(200);
+		expect(spMetadataResValue).toBe(spMetadata);
+	});
 });
 
 describe("SAML SSO with signed AuthnRequests", async () => {


### PR DESCRIPTION
## Description

`/sso/saml2/sp/metadata?providerId=<id>` is the only SAML endpoint in the plugin that calls `ctx.context.adapter.findOne` directly instead of going through the shared `findSAMLProvider` helper. As a result, providers configured via the `defaultSSO` option (which are not persisted to the `ssoProvider` table) cause the endpoint to throw `NOT_FOUND`, even though `signInSSO`, the SAML callback handler, and `signOut` all resolve them correctly.

This swaps the inline adapter lookup for `findSAMLProvider`, which already handles `defaultSSO` matches before falling back to the adapter. `safeJsonParse` is dropped at the call site because `findSAMLProvider` returns `samlConfig` as a parsed object on both code paths.

Closes #9397

## Changes

- `packages/sso/src/routes/sso.ts` — replace `adapter.findOne` with `findSAMLProvider`; drop now-unused `safeJsonParse` call at the spMetadata site (helper is already imported in this file).
- `packages/sso/src/saml.test.ts` — add an `spMetadata` test inside the existing `"SAML SSO with defaultSSO array"` describe block. Without the source change this test throws `NOT_FOUND`; with it the test passes.
- `.changeset/sso-default-metadata.md` — patch changeset for `@better-auth/sso`.

## Breaking changes

None. The endpoint contract is unchanged for DB-backed providers; this only adds `defaultSSO` resolution.

## Tests

- `pnpm --filter @better-auth/sso typecheck` — clean.
- `pnpm --filter @better-auth/sso vitest run src/saml.test.ts` — 109 tests pass (existing 108 + the new `defaultSSO` spMetadata test).