### PR TITLE
fix(scim): reject built-in provider id collisions on SCIM token issuance

### DIFF
--- a/.changeset/fix-scim-provider-ownership-default-on.md
+++ b/.changeset/fix-scim-provider-ownership-default-on.md
@@ -1,0 +1,9 @@
+---
+"@better-auth/scim": patch
+---
+
+`POST /scim/generate-token` accepted a `providerId` that collided with a built-in `account.providerId` value (`credential`, `email-otp`, `magic-link`, `phone-number`, `anonymous`, `siwe`, or any configured social provider key), so a SCIM caller could mint a token that authenticated against accounts it never provisioned.
+
+`generateSCIMToken` now rejects `providerId` values that collide with the built-in account provider list, returning `BAD_REQUEST` at issuance. The configured-social-provider check reads from `options.socialProviders` rather than the resolved provider list so that providers disabled with `enabled: false` are still rejected: their account rows can persist from when the provider was enabled.
+
+`providerOwnership.enabled` stays default `false` on this patch release so existing SQL deployments do not need a schema migration mid-upgrade. The follow-up on `next` flips the default to `true` and ships the corresponding `scimProvider.userId` schema column so non-organization SCIM tokens are owner-locked by default. Operators who need owner-locking immediately can opt in today with `scim({ providerOwnership: { enabled: true } })` and add the `userId` column manually.

--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -33,6 +33,10 @@ export const scim = (options?: SCIMOptions) => {
 		storeSCIMToken: "plain",
 		...options,
 	} satisfies SCIMOptions;
+	// TODO(scim-provider-ownership-default-on): flip default to `true` on next.
+	// Kept default-off on main so existing SQL deployments don't need a schema
+	// migration mid-upgrade. The dedicated next-minor PR adds the
+	// `scimProvider.userId` column and flips the default in one step.
 	const providerOwnershipEnabled = options?.providerOwnership?.enabled ?? false;
 
 	const authMiddleware = authMiddlewareFactory(opts);

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -84,6 +84,10 @@ function resolveRequiredRoles(
 	return Array.from(new Set(["admin", creatorRole ?? "owner"]));
 }
 
+// TODO(scim-provider-ownership-default-on): flip default to `true` on next so
+// new non-org SCIM tokens are owner-locked by default. Coupled with the
+// `scimProvider.userId` schema column. Tracks the SCIM provider-ownership
+// advisory.
 function isProviderOwnershipEnabled(opts: SCIMOptions): boolean {
 	return opts.providerOwnership?.enabled ?? false;
 }
@@ -233,6 +237,36 @@ export const generateSCIMToken = (opts: SCIMOptions) =>
 			if (providerId.includes(":")) {
 				throw new APIError("BAD_REQUEST", {
 					message: "Provider id contains forbidden characters",
+				});
+			}
+
+			// A SCIM token authenticates as the row whose providerId matches the
+			// claim in the bearer token. If a caller mints a token whose
+			// providerId collides with a built-in account.providerId
+			// (`credential`, `email-otp`, `magic-link`, `phone-number`,
+			// `anonymous`, `siwe`, or any configured social provider key), the
+			// resulting token can be used to act against accounts that were
+			// never SCIM-provisioned, which would be a privilege escalation.
+			// Reject the collision at issuance.
+			//
+			// We read social provider keys from `options.socialProviders` (raw
+			// config) rather than `context.socialProviders` (resolved list) so
+			// that providers configured with `enabled: false` are still
+			// rejected: their account rows can persist in the DB from a prior
+			// enabled state.
+			const reservedProviderIds = new Set<string>([
+				"credential",
+				"email-otp",
+				"magic-link",
+				"phone-number",
+				"anonymous",
+				"siwe",
+				...Object.keys(ctx.context.options.socialProviders ?? {}),
+			]);
+			if (reservedProviderIds.has(providerId)) {
+				throw new APIError("BAD_REQUEST", {
+					message:
+						"Provider id collides with a built-in account provider and cannot be used for SCIM",
 				});
 			}
 

