### PR TITLE
fix(oidc-provider, mcp): drop "none" alg, default plain PKCE off, reject missing PKCE method

### DIFF
--- a/.changeset/oidc-pkce-and-alg-none-hardening.md
+++ b/.changeset/oidc-pkce-and-alg-none-hardening.md
@@ -1,0 +1,13 @@
+---
+"better-auth": patch
+---
+
+fix(oidc-provider, mcp): drop `"none"` from advertised signing algorithms, default `allowPlainCodeChallengeMethod` to `false`, and reject missing PKCE method
+
+The legacy `oidc-provider` and `mcp` plugins now follow OAuth 2.1 (RFC 9700) on three protocol gates:
+
+- `id_token_signing_alg_values_supported` (oidc-provider, mcp) and `resource_signing_alg_values_supported` (mcp) no longer include `"none"`. Relying parties that negotiate from this list will no longer be steered toward unsigned tokens.
+- `allowPlainCodeChallengeMethod` defaults to `false`. Callers who need `plain` PKCE must opt in explicitly.
+- Under the secure default the authorize endpoint no longer silently rewrites a missing `code_challenge_method` to `"plain"` before the allowlist check. A request that provides `code_challenge` without `code_challenge_method` is now rejected with `invalid_request`; the inverse case (`code_challenge_method` without `code_challenge`) is also rejected so no inconsistent PKCE state is persisted on the authorization code record.
+
+Non-breaking for callers who never relied on `"none"` advertisement or the plain default. Callers who explicitly set `allowPlainCodeChallengeMethod: true` keep `plain` on the allowlist **and** retain the legacy "missing method defaults to plain" behavior for backward compatibility, so existing integrations that opted into plain PKCE continue to work. The next-minor on `next` will drop both the `plain` allowlist entry and this fallback; until then, the option is the single explicit knob for legacy behavior. Migrate to `@better-auth/oauth-provider` for the canonical, spec-aligned implementation.

--- a/packages/better-auth/src/plugins/mcp/authorize.ts
+++ b/packages/better-auth/src/plugins/mcp/authorize.ts
@@ -149,23 +149,47 @@ export async function authorizeMCPOAuth(
 		);
 	}
 
-	if (!query.code_challenge_method) {
-		query.code_challenge_method = "plain";
-	}
-
-	if (
-		![
-			"s256",
-			options.allowPlainCodeChallengeMethod ? "plain" : "s256",
-		].includes(query.code_challenge_method?.toLowerCase() || "")
-	) {
+	if (query.code_challenge_method && !query.code_challenge) {
 		throw ctx.redirect(
 			redirectErrorURL(
 				query.redirect_uri,
 				"invalid_request",
-				"invalid code_challenge method",
+				"code_challenge_method requires code_challenge",
 			),
 		);
+	}
+
+	if (query.code_challenge) {
+		const allowedCodeChallengeMethods = options.allowPlainCodeChallengeMethod
+			? ["s256", "plain"]
+			: ["s256"];
+		let codeChallengeMethod: AuthorizationQuery["code_challenge_method"] =
+			query.code_challenge_method?.toLowerCase() as AuthorizationQuery["code_challenge_method"];
+		// Backward-compat: callers who explicitly opt into plain PKCE retain the
+		// legacy "default missing method to `plain`" behavior. The secure default
+		// (`allowPlainCodeChallengeMethod: false`) still rejects a missing method.
+		// FIXME(legacy-plain-pkce-removal): remove this fallback on next; require
+		// callers to send `code_challenge_method` explicitly.
+		if (!codeChallengeMethod && options.allowPlainCodeChallengeMethod) {
+			codeChallengeMethod = "plain";
+		}
+		if (
+			!codeChallengeMethod ||
+			!allowedCodeChallengeMethods.includes(codeChallengeMethod)
+		) {
+			throw ctx.redirect(
+				redirectErrorURL(
+					query.redirect_uri,
+					"invalid_request",
+					"invalid code_challenge method",
+				),
+			);
+		}
+		// Persist the normalized value back so the verification record stores the
+		// lowercased and (optionally) fallback-resolved method. The token endpoint
+		// compares against `"plain"` exactly, so casing variations or a missing
+		// method on the opt-in path would otherwise break PKCE verification.
+		query.code_challenge_method = codeChallengeMethod;
 	}
 
 	const code = generateRandomString(32, "a-z", "A-Z", "0-9");

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -83,7 +83,7 @@ export const getMCPProviderMetadata = (
 			"urn:mace:incommon:iap:bronze",
 		],
 		subject_types_supported: ["public"],
-		id_token_signing_alg_values_supported: ["RS256", "none"],
+		id_token_signing_alg_values_supported: ["RS256"],
 		token_endpoint_auth_methods_supported: [
 			"client_secret_basic",
 			"client_secret_post",
@@ -124,7 +124,7 @@ export const getMCPProtectedResourceMetadata = (
 			"offline_access",
 		],
 		bearer_methods_supported: ["header"],
-		resource_signing_alg_values_supported: ["RS256", "none"],
+		resource_signing_alg_values_supported: ["RS256"],
 	};
 };
 
