### PR TITLE
fix cookies with semicolon-only separators

### DIFF
--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -494,6 +494,18 @@ describe("getSessionCookie", async () => {
 		expect(cookies).toBeDefined();
 	});
 
+	it("should parse cookie headers without spaces after semicolons", () => {
+		const headers = new Headers({
+			cookie:
+				"better-auth.session_token=token-123;better-auth.session_data=data",
+		});
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+
+		expect(getSessionCookie(request)).toBe("token-123");
+	});
+
 	describe.each([".", "-"])("with '%s' separator", (separator) => {
 		describe.each([
 			["", "regular"],

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -357,7 +357,7 @@ export function deleteSessionCookie(
 }
 
 export function parseCookies(cookieHeader: string) {
-	const cookies = cookieHeader.split("; ");
+	const cookies = cookieHeader.split(/;\s*/);
 	const cookieMap = new Map<string, string>();
 
 	cookies.forEach((cookie) => {

--- a/packages/better-auth/src/cookies/session-store.ts
+++ b/packages/better-auth/src/cookies/session-store.ts
@@ -33,7 +33,7 @@ function parseCookiesFromContext(
 	}
 
 	const cookies: Record<string, string> = {};
-	const pairs = cookieHeader.split("; ");
+	const pairs = cookieHeader.split(/;\s*/);
 
 	for (const pair of pairs) {
 		const [name, ...valueParts] = pair.split("=");
@@ -248,7 +248,7 @@ export function getChunkedCookie(
 	}
 
 	const cookies: Record<string, string> = {};
-	const pairs = cookieHeader.split("; ");
+	const pairs = cookieHeader.split(/;\s*/);
 	for (const pair of pairs) {
 		const [name, ...valueParts] = pair.split("=");
 		if (name && valueParts.length > 0) {


### PR DESCRIPTION
Fixes #9465

Cookie parsing now accepts both `; ` and `;` separators, which covers AWS Lambda Web Adapter/API Gateway headers.

Changed:
- parse cookies with `/;\s*/` in session cookie lookup and chunked cookie parsing
- add a regression test for `Cookie` headers without spaces

Testing:
- `pnpm --filter @better-auth/core build`
- `node --input-type=module` smoke check against `dist/cookies/index.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cookie parsing to accept semicolon-only separators in Cookie headers. This restores session and chunked cookie handling for AWS Lambda Web Adapter/API Gateway.

- **Bug Fixes**
  - Updated cookie splitting to use /;\s*/ in `parseCookies`, `parseCookiesFromContext`, and `getChunkedCookie`.
  - Added a regression test to cover headers like "a=b;c=d" (no spaces).

<sup>Written for commit 4c4dba2a0dbf0b2e0bbeac161bdf2dcd16510025. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

