### PR TITLE
fix(admin): create credential account in setUserPassword when missing

### DIFF
--- a/.changeset/admin-set-password-creates-credential.md
+++ b/.changeset/admin-set-password-creates-credential.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`admin.setUserPassword` now creates a credential account when the target user does not have one, matching the behavior of `resetPassword`. Previously the call returned `status: true` without doing anything for users without an existing credential account (e.g., social-only or magic-link signups), so admins migrating users from another auth system or assigning an initial password to a social-only user can now do so directly without poking the `account` table.

--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -250,7 +250,7 @@ Changes the role of a user.
 
 ### Set User Password
 
-Changes the password of a user.
+Sets the password for a user. A credential account is created if the user doesn't already have one.
 
 <APIMethod path="/admin/set-user-password" method="POST" requireSession>
   ```ts

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -1333,6 +1333,64 @@ describe("Admin plugin", async () => {
 		expect(res.error?.status).toBe(403);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/3553
+	 */
+	it("should create a credential account when setting password for a user without one", async () => {
+		const created = await client.admin.createUser(
+			{
+				name: "No Credential User",
+				email: "no-credential@email.com",
+				role: "user",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		const userId = created.data?.user?.id || "";
+		expect(userId).not.toBe("");
+
+		const preSignIn = await client.signIn.email({
+			email: "no-credential@email.com",
+			password: "newPassword",
+		});
+		expect(preSignIn.error).toBeDefined();
+
+		const setRes = await client.admin.setUserPassword(
+			{
+				userId,
+				newPassword: "newPassword",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(setRes.data?.status).toBe(true);
+
+		const postSignIn = await client.signIn.email({
+			email: "no-credential@email.com",
+			password: "newPassword",
+		});
+		expect(postSignIn.error).toBeNull();
+		expect(postSignIn.data?.user.id).toBe(userId);
+
+		await client.admin.removeUser({ userId }, { headers: adminHeaders });
+	});
+
+	it("should return USER_NOT_FOUND when setting password for a non-existent user", async () => {
+		const res = await client.admin.setUserPassword(
+			{
+				userId: "non-existent-user-id",
+				newPassword: "newPassword",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.error?.status).toBe(404);
+		expect(res.error?.code).toBe("USER_NOT_FOUND");
+	});
+
 	it("should allow admin to delete user", async () => {
 		const res = await client.admin.removeUser(
 			{

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1717,8 +1717,28 @@ export const setUserPassword = (opts: AdminOptions) =>
 				ctx.context.logger.error("Password is too long");
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 			}
+			const user = await ctx.context.internalAdapter.findUserById(userId);
+			if (!user) {
+				throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
+			}
 			const hashedPassword = await ctx.context.password.hash(newPassword);
-			await ctx.context.internalAdapter.updatePassword(userId, hashedPassword);
+			const accounts = await ctx.context.internalAdapter.findAccounts(userId);
+			const credentialAccount = accounts.find(
+				(account) => account.providerId === "credential",
+			);
+			if (credentialAccount) {
+				await ctx.context.internalAdapter.updatePassword(
+					userId,
+					hashedPassword,
+				);
+			} else {
+				await ctx.context.internalAdapter.createAccount({
+					userId,
+					providerId: "credential",
+					accountId: userId,
+					password: hashedPassword,
+				});
+			}
 			return ctx.json({
 				status: true,
 			});


### PR DESCRIPTION
Mirror the existing branch in resetPassword(https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/api/routes/password.ts#L300-L311):

Look up the accounts, update if a credential account exists, otherwise create one (Upsert)

- Closes #3553
Related #4454