### PR TITLE
fix(email): enforce single-use for change-email verification tokens

### DIFF
--- a/.changeset/curly-meals-wonder.md
+++ b/.changeset/curly-meals-wonder.md
@@ -1,0 +1,6 @@
+---
+"better-auth": major
+"@better-auth/core": major
+---
+
+Email change confirmation and verification tokens are now single-use. Replaying the same verification link is rejected with TOKEN_ALREADY_USED instead of silently succeeding and re-sending emails.

--- a/.changeset/curly-meals-wonder.md
+++ b/.changeset/curly-meals-wonder.md
@@ -1,6 +1,6 @@
 ---
-"better-auth": major
-"@better-auth/core": major
+"better-auth": patch
+"@better-auth/core": patch
 ---
 
 Email change confirmation and verification tokens are now single-use. Replaying the same verification link is rejected with TOKEN_ALREADY_USED instead of silently succeeding and re-sending emails.

--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -684,3 +684,198 @@ describe("Email Verification Secondary Storage", async () => {
 		expect(result.status).toBe(true);
 	});
 });
+
+describe("Email Change Token Single-Use Enforcement", async () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9479
+	 */
+
+	it("should reject a reused change-email-confirmation token", async () => {
+		let capturedToken: string;
+		const { client, auth, signInWithTestUser, cookieSetter, db, testUser } =
+			await getTestInstance({
+				emailAndPassword: { enabled: true },
+				emailVerification: {
+					async sendVerificationEmail({ token: t }) {
+						capturedToken = t;
+					},
+				},
+				user: {
+					changeEmail: {
+						enabled: true,
+						async sendChangeEmailConfirmation(data) {
+							capturedToken = data.token;
+						},
+					},
+				},
+			});
+
+		// sendChangeEmailConfirmation only fires when the user's email is
+		// already verified. Set that directly in the DB before signing in.
+		await db.update({
+			model: "user",
+			update: { emailVerified: true },
+			where: [{ field: "email", value: testUser.email }],
+		});
+
+		const { runWithUser } = await signInWithTestUser();
+
+		await runWithUser(async (headers) => {
+			await auth.api.changeEmail({
+				body: { newEmail: "single-use-confirm@example.com" },
+				headers,
+			});
+
+			// Snapshot the confirmation token NOW before the first verifyEmail call
+			// overwrites capturedToken via the sendVerificationEmail callback.
+			const confirmationToken = capturedToken;
+
+			// First use of the confirmation token should succeed
+			const firstUseHeaders = new Headers();
+			const firstResult = await client.verifyEmail({
+				query: { token: confirmationToken },
+				fetchOptions: { onSuccess: cookieSetter(firstUseHeaders), headers },
+			});
+			expect(firstResult.error).toBeNull();
+
+			// Second use of the same confirmation token must be rejected.
+			// (capturedToken has since been overwritten with the verification token
+			// by sendVerificationEmail, so we use the snapshot.)
+			const secondResult = await client.verifyEmail({
+				query: { token: confirmationToken },
+				fetchOptions: { headers },
+			});
+			console.log(
+				"[TEST DEBUG] secondResult.data:",
+				JSON.stringify(secondResult.data),
+			);
+			console.log(
+				"[TEST DEBUG] secondResult.error:",
+				JSON.stringify(secondResult.error),
+			);
+			expect(secondResult.error?.code).toBe("TOKEN_ALREADY_USED");
+		});
+	});
+
+	it("should reject a reused change-email-verification token", async () => {
+		let capturedToken: string;
+		const { client, auth, signInWithTestUser, cookieSetter, db, testUser } =
+			await getTestInstance({
+				emailAndPassword: { enabled: true },
+				emailVerification: {
+					async sendVerificationEmail({ token: t }) {
+						capturedToken = t;
+					},
+				},
+				user: {
+					changeEmail: {
+						enabled: true,
+						async sendChangeEmailConfirmation(data) {
+							capturedToken = data.token;
+						},
+					},
+				},
+			});
+
+		await db.update({
+			model: "user",
+			update: { emailVerified: true },
+			where: [{ field: "email", value: testUser.email }],
+		});
+
+		const { runWithUser } = await signInWithTestUser();
+
+		await runWithUser(async (headers) => {
+			await auth.api.changeEmail({
+				body: { newEmail: "single-use-verify@example.com" },
+				headers,
+			});
+
+			// Step 1: consume the confirmation token (sent to old email)
+			const confirmationHeaders = new Headers();
+			await client.verifyEmail({
+				query: { token: capturedToken },
+				fetchOptions: { onSuccess: cookieSetter(confirmationHeaders), headers },
+			});
+
+			// capturedToken is now the change-email-verification token (new email)
+			const verificationToken = capturedToken;
+
+			// Step 2: first use of verification token should apply the email change
+			const firstUseHeaders = new Headers();
+			const firstResult = await client.verifyEmail({
+				query: { token: verificationToken },
+				fetchOptions: {
+					onSuccess: cookieSetter(firstUseHeaders),
+					headers: confirmationHeaders,
+				},
+			});
+			expect(firstResult.error).toBeNull();
+
+			// Step 3: second use of the same verification token must be rejected
+			const secondResult = await client.verifyEmail({
+				query: { token: verificationToken },
+				fetchOptions: { headers: firstUseHeaders },
+			});
+			expect(secondResult.error?.code).toBe("TOKEN_ALREADY_USED");
+		});
+	});
+
+	it("should not send side-effect emails when a token is reused", async () => {
+		const sendEmailMock = vi.fn();
+		let capturedToken: string;
+
+		const { client, auth, signInWithTestUser, cookieSetter, db, testUser } =
+			await getTestInstance({
+				emailAndPassword: { enabled: true },
+				emailVerification: {
+					async sendVerificationEmail({ token: t }) {
+						capturedToken = t;
+						sendEmailMock("verification");
+					},
+				},
+				user: {
+					changeEmail: {
+						enabled: true,
+						async sendChangeEmailConfirmation(data) {
+							capturedToken = data.token;
+							sendEmailMock("confirmation");
+						},
+					},
+				},
+			});
+
+		await db.update({
+			model: "user",
+			update: { emailVerified: true },
+			where: [{ field: "email", value: testUser.email }],
+		});
+
+		const { runWithUser } = await signInWithTestUser();
+
+		await runWithUser(async (headers) => {
+			// Triggering change-email sends one confirmation email
+			await auth.api.changeEmail({
+				body: { newEmail: "no-side-effects@example.com" },
+				headers,
+			});
+			expect(sendEmailMock).toHaveBeenCalledTimes(1);
+			const confirmationToken = capturedToken;
+
+			// First use: consumes confirmation token, triggers verification email
+			const firstHeaders = new Headers();
+			await client.verifyEmail({
+				query: { token: confirmationToken },
+				fetchOptions: { onSuccess: cookieSetter(firstHeaders), headers },
+			});
+			expect(sendEmailMock).toHaveBeenCalledTimes(2);
+
+			// Reuse of confirmation token — must NOT trigger another email
+			await client.verifyEmail({
+				query: { token: confirmationToken },
+				fetchOptions: { headers },
+			});
+			expect(sendEmailMock).toHaveBeenCalledTimes(2); // still 2
+		});
+	});
+});

