### PR TITLE
feat(session): allow custom encrypt/decrypt for JWE cookie cache

### DIFF
--- a/packages/better-auth/src/api/routes/session-jwe-hook.test.ts
+++ b/packages/better-auth/src/api/routes/session-jwe-hook.test.ts
@@ -212,4 +212,38 @@ describe("custom crypto hook for JWE session cookie cache", async () => {
 		});
 		expect(session.data).toBeNull();
 	});
+
+	it("accepts synchronous encrypt/decrypt hooks (Awaitable)", async () => {
+		// Synchronous functions must satisfy the type without `as` or
+		// Promise wrapping. If `Awaitable<string>` regresses to
+		// `Promise<string>`, this assignment fails to compile.
+		const hook = {
+			encrypt: vi.fn(
+				(plaintext: string): string =>
+					`sync:${Buffer.from(plaintext, "utf8").toString("base64")}`,
+			),
+			decrypt: vi.fn((ciphertext: string): string => {
+				if (!ciphertext.startsWith("sync:"))
+					throw new Error("not a sync token");
+				return Buffer.from(ciphertext.slice("sync:".length), "base64").toString(
+					"utf8",
+				);
+			}),
+		};
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, strategy: "jwe" } },
+			crypto: hook,
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		expect(session.data?.user.email).toBe(testUser.email);
+		expect(hook.encrypt).toHaveBeenCalled();
+		expect(hook.decrypt).toHaveBeenCalled();
+	});
 });

