### PR TITLE
fix(open-api): emit requestBody for ZodIntersection body schemas

### DIFF
--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -155,6 +155,22 @@ function getRequestBody(options: EndpointOptions): any {
 		return options.metadata.openapi.requestBody;
 	}
 	if (!options.body) return undefined;
+	// Several plugins (email-otp, phone-number, organization, admin) define their
+	// body as `z.object({...}).and(z.record(z.string(), z.any()))` to allow
+	// arbitrary additional fields. Without explicit handling, `instanceof
+	// ZodObject` is false and the request body silently drops out of the spec.
+	if (options.body instanceof z.ZodIntersection) {
+		const schema = processZodType(options.body as z.ZodType<any>);
+		if (!schema) return undefined;
+		return {
+			required: true,
+			content: {
+				"application/json": {
+					schema,
+				},
+			},
+		};
+	}
 	if (
 		options.body instanceof z.ZodObject ||
 		options.body instanceof z.ZodOptional
@@ -194,6 +210,37 @@ function getRequestBody(options: EndpointOptions): any {
 }
 
 function processZodType(zodType: z.ZodType<any>): any {
+	// Intersection (e.g. `z.object({...}).and(z.record(...))`).
+	// Flatten the common "object + open record" pattern to a single object schema
+	// with `additionalProperties: true`; merge two object schemas; otherwise fall
+	// back to OpenAPI's `allOf`.
+	if (zodType instanceof z.ZodIntersection) {
+		const def = (zodType as any)._def;
+		const left = processZodType(def.left);
+		const right = processZodType(def.right);
+		const leftIsOpenRecord = def.left instanceof z.ZodRecord;
+		const rightIsOpenRecord = def.right instanceof z.ZodRecord;
+		if (left.type === "object" && rightIsOpenRecord) {
+			return { ...left, additionalProperties: true };
+		}
+		if (right.type === "object" && leftIsOpenRecord) {
+			return { ...right, additionalProperties: true };
+		}
+		if (left.type === "object" && right.type === "object") {
+			const mergedRequired = Array.from(
+				new Set([...(left.required ?? []), ...(right.required ?? [])]),
+			);
+			return {
+				type: "object",
+				properties: {
+					...(left.properties ?? {}),
+					...(right.properties ?? {}),
+				},
+				...(mergedRequired.length > 0 ? { required: mergedRequired } : {}),
+			};
+		}
+		return { allOf: [left, right] };
+	}
 	// optional unwrapping
 	if (zodType instanceof z.ZodOptional) {
 		const innerType = zodType.unwrap() as any;

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
+import { emailOTP } from "../email-otp";
 import { openAPI } from ".";
 
 describe("open-api", async () => {
@@ -275,5 +276,38 @@ describe("open-api", async () => {
 		expect(signUpProps.rememberMe).toBeDefined();
 		const baseTypes = getBaseType(signUpProps.rememberMe.type);
 		expect(baseTypes).toContain("boolean");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9298
+	 */
+	describe("ZodIntersection body schemas (plugin .and(z.record(...)) pattern)", async () => {
+		const { auth: authWithEmailOTP } = await getTestInstance({
+			plugins: [
+				openAPI(),
+				emailOTP({
+					sendVerificationOTP: async () => {},
+				}),
+			],
+		});
+
+		it("should emit a requestBody for emailOTP /sign-in/email-otp", async () => {
+			const schema = await authWithEmailOTP.api.generateOpenAPISchema();
+			const paths = schema.paths as Record<string, any>;
+			const path = paths["/sign-in/email-otp"];
+			expect(path?.post?.requestBody).toBeDefined();
+			const bodySchema =
+				path.post.requestBody.content["application/json"].schema;
+			expect(bodySchema.type).toBe("object");
+			expect(bodySchema.properties.email).toBeDefined();
+			expect(bodySchema.properties.otp).toBeDefined();
+			expect(bodySchema.properties.name).toBeDefined();
+			expect(bodySchema.properties.image).toBeDefined();
+			expect(bodySchema.required).toEqual(
+				expect.arrayContaining(["email", "otp"]),
+			);
+			// `.and(z.record(z.string(), z.any()))` means "any other keys also allowed".
+			expect(bodySchema.additionalProperties).toBe(true);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Several plugins (`email-otp`, `phone-number`, `organization`, `admin`) define endpoint bodies as `z.object({...}).and(z.record(z.string(), z.any()))` to allow arbitrary additional fields. The OpenAPI generator only recognised `ZodObject` / `ZodOptional`, so every endpoint using `.and()` silently dropped its `requestBody` from the generated spec. The Scalar UI at `/api/auth/reference` then rendered those endpoints without a body, making them untestable from the docs.

Closes #9298 (also resolves the same root cause flagged in #8122 for `phone-number`).

## What changed

- **`getRequestBody`** now recognises `ZodIntersection` and delegates schema generation to `processZodType`.
- **`processZodType`** gains an `intersection` branch that:
  - flattens the common `object + z.record(...)` pattern to the object schema with `additionalProperties: true`,
  - merges two object schemas by combining their `properties` and `required` arrays,
  - falls back to OpenAPI's `allOf` for arbitrary intersections.

## Why this approach

`z.object({...}).and(z.record(z.string(), z.any()))` is semantically "this object plus arbitrary extra keys" — OpenAPI expresses that exactly as `additionalProperties: true` on the object schema. Flattening to a single object keeps the docs UI usable (forms render correctly) instead of producing an `allOf` block that some renderers don't expand. `allOf` is kept as the fallback for genuine intersections of two unrelated schemas.

## Verification

- New regression test in `open-api.test.ts` that loads the `emailOTP` plugin and asserts the `/sign-in/email-otp` request body includes `email`, `otp`, `name`, `image`, marks `email`/`otp` as required, and sets `additionalProperties: true`.
- Existing 11 open-api tests still pass.
- Existing 108 phone-number + email-otp tests still pass.
- `pnpm typecheck` passes.

## Agent disclosure

I am an agent (Claude Code). Author: @jaydeep-pipaliya. Tests run locally; no manual UI testing claimed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits `requestBody` for `ZodIntersection` schemas in the `better-auth` OpenAPI generator, restoring body definitions for endpoints using `z.object(...).and(z.record(...))`. Docs at `/api/auth/reference` now show and accept request payloads.

- **Bug Fixes**
  - `getRequestBody` now handles `ZodIntersection` and returns a JSON schema.
  - `processZodType` adds intersection support: flattens object + `z.record(...)` to `additionalProperties: true`, merges object-object intersections, and falls back to `allOf` otherwise.
  - Added a regression test for `email-otp` `/sign-in/email-otp` ensuring required fields and `additionalProperties: true` are emitted.

<sup>Written for commit d39dedf98783e489b7599559525c3d2afacb94cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

