### PR TITLE
fix(usernames): standardize sign in between /sign-in/email and /sign-in/username

### DIFF
--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -1,8 +1,12 @@
-import type { BetterAuthOptions } from "@better-auth/core";
+import type {
+	BetterAuthOptions,
+	GenericEndpointContext,
+} from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
-import type { User } from "@better-auth/core/db";
+import type { Account, User } from "@better-auth/core/db";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import { SocialProviderListEnum } from "@better-auth/core/social-providers";
+import type { RawError } from "@better-auth/core/utils/error-codes";
 import * as z from "zod";
 import { getAwaitableValue } from "../../context/helpers";
 import { setSessionCookie } from "../../cookies";
@@ -478,126 +482,120 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 					message: "Email and password is not enabled",
 				});
 			}
-			const { email, password } = ctx.body;
+
+			const { email } = ctx.body;
 			const isValidEmail = z.email().safeParse(email);
 			if (!isValidEmail.success) {
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_EMAIL);
 			}
+
 			const user = await ctx.context.internalAdapter.findUserByEmail(email, {
 				includeAccounts: true,
 			});
 
-			if (!user) {
-				// Hash password to prevent timing attacks from revealing valid email addresses
-				// By hashing passwords for invalid emails, we ensure consistent response times
-				await ctx.context.password.hash(password);
-				ctx.context.logger.error("User not found", { email });
-				throw APIError.from(
-					"UNAUTHORIZED",
-					BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,
-				);
-			}
-
-			const credentialAccount = user.accounts.find(
-				(a) => a.providerId === "credential",
-			);
-			if (!credentialAccount) {
-				await ctx.context.password.hash(password);
-				ctx.context.logger.error("Credential account not found", { email });
-				throw APIError.from(
-					"UNAUTHORIZED",
-					BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,
-				);
-			}
-			const currentPassword = credentialAccount?.password;
-			if (!currentPassword) {
-				await ctx.context.password.hash(password);
-				ctx.context.logger.error("Password not found", { email });
-				throw APIError.from(
-					"UNAUTHORIZED",
-					BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,
-				);
-			}
-			const validPassword = await ctx.context.password.verify({
-				hash: currentPassword,
-				password,
-			});
-			if (!validPassword) {
-				ctx.context.logger.error("Invalid password");
-				throw APIError.from(
-					"UNAUTHORIZED",
-					BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,
-				);
-			}
-
-			if (
-				ctx.context.options?.emailAndPassword?.requireEmailVerification &&
-				!user.user.emailVerified
-			) {
-				if (!ctx.context.options?.emailVerification?.sendVerificationEmail) {
-					throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.EMAIL_NOT_VERIFIED);
-				}
-
-				if (ctx.context.options?.emailVerification?.sendOnSignIn) {
-					const token = await createEmailVerificationToken(
-						ctx.context.secret,
-						user.user.email,
-						undefined,
-						ctx.context.options.emailVerification?.expiresIn,
-					);
-					const callbackURL = ctx.body.callbackURL
-						? encodeURIComponent(ctx.body.callbackURL)
-						: encodeURIComponent("/");
-					const url = `${ctx.context.baseURL}/verify-email?token=${token}&callbackURL=${callbackURL}`;
-					await ctx.context.runInBackgroundOrAwait(
-						ctx.context.options.emailVerification.sendVerificationEmail(
-							{
-								user: user.user,
-								url,
-								token,
-							},
-							ctx.request,
-						),
-					);
-				}
-
-				throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.EMAIL_NOT_VERIFIED);
-			}
-
-			const session = await ctx.context.internalAdapter.createSession(
-				user.user.id,
-				ctx.body.rememberMe === false,
-			);
-
-			if (!session) {
-				ctx.context.logger.error("Failed to create session");
-				throw APIError.from(
-					"UNAUTHORIZED",
-					BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION,
-				);
-			}
-
-			await setSessionCookie(
+			return await signInWithPassword(
 				ctx,
-				{
-					session,
-					user: user.user,
-				},
-				ctx.body.rememberMe === false,
+				{ email },
+				BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,
+				user?.user as User<O["user"], O["plugins"]> | undefined,
+				user?.accounts,
+				ctx.body,
 			);
-
-			if (ctx.body.callbackURL) {
-				ctx.setHeader("Location", ctx.body.callbackURL);
-			}
-
-			return ctx.json({
-				redirect: !!ctx.body.callbackURL,
-				token: session.token,
-				url: ctx.body.callbackURL,
-				user: parseUserOutput(ctx.context.options, user.user) as User<
-					O["user"],
-					O["plugins"]
-				>,
-			});
 		},
 	);
