### PR TITLE
fix(organization): default-on `requireEmailVerificationOnInvitation` & extend gate to get/list

### DIFF
--- a/.changeset/fix-organization-invitation-email-verified-gate.md
+++ b/.changeset/fix-organization-invitation-email-verified-gate.md
@@ -1,0 +1,9 @@
+---
+"better-auth": patch
+---
+
+The organization plugin's invitation recipient endpoints (`acceptInvitation`, `rejectInvitation`, `getInvitation`, `listUserInvitations`) treated `invitation.email.toLowerCase() === session.user.email.toLowerCase()` as proof that the calling user owned the invited address. A session-authenticated user whose email matched but was never verified passed the gate, so anyone who could pre-register an unverified account at a victim's email could accept invitations addressed to that email. The `requireEmailVerificationOnInvitation` opt-in option closed the gap only when explicitly enabled and did not protect `getInvitation` or `listUserInvitations` at all.
+
+The gate is now applied on all four recipient endpoints and the `requireEmailVerificationOnInvitation` option default flips from `false` to `true` so existing apps are secure by default. Apps that intentionally accept invitations from unverified accounts can keep the legacy permissive behavior with `organization({ requireEmailVerificationOnInvitation: false })`, but they should understand the takeover risk before doing so. Server-side calls to `listUserInvitations` with `ctx.query.email` and no session continue to bypass the gate (the caller is trusted).
+
+The option is `@deprecated`. The next-minor release on `next` removes it entirely and makes the gate unconditional.

--- a/packages/api-key/src/org-api-key.test.ts
+++ b/packages/api-key/src/org-api-key.test.ts
@@ -37,6 +37,15 @@ describe("organization API keys", async () => {
 							},
 						]),
 					],
+					databaseHooks: {
+						user: {
+							create: {
+								before: async (user) => ({
+									data: { ...user, emailVerified: true },
+								}),
+							},
+						},
+					},
 				},
 				{
 					clientOptions: {
@@ -330,6 +339,15 @@ describe("organization API keys", async () => {
 							},
 						]),
 					],
+					databaseHooks: {
+						user: {
+							create: {
+								before: async (user) => ({
+									data: { ...user, emailVerified: true },
+								}),
+							},
+						},
+					},
 				},
 				{
 					clientOptions: {

--- a/packages/better-auth/src/plugins/organization/error-codes.ts
+++ b/packages/better-auth/src/plugins/organization/error-codes.ts
@@ -38,6 +38,8 @@ export const ORGANIZATION_ERROR_CODES = defineErrorCodes({
 		"You are not the recipient of the invitation",
 	EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_OR_REJECTING_INVITATION:
 		"Email verification required before accepting or rejecting invitation",
+	EMAIL_VERIFICATION_REQUIRED_FOR_INVITATION:
+		"Email verification required to view or list invitations for the session email",
 	YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_INVITATION:
 		"You are not allowed to cancel this invitation",
 	INVITER_IS_NO_LONGER_A_MEMBER_OF_THE_ORGANIZATION:

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -106,6 +106,17 @@ describe("organization", async () => {
 						before: async (data, ctx) => {},
 					},
 				},
+				// Pre-verify every user created in this suite so invitation
+				// acceptance tests focus on role/membership logic rather than
+				// email-ownership; the dedicated emailVerified gate is exercised
+				// in `routes/crud-invites.test.ts`.
+				user: {
+					create: {
+						before: async (user) => ({
+							data: { ...user, emailVerified: true },
+						}),
+					},
+				},
 			},
 		});
 
@@ -1453,6 +1464,15 @@ describe("invitation expiration and filtering", async () => {
 				async sendInvitationEmail() {},
 			}),
 		],
