### PR TITLE
feat(better-auth): add atproto plugin

### DIFF
--- a/.changeset/atproto-plugin.md
+++ b/.changeset/atproto-plugin.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/atproto": minor
+---
+
+Add AT Protocol (Bluesky) OAuth plugin with PKCE, DPoP, account linking, and DB-backed session storage.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,7 @@
       "@better-auth/core",
       "auth",
       "@better-auth/api-key",
+      "@better-auth/atproto",
       "@better-auth/cimd",
       "@better-auth/drizzle-adapter",
       "@better-auth/electron",

--- a/.changeset/fancy-views-notice.md
+++ b/.changeset/fancy-views-notice.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix: add error code to change-email-disabled

--- a/.changeset/fix-api-key-rate-limit-status-429.md
+++ b/.changeset/fix-api-key-rate-limit-status-429.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/api-key": patch
+---
+
+API key requests that exceed the configured rate limit now return HTTP 429 (Too Many Requests) instead of HTTP 401 (Unauthorized), so clients can distinguish throttling from authentication failures.

--- a/.changeset/large-chairs-shout.md
+++ b/.changeset/large-chairs-shout.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+anonymous plugin now correctly calls onLinkAccount when email verification triggers auto sign-in

--- a/.changeset/widen-ipv6-subnet-type.md
+++ b/.changeset/widen-ipv6-subnet-type.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Widen `advanced.ipAddress.ipv6Subnet` to accept any integer prefix length from 0 to 128, not just `32 | 48 | 64 | 128`. The runtime mask code already handled any value in range; the type union was unnecessarily narrow and rejected valid prefix lengths like `/56` (residential ISP allocations) and `/40` (common cloud allocations). Existing values continue to work unchanged.

--- a/.cspell/auth-terms.txt
+++ b/.cspell/auth-terms.txt
@@ -36,3 +36,4 @@ HIBP
 cimd
 dpop
 atproto
+bsky

--- a/.cspell/auth-terms.txt
+++ b/.cspell/auth-terms.txt
@@ -34,3 +34,5 @@ rgba
 idtoken
 HIBP
 cimd
+dpop
+atproto

--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -65,3 +65,4 @@ Oligo
 febf
 fdff
 fffe
+noout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   lint:
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     concurrency:
@@ -91,7 +91,7 @@ jobs:
         run: pnpm lint:types
 
   typecheck:
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     concurrency:
@@ -132,7 +132,7 @@ jobs:
         run: pnpm typecheck:dist
 
   test:
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     timeout-minutes: 30
@@ -185,4 +185,3 @@ jobs:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-             

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.review.author_association)) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.issue.author_association))
       )
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: write
       pull-requests: write