+
+export async function signInWithPassword<U extends User>(
+	ctx: GenericEndpointContext,
+	logContext: object,
+	invalidUserOrPasswordError: RawError,
+	user: U | undefined,
+	accounts: Account[] | undefined,
+	options: { password: string; rememberMe?: boolean; callbackURL?: string },
+) {
+	if (!user) {
+		// Hash password to prevent timing attacks from revealing valid email addresses
+		// By hashing passwords for invalid emails, we ensure consistent response times
+		await ctx.context.password.hash(options.password);
+		ctx.context.logger.error("User not found", logContext);
+		throw APIError.from("UNAUTHORIZED", invalidUserOrPasswordError);
+	}
+
+	const credentialAccount = accounts?.find(
+		(a) => a.providerId === "credential",
+	);
+	if (!credentialAccount) {
+		await ctx.context.password.hash(options.password);
+		ctx.context.logger.error("Credential account not found", logContext);
+		throw APIError.from("UNAUTHORIZED", invalidUserOrPasswordError);
+	}
+
+	const currentPassword = credentialAccount?.password;
+	if (!currentPassword) {
+		await ctx.context.password.hash(options.password);
+		ctx.context.logger.error("Password not found", logContext);
+		throw APIError.from("UNAUTHORIZED", invalidUserOrPasswordError);
+	}
+
+	const validPassword = await ctx.context.password.verify({
+		hash: currentPassword,
+		password: options.password,
+	});
+	if (!validPassword) {
+		ctx.context.logger.error("Invalid password");
+		throw APIError.from("UNAUTHORIZED", invalidUserOrPasswordError);
+	}
+
+	if (
+		ctx.context.options?.emailAndPassword?.requireEmailVerification &&
+		!user.emailVerified
+	) {
+		if (!ctx.context.options?.emailVerification?.sendVerificationEmail) {
+			throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.EMAIL_NOT_VERIFIED);
+		}
+
+		if (ctx.context.options?.emailVerification?.sendOnSignIn) {
+			const token = await createEmailVerificationToken(
+				ctx.context.secret,
+				user.email,
+				undefined,
+				ctx.context.options.emailVerification?.expiresIn,
+			);
+			const callbackURL = options.callbackURL || "/";
+			const url = `${ctx.context.baseURL}/verify-email?${new URLSearchParams({ token, callbackURL })}`;
+			await ctx.context.runInBackgroundOrAwait(
+				ctx.context.options.emailVerification.sendVerificationEmail(
+					{ user, url, token },
+					ctx.request,
+				),
+			);
+		}
+
+		throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.EMAIL_NOT_VERIFIED);
+	}
+
+	const session = await ctx.context.internalAdapter.createSession(
+		user.id,
+		options.rememberMe === false,
+	);
+
+	if (!session) {
+		ctx.context.logger.error("Failed to create session");
+		throw APIError.from(
+			"UNAUTHORIZED",
+			BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION,
+		);
+	}
+
+	await setSessionCookie(ctx, { session, user }, options.rememberMe === false);
+
+	if (options.callbackURL) {
+		ctx.setHeader("Location", options.callbackURL);
+	}
+
+	return ctx.json({
+		redirect: !!options.callbackURL,
+		token: session.token,
+		url: options.callbackURL,
+		user: parseUserOutput(ctx.context.options, user),
+	});
+}

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -4,12 +4,11 @@ import {
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import type { Account, User } from "@better-auth/core/db";
-import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
+import { APIError } from "@better-auth/core/error";
 import * as z from "zod";
-import { createEmailVerificationToken } from "../../api";
+import { signInWithPassword } from "../../api";
 import { getSessionFromCtx } from "../../api/routes/session";
-import { setSessionCookie } from "../../cookies";
-import { mergeSchema, parseUserOutput } from "../../db";
+import { mergeSchema } from "../../db";
 import type { InferOptionSchema } from "../../types/plugins";
 import { PACKAGE_VERSION } from "../../version";
 import { USERNAME_ERROR_CODES as ERROR_CODES } from "./error-codes";
@@ -307,8 +306,12 @@ export const username = (options?: UsernameOptions | undefined) => {
 						);
 					}
 
-					const user = await ctx.context.adapter.findOne<
-						User & { username: string; displayUsername: string }
+					const result = await ctx.context.adapter.findOne<
+						User & {
+							username: string;
+							displayUsername: string;
+							account?: Account[];
+						}
 					>({
 						model: "user",
 						where: [
@@ -317,120 +320,29 @@ export const username = (options?: UsernameOptions | undefined) => {
 								value: normalizer(username),
 							},
 						],
+						join: { account: true },
 					});
