### PR TITLE
test(cli): regression for named + default export via auto-detect (#9477)

### DIFF
--- a/packages/cli/test/get-config.test.ts
+++ b/packages/cli/test/get-config.test.ts
@@ -900,6 +900,31 @@ describe("getConfig", async () => {
 		});
 	});
 
+	it("should resolve named + default exports of the same auth instance via auto-detect", async () => {
+		const authPath = path.join(tmpDir, "server", "auth");
+		await fs.mkdir(authPath, { recursive: true });
+
+		await fs.writeFile(
+			path.join(authPath, "auth.ts"),
+			`import { betterAuth } from "better-auth";
+
+			 export const auth = betterAuth({
+					emailAndPassword: { enabled: true },
+					trustedOrigins: ["http://localhost:3000"]
+			 });
+
+			 export default auth;`,
+		);
+
+		const config = await getConfig({ cwd: tmpDir });
+
+		expect(config).not.toBe(null);
+		expect(config).toMatchObject({
+			emailAndPassword: { enabled: true },
+			trustedOrigins: ["http://localhost:3000"],
+		});
+	});
+
 	it("should load configs importing cloudflare workers", async () => {
 		await fs.writeFile(
 			path.join(tmpDir, "tsconfig.json"),


### PR DESCRIPTION
The test added in PR #9477 is not sufficient, because it already passes on the current `main` branch.