@@ -53,4 +53,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
   smoke:
     name: Smoke test (${{ matrix.node-version }})
     timeout-minutes: 30
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +72,7 @@ jobs:
   integration:
     name: Integration test
     timeout-minutes: 60
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     steps:
@@ -113,7 +113,7 @@ jobs:
         run: docker compose down
   adapter-integration:
     name: ${{ matrix.packages }} Integration Test
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: starsling-ubuntu-24.04
+    runs-on: ${{ github.repository == 'better-auth/better-auth' && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
 

--- a/docs/content/docs/concepts/rate-limit.mdx
+++ b/docs/content/docs/concepts/rate-limit.mdx
@@ -82,16 +82,16 @@ Additionally, IPv4-mapped IPv6 addresses (e.g., `::ffff:192.0.2.1`) are automati
 
 #### IPv6 Subnet Rate Limiting
 
-By default, IPv6 addresses are rate limited individually (using the full /128 address). However, since IPv6 typically allocates large address blocks to single users, attackers could potentially bypass rate limits by rotating through multiple IPv6 addresses from their allocation.
+By default, IPv6 addresses are rate limited per `/64` subnet, not per individual address. ISPs and cloud providers assign IPv6 prefixes (typically `/64` for residential users per [RFC 6177](https://datatracker.ietf.org/doc/html/rfc6177)) rather than single addresses, so any per-address counter would let one client rotate through 2^64 source addresses without exhausting the limit.
 
-To prevent this, you can configure rate limiting to apply to IPv6 subnets instead of individual addresses:
+You can override the prefix length via the `ipv6Subnet` option if your deployment needs a different allocation boundary:
 
 ```ts title="auth.ts"
 export const auth = betterAuth({
     //...other options
     advanced: {
         ipAddress: {
-            ipv6Subnet: 64, // Rate limit by /64 subnet instead of individual addresses
+            ipv6Subnet: 56, // Rate limit by /56 subnet (residential ISP allocation)
         },
     },
     rateLimit: {
@@ -102,12 +102,15 @@ export const auth = betterAuth({
 })
 ```
 
-Common IPv6 subnet prefix lengths:
+Common IPv6 prefix lengths:
 
-* `128` (default): Individual IPv6 address - most restrictive
-* `64`: /64 subnet - typical home/business allocation
-* `48`: /48 subnet - larger network allocation
-* `32`: /32 subnet - ISP-level allocation
+* `128`: Individual IPv6 address. Most restrictive. Only safe when you control the network and trust that each address maps to a distinct client.
+* `64` (default): /64 subnet. Typical home or business allocation.
+* `56`: /56 subnet. Residential ISP allocation per [RFC 6177](https://datatracker.ietf.org/doc/html/rfc6177).
+* `48`: /48 subnet. Larger network allocation.
+* `32`: /32 subnet. ISP-level allocation.
+
+Any integer prefix length from `0` to `128` is accepted; the values above are the most common.
 
 <Callout type="info">
   IPv6 subnet configuration only affects IPv6 addresses. IPv4 addresses are always rate limited individually.

--- a/docs/content/docs/plugins/atproto.mdx
+++ b/docs/content/docs/plugins/atproto.mdx
@@ -1,0 +1,196 @@
+---
+title: AT Protocol (Bluesky)
+description: Sign in with Bluesky / AT Protocol OAuth
+---
+
+The AT Protocol plugin lets users sign in with their Bluesky handle using OAuth 2.0 with PKCE and DPoP. It supports localhost development without tunnels, persists atproto sessions for downstream API calls, and links Bluesky accounts to existing better-auth users.
+
+## Installation
+
+<Steps>
+  <Step>
+    ### Install the plugin
+
+    ```package-install
+    npm install @better-auth/atproto
+    ```
+  </Step>
+
+  <Step>
+    ### Generate a private key (production only)
+
+    AT Protocol OAuth requires an ES256 key for production deployments to sign DPoP proofs and `private_key_jwt` token requests.
+
+    ```bash
+    openssl ecparam -name prime256v1 -genkey -noout -out ec-private.pem
+    ```
+
+    No key is needed for `http://localhost` / `http://127.0.0.1` — the plugin uses AT Protocol's loopback client mode.
+  </Step>
+
+  <Step>
+    ### Add the server plugin
+
+    ```ts title="auth.ts"
+    import { betterAuth } from "better-auth"
+    import { atproto } from "@better-auth/atproto" // [!code highlight]
+
+    export const auth = betterAuth({
+      baseURL: "https://myapp.com",
+      plugins: [
+        atproto({ // [!code highlight]
+          privateKey: process.env.ATPROTO_PRIVATE_KEY, // [!code highlight]
+        }), // [!code highlight]
+      ],
+    })
+    ```
+  </Step>
+
+  <Step>
+    ### Migrate the database
+
+    The plugin adds columns to the `user` table and creates two new tables. Run migrations or generate the schema:
+
+    <Tabs items={["migrate", "generate"]}>
+      <Tab value="migrate">
+        ```package-install
+        npx auth migrate
+        ```
+      </Tab>
+
+      <Tab value="generate">
+        ```package-install
+        npx auth generate
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step>
+    ### Add the client plugin
+
+    ```ts title="auth-client.ts"
+    import { createAuthClient } from "better-auth/client"
+    import { atprotoClient } from "@better-auth/atproto/client" // [!code highlight]
+
+    export const authClient = createAuthClient({
+      plugins: [
+        atprotoClient() // [!code highlight]
+      ]
+    })
+    ```
+  </Step>
+
+  <Step>
+    ### Sign in
+
+    ```ts
+    await authClient.signIn.atproto({
+      handle: "alice.bsky.social",
+      callbackURL: "/dashboard",
+    })
+    ```
+  </Step>
+</Steps>
+
+## Configuration
+
+```ts title="auth.ts"
+atproto({
+  // PEM-encoded ES256 private key. Required for production, optional on localhost.
+  privateKey: process.env.ATPROTO_PRIVATE_KEY,
+
+  clientMetadata: {
+    // Name shown on the authorization screen.
+    clientName: "My App",
+    // OAuth scopes. Default: "atproto transition:generic"
+    scope: "atproto transition:generic",
+  },
+
+  // Customize how the atproto profile maps to better-auth user fields.
+  mapProfileToUser: (profile) => ({
+    name: profile.displayName || `@${profile.handle}`,
+    image: profile.avatar,
+  }),
+
+  // When true, only existing users can sign in. New users get FORBIDDEN.
+  disableSignUp: false,
+})
+```
+
+## Endpoints
+
+| Method | Path                            | Auth | Description                                        |
+| ------ | ------------------------------- | ---- | -------------------------------------------------- |
+| GET    | `/atproto/client-metadata.json` | No   | OAuth client metadata for PDS discovery            |
+| GET    | `/atproto/jwks.json`            | No   | Public JWKS for `private_key_jwt` auth             |
+| POST   | `/atproto/sign-in`              | No   | Initiate sign-in. Body: `{ handle, callbackURL? }` |
+| GET    | `/atproto/callback`             | No   | OAuth callback (handled automatically)             |
+| GET    | `/atproto/session`              | Yes  | atproto session status + fresh profile             |
+| POST   | `/atproto/restore`              | Yes  | Lightweight session check (no profile fetch)       |
+
+`callbackURL` is validated against `trustedOrigins` to prevent open redirects. Add your app origins (e.g. `https://myapp.com`) to `trustedOrigins` for absolute redirect URLs.
+
+## Schema
+
+The plugin extends the `user` table and adds two new tables.
+
+### `user` extensions
+
+| Column          | Type            | Description                          |
+| --------------- | --------------- | ------------------------------------ |
+| `atprotoDid`    | string (unique) | AT Protocol DID (`did:plc:...`)      |
+| `atprotoHandle` | string          | Bluesky handle (`alice.bsky.social`) |
+| `atprotoBio`    | string          | Profile description                  |
+| `atprotoBanner` | string          | Banner image URL                     |
+
+### `atprotoState`
+
+Ephemeral storage for in-flight OAuth requests (auto-expires after 10 minutes).
+
+| Column      | Type            |
+| ----------- | --------------- |
+| `key`       | string (unique) |
+| `state`     | string (JSON)   |
+| `expiresAt` | date            |
+
+### `atprotoSession`
+
+Persistent storage for atproto OAuth sessions (tokens + DPoP keys).
+
+| Column      | Type                             |
+| ----------- | -------------------------------- |
+| `did`       | string (unique)                  |
+| `session`   | string (JSON)                    |
+| `userId`    | string (FK → `user.id`, cascade) |
+| `updatedAt` | date                             |
+
+## Localhost development
+
+For local development no private key or tunnel is needed. The plugin uses AT Protocol's loopback client mode when `baseURL` is `http://localhost:*` or `http://127.0.0.1:*`.
+
+```ts
+export const auth = betterAuth({
+  baseURL: "http://localhost:3000",
+  plugins: [
+    atproto(), // no privateKey needed
+  ],
+})
+```
+
+## Account linking
+
+When a user is already signed in (via email, Google, etc.) and signs in with Bluesky, the plugin links the Bluesky account to their existing user. This respects `account.accountLinking.enabled` — if linking is disabled, the plugin returns `FORBIDDEN` instead.
+
+## Rate limits
+
+| Endpoint            | Window | Max |
+| ------------------- | ------ | --- |
+| `/atproto/sign-in`  | 60s    | 5   |
+| `/atproto/callback` | 60s    | 10  |
+
+Metadata endpoints are not rate limited.
+
+## Runtime support
+
+This plugin currently depends on `@atproto/oauth-client-node` and requires a Node.js-compatible runtime (Node, Bun). Cloudflare Workers and Deno support would require a runtime-agnostic rewrite on top of `@atproto/oauth-client`. Track interest in this on the [issue tracker](https://github.com/better-auth/better-auth/issues).

--- a/docs/content/docs/plugins/atproto.mdx
+++ b/docs/content/docs/plugins/atproto.mdx
@@ -1,9 +1,9 @@
 ---
-title: AT Protocol (Bluesky)
-description: Sign in with Bluesky / AT Protocol OAuth
+title: AT Protocol (Atmosphere)
+description: Sign in via AT Protocol / Atmosphere OAuth
 ---
 
-The AT Protocol plugin lets users sign in with their Bluesky handle using OAuth 2.0 with PKCE and DPoP. It supports localhost development without tunnels, persists atproto sessions for downstream API calls, and links Bluesky accounts to existing better-auth users.
+The AT Protocol plugin lets users sign in with their AT Protocol handle (e.g. a Bluesky handle like `alice.bsky.social`) using OAuth 2.0 with PKCE and DPoP. It works with any AT Protocol PDS in the [Atmosphere ecosystem](https://atproto.com/guides/glossary). It supports localhost development without tunnels, persists atproto sessions for downstream API calls, and links AT Protocol accounts to existing better-auth users.
 
 ## Installation
 
@@ -137,12 +137,12 @@ The plugin extends the `user` table and adds two new tables.
 
 ### `user` extensions
 
-| Column          | Type            | Description                          |
-| --------------- | --------------- | ------------------------------------ |
-| `atprotoDid`    | string (unique) | AT Protocol DID (`did:plc:...`)      |
-| `atprotoHandle` | string          | Bluesky handle (`alice.bsky.social`) |
-| `atprotoBio`    | string          | Profile description                  |
-| `atprotoBanner` | string          | Banner image URL                     |
+| Column          | Type            | Description                                   |
+| --------------- | --------------- | --------------------------------------------- |
+| `atprotoDid`    | string (unique) | AT Protocol DID (`did:plc:...`)               |
+| `atprotoHandle` | string          | AT Protocol handle (e.g. `alice.bsky.social`) |
+| `atprotoBio`    | string          | Profile description                           |
+| `atprotoBanner` | string          | Banner image URL                              |
 
 ### `atprotoState`
 
@@ -180,7 +180,7 @@ export const auth = betterAuth({
 
 ## Account linking
 
-When a user is already signed in (via email, Google, etc.) and signs in with Bluesky, the plugin links the Bluesky account to their existing user. This respects `account.accountLinking.enabled` — if linking is disabled, the plugin returns `FORBIDDEN` instead.
+When a user is already signed in (via email, Google, etc.) and signs in via AT Protocol, the plugin links the AT Protocol account to their existing user. This respects `account.accountLinking.enabled` — if linking is disabled, the plugin returns `FORBIDDEN` instead.
 
 ## Rate limits
 

--- a/docs/content/docs/plugins/atproto.mdx
+++ b/docs/content/docs/plugins/atproto.mdx
@@ -191,6 +191,39 @@ When a user is already signed in (via email, Google, etc.) and signs in with Blu
 
 Metadata endpoints are not rate limited.
 
+## React Native / Expo
+
+The plugin works with `@better-auth/expo` out of the box via the standard server-driven OAuth flow:
+
+1. The mobile app opens an in-app browser to `/atproto/sign-in` with the app's deep-link scheme as the `callbackURL` (e.g. `myapp://auth`).
+2. The atproto OAuth flow runs on the better-auth server.
+3. When the server's `/atproto/callback` redirects to the deep link, `@better-auth/expo`'s hook injects the session cookie as a `?cookie=...` query parameter.
+4. The Expo client picks up the cookie via the deep-link handler and stores the session.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+import { atproto } from "@better-auth/atproto"
+import { expo } from "@better-auth/expo"
+
+export const auth = betterAuth({
+  baseURL: "https://myapp.com",
+  trustedOrigins: ["myapp://"], // your app's scheme
+  plugins: [
+    atproto({ privateKey: process.env.ATPROTO_PRIVATE_KEY }),
+    expo(),
+  ],
+})
+```
+
+```ts title="mobile sign-in"
+await authClient.signIn.atproto({
+  handle: "alice.bsky.social",
+  callbackURL: "myapp://auth",
+})
+```
+
+On-device atproto OAuth (using a React Native atproto OAuth client) is not supported today — it would require a runtime-agnostic rewrite on top of `@atproto/oauth-client`. Track interest in this on the [issue tracker](https://github.com/better-auth/better-auth/issues).
+
 ## Runtime support
 
 This plugin currently depends on `@atproto/oauth-client-node` and requires a Node.js-compatible runtime (Node, Bun). Cloudflare Workers and Deno support would require a runtime-agnostic rewrite on top of `@atproto/oauth-client`. Track interest in this on the [issue tracker](https://github.com/better-auth/better-auth/issues).

--- a/docs/content/docs/plugins/index.mdx
+++ b/docs/content/docs/plugins/index.mdx
@@ -10,7 +10,7 @@ Better Auth ships with 50+ plugins that extend the framework with additional aut
 | Plugin                                               | Description                                                |
 | ---------------------------------------------------- | ---------------------------------------------------------- |
 | [Two-Factor Authentication](/docs/plugins/2fa)       | Enhance your app's security with two-factor authentication |
-| [AT Protocol (Bluesky)](/docs/plugins/atproto)       | Sign in with Bluesky via AT Protocol OAuth                 |
+| [AT Protocol (Atmosphere)](/docs/plugins/atproto)    | Sign in via AT Protocol OAuth (Bluesky, Atmosphere)        |
 | [Passkey](/docs/plugins/passkey)                     | WebAuthn/passkey authentication                            |
 | [Magic Link](/docs/plugins/magic-link)               | Passwordless email magic link authentication               |
 | [Email OTP](/docs/plugins/email-otp)                 | Email-based one-time password authentication               |

--- a/docs/content/docs/plugins/index.mdx
+++ b/docs/content/docs/plugins/index.mdx
@@ -10,6 +10,7 @@ Better Auth ships with 50+ plugins that extend the framework with additional aut
 | Plugin                                               | Description                                                |
 | ---------------------------------------------------- | ---------------------------------------------------------- |
 | [Two-Factor Authentication](/docs/plugins/2fa)       | Enhance your app's security with two-factor authentication |
+| [AT Protocol (Bluesky)](/docs/plugins/atproto)       | Sign in with Bluesky via AT Protocol OAuth                 |
 | [Passkey](/docs/plugins/passkey)                     | WebAuthn/passkey authentication                            |
 | [Magic Link](/docs/plugins/magic-link)               | Passwordless email magic link authentication               |
 | [Email OTP](/docs/plugins/email-otp)                 | Email-based one-time password authentication               |

--- a/docs/content/docs/plugins/meta.json
+++ b/docs/content/docs/plugins/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "2fa",
+    "atproto",
     "passkey",
     "magic-link",
     "email-otp",

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -1017,6 +1017,50 @@ describe("api-key", async () => {
 		expect(response?.valid).toBe(true);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9504
+	 */
+	it("should return 429 when API key rate limit is exceeded via before hook", async () => {
+		const { client: rlClient, signInWithTestUser: rlSignIn } =
+			await getTestInstance(
+				{
+					plugins: [
+						apiKey({
+							enableSessionForAPIKeys: true,
+							rateLimit: {
+								enabled: true,
+								timeWindow: 60000,
+								maxRequests: 2,
+							},
+						}),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [apiKeyClient()],
+					},
+				},
+			);
+
+		const { headers: userHeaders } = await rlSignIn();
+		const { data: rlKey } = await rlClient.apiKey.create(
+			{},
+			{ headers: userHeaders },
+		);
+		if (!rlKey) throw new Error("apiKey.create returned null");
+
+		const headers = new Headers();
+		headers.set("x-api-key", rlKey.key);
+
+		for (let i = 0; i < 2; i++) {
+			const res = await rlClient.getSession({ fetchOptions: { headers } });
+			expect(res.error).toBeNull();
+		}
+
+		const res = await rlClient.getSession({ fetchOptions: { headers } });
+		expect(res.error?.status).toBe(429);
+	});
+
 	it("should check if verifying an API key's remaining count does go down", async () => {
 		const remaining = 10;
 		const { data: apiKey } = await client.apiKey.create(

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -157,7 +157,7 @@ export async function validateApiKey({
 	const { message, success, update, tryAgainIn } = isRateLimited(apiKey, opts);
 
 	if (success === false) {
-		throw new APIError("UNAUTHORIZED", {
+		throw new APIError("TOO_MANY_REQUESTS", {
 			message: message ?? undefined,
 			code: "RATE_LIMITED" as const,
 			details: {

--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @better-auth/atproto

--- a/packages/atproto/README.md
+++ b/packages/atproto/README.md
@@ -1,5 +1,5 @@
 # @better-auth/atproto
 
-AT Protocol (Bluesky) OAuth plugin for [Better Auth](https://better-auth.com).
+AT Protocol (Atmosphere) OAuth plugin for [Better Auth](https://better-auth.com).
 
 See the [documentation](https://www.better-auth.com/docs/plugins/atproto).

--- a/packages/atproto/README.md
+++ b/packages/atproto/README.md
@@ -1,0 +1,5 @@
+# @better-auth/atproto
+
+AT Protocol (Bluesky) OAuth plugin for [Better Auth](https://better-auth.com).
+
+See the [documentation](https://www.better-auth.com/docs/plugins/atproto).

--- a/packages/atproto/package.json
+++ b/packages/atproto/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@better-auth/atproto",
+  "version": "1.6.10",
+  "description": "AT Protocol (Bluesky) OAuth plugin for Better Auth",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/plugins/atproto",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/better-auth/better-auth.git",
+    "directory": "packages/atproto"
+  },
+  "keywords": [
+    "auth",
+    "atproto",
+    "bluesky",
+    "oauth",
+    "dpop",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict --pack false",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "dev-source": "./src/index.ts",
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "./client": {
+      "dev-source": "./src/client.ts",
+      "types": "./dist/client.d.mts",
+      "default": "./dist/client.mjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/index.d.mts"
+      ],
+      "client": [
+        "./dist/client.d.mts"
+      ]
+    }
+  },
+  "dependencies": {
+    "@atproto/api": "^0.19.6",
+    "@atproto/jwk-jose": "^0.1.11",
+    "@atproto/oauth-client-node": "^0.3.17",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@better-auth/core": "workspace:*",
+    "better-auth": "workspace:*",
+    "tsdown": "catalog:"
+  },
+  "peerDependencies": {
+    "@better-auth/core": "workspace:^",
+    "@better-auth/utils": "catalog:",
+    "@better-fetch/fetch": "catalog:",
+    "better-auth": "workspace:^",
+    "better-call": "catalog:"
+  }
+}

--- a/packages/atproto/package.json
+++ b/packages/atproto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-auth/atproto",
-  "version": "1.6.10",
+  "version": "1.7.0-beta.3",
   "description": "AT Protocol (Bluesky) OAuth plugin for Better Auth",
   "type": "module",
   "license": "MIT",

--- a/packages/atproto/package.json
+++ b/packages/atproto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@better-auth/atproto",
   "version": "1.7.0-beta.3",
-  "description": "AT Protocol (Bluesky) OAuth plugin for Better Auth",
+  "description": "AT Protocol (Atmosphere) OAuth plugin for Better Auth",
   "type": "module",
   "license": "MIT",
   "homepage": "https://www.better-auth.com/docs/plugins/atproto",

--- a/packages/atproto/src/client.test.ts
+++ b/packages/atproto/src/client.test.ts
@@ -77,4 +77,26 @@ describe("atprotoClient", () => {
 		});
 		expect(res.data?.url).toBe("https://pds.example.com/authorize?x=1");
 	});
+
+	it("caller-supplied fetchOptions cannot override the fixed method/body", async () => {
+		const { client } = await getTestInstance(
+			{ plugins: [atproto()] },
+			{ clientOptions: { plugins: [atprotoClient()] } },
+		);
+		oauthMocks.authorize.mockResolvedValueOnce(
+			new URL("https://pds.example.com/authorize?x=1"),
+		);
+		// Try to force a GET with no body. The client should still POST the
+		// handle/callbackURL — otherwise the server endpoint would return 405
+		// or the body would be missing and authorize() wouldn't be called.
+		const res = await client.signIn.atproto(
+			{ handle: "alice.bsky.social", callbackURL: "/dashboard" },
+			{ method: "GET", body: undefined } as RequestInit,
+		);
+		expect(res.data?.url).toBe("https://pds.example.com/authorize?x=1");
+		expect(oauthMocks.authorize).toHaveBeenCalledWith(
+			"alice.bsky.social",
+			expect.any(Object),
+		);
+	});
 });

--- a/packages/atproto/src/client.test.ts
+++ b/packages/atproto/src/client.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Same mock setup so the server-side plugin doesn't blow up on import.
+const oauthMocks = vi.hoisted(() => ({
+	authorize: vi.fn(),
+	callback: vi.fn(),
+	restore: vi.fn(),
+	clientMetadata: {
+		client_id: "test-client",
+		client_name: "Better Auth",
+		redirect_uris: ["http://127.0.0.1:3000/api/auth/atproto/callback"],
+		grant_types: ["authorization_code", "refresh_token"],
+		scope: "atproto transition:generic",
+		response_types: ["code"],
+		application_type: "web",
+		token_endpoint_auth_method: "none",
+		dpop_bound_access_tokens: true,
+	},
+	jwks: { keys: [] },
+}));
+
+vi.mock("@atproto/oauth-client-node", () => ({
+	NodeOAuthClient: vi.fn().mockImplementation(function () {
+		return {
+			authorize: oauthMocks.authorize,
+			callback: oauthMocks.callback,
+			restore: oauthMocks.restore,
+			clientMetadata: oauthMocks.clientMetadata,
+			jwks: oauthMocks.jwks,
+		};
+	}),
+}));
+
+vi.mock("@atproto/jwk-jose", () => ({
+	JoseKey: {
+		fromImportable: vi.fn().mockResolvedValue({}),
+	},
+}));
+
+vi.mock("@atproto/api", () => ({ Agent: vi.fn() }));
+
+import { getTestInstance } from "better-auth/test";
+import { atprotoClient } from "./client";
+import { atproto } from "./index";
+
+describe("atprotoClient", () => {
+	it("exposes signIn.atproto, atproto.getSession, atproto.restore", async () => {
+		const { client } = await getTestInstance(
+			{ plugins: [atproto()] },
+			{ clientOptions: { plugins: [atprotoClient()] } },
+		);
+		expect(typeof client.signIn.atproto).toBe("function");
+		expect(typeof client.atproto.getSession).toBe("function");
+		expect(typeof client.atproto.restore).toBe("function");
+	});
+
+	it("declares correct pathMethods", () => {
+		const plugin = atprotoClient();
+		expect(plugin.pathMethods).toEqual({
+			"/atproto/sign-in": "POST",
+			"/atproto/session": "GET",
+			"/atproto/restore": "POST",
+		});
+	});
+
+	it("signIn.atproto POSTs to /atproto/sign-in with handle + callbackURL", async () => {
+		const { client } = await getTestInstance(
+			{ plugins: [atproto()] },
+			{ clientOptions: { plugins: [atprotoClient()] } },
+		);
+		oauthMocks.authorize.mockResolvedValueOnce(
+			new URL("https://pds.example.com/authorize?x=1"),
+		);
+		const res = await client.signIn.atproto({
+			handle: "alice.bsky.social",
+			callbackURL: "/dashboard",
+		});
+		expect(res.data?.url).toBe("https://pds.example.com/authorize?x=1");
+	});
+});

--- a/packages/atproto/src/client.ts
+++ b/packages/atproto/src/client.ts
@@ -1,0 +1,57 @@
+import type { BetterAuthClientPlugin } from "@better-auth/core";
+import type { atproto } from "./index";
+
+export const atprotoClient = () => {
+	return {
+		id: "atproto",
+		$InferServerPlugin: {} as ReturnType<typeof atproto>,
+		getActions: ($fetch) => ({
+			signIn: {
+				atproto: async (
+					data: { handle: string; callbackURL?: string },
+					fetchOptions?: RequestInit,
+				) => {
+					const res = await $fetch<{ url: string; redirect: boolean }>(
+						"/atproto/sign-in",
+						{
+							method: "POST",
+							body: {
+								handle: data.handle,
+								callbackURL: data.callbackURL,
+							},
+							...fetchOptions,
+						},
+					);
+					if (res.data?.url && typeof window !== "undefined") {
+						window.location.href = res.data.url;
+					}
+					return res;
+				},
+			},
+			atproto: {
+				getSession: async (fetchOptions?: RequestInit) => {
+					return $fetch<{
+						active: boolean;
+						did?: string;
+						handle?: string;
+						displayName?: string;
+						avatar?: string;
+						banner?: string;
+						description?: string;
+					}>("/atproto/session", { method: "GET", ...fetchOptions });
+				},
+				restore: async (fetchOptions?: RequestInit) => {
+					return $fetch<{ active: boolean; did?: string }>("/atproto/restore", {
+						method: "POST",
+						...fetchOptions,
+					});
+				},
+			},
+		}),
+		pathMethods: {
+			"/atproto/sign-in": "POST",
+			"/atproto/session": "GET",
+			"/atproto/restore": "POST",
+		},
+	} satisfies BetterAuthClientPlugin;
+};

--- a/packages/atproto/src/client.ts
+++ b/packages/atproto/src/client.ts
@@ -14,12 +14,12 @@ export const atprotoClient = () => {
 					const res = await $fetch<{ url: string; redirect: boolean }>(
 						"/atproto/sign-in",
 						{
+							...fetchOptions,
 							method: "POST",
 							body: {
 								handle: data.handle,
 								callbackURL: data.callbackURL,
 							},
-							...fetchOptions,
 						},
 					);
 					if (res.data?.url && typeof window !== "undefined") {
@@ -38,12 +38,12 @@ export const atprotoClient = () => {
 						avatar?: string;
 						banner?: string;
 						description?: string;
-					}>("/atproto/session", { method: "GET", ...fetchOptions });
+					}>("/atproto/session", { ...fetchOptions, method: "GET" });
 				},
 				restore: async (fetchOptions?: RequestInit) => {
 					return $fetch<{ active: boolean; did?: string }>("/atproto/restore", {
-						method: "POST",
 						...fetchOptions,
+						method: "POST",
 					});
 				},
 			},

--- a/packages/atproto/src/index.ts
+++ b/packages/atproto/src/index.ts
@@ -1,0 +1,114 @@
+import { JoseKey } from "@atproto/jwk-jose";
+import { NodeOAuthClient } from "@atproto/oauth-client-node";
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { mergeSchema } from "better-auth/db";
+import { createAtprotoEndpoints } from "./routes";
+import { schema } from "./schema";
+import { createSessionStore, createStateStore } from "./stores";
+import type { AtprotoAuthOptions } from "./types";
+import { isLocalhost, resolveBaseURL } from "./utils";
+import { PACKAGE_VERSION } from "./version";
+
+declare module "@better-auth/core" {
+	interface BetterAuthPluginRegistry<AuthOptions, Options> {
+		atproto: {
+			creator: typeof atproto;
+		};
+	}
+}
+
+export type {
+	AtprotoAuthOptions,
+	AtprotoProfile,
+	AtprotoUserFields,
+} from "./types";
+
+export const atproto = (options: AtprotoAuthOptions = {}): BetterAuthPlugin => {
+	let oauthClient: NodeOAuthClient | undefined;
+	const getClient = (): NodeOAuthClient => {
+		if (!oauthClient) {
+			throw new Error(
+				"[atproto] OAuth client not initialized — was the plugin registered before use?",
+			);
+		}
+		return oauthClient;
+	};
+
+	return {
+		id: "atproto",
+		version: PACKAGE_VERSION,
+		schema: mergeSchema(schema, options.schema),
+
+		rateLimit: [
+			{
+				pathMatcher: (path) => path === "/atproto/sign-in",
+				window: 60,
+				max: 5,
+			},
+			{
+				pathMatcher: (path) => path === "/atproto/callback",
+				window: 60,
+				max: 10,
+			},
+		],
+
+		init: async (ctx) => {
+			const baseURL = resolveBaseURL(ctx.options.baseURL);
+			const basePath = ctx.options.basePath || "/api/auth";
+			const prefix = `${baseURL}${basePath}`;
+			const isLocal = isLocalhost(baseURL);
+			const scope =
+				options.clientMetadata?.scope || "atproto transition:generic";
+
+			// RFC 8252: loopback redirect URIs must use 127.0.0.1, not "localhost".
+			const port = new URL(baseURL).port ? `:${new URL(baseURL).port}` : "";
+			const redirectUri = isLocal
+				? `http://127.0.0.1${port}${basePath}/atproto/callback`
+				: `${prefix}/atproto/callback`;
+
+			if (!isLocal && !options.privateKey) {
+				throw new Error(
+					"[atproto] privateKey is required for non-localhost deployments. " +
+						"Generate one with: openssl ecparam -name prime256v1 -genkey -noout",
+				);
+			}
+
+			const keyset = options.privateKey
+				? [await JoseKey.fromImportable(options.privateKey, "atproto-key")]
+				: [];
+
+			const clientId = isLocal
+				? `http://localhost?redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}`
+				: `${prefix}/atproto/client-metadata.json`;
+
+			const { adapter } = ctx;
+			const stateStore = createStateStore(adapter as any);
+			const sessionStore = createSessionStore(adapter as any);
+
+			oauthClient = new NodeOAuthClient({
+				clientMetadata: {
+					client_id: clientId,
+					client_name: options.clientMetadata?.clientName || "Better Auth",
+					redirect_uris: [redirectUri],
+					grant_types: ["authorization_code", "refresh_token"],
+					scope,
+					response_types: ["code"],
+					application_type: "web",
+					token_endpoint_auth_method: isLocal ? "none" : "private_key_jwt",
+					dpop_bound_access_tokens: true,
+					...(isLocal
+						? {}
+						: {
+								token_endpoint_auth_signing_alg: "ES256",
+								jwks_uri: `${prefix}/atproto/jwks.json`,
+							}),
+				},
+				keyset,
+				stateStore,
+				sessionStore,
+			});
+		},
+
+		endpoints: createAtprotoEndpoints(getClient, options),
+	};
+};

--- a/packages/atproto/src/index.ts
+++ b/packages/atproto/src/index.ts
@@ -93,7 +93,7 @@ export const atproto = (options: AtprotoAuthOptions = {}): BetterAuthPlugin => {
 					grant_types: ["authorization_code", "refresh_token"],
 					scope,
 					response_types: ["code"],
-					application_type: "web",
+					application_type: isLocal ? "native" : "web",
 					token_endpoint_auth_method: isLocal ? "none" : "private_key_jwt",
 					dpop_bound_access_tokens: true,
 					...(isLocal

--- a/packages/atproto/src/routes.test.ts
+++ b/packages/atproto/src/routes.test.ts
@@ -336,6 +336,126 @@ describe("atproto callback", () => {
 		expect(res.status).toBe(403);
 	});
 
+	it("persists atprotoDid/atprotoHandle on the user row after callback", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [atproto()],
+			disableTestUser: true,
+		} as never);
+
+		const { Agent } = await import("@atproto/api");
+		vi.mocked(Agent).mockImplementation(function () {
+			return {
+				getProfile: vi.fn().mockResolvedValue({
+					data: {
+						handle: "alice.bsky.social",
+						displayName: "Alice",
+						avatar: "https://cdn/avatar.jpg",
+						description: "hi",
+					},
+				}),
+			};
+		} as never);
+
+		oauthMocks.callback.mockResolvedValueOnce({
+			session: { did: "did:plc:fields-test" },
+			state: JSON.stringify({ callbackURL: "/" }),
+		});
+
+		const req = new Request(
+			"http://localhost:3000/api/auth/atproto/callback?code=x&state=y",
+			{ method: "GET", redirect: "manual" },
+		);
+		await auth.handler(req);
+
+		// Query the user row directly to assert the atproto fields landed
+		// (and so by extension, the session cookie's cached user payload —
+		// which is built from the same userRecord — has them too).
+		const ctx = await auth.$context;
+		const account = await ctx.adapter.findOne<{ userId: string }>({
+			model: "account",
+			where: [
+				{ field: "providerId", value: "atproto" },
+				{ field: "accountId", value: "did:plc:fields-test" },
+			],
+		});
+		expect(account?.userId).toBeDefined();
+		const user = await ctx.adapter.findOne<{
+			atprotoDid?: string;
+			atprotoHandle?: string;
+		}>({
+			model: "user",
+			where: [{ field: "id", value: account!.userId }],
+		});
+		expect(user?.atprotoDid).toBe("did:plc:fields-test");
+		expect(user?.atprotoHandle).toBe("alice.bsky.social");
+	});
+
+	it("does not auto-link an atproto DID to a user holding the synthetic placeholder email", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [atproto()],
+			disableTestUser: true,
+			emailAndPassword: { enabled: true },
+		} as never);
+
+		const ctx = await auth.$context;
+		// Pre-create a user whose email happens to match the placeholder
+		// pattern that the atproto plugin would derive for did:plc:colliding.
+		// Without the direct-account-lookup fix, this user would be picked
+		// up via the email fallback in `findOAuthUser` and silently linked.
+		const sanitized = "did_plc_colliding";
+		const placeholder = `${sanitized}@atproto.invalid`;
+		const preexisting = await ctx.adapter.create<{ id: string }>({
+			model: "user",
+			data: {
+				name: "Unrelated User",
+				email: placeholder,
+				emailVerified: false,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+
+		const { Agent } = await import("@atproto/api");
+		vi.mocked(Agent).mockImplementation(function () {
+			return {
+				getProfile: vi.fn().mockResolvedValue({
+					data: { handle: "stranger.bsky.social" },
+				}),
+			};
+		} as never);
+
+		oauthMocks.callback.mockResolvedValueOnce({
+			session: { did: "did:plc:colliding" },
+			state: JSON.stringify({ callbackURL: "/" }),
+		});
+
+		const req = new Request(
+			"http://localhost:3000/api/auth/atproto/callback?code=x&state=y",
+			{ method: "GET", redirect: "manual" },
+		);
+		await auth.handler(req);
+
+		// The pre-existing user must NOT have had the atproto DID linked.
+		const preexistingAfter = await ctx.adapter.findOne<{
+			atprotoDid?: string;
+		}>({
+			model: "user",
+			where: [{ field: "id", value: preexisting.id }],
+		});
+		expect(preexistingAfter?.atprotoDid).toBeFalsy();
+
+		// And no account row should reference the pre-existing user with the
+		// atproto provider.
+		const linkedAccount = await ctx.adapter.findOne({
+			model: "account",
+			where: [
+				{ field: "providerId", value: "atproto" },
+				{ field: "userId", value: preexisting.id },
+			],
+		});
+		expect(linkedAccount).toBeNull();
+	});
+
 	it("returns BAD_REQUEST when appState.callbackURL is untrusted", async () => {
 		const { auth } = await getTestInstance({
 			plugins: [atproto()],

--- a/packages/atproto/src/routes.test.ts
+++ b/packages/atproto/src/routes.test.ts
@@ -1,0 +1,392 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoist the NodeOAuthClient mock so it's in place before any imports
+// that depend on it.
+const oauthMocks = vi.hoisted(() => ({
+	authorize: vi.fn(),
+	callback: vi.fn(),
+	restore: vi.fn(),
+	clientMetadata: {
+		client_id: "test-client",
+		client_name: "Better Auth",
+		redirect_uris: ["http://127.0.0.1:3000/api/auth/atproto/callback"],
+		grant_types: ["authorization_code", "refresh_token"],
+		scope: "atproto transition:generic",
+		response_types: ["code"],
+		application_type: "web",
+		token_endpoint_auth_method: "none",
+		dpop_bound_access_tokens: true,
+	},
+	jwks: { keys: [] },
+}));
+
+vi.mock("@atproto/oauth-client-node", () => ({
+	NodeOAuthClient: vi.fn().mockImplementation(function () {
+		return {
+			authorize: oauthMocks.authorize,
+			callback: oauthMocks.callback,
+			restore: oauthMocks.restore,
+			clientMetadata: oauthMocks.clientMetadata,
+			jwks: oauthMocks.jwks,
+		};
+	}),
+}));
+
+vi.mock("@atproto/jwk-jose", () => ({
+	JoseKey: {
+		fromImportable: vi.fn().mockResolvedValue({
+			kid: "atproto-key",
+			privateJwk: {},
+			publicJwk: {},
+		}),
+	},
+}));
+
+vi.mock("@atproto/api", () => ({
+	Agent: vi.fn(),
+}));
+
+import { getTestInstance } from "better-auth/test";
+import { atprotoClient } from "./client";
+import { atproto } from "./index";
+
+describe("atproto plugin — structure", () => {
+	it("exposes id and version", () => {
+		const plugin = atproto();
+		expect(plugin.id).toBe("atproto");
+		expect(typeof plugin.version).toBe("string");
+	});
+
+	it("registers user schema extensions and atproto tables", () => {
+		const plugin = atproto();
+		expect(plugin.schema?.user?.fields.atprotoDid).toBeDefined();
+		expect(plugin.schema?.user?.fields.atprotoHandle).toBeDefined();
+		expect(plugin.schema?.user?.fields.atprotoBio).toBeDefined();
+		expect(plugin.schema?.user?.fields.atprotoBanner).toBeDefined();
+		expect(plugin.schema?.atprotoState).toBeDefined();
+		expect(plugin.schema?.atprotoSession).toBeDefined();
+	});
+
+	it("atprotoDid is unique on user", () => {
+		const plugin = atproto();
+		const field = plugin.schema?.user?.fields.atprotoDid as {
+			unique?: boolean;
+		};
+		expect(field.unique).toBe(true);
+	});
+
+	it("atprotoSession.userId cascades on user delete", () => {
+		const plugin = atproto();
+		const field = plugin.schema?.atprotoSession?.fields.userId as {
+			references?: { model: string; field: string; onDelete: string };
+		};
+		expect(field.references).toEqual({
+			model: "user",
+			field: "id",
+			onDelete: "cascade",
+		});
+	});
+
+	it("rate-limits sign-in (5/60s) and callback (10/60s) but not metadata", () => {
+		const plugin = atproto();
+		const rules = plugin.rateLimit ?? [];
+		const signIn = rules.find((r) => r.pathMatcher("/atproto/sign-in"));
+		const callback = rules.find((r) => r.pathMatcher("/atproto/callback"));
+		expect(signIn).toMatchObject({ window: 60, max: 5 });
+		expect(callback).toMatchObject({ window: 60, max: 10 });
+		expect(
+			rules.some((r) => r.pathMatcher("/atproto/client-metadata.json")),
+		).toBe(false);
+		expect(rules.some((r) => r.pathMatcher("/atproto/jwks.json"))).toBe(false);
+	});
+});
+
+describe("atproto plugin — init validation", () => {
+	const makeCtx = (overrides: Record<string, unknown> = {}) =>
+		({
+			options: {
+				baseURL: "http://127.0.0.1:3000",
+				basePath: "/api/auth",
+				...overrides,
+			},
+			adapter: {
+				findOne: vi.fn().mockResolvedValue(null),
+				create: vi.fn().mockResolvedValue({ id: "1" }),
+				update: vi.fn().mockResolvedValue({}),
+				delete: vi.fn().mockResolvedValue({}),
+				deleteMany: vi.fn().mockResolvedValue({}),
+			},
+		}) as unknown as Parameters<
+			NonNullable<ReturnType<typeof atproto>["init"]>
+		>[0];
+
+	it("throws when baseURL is missing", async () => {
+		const plugin = atproto();
+		await expect(
+			plugin.init?.(makeCtx({ baseURL: undefined })),
+		).rejects.toThrow("baseURL is required");
+	});
+
+	it("throws when DynamicBaseURLConfig has no fallback", async () => {
+		const plugin = atproto();
+		await expect(
+			plugin.init?.(makeCtx({ baseURL: { allowedHosts: ["example.com"] } })),
+		).rejects.toThrow("must be a string or have a fallback URL");
+	});
+
+	it("throws on non-localhost without privateKey", async () => {
+		const plugin = atproto();
+		await expect(
+			plugin.init?.(makeCtx({ baseURL: "https://example.com" })),
+		).rejects.toThrow("privateKey is required");
+	});
+
+	it("succeeds for localhost without privateKey", async () => {
+		const plugin = atproto();
+		await expect(
+			plugin.init?.(makeCtx({ baseURL: "http://127.0.0.1:3000" })),
+		).resolves.not.toThrow();
+	});
+
+	it("resolves DynamicBaseURLConfig with fallback", async () => {
+		const plugin = atproto();
+		await expect(
+			plugin.init?.(
+				makeCtx({
+					baseURL: {
+						allowedHosts: ["example.com"],
+						fallback: "http://127.0.0.1:3000",
+					},
+				}),
+			),
+		).resolves.not.toThrow();
+	});
+});
+
+describe("atproto endpoints — metadata", () => {
+	it("returns client metadata", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [atproto()],
+		});
+		const api = auth.api as unknown as {
+			atprotoClientMetadata: () => Promise<{
+				client_id: string;
+				dpop_bound_access_tokens: boolean;
+			}>;
+		};
+		const res = await api.atprotoClientMetadata();
+		expect(res.client_id).toBe("test-client");
+		expect(res.dpop_bound_access_tokens).toBe(true);
+	});
+
+	it("returns jwks", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [atproto()],
+		});
+		const api = auth.api as unknown as {
+			atprotoJwks: () => Promise<{ keys: unknown[] }>;
+		};
+		const res = await api.atprotoJwks();
+		expect(res).toEqual({ keys: [] });
+	});
+});
+
+describe("atproto sign-in", () => {
+	beforeEach(() => {
+		oauthMocks.authorize.mockReset();
+	});
+
+	it("returns the authorization URL", async () => {
+		const { client } = await getTestInstance(
+			{ plugins: [atproto()] },
+			{ clientOptions: { plugins: [atprotoClient()] } },
+		);
+		oauthMocks.authorize.mockResolvedValueOnce(
+			new URL("https://pds.example.com/authorize?x=1"),
+		);
+		const res = await client.signIn.atproto({
+			handle: "alice.bsky.social",
+			callbackURL: "/dashboard",
+		});
+		expect(res.data?.url).toBe("https://pds.example.com/authorize?x=1");
+		expect(res.data?.redirect).toBe(true);
+	});
+
+	it("rejects untrusted callbackURL", async () => {
+		const { client } = await getTestInstance(
+			{ plugins: [atproto()] },
+			{ clientOptions: { plugins: [atprotoClient()] } },
+		);
+		const res = await client.signIn.atproto({
+			handle: "alice.bsky.social",
+			callbackURL: "https://evil.example.com/steal",
+		});
+		expect(res.error?.status).toBe(400);
+	});
+
+	it("returns BAD_REQUEST when authorize throws", async () => {
+		const { client } = await getTestInstance(
+			{ plugins: [atproto()] },
+			{ clientOptions: { plugins: [atprotoClient()] } },
+		);
+		oauthMocks.authorize.mockRejectedValueOnce(
+			new Error("unresolvable handle"),
+		);
+		const res = await client.signIn.atproto({
+			handle: "not-real.bsky.social",
+			callbackURL: "/",
+		});
+		expect(res.error?.status).toBe(400);
+	});
+});
+
+describe("atproto callback", () => {
+	beforeEach(() => {
+		oauthMocks.callback.mockReset();
+	});
+
+	it("returns UNAUTHORIZED when params include error", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [atproto()],
+		});
+		const req = new Request(
+			"http://localhost:3000/api/auth/atproto/callback?error=access_denied",
+			{ method: "GET" },
+		);
+		const res = await auth.handler(req);
+		expect(res.status).toBe(401);
+	});
+
+	it("returns UNAUTHORIZED when the OAuth callback throws", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [atproto()],
+		});
+		oauthMocks.callback.mockRejectedValueOnce(new Error("boom"));
+		const req = new Request(
+			"http://localhost:3000/api/auth/atproto/callback?code=x&state=y",
+			{ method: "GET" },
+		);
+		const res = await auth.handler(req);
+		expect(res.status).toBe(401);
+	});
+
+	it("creates user, links account, sets cookie, and redirects on happy path", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [atproto()],
+			disableTestUser: true,
+		} as never);
+
+		// Mock the authenticated Agent.getProfile via @atproto/api
+		const { Agent } = await import("@atproto/api");
+		vi.mocked(Agent).mockImplementation(function () {
+			return {
+				getProfile: vi.fn().mockResolvedValue({
+					data: {
+						handle: "alice.bsky.social",
+						displayName: "Alice",
+						avatar: "https://cdn/avatar.jpg",
+						banner: "https://cdn/banner.jpg",
+						description: "hi",
+					},
+				}),
+			};
+		} as never);
+
+		oauthMocks.callback.mockResolvedValueOnce({
+			session: { did: "did:plc:alice" },
+			state: JSON.stringify({ callbackURL: "/dashboard" }),
+		});
+
+		const req = new Request(
+			"http://localhost:3000/api/auth/atproto/callback?code=x&state=y",
+			{ method: "GET", redirect: "manual" },
+		);
+		const res = await auth.handler(req);
+		expect(res.status).toBeGreaterThanOrEqual(300);
+		expect(res.status).toBeLessThan(400);
+		expect(res.headers.get("location")).toContain("/dashboard");
+		expect(res.headers.get("set-cookie")).toMatch(/better-auth\.session_token/);
+	});
+
+	it("returns FORBIDDEN with disableSignUp and unknown DID", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [atproto({ disableSignUp: true })],
+			disableTestUser: true,
+		} as never);
+
+		const { Agent } = await import("@atproto/api");
+		vi.mocked(Agent).mockImplementation(function () {
+			return {
+				getProfile: vi.fn().mockResolvedValue({
+					data: { handle: "stranger.bsky.social" },
+				}),
+			};
+		} as never);
+
+		oauthMocks.callback.mockResolvedValueOnce({
+			session: { did: "did:plc:stranger" },
+			state: JSON.stringify({ callbackURL: "/" }),
+		});
+
+		const req = new Request(
+			"http://localhost:3000/api/auth/atproto/callback?code=x&state=y",
+			{ method: "GET", redirect: "manual" },
+		);
+		const res = await auth.handler(req);
+		expect(res.status).toBe(403);
+	});
+
+	it("returns BAD_REQUEST when appState.callbackURL is untrusted", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [atproto()],
+			disableTestUser: true,
+		} as never);
+
+		const { Agent } = await import("@atproto/api");
+		vi.mocked(Agent).mockImplementation(function () {
+			return {
+				getProfile: vi.fn().mockResolvedValue({
+					data: { handle: "alice.bsky.social" },
+				}),
+			};
+		} as never);
+
+		oauthMocks.callback.mockResolvedValueOnce({
+			session: { did: "did:plc:alice2" },
+			state: JSON.stringify({ callbackURL: "https://evil.example.com/" }),
+		});
+
+		const req = new Request(
+			"http://localhost:3000/api/auth/atproto/callback?code=x&state=y",
+			{ method: "GET", redirect: "manual" },
+		);
+		const res = await auth.handler(req);
+		expect(res.status).toBe(400);
+	});
+});
+
+describe("atproto session + restore", () => {
+	beforeEach(() => {
+		oauthMocks.restore.mockReset();
+	});
+
+	it("/atproto/session returns active:false when user has no atprotoDid", async () => {
+		const { client, signInWithTestUser } = await getTestInstance(
+			{ plugins: [atproto()] },
+			{ clientOptions: { plugins: [atprotoClient()] } },
+		);
+		const { headers } = await signInWithTestUser();
+		const res = await client.atproto.getSession({ headers });
+		expect(res.data).toEqual({ active: false });
+	});
+
+	it("/atproto/restore returns active:false when user has no atprotoDid", async () => {
+		const { client, signInWithTestUser } = await getTestInstance(
+			{ plugins: [atproto()] },
+			{ clientOptions: { plugins: [atprotoClient()] } },
+		);
+		const { headers } = await signInWithTestUser();
+		const res = await client.atproto.restore({ headers });
+		expect(res.data).toEqual({ active: false });
+	});
+});

