### PR TITLE
fix(oidc-provider, mcp): authenticate confidential clients on refresh_token grant

### DIFF
--- a/.changeset/legacy-oauth-refresh-client-auth.md
+++ b/.changeset/legacy-oauth-refresh-client-auth.md
@@ -1,0 +1,9 @@
+---
+"better-auth": patch
+---
+
+fix(oidc-provider, mcp): authenticate confidential clients on refresh_token grant and harden secret comparison
+
+Refresh-token grants on the legacy `oidc-provider` and `mcp` plugins now require the registered `client_secret` from confidential clients, matching the `authorization_code` path. Public clients (where `code_verifier` substitutes for the secret on the auth-code grant) continue to skip secret validation. Secret comparisons across both plugins now use constant-time equality. The `/mcp/token` endpoint no longer emits a wildcard CORS `Access-Control-Allow-Origin: *` header.
+
+These plugins are deprecated in favor of `@better-auth/oauth-provider`, which is unaffected. New deployments should adopt the replacement; this patch keeps existing deployments protected while migrating.

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -17,7 +17,7 @@ import * as z from "zod";
 import { APIError, getSessionFromCtx } from "../../api";
 import { resolveDynamicTrustedProxyHeaders } from "../../context/helpers";
 import { expireCookie, parseSetCookieHeader } from "../../cookies";
-import { generateRandomString } from "../../crypto";
+import { constantTimeEqual, generateRandomString } from "../../crypto";
 import { HIDE_METADATA } from "../../utils";
 import {
 	getBaseURL,
@@ -326,15 +326,6 @@ export const mcp = (options: MCPOptions) => {
 					},
 				},
 				async (ctx) => {
-					//cors
-					ctx.setHeader("Access-Control-Allow-Origin", "*");
-					ctx.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-					ctx.setHeader(
-						"Access-Control-Allow-Headers",
-						"Content-Type, Authorization",
-					);
-					ctx.setHeader("Access-Control-Max-Age", "86400");
-
 					let { body } = ctx;
 					if (!body) {
 						throw ctx.error("BAD_REQUEST", {
@@ -356,34 +347,56 @@ export const mcp = (options: MCPOptions) => {
 						ctx.request?.headers.get("authorization") || null;
 					if (
 						authorization &&
-						!client_id &&
 						!client_secret &&
 						authorization.startsWith("Basic ")
 					) {
+						let decoded: string;
 						try {
 							const encoded = authorization.replace("Basic ", "");
-							const decoded = new TextDecoder().decode(base64.decode(encoded));
-							if (!decoded.includes(":")) {
-								throw new APIError("UNAUTHORIZED", {
-									error_description: "invalid authorization header format",
-									error: "invalid_client",
-								});
-							}
-							const [id, secret] = decoded.split(":");
-							if (!id || !secret) {
-								throw new APIError("UNAUTHORIZED", {
-									error_description: "invalid authorization header format",
-									error: "invalid_client",
-								});
-							}
-							client_id = id;
-							client_secret = secret;
+							decoded = new TextDecoder().decode(base64.decode(encoded));
 						} catch {
 							throw new APIError("UNAUTHORIZED", {
 								error_description: "invalid authorization header format",
 								error: "invalid_client",
 							});
 						}
+						// RFC 6749 §2.3.1: split on the first `:` (the secret may contain
+						// further colons), then percent-decode each half before comparing
+						// against stored credentials (the client encodes reserved
+						// characters per RFC 3986 before base64).
+						const colonIndex = decoded.indexOf(":");
+						if (colonIndex === -1) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "invalid authorization header format",
+								error: "invalid_client",
+							});
+						}
+						let id: string;
+						let secret: string;
+						try {
+							id = decodeURIComponent(decoded.slice(0, colonIndex));
+							secret = decodeURIComponent(decoded.slice(colonIndex + 1));
+						} catch {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "invalid authorization header format",
+								error: "invalid_client",
+							});
+						}
+						if (!id || !secret) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "invalid authorization header format",
+								error: "invalid_client",
+							});
+						}
+						if (client_id && client_id.toString() !== id) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description:
+									"client_id in body does not match Authorization header",
+								error: "invalid_client",
+							});
+						}
+						client_id = id;
+						client_secret = secret;
 					}
 					const {
 						grant_type,
@@ -425,6 +438,52 @@ export const mcp = (options: MCPOptions) => {
 								error_description: "refresh token expired",
 								error: "invalid_grant",
 							});
