### PR TITLE
refactor(phone-number): unify verifyPhoneNumber completion paths

### DIFF
--- a/.changeset/phone-number-finalize-helper.md
+++ b/.changeset/phone-number-finalize-helper.md
@@ -1,0 +1,12 @@
+---
+"better-auth": patch
+---
+
+refactor(phone-number): unify `verifyPhoneNumber` completion paths through a single `finalize` helper
+
+The three terminal branches of `/phone-number/verify-otp` (token reuse, new
+session, no-session) each duplicated the call to `callbackOnVerification` and
+the response shape. They now route through a single `finalize` helper that
+encodes the session strategy as a discriminated union, so future changes to
+the response or the verification callback can't drift between branches.
+No behavior change.

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -146,6 +146,9 @@ describe("phone-number callbackOnVerification on updatePhoneNumber", async () =>
 			{ phoneNumber: initialPhoneNumber, code: otp },
 			{ onSuccess: sessionSetter(headers) },
 		);
+		// First verify is the sign-up-on-verification branch — the callback
+		// should have fired here too. See #9290.
+		expect(callbackOnVerification).toHaveBeenCalledTimes(1);
 		callbackOnVerification.mockClear();
 
 		await client.phoneNumber.sendOtp({

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -538,6 +538,46 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				);
 			}
 
+			// Single completion path. Each branch above computes `user` and decides
+			// the session strategy; finalize() is the only place that fires the
+			// `callbackOnVerification` hook and shapes the response, so a future
+			// branch can't accidentally skip either.
+			const finalize = async (
+				user: UserWithPhoneNumber,
+				sessionStrategy:
+					| { type: "reuse"; token: string }
+					| { type: "create" }
+					| { type: "none" },
+			) => {
+				await opts?.callbackOnVerification?.(
+					{ phoneNumber: ctx.body.phoneNumber, user },
+					ctx,
+				);
+
+				let token: string | null = null;
+				if (sessionStrategy.type === "reuse") {
+					token = sessionStrategy.token;
+				} else if (sessionStrategy.type === "create") {
+					const session = await ctx.context.internalAdapter.createSession(
+						user.id,
+					);
+					if (!session) {
+						throw APIError.from(
+							"INTERNAL_SERVER_ERROR",
+							BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION,
+						);
+					}
+					await setSessionCookie(ctx, { session, user });
+					token = session.token;
+				}
+
+				return ctx.json({
+					status: true,
+					token,
+					user: parseUserOutput(ctx.context.options, user),
+				});
+			};
+
 			if (ctx.body.updatePhoneNumber) {
 				const session = await getSessionFromCtx(ctx);
 				if (!session) {
@@ -573,17 +613,9 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 						BASE_ERROR_CODES.FAILED_TO_UPDATE_USER,
 					);
 				}
-				await opts?.callbackOnVerification?.(
-					{
-						phoneNumber: ctx.body.phoneNumber,
-						user,
-					},
-					ctx,
-				);
-				return ctx.json({
-					status: true,
+				return finalize(user, {
+					type: "reuse",
 					token: session.session.token,
-					user: parseUserOutput(ctx.context.options, user),
 				});
 			}
 
@@ -645,40 +677,10 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				);
 			}
 
-			await opts?.callbackOnVerification?.(
-				{
-					phoneNumber: ctx.body.phoneNumber,
-					user,
-				},
-				ctx,
+			return finalize(
+				user,
+				ctx.body.disableSession ? { type: "none" } : { type: "create" },
 			);
-
-			if (!ctx.body.disableSession) {
-				const session = await ctx.context.internalAdapter.createSession(
-					user.id,
-				);
-				if (!session) {
-					throw APIError.from(
-						"INTERNAL_SERVER_ERROR",
-						BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION,
-					);
-				}
-				await setSessionCookie(ctx, {
-					session,
-					user,
-				});
-				return ctx.json({
-					status: true,
-					token: session.token,
-					user: parseUserOutput(ctx.context.options, user),
-				});
-			}
-
-			return ctx.json({
-				status: true,
-				token: null,
-				user: parseUserOutput(ctx.context.options, user),
-			});
 		},
 	);
 


### PR DESCRIPTION
The `/phone-number/verify` handler had three exit branches — update an authenticated user's number, sign-up-on-verification, and `disableSession` — and each was independently responsible for firing `callbackOnVerification`, building the response, and creating a session. That shape is what made #4839 happen: the update branch silently returned without calling the callback while the other two did. PR #4894 copied the call into the third branch, but the underlying structure stayed the same, so the next branch added later (account-linking, admin-initiated verification, etc.) can quietly omit the callback again.

Extracted a single `finalize()` step inside the handler. Each branch computes `user` plus a session strategy (`reuse` for the update path that already has a session, `create` for sign-up, `none` for `disableSession`) and returns through `finalize`, which is the only place that fires `callbackOnVerification` and shapes the response. The compiler can't yet enforce "you must call finalize", but the call sites are now structurally trivial — three lines each — and the bookkeeping is in one place.

No behaviour change — the existing 32 phone-number tests pass. Also strengthened the #4839 regression to assert the callback fires on the sign-up branch (it was firing already, the test just wasn't asserting it).

Closes #9290

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified completion in `/phone-number/verify` so all branches call a single `finalize()` that always fires `callbackOnVerification` and builds the response/session, addressing #9290. No behavior change; tests strengthened for the sign‑up path.

- **Refactors**
  - Introduced `finalize(user, sessionStrategy)` to trigger `callbackOnVerification`, manage session (`reuse` | `create` | `none`), and return the JSON response.
  - All paths now return via `finalize()` (`updatePhoneNumber` → `reuse`, sign‑up → `create`, `disableSession` → `none`).
  - Tests now assert the callback fires on sign‑up; added a changeset to publish a patch for `better-auth`.

<sup>Written for commit 3ee96c5029afbcd8cec52a95433a41fcecfd22a7. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9476?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

