### PR TITLE
docs(stripe): document user deletion with active subscriptions recipe

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -982,29 +982,32 @@ await stripeClient.customers.update(organization.stripeCustomerId, {
 Organizations with active subscriptions are blocked from deletion automatically, but users are not. To mirror the same behavior on user deletion, throw from the [`beforeDelete`](/docs/concepts/users-accounts#callbacks) callback when a subscription is active:
 
 ```ts title="auth.ts"
+import { betterAuth } from "better-auth";
 import { APIError } from "better-auth/api";
 
-deleteUser: {
-    enabled: true,
-    beforeDelete: async (user) => {
-        if (!user.stripeCustomerId) return;
+export const auth = betterAuth({
+    user: {
+        deleteUser: {
+            enabled: true,
+            beforeDelete: async (user) => {
+                if (!user.stripeCustomerId) return;
 
-        const subscriptions = await stripeClient.subscriptions.list({
-            customer: user.stripeCustomerId,
-            status: "all",
-        });
+                for await (const sub of stripeClient.subscriptions.list({
+                    customer: user.stripeCustomerId,
+                    status: "all",
+                })) {
+                    if (["canceled", "incomplete", "incomplete_expired"].includes(sub.status)) continue;
 
-        for (const sub of subscriptions.data) {
-            if (["canceled", "incomplete", "incomplete_expired"].includes(sub.status)) continue;
-
-            throw new APIError("BAD_REQUEST", {
-                message: "Cancel your active subscription before deleting your account",
-            });
-            // Or cancel immediately: await stripeClient.subscriptions.cancel(sub.id);
-            // Or at period end:      await stripeClient.subscriptions.update(sub.id, { cancel_at_period_end: true });
-        }
+                    throw new APIError("BAD_REQUEST", {
+                        message: "Cancel your active subscription before deleting your account",
+                    });
+                    // Or cancel immediately: await stripeClient.subscriptions.cancel(sub.id);
+                    // Or at period end:      await stripeClient.subscriptions.update(sub.id, { cancel_at_period_end: true });
+                }
+            },
+        },
     },
-}
+});
 ```
 
 ### Custom Checkout Session Parameters

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -977,6 +977,36 @@ await stripeClient.customers.update(organization.stripeCustomerId, {
 });
 ```
 
+### Handling user deletion
+
+Organizations with active subscriptions are blocked from deletion automatically, but users are not. To mirror the same behavior on user deletion, throw from the [`beforeDelete`](/docs/concepts/users-accounts#callbacks) callback when a subscription is active:
+
+```ts title="auth.ts"
+import { APIError } from "better-auth/api";
+
+deleteUser: {
+    enabled: true,
+    beforeDelete: async (user) => {
+        if (!user.stripeCustomerId) return;
+
+        const subscriptions = await stripeClient.subscriptions.list({
+            customer: user.stripeCustomerId,
+            status: "all",
+        });
+
+        for (const sub of subscriptions.data) {
+            if (["canceled", "incomplete", "incomplete_expired"].includes(sub.status)) continue;
+
+            throw new APIError("BAD_REQUEST", {
+                message: "Cancel your active subscription before deleting your account",
+            });
+            // Or cancel immediately: await stripeClient.subscriptions.cancel(sub.id);
+            // Or at period end:      await stripeClient.subscriptions.update(sub.id, { cancel_at_period_end: true });
+        }
+    },
+}
+```
+
 ### Custom Checkout Session Parameters
 
 You can customize the Stripe Checkout session with additional parameters:


### PR DESCRIPTION
> [!NOTE]
> Considered exposing this as a dedicated option, but decided against it and documented the approach instead.
> 
> The core concept (e.g. hooks, databaseHooks, and callbacks) already provides sufficient flexibility for customization.
> 
> Stripe is fairly low-level and comes with many complex use cases. Rather than trying to cover every scenario with options, it's better to keep the plugin focused on the core logic of user management and leave customization open-ended. 