### PR TITLE
chore(changeset): restore changeset for cli named+default fix (#9477)

### DIFF
--- a/.changeset/cli-named-default-auto-detect.md
+++ b/.changeset/cli-named-default-auto-detect.md
@@ -1,0 +1,5 @@
+---
+"auth": minor
+---
+
+The CLI now auto-detects auth configs that export the same instance as both a named export and the default export (e.g. `export const auth = betterAuth(...); export default auth;`). Previously such configs failed when no explicit `--config` path was passed.


### PR DESCRIPTION
Restoring the changeset I dropped in #9492. I had misread it as an internal refactor. The original wording listed shapes that were already supported, which threw me off. The real fix was that `export const auth = ...; export default auth;` configs now work under auto-detect (previously failed with no `--config`). Bumped to `minor` to match the sibling PR #9431.

- Also relate to https://github.com/better-auth/better-auth/pull/9500

@pi0 looks good? 😁