### PR TITLE
fix(oauth): block OAuth linking to unverified local accounts

### DIFF
--- a/.changeset/fix-oauth2-implicit-link-require-local-emailverified.md
+++ b/.changeset/fix-oauth2-implicit-link-require-local-emailverified.md
@@ -1,0 +1,12 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+---
+
+`handleOAuthUserInfo` (used by every social provider, generic-oauth, oauth-proxy, SSO OIDC and SAML, and idToken sign-in) implicitly linked a returning OAuth identity into a local user row whenever the IdP's `email_verified` claim was true or the provider was trusted. The local row's own `emailVerified` flag was read only to flip it after linking, never as a precondition. `POST /sign-up/email` creates rows with `emailVerified: false` for any caller, so an attacker who pre-registered a victim's email at the application could wait for the legitimate user's first OAuth sign-in: the IdP's verified claim was treated as ownership proof, and the victim's IdP identity was linked into the attacker-owned row.
+
+The implicit-link gate now requires `dbUser.user.emailVerified === true` in addition to the provider trust check by default. A new `account.accountLinking.requireLocalEmailVerified` option (default `true`) is the public surface for this gate. Apps whose users sign up via OAuth without verifying their email locally can opt back into the legacy behavior with `account: { accountLinking: { requireLocalEmailVerified: false } }`; understand the takeover risk before doing so. The option is `@deprecated`; a FIXME at each gate site points at the next-minor follow-up on `next` that drops the option and makes the gate unconditional.
+
+The `one-tap` plugin honored its own copy of the gate and was updated identically: `requireLocalEmailVerified` and `accountLinking.disableImplicitLinking` both apply on `/one-tap/callback`. The `email_verified` claim from the Google ID token is now normalized via `toBoolean` so a string `"false"` is treated as falsy.
+
+Test fixtures across `admin`, `oidc-provider`, `mcp`, `generic-oauth`, `last-login-method`, and `oauth-provider` suites now mark users `emailVerified: true` via a `databaseHooks.user.create.before` hook (or the `disableTestUser` opt-in on the oauth-provider RP) so the suites continue to exercise their role/flow logic rather than the new gate.

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -56,7 +56,7 @@ describe("oauth2 - email verification on link", async () => {
 
 	const ctx = await auth.$context;
 
-	async function linkGoogleAccount() {
+	async function linkGoogleAccount(): Promise<{ redirectLocation: string }> {
 		server.use(
 			http.post("https://oauth2.googleapis.com/token", async () => {
 				const profile: GoogleProfile = {
@@ -94,18 +94,24 @@ describe("oauth2 - email verification on link", async () => {
 			},
 		});
 		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		let redirectLocation = "";
 		await client.$fetch("/callback/google", {
 			query: { state, code: "test_code" },
 			method: "GET",
 			headers: oAuthHeaders,
 			onError(context) {
 				expect(context.response.status).toBe(302);
+				redirectLocation = context.response.headers.get("location") || "";
 			},
 		});
+		return { redirectLocation };
 	}
 
-	it("should update emailVerified when linking account with verified email", async () => {
-		const testEmail = "test@example.com";
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-g38m-r43w-p2q7
+	 */
+	it("should reject implicit link when local user is unverified, even if provider email is verified", async () => {
+		const testEmail = "unverified-local@example.com";
 
 		// Create user with unverified email
 		mockEmail = testEmail;
@@ -119,23 +125,74 @@ describe("oauth2 - email verification on link", async () => {
 
 		const userId = signUpRes.data!.user.id;
 
-		// Verify initial state
+		// Initial state: local row is unverified
 		let user = await ctx.adapter.findOne<User>({
 			model: "user",
 			where: [{ field: "id", value: userId }],
 		});
 		expect(user?.emailVerified).toBe(false);
 
-		// Link with Google account that has verified email
+		// Attempt to link with Google account that has verified email
 		mockEmailVerified = true;
-		await linkGoogleAccount();
+		const { redirectLocation } = await linkGoogleAccount();
 
-		// Verify email is now verified
+		// Callback redirects with the documented account_not_linked error code so
+		// the test can't pass on an unrelated redirect (e.g. server-side failure).
+		expect(redirectLocation).toContain("error=account_not_linked");
+
+		// Link is rejected: no Google account row, local emailVerified untouched
+		const accounts = await ctx.adapter.findMany<{
+			providerId: string;
+		}>({
+			model: "account",
+			where: [{ field: "userId", value: userId }],
+		});
+		const googleAccount = accounts.find((a) => a.providerId === "google");
+		expect(googleAccount).toBeUndefined();
+
 		user = await ctx.adapter.findOne<User>({
 			model: "user",
 			where: [{ field: "id", value: userId }],
 		});
+		expect(user?.emailVerified).toBe(false);
+	});
+
+	it("should link account and preserve emailVerified when local user is already verified", async () => {
+		const testEmail = "verified-local@example.com";
+
+		mockEmail = testEmail;
+		mockEmailVerified = true;
+
+		const signUpRes = await client.signUp.email({
+			email: testEmail,
+			password: "password123",
+			name: "Test User",
+		});
+
+		const userId = signUpRes.data!.user.id;
+
+		// Pre-verify the local user (e.g. via email-otp or verification token)
+		await ctx.adapter.update({
+			model: "user",
+			where: [{ field: "id", value: userId }],
+			update: { emailVerified: true },
+		});
+
+		await linkGoogleAccount();
+
+		const user = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "id", value: userId }],
+		});
 		expect(user?.emailVerified).toBe(true);
+
+		const accounts = await ctx.adapter.findMany<{
+			providerId: string;
+		}>({
+			model: "account",
+			where: [{ field: "userId", value: userId }],
+		});
+		expect(accounts.find((a) => a.providerId === "google")).toBeDefined();
 	});
 
 	it("should not update emailVerified when provider reports unverified", async () => {
@@ -497,7 +554,7 @@ describe("oauth2 - account linking without trustedProviders", async () => {
 		expect(googleAccount).toBeUndefined();
 	});
 
-	it("should allow account linking when email is verified by provider", async () => {
+	it("should allow account linking when email is verified by provider and local user", async () => {
 		const testEmail = "verified-provider@example.com";
 
 		await ctx.adapter.create({
@@ -506,7 +563,7 @@ describe("oauth2 - account linking without trustedProviders", async () => {
 				id: "existing-user-verified",
 				email: testEmail,
 				name: "Existing User",
-				emailVerified: false,
+				emailVerified: true,
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			},
@@ -825,7 +882,7 @@ describe("oauth2 - override user info on sign-in", async () => {
 			data: {
 				email: testEmail,
 				name: "Initial Name",
-				emailVerified: false,
+				emailVerified: true,
 			},
 		});
 
@@ -1276,5 +1333,108 @@ describe("oauth2 - providers without email", async () => {
 
 			expect(redirectLocation).toContain("error=email_not_found");
 		});
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-g38m-r43w-p2q7
+ */
+describe("oauth2 - accountLinking.requireLocalEmailVerified: false opt-out", async () => {
+	const { auth, client, cookieSetter } = await getTestInstance({
+		socialProviders: {
+			google: {
+				clientId: "test",
+				clientSecret: "test",
+				enabled: true,
+			},
+		},
+		emailAndPassword: { enabled: true },
+		account: {
+			accountLinking: {
+				enabled: true,
+				trustedProviders: ["google"],
+				requireLocalEmailVerified: false,
+			},
+		},
+	});
+	const ctx = await auth.$context;
+
+	async function linkGoogleAccount() {
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				const profile: GoogleProfile = {
+					email: mockEmail,
+					email_verified: mockEmailVerified,
+					name: "Test User",
+					picture: "",
+					exp: 1,
+					sub: "google_opt_out_sub",
+					iat: 1,
+					aud: "test",
+					azp: "test",
+					nbf: 1,
+					iss: "test",
+					locale: "en",
+					jti: "test",
+					given_name: "Test",
+					family_name: "User",
+				};
+				const idToken = await signJWT(profile, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: "t",
+					refresh_token: "r",
+					id_token: idToken,
+				});
+			}),
+		);
+
+		const oAuthHeaders = new Headers();
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/",
+			fetchOptions: { onSuccess: cookieSetter(oAuthHeaders) },
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test_code" },
+			method: "GET",
+			headers: oAuthHeaders,
+			onError(context) {
+				// The callback ends in a 302 to the callbackURL on success; the
+				// HTTP client surfaces that as an error path. Ignore the redirect
+				// so the test reaches the post-callback adapter assertions.
+				expect(context.response.status).toBe(302);
+			},
+		});
+	}
+
+	it("links the account when local user is unverified and the option opts out", async () => {
+		mockEmail = "opt-out@example.com";
+		mockEmailVerified = true;
+		const signUpRes = await client.signUp.email({
+			email: mockEmail,
+			password: "password123",
+			name: "Opt Out User",
+		});
+		const userId = signUpRes.data!.user.id;
+
+		await linkGoogleAccount();
+
+		const accounts = await ctx.adapter.findMany<{
+			providerId: string;
+			userId: string;
+		}>({
+			model: "account",
+			where: [{ field: "userId", value: userId }],
+		});
+		expect(accounts.some((a) => a.providerId === "google")).toBe(true);
+
+		// The legacy emailVerified-promotion path is reachable when the gate is
+		// opted out, so the IdP's verified email lifts the local row.
+		const promoted = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "id", value: userId }],
+		});
+		expect(promoted?.emailVerified).toBe(true);
 	});
 });

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -52,8 +52,13 @@ export async function handleOAuthUserInfo(
 			const isTrustedProvider =
 				opts.isTrustedProvider ||
 				c.context.trustedProviders.includes(account.providerId);
+			// FIXME(next-minor): drop `requireLocalEmailVerified` option and make
+			// the gate unconditional.
+			const requireLocalEmailVerified =
+				accountLinking?.requireLocalEmailVerified ?? true;
 			if (
 				(!isTrustedProvider && !userInfo.emailVerified) ||
+				(requireLocalEmailVerified && !dbUser.user.emailVerified) ||
 				accountLinking?.enabled === false ||
 				accountLinking?.disableImplicitLinking === true
 			) {
@@ -87,6 +92,10 @@ export async function handleOAuthUserInfo(
 				};
 			}
 
+			// Reachable only when `requireLocalEmailVerified: false` lets the link
+			// proceed for an unverified local row. The IdP's verified email is
+			// promoted to the local row so subsequent flows treat it as verified.
+			// FIXME(next-minor): unreachable once the gate becomes unconditional.
 			if (
 				userInfo.emailVerified &&
 				!dbUser.user.emailVerified &&

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -83,16 +83,13 @@ describe("Admin plugin", async () => {
 			databaseHooks: {
 				user: {
 					create: {
-						before: async (user) => {
-							if (user.name === "Admin") {
-								return {
-									data: {
-										...user,
-										role: "admin",
-									},
-								};
-							}
-						},
+						before: async (user) => ({
+							data: {
+								...user,
+								emailVerified: true,
+								...(user.name === "Admin" ? { role: "admin" } : {}),
+							},
+						}),
 					},
 				},
 			},
@@ -1858,16 +1855,13 @@ describe("edge cases: userId validation", async () => {
 			databaseHooks: {
 				user: {
 					create: {
-						before: async (user) => {
-							if (user.name === "Admin") {
-								return {
-									data: {
-										...user,
-										role: "admin",
-									},
-								};
-							}
-						},
+						before: async (user) => ({
+							data: {
+								...user,
+								emailVerified: true,
+								...(user.name === "Admin" ? { role: "admin" } : {}),
+							},
+						}),
 					},
 				},
 			},

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -29,6 +29,15 @@ describe("oauth2", async () => {
 	});
 
 	const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+		databaseHooks: {
+			user: {
+				create: {
+					before: async (user) => ({
+						data: { ...user, emailVerified: true },
+					}),
+				},
+			},
+		},
 		plugins: [
 			genericOAuth({
 				config: [

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -521,6 +521,15 @@ describe("lastLoginMethod", async () => {
 					trustedProviders: ["google"],
 				},
 			},
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => ({
+							data: { ...user, emailVerified: true },
+						}),
+					},
+				},
+			},
 		});
 
 		await client.signUp.email(

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -9,6 +9,18 @@ import { jwt } from "../jwt";
 import type { Client } from "../oidc-provider/types";
 import { mcp, withMcpAuth } from ".";
 
+// Pre-verifies any user the RP creates via OAuth signup so the existing-user
+// path on the RP side does not trip the local-emailVerified gate.
+const autoVerifyUserHook = {
+	user: {
+		create: {
+			before: async (user: Record<string, unknown>) => ({
+				data: { ...user, emailVerified: true },
+			}),
+		},
+	},
+} as const;
+
 describe("mcp", async () => {
 	// Start server on ephemeral port first to get available port
 	const tempServer = await listen(
@@ -168,6 +180,7 @@ describe("mcp", async () => {
 						trustedProviders: ["test-public"],
 					},
 				},
+				databaseHooks: autoVerifyUserHook,
 				plugins: [
 					genericOAuth({
 						config: [
@@ -264,6 +277,7 @@ describe("mcp", async () => {
 						trustedProviders: ["test-confidential"],
 					},
 				},
+				databaseHooks: autoVerifyUserHook,
 				plugins: [
 					genericOAuth({
 						config: [
@@ -445,6 +459,7 @@ describe("mcp", async () => {
 					trustedProviders: ["test-userinfo"],
 				},
 			},
+			databaseHooks: autoVerifyUserHook,
 			plugins: [
 				genericOAuth({
 					config: [

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -22,6 +22,18 @@ import type { OidcClientPlugin } from "./client";
 import { oidcClient } from "./client";
 import type { Client } from "./types";
 
+// Pre-verifies any user the RP creates via OAuth signup so the existing-user
+// path on the RP side does not trip the local-emailVerified gate.
+const autoVerifyUserHook = {
+	user: {
+		create: {
+			before: async (user: Record<string, unknown>) => ({
+				data: { ...user, emailVerified: true },
+			}),
+		},
+	},
+} as const;
+
 // Type for the server client with OIDC plugin
 type ServerClient = AuthClient<{
 	plugins: [OidcClientPlugin];
@@ -200,6 +212,7 @@ describe("oidc", async () => {
 						trustedProviders: ["test"],
 					},
 				},
+				databaseHooks: autoVerifyUserHook,
 				plugins: [
 					genericOAuth({
 						config: [
@@ -286,6 +299,7 @@ describe("oidc", async () => {
 						trustedProviders: ["test"],
 					},
 				},
+				databaseHooks: autoVerifyUserHook,
 				plugins: [
 					genericOAuth({
 						config: [
@@ -375,6 +389,7 @@ describe("oidc", async () => {
 						trustedProviders: ["test"],
 					},
 				},
+				databaseHooks: autoVerifyUserHook,
 				plugins: [
 					genericOAuth({
 						config: [
@@ -1147,6 +1162,7 @@ describe("oidc storage", async () => {
 						trustedProviders: ["test"],
 					},
 				},
+				databaseHooks: autoVerifyUserHook,
 				plugins: [
 					genericOAuth({
 						config: [
@@ -1268,6 +1284,7 @@ describe("oidc token response format", async () => {
 
 		const { customFetchImpl: customFetchImplRP, cookieSetter } =
 			await getTestInstance({
+				databaseHooks: autoVerifyUserHook,
 				plugins: [
 					genericOAuth({
 						config: [
@@ -1527,6 +1544,7 @@ describe("oidc-jwt", async () => {
 						trustedProviders: ["test"],
 					},
 				},
+				databaseHooks: autoVerifyUserHook,
 				plugins: [
 					genericOAuth({
 						config: [

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -159,10 +159,20 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 					const account = await ctx.context.internalAdapter.findAccount(sub);
 					if (!account) {
 						const accountLinking = ctx.context.options.account?.accountLinking;
+						const providerEmailVerified =
+							typeof email_verified === "boolean"
+								? email_verified
+								: toBoolean(email_verified);
+						// FIXME(next-minor): drop `requireLocalEmailVerified` option and
+						// make the gate unconditional.
+						const requireLocalEmailVerified =
+							accountLinking?.requireLocalEmailVerified ?? true;
 						const shouldLinkAccount =
 							accountLinking?.enabled !== false &&
+							accountLinking?.disableImplicitLinking !== true &&
+							(!requireLocalEmailVerified || user.user.emailVerified) &&
 							(ctx.context.trustedProviders.includes("google") ||
-								email_verified);
+								providerEmailVerified);
 						if (shouldLinkAccount) {
 							await ctx.context.internalAdapter.linkAccount({
 								userId: user.user.id,
@@ -173,7 +183,8 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 							});
 						} else {
 							throw new APIError("UNAUTHORIZED", {
-								message: "Google sub doesn't match",
+								message:
+									"Google identity cannot be linked: implicit account-linking is disabled, the local email is not verified, or the Google email_verified claim is false and Google is not a trusted provider",
 							});
 						}
 					}

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { oneTap } from "./index";
+
+const verifiedPayload = {
+	email: "one-tap-user@example.com",
+	email_verified: true,
+	name: "One Tap User",
+	picture: "https://example.com/photo.jpg",
+	sub: "google_oauth_sub_one_tap",
+};
+
+vi.mock("jose", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("jose")>();
+	return {
+		...actual,
+		createRemoteJWKSet: vi.fn(() => async () => undefined),
+		jwtVerify: vi.fn(async () => ({
+			payload: verifiedPayload,
+			protectedHeader: { alg: "RS256" },
+		})),
+	};
+});
+
+describe("one-tap implicit linking gate", async () => {
+	afterEach(() => {
+		verifiedPayload.email_verified = true;
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-g38m-r43w-p2q7
+	 */
+	it("rejects implicit linking when the local user is unverified", async () => {
+		const { client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+				},
+			},
+			plugins: [oneTap()],
+		});
+
+		await client.signUp.email({
+			email: verifiedPayload.email,
+			password: "password123",
+			name: "Pre-existing Unverified",
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number; code?: string } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error?.status).toBe(401);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-g38m-r43w-p2q7
+	 */
+	it("allows implicit linking once the local user is verified", async () => {
+		const { auth, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+				},
+			},
+			plugins: [oneTap()],
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => ({
+							data: { ...user, emailVerified: true },
+						}),
+					},
+				},
+			},
+		});
+
+		await client.signUp.email({
+			email: verifiedPayload.email,
+			password: "password123",
+			name: "Pre-existing Verified",
+		});
+
+		const res = await client.$fetch<{
+			data: { user: { id: string } } | null;
+			error: unknown;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error).toBeFalsy();
+		const ctx = await auth.$context;
+		const accounts = await ctx.adapter.findMany<{ providerId: string }>({
+			model: "account",
+			where: [
+				{
+					field: "providerId",
+					value: "google",
+				},
+			],
+		});
+		expect(accounts.length).toBeGreaterThanOrEqual(1);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-g38m-r43w-p2q7
+	 */
+	it("links the account when requireLocalEmailVerified is opted out, even for an unverified local user", async () => {
+		const { auth, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+				},
+			},
+			account: {
+				accountLinking: {
+					requireLocalEmailVerified: false,
+				},
+			},
+			plugins: [oneTap()],
+		});
+
+		await client.signUp.email({
+			email: verifiedPayload.email,
+			password: "password123",
+			name: "Pre-existing Unverified (Opted-out)",
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error).toBeFalsy();
+		const ctx = await auth.$context;
+		const accounts = await ctx.adapter.findMany<{ providerId: string }>({
+			model: "account",
+			where: [
+				{
+					field: "providerId",
+					value: "google",
+				},
+			],
+		});
+		expect(accounts.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("honors accountLinking.disableImplicitLinking even when the local user is verified", async () => {
+		const { auth, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+				},
+			},
+			account: {
+				accountLinking: {
+					disableImplicitLinking: true,
+				},
+			},
+			plugins: [oneTap()],
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => ({
+							data: { ...user, emailVerified: true },
+						}),
+					},
+				},
+			},
+		});
+
+		await client.signUp.email({
+			email: verifiedPayload.email,
+			password: "password123",
+			name: "Pre-existing Verified, Linking Disabled",
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error?.status).toBe(401);
+
+		const ctx = await auth.$context;
+		const accounts = await ctx.adapter.findMany<{ providerId: string }>({
+			model: "account",
+			where: [
+				{
+					field: "providerId",
+					value: "google",
+				},
+			],
+		});
+		expect(accounts.length).toBe(0);
+	});
+});

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1022,6 +1022,25 @@ export type BetterAuthOptions = {
 					 */
 					disableImplicitLinking?: boolean;
 					/**
+					 * Require the existing local user row to have
+					 * `emailVerified: true` before implicit account linking
+					 * uses the IdP's `email_verified` claim as ownership
+					 * proof. Defaults to `true` so an attacker who
+					 * pre-registers an unverified account at a victim's
+					 * email cannot have the victim's OAuth identity linked
+					 * into the attacker-owned row on first sign-in. Set to
+					 * `false` for backward compatibility on apps whose
+					 * users sign up via OAuth without verifying their email
+					 * locally; understand the takeover risk before doing
+					 * so.
+					 *
+					 * @default true
+					 *
+					 * @deprecated The option will be removed on the next
+					 * minor; the gate will become unconditional.
+					 */
+					requireLocalEmailVerified?: boolean;
+					/**
 					 * List of trusted providers. Can be a static array or a function
 					 * that returns providers dynamically. The function is called
 					 * during context init (with `request` undefined) and again

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -304,38 +304,47 @@ describe("oauth", async () => {
 		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
 			throw Error("beforeAll not run properly");
 		}
-		return await getTestInstance({
-			// Used to trust callbackUrl in test
-			account: {
-				accountLinking: {
-					trustedProviders: [providerId],
+		return await getTestInstance(
+			{
+				// Used to trust callbackUrl in test
+				account: {
+					accountLinking: {
+						trustedProviders: [providerId],
+					},
 				},
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								scopes: ["openid", "profile", "email"],
+								...config,
+								providerId,
+								redirectURI: redirectUri,
+								authorizationUrl: config?.discoveryUrl
+									? undefined
+									: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+								tokenUrl: config?.discoveryUrl
+									? undefined
+									: `${authServerBaseUrl}/api/auth/oauth2/token`,
+								userInfoUrl: config?.discoveryUrl
+									? undefined
+									: `${authServerBaseUrl}/api/auth/oauth2/userinfo`,
+								clientId: oauthClient.client_id,
+								clientSecret: oauthClient.client_secret,
+								pkce: true,
+							},
+						],
+					}),
+				],
 			},
-			plugins: [
-				genericOAuth({
-					config: [
-						{
-							scopes: ["openid", "profile", "email"],
-							...config,
-							providerId,
-							redirectURI: redirectUri,
-							authorizationUrl: config?.discoveryUrl
-								? undefined
-								: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
-							tokenUrl: config?.discoveryUrl
-								? undefined
-								: `${authServerBaseUrl}/api/auth/oauth2/token`,
-							userInfoUrl: config?.discoveryUrl
-								? undefined
-								: `${authServerBaseUrl}/api/auth/oauth2/userinfo`,
-							clientId: oauthClient.client_id,
-							clientSecret: oauthClient.client_secret,
-							pkce: true,
-						},
-					],
-				}),
-			],
-		});
+			{
+				// The OAuth flow creates the RP-side user on first sign-in. Skipping
+				// the default test-user prevents a same-email collision that would
+				// otherwise route through the existing-user-no-link branch and trip
+				// the local-emailVerified gate.
+				disableTestUser: true,
+			},
+		);
 	}
 
 	// Tests if it is oauth2 compatible
@@ -1139,38 +1148,47 @@ describe("oauth - prompt", async () => {
 		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
 			throw Error("beforeAll not run properly");
 		}
-		return await getTestInstance({
-			// Used to trust callbackUrl in test
-			account: {
-				accountLinking: {
-					trustedProviders: [providerId],
+		return await getTestInstance(
+			{
+				// Used to trust callbackUrl in test
+				account: {
+					accountLinking: {
+						trustedProviders: [providerId],
+					},
 				},
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								scopes: ["openid", "profile", "email"],
+								...config,
+								providerId,
+								redirectURI: redirectUri,
+								authorizationUrl: config?.discoveryUrl
+									? undefined
+									: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+								tokenUrl: config?.discoveryUrl
+									? undefined
+									: `${authServerBaseUrl}/api/auth/oauth2/token`,
+								userInfoUrl: config?.discoveryUrl
+									? undefined
+									: `${authServerBaseUrl}/api/auth/oauth2/userinfo`,
+								clientId: oauthClient.client_id,
+								clientSecret: oauthClient.client_secret,
+								pkce: true,
+							},
+						],
+					}),
+				],
 			},
-			plugins: [
-				genericOAuth({
-					config: [
-						{
-							scopes: ["openid", "profile", "email"],
-							...config,
-							providerId,
-							redirectURI: redirectUri,
-							authorizationUrl: config?.discoveryUrl
-								? undefined
-								: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
-							tokenUrl: config?.discoveryUrl
-								? undefined
-								: `${authServerBaseUrl}/api/auth/oauth2/token`,
-							userInfoUrl: config?.discoveryUrl
-								? undefined
-								: `${authServerBaseUrl}/api/auth/oauth2/userinfo`,
-							clientId: oauthClient.client_id,
-							clientSecret: oauthClient.client_secret,
-							pkce: true,
-						},
-					],
-				}),
-			],
-		});
+			{
+				// The OAuth flow creates the RP-side user on first sign-in. Skipping
+				// the default test-user prevents a same-email collision that would
+				// otherwise route through the existing-user-no-link branch and trip
+				// the local-emailVerified gate.
+				disableTestUser: true,
+			},
+		);
 	}
 
 	it("login - should always redirect to login", async () => {
@@ -2665,38 +2683,47 @@ describe("oauth - config", () => {
 		if (!oauthClient?.client_id) {
 			throw Error("beforeAll not run properly");
 		}
-		return await getTestInstance({
-			// Used to trust callbackUrl in test
-			account: {
-				accountLinking: {
-					trustedProviders: [providerId],
+		return await getTestInstance(
+			{
+				// Used to trust callbackUrl in test
+				account: {
+					accountLinking: {
+						trustedProviders: [providerId],
+					},
 				},
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								scopes: ["openid", "profile", "email"],
+								...config,
+								providerId,
+								redirectURI: redirectUri,
+								authorizationUrl: config?.discoveryUrl
+									? undefined
+									: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+								tokenUrl: config?.discoveryUrl
+									? undefined
+									: `${authServerBaseUrl}/api/auth/oauth2/token`,
+								userInfoUrl: config?.discoveryUrl
+									? undefined
+									: `${authServerBaseUrl}/api/auth/oauth2/userinfo`,
+								clientId: oauthClient.client_id,
+								clientSecret: oauthClient?.client_secret,
+								pkce: true,
+							},
+						],
+					}),
+				],
 			},
-			plugins: [
-				genericOAuth({
-					config: [
-						{
-							scopes: ["openid", "profile", "email"],
-							...config,
-							providerId,
-							redirectURI: redirectUri,
-							authorizationUrl: config?.discoveryUrl
-								? undefined
-								: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
-							tokenUrl: config?.discoveryUrl
-								? undefined
-								: `${authServerBaseUrl}/api/auth/oauth2/token`,
-							userInfoUrl: config?.discoveryUrl
-								? undefined
-								: `${authServerBaseUrl}/api/auth/oauth2/userinfo`,
-							clientId: oauthClient.client_id,
-							clientSecret: oauthClient?.client_secret,
-							pkce: true,
-						},
-					],
-				}),
-			],
-		});
+			{
+				// The OAuth flow creates the RP-side user on first sign-in. Skipping
+				// the default test-user prevents a same-email collision that would
+				// otherwise route through the existing-user-no-link branch and trip
+				// the local-emailVerified gate.
+				disableTestUser: true,
+			},
+		);
 	}
 
 	/**


### PR DESCRIPTION
A user can sign up with email and password without yet proving they own the email; the local account is created marked unverified. Separately, when a user signs in through OAuth (Google, GitHub, any SSO provider), Better Auth attaches the OAuth identity to an existing local account that shares the same email, as long as the identity provider's `email_verified` claim is true or the provider is trusted. Until this fix, those two paths did not talk to each other. The OAuth-link step trusted the identity provider's verification but never checked whether the local account it was linking into had a verified email.

That gave an attacker a stable account-takeover primitive. The attacker signs up at the victim's email through email and password; the account is created unverified, and the registration is not refused. Then they wait. When the victim eventually signs in through Google, GitHub, an SSO IdP, or any other OAuth source, the OAuth identity is attached to the attacker's pre-registered row. After that point, anyone who logs in with either credential set lands in the attacker's account.

The fix gates implicit linking on the local account's verification status. A new `account.accountLinking.requireLocalEmailVerified` option, defaulted to `true`, blocks the link unless the local row is already verified. The same gate now applies in the `one-tap` sign-in plugin, which previously had its own simpler linking path. The Google ID-token `email_verified` claim is also normalized: some Google responses send the string `"false"` instead of the boolean, which the prior code treated as truthy.

Apps whose users sign up through OAuth without ever verifying their email locally can opt out with `account: { accountLinking: { requireLocalEmailVerified: false } }`. The option is marked deprecated; a FIXME at each gate site points at the next-minor follow-up that drops the option and makes the gate unconditional.

Test fixtures across `admin`, `oidc-provider`, `mcp`, `generic-oauth`, `last-login-method`, and `oauth-provider` suites now pre-verify created users via `databaseHooks.user.create.before` (or the `disableTestUser` opt-in on the oauth-provider RP test fixture) so the suites continue to exercise their role and flow logic rather than tripping the new gate.

See GHSA-g38m-r43w-p2q7.