+		databaseHooks: {
+			user: {
+				create: {
+					before: async (user) => ({
+						data: { ...user, emailVerified: true },
+					}),
+				},
+			},
+		},
 	});
 
 	const client = createAuthClient({
@@ -2535,6 +2555,15 @@ describe("Additional Fields", async () => {
 		plugins: [organization(orgOptions), nextCookies()],
 		logger: {
 			level: "error",
+		},
+		databaseHooks: {
+			user: {
+				create: {
+					before: async (user) => ({
+						data: { ...user, emailVerified: true },
+					}),
+				},
+			},
 		},
 	});
 

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+import { getTestInstance } from "../../../test-utils/test-instance";
+import { organizationClient } from "../client";
+import { organization } from "../organization";
+
+/**
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-fmh4-wcc4-5jm3
+ */
+describe("organization invitation recipient gate requires emailVerified", async () => {
+	const VICTIM_EMAIL = "victim@target.example";
+	const ATTACKER_PASSWORD = "attacker-password-123";
+
+	async function setupInvite() {
+		const helpers = await getTestInstance(
+			{ plugins: [organization()] },
+			{ clientOptions: { plugins: [organizationClient()] } },
+		);
+		const { client, signInWithTestUser, cookieSetter } = helpers;
+		const { headers: adminHeaders } = await signInWithTestUser();
+		const org = await client.organization.create({
+			name: "Acme",
+			slug: "acme",
+			fetchOptions: {
+				headers: adminHeaders,
+				onSuccess: cookieSetter(adminHeaders),
+			},
+		});
+		const invite = await client.organization.inviteMember({
+			organizationId: org.data!.id,
+			email: VICTIM_EMAIL,
+			role: "member",
+			fetchOptions: { headers: adminHeaders },
+		});
+		return {
+			...helpers,
+			adminHeaders,
+			orgId: org.data!.id,
+			invitationId: invite.data!.id!,
+		};
+	}
+
+	async function signUpUnverifiedVictim(
+		client: Awaited<ReturnType<typeof setupInvite>>["client"],
+		signInWithUser: Awaited<ReturnType<typeof setupInvite>>["signInWithUser"],
+	) {
+		await client.signUp.email({
+			email: VICTIM_EMAIL,
+			password: ATTACKER_PASSWORD,
+			name: "attacker",
+		});
+		const { headers, res } = await signInWithUser(
+			VICTIM_EMAIL,
+			ATTACKER_PASSWORD,
+		);
+		expect(res.user.email).toBe(VICTIM_EMAIL);
+		expect(res.user.emailVerified).toBe(false);
+		return headers;
+	}
+
+	it("rejects acceptInvitation from an unverified session that matches the invitation email", async () => {
+		const { client, signInWithUser, invitationId, auth, adminHeaders } =
+			await setupInvite();
+		const attackerHeaders = await signUpUnverifiedVictim(
+			client,
+			signInWithUser,
+		);
+
+		const accept = await client.organization.acceptInvitation({
+			invitationId,
+			fetchOptions: { headers: attackerHeaders },
+		});
+
+		expect(accept.data).toBeNull();
+		expect(accept.error?.status).toBe(403);
+
+		const orgAfter = await auth.api.getFullOrganization({
+			headers: adminHeaders,
+		});
+		const memberEmails = (orgAfter?.members ?? []).map((m) => m.user.email);
+		expect(memberEmails).not.toContain(VICTIM_EMAIL);
+	});
+
+	it("rejects rejectInvitation from an unverified session that matches the invitation email", async () => {
+		const { client, signInWithUser, invitationId } = await setupInvite();
+		const attackerHeaders = await signUpUnverifiedVictim(
+			client,
+			signInWithUser,
+		);
+
+		const reject = await client.organization.rejectInvitation({
+			invitationId,
+			fetchOptions: { headers: attackerHeaders },
+		});
+
+		expect(reject.data).toBeNull();
+		expect(reject.error?.status).toBe(403);
+	});
+
+	it("rejects getInvitation from an unverified session that matches the invitation email", async () => {
+		const { client, signInWithUser, invitationId } = await setupInvite();
+		const attackerHeaders = await signUpUnverifiedVictim(
+			client,
+			signInWithUser,
+		);
+
+		const got = await client.organization.getInvitation({
+			query: { id: invitationId },
+			fetchOptions: { headers: attackerHeaders },
+		});
+
+		expect(got.data).toBeNull();
+		expect(got.error?.status).toBe(403);
+	});
+
+	it("rejects listUserInvitations from an unverified session", async () => {
+		const { client, signInWithUser } = await setupInvite();
+		const attackerHeaders = await signUpUnverifiedVictim(
+			client,
+			signInWithUser,
+		);
+
+		const list = await client.organization.listUserInvitations({
+			fetchOptions: { headers: attackerHeaders },
+		});
+
+		expect(list.data).toBeNull();
+		expect(list.error?.status).toBe(403);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-fmh4-wcc4-5jm3
+	 */
+	it("respects requireEmailVerificationOnInvitation: false (legacy permissive opt-out)", async () => {
+		const helpers = await getTestInstance(
+			{
+				plugins: [
+					organization({ requireEmailVerificationOnInvitation: false }),
+				],
+			},
+			{ clientOptions: { plugins: [organizationClient()] } },
+		);
+		const { client, signInWithTestUser, signInWithUser, cookieSetter } =
+			helpers;
+		const { headers: adminHeaders } = await signInWithTestUser();
+		const org = await client.organization.create({
+			name: "Permissive Org",
+			slug: "permissive-org",
+			fetchOptions: {
+				headers: adminHeaders,
+				onSuccess: cookieSetter(adminHeaders),
+			},
+		});
+		const invite = await client.organization.inviteMember({
+			organizationId: org.data!.id,
+			email: VICTIM_EMAIL,
+			role: "member",
+			fetchOptions: { headers: adminHeaders },
+		});
+		await client.signUp.email({
+			email: VICTIM_EMAIL,
+			password: ATTACKER_PASSWORD,
+			name: "unverified",
+		});
+		const { headers: unverifiedHeaders } = await signInWithUser(
+			VICTIM_EMAIL,
+			ATTACKER_PASSWORD,
+		);
+
+		// Read-side endpoints should also ignore the gate when opted out so the
+		// option is consistent across the four documented recipient calls.
+		const got = await client.organization.getInvitation({
+			query: { id: invite.data!.id! },
+			fetchOptions: { headers: unverifiedHeaders },
+		});
+		expect(got.error).toBeNull();
+		expect(got.data?.email).toBe(VICTIM_EMAIL);
+
+		const list = await client.organization.listUserInvitations({
+			fetchOptions: { headers: unverifiedHeaders },
+		});
+		expect(list.error).toBeNull();
+		expect(list.data?.length ?? 0).toBeGreaterThanOrEqual(1);
+
+		const accept = await client.organization.acceptInvitation({
+			invitationId: invite.data!.id!,
+			fetchOptions: { headers: unverifiedHeaders },
+		});
+		expect(accept.error).toBeNull();
+		expect(accept.data?.invitation?.status).toBe("accepted");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-fmh4-wcc4-5jm3
+	 */
+	it("respects opt-out on rejectInvitation", async () => {
+		const helpers = await getTestInstance(
+			{
+				plugins: [
+					organization({ requireEmailVerificationOnInvitation: false }),
+				],
+			},
+			{ clientOptions: { plugins: [organizationClient()] } },
+		);
+		const { client, signInWithTestUser, signInWithUser, cookieSetter } =
+			helpers;
+		const { headers: adminHeaders } = await signInWithTestUser();
+		const org = await client.organization.create({
+			name: "Permissive Reject Org",
+			slug: "permissive-reject",
+			fetchOptions: {
+				headers: adminHeaders,
+				onSuccess: cookieSetter(adminHeaders),
+			},
+		});
+		const invite = await client.organization.inviteMember({
+			organizationId: org.data!.id,
+			email: VICTIM_EMAIL,
+			role: "member",
+			fetchOptions: { headers: adminHeaders },
+		});
+		await client.signUp.email({
+			email: VICTIM_EMAIL,
+			password: ATTACKER_PASSWORD,
+			name: "unverified",
+		});
+		const { headers: unverifiedHeaders } = await signInWithUser(
+			VICTIM_EMAIL,
+			ATTACKER_PASSWORD,
+		);
+
+		const reject = await client.organization.rejectInvitation({
+			invitationId: invite.data!.id!,
+			fetchOptions: { headers: unverifiedHeaders },
+		});
+		expect(reject.error).toBeNull();
+	});
+
+	it("accepts the invitation once the recipient verifies their email", async () => {
+		const { client, signInWithUser, invitationId, auth, adminHeaders } =
+			await setupInvite();
+		await client.signUp.email({
+			email: VICTIM_EMAIL,
+			password: ATTACKER_PASSWORD,
+			name: "victim",
+		});
+		const ctx = await auth.$context;
+		const victim = await ctx.internalAdapter.findUserByEmail(VICTIM_EMAIL);
+		await ctx.internalAdapter.updateUser(victim!.user.id, {
+			emailVerified: true,
+		});
+		const { headers: victimHeaders } = await signInWithUser(
+			VICTIM_EMAIL,
+			ATTACKER_PASSWORD,
+		);
+
+		const accept = await client.organization.acceptInvitation({
+			invitationId,
+			fetchOptions: { headers: victimHeaders },
+		});
+
+		expect(accept.error).toBeNull();
+		expect(accept.data?.invitation?.status).toBe("accepted");
+
+		const orgAfter = await auth.api.getFullOrganization({
+			headers: adminHeaders,
+		});
+		const memberEmails = (orgAfter?.members ?? []).map((m) => m.user.email);
+		expect(memberEmails).toContain(VICTIM_EMAIL);
+	});
+});

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -598,8 +598,13 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				);
 			}
 
+			// Email-string equality is not ownership proof: a session whose user.email
+			// matches the invitation but has not been verified must not be treated as
+			// the invitation recipient. Gate is on by default; apps that intentionally
+			// allow unverified accept can opt out with `requireEmailVerificationOnInvitation: false`.
+			// FIXME(next-minor): drop the option and make the gate unconditional.
 			if (
-				ctx.context.orgOptions.requireEmailVerificationOnInvitation &&
+				(ctx.context.orgOptions.requireEmailVerificationOnInvitation ?? true) &&
 				!session.user.emailVerified
 			) {
 				throw APIError.from(
@@ -796,8 +801,9 @@ export const rejectInvitation = <O extends OrganizationOptions>(options: O) =>
 				);
 			}
 
+			// FIXME(next-minor): drop the option and make the gate unconditional.
 			if (
-				ctx.context.orgOptions.requireEmailVerificationOnInvitation &&
+				(ctx.context.orgOptions.requireEmailVerificationOnInvitation ?? true) &&
 				!session.user.emailVerified
 			) {
 				throw APIError.from(
@@ -1060,6 +1066,16 @@ export const getInvitation = <O extends OrganizationOptions>(options: O) =>
 					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION,
 				);
 			}
+			// FIXME(next-minor): drop the option and make the gate unconditional.
+			if (
+				(ctx.context.orgOptions.requireEmailVerificationOnInvitation ?? true) &&
+				!session.user.emailVerified
+			) {
+				throw APIError.from(
+					"FORBIDDEN",
+					ORGANIZATION_ERROR_CODES.EMAIL_VERIFICATION_REQUIRED_FOR_INVITATION,
+				);
+			}
 			const organization = await adapter.findOrganizationById(
 				invitation.organizationId,
 			);
@@ -1238,6 +1254,21 @@ export const listUserInvitations = <O extends OrganizationOptions>(
 				throw APIError.fromStatus("BAD_REQUEST", {
 					message: "User email cannot be passed for client side API calls.",
 				});
+			}
+
+			// When the caller has a session, require an ownership signal stronger
+			// than the email string before enumerating invitations targeted at it.
+			// Server-side SDK calls without a session are trusted and skip the gate.
+			// FIXME(next-minor): drop the option and make the gate unconditional.
+			if (
+				session &&
+				(ctx.context.orgOptions.requireEmailVerificationOnInvitation ?? true) &&
+				!session.user.emailVerified
+			) {
+				throw APIError.from(
+					"FORBIDDEN",
+					ORGANIZATION_ERROR_CODES.EMAIL_VERIFICATION_REQUIRED_FOR_INVITATION,
+				);
 			}
 
 			const userEmail = session?.user.email || ctx.query?.email;

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -23,6 +23,15 @@ describe("team", async () => {
 		logger: {
 			level: "error",
 		},
+		databaseHooks: {
+			user: {
+				create: {
+					before: async (user) => ({
+						data: { ...user, emailVerified: true },
+					}),
+				},
+			},
+		},
 	});
 
 	const { headers } = await signInWithTestUser();
@@ -418,6 +427,15 @@ describe("team", async () => {
 			logger: {
 				level: "error",
 			},
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => ({
+							data: { ...user, emailVerified: true },
+						}),
+					},
+				},
+			},
 		});
 
 		const { headers } = await signInWithTestUser();
@@ -517,6 +535,15 @@ describe("setActiveTeam org scoping", async () => {
 		],
 		logger: {
 			level: "error",
+		},
+		databaseHooks: {
+			user: {
+				create: {
+					before: async (user) => ({
+						data: { ...user, emailVerified: true },
+					}),
+				},
+			},
 		},
 	});
 