--- a/packages/atproto/src/routes.ts
+++ b/packages/atproto/src/routes.ts
@@ -190,8 +190,7 @@ export function createAtprotoEndpoints(
 					});
 				} else if (currentUserId) {
 					const linkingEnabled =
-						(ctx.context.options as any).account?.accountLinking?.enabled !==
-						false;
+						ctx.context.options.account?.accountLinking?.enabled !== false;
 					if (!linkingEnabled) {
 						throw new APIError("FORBIDDEN", {
 							message:

--- a/packages/atproto/src/routes.ts
+++ b/packages/atproto/src/routes.ts
@@ -1,0 +1,366 @@
+import { Agent } from "@atproto/api";
+import type { NodeOAuthClient } from "@atproto/oauth-client-node";
+import { createAuthEndpoint } from "@better-auth/core/api";
+import { APIError } from "@better-auth/core/error";
+import { sessionMiddleware } from "better-auth/api";
+import { setSessionCookie } from "better-auth/cookies";
+import * as z from "zod";
+import type { AtprotoAuthOptions, AtprotoUserFields } from "./types";
+import { atprotoPlaceholderEmail, fetchProfileWithAgent } from "./utils";
+
+const ATPROTO_PROVIDER_ID = "atproto";
+
+/**
+ * Validate a user-supplied callbackURL against trustedOrigins to prevent
+ * open-redirect. Returns the validated URL or throws BAD_REQUEST.
+ */
+function assertTrustedCallback(
+	ctx: any,
+	callbackURL: string | undefined,
+): string {
+	const target = callbackURL || "/";
+	if (target.startsWith("/")) {
+		// Relative paths are safe; isTrustedOrigin will accept them with the flag.
+		if (!ctx.context.isTrustedOrigin(target, { allowRelativePaths: true })) {
+			throw new APIError("BAD_REQUEST", {
+				message: "callbackURL is not a trusted origin",
+			});
+		}
+		return target;
+	}
+	if (!ctx.context.isTrustedOrigin(target)) {
+		throw new APIError("BAD_REQUEST", {
+			message: "callbackURL is not a trusted origin",
+		});
+	}
+	return target;
+}
+
+export function createAtprotoEndpoints(
+	getClient: () => NodeOAuthClient,
+	options: AtprotoAuthOptions,
+) {
+	return {
+		atprotoClientMetadata: createAuthEndpoint(
+			"/atproto/client-metadata.json",
+			{ method: "GET" },
+			async (ctx) => {
+				return ctx.json(getClient().clientMetadata);
+			},
+		),
+
+		atprotoJwks: createAuthEndpoint(
+			"/atproto/jwks.json",
+			{ method: "GET" },
+			async (ctx) => {
+				return ctx.json(getClient().jwks);
+			},
+		),
+
+		atprotoSignIn: createAuthEndpoint(
+			"/atproto/sign-in",
+			{
+				method: "POST",
+				body: z.object({
+					handle: z.string(),
+					callbackURL: z.string().optional(),
+				}),
+			},
+			async (ctx) => {
+				const { handle, callbackURL } = ctx.body as {
+					handle: string;
+					callbackURL?: string;
+				};
+				const safeCallback = assertTrustedCallback(ctx, callbackURL);
+				try {
+					const url = await getClient().authorize(handle, {
+						state: JSON.stringify({ callbackURL: safeCallback }),
+					});
+					return ctx.json({ url: url.toString(), redirect: true });
+				} catch (err) {
+					ctx.context.logger.error("atproto sign-in failed", err);
+					throw new APIError("BAD_REQUEST", {
+						message: `Failed to initiate atproto auth for handle: ${handle}`,
+					});
+				}
+			},
+		),
+
+		atprotoCallback: createAuthEndpoint(
+			"/atproto/callback",
+			{
+				method: "GET",
+				query: z
+					.object({
+						code: z.string().optional(),
+						state: z.string().optional(),
+						iss: z.string().optional(),
+						error: z.string().optional(),
+						error_description: z.string().optional(),
+					})
+					.optional(),
+			},
+			async (ctx) => {
+				const query = (ctx.query ?? {}) as Record<string, string | undefined>;
+
+				if (query.error) {
+					ctx.context.logger.error(
+						"atproto callback error param",
+						query.error,
+						query.error_description,
+					);
+					throw new APIError("UNAUTHORIZED", {
+						message: "atproto authentication was rejected",
+					});
+				}
+
+				// Reconstruct URLSearchParams from the validated query object so that
+				// NodeOAuthClient.callback() can parse the OAuth response parameters.
+				const params = new URLSearchParams();
+				for (const [key, val] of Object.entries(query)) {
+					if (val !== undefined) params.set(key, val);
+				}
+
+				let atSession: Awaited<
+					ReturnType<NodeOAuthClient["callback"]>
+				>["session"];
+				let appState: { callbackURL?: string } = {};
+				try {
+					const result = await getClient().callback(params);
+					atSession = result.session;
+					appState = JSON.parse(result.state || "{}");
+				} catch (err) {
+					ctx.context.logger.error("atproto callback exchange failed", err);
+					throw new APIError("UNAUTHORIZED", {
+						message: "Failed to complete atproto authentication",
+					});
+				}
+
+				const did = atSession.did;
+				const profile = await fetchProfileWithAgent(atSession);
+				const { internalAdapter, adapter } = ctx.context;
+				const placeholderEmail = atprotoPlaceholderEmail(did);
+
+				// Detect an existing logged-in session to support account linking.
+				let currentUserId: string | undefined;
+				try {
+					const cookieName = ctx.context.authCookies.sessionToken.name;
+					const sessionToken = await ctx.getSignedCookie(
+						cookieName,
+						ctx.context.secret,
+					);
+					if (sessionToken) {
+						const existingSession = await adapter.findOne<{ userId: string }>({
+							model: "session",
+							where: [{ field: "token", value: sessionToken }],
+						});
+						if (existingSession) currentUserId = existingSession.userId;
+					}
+				} catch {
+					// No existing session, proceed with regular flow.
+				}
+
+				const existingUser = await internalAdapter.findOAuthUser(
+					placeholderEmail,
+					did,
+					ATPROTO_PROVIDER_ID,
+				);
+
+				let userId: string;
+				let userRecord: Record<string, unknown>;
+
+				if (existingUser) {
+					userId = existingUser.user.id;
+					userRecord = existingUser.user as Record<string, unknown>;
+					if (!existingUser.linkedAccount) {
+						await internalAdapter.linkAccount({
+							providerId: ATPROTO_PROVIDER_ID,
+							accountId: did,
+							userId,
+							accessToken: "atproto-session",
+							refreshToken: undefined,
+							accessTokenExpiresAt: undefined,
+							refreshTokenExpiresAt: undefined,
+						});
+					}
+					await adapter.update({
+						model: "user",
+						where: [{ field: "id", value: userId }],
+						update: buildUserUpdate(did, profile, /*newUser*/ true),
+					});
+				} else if (currentUserId) {
+					const linkingEnabled =
+						(ctx.context.options as any).account?.accountLinking?.enabled !==
+						false;
+					if (!linkingEnabled) {
+						throw new APIError("FORBIDDEN", {
+							message:
+								"Account linking is disabled. Cannot link atproto account to an existing user.",
+						});
+					}
+					userId = currentUserId;
+					// Fetch user record for session cookie
+					const foundUser = await internalAdapter.findUserById(userId);
+					if (!foundUser) {
+						throw new APIError("INTERNAL_SERVER_ERROR", {
+							message: "User not found",
+						});
+					}
+					userRecord = foundUser as Record<string, unknown>;
+					await internalAdapter.linkAccount({
+						providerId: ATPROTO_PROVIDER_ID,
+						accountId: did,
+						userId,
+						accessToken: "atproto-session",
+						refreshToken: undefined,
+						accessTokenExpiresAt: undefined,
+						refreshTokenExpiresAt: undefined,
+					});
+					await adapter.update({
+						model: "user",
+						where: [{ field: "id", value: userId }],
+						update: buildUserUpdate(did, profile, /*newUser*/ false),
+					});
+				} else {
+					if (options.disableSignUp) {
+						throw new APIError("FORBIDDEN", {
+							message:
+								"Sign up is disabled. Only existing users can sign in with atproto.",
+						});
+					}
+					const mapped = options.mapProfileToUser?.(profile);
+					const created = await internalAdapter.createOAuthUser(
+						{
+							name:
+								mapped?.name || profile.displayName || profile.handle || did,
+							email: mapped?.email || placeholderEmail,
+							image: mapped?.image || profile.avatar || undefined,
+							emailVerified: false,
+						},
+						{
+							providerId: ATPROTO_PROVIDER_ID,
+							accountId: did,
+							accessToken: "atproto-session",
+							refreshToken: undefined,
+							accessTokenExpiresAt: undefined,
+							refreshTokenExpiresAt: undefined,
+						},
+					);
+					if (!created?.user?.id) {
+						throw new APIError("INTERNAL_SERVER_ERROR", {
+							message: "Failed to create user",
+						});
+					}
+					userId = created.user.id;
+					userRecord = created.user as Record<string, unknown>;
+					await adapter.update({
+						model: "user",
+						where: [{ field: "id", value: userId }],
+						update: buildUserUpdate(did, profile, /*newUser*/ true),
+					});
+				}
+
+				// Backfill userId on the atprotoSession row so it links to the user.
+				const sessionRow = await adapter.findOne<{ id: string }>({
+					model: "atprotoSession",
+					where: [{ field: "did", value: did }],
+				});
+				if (sessionRow) {
+					await adapter.update({
+						model: "atprotoSession",
+						where: [{ field: "id", value: sessionRow.id }],
+						update: { userId },
+					});
+				}
+
+				const newSession = await internalAdapter.createSession(userId);
+				await setSessionCookie(ctx, {
+					session: newSession,
+					user: userRecord as any,
+				});
+
+				// Re-validate callbackURL before redirecting (defense in depth).
+				const finalCallback = assertTrustedCallback(ctx, appState.callbackURL);
+				return ctx.redirect(finalCallback);
+			},
+		),
+
+		atprotoGetSession: createAuthEndpoint(
+			"/atproto/session",
+			{ method: "GET", use: [sessionMiddleware] },
+			async (ctx) => {
+				const user = ctx.context.session.user as Partial<AtprotoUserFields>;
+				const did = user.atprotoDid;
+				if (!did) return ctx.json({ active: false });
+				const controller = new AbortController();
+				const timer = setTimeout(() => controller.abort(), 5000);
+				try {
+					const atSession = await getClient().restore(did);
+					const agent = new Agent(atSession);
+					const res = await agent.getProfile(
+						{ actor: did },
+						{ signal: controller.signal },
+					);
+					return ctx.json({
+						active: true,
+						did,
+						handle: res.data.handle,
+						displayName: res.data.displayName,
+						avatar: res.data.avatar,
+						banner: res.data.banner,
+						description: res.data.description,
+					});
+				} catch (err) {
+					ctx.context.logger.error("atproto session restore failed", err);
+					return ctx.json({ active: false, did });
+				} finally {
+					clearTimeout(timer);
+				}
+			},
+		),
+
+		atprotoRestore: createAuthEndpoint(
+			"/atproto/restore",
+			{ method: "POST", use: [sessionMiddleware] },
+			async (ctx) => {
+				const user = ctx.context.session.user as Partial<AtprotoUserFields>;
+				const did = user.atprotoDid;
+				if (!did) return ctx.json({ active: false });
+				try {
+					await getClient().restore(did);
+					return ctx.json({ active: true, did });
+				} catch (err) {
+					ctx.context.logger.error("atproto restore failed", err);
+					return ctx.json({ active: false, did });
+				}
+			},
+		),
+	};
+}
+
+function buildUserUpdate(
+	did: string,
+	profile: {
+		handle: string;
+		displayName?: string;
+		avatar?: string;
+		description?: string;
+		banner?: string;
+	},
+	newUser: boolean,
+) {
+	const update: Record<string, unknown> = {
+		atprotoDid: did,
+		atprotoHandle: profile.handle,
+		updatedAt: new Date(),
+	};
+	// Avoid overwriting an existing user's `name`/`image` for the linking path.
+	if (newUser) {
+		if (profile.displayName) update.name = profile.displayName;
+		if (profile.avatar) update.image = profile.avatar;
+	}
+	if (profile.description !== undefined)
+		update.atprotoBio = profile.description;
+	if (profile.banner !== undefined) update.atprotoBanner = profile.banner;
+	return update;
+}

--- a/packages/atproto/src/routes.ts
+++ b/packages/atproto/src/routes.ts
@@ -160,34 +160,48 @@ export function createAtprotoEndpoints(
 					// No existing session, proceed with regular flow.
 				}
 
-				const existingUser = await internalAdapter.findOAuthUser(
-					placeholderEmail,
-					did,
-					ATPROTO_PROVIDER_ID,
-				);
+				// Look up by (providerId, accountId=DID) only. We deliberately do
+				// not use `internalAdapter.findOAuthUser`, which falls back to an
+				// email lookup — and our synthetic `*@atproto.invalid` placeholder
+				// email could collide with an unrelated user holding that exact
+				// email, silently auto-linking the atproto DID to the wrong
+				// account and bypassing the normal account-linking safeguards.
+				const existingAccount = await adapter.findOne<{ userId: string }>({
+					model: "account",
+					where: [
+						{ field: "providerId", value: ATPROTO_PROVIDER_ID },
+						{ field: "accountId", value: did },
+					],
+				});
+				let existingUser: {
+					user: Record<string, unknown> & { id: string };
+				} | null = null;
+				if (existingAccount) {
+					const user = await internalAdapter.findUserById(
+						existingAccount.userId,
+					);
+					if (user) {
+						existingUser = {
+							user: user as Record<string, unknown> & { id: string },
+						};
+					}
+				}
 
 				let userId: string;
 				let userRecord: Record<string, unknown>;
 
 				if (existingUser) {
 					userId = existingUser.user.id;
-					userRecord = existingUser.user as Record<string, unknown>;
-					if (!existingUser.linkedAccount) {
-						await internalAdapter.linkAccount({
-							providerId: ATPROTO_PROVIDER_ID,
-							accountId: did,
-							userId,
-							accessToken: "atproto-session",
-							refreshToken: undefined,
-							accessTokenExpiresAt: undefined,
-							refreshTokenExpiresAt: undefined,
-						});
-					}
+					const update = buildUserUpdate(did, profile, /*newUser*/ true);
 					await adapter.update({
 						model: "user",
 						where: [{ field: "id", value: userId }],
-						update: buildUserUpdate(did, profile, /*newUser*/ true),
+						update,
 					});
+					// Merge the update locally so the session cookie's cached user
+					// payload carries the freshly written atproto fields without
+					// an extra round-trip.
+					userRecord = { ...existingUser.user, ...update };
 				} else if (currentUserId) {
 					const linkingEnabled =
 						ctx.context.options.account?.accountLinking?.enabled !== false;
@@ -198,14 +212,12 @@ export function createAtprotoEndpoints(
 						});
 					}
 					userId = currentUserId;
-					// Fetch user record for session cookie
 					const foundUser = await internalAdapter.findUserById(userId);
 					if (!foundUser) {
 						throw new APIError("INTERNAL_SERVER_ERROR", {
 							message: "User not found",
 						});
 					}
-					userRecord = foundUser as Record<string, unknown>;
 					await internalAdapter.linkAccount({
 						providerId: ATPROTO_PROVIDER_ID,
 						accountId: did,
@@ -215,11 +227,13 @@ export function createAtprotoEndpoints(
 						accessTokenExpiresAt: undefined,
 						refreshTokenExpiresAt: undefined,
 					});
+					const update = buildUserUpdate(did, profile, /*newUser*/ false);
 					await adapter.update({
 						model: "user",
 						where: [{ field: "id", value: userId }],
-						update: buildUserUpdate(did, profile, /*newUser*/ false),
+						update,
 					});
+					userRecord = { ...(foundUser as Record<string, unknown>), ...update };
 				} else {
 					if (options.disableSignUp) {
 						throw new APIError("FORBIDDEN", {
@@ -251,12 +265,16 @@ export function createAtprotoEndpoints(
 						});
 					}
 					userId = created.user.id;
-					userRecord = created.user as Record<string, unknown>;
+					const update = buildUserUpdate(did, profile, /*newUser*/ true);
 					await adapter.update({
 						model: "user",
 						where: [{ field: "id", value: userId }],
-						update: buildUserUpdate(did, profile, /*newUser*/ true),
+						update,
 					});
+					userRecord = {
+						...(created.user as Record<string, unknown>),
+						...update,
+					};
 				}
 
 				// Backfill userId on the atprotoSession row so it links to the user.

--- a/packages/atproto/src/schema.ts
+++ b/packages/atproto/src/schema.ts
@@ -1,0 +1,70 @@
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
+
+export const schema = {
+	user: {
+		fields: {
+			atprotoDid: {
+				type: "string",
+				required: false,
+				unique: true,
+			},
+			atprotoHandle: {
+				type: "string",
+				required: false,
+			},
+			atprotoBio: {
+				type: "string",
+				required: false,
+			},
+			atprotoBanner: {
+				type: "string",
+				required: false,
+			},
+		},
+	},
+	atprotoState: {
+		modelName: "atprotoState",
+		fields: {
+			key: {
+				type: "string",
+				required: true,
+				unique: true,
+			},
+			state: {
+				type: "string",
+				required: true,
+			},
+			expiresAt: {
+				type: "date",
+				required: true,
+			},
+		},
+	},
+	atprotoSession: {
+		modelName: "atprotoSession",
+		fields: {
+			did: {
+				type: "string",
+				required: true,
+				unique: true,
+			},
+			session: {
+				type: "string",
+				required: true,
+			},
+			userId: {
+				type: "string",
+				required: false,
+				references: {
+					model: "user",
+					field: "id",
+					onDelete: "cascade",
+				},
+			},
+			updatedAt: {
+				type: "date",
+				required: true,
+			},
+		},
+	},
+} satisfies BetterAuthPluginDBSchema;

--- a/packages/atproto/src/stores.test.ts
+++ b/packages/atproto/src/stores.test.ts
@@ -18,7 +18,9 @@ function makeAdapter(): AdapterStub {
 	return {
 		findOne: vi.fn().mockResolvedValue(null),
 		create: vi.fn().mockResolvedValue({ id: "1" }),
-		update: vi.fn().mockResolvedValue({}),
+		// `update` returns null when no row matches the where clause; the stores
+		// use that signal to decide whether to fall back to `create`.
+		update: vi.fn().mockResolvedValue(null),
 		delete: vi.fn().mockResolvedValue({}),
 		deleteMany: vi.fn().mockResolvedValue({}),
 	} as unknown as AdapterStub;
@@ -49,11 +51,21 @@ describe("createStateStore", () => {
 	});
 	it("set: updates when row exists", async () => {
 		const adapter = makeAdapter();
-		adapter.findOne.mockResolvedValueOnce({ id: "row-1" });
+		adapter.update.mockResolvedValueOnce({ id: "row-1" });
 		const store = createStateStore(adapter);
 		await store.set("key-1", { x: 1 } as unknown as NodeSavedState);
-		expect(adapter.update).toHaveBeenCalled();
+		expect(adapter.update).toHaveBeenCalledTimes(1);
 		expect(adapter.create).not.toHaveBeenCalled();
+	});
+	it("set: falls back to update when concurrent create loses the race", async () => {
+		const adapter = makeAdapter();
+		// First update sees no row → create attempted → create throws (race
+		// with another writer that just inserted) → fallback update wins.
+		adapter.create.mockRejectedValueOnce(new Error("unique constraint"));
+		const store = createStateStore(adapter);
+		await store.set("key-1", { x: 1 } as unknown as NodeSavedState);
+		expect(adapter.update).toHaveBeenCalledTimes(2);
+		expect(adapter.create).toHaveBeenCalledTimes(1);
 	});
 	it("get: returns parsed state when not expired", async () => {
 		const adapter = makeAdapter();
@@ -144,13 +156,23 @@ describe("createSessionStore", () => {
 	});
 	it("set: updates existing session", async () => {
 		const adapter = makeAdapter();
-		adapter.findOne.mockResolvedValueOnce({ id: "row-1" });
+		adapter.update.mockResolvedValueOnce({ id: "row-1" });
 		const store = createSessionStore(adapter);
 		await store.set("did:plc:abc", {
 			tokens: 2,
 		} as unknown as NodeSavedSession);
-		expect(adapter.update).toHaveBeenCalled();
+		expect(adapter.update).toHaveBeenCalledTimes(1);
 		expect(adapter.create).not.toHaveBeenCalled();
+	});
+	it("set: falls back to update when concurrent create loses the race", async () => {
+		const adapter = makeAdapter();
+		adapter.create.mockRejectedValueOnce(new Error("unique constraint"));
+		const store = createSessionStore(adapter);
+		await store.set("did:plc:abc", {
+			tokens: 2,
+		} as unknown as NodeSavedSession);
+		expect(adapter.update).toHaveBeenCalledTimes(2);
+		expect(adapter.create).toHaveBeenCalledTimes(1);
 	});
 	it("get: returns parsed session", async () => {
 		const adapter = makeAdapter();

--- a/packages/atproto/src/stores.test.ts
+++ b/packages/atproto/src/stores.test.ts
@@ -1,0 +1,177 @@
+import type {
+	NodeSavedSession,
+	NodeSavedState,
+} from "@atproto/oauth-client-node";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AtprotoAdapter } from "./stores";
+import { createSessionStore, createStateStore } from "./stores";
+
+type AdapterStub = AtprotoAdapter & {
+	findOne: ReturnType<typeof vi.fn>;
+	create: ReturnType<typeof vi.fn>;
+	update: ReturnType<typeof vi.fn>;
+	delete: ReturnType<typeof vi.fn>;
+	deleteMany: ReturnType<typeof vi.fn>;
+};
+
+function makeAdapter(): AdapterStub {
+	return {
+		findOne: vi.fn().mockResolvedValue(null),
+		create: vi.fn().mockResolvedValue({ id: "1" }),
+		update: vi.fn().mockResolvedValue({}),
+		delete: vi.fn().mockResolvedValue({}),
+		deleteMany: vi.fn().mockResolvedValue({}),
+	} as unknown as AdapterStub;
+}
+
+describe("createStateStore", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-11T10:00:00Z"));
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+	it("set: inserts when no existing row", async () => {
+		const adapter = makeAdapter();
+		const store = createStateStore(adapter);
+		const value = { fake: "state" } as unknown as NodeSavedState;
+		await store.set("key-1", value);
+		expect(adapter.create).toHaveBeenCalledWith({
+			model: "atprotoState",
+			data: expect.objectContaining({
+				key: "key-1",
+				state: JSON.stringify(value),
+				expiresAt: new Date("2026-05-11T10:10:00Z"),
+			}),
+		});
+	});
+	it("set: updates when row exists", async () => {
+		const adapter = makeAdapter();
+		adapter.findOne.mockResolvedValueOnce({ id: "row-1" });
+		const store = createStateStore(adapter);
+		await store.set("key-1", { x: 1 } as unknown as NodeSavedState);
+		expect(adapter.update).toHaveBeenCalled();
+		expect(adapter.create).not.toHaveBeenCalled();
+	});
+	it("get: returns parsed state when not expired", async () => {
+		const adapter = makeAdapter();
+		adapter.findOne.mockResolvedValueOnce({
+			state: JSON.stringify({ y: 2 }),
+			expiresAt: new Date("2026-05-11T10:09:00Z"),
+		});
+		const store = createStateStore(adapter);
+		const result = await store.get("key-1");
+		expect(result).toEqual({ y: 2 });
+	});
+	it("get: returns undefined and deletes when expired", async () => {
+		const adapter = makeAdapter();
+		adapter.findOne.mockResolvedValueOnce({
+			state: "{}",
+			expiresAt: new Date("2026-05-11T09:00:00Z"),
+		});
+		const store = createStateStore(adapter);
+		const result = await store.get("expired-key");
+		expect(result).toBeUndefined();
+		expect(adapter.delete).toHaveBeenCalledWith({
+			model: "atprotoState",
+			where: [{ field: "key", value: "expired-key" }],
+		});
+	});
+	it("get: returns undefined when not found", async () => {
+		const adapter = makeAdapter();
+		const store = createStateStore(adapter);
+		expect(await store.get("missing")).toBeUndefined();
+	});
+	it("del: deletes the row", async () => {
+		const adapter = makeAdapter();
+		const store = createStateStore(adapter);
+		await store.del("key-1");
+		expect(adapter.delete).toHaveBeenCalledWith({
+			model: "atprotoState",
+			where: [{ field: "key", value: "key-1" }],
+		});
+	});
+	it("set: opportunistic sweep deletes expired rows when random < 0.01", async () => {
+		const adapter = makeAdapter();
+		vi.spyOn(Math, "random").mockReturnValue(0.005);
+		const store = createStateStore(adapter);
+		await store.set("key-1", { x: 1 } as unknown as NodeSavedState);
+		expect(adapter.deleteMany).toHaveBeenCalledWith({
+			model: "atprotoState",
+			where: [
+				{
+					field: "expiresAt",
+					operator: "lt",
+					value: new Date("2026-05-11T10:00:00Z"),
+				},
+			],
+		});
+	});
+	it("set: no sweep when random >= 0.01", async () => {
+		const adapter = makeAdapter();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const store = createStateStore(adapter);
+		await store.set("key-1", { x: 1 } as unknown as NodeSavedState);
+		expect(adapter.deleteMany).not.toHaveBeenCalled();
+	});
+});
+
+describe("createSessionStore", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-11T10:00:00Z"));
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+	it("set: inserts null userId when no existing row", async () => {
+		const adapter = makeAdapter();
+		const store = createSessionStore(adapter);
+		await store.set("did:plc:abc", {
+			tokens: 1,
+		} as unknown as NodeSavedSession);
+		expect(adapter.create).toHaveBeenCalledWith({
+			model: "atprotoSession",
+			data: expect.objectContaining({
+				did: "did:plc:abc",
+				session: JSON.stringify({ tokens: 1 }),
+				userId: null,
+				updatedAt: expect.any(Date),
+			}),
+		});
+	});
+	it("set: updates existing session", async () => {
+		const adapter = makeAdapter();
+		adapter.findOne.mockResolvedValueOnce({ id: "row-1" });
+		const store = createSessionStore(adapter);
+		await store.set("did:plc:abc", {
+			tokens: 2,
+		} as unknown as NodeSavedSession);
+		expect(adapter.update).toHaveBeenCalled();
+		expect(adapter.create).not.toHaveBeenCalled();
+	});
+	it("get: returns parsed session", async () => {
+		const adapter = makeAdapter();
+		adapter.findOne.mockResolvedValueOnce({
+			session: JSON.stringify({ tokens: 3 }),
+		});
+		const store = createSessionStore(adapter);
+		expect(await store.get("did:plc:abc")).toEqual({ tokens: 3 });
+	});
+	it("get: returns undefined when missing", async () => {
+		const adapter = makeAdapter();
+		const store = createSessionStore(adapter);
+		expect(await store.get("did:plc:nope")).toBeUndefined();
+	});
+	it("del: deletes by did", async () => {
+		const adapter = makeAdapter();
+		const store = createSessionStore(adapter);
+		await store.del("did:plc:abc");
+		expect(adapter.delete).toHaveBeenCalledWith({
+			model: "atprotoSession",
+			where: [{ field: "did", value: "did:plc:abc" }],
+		});
+	});
+});

--- a/packages/atproto/src/stores.ts
+++ b/packages/atproto/src/stores.ts
@@ -21,28 +21,28 @@ export function createStateStore(adapter: AtprotoAdapter): NodeSavedStateStore {
 		set: async (key: string, val: NodeSavedState) => {
 			const now = new Date();
 			const expiresAt = new Date(now.getTime() + STATE_TTL_MS);
-			const existing = (await adapter.findOne({
+			const data = { state: JSON.stringify(val), expiresAt };
+			// Update-first → create-on-null → update-on-race-loss. The unique
+			// constraint on `key` makes this race-safe: only one of two
+			// concurrent creates can win, and the loser falls back to update.
+			const updated = await adapter.update({
 				model: "atprotoState",
 				where: [{ field: "key", value: key }],
-			})) as { id: string } | null;
-			if (existing) {
-				await adapter.update({
-					model: "atprotoState",
-					where: [{ field: "id", value: existing.id }],
-					update: {
-						state: JSON.stringify(val),
-						expiresAt,
-					},
-				});
-			} else {
-				await adapter.create({
-					model: "atprotoState",
-					data: {
-						key,
-						state: JSON.stringify(val),
-						expiresAt,
-					},
-				});
+				update: data,
+			});
+			if (updated === null) {
+				try {
+					await adapter.create({
+						model: "atprotoState",
+						data: { key, ...data },
+					});
+				} catch {
+					await adapter.update({
+						model: "atprotoState",
+						where: [{ field: "key", value: key }],
+						update: data,
+					});
+				}
 			}
 
 			// Opportunistic sweep of expired rows.
@@ -83,32 +83,32 @@ export function createSessionStore(
 	return {
 		set: async (sub: string, val: NodeSavedSession) => {
 			const updatedAt = new Date();
-			const existing = (await adapter.findOne({
+			const data = { session: JSON.stringify(val), updatedAt };
+			// Update-first → create-on-null → update-on-race-loss. The unique
+			// constraint on `did` makes this race-safe across concurrent writers
+			// (e.g. multi-instance deployments where NodeOAuthClient's per-DID
+			// `requestLock` doesn't span processes).
+			const updated = await adapter.update({
 				model: "atprotoSession",
 				where: [{ field: "did", value: sub }],
-			})) as { id: string } | null;
-			if (existing) {
-				await adapter.update({
-					model: "atprotoSession",
-					where: [{ field: "id", value: existing.id }],
-					update: {
-						session: JSON.stringify(val),
-						updatedAt,
-					},
-				});
-			} else {
-				// userId is backfilled by the callback handler once it knows
-				// which better-auth user this DID belongs to. Stored as null
-				// (rather than empty string) to satisfy FK constraints on Postgres/MySQL.
-				await adapter.create({
-					model: "atprotoSession",
-					data: {
-						did: sub,
-						session: JSON.stringify(val),
-						userId: null,
-						updatedAt,
-					},
-				});
+				update: data,
+			});
+			if (updated === null) {
+				try {
+					// userId is backfilled by the callback handler once it knows
+					// which better-auth user this DID belongs to. Stored as null
+					// (rather than empty string) to satisfy FK constraints.
+					await adapter.create({
+						model: "atprotoSession",
+						data: { did: sub, ...data, userId: null },
+					});
+				} catch {
+					await adapter.update({
+						model: "atprotoSession",
+						where: [{ field: "did", value: sub }],
+						update: data,
+					});
+				}
 			}
 		},
 		get: async (sub: string): Promise<NodeSavedSession | undefined> => {

--- a/packages/atproto/src/stores.ts
+++ b/packages/atproto/src/stores.ts
@@ -1,0 +1,129 @@
+import type {
+	NodeSavedSession,
+	NodeSavedSessionStore,
+	NodeSavedState,
+	NodeSavedStateStore,
+} from "@atproto/oauth-client-node";
+
+const STATE_TTL_MS = 10 * 60 * 1000;
+const STATE_SWEEP_PROBABILITY = 0.01;
+
+export interface AtprotoAdapter {
+	findOne: (...args: any[]) => Promise<any>;
+	create: (...args: any[]) => Promise<any>;
+	update: (...args: any[]) => Promise<any>;
+	delete: (...args: any[]) => Promise<any>;
+	deleteMany: (...args: any[]) => Promise<any>;
+}
+
+export function createStateStore(adapter: AtprotoAdapter): NodeSavedStateStore {
+	return {
+		set: async (key: string, val: NodeSavedState) => {
+			const now = new Date();
+			const expiresAt = new Date(now.getTime() + STATE_TTL_MS);
+			const existing = (await adapter.findOne({
+				model: "atprotoState",
+				where: [{ field: "key", value: key }],
+			})) as { id: string } | null;
+			if (existing) {
+				await adapter.update({
+					model: "atprotoState",
+					where: [{ field: "id", value: existing.id }],
+					update: {
+						state: JSON.stringify(val),
+						expiresAt,
+					},
+				});
+			} else {
+				await adapter.create({
+					model: "atprotoState",
+					data: {
+						key,
+						state: JSON.stringify(val),
+						expiresAt,
+					},
+				});
+			}
+
+			// Opportunistic sweep of expired rows.
+			if (Math.random() < STATE_SWEEP_PROBABILITY) {
+				await adapter.deleteMany({
+					model: "atprotoState",
+					where: [{ field: "expiresAt", operator: "lt", value: new Date() }],
+				});
+			}
+		},
+		get: async (key: string): Promise<NodeSavedState | undefined> => {
+			const row = (await adapter.findOne({
+				model: "atprotoState",
+				where: [{ field: "key", value: key }],
+			})) as { state: string; expiresAt: Date } | null;
+			if (!row) return undefined;
+			if (new Date(row.expiresAt) < new Date()) {
+				await adapter.delete({
+					model: "atprotoState",
+					where: [{ field: "key", value: key }],
+				});
+				return undefined;
+			}
+			return JSON.parse(row.state) as NodeSavedState;
+		},
+		del: async (key: string) => {
+			await adapter.delete({
+				model: "atprotoState",
+				where: [{ field: "key", value: key }],
+			});
+		},
+	};
+}
+
+export function createSessionStore(
+	adapter: AtprotoAdapter,
+): NodeSavedSessionStore {
+	return {
+		set: async (sub: string, val: NodeSavedSession) => {
+			const updatedAt = new Date();
+			const existing = (await adapter.findOne({
+				model: "atprotoSession",
+				where: [{ field: "did", value: sub }],
+			})) as { id: string } | null;
+			if (existing) {
+				await adapter.update({
+					model: "atprotoSession",
+					where: [{ field: "id", value: existing.id }],
+					update: {
+						session: JSON.stringify(val),
+						updatedAt,
+					},
+				});
+			} else {
+				// userId is backfilled by the callback handler once it knows
+				// which better-auth user this DID belongs to. Stored as null
+				// (rather than empty string) to satisfy FK constraints on Postgres/MySQL.
+				await adapter.create({
+					model: "atprotoSession",
+					data: {
+						did: sub,
+						session: JSON.stringify(val),
+						userId: null,
+						updatedAt,
+					},
+				});
+			}
+		},
+		get: async (sub: string): Promise<NodeSavedSession | undefined> => {
+			const row = (await adapter.findOne({
+				model: "atprotoSession",
+				where: [{ field: "did", value: sub }],
+			})) as { session: string } | null;
+			if (!row) return undefined;
+			return JSON.parse(row.session) as NodeSavedSession;
+		},
+		del: async (sub: string) => {
+			await adapter.delete({
+				model: "atprotoSession",
+				where: [{ field: "did", value: sub }],
+			});
+		},
+	};
+}

--- a/packages/atproto/src/types.ts
+++ b/packages/atproto/src/types.ts
@@ -1,0 +1,67 @@
+import type { InferOptionSchema } from "better-auth/types";
+import type { schema } from "./schema";
+
+export interface AtprotoProfile {
+	did: string;
+	handle: string;
+	displayName?: string;
+	avatar?: string;
+	banner?: string;
+	description?: string;
+}
+
+export type MappedUserFields = Partial<{
+	name: string;
+	email: string;
+	image: string;
+}>;
+
+export interface AtprotoAuthOptions {
+	/**
+	 * PEM-encoded ES256 private key for signing JWTs and DPoP proofs.
+	 * Required for production. Optional for localhost development —
+	 * atproto allows unauthenticated loopback clients.
+	 *
+	 * Generate with: openssl ecparam -name prime256v1 -genkey -noout
+	 */
+	privateKey?: string | undefined;
+
+	clientMetadata?:
+		| {
+				/** Display name shown during authorization. Defaults to "Better Auth". */
+				clientName?: string | undefined;
+				/** OAuth scopes to request. Defaults to "atproto transition:generic". */
+				scope?: string | undefined;
+		  }
+		| undefined;
+
+	/**
+	 * Customize how the atproto profile maps to better-auth user fields.
+	 * Return a partial user object to override defaults.
+	 */
+	mapProfileToUser?:
+		| ((profile: AtprotoProfile) => MappedUserFields)
+		| undefined;
+
+	/**
+	 * When true, only allow sign-in for existing users. New users will
+	 * receive a FORBIDDEN error instead of being created automatically.
+	 */
+	disableSignUp?: boolean | undefined;
+
+	/**
+	 * Schema overrides for the atproto plugin.
+	 */
+	schema?: InferOptionSchema<typeof schema> | undefined;
+}
+
+/**
+ * User fields added by the atproto plugin.
+ * Consumers see these as typed properties on `session.user`.
+ */
+export interface AtprotoUserFields {
+	atprotoDid: string | null;
+	atprotoHandle: string | null;
+	atprotoBio: string | null;
+	atprotoBanner: string | null;
+}

--- a/packages/atproto/src/utils.test.ts
+++ b/packages/atproto/src/utils.test.ts
@@ -1,0 +1,171 @@
+import { Agent } from "@atproto/api";
+import type { OAuthSession } from "@atproto/oauth-client-node";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	atprotoPlaceholderEmail,
+	fetchAtprotoProfilePublic,
+	fetchProfileWithAgent,
+	isLocalhost,
+	resolveBaseURL,
+} from "./utils";
+
+vi.mock("@atproto/api", () => ({
+	Agent: vi.fn(),
+}));
+
+describe("isLocalhost", () => {
+	it("returns true for http://localhost", () => {
+		expect(isLocalhost("http://localhost")).toBe(true);
+	});
+	it("returns true for http://localhost:3000", () => {
+		expect(isLocalhost("http://localhost:3000")).toBe(true);
+	});
+	it("returns true for http://127.0.0.1", () => {
+		expect(isLocalhost("http://127.0.0.1")).toBe(true);
+	});
+	it("returns true for http://127.0.0.1:8080", () => {
+		expect(isLocalhost("http://127.0.0.1:8080")).toBe(true);
+	});
+	it("returns true for http://[::1]:3000", () => {
+		expect(isLocalhost("http://[::1]:3000")).toBe(true);
+	});
+	it("returns false for https://example.com", () => {
+		expect(isLocalhost("https://example.com")).toBe(false);
+	});
+	it("returns false for invalid URL", () => {
+		expect(isLocalhost("not-a-url")).toBe(false);
+	});
+});
+
+describe("atprotoPlaceholderEmail", () => {
+	it("converts did:plc to a valid email", () => {
+		expect(atprotoPlaceholderEmail("did:plc:abc123")).toBe(
+			"did_plc_abc123@atproto.invalid",
+		);
+	});
+	it("converts did:web to a valid email", () => {
+		expect(atprotoPlaceholderEmail("did:web:example.com")).toBe(
+			"did_web_example_com@atproto.invalid",
+		);
+	});
+	it("is deterministic", () => {
+		const did = "did:plc:xyz789";
+		expect(atprotoPlaceholderEmail(did)).toBe(atprotoPlaceholderEmail(did));
+	});
+	it("produces distinct emails for distinct DIDs", () => {
+		expect(atprotoPlaceholderEmail("did:plc:aaa")).not.toBe(
+			atprotoPlaceholderEmail("did:plc:bbb"),
+		);
+	});
+});
+
+describe("fetchAtprotoProfilePublic", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+	it("returns profile data on success", async () => {
+		const mockProfile = {
+			handle: "alice.bsky.social",
+			displayName: "Alice",
+			avatar: "https://cdn/avatar.jpg",
+			banner: "https://cdn/banner.jpg",
+			description: "hi",
+		};
+		vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response(JSON.stringify(mockProfile), { status: 200 }),
+		);
+		const profile = await fetchAtprotoProfilePublic("did:plc:abc");
+		expect(profile.did).toBe("did:plc:abc");
+		expect(profile.handle).toBe("alice.bsky.social");
+		expect(profile.displayName).toBe("Alice");
+	});
+	it("returns fallback on HTTP error", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response("Not Found", { status: 404 }),
+		);
+		const profile = await fetchAtprotoProfilePublic("did:plc:x");
+		expect(profile.did).toBe("did:plc:x");
+		expect(profile.handle).toBe("did:plc:x");
+	});
+	it("returns fallback on network failure", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("net"));
+		const profile = await fetchAtprotoProfilePublic("did:plc:y");
+		expect(profile.did).toBe("did:plc:y");
+		expect(profile.handle).toBe("did:plc:y");
+	});
+	it("URL-encodes the DID", async () => {
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ handle: "x" }), { status: 200 }),
+			);
+		await fetchAtprotoProfilePublic("did:plc:abc");
+		expect(spy).toHaveBeenCalledWith(
+			"https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=did%3Aplc%3Aabc",
+			expect.objectContaining({ signal: expect.any(Object) }),
+		);
+	});
+});
+
+describe("fetchProfileWithAgent", () => {
+	beforeEach(() => {
+		vi.mocked(Agent).mockReset();
+	});
+	it("returns profile from authenticated agent on success", async () => {
+		const getProfile = vi.fn().mockResolvedValue({
+			data: {
+				handle: "alice.bsky.social",
+				displayName: "Alice",
+				avatar: "https://cdn/avatar.jpg",
+				banner: "https://cdn/banner.jpg",
+				description: "hi",
+			},
+		});
+		vi.mocked(Agent).mockImplementation(function () {
+			return { getProfile } as unknown as InstanceType<typeof Agent>;
+		});
+		const profile = await fetchProfileWithAgent({
+			did: "did:plc:abc",
+		} as unknown as OAuthSession);
+		expect(profile.handle).toBe("alice.bsky.social");
+		expect(profile.displayName).toBe("Alice");
+	});
+	it("falls back to public API on agent failure", async () => {
+		vi.mocked(Agent).mockImplementation(function () {
+			return {
+				getProfile: vi.fn().mockRejectedValue(new Error("nope")),
+			} as unknown as InstanceType<typeof Agent>;
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response(JSON.stringify({ handle: "fallback" }), { status: 200 }),
+		);
+		const profile = await fetchProfileWithAgent({
+			did: "did:plc:abc",
+		} as unknown as OAuthSession);
+		expect(profile.handle).toBe("fallback");
+	});
+});
+
+describe("resolveBaseURL", () => {
+	it("returns string baseURL as-is", () => {
+		expect(resolveBaseURL("http://localhost:3000")).toBe(
+			"http://localhost:3000",
+		);
+	});
+	it("returns fallback for DynamicBaseURLConfig", () => {
+		expect(
+			resolveBaseURL({
+				allowedHosts: ["example.com"],
+				fallback: "http://127.0.0.1:3000",
+			}),
+		).toBe("http://127.0.0.1:3000");
+	});
+	it("throws if undefined", () => {
+		expect(() => resolveBaseURL(undefined)).toThrow("baseURL is required");
+	});
+	it("throws if DynamicBaseURLConfig has no fallback", () => {
+		expect(() => resolveBaseURL({ allowedHosts: ["example.com"] })).toThrow(
+			"must be a string or have a fallback URL",
+		);
+	});
+});

--- a/packages/atproto/src/utils.ts
+++ b/packages/atproto/src/utils.ts
@@ -1,0 +1,92 @@
+import { Agent } from "@atproto/api";
+import type { OAuthSession } from "@atproto/oauth-client-node";
+import type { AtprotoProfile } from "./types";
+
+const PUBLIC_PROFILE_URL =
+	"https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile";
+
+/**
+ * Returns true if the URL refers to a loopback address
+ * (localhost, 127.0.0.1, or ::1).
+ */
+export function isLocalhost(url: string): boolean {
+	try {
+		const u = new URL(url);
+		const host = u.hostname.replace(/^\[|\]$/g, "");
+		return host === "localhost" || host === "127.0.0.1" || host === "::1";
+	} catch {
+		return false;
+	}
+}
+
+/** Deterministic placeholder email for atproto users (atproto doesn't expose emails). */
+export function atprotoPlaceholderEmail(did: string): string {
+	return `${did.replace(/[^a-zA-Z0-9]/g, "_")}@atproto.invalid`;
+}
+
+/** Fetch the user's profile via an authenticated atproto Agent. */
+export async function fetchProfileWithAgent(
+	session: OAuthSession,
+): Promise<AtprotoProfile> {
+	try {
+		const agent = new Agent(session);
+		const res = await agent.getProfile({ actor: session.did });
+		return {
+			did: session.did,
+			handle: res.data.handle,
+			displayName: res.data.displayName,
+			avatar: res.data.avatar,
+			banner: res.data.banner,
+			description: res.data.description,
+		};
+	} catch {
+		return fetchAtprotoProfilePublic(session.did);
+	}
+}
+
+/** Fallback profile fetch using the public Bluesky API. */
+export async function fetchAtprotoProfilePublic(
+	did: string,
+): Promise<AtprotoProfile> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 5000);
+	try {
+		const res = await fetch(
+			`${PUBLIC_PROFILE_URL}?actor=${encodeURIComponent(did)}`,
+			{ signal: controller.signal },
+		);
+		if (res.ok) {
+			const data = (await res.json()) as Partial<Record<string, string>>;
+			return {
+				did,
+				handle: data.handle ?? did,
+				displayName: data.displayName,
+				avatar: data.avatar,
+				banner: data.banner,
+				description: data.description,
+			};
+		}
+	} catch {
+		// Best-effort — covers network errors and timeout aborts.
+	} finally {
+		clearTimeout(timer);
+	}
+	return { did, handle: did };
+}
+
+type BaseURLInput =
+	| string
+	| { allowedHosts?: readonly string[]; fallback?: string }
+	| undefined;
+
+/** Resolve a string baseURL from better-auth's BaseURL option, or throw with a clear message. */
+export function resolveBaseURL(raw: BaseURLInput): string {
+	if (!raw) {
+		throw new Error("[atproto] better-auth baseURL is required");
+	}
+	if (typeof raw === "string") return raw;
+	if (raw.fallback) return raw.fallback;
+	throw new Error(
+		"[atproto] better-auth baseURL must be a string or have a fallback URL",
+	);
+}

--- a/packages/atproto/src/version.ts
+++ b/packages/atproto/src/version.ts
@@ -1,0 +1,3 @@
+import pkg from "../package.json" with { type: "json" };
+
+export const PACKAGE_VERSION = pkg.version;

--- a/packages/atproto/tsconfig.json
+++ b/packages/atproto/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom", "dom.iterable"]
+  },
+  "include": ["./src", "./package.json"],
+  "references": [
+    { "path": "../better-auth/tsconfig.json" },
+    { "path": "../core/tsconfig.json" }
+  ]
+}

