### PR TITLE
fix(passkey): handle autofill ceremony failures

### DIFF
--- a/.changeset/calm-passkeys-report.md
+++ b/.changeset/calm-passkeys-report.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/passkey": patch
+---
+
+Return a handled auth cancellation when passkey autofill authentication cannot start.

--- a/packages/passkey/src/client.test.ts
+++ b/packages/passkey/src/client.test.ts
@@ -144,4 +144,61 @@ describe("passkey client", () => {
 			credProps: true,
 		});
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9373
+	 */
+	it("returns an auth error without logging expected authentication ceremony failures", async () => {
+		mocks.startAuthentication.mockRejectedValueOnce(
+			new Error(
+				"Resident credentials or empty 'allowCredentials' lists are not supported at this time.",
+			),
+		);
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const fetchMock = vi.fn(async (path: string) => {
+			if (path === "/passkey/generate-authenticate-options") {
+				return {
+					data: {
+						challenge: "challenge",
+						rpId: "example.com",
+						allowCredentials: [],
+						userVerification: "preferred",
+					},
+				};
+			}
+			if (path === "/passkey/verify-authentication") {
+				throw new Error("verification should not run after ceremony failure");
+			}
+			return { data: null };
+		});
+		const listPasskeys = { set: vi.fn() };
+		const store = { notify: vi.fn() };
+		const actions = getPasskeyActions(fetchMock as any, {
+			$listPasskeys: listPasskeys as any,
+			$store: store as any,
+		});
+
+		try {
+			const result = await actions.signIn.passkey({ autoFill: true });
+
+			expect(result).toEqual({
+				data: null,
+				error: {
+					code: "AUTH_CANCELLED",
+					message: "Auth cancelled",
+					status: 400,
+					statusText: "BAD_REQUEST",
+				},
+			});
+			expect(consoleError).not.toHaveBeenCalled();
+			expect(fetchMock).not.toHaveBeenCalledWith(
+				"/passkey/verify-authentication",
+				expect.anything(),
+			);
+		} finally {
+			consoleError.mockRestore();
+		}
+	});
 });

--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -58,21 +58,34 @@ export const getPasskeyActions = (
 		if (!response.data) {
 			return response;
 		}
+		const mergedExtensions =
+			response.data.extensions || opts?.extensions
+				? {
+						...(response.data.extensions || {}),
+						...(opts?.extensions || {}),
+					}
+				: undefined;
+		let res: AuthenticationResponseJSON;
 		try {
-			const mergedExtensions =
-				response.data.extensions || opts?.extensions
-					? {
-							...(response.data.extensions || {}),
-							...(opts?.extensions || {}),
-						}
-					: undefined;
-			const res = await startAuthentication({
+			res = await startAuthentication({
 				optionsJSON: {
 					...response.data,
 					extensions: mergedExtensions,
 				},
 				useBrowserAutofill: opts?.autoFill,
 			});
+		} catch (err) {
+			return {
+				data: null,
+				error: {
+					code: err instanceof WebAuthnError ? err.code : "AUTH_CANCELLED",
+					message: PASSKEY_ERROR_CODES.AUTH_CANCELLED.message,
+					status: 400,
+					statusText: "BAD_REQUEST",
+				},
+			};
+		}
+		try {
 			const { clientExtensionResults, ...responseBody } = res;
 			const verified = await $fetch<{
 				session: Session;
@@ -93,7 +106,7 @@ export const getPasskeyActions = (
 				return {
 					...verified,
 					webauthn: {
-						response: res as AuthenticationResponseJSON,
+						response: res,
 						clientExtensionResults:
 							clientExtensionResults as AuthenticationExtensionsClientOutputs,
 					},


### PR DESCRIPTION
## Summary
- Handles passkey authentication ceremony failures before posting to the verify route, returning the existing auth-cancelled response shape without logging an Error object to the console.
- Adds regression coverage for conditional UI/autofill failures and a patch changeset for `@better-auth/passkey`.

## Test Plan
- `pnpm vitest packages/passkey/src/client.test.ts -t "returns an auth error" --run --reporter verbose`
- `pnpm vitest packages/passkey/src/client.test.ts --run --reporter dot`
- `pnpm vitest packages/passkey/src --run --reporter dot`
- `pnpm biome check packages/passkey/src/client.ts packages/passkey/src/client.test.ts .changeset/calm-passkeys-report.md`
- `pnpm --filter @better-auth/passkey typecheck`
- `pnpm cspell packages/passkey/src/client.ts packages/passkey/src/client.test.ts .changeset/calm-passkeys-report.md --color`
- `NODE_OPTIONS=--max-old-space-size=2048 pnpm --filter @better-auth/passkey build`
- `git diff --check HEAD~1..HEAD`

Fixes #9373

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle passkey autofill/conditional UI auth failures by catching WebAuthn ceremony errors and returning a consistent AUTH_CANCELLED response, without calling verify. Adds regression tests and a patch changeset for `@better-auth/passkey`.

- **Bug Fixes**
  - Catch `startAuthentication` rejections; return AUTH_CANCELLED (use `WebAuthnError` code when present).
  - Skip `/passkey/verify-authentication` after ceremony failure and avoid console logging.

<sup>Written for commit 4cd65eb89db3432a81a578cd0299a2a5289ba060. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

