### PR TITLE
fix(stripe): lock library-owned Checkout Session fields against `getCheckoutSessionParams`

### DIFF
--- a/.changeset/fix-stripe-lock-checkout-fields.md
+++ b/.changeset/fix-stripe-lock-checkout-fields.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/stripe": patch
+---
+
+`getCheckoutSessionParams` no longer overrides fields the plugin manages internally for webhook reconciliation and billing: `success_url`, `cancel_url`, `mode`, `customer`, `customer_email`, `client_reference_id`, and `line_items`. All other Checkout Session parameters pass through as before.

--- a/packages/stripe/src/routes.ts
+++ b/packages/stripe/src/routes.ts
@@ -1077,15 +1077,19 @@ export const upgradeSubscription = (options: StripeOptions) => {
 			const checkoutSession = await client.checkout.sessions
 				.create(
 					{
+						...params?.params,
+						mode: "subscription",
 						...(customerId
 							? {
 									customer: customerId,
+									customer_email: undefined,
 									customer_update:
 										customerType !== "user"
 											? ({ address: "auto" } as const)
 											: ({ name: "auto", address: "auto" } as const), // The customer name is automatically set only for users
 								}
 							: {
+									customer: undefined,
 									customer_email: user.email,
 								}),
 						locale: ctx.body.locale,
@@ -1101,6 +1105,7 @@ export const upgradeSubscription = (options: StripeOptions) => {
 							)}&checkoutSessionId={CHECKOUT_SESSION_ID}`,
 						),
 						cancel_url: getUrl(ctx, ctx.body.cancelUrl),
+						client_reference_id: referenceId,
 						line_items: [
 							// Base price
 							...(!isSeatOnlyPlan
@@ -1124,9 +1129,6 @@ export const upgradeSubscription = (options: StripeOptions) => {
 							// Additional line items (metered prices, add-ons, etc.)
 							...(plan.lineItems ?? []),
 						],
-						mode: "subscription",
-						client_reference_id: referenceId,
-						...params?.params,
 						subscription_data: {
 							...freeTrial,
 							...params?.params?.subscription_data,

--- a/packages/stripe/src/routes.ts
+++ b/packages/stripe/src/routes.ts
@@ -1074,25 +1074,38 @@ export const upgradeSubscription = (options: StripeOptions) => {
 					? { trial_period_days: plan.freeTrial.days }
 					: undefined;
 
+			// Strip plugin-owned fields
+			const {
+				mode: _mode,
+				customer: _customer,
+				customer_email: _customer_email,
+				success_url: _success_url,
+				cancel_url: _cancel_url,
+				line_items: _line_items,
+				client_reference_id: _client_reference_id,
+				...additionalParams
+			} = params?.params ?? {};
+
 			const checkoutSession = await client.checkout.sessions
 				.create(
 					{
-						...params?.params,
+						...additionalParams,
 						mode: "subscription",
 						...(customerId
 							? {
 									customer: customerId,
 									customer_email: undefined,
 									customer_update:
-										customerType !== "user"
+										additionalParams.customer_update ??
+										(customerType !== "user"
 											? ({ address: "auto" } as const)
-											: ({ name: "auto", address: "auto" } as const), // The customer name is automatically set only for users
+											: ({ name: "auto", address: "auto" } as const)), // The customer name is automatically set only for users
 								}
 							: {
 									customer: undefined,
 									customer_email: user.email,
 								}),
-						locale: ctx.body.locale,
+						locale: ctx.body.locale ?? additionalParams.locale,
 						success_url: getUrl(
 							ctx,
 							`${
@@ -1105,7 +1118,6 @@ export const upgradeSubscription = (options: StripeOptions) => {
 							)}&checkoutSessionId={CHECKOUT_SESSION_ID}`,
 						),
 						cancel_url: getUrl(ctx, ctx.body.cancelUrl),
-						client_reference_id: referenceId,
 						line_items: [
 							// Base price
 							...(!isSeatOnlyPlan
@@ -1129,9 +1141,10 @@ export const upgradeSubscription = (options: StripeOptions) => {
 							// Additional line items (metered prices, add-ons, etc.)
 							...(plan.lineItems ?? []),
 						],
+						client_reference_id: referenceId,
 						subscription_data: {
 							...freeTrial,
-							...params?.params?.subscription_data,
+							...additionalParams.subscription_data,
 							metadata: subscriptionMetadata.set(
 								{
 									userId: user.id,
@@ -1139,7 +1152,7 @@ export const upgradeSubscription = (options: StripeOptions) => {
 									referenceId,
 								},
 								ctx.body.metadata,
-								params?.params?.subscription_data?.metadata,
+								additionalParams.subscription_data?.metadata,
 							),
 						},
 						metadata: subscriptionMetadata.set(
@@ -1149,7 +1162,7 @@ export const upgradeSubscription = (options: StripeOptions) => {
 								referenceId,
 							},
 							ctx.body.metadata,
-							params?.params?.metadata,
+							additionalParams.metadata,
 						),
 					},
 					params?.options,

--- a/packages/stripe/test/stripe.test.ts
+++ b/packages/stripe/test/stripe.test.ts
@@ -8740,6 +8740,139 @@ describe("stripe", () => {
 			);
 		});
 
+		it("does not let getCheckoutSessionParams override library-owned flow-routing fields", async () => {
+			const hijackOptions = {
+				...stripeOptions,
+				subscription: {
+					enabled: true,
+					plans: [
+						{
+							priceId: process.env.STRIPE_PRICE_ID_1!,
+							name: "starter",
+							lookupKey: "lookup_key_123",
+						},
+					],
+					getCheckoutSessionParams: async () => ({
+						params: {
+							success_url: "https://attacker.example/success",
+							cancel_url: "https://attacker.example/cancel",
+							mode: "payment" as const,
+							client_reference_id: "attacker-controlled",
+							customer: "cus_attacker",
+							customer_email: "attacker@example.com",
+							line_items: [{ price: "price_attacker", quantity: 99 }],
+						},
+					}),
+				},
+			} satisfies StripeOptions;
+
+			const { client, sessionSetter } = await getTestInstance(
+				{
+					database: memory,
+					plugins: [stripe(hijackOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [stripeClient({ subscription: true })],
+					},
+				},
+			);
+
+			const email = "hijack-attempt@email.com";
+			await client.signUp.email({ ...testUser, email }, { throw: true });
+			const headers = new Headers();
+			await client.signIn.email(
+				{ ...testUser, email },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			mockStripe.checkout.sessions.create.mockClear();
+			await client.subscription.upgrade({
+				plan: "starter",
+				fetchOptions: { headers },
+			});
+
+			const callArgs = mockStripe.checkout.sessions.create.mock.calls[0]?.[0];
+			expect(callArgs).toBeDefined();
+			expect(callArgs.mode).toBe("subscription");
+			expect(callArgs.client_reference_id).not.toBe("attacker-controlled");
+			expect(callArgs.customer).not.toBe("cus_attacker");
+			expect(callArgs.customer_email).not.toBe("attacker@example.com");
+			expect(callArgs.success_url).not.toBe("https://attacker.example/success");
+			expect(callArgs.success_url).toContain("/subscription/success");
+			expect(callArgs.cancel_url).not.toBe("https://attacker.example/cancel");
+			expect(callArgs.line_items).not.toEqual([
+				{ price: "price_attacker", quantity: 99 },
+			]);
+			expect(callArgs.line_items[0].price).toBe("price_lookup_123");
+		});
+
+		it("passes UX-only params from getCheckoutSessionParams through to Stripe", async () => {
+			const passthroughOptions = {
+				...stripeOptions,
+				subscription: {
+					enabled: true,
+					plans: [
+						{
+							priceId: process.env.STRIPE_PRICE_ID_1!,
+							name: "starter",
+							lookupKey: "lookup_key_123",
+						},
+					],
+					getCheckoutSessionParams: async () => ({
+						params: {
+							allow_promotion_codes: true,
+							payment_method_collection: "if_required" as const,
+							tax_id_collection: { enabled: true },
+							custom_text: {
+								submit: { message: "Welcome aboard" },
+							},
+							billing_address_collection: "required" as const,
+						},
+					}),
+				},
+			} satisfies StripeOptions;
+
+			const { client, sessionSetter } = await getTestInstance(
+				{
+					database: memory,
+					plugins: [stripe(passthroughOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [stripeClient({ subscription: true })],
+					},
+				},
+			);
+
+			const email = "passthrough@email.com";
+			await client.signUp.email({ ...testUser, email }, { throw: true });
+			const headers = new Headers();
+			await client.signIn.email(
+				{ ...testUser, email },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			mockStripe.checkout.sessions.create.mockClear();
+			await client.subscription.upgrade({
+				plan: "starter",
+				fetchOptions: { headers },
+			});
+
+			expect(mockStripe.checkout.sessions.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					allow_promotion_codes: true,
+					payment_method_collection: "if_required",
+					tax_id_collection: { enabled: true },
+					custom_text: { submit: { message: "Welcome aboard" } },
+					billing_address_collection: "required",
+				}),
+				undefined,
+			);
+		});
+
 		it("preserves internal subscription metadata when getCheckoutSessionParams returns custom subscription_data", async () => {
 			const { client, sessionSetter } = await getTestInstance(
 				{

--- a/packages/stripe/test/stripe.test.ts
+++ b/packages/stripe/test/stripe.test.ts
@@ -8873,6 +8873,214 @@ describe("stripe", () => {
 			);
 		});
 
+		it("lets getCheckoutSessionParams override customer_update", async () => {
+			const overrideOptions = {
+				...stripeOptions,
+				subscription: {
+					enabled: true,
+					plans: [
+						{
+							priceId: process.env.STRIPE_PRICE_ID_1!,
+							name: "starter",
+							lookupKey: "lookup_key_123",
+						},
+					],
+					getCheckoutSessionParams: async () => ({
+						params: {
+							customer_update: { name: "never" } as const,
+						},
+					}),
+				},
+			} satisfies StripeOptions;
+
+			const { client, sessionSetter } = await getTestInstance(
+				{
+					database: memory,
+					plugins: [stripe(overrideOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [stripeClient({ subscription: true })],
+					},
+				},
+			);
+
+			const email = "customer-update-override@email.com";
+			await client.signUp.email({ ...testUser, email }, { throw: true });
+			const headers = new Headers();
+			await client.signIn.email(
+				{ ...testUser, email },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			mockStripe.checkout.sessions.create.mockClear();
+			await client.subscription.upgrade({
+				plan: "starter",
+				fetchOptions: { headers },
+			});
+
+			const callArgs = mockStripe.checkout.sessions.create.mock.calls[0]?.[0];
+			expect(callArgs.customer_update).toEqual({ name: "never" });
+		});
+
+		it("falls back to library default customer_update when getCheckoutSessionParams omits it", async () => {
+			const defaultOptions = {
+				...stripeOptions,
+				subscription: {
+					enabled: true,
+					plans: [
+						{
+							priceId: process.env.STRIPE_PRICE_ID_1!,
+							name: "starter",
+							lookupKey: "lookup_key_123",
+						},
+					],
+					getCheckoutSessionParams: async () => ({
+						params: {
+							allow_promotion_codes: true,
+						},
+					}),
+				},
+			} satisfies StripeOptions;
+
+			const { client, sessionSetter } = await getTestInstance(
+				{
+					database: memory,
+					plugins: [stripe(defaultOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [stripeClient({ subscription: true })],
+					},
+				},
+			);
+
+			const email = "customer-update-default@email.com";
+			await client.signUp.email({ ...testUser, email }, { throw: true });
+			const headers = new Headers();
+			await client.signIn.email(
+				{ ...testUser, email },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			mockStripe.checkout.sessions.create.mockClear();
+			await client.subscription.upgrade({
+				plan: "starter",
+				fetchOptions: { headers },
+			});
+
+			const callArgs = mockStripe.checkout.sessions.create.mock.calls[0]?.[0];
+			expect(callArgs.customer_update).toEqual({
+				name: "auto",
+				address: "auto",
+			});
+		});
+
+		it("uses request-time locale over getCheckoutSessionParams locale", async () => {
+			const localeOptions = {
+				...stripeOptions,
+				subscription: {
+					enabled: true,
+					plans: [
+						{
+							priceId: process.env.STRIPE_PRICE_ID_1!,
+							name: "starter",
+							lookupKey: "lookup_key_123",
+						},
+					],
+					getCheckoutSessionParams: async () => ({
+						params: {
+							locale: "ko" as const,
+						},
+					}),
+				},
+			} satisfies StripeOptions;
+
+			const { client, sessionSetter } = await getTestInstance(
+				{
+					database: memory,
+					plugins: [stripe(localeOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [stripeClient({ subscription: true })],
+					},
+				},
+			);
+
+			const email = "locale-request-wins@email.com";
+			await client.signUp.email({ ...testUser, email }, { throw: true });
+			const headers = new Headers();
+			await client.signIn.email(
+				{ ...testUser, email },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			mockStripe.checkout.sessions.create.mockClear();
+			await client.subscription.upgrade({
+				plan: "starter",
+				locale: "en",
+				fetchOptions: { headers },
+			});
+
+			const callArgs = mockStripe.checkout.sessions.create.mock.calls[0]?.[0];
+			expect(callArgs.locale).toBe("en");
+		});
+
+		it("falls back to getCheckoutSessionParams locale when request omits locale", async () => {
+			const localeOptions = {
+				...stripeOptions,
+				subscription: {
+					enabled: true,
+					plans: [
+						{
+							priceId: process.env.STRIPE_PRICE_ID_1!,
+							name: "starter",
+							lookupKey: "lookup_key_123",
+						},
+					],
+					getCheckoutSessionParams: async () => ({
+						params: {
+							locale: "ko" as const,
+						},
+					}),
+				},
+			} satisfies StripeOptions;
+
+			const { client, sessionSetter } = await getTestInstance(
+				{
+					database: memory,
+					plugins: [stripe(localeOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [stripeClient({ subscription: true })],
+					},
+				},
+			);
+
+			const email = "locale-fallback@email.com";
+			await client.signUp.email({ ...testUser, email }, { throw: true });
+			const headers = new Headers();
+			await client.signIn.email(
+				{ ...testUser, email },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			mockStripe.checkout.sessions.create.mockClear();
+			await client.subscription.upgrade({
+				plan: "starter",
+				fetchOptions: { headers },
+			});
+
+			const callArgs = mockStripe.checkout.sessions.create.mock.calls[0]?.[0];
+			expect(callArgs.locale).toBe("ko");
+		});
+
 		it("preserves internal subscription metadata when getCheckoutSessionParams returns custom subscription_data", async () => {
 			const { client, sessionSetter } = await getTestInstance(
 				{


### PR DESCRIPTION
- Following up from #9474 

`getCheckoutSessionParams` is designed to allow extending checkout session params beyond what the library manages internally. Allowing it to override internally-owned checkout session fields could lead to unexpected bugs.

While this can be seen as a behavior change (-> beta track), the docs already present it as a way to add custom fields, and this aligns with the intended purpose of `getCheckoutSessionParams`, so this is being addressed as a stable track.

+) Mutually exclude `customer` / `customer_email` so the unused side cannot leak through.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>