### PR TITLE
feat(cli): generate Drizzle MSSQL schemas

### DIFF
--- a/.changeset/cli-drizzle-mssql-generator.md
+++ b/.changeset/cli-drizzle-mssql-generator.md
@@ -1,0 +1,7 @@
+---
+"auth": minor
+---
+
+Add MSSQL support to the Drizzle schema generator (`npx better-auth generate` for projects using `provider: "mssql"`). Emits `mssqlTable` schemas with appropriate column types: `varchar` (with bounded length for indexed/unique/sortable strings, `length: "max"` otherwise), `bit` for booleans, `int`/`bigint` for numbers, `datetime2({ precision: 3 })` for dates, and `varchar({ length: "max", mode: "json" })` for arrays/json. `int().identity()` is used for serial-id primary keys. `SYSUTCDATETIME()` is emitted for `defaultNow`-style date defaults since MSSQL drizzle has no `.defaultNow()` helper.
+
+Requires `drizzle-orm@^1.0.0-rc` at runtime in the consuming project (where `mssql-core` and `node-mssql` live).

--- a/.changeset/drizzle-adapter-mssql-provider.md
+++ b/.changeset/drizzle-adapter-mssql-provider.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/drizzle-adapter": minor
+---
+
+Add MSSQL (Microsoft SQL Server) support to the Drizzle adapter. Pass `provider: "mssql"` to `drizzleAdapter` when using a Drizzle MSSQL instance (`drizzle-orm@^1.0.0-rc` and `drizzle-orm/node-mssql`). Because MSSQL does not support the `.returning()` shape used by Postgres/SQLite, the adapter executes writes and re-selects affected rows, mirroring the existing MySQL fallback path.

--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -25,3 +25,4 @@ Suliman
 Abdulrazzaq
 rethrowing
 dedupe
+SYSUTCDATETIME

--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -26,7 +26,7 @@ import { db } from "./database.ts";
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, { // [!code highlight]
-    provider: "sqlite", // or "pg" or "mysql" // [!code highlight]
+    provider: "sqlite", // or "pg", "mysql", or "mssql" // [!code highlight]
   }), // [!code highlight]
   //... the rest of your config
 });
