### PR TITLE
fix(anonymous): call `onLinkAccount` on email verification sign-in

### DIFF
--- a/.changeset/large-chairs-shout.md
+++ b/.changeset/large-chairs-shout.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+anonymous plugin now correctly calls onLinkAccount when email verification triggers auto sign-in

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -154,6 +154,67 @@ describe("anonymous", async () => {
 		expect(linkAccountFn).toHaveBeenCalledWith(expect.any(Object));
 	});
 
+	it("should call onLinkAccount when anonymous user verifies email", async () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/9485
+		 */
+		const linkAccountFn = vi.fn();
+		let verificationToken = "";
+
+		const { client, sessionSetter, auth } = await getTestInstance(
+			{
+				plugins: [
+					anonymous({
+						async onLinkAccount(data) {
+							linkAccountFn(data);
+						},
+					}),
+				],
+				emailAndPassword: {
+					enabled: true,
+					requireEmailVerification: true,
+				},
+				emailVerification: {
+					autoSignInAfterVerification: true,
+					async sendVerificationEmail({ url }) {
+						verificationToken = new URL(url).searchParams.get("token") || "";
+					},
+				},
+			},
+			{
+				clientOptions: {
+					plugins: [anonymousClient()],
+				},
+				disableTestUser: true,
+			},
+		);
+
+		const anonHeaders = new Headers();
+
+		await client.signIn.anonymous({
+			fetchOptions: {
+				onSuccess: sessionSetter(anonHeaders),
+			},
+		});
+
+		await auth.api.signUpEmail({
+			body: {
+				email: "newuser@example.com",
+				password: "password123",
+				name: "New User",
+			},
+			headers: anonHeaders,
+		});
+
+		await auth.api.verifyEmail({
+			query: { token: verificationToken },
+			headers: anonHeaders,
+		});
+
+		expect(linkAccountFn).toHaveBeenCalledTimes(1);
+		expect(linkAccountFn).toHaveBeenCalledWith(expect.any(Object));
+	});
+
 	it("should work with generateName", async () => {
 		const { client, sessionSetter } = await getTestInstance(
 			{

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -246,6 +246,7 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 							ctx.path?.startsWith("/one-tap/callback") ||
 							ctx.path?.startsWith("/passkey/verify-authentication") ||
 							ctx.path?.startsWith("/phone-number/verify") ||
+							ctx.path?.startsWith("/verify-email") ||
 							false
 						);
 					},


### PR DESCRIPTION
## What changed
Added `/verify-email` to the after hook matcher in the anonymous plugin 
so that `onLinkAccount` is correctly called when a user verifies their 
email with `autoSignInAfterVerification: true`.

## Why
When an anonymous user signed up with email and verified via the 
verification link, the after hook never ran because `/verify-email` 
was not in the matcher path list.

## Test
Added a regression test that reproduces the exact flow described in the issue.

Closes #9485

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where `onLinkAccount` wasn’t called after email verification with auto sign-in for anonymous users by matching the `/verify-email` route so the after hook runs. Fixes #9485.

- **Bug Fixes**
  - Add `/verify-email` to the anonymous plugin’s after-hook matcher in `better-auth` to trigger `onLinkAccount` on auto sign-in after verification.
  - Add a regression test for the anonymous → email sign-up → verify email → auto sign-in flow.
  - Add a changeset to publish a `better-auth` patch.

<sup>Written for commit 0b09fe82f73213f08bf730ca4191a5d218b8c5b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

