### PR TITLE
fix(stripe)!: make `onSubscriptionCancel.event` required

### DIFF
--- a/.changeset/restore-stripe-cancel-event-required.md
+++ b/.changeset/restore-stripe-cancel-event-required.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/stripe": minor
+---
+
+The `onSubscriptionCancel` callback's `event` parameter is now required, consistent with the other subscription lifecycle callbacks. Update your callback to declare `event` as a required parameter and remove any `undefined` guards around it.

--- a/packages/stripe/CHANGELOG.md
+++ b/packages/stripe/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 1.7.0-beta.3
 
-### Minor Changes
-
-- [#9359](https://github.com/better-auth/better-auth/pull/9359) [`a9d48c9`](https://github.com/better-auth/better-auth/commit/a9d48c993de0fc2b9ba5829c9cb985716ce00c45) Thanks [@bytaesu](https://github.com/bytaesu)! - `onSubscriptionCancel` callback `event` is no longer marked optional, consistent with all other subscription lifecycle callbacks. The only call site always provides an event, so the optional marker was inaccurate.
-
 ### Patch Changes
 
 - Updated dependencies [[`4e8e4c7`](https://github.com/better-auth/better-auth/commit/4e8e4c7fc5fb2723144cbf41c4a1bfa28de8d671), [`523f95c`](https://github.com/better-auth/better-auth/commit/523f95c10db24b790bbd75fe85c86c34d3465267), [`729c00d`](https://github.com/better-auth/better-auth/commit/729c00d74c94f558893da1e3a9ee86451d1b23da)]:

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -309,7 +309,7 @@ export type SubscriptionOptions = {
 	 */
 	onSubscriptionCancel?:
 		| ((data: {
-				event?: Stripe.Event;
+				event: Stripe.Event;
 				stripeSubscription: Stripe.Subscription;
 				subscription: Subscription;
 				cancellationDetails?: Stripe.Subscription.CancellationDetails | null;


### PR DESCRIPTION
There was a tiny regression here caused during a huge conflict resolution while handling conflicts that had built up over the past two weeks. Since this isn't an urgent fix, I'm dropping the changeset and will reintroduce it in the next beta 🙏