### PR TITLE
chore(repo): upgrade pnpm to v11.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@better-auth/root",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.30.2",
+  "packageManager": "pnpm@11.0.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,28 +52,26 @@ catalogs:
     '@vitest/ui': ^4.0.18
     vitest: ^4.0.18
 
-ignoredBuiltDependencies:
-  - electron
+allowBuilds:
+  '@parcel/watcher': true
+  '@prisma/client': true
+  '@prisma/engines': true
+  '@swc/core': true
+  '@tsparticles/engine': true
+  better-sqlite3: true
+  esbuild: true
+  lefthook: true
+  less: true
+  msw: true
+  prisma: true
+  protobufjs: true
+  sharp: true
+  workerd: true
+  electron: false
 
 linkWorkspacePackages: true
 
 minimumReleaseAge: 0
-
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - '@prisma/client'
-  - '@prisma/engines'
-  - '@swc/core'
-  - '@tsparticles/engine'
-  - better-sqlite3
-  - esbuild
-  - lefthook
-  - less
-  - msw
-  - prisma
-  - protobufjs
-  - sharp
-  - workerd
 
 patchedDependencies:
   '@changesets/assemble-release-plan': patches/@changesets__assemble-release-plan.patch


### PR DESCRIPTION
## Summary

Bumps the repo from pnpm v10.30.2 to v11.0.3 and migrates the build-dependency settings to the v11 shape.

- `packageManager` → `pnpm@11.0.3`
- `onlyBuiltDependencies` (14 packages) and `ignoredBuiltDependencies: [electron]` collapsed into a single `allowBuilds` map (`true` = allow build, `false` = block) per the v11 migration guide.

No lockfile diff: `pnpm-lock.yaml` stays at `lockfileVersion: '9.0'`, which v10 and v11 both produce.

## Why now

v11 ships native `publish`/`login`/`view`/`dist-tag`/`version` (no more npm CLI delegation, relevant to our changesets release pipeline), a SQLite-backed store, undici HTTP, and CAS direct writes. Defaults we already opt into (`blockExoticSubdeps: true`) become the v11 baseline.

## Local verification

- `pnpm install --no-frozen-lockfile` — succeeds in 45s, no deprecation warnings for any other config key we use (`linkWorkspacePackages`, `trustPolicy`, `trustPolicyIgnoreAfter`, `minimumReleaseAge`, `blockExoticSubdeps`, `patchedDependencies`, `overrides`, `catalog`/`catalogs`).
- `pnpm typecheck` — passes.
- Lefthook hooks (`lockfile`, `spell`, `biome`) — pass on commit.

## CI / runtime impact

- Node.js: v11 requires Node 22+. We already CI on Node 22.x and 24.x, and `.nvmrc` is `24`.
- `pnpm/action-setup@v4.2.0` reads `packageManager` from `package.json`, so it auto-picks v11 with no workflow changes needed.
- No `.npmrc` exists at repo root, no `pnpm` field in any `package.json`, no `npm_config_*` env vars, no `useNodeVersion` / `allowNonAppliedPatches` / `ignorePatchFailures` usages — none of the other v11 breaking changes apply.

## Known minor surface

The root `clean` script (`turbo clean ... && rm -rf node_modules`) shadows the new v11 built-in `pnpm clean` (also removes `node_modules`). `pnpm run clean` continues to work, and CI uses `turbo clean` directly, so no functional impact. Worth a follow-up note in CONTRIBUTING if anyone relies on bare `pnpm clean`.

## Refs

- Release notes: https://pnpm.io/blog/releases/11.0
- Migration guide: https://pnpm.io/11.x/migration
- `allowBuilds` shape: https://pnpm.io/11.x/settings#allowbuilds

## Test plan

- [ ] CI green on Node 22.x and 24.x matrix
- [ ] adapter / smoke / integration e2e jobs pass under v11
- [ ] release.yml dry-run sanity (changesets `version` + `publish` paths)