### PR TITLE
fix(access): preserve exact role statement types

### DIFF
--- a/.changeset/fix-org-role-statement-types.md
+++ b/.changeset/fix-org-role-statement-types.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Preserve exact access-control role statement types so predefined organization roles expose only their configured permissions in TypeScript.

--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -47,6 +47,19 @@ describe("access", () => {
 		expect(true).toBe(true);
 	});
 
+	it("should accept dynamic role records", () => {
+		const dynamicStatements: Record<string, string[]> = {
+			project: ["create"],
+			ui: ["view"],
+		};
+
+		const dynamicRole = ac.newRole(dynamicStatements);
+		const response = dynamicRole.authorize({
+			project: ["create"],
+		});
+		expect(response.success).toBe(true);
+	});
+
 	it("should validate permissions", async () => {
 		const response = role1.authorize({
 			project: ["create"],

--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAccessControl } from "./access";
 
 describe("access", () => {
@@ -19,6 +19,32 @@ describe("access", () => {
 			project: ["create"],
 		});
 		expect(response.success).toBe(true);
+	});
+
+	it("should preserve exact role statement types", () => {
+		const role2 = ac.newRole({
+			project: ["create", "update"],
+			ui: ["view"],
+		});
+
+		expectTypeOf(role2.statements.project).toEqualTypeOf<
+			readonly ["create", "update"]
+		>();
+		expectTypeOf(role2.statements.ui).toEqualTypeOf<readonly ["view"]>();
+
+		const failedResponse = role2.authorize({
+			project: ["delete-many"],
+		});
+		expect(failedResponse.success).toBe(false);
+	});
+
+	it("should reject invalid role statements at type level", () => {
+		// @ts-expect-error - "publish" is not part of the project statement.
+		ac.newRole({ project: ["publish"] });
+		// @ts-expect-error - "billing" is not a configured resource.
+		ac.newRole({ billing: ["read"] });
+
+		expect(true).toBe(true);
 	});
 
 	it("should validate permissions", async () => {

--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -1,21 +1,25 @@
 import { BetterAuthError } from "@better-auth/core/error";
-import type { Statements, Subset } from "./types";
+import type {
+	ExactRoleStatements,
+	Role,
+	RoleAuthorizeRequest,
+	RoleStatements,
+	Statements,
+} from "./types";
 
 export type AuthorizeResponse =
 	| { success: false; error: string }
 	| { success: true; error?: never | undefined };
 
-export function role<TStatements extends Statements>(statements: TStatements) {
+export function role<
+	const TRoleStatements extends Statements,
+	TAuthorizeStatements extends Statements = TRoleStatements,
+>(
+	statements: TRoleStatements,
+): Role<ExactRoleStatements<TRoleStatements>, TAuthorizeStatements> {
 	return {
-		authorize<K extends keyof TStatements>(
-			request: {
-				[key in K]?:
-					| TStatements[key]
-					| {
-							actions: TStatements[key];
-							connector: "OR" | "AND";
-					  };
-			},
+		authorize(
+			request: RoleAuthorizeRequest<TAuthorizeStatements>,
 			connector: "OR" | "AND" = "AND",
 		): AuthorizeResponse {
 			let success = false;
@@ -80,8 +84,12 @@ export function createAccessControl<const TStatements extends Statements>(
 	s: TStatements,
 ) {
 	return {
-		newRole<K extends keyof TStatements>(statements: Subset<K, TStatements>) {
-			return role<Subset<K, TStatements>>(statements);
+		newRole<const TRoleStatements extends Statements>(
+			statements: TRoleStatements &
+				RoleStatements<TStatements> &
+				Record<Exclude<keyof TRoleStatements, keyof TStatements>, never>,
+		) {
+			return role<TRoleStatements, TStatements>(statements);
 		},
 		statements: s,
 	};

--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -3,7 +3,7 @@ import type {
 	ExactRoleStatements,
 	Role,
 	RoleAuthorizeRequest,
-	RoleStatements,
+	RoleInput,
 	Statements,
 } from "./types";
 
@@ -85,9 +85,7 @@ export function createAccessControl<const TStatements extends Statements>(
 ) {
 	return {
 		newRole<const TRoleStatements extends Statements>(
-			statements: TRoleStatements &
-				RoleStatements<TStatements> &
-				Record<Exclude<keyof TRoleStatements, keyof TStatements>, never>,
+			statements: RoleInput<TStatements, TRoleStatements>,
 		) {
 			return role<TRoleStatements, TStatements>(statements);
 		},

--- a/packages/better-auth/src/plugins/access/types.ts
+++ b/packages/better-auth/src/plugins/access/types.ts
@@ -25,6 +25,15 @@ export type RoleStatements<TStatements extends Statements> = {
 	readonly [P in keyof TStatements]?: SubArray<TStatements[P]>;
 };
 
+export type RoleInput<
+	TStatements extends Statements,
+	TRoleStatements extends Statements,
+> = TRoleStatements &
+	(string extends keyof TRoleStatements
+		? {}
+		: RoleStatements<TStatements> &
+				Record<Exclude<keyof TRoleStatements, keyof TStatements>, never>);
+
 export type ExactRoleStatements<TStatements extends Statements> = {
 	readonly [P in keyof TStatements]: readonly [...TStatements[P]];
 };

--- a/packages/better-auth/src/plugins/access/types.ts
+++ b/packages/better-auth/src/plugins/access/types.ts
@@ -21,13 +21,33 @@ export type Statements = {
 	readonly [resource: string]: readonly LiteralString[];
 };
 
+export type RoleStatements<TStatements extends Statements> = {
+	readonly [P in keyof TStatements]?: SubArray<TStatements[P]>;
+};
+
+export type ExactRoleStatements<TStatements extends Statements> = {
+	readonly [P in keyof TStatements]: readonly [...TStatements[P]];
+};
+
 export type AccessControl<TStatements extends Statements = Statements> =
 	ReturnType<typeof createAccessControl<TStatements>>;
 
-export type Role<TStatements extends Statements = Record<string, any>> = {
+export type RoleAuthorizeRequest<TStatements extends Statements> = {
+	[P in keyof TStatements]?:
+		| SubArray<TStatements[P]>
+		| {
+				actions: SubArray<TStatements[P]>;
+				connector: "OR" | "AND";
+		  };
+};
+
+export type Role<
+	TRoleStatements extends Statements = Record<string, any>,
+	TAuthorizeStatements extends Statements = TRoleStatements,
+> = {
 	authorize: (
-		request: any,
+		request: RoleAuthorizeRequest<TAuthorizeStatements>,
 		connector?: ("OR" | "AND") | undefined,
 	) => AuthorizeResponse;
-	statements: TStatements;
+	statements: TRoleStatements;
 };

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
@@ -10,6 +10,16 @@ import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { organization } from "../organization";
 
 describe("dynamic access control", async () => {
+	it("should preserve exact built-in organization role statement types", () => {
+		expectTypeOf(adminAc.statements.organization).toEqualTypeOf<
+			readonly ["update"]
+		>();
+		expectTypeOf(ownerAc.statements.organization).toEqualTypeOf<
+			readonly ["update", "delete"]
+		>();
+		expectTypeOf(memberAc.statements.organization).toEqualTypeOf<readonly []>();
+	});
+
 	const ac = createAccessControl({
 		project: ["create", "read", "update", "delete"],
 		sales: ["create", "read", "update", "delete"],


### PR DESCRIPTION
## Summary
- Preserve exact `.statements` literal types returned by `createAccessControl().newRole()`
- Keep `authorize()` typed against the full access-control statement universe
- Add regressions for organization default roles so `adminAc` no longer appears to include owner-only permissions

## Closes
#9483 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves exact role statement literal types in `better-auth` access control and allows dynamic role records. Fixes org default role typings and keeps `authorize()` typed against the full statement universe so `adminAc` no longer surfaces owner-only permissions.

- **Bug Fixes**
  - Enforce exact role statements with stricter generics and new types (e.g., `ExactRoleStatements`, `RoleAuthorizeRequest`, `RoleInput`).
  - Validate `newRole()` at the type level: no unknown resources or actions; `authorize()` accepts precise subsets.
  - Allow dynamic role records (`Record<string, string[]>`) in `newRole()` without losing type safety.
  - Add tests for built-in organization roles and dynamic records, plus a patch changeset for `better-auth`.

<sup>Written for commit e99bf1918ffadf688c3273bc27c999e23ade4464. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

