### PR TITLE
fix(core): getSessionCookie fails when Cookie header uses ";" without…

### DIFF
--- a/.changeset/silent-meals-work.md
+++ b/.changeset/silent-meals-work.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+getSessionCookie fails when Cookie header uses ";" without space as separator

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1437,6 +1437,20 @@ describe("parse cookies", () => {
 			"session-data.signature=",
 		);
 	});
+
+	it("should parse cookies separated only by a semi-colon", () => {
+		const cookieHeader =
+			"better-auth.session_token=session-token.signature;better-auth.session_data=session-data.signature";
+
+		const parsedCookies = parseCookies(cookieHeader);
+
+		expect(parsedCookies.get("better-auth.session_token")).toBe(
+			"session-token.signature",
+		);
+		expect(parsedCookies.get("better-auth.session_data")).toBe(
+			"session-data.signature",
+		);
+	});
 });
 
 describe("expireCookie", () => {

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -357,7 +357,7 @@ export function deleteSessionCookie(
 }
 
 export function parseCookies(cookieHeader: string) {
-	const cookies = cookieHeader.split("; ");
+	const cookies = cookieHeader.split(/; ?/);
 	const cookieMap = new Map<string, string>();
 
 	cookies.forEach((cookie) => {


### PR DESCRIPTION
… space as separator.

`getSessionCookie` returns null even when the session cookie is present in the request, when the app is deployed on AWS Lambda behind API Gateway (v2).

The root cause is that `parseCookies` splits the Cookie header on `"; "` (semicolon + space), but API Gateway forwards the header with cookies separated by `";"` (semicolon only, no space). This causes the entire cookie string to be treated as a single unparseable token.

- Closes: https://github.com/better-auth/better-auth/issues/9465

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix session cookie parsing in `better-auth` when the Cookie header uses ";" without a space, which caused `getSessionCookie` to return null in some gateways. `parseCookies` now splits on `/; ?/` and a test covers semicolon-only separators.

<sup>Written for commit 50ecfb09c639581786d731b96666971faae13bc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

