### PR TITLE
feat: require verified emails for OAuth sessions

### DIFF
--- a/.changeset/fix-oauth-require-email-verification.md
+++ b/.changeset/fix-oauth-require-email-verification.md
@@ -1,5 +1,6 @@
 ---
 "better-auth": minor
+"@better-auth/core": minor
 ---
 
 Respect requireEmailVerification before creating OAuth callback sessions and add socialProviders.requireEmailVerification.

--- a/.changeset/fix-oauth-require-email-verification.md
+++ b/.changeset/fix-oauth-require-email-verification.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Respect requireEmailVerification before creating OAuth callback sessions and add socialProviders.requireEmailVerification.

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -166,8 +166,10 @@ Once the user clicks on the link in the email, if the token is valid, the user w
 If you enable require email verification, users must verify their email before they can log in. And every time a user tries to sign in, sendVerificationEmail is called.
 
 <Callout>
-  This only works if you have sendVerificationEmail implemented and if the user
-  is trying to sign in with email and password.
+  For email and password sign-in, this only works if you have
+  sendVerificationEmail implemented. Social sign-in follows this setting when
+  `socialProviders.requireEmailVerification` is not set. See
+  [OAuth email verification](/docs/concepts/oauth#require-verified-emails).
 
   When `requireEmailVerification` is enabled, signing up with an existing email returns a success response instead of an error to prevent user enumeration.
 </Callout>

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -49,6 +49,49 @@ await auth.api.signInSocial({
 });
 ```
 
+### Require Verified Emails
+
+To require verified provider emails before creating OAuth sessions, set
+`requireEmailVerification` on `socialProviders`.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  socialProviders: {
+    requireEmailVerification: true,
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    },
+  },
+});
+```
+
+When this is enabled, Better Auth still creates or links the user and account,
+but it does not create a session if the provider reports the email as
+unverified. OAuth callbacks redirect with `error=email_not_verified`, and
+ID token sign-in returns `EMAIL_NOT_VERIFIED`.
+
+If `socialProviders.requireEmailVerification` is not set, OAuth sign-in follows
+`emailAndPassword.requireEmailVerification`. Set
+`socialProviders.requireEmailVerification` to `false` if you want to require
+email verification for email and password sign-in without requiring it for
+social sign-in.
+
+If `emailVerification.sendVerificationEmail` is configured, Better Auth sends a
+verification email to new unverified OAuth users when this requirement is
+enabled, unless `emailVerification.sendOnSignUp` is set to `false`. For existing
+unverified users, set `emailVerification.sendOnSignIn` to `true` to send a new
+verification email on sign-in attempts.
+
+<Callout type="info">
+  Some providers do not expose a trustworthy email verification signal and are
+  treated as unverified. See
+  [Handling Providers Without Email](/docs/concepts/oauth#handling-providers-without-email)
+  for provider-specific notes.
+</Callout>
+
 ### Link account
 
 To link an account to a social provider, you can use the `linkAccount` function with the `authClient` or `auth.api` for server-side usage.

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -324,6 +324,7 @@ Configure social login providers.
 import { betterAuth } from "better-auth";
 export const auth = betterAuth({
 	socialProviders: {
+		requireEmailVerification: true,
 		google: {
 			clientId: "your-client-id",
 			clientSecret: "your-client-secret",
@@ -338,6 +339,7 @@ export const auth = betterAuth({
 })
 ```
 
+* `requireEmailVerification`: Require emails returned by social providers to be verified before a session can be created. When unset, social sign-in follows `emailAndPassword.requireEmailVerification` (optional)
 * `clientId`: OAuth client ID from the provider
 * `clientSecret`: OAuth client secret from the provider
 * `clientKey`: Client key (used by some providers like TikTok instead of clientId) (optional)

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -288,6 +288,9 @@ export const callbackOAuth = createAuthEndpoint(
 				(provider.disableImplicitSignUp && !requestSignUp) ||
 				provider.options?.disableSignUp,
 			overrideUserInfo: provider.options?.overrideUserInfoOnSignIn,
+			requireEmailVerification:
+				c.context.options.socialProviders?.requireEmailVerification ??
+				c.context.options.emailAndPassword?.requireEmailVerification,
 		});
 		if (result.error) {
 			c.context.logger.error(result.error.split(" ").join("_"));

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -320,6 +320,12 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						c.context.options.emailAndPassword?.requireEmailVerification,
 				});
 				if (data.error) {
+					if (data.error === "email not verified") {
+						throw APIError.from(
+							"FORBIDDEN",
+							BASE_ERROR_CODES.EMAIL_NOT_VERIFIED,
+						);
+					}
 					throw APIError.from("UNAUTHORIZED", {
 						message: data.error,
 						code: "OAUTH_LINK_ERROR",

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -315,6 +315,9 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 					disableSignUp:
 						(provider.disableImplicitSignUp && !c.body.requestSignUp) ||
 						provider.disableSignUp,
+					requireEmailVerification:
+						c.context.options.socialProviders?.requireEmailVerification ??
+						c.context.options.emailAndPassword?.requireEmailVerification,
 				});
 				if (data.error) {
 					throw APIError.from("UNAUTHORIZED", {

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -194,12 +194,15 @@ Most of the features of Better Auth will not work correctly.`,
 			(
 				Object.entries(
 					options.socialProviders || {},
-				) as unknown as Entries<SocialProviders>
+				) as Entries<SocialProviders>
 			).map(async ([key, originalConfig]) => {
-				const config =
+				if (key === "requireEmailVerification") {
+					return null;
+				}
+				const config: any =
 					typeof originalConfig === "function"
 						? await originalConfig()
-						: originalConfig;
+						: (originalConfig as any);
 				if (config == null) {
 					return null;
 				}
@@ -211,7 +214,12 @@ Most of the features of Better Auth will not work correctly.`,
 						`Social provider ${key} is missing clientId or clientSecret`,
 					);
 				}
-				const provider = socialProviders[key](config as never);
+				const providerFactory =
+					socialProviders[key as keyof typeof socialProviders];
+				if (!providerFactory) {
+					return null;
+				}
+				const provider = providerFactory(config as never);
 				(provider as OAuthProvider).disableImplicitSignUp =
 					config.disableImplicitSignUp;
 				return provider as OAuthProvider;

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -217,6 +217,9 @@ Most of the features of Better Auth will not work correctly.`,
 				const providerFactory =
 					socialProviders[key as keyof typeof socialProviders];
 				if (!providerFactory) {
+					logger.warn(
+						`Unknown social provider "${key}" in options.socialProviders; this entry will be ignored.`,
+					);
 					return null;
 				}
 				const provider = providerFactory(config as never);

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -13,6 +13,7 @@ import {
 	it,
 	vi,
 } from "vitest";
+import { parseSetCookieHeader } from "../cookies";
 import { signJWT } from "../crypto";
 import { getTestInstance } from "../test-utils/test-instance";
 import type { User } from "../types";
@@ -32,6 +33,177 @@ afterEach(() => {
 });
 
 afterAll(() => server.close());
+
+describe("oauth2 - require email verification before session creation", async () => {
+	async function setupOAuthCallback({
+		sendVerificationEmail = vi.fn(async () => {}),
+		sendOnSignIn,
+		emailPasswordRequireEmailVerification = true,
+		socialRequireEmailVerification,
+	}: {
+		sendVerificationEmail?: ((...args: any[]) => Promise<void>) | undefined;
+		sendOnSignIn?: boolean | undefined;
+		emailPasswordRequireEmailVerification?: boolean | undefined;
+		socialRequireEmailVerification?: boolean | undefined;
+	} = {}) {
+		const { auth, client, cookieSetter } = await getTestInstance(
+			{
+				socialProviders: {
+					requireEmailVerification: socialRequireEmailVerification,
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+						enabled: true,
+					},
+				},
+				emailAndPassword: {
+					enabled: true,
+					requireEmailVerification: emailPasswordRequireEmailVerification,
+				},
+				emailVerification: {
+					sendOnSignIn,
+					sendVerificationEmail,
+				},
+			},
+			{
+				disableTestUser: true,
+			},
+		);
+		const ctx = await auth.$context;
+
+		async function callbackWithProfile(profile: {
+			email: string;
+			email_verified: boolean;
+			name: string;
+			sub: string;
+		}) {
+			server.use(
+				http.post("https://oauth2.googleapis.com/token", async () => {
+					const idToken = await signJWT(
+						{
+							...profile,
+							iat: 1234567890,
+							exp: 1234567890,
+							aud: "test",
+							iss: "test",
+						},
+						DEFAULT_SECRET,
+					);
+					return HttpResponse.json({
+						access_token: "test_access_token",
+						refresh_token: "test_refresh_token",
+						id_token: idToken,
+					});
+				}),
+			);
+
+			const headers = new Headers();
+			const signInRes = await client.signIn.social({
+				provider: "google",
+				callbackURL: "/dashboard",
+				newUserCallbackURL: "/welcome",
+				fetchOptions: {
+					onSuccess: cookieSetter(headers),
+				},
+			});
+			const state =
+				new URL(signInRes.data!.url!).searchParams.get("state") || "";
+
+			let redirectLocation = "";
+			let setCookie = "";
+			await client.$fetch("/callback/google", {
+				query: { state, code: "test_code" },
+				method: "GET",
+				headers,
+				onError(context) {
+					expect(context.response.status).toBe(302);
+					redirectLocation = context.response.headers.get("location") || "";
+					setCookie = context.response.headers.get("set-cookie") || "";
+				},
+			});
+
+			return { redirectLocation, setCookie };
+		}
+
+		return { callbackWithProfile, ctx };
+	}
+
+	it("should block session creation for a new OAuth user with an unverified provider email", async () => {
+		const sendVerificationEmail = vi.fn(async () => {});
+		const { callbackWithProfile, ctx } = await setupOAuthCallback({
+			emailPasswordRequireEmailVerification: false,
+			sendVerificationEmail,
+			socialRequireEmailVerification: true,
+		});
+		const email = "oauth-unverified-new@example.com";
+
+		const { redirectLocation, setCookie } = await callbackWithProfile({
+			email,
+			email_verified: false,
+			name: "OAuth Unverified",
+			sub: "oauth_unverified_new",
+		});
+
+		expect(redirectLocation).toContain("error=email_not_verified");
+		expect(
+			parseSetCookieHeader(setCookie).get("better-auth.session_token")?.value,
+		).toBeUndefined();
+		expect(sendVerificationEmail).toHaveBeenCalledTimes(1);
+
+		const user = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: email }],
+		});
+		expect(user?.emailVerified).toBe(false);
+	});
+
+	it("should create a session for a new OAuth user with a verified provider email", async () => {
+		const sendVerificationEmail = vi.fn(async () => {});
+		const { callbackWithProfile } = await setupOAuthCallback({
+			emailPasswordRequireEmailVerification: false,
+			sendVerificationEmail,
+			socialRequireEmailVerification: true,
+		});
+
+		const { redirectLocation, setCookie } = await callbackWithProfile({
+			email: "oauth-verified-new@example.com",
+			email_verified: true,
+			name: "OAuth Verified",
+			sub: "oauth_verified_new",
+		});
+
+		expect(redirectLocation).toContain("/welcome");
+		expect(
+			parseSetCookieHeader(setCookie).get("better-auth.session_token")?.value,
+		).toBeDefined();
+		expect(sendVerificationEmail).not.toHaveBeenCalled();
+	});
+
+	it("should block session creation for an existing linked OAuth user whose email remains unverified", async () => {
+		const sendVerificationEmail = vi.fn(async () => {});
+		const { callbackWithProfile } = await setupOAuthCallback({
+			sendOnSignIn: true,
+			sendVerificationEmail,
+		});
+		const profile = {
+			email: "oauth-unverified-existing@example.com",
+			email_verified: false,
+			name: "OAuth Unverified Existing",
+			sub: "oauth_unverified_existing",
+		};
+
+		await callbackWithProfile(profile);
+		sendVerificationEmail.mockClear();
+
+		const { redirectLocation, setCookie } = await callbackWithProfile(profile);
+
+		expect(redirectLocation).toContain("error=email_not_verified");
+		expect(
+			parseSetCookieHeader(setCookie).get("better-auth.session_token")?.value,
+		).toBeUndefined();
+		expect(sendVerificationEmail).toHaveBeenCalledTimes(1);
+	});
+});
 
 describe("oauth2 - email verification on link", async () => {
 	const { auth, client, cookieSetter } = await getTestInstance({

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -266,14 +266,17 @@ describe("oauth2 - email verification on link", async () => {
 			},
 		});
 		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		let redirectLocation = "";
 		await client.$fetch("/callback/google", {
 			query: { state, code: "test_code" },
 			method: "GET",
 			headers: oAuthHeaders,
 			onError(context) {
 				expect(context.response.status).toBe(302);
+				redirectLocation = context.response.headers.get("location") || "";
 			},
 		});
+		return redirectLocation;
 	}
 
 	it("should update emailVerified when linking account with verified email", async () => {
@@ -300,7 +303,7 @@ describe("oauth2 - email verification on link", async () => {
 
 		// Link with Google account that has verified email
 		mockEmailVerified = true;
-		await linkGoogleAccount();
+		const redirectLocation = await linkGoogleAccount();
 
 		// Verify email is now verified
 		user = await ctx.adapter.findOne<User>({
@@ -308,6 +311,7 @@ describe("oauth2 - email verification on link", async () => {
 			where: [{ field: "id", value: userId }],
 		});
 		expect(user?.emailVerified).toBe(true);
+		expect(redirectLocation).not.toContain("error=email_not_verified");
 	});
 
 	it("should not update emailVerified when provider reports unverified", async () => {

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -17,6 +17,7 @@ export async function handleOAuthUserInfo(
 		disableSignUp?: boolean | undefined;
 		overrideUserInfo?: boolean | undefined;
 		isTrustedProvider?: boolean | undefined;
+		requireEmailVerification?: boolean | undefined;
 	},
 ) {
 	const { userInfo, account, callbackURL, disableSignUp, overrideUserInfo } =
@@ -182,10 +183,14 @@ export async function handleOAuthUserInfo(
 			if (c.context.options.account?.storeAccountCookie) {
 				await setAccountCookie(c, createdAccount);
 			}
+			const shouldSendVerificationEmail =
+				c.context.options.emailVerification?.sendOnSignUp ??
+				opts.requireEmailVerification ??
+				c.context.options.emailAndPassword?.requireEmailVerification;
 			if (
 				!userInfo.emailVerified &&
 				user &&
-				c.context.options.emailVerification?.sendOnSignUp &&
+				shouldSendVerificationEmail &&
 				c.context.options.emailVerification?.sendVerificationEmail
 			) {
 				const token = await createEmailVerificationToken(
@@ -227,6 +232,41 @@ export async function handleOAuthUserInfo(
 			error: "unable to create user",
 			data: null,
 			isRegister: false,
+		};
+	}
+
+	if (
+		(opts.requireEmailVerification ??
+			c.context.options.emailAndPassword?.requireEmailVerification) &&
+		!user.emailVerified
+	) {
+		if (
+			!isRegister &&
+			c.context.options.emailVerification?.sendOnSignIn &&
+			c.context.options.emailVerification?.sendVerificationEmail
+		) {
+			const token = await createEmailVerificationToken(
+				c.context.secret,
+				user.email,
+				undefined,
+				c.context.options.emailVerification?.expiresIn,
+			);
+			const url = `${c.context.baseURL}/verify-email?token=${token}&callbackURL=${callbackURL}`;
+			await c.context.runInBackgroundOrAwait(
+				c.context.options.emailVerification.sendVerificationEmail(
+					{
+						user,
+						url,
+						token,
+					},
+					c.request,
+				),
+			);
+		}
+		return {
+			error: "email not verified",
+			data: null,
+			isRegister,
 		};
 	}
 

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -22,6 +22,11 @@ export async function handleOAuthUserInfo(
 ) {
 	const { userInfo, account, callbackURL, disableSignUp, overrideUserInfo } =
 		opts;
+	const getVerificationURL = (token: string) =>
+		`${c.context.baseURL}/verify-email?${new URLSearchParams({
+			token,
+			callbackURL: String(callbackURL),
+		})}`;
 	const dbUser = await c.context.internalAdapter
 		.findOAuthUser(
 			userInfo.email.toLowerCase(),
@@ -93,7 +98,7 @@ export async function handleOAuthUserInfo(
 				!dbUser.user.emailVerified &&
 				userInfo.email.toLowerCase() === dbUser.user.email
 			) {
-				await c.context.internalAdapter.updateUser(dbUser.user.id, {
+				user = await c.context.internalAdapter.updateUser(dbUser.user.id, {
 					emailVerified: true,
 				});
 			}
@@ -134,7 +139,7 @@ export async function handleOAuthUserInfo(
 				!dbUser.user.emailVerified &&
 				userInfo.email.toLowerCase() === dbUser.user.email
 			) {
-				await c.context.internalAdapter.updateUser(dbUser.user.id, {
+				user = await c.context.internalAdapter.updateUser(dbUser.user.id, {
 					emailVerified: true,
 				});
 			}
@@ -199,7 +204,7 @@ export async function handleOAuthUserInfo(
 					undefined,
 					c.context.options.emailVerification?.expiresIn,
 				);
-				const url = `${c.context.baseURL}/verify-email?token=${token}&callbackURL=${callbackURL}`;
+				const url = getVerificationURL(token);
 				await c.context.runInBackgroundOrAwait(
 					c.context.options.emailVerification.sendVerificationEmail(
 						{
@@ -251,7 +256,7 @@ export async function handleOAuthUserInfo(
 				undefined,
 				c.context.options.emailVerification?.expiresIn,
 			);
-			const url = `${c.context.baseURL}/verify-email?token=${token}&callbackURL=${callbackURL}`;
+			const url = getVerificationURL(token);
 			await c.context.runInBackgroundOrAwait(
 				c.context.options.emailVerification.sendVerificationEmail(
 					{

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -1009,12 +1009,21 @@ describe("Google Provider — multiple client IDs", async () => {
 	const iosClientId = "456-ios.googleusercontent.com";
 	const androidClientId = "789-android.googleusercontent.com";
 
-	const signIdToken = (audience: string) =>
+	const signIdToken = (
+		audience: string,
+		payload?: {
+			email?: string;
+			email_verified?: boolean;
+			name?: string;
+			sub?: string;
+		},
+	) =>
 		new SignJWT({
 			email: "mobile-user@example.com",
 			email_verified: true,
 			name: "Mobile User",
 			sub: "google-sub-999",
+			...payload,
 		})
 			.setProtectedHeader({ alg: "RS256", kid: googleKid })
 			.setIssuedAt()
@@ -1058,6 +1067,39 @@ describe("Google Provider — multiple client IDs", async () => {
 		expect(res.data!.redirect).toBe(false);
 		const data = res.data as { user: { email: string } };
 		expect(data.user.email).toBe("mobile-user@example.com");
+	});
+
+	it("returns EMAIL_NOT_VERIFIED for an unverified id token when social verification is required", async () => {
+		const idToken = await signIdToken(webClientId, {
+			email: "mobile-unverified@example.com",
+			email_verified: false,
+			name: "Mobile Unverified",
+			sub: "google-sub-unverified",
+		});
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					requireEmailVerification: true,
+					google: {
+						clientId: [webClientId, iosClientId, androidClientId],
+						clientSecret: "test-secret",
+					},
+				},
+				emailAndPassword: {
+					enabled: true,
+					requireEmailVerification: false,
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const res = await client.signIn.social({
+			provider: "google",
+			idToken: { token: idToken },
+		});
+
+		expect(res.error?.status).toBe(403);
+		expect(res.error?.code).toBe("EMAIL_NOT_VERIFIED");
 	});
 
 	it("rejects an id token whose audience is not configured", async () => {

--- a/packages/core/src/social-providers/index.ts
+++ b/packages/core/src/social-providers/index.ts
@@ -86,6 +86,13 @@ export const SocialProviderListEnum = z
 export type SocialProvider = z.infer<typeof SocialProviderListEnum>;
 
 export type SocialProviders = {
+	/**
+	 * Require emails returned by social providers to be verified before a session
+	 * can be created. When unset, social sign-in follows
+	 * `emailAndPassword.requireEmailVerification`.
+	 */
+	requireEmailVerification?: boolean | undefined;
+} & {
 	[K in SocialProviderList[number]]?: AwaitableFunction<
 		Parameters<(typeof socialProviders)[K]>[0] & {
 			enabled?: boolean | undefined;

--- a/packages/telemetry/src/detectors/detect-auth-config.ts
+++ b/packages/telemetry/src/detectors/detect-auth-config.ts
@@ -41,12 +41,13 @@ export async function getTelemetryAuthConfig(
 		},
 		socialProviders: await Promise.all(
 			Object.keys(options.socialProviders || {}).map(async (key) => {
+				if (key === "requireEmailVerification") return {};
 				const p =
 					options.socialProviders?.[
 						key as keyof typeof options.socialProviders
 					];
 				if (!p) return {};
-				const provider = typeof p === "function" ? await p() : p;
+				const provider: any = typeof p === "function" ? await p() : p;
 				return {
 					id: key,
 					mapProfileToUser: !!provider.mapProfileToUser,


### PR DESCRIPTION
## Summary

Closes #9486.

Adds support for `socialProviders.requireEmailVerification` and applies email verification requirements before creating OAuth/social login sessions.

When enabled, OAuth users whose provider email is not verified no longer receive a session. The flow still creates/links the user/account as before, sends verification email when configured, and redirects with `email_not_verified` instead of issuing a session token.

The OAuth flow also falls back to `emailAndPassword.requireEmailVerification` when `socialProviders.requireEmailVerification` is not set.

## Changes

- Thread `requireEmailVerification` through OAuth callback and social sign-in flows
- Add the unverified-email guard before session creation in `handleOAuthUserInfo`
- Add `socialProviders.requireEmailVerification` to the public social provider config type
- Skip the new social provider config key during provider initialization
- Add regression tests for unverified OAuth users and verified OAuth happy path
- Add a minor changeset

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require verified emails before creating OAuth sessions. Adds `socialProviders.requireEmailVerification`, enforces it in OAuth callbacks and `signIn.social` (including id-token), and updates docs to explain behavior and fallback.

- **New Features**
  - Added `socialProviders.requireEmailVerification`; falls back to `emailAndPassword.requireEmailVerification` when unset.
  - Enforced in OAuth callback and social sign-in: unverified users are created/linked, verification emails are sent on sign-up/sign-in per `emailVerification` settings, redirects include `error=email_not_verified` with no session cookie, and direct sign-in calls return 403 `EMAIL_NOT_VERIFIED`.
  - Provider init ignores the top-level flag and warns on unknown provider keys; telemetry detection skips `requireEmailVerification`.
  - Docs: added OAuth email verification guidance, fallback behavior, and options reference updates; tests cover new/existing unverified users and Google multi-client-ID id-token cases.

<sup>Written for commit 8f2404b95f2ecd4872ee4e7f16857ab77a253c38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

