### PR TITLE
fix(magic-link): consume verification token atomically on verify

### DIFF
--- a/.changeset/fix-magic-link-atomic-consume.md
+++ b/.changeset/fix-magic-link-atomic-consume.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix race condition in the `magic-link` plugin's verify handler that allowed two concurrent requests to mint two sessions from the same single-use token. The handler now consumes the verification row atomically via `internalAdapter.consumeVerificationValue`, so a given magic link mints at most one session regardless of concurrency. The `allowedAttempts` option is retained for backward compatibility but no longer multiplies successful redemptions; tokens are single-use. The second-redeem error code changes from `ATTEMPTS_EXCEEDED` to `INVALID_TOKEN` (the token no longer exists after consumption).

--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -1,3 +1,5 @@
+GHSA
+rggr
 SCIMAPI
 MCPO
 tocnav

--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -128,7 +128,7 @@ and a `ctx` context object as the second parameter.
 
 **expiresIn**: specifies the time in seconds after which the magic link will expire. The default value is `300` seconds (5 minutes).
 
-**allowedAttempts**: Specifies the number of allowed attempts for verifying the magic link. The default value is `1`. When the limit is exceeded, the token is deleted and the user is redirected with `?error=ATTEMPTS_EXCEEDED`. Set to `Infinity` to allow unlimited attempts.
+**allowedAttempts** (deprecated): Each verification call now consumes the token atomically on the first attempt, so retries always fail with `?error=INVALID_TOKEN` regardless of this setting (see [GHSA-hc7v-rggr-4hvx](https://github.com/better-auth/better-auth/security/advisories/GHSA-hc7v-rggr-4hvx)). The option is kept for source compatibility but ignored; multi-attempt redemption is no longer supported. Setting it to any value other than `1` emits a `console.warn` at startup (including `0`, which previously rejected immediately and now has no effect).
 
 **disableSignUp**: If set to `true`, the user will not be able to sign up using the magic link. The default value is `false`.
 
@@ -151,3 +151,7 @@ The `storeToken` function can be one of the following:
 * `{ type: "custom-hasher", hash: (token: string) => Promise<string> }`: The token is hashed using a custom hasher.
 
 The storage backend itself is controlled by the global [`verification`](/docs/reference/options#verification) config. If you configure `secondaryStorage`, magic link verification records can be stored there instead of the database.
+
+<Callout type="warn">
+  When `secondaryStorage` backs verification (`verification.storeInDatabase: false`), the atomic single-use guarantee from [GHSA-hc7v-rggr-4hvx](https://github.com/better-auth/better-auth/security/advisories/GHSA-hc7v-rggr-4hvx) requires your secondary storage to expose `getAndDelete` (Redis `GETDEL`, KV `getAndDelete`). If the implementation only exposes `get` and `delete`, the consume falls back to an in-process JavaScript lock that does not coordinate across multiple application instances. Multi-instance deployments using secondary-storage verification MUST configure a backend that implements `getAndDelete`.
+</Callout>

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1262,9 +1262,17 @@ export const createInternalAdapter = (
 			if (secondaryStorage && !options.verification?.storeInDatabase) {
 				const parseCachedVerification = (raw: unknown) => {
 					if (!raw) return null;
-					return safeJSONParse<Verification>(
-						typeof raw === "string" ? raw : String(raw),
-					);
+					// Secondary storage wrappers can return either a JSON string
+					// (the default codec) or a pre-parsed object (some Redis client
+					// integrations do this). Accept both shapes; only call
+					// safeJSONParse when we actually have a string.
+					if (typeof raw === "string") {
+						return safeJSONParse<Verification>(raw);
+					}
+					if (typeof raw === "object") {
+						return raw as Verification;
+					}
+					return null;
 				};
 				const consumeCacheKey = async (key: string) => {
 					if (secondaryStorage.getAndDelete) {

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -28,7 +28,14 @@ export interface MagicLinkOptions {
 	expiresIn?: number | undefined;
 	/**
 	 * Allowed attempts for verifying the magic link token.
-	 * Note: Passing Infinity will allow unlimited attempts.
+	 *
+	 * @deprecated Multi-attempt verification is no longer supported. Each
+	 * magic link token is consumed atomically on the first verification call,
+	 * so a given token mints at most one session regardless of this value
+	 * (see GHSA-hc7v-rggr-4hvx). The option is kept for source compatibility
+	 * and may be removed in a future major; any value other than `1` is
+	 * ignored and emits a `console.warn` at plugin construction.
+	 *
 	 * @default 1
 	 */
 	allowedAttempts?: number;
@@ -153,6 +160,12 @@ export const magicLink = (options: MagicLinkOptions) => {
 		...options,
 	} satisfies MagicLinkOptions;
 
+	if (options.allowedAttempts !== undefined && options.allowedAttempts !== 1) {
+		console.warn(
+			"[better-auth/magic-link] `allowedAttempts` is ignored: tokens are consumed atomically on the first verification call (GHSA-hc7v-rggr-4hvx). Any value other than `1` has no effect; remove the option to silence this warning.",
+		);
+	}
+
 	async function storeToken(ctx: GenericEndpointContext, token: string) {
 		if (opts.storeToken === "hashed") {
 			return await defaultKeyHasher(token);
@@ -225,7 +238,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					const storedToken = await storeToken(ctx, verificationToken);
 					await ctx.context.internalAdapter.createVerificationValue({
 						identifier: storedToken,
-						value: JSON.stringify({ email, name: ctx.body.name, attempt: 0 }),
+						value: JSON.stringify({ email, name: ctx.body.name }),
 						expiresAt: new Date(Date.now() + (opts.expiresIn || 60 * 5) * 1000),
 					});
 					const realBaseURL = new URL(ctx.context.baseURL);
@@ -357,43 +370,19 @@ export const magicLink = (options: MagicLinkOptions) => {
 					).toString();
 					const storedToken = await storeToken(ctx, token);
 					const tokenValue =
-						await ctx.context.internalAdapter.findVerificationValue(
+						await ctx.context.internalAdapter.consumeVerificationValue(
 							storedToken,
 						);
 					if (!tokenValue) {
 						redirectWithError("INVALID_TOKEN");
 					}
 					if (tokenValue.expiresAt < new Date()) {
-						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							storedToken,
-						);
 						redirectWithError("EXPIRED_TOKEN");
 					}
-					const {
-						email,
-						name,
-						attempt = 0,
-					} = JSON.parse(tokenValue.value) as {
+					const { email, name } = JSON.parse(tokenValue.value) as {
 						email: string;
 						name?: string | undefined;
-						attempt?: number | undefined;
 					};
-					if (attempt >= opts.allowedAttempts) {
-						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							storedToken,
-						);
-						redirectWithError("ATTEMPTS_EXCEEDED");
-					}
-					await ctx.context.internalAdapter.updateVerificationByIdentifier(
-						storedToken,
-						{
-							value: JSON.stringify({
-								email,
-								name,
-								attempt: attempt + 1,
-							}),
-						},
-					);
 
 					let isNewUser = false;
 					let user = await ctx.context.internalAdapter

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -95,7 +95,7 @@ describe("magic link", async () => {
 				onError(context) {
 					expect(context.response.status).toBe(302);
 					const location = context.response.headers.get("location");
-					expect(location).toContain("?error=ATTEMPTS_EXCEEDED");
+					expect(location).toContain("?error=INVALID_TOKEN");
 				},
 			},
 		);
@@ -551,8 +551,19 @@ describe("magic link storeToken", async () => {
 	});
 });
 
-describe("magic link allowedAttempts", async () => {
-	it("should reject second verification attempt with default allowedAttempts (1)", async () => {
+/**
+ * Magic-link tokens are consumed atomically on the first verification call that
+ * finds the token: the row is deleted before any subsequent success checks
+ * (signup gates, session creation, etc.), so even a verify that ends in
+ * `EXPIRED_TOKEN`, `new_user_signup_disabled`, or `failed_to_create_session`
+ * still burns the token. `allowedAttempts` is retained on the options type for
+ * backward compatibility but does not multiply redemptions; a token mints at
+ * most one session regardless of the value.
+ *
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-hc7v-rggr-4hvx
+ */
+describe("magic link single-use semantics", async () => {
+	async function setup(allowedAttempts?: number) {
 		let verificationEmail: VerificationEmail = {
 			email: "",
 			token: "",
@@ -561,56 +572,50 @@ describe("magic link allowedAttempts", async () => {
 		const { customFetchImpl, testUser, sessionSetter } = await getTestInstance({
 			plugins: [
 				magicLink({
+					...(allowedAttempts !== undefined ? { allowedAttempts } : {}),
 					async sendMagicLink(data) {
 						verificationEmail = data;
 					},
 				}),
 			],
 		});
-
 		const client = createAuthClient({
 			plugins: [magicLinkClient()],
-			fetchOptions: {
-				customFetchImpl,
-			},
+			fetchOptions: { customFetchImpl },
 			baseURL: "http://localhost:3000",
 			basePath: "/api/auth",
 		});
+		return {
+			client,
+			testUser,
+			sessionSetter,
+			getToken: () =>
+				new URL(verificationEmail.url).searchParams.get("token") || "",
+			triggerSignIn: () => client.signIn.magicLink({ email: testUser.email }),
+		};
+	}
 
-		await client.signIn.magicLink({
-			email: testUser.email,
-		});
+	it("rejects the second verification with the default allowedAttempts (1)", async () => {
+		const { client, sessionSetter, getToken, triggerSignIn } = await setup();
+		await triggerSignIn();
+		const token = getToken();
 
-		const token =
-			new URL(verificationEmail.url).searchParams.get("token") || "";
-
-		// First attempt should succeed
 		const headers = new Headers();
 		const response = await client.magicLink.verify({
-			query: {
-				token,
-			},
-			fetchOptions: {
-				onSuccess: sessionSetter(headers),
-			},
+			query: { token },
+			fetchOptions: { onSuccess: sessionSetter(headers) },
 		});
-
 		expect(response.data?.token).toBeDefined();
-		const betterAuthCookie = headers.get("set-cookie");
-		expect(betterAuthCookie).toBeDefined();
+		expect(headers.get("set-cookie")).toBeDefined();
 
-		// Second attempt should be rejected with ATTEMPTS_EXCEEDED
 		await client.magicLink.verify(
-			{
-				query: {
-					token,
-				},
-			},
+			{ query: { token } },
 			{
 				onError(context) {
 					expect(context.response.status).toBe(302);
-					const location = context.response.headers.get("location");
-					expect(location).toContain("?error=ATTEMPTS_EXCEEDED");
+					expect(context.response.headers.get("location")).toContain(
+						"?error=INVALID_TOKEN",
+					);
 				},
 				onSuccess() {
 					throw new Error("Should not succeed");
@@ -619,67 +624,26 @@ describe("magic link allowedAttempts", async () => {
 		);
 	});
 
-	it("should respect allowedAttempts value of 3", async () => {
-		let verificationEmail: VerificationEmail = {
-			email: "",
-			token: "",
-			url: "",
-		};
-		const { customFetchImpl, testUser, sessionSetter } = await getTestInstance({
-			plugins: [
-				magicLink({
-					allowedAttempts: 3,
-					async sendMagicLink(data) {
-						verificationEmail = data;
-					},
-				}),
-			],
+	it("rejects the second verification even when allowedAttempts is set to 3", async () => {
+		const { client, sessionSetter, getToken, triggerSignIn } = await setup(3);
+		await triggerSignIn();
+		const token = getToken();
+
+		const headers = new Headers();
+		const response = await client.magicLink.verify({
+			query: { token },
+			fetchOptions: { onSuccess: sessionSetter(headers) },
 		});
+		expect(response.data?.token).toBeDefined();
 
-		const client = createAuthClient({
-			plugins: [magicLinkClient()],
-			fetchOptions: {
-				customFetchImpl,
-			},
-			baseURL: "http://localhost:3000",
-			basePath: "/api/auth",
-		});
-
-		await client.signIn.magicLink({
-			email: testUser.email,
-		});
-
-		const token =
-			new URL(verificationEmail.url).searchParams.get("token") || "";
-
-		// 3 attempts should succeed
-		for (let i = 0; i < 3; i++) {
-			const headers = new Headers();
-			const response = await client.magicLink.verify({
-				query: {
-					token,
-				},
-				fetchOptions: {
-					onSuccess: sessionSetter(headers),
-				},
-			});
-			expect(response.data?.token).toBeDefined();
-			const betterAuthCookie = headers.get("set-cookie");
-			expect(betterAuthCookie).toBeDefined();
-		}
-
-		// Fourth attempt should be rejected with ATTEMPTS_EXCEEDED
 		await client.magicLink.verify(
-			{
-				query: {
-					token,
-				},
-			},
+			{ query: { token } },
 			{
 				onError(context) {
 					expect(context.response.status).toBe(302);
-					const location = context.response.headers.get("location");
-					expect(location).toContain("?error=ATTEMPTS_EXCEEDED");
+					expect(context.response.headers.get("location")).toContain(
+						"?error=INVALID_TOKEN",
+					);
 				},
 				onSuccess() {
 					throw new Error("Should not succeed");
@@ -688,70 +652,26 @@ describe("magic link allowedAttempts", async () => {
 		);
 	});
 
-	it("shouldn't verify magic link with an expired token on second attempt", async () => {
-		let verificationEmail: VerificationEmail = {
-			email: "",
-			token: "",
-			url: "",
-		};
-		const { customFetchImpl, testUser, sessionSetter } = await getTestInstance({
-			plugins: [
-				magicLink({
-					allowedAttempts: 3,
-					async sendMagicLink(data) {
-						verificationEmail = data;
-					},
-				}),
-			],
+	it("rejects the second verification even when allowedAttempts is Infinity", async () => {
+		const { client, sessionSetter, getToken, triggerSignIn } =
+			await setup(Infinity);
+		await triggerSignIn();
+		const token = getToken();
+
+		const headers = new Headers();
+		await client.magicLink.verify({
+			query: { token },
+			fetchOptions: { onSuccess: sessionSetter(headers) },
 		});
 
-		const client = createAuthClient({
-			plugins: [magicLinkClient()],
-			fetchOptions: {
-				customFetchImpl,
-			},
-			baseURL: "http://localhost:3000",
-			basePath: "/api/auth",
-		});
-
-		await client.signIn.magicLink({
-			email: testUser.email,
-		});
-
-		const token =
-			new URL(verificationEmail.url).searchParams.get("token") || "";
-
-		// 2 attempts should succeed
-		for (let i = 0; i < 2; i++) {
-			const headers = new Headers();
-			const response = await client.magicLink.verify({
-				query: {
-					token,
-				},
-				fetchOptions: {
-					onSuccess: sessionSetter(headers),
-				},
-			});
-			expect(response.data?.token).toBeDefined();
-			const betterAuthCookie = headers.get("set-cookie");
-			expect(betterAuthCookie).toBeDefined();
-		}
-
-		// Third attempt after expiration should be rejected with EXPIRED_TOKEN
-		vi.useFakeTimers();
-		await vi.advanceTimersByTimeAsync(1000 * 60 * 5 + 1);
-		const _response = await client.magicLink.verify(
-			{
-				query: {
-					token,
-					callbackURL: "/callback",
-				},
-			},
+		await client.magicLink.verify(
+			{ query: { token } },
 			{
 				onError(context) {
 					expect(context.response.status).toBe(302);
-					const location = context.response.headers.get("location");
-					expect(location).toContain("?error=EXPIRED_TOKEN");
+					expect(context.response.headers.get("location")).toContain(
+						"?error=INVALID_TOKEN",
+					);
 				},
 				onSuccess() {
 					throw new Error("Should not succeed");
@@ -760,53 +680,31 @@ describe("magic link allowedAttempts", async () => {
 		);
 	});
 
-	it("should respect allowedAttempts value of Infinity", async () => {
-		let verificationEmail: VerificationEmail = {
-			email: "",
-			token: "",
-			url: "",
-		};
-		const { customFetchImpl, testUser, sessionSetter } = await getTestInstance({
-			plugins: [
-				magicLink({
-					allowedAttempts: Infinity,
-					async sendMagicLink(data) {
-						verificationEmail = data;
-					},
-				}),
-			],
-		});
+	/**
+	 * Two HTTP requests that race the same verification token must produce
+	 * exactly one session. Reproduces the original race described in the
+	 * advisory, where both requests passed the find-check-update sequence
+	 * before either consumed the row.
+	 *
+	 * The interleaving relies on the in-memory adapter yielding control at
+	 * each `await` boundary; reverting `signInMagicLink` to its pre-patch
+	 * find/update/delete sequence makes this test fail with two session
+	 * tokens (verified empirically), so a synthetic scheduling barrier is
+	 * unnecessary.
+	 */
+	it("mints at most one session under concurrent verification of the same token", async () => {
+		const { client, getToken, triggerSignIn } = await setup();
+		await triggerSignIn();
+		const token = getToken();
 
-		const client = createAuthClient({
-			plugins: [magicLinkClient()],
-			fetchOptions: {
-				customFetchImpl,
-			},
-			baseURL: "http://localhost:3000",
-			basePath: "/api/auth",
-		});
+		const responses = await Promise.all([
+			client.magicLink.verify({ query: { token } }),
+			client.magicLink.verify({ query: { token } }),
+		]);
 
-		await client.signIn.magicLink({
-			email: testUser.email,
-		});
-
-		const token =
-			new URL(verificationEmail.url).searchParams.get("token") || "";
-
-		// verify that at least 10 attempts succeed
-		for (let i = 0; i < 10; i++) {
-			const headers = new Headers();
-			const response = await client.magicLink.verify({
-				query: {
-					token,
-				},
-				fetchOptions: {
-					onSuccess: sessionSetter(headers),
-				},
-			});
-			expect(response.data?.token).toBeDefined();
-			const betterAuthCookie = headers.get("set-cookie");
-			expect(betterAuthCookie).toBeDefined();
-		}
+		const sessionTokens = responses
+			.map((r) => r.data?.token)
+			.filter((t): t is string => typeof t === "string" && t.length > 0);
+		expect(sessionTokens).toHaveLength(1);
 	});
 });

--- a/test/unit/magic-link-secondary-storage.test.ts
+++ b/test/unit/magic-link-secondary-storage.test.ts
@@ -107,7 +107,10 @@ describe("magic link with secondary storage (string return)", async () => {
 		});
 	});
 
-	it("should track attempts and reject when exceeded", async () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-hc7v-x88r-fmh4
+	 */
+	it("consumes the token atomically on first verify, INVALID_TOKEN on retries", async () => {
 		const attemptStore = new Map<string, string>();
 		let attemptEmail: VerificationEmail = { email: "", token: "", url: "" };
 
@@ -131,7 +134,6 @@ describe("magic link with secondary storage (string return)", async () => {
 				rateLimit: { enabled: false },
 				plugins: [
 					magicLink({
-						allowedAttempts: 3,
 						async sendMagicLink(data) {
 							attemptEmail = data;
 						},
@@ -148,27 +150,25 @@ describe("magic link with secondary storage (string return)", async () => {
 		await c.signIn.magicLink({ email: tu.email });
 		const token = new URL(attemptEmail.url).searchParams.get("token")!;
 
-		// 3 attempts should succeed
-		for (let i = 0; i < 3; i++) {
-			const headers = new Headers();
-			const response = await c.magicLink.verify({
-				query: { token },
-				fetchOptions: { onSuccess: ss(headers) },
-			});
-			expect(response.data?.token).toBeDefined();
-		}
+		const firstHeaders = new Headers();
+		const firstResponse = await c.magicLink.verify({
+			query: { token },
+			fetchOptions: { onSuccess: ss(firstHeaders) },
+		});
+		expect(firstResponse.data?.token).toBeDefined();
 
-		// 4th attempt should be rejected
-		await c.magicLink.verify(
-			{ query: { token } },
-			{
-				onError(context) {
-					expect(context.response.status).toBe(302);
-					const location = context.response.headers.get("location");
-					expect(location).toContain("?error=ATTEMPTS_EXCEEDED");
+		for (let i = 0; i < 3; i++) {
+			await c.magicLink.verify(
+				{ query: { token } },
+				{
+					onError(context) {
+						expect(context.response.status).toBe(302);
+						const location = context.response.headers.get("location");
+						expect(location).toContain("?error=INVALID_TOKEN");
+					},
 				},
-			},
-		);
+			);
+		}
 	});
 
 	it("should delete expired verification on verify", async () => {
@@ -290,7 +290,10 @@ describe("magic link with secondary storage (pre-parsed object return)", async (
 		expect(betterAuthCookie).toBeDefined();
 	});
 
-	it("should track attempts with pre-parsed storage", async () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-hc7v-x88r-fmh4
+	 */
+	it("consumes the token atomically with pre-parsed storage, INVALID_TOKEN on retries", async () => {
 		const attemptStore = new Map<string, any>();
 		let attemptEmail: VerificationEmail = { email: "", token: "", url: "" };
 
@@ -314,7 +317,6 @@ describe("magic link with secondary storage (pre-parsed object return)", async (
 				rateLimit: { enabled: false },
 				plugins: [
 					magicLink({
-						allowedAttempts: 2,
 						async sendMagicLink(data) {
 							attemptEmail = data;
 						},
@@ -331,26 +333,24 @@ describe("magic link with secondary storage (pre-parsed object return)", async (
 		await c.signIn.magicLink({ email: tu.email });
 		const token = new URL(attemptEmail.url).searchParams.get("token")!;
 
-		// 2 attempts should succeed
-		for (let i = 0; i < 2; i++) {
-			const headers = new Headers();
-			const response = await c.magicLink.verify({
-				query: { token },
-				fetchOptions: { onSuccess: ss(headers) },
-			});
-			expect(response.data?.token).toBeDefined();
-		}
+		const firstHeaders = new Headers();
+		const firstResponse = await c.magicLink.verify({
+			query: { token },
+			fetchOptions: { onSuccess: ss(firstHeaders) },
+		});
+		expect(firstResponse.data?.token).toBeDefined();
 
-		// 3rd attempt should be rejected
-		await c.magicLink.verify(
-			{ query: { token } },
-			{
-				onError(context) {
-					expect(context.response.status).toBe(302);
-					const location = context.response.headers.get("location");
-					expect(location).toContain("?error=ATTEMPTS_EXCEEDED");
+		for (let i = 0; i < 2; i++) {
+			await c.magicLink.verify(
+				{ query: { token } },
+				{
+					onError(context) {
+						expect(context.response.status).toBe(302);
+						const location = context.response.headers.get("location");
+						expect(location).toContain("?error=INVALID_TOKEN");
+					},
 				},
-			},
-		);
+			);
+		}
 	});
 });


### PR DESCRIPTION
A magic link could be redeemed more than once when two requests arrived for the same token at the same time. The verify handler used to look up the token, mark it as used, and create the session as three separate database operations. Two parallel requests both saw the token as valid before either invalidated it, so each one got a working session for the same user.

The realistic ways someone observes a magic link before the recipient does: mail-server prefetchers, antivirus link scanners, shared inboxes, browser history on a shared device. Any of those, racing the legitimate click, would land an attacker session sitting next to the user's own.

The fix collapses lookup-and-invalidate into a single atomic step. The first request to arrive consumes the token and continues to session creation; every other request that races it sees the token as already consumed and returns `INVALID_TOKEN`.

The `allowedAttempts` option is deprecated. It still exists for source compatibility but no longer affects behavior; any value above `1` logs a warning at plugin construction. Replace any UI that handled `ATTEMPTS_EXCEEDED` with one that handles `INVALID_TOKEN`. If you store verification state in `secondaryStorage`, the backend needs an atomic get-and-delete primitive (Redis `GETDEL` or KV `getAndDelete`) for the protection to hold across instances; without one, the fallback in-process lock is not safe in multi-replica deployments.

See GHSA-hc7v-rggr-4hvx.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `better-auth`’s `magic-link` verify flow by atomically consuming the token so each link mints at most one session. Deprecates `allowedAttempts`; a second redeem now returns `INVALID_TOKEN`.

- **Bug Fixes**
  - Verify now calls `internalAdapter.consumeVerificationValue` to atomically get-and-delete the token; one request succeeds, racers get `INVALID_TOKEN`.
  - Secondary-storage consumption accepts both JSON strings and pre-parsed objects for better Redis/KV client compatibility.

- **Migration**
  - Magic links are single-use. `allowedAttempts` is ignored and deprecated; any value other than `1` emits a `console.warn`.
  - Update any handlers that expected `ATTEMPTS_EXCEEDED` to handle `INVALID_TOKEN` instead.
  - If verification uses `secondaryStorage`, your backend must support `getAndDelete` (e.g., Redis `GETDEL`, KV `getAndDelete`) for cross-instance atomicity; otherwise the fallback lock is per-process only and unsafe in multi-instance setups.

<sup>Written for commit 820508459966516a735f132d57daf13d6d878c50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
