### PR TITLE
docs: improve careers job board rendering and tests

### DIFF
--- a/docs/app/careers/careers-client-filter.test.ts
+++ b/docs/app/careers/careers-client-filter.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from "react";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+(
+	globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("framer-motion", () => ({
+	motion: {
+		div: ({
+			children,
+			initial: _initial,
+			animate: _animate,
+			transition: _transition,
+			...props
+		}: Record<string, unknown>) =>
+			createElement("div", props, children as ReactNode),
+	},
+}));
+
+vi.mock("@/components/landing/footer", () => ({
+	default: () => createElement("div", { "data-testid": "footer" }),
+}));
+
+vi.mock("@/components/landing/halftone-bg", () => ({
+	HalftoneBackground: () => createElement("div", { "data-testid": "halftone" }),
+}));
+
+import { CareersPageClient } from "./careers-client";
+import type { Job } from "./careers-data";
+
+const jobs: Job[] = [
+	{
+		id: "job-1",
+		title: "Product Manager",
+		absolute_url: "https://jobs.gem.com/test-board/job-1",
+		location: { name: "New York, United States" },
+		employment_type: "full_time",
+		departments: [{ name: "Engineering" }],
+		roleParagraphs: ["Lead product direction."],
+	},
+	{
+		id: "job-2",
+		title: "Backend Engineer",
+		absolute_url: "https://jobs.gem.com/test-board/job-2",
+		location: { name: "San Francisco, United States" },
+		employment_type: "contract",
+		departments: [{ name: "Platform" }],
+		roleParagraphs: ["Build backend APIs."],
+	},
+	{
+		id: "job-3",
+		title: "Staff Software Engineer — TypeScript",
+		absolute_url: "https://jobs.gem.com/test-board/job-3",
+		location: { name: "New York, United States" },
+		employment_type: "full_time",
+		departments: [{ name: "Engineering" }],
+		roleParagraphs: ["Drive TypeScript architecture."],
+	},
+];
+
+describe("CareersPageClient filtering", () => {
+	let container: HTMLDivElement;
+
+	afterEach(() => {
+		container?.remove();
+	});
+
+	it("filters the visible jobs by the selected location and department", async () => {
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		const root = createRoot(container);
+
+		await act(async () => {
+			root.render(createElement(CareersPageClient, { jobs }));
+		});
+
+		expect(container.textContent).toContain("Product Manager");
+		expect(container.textContent).toContain("Backend Engineer");
+		expect(container.textContent).toContain(
+			"Staff Software Engineer — TypeScript",
+		);
+
+		const filterButton = container.querySelector(
+			'[data-testid="filter-New York-Engineering"]',
+		) as HTMLButtonElement | null;
+		expect(filterButton).not.toBeNull();
+
+		await act(async () => {
+			filterButton?.click();
+		});
+
+		expect(container.textContent).toContain("Product Manager");
+		expect(container.textContent).toContain(
+			"Staff Software Engineer — TypeScript",
+		);
+		expect(container.textContent).not.toContain("Backend Engineer");
+		expect(container.textContent).toContain("Showing New York / Engineering");
+
+		await act(async () => {
+			filterButton?.click();
+		});
+
+		expect(container.textContent).toContain("Product Manager");
+		expect(container.textContent).toContain("Backend Engineer");
+		expect(container.textContent).toContain(
+			"Staff Software Engineer — TypeScript",
+		);
+		expect(container.textContent).not.toContain(
+			"Showing New York / Engineering",
+		);
+
+		await act(async () => {
+			filterButton?.click();
+		});
+
+		expect(container.textContent).toContain("Product Manager");
+		expect(container.textContent).toContain(
+			"Staff Software Engineer — TypeScript",
+		);
+		expect(container.textContent).not.toContain("Backend Engineer");
+		expect(container.textContent).toContain("Showing New York / Engineering");
+
+		const clearButton = container.querySelector(
+			'[data-testid="clear-role-filter"]',
+		) as HTMLButtonElement | null;
+		expect(clearButton).not.toBeNull();
+
+		await act(async () => {
+			clearButton?.click();
+		});
+
+		expect(container.textContent).toContain("Product Manager");
+		expect(container.textContent).toContain("Backend Engineer");
+		expect(container.textContent).toContain(
+			"Staff Software Engineer — TypeScript",
+		);
+	});
+});

--- a/docs/app/careers/careers-client-render.test.ts
+++ b/docs/app/careers/careers-client-render.test.ts
@@ -1,0 +1,173 @@
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("framer-motion", () => ({
+	motion: {
+		div: ({
+			children,
+			initial: _initial,
+			animate: _animate,
+			transition: _transition,
+			...props
+		}: Record<string, unknown>) =>
+			createElement("div", props, children as ReactNode),
+	},
+}));
+
+vi.mock("@/components/landing/footer", () => ({
+	default: () => createElement("div", { "data-testid": "footer" }),
+}));
+
+vi.mock("@/components/landing/halftone-bg", () => ({
+	HalftoneBackground: () => createElement("div", { "data-testid": "halftone" }),
+}));
+
+import { CareersPageClient } from "./careers-client";
+import type { Job } from "./careers-data";
+
+type GemJobFixture = Job & {
+	first_published_at: string;
+	internal_job_id: string;
+	location_type: string;
+	requisition_id: string;
+	departments: Array<{
+		id: string;
+		name: string;
+		parent_id: string | null;
+		child_ids: string[];
+	}>;
+	offices: Array<{
+		id: string;
+		name: string;
+		location: { name: string };
+		parent_id: string | null;
+		child_ids: string[];
+		parent_office_external_id: string | null;
+		child_office_external_ids: string[];
+		deleted_at: string | null;
+	}>;
+};
+
+describe("CareersPageClient", () => {
+	it("renders realistic Gem job data", () => {
+		const jobs: GemJobFixture[] = [
+			{
+				id: "am9icG9zdDox",
+				title: "Product Manager",
+				first_published_at: "2023-09-22T20:17:34.000Z",
+				internal_job_id: "job-internal-product-manager-1",
+				absolute_url: "https://jobs.gem.com/test-board/job-1",
+				location: { name: "New York, United States" },
+				location_type: "hybrid",
+				employment_type: "full_time",
+				requisition_id: "R16",
+				departments: [
+					{ id: "dept-1", name: "Engineering", parent_id: null, child_ids: [] },
+				],
+				roleParagraphs: [
+					"Lead product direction across the auth platform.",
+					"Partner closely with engineering and design.",
+				],
+				offices: [
+					{
+						id: "office-1",
+						name: "NYC",
+						location: { name: "New York, United States" },
+						parent_id: null,
+						child_ids: [],
+						parent_office_external_id: null,
+						child_office_external_ids: [],
+						deleted_at: null,
+					},
+				],
+			},
+			{
+				id: "am9icG9zdDoy",
+				title: "Backend Engineer",
+				first_published_at: "2024-01-10T12:00:00.000Z",
+				internal_job_id: "job-internal-backend-2",
+				absolute_url: "https://jobs.gem.com/test-board/job-2",
+				location: { name: "San Francisco, United States" },
+				location_type: "onsite",
+				employment_type: "contract",
+				requisition_id: "R17",
+				departments: [
+					{ id: "dept-2", name: "Platform", parent_id: null, child_ids: [] },
+				],
+				roleParagraphs: ["Build backend APIs and platform primitives."],
+				offices: [
+					{
+						id: "office-2",
+						name: "SF",
+						location: { name: "San Francisco, United States" },
+						parent_id: null,
+						child_ids: [],
+						parent_office_external_id: null,
+						child_office_external_ids: [],
+						deleted_at: null,
+					},
+				],
+			},
+			{
+				id: "am9icG9zdDoz",
+				title: "Staff Software Engineer — TypeScript",
+				first_published_at: "2024-02-15T12:00:00.000Z",
+				internal_job_id: "job-internal-staff-3",
+				absolute_url: "https://jobs.gem.com/test-board/job-3",
+				location: { name: "New York, United States" },
+				location_type: "hybrid",
+				employment_type: "full_time",
+				requisition_id: "R18",
+				departments: [
+					{ id: "dept-3", name: "Engineering", parent_id: null, child_ids: [] },
+				],
+				roleParagraphs: ["Drive architecture across the TypeScript platform."],
+				offices: [
+					{
+						id: "office-3",
+						name: "NYC",
+						location: { name: "New York, United States" },
+						parent_id: null,
+						child_ids: [],
+						parent_office_external_id: null,
+						child_office_external_ids: [],
+						deleted_at: null,
+					},
+				],
+			},
+		];
+
+		const html = renderToStaticMarkup(
+			createElement(CareersPageClient, { jobs }),
+		);
+
+		expect(html).toContain("Product Manager");
+		expect(html).toContain("Backend Engineer");
+		expect(html).toContain("Staff Software Engineer — TypeScript");
+		expect(html).toContain("Full-time");
+		expect(html).toContain("Contract");
+		expect(html).toContain("New York");
+		expect(html).toContain("San Francisco");
+		expect(html).toContain("Engineering");
+		expect(html).toContain("Platform");
+		expect(html).toContain("Location");
+		expect(html).toContain("Department");
+		expect(html).toContain("Open roles");
+		expect(html).toContain("Lead product direction across the auth platform.");
+		expect(html).toContain("Partner closely with engineering and design.");
+		expect(html).toContain("Build backend APIs and platform primitives.");
+		expect(html).toContain(
+			"Drive architecture across the TypeScript platform.",
+		);
+		expect(html).toContain('href="https://jobs.gem.com/test-board/job-1"');
+		expect(html).toContain('target="_blank"');
+		expect(html).toMatch(
+			/New York<\/span>\s*<span[^>]*>Engineering<\/span>\s*<span[^>]*>2<\/span>/,
+		);
+		expect(html).toMatch(
+			/San Francisco<\/span>\s*<span[^>]*>Platform<\/span>\s*<span[^>]*>1<\/span>/,
+		);
+	});
+});

--- a/docs/app/careers/careers-client.tsx
+++ b/docs/app/careers/careers-client.tsx
@@ -1,250 +1,71 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import { useState } from "react";
 import Footer from "@/components/landing/footer";
 import { HalftoneBackground } from "@/components/landing/halftone-bg";
+import type { Job } from "./careers-data";
 
-const roles = [
-	{
-		title: "Founding Design Engineer",
-		type: "Full-time",
-		location: "San Francisco",
-		description:
-			"Craft the visual identity and UI of Better Auth's products — dashboard, docs, landing pages. You'll own design end-to-end.",
-		requirements: [
-			"Strong portfolio with shipped product work",
-			"React / Next.js proficiency",
-			"CSS mastery and responsive design",
-			"Eye for detail and micro-interactions",
-			"Experience shipping design systems",
-		],
-	},
-	{
-		title: "Senior Developer Relations",
-		type: "Full-time",
-		location: "San Francisco",
-		description:
-			"Be the bridge between Better Auth and its developer community. Create content, speak at events, build demos, and shape the developer experience.",
-		requirements: [
-			"Developer background with public repos or OSS contributions",
-			"Content creation experience (blogs, videos, tutorials)",
-			"Public speaking and conference experience",
-			"Community building track record",
-			"Familiarity with auth / security space",
-		],
-	},
-];
+type RoleFilter = {
+	city: string;
+	department: string;
+};
 
-function ApplyDialog({
-	role,
-	onClose,
-}: {
-	role: (typeof roles)[number];
-	onClose: () => void;
-}) {
-	const [submitted, setSubmitted] = useState(false);
+function formatEmploymentType(type: string): string {
+	const map: Record<string, string> = {
+		full_time: "Full-time",
+		part_time: "Part-time",
+		contract: "Contract",
+		intern: "Intern",
+		temporary: "Temporary",
+	};
+	return map[type] ?? type.replace(/_/g, "-");
+}
 
+function getCity(locationName?: string | null) {
+	return (locationName?.split(",")[0] ?? "Remote").trim();
+}
+
+function getDepartmentName(departments?: Array<{ name: string }> | null) {
+	return departments?.[0]?.name?.trim() || null;
+}
+
+function getLocationDepartmentRows(
+	jobs: Job[],
+): Array<{ city: string; department: string; openRoles: number }> {
+	const counts = jobs.reduce<
+		Record<string, { city: string; department: string; openRoles: number }>
+	>((acc, job) => {
+		const city = getCity(job.location?.name);
+		const department = getDepartmentName(job.departments) ?? "—";
+		const key = `${city}::${department}`;
+		acc[key] = acc[key]
+			? { ...acc[key], openRoles: acc[key].openRoles + 1 }
+			: { city, department, openRoles: 1 };
+		return acc;
+	}, {});
+	return Object.values(counts).sort((a, b) => {
+		if (a.city !== b.city) return a.city.localeCompare(b.city);
+		return a.department.localeCompare(b.department);
+	});
+}
+
+function matchesFilter(job: Job, filter: RoleFilter) {
 	return (
-		<motion.div
-			initial={{ opacity: 0 }}
-			animate={{ opacity: 1 }}
-			exit={{ opacity: 0 }}
-			transition={{ duration: 0.15 }}
-			className="fixed inset-0 z-[100] flex items-center justify-center p-4"
-			onClick={onClose}
-		>
-			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/40 backdrop-blur-md dark:bg-black/72" />
-
-			{/* Dialog */}
-			<motion.div
-				initial={{ opacity: 0, y: 10, scale: 0.98 }}
-				animate={{ opacity: 1, y: 0, scale: 1 }}
-				exit={{ opacity: 0, y: 10, scale: 0.98 }}
-				transition={{ duration: 0.2, ease: "easeOut" }}
-				onClick={(e: React.MouseEvent) => e.stopPropagation()}
-				className="relative w-full max-w-md overflow-hidden border border-foreground/[0.14] bg-background/95 shadow-2xl shadow-black/12 ring-1 ring-black/5 backdrop-blur dark:border-white/[0.08] dark:bg-[#050505]/95 dark:shadow-black/65 dark:ring-white/[0.04]"
-			>
-				{/* Corner marks */}
-				<span className="absolute top-2 left-2 text-[9px] font-mono text-foreground/25 dark:text-foreground/18 select-none leading-none">
-					+
-				</span>
-				<span className="absolute top-2 right-2 text-[9px] font-mono text-foreground/25 dark:text-foreground/18 select-none leading-none">
-					+
-				</span>
-				<span className="absolute bottom-2 left-2 text-[9px] font-mono text-foreground/25 dark:text-foreground/18 select-none leading-none">
-					+
-				</span>
-				<span className="absolute bottom-2 right-2 text-[9px] font-mono text-foreground/25 dark:text-foreground/18 select-none leading-none">
-					+
-				</span>
-
-				<div className="p-6 sm:p-8">
-					{/* Close button */}
-					<button
-						type="button"
-						onClick={onClose}
-						aria-label="Close dialog"
-						className="absolute top-4 right-4 text-foreground/50 hover:text-foreground/80 transition-colors"
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="14"
-							height="14"
-							viewBox="0 0 24 24"
-							aria-hidden="true"
-						>
-							<path
-								fill="currentColor"
-								d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12z"
-							/>
-						</svg>
-					</button>
-
-					{submitted ? (
-						<motion.div
-							initial={{ opacity: 0, y: 6 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.3 }}
-							className="text-center py-6 space-y-3"
-						>
-							<p className="text-sm text-foreground/92 dark:text-foreground/88">
-								Application sent
-							</p>
-							<p className="text-xs text-foreground/60 dark:text-foreground/52 leading-relaxed max-w-xs mx-auto">
-								Thanks for applying for {role.title}. We&apos;ll review your
-								application and get back to you soon.
-							</p>
-							<button
-								type="button"
-								onClick={onClose}
-								className="mt-4 inline-flex items-center px-4 py-2 border border-foreground/[0.18] bg-foreground/[0.03] text-foreground/72 hover:text-foreground/90 hover:border-foreground/28 hover:bg-foreground/[0.06] transition-all font-mono text-[10px] uppercase tracking-widest dark:border-white/[0.1] dark:bg-white/[0.03] dark:text-foreground/68 dark:hover:text-foreground/84 dark:hover:bg-white/[0.05]"
-							>
-								Close
-							</button>
-						</motion.div>
-					) : (
-						<>
-							<div className="mb-6 space-y-1">
-								<p className="text-[10px] uppercase tracking-widest text-foreground/55 dark:text-foreground/50 font-mono">
-									# Apply
-								</p>
-								<h3 className="text-sm text-foreground/92 dark:text-foreground/86">
-									{role.title}
-								</h3>
-								<div className="flex items-center gap-2 pt-1">
-									<span className="text-[8px] font-mono uppercase tracking-widest text-foreground/60 dark:text-foreground/50 border border-foreground/[0.15] bg-foreground/[0.03] px-1.5 py-0.5 leading-none dark:border-white/[0.08] dark:bg-white/[0.03]">
-										{role.type}
-									</span>
-									<span className="text-[8px] font-mono uppercase tracking-widest text-foreground/60 dark:text-foreground/50 border border-foreground/[0.15] bg-foreground/[0.03] px-1.5 py-0.5 leading-none dark:border-white/[0.08] dark:bg-white/[0.03]">
-										{role.location}
-									</span>
-								</div>
-							</div>
-
-							<form
-								onSubmit={(e) => {
-									e.preventDefault();
-									setSubmitted(true);
-								}}
-								className="space-y-4"
-							>
-								<div className="space-y-1.5">
-									<label
-										htmlFor="careers-name"
-										className="text-[9px] text-foreground/58 dark:text-foreground/48 uppercase tracking-widest font-mono"
-									>
-										Name
-									</label>
-									<input
-										id="careers-name"
-										type="text"
-										required
-										className="w-full border border-foreground/[0.15] bg-foreground/[0.025] px-3 py-2 text-[12px] text-foreground/88 placeholder:text-foreground/38 focus:outline-none focus:border-foreground/38 dark:border-white/[0.1] dark:bg-white/[0.03] dark:text-foreground/78 dark:placeholder:text-foreground/28 dark:focus:border-white/[0.2] transition-colors"
-										placeholder="Your full name"
-									/>
-								</div>
-
-								<div className="space-y-1.5">
-									<label
-										htmlFor="careers-email"
-										className="text-[9px] text-foreground/58 dark:text-foreground/48 uppercase tracking-widest font-mono"
-									>
-										Email
-									</label>
-									<input
-										id="careers-email"
-										type="email"
-										required
-										className="w-full border border-foreground/[0.15] bg-foreground/[0.025] px-3 py-2 text-[12px] text-foreground/88 placeholder:text-foreground/38 focus:outline-none focus:border-foreground/38 dark:border-white/[0.1] dark:bg-white/[0.03] dark:text-foreground/78 dark:placeholder:text-foreground/28 dark:focus:border-white/[0.2] transition-colors"
-										placeholder="you@example.com"
-									/>
-								</div>
-
-								<div className="space-y-1.5">
-									<label
-										htmlFor="careers-portfolio"
-										className="text-[9px] text-foreground/58 dark:text-foreground/48 uppercase tracking-widest font-mono"
-									>
-										Portfolio / GitHub
-									</label>
-									<input
-										id="careers-portfolio"
-										type="url"
-										required
-										className="w-full border border-foreground/[0.15] bg-foreground/[0.025] px-3 py-2 text-[12px] text-foreground/88 placeholder:text-foreground/38 focus:outline-none focus:border-foreground/38 dark:border-white/[0.1] dark:bg-white/[0.03] dark:text-foreground/78 dark:placeholder:text-foreground/28 dark:focus:border-white/[0.2] transition-colors"
-										placeholder="https://"
-									/>
-								</div>
-
-								<div className="space-y-1.5">
-									<label
-										htmlFor="careers-why"
-										className="text-[9px] text-foreground/58 dark:text-foreground/48 uppercase tracking-widest font-mono"
-									>
-										Why Better Auth?
-									</label>
-									<textarea
-										id="careers-why"
-										required
-										rows={3}
-										className="w-full border border-foreground/[0.15] bg-foreground/[0.025] px-3 py-2 text-[12px] text-foreground/88 placeholder:text-foreground/38 focus:outline-none focus:border-foreground/38 dark:border-white/[0.1] dark:bg-white/[0.03] dark:text-foreground/78 dark:placeholder:text-foreground/28 dark:focus:border-white/[0.2] transition-colors resize-none"
-										placeholder="Tell us why you want to join..."
-									/>
-								</div>
-
-								<div className="pt-2">
-									<button
-										type="submit"
-										className="inline-flex items-center gap-1.5 px-4 py-2 bg-foreground text-background hover:opacity-90 transition-all"
-									>
-										<span className="font-mono text-[10px] uppercase tracking-widest">
-											Submit Application
-										</span>
-										<svg
-											className="h-2.5 w-2.5 opacity-80"
-											viewBox="0 0 10 10"
-											fill="none"
-										>
-											<path
-												d="M1 9L9 1M9 1H3M9 1V7"
-												stroke="currentColor"
-												strokeWidth="1.2"
-											/>
-										</svg>
-									</button>
-								</div>
-							</form>
-						</>
-					)}
-				</div>
-			</motion.div>
-		</motion.div>
+		getCity(job.location?.name) === filter.city &&
+		(getDepartmentName(job.departments) ?? "—") === filter.department
 	);
 }
 
-function CareersHero() {
+function CareersHero({
+	rows,
+	activeFilter,
+	onFilterSelect,
+}: {
+	rows: Array<{ city: string; department: string; openRoles: number }>;
+	activeFilter: RoleFilter | null;
+	onFilterSelect: (filter: RoleFilter) => void;
+}) {
 	return (
 		<motion.div
 			initial={{ opacity: 0, y: 12 }}
@@ -262,31 +83,72 @@ function CareersHero() {
 					</p>
 				</div>
 
-				{/* Quick stats */}
-				<div className="border-t border-foreground/10 pt-4 space-y-0">
-					{[
-						{ label: "Location", value: "San Francisco" },
-						{ label: "Open roles", value: `${roles.length}` },
-					].map((item, i) => (
-						<motion.div
-							key={item.label}
-							initial={{ opacity: 0, x: -8 }}
-							animate={{ opacity: 1, x: 0 }}
-							transition={{
-								duration: 0.25,
-								delay: 0.3 + i * 0.06,
-								ease: "easeOut",
-							}}
-							className="flex items-baseline justify-between py-1.5 border-b border-dashed border-foreground/[0.06] last:border-0"
-						>
-							<span className="text-sm text-foreground/70 dark:text-foreground/50 uppercase tracking-wider">
-								{item.label}
+				{/* Location table */}
+				<div className="border-t border-foreground/10 pt-4">
+					<div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_5rem] gap-3 border-b border-foreground/[0.06] pb-1.5">
+						<span className="text-[9px] font-mono uppercase tracking-[0.18em] text-foreground/50 dark:text-foreground/40">
+							Location
+						</span>
+						<span className="text-[9px] font-mono uppercase tracking-[0.18em] text-foreground/50 dark:text-foreground/40">
+							Department
+						</span>
+						<span className="text-right text-[9px] font-mono uppercase tracking-[0.18em] text-foreground/50 dark:text-foreground/40">
+							Open roles
+						</span>
+					</div>
+					{rows.length === 0 ? (
+						<div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_5rem] gap-3 py-1.5">
+							<span className="text-sm text-foreground/50 dark:text-foreground/40">
+								—
 							</span>
-							<span className="text-sm text-foreground/85 dark:text-foreground/75 font-mono">
-								{item.value}
+							<span className="text-sm text-foreground/50 dark:text-foreground/40">
+								—
 							</span>
-						</motion.div>
-					))}
+							<span className="text-right text-sm text-foreground/50 dark:text-foreground/40 font-mono">
+								0
+							</span>
+						</div>
+					) : (
+						rows.map(({ city, department, openRoles }, i) => (
+							<motion.div
+								key={`${city}-${department}`}
+								initial={{ opacity: 0, x: -8 }}
+								animate={{ opacity: 1, x: 0 }}
+								transition={{
+									duration: 0.25,
+									delay: 0.3 + i * 0.06,
+									ease: "easeOut",
+								}}
+								className="border-b border-dashed border-foreground/[0.06] last:border-0"
+							>
+								<button
+									type="button"
+									onClick={() => onFilterSelect({ city, department })}
+									aria-pressed={
+										activeFilter?.city === city &&
+										activeFilter?.department === department
+									}
+									data-testid={`filter-${city}-${department}`}
+									className={`grid w-full grid-cols-[minmax(0,1fr)_minmax(0,1fr)_5rem] gap-3 py-1.5 text-left transition-colors ${
+										activeFilter?.city === city &&
+										activeFilter?.department === department
+											? "bg-foreground/[0.04]"
+											: "hover:bg-foreground/[0.02]"
+									}`}
+								>
+									<span className="text-[13px] text-foreground/70 dark:text-foreground/50 uppercase tracking-wide">
+										{city}
+									</span>
+									<span className="text-[13px] text-foreground/70 dark:text-foreground/50 uppercase tracking-wide">
+										{department}
+									</span>
+									<span className="text-right text-[13px] text-foreground/85 dark:text-foreground/75 font-mono">
+										{openRoles}
+									</span>
+								</button>
+							</motion.div>
+						))
+					)}
 				</div>
 
 				{/* Contact link */}
@@ -314,15 +176,13 @@ function CareersHero() {
 	);
 }
 
-function RoleCard({
-	role,
-	index,
-	onApply,
-}: {
-	role: (typeof roles)[number];
-	index: number;
-	onApply: () => void;
-}) {
+function RoleCard({ role, index }: { role: Job; index: number }) {
+	const city = getCity(role.location?.name);
+	const department = getDepartmentName(role.departments);
+	const applyUrl = role.absolute_url.startsWith("https://")
+		? role.absolute_url
+		: null;
+
 	return (
 		<motion.div
 			initial={{ opacity: 0, y: 10 }}
@@ -354,51 +214,65 @@ function RoleCard({
 				{/* Header */}
 				<div className="space-y-3">
 					<h3 className="text-base sm:text-lg text-foreground/92 dark:text-foreground/86 tracking-tight">
-						{role.title}
+						{applyUrl ? (
+							<a
+								href={applyUrl}
+								target="_blank"
+								rel="noreferrer"
+								className="inline-flex items-center gap-1.5 underline decoration-foreground/30 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/70 dark:hover:text-foreground"
+							>
+								{role.title}
+								<svg
+									className="mt-px h-3 w-3 shrink-0 opacity-65"
+									viewBox="0 0 10 10"
+									fill="none"
+									aria-hidden="true"
+								>
+									<path
+										d="M1 9L9 1M9 1H3M9 1V7"
+										stroke="currentColor"
+										strokeWidth="1.2"
+									/>
+								</svg>
+							</a>
+						) : (
+							role.title
+						)}
 					</h3>
 					<div className="flex items-center gap-2">
 						<span className="border border-foreground/[0.14] bg-foreground/[0.03] px-1.5 py-0.5 text-[8px] font-mono uppercase tracking-widest text-foreground/58 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-foreground/48 leading-none">
-							{role.type}
+							{formatEmploymentType(role.employment_type)}
 						</span>
 						<span className="border border-foreground/[0.14] bg-foreground/[0.03] px-1.5 py-0.5 text-[8px] font-mono uppercase tracking-widest text-foreground/58 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-foreground/48 leading-none">
-							{role.location}
+							{city}
 						</span>
+						{department && (
+							<span className="border border-foreground/[0.14] bg-foreground/[0.03] px-1.5 py-0.5 text-[8px] font-mono uppercase tracking-widest text-foreground/58 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-foreground/48 leading-none">
+								{department}
+							</span>
+						)}
 					</div>
 				</div>
 
-				{/* Description */}
-				<p className="max-w-lg text-[14px] leading-relaxed text-foreground/66 dark:text-foreground/56">
-					{role.description}
-				</p>
-
-				{/* Divider */}
-				<div className="border-t border-foreground/[0.08] dark:border-white/[0.06]" />
-
-				{/* Requirements */}
-				<div>
-					<p className="mb-3 text-[9px] font-mono uppercase tracking-[0.18em] text-foreground/52 dark:text-foreground/44">
-						Requirements
-					</p>
-					<ul className="space-y-2">
-						{role.requirements.map((req) => (
-							<li
-								key={req}
-								className="flex items-start gap-2 text-[14px] leading-relaxed text-foreground/56 transition-colors duration-300 group-hover:text-foreground/68 dark:text-foreground/48 dark:group-hover:text-foreground/60"
+				{role.roleParagraphs.length > 0 && (
+					<div className="space-y-3">
+						{role.roleParagraphs.map((paragraph, paragraphIndex) => (
+							<p
+								key={`${role.id}-${paragraphIndex}`}
+								className="text-[14px] leading-relaxed text-foreground/66 dark:text-foreground/56"
 							>
-								<span className="mt-px shrink-0 select-none font-mono text-[9px] leading-none text-foreground/60 dark:text-foreground/46">
-									+
-								</span>
-								<span>{req}</span>
-							</li>
+								{paragraph}
+							</p>
 						))}
-					</ul>
-				</div>
+					</div>
+				)}
 
 				{/* Apply CTA */}
 				<div className="pt-2">
-					<button
-						type="button"
-						onClick={onApply}
+					<a
+						href={applyUrl ?? "#"}
+						target="_blank"
+						rel="noreferrer"
 						className="inline-flex items-center gap-1.5 bg-foreground px-3.5 py-2 text-background transition-all hover:opacity-90 cursor-pointer"
 					>
 						<span className="font-mono text-[10px] uppercase tracking-widest">
@@ -415,17 +289,27 @@ function RoleCard({
 								strokeWidth="1.2"
 							/>
 						</svg>
-					</button>
+					</a>
 				</div>
 			</div>
 		</motion.div>
 	);
 }
 
-export function CareersPageClient() {
-	const [applyingRole, setApplyingRole] = useState<
-		(typeof roles)[number] | null
-	>(null);
+export function CareersPageClient({ jobs }: { jobs: Job[] }) {
+	const [activeFilter, setActiveFilter] = useState<RoleFilter | null>(null);
+	const rows = getLocationDepartmentRows(jobs);
+	const filteredJobs = activeFilter
+		? jobs.filter((job) => matchesFilter(job, activeFilter))
+		: jobs;
+
+	function handleFilterSelect(filter: RoleFilter) {
+		setActiveFilter((current) =>
+			current?.city === filter.city && current?.department === filter.department
+				? null
+				: filter,
+		);
+	}
 
 	return (
 		<div className="relative min-h-dvh pt-14 lg:pt-0">
@@ -436,7 +320,11 @@ export function CareersPageClient() {
 						<div className="hidden lg:block">
 							<HalftoneBackground />
 						</div>
-						<CareersHero />
+						<CareersHero
+							rows={rows}
+							activeFilter={activeFilter}
+							onFilterSelect={handleFilterSelect}
+						/>
 					</div>
 
 					{/* Right side */}
@@ -519,32 +407,48 @@ export function CareersPageClient() {
 								animate={{ opacity: 1, y: 0 }}
 								transition={{ duration: 0.3, delay: 0.15 }}
 							>
-								<div className="space-y-4">
-									{roles.map((role, i) => (
-										<RoleCard
-											key={role.title}
-											role={role}
-											index={i}
-											onApply={() => setApplyingRole(role)}
-										/>
-									))}
-								</div>
+								{filteredJobs.length === 0 ? (
+									<p className="text-sm text-foreground/50 dark:text-foreground/40">
+										{activeFilter
+											? "No open positions match the current filter. Adjust the table selection or reach out at "
+											: "No open positions right now. Check back soon or reach out at "}
+										<a
+											href="mailto:careers@better-auth.com"
+											className="underline underline-offset-2 hover:text-foreground/70 transition-colors"
+										>
+											careers@better-auth.com
+										</a>
+										.
+									</p>
+								) : (
+									<div className="space-y-4">
+										{activeFilter && (
+											<div className="flex items-center justify-between gap-3 border border-dashed border-foreground/[0.08] px-4 py-3">
+												<p className="text-[12px] font-mono uppercase tracking-[0.16em] text-foreground/55">
+													Showing {activeFilter.city} /{" "}
+													{activeFilter.department}
+												</p>
+												<button
+													type="button"
+													onClick={() => setActiveFilter(null)}
+													data-testid="clear-role-filter"
+													className="text-[10px] font-mono uppercase tracking-[0.16em] text-foreground/45 transition-colors hover:text-foreground/70"
+												>
+													Show all roles
+												</button>
+											</div>
+										)}
+										{filteredJobs.map((role, i) => (
+											<RoleCard key={role.id} role={role} index={i} />
+										))}
+									</div>
+								)}
 							</motion.div>
 						</div>
 						<Footer />
 					</div>
 				</div>
 			</div>
-
-			{/* Apply dialog */}
-			<AnimatePresence>
-				{applyingRole && (
-					<ApplyDialog
-						role={applyingRole}
-						onClose={() => setApplyingRole(null)}
-					/>
-				)}
-			</AnimatePresence>
 		</div>
 	);
 }

--- a/docs/app/careers/careers-data.test.ts
+++ b/docs/app/careers/careers-data.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { getRoleParagraphs } from "./careers-data";
+
+describe("getRoleParagraphs", () => {
+	const cases: Array<{
+		name: string;
+		content?: string;
+		expected: string[];
+	}> = [
+		{
+			name: "Role",
+			content: [
+				"About Better Auth",
+				"Intro copy",
+				"",
+				"Role",
+				"Build core systems.",
+				"Ship product.",
+				"",
+				"Why You Should Join",
+				"Other section",
+			].join("\n"),
+			expected: ["Build core systems.", "Ship product."],
+		},
+		{
+			name: "The Role",
+			content: [
+				"The Role",
+				"Design APIs.",
+				"",
+				"What You'll Work On",
+				"Other section",
+			].join("\n"),
+			expected: ["Design APIs."],
+		},
+		{
+			name: "About the Role with trailing colon",
+			content: [
+				"About the Role:",
+				"Lead architecture decisions.",
+				"",
+				"Why You Should Join:",
+				"Other section",
+			].join("\n"),
+			expected: ["Lead architecture decisions."],
+		},
+		{
+			name: "does not match prose containing role",
+			content: [
+				"About Better Auth",
+				"This role is a chance to build interesting systems.",
+				"Why You Should Join",
+				"Other section",
+			].join("\n"),
+			expected: [],
+		},
+		{
+			name: "undefined input",
+			content: undefined,
+			expected: [],
+		},
+		{
+			name: "empty string",
+			content: "",
+			expected: [],
+		},
+	];
+
+	it.each(cases)("extracts role paragraphs for $name", ({
+		content,
+		expected,
+	}) => {
+		expect(getRoleParagraphs(content)).toEqual(expected);
+	});
+});

--- a/docs/app/careers/careers-data.ts
+++ b/docs/app/careers/careers-data.ts
@@ -1,0 +1,117 @@
+export type GemEmploymentType =
+	| "contract"
+	| "full_time"
+	| "intern"
+	| "part_time"
+	| "temporary"
+	| (string & {});
+
+export interface GemLocationName {
+	name: string;
+}
+
+export interface GemDepartment {
+	id?: string;
+	name: string;
+	parent_id?: string | null;
+	child_ids?: string[];
+}
+
+export interface GemJobPost {
+	id: string;
+	title: string;
+	absolute_url: string;
+	content?: string;
+	content_plain?: string;
+	departments?: GemDepartment[] | null;
+	location?: GemLocationName | null;
+	employment_type: GemEmploymentType;
+}
+
+const JOB_POSTS_URL = "https://api.gem.com/job_board/v0/better-auth/job_posts";
+
+type JobBase = Pick<
+	GemJobPost,
+	| "id"
+	| "title"
+	| "absolute_url"
+	| "departments"
+	| "location"
+	| "employment_type"
+>;
+
+export type RawJob = JobBase & Pick<GemJobPost, "content" | "content_plain">;
+
+export type Job = JobBase & {
+	roleParagraphs: string[];
+};
+
+export function getRoleParagraphs(contentPlain?: string): string[] {
+	if (!contentPlain) return [];
+
+	const normalize = (line: string) =>
+		line
+			.replace(/[\u2018\u2019']/g, "'")
+			.replace(/\s+/g, " ")
+			.replace(/:\s*$/, "")
+			.trim();
+
+	const isHeading = (line: string) => {
+		const n = normalize(line);
+		return (
+			n.length > 0 && n.length <= 48 && /^[A-Z0-9]/.test(n) && !/[.!?]$/.test(n)
+		);
+	};
+
+	const isRoleSection = (line: string) => {
+		const n = normalize(line);
+		return /^(?:about\s+)?(?:the\s+)?role$/i.test(n) && isHeading(line);
+	};
+
+	const lines = contentPlain
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+	const roleIndex = lines.findIndex(isRoleSection);
+	if (roleIndex === -1) return [];
+
+	const paragraphs: string[] = [];
+	for (const line of lines.slice(roleIndex + 1)) {
+		if (isHeading(line)) break;
+		paragraphs.push(line.replace(/\s+/g, " ").trim());
+	}
+
+	return paragraphs;
+}
+
+export function toJob(rawJob: RawJob): Job {
+	const { content: _content, content_plain, ...job } = rawJob;
+
+	return {
+		...job,
+		roleParagraphs: getRoleParagraphs(content_plain),
+	};
+}
+
+export async function fetchGemJobPosts(): Promise<GemJobPost[]> {
+	try {
+		const res = await fetch(JOB_POSTS_URL, {
+			next: { revalidate: 60 },
+		});
+		if (!res.ok) {
+			console.error("Failed to fetch Gem job posts:", res.status);
+			return [];
+		}
+
+		const data = await res.json();
+		if (!Array.isArray(data)) {
+			console.error("Unexpected Gem response shape:", typeof data);
+			return [];
+		}
+
+		return data as GemJobPost[];
+	} catch (error) {
+		console.error("Error fetching Gem job posts:", error);
+		return [];
+	}
+}

--- a/docs/app/careers/page.tsx
+++ b/docs/app/careers/page.tsx
@@ -1,12 +1,14 @@
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { CareersPageClient } from "./careers-client";
+import { fetchGemJobPosts, toJob } from "./careers-data";
 
 export const metadata: Metadata = createMetadata({
 	title: "Careers",
 	description: "Join the Better Auth team — open positions and how to apply.",
 });
 
-export default function CareersPage() {
-	return <CareersPageClient />;
+export default async function CareersPage() {
+	const jobs = (await fetchGemJobPosts()).map(toJob);
+	return <CareersPageClient jobs={jobs} />;
 }

--- a/docs/components/landing/footer.tsx
+++ b/docs/components/landing/footer.tsx
@@ -8,6 +8,7 @@ const footerLinks = [
 	{ label: "Blog", href: "/blog" },
 	{ label: "Community", href: "/community" },
 	{ label: "Changelog", href: "/changelog" },
+	{ label: "Careers", href: "/careers" },
 ];
 
 export default function Footer() {

--- a/docs/components/landing/signature-mark.tsx
+++ b/docs/components/landing/signature-mark.tsx
@@ -21,6 +21,13 @@ export function SignatureMark() {
 				</Link>
 				<span className="text-foreground/15">/</span>
 				<Link
+					href="/careers"
+					className="hover:text-foreground/80 transition-colors"
+				>
+					Careers
+				</Link>
+				<span className="text-foreground/15">/</span>
+				<Link
 					href="/legal"
 					className="hover:text-foreground/80 transition-colors"
 				>

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,8 @@
     "sync-beta": "node scripts/sync-beta-content.ts",
     "sync-typesense": "node scripts/sync-typesense.ts",
     "format:md": "remark . --ext md,mdx --output --quiet",
-    "format:check": "remark . --ext md,mdx --quiet --frail"
+    "format:check": "remark . --ext md,mdx --quiet --frail",
+    "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.44",

--- a/docs/vitest.config.ts
+++ b/docs/vitest.config.ts
@@ -1,0 +1,17 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineProject } from "vitest/config";
+
+const docsDir = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineProject({
+	resolve: {
+		alias: {
+			"@": resolve(docsDir, "."),
+		},
+	},
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});


### PR DESCRIPTION
## Summary

Improve the careers page to render live Gem job board data with clearer role cards, left-side filtering, and focused test coverage.

## What changed

- fetch careers data from the Gem job board API on the server
- render title, employment type, city, department, role section, and apply link for each job
- add left-side grouping by location and department
- add client-side filtering from the left table to the job list
- add homepage/footer careers links
- add focused tests for role parsing, careers rendering, and filter interactions

## Why

- keeps the careers page aligned with the live source of truth
- makes jobs easier to scan and filter
- adds regression coverage for the role-section parsing and interactive filtering behavior

## Testing

- 
 RUN  v4.0.18 /Users/fiatlux/better-auth/better-auth

 ✓ |@better-auth-test/test| unit/careers-utils.test.ts (6 tests) 2ms
 ✓ |@better-auth-test/test| unit/careers-client-render.test.ts (1 test) 17ms
 ✓ |@better-auth-test/test| unit/careers-client-filter.test.ts (1 test) 33ms

 Test Files  3 passed (3)
      Tests  8 passed (8)
   Start at  22:45:19
   Duration  401ms (transform 108ms, setup 0ms, import 350ms, tests 52ms, environment 192ms)

## Screenshots

- Added for careers page updates

<img width="1496" height="686" alt="image" src="https://github.com/user-attachments/assets/3f5c43a4-e455-414b-ba42-215551b98336" />

- Added Careers link in footer
<img width="603" height="78" alt="image" src="https://github.com/user-attachments/assets/9d231098-4b68-4d27-a576-6bddcfee38b3" />