+						}
+						const refreshClient = await ctx.context.adapter
+							.findOne<Record<string, any>>({
+								model: modelName.oauthClient,
+								where: [{ field: "clientId", value: client_id.toString() }],
+							})
+							.then((res) => {
+								if (!res) {
+									return null;
+								}
+								return {
+									...res,
+									redirectUrls: res.redirectUrls.split(","),
+									metadata: res.metadata ? JSON.parse(res.metadata) : {},
+								} as Client;
+							});
+						if (!refreshClient) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "invalid client_id",
+								error: "invalid_client",
+							});
+						}
+						if (refreshClient.disabled) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "client is disabled",
+								error: "invalid_client",
+							});
+						}
+						if (refreshClient.type !== "public") {
+							if (!refreshClient.clientSecret || !client_secret) {
+								throw new APIError("UNAUTHORIZED", {
+									error_description:
+										"client_secret is required for confidential clients",
+									error: "invalid_client",
+								});
+							}
+							const isValidSecret = constantTimeEqual(
+								refreshClient.clientSecret,
+								client_secret.toString(),
+							);
+							if (!isValidSecret) {
+								throw new APIError("UNAUTHORIZED", {
+									error_description: "invalid client_secret",
+									error: "invalid_client",
+								});
+							}
 						}
 						const accessToken = generateRandomString(32, "a-z", "A-Z");
 						const newRefreshToken = generateRandomString(32, "a-z", "A-Z");
