### PR TITLE
fix(organization): cancelPendingInvitationsOnReInvite is unreachable — re-invite returns 400 (#9452)

### DIFF
--- a/.changeset/silly-regions-sin.md
+++ b/.changeset/silly-regions-sin.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The organization plugin's `cancelPendingInvitationsOnReInvite` option now actually cancels the prior pending invitation when re-inviting the same email. Previously the option had no effect — re-inviting always failed with `USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION`

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1935,6 +1935,109 @@ describe("cancel pending invitations on re-invite", async () => {
 				.length,
 		).toBe(1);
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9452
+	 */
+	it("should cancel pending invitation and create a new one when re-inviting without resend", async () => {
+		const invite = await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "test9b@test.com",
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+		expect(invite.data?.status).toBe("pending");
+		const originalInviteId = invite.data?.id;
+
+		const invite2 = await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "test9b@test.com",
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+		expect(invite2.error).toBeNull();
+		expect(invite2.data?.status).toBe("pending");
+		expect(invite2.data?.id).not.toBe(originalInviteId);
+
+		const listInvitations = await client.organization.listInvitations({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(
+			listInvitations.data?.filter(
+				(i) => i.email === "test9b@test.com" && i.status === "pending",
+			).length,
+		).toBe(1);
+		expect(
+			listInvitations.data?.filter(
+				(i) => i.email === "test9b@test.com" && i.status === "canceled",
+			).length,
+		).toBe(1);
+	});
+});
+
+describe("re-invite without cancelPendingInvitationsOnReInvite still throws", async () => {
+	const { customFetchImpl, signInWithTestUser } = await getTestInstance({
+		plugins: [organization()],
+	});
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+	const { headers } = await signInWithTestUser();
+	const org = await client.organization.create(
+		{
+			name: "test",
+			slug: "test",
+		},
+		{
+			headers,
+		},
+	);
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9452
+	 */
+	it("should still throw USER_IS_ALREADY_INVITED when option is disabled", async () => {
+		const invite = await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "test9c@test.com",
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+		expect(invite.data?.status).toBe("pending");
+
+		const invite2 = await client.organization.inviteMember(
+			{
+				organizationId: org.data?.id as string,
+				email: "test9c@test.com",
+				role: "member",
+			},
+			{
+				headers,
+			},
+		);
+		expect(invite2.error?.message).toBe(
+			ORGANIZATION_ERROR_CODES.USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION
+				.message,
+		);
+	});
 });
 
 describe("resend invitation should reuse existing", async () => {

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -289,7 +289,11 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 				email: email,
 				organizationId: organizationId,
 			});
-			if (alreadyInvited.length && !ctx.body.resend) {
+			if (
+				alreadyInvited.length &&
+				!ctx.body.resend &&
+				!ctx.context.orgOptions.cancelPendingInvitationsOnReInvite
+			) {
 				throw APIError.from(
 					"BAD_REQUEST",
 					ORGANIZATION_ERROR_CODES.USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION,


### PR DESCRIPTION
## Summary

The `cancelPendingInvitationsOnReInvite` option in the organization plugin had no effect: re-inviting the same email always returned `400 USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION` because an unconditional early throw at the top of the route fired before the cancel-on-reinvite branch could run.

In `packages/better-auth/src/plugins/organization/routes/crud-invites.ts`, the order was:

1. **L292** — `if (alreadyInvited.length && !ctx.body.resend) throw USER_IS_ALREADY_INVITED…` (unconditional w.r.t. the flag)
2. **L308** — resend branch (only reached when `resend: true`)
3. **L358** — `if (alreadyInvited.length && cancelPendingInvitationsOnReInvite) await adapter.updateInvitation({ status: "canceled" })`

Step 3 was unreachable for *every* code path: a no-resend re-invite hits the throw at step 1, and a `resend: true` re-invite returns from step 2.

## Fix

Gate the early throw on `!cancelPendingInvitationsOnReInvite` so callers who opted into the cancel-on-reinvite semantics fall through to the cancel branch:

```ts
  if (
    alreadyInvited.length &&
    !ctx.body.resend &&
    !ctx.context.orgOptions.cancelPendingInvitationsOnReInvite
  ) {
    throw APIError.from(
      "BAD_REQUEST",
      ORGANIZATION_ERROR_CODES.USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION,
    );
  }
```

## Tests

Two regression cases added in organization.test.ts, both tagged with @see https://github.com/better-auth/better-auth/issues/9452:

1. With cancelPendingInvitationsOnReInvite: true enabled, a no-resend re-invite returns 200, the prior row ends up status: "canceled", and a fresh pending row exists for the same email.
2. With the option disabled, the existing 400 USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION behavior is preserved (guards against the inverse regression).

## Verified locally:

`pnpm vitest packages/better-auth/src/plugins/organization --run`

## Changeset

Patch bump (bug fix, no user-visible behavior change unless the user explicitly opted into cancelPendingInvitationsOnReInvite: true).

## Related

Closes #9452

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the organization re-invite flow so `cancelPendingInvitationsOnReInvite` works as intended: re-inviting the same email without `resend` now cancels the previous pending invite and creates a new one; previously it returned 400.

- **Bug Fixes**
  - Gated the early “already invited” error on `!cancelPendingInvitationsOnReInvite`, allowing the cancel-and-recreate path when enabled.
  - Added tests for both enabled and disabled behaviors.

<sup>Written for commit a5d84081e58d1c9b5c540845b04a83c01ace133e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

