### PR TITLE
docs: add better-near-auth to community plugins

### DIFF
--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -30,3 +30,4 @@ ejirocodes
 0-Sandy
 qamarq
 C-W-D-Harshit
+efiz

--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -31,3 +31,4 @@ ejirocodes
 qamarq
 C-W-D-Harshit
 efiz
+Braem

--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -270,4 +270,15 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/ejirocodes.png",
 		},
 	},
+	{
+		name: "better-near-auth",
+		url: "https://github.com/elliotBraem/better-near-auth",
+		description:
+			"Sign in with NEAR plugin with built-in gasless relay for on-chain delegate actions.",
+		author: {
+			name: "efiz.near",
+			github: "elliotBraem",
+			avatar: "https://github.com/elliotBraem.png",
+		},
+	},
 ];


### PR DESCRIPTION
Adds the [better-near-auth](https://github.com/elliotBraem/better-near-auth) plugin to the community plugins list.

- Sign in with NEAR (SIWN) plugin for Better Auth
- Built-in gasless relay for on-chain delegate actions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `better-near-auth` to the community plugins list — a Sign in with NEAR plugin with a built-in gasless relay for on-chain delegate actions. Also updates `.cspell` names to include `efiz` and `Braem` to fix linting.

<sup>Written for commit 7eebd112179b9e6f1712f4509ffce2c7f99ef8fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