@@ -100,7 +100,7 @@ import { schema } from "./schema";
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
-    provider: "sqlite", // or "pg" or "mysql"
+    provider: "sqlite", // or "pg", "mysql", or "mssql"
     schema: { // [!code highlight]
       ...schema, // [!code highlight]
       user: schema.users, // [!code highlight]
@@ -118,7 +118,7 @@ import { betterAuth } from "better-auth";
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
-    provider: "sqlite", // or "pg" or "mysql"
+    provider: "sqlite", // or "pg", "mysql", or "mssql"
     schema,
   }),
   user: {
@@ -152,7 +152,7 @@ import { betterAuth } from "better-auth";
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
-    provider: "sqlite", // or "pg" or "mysql"
+    provider: "sqlite", // or "pg", "mysql", or "mssql"
     schema,
   }),
   user: {

--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -37,10 +37,6 @@ export const auth = betterAuth({
 The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate
 your database schema based on your Better Auth configuration and plugins.
 
-<Callout type="warn">
-  CLI schema generation is currently supported for `pg`, `mysql`, and `sqlite` only. If you are using `provider: "mssql"`, define your `mssqlTable` schema by hand and pass it to `drizzleAdapter(db, { provider: "mssql", schema })` — MSSQL CLI generation is tracked as a follow-up.
-</Callout>
-
 To generate the schema required by Better Auth, run the following command:
 
 ```package-install

--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -37,6 +37,10 @@ export const auth = betterAuth({
 The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate
 your database schema based on your Better Auth configuration and plugins.
 
+<Callout type="warn">
+  CLI schema generation is currently supported for `pg`, `mysql`, and `sqlite` only. If you are using `provider: "mssql"`, define your `mssqlTable` schema by hand and pass it to `drizzleAdapter(db, { provider: "mssql", schema })` — MSSQL CLI generation is tracked as a follow-up.
+</Callout>
+
 To generate the schema required by Better Auth, run the following command:
 
 ```package-install

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -126,7 +126,7 @@ description: Learn how to configure Better Auth in your project.
 
         export const auth = betterAuth({
             database: drizzleAdapter(db, {
-                provider: "pg", // or "mysql", "sqlite"
+                provider: "pg", // or "mysql", "sqlite", "mssql"
             }),
         });
         ```

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -40,7 +40,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 }) => {
 	const tables = getAuthTables(options);
 	const filePath = file || "./auth-schema.ts";
-	const databaseType: "sqlite" | "mysql" | "pg" | undefined =
+	const databaseType: "sqlite" | "mysql" | "pg" | "mssql" | undefined =
 		adapter.options?.provider;
 
 	const schemaName = adapter.options?.schemaName;
@@ -135,6 +135,8 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 						return `integer('${name}')`;
 					} else if (databaseType === "mysql") {
 						return `int('${name}')`;
+					} else if (databaseType === "mssql") {
+						return `int('${name}')`;
 					} else {
 						// using sqlite
 						return `integer('${name}')`;
@@ -147,6 +149,12 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 					if (databaseType === "mysql") {
 						return `varchar('${name}', { length: 36 })`;
 					}
+					if (databaseType === "mssql") {
+						return `varchar('${name}', { length: 36 })`;
+					}
+				}
+				if (databaseType === "mssql") {
+					return `varchar('${name}', { length: 'max' })`;
 				}
 				return `text('${name}')`;
 			}
@@ -157,6 +165,10 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 						sqlite: `text('${name}', { enum: [${type.map((x) => `'${x}'`).join(", ")}] })`,
 						pg: `text('${name}', { enum: [${type.map((x) => `'${x}'`).join(", ")}] })`,
 						mysql: `mysqlEnum('${name}', [${type.map((x) => `'${x}'`).join(", ")}])`,
+						// MSSQL has no native enum — emit a varchar with the enum tag.
+						mssql: `varchar('${name}', { length: 255, enum: [${type
+							.map((x) => `'${x}'`)
+							.join(", ")}] })`,
 					}[databaseType];
 				} else {
 					throw new TypeError(
@@ -164,6 +176,12 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 					);
 				}
 			}
+			// MSSQL: indexed/sorted/unique strings need a bounded length so SQL
+			// Server can build an index; everything else uses varchar(max).
+			const mssqlVarchar = (length: number | "max") =>
+				`varchar('${name}', { length: ${
+					typeof length === "number" ? length : `'${length}'`
+				} })`;
 			const typeMap: Record<
 				typeof type,
 				Record<typeof databaseType, string>
@@ -182,11 +200,21 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 									: field.index
 										? `varchar('${name}', { length: 255 })`
 										: `text('${name}')`,
+					mssql: field.unique
+						? mssqlVarchar(255)
+						: field.references
+							? mssqlVarchar(36)
+							: field.sortable
+								? mssqlVarchar(255)
+								: field.index
+									? mssqlVarchar(255)
+									: mssqlVarchar("max"),
 				},
 				boolean: {
 					sqlite: `integer('${name}', { mode: 'boolean' })`,
 					pg: `boolean('${name}')`,
 					mysql: `boolean('${name}')`,
+					mssql: `bit('${name}')`,
 				},
 				number: {
 					sqlite: `integer('${name}')`,
@@ -196,11 +224,15 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 					mysql: field.bigint
 						? `bigint('${name}', { mode: 'number' })`
 						: `int('${name}')`,
+					mssql: field.bigint
+						? `bigint('${name}', { mode: 'number' })`
+						: `int('${name}')`,
 				},
 				date: {
 					sqlite: `integer('${name}', { mode: 'timestamp_ms' })`,
 					pg: `timestamp('${name}')`,
 					mysql: `timestamp('${name}', { fsp: 3 })`,
+					mssql: `datetime2('${name}', { precision: 3 })`,
 				},
 				"number[]": {
 					sqlite: `text('${name}', { mode: "json" })`,
@@ -208,16 +240,20 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 						? `bigint('${name}', { mode: 'number' }).array()`
 						: `integer('${name}').array()`,
 					mysql: `text('${name}', { mode: 'json' })`,
+					// MSSQL has no array type — store JSON in nvarchar(max).
+					mssql: `varchar('${name}', { length: 'max', mode: "json" })`,
 				},
 				"string[]": {
 					sqlite: `text('${name}', { mode: "json" })`,
 					pg: `text('${name}').array()`,
 					mysql: `text('${name}', { mode: "json" })`,
+					mssql: `varchar('${name}', { length: 'max', mode: "json" })`,
 				},
 				json: {
 					sqlite: `text('${name}', { mode: "json" })`,
 					pg: `jsonb('${name}')`,
 					mysql: `json('${name}', { mode: "json" })`,
+					mssql: `varchar('${name}', { length: 'max', mode: "json" })`,
 				},
 			} as const;
 			const dbTypeMap = (
@@ -243,6 +279,8 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				id = `integer("id").generatedByDefaultAsIdentity().primaryKey()`;
 			} else if (databaseType === "sqlite") {
 				id = `integer("id", { mode: "number" }).primaryKey({ autoIncrement: true })`;
+			} else if (databaseType === "mssql") {
+				id = `int("id").identity().primaryKey()`;
 			} else {
 				id = `int("id").autoincrement().primaryKey()`;
 			}
@@ -251,6 +289,8 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				id = `varchar('id', { length: 36 }).primaryKey()`;
 			} else if (databaseType === "pg") {
 				id = `text('id').primaryKey()`;
+			} else if (databaseType === "mssql") {
+				id = `varchar('id', { length: 36 }).primaryKey()`;
 			} else {
 				id = `text('id').primaryKey()`;
 			}
@@ -341,6 +381,9 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 									) {
 										if (databaseType === "sqlite") {
 											type += `.default(sql\`(cast(unixepoch('subsecond') * 1000 as integer))\`)`;
+										} else if (databaseType === "mssql") {
+											// MSSQL drizzle has no .defaultNow() — emit the SQL function.
+											type += `.default(sql\`SYSUTCDATETIME()\`)`;
 										} else {
 											type += `.defaultNow()`;
 										}
@@ -652,7 +695,7 @@ function generateImport({
 	options,
 	schemaName,
 }: {
-	databaseType: "sqlite" | "mysql" | "pg";
+	databaseType: "sqlite" | "mysql" | "pg" | "mssql";
 	tables: BetterAuthDBSchema;
 	options: BetterAuthOptions;
 	schemaName?: string;
@@ -688,12 +731,19 @@ function generateImport({
 			? "varchar, text"
 			: databaseType === "pg"
 				? "text"
-				: "text",
+				: databaseType === "mssql"
+					? "varchar"
+					: "text",
 	);
 	coreImports.push(
 		hasBigint ? (databaseType !== "sqlite" ? "bigint" : "") : "",
 	);
-	coreImports.push(databaseType !== "sqlite" ? "timestamp, boolean" : "");
+	if (databaseType === "mssql") {
+		// MSSQL has no native boolean (uses bit) and no timestamp (uses datetime2).
+		coreImports.push("datetime2, bit");
+	} else if (databaseType !== "sqlite") {
+		coreImports.push("timestamp, boolean");
+	}
 	if (databaseType === "mysql") {
 		// Only include int for MySQL if actually needed
 		const hasNonBigintNumber = Object.values(tables).some((table) =>
@@ -743,6 +793,18 @@ function generateImport({
 		if (needsInteger) {
 			coreImports.push("integer");
 		}
+	} else if (databaseType === "mssql") {
+		// `int` is needed for non-bigint numbers and for serial-id FKs/primary keys.
+		const hasNonBigintNumber = Object.values(tables).some((table) =>
+			Object.values(table.fields).some(
+				(field) =>
+					(field.type === "number" || field.type === "number[]") &&
+					!field.bigint,
+			),
+		);
+		if (useNumberId || hasNonBigintNumber) {
+			coreImports.push("int");
+		}
 	} else {
 		coreImports.push("integer");
 	}
@@ -757,9 +819,10 @@ function generateImport({
 		// sqlite uses text for JSON, so there's no need to handle this case
 	}
 
-	// Add sql import for SQLite timestamps with defaultNow
-	const hasSQLiteTimestamp =
-		databaseType === "sqlite" &&
+	// SQLite and MSSQL render their `now()` defaults via the `sql` template tag
+	// (sqlite uses unixepoch, mssql uses SYSUTCDATETIME()).
+	const hasNowDefault =
+		(databaseType === "sqlite" || databaseType === "mssql") &&
 		Object.values(tables).some((table) =>
 			Object.values(table.fields).some(
 				(field) =>
@@ -770,7 +833,7 @@ function generateImport({
 			),
 		);
 
-	if (hasSQLiteTimestamp) {
+	if (hasNowDefault) {
 		rootImports.push("sql");
 	}
 

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -153,9 +153,6 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 						return `varchar('${name}', { length: 36 })`;
 					}
 				}
-				if (databaseType === "mssql") {
-					return `varchar('${name}', { length: 'max' })`;
-				}
 				return `text('${name}')`;
 			}
 			const type = field.type;

--- a/packages/cli/test/__snapshots__/auth-schema-mssql-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mssql-number-id.txt
@@ -1,0 +1,140 @@
+import { relations, sql } from "drizzle-orm";
+import {
+  mssqlTable,
+  varchar,
+  datetime2,
+  bit,
+  int,
+  index,
+} from "drizzle-orm/mssql-core";
+
+export const custom_user = mssqlTable("custom_user", {
+  id: int("id").identity().primaryKey(),
+  name: varchar("name", { length: 255 }).notNull(),
+  email: varchar("email", { length: 255 }).notNull().unique(),
+  emailVerified: bit("email_verified").default(false).notNull(),
+  image: varchar("image", { length: "max" }),
+  createdAt: datetime2("created_at", { precision: 3 })
+    .default(sql`SYSUTCDATETIME()`)
+    .notNull(),
+  updatedAt: datetime2("updated_at", { precision: 3 })
+    .default(sql`SYSUTCDATETIME()`)
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  twoFactorEnabled: bit("two_factor_enabled").default(false),
+  username: varchar("username", { length: 255 }).unique(),
+  displayUsername: varchar("display_username", { length: "max" }),
+});
+
+export const custom_session = mssqlTable(
+  "custom_session",
+  {
+    id: int("id").identity().primaryKey(),
+    expiresAt: datetime2("expires_at", { precision: 3 }).notNull(),
+    token: varchar("token", { length: 255 }).notNull().unique(),
+    createdAt: datetime2("created_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .notNull(),
+    updatedAt: datetime2("updated_at", { precision: 3 })
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    ipAddress: varchar("ip_address", { length: "max" }),
+    userAgent: varchar("user_agent", { length: "max" }),
+    userId: int("user_id")
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+  },
+  (table) => [index("custom_session_userId_idx").on(table.userId)],
+);
+
+export const custom_account = mssqlTable(
+  "custom_account",
+  {
+    id: int("id").identity().primaryKey(),
+    accountId: varchar("account_id", { length: "max" }).notNull(),
+    providerId: varchar("provider_id", { length: "max" }).notNull(),
+    userId: int("user_id")
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+    accessToken: varchar("access_token", { length: "max" }),
+    refreshToken: varchar("refresh_token", { length: "max" }),
+    idToken: varchar("id_token", { length: "max" }),
+    accessTokenExpiresAt: datetime2("access_token_expires_at", {
+      precision: 3,
+    }),
+    refreshTokenExpiresAt: datetime2("refresh_token_expires_at", {
+      precision: 3,
+    }),
+    scope: varchar("scope", { length: "max" }),
+    password: varchar("password", { length: "max" }),
+    createdAt: datetime2("created_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .notNull(),
+    updatedAt: datetime2("updated_at", { precision: 3 })
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("custom_account_userId_idx").on(table.userId)],
+);
+
+export const custom_verification = mssqlTable(
+  "custom_verification",
+  {
+    id: int("id").identity().primaryKey(),
+    identifier: varchar("identifier", { length: 255 }).notNull(),
+    value: varchar("value", { length: "max" }).notNull(),
+    expiresAt: datetime2("expires_at", { precision: 3 }).notNull(),
+    createdAt: datetime2("created_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .notNull(),
+    updatedAt: datetime2("updated_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("custom_verification_identifier_idx").on(table.identifier)],
+);
+
+export const twoFactor = mssqlTable(
+  "two_factor",
+  {
+    id: int("id").identity().primaryKey(),
+    secret: varchar("secret", { length: 255 }).notNull(),
+    backupCodes: varchar("backup_codes", { length: "max" }).notNull(),
+    userId: int("user_id")
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+    verified: bit("verified").default(true),
+  },
+  (table) => [
+    index("twoFactor_secret_idx").on(table.secret),
+    index("twoFactor_userId_idx").on(table.userId),
+  ],
+);
+
+export const custom_userRelations = relations(custom_user, ({ many }) => ({
+  custom_sessions: many(custom_session),
+  custom_accounts: many(custom_account),
+  twoFactors: many(twoFactor),
+}));
+
+export const custom_sessionRelations = relations(custom_session, ({ one }) => ({
+  custom_user: one(custom_user, {
+    fields: [custom_session.userId],
+    references: [custom_user.id],
+  }),
+}));
+
+export const custom_accountRelations = relations(custom_account, ({ one }) => ({
+  custom_user: one(custom_user, {
+    fields: [custom_account.userId],
+    references: [custom_user.id],
+  }),
+}));
+
+export const twoFactorRelations = relations(twoFactor, ({ one }) => ({
+  custom_user: one(custom_user, {
+    fields: [twoFactor.userId],
+    references: [custom_user.id],
+  }),
+}));

--- a/packages/cli/test/__snapshots__/auth-schema-mssql-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mssql-number-id.txt
@@ -105,6 +105,8 @@ export const twoFactor = mssqlTable(
       .notNull()
       .references(() => custom_user.id, { onDelete: "cascade" }),
     verified: bit("verified").default(true),
+    failedVerificationCount: int("failed_verification_count").default(0),
+    lockedUntil: datetime2("locked_until", { precision: 3 }),
   },
   (table) => [
     index("twoFactor_secret_idx").on(table.secret),

--- a/packages/cli/test/__snapshots__/auth-schema-mssql-passkey.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mssql-passkey.txt
@@ -1,0 +1,143 @@
+import { relations, sql } from "drizzle-orm";
+import {
+  mssqlTable,
+  varchar,
+  datetime2,
+  bit,
+  int,
+  index,
+} from "drizzle-orm/mssql-core";
+
+export const user = mssqlTable("user", {
+  id: varchar("id", { length: 36 }).primaryKey(),
+  name: varchar("name", { length: 255 }).notNull(),
+  email: varchar("email", { length: 255 }).notNull().unique(),
+  emailVerified: bit("email_verified").default(false).notNull(),
+  image: varchar("image", { length: "max" }),
+  createdAt: datetime2("created_at", { precision: 3 })
+    .default(sql`SYSUTCDATETIME()`)
+    .notNull(),
+  updatedAt: datetime2("updated_at", { precision: 3 })
+    .default(sql`SYSUTCDATETIME()`)
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const session = mssqlTable(
+  "session",
+  {
+    id: varchar("id", { length: 36 }).primaryKey(),
+    expiresAt: datetime2("expires_at", { precision: 3 }).notNull(),
+    token: varchar("token", { length: 255 }).notNull().unique(),
+    createdAt: datetime2("created_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .notNull(),
+    updatedAt: datetime2("updated_at", { precision: 3 })
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    ipAddress: varchar("ip_address", { length: "max" }),
+    userAgent: varchar("user_agent", { length: "max" }),
+    userId: varchar("user_id", { length: 36 })
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+  },
+  (table) => [index("session_userId_idx").on(table.userId)],
+);
+
+export const account = mssqlTable(
+  "account",
+  {
+    id: varchar("id", { length: 36 }).primaryKey(),
+    accountId: varchar("account_id", { length: "max" }).notNull(),
+    providerId: varchar("provider_id", { length: "max" }).notNull(),
+    userId: varchar("user_id", { length: 36 })
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    accessToken: varchar("access_token", { length: "max" }),
+    refreshToken: varchar("refresh_token", { length: "max" }),
+    idToken: varchar("id_token", { length: "max" }),
+    accessTokenExpiresAt: datetime2("access_token_expires_at", {
+      precision: 3,
+    }),
+    refreshTokenExpiresAt: datetime2("refresh_token_expires_at", {
+      precision: 3,
+    }),
+    scope: varchar("scope", { length: "max" }),
+    password: varchar("password", { length: "max" }),
+    createdAt: datetime2("created_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .notNull(),
+    updatedAt: datetime2("updated_at", { precision: 3 })
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("account_userId_idx").on(table.userId)],
+);
+
+export const verification = mssqlTable(
+  "verification",
+  {
+    id: varchar("id", { length: 36 }).primaryKey(),
+    identifier: varchar("identifier", { length: 255 }).notNull(),
+    value: varchar("value", { length: "max" }).notNull(),
+    expiresAt: datetime2("expires_at", { precision: 3 }).notNull(),
+    createdAt: datetime2("created_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .notNull(),
+    updatedAt: datetime2("updated_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("verification_identifier_idx").on(table.identifier)],
+);
+
+export const passkey = mssqlTable(
+  "passkey",
+  {
+    id: varchar("id", { length: 36 }).primaryKey(),
+    name: varchar("name", { length: "max" }),
+    publicKey: varchar("public_key", { length: "max" }).notNull(),
+    userId: varchar("user_id", { length: 36 })
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    credentialID: varchar("credential_id", { length: 255 }).notNull(),
+    counter: int("counter").notNull(),
+    deviceType: varchar("device_type", { length: "max" }).notNull(),
+    backedUp: bit("backed_up").notNull(),
+    transports: varchar("transports", { length: "max" }),
+    createdAt: datetime2("created_at", { precision: 3 }),
+    aaguid: varchar("aaguid", { length: "max" }),
+  },
+  (table) => [
+    index("passkey_userId_idx").on(table.userId),
+    index("passkey_credentialID_idx").on(table.credentialID),
+  ],
+);
+
+export const userRelations = relations(user, ({ many }) => ({
+  sessions: many(session),
+  accounts: many(account),
+  passkeys: many(passkey),
+}));
+
+export const sessionRelations = relations(session, ({ one }) => ({
+  user: one(user, {
+    fields: [session.userId],
+    references: [user.id],
+  }),
+}));
+
+export const accountRelations = relations(account, ({ one }) => ({
+  user: one(user, {
+    fields: [account.userId],
+    references: [user.id],
+  }),
+}));
+
+export const passkeyRelations = relations(passkey, ({ one }) => ({
+  user: one(user, {
+    fields: [passkey.userId],
+    references: [user.id],
+  }),
+}));

--- a/packages/cli/test/__snapshots__/auth-schema-mssql.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mssql.txt
@@ -4,6 +4,7 @@ import {
   varchar,
   datetime2,
   bit,
+  int,
   index,
 } from "drizzle-orm/mssql-core";
 
@@ -104,6 +105,8 @@ export const twoFactor = mssqlTable(
       .notNull()
       .references(() => custom_user.id, { onDelete: "cascade" }),
     verified: bit("verified").default(true),
+    failedVerificationCount: int("failed_verification_count").default(0),
+    lockedUntil: datetime2("locked_until", { precision: 3 }),
   },
   (table) => [
     index("twoFactor_secret_idx").on(table.secret),

--- a/packages/cli/test/__snapshots__/auth-schema-mssql.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mssql.txt
@@ -1,0 +1,139 @@
+import { relations, sql } from "drizzle-orm";
+import {
+  mssqlTable,
+  varchar,
+  datetime2,
+  bit,
+  index,
+} from "drizzle-orm/mssql-core";
+
+export const custom_user = mssqlTable("custom_user", {
+  id: varchar("id", { length: 36 }).primaryKey(),
+  name: varchar("name", { length: 255 }).notNull(),
+  email: varchar("email", { length: 255 }).notNull().unique(),
+  emailVerified: bit("email_verified").default(false).notNull(),
+  image: varchar("image", { length: "max" }),
+  createdAt: datetime2("created_at", { precision: 3 })
+    .default(sql`SYSUTCDATETIME()`)
+    .notNull(),
+  updatedAt: datetime2("updated_at", { precision: 3 })
+    .default(sql`SYSUTCDATETIME()`)
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  twoFactorEnabled: bit("two_factor_enabled").default(false),
+  username: varchar("username", { length: 255 }).unique(),
+  displayUsername: varchar("display_username", { length: "max" }),
+});
+
+export const custom_session = mssqlTable(
+  "custom_session",
+  {
+    id: varchar("id", { length: 36 }).primaryKey(),
+    expiresAt: datetime2("expires_at", { precision: 3 }).notNull(),
+    token: varchar("token", { length: 255 }).notNull().unique(),
+    createdAt: datetime2("created_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .notNull(),
+    updatedAt: datetime2("updated_at", { precision: 3 })
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    ipAddress: varchar("ip_address", { length: "max" }),
+    userAgent: varchar("user_agent", { length: "max" }),
+    userId: varchar("user_id", { length: 36 })
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+  },
+  (table) => [index("custom_session_userId_idx").on(table.userId)],
+);
+
+export const custom_account = mssqlTable(
+  "custom_account",
+  {
+    id: varchar("id", { length: 36 }).primaryKey(),
+    accountId: varchar("account_id", { length: "max" }).notNull(),
+    providerId: varchar("provider_id", { length: "max" }).notNull(),
+    userId: varchar("user_id", { length: 36 })
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+    accessToken: varchar("access_token", { length: "max" }),
+    refreshToken: varchar("refresh_token", { length: "max" }),
+    idToken: varchar("id_token", { length: "max" }),
+    accessTokenExpiresAt: datetime2("access_token_expires_at", {
+      precision: 3,
+    }),
+    refreshTokenExpiresAt: datetime2("refresh_token_expires_at", {
+      precision: 3,
+    }),
+    scope: varchar("scope", { length: "max" }),
+    password: varchar("password", { length: "max" }),
+    createdAt: datetime2("created_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .notNull(),
+    updatedAt: datetime2("updated_at", { precision: 3 })
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("custom_account_userId_idx").on(table.userId)],
+);
+
+export const custom_verification = mssqlTable(
+  "custom_verification",
+  {
+    id: varchar("id", { length: 36 }).primaryKey(),
+    identifier: varchar("identifier", { length: 255 }).notNull(),
+    value: varchar("value", { length: "max" }).notNull(),
+    expiresAt: datetime2("expires_at", { precision: 3 }).notNull(),
+    createdAt: datetime2("created_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .notNull(),
+    updatedAt: datetime2("updated_at", { precision: 3 })
+      .default(sql`SYSUTCDATETIME()`)
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("custom_verification_identifier_idx").on(table.identifier)],
+);
+
+export const twoFactor = mssqlTable(
+  "two_factor",
+  {
+    id: varchar("id", { length: 36 }).primaryKey(),
+    secret: varchar("secret", { length: 255 }).notNull(),
+    backupCodes: varchar("backup_codes", { length: "max" }).notNull(),
+    userId: varchar("user_id", { length: 36 })
+      .notNull()
+      .references(() => custom_user.id, { onDelete: "cascade" }),
+    verified: bit("verified").default(true),
+  },
+  (table) => [
+    index("twoFactor_secret_idx").on(table.secret),
+    index("twoFactor_userId_idx").on(table.userId),
+  ],
+);
+
+export const custom_userRelations = relations(custom_user, ({ many }) => ({
+  custom_sessions: many(custom_session),
+  custom_accounts: many(custom_account),
+  twoFactors: many(twoFactor),
+}));
+
+export const custom_sessionRelations = relations(custom_session, ({ one }) => ({
+  custom_user: one(custom_user, {
+    fields: [custom_session.userId],
+    references: [custom_user.id],
+  }),
+}));
+
+export const custom_accountRelations = relations(custom_account, ({ one }) => ({
+  custom_user: one(custom_user, {
+    fields: [custom_account.userId],
+    references: [custom_user.id],
+  }),
+}));
+
+export const twoFactorRelations = relations(twoFactor, ({ one }) => ({
+  custom_user: one(custom_user, {
+    fields: [twoFactor.userId],
+    references: [custom_user.id],
+  }),
+}));

--- a/packages/cli/test/generate-all-db.test.ts
+++ b/packages/cli/test/generate-all-db.test.ts
@@ -496,4 +496,95 @@ describe("generate drizzle schema for all databases with passkey plugin", async 
 			"./__snapshots__/auth-schema-sqlite-passkey-number-id.txt",
 		);
 	});
+
+	it("should generate drizzle schema for MSSQL", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "mssql",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "mssql",
+						schema: {},
+					},
+				),
+				plugins: [twoFactor(), username()],
+				user: { modelName: "custom_user" },
+				account: { modelName: "custom_account" },
+				session: { modelName: "custom_session" },
+				verification: { modelName: "custom_verification" },
+			},
+		});
+		await expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-mssql.txt",
+		);
+	});
+
+	it("should generate drizzle schema for MSSQL with number id", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "mssql",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "mssql",
+						schema: {},
+					},
+				),
+				plugins: [twoFactor(), username()],
+				advanced: {
+					database: {
+						generateId: "serial",
+					},
+				},
+				user: { modelName: "custom_user" },
+				account: { modelName: "custom_account" },
+				session: { modelName: "custom_session" },
+				verification: { modelName: "custom_verification" },
+			},
+		});
+		await expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-mssql-number-id.txt",
+		);
+	});
+
+	it("should generate drizzle schema for MSSQL with passkey plugin", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "mssql",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "mssql",
+						schema: {},
+					},
+				),
+				plugins: [passkey()],
+			},
+		});
+		await expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-mssql-passkey.txt",
+		);
+	});
 });

--- a/packages/drizzle-adapter/package.json
+++ b/packages/drizzle-adapter/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "@better-auth/utils": "catalog:",
-    "drizzle-orm": "^0.45.2",
+    "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -458,6 +458,60 @@ describe("drizzle-adapter", () => {
 
 			expect(result).toBeNull();
 		});
