### PR TITLE
chore(ci): use ubuntu-24.04 fallback runner for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   lint:
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     concurrency:
@@ -91,7 +91,7 @@ jobs:
         run: pnpm lint:types
 
   typecheck:
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     concurrency:
@@ -132,7 +132,7 @@ jobs:
         run: pnpm typecheck:dist
 
   test:
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     timeout-minutes: 30
@@ -185,4 +185,3 @@ jobs:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-             

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.review.author_association)) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.issue.author_association))
       )
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: write
       pull-requests: write
@@ -53,4 +53,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
   smoke:
     name: Smoke test (${{ matrix.node-version }})
     timeout-minutes: 30
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +72,7 @@ jobs:
   integration:
     name: Integration test
     timeout-minutes: 60
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     steps:
@@ -113,7 +113,7 @@ jobs:
         run: docker compose down
   adapter-integration:
     name: ${{ matrix.packages }} Integration Test
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
 


### PR DESCRIPTION
## Problem

Closes #9539

Workflows use `starsling-ubuntu-24.04` which is a custom runner only 
available in the `better-auth/better-auth` org. When contributors fork 
the repo and push to their fork, CI jobs queue indefinitely waiting for 
a runner that will never come — or worse, bill them if their org has 
starsling configured.

## Fix

Replace every `runs-on: starsling-ubuntu-24.04` with a conditional 
expression:

`runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}`

In the official repo everything works as before. In any fork, jobs 
automatically fall back to standard GitHub-hosted `ubuntu-24.04` runners.

## Files changed

- `.github/workflows/ci.yml`
- `.github/workflows/e2e.yml`
- `.github/workflows/preview.yml`
- `.github/workflows/claude.yml`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use conditional runners in GitHub Actions to fall back to `ubuntu-24.04` on forks, so CI runs instead of waiting for the private `starsling-ubuntu-24.04` runner. This unblocks contributors and avoids unintended billing.

- **Bug Fixes**
  - Replaced `runs-on` with `runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}` in `ci.yml`, `e2e.yml`, `preview.yml`, and `claude.yml`.
  - No change for the main repo; forks use GitHub-hosted runners automatically.

<sup>Written for commit ab335bc69dfb015852cb566463b038ae35d9a53a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