@@ -772,6 +799,15 @@ describe("multi team support", async () => {
 			],
 			logger: {
 				level: "error",
+			},
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => ({
+							data: { ...user, emailVerified: true },
+						}),
+					},
+				},
 			},
 		},
 		{

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -205,9 +205,19 @@ export interface OrganizationOptions {
 	 */
 	cancelPendingInvitationsOnReInvite?: boolean | undefined;
 	/**
-	 * Require email verification on accepting or rejecting an invitation
+	 * Require email verification on session-authenticated recipient invitation
+	 * calls (accept, reject, get, list). Defaults to `true` so unverified
+	 * accounts registered against a victim's email cannot accept, read, or
+	 * enumerate invitations targeted at that email. Server-side
+	 * `listUserInvitations` calls without a session (caller passes
+	 * `ctx.query.email`) continue to bypass the gate because the caller is
+	 * trusted. Set to `false` for backward compatibility on apps that do not
+	 * require email verification; understand the takeover risk before doing so.
 	 *
-	 * @default false
+	 * @default true
+	 *
+	 * @deprecated The option will be removed on the next minor; the gate will
+	 * become unconditional. Plan to verify emails before invitation acceptance.
 	 */
 	requireEmailVerificationOnInvitation?: boolean | undefined;
 	/**

--- a/packages/stripe/test/seat-based-billing.test.ts
+++ b/packages/stripe/test/seat-based-billing.test.ts
@@ -975,7 +975,11 @@ describe("seat-based billing", () => {
 
 			const newMember = await ctx.adapter.create({
 				model: "user",
-				data: { email: "new-member@test.com", name: "New Member" },
+				data: {
+					email: "new-member@test.com",
+					name: "New Member",
+					emailVerified: true,
+				},
 			});
 			await ctx.adapter.create({
 				model: "account",


### PR DESCRIPTION
The organization plugin's recipient-side invitation endpoints (accept, reject, get, list) trusted a string match between the session user's email and the invitation's email as proof that the caller owned the address. The email did not have to be verified. Anyone who pre-registered an unverified account at someone else's email could then accept, reject, read, or enumerate invitations targeted at that email before the legitimate owner ever signed up.

The existing `requireEmailVerificationOnInvitation` option blocked the takeover only when explicitly enabled, and even then it covered only accept and reject, not get or list.

All four recipient endpoints now require a verified session email. `requireEmailVerificationOnInvitation` still exists for backward compatibility but defaults to `true`, so apps are secure by default. Integrators who specifically want the legacy permissive behavior can set the flag to `false`. The option is marked deprecated; a FIXME on each gate site points at the next-minor release that drops the flag entirely and makes the gate unconditional.

The accept and reject endpoints keep the existing `EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_OR_REJECTING_INVITATION` error code. Get and list use a new `EMAIL_VERIFICATION_REQUIRED_FOR_INVITATION` code so the wording matches the operation. Server-side calls to list-invitations (callers passing an email and no session) continue to bypass the gate; the gate is specific to session-authenticated recipient calls.

Affected test suites in this plugin and a few adjacent ones (organization, team, Stripe seat-billing fixture, organization API keys) now pre-verify their test users via `databaseHooks` so they continue to exercise their role and flow assertions rather than tripping the new gate.

See GHSA-fmh4-wcc4-5jm3.