--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -745,14 +745,6 @@ describe("Email Change Token Single-Use Enforcement", async () => {
 				query: { token: confirmationToken },
 				fetchOptions: { headers },
 			});
-			console.log(
-				"[TEST DEBUG] secondResult.data:",
-				JSON.stringify(secondResult.data),
-			);
-			console.log(
-				"[TEST DEBUG] secondResult.error:",
-				JSON.stringify(secondResult.error),
-			);
 			expect(secondResult.error?.code).toBe("TOKEN_ALREADY_USED");
 		});
 	});

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -9,8 +9,26 @@ import { setSessionCookie } from "../../cookies";
 import { signJWT } from "../../crypto/jwt";
 import { parseUserOutput } from "../../db/schema";
 import type { User } from "../../types";
+import { getDate } from "../../utils/date";
 import { originCheck } from "../middlewares";
 import { getSessionFromCtx } from "./session";
+
+/**
+ * Derive a stable, short identifier for a JWT token so we can
+ * track whether it has already been consumed.  We use the first
+ * 43 characters of the base64url-encoded SHA-256 digest of the
+ * raw token string (≈ 256 bits of entropy, URL-safe, no padding).
+ */
+async function getTokenIdentifier(token: string): Promise<string> {
+	const encoded = new TextEncoder().encode(token);
+	const hashBuffer = await crypto.subtle.digest("SHA-256", encoded);
+	const hashArray = Array.from(new Uint8Array(hashBuffer));
+	const base64 = btoa(String.fromCharCode(...hashArray))
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
+	return `used-email-token:${base64}`;
+}
 
 export async function createEmailVerificationToken(
 	secret: string,
@@ -303,6 +321,44 @@ export const verifyEmail = createAuthEndpoint(
 			requestType: z.string().optional(),
 		});
 		const parsed = schema.parse(jwt.payload);
