### PR TITLE
fix(username): respect callbackURL on sign-in

### DIFF
--- a/.changeset/fix-username-callback-url-redirect.md
+++ b/.changeset/fix-username-callback-url-redirect.md
@@ -1,0 +1,11 @@
+---
+"better-auth": patch
+---
+
+fix(username): respect callbackURL on `/sign-in/username`
+
+The endpoint accepted a `callbackURL` body field but ignored it, so
+`authClient.signIn.username({ ..., callbackURL })` silently did nothing
+while `authClient.signIn.email` redirected as expected. The handler now
+sets a `Location` header when `callbackURL` is provided and returns
+`{ redirect, url }` alongside `token`/`user`, matching the email flow.

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -109,7 +109,8 @@ const signInUsernameBodySchema = z.object({
 	callbackURL: z
 		.string()
 		.meta({
-			description: "The URL to redirect to after email verification",
+			description:
+				"URL to redirect to after sign in (also used as the redirect target for email verification when required)",
 		})
 		.optional(),
 });
@@ -214,16 +215,27 @@ export const username = (options?: UsernameOptions | undefined) => {
 											schema: {
 												type: "object",
 												properties: {
+													redirect: {
+														type: "boolean",
+														description:
+															"Whether the client should follow the Location header. True when callbackURL was provided.",
+													},
 													token: {
 														type: "string",
 														description:
 															"Session token for the authenticated session",
 													},
+													url: {
+														type: "string",
+														nullable: true,
+														description:
+															"The callbackURL echoed back so the client can redirect.",
+													},
 													user: {
 														$ref: "#/components/schemas/User",
 													},
 												},
-												required: ["token", "user"],
+												required: ["redirect", "token", "user"],
 											},
 										},
 									},
@@ -410,8 +422,13 @@ export const username = (options?: UsernameOptions | undefined) => {
 						{ session, user },
 						ctx.body.rememberMe === false,
 					);
+					if (ctx.body.callbackURL) {
+						ctx.setHeader("Location", ctx.body.callbackURL);
+					}
 					return ctx.json({
+						redirect: !!ctx.body.callbackURL,
 						token: session.token,
+						url: ctx.body.callbackURL,
 						user: parseUserOutput(ctx.context.options, user),
 					});
 				},

--- a/packages/better-auth/src/plugins/username/username.test.ts
+++ b/packages/better-auth/src/plugins/username/username.test.ts
@@ -53,6 +53,30 @@ describe("username", async () => {
 		);
 		expect(res.data?.token).toBeDefined();
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9469
+	 */
+	it("should redirect to callbackURL on sign-in (parity with sign-in/email)", async () => {
+		const res = await client.signIn.username({
+			username: "new_username",
+			password: "new-password",
+			callbackURL: "/dashboard",
+		});
+		expect(res.data?.redirect).toBe(true);
+		expect(res.data?.url).toBe("/dashboard");
+		expect(res.data?.token).toBeDefined();
+	});
+
+	it("should not set redirect when callbackURL is omitted", async () => {
+		const res = await client.signIn.username({
+			username: "new_username",
+			password: "new-password",
+		});
+		expect(res.data?.redirect).toBe(false);
+		expect(res.data?.url).toBeUndefined();
+	});
+
 	it("should update username", async () => {
 		await client.updateUser({
 			username: "new_username_2.1",


### PR DESCRIPTION
`/sign-in/email` honours `callbackURL` — it sets a `Location` header and returns `{ redirect, url }`. `/sign-in/username` accepts the same field on the body but ignores it: the handler just returns `{ token, user }`, so `authClient.signIn.username({ ..., callbackURL: '/' })` silently does nothing while the email equivalent redirects.

Reported in #9469.

This mirrors the email-and-password flow in the username sign-in handler: set `Location` when `callbackURL` is present, and add `redirect`/`url` to the JSON response. The OpenAPI metadata and the body field description are updated to match.

Two regression tests added in `username.test.ts` covering the with- and without-`callbackURL` paths. Existing 33 tests still pass; full username suite is 35.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/sign-in/username` honor `callbackURL` on sign-in, matching the email flow for consistent client redirects.

- **Bug Fixes**
  - Set `Location` when `callbackURL` is provided and return `redirect` and `url` in JSON.
  - Updated OpenAPI schema and body field description; added regression tests for with/without `callbackURL`; included a changeset.

<sup>Written for commit 773b4fb2cdc7e677a103d3f7d02c5a76c2e759b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

