### PR TITLE
fix(invites): prevent re-invitation if pending invitations are not canceled

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -289,7 +289,11 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 				email: email,
 				organizationId: organizationId,
 			});
-			if (alreadyInvited.length && !ctx.body.resend) {
+			if (
+				alreadyInvited.length &&
+				!ctx.body.resend &&
+				!ctx.context.orgOptions.cancelPendingInvitationsOnReInvite
+			) {
 				throw APIError.from(
 					"BAD_REQUEST",
 					ORGANIZATION_ERROR_CODES.USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent re-inviting a user if they already have a pending invitation, unless the org has `cancelPendingInvitationsOnReInvite` enabled. Re-invites via the `resend` flow continue to work.

<sup>Written for commit 09ff909cd8a0d224d8fe94fc38e9d57d81b02402. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

