### PR TITLE
fix(device-authorization): bind approval to verifier session

### DIFF
--- a/.changeset/device-auth-claim-at-verify.md
+++ b/.changeset/device-auth-claim-at-verify.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+fix(device-authorization): require verify-time ownership claim for approve/deny
+
+Pending device codes were not bound to the user who entered the code on the verification page until approval, leaving a window where any authenticated user could approve or deny another user's pending code by knowing the `user_code`. `GET /device` now claims the pending row for the calling session, and `POST /device/approve` and `POST /device/deny` require the calling session to match the claimed owner. Custom verification pages must be served to an authenticated session for the flow to succeed.

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -206,18 +206,20 @@ pollForToken();
 
 The user authorization flow requires two steps:
 
-1. **Code Verification**: Check if the entered user code is valid
-2. **Authorization**: User must be authenticated to approve/deny the device
+1. **Code Verification**: Validate the user code via `GET /device`. The verification request claims the pending device code for the calling session.
+2. **Authorization**: The session that claimed the code can approve or deny it.
 
 <Callout type="warn">
-  Users must be authenticated before they can approve or deny device authorization requests. If not authenticated, redirect them to the login page with a return URL.
+  Users must be authenticated when calling `GET /device`, because the verification step binds the pending device code to that session. Only the same session can later approve or deny. If the user is not authenticated when entering the code, redirect them to the login page with a return URL and re-call `GET /device` after sign-in.
 </Callout>
 
 Create a page where users can enter their code:
 
 ```tsx title="app/device/page.tsx"
 export default function DeviceAuthorizationPage() {
-  const [userCode, setUserCode] = useState("");
+  const { data: session } = authClient.useSession();
+  const searchParams = useSearchParams();
+  const [userCode, setUserCode] = useState(searchParams.get("user_code") || "");
   const [error, setError] = useState(null);
   
   const handleSubmit = async (e) => {
@@ -226,6 +228,13 @@ export default function DeviceAuthorizationPage() {
     try {
       // Format the code: remove dashes and convert to uppercase
       const formattedCode = userCode.trim().replace(/-/g, "").toUpperCase();
+      const approvalPath = `/device/approve?user_code=${encodeURIComponent(formattedCode)}`;
+
+      if (!session?.user) {
+        const verificationPath = `/device?user_code=${encodeURIComponent(formattedCode)}`;
+        window.location.href = `/login?redirect=${encodeURIComponent(verificationPath)}`;
+        return;
+      }
 
       // Check if the code is valid using GET /device endpoint
       const response = await authClient.device({
@@ -234,7 +243,7 @@ export default function DeviceAuthorizationPage() {
       
       if (response.data) {
         // Redirect to approval page
-        window.location.href = `/device/approve?user_code=${formattedCode}`;
+        window.location.href = approvalPath;
       }
     } catch (err) {
       setError("Invalid or expired code");
@@ -327,7 +336,8 @@ export default function DeviceApprovalPage() {
 
   if (!user) {
     // Redirect to login if not authenticated
-    window.location.href = `/login?redirect=/device/approve?user_code=${userCode}`;
+    const verificationPath = `/device?user_code=${encodeURIComponent(userCode || "")}`;
+    window.location.href = `/login?redirect=${encodeURIComponent(verificationPath)}`;
     return null;
   }
   
@@ -545,7 +555,7 @@ authenticateCLI().catch((err) => {
 3. **Client Validation**: Always validate client IDs in production to prevent unauthorized access
 4. **HTTPS Only**: Always use HTTPS in production for device authorization
 5. **User Code Format**: User codes use a limited character set (excluding similar-looking characters like 0/O, 1/I) to reduce typing errors
-6. **Authentication Required**: Users must be authenticated before they can approve or deny device requests
+6. **Authentication Required**: Users must be authenticated when calling `GET /device`. The verification step claims the pending device code for the calling session, and only that session can later approve or deny it
 
 ## Options
 

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -1,3 +1,8 @@
+import type { BetterAuthOptions } from "@better-auth/core";
+import { getAuthTables } from "@better-auth/core/db";
+import type { DBAdapter } from "@better-auth/core/db/adapter";
+import type { MemoryDB } from "@better-auth/memory-adapter";
+import { memoryAdapter } from "@better-auth/memory-adapter";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { deviceAuthorization, deviceAuthorizationOptionsSchema } from ".";
@@ -290,6 +295,11 @@ describe("device authorization flow", async () => {
 				},
 			});
 
+			await auth.api.deviceVerify({
+				query: { user_code },
+				headers,
+			});
+
 			// Approve the device
 			const approveResponse = await auth.api.deviceApprove({
 				body: { userCode: user_code },
@@ -324,6 +334,11 @@ describe("device authorization flow", async () => {
 				body: {
 					client_id: "test-client",
 				},
+			});
+
+			await auth.api.deviceVerify({
+				query: { user_code },
+				headers,
 			});
 
 			// Deny the device
@@ -418,6 +433,10 @@ describe("device authorization flow", async () => {
 					client_id: "test-client",
 				},
 			});
+			await auth.api.deviceVerify({
+				query: { user_code: userCode },
+				headers,
+			});
 			await auth.api.deviceApprove({
 				body: { userCode },
 				headers,
@@ -458,6 +477,11 @@ describe("device authorization flow", async () => {
 					client_id: "test-client",
 					scope: "read write profile",
 				},
+			});
+
+			await auth.api.deviceVerify({
+				query: { user_code },
+				headers,
 			});
 
 			await auth.api.deviceApprove({
@@ -508,6 +532,11 @@ describe("device authorization flow", async () => {
 				},
 			});
 
+			await auth.api.deviceVerify({
+				query: { user_code },
+				headers,
+			});
+
 			// User approves - this should succeed
 			const approveResponse = await auth.api.deviceApprove({
 				body: { userCode: user_code },
@@ -539,6 +568,314 @@ describe("device authorization flow", async () => {
 				},
 			});
 		});
+	});
+});
+
+describe("device authorization ownership gate", () => {
+	const ATTACKER_EMAIL = "attacker@example.test";
+	const ATTACKER_PASSWORD = "attacker-password-123";
+	type AdapterUpdateData = Parameters<
+		DBAdapter<BetterAuthOptions>["update"]
+	>[0];
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-cq3f-vc6p-68fh
+	 */
+	it("rejects approve from a session that did not claim the pending code", async () => {
+		const { auth, client, db, signInWithUser } = await getTestInstance(
+			{
+				plugins: [
+					deviceAuthorization({
+						expiresIn: "5min",
+						interval: "2s",
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [deviceAuthorizationClient()],
+				},
+			},
+		);
+
+		await client.signUp.email({
+			email: ATTACKER_EMAIL,
+			password: ATTACKER_PASSWORD,
+			name: "attacker",
+		});
+		const { headers: attackerHeaders, res: attackerSession } =
+			await signInWithUser(ATTACKER_EMAIL, ATTACKER_PASSWORD);
+		const attackerId = attackerSession.user.id;
+
+		const { device_code, user_code } = await auth.api.deviceCode({
+			body: { client_id: "test-client" },
+		});
+		expect(device_code).toBeTruthy();
+		expect(user_code).toBeTruthy();
+
+		await expect(
+			auth.api.deviceApprove({
+				body: { userCode: user_code },
+				headers: attackerHeaders,
+			}),
+		).rejects.toMatchObject({
+			body: { error: "invalid_request" },
+		});
+
+		const rowAfter = await db.findOne<DeviceCode>({
+			model: "deviceCode",
+			where: [{ field: "userCode", value: user_code }],
+		});
+		expect(rowAfter?.userId).not.toBe(attackerId);
+		expect(rowAfter?.status).toBe("pending");
+
+		await expect(
+			auth.api.deviceToken({
+				body: {
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code,
+					client_id: "test-client",
+				},
+			}),
+		).rejects.toMatchObject({
+			body: { error: "authorization_pending" },
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-cq3f-vc6p-68fh
+	 */
+	it("rejects deny from a session that did not claim the pending code", async () => {
+		const { auth, client, db, signInWithUser } = await getTestInstance(
+			{
+				plugins: [
+					deviceAuthorization({
+						expiresIn: "5min",
+						interval: "2s",
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [deviceAuthorizationClient()],
+				},
+			},
+		);
+
+		await client.signUp.email({
+			email: ATTACKER_EMAIL,
+			password: ATTACKER_PASSWORD,
+			name: "attacker",
+		});
+		const { headers: attackerHeaders, res: attackerSession } =
+			await signInWithUser(ATTACKER_EMAIL, ATTACKER_PASSWORD);
+		const attackerId = attackerSession.user.id;
+
+		const { user_code } = await auth.api.deviceCode({
+			body: { client_id: "test-client" },
+		});
+
+		await expect(
+			auth.api.deviceDeny({
+				body: { userCode: user_code },
+				headers: attackerHeaders,
+			}),
+		).rejects.toMatchObject({
+			body: { error: "invalid_request" },
+		});
+
+		const rowAfter = await db.findOne<DeviceCode>({
+			model: "deviceCode",
+			where: [{ field: "userCode", value: user_code }],
+		});
+		expect(rowAfter?.userId).not.toBe(attackerId);
+		expect(rowAfter?.status).toBe("pending");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-cq3f-vc6p-68fh
+	 */
+	it("allows approve when the same session called verify first", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				deviceAuthorization({
+					expiresIn: "5min",
+					interval: "2s",
+				}),
+			],
+		});
+
+		const { headers: legitHeaders } = await signInWithTestUser();
+
+		const { user_code } = await auth.api.deviceCode({
+			body: { client_id: "test-client" },
+		});
+
+		await auth.api.deviceVerify({
+			query: { user_code },
+			headers: legitHeaders,
+		});
+
+		const approve = await auth.api.deviceApprove({
+			body: { userCode: user_code },
+			headers: legitHeaders,
+		});
+		expect(approve).toMatchObject({ success: true });
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-cq3f-vc6p-68fh
+	 */
+	it("rejects approve from a different user after another claimed the code", async () => {
+		const { auth, client, signInWithTestUser, signInWithUser } =
+			await getTestInstance(
+				{
+					plugins: [
+						deviceAuthorization({
+							expiresIn: "5min",
+							interval: "2s",
+						}),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [deviceAuthorizationClient()],
+					},
+				},
+			);
+
+		const { headers: claimerHeaders } = await signInWithTestUser();
+
+		await client.signUp.email({
+			email: ATTACKER_EMAIL,
+			password: ATTACKER_PASSWORD,
+			name: "attacker",
+		});
+		const { headers: attackerHeaders } = await signInWithUser(
+			ATTACKER_EMAIL,
+			ATTACKER_PASSWORD,
+		);
+
+		const { user_code } = await auth.api.deviceCode({
+			body: { client_id: "test-client" },
+		});
+
+		await auth.api.deviceVerify({
+			query: { user_code },
+			headers: claimerHeaders,
+		});
+
+		await expect(
+			auth.api.deviceApprove({
+				body: { userCode: user_code },
+				headers: attackerHeaders,
+			}),
+		).rejects.toMatchObject({
+			status: "FORBIDDEN",
+			body: { error: "access_denied" },
+		});
+
+		await expect(
+			auth.api.deviceDeny({
+				body: { userCode: user_code },
+				headers: attackerHeaders,
+			}),
+		).rejects.toMatchObject({
+			status: "FORBIDDEN",
+			body: { error: "access_denied" },
+		});
+	});
+
+	it("does not overwrite a device code claimed after verify reads it", async () => {
+		let adapter: DBAdapter<BetterAuthOptions> | null = null;
+		let concurrentOwnerId: string | undefined;
+		let simulateConcurrentClaim = false;
+
+		const database = ((options: BetterAuthOptions) => {
+			if (adapter) {
+				return adapter;
+			}
+			const tables = getAuthTables(options);
+			const memoryDB = Object.keys(tables).reduce<MemoryDB>((db, table) => {
+				db[table] = [];
+				return db;
+			}, {});
+			const baseAdapter = memoryAdapter(memoryDB)(options);
+			adapter = {
+				...baseAdapter,
+				update: async <T>(data: AdapterUpdateData) => {
+					if (
+						simulateConcurrentClaim &&
+						concurrentOwnerId &&
+						data.model === "deviceCode" &&
+						data.update.userId
+					) {
+						simulateConcurrentClaim = false;
+						const deviceCodeId = data.where.find(
+							(where) => where.field === "id",
+						)?.value;
+						if (typeof deviceCodeId === "string") {
+							await baseAdapter.update<DeviceCode>({
+								model: "deviceCode",
+								where: [{ field: "id", value: deviceCodeId }],
+								update: { userId: concurrentOwnerId },
+							});
+						}
+					}
+					return baseAdapter.update<T>(data);
+				},
+			};
+			return adapter;
+		}) satisfies BetterAuthOptions["database"];
+
+		const { auth, client, db, signInWithUser } = await getTestInstance({
+			database,
+			plugins: [
+				deviceAuthorization({
+					expiresIn: "5min",
+					interval: "2s",
+				}),
+			],
+		});
+
+		await client.signUp.email({
+			email: "concurrent-owner@example.test",
+			password: "concurrent-owner-password-123",
+			name: "concurrent owner",
+		});
+		const { res: concurrentOwnerSession } = await signInWithUser(
+			"concurrent-owner@example.test",
+			"concurrent-owner-password-123",
+		);
+		concurrentOwnerId = concurrentOwnerSession.user.id;
+
+		await client.signUp.email({
+			email: "racer@example.test",
+			password: "racer-password-123",
+			name: "racer",
+		});
+		const { headers: racerHeaders, res: racerSession } = await signInWithUser(
+			"racer@example.test",
+			"racer-password-123",
+		);
+
+		const { user_code } = await auth.api.deviceCode({
+			body: { client_id: "test-client" },
+		});
+
+		simulateConcurrentClaim = true;
+		await auth.api.deviceVerify({
+			query: { user_code },
+			headers: racerHeaders,
+		});
+
+		const rowAfter = await db.findOne<DeviceCode>({
+			model: "deviceCode",
+			where: [{ field: "userCode", value: user_code }],
+		});
+		expect(rowAfter?.userId).toBe(concurrentOwnerId);
+		expect(rowAfter?.userId).not.toBe(racerSession.user.id);
+		expect(rowAfter?.status).toBe("pending");
 	});
 });
 

--- a/packages/better-auth/src/plugins/device-authorization/error-codes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/error-codes.ts
@@ -8,6 +8,8 @@ export const DEVICE_AUTHORIZATION_ERROR_CODES = defineErrorCodes({
 	ACCESS_DENIED: "Access denied",
 	INVALID_USER_CODE: "Invalid user code",
 	DEVICE_CODE_ALREADY_PROCESSED: "Device code already processed",
+	DEVICE_CODE_NOT_CLAIMED:
+		"Device code has not been claimed by a verifying session; call `GET /device` with the `user_code` while signed in before approving or denying",
 	POLLING_TOO_FREQUENTLY: "Polling too frequently",
 	USER_NOT_FOUND: "User not found",
 	FAILED_TO_CREATE_SESSION: "Failed to create session",

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -146,6 +146,7 @@ Follow [rfc8628#section-3.2](https://datatracker.ietf.org/doc/html/rfc8628#secti
 				data: {
 					deviceCode,
 					userCode,
+					userId: null,
 					expiresAt,
 					status: "pending",
 					pollingInterval: ms(opts.interval),
@@ -555,6 +556,27 @@ export const deviceVerify = createAuthEndpoint(
 			});
 		}
 
+		const session = await getSessionFromCtx(ctx);
+		if (
+			session?.user?.id &&
+			!deviceCodeRecord.userId &&
+			deviceCodeRecord.status === "pending"
+		) {
+			const claimedDeviceCodeRecord =
+				await ctx.context.adapter.update<DeviceCode>({
+					model: "deviceCode",
+					where: [
+						{ field: "id", value: deviceCodeRecord.id },
+						{ field: "status", value: "pending" },
+						{ field: "userId", operator: "eq", value: null },
+					],
+					update: { userId: session.user.id },
+				});
+			if (claimedDeviceCodeRecord) {
+				deviceCodeRecord.userId = session.user.id;
+			}
+		}
+
 		return ctx.json({
 			user_code: user_code,
 			status: deviceCodeRecord.status,
@@ -659,11 +681,15 @@ export const deviceApprove = createAuthEndpoint(
 			});
 		}
 
-		// Check if userId is set and matches the current user
-		if (
-			deviceCodeRecord.userId &&
-			deviceCodeRecord.userId !== session.user.id
-		) {
+		if (!deviceCodeRecord.userId) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_request",
+				error_description:
+					DEVICE_AUTHORIZATION_ERROR_CODES.DEVICE_CODE_NOT_CLAIMED.message,
+			});
+		}
+
+		if (deviceCodeRecord.userId !== session.user.id) {
 			throw new APIError("FORBIDDEN", {
 				error: "access_denied",
 				error_description:
@@ -788,11 +814,15 @@ export const deviceDeny = createAuthEndpoint(
 			});
 		}
 
-		// Check if userId is set and matches the current user
-		if (
-			deviceCodeRecord.userId &&
-			deviceCodeRecord.userId !== session.user.id
-		) {
+		if (!deviceCodeRecord.userId) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_request",
+				error_description:
+					DEVICE_AUTHORIZATION_ERROR_CODES.DEVICE_CODE_NOT_CLAIMED.message,
+			});
+		}
+
+		if (deviceCodeRecord.userId !== session.user.id) {
 			throw new APIError("FORBIDDEN", {
 				error: "access_denied",
 				error_description:
@@ -800,7 +830,6 @@ export const deviceDeny = createAuthEndpoint(
 			});
 		}
 
-		// Update device code with denied status and userId if not already set
 		await ctx.context.adapter.update({
 			model: "deviceCode",
 			where: [
@@ -811,7 +840,7 @@ export const deviceDeny = createAuthEndpoint(
 			],
 			update: {
 				status: "denied",
-				userId: deviceCodeRecord.userId || session.user.id,
+				userId: session.user.id,
 			},
 		});
 


### PR DESCRIPTION
`POST /device/approve` and `POST /device/deny` gate ownership with `if (deviceCodeRecord.userId && deviceCodeRecord.userId !== session.user.id) throw`. The `userId` column is `NULL` for the entire pending lifetime of a device code (no row-creation or verification-page code path writes it), so the leading short-circuit skips the FORBIDDEN branch for every pending row and any authenticated session can approve or deny a code it did not originate. The polling device's next `/device/token` call then mints a session bound to the calling user id, which is the attacker's, not the user who saw the verification page.

The fix binds ownership at verification time. `GET /device` now claims the pending row for the authenticated session by writing `userId`. Subsequent approve and deny calls have a non-null value to compare, the ownership gate drops the short-circuit, and a missing `userId` becomes a hard error rather than implicit consent. The deny update also stops re-binding the row to the calling session.

See GHSA-cq3f-vc6p-68fh.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind device-authorization approval and denial to the session that verified the code to prevent cross‑session hijacking. `GET /device` now claims the pending code for the signed-in verifier; only that session can approve or deny.

- **Bug Fixes**
  - Claim pending device codes during `GET /device` by setting `userId` for the authenticated session, using a DB-side “pending + unclaimed” predicate to avoid races.
  - Enforce ownership in `POST /device/approve` and `POST /device/deny`; unclaimed codes now return `invalid_request`, and mismatched users return `access_denied`.
  - Stop re-binding on deny; keep the existing owner and only set `status: denied`.
  - Add regression tests for cross-session approval/denial and concurrent claim races.
  - Update docs to reflect the authenticated verification flow.

- **Migration**
  - Serve the verification page to an authenticated session and call `GET /device` after login to claim the code.
  - Approve or deny only from the same session that verified; calling without prior verify now fails with `invalid_request`.

<sup>Written for commit 6184ec3b40d40be050d46f2d46edcb7cbd6ee81c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


