### PR TITLE
docs: fix organization invite callout list

### DIFF
--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -897,10 +897,11 @@ To invite users to an organization, you can use the `invite` function provided b
 
 <Callout>
   * If the user is already a member of the organization, the invitation will be
-    canceled. - If the user is already invited to the organization, unless
-    `resend` is set to `true`, the invitation will not be sent again. - If
-    `cancelPendingInvitationsOnReInvite` is set to `true`, the invitation will be
-    canceled if the user is already invited to the organization and a new
+    canceled.
+  * If the user is already invited to the organization, unless `resend` is set
+    to `true`, the invitation will not be sent again.
+  * If `cancelPendingInvitationsOnReInvite` is set to `true`, the invitation will
+    be canceled if the user is already invited to the organization and a new
     invitation is sent.
 </Callout>
 


### PR DESCRIPTION
## Summary

Fixes #9441.

Updates the Organization plugin docs so the invitation behavior callout renders as three separate list items instead of one long list item with literal `- If` text.

## Root Cause

The MDX list had the second and third bullets inline after the first bullet’s wrapped text, so they were parsed as plain text inside the first `<li>`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Organization plugin docs by correcting the invitation behavior callout to render as three separate bullets. Prevents the merged list item that showed literal "- If" text.

<sup>Written for commit 2f927d7ec7d38f853aceabe8c270d8ff8c06186b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

