### PR TITLE
fix(context): emit base URL warning only once, suppress with trustedProxyHeaders

### DIFF
--- a/.changeset/base-url-warn-dedup.md
+++ b/.changeset/base-url-warn-dedup.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The missing base URL warning no longer spams on every request. It now emits only once per process, and is suppressed entirely when `advanced.trustedProxyHeaders` is set (because the URL is resolved from proxy headers at runtime). The warning message has also been updated to clarify that the URL will be inferred from the first incoming request.

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -1921,4 +1921,62 @@ describe("base context creation", () => {
 			expect(ctx.hasPlugin("plugin-4")).toBe(false);
 		});
 	});
+
+	describe("base URL warning deduplication", () => {
+		it("should only emit the missing-base-URL warning once across multiple createAuthContext calls", async () => {
+			vi.resetModules();
+
+			const { createAuthContext: freshCreateAuthContext } = await import(
+				"../context/create-context"
+			);
+			const { getAdapter: freshGetAdapter } = await import(
+				"../db/adapter-kysely"
+			);
+
+			const log = vi.fn();
+			const opts: BetterAuthOptions = {
+				logger: { level: "warn", log } as any,
+			};
+			const adapter = await freshGetAdapter(opts);
+			const getDatabaseType = () => "memory";
+
+			await freshCreateAuthContext(adapter, opts, getDatabaseType);
+			await freshCreateAuthContext(adapter, opts, getDatabaseType);
+
+			const baseURLWarnings = log.mock.calls.filter((args) =>
+				String(args[1]).includes("Base URL could not be determined"),
+			);
+			expect(baseURLWarnings).toHaveLength(1);
+
+			vi.resetModules();
+		});
+
+		it("should not warn about missing base URL when trustedProxyHeaders is enabled", async () => {
+			vi.resetModules();
+
+			const { createAuthContext: freshCreateAuthContext } = await import(
+				"../context/create-context"
+			);
+			const { getAdapter: freshGetAdapter } = await import(
+				"../db/adapter-kysely"
+			);
+
+			const log = vi.fn();
+			const opts: BetterAuthOptions = {
+				logger: { level: "warn", log } as any,
+				advanced: { trustedProxyHeaders: true },
+			};
+			const adapter = await freshGetAdapter(opts);
+			const getDatabaseType = () => "memory";
+
+			await freshCreateAuthContext(adapter, opts, getDatabaseType);
+
+			const baseURLWarnings = log.mock.calls.filter((args) =>
+				String(args[1]).includes("Base URL could not be determined"),
+			);
+			expect(baseURLWarnings).toHaveLength(0);
+
+			vi.resetModules();
+		});
+	});
 });

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -89,6 +89,8 @@ function validateSecret(
 	}
 }
 
+let baseURLWarnEmitted = false;
+
 export async function createAuthContext<Options extends BetterAuthOptions>(
 	adapter: DBAdapter,
 	options: Options,
@@ -134,9 +136,15 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 				options.basePath,
 			);
 
-	if (!baseURL && !isDynamicConfig) {
+	if (
+		!baseURL &&
+		!isDynamicConfig &&
+		!baseURLWarnEmitted &&
+		!options.advanced?.trustedProxyHeaders
+	) {
+		baseURLWarnEmitted = true;
 		logger.warn(
-			`[better-auth] Base URL could not be determined. Please set a valid base URL using the baseURL config option or the BETTER_AUTH_URL environment variable. Without this, callbacks and redirects may not work correctly.`,
+			`[better-auth] Base URL could not be determined at startup. It will be inferred from the first incoming request. For reliable redirects and callbacks, set the BETTER_AUTH_URL environment variable or the baseURL option.`,
 		);
 	}
 


### PR DESCRIPTION
## Summary

- The missing-base-URL warning was firing on every `createAuthContext` call (e.g. on every request in environments where the module re-initialises per render). A module-level flag now ensures it emits **at most once per process**.
- The warning is **suppressed entirely** when `advanced.trustedProxyHeaders` is enabled — users who set this option have explicitly configured proxy-header-based URL resolution, so the warning is both misleading and noisy for them.
- The warning message has been updated to clarify that the URL will be **inferred from the first incoming request**, rather than implying redirects/callbacks will never work.

## Test Plan

- [x] New test: `should only emit the missing-base-URL warning once across multiple createAuthContext calls` — verifies deduplication via `vi.resetModules()` + fresh module import
- [x] New test: `should not warn about missing base URL when trustedProxyHeaders is enabled` — verifies suppression when the option is set
- [x] All 117 existing tests in `create-context.test.ts` still pass
- [x] `pnpm typecheck` passes
- [x] Lefthook (biome + spell) passes on commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the missing base URL warning in `better-auth` so it fires only once per process, and suppresses it when `advanced.trustedProxyHeaders` is enabled. Updates the message to clarify the URL is inferred from the first incoming request.

- **Bug Fixes**
  - Emit the warning only once using a module-level flag (no more per-`createAuthContext` spam).
  - Suppress the warning when `advanced.trustedProxyHeaders` is true, since proxy headers resolve the URL.
  - Reword the warning to note inference from the first request and recommend `BETTER_AUTH_URL` or `baseURL`.

<sup>Written for commit d576165fbeeb1317ff2515944050c915e9a0ffd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

