### PR TITLE
feat(cli): add create-admin command

### DIFF
--- a/.changeset/create-initial-admin-cli.md
+++ b/.changeset/create-initial-admin-cli.md
@@ -1,0 +1,5 @@
+---
+"auth": minor
+---
+
+Add a `create-admin` CLI command for creating an initial admin user through the configured Better Auth instance.

--- a/docs/content/docs/concepts/cli.mdx
+++ b/docs/content/docs/concepts/cli.mdx
@@ -1,9 +1,9 @@
 ---
 title: CLI
-description: Learn about the Better Auth CLI commands for generating and migrating database schemas, initializing projects, generating secret keys, and gathering diagnostic info.
+description: Learn about the Better Auth CLI commands for generating and migrating database schemas, creating initial admins, initializing projects, generating secret keys, and gathering diagnostic info.
 ---
 
-Better Auth comes with a built-in CLI to help you manage the database schemas, initialize your project, generate a secret key for your application, and gather diagnostic information about your setup.
+Better Auth comes with a built-in CLI to help you manage the database schemas, create initial admin users, initialize your project, generate a secret key for your application, and gather diagnostic information about your setup.
 
 ## Generate
 
@@ -37,6 +37,28 @@ npx auth@latest migrate
 
   The migrate command automatically detects your configured `search_path` and creates tables in the correct schema. See the [PostgreSQL adapter documentation](/docs/adapters/postgresql#use-a-non-default-schema) for configuration details.
 </Callout>
+
+## Create Admin
+
+The `create-admin` command creates an initial admin user through your configured Better Auth instance. It requires the Admin plugin and a persistent database, and it uses the same server-side `auth.api.createUser` path as the Admin plugin so passwords are hashed and database hooks still run.
+
+```package-install title="Terminal"
+npx auth@latest create-admin --email admin@example.com --name "Admin" --role admin
+```
+
+If users already exist, the command asks for confirmation. Use `--force` or `--yes` to skip that prompt.
+
+### Options
+
+* `--email` - The email address for the admin user.
+* `--password` - The password for the admin user. If omitted, the CLI will prompt for it.
+* `--name` - The name for the admin user. Defaults to `Admin`.
+* `--role` - The role to assign. Defaults to `admin`.
+* `--data` - Additional user fields as a JSON object.
+* `--no-email-verified` - Create the admin user with an unverified email. By default, the CLI marks the admin email as verified.
+* `--config` - The path to your Better Auth config file.
+* `--force` - Create the admin user even when users already exist.
+* `--yes` - Skip the existing-users confirmation prompt.
 
 ## Init
 

--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -70,6 +70,14 @@ The Admin plugin provides a set of administrative functions for user management 
 
 Before performing any admin operations, the user must be authenticated with an admin account. An admin is any user assigned the `admin` role or any user whose ID is included in the `adminUserIds` option.
 
+To create the first admin user, run the CLI after adding the Admin plugin and applying the schema:
+
+```package-install title="Terminal"
+npx auth@latest create-admin --email admin@example.com --name "Admin" --role admin
+```
+
+If users already exist, the CLI asks for confirmation before creating another admin. Use `--force` or `--yes` to skip that prompt. The CLI marks the admin email as verified by default; pass `--no-email-verified` to disable that.
+
 ### Create User
 
 Allows an admin to create a new user.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,8 @@
 # Better Auth CLI
 
 Better Auth comes with a built-in CLI to help you manage the database schema
-needed for both core functionality and plugins.
+needed for both core functionality and plugins, and to create an initial admin user
+for projects using the Admin plugin.
 
 ### **Init**
 
@@ -32,6 +33,16 @@ tool.
 
 ```bash title="terminal"
 npx auth@latest migrate
+```
+
+### **Create Admin**
+
+Create the first admin user for an app using the Admin plugin. The command
+uses your Better Auth config and prompts before creating an admin when users
+already exist. The created admin email is marked as verified by default.
+
+```bash title="terminal"
+npx auth@latest create-admin --email admin@example.com --name "Admin" --role admin
 ```
 
 ### **Secret**

--- a/packages/cli/src/commands/create-admin.ts
+++ b/packages/cli/src/commands/create-admin.ts
@@ -1,0 +1,237 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { APIError } from "@better-auth/core/error";
+import { betterAuth } from "better-auth";
+import chalk from "chalk";
+import { Command } from "commander";
+import prompts from "prompts";
+import * as z from "zod";
+import { getConfig } from "../utils/get-config";
+
+type CreateUserApi = (input: {
+	body: {
+		email: string;
+		password: string;
+		name: string;
+		role: string;
+		data?: Record<string, unknown> | undefined;
+	};
+}) => Promise<{
+	user?: {
+		id?: string | number | undefined;
+		email?: string | undefined;
+		role?: string | undefined;
+	};
+}>;
+
+function exitWithError(message: string): never {
+	console.error(chalk.red(`Error: ${message}`));
+	process.exit(1);
+	throw new Error(message);
+}
+
+function parseData(data: string | undefined) {
+	if (!data) return undefined;
+	try {
+		const parsed = JSON.parse(data);
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			exitWithError("--data must be a JSON object.");
+		}
+		return parsed as Record<string, unknown>;
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			exitWithError("--data must be valid JSON.");
+		}
+		throw error;
+	}
+}
+
+async function resolveRequiredInput(options: {
+	email?: string | undefined;
+	password?: string | undefined;
+	name?: string | undefined;
+}) {
+	let { email, password, name } = options;
+
+	if (!email) {
+		const response = await prompts({
+			type: "text",
+			name: "email",
+			message: "Admin email",
+		});
+		email = response.email;
+	}
+
+	if (!password) {
+		const response = await prompts({
+			type: "password",
+			name: "password",
+			message: "Admin password",
+		});
+		password = response.password;
+	}
+
+	if (!name) {
+		const response = await prompts({
+			type: "text",
+			name: "name",
+			message: "Admin name",
+			initial: "Admin",
+		});
+		name = response.name;
+	}
+
+	if (!email) exitWithError("Admin email is required.");
+	if (!password) exitWithError("Admin password is required.");
+	if (!name) exitWithError("Admin name is required.");
+
+	return {
+		email,
+		password,
+		name,
+	};
+}
+
+/** @internal */
+export async function createAdminAction(opts: unknown) {
+	const options = z
+		.object({
+			cwd: z.string(),
+			config: z.string().optional(),
+			email: z.string().optional(),
+			password: z.string().optional(),
+			name: z.string().optional(),
+			role: z.string().default("admin"),
+			data: z.string().optional(),
+			emailVerified: z.boolean().default(true),
+			force: z.boolean().optional(),
+			y: z.boolean().optional(),
+			yes: z.boolean().optional(),
+		})
+		.parse(opts);
+
+	const cwd = path.resolve(options.cwd);
+	if (!existsSync(cwd)) {
+		exitWithError(`The directory "${cwd}" does not exist.`);
+	}
+
+	if (options.y) {
+		console.warn("WARNING: --y is deprecated. Consider -y or --yes");
+		options.yes = true;
+	}
+
+	const config = await getConfig({
+		cwd,
+		configPath: options.config,
+	});
+	if (!config) {
+		exitWithError(
+			"No configuration file found. Add an `auth.ts` file to your project or pass the path to the configuration file using the `--config` flag.",
+		);
+	}
+
+	if (!config.database) {
+		exitWithError(
+			"No database is configured. Add a persistent database before creating an admin user.",
+		);
+	}
+
+	const auth = betterAuth(config);
+	const createUser = (auth.api as Record<string, unknown>).createUser as
+		| CreateUserApi
+		| undefined;
+
+	if (typeof createUser !== "function") {
+		exitWithError(
+			"The admin plugin is required. Add `admin()` to your Better Auth plugins before running this command.",
+		);
+	}
+
+	const { email, password, name } = await resolveRequiredInput(options);
+	const emailResult = z.email().safeParse(email);
+	if (!emailResult.success) {
+		exitWithError("Invalid email address.");
+	}
+	const data = {
+		...parseData(options.data),
+		emailVerified: options.emailVerified,
+	};
+
+	const context = await auth.$context;
+	const totalUsers = await context.internalAdapter.countTotalUsers();
+	if (totalUsers > 0 && !options.force && !options.yes) {
+		const response = await prompts({
+			type: "confirm",
+			name: "confirmed",
+			message: `Found ${totalUsers} existing user${
+				totalUsers === 1 ? "" : "s"
+			}. Create an admin user anyway?`,
+			initial: false,
+		});
+		if (!response.confirmed) {
+			console.log("Create admin cancelled.");
+			process.exit(0);
+			return;
+		}
+	}
+
+	try {
+		const result = await createUser({
+			body: {
+				email,
+				password,
+				name,
+				role: options.role,
+				data,
+			},
+		});
+		console.log(chalk.green("Admin user created successfully."));
+		if (result.user?.id) {
+			console.log(`User ID: ${result.user.id}`);
+		}
+		console.log(`Email: ${result.user?.email ?? email.toLowerCase()}`);
+		console.log(`Role: ${result.user?.role ?? options.role}`);
+		process.exit(0);
+	} catch (error) {
+		if (error instanceof APIError) {
+			exitWithError(error.message);
+		}
+		if (error instanceof Error) {
+			exitWithError(error.message);
+		}
+		exitWithError("Failed to create admin user.");
+	}
+}
+
+export const createAdmin = new Command("create-admin")
+	.description("Create an initial admin user")
+	.option(
+		"-c, --cwd <cwd>",
+		"the working directory. defaults to the current directory.",
+		process.cwd(),
+	)
+	.option(
+		"--config <config>",
+		"the path to the configuration file. defaults to the first configuration file found.",
+	)
+	.option("--email <email>", "the email address for the admin user")
+	.option("--password <password>", "the password for the admin user")
+	.option("--name <name>", "the name for the admin user", "Admin")
+	.option("--role <role>", "the role to assign to the user", "admin")
+	.option("--data <json>", "additional user fields as a JSON object")
+	.option(
+		"--no-email-verified",
+		"create the admin user with an unverified email",
+	)
+	.option(
+		"--force",
+		"create an admin user even when users already exist",
+		false,
+	)
+	.option(
+		"-y, --yes",
+		"automatically confirm creating an admin when users already exist",
+		false,
+	)
+	.option("--y", "(deprecated) same as --yes", false)
+	.action(createAdminAction);