@@ -175,7 +175,7 @@ export const mcp = (options: MCPOptions) => {
 		defaultScope: "openid",
 		accessTokenExpiresIn: 3600,
 		refreshTokenExpiresIn: 604800,
-		allowPlainCodeChallengeMethod: true,
+		allowPlainCodeChallengeMethod: false,
 		...options.oidcConfig,
 		loginPage: options.loginPage,
 		scopes: [
@@ -661,18 +661,20 @@ export const mcp = (options: MCPOptions) => {
 						});
 					}
 
-					const challenge =
-						value.codeChallengeMethod === "plain"
-							? code_verifier
-							: await createHash("SHA-256", "base64urlnopad").digest(
-									code_verifier,
-								);
+					if (value.codeChallenge) {
+						const challenge =
+							value.codeChallengeMethod === "plain"
+								? code_verifier
+								: await createHash("SHA-256", "base64urlnopad").digest(
+										code_verifier,
+									);
 
-					if (challenge !== value.codeChallenge) {
-						throw new APIError("UNAUTHORIZED", {
-							error_description: "code verification failed",
-							error: "invalid_request",
-						});
+						if (challenge !== value.codeChallenge) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "code verification failed",
+								error: "invalid_request",
+							});
+						}
 					}
 
 					const requestedScopes = value.scope;

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -341,7 +341,7 @@ describe("mcp", async () => {
 			response_modes_supported: ["query"],
 			grant_types_supported: ["authorization_code", "refresh_token"],
 			subject_types_supported: ["public"],
-			id_token_signing_alg_values_supported: ["RS256", "none"],
+			id_token_signing_alg_values_supported: ["RS256"],
 			token_endpoint_auth_methods_supported: [
 				"client_secret_basic",
 				"client_secret_post",
@@ -375,7 +375,7 @@ describe("mcp", async () => {
 			jwks_uri: `${baseURL}/api/auth/mcp/jwks`,
 			scopes_supported: ["openid", "profile", "email", "offline_access"],
 			bearer_methods_supported: ["header"],
-			resource_signing_alg_values_supported: ["RS256", "none"],
+			resource_signing_alg_values_supported: ["RS256"],
 		});
 	});
 
@@ -1074,5 +1074,41 @@ describe("mcp refresh_token grant client authentication", () => {
 		expect(response.status).toBe(401);
 		expect(body?.error).toBe("invalid_client");
 		expect(body?.access_token).toBeUndefined();
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-9h47-pqcx-hjr4
+ */
+describe("mcp discovery metadata (security)", async () => {
+	const { auth } = await getTestInstance({
+		baseURL: "http://localhost:3000",
+		plugins: [mcp({ loginPage: "/login" })],
+	});
+
+	it("/.well-known/oauth-authorization-server must not advertise alg=none", async () => {
+		const res = await auth.handler(
+			new Request(
+				"http://localhost:3000/api/auth/.well-known/oauth-authorization-server",
+				{ method: "GET" },
+			),
+		);
+		const body = (await res.json()) as {
+			id_token_signing_alg_values_supported: string[];
+		};
+		expect(body.id_token_signing_alg_values_supported).not.toContain("none");
+	});
+
+	it("/.well-known/oauth-protected-resource must not advertise alg=none", async () => {
+		const res = await auth.handler(
+			new Request(
+				"http://localhost:3000/api/auth/.well-known/oauth-protected-resource",
+				{ method: "GET" },
+			),
+		);
+		const body = (await res.json()) as {
+			resource_signing_alg_values_supported: string[];
+		};
+		expect(body.resource_signing_alg_values_supported).not.toContain("none");
 	});
 });

--- a/packages/better-auth/src/plugins/oidc-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/authorize.ts
@@ -197,23 +197,49 @@ export async function authorize(
 		);
 	}
 
-	if (!query.code_challenge_method) {
-		query.code_challenge_method = "plain";
-	}
-
-	if (
-		![
-			"s256",
-			options.allowPlainCodeChallengeMethod ? "plain" : "s256",
-		].includes(query.code_challenge_method?.toLowerCase() || "")
-	) {
+	if (query.code_challenge_method && !query.code_challenge) {
 		return handleRedirect(
 			formatErrorURL(
 				query.redirect_uri,
 				"invalid_request",
-				"invalid code_challenge method",
+				"code_challenge_method requires code_challenge",
 			),
 		);
+	}
+
+	if (query.code_challenge) {
+		const allowedCodeChallengeMethods = options.allowPlainCodeChallengeMethod
+			? ["s256", "plain"]
+			: ["s256"];
+		let codeChallengeMethod: AuthorizationQuery["code_challenge_method"] =
+			query.code_challenge_method?.toLowerCase() as AuthorizationQuery["code_challenge_method"];
+		// Backward-compat: callers who explicitly opt into plain PKCE retain the
+		// legacy "default missing method to `plain`" behavior. The secure default
+		// (`allowPlainCodeChallengeMethod: false`) still rejects a missing method
+		// as `invalid_request`. The whole branch should be removed once the next
+		// minor drops the `plain` PKCE allowlist entry (see FIXME below).
+		// FIXME(legacy-plain-pkce-removal): remove this fallback on next; require
+		// callers to send `code_challenge_method` explicitly.
+		if (!codeChallengeMethod && options.allowPlainCodeChallengeMethod) {
+			codeChallengeMethod = "plain";
+		}
+		if (
+			!codeChallengeMethod ||
+			!allowedCodeChallengeMethods.includes(codeChallengeMethod)
+		) {
+			return handleRedirect(
+				formatErrorURL(
+					query.redirect_uri,
+					"invalid_request",
+					"invalid code_challenge method",
+				),
+			);
+		}
+		// Persist the normalized value back so the verification record stores the
+		// lowercased and (optionally) fallback-resolved method. The token endpoint
+		// compares against `"plain"` exactly, so casing variations or a missing
+		// method on the opt-in path would otherwise break PKCE verification.
+		query.code_challenge_method = codeChallengeMethod;
 	}
 
 	const code = generateRandomString(32, "a-z", "A-Z", "0-9");

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -95,9 +95,7 @@ export const getMetadata = (
 			? jwtPlugin.options.jwt.issuer
 			: (ctx.context.options.baseURL as string);
 	const baseURL = ctx.context.baseURL;
-	const supportedAlgs = options?.useJWTPlugin
-		? ["RS256", "EdDSA", "none"]
-		: ["HS256", "none"];
+	const supportedAlgs = options?.useJWTPlugin ? ["RS256", "EdDSA"] : ["HS256"];
 	return {
 		issuer,
 		authorization_endpoint: `${baseURL}/oauth2/authorize`,
@@ -309,7 +307,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 		defaultScope: "openid",
 		accessTokenExpiresIn: DEFAULT_ACCESS_TOKEN_EXPIRES_IN,
 		refreshTokenExpiresIn: DEFAULT_REFRESH_TOKEN_EXPIRES_IN,
-		allowPlainCodeChallengeMethod: true,
+		allowPlainCodeChallengeMethod: false,
 		storeClientSecret: "plain" as const,
 		...options,
 		scopes: [
@@ -980,18 +978,20 @@ export const oidcProvider = (options: OIDCOptions) => {
 							});
 						}
 					}
-					const challenge =
-						value.codeChallengeMethod === "plain"
-							? code_verifier
-							: await createHash("SHA-256", "base64urlnopad").digest(
-									code_verifier,
-								);
+					if (value.codeChallenge) {
+						const challenge =
+							value.codeChallengeMethod === "plain"
+								? code_verifier
+								: await createHash("SHA-256", "base64urlnopad").digest(
+										code_verifier,
+									);
 
-					if (challenge !== value.codeChallenge) {
-						throw new APIError("UNAUTHORIZED", {
-							error_description: "code verification failed",
-							error: "invalid_request",
-						});
+						if (challenge !== value.codeChallenge) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "code verification failed",
+								error: "invalid_request",
+							});
+						}
 					}
 
 					const requestedScopes = value.scope;

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -77,7 +77,7 @@ describe("oidc init", () => {
 		expect(options).toMatchInlineSnapshot(`
 			{
 			  "accessTokenExpiresIn": 3600,
-			  "allowPlainCodeChallengeMethod": true,
+			  "allowPlainCodeChallengeMethod": false,
 			  "codeExpiresIn": 600,
 			  "defaultScope": "openid",
 			  "loginPage": "/login",
@@ -1914,5 +1914,213 @@ describe("oidc-provider refresh_token grant client authentication", () => {
 		expect(response.status).toBe(401);
 		expect(body?.error).toBe("invalid_client");
 		expect(body?.access_token).toBeUndefined();
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-9h47-pqcx-hjr4
+ */
+describe("oidc-provider discovery metadata and PKCE gate (security)", () => {
+	const buildInstance = async (
+		options?: Partial<Parameters<typeof oidcProvider>[0]>,
+	) => {
+		const { auth, customFetchImpl, signInWithTestUser } = await getTestInstance(
+			{
+				baseURL: "http://localhost:3000",
+				plugins: [
+					oidcProvider({
+						loginPage: "/login",
+						consentPage: "/oauth2/authorize",
+						...options,
+					}),
+				],
+			},
+		);
+		return { auth, customFetchImpl, signInWithTestUser };
+	};
+
+	it("/.well-known/openid-configuration must not advertise alg=none", async () => {
+		const { auth } = await buildInstance();
+		const res = await auth.handler(
+			new Request(
+				"http://localhost:3000/api/auth/.well-known/openid-configuration",
+				{ method: "GET" },
+			),
+		);
+		const body = (await res.json()) as {
+			id_token_signing_alg_values_supported: string[];
+			code_challenge_methods_supported: string[];
+		};
+		expect(body.id_token_signing_alg_values_supported).not.toContain("none");
+		expect(body.code_challenge_methods_supported).toEqual(["S256"]);
+	});
+
+	it("authorize must reject code_challenge_method=plain when allowPlainCodeChallengeMethod is false (default)", async () => {
+		const trustedClient: Client = {
+			clientId: "pkce-plain-rejection-client",
+			clientSecret: "test-client-secret",
+			redirectUrls: ["http://localhost:3000/cb"],
+			metadata: {},
+			type: "web",
+			disabled: false,
+			name: "test",
+			icon: undefined,
+			skipConsent: true,
+		};
+		const { auth, signInWithTestUser } = await buildInstance({
+			trustedClients: [trustedClient],
+		});
+		const { headers: sessionHeaders } = await signInWithTestUser();
+
+		const url = new URL("http://localhost:3000/api/auth/oauth2/authorize");
+		url.searchParams.set("client_id", trustedClient.clientId);
+		url.searchParams.set("redirect_uri", trustedClient.redirectUrls[0]!);
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("scope", "openid profile email");
+		url.searchParams.set("state", "xyz");
+		url.searchParams.set(
+			"code_challenge",
+			"plainPkceVerifier_at_least_43_chars_long_for_validity",
+		);
+		url.searchParams.set("code_challenge_method", "plain");
+
+		const res = await auth.handler(
+			new Request(url, { method: "GET", headers: sessionHeaders }),
+		);
+		const location = res.headers.get("location") ?? "";
+		expect(location).toContain("error=invalid_request");
+		expect(location).toMatch(/invalid.*code.*challenge.*method/i);
+	});
+
+	it("authorize must reject missing code_challenge_method when code_challenge is provided", async () => {
+		const trustedClient: Client = {
+			clientId: "pkce-missing-method-client",
+			clientSecret: "test-client-secret",
+			redirectUrls: ["http://localhost:3000/cb"],
+			metadata: {},
+			type: "web",
+			disabled: false,
+			name: "test",
+			icon: undefined,
+			skipConsent: true,
+		};
+		const { auth, signInWithTestUser } = await buildInstance({
+			trustedClients: [trustedClient],
+		});
+		const { headers: sessionHeaders } = await signInWithTestUser();
+
+		const url = new URL("http://localhost:3000/api/auth/oauth2/authorize");
+		url.searchParams.set("client_id", trustedClient.clientId);
+		url.searchParams.set("redirect_uri", trustedClient.redirectUrls[0]!);
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("scope", "openid profile email");
+		url.searchParams.set("state", "xyz");
+		url.searchParams.set(
+			"code_challenge",
+			"someChallengeValue_at_least_43_chars_long_for_validity",
+		);
+		// code_challenge_method intentionally omitted
+
+		const res = await auth.handler(
+			new Request(url, { method: "GET", headers: sessionHeaders }),
+		);
+		const location = res.headers.get("location") ?? "";
+		const callback = trustedClient.redirectUrls[0]!;
+		const issuedCode =
+			location.startsWith(callback) && /[?&]code=/.test(location);
+		expect(issuedCode).toBe(false);
+		expect(location).toContain("error=invalid_request");
+	});
+
+	it("authorize must reject code_challenge_method without code_challenge", async () => {
+		const trustedClient: Client = {
+			clientId: "pkce-method-without-challenge-client",
+			clientSecret: "test-client-secret",
+			redirectUrls: ["http://localhost:3000/cb"],
+			metadata: {},
+			type: "web",
+			disabled: false,
+			name: "test",
+			icon: undefined,
+			skipConsent: true,
+		};
+		const { auth, signInWithTestUser } = await buildInstance({
+			trustedClients: [trustedClient],
+		});
+		const { headers: sessionHeaders } = await signInWithTestUser();
+
+		const url = new URL("http://localhost:3000/api/auth/oauth2/authorize");
+		url.searchParams.set("client_id", trustedClient.clientId);
+		url.searchParams.set("redirect_uri", trustedClient.redirectUrls[0]!);
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("scope", "openid profile email");
+		url.searchParams.set("state", "xyz");
+		url.searchParams.set("code_challenge_method", "S256");
+		// code_challenge intentionally omitted
+
+		const res = await auth.handler(
+			new Request(url, { method: "GET", headers: sessionHeaders }),
+		);
+		const location = res.headers.get("location") ?? "";
+		const callback = trustedClient.redirectUrls[0]!;
+		const issuedCode =
+			location.startsWith(callback) && /[?&]code=/.test(location);
+		expect(issuedCode).toBe(false);
+		expect(location).toContain("error=invalid_request");
+	});
+
+	it("authorize accepts missing code_challenge_method when allowPlainCodeChallengeMethod is opted in", async () => {
+		const trustedClient: Client = {
+			clientId: "pkce-plain-opt-in-client",
+			clientSecret: "test-client-secret",
+			redirectUrls: ["http://localhost:3000/cb"],
+			metadata: {},
+			type: "web",
+			disabled: false,
+			name: "test",
+			icon: undefined,
+			skipConsent: true,
+		};
+		const { auth, signInWithTestUser } = await buildInstance({
+			trustedClients: [trustedClient],
+			allowPlainCodeChallengeMethod: true,
+		});
+		const { headers: sessionHeaders } = await signInWithTestUser();
+
+		const codeChallenge =
+			"someChallengeValue_at_least_43_chars_long_for_validity";
+		const url = new URL("http://localhost:3000/api/auth/oauth2/authorize");
+		url.searchParams.set("client_id", trustedClient.clientId);
+		url.searchParams.set("redirect_uri", trustedClient.redirectUrls[0]!);
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("scope", "openid profile email");
+		url.searchParams.set("state", "xyz");
+		url.searchParams.set("code_challenge", codeChallenge);
+		// code_challenge_method intentionally omitted; the opt-in retains the
+		// legacy "default to plain" behavior so this should issue a code.
+
+		const res = await auth.handler(
+			new Request(url, { method: "GET", headers: sessionHeaders }),
+		);
+		const location = res.headers.get("location") ?? "";
+		const callback = trustedClient.redirectUrls[0]!;
+		const issuedCode =
+			location.startsWith(callback) && /[?&]code=/.test(location);
+		expect(issuedCode).toBe(true);
+		expect(location).not.toContain("error=");
+
+		// Inspect the persisted verification value to prove the fallback-resolved
+		// `plain` method was written to storage. Regression: a previous shape only
+		// touched a local and never wrote it back to `query.code_challenge_method`,
+		// so the token endpoint compared against `undefined` at exchange time and
+		// broke PKCE verification.
+		const code = new URL(location).searchParams.get("code")!;
+		const { internalAdapter } = await auth.$context;
+		const stored = await internalAdapter.findVerificationValue(code);
+		expect(stored).toBeDefined();
+		const storedValue = JSON.parse(stored!.value) as {
+			codeChallengeMethod?: string;
+		};
+		expect(storedValue.codeChallengeMethod).toBe("plain");
 	});
 });


### PR DESCRIPTION
Two legacy OAuth plugins (`oidc-provider` and `mcp`) shipped with three pre-spec defaults that each downgrade token security.

**Discovery advertised `alg=none`.** RFC 9700 forbids unsigned ID tokens. A client that consumes our discovery document and trusts everything in `id_token_signing_alg_values_supported` would have accepted an attacker-forged token with no signature.

**Plain PKCE was enabled by default.** OAuth 2.1 forbids the plain code-challenge method because it offers no protection when the verifier leaks during the flow. Our default allowed any client to fall back to it.

**A missing PKCE method was silently rewritten to `plain`.** If a client sent `code_challenge` without `code_challenge_method`, the handler filled in `plain` and proceeded. The intent was lenient handling; the effect was a silent PKCE downgrade for clients that thought they were sending S256.

Discovery metadata no longer advertises `none`. The `allowPlainCodeChallengeMethod` option defaults to `false`, so an explicit `code_challenge_method=plain` request is rejected unless the integrator opts in. A request that omits `code_challenge_method` returns `invalid_request` instead of silently becoming plain.

Integrators who still need plain PKCE for legacy clients can keep the old behavior with `allowPlainCodeChallengeMethod: true`. Both plugins are deprecated long-term; the migration path is `@better-auth/oauth-provider`.

See GHSA-9h47-pqcx-hjr4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `oidc-provider` and `mcp` by removing `alg=none`, defaulting plain PKCE off, and enforcing strict PKCE parameter pairing to prevent unsigned tokens and PKCE downgrades.

- **Bug Fixes**
  - Discovery no longer advertises `"none"` in `id_token_signing_alg_values_supported` (both) and `resource_signing_alg_values_supported` (`mcp`); `code_challenge_methods_supported` now defaults to `["S256"]`.
  - Defaulted `allowPlainCodeChallengeMethod` to `false`. Authorize rejects `code_challenge` without `code_challenge_method` and vice versa; only `S256` is allowed unless plain is explicitly opted in. If opted in, a missing method defaults to `"plain"` and is persisted in normalized form for token verification.
  - Token endpoint verifies PKCE only when a `code_challenge` exists, preserving non-PKCE flows.

- **Migration**
  - To use plain PKCE or keep the legacy “missing method ⇒ plain,” set `allowPlainCodeChallengeMethod: true`.
  - Always send `code_challenge` and `code_challenge_method` together.
  - If clients relied on `alg=none`, update them to accept signed tokens; consider migrating to `@better-auth/oauth-provider`.

<sup>Written for commit 3fd723b0737f0320f8f92ba214756c9115feb183. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

