### PR TITLE
fix(microsoft): use RSA256 if alg is not received

### DIFF
--- a/packages/core/src/social-providers/microsoft-entra-id.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.ts
@@ -194,17 +194,21 @@ export const microsoft = (options: MicrosoftOptions) => {
 			}
 
 			try {
-				const { kid, alg: jwtAlg } = decodeProtectedHeader(token);
-				if (!kid || !jwtAlg) return false;
+				const { kid } = decodeProtectedHeader(token);
+				if (!kid) return false;
 
 				const publicKey = await getMicrosoftPublicKey(kid, tenant, authority);
+				// Microsoft Entra ID signs ID tokens with RS256. Hardcoding the
+				// allowlist prevents algorithm-confusion/downgrade attacks where a
+				// token's own header dictates which algorithms are accepted.
+				// @see https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens#validate-tokens
 				const verifyOptions: {
-					algorithms: [string];
+					algorithms: ["RS256"];
 					audience: string | string[];
 					maxTokenAge: string;
 					issuer?: string;
 				} = {
-					algorithms: [jwtAlg],
+					algorithms: ["RS256"],
 					audience: options.clientId,
 					maxTokenAge: "1h",
 				};
@@ -327,13 +331,13 @@ export const getMicrosoftPublicKey = async (
 	const { data } = await betterFetch<{
 		keys: Array<{
 			kid: string;
-			alg: string;
 			kty: string;
 			use: string;
 			n: string;
 			e: string;
 			x5c?: string[];
 			x5t?: string;
+			alg?: string;
 		}>;
 	}>(`${authority}/${tenant}/discovery/v2.0/keys`);
 
@@ -346,6 +350,17 @@ export const getMicrosoftPublicKey = async (
 	const jwk = data.keys.find((key) => key.kid === kid);
 	if (!jwk) {
 		throw new Error(`JWK with kid ${kid} not found`);
+	}
+
+	// Microsoft Entra ID signs ID tokens with RS256, but the JWKS does not
+	// always include the `alg` field. Default to RS256 for RSA signing keys.
+	// @see https://login.microsoftonline.com/common/discovery/v2.0/keys
+	if (!jwk.alg) {
+		if (jwk.kty === "RSA" && jwk.use === "sig") {
+			jwk.alg = "RS256";
+		} else {
+			throw new Error("Unable to determine algorithm for JWK");
+		}
 	}
 
 	return await importJWK(jwk, jwk.alg);


### PR DESCRIPTION
When authenticating with Microsoft, we are experiencing the following error:

```sh
[Better Auth]: Failed to verify ID token: TypeError: “alg” argument is required when “jwk.alg” is not present
```

After some digging, it appears Microsoft does not include the `alg` on their [JWKS default endpoints](https://login.microsoftonline.com/common/discovery/v2.0/keys). In the event this ever changes, the code as it is today would work. However, hard coding RSA256 based on the `kty` and `use` should work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Microsoft Entra ID authentication by enforcing `RS256` for token verification and defaulting missing JWKS `alg` to `RS256` for RSA keys. Restores verification, prevents “alg argument is required...” errors, and avoids algorithm-confusion attacks.

- **Bug Fixes**
  - Always verify with `algorithms: ["RS256"]`; stop relying on the token header `alg`.
  - Treat JWKS `alg` as optional; default RSA `sig` keys to `RS256`, otherwise throw a clear error.
  - Use the resolved `alg` when calling `importJWK` to build the public key.

<sup>Written for commit 94a05f8292a29a743698c91a17bf1b7356b39c0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

