### PR TITLE
fix(stripe): add priceId field in the subscription table, edited test accordingly

### DIFF
--- a/.changeset/sparkly-sites-design.md
+++ b/.changeset/sparkly-sites-design.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/stripe": patch
+---
+
+Persist Stripe canonical priceId on subscription rows; add priceId to schema; persist on create/update/checkout/webhook; update tests/docs.

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -375,10 +375,17 @@ To get the user's active subscriptions:
       sub => sub.status === "active" || sub.status === "trialing"
   );
 
+  // Persisted Stripe price id on the subscription row
+    const activePriceId = activeSubscription?.priceId;
+
   // Check subscription limits
   const projectLimit = subscriptions?.limits?.projects || 0;
   ```
 </APIMethod>
+
+<Callout type="info">
+  `subscription.list` returns the persisted `subscription.priceId` from your database. After checkout and webhook sync, this value reflects the canonical Stripe subscription item price ID.
+</Callout>
 
 Make sure to provide `authorizeReference` in your plugin config to authorize the reference ID
 
@@ -711,6 +718,13 @@ export const stripeSubscriptionTableFields = [
 		type: "string",
 		description: "The name of the subscription plan",
 	},
+    {
+        name: "priceId",
+        type: "string",
+        description:
+            "The Stripe price ID persisted on the subscription row and synced from Stripe subscription items.",
+        isOptional: true,
+    },
 	{
 		name: "referenceId",
 		type: "string",
@@ -1114,7 +1128,7 @@ If webhooks aren't being processed correctly:
 If subscription statuses aren't updating correctly:
 
 1. Make sure the webhook events are being received and processed
-2. Check that the `stripeCustomerId` and `stripeSubscriptionId` fields are correctly populated
+2. Check that the `stripeCustomerId`, `stripeSubscriptionId`, and `priceId` fields are correctly populated
 3. Verify that the reference IDs match between your application and Stripe
 
 ### Testing Webhooks Locally

--- a/packages/stripe/src/hooks.ts
+++ b/packages/stripe/src/hooks.ts
@@ -102,6 +102,7 @@ export async function onCheckoutSessionCompleted(
 							: null,
 						seats: seats,
 						billingInterval: subscriptionItem.price.recurring?.interval,
+						priceId: subscriptionItem.price.id,
 					},
 					where: [
 						{
@@ -250,6 +251,7 @@ export async function onSubscriptionCreated(
 				periodEnd,
 				seats,
 				billingInterval: subscriptionItem.price.recurring?.interval,
+				priceId: subscriptionItem.price.id,
 			},
 		});
 
@@ -371,6 +373,7 @@ export async function onSubscriptionUpdated(
 				seats,
 				stripeSubscriptionId: stripeSubscriptionUpdated.id,
 				billingInterval: subscriptionItem.price.recurring?.interval,
+				priceId: subscriptionItem.price.id,
 				stripeScheduleId: stripeSubscriptionUpdated.schedule
 					? typeof stripeSubscriptionUpdated.schedule === "string"
 						? stripeSubscriptionUpdated.schedule

--- a/packages/stripe/src/routes.ts
+++ b/packages/stripe/src/routes.ts
@@ -659,6 +659,7 @@ export const upgradeSubscription = (options: StripeOptions) => {
 						model: "subscription",
 						update: {
 							stripeSubscriptionId: activeSubscription.id,
+							priceId: planItem?.price.id,
 							updatedAt: new Date(),
 						},
 						where: [
@@ -1011,6 +1012,7 @@ export const upgradeSubscription = (options: StripeOptions) => {
 					update: {
 						plan: plan.name.toLowerCase(),
 						seats: isAutoManagedSeats ? memberCount : ctx.body.seats || 1,
+						priceId: priceIdToUse,
 						updatedAt: new Date(),
 					},
 					where: [
@@ -1032,6 +1034,7 @@ export const upgradeSubscription = (options: StripeOptions) => {
 						status: "incomplete",
 						referenceId,
 						seats: isAutoManagedSeats ? memberCount : ctx.body.seats || 1,
+						priceId: priceIdToUse,
 					},
 				});
 			}
@@ -1816,6 +1819,7 @@ export const subscriptionSuccess = (options: StripeOptions) => {
 					periodEnd: new Date(subscriptionItem.current_period_end * 1000),
 					periodStart: new Date(subscriptionItem.current_period_start * 1000),
 					stripeSubscriptionId: stripeSubscription.id,
+					priceId: subscriptionItem.price.id,
 					cancelAtPeriodEnd: stripeSubscription.cancel_at_period_end,
 					cancelAt: stripeSubscription.cancel_at
 						? new Date(stripeSubscription.cancel_at * 1000)

--- a/packages/stripe/src/schema.ts
+++ b/packages/stripe/src/schema.ts
@@ -66,6 +66,10 @@ export const subscriptions = {
 				type: "string",
 				required: false,
 			},
+			priceId: {
+				type: "string",
+				required: false,
+			},
 			stripeScheduleId: {
 				type: "string",
 				required: false,

--- a/packages/stripe/test/stripe.test.ts
+++ b/packages/stripe/test/stripe.test.ts
@@ -342,6 +342,7 @@ describe("stripe", () => {
 			trialStart: undefined,
 			trialEnd: undefined,
 		});
+		expect(subscription?.priceId).toEqual(expect.any(String));
 	});
 
 	it("should not allow cross-user subscriptionId operations (upgrade/cancel/restore)", async () => {
@@ -822,6 +823,8 @@ describe("stripe", () => {
 			periodEnd: expect.any(Date),
 			plan: "starter",
 		});
+
+		expect(updatedSubscription?.priceId).toEqual(expect.any(String));
 	});
 
 	it("should handle subscription webhook events with trial", async () => {
@@ -945,6 +948,7 @@ describe("stripe", () => {
 			plan: "starter",
 			trialStart: expect.any(Date),
 			trialEnd: expect.any(Date),
+			priceId: expect.any(String),
 		});
 	});
 
@@ -1658,6 +1662,7 @@ describe("stripe", () => {
 		);
 		expect(incompleteSubscription.status).toBe("incomplete");
 		expect(incompleteSubscription.stripeSubscriptionId).toBeUndefined();
+		expect(incompleteSubscription.priceId).toEqual(expect.any(String));
 
 		// Get user with stripeCustomerId
 		const user = await testCtx.adapter.findOne<any>({


### PR DESCRIPTION
Fixes #8821 

- Added an optional 'priceId' field in the subscription model's schema.
- Edited tests accordingly
- Updated the strips docs
- Persist priceId on create/update/checkout/webhook sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Stripe `priceId` on subscription records and return it from `subscription.list` so plans and billing stay in sync with Stripe across checkout, upgrades, and webhook syncs. Optional field only; no breaking changes.

- **Bug Fixes**
  - Added optional `priceId` to the subscription schema in `@better-auth/stripe`.
  - Persist `priceId` from subscription items in checkout completion, subscription created/updated webhooks, and upgrade/success routes.
  - Expose persisted `priceId` in `subscription.list` and update `docs/plugins/stripe.mdx` with usage and troubleshooting notes.
  - Updated tests to assert `priceId` is stored; added a changeset to publish a patch for `@better-auth/stripe`.

<sup>Written for commit 45b3dcf995677445919c975d6d2dcc529dccf918. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

