### PR TITLE
feat: add sendResetPasswordNoAccount callback for /request-password-reset

### DIFF
--- a/.changeset/reset-password-no-account-callback.md
+++ b/.changeset/reset-password-no-account-callback.md
@@ -1,0 +1,8 @@
+---
+"better-auth": minor
+"@better-auth/core": minor
+---
+
+feat(auth): add `sendResetPasswordNoAccount` callback for `/request-password-reset`
+
+Optional callback on `emailAndPassword` config, triggered when the endpoint receives an email with no associated account. Lets you send a "create your account" email without breaking enumeration protection — the HTTP response is identical regardless of whether the email exists.

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -346,7 +346,9 @@ export const auth = betterAuth({
 ```
 
 <Callout type="info">
-  This is safe because the only observable difference between "email exists" and "email doesn't exist" is what the submitter sees in **their own inbox** — by definition not an enumeration vector. The HTTP response and timing remain identical (same JSON body, same status, same latency thanks to the existing timing-attack mitigation), and `sendResetPasswordNoAccount` runs via `runInBackgroundOrAwait` exactly like `sendResetPassword` does for known emails.
+  The HTTP **response body and status** are identical for both branches (known and unknown emails). The only observable difference is what the submitter sees in their **own inbox** — by definition not an enumeration vector.
+
+  About **latency**: both branches dispatch their email callback through the same `runInBackgroundOrAwait` helper. When `advanced.backgroundTasks.handler` is configured, both return immediately (work is deferred); without it, both are awaited. Latency stays equivalent **as long as `sendResetPasswordNoAccount` and `sendResetPassword` have similar execution characteristics** (e.g. both queue an async email send rather than blocking on SMTP).
 </Callout>
 
 Once you configured your server you can call `requestPasswordReset` function to send reset password link to user. If the user exists, it will trigger the `sendResetPassword` function you provided in the auth config.

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -323,6 +323,32 @@ export const auth = betterAuth({
 
 Additionally, you can provide an `onPasswordReset` callback to execute logic after a password has been successfully reset.
 
+#### Encouraging Account Creation for Unknown Emails
+
+By default, when `/request-password-reset` is called with an email that has no associated account, no email is sent (and the API response is identical to the success case to prevent enumeration attacks).
+
+If you want to send a "create your account" email instead — without leaking whether the email exists — provide a `sendResetPasswordNoAccount` callback:
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+  emailAndPassword: {
+    enabled: true,
+    sendResetPassword: async ({ user, url }) => { /* ... */ },
+    sendResetPasswordNoAccount: async ({ email }, request) => {
+      void sendEmail({
+        to: email,
+        subject: "Create your account",
+        text: `You tried to reset a password but no account exists for ${email}. Sign up here: https://example.com/sign-up`,
+      });
+    },
+  },
+});
+```
+
+<Callout type="info">
+  This is safe because the only observable difference between "email exists" and "email doesn't exist" is what the submitter sees in **their own inbox** — by definition not an enumeration vector. The HTTP response and timing remain identical (same JSON body, same status, same latency thanks to the existing timing-attack mitigation), and `sendResetPasswordNoAccount` runs via `runInBackgroundOrAwait` exactly like `sendResetPassword` does for known emails.
+</Callout>
+
 Once you configured your server you can call `requestPasswordReset` function to send reset password link to user. If the user exists, it will trigger the `sendResetPassword` function you provided in the auth config.
 
 <APIMethod path="/request-password-reset" method="POST">
@@ -491,6 +517,12 @@ export const emailPasswordOptionsType = {
     description:
       "Sends a password reset email. It takes a function that takes two parameters: token and user.",
     type: "function",
+  },
+  sendResetPasswordNoAccount: {
+    description:
+      "Optional. Triggered when /request-password-reset is called for an email with no account. Lets you send a 'create your account' email without breaking enumeration protection (the HTTP response stays identical).",
+    type: "function",
+    default: "undefined",
   },
   onPasswordReset: {
     description:

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -350,6 +350,8 @@ export const auth = betterAuth({
 <Callout type="info">
   The HTTP **response body and status** are identical for both branches (known and unknown emails). The only observable difference is what the submitter sees in their **own inbox** — by definition not an enumeration vector.
 
+  Synchronous exceptions and rejected promises from `sendResetPasswordNoAccount` are logged without changing the generic success response, with or without a background task handler.
+
   About **latency**: both branches dispatch their email callback through the same `runInBackgroundOrAwait` helper. When `advanced.backgroundTasks.handler` is configured, both return immediately (work is deferred); without it, both are awaited. Latency stays equivalent **as long as `sendResetPasswordNoAccount` and `sendResetPassword` have similar execution characteristics** (e.g. both queue an async email send rather than blocking on SMTP).
 </Callout>
 

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -325,6 +325,32 @@ export const auth = betterAuth({
 
 Additionally, you can provide an `onPasswordReset` callback to execute logic after a password has been successfully reset.
 
+#### Encouraging Account Creation for Unknown Emails
+
+By default, when `/request-password-reset` is called with an email that has no associated account, no email is sent (and the API response is identical to the success case to prevent enumeration attacks).
+
+If you want to send a "create your account" email instead — without leaking whether the email exists — provide a `sendResetPasswordNoAccount` callback:
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+  emailAndPassword: {
+    enabled: true,
+    sendResetPassword: async ({ user, url }) => { /* ... */ },
+    sendResetPasswordNoAccount: async ({ email }, request) => {
+      void sendEmail({
+        to: email,
+        subject: "Create your account",
+        text: `You tried to reset a password but no account exists for ${email}. Sign up here: https://example.com/sign-up`,
+      });
+    },
+  },
+});
+```
+
+<Callout type="info">
+  This is safe because the only observable difference between "email exists" and "email doesn't exist" is what the submitter sees in **their own inbox** — by definition not an enumeration vector. The HTTP response and timing remain identical (same JSON body, same status, same latency thanks to the existing timing-attack mitigation), and `sendResetPasswordNoAccount` runs via `runInBackgroundOrAwait` exactly like `sendResetPassword` does for known emails.
+</Callout>
+
 Once you configured your server you can call `requestPasswordReset` function to send reset password link to user. If the user exists, it will trigger the `sendResetPassword` function you provided in the auth config.
 
 <APIMethod path="/request-password-reset" method="POST">
@@ -493,6 +519,12 @@ export const emailPasswordOptionsType = {
     description:
       "Sends a password reset email. It takes a function that takes two parameters: token and user.",
     type: "function",
+  },
+  sendResetPasswordNoAccount: {
+    description:
+      "Optional. Triggered when /request-password-reset is called for an email with no account. Lets you send a 'create your account' email without breaking enumeration protection (the HTTP response stays identical).",
+    type: "function",
+    default: "undefined",
   },
   onPasswordReset: {
     description:

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -348,7 +348,9 @@ export const auth = betterAuth({
 ```
 
 <Callout type="info">