@@ -562,15 +621,17 @@ export const mcp = (options: MCPOptions) => {
 						// PKCE validation happens later in the flow, so we skip client_secret validation
 					} else {
 						// For confidential clients, validate client_secret
-						if (!client_secret) {
+						if (!client.clientSecret || !client_secret) {
 							throw new APIError("UNAUTHORIZED", {
 								error_description:
 									"client_secret is required for confidential clients",
 								error: "invalid_client",
 							});
 						}
-						const isValidSecret =
-							client.clientSecret === client_secret.toString();
+						const isValidSecret = constantTimeEqual(
+							client.clientSecret,
+							client_secret.toString(),
+						);
 						if (!isValidSecret) {
 							throw new APIError("UNAUTHORIZED", {
 								error_description: "invalid client_secret",

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -1,5 +1,5 @@
 import { listen } from "listhen";
-import { afterAll, describe, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { createAuthClient } from "../../client";
 import { toNodeHandler } from "../../integrations/node";
 import { getTestInstance } from "../../test-utils/test-instance";
@@ -849,5 +849,230 @@ describe("mcp", async () => {
 
 			expect(shouldHaveValidRedirect).toBe(true);
 		});
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-pw9m-5jxm-xr6h
+ */
+describe("mcp refresh_token grant client authentication", () => {
+	const REFRESH_TOKEN = "pw9m-mcp-test-refresh-token";
+	const CLIENT_ID = "pw9m-mcp-confidential-test-client";
+	const CLIENT_SECRET = "pw9m-mcp-secret-only-the-client-knows";
+
+	async function seedConfidentialClientAndToken(
+		db: Awaited<ReturnType<typeof getTestInstance>>["db"],
+		userId: string,
+	) {
+		await db.create({
+			model: "oauthApplication",
+			data: {
+				clientId: CLIENT_ID,
+				clientSecret: CLIENT_SECRET,
+				type: "web",
+				name: "Confidential Test Client",
+				redirectUrls: "http://localhost/callback",
+				disabled: false,
+				metadata: null,
+				icon: null,
+				userId: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await db.create({
+			model: "oauthAccessToken",
+			data: {
+				accessToken: "stale-access-token-not-used",
+				refreshToken: REFRESH_TOKEN,
+				accessTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+				refreshTokenExpiresAt: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+				clientId: CLIENT_ID,
+				userId,
+				scopes: "openid profile email offline_access",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+	}
+
+	it("should reject refresh_token grant on confidential client without client_secret", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [mcp({ loginPage: "/login" })],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/mcp/token",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: CLIENT_ID,
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(401);
+		expect(body?.error).toBe("invalid_client");
+		expect(body?.access_token).toBeUndefined();
+	});
+
+	it("should reject refresh_token grant on confidential client with wrong client_secret", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [mcp({ loginPage: "/login" })],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/mcp/token",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: CLIENT_ID,
+					client_secret: "wrong-secret",
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(401);
+		expect(body?.error).toBe("invalid_client");
+		expect(body?.access_token).toBeUndefined();
+	});
+
+	it("should accept refresh_token grant when client_secret comes via Authorization: Basic", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [mcp({ loginPage: "/login" })],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const basic = `Basic ${Buffer.from(
+			`${CLIENT_ID}:${CLIENT_SECRET}`,
+		).toString("base64")}`;
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/mcp/token",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					authorization: basic,
+				},
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(200);
+		expect(body?.access_token).toBeDefined();
+		expect(body?.refresh_token).toBeDefined();
+	});
+
+	it("should accept refresh_token grant when Authorization: Basic and matching client_id is in body", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [mcp({ loginPage: "/login" })],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const basic = `Basic ${Buffer.from(
+			`${CLIENT_ID}:${CLIENT_SECRET}`,
+		).toString("base64")}`;
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/mcp/token",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					authorization: basic,
+				},
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: CLIENT_ID,
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(200);
+		expect(body?.access_token).toBeDefined();
+	});
+
+	it("should reject refresh_token grant when body client_id does not match Authorization: Basic", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [mcp({ loginPage: "/login" })],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const basic = `Basic ${Buffer.from(
+			`${CLIENT_ID}:${CLIENT_SECRET}`,
+		).toString("base64")}`;
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/mcp/token",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					authorization: basic,
+				},
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: "different-client-id",
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(401);
+		expect(body?.error).toBe("invalid_client");
+	});
+
+	it("should reject refresh_token grant when the confidential client is disabled", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [mcp({ loginPage: "/login" })],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+		await db.update<{ disabled: boolean }>({
+			model: "oauthApplication",
+			where: [{ field: "clientId", value: CLIENT_ID }],
+			update: { disabled: true },
+		});
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/mcp/token",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: CLIENT_ID,
+					client_secret: CLIENT_SECRET,
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+		expect(response.status).toBe(401);
+		expect(body?.error).toBe("invalid_client");
+		expect(body?.access_token).toBeUndefined();
 	});
 });

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -16,6 +16,7 @@ import * as z from "zod";
 import { APIError, getSessionFromCtx, sessionMiddleware } from "../../api";
 import { expireCookie, parseSetCookieHeader } from "../../cookies";
 import {
+	constantTimeEqual,
 	generateRandomString,
 	symmetricDecrypt,
 	symmetricEncrypt,
@@ -363,16 +364,15 @@ export const oidcProvider = (options: OIDCOptions) => {
 		clientSecret: string,
 	): Promise<boolean> {
 		if (opts.storeClientSecret === "encrypted") {
-			return (
-				(await symmetricDecrypt({
-					key: ctx.context.secretConfig,
-					data: storedClientSecret,
-				})) === clientSecret
-			);
+			const decrypted = await symmetricDecrypt({
+				key: ctx.context.secretConfig,
+				data: storedClientSecret,
+			});
+			return constantTimeEqual(decrypted, clientSecret);
 		}
 		if (opts.storeClientSecret === "hashed") {
 			const hashedClientSecret = await defaultClientSecretHasher(clientSecret);
-			return hashedClientSecret === storedClientSecret;
+			return constantTimeEqual(hashedClientSecret, storedClientSecret);
 		}
 		if (
 			typeof opts.storeClientSecret === "object" &&
@@ -380,7 +380,7 @@ export const oidcProvider = (options: OIDCOptions) => {
 		) {
 			const hashedClientSecret =
 				await opts.storeClientSecret.hash(clientSecret);
-			return hashedClientSecret === storedClientSecret;
+			return constantTimeEqual(hashedClientSecret, storedClientSecret);
 		}
 		if (
 			typeof opts.storeClientSecret === "object" &&
@@ -388,10 +388,10 @@ export const oidcProvider = (options: OIDCOptions) => {
 		) {
 			const decryptedClientSecret =
 				await opts.storeClientSecret.decrypt(storedClientSecret);
-			return decryptedClientSecret === clientSecret;
+			return constantTimeEqual(decryptedClientSecret, clientSecret);
 		}
 
-		return clientSecret === storedClientSecret;
+		return constantTimeEqual(clientSecret, storedClientSecret);
 	}
 
 	return {
@@ -687,34 +687,56 @@ export const oidcProvider = (options: OIDCOptions) => {
 						ctx.request?.headers.get("authorization") || null;
 					if (
 						authorization &&
-						!client_id &&
 						!client_secret &&
 						authorization.startsWith("Basic ")
 					) {
+						let decoded: string;
 						try {
 							const encoded = authorization.replace("Basic ", "");
-							const decoded = new TextDecoder().decode(base64.decode(encoded));
-							if (!decoded.includes(":")) {
-								throw new APIError("UNAUTHORIZED", {
-									error_description: "invalid authorization header format",
-									error: "invalid_client",
-								});
-							}
-							const [id, secret] = decoded.split(":");
-							if (!id || !secret) {
-								throw new APIError("UNAUTHORIZED", {
-									error_description: "invalid authorization header format",
-									error: "invalid_client",
-								});
-							}
-							client_id = id;
-							client_secret = secret;
+							decoded = new TextDecoder().decode(base64.decode(encoded));
 						} catch {
 							throw new APIError("UNAUTHORIZED", {
 								error_description: "invalid authorization header format",
 								error: "invalid_client",
 							});
 						}
+						// RFC 6749 §2.3.1: split on the first `:` (the secret may contain
+						// further colons), then percent-decode each half before comparing
+						// against stored credentials (the client encodes reserved
+						// characters per RFC 3986 before base64).
+						const colonIndex = decoded.indexOf(":");
+						if (colonIndex === -1) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "invalid authorization header format",
+								error: "invalid_client",
+							});
+						}
+						let id: string;
+						let secret: string;
+						try {
+							id = decodeURIComponent(decoded.slice(0, colonIndex));
+							secret = decodeURIComponent(decoded.slice(colonIndex + 1));
+						} catch {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "invalid authorization header format",
+								error: "invalid_client",
+							});
+						}
+						if (!id || !secret) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "invalid authorization header format",
+								error: "invalid_client",
+							});
+						}
+						if (client_id && client_id.toString() !== id) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description:
+									"client_id in body does not match Authorization header",
+								error: "invalid_client",
+							});
+						}
+						client_id = id;
+						client_secret = secret;
 					}
 
 					const now = Date.now();
