### PR TITLE
chore: drop changeset for cli refactor (#9477)

### DIFF
--- a/.changeset/cli-c12-v4-resolve-module.md
+++ b/.changeset/cli-c12-v4-resolve-module.md
@@ -1,5 +1,0 @@
----
-"auth": patch
----
-
-simplify auth config loading by leveraging c12 v4's `resolveModule` option to handle `auth`, `default.auth`, and `default` export shapes in a single place


### PR DESCRIPTION
Follow-up from #9477

The behavior described by that changeset was already possible before, so at this point the PR seems to be purely a refactor.