-					if (!user) {
-						// Hash password to prevent timing attacks from revealing valid usernames
-						// By hashing passwords for invalid usernames, we ensure consistent response times
-						await ctx.context.password.hash(ctx.body.password);
-						ctx.context.logger.error("User not found", {
-							username,
-						});
-						throw APIError.from(
-							"UNAUTHORIZED",
+
+					if (!result) {
+						return await signInWithPassword(
+							ctx,
+							{ username },
 							ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,
+							undefined,
+							undefined,
+							ctx.body,
 						);
 					}
 
-					const account = await ctx.context.adapter.findOne<Account>({
-						model: "account",
-						where: [
-							{
-								field: "userId",
-								value: user.id,
-							},
-							{
-								field: "providerId",
-								value: "credential",
-							},
-						],
-					});
-					if (!account) {
-						throw APIError.from(
-							"UNAUTHORIZED",
-							ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,
-						);
-					}
-					const currentPassword = account?.password;
-					if (!currentPassword) {
-						ctx.context.logger.error("Password not found", {
-							username,
-						});
-						throw APIError.from(
-							"UNAUTHORIZED",
-							ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,
-						);
-					}
-					const validPassword = await ctx.context.password.verify({
-						hash: currentPassword,
-						password: ctx.body.password,
-					});
-					if (!validPassword) {
-						ctx.context.logger.error("Invalid password");
-						throw APIError.from(
-							"UNAUTHORIZED",
-							ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,
-						);
-					}
-
-					if (
-						ctx.context.options?.emailAndPassword?.requireEmailVerification &&
-						!user.emailVerified
-					) {
-						if (
-							!ctx.context.options?.emailVerification?.sendVerificationEmail
-						) {
-							throw APIError.from("FORBIDDEN", ERROR_CODES.EMAIL_NOT_VERIFIED);
-						}
-
-						if (ctx.context.options?.emailVerification?.sendOnSignIn) {
-							const token = await createEmailVerificationToken(
-								ctx.context.secret,
-								user.email,
-								undefined,
-								ctx.context.options.emailVerification?.expiresIn,
-							);
-							const url = `${ctx.context.baseURL}/verify-email?token=${token}&callbackURL=${
-								ctx.body.callbackURL || "/"
-							}`;
-							await ctx.context.runInBackgroundOrAwait(
-								ctx.context.options.emailVerification.sendVerificationEmail(
-									{
-										user: user,
-										url,
-										token,
-									},
-									ctx.request,
-								),
-							);
-						}
-
-						throw APIError.from("FORBIDDEN", ERROR_CODES.EMAIL_NOT_VERIFIED);
-					}
-
-					const session = await ctx.context.internalAdapter.createSession(
-						user.id,
-						ctx.body.rememberMe === false,
-					);
-					if (!session) {
-						throw APIError.from(
-							"INTERNAL_SERVER_ERROR",
-							BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION,
-						);
-					}
-					await setSessionCookie(
+					const { account: accounts, ...user } = result;
+					return await signInWithPassword(
 						ctx,
-						{ session, user },
-						ctx.body.rememberMe === false,
+						{ username },
+						ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,
+						user,
+						accounts,
+						ctx.body,
 					);
-					if (ctx.body.callbackURL) {
-						ctx.setHeader("Location", ctx.body.callbackURL);
-					}
-					return ctx.json({
-						redirect: !!ctx.body.callbackURL,
-						token: session.token,
-						url: ctx.body.callbackURL,
-						user: parseUserOutput(ctx.context.options, user),
-					});
 				},
 			),
 			isUsernameAvailable: createAuthEndpoint(


### PR DESCRIPTION
I noticed the /sign-in/username had some problems:
- doesn't hash password on every INVALID_USERNAME_OR_PASSWORD branch
- doesn't encode callbackURL for verify-email URL properly

Also it fetches accounts with an explicit extra query instead of using the join option.

Now granted by default there is the `/is-username-available` endpoint which can be used to enumerate usernames. But you could always disable that endpoint if you are doing a setup where users can't make their own accounts (signups disabled), for full protection.

After some quick looking around I figured it was originally copied and pasted from `/sign-in/email`, because its basically the same thing except for how the user is queried (username vs email). I figured it would be best to write a little `signInWithPassword` function so that these endpoints don't end up deviating so much again in the implementation.

I also have a question

> // Hash password to prevent timing attacks from revealing valid email addresses
> // By hashing passwords for invalid emails, we ensure consistent response times
> await ctx.context.password.hash(options.password);

From what I can tell, the timing differences between `verify` and `hash` are not distinguishable. Still, I’m wondering whether it would be more resilient to use `password.verify` with a dummy password hash instead, since I’m not sure the contract of a password hashing function guarantees equivalent timing characteristics between verification and hashing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized password sign-in for `/sign-in/email` and `/sign-in/username` by extracting a shared `signInWithPassword` flow. Fixes missing password hashing on invalid branches and corrects `callbackURL` encoding for email verification.

- **Bug Fixes**
  - Hash passwords on all invalid-credential paths to mitigate timing attacks.
  - Properly encode `callbackURL` in verify-email links using `URLSearchParams`.
  - Consistent handling for missing credential account or password.

- **Refactors**
  - Added `signInWithPassword` to centralize verification, email-verification checks, session creation, and response shaping.
  - `/sign-in/username` now fetches accounts via `join` and defers to the shared helper, removing an extra DB query and duplicate logic.

<sup>Written for commit d9918e789ea59b260724bffc8d7b2956dd92c138. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