@@ -766,6 +788,42 @@ export const oidcProvider = (options: OIDCOptions) => {
 								error_description: "refresh token expired",
 								error: "invalid_grant",
 							});
+						}
+						const refreshClient = await getClient(
+							client_id.toString(),
+							trustedClients,
+						);
+						if (!refreshClient) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "invalid client_id",
+								error: "invalid_client",
+							});
+						}
+						if (refreshClient.disabled) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description: "client is disabled",
+								error: "invalid_client",
+							});
+						}
+						if (refreshClient.type !== "public") {
+							if (!refreshClient.clientSecret || !client_secret) {
+								throw new APIError("UNAUTHORIZED", {
+									error_description:
+										"client_secret is required for confidential clients",
+									error: "invalid_client",
+								});
+							}
+							const isValidSecret = await verifyStoredClientSecret(
+								ctx,
+								refreshClient.clientSecret,
+								client_secret.toString(),
+							);
+							if (!isValidSecret) {
+								throw new APIError("UNAUTHORIZED", {
+									error_description: "invalid client_secret",
+									error: "invalid_client",
+								});
+							}
 						}
 						const accessToken = generateRandomString(32, "a-z", "A-Z");
 						const newRefreshToken = generateRandomString(32, "a-z", "A-Z");

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -1655,3 +1655,264 @@ describe("oidc-jwt", async () => {
 		expect(decoded.alg).toBe(expected);
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-pw9m-5jxm-xr6h
+ */
+describe("oidc-provider refresh_token grant client authentication", () => {
+	const REFRESH_TOKEN = "pw9m-test-refresh-token";
+	const CLIENT_ID = "pw9m-confidential-test-client";
+	const CLIENT_SECRET = "pw9m-secret-only-the-client-knows";
+
+	async function seedConfidentialClientAndToken(
+		db: Awaited<ReturnType<typeof getTestInstance>>["db"],
+		userId: string,
+	) {
+		await db.create({
+			model: "oauthApplication",
+			data: {
+				clientId: CLIENT_ID,
+				clientSecret: CLIENT_SECRET,
+				type: "web",
+				name: "Confidential Test Client",
+				redirectUrls: "http://localhost/callback",
+				disabled: false,
+				metadata: null,
+				icon: null,
+				userId: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await db.create({
+			model: "oauthAccessToken",
+			data: {
+				accessToken: "stale-access-token-not-used",
+				refreshToken: REFRESH_TOKEN,
+				accessTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+				refreshTokenExpiresAt: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+				clientId: CLIENT_ID,
+				userId,
+				scopes: "openid profile email offline_access",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+	}
+
+	it("should reject refresh_token grant on confidential client without client_secret", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [
+				oidcProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					requirePKCE: false,
+				}),
+			],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/oauth2/token",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: CLIENT_ID,
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(401);
+		expect(body?.error).toBe("invalid_client");
+		expect(body?.access_token).toBeUndefined();
+	});
+
+	it("should reject refresh_token grant on confidential client with wrong client_secret", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [
+				oidcProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					requirePKCE: false,
+				}),
+			],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/oauth2/token",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: CLIENT_ID,
+					client_secret: "wrong-secret",
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(401);
+		expect(body?.error).toBe("invalid_client");
+		expect(body?.access_token).toBeUndefined();
+	});
+
+	it("should accept refresh_token grant when client_secret comes via Authorization: Basic", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [
+				oidcProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					requirePKCE: false,
+				}),
+			],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const basic = `Basic ${Buffer.from(
+			`${CLIENT_ID}:${CLIENT_SECRET}`,
+		).toString("base64")}`;
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/oauth2/token",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					authorization: basic,
+				},
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(200);
+		expect(body?.access_token).toBeDefined();
+		expect(body?.refresh_token).toBeDefined();
+	});
+
+	it("should accept refresh_token grant when Authorization: Basic and matching client_id is in body", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [
+				oidcProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					requirePKCE: false,
+				}),
+			],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const basic = `Basic ${Buffer.from(
+			`${CLIENT_ID}:${CLIENT_SECRET}`,
+		).toString("base64")}`;
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/oauth2/token",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					authorization: basic,
+				},
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: CLIENT_ID,
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(200);
+		expect(body?.access_token).toBeDefined();
+	});
+
+	it("should reject refresh_token grant when body client_id does not match Authorization: Basic", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [
+				oidcProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					requirePKCE: false,
+				}),
+			],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+
+		const basic = `Basic ${Buffer.from(
+			`${CLIENT_ID}:${CLIENT_SECRET}`,
+		).toString("base64")}`;
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/oauth2/token",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					authorization: basic,
+				},
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: "different-client-id",
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(401);
+		expect(body?.error).toBe("invalid_client");
+	});
+
+	it("should reject refresh_token grant when the confidential client is disabled", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			plugins: [
+				oidcProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					requirePKCE: false,
+				}),
+			],
+		});
+		const { user } = await signInWithTestUser();
+		await seedConfidentialClientAndToken(db, user.id);
+		await db.update<{ disabled: boolean }>({
+			model: "oauthApplication",
+			where: [{ field: "clientId", value: CLIENT_ID }],
+			update: { disabled: true },
+		});
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/oauth2/token",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: REFRESH_TOKEN,
+					client_id: CLIENT_ID,
+					client_secret: CLIENT_SECRET,
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+		expect(response.status).toBe(401);
+		expect(body?.error).toBe("invalid_client");
+		expect(body?.access_token).toBeUndefined();
+	});
+});