--- a/packages/cli/src/commands/create-admin.ts
+++ b/packages/cli/src/commands/create-admin.ts
@@ -49,9 +49,8 @@ function parseData(data: string | undefined) {
 async function resolveRequiredInput(options: {
 	email?: string | undefined;
 	password?: string | undefined;
-	name?: string | undefined;
 }) {
-	let { email, password, name } = options;
+	let { email, password } = options;
 
 	if (!email) {
 		const response = await prompts({
@@ -71,24 +70,12 @@ async function resolveRequiredInput(options: {
 		password = response.password;
 	}
 
-	if (!name) {
-		const response = await prompts({
-			type: "text",
-			name: "name",
-			message: "Admin name",
-			initial: "Admin",
-		});
-		name = response.name;
-	}
-
 	if (!email) exitWithError("Admin email is required.");
 	if (!password) exitWithError("Admin password is required.");
-	if (!name) exitWithError("Admin name is required.");
 
 	return {
 		email,
 		password,
-		name,
 	};
 }
 
@@ -100,7 +87,7 @@ export async function createAdminAction(opts: unknown) {
 			config: z.string().optional(),
 			email: z.string().optional(),
 			password: z.string().optional(),
-			name: z.string().optional(),
+			name: z.string().default("Admin"),
 			role: z.string().default("admin"),
 			data: z.string().optional(),
 			emailVerified: z.boolean().default(true),
@@ -147,7 +134,9 @@ export async function createAdminAction(opts: unknown) {
 		);
 	}
 
-	const { email, password, name } = await resolveRequiredInput(options);
+	if (!options.name) exitWithError("Admin name is required.");
+
+	const { email, password } = await resolveRequiredInput(options);
 	const emailResult = z.email().safeParse(email);
 	if (!emailResult.success) {
 		exitWithError("Invalid email address.");
@@ -157,22 +146,30 @@ export async function createAdminAction(opts: unknown) {
 		emailVerified: options.emailVerified,
 	};
 
-	const context = await auth.$context;
-	const totalUsers = await context.internalAdapter.countTotalUsers();
-	if (totalUsers > 0 && !options.force && !options.yes) {
-		const response = await prompts({
-			type: "confirm",
-			name: "confirmed",
-			message: `Found ${totalUsers} existing user${
-				totalUsers === 1 ? "" : "s"
-			}. Create an admin user anyway?`,
-			initial: false,
-		});
-		if (!response.confirmed) {
-			console.log("Create admin cancelled.");
-			process.exit(0);
-			return;
+	try {
+		const context = await auth.$context;
+		const totalUsers = await context.internalAdapter.countTotalUsers();
+		if (totalUsers > 0 && !options.force && !options.yes) {
+			const response = await prompts({
+				type: "confirm",
+				name: "confirmed",
+				message: `Found ${totalUsers} existing user${
+					totalUsers === 1 ? "" : "s"
+				}. Create an admin user anyway?`,
+				initial: false,
+			});
+			if (!response.confirmed) {
+				console.log("Create admin cancelled.");
+				process.exit(0);
+				return;
+			}
 		}
+	} catch (error) {
+		exitWithError(
+			`Failed to inspect existing users. Make sure your database is reachable and your Better Auth schema is migrated before running this command.${
+				error instanceof Error ? `\n${error.message}` : ""
+			}`,
+		);
 	}
 
 	try {
@@ -180,7 +177,7 @@ export async function createAdminAction(opts: unknown) {
 			body: {
 				email,
 				password,
-				name,
+				name: options.name,
 				role: options.role,
 				data,
 			},

--- a/packages/cli/src/commands/create-admin.ts
+++ b/packages/cli/src/commands/create-admin.ts
@@ -27,7 +27,6 @@ type CreateUserApi = (input: {
 function exitWithError(message: string): never {
 	console.error(chalk.red(`Error: ${message}`));
 	process.exit(1);
-	throw new Error(message);
 }
 
 function parseData(data: string | undefined) {
@@ -133,8 +132,6 @@ export async function createAdminAction(opts: unknown) {
 			"The admin plugin is required. Add `admin()` to your Better Auth plugins before running this command.",
 		);
 	}
-
-	if (!options.name) exitWithError("Admin name is required.");
 
 	const { email, password } = await resolveRequiredInput(options);
 	const emailResult = z.email().safeParse(email);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from "commander";
 import { ai } from "./commands/ai";
+import { createAdmin } from "./commands/create-admin";
 import { generate } from "./commands/generate";
 import { info } from "./commands/info";
 import { init } from "./commands/init";
@@ -32,6 +33,7 @@ async function main() {
 	}
 	program
 		.addCommand(ai)
+		.addCommand(createAdmin)
 		.addCommand(init)
 		.addCommand(migrate)
 		.addCommand(generate)

--- a/packages/cli/test/create-admin.test.ts
+++ b/packages/cli/test/create-admin.test.ts
@@ -15,6 +15,7 @@ describe("create-admin", () => {
 	let db: Database.Database;
 
 	beforeEach(() => {
+		vi.mocked(prompts).mockReset();
 		vi.spyOn(process, "exit").mockImplementation((code) => {
 			return code as never;
 		});
@@ -84,6 +85,23 @@ describe("create-admin", () => {
 		expect(signIn.user.email).toBe("admin@example.com");
 	});
 
+	it("uses Admin as the default name without prompting", async () => {
+		await setupAuth();
+
+		await createAdminAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			email: "admin@example.com",
+			password: "secure-password",
+		});
+
+		const user = db
+			.prepare("SELECT name FROM user WHERE email = ?")
+			.get("admin@example.com") as { name: string };
+		expect(user.name).toBe("Admin");
+		expect(prompts).not.toHaveBeenCalled();
+	});
+
 	it("passes additional user data to the admin create-user API", async () => {
 		await setupAuth();
 
@@ -137,6 +155,49 @@ describe("create-admin", () => {
 				name: "Root Admin",
 			}),
 		).rejects.toThrow(/admin plugin is required/i);
+	});
+
+	it("returns a friendly error when existing-user inspection fails", async () => {
+		const adapter = {
+			id: "test",
+			create: vi.fn(),
+			findOne: vi.fn(),
+			findMany: vi.fn(),
+			count: vi.fn().mockRejectedValue(new Error("missing user table")),
+			update: vi.fn(),
+			updateMany: vi.fn(),
+			delete: vi.fn(),
+			deleteMany: vi.fn(),
+			transaction: vi.fn(async (callback: (adapter: unknown) => unknown) =>
+				callback(adapter),
+			),
+		} as any;
+		const auth = betterAuth({
+			baseURL: "http://localhost:3000",
+			database: () => adapter,
+			emailAndPassword: {
+				enabled: true,
+			},
+			plugins: [admin()],
+		});
+		vi.spyOn(config, "getConfig").mockImplementation(async () => auth.options);
+
+		await expect(
+			createAdminAction({
+				cwd: process.cwd(),
+				config: "test/auth.ts",
+				email: "admin@example.com",
+				password: "secure-password",
+			}),
+		).rejects.toThrow(/Failed to inspect existing users/);
+		await expect(
+			createAdminAction({
+				cwd: process.cwd(),
+				config: "test/auth.ts",
+				email: "admin@example.com",
+				password: "secure-password",
+			}),
+		).rejects.toThrow(/missing user table/);
 	});
 
 	it("asks for confirmation when users already exist", async () => {

--- a/packages/cli/test/create-admin.test.ts
+++ b/packages/cli/test/create-admin.test.ts
@@ -13,10 +13,18 @@ vi.mock("prompts", () => ({
 
 describe("create-admin", () => {
 	let db: Database.Database;
+	let lastConsoleError = "";
 
 	beforeEach(() => {
+		lastConsoleError = "";
 		vi.mocked(prompts).mockReset();
+		vi.spyOn(console, "error").mockImplementation((message) => {
+			lastConsoleError = String(message);
+		});
 		vi.spyOn(process, "exit").mockImplementation((code) => {
+			if (code && Number(code) !== 0) {
+				throw new Error(lastConsoleError || "process.exit(" + code + ")");
+			}
 			return code as never;
 		});
 	});

--- a/packages/cli/test/create-admin.test.ts
+++ b/packages/cli/test/create-admin.test.ts
@@ -1,0 +1,173 @@
+import { betterAuth } from "better-auth";
+import { admin } from "better-auth/plugins";
+import Database from "better-sqlite3";
+import prompts from "prompts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAdminAction } from "../src/commands/create-admin";
+import { migrateAction } from "../src/commands/migrate";
+import * as config from "../src/utils/get-config";
+
+vi.mock("prompts", () => ({
+	default: vi.fn(),
+}));
+
+describe("create-admin", () => {
+	let db: Database.Database;
+
+	beforeEach(() => {
+		vi.spyOn(process, "exit").mockImplementation((code) => {
+			return code as never;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		db?.close();
+	});
+
+	async function setupAuth(withAdmin = true, requireEmailVerification = false) {
+		db = new Database(":memory:");
+		const auth = betterAuth({
+			baseURL: "http://localhost:3000",
+			database: db,
+			emailAndPassword: {
+				enabled: true,
+				requireEmailVerification,
+			},
+			plugins: withAdmin ? [admin()] : [],
+		});
+
+		vi.spyOn(config, "getConfig").mockImplementation(async () => auth.options);
+		await migrateAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			yes: true,
+		});
+
+		return auth;
+	}
+
+	it("creates an initial admin user that can sign in with password", async () => {
+		const auth = await setupAuth(true, true);
+
+		await createAdminAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			email: "Admin@Example.com",
+			password: "secure-password",
+			name: "Root Admin",
+		});
+
+		const user = db
+			.prepare(
+				"SELECT email, name, role, emailVerified FROM user WHERE email = ?",
+			)
+			.get("admin@example.com") as {
+			email: string;
+			name: string;
+			role: string;
+			emailVerified: number | boolean;
+		};
+		expect(user).toMatchObject({
+			email: "admin@example.com",
+			name: "Root Admin",
+			role: "admin",
+		});
+		expect(Boolean(user.emailVerified)).toBe(true);
+
+		const signIn = await auth.api.signInEmail({
+			body: {
+				email: "admin@example.com",
+				password: "secure-password",
+			},
+		});
+		expect(signIn.user.email).toBe("admin@example.com");
+	});
+
+	it("passes additional user data to the admin create-user API", async () => {
+		await setupAuth();
+
+		await createAdminAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			email: "admin@example.com",
+			password: "secure-password",
+			name: "Root Admin",
+			data: JSON.stringify({ image: "https://example.com/avatar.png" }),
+		});
+
+		const user = db
+			.prepare("SELECT image FROM user WHERE email = ?")
+			.get("admin@example.com") as { image: string };
+		expect(user.image).toBe("https://example.com/avatar.png");
+	});
+
+	it("rejects duplicate admin email addresses", async () => {
+		await setupAuth();
+
+		await createAdminAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			email: "admin@example.com",
+			password: "secure-password",
+			name: "Root Admin",
+		});
+
+		await expect(
+			createAdminAction({
+				cwd: process.cwd(),
+				config: "test/auth.ts",
+				email: "admin@example.com",
+				password: "secure-password",
+				name: "Root Admin",
+				force: true,
+			}),
+		).rejects.toThrow(/already exists/i);
+	});
+
+	it("requires the admin plugin", async () => {
+		await setupAuth(false);
+
+		await expect(
+			createAdminAction({
+				cwd: process.cwd(),
+				config: "test/auth.ts",
+				email: "admin@example.com",
+				password: "secure-password",
+				name: "Root Admin",
+			}),
+		).rejects.toThrow(/admin plugin is required/i);
+	});
+
+	it("asks for confirmation when users already exist", async () => {
+		const auth = await setupAuth();
+		vi.mocked(prompts).mockResolvedValueOnce({ confirmed: false });
+
+		await auth.api.signUpEmail({
+			body: {
+				email: "user@example.com",
+				password: "password",
+				name: "Existing User",
+			},
+		});
+
+		await createAdminAction({
+			cwd: process.cwd(),
+			config: "test/auth.ts",
+			email: "admin@example.com",
+			password: "secure-password",
+			name: "Root Admin",
+		});
+
+		expect(prompts).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "confirm",
+				name: "confirmed",
+			}),
+		);
+		const count = db.prepare("SELECT COUNT(*) as count FROM user").get() as {
+			count: number;
+		};
+		expect(count.count).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary
- Add `auth create-admin` for bootstrapping an initial admin user
- Use the configured Better Auth instance and existing admin `createUser` API path
- Prompt before creating admins when users already exist
- Prefer masked password prompt in docs examples

Closes #9546

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `auth create-admin` to bootstrap the first admin user through your configured `better-auth` instance. Uses the Admin plugin’s `createUser` API so passwords are hashed and hooks run, with improved errors and confirmation prompts.

- **New Features**
  - New `auth create-admin` command; requires a Better Auth config, a persistent database, and the `admin()` plugin.
  - Prompts for missing email/password; supports `--email`, `--password`, `--name`, `--role`, `--data`, `--no-email-verified`, `--force`, `-y/--yes` (`--y` deprecated), `--config`, and `--cwd`. Marks the admin email as verified by default.
  - Confirms when users already exist (`--force`/`--yes` skip). Registers the command in the CLI and updates docs/tests.

- **Bug Fixes**
  - Clearer errors when the working directory is invalid, config/database is missing, the `admin()` plugin is not enabled, the email is invalid, or checking existing users fails (includes the underlying error).

<sup>Written for commit 0dcd5099315f237de75dc5dcff7c4fc593db62e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