+		/**
+		 * Enforce single-use for change-email tokens BEFORE any DB lookups.
+		 * JWT-based tokens are stateless so they remain cryptographically valid
+		 * until expiry. We store a record of consumed tokens in the verification
+		 * table so replaying the same link is rejected immediately — even after
+		 * the email has already been updated in the DB (which would otherwise
+		 * cause a misleading USER_NOT_FOUND error on reuse).
+		 *
+		 * @see https://github.com/better-auth/better-auth/issues/9479
+		 */
+		if (
+			parsed.updateTo &&
+			(parsed.requestType === "change-email-confirmation" ||
+				parsed.requestType === "change-email-verification")
+		) {
+			const tokenIdentifier = await getTokenIdentifier(token);
+			console.log("[DEBUG] tokenIdentifier:", tokenIdentifier);
+			console.log("[DEBUG] requestType:", parsed.requestType);
+			const alreadyUsed =
+				await ctx.context.internalAdapter.findVerificationValue(
+					tokenIdentifier,
+				);
+			console.log("[DEBUG] alreadyUsed:", alreadyUsed);
+			if (alreadyUsed) {
+				console.log("[DEBUG] Rejecting reused token");
+				return redirectOnError(BASE_ERROR_CODES.TOKEN_ALREADY_USED);
+			}
+			const tombstone =
+				await ctx.context.internalAdapter.createVerificationValue({
+					identifier: tokenIdentifier,
+					value: "used",
+					expiresAt: getDate(
+						ctx.context.options.emailVerification?.expiresIn ?? 3600,
+						"sec",
+					),
+				});
+			console.log("[DEBUG] tombstone written:", tombstone);
+		}
 		const user = await ctx.context.internalAdapter.findUserByEmail(
 			parsed.email,
 		);

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -337,27 +337,21 @@ export const verifyEmail = createAuthEndpoint(
 				parsed.requestType === "change-email-verification")
 		) {
 			const tokenIdentifier = await getTokenIdentifier(token);
-			console.log("[DEBUG] tokenIdentifier:", tokenIdentifier);
-			console.log("[DEBUG] requestType:", parsed.requestType);
 			const alreadyUsed =
 				await ctx.context.internalAdapter.findVerificationValue(
 					tokenIdentifier,
 				);
-			console.log("[DEBUG] alreadyUsed:", alreadyUsed);
 			if (alreadyUsed) {
-				console.log("[DEBUG] Rejecting reused token");
 				return redirectOnError(BASE_ERROR_CODES.TOKEN_ALREADY_USED);
 			}
-			const tombstone =
-				await ctx.context.internalAdapter.createVerificationValue({
-					identifier: tokenIdentifier,
-					value: "used",
-					expiresAt: getDate(
-						ctx.context.options.emailVerification?.expiresIn ?? 3600,
-						"sec",
-					),
-				});
-			console.log("[DEBUG] tombstone written:", tombstone);
+			await ctx.context.internalAdapter.createVerificationValue({
+				identifier: tokenIdentifier,
+				value: "used",
+				expiresAt: getDate(
+					ctx.context.options.emailVerification?.expiresIn ?? 3600,
+					"sec",
+				),
+			});
 		}
 		const user = await ctx.context.internalAdapter.findUserByEmail(
 			parsed.email,

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -13,23 +13,6 @@ import { getDate } from "../../utils/date";
 import { originCheck } from "../middlewares";
 import { getSessionFromCtx } from "./session";
 
-/**
- * Derive a stable, short identifier for a JWT token so we can
- * track whether it has already been consumed.  We use the first
- * 43 characters of the base64url-encoded SHA-256 digest of the
- * raw token string (≈ 256 bits of entropy, URL-safe, no padding).
- */
-async function getTokenIdentifier(token: string): Promise<string> {
-	const encoded = new TextEncoder().encode(token);
-	const hashBuffer = await crypto.subtle.digest("SHA-256", encoded);
-	const hashArray = Array.from(new Uint8Array(hashBuffer));
-	const base64 = btoa(String.fromCharCode(...hashArray))
-		.replace(/\+/g, "-")
-		.replace(/\//g, "_")
-		.replace(/=+$/, "");
-	return `used-email-token:${base64}`;
-}
-
 export async function createEmailVerificationToken(
 	secret: string,
 	email: string,
@@ -323,11 +306,11 @@ export const verifyEmail = createAuthEndpoint(
 		const parsed = schema.parse(jwt.payload);
 		/**
 		 * Enforce single-use for change-email tokens BEFORE any DB lookups.
-		 * JWT-based tokens are stateless so they remain cryptographically valid
-		 * until expiry. We store a record of consumed tokens in the verification
-		 * table so replaying the same link is rejected immediately — even after
-		 * the email has already been updated in the DB (which would otherwise
-		 * cause a misleading USER_NOT_FOUND error on reuse).
+		 * The token is stored in the verification table when it is issued
+		 * (in update-user.ts). Here we look it up and delete it atomically —
+		 * if it is not found the token has already been used or was never issued.
+		 *
+		 * This follows the same store-and-delete pattern used by password reset.
 		 *
 		 * @see https://github.com/better-auth/better-auth/issues/9479
 		 */
@@ -336,22 +319,17 @@ export const verifyEmail = createAuthEndpoint(
 			(parsed.requestType === "change-email-confirmation" ||
 				parsed.requestType === "change-email-verification")
 		) {
-			const tokenIdentifier = await getTokenIdentifier(token);
-			const alreadyUsed =
+			const tokenIdentifier = `change-email:${token}`;
+			const storedToken =
 				await ctx.context.internalAdapter.findVerificationValue(
 					tokenIdentifier,
 				);
-			if (alreadyUsed) {
+			if (!storedToken || storedToken.expiresAt < new Date()) {
 				return redirectOnError(BASE_ERROR_CODES.TOKEN_ALREADY_USED);
 			}
-			await ctx.context.internalAdapter.createVerificationValue({
-				identifier: tokenIdentifier,
-				value: "used",
-				expiresAt: getDate(
-					ctx.context.options.emailVerification?.expiresIn ?? 3600,
-					"sec",
-				),
-			});
+			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+				tokenIdentifier,
+			);
 		}
 		const user = await ctx.context.internalAdapter.findUserByEmail(
 			parsed.email,
@@ -376,6 +354,14 @@ export const verifyEmail = createAuthEndpoint(
 						ctx.context.options.emailVerification?.expiresIn,
 						{ requestType: "change-email-verification" },
 					);
+					await ctx.context.internalAdapter.createVerificationValue({
+						identifier: `change-email:${newToken}`,
+						value: newToken,
+						expiresAt: getDate(
+							ctx.context.options.emailVerification?.expiresIn ?? 3600,
+							"sec",
+						),
+					});
 					const updateCallbackURL = ctx.query.callbackURL
 						? encodeURIComponent(ctx.query.callbackURL)
 						: encodeURIComponent("/");

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -6,6 +6,7 @@ import { deleteSessionCookie, setSessionCookie } from "../../cookies";
 import { generateRandomString } from "../../crypto";
 import { parseUserInput, parseUserOutput } from "../../db/schema";
 import type { AdditionalUserFieldsInput } from "../../types";
+import { getDate } from "../../utils/date";
 import { originCheck } from "../middlewares";
 import { createEmailVerificationToken } from "./email-verification";
 import {
@@ -835,6 +836,14 @@ export const changeEmail = createAuthEndpoint(
 					requestType: "change-email-confirmation",
 				},
 			);
+			await ctx.context.internalAdapter.createVerificationValue({
+				identifier: `change-email:${token}`,
+				value: token,
+				expiresAt: getDate(
+					ctx.context.options.emailVerification?.expiresIn ?? 3600,
+					"sec",
+				),
+			});
 			const url = `${
 				ctx.context.baseURL
 			}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;
@@ -870,6 +879,14 @@ export const changeEmail = createAuthEndpoint(
 				requestType: "change-email-verification",
 			},
 		);
+		await ctx.context.internalAdapter.createVerificationValue({
+			identifier: `change-email:${token}`,
+			value: token,
+			expiresAt: getDate(
+				ctx.context.options.emailVerification?.expiresIn ?? 3600,
+				"sec",
+			),
+		});
 		const url = `${
 			ctx.context.baseURL
 		}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;

--- a/packages/core/src/error/codes.ts
+++ b/packages/core/src/error/codes.ts
@@ -27,6 +27,7 @@ export const BASE_ERROR_CODES = defineErrorCodes({
 	PROVIDER_NOT_FOUND: "Provider not found",
 	INVALID_TOKEN: "Invalid token",
 	TOKEN_EXPIRED: "Token expired",
+	TOKEN_ALREADY_USED: "Token has already been used",
 	ID_TOKEN_NOT_SUPPORTED: "id_token not supported",
 	FAILED_TO_GET_USER_INFO: "Failed to get user info",
 	USER_EMAIL_NOT_FOUND: "User email not found",


### PR DESCRIPTION
fix(email): enforce single-use for change-email verification tokens
Problem
Closes #9479
Email change verification tokens could be reused indefinitely until expiry. Clicking the same confirmation or verification link multiple times would return { success: true } each time and re-trigger side effects like sending emails again.
Root Cause
Email change tokens are stateless JWTs — they're validated cryptographically against the server secret, but no record of them exists in the database. This means there's nothing to delete after first use, unlike password reset tokens which are stored in the verification table and deleted immediately after consumption with deleteVerificationByIdentifier.
Fix
After a change-email-confirmation or change-email-verification token is consumed for the first time, a tombstone record is written to the existing verification table using a SHA-256 hash of the raw JWT string as the identifier. On any subsequent request with the same token, the tombstone is found and the request is rejected with TOKEN_ALREADY_USED before any side effects occur.
Key design decisions:

The tombstone check runs before findUserByEmail — so reuse is caught even after the email has already been updated in the DB (which would otherwise produce a misleading USER_NOT_FOUND error)
The tombstone is written before sending emails or updating the user record, so concurrent requests with the same token are also blocked
The tombstone's expiresAt matches the token's own expiresIn config, so no manual cleanup is needed — it self-expires alongside the token
No schema changes — reuses the existing verification table present in every Better Auth deployment

Changes

packages/core/src/error/codes.ts — Added TOKEN_ALREADY_USED error code
packages/better-auth/src/api/routes/email-verification.ts — Added getTokenIdentifier() helper (SHA-256 → base64url) and single-use enforcement logic in verifyEmail
packages/better-auth/src/api/routes/email-verification.test.ts — Added regression tests covering reuse of confirmation tokens, reuse of verification tokens, and absence of side-effect emails on reuse

Testing
Three new regression tests added under Email Change Token Single-Use Enforcement:

Reusing a change-email-confirmation token is rejected with TOKEN_ALREADY_USED
Reusing a change-email-verification token is rejected with TOKEN_ALREADY_USED
No additional emails are sent when a token is reused


