### PR TITLE
feat: make `Auth` instance fetchable

### DIFF
--- a/.changeset/hungry-drinks-read.md
+++ b/.changeset/hungry-drinks-read.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+feat: make `Auth` instance fetchable

--- a/packages/better-auth/src/auth/base.ts
+++ b/packages/better-auth/src/auth/base.ts
@@ -26,59 +26,58 @@ export const createBetterAuth = <Options extends BetterAuthOptions>(
 		}
 		return acc;
 	}, {});
-	return {
-		handler: async (request: Request) => {
-			const ctx = await authContext;
-			const basePath = ctx.options.basePath || "/api/auth";
+	const handler = async (request: Request) => {
+		const ctx = await authContext;
+		const basePath = ctx.options.basePath || "/api/auth";
 
-			let handlerCtx: AuthContext;
+		let handlerCtx: AuthContext;
 
-			if (isDynamicBaseURLConfig(options.baseURL)) {
-				// Per-request clone avoids mutating shared ctx under concurrent
-				// requests that may resolve to different hosts.
-				handlerCtx = await resolveRequestContext(
-					ctx,
+		if (isDynamicBaseURLConfig(options.baseURL)) {
+			// Per-request clone avoids mutating shared ctx under concurrent
+			// requests that may resolve to different hosts.
+			handlerCtx = await resolveRequestContext(
+				ctx,
+				request,
+				resolveDynamicTrustedProxyHeaders(ctx.options),
+			);
+		} else {
+			handlerCtx = ctx;
+			// Static config with no baseURL: memoize on the shared ctx from
+			// the first request. A concurrent-first-requests race is
+			// harmless since both writes resolve to the same value. Cloning
+			// via `Object.create` (as the dynamic branch does) would break
+			// downstream references that depend on `ctx.options` being
+			// mutated in place.
+			if (!ctx.options.baseURL) {
+				const baseURL = getBaseURL(
+					undefined,
+					basePath,
 					request,
-					resolveDynamicTrustedProxyHeaders(ctx.options),
+					undefined,
+					ctx.options.advanced?.trustedProxyHeaders,
 				);
-			} else {
-				handlerCtx = ctx;
-				// Static config with no baseURL: memoize on the shared ctx from
-				// the first request. A concurrent-first-requests race is
-				// harmless since both writes resolve to the same value. Cloning
-				// via `Object.create` (as the dynamic branch does) would break
-				// downstream references that depend on `ctx.options` being
-				// mutated in place.
-				if (!ctx.options.baseURL) {
-					const baseURL = getBaseURL(
-						undefined,
-						basePath,
-						request,
-						undefined,
-						ctx.options.advanced?.trustedProxyHeaders,
+				if (baseURL) {
+					ctx.baseURL = baseURL;
+					ctx.options.baseURL = getOrigin(ctx.baseURL) || undefined;
+				} else {
+					throw new BetterAuthError(
+						"Could not get base URL from request. Please provide a valid base URL.",
 					);
-					if (baseURL) {
-						ctx.baseURL = baseURL;
-						ctx.options.baseURL = getOrigin(ctx.baseURL) || undefined;
-					} else {
-						throw new BetterAuthError(
-							"Could not get base URL from request. Please provide a valid base URL.",
-						);
-					}
 				}
-				handlerCtx.trustedOrigins = await getTrustedOrigins(
-					ctx.options,
-					request,
-				);
-				handlerCtx.trustedProviders = await getTrustedProviders(
-					ctx.options,
-					request,
-				);
 			}
+			handlerCtx.trustedOrigins = await getTrustedOrigins(ctx.options, request);
+			handlerCtx.trustedProviders = await getTrustedProviders(
+				ctx.options,
+				request,
+			);
+		}
 
-			const { handler } = router(handlerCtx, options);
-			return runWithAdapter(handlerCtx.adapter, () => handler(request));
-		},
+		const { handler } = router(handlerCtx, options);
+		return runWithAdapter(handlerCtx.adapter, () => handler(request));
+	};
+	return {
+		handler,
+		fetch: handler,
 		api,
 		options: options,
 		$context: authContext,

--- a/packages/better-auth/src/types/auth.ts
+++ b/packages/better-auth/src/types/auth.ts
@@ -7,6 +7,10 @@ import type { InferPluginContext, InferPluginErrorCodes } from "./plugins";
 
 export type Auth<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	handler: (request: Request) => Promise<Response>;
+	/**
+	 * Alias for {@link Auth.handler}.
+	 */
+	fetch: (request: Request) => Promise<Response>;
 	api: InferAPI<ReturnType<typeof router<Options>>["endpoints"]>;
 	options: Options;
 	$ERROR_CODES: InferPluginErrorCodes<Options> & typeof BASE_ERROR_CODES;


### PR DESCRIPTION
This PR adds `auth.fetch` as alias to `auth.handler`.

I am trying to figure out super minimal or ideally zero config support for better-auth via `auth.ts` [for Nitro](https://github.com/nitrojs/nitro/pull/3942/). Ideally something like this is all one will have to do:

```ts
// auth.ts
import { betterAuth } from "better-auth"
export default betterAuth({ /* ... */ })
```

Today, modern http frameworks (H3, Hono, Elysia) and platforms (Vercel, Cloudflare, Deno) and Runtimes (Bun, Deno and srvx) support fetchable default exports. `export default app` / `export default { fetch }` works out of the box.

Nitro v3 too supports this as a universal convention. By this change, a simple `auth.ts` in any Nitro app can be elegantly used for both better-auth CLI migrator and route handler for `/api/auth/**`.

## Alternatives

Today one can make a `api/auth/[..].ts` that basically reexports `auth.handler` in a wrapper. It adds an unncessary extra file.

Anther alternative could be `export const auth` + `export const fetch = auth.handler` but this pattern is really not supported (both runtimes and nitro expect a default export with `.fetch` attached to) and is also less intuative. 

Relavant fixes: https://github.com/better-auth/better-auth/pull/9477

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `auth.fetch` as an alias to `auth.handler`, making `Auth` instances directly fetchable for zero‑config default exports in Nitro v3 and other fetch-based runtimes.

- **New Features**
  - Added `auth.fetch(request)`, identical to `auth.handler(request)`, for platforms expecting a default `fetch`.
  - Exposed `Auth.fetch` in types; release as a minor update in `better-auth`.

<sup>Written for commit e8d8f266bce00fdf4203bcda94edbb0cf6e4d490. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



