### PR TITLE
feat(db): add atomic `claimOne` adapter primitive

### DIFF
--- a/.changeset/atomic-claim-one-primitive.md
+++ b/.changeset/atomic-claim-one-primitive.md
@@ -1,5 +1,12 @@
 ---
+"@better-auth/core": patch
+"@better-auth/drizzle-adapter": patch
+"@better-auth/kysely-adapter": patch
+"@better-auth/memory-adapter": patch
+"@better-auth/mongo-adapter": patch
+"@better-auth/prisma-adapter": patch
+"@better-auth/redis-storage": patch
 "better-auth": patch
 ---
 
-Add `internalAdapter.consumeVerificationValue(identifier)`: atomically consume a verification row keyed by identifier. The first concurrent caller receives the row; later racers receive `null`. Backed by a new `DBAdapter.claimOne` primitive implemented natively per adapter (memory, mongo, drizzle, kysely, prisma), with a `transaction(findMany + delete)` factory fallback. `SecondaryStorage.getAndDelete` is added as an optional companion; Redis ships it via `GETDEL`.
+Add `internalAdapter.consumeVerificationValue(identifier)`: atomically consume a verification row keyed by identifier. The first concurrent caller receives the row; later racers receive `null`. Backed by a new `DBAdapter.claimOne` primitive implemented natively per adapter (memory, mongo, drizzle, kysely, prisma), with a `transaction(findMany + delete)` factory fallback. `SecondaryStorage.getAndDelete` is added as an optional companion; Redis ships it via an atomic Lua get-and-delete operation for compatibility with Redis versions before 6.2.

--- a/.changeset/atomic-claim-one-primitive.md
+++ b/.changeset/atomic-claim-one-primitive.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": minor
+"better-auth": patch
 ---
 
 Add `internalAdapter.consumeVerificationValue(identifier)`: atomically consume a verification row keyed by identifier. The first concurrent caller receives the row; later racers receive `null`. Backed by a new `DBAdapter.claimOne` primitive implemented natively per adapter (memory, mongo, drizzle, kysely, prisma), with a `transaction(findMany + delete)` factory fallback. `SecondaryStorage.getAndDelete` is added as an optional companion; Redis ships it via `GETDEL`.

--- a/.changeset/atomic-claim-one-primitive.md
+++ b/.changeset/atomic-claim-one-primitive.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Add `internalAdapter.consumeVerificationValue(identifier)`: atomically consume a verification row keyed by identifier. The first concurrent caller receives the row; later racers receive `null`. Backed by a new `DBAdapter.claimOne` primitive implemented natively per adapter (memory, mongo, drizzle, kysely, prisma), with a `transaction(findMany + delete)` factory fallback. `SecondaryStorage.getAndDelete` is added as an optional companion; Redis ships it via `GETDEL`.

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -4702,9 +4702,9 @@ describe("listApiKeys with integer user.id (postgres + serial)", async () => {
 			clientOptions: { plugins: [apiKeyClient()] },
 		},
 	);
