### PR TITLE
fix(organization): listMembers fails with "User not found" for orgs with 100+ members

### DIFF
--- a/.changeset/strong-meals-hang.md
+++ b/.changeset/strong-meals-hang.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix listMembers failing with "User not found" error when an organization has more than 100 members

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -196,6 +196,12 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 						operator: "in",
 					},
 				],
+				limit:
+					data.limit ||
+					(typeof options?.membershipLimit === "number"
+						? options.membershipLimit
+						: 100) ||
+					100,
 			});
 			return {
 				members: members[0].map((member) => {


### PR DESCRIPTION
Fixes #9407

- [x] pnpm typecheck (repo root)

`listMembers` was throwing `"Unexpected error: User not found for member"` for organizations with more than 100 members.

## Root Cause

`listMembers` in `packages/better-auth/src/plugins/organization/adapter.ts` runs two sequential queries:

1. **Fetch members** — correctly limited by `data.limit || membershipLimit || 100`
2. **Fetch users** for those members — had **no `limit`** at all

The Prisma adapter's `findMany` defaults to `take: limit || 100` when no limit is provided, silently capping the user results at 100. Any member beyond index 100 had no matching user in the result, causing the error.

The Kysely and Drizzle adapters happen not to apply a default cap, which is why the bug was Prisma-specific.

## Fix

Added the same `limit` expression to the users `findMany` call that was already on the members query, consistent with how `findFullOrganization` handles the same pattern (fixed previously in #4724):

```diff
  const users = await adapter.findMany<User>({
    model: "user",
    where: [{ field: "id", value: members[0].map((m) => m.userId), operator: "in" }],
+   limit:
+     data.limit ||
+     (typeof options?.membershipLimit === "number"
+       ? options.membershipLimit
+       : 100) ||
+     100,
  });