+
+		// mssql-core has no .for("update")/.limit(); the guard-select must use
+		// .top(1) instead, and the DELETE must go through .execute() rather than
+		// .returning() (which mssql-core also doesn't support).
+		function createMssqlConsumeDb(driverResult: unknown) {
+			const selectExecute = vi.fn().mockResolvedValue([verificationRow]);
+			const selectWhere = vi.fn().mockReturnValue({ execute: selectExecute });
+			const selectFrom = vi.fn().mockReturnValue({ where: selectWhere });
+			const top = vi.fn().mockReturnValue({ from: selectFrom });
+			const execute = vi.fn().mockResolvedValue(driverResult);
+			const deleteWhere = vi.fn().mockReturnValue({ execute });
+			const tx = {
+				select: vi.fn().mockReturnValue({ top, from: selectFrom }),
+				delete: vi.fn().mockReturnValue({ where: deleteWhere }),
+			};
+			const db = {
+				_: { fullSchema: { verification: verificationTable } },
+				transaction: vi
+					.fn()
+					.mockImplementation((fn: (transaction: typeof tx) => unknown) =>
+						fn(tx),
+					),
+			} as Parameters<typeof drizzleAdapter>[0];
+			return { db, top };
+		}
+
+		it("returns the consumed row for MSSQL via TOP(1) instead of .limit()", async () => {
+			const { db, top } = createMssqlConsumeDb({ rowsAffected: [1] });
+			const adapter = drizzleAdapter(db, { provider: "mssql" })({
+				secret: defaultSecret,
+			});
+
+			const result = await adapter.consumeOne({
+				model: "verification",
+				where: [{ field: "id", value: verificationRow.id }],
+			});
+
+			expect(result).toEqual(verificationRow);
+			expect(top).toHaveBeenCalledWith(1);
+		});
+
+		it("returns null when the MSSQL delete does not affect a row", async () => {
+			const { db } = createMssqlConsumeDb({ rowsAffected: [0] });
+			const adapter = drizzleAdapter(db, { provider: "mssql" })({
+				secret: defaultSecret,
+			});
+
+			const result = await adapter.consumeOne({
+				model: "verification",
+				where: [{ field: "id", value: verificationRow.id }],
+			});
+
+			expect(result).toBeNull();
+		});
 	});
 
 	describe("incrementOne", () => {
@@ -614,6 +668,94 @@ describe("drizzle-adapter", () => {
 				// A `gt` guard that no row satisfies must yield null, never a row.
 				where: [{ field: "attempts", value: 100, operator: "gt" }],
 				increment: { attempts: -1 },
+			});
+
+			expect(result).toBeNull();
+		});
+
+		// mssql-core has no .for("update")/.limit(); the guard-select and the
+		// post-update re-select must both use .top(1), and the UPDATE must go
+		// through .execute() rather than .returning() (unsupported on mssql-core).
+		function createMssqlIncrementDb(guardRow: unknown, updatedRow: unknown) {
+			const guardExecute = vi
+				.fn()
+				.mockResolvedValue(guardRow ? [guardRow] : []);
+			const guardWhere = vi.fn().mockReturnValue({ execute: guardExecute });
+			const guardFrom = vi.fn().mockReturnValue({ where: guardWhere });
+			const guardTop = vi.fn().mockReturnValue({ from: guardFrom });
+
+			const reselectExecute = vi
+				.fn()
+				.mockResolvedValue(updatedRow ? [updatedRow] : []);
+			const reselectWhere = vi
+				.fn()
+				.mockReturnValue({ execute: reselectExecute });
+			const reselectFrom = vi.fn().mockReturnValue({ where: reselectWhere });
+			const reselectTop = vi.fn().mockReturnValue({ from: reselectFrom });
+
+			const top = vi
+				.fn()
+				.mockReturnValueOnce({ from: guardFrom })
+				.mockReturnValueOnce({ from: reselectFrom });
+
+			const updateExecute = vi.fn().mockResolvedValue(undefined);
+			const updateWhere = vi.fn().mockReturnValue({ execute: updateExecute });
+			const set = vi.fn().mockReturnValue({ where: updateWhere });
+
+			const tx = {
+				select: vi.fn().mockReturnValue({ top }),
+				update: vi.fn().mockReturnValue({ set }),
+			};
+			const db = {
+				_: { fullSchema: { user: userTable } },
+				transaction: vi
+					.fn()
+					.mockImplementation((fn: (transaction: typeof tx) => unknown) =>
+						fn(tx),
+					),
+			} as any;
+			return { db, top, guardTop, reselectTop };
+		}
+
+		it("increments and re-reads via TOP(1) on MSSQL instead of .limit()", async () => {
+			const guardRow = { id: "user-1", attempts: 4 };
+			const updatedRow = { id: "user-1", attempts: 5 };
+			const { db, top } = createMssqlIncrementDb(guardRow, updatedRow);
+			const adapter = drizzleAdapter(db, { provider: "mssql" })({
+				secret: defaultSecret,
+				user: {
+					additionalFields: {
+						attempts: { type: "number", required: false },
+					},
+				},
+			});
+
+			const result = await adapter.incrementOne({
+				model: "user",
+				where: [{ field: "id", value: "user-1" }],
+				increment: { attempts: 1 },
+			});
+
+			expect(result).toEqual(updatedRow);
+			expect(top).toHaveBeenCalledWith(1);
+			expect(top).toHaveBeenCalledTimes(2);
+		});
+
+		it("returns null when the MSSQL guard matches no row", async () => {
+			const { db } = createMssqlIncrementDb(null, null);
+			const adapter = drizzleAdapter(db, { provider: "mssql" })({
+				secret: defaultSecret,
+				user: {
+					additionalFields: {
+						attempts: { type: "number", required: false },
+					},
+				},
+			});
+
+			const result = await adapter.incrementOne({
+				model: "user",
+				where: [{ field: "id", value: "user-1" }],
+				increment: { attempts: 1 },
 			});
 
 			expect(result).toBeNull();

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -89,6 +89,19 @@ describe("drizzle-adapter", () => {
 		expect(db.transaction).toHaveBeenCalled();
 	});
 
+	it("should create drizzle adapter with mssql provider", () => {
+		const db = {
+			_: {
+				fullSchema: {},
+			},
+		} as any;
+		const config = {
+			provider: "mssql" as const,
+		};
+		const adapter = drizzleAdapter(db, config);
+		expect(adapter).toBeDefined();
+	});
+
 	describe("checkMissingFields", () => {
 		function createMockDb(schema: Record<string, Record<string, any>>) {
 			return {
@@ -184,6 +197,53 @@ describe("drizzle-adapter", () => {
 			).rejects.toThrow(
 				/does not exist in the "user" Drizzle schema.*update your drizzle schema/,
 			);
+		});
+
+		it("should not call .returning() on mssql (uses execute + re-select)", async () => {
+			const userTable = {
+				id: { name: "id" },
+				name: { name: "name" },
+				email: { name: "email" },
+				emailVerified: { name: "emailVerified" },
+				image: { name: "image" },
+				createdAt: { name: "createdAt" },
+				updatedAt: { name: "updatedAt" },
+			};
+			const insertedRow = {
+				id: "abc",
+				name: "Test",
+				email: "test@example.com",
+			};
+			const returning = vi.fn();
+			const execute = vi.fn().mockResolvedValue(undefined);
+			const limit = vi
+				.fn()
+				.mockReturnValue({ execute: vi.fn().mockResolvedValue([insertedRow]) });
+			const where = vi.fn().mockReturnValue({ limit });
+			const orderBy = vi.fn().mockReturnValue({ limit });
+			const from = vi.fn().mockReturnValue({ where, orderBy });
+			const select = vi.fn().mockReturnValue({ from });
+			const db = {
+				_: { fullSchema: { user: userTable } },
+				insert: vi.fn().mockReturnValue({
+					values: vi.fn().mockReturnValue({
+						config: { values: [{ id: { value: "abc" } }] },
+						execute,
+						returning,
+					}),
+				}),
+				select,
+			} as any;
+			const factory = drizzleAdapter(db, { provider: "mssql" });
+			const adapter = factory({ secret: defaultSecret });
+
+			await adapter.create({
+				model: "user",
+				data: { name: "Test", email: "test@example.com" },
+			});
+
+			expect(execute).toHaveBeenCalledTimes(1);
+			expect(returning).not.toHaveBeenCalled();
 		});
 
 		it("should throw when schema is not provided", async () => {

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -216,13 +216,17 @@ describe("drizzle-adapter", () => {
 			};
 			const returning = vi.fn();
 			const execute = vi.fn().mockResolvedValue(undefined);
-			const limit = vi
-				.fn()
-				.mockReturnValue({ execute: vi.fn().mockResolvedValue([insertedRow]) });
-			const where = vi.fn().mockReturnValue({ limit });
-			const orderBy = vi.fn().mockReturnValue({ limit });
+			// MSSQL select shape: db.select().top(1).from(table).where(...).execute()
+			// — no .limit() in the chain. Asserting that .top() is called and
+			// .limit() is not is what makes this test meaningful for MSSQL.
+			const top = vi.fn();
+			const limit = vi.fn();
+			const finalExecute = vi.fn().mockResolvedValue([insertedRow]);
+			const where = vi.fn().mockReturnValue({ execute: finalExecute, limit });
+			const orderBy = vi.fn().mockReturnValue({ execute: finalExecute, limit });
 			const from = vi.fn().mockReturnValue({ where, orderBy });
-			const select = vi.fn().mockReturnValue({ from });
+			top.mockReturnValue({ from });
+			const select = vi.fn().mockReturnValue({ from, top });
 			const db = {
 				_: { fullSchema: { user: userTable } },
 				insert: vi.fn().mockReturnValue({
@@ -244,6 +248,10 @@ describe("drizzle-adapter", () => {
 
 			expect(execute).toHaveBeenCalledTimes(1);
 			expect(returning).not.toHaveBeenCalled();
+			// MSSQL re-select must use TOP(1), not .limit(1) — the latter
+			// throws at runtime because mssql-core doesn't expose .limit().
+			expect(top).toHaveBeenCalledWith(1);
+			expect(limit).not.toHaveBeenCalled();
 		});
 
 		it("should throw when schema is not provided", async () => {

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -676,7 +676,11 @@ describe("drizzle-adapter", () => {
 		// mssql-core has no .for("update")/.limit(); the guard-select and the
 		// post-update re-select must both use .top(1), and the UPDATE must go
 		// through .execute() rather than .returning() (unsupported on mssql-core).
-		function createMssqlIncrementDb(guardRow: unknown, updatedRow: unknown) {
+		function createMssqlIncrementDb(
+			guardRow: unknown,
+			updatedRow: unknown,
+			updateResult: unknown = { rowsAffected: [1] },
+		) {
 			const guardExecute = vi
 				.fn()
 				.mockResolvedValue(guardRow ? [guardRow] : []);
@@ -698,7 +702,7 @@ describe("drizzle-adapter", () => {
 				.mockReturnValueOnce({ from: guardFrom })
 				.mockReturnValueOnce({ from: reselectFrom });
 
-			const updateExecute = vi.fn().mockResolvedValue(undefined);
+			const updateExecute = vi.fn().mockResolvedValue(updateResult);
 			const updateWhere = vi.fn().mockReturnValue({ execute: updateExecute });
 			const set = vi.fn().mockReturnValue({ where: updateWhere });
 
@@ -739,6 +743,36 @@ describe("drizzle-adapter", () => {
 			expect(result).toEqual(updatedRow);
 			expect(top).toHaveBeenCalledWith(1);
 			expect(top).toHaveBeenCalledTimes(2);
+		});
+
+		it("returns null on MSSQL when the guard no longer matches at update time", async () => {
+			// The guard-select finds a row, but the row's guarded fields changed
+			// before the UPDATE runs (e.g. a concurrent request already mutated
+			// it) — the UPDATE re-checks the original clause, affects zero rows,
+			// and must report null rather than the stale guard-select snapshot.
+			const guardRow = { id: "user-1", attempts: 4 };
+			const { db, top } = createMssqlIncrementDb(guardRow, null, {
+				rowsAffected: [0],
+			});
+			const adapter = drizzleAdapter(db, { provider: "mssql" })({
+				secret: defaultSecret,
+				user: {
+					additionalFields: {
+						attempts: { type: "number", required: false },
+					},
+				},
+			});
+
+			const result = await adapter.incrementOne({
+				model: "user",
+				where: [{ field: "id", value: "user-1" }],
+				increment: { attempts: 1 },
+			});
+
+			expect(result).toBeNull();
+			// The guard-select still ran, but the re-select after the update must
+			// not — the function must short-circuit on the zero-row update.
+			expect(top).toHaveBeenCalledTimes(1);
 		});
 
 		it("returns null when the MSSQL guard matches no row", async () => {

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -237,6 +237,7 @@ describe("drizzle-adapter", () => {
 					}),
 				}),
 				select,
+				transaction: vi.fn().mockImplementation((fn: any) => fn(db)),
 			} as any;
 			const factory = drizzleAdapter(db, { provider: "mssql" });
 			const adapter = factory({ secret: defaultSecret });

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -318,6 +318,18 @@ describe("drizzle-adapter", () => {
 				result: [{ affectedRows: 2 }],
 				expected: 2,
 			},
+			// MSSQL returns rowsAffected as number[] (one entry per batch
+			// statement) rather than a plain number.
+			{
+				provider: "mssql" as const,
+				result: { rowsAffected: [2] },
+				expected: 2,
+			},
+			{
+				provider: "mssql" as const,
+				result: { rowsAffected: [1, 1] },
+				expected: 2,
+			},
 			// postgres-js / bun-sql return an Array subclass carrying `count`;
 			// a non-RETURNING write has length 0, so the count must be read off
 			// the array itself, not from `result.length`.

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -27,7 +27,6 @@ import {
 	ne,
 	notInArray,
 	or,
-	sql,
 } from "drizzle-orm";
 import {
 	insensitiveEq,

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -95,16 +95,23 @@ function getAffectedRowCount(
 function readDriverRowCount(result: unknown): unknown {
 	if (!result || typeof result !== "object") return undefined;
 	const driverResult = result as Record<string, unknown>;
-	if ("affectedRows" in driverResult) return driverResult.affectedRows;
-	if ("rowsAffected" in driverResult) return driverResult.rowsAffected;
-	if ("changes" in driverResult) return driverResult.changes;
+	// MSSQL returns rowsAffected as number[] (one entry per batch statement).
+	const sumIfArray = (raw: unknown) =>
+		Array.isArray(raw)
+			? raw.reduce((sum: number, n: number) => sum + n, 0)
+			: raw;
+	if ("affectedRows" in driverResult)
+		return sumIfArray(driverResult.affectedRows);
+	if ("rowsAffected" in driverResult)
+		return sumIfArray(driverResult.rowsAffected);
+	if ("changes" in driverResult) return sumIfArray(driverResult.changes);
 
 	// Cloudflare D1 nests the affected-row count under `meta.changes`.
 	// @see https://developers.cloudflare.com/d1/worker-api/return-object/
 	if ("meta" in driverResult) {
 		const meta = driverResult.meta;
 		if (meta && typeof meta === "object" && "changes" in meta) {
-			return meta.changes;
+			return sumIfArray(meta.changes);
 		}
 	}
 

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -55,7 +55,7 @@ export interface DB {
  */
 function getAffectedRowCount(
 	result: unknown,
-	operation: "updateMany" | "deleteMany" | "consumeOne",
+	operation: "updateMany" | "deleteMany" | "consumeOne" | "incrementOne",
 	context: { model: string; where: Where[] },
 ): number {
 	let count: unknown = 0;
@@ -1064,12 +1064,13 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 
 					if (config.provider === "mysql" || config.provider === "mssql") {
 						// MySQL and MSSQL have no DELETE ... RETURNING. Read the row
-						// first, then delete it by id and only report success if the
-						// delete actually removed a row — this still resolves the race
-						// between concurrent claimants without a locking hint, since at
-						// most one DELETE can affect a row that's already gone.
-						// mssql-core has no .for("update")/.limit(); MySQL locks the row
-						// under SELECT ... FOR UPDATE inside the transaction instead.
+						// first, then delete by id while re-checking the original guard
+						// clause, so a row whose guarded fields changed since the SELECT
+						// (e.g. another request already consumed or altered it) affects
+						// zero rows and reports null instead of returning stale data.
+						// mssql-core has no .for("update")/.limit(); MySQL additionally
+						// locks the row under SELECT ... FOR UPDATE inside the
+						// transaction so the guard can't change before the DELETE runs.
 						const claimFromTransaction = async (tx: DB) => {
 							const rows =
 								config.provider === "mssql"
@@ -1091,7 +1092,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							}
 							const delRes = await tx
 								.delete(schemaModel)
-								.where(eq(idColumn, targetId))
+								.where(...clause, eq(idColumn, targetId))
 								.execute();
 							const count = getAffectedRowCount(delRes, "consumeOne", {
 								model,
@@ -1153,9 +1154,13 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 
 					if (config.provider === "mysql" || config.provider === "mssql") {
 						// MySQL and MSSQL have no UPDATE ... RETURNING. Guard-select the
-						// row, update it by id, then read the mutated row back.
-						// mssql-core has no .for("update")/.limit(); MySQL locks the row
-						// under SELECT ... FOR UPDATE inside the transaction instead.
+						// row, then update it while re-checking the original guard
+						// clause (not just id), so a row whose guarded fields changed
+						// since the SELECT affects zero rows and reports null instead
+						// of mutating/returning based on a stale snapshot. mssql-core
+						// has no .for("update")/.limit(); MySQL additionally locks the
+						// row under SELECT ... FOR UPDATE inside the transaction so the
+						// guard can't change before the UPDATE runs.
 						const mutateInTransaction = async (tx: DB) => {
 							const rows =
 								config.provider === "mssql"
@@ -1175,11 +1180,16 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							if (targetId === undefined || targetId === null || !idColumn) {
 								return null;
 							}
-							await tx
+							const updateRes = await tx
 								.update(schemaModel)
 								.set(assignments)
-								.where(eq(idColumn, targetId))
+								.where(...clause, eq(idColumn, targetId))
 								.execute();
+							const count = getAffectedRowCount(updateRes, "incrementOne", {
+								model,
+								where,
+							});
+							if (count === 0) return null;
 							const updated = await withLimit(
 								withTop(tx.select(), 1)
 									.from(schemaModel)

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -123,7 +123,7 @@ export interface DrizzleAdapterConfig {
 	/**
 	 * The database provider
 	 */
-	provider: "pg" | "mysql" | "sqlite";
+	provider: "pg" | "mysql" | "sqlite" | "mssql";
 	/**
 	 * If the table names in the schema are plural
 	 * set this to true. For example, if the schema
@@ -216,10 +216,14 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				data: Record<string, any>,
 				where?: Where[] | undefined,
 			) => {
-				if (config.provider !== "mysql") {
+				if (config.provider !== "mysql" && config.provider !== "mssql") {
 					const c = await builder.returning();
 					return c[0];
 				}
+				// MySQL and MSSQL do not support .returning() in the same shape:
+				// MySQL has no RETURNING clause; MSSQL uses OUTPUT but with a
+				// different builder shape (.output() before .values()). Both fall
+				// back to executing the write, then re-selecting the affected row.
 				await builder.execute();
 				const schemaModel = getSchema(model);
 				const builderVal = builder.config?.values;
@@ -263,13 +267,18 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						return res[0] ?? null;
 					}
 
-					// 3. Serial auto-increment: LAST_INSERT_ID() is connection-scoped
+					// 3. Serial auto-increment: LAST_INSERT_ID()/SCOPE_IDENTITY() is
+					// connection-scoped
 					if (
 						options.advanced?.database?.generateId === "serial" &&
 						schemaModel.id
 					) {
+						const lastInsertIdSql =
+							config.provider === "mssql"
+								? sql`SCOPE_IDENTITY()`
+								: sql`LAST_INSERT_ID()`;
 						const lastInsertId = await tx
-							.select({ id: sql`LAST_INSERT_ID()` })
+							.select({ id: lastInsertIdSql })
 							.from(schemaModel)
 							.limit(1)
 							.execute();

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -27,6 +27,7 @@ import {
 	ne,
 	notInArray,
 	or,
+	sql,
 } from "drizzle-orm";
 import {
 	insensitiveEq,
@@ -225,6 +226,13 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				// back to executing the write, then re-selecting the affected row.
 				await builder.execute();
 				const schemaModel = getSchema(model);
+				// MSSQL's drizzle select builder has no .limit(); use TOP(N)
+				// chained on the pre-from builder instead. These two helpers
+				// keep the rest of the code shape-agnostic across providers.
+				const withTop = (b: any, n: number) =>
+					config.provider === "mssql" ? b.top(n) : b;
+				const withLimit = (b: any, n: number) =>
+					config.provider === "mssql" ? b : b.limit(n);
 				const builderVal = builder.config?.values;
 				if (where?.length) {
 					const updatedWhere = where.map((w) => {
@@ -246,23 +254,23 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					// 1. Known id from the Drizzle builder internals
 					const builderId = builderVal?.[0]?.id?.value;
 					if (builderId) {
-						const res = await tx
-							.select()
-							.from(schemaModel)
-							.where(eq(schemaModel.id, builderId))
-							.limit(1)
-							.execute();
+						const res = await withLimit(
+							withTop(tx.select(), 1)
+								.from(schemaModel)
+								.where(eq(schemaModel.id, builderId)),
+							1,
+						).execute();
 						return res[0] ?? null;
 					}
 
 					// 2. Known id from the data object
 					if (data.id) {
-						const res = await tx
-							.select()
-							.from(schemaModel)
-							.where(eq(schemaModel.id, data.id))
-							.limit(1)
-							.execute();
+						const res = await withLimit(
+							withTop(tx.select(), 1)
+								.from(schemaModel)
+								.where(eq(schemaModel.id, data.id)),
+							1,
+						).execute();
 						return res[0] ?? null;
 					}
 
@@ -276,19 +284,18 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							config.provider === "mssql"
 								? sql`SCOPE_IDENTITY()`
 								: sql`LAST_INSERT_ID()`;
-						const lastInsertId = await tx
-							.select({ id: lastInsertIdSql })
-							.from(schemaModel)
-							.limit(1)
-							.execute();
+						const lastInsertId = await withLimit(
+							withTop(tx.select({ id: lastInsertIdSql }), 1).from(schemaModel),
+							1,
+						).execute();
 						const lastId = lastInsertId[0]?.id;
 						if (lastId) {
-							const res = await tx
-								.select()
-								.from(schemaModel)
-								.where(eq(schemaModel.id, lastId))
-								.limit(1)
-								.execute();
+							const res = await withLimit(
+								withTop(tx.select(), 1)
+									.from(schemaModel)
+									.where(eq(schemaModel.id, lastId)),
+								1,
+							).execute();
 							return res[0] ?? null;
 						}
 					}
@@ -305,17 +312,17 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							const val = data[dbFieldName];
 							if (val === undefined || val === null) continue;
 							if (!schemaModel[dbFieldName]) continue;
-							const res = await tx
-								.select()
-								.from(schemaModel)
-								.where(eq(schemaModel[dbFieldName], val))
-								.limit(1)
-								.execute();
+							const res = await withLimit(
+								withTop(tx.select(), 1)
+									.from(schemaModel)
+									.where(eq(schemaModel[dbFieldName], val)),
+								1,
+							).execute();
 							if (res[0]) return res[0];
 						}
 					}
 
-					// 5. Full-field match (last resort) — LIMIT 2 to detect ambiguity
+					// 5. Full-field match (last resort) — TOP/LIMIT 2 to detect ambiguity
 					const conditions: SQL<unknown>[] = [];
 					for (const [key, val] of Object.entries(data)) {
 						if (val === undefined || !schemaModel[key]) continue;
@@ -328,12 +335,10 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					if (conditions.length > 0) {
 						const combined = and(...conditions);
 						if (combined) {
-							const res = await tx
-								.select()
-								.from(schemaModel)
-								.where(combined)
-								.limit(2)
-								.execute();
+							const res = await withLimit(
+								withTop(tx.select(), 2).from(schemaModel).where(combined),
+								2,
+							).execute();
 							if (res.length === 1) return res[0];
 						}
 					}
@@ -922,37 +927,82 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						}
 					}
 
-					let builder = db
-						.select(
-							select?.length && select.length > 0
-								? select.reduce((acc, field) => {
+					const selectShape =
+						select?.length && select.length > 0
+							? select.reduce(
+									(acc, field) => {
 										const fieldName = getFieldName({ model, field });
 										return {
 											...acc,
 											[fieldName]: schemaModel[fieldName],
 										};
-									}, {})
-								: undefined,
-						)
-						.from(schemaModel);
+									},
+									{} as Record<string, unknown>,
+								)
+							: undefined;
+					const baseSelect = selectShape ? db.select(selectShape) : db.select();
 
 					const effectiveLimit = limit;
 					const effectiveOffset = offset;
+					const sortByField = sortBy?.field;
 
-					if (typeof effectiveLimit !== "undefined") {
-						builder = builder.limit(effectiveLimit);
-					}
+					let builder: any;
+					if (config.provider === "mssql") {
+						// MSSQL select builder has no .limit() or .offset() chain.
+						// Two paths exist: TOP(N) (must precede .from()) for the
+						// simple "limit only, no offset, no sort" case, and
+						// OFFSET/FETCH (after ORDER BY) for everything else.
+						// SQL Server requires an ORDER BY when OFFSET/FETCH is used,
+						// so when the caller hasn't supplied one we fall back to
+						// ascending id ordering, which is deterministic and matches
+						// what the existing pg/mysql/sqlite paths effectively do
+						// when no sort is requested.
+						const useTopOnly =
+							typeof effectiveLimit !== "undefined" &&
+							typeof effectiveOffset === "undefined" &&
+							!sortByField;
+						builder = useTopOnly
+							? baseSelect.top(effectiveLimit).from(schemaModel)
+							: baseSelect.from(schemaModel);
 
-					if (typeof effectiveOffset !== "undefined") {
-						builder = builder.offset(effectiveOffset);
-					}
+						if (sortByField) {
+							builder = builder.orderBy(
+								sortFn(
+									schemaModel[getFieldName({ model, field: sortByField })],
+								),
+							);
+						}
 
-					if (sortBy?.field) {
-						builder = builder.orderBy(
-							sortFn(
-								schemaModel[getFieldName({ model, field: sortBy?.field })],
-							),
-						);
+						const needsOffsetFetch =
+							typeof effectiveOffset !== "undefined" ||
+							(typeof effectiveLimit !== "undefined" && !useTopOnly);
+						if (needsOffsetFetch) {
+							if (!sortByField) {
+								builder = builder.orderBy(asc(schemaModel.id));
+							}
+							builder = builder.offset(effectiveOffset ?? 0);
+							if (typeof effectiveLimit !== "undefined") {
+								builder = builder.fetch(effectiveLimit);
+							}
+						}
+					} else {
+						builder = baseSelect.from(schemaModel);
+
+						if (typeof effectiveLimit !== "undefined") {
+							builder = builder.limit(effectiveLimit);
+						}
+
+						if (typeof effectiveOffset !== "undefined") {
+							builder = builder.offset(effectiveOffset);
+						}
+
+						if (sortByField) {
+							builder = builder.orderBy(
+								sortFn(
+									schemaModel[getFieldName({ model, field: sortByField })],
+								),
+							);
+						}
 					}
 
 					const res = await builder.where(...clause);

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -217,6 +217,13 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				}
 				return schemaModel;
 			}
+			// MSSQL's drizzle select builder has no .limit(); use TOP(N) chained
+			// on the pre-from builder instead. These two helpers keep the rest
+			// of the code shape-agnostic across providers.
+			const withTop = (b: any, n: number) =>
+				config.provider === "mssql" ? b.top(n) : b;
+			const withLimit = (b: any, n: number) =>
+				config.provider === "mssql" ? b : b.limit(n);
 			const withReturning = async (
 				model: string,
 				builder: any,
@@ -233,13 +240,6 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				// back to executing the write, then re-selecting the affected row.
 				await builder.execute();
 				const schemaModel = getSchema(model);
-				// MSSQL's drizzle select builder has no .limit(); use TOP(N)
-				// chained on the pre-from builder instead. These two helpers
-				// keep the rest of the code shape-agnostic across providers.
-				const withTop = (b: any, n: number) =>
-					config.provider === "mssql" ? b.top(n) : b;
-				const withLimit = (b: any, n: number) =>
-					config.provider === "mssql" ? b : b.limit(n);
 				const builderVal = builder.config?.values;
 				if (where?.length) {
 					const updatedWhere = where.map((w) => {
@@ -1062,17 +1062,27 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					const idField = getFieldName({ model, field: "id" });
 					const idColumn = schemaModel[idField];
 
-					if (config.provider === "mysql") {
-						// MySQL has no DELETE ... RETURNING. Hold the row under
-						// SELECT ... FOR UPDATE inside a transaction so concurrent
-						// claimants block until the row is gone.
+					if (config.provider === "mysql" || config.provider === "mssql") {
+						// MySQL and MSSQL have no DELETE ... RETURNING. Read the row
+						// first, then delete it by id and only report success if the
+						// delete actually removed a row — this still resolves the race
+						// between concurrent claimants without a locking hint, since at
+						// most one DELETE can affect a row that's already gone.
+						// mssql-core has no .for("update")/.limit(); MySQL locks the row
+						// under SELECT ... FOR UPDATE inside the transaction instead.
 						const claimFromTransaction = async (tx: DB) => {
-							const rows = await tx
-								.select()
-								.from(schemaModel)
-								.where(...clause)
-								.for("update")
-								.limit(1);
+							const rows =
+								config.provider === "mssql"
+									? await withTop(tx.select(), 1)
+											.from(schemaModel)
+											.where(...clause)
+											.execute()
+									: await tx
+											.select()
+											.from(schemaModel)
+											.where(...clause)
+											.for("update")
+											.limit(1);
 							const target = rows[0];
 							if (!target) return null;
 							const targetId = target[idField] ?? (target as any).id;
@@ -1141,17 +1151,24 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						}
 					}
 
-					if (config.provider === "mysql") {
-						// MySQL has no UPDATE ... RETURNING. Hold the guarded row under
-						// SELECT ... FOR UPDATE inside a transaction so concurrent updates
-						// serialize, then read the mutated row back by id.
+					if (config.provider === "mysql" || config.provider === "mssql") {
+						// MySQL and MSSQL have no UPDATE ... RETURNING. Guard-select the
+						// row, update it by id, then read the mutated row back.
+						// mssql-core has no .for("update")/.limit(); MySQL locks the row
+						// under SELECT ... FOR UPDATE inside the transaction instead.
 						const mutateInTransaction = async (tx: DB) => {
-							const rows = await tx
-								.select()
-								.from(schemaModel)
-								.where(...clause)
-								.for("update")
-								.limit(1);
+							const rows =
+								config.provider === "mssql"
+									? await withTop(tx.select(), 1)
+											.from(schemaModel)
+											.where(...clause)
+											.execute()
+									: await tx
+											.select()
+											.from(schemaModel)
+											.where(...clause)
+											.for("update")
+											.limit(1);
 							const target = rows[0];
 							if (!target) return null;
 							const targetId = target[idField] ?? (target as any).id;
@@ -1163,12 +1180,12 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								.set(assignments)
 								.where(eq(idColumn, targetId))
 								.execute();
-							const updated = await tx
-								.select()
-								.from(schemaModel)
-								.where(eq(idColumn, targetId))
-								.limit(1)
-								.execute();
+							const updated = await withLimit(
+								withTop(tx.select(), 1)
+									.from(schemaModel)
+									.where(eq(idColumn, targetId)),
+								1,
+							).execute();
 							return (updated[0] as any) ?? null;
 						};
 						return inTransaction

--- a/packages/drizzle-adapter/src/query-builders.ts
+++ b/packages/drizzle-adapter/src/query-builders.ts
@@ -3,7 +3,7 @@ import { ilike, sql } from "drizzle-orm";
 
 type DrizzleColumn = Parameters<typeof ilike>[0];
 
-type DrizzleProvider = "pg" | "mysql" | "sqlite";
+type DrizzleProvider = "pg" | "mysql" | "sqlite" | "mssql";
 
 /**
  * Case-insensitive LIKE/ILIKE for pattern matching.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1268,7 +1268,7 @@ importers:
         specifier: 'catalog:'
         version: 0.4.2
       drizzle-orm:
-        specifier: ^0.45.2
+        specifier: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
         version: 0.45.2(@cloudflare/workers-types@4.20260226.1)(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(better-sqlite3@12.11.1)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.22.5(@types/node@25.9.4))(pg@8.22.0)(postgres@3.4.8)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))
       tsdown:
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

Extends the Drizzle schema generator (`packages/cli/src/generators/drizzle.ts`) to support `provider: "mssql"` so `npx better-auth generate` emits a working `mssqlTable` schema. Stacks on top of #9510 (which adds MSSQL provider support to `@better-auth/drizzle-adapter` itself) — together they close #7896.

## Type mapping

| Field | MSSQL output |
|---|---|
| `string` (general) | `varchar({ length: "max" })` |
| `string` (unique / indexed / sortable / FK) | `varchar({ length: 255 })` (length-bounded so SQL Server can index it; FK columns use `length: 36` to match the string id) |
| `string` enum | `varchar({ length: 255, enum: [...] })` |
| `boolean` | `bit()` (drizzle MSSQL `bit` maps to boolean) |
| `number` | `int()` / `bigint({ mode: "number" })` |
| `date` | `datetime2({ precision: 3 })` |
| `string[]` / `number[]` / `json` | `varchar({ length: "max", mode: "json" })` |

## ID columns

- String id (default): `varchar("id", { length: 36 }).primaryKey()`
- Serial id: `int("id").identity().primaryKey()`
- UUID: not specialized; falls back to string-id behavior (same as MySQL today)

## `defaultNow`-style date defaults

MSSQL drizzle has no `.defaultNow()` helper, so `createdAt` / `updatedAt`-style fields render `.default(sql\`SYSUTCDATETIME()\`)`. UTC was chosen because that's what `new Date()` round-trips through on the JS side.

## Imports

Emits from `drizzle-orm/mssql-core`, pulling in only the column helpers that are actually needed — e.g. `int` is only imported when the schema has a non-bigint number or a serial id. Mirrors the conditional-import behavior already used for pg and mysql.

## Tests

Three new snapshot tests in `packages/cli/test/generate-all-db.test.ts`:
- `should generate drizzle schema for MSSQL` — default config, exercises every type mapping
- `should generate drizzle schema for MSSQL with number id` — exercises `.identity()` PKs and FK widening
- `should generate drizzle schema for MSSQL with passkey plugin` — exercises a representative plugin schema

Snapshots checked into `packages/cli/test/__snapshots__/`. Existing pg/mysql/sqlite snapshots are unchanged.

## Out of scope

An end-to-end MSSQL adapter test in `e2e/adapter/test/drizzle-adapter/`. The MSSQL driver only exists in `drizzle-orm@^1.0.0-rc`, and v1 has API breaks (notably `relations()`) that affect the existing pg/mysql/sqlite e2e tests in that package. Migrating that test package to drizzle v1 belongs in its own PR; the e2e MSSQL test can land on top of that.

## Test plan

- [x] `pnpm --filter auth typecheck`
- [x] `pnpm --filter auth exec vitest --run test/generate-all-db.test.ts` — 15/15 pass (12 existing + 3 new MSSQL snapshots)
- [x] Drizzle SQLite e2e regression check: 441/441 pass (sanity check that bumping the changeset / lockfile didn't ripple)
- [ ] Drizzle Postgres / MySQL e2e regression check (recommend running in CI)

Stacks on #9510. Closes #7896 together with that PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Microsoft SQL Server support to `@better-auth/drizzle-adapter` and the CLI schema generator so you can use Better Auth with Drizzle MSSQL. Closes #7896.

- **New Features**
  - CLI: when `provider: "mssql"`, generates `mssqlTable` with MSSQL types — strings `varchar(255)` for indexed/unique/sortable/FK (else `varchar("max")`), booleans `bit`, numbers `int`/`bigint({ mode: "number" })`, dates `datetime2({ precision: 3 })`, arrays/json `varchar({ length: "max", mode: "json" })`, enums `varchar(255, { enum: [...] })`; IDs: string → `varchar(36)`, serial → `int().identity()`. Date defaults use `sql`SYSUTCDATETIME()``. Imports from `drizzle-orm/mssql-core`.
  - Adapter: supports `provider: "mssql"`, skips `.returning()` (executes then re-selects), and paginates with `TOP` or `OFFSET/FETCH` with an `ORDER BY` fallback. Docs mention `"mssql"`. `drizzle-orm` range widened to `^0.45.2 || >=1.0.0-rc.1 <2.0.0`.

- **Bug Fixes**
  - MSSQL compatibility: replace `.limit()` with `TOP`/`OFFSET-FETCH` (adds `ORDER BY` when needed); use `SCOPE_IDENTITY()` for serial id fallback; sum `rowsAffected` arrays in `deleteMany`.
  - Single-row ops on MSSQL: use `TOP(1)` guard-select, then `DELETE`/`UPDATE` re-checking the original guard clause; return `null` when 0 rows are affected.

<sup>Written for commit c2ccb70ae050c9f2fd68a7ffc382ff9006dc33c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