-	const { headers } = await signInWithTestUser();
 
 	it("returns the key that createApiKey just wrote", async () => {
+		const { headers } = await signInWithTestUser();
 		const created = await auth.api.createApiKey({ body: {}, headers });
 		expect(created.id).toBeDefined();
 

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -4690,6 +4690,7 @@ describe("api-key", async () => {
 });
 
 describe("listApiKeys with integer user.id (postgres + serial)", async () => {
+	const testUserEmail = `api-key-serial-${crypto.randomUUID()}@test.com`;
 	const { auth, signInWithTestUser } = await getTestInstance(
 		{
 			plugins: [apiKey()],
@@ -4699,12 +4700,13 @@ describe("listApiKeys with integer user.id (postgres + serial)", async () => {
 		},
 		{
 			testWith: "postgres",
+			testUser: { email: testUserEmail },
 			clientOptions: { plugins: [apiKeyClient()] },
 		},
 	);
+	const { headers } = await signInWithTestUser();
 
 	it("returns the key that createApiKey just wrote", async () => {
-		const { headers } = await signInWithTestUser();
 		const created = await auth.api.createApiKey({ body: {}, headers });
 		expect(created.id).toBeDefined();
 

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1493,4 +1493,223 @@ describe("internal adapter test", async () => {
 			expect(found!.expiresAt).toBeInstanceOf(Date);
 		});
 	});
+
+	describe("consumeVerificationValue", () => {
+		async function makeAdapter(overrides?: Partial<BetterAuthOptions>) {
+			const opts = {
+				database: new DatabaseSync(":memory:"),
+				...overrides,
+			} satisfies BetterAuthOptions;
+			(await getMigrations(opts)).runMigrations();
+			const ctx = await init(opts);
+			return ctx.internalAdapter;
+		}
+
+		it("returns the row to the first caller and null to subsequent reads", async () => {
+			const adapter = await makeAdapter();
+			await adapter.createVerificationValue({
+				identifier: "consume:single",
+				value: "user-1",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+
+			const first = await adapter.consumeVerificationValue("consume:single");
+			expect(first).not.toBeNull();
+			expect(first!.value).toBe("user-1");
+
+			const second = await adapter.consumeVerificationValue("consume:single");
+			expect(second).toBeNull();
+		});
+
+		it("yields exactly one winner under concurrent consume", async () => {
+			const adapter = await makeAdapter();
+			await adapter.createVerificationValue({
+				identifier: "consume:race",
+				value: "user-2",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+
+			const results = await Promise.all([
+				adapter.consumeVerificationValue("consume:race"),
+				adapter.consumeVerificationValue("consume:race"),
+				adapter.consumeVerificationValue("consume:race"),
+			]);
+
+			const winners = results.filter((r) => r !== null);
+			expect(winners).toHaveLength(1);
+			expect(winners[0]!.value).toBe("user-2");
+		});
+
+		it("returns null for an unknown identifier", async () => {
+			const adapter = await makeAdapter();
+			const result = await adapter.consumeVerificationValue("consume:missing");
+			expect(result).toBeNull();
+		});
+
+		it("aborts the consume when a delete.before hook returns false", async () => {
+			const veto = vi.fn().mockReturnValue(false);
+			const adapter = await makeAdapter({
+				databaseHooks: {
+					verification: {
+						delete: {
+							before: veto,
+						},
+					},
+				},
+			});
+			await adapter.createVerificationValue({
+				identifier: "consume:veto",
+				value: "user-3",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+
+			const result = await adapter.consumeVerificationValue("consume:veto");
+			expect(result).toBeNull();
+			expect(veto).toHaveBeenCalledTimes(1);
+
+			const stillThere = await adapter.findVerificationValue("consume:veto");
+			expect(stillThere).not.toBeNull();
+		});
+
+		it("fires delete.after only for the winning racer", async () => {
+			const afterHook = vi.fn();
+			const adapter = await makeAdapter({
+				databaseHooks: {
+					verification: {
+						delete: {
+							after: afterHook,
+						},
+					},
+				},
+			});
+			await adapter.createVerificationValue({
+				identifier: "consume:after-once",
+				value: "user-4",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+
+			const results = await Promise.all([
+				adapter.consumeVerificationValue("consume:after-once"),
+				adapter.consumeVerificationValue("consume:after-once"),
+			]);
+
+			expect(results.filter((r) => r !== null)).toHaveLength(1);
+			expect(afterHook).toHaveBeenCalledTimes(1);
+		});
+
+		it("consumes via the original identifier when storeIdentifier is hashed", async () => {
+			const adapter = await makeAdapter({
+				verification: { storeIdentifier: "hashed" },
+			});
+			await adapter.createVerificationValue({
+				identifier: "consume:hashed",
+				value: "user-5",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+
+			const result = await adapter.consumeVerificationValue("consume:hashed");
+			expect(result).not.toBeNull();
+			expect(result!.value).toBe("user-5");
+
+			const replay = await adapter.consumeVerificationValue("consume:hashed");
+			expect(replay).toBeNull();
+		});
+
+		it("consumes the latest row and invalidates stale rows for the identifier", async () => {
+			const adapter = await makeAdapter();
+			await adapter.createVerificationValue({
+				identifier: "consume:multi",
+				value: "older",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			await adapter.createVerificationValue({
+				identifier: "consume:multi",
+				value: "newer",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+
+			const consumed = await adapter.consumeVerificationValue("consume:multi");
+			expect(consumed).not.toBeNull();
+			expect(consumed!.value).toBe("newer");
+
+			const leftover = await adapter.findVerificationValue("consume:multi");
+			expect(leftover).toBeNull();
+		});
+
+		it("uses secondary storage getAndDelete when verification values are storage-only", async () => {
+			const store = new Map<string, string>();
+			const getAndDelete = vi.fn((key: string) => {
+				const value = store.get(key) ?? null;
+				store.delete(key);
+				return value;
+			});
+			const adapter = await makeAdapter({
+				verification: { storeInDatabase: false },
+				secondaryStorage: {
+					set(key, value) {
+						store.set(key, value);
+					},
+					get(key) {
+						return store.get(key) ?? null;
+					},
+					getAndDelete,
+					delete(key) {
+						store.delete(key);
+					},
+				},
+			});
+			await adapter.createVerificationValue({
+				identifier: "consume:secondary",
+				value: "secondary-user",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+
+			const results = await Promise.all([
+				adapter.consumeVerificationValue("consume:secondary"),
+				adapter.consumeVerificationValue("consume:secondary"),
+			]);
+
+			expect(results.filter((r) => r !== null)).toHaveLength(1);
+			expect(results.find((r) => r !== null)?.value).toBe("secondary-user");
+			expect(getAndDelete).toHaveBeenCalledWith(
+				"verification:consume:secondary",
+			);
+			expect(store.has("verification:consume:secondary")).toBe(false);
+		});
+
+		it("serializes the secondary storage compatibility fallback within one process", async () => {
+			const store = new Map<string, string>();
+			const adapter = await makeAdapter({
+				verification: { storeInDatabase: false },
+				secondaryStorage: {
+					set(key, value) {
+						store.set(key, value);
+					},
+					async get(key) {
+						await new Promise((resolve) => setTimeout(resolve, 5));
+						return store.get(key) ?? null;
+					},
+					delete(key) {
+						store.delete(key);
+					},
+				},
+			});
+			await adapter.createVerificationValue({
+				identifier: "consume:secondary-fallback",
+				value: "fallback-user",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+
+			const results = await Promise.all([
+				adapter.consumeVerificationValue("consume:secondary-fallback"),
+				adapter.consumeVerificationValue("consume:secondary-fallback"),
+				adapter.consumeVerificationValue("consume:secondary-fallback"),
+			]);
+
+			expect(results.filter((r) => r !== null)).toHaveLength(1);
+			expect(results.find((r) => r !== null)?.value).toBe("fallback-user");
+			expect(store.has("verification:consume:secondary-fallback")).toBe(false);
+		});
+	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -45,6 +45,7 @@ export const createInternalAdapter = (
 	const logger = ctx.logger;
 	const options = ctx.options;
 	const secondaryStorage = options.secondaryStorage;
+	const verificationConsumeLocks = new Map<string, Promise<void>>();
 	const sessionExpiration = options.session?.expiresIn || 60 * 60 * 24 * 7; // 7 days
 	const {
 		createWithHooks,
@@ -52,6 +53,7 @@ export const createInternalAdapter = (
 		updateManyWithHooks,
 		deleteWithHooks,
 		deleteManyWithHooks,
+		consumeOneWithHooks,
 	} = getWithHooks(adapter, ctx);
 
 	async function refreshUserSessions(user: User) {
@@ -84,6 +86,28 @@ export const createInternalAdapter = (
 				);
 			}),
 		);
+	}
+
+	async function withVerificationConsumeLock<T>(
+		key: string,
+		fn: () => Promise<T>,
+	): Promise<T> {
+		const previous = verificationConsumeLocks.get(key) ?? Promise.resolve();
+		let release!: () => void;
+		const current = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const next = previous.catch(() => {}).then(() => current);
+		verificationConsumeLocks.set(key, next);
+		await previous.catch(() => {});
+		try {
+			return await fn();
+		} finally {
+			release();
+			if (verificationConsumeLocks.get(key) === next) {
+				verificationConsumeLocks.delete(key);
+			}
+		}
 	}
 
 	return {
@@ -1194,6 +1218,142 @@ export const createInternalAdapter = (
 					undefined,
 				);
 			}
+		},
+		/**
+		 * Atomically consume a single-use verification row by `identifier` and
+		 * return it. The first concurrent caller receives the latest row for the
+		 * identifier; every other caller racing against it receives `null`.
+		 *
+		 * Race-safe replacement for the `findVerificationValue` then
+		 * `deleteVerificationByIdentifier` pair. Callers MUST gate any state
+		 * change (issue session, mint token, change password) on a non-null
+		 * return value, because consuming one row invalidates the whole
+		 * identifier and stale rows cannot be replayed.
+		 *
+		 * Expiry is intentionally not checked here. Callers retain their
+		 * existing expiry handling so each call site can surface its own
+		 * error code (for example `token_expired` vs `invalid_grant`).
+		 *
+		 * The secondary-storage-only path (`storeInDatabase: false`) is atomic
+		 * only when the configured storage implements `getAndDelete`; otherwise
+		 * it falls back to an in-process lock around `get` then `delete`.
+		 *
+		 * FIXME(consume-atomic): make `SecondaryStorage.getAndDelete` required
+		 * in the next breaking release, or require database-backed verification
+		 * storage for security-sensitive consume paths. The compatibility
+		 * fallback cannot coordinate across multiple application processes.
+		 */
+		consumeVerificationValue: async (
+			identifier: string,
+		): Promise<Verification | null> => {
+			const storageOption = getStorageOption(
+				identifier,
+				options.verification?.storeIdentifier,
+			);
+			const storedIdentifier = await processIdentifier(
+				identifier,
+				storageOption,
+			);
+			const identifiersToTry =
+				storageOption && storageOption !== "plain"
+					? [storedIdentifier, identifier]
+					: [storedIdentifier];
+
+			if (secondaryStorage && !options.verification?.storeInDatabase) {
+				const parseCachedVerification = (raw: unknown) => {
+					if (!raw) return null;
+					return safeJSONParse<Verification>(
+						typeof raw === "string" ? raw : String(raw),
+					);
+				};
+				const consumeCacheKey = async (key: string) => {
+					if (secondaryStorage.getAndDelete) {
+						return parseCachedVerification(
+							await secondaryStorage.getAndDelete(key),
+						);
+					}
+					return withVerificationConsumeLock(key, async () => {
+						const raw = await secondaryStorage.get(key);
+						const parsed = parseCachedVerification(raw);
+						if (!parsed) return null;
+						await secondaryStorage.delete(key);
+						return parsed;
+					});
+				};
+
+				for (const stored of identifiersToTry) {
+					const cacheKey = `verification:${stored}`;
+					const cached = await consumeCacheKey(cacheKey);
+					if (!cached) continue;
+					await Promise.all(
+						identifiersToTry
+							.filter((candidate) => candidate !== stored)
+							.map((candidate) =>
+								secondaryStorage.delete(`verification:${candidate}`),
+							),
+					);
+					return cached;
+				}
+				return null;
+			}
+
+			async function consumeByIdentifier(
+				id: string,
+			): Promise<Verification | null> {
+				const where = [{ field: "identifier", value: id }];
+				return withVerificationConsumeLock(`verification:${id}`, () =>
+					runWithTransaction(adapter, async () => {
+						const txAdapter = await getCurrentAdapter(adapter);
+						const rows = await txAdapter.findMany<Verification>({
+							model: "verification",
+							where,
+							sortBy: { field: "createdAt", direction: "desc" },
+							limit: 1,
+						});
+						const latest = rows[0] ?? null;
+						if (!latest) return null;
+
+						// FIXME(consume-identifier-atomic): add an adapter primitive that
+						// deletes all rows for an identifier and returns the latest row in
+						// one operation. Until then, claim the latest row as the race gate
+						// and invalidate stale rows inside the same transaction/local lock.
+						const hookWhere = [{ field: "id", value: latest.id }];
+						return consumeOneWithHooks<Verification>(
+							"verification",
+							hookWhere,
+							async () => {
+								const claimed = await txAdapter.claimOne<Verification>({
+									model: "verification",
+									where: hookWhere,
+								});
+								if (!claimed) return null;
+								await txAdapter.deleteMany({
+									model: "verification",
+									where,
+								});
+								return claimed;
+							},
+							latest,
+						);
+					}),
+				);
+			}
+
+			let consumed: Verification | null = null;
+			for (const stored of identifiersToTry) {
+				consumed = await consumeByIdentifier(stored);
+				if (consumed) break;
+			}
+
+			if (consumed && secondaryStorage) {
+				await Promise.all(
+					identifiersToTry.map((stored) =>
+						secondaryStorage.delete(`verification:${stored}`),
+					),
+				);
+			}
+
+			return consumed;
 		},
 		updateVerificationByIdentifier: async (
 			identifier: string,

--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -415,11 +415,98 @@ export function getWithHooks(
 		return deleted;
 	}
 
+	/**
+	 * Wraps an atomic claim operation in the plugin `delete.before` and
+	 * `delete.after` hook lifecycle. The caller supplies a `claimFn` that
+	 * performs the actual single-row delete-and-return (typically the
+	 * adapter's `claimOne`). The first concurrent caller wins, subsequent
+	 * racers resolve to `null` without firing `delete.after` hooks.
+	 *
+	 * `preSnapshot` lets the caller hand in a row it already fetched so
+	 * `delete.before` hooks don't trigger a second read. Without it, the
+	 * helper falls back to a best-effort `findMany` against `hookWhere`.
+	 * The snapshot only feeds `delete.before`; the `claimFn` return value
+	 * is the race gate.
+	 *
+	 * Returning `false` from a `delete.before` hook aborts the claim and
+	 * the helper resolves to `null` (no `claimFn` call, no after hooks).
+	 */
+	async function consumeOneWithHooks<T extends Record<string, any>>(
+		model: BaseModelNames,
+		hookWhere: Where[],
+		claimFn: () => Promise<T | null>,
+		preSnapshot?: T | null,
+	): Promise<T | null> {
+		const context = await getCurrentAuthContext().catch(() => null);
+		const beforeHooks = hooksEntries.flatMap(({ source, hooks }) => {
+			const fn = hooks[model]?.delete?.before;
+			return fn ? [{ source, fn }] : [];
+		});
+
+		let snapshot: T | null = preSnapshot ?? null;
+		if (beforeHooks.length) {
+			if (!snapshot) {
+				try {
+					const rows = await (await getCurrentAdapter(adapter)).findMany<T>({
+						model,
+						where: hookWhere,
+						limit: 1,
+					});
+					snapshot = rows[0] || null;
+				} catch {}
+			}
+
+			if (snapshot) {
+				for (const { source, fn } of beforeHooks) {
+					const result = await withSpan(
+						`db delete.before ${model}`,
+						{
+							[ATTR_HOOK_TYPE]: "delete.before",
+							[ATTR_DB_COLLECTION_NAME]: model,
+							[ATTR_CONTEXT]: source,
+						},
+						() =>
+							// @ts-expect-error context type mismatch
+							fn(snapshot as any, context),
+					);
+					if (result === false) {
+						return null;
+					}
+				}
+			}
+		}
+
+		const claimed = await claimFn();
+		if (!claimed) return null;
+
+		for (const { source, hooks } of hooksEntries) {
+			const toRun = hooks[model]?.delete?.after;
+			if (toRun) {
+				await queueAfterTransactionHook(async () => {
+					await withSpan(
+						`db delete.after ${model}`,
+						{
+							[ATTR_HOOK_TYPE]: "delete.after",
+							[ATTR_DB_COLLECTION_NAME]: model,
+							[ATTR_CONTEXT]: source,
+						},
+						() =>
+							// @ts-expect-error context type mismatch
+							toRun(claimed as any, context),
+					);
+				});
+			}
+		}
+
+		return claimed;
+	}
+
 	return {
 		createWithHooks,
 		updateWithHooks,
 		updateManyWithHooks,
 		deleteWithHooks,
 		deleteManyWithHooks,
+		consumeOneWithHooks,
 	};
 }

--- a/packages/better-auth/src/test-utils/test-instance.ts
+++ b/packages/better-auth/src/test-utils/test-instance.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
 import type {
 	Awaitable,
 	BetterAuthClientOptions,
@@ -46,16 +47,33 @@ export async function getTestInstance<
 		| undefined,
 ) {
 	const testWith = config?.testWith || "sqlite";
+	const postgresSchema =
+		testWith === "postgres"
+			? `ba_test_${randomUUID().replaceAll("-", "_")}`
+			: undefined;
+
+	const quotePostgresIdentifier = (identifier: string) =>
+		`"${identifier.replaceAll('"', '""')}"`;
 
 	async function getPostgres() {
 		const { Kysely, PostgresDialect } = await import("kysely");
 		const { Pool } = await import("pg");
+		const pool = new Pool({
+			connectionString: "postgres://user:password@localhost:5432/better_auth",
+			options: postgresSchema
+				? `-c search_path=${postgresSchema},public`
+				: undefined,
+		});
+		if (postgresSchema) {
+			await pool.query(
+				`CREATE SCHEMA IF NOT EXISTS ${quotePostgresIdentifier(
+					postgresSchema,
+				)}`,
+			);
+		}
 		return new Kysely({
 			dialect: new PostgresDialect({
-				pool: new Pool({
-					connectionString:
-						"postgres://user:password@localhost:5432/better_auth",
-				}),
+				pool,
 			}),
 		});
 	}
@@ -182,9 +200,19 @@ export async function getTestInstance<
 		}
 		if (testWith === "postgres") {
 			const postgres = await getPostgres();
-			await sql`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`.execute(
-				postgres,
-			);
+			if (postgresSchema) {
+				await sql
+					.raw(
+						`DROP SCHEMA IF EXISTS ${quotePostgresIdentifier(
+							postgresSchema,
+						)} CASCADE`,
+					)
+					.execute(postgres);
+			} else {
+				await sql`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`.execute(
+					postgres,
+				);
+			}
 			await postgres.destroy();
 			return;
 		}

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -61,6 +61,9 @@ function createMockAdapter(adapterId: string, dialect?: string): DBAdapter {
 		deleteMany: async () => {
 			throw new Error("Mock adapter methods should not be called");
 		},
+		claimOne: async () => {
+			throw new Error("Mock adapter methods should not be called");
+		},
 		transaction: async (callback) => {
 			throw new Error("Mock adapter methods should not be called");
 		},

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -1093,6 +1093,9 @@ describe("--adapter flag support (mock adapter)", () => {
 			deleteMany: async () => {
 				throw new Error("Mock adapter methods should not be called");
 			},
+			claimOne: async () => {
+				throw new Error("Mock adapter methods should not be called");
+			},
 			transaction: async (callback) => {
 				throw new Error("Mock adapter methods should not be called");
 			},
@@ -1330,6 +1333,9 @@ describe("--dialect flag support", () => {
 				throw new Error("Mock adapter methods should not be called");
 			},
 			deleteMany: async () => {
+				throw new Error("Mock adapter methods should not be called");
+			},
+			claimOne: async () => {
 				throw new Error("Mock adapter methods should not be called");
 			},
 			transaction: async (callback) => {

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import type { BetterAuthOptions } from "../../types";
+import { createAdapterFactory } from "./factory";
+import type { CleanedWhere, CustomAdapter } from "./index";
+
+function createCustomAdapter(overrides: Partial<CustomAdapter>): CustomAdapter {
+	return {
+		create: async <T extends Record<string, any>>({ data }: { data: T }) =>
+			data,
+		update: async <T>() => null as T | null,
+		updateMany: async () => 0,
+		findOne: async <T>() => null as T | null,
+		findMany: async <T>() => [] as T[],
+		delete: async () => {},
+		deleteMany: async () => 0,
+		count: async () => 0,
+		...overrides,
+	};
+}
+
+function createTestAdapter({
+	adapter,
+	options = {},
+}: {
+	adapter: CustomAdapter;
+	options?: BetterAuthOptions;
+}) {
+	return createAdapterFactory<BetterAuthOptions>({
+		config: {
+			adapterId: "test-adapter",
+			adapterName: "Test Adapter",
+			usePlural: true,
+			customTransformInput({ action, data, field }) {
+				if (field === "identifier_text" && typeof data === "string") {
+					return `${data}:${action}`;
+				}
+				return data;
+			},
+			customTransformOutput({ data, field }) {
+				if (field === "identifier" && typeof data === "string") {
+					return `${data}:output`;
+				}
+				return data;
+			},
+		},
+		adapter: () => adapter,
+	})({
+		...options,
+		verification: {
+			modelName: "verificationRecord",
+			fields: {
+				identifier: "identifier_text",
+			},
+			...options.verification,
+		},
+	});
+}
+
+describe("createAdapterFactory claimOne fallback", () => {
+	it("uses transaction adapter methods without double-transforming input or output", async () => {
+		const findMany: CustomAdapter["findMany"] = async <T>(
+			params: Parameters<CustomAdapter["findMany"]>[0],
+		) => {
+			const { model, where, limit } = params;
+			expect(model).toBe("verificationRecords");
+			expect(limit).toBe(1);
+			expect(where).toEqual([
+				{
+					field: "identifier_text",
+					value: "token:findMany",
+					operator: "eq",
+					connector: "AND",
+					mode: "sensitive",
+				},
+			]);
+			return [
+				{
+					id: "verification-id",
+					identifier_text: "stored-token",
+				},
+			] as T[];
+		};
+		const deleteMany: CustomAdapter["deleteMany"] = async ({
+			model,
+			where,
+		}) => {
+			expect(model).toBe("verificationRecords");
+			expect(where).toEqual([
+				{
+					field: "identifier_text",
+					value: "token:deleteMany",
+					operator: "eq",
+					connector: "AND",
+					mode: "sensitive",
+				},
+				{
+					field: "id",
+					value: "verification-id",
+					operator: "eq",
+					connector: "AND",
+					mode: "sensitive",
+				},
+			] satisfies CleanedWhere[]);
+			return 1;
+		};
+
+		const adapter = createTestAdapter({
+			adapter: createCustomAdapter({
+				findMany,
+				deleteMany,
+			}),
+		});
+
+		const result = await adapter.claimOne<{ id: string; identifier: string }>({
+			model: "verification",
+			where: [{ field: "identifier", value: "token" }],
+		});
+
+		expect(result?.id).toBe("verification-id");
+		expect(result?.identifier).toBe("stored-token:output");
+	});
+
+	it("returns null when the delete loses the claim race", async () => {
+		const adapter = createTestAdapter({
+			adapter: createCustomAdapter({
+				findMany: async <T>() =>
+					[
+						{
+							id: "verification-id",
+							identifier_text: "stored-token",
+						},
+					] as T[],
+				deleteMany: async () => 0,
+			}),
+		});
+
+		const result = await adapter.claimOne({
+			model: "verification",
+			where: [{ field: "identifier", value: "token" }],
+		});
+
+		expect(result).toBeNull();
+	});
+});

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -133,6 +133,8 @@ export const createAdapterFactory =
 							!config.debugLogs.deleteMany
 						) {
 							return;
+						} else if (method === "claimOne" && !config.debugLogs.claimOne) {
+							return;
 						} else if (method === "count" && !config.debugLogs.count) {
 							return;
 						}
@@ -485,6 +487,7 @@ export const createAdapterFactory =
 				| "updateMany"
 				| "delete"
 				| "deleteMany"
+				| "claimOne"
 				| "count";
 		}): W extends undefined ? undefined : CleanedWhere[] => {
 			if (!where) return undefined as any;
@@ -1311,6 +1314,100 @@ export const createAdapterFactory =
 					{ model, data: res },
 				);
 				return res;
+			},
+			claimOne: async <T>({
+				model: unsafeModel,
+				where: unsafeWhere,
+			}: {
+				model: string;
+				where: Where[];
+			}): Promise<T | null> => {
+				transactionId++;
+				const thisTransactionId = transactionId;
+				const model = getModelName(unsafeModel);
+				const where = transformWhereClause({
+					model: unsafeModel,
+					where: unsafeWhere,
+					action: "claimOne",
+				});
+				unsafeModel = getDefaultModelName(unsafeModel);
+				debugLog(
+					{ method: "claimOne" },
+					`${formatTransactionId(thisTransactionId)} ${formatStep(1, 3)}`,
+					`${formatMethod("claimOne")} ${formatAction("ClaimOne")}:`,
+					{ model, where },
+				);
+
+				let res: T | null;
+				if (adapterInstance.claimOne) {
+					res = await withSpan(
+						`db claimOne ${model}`,
+						{
+							[ATTR_DB_OPERATION_NAME]: "claimOne",
+							[ATTR_DB_COLLECTION_NAME]: model,
+						},
+						() => adapterInstance.claimOne!<T>({ model, where }),
+					);
+				} else {
+					// TODO(claim-one-required): adapters without native `claimOne`
+					// fall back to `transaction(findMany + delete)`. Race-safe on
+					// engines with real transaction isolation; race window narrows
+					// (does not close) on adapters that fall through to sequential
+					// execution. Remove this branch when claimOne becomes required.
+					res = await withSpan(
+						`db claimOne ${model}`,
+						{
+							[ATTR_DB_OPERATION_NAME]: "claimOne",
+							[ATTR_DB_COLLECTION_NAME]: model,
+						},
+						() =>
+							adapter.transaction(async (trx) => {
+								const rows = await trx.findMany<Record<string, any>>({
+									model,
+									where,
+									limit: 1,
+								});
+								const target = rows[0];
+								if (!target) return null;
+								await trx.delete({
+									model,
+									where: [
+										{
+											field: "id",
+											value: target.id,
+											operator: "eq",
+											connector: "AND",
+											mode: "sensitive",
+										},
+									],
+								});
+								return target as T;
+							}),
+					);
+				}
+
+				debugLog(
+					{ method: "claimOne" },
+					`${formatTransactionId(thisTransactionId)} ${formatStep(2, 3)}`,
+					`${formatMethod("claimOne")} ${formatAction("DB Result")}:`,
+					{ model, data: res },
+				);
+				let transformed: any = res;
+				if (!config.disableTransformOutput && res) {
+					transformed = await transformOutput(
+						res as Record<string, any>,
+						unsafeModel,
+						undefined,
+						undefined,
+					);
+				}
+				debugLog(
+					{ method: "claimOne" },
+					`${formatTransactionId(thisTransactionId)} ${formatStep(3, 3)}`,
+					`${formatMethod("claimOne")} ${formatAction("Parsed Result")}:`,
+					{ model, data: transformed },
+				);
+				return transformed as T | null;
 			},
 			count: async ({
 				model: unsafeModel,

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -1339,6 +1339,7 @@ export const createAdapterFactory =
 				);
 
 				let res: T | null;
+				let resultNeedsOutputTransform = true;
 				if (adapterInstance.claimOne) {
 					res = await withSpan(
 						`db claimOne ${model}`,
@@ -1350,7 +1351,7 @@ export const createAdapterFactory =
 					);
 				} else {
 					// TODO(claim-one-required): adapters without native `claimOne`
-					// fall back to `transaction(findMany + delete)`. Race-safe on
+					// fall back to `transaction(findMany + deleteMany)`. Race-safe on
 					// engines with real transaction isolation; race window narrows
 					// (does not close) on adapters that fall through to sequential
 					// execution. Remove this branch when claimOne becomes required.
@@ -1368,15 +1369,16 @@ export const createAdapterFactory =
 						() =>
 							adapter.transaction(async (trx) => {
 								const rows = await trx.findMany<Record<string, any>>({
-									model,
-									where,
+									model: unsafeModel,
+									where: unsafeWhere,
 									limit: 1,
 								});
 								const target = rows[0];
 								if (!target) return null;
-								await trx.delete({
-									model,
+								const deleted = await trx.deleteMany({
+									model: unsafeModel,
 									where: [
+										...unsafeWhere,
 										{
 											field: "id",
 											value: target.id,
@@ -1386,9 +1388,10 @@ export const createAdapterFactory =
 										},
 									],
 								});
-								return target as T;
+								return deleted > 0 ? (target as T) : null;
 							}),
 					);
+					resultNeedsOutputTransform = false;
 				}
 
 				debugLog(
@@ -1398,7 +1401,11 @@ export const createAdapterFactory =
 					{ model, data: res },
 				);
 				let transformed: any = res;
-				if (!config.disableTransformOutput && res) {
+				if (
+					!config.disableTransformOutput &&
+					resultNeedsOutputTransform &&
+					res
+				) {
 					transformed = await transformOutput(
 						res as Record<string, any>,
 						unsafeModel,

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -1354,6 +1354,11 @@ export const createAdapterFactory =
 					// engines with real transaction isolation; race window narrows
 					// (does not close) on adapters that fall through to sequential
 					// execution. Remove this branch when claimOne becomes required.
+					// FIXME(claim-one-nested-transaction): custom adapters without a
+					// native claimOne have no portable signal for "already inside a
+					// transaction". First-party adapters mark transaction-scoped
+					// adapters as as-is; make that capability explicit in the next
+					// breaking adapter contract.
 					res = await withSpan(
 						`db claimOne ${model}`,
 						{

--- a/packages/core/src/db/adapter/index.ts
+++ b/packages/core/src/db/adapter/index.ts
@@ -460,7 +460,8 @@ export type DBAdapter<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	 *
 	 * Always defined on the factory-wrapped adapter. When the underlying
 	 * `CustomAdapter` does not implement `claimOne`, the factory provides
-	 * a fallback that wraps `findMany + delete` in `transaction(...)`.
+	 * a fallback that wraps `findMany + deleteMany` in `transaction(...)`
+	 * and returns the row only when the delete reports an affected row.
 	 */
 	claimOne: <T>(data: { model: string; where: Where[] }) => Promise<T | null>;
 	/**
@@ -551,8 +552,8 @@ export interface CustomAdapter {
 	}) => Promise<number>;
 	/**
 	 * Optional native atomic single-row claim. When omitted, the adapter
-	 * factory falls back to `transaction(findMany + delete)`. Implementing
-	 * this method natively (e.g. `DELETE ... RETURNING *`,
+	 * factory falls back to `transaction(findMany + deleteMany)`.
+	 * Implementing this method natively (e.g. `DELETE ... RETURNING *`,
 	 * `findOneAndDelete`, `OUTPUT deleted.*`) gives one round trip and the
 	 * strongest race-safety guarantee. Implementations must delete at most
 	 * one matching row. TODO(claim-one-required): tighten to required in the

--- a/packages/core/src/db/adapter/index.ts
+++ b/packages/core/src/db/adapter/index.ts
@@ -15,6 +15,7 @@ export type DBAdapterDebugLogOption =
 			findMany?: boolean | undefined;
 			delete?: boolean | undefined;
 			deleteMany?: boolean | undefined;
+			claimOne?: boolean | undefined;
 			count?: boolean | undefined;
 	  }
 	| {
@@ -211,6 +212,7 @@ export interface DBAdapterFactoryConfig<
 					| "updateMany"
 					| "delete"
 					| "deleteMany"
+					| "claimOne"
 					| "count";
 				/**
 				 * The model name.
@@ -446,6 +448,22 @@ export type DBAdapter<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	delete: <_T>(data: { model: string; where: Where[] }) => Promise<void>;
 	deleteMany: (data: { model: string; where: Where[] }) => Promise<number>;
 	/**
+	 * Atomically claim a single row matching the where clause: delete it and
+	 * return the deleted row, or return `null` if no row matched.
+	 * Implementations MUST NOT delete any additional rows that also match a
+	 * non-unique predicate.
+	 *
+	 * Under concurrent invocation against the same row, exactly one caller
+	 * receives the row; subsequent racers receive `null`. This is the
+	 * race-safe primitive for consuming single-use credentials
+	 * (verification tokens, authorization codes, one-time tokens).
+	 *
+	 * Always defined on the factory-wrapped adapter. When the underlying
+	 * `CustomAdapter` does not implement `claimOne`, the factory provides
+	 * a fallback that wraps `findMany + delete` in `transaction(...)`.
+	 */
+	claimOne: <T>(data: { model: string; where: Where[] }) => Promise<T | null>;
+	/**
 	 * Execute multiple operations in a transaction.
 	 * If the adapter doesn't support transactions, operations will be executed sequentially.
 	 */
@@ -531,6 +549,19 @@ export interface CustomAdapter {
 		model: string;
 		where: CleanedWhere[];
 	}) => Promise<number>;
+	/**
+	 * Optional native atomic single-row claim. When omitted, the adapter
+	 * factory falls back to `transaction(findMany + delete)`. Implementing
+	 * this method natively (e.g. `DELETE ... RETURNING *`,
+	 * `findOneAndDelete`, `OUTPUT deleted.*`) gives one round trip and the
+	 * strongest race-safety guarantee. Implementations must delete at most
+	 * one matching row. TODO(claim-one-required): tighten to required in the
+	 * next minor on `next`.
+	 */
+	claimOne?: <T>(data: {
+		model: string;
+		where: CleanedWhere[];
+	}) => Promise<T | null>;
 	count: ({
 		model,
 		where,

--- a/packages/core/src/db/adapter/types.ts
+++ b/packages/core/src/db/adapter/types.ts
@@ -122,6 +122,7 @@ export type AdapterFactoryCustomizeAdapterCreator = (config: {
 			| "updateMany"
 			| "delete"
 			| "deleteMany"
+			| "claimOne"
 			| "count";
 	}) => W extends undefined ? undefined : CleanedWhere[];
 }) => CustomAdapter;

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -311,6 +311,18 @@ export interface SecondaryStorage {
 	 * @returns - Value of the key
 	 */
 	get: (key: string) => Awaitable<unknown>;
+	/**
+	 * Atomically get a value and delete it from storage.
+	 *
+	 * This is optional for backwards compatibility with existing secondary
+	 * storage implementations. Single-use credential consumers use it when
+	 * present to avoid a read-then-delete race.
+	 *
+	 * TODO(secondary-storage-atomic-consume): make this required in the next
+	 * breaking release, or require database-backed verification storage for
+	 * security-sensitive consume paths.
+	 */
+	getAndDelete?: (key: string) => Awaitable<unknown>;
 	set: (
 		/**
 		 * Key to store

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -216,6 +216,19 @@ export interface InternalAdapter<
 
 	deleteVerificationByIdentifier(identifier: string): Promise<void>;
 
+	/**
+	 * Atomically consume a single-use verification row by `identifier` and
+	 * return it. Only the first concurrent caller receives the latest row;
+	 * subsequent callers receive `null`. Consuming one row invalidates the
+	 * whole identifier so stale rows cannot be replayed. Callers MUST gate any
+	 * state change (issue session, mint token, change password) on a non-null
+	 * result.
+	 *
+	 * Replaces the racy `findVerificationValue` + `deleteVerificationByIdentifier`
+	 * pair at single-use credential consumption sites.
+	 */
+	consumeVerificationValue(identifier: string): Promise<Verification | null>;
+
 	updateVerificationByIdentifier(
 		identifier: string,
 		data: Partial<Verification>,

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -836,6 +836,60 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					}
 					return count;
 				},
+				async claimOne({ model, where }) {
+					const schemaModel = getSchema(model);
+					const clause = convertWhereClause(where, model);
+					const idField = getFieldName({ model, field: "id" });
+					const idColumn = schemaModel[idField];
+
+					if (config.provider === "mysql") {
+						// MySQL has no DELETE ... RETURNING. Hold the row under
+						// SELECT ... FOR UPDATE inside a transaction so concurrent
+						// claimants block until the row is gone.
+						return db.transaction(async (tx: DB) => {
+							const rows = await tx
+								.select()
+								.from(schemaModel)
+								.where(...clause)
+								.for("update")
+								.limit(1);
+							const target = rows[0];
+							if (!target) return null;
+							const targetId = target[idField] ?? (target as any).id;
+							if (targetId === undefined || targetId === null || !idColumn) {
+								return null;
+							}
+							const delRes = await tx
+								.delete(schemaModel)
+								.where(eq(idColumn, targetId))
+								.execute();
+							const count =
+								(delRes &&
+									(delRes.rowsAffected ??
+										delRes.affectedRows ??
+										delRes.changes)) ??
+								0;
+							return count > 0 ? (target as any) : null;
+						});
+					}
+
+					const rows = await db
+						.select()
+						.from(schemaModel)
+						.where(...clause)
+						.limit(1);
+					const target = rows[0];
+					if (!target) return null;
+					const targetId = target[idField] ?? (target as any).id;
+					if (targetId === undefined || targetId === null || !idColumn) {
+						return null;
+					}
+					const deleted = await db
+						.delete(schemaModel)
+						.where(eq(idColumn, targetId))
+						.returning();
+					return (deleted[0] as any) ?? null;
+				},
 				options: config,
 			};
 		};

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -82,7 +82,7 @@ export interface DrizzleAdapterConfig {
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	const createCustomAdapter =
-		(db: DB): AdapterFactoryCustomizeAdapterCreator =>
+		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({ getFieldName, getDefaultFieldName, options }) => {
 			function getSchema(model: string) {
 				const schema = config.schema || db._.fullSchema;
@@ -846,7 +846,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						// MySQL has no DELETE ... RETURNING. Hold the row under
 						// SELECT ... FOR UPDATE inside a transaction so concurrent
 						// claimants block until the row is gone.
-						return db.transaction(async (tx: DB) => {
+						const claimFromTransaction = async (tx: DB) => {
 							const rows = await tx
 								.select()
 								.from(schemaModel)
@@ -870,23 +870,23 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 										delRes.changes)) ??
 								0;
 							return count > 0 ? (target as any) : null;
-						});
+						};
+						return inTransaction
+							? claimFromTransaction(db)
+							: db.transaction(claimFromTransaction);
 					}
 
-					const rows = await db
-						.select()
+					if (!idColumn) {
+						return null;
+					}
+					const targetIds = db
+						.select({ id: idColumn })
 						.from(schemaModel)
 						.where(...clause)
 						.limit(1);
-					const target = rows[0];
-					if (!target) return null;
-					const targetId = target[idField] ?? (target as any).id;
-					if (targetId === undefined || targetId === null || !idColumn) {
-						return null;
-					}
 					const deleted = await db
 						.delete(schemaModel)
-						.where(eq(idColumn, targetId))
+						.where(inArray(idColumn, targetIds))
 						.returning();
 					return (deleted[0] as any) ?? null;
 				},
@@ -922,8 +922,11 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					? (cb) =>
 							db.transaction((tx: DB) => {
 								const adapter = createAdapterFactory({
-									config: adapterOptions!.config,
-									adapter: createCustomAdapter(tx),
+									config: {
+										...adapterOptions!.config,
+										transaction: false,
+									},
+									adapter: createCustomAdapter(tx, true),
 								})(lazyOptions!);
 								return cb(adapter);
 							})

--- a/packages/kysely-adapter/src/kysely-adapter.test.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.test.ts
@@ -1,5 +1,5 @@
 import { Kysely, SqliteDialect } from "kysely";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { kyselyAdapter } from "./kysely-adapter";
 
 describe("kysely-adapter", () => {
@@ -20,5 +20,45 @@ describe("kysely-adapter", () => {
 		});
 		const adapter = kyselyAdapter(db);
 		expect(adapter).toBeDefined();
+	});
+
+	it("claimOne deletes only the selected row for non-unique predicates", async () => {
+		const selected = {
+			id: "verification-1",
+			identifier: "same-identifier",
+			value: "first",
+		};
+		const deleted = { ...selected };
+		const selectQuery = {
+			selectAll: vi.fn(() => selectQuery),
+			where: vi.fn(() => selectQuery),
+			limit: vi.fn(() => selectQuery),
+			executeTakeFirst: vi.fn().mockResolvedValue(selected),
+		};
+		const deleteQuery = {
+			where: vi.fn(() => deleteQuery),
+			returningAll: vi.fn(() => deleteQuery),
+			executeTakeFirst: vi.fn().mockResolvedValue(deleted),
+		};
+		const db = {
+			selectFrom: vi.fn(() => selectQuery),
+			deleteFrom: vi.fn(() => deleteQuery),
+		} as any;
+		const adapter = kyselyAdapter(db)({});
+
+		const result = await adapter.claimOne({
+			model: "verification",
+			where: [{ field: "identifier", value: "same-identifier" }],
+		});
+
+		expect(result).toEqual(deleted);
+		expect(selectQuery.where).toHaveBeenCalledTimes(1);
+		expect(deleteQuery.where).toHaveBeenCalledTimes(1);
+		expect(deleteQuery.where).toHaveBeenCalledWith(
+			"verification.id",
+			"=",
+			"verification-1",
+		);
+		expect(deleteQuery.returningAll).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/kysely-adapter/src/kysely-adapter.test.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.test.ts
@@ -23,17 +23,15 @@ describe("kysely-adapter", () => {
 	});
 
 	it("claimOne deletes only the selected row for non-unique predicates", async () => {
-		const selected = {
+		const selectQuery = {
+			select: vi.fn(() => selectQuery),
+			where: vi.fn(() => selectQuery),
+			limit: vi.fn(() => selectQuery),
+		};
+		const deleted = {
 			id: "verification-1",
 			identifier: "same-identifier",
 			value: "first",
-		};
-		const deleted = { ...selected };
-		const selectQuery = {
-			selectAll: vi.fn(() => selectQuery),
-			where: vi.fn(() => selectQuery),
-			limit: vi.fn(() => selectQuery),
-			executeTakeFirst: vi.fn().mockResolvedValue(selected),
 		};
 		const deleteQuery = {
 			where: vi.fn(() => deleteQuery),
@@ -52,12 +50,13 @@ describe("kysely-adapter", () => {
 		});
 
 		expect(result).toEqual(deleted);
+		expect(selectQuery.select).toHaveBeenCalledWith("verification.id");
 		expect(selectQuery.where).toHaveBeenCalledTimes(1);
 		expect(deleteQuery.where).toHaveBeenCalledTimes(1);
 		expect(deleteQuery.where).toHaveBeenCalledWith(
 			"verification.id",
-			"=",
-			"verification-1",
+			"in",
+			selectQuery,
 		);
 		expect(deleteQuery.returningAll).toHaveBeenCalledTimes(1);
 	});

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -662,6 +662,68 @@ export const kyselyAdapter = (
 						? Number.MAX_SAFE_INTEGER
 						: Number(res);
 				},
+				async claimOne({ model, where }) {
+					const { and, or } = convertWhereClause(model, where);
+					const applyWhere = (query: any) => {
+						if (and) {
+							query = query.where((eb: any) =>
+								eb.and(and.map((expr) => expr(eb))),
+							);
+						}
+						if (or) {
+							query = query.where((eb: any) =>
+								eb.or(or.map((expr) => expr(eb))),
+							);
+						}
+						return query;
+					};
+					const idField = getFieldName({ model, field: "id" });
+					const deleteSelectedRow = async (db: any, row: any) => {
+						const targetId = row[idField] ?? row.id;
+						if (targetId === undefined || targetId === null) {
+							return null;
+						}
+						const query: any = db
+							.deleteFrom(model)
+							.where(`${model}.${idField}`, "=", targetId);
+
+						if (config?.type === "mysql") {
+							const result = await query.executeTakeFirst();
+							return Number(result.numDeletedRows) > 0 ? row : null;
+						}
+
+						if (config?.type === "mssql") {
+							return (
+								(await query.outputAll("deleted").executeTakeFirst()) ?? null
+							);
+						}
+
+						return (await query.returningAll().executeTakeFirst()) ?? null;
+					};
+
+					if (config?.type === "mysql") {
+						// MySQL does not support `DELETE ... RETURNING`. Hold the row
+						// under `SELECT ... FOR UPDATE`, then delete inside the same
+						// transaction. Concurrent claimants block until the lock
+						// releases, at which point the row is gone and they observe
+						// nothing.
+						return db.transaction().execute(async (trx) => {
+							const row = await applyWhere(
+								trx.selectFrom(model).selectAll().forUpdate(),
+							)
+								.limit(1)
+								.executeTakeFirst();
+							if (!row) return null;
+							return deleteSelectedRow(trx, row);
+						});
+					}
+
+					const row = await applyWhere(db.selectFrom(model).selectAll())
+						.limit(1)
+						.executeTakeFirst();
+					if (!row) return null;
+					return deleteSelectedRow(db, row);
+				},
 				options: config,
 			};
 		};

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -59,6 +59,7 @@ export const kyselyAdapter = (
 	let lazyOptions: BetterAuthOptions | null = null;
 	const createCustomAdapter = (
 		db: Kysely<any>,
+		inTransaction = false,
 	): AdapterFactoryCustomizeAdapterCreator => {
 		return ({
 			getFieldName,
@@ -700,6 +701,14 @@ export const kyselyAdapter = (
 
 						return (await query.returningAll().executeTakeFirst()) ?? null;
 					};
+					const deleteWithReturning = async (query: any) => {
+						if (config?.type === "mssql") {
+							return (
+								(await query.outputAll("deleted").executeTakeFirst()) ?? null
+							);
+						}
+						return (await query.returningAll().executeTakeFirst()) ?? null;
+					};
 
 					if (config?.type === "mysql") {
 						// MySQL does not support `DELETE ... RETURNING`. Hold the row
@@ -707,7 +716,7 @@ export const kyselyAdapter = (
 						// transaction. Concurrent claimants block until the lock
 						// releases, at which point the row is gone and they observe
 						// nothing.
-						return db.transaction().execute(async (trx) => {
+						const claimFromTransaction = async (trx: any) => {
 							const row = await applyWhere(
 								trx.selectFrom(model).selectAll().forUpdate(),
 							)
@@ -715,14 +724,19 @@ export const kyselyAdapter = (
 								.executeTakeFirst();
 							if (!row) return null;
 							return deleteSelectedRow(trx, row);
-						});
+						};
+						return inTransaction
+							? claimFromTransaction(db)
+							: db.transaction().execute(claimFromTransaction);
 					}
 
-					const row = await applyWhere(db.selectFrom(model).selectAll())
-						.limit(1)
-						.executeTakeFirst();
-					if (!row) return null;
-					return deleteSelectedRow(db, row);
+					const targetIds = applyWhere(
+						db.selectFrom(model).select(`${model}.${idField}`),
+					).limit(1);
+					const query = db
+						.deleteFrom(model)
+						.where(`${model}.${idField}`, "in", targetIds);
+					return deleteWithReturning(query);
 				},
 				options: config,
 			};
@@ -756,8 +770,11 @@ export const kyselyAdapter = (
 				? (cb) =>
 						db.transaction().execute((trx) => {
 							const adapter = createAdapterFactory({
-								config: adapterOptions!.config,
-								adapter: createCustomAdapter(trx),
+								config: {
+									...adapterOptions!.config,
+									transaction: false,
+								},
+								adapter: createCustomAdapter(trx, true),
 							})(lazyOptions!);
 							return cb(adapter);
 						})

--- a/packages/memory-adapter/src/memory-adapter.ts
+++ b/packages/memory-adapter/src/memory-adapter.ts
@@ -386,6 +386,14 @@ export const memoryAdapter = (
 					});
 					return count;
 				},
+				claimOne: async ({ model, where }) => {
+					const table = db[model]!;
+					const matches = convertWhereClause(where, model);
+					const target = matches[0];
+					if (!target) return null;
+					db[model] = table.filter((record) => record !== target);
+					return target as any;
+				},
 				updateMany({ model, where, update }) {
 					const res = convertWhereClause(where, model);
 					res.forEach((record) => {

--- a/packages/mongo-adapter/src/mongodb-adapter.test.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.test.ts
@@ -10,6 +10,34 @@ describe("mongodb-adapter", () => {
 		const adapter = mongodbAdapter(db);
 		expect(adapter).toBeDefined();
 	});
+
+	it("claimOne returns the deleted document from Mongo metadata", async () => {
+		const deleted = {
+			_id: "verification-id",
+			identifier: "magic-link-token",
+		};
+		const findOneAndDelete = vi.fn(async () => ({ value: deleted }));
+		const db = {
+			collection: vi.fn(() => ({
+				findOneAndDelete,
+			})),
+		} as any;
+		const adapter = mongodbAdapter(db, { transaction: false })({});
+
+		const result = await adapter.claimOne({
+			model: "verification",
+			where: [{ field: "identifier", value: "magic-link-token" }],
+		});
+
+		expect(result).toMatchObject({
+			id: "verification-id",
+			identifier: "magic-link-token",
+		});
+		expect(findOneAndDelete).toHaveBeenCalledWith(
+			{ identifier: "magic-link-token" },
+			expect.objectContaining({ includeResultMetadata: true }),
+		);
+	});
 });
 
 describe("uuid support", () => {

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -630,6 +630,13 @@ export const mongodbAdapter = (
 						.deleteMany(clause, { session });
 					return res.deletedCount;
 				},
+				async claimOne({ model, where }) {
+					const clause = convertWhereClause({ where, model });
+					const doc = await db
+						.collection(model)
+						.findOneAndDelete(clause, { session });
+					return (doc as any) ?? null;
+				},
 			};
 		};
 

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -632,10 +632,11 @@ export const mongodbAdapter = (
 				},
 				async claimOne({ model, where }) {
 					const clause = convertWhereClause({ where, model });
-					const doc = await db
-						.collection(model)
-						.findOneAndDelete(clause, { session });
-					return (doc as any) ?? null;
+					const doc = await db.collection(model).findOneAndDelete(clause, {
+						session,
+						includeResultMetadata: true,
+					});
+					return ((doc as any)?.value as any) ?? null;
 				},
 			};
 		};
@@ -671,7 +672,10 @@ export const mongodbAdapter = (
 								session.startTransaction();
 
 								const adapter = createAdapterFactory({
-									config: adapterOptions!.config,
+									config: {
+										...adapterOptions!.config,
+										transaction: false,
+									},
 									adapter: createCustomAdapter(db, session),
 								})(lazyOptions!);
 

--- a/packages/prisma-adapter/src/prisma-adapter.test.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.test.ts
@@ -213,4 +213,73 @@ describe("prisma-adapter", () => {
 			name: "Updated",
 		});
 	});
+
+	it("claimOne rechecks non-unique predicates before deleting", async () => {
+		const target = {
+			id: "verification-id",
+			identifier: "magic-link-token",
+			value: "otp",
+		};
+		const txClient = {
+			verification: {
+				findFirst: vi.fn().mockResolvedValue(target),
+				deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+			},
+		};
+		const transaction = vi.fn(async (cb) => cb(txClient));
+		const adapter = createTestAdapter({
+			$transaction: transaction,
+			verification: {
+				delete: vi.fn(),
+			},
+		});
+
+		const result = await adapter.claimOne({
+			model: "verification",
+			where: [{ field: "identifier", value: "magic-link-token" }],
+		});
+
+		expect(result).toEqual(target);
+		expect(transaction).toHaveBeenCalledTimes(1);
+		expect(txClient.verification.deleteMany).toHaveBeenCalledWith({
+			where: {
+				AND: [
+					{ identifier: { equals: "magic-link-token" } },
+					{ id: { equals: "verification-id" } },
+				],
+			},
+		});
+	});
+
+	it("claimOne does not open a nested transaction from a transaction adapter", async () => {
+		const target = {
+			id: "verification-id",
+			identifier: "magic-link-token",
+		};
+		const txClient = {
+			verification: {
+				findFirst: vi.fn().mockResolvedValue(target),
+				deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+			},
+		};
+		const transaction = vi.fn(async (cb) => cb(txClient));
+		const adapter = prismaAdapter(
+			{
+				$transaction: transaction,
+			} as never,
+			{
+				provider: "sqlite",
+				transaction: true,
+			},
+		)({} as BetterAuthOptions);
+
+		await adapter.transaction(async (trx) => {
+			await trx.claimOne({
+				model: "verification",
+				where: [{ field: "identifier", value: "magic-link-token" }],
+			});
+		});
+
+		expect(transaction).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/prisma-adapter/src/prisma-adapter.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.ts
@@ -48,6 +48,12 @@ export interface PrismaConfig {
 
 interface PrismaClient {}
 
+function isPrismaNotFoundError(e: any): boolean {
+	return (
+		e?.code === "P2025" || e?.meta?.cause === "Record to delete does not exist."
+	);
+}
+
 type PrismaClientInternal = {
 	$transaction: (
 		callback: (db: PrismaClient) => Awaitable<any>,
@@ -593,9 +599,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 							where: whereClause,
 						});
 					} catch (e: any) {
-						// If the record doesn't exist, we don't want to throw an error
-						if (e?.meta?.cause === "Record to delete does not exist.") return;
-						if (e?.code === "P2025") return; // Prisma 7+
+						if (isPrismaNotFoundError(e)) return;
 						// otherwise if it's an unknown error, we want to just log it for debugging.
 						console.log(e);
 					}
@@ -610,6 +614,55 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 						where: whereClause,
 					});
 					return result ? (result.count as number) : 0;
+				},
+				async claimOne({ model, where }) {
+					if (!db[model]) {
+						throw new BetterAuthError(
+							`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
+						);
+					}
+
+					// `prisma.model.delete` requires a WhereUniqueInput. When the
+					// caller keys on the primary key we get a single round trip;
+					// otherwise we fall back to find-then-delete inside an
+					// interactive transaction so two racers serialize behind the
+					// same row.
+					const hasIdField = where?.some((w) => w.field === "id");
+					if (hasIdField) {
+						const whereClause = convertWhereClause({
+							model,
+							where,
+							action: "delete",
+						});
+						try {
+							const row = await db[model]!.delete({ where: whereClause });
+							return (row as any) ?? null;
+						} catch (e: any) {
+							if (isPrismaNotFoundError(e)) return null;
+							throw e;
+						}
+					}
+
+					const findWhere = convertWhereClause({
+						model,
+						where,
+						action: "findOne",
+					});
+					return (prisma as PrismaClientInternal).$transaction(async (tx) => {
+						const target = await (tx as any)[model].findFirst({
+							where: findWhere,
+						});
+						if (!target) return null;
+						try {
+							const row = await (tx as any)[model].delete({
+								where: { id: (target as any).id },
+							});
+							return (row as any) ?? null;
+						} catch (e: any) {
+							if (isPrismaNotFoundError(e)) return null;
+							throw e;
+						}
+					});
 				},
 				options: config,
 			};

--- a/packages/prisma-adapter/src/prisma-adapter.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.ts
@@ -676,7 +676,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 									action: "deleteMany",
 								}),
 							});
-							return result?.count > 0 ? ((target as any) ?? null) : null;
+							return result?.count > 0 ? (target as any) : null;
 						} catch (e: any) {
 							if (isPrismaNotFoundError(e)) return null;
 							throw e;

--- a/packages/prisma-adapter/src/prisma-adapter.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.ts
@@ -73,7 +73,10 @@ type PrismaClientInternal = {
 export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	const createCustomAdapter =
-		(prisma: PrismaClient): AdapterFactoryCustomizeAdapterCreator =>
+		(
+			prisma: PrismaClient,
+			inTransaction = false,
+		): AdapterFactoryCustomizeAdapterCreator =>
 		({
 			getFieldName,
 			getModelName,
@@ -624,9 +627,12 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 
 					// `prisma.model.delete` requires a WhereUniqueInput. When the
 					// caller keys on the primary key we get a single round trip;
-					// otherwise we fall back to find-then-delete inside an
-					// interactive transaction so two racers serialize behind the
-					// same row.
+					// otherwise we fall back to find-then-deleteMany inside a
+					// transaction. deleteMany rechecks the original predicate with the
+					// selected id so we do not delete a row that stopped matching.
+					// FIXME(claim-one-prisma-locking): Prisma has no portable
+					// row-locking API for findFirst. Add provider-specific locking
+					// when a breaking adapter contract can expose it cleanly.
 					const hasIdField = where?.some((w) => w.field === "id");
 					if (hasIdField) {
 						const whereClause = convertWhereClause({
@@ -648,21 +654,37 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 						where,
 						action: "findOne",
 					});
-					return (prisma as PrismaClientInternal).$transaction(async (tx) => {
+					const claimFromTransaction = async (tx: PrismaClient) => {
 						const target = await (tx as any)[model].findFirst({
 							where: findWhere,
 						});
 						if (!target) return null;
 						try {
-							const row = await (tx as any)[model].delete({
-								where: { id: (target as any).id },
+							const result = await (tx as any)[model].deleteMany({
+								where: convertWhereClause({
+									model,
+									where: [
+										...(where ?? []),
+										{
+											field: "id",
+											value: (target as any).id,
+											operator: "eq",
+											connector: "AND",
+											mode: "sensitive",
+										},
+									],
+									action: "deleteMany",
+								}),
 							});
-							return (row as any) ?? null;
+							return result?.count > 0 ? ((target as any) ?? null) : null;
 						} catch (e: any) {
 							if (isPrismaNotFoundError(e)) return null;
 							throw e;
 						}
-					});
+					};
+					return inTransaction || typeof db.$transaction !== "function"
+						? claimFromTransaction(db)
+						: db.$transaction(claimFromTransaction);
 				},
 				options: config,
 			};
@@ -685,8 +707,11 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 					? (cb) =>
 							(prisma as PrismaClientInternal).$transaction((tx) => {
 								const adapter = createAdapterFactory({
-									config: adapterOptions!.config,
-									adapter: createCustomAdapter(tx),
+									config: {
+										...adapterOptions!.config,
+										transaction: false,
+									},
+									adapter: createCustomAdapter(tx, true),
 								})(lazyOptions!);
 								return cb(adapter);
 							})

--- a/packages/redis-storage/src/redis-storage.ts
+++ b/packages/redis-storage/src/redis-storage.ts
@@ -46,6 +46,10 @@ export function redisStorage(config: RedisStorageConfig) {
 			return client.get(prefixKey(key));
 		},
 
+		async getAndDelete(key: string) {
+			return client.call("GETDEL", prefixKey(key));
+		},
+
 		async set(key: string, value: string, ttl?: number | undefined) {
 			const prefixedKey = prefixKey(key);
 			if (ttl !== undefined && ttl > 0) {

--- a/packages/redis-storage/src/redis-storage.ts
+++ b/packages/redis-storage/src/redis-storage.ts
@@ -36,6 +36,7 @@ export interface RedisStorageConfig {
  */
 export function redisStorage(config: RedisStorageConfig) {
 	const { client, keyPrefix = "better-auth:" } = config;
+	let supportsGetDel = true;
 	const getAndDeleteScript = `
 local value = redis.call("GET", KEYS[1])
 if value ~= false then
@@ -47,6 +48,9 @@ return value
 	const prefixKey = (key: string): string => {
 		return `${keyPrefix}${key}`;
 	};
+	const isUnknownCommandError = (error: unknown) =>
+		error instanceof Error &&
+		error.message.toLowerCase().includes("unknown command");
 
 	return {
 		async get(key: string) {
@@ -54,7 +58,20 @@ return value
 		},
 
 		async getAndDelete(key: string) {
-			return client.eval(getAndDeleteScript, 1, prefixKey(key));
+			const prefixedKey = prefixKey(key);
+			if (supportsGetDel) {
+				try {
+					return await client.call("GETDEL", prefixedKey);
+				} catch (error) {
+					if (!isUnknownCommandError(error)) {
+						throw error;
+					}
+					supportsGetDel = false;
+				}
+			}
+			// TODO(redis-6.2-required): require Redis >= 6.2 in the next
+			// breaking branch and remove this Lua compatibility fallback.
+			return client.eval(getAndDeleteScript, 1, prefixedKey);
 		},
 
 		async set(key: string, value: string, ttl?: number | undefined) {

--- a/packages/redis-storage/src/redis-storage.ts
+++ b/packages/redis-storage/src/redis-storage.ts
@@ -36,6 +36,13 @@ export interface RedisStorageConfig {
  */
 export function redisStorage(config: RedisStorageConfig) {
 	const { client, keyPrefix = "better-auth:" } = config;
+	const getAndDeleteScript = `
+local value = redis.call("GET", KEYS[1])
+if value ~= false then
+  redis.call("DEL", KEYS[1])
+end
+return value
+`;
 
 	const prefixKey = (key: string): string => {
 		return `${keyPrefix}${key}`;
@@ -47,7 +54,7 @@ export function redisStorage(config: RedisStorageConfig) {
 		},
 
 		async getAndDelete(key: string) {
-			return client.call("GETDEL", prefixKey(key));
+			return client.eval(getAndDeleteScript, 1, prefixKey(key));
 		},
 
 		async set(key: string, value: string, ttl?: number | undefined) {

--- a/packages/redis-storage/test/redis-storage.test.ts
+++ b/packages/redis-storage/test/redis-storage.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { redisStorage } from "../src/redis-storage";
+
+describe("redisStorage", () => {
+	it("uses an atomic Lua get-and-delete operation", async () => {
+		const evalMock = vi.fn().mockResolvedValue("stored-value");
+		const storage = redisStorage({
+			client: {
+				eval: evalMock,
+			} as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.getAndDelete("verification-key")).resolves.toBe(
+			"stored-value",
+		);
+		expect(evalMock).toHaveBeenCalledWith(
+			expect.stringContaining('redis.call("GET", KEYS[1])'),
+			1,
+			"ba:verification-key",
+		);
+	});
+});

--- a/packages/redis-storage/test/redis-storage.test.ts
+++ b/packages/redis-storage/test/redis-storage.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { redisStorage } from "../src/redis-storage";
 
 describe("redisStorage", () => {
-	it("uses an atomic Lua get-and-delete operation", async () => {
-		const evalMock = vi.fn().mockResolvedValue("stored-value");
+	it("uses GETDEL when it is supported", async () => {
+		const callMock = vi.fn().mockResolvedValue("stored-value");
+		const evalMock = vi.fn();
 		const storage = redisStorage({
 			client: {
+				call: callMock,
 				eval: evalMock,
 			} as any,
 			keyPrefix: "ba:",
@@ -14,10 +16,57 @@ describe("redisStorage", () => {
 		await expect(storage.getAndDelete("verification-key")).resolves.toBe(
 			"stored-value",
 		);
+		expect(callMock).toHaveBeenCalledWith("GETDEL", "ba:verification-key");
+		expect(evalMock).not.toHaveBeenCalled();
+	});
+
+	it("falls back to Lua when GETDEL is unavailable", async () => {
+		const callMock = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("ERR unknown command 'GETDEL'"));
+		const evalMock = vi.fn().mockResolvedValue("stored-value");
+		const storage = redisStorage({
+			client: {
+				call: callMock,
+				eval: evalMock,
+			} as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.getAndDelete("verification-key")).resolves.toBe(
+			"stored-value",
+		);
+		await expect(storage.getAndDelete("other-verification-key")).resolves.toBe(
+			"stored-value",
+		);
+		expect(callMock).toHaveBeenCalledTimes(1);
 		expect(evalMock).toHaveBeenCalledWith(
 			expect.stringContaining('redis.call("GET", KEYS[1])'),
 			1,
 			"ba:verification-key",
 		);
+		expect(evalMock).toHaveBeenCalledWith(
+			expect.stringContaining('redis.call("GET", KEYS[1])'),
+			1,
+			"ba:other-verification-key",
+		);
+	});
+
+	it("rethrows GETDEL errors that are not unknown-command errors", async () => {
+		const callError = new Error("Authentication required");
+		const callMock = vi.fn().mockRejectedValue(callError);
+		const evalMock = vi.fn();
+		const storage = redisStorage({
+			client: {
+				call: callMock,
+				eval: evalMock,
+			} as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.getAndDelete("verification-key")).rejects.toThrow(
+			callError,
+		);
+		expect(evalMock).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Adds `DBAdapter.claimOne(model, where)`, an atomic single-row delete-and-return primitive. Native implementations ship for memory, mongo, drizzle, kysely, and prisma using each backend's atomic operator (`DELETE ... RETURNING` on PostgreSQL/SQLite, `findOneAndDelete` on MongoDB, `SELECT ... FOR UPDATE` inside a transaction on MySQL). The factory provides a `transaction(findMany + delete)` fallback when `CustomAdapter.claimOne` isn't implemented.

Layered on top, `internalAdapter.consumeVerificationValue(identifier)` atomically consumes a verification row keyed by identifier: the first concurrent caller wins, later racers receive `null`. The new `consumeOneWithHooks` helper wires the atomic claim into the existing `delete.before` / `delete.after` hook lifecycle.

`SecondaryStorage.getAndDelete` is added as an optional companion method; redis-storage ships it via `GETDEL`. The secondary-storage path of `consumeVerificationValue` uses it when available and falls back to a per-key in-process lock otherwise.

This PR ships the primitive only; existing call sites are not migrated.

## Notes for adapter implementers

- `DBAdapter.claimOne` is always defined (the factory provides a fallback); `CustomAdapter.claimOne` remains optional.
- `claimOne` MUST delete at most one row even when the predicate matches several.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an atomic single-row delete-and-return primitive and uses it to safely consume verification values so only one caller can use a token; others get null. Factory fallback and adapter implementations were hardened; `redis-storage` now prefers `GETDEL` with a Lua fallback for older Redis.

- **New Features**
  - Added `DBAdapter.claimOne(model, where)` for atomic delete-and-return. Implemented in `memory-adapter`, `mongo-adapter`, `drizzle-adapter`, `kysely-adapter`, and `prisma-adapter`; the factory falls back to `transaction(findMany + deleteMany)` and only returns the row if the delete succeeds. Hardened across adapters: MySQL uses row locks (`SELECT ... FOR UPDATE`) in a transaction, Prisma rechecks non-unique predicates and avoids nested transactions, and all ensure at-most-one row is deleted.
  - Added `internalAdapter.consumeVerificationValue(identifier)` to atomically claim the latest verification row and invalidate stale ones. Supports hashed identifiers and runs existing `delete.before` / `delete.after` hooks via `consumeOneWithHooks`. Secondary-storage-only paths use `getAndDelete` when available or a per-key in-process lock as a fallback.
  - Added optional `SecondaryStorage.getAndDelete`; `redis-storage` implements it via `GETDEL` when available, with an atomic Lua get-and-delete fallback for Redis versions before 6.2.

- **Migration**
  - No app changes required; call sites are not migrated in this PR.
  - Adapter authors can implement `claimOne` for stronger guarantees and fewer round trips; otherwise the hardened factory fallback is used.
  - Secondary storage providers should add `getAndDelete` to make cross-process consumption atomic.

<sup>Written for commit 4ac65db2558f14315a8975a61925f723da8889e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