--- a/packages/scim/src/scim.management.test.ts
+++ b/packages/scim/src/scim.management.test.ts
@@ -168,6 +168,105 @@ describe("SCIM provider management", () => {
 			);
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-2g28-66mv-wghh
+		 */
+		it("rejects providerId values that collide with built-in account providers", async () => {
+			const { auth, getAuthCookieHeaders } = createTestInstance();
+			const headers = await getAuthCookieHeaders();
+			const generateSCIMToken = (providerId: string) =>
+				auth.api.generateSCIMToken({ body: { providerId }, headers });
+
+			for (const reserved of [
+				"credential",
+				"email-otp",
+				"magic-link",
+				"phone-number",
+				"anonymous",
+				"siwe",
+			]) {
+				await expect(generateSCIMToken(reserved)).rejects.toThrowError(
+					expect.objectContaining({
+						message:
+							"Provider id collides with a built-in account provider and cannot be used for SCIM",
+					}),
+				);
+			}
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-2g28-66mv-wghh
+		 */
+		it("rejects providerId values that collide with configured social providers", async () => {
+			const data = {
+				user: [],
+				session: [],
+				verification: [],
+				account: [],
+				ssoProvider: [],
+				scimProvider: [],
+				organization: [],
+				member: [],
+			};
+			const memory = memoryAdapter(data);
+			const auth = betterAuth({
+				database: memory,
+				baseURL: "http://localhost:3000",
+				emailAndPassword: { enabled: true },
+				socialProviders: {
+					google: {
+						clientId: "google-client-id",
+						clientSecret: "google-client-secret",
+						enabled: true,
+					},
+					github: {
+						clientId: "github-client-id",
+						clientSecret: "github-client-secret",
+						enabled: true,
+					},
+					// Disabled providers must still be rejected: a previously
+					// enabled provider can have leftover account rows in the DB.
+					discord: {
+						clientId: "discord-client-id",
+						clientSecret: "discord-client-secret",
+						enabled: false,
+					},
+				},
+				plugins: [scim()],
+			});
+			const authClient = createAuthClient({
+				baseURL: "http://localhost:3000",
+				plugins: [bearer(), scimClient()],
+				fetchOptions: {
+					customFetchImpl: async (url, init) =>
+						auth.handler(new Request(url, init)),
+				},
+			});
+			const headers = new Headers();
+			await authClient.signUp.email({
+				email: "social@email.com",
+				password: "password",
+				name: "Social User",
+			});
+			await authClient.signIn.email(
+				{ email: "social@email.com", password: "password" },
+				{ throw: true, onSuccess: setCookieToHeader(headers) },
+			);
+			for (const reserved of ["google", "github", "discord"]) {
+				await expect(
+					auth.api.generateSCIMToken({
+						body: { providerId: reserved },
+						headers,
+					}),
+				).rejects.toThrowError(
+					expect.objectContaining({
+						message:
+							"Provider id collides with a built-in account provider and cannot be used for SCIM",
+					}),
+				);
+			}
+		});
+
 		it("should generate a new scim token (client)", async () => {
 			const { auth, authClient, getAuthCookieHeaders } = createTestInstance();
 


### PR DESCRIPTION
Better Auth records every credential a user can authenticate with as a row in a single `account` table. Each row carries a `providerId` naming the credential type: `credential` for password rows, `magic-link` for magic-link rows, `siwe` for sign-in-with-Ethereum rows, and one row per configured social-login (`google`, `github`, and so on). When a SCIM source provisions a user, it adds its own row with a `providerId` chosen by the SCIM operator.

The SCIM token-generation endpoint accepted any string as that operator-chosen `providerId`, including names already used by built-in credentials. A SCIM operator could pick `credential`, or any social-login key the app had configured, for their token; subsequent SCIM operations would then authenticate against accounts the real password or social-login flows had created. The result was a privilege escalation: a SCIM token acting as the source of accounts it never provisioned.

SCIM token generation now rejects any `providerId` that collides with a built-in account provider name: the credential-type names (`credential`, `email-otp`, `magic-link`, `phone-number`, `anonymous`, `siwe`) and every key under `socialProviders` in the app's configuration. The social-provider check reads from the raw config rather than the resolved enabled list, so a provider disabled with `enabled: false` is still rejected. Its old account rows can persist in the database from a prior enabled state, and an attacker matching that `providerId` would still gain access to them.

The broader owner-locking work (`providerOwnership.enabled`) stays opt-in on this patch release so SQL-backed deployments do not take a schema migration mid-upgrade. The next-minor release on the `next` branch flips the default to `true` and ships the corresponding column. Deployments that need owner-locking immediately can opt in today by setting `providerOwnership.enabled: true` and adding the `userId` column to their `scimProvider` table manually.

See GHSA-2g28-66mv-wghh.