--- a/packages/atproto/tsdown.config.ts
+++ b/packages/atproto/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	dts: { build: true, incremental: true },
+	format: ["esm"],
+	entry: ["./src/index.ts", "./src/client.ts"],
+	treeshake: true,
+});

--- a/packages/atproto/vitest.config.ts
+++ b/packages/atproto/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -717,9 +717,10 @@ export const changeEmail = createAuthEndpoint(
 	async (ctx) => {
 		if (!ctx.context.options.user?.changeEmail?.enabled) {
 			ctx.context.logger.error("Change email is disabled.");
-			throw APIError.fromStatus("BAD_REQUEST", {
-				message: "Change email is disabled",
-			});
+			throw APIError.from(
+				"BAD_REQUEST",
+				BASE_ERROR_CODES.CHANGE_EMAIL_DISABLED,
+			);
 		}
 
 		const newEmail = ctx.body.newEmail.toLowerCase();

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -154,6 +154,67 @@ describe("anonymous", async () => {
 		expect(linkAccountFn).toHaveBeenCalledWith(expect.any(Object));
 	});
 
+	it("should call onLinkAccount when anonymous user verifies email", async () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/9485
+		 */
+		const linkAccountFn = vi.fn();
+		let verificationToken = "";
+
+		const { client, sessionSetter, auth } = await getTestInstance(
+			{
+				plugins: [
+					anonymous({
+						async onLinkAccount(data) {
+							linkAccountFn(data);
+						},
+					}),
+				],
+				emailAndPassword: {
+					enabled: true,
+					requireEmailVerification: true,
+				},
+				emailVerification: {
+					autoSignInAfterVerification: true,
+					async sendVerificationEmail({ url }) {
+						verificationToken = new URL(url).searchParams.get("token") || "";
+					},
+				},
+			},
+			{
+				clientOptions: {
+					plugins: [anonymousClient()],
+				},
+				disableTestUser: true,
+			},
+		);
+
+		const anonHeaders = new Headers();
+
+		await client.signIn.anonymous({
+			fetchOptions: {
+				onSuccess: sessionSetter(anonHeaders),
+			},
+		});
+
+		await auth.api.signUpEmail({
+			body: {
+				email: "newuser@example.com",
+				password: "password123",
+				name: "New User",
+			},
+			headers: anonHeaders,
+		});
+
+		await auth.api.verifyEmail({
+			query: { token: verificationToken },
+			headers: anonHeaders,
+		});
+
+		expect(linkAccountFn).toHaveBeenCalledTimes(1);
+		expect(linkAccountFn).toHaveBeenCalledWith(expect.any(Object));
+	});
+
 	it("should work with generateName", async () => {
 		const { client, sessionSetter } = await getTestInstance(
 			{

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -245,6 +245,7 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 							ctx.path?.startsWith("/one-tap/callback") ||
 							ctx.path?.startsWith("/passkey/verify-authentication") ||
 							ctx.path?.startsWith("/phone-number/verify") ||
+							ctx.path?.startsWith("/verify-email") ||
 							false
 						);
 					},

--- a/packages/core/src/error/codes.ts
+++ b/packages/core/src/error/codes.ts
@@ -37,6 +37,7 @@ export const BASE_ERROR_CODES = defineErrorCodes({
 	USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL:
 		"User already exists. Use another email.",
 	EMAIL_CAN_NOT_BE_UPDATED: "Email can not be updated",
+	CHANGE_EMAIL_DISABLED: "Change email is disabled",
 	CREDENTIAL_ACCOUNT_NOT_FOUND: "Credential account not found",
 	SESSION_EXPIRED: "Session expired. Re-authenticate to perform this action.",
 	FAILED_TO_UNLINK_LAST_ACCOUNT: "You can't unlink your last account",

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -207,12 +207,13 @@ export type BetterAuthAdvancedOptions = {
 				 */
 				disableIpTracking?: boolean;
 				/**
-				 * IPv6 subnet prefix length for rate limiting.
-				 * IPv6 addresses will be normalized to this subnet.
+				 * IPv6 prefix length used to collapse addresses before rate-limit keying.
+				 * Any integer from 0 to 128 is accepted; common values are 32, 48, 56, 64, 128.
+				 * Out-of-range values fall back to safe behavior (negative -> mask all, > 128 -> no mask).
 				 *
 				 * @default 64
 				 */
-				ipv6Subnet?: 128 | 64 | 48 | 32;
+				ipv6Subnet?: number;
 		  }
 		| undefined;
 	/**

--- a/packages/core/src/utils/ip.test.ts
+++ b/packages/core/src/utils/ip.test.ts
@@ -151,6 +151,28 @@ describe("IP Normalization", () => {
 				"192.168.1.1",
 			);
 		});
+
+		it("should accept any integer prefix length, not just 32 | 48 | 64 | 128", () => {
+			// /56 (residential ISP allocation): zero out the last 72 bits.
+			expect(
+				normalizeIP("2001:db8:abcd:ef00:1111:2222:3333:4444", {
+					ipv6Subnet: 56,
+				}),
+			).toBe("2001:0db8:abcd:ef00:0000:0000:0000:0000");
+
+			// /40 (cloud-style allocation): zero out everything after the first 40 bits.
+			expect(
+				normalizeIP("2001:db8:ab00:1234:5678:9abc:def0:1234", {
+					ipv6Subnet: 40,
+				}),
+			).toBe("2001:0db8:ab00:0000:0000:0000:0000:0000");
+		});
+
+		it("should honour an explicit /0 prefix instead of falling back to the default", () => {
+			expect(normalizeIP("2001:db8::1", { ipv6Subnet: 0 })).toBe(
+				"0000:0000:0000:0000:0000:0000:0000:0000",
+			);
+		});
 	});
 
 	describe("Rate Limit Key Creation", () => {

--- a/packages/core/src/utils/ip.ts
+++ b/packages/core/src/utils/ip.ts
@@ -12,12 +12,13 @@ import * as z from "zod";
 
 interface NormalizeIPOptions {
 	/**
-	 * For IPv6 addresses, extract the subnet prefix instead of full address.
-	 * Common values: 32, 48, 64, 128 (default: 128 = full address)
+	 * Prefix length used to collapse IPv6 addresses before keying.
+	 * Any integer from 0 to 128 is accepted. Common values: 32, 48, 56, 64, 128.
+	 * Values outside 0-128 are clamped.
 	 *
-	 * @default 128
+	 * @default 64
 	 */
-	ipv6Subnet?: 128 | 64 | 48 | 32;
+	ipv6Subnet?: number;
 }
 
 /**
@@ -117,15 +118,13 @@ function expandIPv6(ipv6: string): string[] {
  * Normalizes an IPv6 address to canonical form
  * e.g., "2001:DB8::1" -> "2001:0db8:0000:0000:0000:0000:0000:0001"
  */
-function normalizeIPv6(
-	ipv6: string,
-	subnetPrefix?: 128 | 32 | 48 | 64,
-): string {
+function normalizeIPv6(ipv6: string, subnetPrefix?: number): string {
 	const groups = expandIPv6(ipv6);
 
-	if (subnetPrefix && subnetPrefix < 128) {
-		// Apply subnet mask
-		const prefix = subnetPrefix;
+	if (subnetPrefix !== undefined && subnetPrefix < 128) {
+		// Clamp to a valid bit range so out-of-spec inputs degrade safely:
+		// negative or fractional values would otherwise produce malformed masks.
+		const prefix = Math.max(0, Math.floor(subnetPrefix));
 		let bitsRemaining: number = prefix;
 
 		const maskedGroups = groups.map((group) => {
@@ -191,8 +190,8 @@ export function normalizeIP(
 		return ipv4.toLowerCase();
 	}
 
-	// Normalize IPv6
-	const subnetPrefix = options.ipv6Subnet || 64;
+	// Normalize IPv6. Use ?? so an explicit 0 (mask-all) is honoured.
+	const subnetPrefix = options.ipv6Subnet ?? 64;
 	return normalizeIPv6(ip, subnetPrefix);
 }
 

--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -64,6 +64,7 @@ export const expo = (options?: ExpoOptions | undefined) => {
 					matcher(context) {
 						return !!(
 							context.path?.startsWith("/callback") ||
+							context.path?.startsWith("/atproto/callback") ||
 							context.path?.startsWith("/magic-link/verify") ||
 							context.path?.startsWith("/verify-email")
 						);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -834,6 +834,40 @@ importers:
         specifier: 'catalog:'
         version: 0.21.1(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.19.0)(publint@0.3.17)(synckit@0.11.11)(typescript@5.9.3)
 
+  packages/atproto:
+    dependencies:
+      '@atproto/api':
+        specifier: ^0.19.6
+        version: 0.19.16
+      '@atproto/jwk-jose':
+        specifier: ^0.1.11
+        version: 0.1.11
+      '@atproto/oauth-client-node':
+        specifier: ^0.3.17
+        version: 0.3.17
+      '@better-auth/utils':
+        specifier: 'catalog:'
+        version: 0.4.0
+      '@better-fetch/fetch':
+        specifier: 'catalog:'
+        version: 1.1.21
+      better-call:
+        specifier: 'catalog:'
+        version: 1.3.5(zod@4.3.6)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@better-auth/core':
+        specifier: workspace:*
+        version: link:../core
+      better-auth:
+        specifier: workspace:*
+        version: link:../better-auth
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.1(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.19.0)(publint@0.3.17)(synckit@0.11.11)(typescript@5.9.3)
+
   packages/better-auth:
     dependencies:
       '@better-auth/core':
@@ -1721,6 +1755,78 @@ packages:
   '@arethetypeswrong/core@0.18.2':
     resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
     engines: {node: '>=20'}
+
+  '@atproto-labs/did-resolver@0.2.6':
+    resolution: {integrity: sha512-2K1bC04nI2fmgNcvof+yA28IhGlpWn2JKYlPa7To9JTKI45FINCGkQSGiL2nyXlyzDJJ34fZ1aq6/IRFIOIiqg==}
+
+  '@atproto-labs/fetch-node@0.2.0':
+    resolution: {integrity: sha512-Krq09nH/aeoiU2s9xdHA0FjTEFWG9B5FFenipv1iRixCcPc7V3DhTNDawxG9gI8Ny0k4dBVS9WTRN/IDzBx86Q==}
+    engines: {node: '>=18.7.0'}
+
+  '@atproto-labs/fetch@0.2.3':
+    resolution: {integrity: sha512-NZtbJOCbxKUFRFKMpamT38PUQMY0hX0p7TG5AEYOPhZKZEP7dHZ1K2s1aB8MdVH0qxmqX7nQleNrrvLf09Zfdw==}
+
+  '@atproto-labs/handle-resolver-node@0.1.25':
+    resolution: {integrity: sha512-NY9WYM2VLd3IuMGRkkmvGBg8xqVEaK/fitv1vD8SMXqFTekdpjOLCCyv7EFtqVHouzmDcL83VOvWRfHVa8V9Yw==}
+    engines: {node: '>=18.7.0'}
+
+  '@atproto-labs/handle-resolver@0.3.6':
+    resolution: {integrity: sha512-qnSTXvOBNj1EHhp2qTWSX8MS5q3AwYU5LKlt5fBvSbCjgmTr2j0URHCv+ydrwO55KvsojIkTMgeMOh4YuY4fCA==}
+
+  '@atproto-labs/identity-resolver@0.3.6':
+    resolution: {integrity: sha512-qoWqBDRobln0NR8L8dQjSp79E0chGkBhibEgxQa2f9WD+JbJdjQ0YvwwO5yeQn05pJoJmAwmI2wyJ45zjU7aWg==}
+
+  '@atproto-labs/pipe@0.1.1':
+    resolution: {integrity: sha512-hdNw2oUs2B6BN1lp+32pF7cp8EMKuIN5Qok2Vvv/aOpG/3tNSJ9YkvfI0k6Zd188LeDDYRUpYpxcoFIcGH/FNg==}
+
+  '@atproto-labs/simple-store-memory@0.1.4':
+    resolution: {integrity: sha512-3mKY4dP8I7yKPFj9VKpYyCRzGJOi5CEpOLPlRhoJyLmgs3J4RzDrjn323Oakjz2Aj2JzRU/AIvWRAZVhpYNJHw==}
+
+  '@atproto-labs/simple-store@0.3.0':
+    resolution: {integrity: sha512-nOb6ONKBRJHRlukW1sVawUkBqReLlLx6hT35VS3imaNPwiXDxLnTK7lxw3Lrl9k5yugSBDQAkZAq3MPTEFSUBQ==}
+
+  '@atproto/api@0.19.16':
+    resolution: {integrity: sha512-OAnY0+JDucUjPuPIrRVNT3h1PMi8txHd+lOdzenCcDAhtEsMRrUEWv4/IpEHRMclUAnX4ekfJDLlYleaOCQcng==}
+
+  '@atproto/common-web@0.4.21':
+    resolution: {integrity: sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==}
+
+  '@atproto/did@0.3.0':
+    resolution: {integrity: sha512-raUPzUGegtW/6OxwCmM8bhZvuIMzxG5t9oWsth6Tp91Kb5fTnHV2h/KKNF1C82doeA4BdXCErTyg7ISwLbQkzA==}
+
+  '@atproto/jwk-jose@0.1.11':
+    resolution: {integrity: sha512-i4Fnr2sTBYmMmHXl7NJh8GrCH+tDQEVWrcDMDnV5DjJfkgT17wIqvojIw9SNbSL4Uf0OtfEv6AgG0A+mgh8b5Q==}
+
+  '@atproto/jwk-webcrypto@0.2.0':
+    resolution: {integrity: sha512-UmgRrrEAkWvxwhlwe30UmDOdTEFidlIzBC7C3cCbeJMcBN1x8B3KH+crXrsTqfWQBG58mXgt8wgSK3Kxs2LhFg==}
+
+  '@atproto/jwk@0.6.0':
+    resolution: {integrity: sha512-bDoJPvt7TrQVi/rBfBrSSpGykhtIriKxeYCYQTiPRKFfyRhbgpElF0wPXADjIswnbzZdOwbY63az4E/CFVT3Tw==}
+
+  '@atproto/lex-data@0.0.15':
+    resolution: {integrity: sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==}
+
+  '@atproto/lex-json@0.0.16':
+    resolution: {integrity: sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==}
+
+  '@atproto/lexicon@0.6.2':
+    resolution: {integrity: sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==}
+
+  '@atproto/oauth-client-node@0.3.17':
+    resolution: {integrity: sha512-67LNuKAlC35Exe7CB5S0QCAnEqr6fKV9Nvp64jAHFof1N+Vc9Ltt1K9oekE5Ctf7dvpGByrHRF0noUw9l9sWLA==}
+    engines: {node: '>=18.7.0'}
+
+  '@atproto/oauth-client@0.6.1':
+    resolution: {integrity: sha512-QTLbEFyv7EJuwJf4A8IZnsylK5wwrzrSsxy0INcZf9zktPVQvgckWhSvbfK8alp60M+rwWfQQAlodcCF4WB78A==}
+
+  '@atproto/oauth-types@0.6.3':
+    resolution: {integrity: sha512-jdKuoPknJuh/WjI+mYk7agSbx9mNVMbS6Dr3k1z2YMY2oRiCQjxYBuo4MLKATbxj05nMQaZRWlHRUazoAu5Cng==}
+
+  '@atproto/syntax@0.5.4':
+    resolution: {integrity: sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==}
+
+  '@atproto/xrpc@0.7.7':
+    resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
 
   '@authenio/xml-encryption@2.0.2':
     resolution: {integrity: sha512-cTlrKttbrRHEw3W+0/I609A2Matj5JQaRvfLtEIGZvlN0RaPi+3ANsMeqAyCAVlH/lUIW2tmtBlSMni74lcXeg==}
@@ -7737,6 +7843,9 @@ packages:
   atomically@2.1.1:
     resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
 
+  await-lock@2.2.2:
+    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
+
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
@@ -8464,6 +8573,9 @@ packages:
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -10449,6 +10561,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -10614,6 +10730,9 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  iso-datestring-validator@2.2.2:
+    resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -10702,6 +10821,9 @@ packages:
 
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
@@ -11879,6 +12001,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  multiformats@9.9.0:
+    resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -13458,9 +13583,6 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
-  set-cookie-parser@3.0.1:
-    resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
-
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
@@ -14032,10 +14154,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -14059,6 +14177,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -14265,6 +14387,9 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
+  uint8arrays@3.0.0:
+    resolution: {integrity: sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==}
+
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
@@ -14325,6 +14450,9 @@ packages:
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  unicode-segmenter@0.14.5:
+    resolution: {integrity: sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==}
 
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
@@ -15387,6 +15515,154 @@ snapshots:
       semver: 7.7.4
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
+
+  '@atproto-labs/did-resolver@0.2.6':
+    dependencies:
+      '@atproto-labs/fetch': 0.2.3
+      '@atproto-labs/pipe': 0.1.1
+      '@atproto-labs/simple-store': 0.3.0
+      '@atproto-labs/simple-store-memory': 0.1.4
+      '@atproto/did': 0.3.0
+      zod: 3.25.76
+
+  '@atproto-labs/fetch-node@0.2.0':
+    dependencies:
+      '@atproto-labs/fetch': 0.2.3
+      '@atproto-labs/pipe': 0.1.1
+      ipaddr.js: 2.4.0
+      undici: 6.25.0
+
+  '@atproto-labs/fetch@0.2.3':
+    dependencies:
+      '@atproto-labs/pipe': 0.1.1
+
+  '@atproto-labs/handle-resolver-node@0.1.25':
+    dependencies:
+      '@atproto-labs/fetch-node': 0.2.0
+      '@atproto-labs/handle-resolver': 0.3.6
+      '@atproto/did': 0.3.0
+
+  '@atproto-labs/handle-resolver@0.3.6':
+    dependencies:
+      '@atproto-labs/simple-store': 0.3.0
+      '@atproto-labs/simple-store-memory': 0.1.4
+      '@atproto/did': 0.3.0
+      zod: 3.25.76
+
+  '@atproto-labs/identity-resolver@0.3.6':
+    dependencies:
+      '@atproto-labs/did-resolver': 0.2.6
+      '@atproto-labs/handle-resolver': 0.3.6
+
+  '@atproto-labs/pipe@0.1.1': {}
+
+  '@atproto-labs/simple-store-memory@0.1.4':
+    dependencies:
+      '@atproto-labs/simple-store': 0.3.0
+      lru-cache: 10.4.3
+
+  '@atproto-labs/simple-store@0.3.0': {}
+
+  '@atproto/api@0.19.16':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/lexicon': 0.6.2
+      '@atproto/syntax': 0.5.4
+      '@atproto/xrpc': 0.7.7
+      await-lock: 2.2.2
+      multiformats: 9.9.0
+      tlds: 1.261.0
+      zod: 3.25.76
+
+  '@atproto/common-web@0.4.21':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      '@atproto/lex-json': 0.0.16
+      '@atproto/syntax': 0.5.4
+      zod: 3.25.76
+
+  '@atproto/did@0.3.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@atproto/jwk-jose@0.1.11':
+    dependencies:
+      '@atproto/jwk': 0.6.0
+      jose: 5.10.0
+
+  '@atproto/jwk-webcrypto@0.2.0':
+    dependencies:
+      '@atproto/jwk': 0.6.0
+      '@atproto/jwk-jose': 0.1.11
+      zod: 3.25.76
+
+  '@atproto/jwk@0.6.0':
+    dependencies:
+      multiformats: 9.9.0
+      zod: 3.25.76
+
+  '@atproto/lex-data@0.0.15':
+    dependencies:
+      multiformats: 9.9.0
+      tslib: 2.8.1
+      uint8arrays: 3.0.0
+      unicode-segmenter: 0.14.5
+
+  '@atproto/lex-json@0.0.16':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      tslib: 2.8.1
+
+  '@atproto/lexicon@0.6.2':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/syntax': 0.5.4
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.25.76
+
+  '@atproto/oauth-client-node@0.3.17':
+    dependencies:
+      '@atproto-labs/did-resolver': 0.2.6
+      '@atproto-labs/handle-resolver-node': 0.1.25
+      '@atproto-labs/simple-store': 0.3.0
+      '@atproto/did': 0.3.0
+      '@atproto/jwk': 0.6.0
+      '@atproto/jwk-jose': 0.1.11
+      '@atproto/jwk-webcrypto': 0.2.0
+      '@atproto/oauth-client': 0.6.1
+      '@atproto/oauth-types': 0.6.3
+
+  '@atproto/oauth-client@0.6.1':
+    dependencies:
+      '@atproto-labs/did-resolver': 0.2.6
+      '@atproto-labs/fetch': 0.2.3
+      '@atproto-labs/handle-resolver': 0.3.6
+      '@atproto-labs/identity-resolver': 0.3.6
+      '@atproto-labs/simple-store': 0.3.0
+      '@atproto-labs/simple-store-memory': 0.1.4
+      '@atproto/did': 0.3.0
+      '@atproto/jwk': 0.6.0
+      '@atproto/oauth-types': 0.6.3
+      '@atproto/xrpc': 0.7.7
+      core-js: 3.49.0
+      multiformats: 9.9.0
+      zod: 3.25.76
+
+  '@atproto/oauth-types@0.6.3':
+    dependencies:
+      '@atproto/did': 0.3.0
+      '@atproto/jwk': 0.6.0
+      zod: 3.25.76
+
+  '@atproto/syntax@0.5.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@atproto/xrpc@0.7.7':
+    dependencies:
+      '@atproto/lexicon': 0.6.2
+      zod: 3.25.76
 
   '@authenio/xml-encryption@2.0.2':
     dependencies:
@@ -20064,7 +20340,7 @@ snapshots:
   '@react-native/codegen@0.84.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       hermes-parser: 0.32.0
       invariant: 2.2.4
       nullthrows: 1.1.1
@@ -21061,7 +21337,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       ansis: 4.2.0
       babel-dead-code-elimination: 1.0.12
@@ -21852,7 +22128,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.29':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@vue/shared': 3.5.29
       entities: 7.0.1
       estree-walker: 2.0.2
@@ -22182,6 +22458,8 @@ snapshots:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
 
+  await-lock@2.2.2: {}
+
   aws-ssl-profiles@1.1.2: {}
 
   axios@1.13.5:
@@ -22384,7 +22662,7 @@ snapshots:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
-      set-cookie-parser: 3.0.1
+      set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.3.6
 
@@ -23067,6 +23345,8 @@ snapshots:
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
+
+  core-js@3.49.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -25343,6 +25623,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.4.0: {}
+
   iron-webcrypto@1.2.1: {}
 
   is-alphabetical@2.0.1: {}
@@ -25461,6 +25743,8 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
+
+  iso-datestring-validator@2.2.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -25610,6 +25894,8 @@ snapshots:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
     optional: true
+
+  jose@5.10.0: {}
 
   jose@6.1.3: {}
 
@@ -27443,6 +27729,8 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+
+  multiformats@9.9.0: {}
 
   mute-stream@2.0.0: {}
 
@@ -29657,8 +29945,6 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
-  set-cookie-parser@3.0.1: {}
-
   set-cookie-parser@3.1.0: {}
 
   setprototypeof@1.2.0: {}
@@ -30294,8 +30580,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.2: {}
-
   tinyexec@1.0.4: {}
 
   tinyexec@1.1.1: {}
@@ -30313,6 +30597,8 @@ snapshots:
   tinyrainbow@3.0.3: {}
 
   tinyrainbow@3.1.0: {}
+
+  tlds@1.261.0: {}
 
   tldts-core@6.1.86: {}
 
@@ -30495,6 +30781,10 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
+  uint8arrays@3.0.0:
+    dependencies:
+      multiformats: 9.9.0
+
   ultrahtml@1.6.0: {}
 
   unconfig-core@7.5.0:
@@ -30549,6 +30839,8 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unicode-segmenter@0.14.5: {}
 
   unicode-trie@2.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31386,7 +31386,7 @@ snapshots:
       picomatch: 4.0.3
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
+      tinyexec: 1.1.1
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
## Summary

- Adds `@better-auth/atproto` — an AT Protocol (Bluesky) OAuth plugin with PKCE + DPoP, DB-backed state and session stores, account linking, and rate-limited sign-in/callback endpoints.
- Closes the asks in #7953.

## What's included

- New workspace package at `packages/atproto/` published as `@better-auth/atproto`
- Server plugin: `/atproto/sign-in`, `/atproto/callback`, `/atproto/client-metadata.json`, `/atproto/jwks.json`, `/atproto/session`, `/atproto/restore`
- Client plugin: `signIn.atproto({ handle, callbackURL })`, `atproto.getSession()`, `atproto.restore()`
- Schema: user extensions (`atprotoDid`, `atprotoHandle`, `atprotoBio`, `atprotoBanner`) + `atprotoState`, `atprotoSession` tables
- Docs page at `/docs/plugins/atproto`
- Changeset (minor bump on `@better-auth/atproto`)
- Tests using `getTestInstance()` with `NodeOAuthClient` mocked

## Hardening compared to the upstream draft

- `callbackURL` is validated against `trustedOrigins` to prevent open-redirect (checked both at sign-in and at callback time)
- Failed OAuth exchanges and unexpected errors are logged via `ctx.context.logger.error` instead of being swallowed
- Typed user-field augmentation replaces `as Record<string, unknown>` casts
- Opportunistic sweep of expired `atprotoState` rows on writes (~1% probability) keeps the table bounded

## Known limitations / follow-ups

- **Runtime support:** depends on `@atproto/oauth-client-node`, which is Node-only. Bun works; Cloudflare Workers and Deno do not. A runtime-agnostic rewrite would build on `@atproto/oauth-client` with custom `runtimeImplementation` (`createKey`, `getRandomValues`, `digest`, `requestLock`). Happy to do this in a follow-up if there's appetite.
- **`account.accessToken`:** currently stored as the placeholder string `"atproto-session"`. The real token lives in `atprotoSession.session` (DPoP-bound + bundled with keys). Open to feedback on whether this should be unified.
- **Multi-instance deployments:** `NodeOAuthClient`'s `requestLock` is single-process. Distributed deployments would need a Redis-backed lock.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@better-auth/atproto`, an AT Protocol (Atmosphere) OAuth plugin with PKCE + DPoP, account linking, and DB-backed state/session storage. Also returns 429 on API key throttling, widens IPv6 subnet typing and documents a /64 default, adds a change-email-disabled error, fixes anonymous `onLinkAccount` on email verification, enforces client method/body, hardens race-safety and callback flows, and updates docs and Expo deep-link handling.

- **New Features**
  - `@better-auth/atproto`: endpoints `/atproto/sign-in`, `/atproto/callback`, `/atproto/client-metadata.json`, `/atproto/jwks.json`, `/atproto/session`, `/atproto/restore`; client actions `signIn.atproto({ handle, callbackURL })`, `atproto.getSession()`, `atproto.restore()`.
  - Security & UX: trusted `callbackURL` origins, DPoP-bound tokens, account linking with optional `disableSignUp`, loopback uses `application_type: native`, Expo injects session on `/atproto/callback` deep-link redirects, rate limits (sign-in 5/min, callback 10/min).
  - Reliability: race-safe state/session store writes, direct provider/account lookup to avoid email-collision auto-link, session cookie updated with atproto fields, client helpers force correct HTTP method/body, comprehensive docs under “AT Protocol (Atmosphere)”.

- **Migration**
  - DB: add user fields (`atprotoDid`, `atprotoHandle`, `atprotoBio`, `atprotoBanner`) and tables `atprotoState`, `atprotoSession`.
  - Server: add `atproto({ privateKey })`; generate an ES256 key for production (localhost needs no key).
  - Client: add `atprotoClient()` and configure `trustedOrigins` (include your deep-link scheme).

<sup>Written for commit 5f5118c6122a8c67114cb644d4f194b2f81f99b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