-  This is safe because the only observable difference between "email exists" and "email doesn't exist" is what the submitter sees in **their own inbox** — by definition not an enumeration vector. The HTTP response and timing remain identical (same JSON body, same status, same latency thanks to the existing timing-attack mitigation), and `sendResetPasswordNoAccount` runs via `runInBackgroundOrAwait` exactly like `sendResetPassword` does for known emails.
+  The HTTP **response body and status** are identical for both branches (known and unknown emails). The only observable difference is what the submitter sees in their **own inbox** — by definition not an enumeration vector.
+
+  About **latency**: both branches dispatch their email callback through the same `runInBackgroundOrAwait` helper. When `advanced.backgroundTasks.handler` is configured, both return immediately (work is deferred); without it, both are awaited. Latency stays equivalent **as long as `sendResetPasswordNoAccount` and `sendResetPassword` have similar execution characteristics** (e.g. both queue an async email send rather than blocking on SMTP).
 </Callout>
 
 Once you configured your server you can call `requestPasswordReset` function to send reset password link to user. If the user exists, it will trigger the `sendResetPassword` function you provided in the auth config.

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -395,6 +395,67 @@ describe("forgot password", async () => {
 			"If this email exists in our system, check your email for the reset link",
 		);
 	});
+
+	it("should call sendResetPasswordNoAccount when email has no account", async () => {
+		const mockSendNoAccount = vi.fn();
+		const { client } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword() {},
+				sendResetPasswordNoAccount: async ({ email }) => {
+					await mockSendNoAccount(email);
+				},
+			},
+		});
+		await client.requestPasswordReset({
+			email: "non-existent-user@email.com",
+			redirectTo: "http://localhost:3000",
+		});
+		expect(mockSendNoAccount).toHaveBeenCalledWith(
+			"non-existent-user@email.com",
+		);
+	});
+
+	it("should not call sendResetPasswordNoAccount when email has an account", async () => {
+		const mockSendNoAccount = vi.fn();
+		const mockSendReset = vi.fn();
+		const { client, testUser } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword() {
+					await mockSendReset();
+				},
+				sendResetPasswordNoAccount: async () => {
+					await mockSendNoAccount();
+				},
+			},
+		});
+		await client.requestPasswordReset({
+			email: testUser.email,
+			redirectTo: "http://localhost:3000",
+		});
+		expect(mockSendReset).toHaveBeenCalled();
+		expect(mockSendNoAccount).not.toHaveBeenCalled();
+	});
+
+	it("should preserve enumeration protection when sendResetPasswordNoAccount is set", async () => {
+		const { client, testUser } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword() {},
+				sendResetPasswordNoAccount: async () => {},
+			},
+		});
+		const existing = await client.requestPasswordReset({
+			email: testUser.email,
+			redirectTo: "http://localhost:3000",
+		});
+		const unknown = await client.requestPasswordReset({
+			email: "non-existent-user@email.com",
+			redirectTo: "http://localhost:3000",
+		});
+		expect(existing.data).toEqual(unknown.data);
+	});
 });
 
 describe("revoke sessions on password reset", async () => {

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -456,6 +456,26 @@ describe("forgot password", async () => {
 		});
 		expect(existing.data).toEqual(unknown.data);
 	});
