### PR TITLE
fix: invalid instrumentation import list

### DIFF
--- a/.changeset/lemon-dryers-show.md
+++ b/.changeset/lemon-dryers-show.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+fix: invalid instrumentation import list

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -102,12 +102,13 @@
     "./instrumentation": {
       "dev-source": "./src/instrumentation/index.ts",
       "types": "./dist/instrumentation/index.d.mts",
+      "workerd": "./dist/instrumentation/pure.index.mjs",
+      "edge": "./dist/instrumentation/pure.index.mjs",
+      "browser": "./dist/instrumentation/pure.index.mjs",
       "node": "./dist/instrumentation/index.mjs",
       "deno": "./dist/instrumentation/index.mjs",
       "bun": "./dist/instrumentation/index.mjs",
-      "edge": "./dist/instrumentation/pure.index.mjs",
-      "workerd": "./dist/instrumentation/pure.index.mjs",
-      "browser": "./dist/instrumentation/pure.index.mjs",
+      "import": "./dist/instrumentation/index.mjs",
       "default": "./dist/instrumentation/index.mjs"
     }
   },


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/9550


The Node.js export resolution algorithm iterates keys in definition order and selects the first match. Vite SSR automatically adds "node" to its condition set, so "node" matches first, resolving to `index.mjs` (full OpenTelemetry), even when "workerd" is also in the condition set. This is why `resolve.conditions: ['workerd']` in Vite config doesn't help.

Also, we were missing the "import" condition. Generic ESM bundlers that resolve with only ["import"] find no matching key and fall through to "default", which is also the full OpenTelemetry path.


