### PR TITLE
test: cover OpenAPI schema API typing

### DIFF
--- a/e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler/src/open-api.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler/src/open-api.ts
@@ -1,0 +1,19 @@
+import { betterAuth } from "better-auth";
+import { openAPI } from "better-auth/plugins";
+import { expectTypeOf } from "vitest";
+
+const auth = betterAuth({
+	plugins: [openAPI()],
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8688
+ */
+expectTypeOf(auth.api.generateOpenAPISchema).toBeFunction();
+expectTypeOf<
+	Awaited<ReturnType<typeof auth.api.generateOpenAPISchema>>
+>().toMatchTypeOf<{
+	openapi: string;
+	paths: Record<string, unknown>;
+	components: Record<string, unknown>;
+}>();


### PR DESCRIPTION
## Summary

- Adds a consumer-style TypeScript smoke fixture for `betterAuth({ plugins: [openAPI()] })`.
- Covers that `auth.api.generateOpenAPISchema` is exposed in public API typings and returns an OpenAPI schema shape.

Refs #8688

## Test Plan

- `NODE_OPTIONS=--max-old-space-size=2048 pnpm turbo run build --filter=@better-auth/passkey --filter=@better-auth/sso --filter=@better-auth/stripe --filter=@better-auth/oauth-provider --filter=better-auth`
- `cd e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler && pnpm run typecheck`
- `pnpm biome check e2e/smoke/test/fixtures/tsconfig-isolated-module-bundler/src/open-api.ts`
- `git diff --check HEAD~1..HEAD`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TypeScript smoke test to ensure `better-auth` with `openAPI()` exposes `auth.api.generateOpenAPISchema` and that it returns a valid OpenAPI schema shape. This safeguards the public API typing for schema generation.

<sup>Written for commit fab2529ce6a97078395a336ce75ef14edccd39cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