+
+	it("should not reveal failure of email sending in the no-account branch", async () => {
+		const { client } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword() {},
+				sendResetPasswordNoAccount: async () => {
+					throw new Error("Failed to send email");
+				},
+			},
+		});
+		const res = await client.requestPasswordReset({
+			email: "non-existent-user@email.com",
+			redirectTo: "http://localhost:3000",
+		});
+		expect(res.data?.status).toBe(true);
+		expect(res.data?.message).toBe(
+			"If this email exists in our system, check your email for the reset link",
+		);
+	});
 });
 
 describe("revoke sessions on password reset", async () => {

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -400,6 +400,67 @@ describe("forgot password", async () => {
 			"If this email exists in our system, check your email for the reset link",
 		);
 	});
+
+	it("should call sendResetPasswordNoAccount when email has no account", async () => {
+		const mockSendNoAccount = vi.fn();
+		const { client } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword() {},
+				sendResetPasswordNoAccount: async ({ email }) => {
+					await mockSendNoAccount(email);
+				},
+			},
+		});
+		await client.requestPasswordReset({
+			email: "non-existent-user@email.com",
+			redirectTo: "http://localhost:3000",
+		});
+		expect(mockSendNoAccount).toHaveBeenCalledWith(
+			"non-existent-user@email.com",
+		);
+	});
+
+	it("should not call sendResetPasswordNoAccount when email has an account", async () => {
+		const mockSendNoAccount = vi.fn();
+		const mockSendReset = vi.fn();
+		const { client, testUser } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword() {
+					await mockSendReset();
+				},
+				sendResetPasswordNoAccount: async () => {
+					await mockSendNoAccount();
+				},
+			},
+		});
+		await client.requestPasswordReset({
+			email: testUser.email,
+			redirectTo: "http://localhost:3000",
+		});
+		expect(mockSendReset).toHaveBeenCalled();
+		expect(mockSendNoAccount).not.toHaveBeenCalled();
+	});
+
+	it("should preserve enumeration protection when sendResetPasswordNoAccount is set", async () => {
+		const { client, testUser } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword() {},
+				sendResetPasswordNoAccount: async () => {},
+			},
+		});
+		const existing = await client.requestPasswordReset({
+			email: testUser.email,
+			redirectTo: "http://localhost:3000",
+		});
+		const unknown = await client.requestPasswordReset({
+			email: "non-existent-user@email.com",
+			redirectTo: "http://localhost:3000",
+		});
+		expect(existing.data).toEqual(unknown.data);
+	});
 });
 
 describe("revoke sessions on password reset", async () => {

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -461,6 +461,26 @@ describe("forgot password", async () => {
 		});
 		expect(existing.data).toEqual(unknown.data);
 	});
