### PR TITLE
fix(internal-adapter): rename deleteAccount param from `accountId` to `id`

### DIFF
--- a/.changeset/internal-adapter-delete-account-param-rename.md
+++ b/.changeset/internal-adapter-delete-account-param-rename.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`internalAdapter.deleteAccount` parameter renamed from `accountId` to `id` to reflect that it queries by primary key, not the `accountId` column. No runtime behavior change.

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -735,9 +735,19 @@ export const createInternalAdapter = (
 				undefined,
 			);
 		},
-		deleteAccount: async (accountId: string) => {
+		/**
+		 * Delete an account by its primary key.
+		 *
+		 * @param id - The account row's primary key (the `id` column, not the `accountId` column).
+		 */
+		deleteAccount: async (id: string) => {
 			await deleteWithHooks(
-				[{ field: "id", value: accountId }],
+				[
+					{
+						field: "id",
+						value: id,
+					},
+				],
 				"account",
 				undefined,
 			);

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -151,7 +151,12 @@ export interface InternalAdapter<
 
 	deleteAccounts(userId: string): Promise<void>;
 
-	deleteAccount(accountId: string): Promise<void>;
+	/**
+	 * Delete an account by its primary key.
+	 *
+	 * @param id - The account row's primary key (the `id` column, not the `accountId` column).
+	 */
+	deleteAccount(id: string): Promise<void>;
 
 	deleteSessions(userIdOrSessionTokens: string | string[]): Promise<void>;
 


### PR DESCRIPTION
Misleading parameter name could cause silent no-ops when callers pass an `accountId` column value instead of the PK

Related to #9502 - (1)