### PR DESCRIPTION
The legacy OIDC and MCP plugins required a client to authenticate with its `client_secret` when exchanging an authorization code for tokens, but skipped the same check when exchanging a refresh token for tokens. Refresh tokens were treated as proof of both the user's consent and the client's identity. The OAuth spec only treats them as the first.

That asymmetry meant any caller who obtained a refresh token (a malicious browser extension, a logging proxy that captured the response, a leak from local storage, an exfiltrating SDK) could trade it directly for fresh access tokens at the token endpoint, impersonating the confidential client the token was issued to. Public clients are not affected; they have no secret to skip.

The refresh-token grant in both plugins now requires the client secret for confidential clients and validates it against stored credentials using the same constant-time comparison the authorization-code grant already used. The token endpoint's CORS configuration is tightened in the same change: refresh exchanges are server-side only, matching the standalone `@better-auth/oauth-provider` package.

The `Authorization: Basic` parser was also fixed to follow RFC 6749 §2.3.1: split on the first colon, then percent-decode each half. Client IDs or secrets containing reserved characters now authenticate correctly.

See GHSA-pw9m-5jxm-xr6h.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticate confidential clients on the `refresh_token` grant in legacy `oidc-provider` and `mcp`, aligning with `authorization_code`. Also use constant-time secret checks and remove wildcard CORS from `/mcp/token`.

- **Bug Fixes**
  - Require and verify `client_secret` for confidential clients on `refresh_token`; public clients unchanged; reject unknown/disabled clients.
  - Support RFC 6749–compliant `Authorization: Basic`; if body `client_id` is sent it must match the header.
  - Use constant-time equality for client secret checks across both plugins; works with encrypted/hashed/custom/plain storage in `oidc-provider`.
  - Drop `Access-Control-Allow-Origin: *` from `/mcp/token`.

<sup>Written for commit fabbe93876af1a0b54cafd6875b74d898661d175. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