+
+	it("should not reveal failure of email sending in the no-account branch", async () => {
+		const { client } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword() {},
+				sendResetPasswordNoAccount: async () => {
+					throw new Error("Failed to send email");
+				},
+			},
+		});
+		const res = await client.requestPasswordReset({
+			email: "non-existent-user@email.com",
+			redirectTo: "http://localhost:3000",
+		});
+		expect(res.data?.status).toBe(true);
+		expect(res.data?.message).toBe(
+			"If this email exists in our system, check your email for the reset link",
+		);
+	});
 });
 
 describe("revoke sessions on password reset", async () => {

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -483,6 +483,58 @@ describe("forgot password", async () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/pull/9561
+ */
+it.each([
+	false,
+	true,
+])("should mask synchronous no-account callback errors with background tasks %s", async (background) => {
+	const tasks: Promise<unknown>[] = [];
+	const statuses: number[] = [];
+	const sendNoAccount = vi.fn(() => {
+		throw new Error("Email SDK rejected its configuration");
+	});
+	const { client, testUser } = await getTestInstance({
+		emailAndPassword: {
+			enabled: true,
+			async sendResetPassword() {},
+			sendResetPasswordNoAccount: sendNoAccount,
+		},
+		advanced: {
+			backgroundTasks: background
+				? {
+						handler: (task) => {
+							tasks.push(task);
+						},
+					}
+				: undefined,
+		},
+	});
+	const existing = await client.requestPasswordReset({
+		email: testUser.email,
+		fetchOptions: {
+			onResponse: ({ response }) => {
+				statuses.push(response.status);
+			},
+		},
+	});
+	const unknown = await client.requestPasswordReset({
+		email: "unknown@example.com",
+		fetchOptions: {
+			onResponse: ({ response }) => {
+				statuses.push(response.status);
+			},
+		},
+	});
+	await Promise.all(tasks);
+	expect(sendNoAccount).toHaveBeenCalledTimes(1);
+	expect(statuses).toEqual([200, 200]);
+	expect(existing.data?.status).toBe(true);
+	expect(unknown.error).toBeNull();
+	expect(unknown.data).toEqual(existing.data);
+});
+
 describe("revoke sessions on password reset", async () => {
 	const mockSendEmail = vi.fn();
 	let token = "";

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -111,6 +111,14 @@ export const requestPasswordReset = createAuthEndpoint(
 				"dummy-verification-token",
 			);
 			ctx.context.logger.warn("Reset Password: User not found");
+			if (ctx.context.options.emailAndPassword?.sendResetPasswordNoAccount) {
+				await ctx.context.runInBackgroundOrAwait(
+					ctx.context.options.emailAndPassword.sendResetPasswordNoAccount(
+						{ email },
+						ctx.request,
+					),
+				);
+			}
 			return ctx.json({
 				status: true,
 				message:

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -112,6 +112,14 @@ export const requestPasswordReset = createAuthEndpoint(
 				"dummy-verification-token",
 			);
 			ctx.context.logger.warn("Reset Password: User not found");
+			if (ctx.context.options.emailAndPassword?.sendResetPasswordNoAccount) {
+				await ctx.context.runInBackgroundOrAwait(
+					ctx.context.options.emailAndPassword.sendResetPasswordNoAccount(
+						{ email },
+						ctx.request,
+					),
+				);
+			}
 			return ctx.json({
 				status: true,
 				message:

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -114,9 +114,11 @@ export const requestPasswordReset = createAuthEndpoint(
 			ctx.context.logger.warn("Reset Password: User not found");
 			if (ctx.context.options.emailAndPassword?.sendResetPasswordNoAccount) {
 				await ctx.context.runInBackgroundOrAwait(
-					ctx.context.options.emailAndPassword.sendResetPasswordNoAccount(
-						{ email },
-						ctx.request,
+					Promise.resolve().then(() =>
+						ctx.context.options.emailAndPassword?.sendResetPasswordNoAccount?.(
+							{ email },
+							ctx.request,
+						),
 					),
 				);
 			}

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -711,6 +711,27 @@ export type BetterAuthOptions = {
 					request?: Request,
 				) => Promise<void>;
 				/**
+				 * Optional callback triggered when `/request-password-reset`
+				 * is called for an email that has no account. Use it to
+				 * encourage account creation (e.g. send a "create your
+				 * account" email) without breaking enumeration protection
+				 * — the HTTP response is identical regardless of whether
+				 * the email exists.
+				 *
+				 * If unset, no email is sent for unknown emails.
+				 */
+				sendResetPasswordNoAccount?: (
+					/**
+					 * @param email the email address that was submitted
+					 * but has no associated account
+					 */
+					data: { email: string },
+					/**
+					 * The request object
+					 */
+					request?: Request,
+				) => Promise<void>;
+				/**
 				 * Number of seconds the reset password token is
 				 * valid for.
 				 * @default 1 hour (60 * 60)

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -808,6 +808,27 @@ export type BetterAuthOptions = {
 					request?: Request,
 				) => Promise<void>;
 				/**
+				 * Optional callback triggered when `/request-password-reset`
+				 * is called for an email that has no account. Use it to
+				 * encourage account creation (e.g. send a "create your
+				 * account" email) without breaking enumeration protection
+				 * — the HTTP response is identical regardless of whether
+				 * the email exists.
+				 *
+				 * If unset, no email is sent for unknown emails.
+				 */
+				sendResetPasswordNoAccount?: (
+					/**
+					 * @param email the email address that was submitted
+					 * but has no associated account
+					 */
+					data: { email: string },
+					/**
+					 * The request object
+					 */
+					request?: Request,
+				) => Promise<void>;
+				/**
 				 * Number of seconds the reset password token is
 				 * valid for.
 				 * @default 1 hour (60 * 60)


### PR DESCRIPTION
Closes #10455

## Summary

`/request-password-reset` deliberately does nothing when the submitted email has no account,
so the response can't be used to enumerate users. That's correct — but it leaves apps with no
way to react at all. This adds an opt-in callback for that branch, so you can send a "you
don't have an account yet" email or log the attempt, without weakening the endpoint.

```ts
emailAndPassword: {
  sendResetPasswordNoAccount: async ({ email }, request) => {
    await sendCreateAccountEmail(email);
  },
}
```

## Why enumeration protection still holds

The observable surface is the HTTP response and its timing:

1. **Identical response** — same JSON body, same status, both branches. The callback can't
   influence what the client sees.
2. **Same dispatch mechanism** — the callback runs after the existing mitigation
   (`generateId(24)` + dummy `findVerificationValue`) through `runInBackgroundOrAwait`, exactly
   as `sendResetPassword` does on the other branch. With
   `advanced.backgroundTasks.handler` configured both branches return immediately; without it
   both are awaited, so timing equivalence then depends on the two callbacks being comparable
   in cost. The docs state that caveat.
3. **The mail goes to the address the requester typed**, never one read from the database. An
   attacker probing for account existence learns nothing they didn't already supply.


## Changes

| File | |
|---|---|
| `packages/core/src/types/init-options.ts` | `sendResetPasswordNoAccount` type + JSDoc |
| `packages/better-auth/src/api/routes/password.ts` | wiring inside the existing `if (!user)` branch |
| `packages/better-auth/src/api/routes/password.test.ts` | 4 tests |
| `docs/content/docs/authentication/email-password.mdx` | section + callout + reference entry |
| `.changeset/…` | minor bump |

+152 / −0.

## Status

Rebased on current `main` (`4e685eef4`); suite green, 257 vs 253 baseline — the +4 are this
PR's own tests.

Now targets `main` rather than `next`, since the change is additive and non-breaking. The
changeset is `minor`, which I understand routes it back to `next` automatically — happy to
follow whatever you prefer there.

## Designed as a set

This is the narrowest of three coordinated contributions — #8915, #9561 and #8916 — that give
applications a way to observe and react to security-sensitive account lifecycle moments, so they
can send notifications and keep an activity history without reverse-engineering framework
internals.

- **#8915** adds named callbacks for events that already happen but have no hook: login,
  logout, password change, password reset requested, email verification requested, 2FA
  enabled/disabled, passkey added/deleted, magic link requested.
- **#9561** covers the one branch of `/request-password-reset` that deliberately does nothing
  today, so an attempt from an unknown address can still be reacted to.
- **#8916** brings the same treatment to email changes — requested / completed / cancelled —
  behind an opt-in strategy.

They can land independently, but feedback on the shared shape is useful because the APIs
are meant to feel consistent. #8915 is where the overall shape is best discussed.
