### PR TITLE
docs: document account storeStateStrategy

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -474,7 +474,7 @@ export const auth = betterAuth({
 			userId: "user_id"
 		},
 		encryptOAuthTokens: true, // Encrypt OAuth tokens before storing them in the database
-		storeStateStrategy: "database", // Store OAuth state in the database instead of an encrypted cookie
+		storeStateStrategy: "database", // Store OAuth state payload in verification storage
 		storeAccountCookie: true, // Store account data after OAuth flow in a cookie (useful for database-less flows)
 		accountLinking: {
 			enabled: true,
@@ -502,7 +502,7 @@ will be updated on sign in with the latest data from the provider.
 Controls where OAuth state data is stored during the authentication flow.
 
 * `"cookie"`: Store the state payload in an encrypted cookie. This keeps OAuth state stateless and avoids a database write during the start of the flow.
-* `"database"`: Store the state payload in the verification storage/table and validate it with the signed state cookie returned from the OAuth callback.
+* `"database"`: Store the state payload in the verification storage/table, set a signed state cookie when starting the flow, and validate the stored state against the signed cookie sent by the browser on the OAuth callback request.
 
 Defaults to `"database"` when a database is configured and `"cookie"` for database-less/stateless setups.
 

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -504,7 +504,7 @@ Controls where OAuth state data is stored during the authentication flow.
 * `"cookie"`: Store the state payload in an encrypted cookie. This keeps OAuth state stateless and avoids a database write during the start of the flow.
 * `"database"`: Store the state payload in the verification storage/table, set a signed state cookie when starting the flow, and validate the stored state against the signed cookie sent by the browser on the OAuth callback request.
 
-Defaults to `"database"` when a database is configured and `"cookie"` for database-less/stateless setups.
+Defaults to `"database"` when a database is configured and `"cookie"` for database-less/stateless setups. If you only provide `secondaryStorage`, set this to `"database"` to store OAuth state there instead of in the cookie.
 
 ### `storeAccountCookie`
 

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -474,6 +474,7 @@ export const auth = betterAuth({
 			userId: "user_id"
 		},
 		encryptOAuthTokens: true, // Encrypt OAuth tokens before storing them in the database
+		storeStateStrategy: "database", // Store OAuth state in the database instead of an encrypted cookie
 		storeAccountCookie: true, // Store account data after OAuth flow in a cookie (useful for database-less flows)
 		accountLinking: {
 			enabled: true,
@@ -495,6 +496,15 @@ Encrypt OAuth tokens before storing them in the database. Default: `false`.
 
 If enabled (true), the user account data (accessToken, idToken, refreshToken, etc.)
 will be updated on sign in with the latest data from the provider.
+
+### `storeStateStrategy`
+
+Controls where OAuth state data is stored during the authentication flow.
+
+* `"cookie"`: Store the state payload in an encrypted cookie. This keeps OAuth state stateless and avoids a database write during the start of the flow.
+* `"database"`: Store the state payload in the verification storage/table and validate it with the signed state cookie returned from the OAuth callback.
+
+Defaults to `"database"` when a database is configured and `"cookie"` for database-less/stateless setups.
 
 ### `storeAccountCookie`
 


### PR DESCRIPTION
## What Changed

Added documentation for `account.storeStateStrategy` in the Options reference account section.

The option was already referenced under `advanced`, but the account section did not explain what it does or which values are supported.

Closes #9556

## Details

- Added `storeStateStrategy` to the `account` example.
- Documented `"cookie"` and `"database"` strategies.
- Clarified the default behavior:
  - `"database"` when a database is configured
  - `"cookie"` for database-less/stateless setups

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the `account.storeStateStrategy` option in the Options reference and added it to the account example. Explains `cookie` (store state in an encrypted cookie, no DB write) vs `database` (store in verification storage, set and validate a signed state cookie), defaults (`database` with a DB, `cookie` otherwise), and how to use `secondaryStorage` by setting `storeStateStrategy` to `database` to persist state there instead of in the cookie.

<sup>Written for commit 12cdc1c306382b9d9300084f3c7d6d8803093672. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