--- a/packages/better-auth/src/api/routes/session-jwe-hook.test.ts
+++ b/packages/better-auth/src/api/routes/session-jwe-hook.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+
+const makeHook = () => {
+	const encrypt = vi.fn(
+		async (plaintext: string) =>
+			`mock:${Buffer.from(plaintext, "utf8").toString("base64")}`,
+	);
+	const decrypt = vi.fn(async (ciphertext: string) => {
+		if (!ciphertext.startsWith("mock:")) throw new Error("not a mock token");
+		return Buffer.from(ciphertext.slice("mock:".length), "base64").toString(
+			"utf8",
+		);
+	});
+	return { encrypt, decrypt };
+};
+
+describe("custom crypto hook for JWE session cookie cache", async () => {
+	it("encrypts the session cookie via the hook and decrypts via the hook", async () => {
+		const hook = makeHook();
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, strategy: "jwe" } },
+			crypto: hook,
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+
+		expect(hook.encrypt).toHaveBeenCalled();
+		// Inspect the actual session_data cookie that was just set.
+		const cookie = headers.get("cookie") ?? "";
+		const sessionDataMatch = cookie.match(
+			/(?:^|;\s*)[^;=\s]*session_data=([^;]+)/,
+		);
+		expect(sessionDataMatch).not.toBeNull();
+		const value = decodeURIComponent(sessionDataMatch![1]!);
+		expect(value.startsWith("mock:")).toBe(true);
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		expect(session.data?.user.email).toBe(testUser.email);
+		expect(hook.decrypt).toHaveBeenCalled();
+	});
+
+	it("treats an expired hook payload as no cache (decrypt returns null)", async () => {
+		const hook = {
+			encrypt: vi.fn(async (plaintext: string) => {
+				const obj = JSON.parse(plaintext);
+				obj.exp = ((Date.now() / 1000) | 0) - 3600;
+				return `mock:${Buffer.from(JSON.stringify(obj), "utf8").toString(
+					"base64",
+				)}`;
+			}),
+			decrypt: vi.fn(async (ciphertext: string) =>
+				Buffer.from(ciphertext.slice("mock:".length), "base64").toString(
+					"utf8",
+				),
+			),
+		};
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, strategy: "jwe" } },
+			crypto: hook,
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		// Expired cache: matches built-in behavior in session.ts — null result.
+		expect(session.data).toBeNull();
+		expect(hook.decrypt).toHaveBeenCalled();
+	});
+
+	it("does not call the hook when strategy is 'compact'", async () => {
+		const hook = makeHook();
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, strategy: "compact" } },
+			crypto: hook,
+		});
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+		await client.getSession({ fetchOptions: { headers } });
+		expect(hook.encrypt).not.toHaveBeenCalled();
+		expect(hook.decrypt).not.toHaveBeenCalled();
+	});
+
+	it("returns null when the hook's decrypt throws", async () => {
+		const hook = {
+			encrypt: vi.fn(
+				async (plaintext: string) =>
+					`mock:${Buffer.from(plaintext, "utf8").toString("base64")}`,
+			),
+			decrypt: vi.fn(async () => {
+				throw new Error("vault unreachable");
+			}),
+		};
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, strategy: "jwe" } },
+			crypto: hook,
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		expect(session.data).toBeNull();
+		expect(hook.decrypt).toHaveBeenCalled();
+	});
+
+	it("stores hook ciphertext directly (no JWE wrapping)", async () => {
+		const hook = makeHook();
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, strategy: "jwe" } },
+			crypto: hook,
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+
+		const cookie = headers.get("cookie") ?? "";
+		const sessionDataMatch = cookie.match(
+			/(?:^|;\s*)[^;=\s]*session_data=([^;]+)/,
+		);
+		expect(sessionDataMatch).not.toBeNull();
+		const value = decodeURIComponent(sessionDataMatch![1]!);
+		// Bypassed JWE codec: cookie must NOT be a compact JWS/JWE (eyJ...).
+		expect(value.startsWith("eyJ")).toBe(false);
+		expect(value.startsWith("mock:")).toBe(true);
+		// And the plaintext that the hook encrypted must be the JSON envelope
+		// — confirming the JWE codec did not run before the hook.
+		const lastEncryptArg = hook.encrypt.mock.calls.at(-1)?.[0] ?? "";
+		expect(() => JSON.parse(lastEncryptArg)).not.toThrow();
+		const envelope = JSON.parse(lastEncryptArg);
+		expect(envelope).toMatchObject({ session: expect.any(Object) });
+		expect(typeof envelope.exp).toBe("number");
+		expect(typeof envelope.iat).toBe("number");
+		expect(typeof envelope.jti).toBe("string");
+	});
+
+	it("calls the hook's decrypt on every cached getSession (cache hits)", async () => {
+		const hook = makeHook();
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, strategy: "jwe" } },
+			crypto: hook,
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+
+		const before = hook.decrypt.mock.calls.length;
+		await client.getSession({ fetchOptions: { headers } });
+		await client.getSession({ fetchOptions: { headers } });
+		await client.getSession({ fetchOptions: { headers } });
+		expect(hook.decrypt.mock.calls.length - before).toBe(3);
+	});
+
+	it("rejects payloads tampered with after the hook encrypted them", async () => {
+		// Real-world property: the hook is the security boundary. If we hand
+		// it a corrupted token and it throws, getSession must return null —
+		// not silently fall back to a built-in codec.
+		const hook = {
+			encrypt: vi.fn(
+				async (plaintext: string) =>
+					`mock:${Buffer.from(plaintext, "utf8").toString("base64")}`,
+			),
+			decrypt: vi.fn(async (ciphertext: string) => {
+				if (!ciphertext.startsWith("mock:")) {
+					throw new Error("invalid ciphertext");
+				}
+				return Buffer.from(ciphertext.slice("mock:".length), "base64").toString(
+					"utf8",
+				);
+			}),
+		};
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, strategy: "jwe" } },
+			crypto: hook,
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+
+		const tampered = new Headers(headers);
+		const cookie = (tampered.get("cookie") ?? "").replace(
+			/session_data=[^;]+/,
+			"session_data=garbage-not-a-mock-token",
+		);
+		tampered.set("cookie", cookie);
+
+		const session = await client.getSession({
+			fetchOptions: { headers: tampered },
+		});
+		expect(session.data).toBeNull();
+	});
+});

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -21,7 +21,7 @@ import {
 	setSessionCookie,
 } from "../../cookies";
 import { getSessionQuerySchema } from "../../cookies/session-store";
-import { symmetricDecodeJWT, verifyJWT } from "../../crypto";
+import { hookDecodeSession, symmetricDecodeJWT, verifyJWT } from "../../crypto";
 import { parseSessionOutput, parseUserOutput } from "../../db";
 import type { Prettify, Session, User } from "../../types";
 import { getDate } from "../../utils/date";
@@ -112,18 +112,28 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 						ctx.context.options.session?.cookieCache?.strategy || "compact";
 
 					if (strategy === "jwe") {
-						// Decode JWE (encrypted)
-						const payload = await symmetricDecodeJWT<{
-							session: Session;
-							user: User;
-							updatedAt: number;
-							version?: string;
-							exp?: number;
-						}>(
-							sessionDataCookie,
-							ctx.context.secretConfig,
-							"better-auth-session",
-						);
+						// Decode JWE (encrypted). When a `crypto` hook is
+						// configured, delegate to it instead of the built-in
+						// JWE codec.
+						const payload = ctx.context.crypto
+							? await hookDecodeSession<{
+									session: Session;
+									user: User;
+									updatedAt: number;
+									version?: string;
+									exp?: number;
+								}>(sessionDataCookie, ctx.context.crypto)
+							: await symmetricDecodeJWT<{
+									session: Session;
+									user: User;
+									updatedAt: number;
+									version?: string;
+									exp?: number;
+								}>(
+									sessionDataCookie,
+									ctx.context.secretConfig,
+									"better-auth-session",
+								);
 
 						if (payload && payload.session && payload.user) {
 							sessionDataPayload = {

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -326,6 +326,7 @@ Most of the features of Better Auth will not work correctly.`,
 		},
 		secret,
 		secretConfig,
+		crypto: options.crypto,
 		rateLimit: {
 			...options.rateLimit,
 			enabled: options.rateLimit?.enabled ?? isProduction,

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -12,7 +12,10 @@ import { base64Url } from "@better-auth/utils/base64";
 import { binary } from "@better-auth/utils/binary";
 import { createHMAC } from "@better-auth/utils/hmac";
 import type { CookieOptions } from "better-call";
+import type { SessionCryptoHook } from "../crypto/jwt";
 import {
+	hookDecodeSession,
+	hookEncodeSession,
 	signJWT,
 	symmetricDecodeJWT,
 	symmetricEncodeJWT,
@@ -195,13 +198,21 @@ export async function setCookieCache(
 	let data: string;
 
 	if (strategy === "jwe") {
-		// Use JWE strategy (JSON Web Encryption) with A256CBC-HS512 + HKDF
-		data = await symmetricEncodeJWT(
-			sessionData,
-			ctx.context.secretConfig,
-			"better-auth-session",
-			options.maxAge || 60 * 5,
-		);
+		// Use JWE strategy (JSON Web Encryption) with A256CBC-HS512 + HKDF.
+		// When a `crypto` hook is configured, delegate to it instead — the
+		// payload is JSON-stringified and replaced with hook ciphertext.
+		data = ctx.context.crypto
+			? await hookEncodeSession(
+					sessionData,
+					ctx.context.crypto,
+					options.maxAge || 60 * 5,
+				)
+			: await symmetricEncodeJWT(
+					sessionData,
+					ctx.context.secretConfig,
+					"better-auth-session",
+					options.maxAge || 60 * 5,
+				);
 	} else if (strategy === "jwt") {
 		// Use JWT strategy with HMAC-SHA256 signature (HS256), no encryption
 		data = await signJWT(
@@ -420,6 +431,13 @@ export const getCookieCache = async <
 				isSecure?: boolean;
 				secret?: string;
 				strategy?: "compact" | "jwt" | "jwe"; // base64-hmac for backward compatibility
+				/**
+				 * Custom encryption hook. When provided alongside
+				 * `strategy: "jwe"`, the built-in JWE codec is bypassed and
+				 * the cookie is decrypted via this hook. Must match the hook
+				 * configured on the `auth` instance.
+				 */
+				crypto?: SessionCryptoHook;
 				version?:
 					| string
 					| ((
@@ -477,22 +495,28 @@ export const getCookieCache = async <
 	}
 
 	if (sessionData) {
-		const secret = config?.secret || env.BETTER_AUTH_SECRET;
-		if (!secret) {
-			throw new BetterAuthError(
-				"getCookieCache requires a secret to be provided. Either pass it as an option or set the BETTER_AUTH_SECRET environment variable",
-			);
-		}
-
 		const strategy = config?.strategy || "compact";
+		const secret = config?.secret || env.BETTER_AUTH_SECRET;
+
+		const requireSecret = () => {
+			if (!secret) {
+				throw new BetterAuthError(
+					"getCookieCache requires a secret to be provided. Either pass it as an option or set the BETTER_AUTH_SECRET environment variable",
+				);
+			}
+			return secret;
+		};
 
 		if (strategy === "jwe") {
-			// Use JWE strategy (encrypted)
-			const payload = await symmetricDecodeJWT<S>(
-				sessionData,
-				secret,
-				"better-auth-session",
-			);
+			// `secret` is not needed when a `crypto` hook is provided —
+			// the hook owns the key.
+			const payload = config?.crypto
+				? await hookDecodeSession<S>(sessionData, config.crypto)
+				: await symmetricDecodeJWT<S>(
+						sessionData,
+						requireSecret(),
+						"better-auth-session",
+					);
 
 			if (payload && payload.session && payload.user) {
 				// Validate version if provided
@@ -514,7 +538,7 @@ export const getCookieCache = async <
 			return null;
 		} else if (strategy === "jwt") {
 			// Use JWT strategy with HMAC signature (HS256), no encryption
-			const payload = await verifyJWT<S>(sessionData, secret);
+			const payload = await verifyJWT<S>(sessionData, requireSecret());
 
 			if (payload && payload.session && payload.user) {
 				// Validate version if provided
@@ -545,7 +569,7 @@ export const getCookieCache = async <
 				return null;
 			}
 			const isValid = await createHMAC("SHA-256", "base64urlnopad").verify(
-				secret,
+				requireSecret(),
 				JSON.stringify({
 					...sessionDataPayload.session,
 					expiresAt: sessionDataPayload.expiresAt,

--- a/packages/better-auth/src/crypto/jwt.ts
+++ b/packages/better-auth/src/crypto/jwt.ts
@@ -1,3 +1,4 @@
+import type { Awaitable } from "@better-auth/core";
 import { hkdf } from "@noble/hashes/hkdf.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import {
@@ -88,8 +89,8 @@ function getAllSecrets(
 }
 
 export type SessionCryptoHook = {
-	encrypt: (plaintext: string) => Promise<string>;
-	decrypt: (ciphertext: string) => Promise<string>;
+	encrypt: (plaintext: string) => Awaitable<string>;
+	decrypt: (ciphertext: string) => Awaitable<string>;
 };
 
 export async function hookEncodeSession<T extends Record<string, any>>(

--- a/packages/better-auth/src/crypto/jwt.ts
+++ b/packages/better-auth/src/crypto/jwt.ts
@@ -87,6 +87,50 @@ function getAllSecrets(
 	return result;
 }
 
+export type SessionCryptoHook = {
+	encrypt: (plaintext: string) => Promise<string>;
+	decrypt: (ciphertext: string) => Promise<string>;
+};
+
+export async function hookEncodeSession<T extends Record<string, any>>(
+	payload: T,
+	hook: SessionCryptoHook,
+	expiresIn: number = 3600,
+): Promise<string> {
+	const iat = now();
+	const envelope = {
+		...payload,
+		iat,
+		exp: iat + expiresIn,
+		jti: crypto.randomUUID(),
+	};
+	return hook.encrypt(JSON.stringify(envelope));
+}
+
+export async function hookDecodeSession<T = any>(
+	token: string,
+	hook: SessionCryptoHook,
+	clockToleranceSeconds: number = 15,
+): Promise<T | null> {
+	if (!token) return null;
+	let plaintext: string;
+	try {
+		plaintext = await hook.decrypt(token);
+	} catch {
+		return null;
+	}
+	let parsed: any;
+	try {
+		parsed = JSON.parse(plaintext);
+	} catch {
+		return null;
+	}
+	if (typeof parsed?.exp === "number") {
+		if (parsed.exp + clockToleranceSeconds < now()) return null;
+	}
+	return parsed as T;
+}
+
 export async function symmetricEncodeJWT<T extends Record<string, any>>(
 	payload: T,
 	secret: string | SecretConfig,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -348,8 +348,8 @@ export type AuthContext<Options extends BetterAuthOptions = BetterAuthOptions> =
 			 */
 			crypto?:
 				| {
-						encrypt: (plaintext: string) => Promise<string>;
-						decrypt: (ciphertext: string) => Promise<string>;
+						encrypt: (plaintext: string) => Awaitable<string>;
+						decrypt: (ciphertext: string) => Awaitable<string>;
 				  }
 				| undefined;
 			sessionConfig: {

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -342,6 +342,16 @@ export type AuthContext<Options extends BetterAuthOptions = BetterAuthOptions> =
 			createAuthCookie: CreateCookieGetterFn;
 			secret: string;
 			secretConfig: string | SecretConfig;
+			/**
+			 * Optional encryption hook for the JWE session cookie cache.
+			 * Mirrors `BetterAuthOptions.crypto`.
+			 */
+			crypto?:
+				| {
+						encrypt: (plaintext: string) => Promise<string>;
+						decrypt: (ciphertext: string) => Promise<string>;
+				  }
+				| undefined;
 			sessionConfig: {
 				updateAge: number;
 				expiresIn: number;

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -465,6 +465,34 @@ export type BetterAuthOptions = {
 	 */
 	secrets?: Array<{ version: number; value: string }> | undefined;
 	/**
+	 * Override symmetric encryption for the JWE session cookie cache.
+	 *
+	 * Active only when `session.cookieCache.strategy === "jwe"`. When set,
+	 * the built-in JWE codec is bypassed: the session payload is
+	 * JSON-stringified, passed to `encrypt`, and the returned ciphertext
+	 * is what gets stored in the cookie. `decrypt` must return the
+	 * original JSON string.
+	 *
+	 * Useful for delegating to a KMS / HashiCorp Vault Transit so the
+	 * application never holds the encryption key.
+	 *
+	 * Strict scope: this hook is NOT used for any other crypto in the
+	 * library (OAuth tokens, 2FA secrets, JWKS rows, OAuth state cookie,
+	 * OIDC codes, email-otp, oauth-proxy). Those continue to use
+	 * `secret` / `secrets`.
+	 *
+	 * NOTE: Enabling this on a running deployment makes existing JWE
+	 * cookies unreadable; affected requests fall through to the database
+	 * / secondary storage on the next read (normal cookie-cache miss
+	 * behavior). No persisted data is impacted.
+	 */
+	crypto?:
+		| {
+				encrypt: (plaintext: string) => Promise<string>;
+				decrypt: (ciphertext: string) => Promise<string>;
+		  }
+		| undefined;
+	/**
 	 * Database configuration
 	 */
 	database?:

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -476,6 +476,22 @@ export type BetterAuthOptions = {
 	 * Useful for delegating to a KMS / HashiCorp Vault Transit so the
 	 * application never holds the encryption key.
 	 *
+	 * **Ciphertext format requirements.** The string returned by `encrypt`
+	 * is written into a `Set-Cookie` value and, for payloads over the
+	 * 4093-byte cookie limit, split into chunks by raw string length and
+	 * re-joined verbatim on read. To stay safe across browsers and the
+	 * chunking path, the ciphertext MUST be:
+	 *
+	 * - printable ASCII only (base64url is recommended);
+	 * - free of cookie delimiters and whitespace (`;`, `,`, `=`, space,
+	 *   tabs, CR, LF) and free of control characters;
+	 * - byte-splittable at any offset (no multi-byte sequences that the
+	 *   chunk re-join could tear).
+	 *
+	 * Vault Transit's `vault:v1:<base64>` and AWS KMS base64 ciphertext
+	 * blobs satisfy these constraints. Raw binary or arbitrary UTF-8 does
+	 * not — base64url-encode it before returning.
+	 *
 	 * Strict scope: this hook is NOT used for any other crypto in the
 	 * library (OAuth tokens, 2FA secrets, JWKS rows, OAuth state cookie,
 	 * OIDC codes, email-otp, oauth-proxy). Those continue to use

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -488,8 +488,8 @@ export type BetterAuthOptions = {
 	 */
 	crypto?:
 		| {
-				encrypt: (plaintext: string) => Promise<string>;
-				decrypt: (ciphertext: string) => Promise<string>;
+				encrypt: (plaintext: string) => Awaitable<string>;
+				decrypt: (ciphertext: string) => Awaitable<string>;
 		  }
 		| undefined;
 	/**


### PR DESCRIPTION
## Summary

Adds an opt-in `crypto: { encrypt, decrypt }` option on `BetterAuthOptions`. When set **and** `session.cookieCache.strategy === "jwe"`, the built-in JWE codec is bypassed: the session payload is JSON-stringified, handed to `encrypt`, and the returned ciphertext is what's stored in the cookie. `decrypt` must return the original JSON string.

The use case is delegating session-cookie encryption to a KMS / HashiCorp Vault Transit so the application never holds the encryption key.

**Strict scope.** The hook is only consumed by the JWE cookie cache. Every other use of symmetric crypto in the library (OAuth tokens, 2FA secrets, JWKS rows, OAuth state cookie, OIDC codes, email-otp, oauth-proxy) continues to use `secret` / `secrets` and is untouched.

**No fallback.** When the hook is configured, in-flight cookies issued before the switch fail to decode and fall through to the database / secondary storage on the next read — normal cookie-cache miss behavior. No persisted data is impacted.

## Changes

- `packages/core/src/types/init-options.ts` — new optional `crypto` field on `BetterAuthOptions`.
- `packages/core/src/types/context.ts` — matching optional `crypto` field on `AuthContext`.
- `packages/better-auth/src/context/create-context.ts` — passes `options.crypto` onto the context.
- `packages/better-auth/src/crypto/jwt.ts` — new `hookEncodeSession` / `hookDecodeSession` helpers (JSON envelope with `iat` / `exp` / `jti`, clock-tolerant `exp` enforcement, `null` on failure to match `symmetricDecodeJWT`).
- `packages/better-auth/src/cookies/index.ts` — branches the JWE encode (line ~204) and the standalone `getCookieCache` decode (~510). `secret` stays required for `compact` / `jwt` strategies.
- `packages/better-auth/src/api/routes/session.ts` — branches the JWE decode on session retrieval.
- `packages/better-auth/src/api/routes/session-jwe-hook.test.ts` — new test file with 7 cases.

## Example

\`\`\`ts
betterAuth({
  session: { cookieCache: { enabled: true, strategy: "jwe" } },
  crypto: {
    encrypt: async (plaintext) => /* fetch Vault transit/encrypt */,
    decrypt: async (ciphertext) => /* fetch Vault transit/decrypt */,
  },
});
\`\`\`

## Test plan

- [x] \`pnpm typecheck\` passes (repo-wide).
- [x] New: \`vitest run packages/better-auth/src/api/routes/session-jwe-hook.test.ts\` — 7 / 7 passing.
  - hook roundtrip (encrypt on sign-in, decrypt on \`getSession\`)
  - expired hook payload → \`getSession\` returns null
  - decrypt throws → \`getSession\` returns null (no silent fallback)
  - cookie value is hook ciphertext, not a compact JWE (\`eyJ…\`); plaintext fed to the hook is the JSON envelope
  - \`decrypt\` is called on every cached \`getSession\`
  - tampered ciphertext → \`getSession\` returns null
  - hook is **not** called when strategy is \`compact\`
- [x] Regression: \`vitest run -t "JWE strategy"\` — pre-existing 4 cases in \`session-api.test.ts\` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `crypto: { encrypt, decrypt }` hook for the JWE session cookie cache so apps can delegate cookie encryption to a KMS/Vault. Hooks can be sync or async, and docs now clarify ciphertext must be cookie-safe ASCII for chunking.

- New Features
  - Added `crypto` to `BetterAuthOptions` and `AuthContext`; JWE cookie read/write branches to it. `getCookieCache` accepts `crypto` and doesn’t require `secret` with the hook; `secret` is still required for `compact`/`jwt`.
  - Introduced `hookEncodeSession`/`hookDecodeSession` with a JSON envelope (`iat`, `exp`, `jti`) and clock-tolerant `exp` checks; failures return null.
  - Hooks support synchronous or async functions (`Awaitable<string>`), no Promise wrapping needed.
  - Documented ciphertext requirements for `encrypt` output: printable ASCII/base64url, no cookie delimiters/whitespace, and byte-splittable for safe chunking.

- Migration
  - Enable by setting `session.cookieCache.strategy: "jwe"` and providing `crypto.encrypt`/`crypto.decrypt` in `betterAuth(...)`.
  - If calling `getCookieCache` directly, pass the same `crypto` in its config.
  - Switching on an existing deployment invalidates current JWE cookies; requests will fall back to the database on next read. No persisted data is affected.

<sup>Written for commit 3ec7db08003885e85f013216b30a6e116ed57a90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

