### PR TITLE
fix(account): default `storeStateStrategy` to "database" when using `secondaryStorage`

### DIFF
--- a/.changeset/fair-parts-act.md
+++ b/.changeset/fair-parts-act.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+When only secondaryStorage is configured without a primary database, storeStateStrategy now defaults to "database" instead of "cookie", preventing oversized cookie errors on platforms like AWS Lambda.

--- a/.changeset/fair-parts-act.md
+++ b/.changeset/fair-parts-act.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-When only secondaryStorage is configured without a primary database, storeStateStrategy now defaults to "database" instead of "cookie", preventing oversized cookie errors on platforms like AWS Lambda.
+When only `secondaryStorage` is configured (no primary database), `storeStateStrategy` now defaults to `"database"` instead of `"cookie"`, preventing oversized-cookie errors on platforms like AWS Lambda. The account cookie that holds OAuth tokens in database-less setups stays enabled, so `getAccessToken` keeps working.

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -504,7 +504,7 @@ Controls where OAuth state data is stored during the authentication flow.
 * `"cookie"`: Store the state payload in an encrypted cookie. This keeps OAuth state stateless and avoids a database write during the start of the flow.
 * `"database"`: Store the state payload in the verification storage/table, set a signed state cookie when starting the flow, and validate the stored state against the signed cookie sent by the browser on the OAuth callback request.
 
-Defaults to `"database"` when a database is configured and `"cookie"` for database-less/stateless setups. If you only provide `secondaryStorage`, set this to `"database"` to store OAuth state there instead of in the cookie.
+Defaults to `"database"` when a database or `secondaryStorage` is configured, and to `"cookie"` only when neither is set (a fully stateless setup). With `secondaryStorage`, OAuth state is stored there automatically; you no longer need to set this manually.
 
 ### `storeAccountCookie`
 

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -856,6 +856,17 @@ describe("base context creation", () => {
 			});
 			expect(res.oauthConfig.skipStateCookieCheck).toBe(true);
 		});
+
+		it("should default storeStateStrategy to 'database' when only secondaryStorage is configured", async () => {
+			const res = await initBase({
+				secondaryStorage: {
+					get: vi.fn(),
+					set: vi.fn(),
+					delete: vi.fn(),
+				},
+			});
+			expect(res.oauthConfig.storeStateStrategy).toBe("database");
+		});
 	});
 
 	describe("app name", () => {

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -867,6 +867,28 @@ describe("base context creation", () => {
 			});
 			expect(res.oauthConfig.storeStateStrategy).toBe("database");
 		});
+
+		/**
+		 * Regression: secondaryStorage stores sessions and verification, not
+		 * account records, so a secondaryStorage-only setup must keep the account
+		 * cookie. Otherwise OAuth tokens have no durable home and getAccessToken
+		 * fails with ACCOUNT_NOT_FOUND on the next stateless invocation.
+		 *
+		 * @see https://github.com/better-auth/better-auth/issues/9581
+		 */
+		it("should keep storeAccountCookie enabled when only secondaryStorage is configured", async () => {
+			const res = await initBase({
+				secondaryStorage: {
+					get: vi.fn(),
+					set: vi.fn(),
+					delete: vi.fn(),
+				},
+			});
+			expect(
+				(res.options as { account?: { storeAccountCookie?: boolean } }).account
+					?.storeAccountCookie,
+			).toBe(true);
+		});
 	});
 
 	describe("app name", () => {

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -94,8 +94,12 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 	options: Options,
 	getDatabaseType: (database: Options["database"]) => string,
 ): Promise<AuthContext<Options>> {
-	//set default options for stateless mode
-	if (!options.database && !options.secondaryStorage) {
+	// secondaryStorage is a durable server-side store, so treat it like a database.
+	const isStateful = !!options.database || !!options.secondaryStorage;
+
+	// Cookie-cached sessions stand in for a durable store; only default them on
+	// when there is no durable store at all.
+	if (!isStateful) {
 		options = defu(options, {
 			session: {
 				cookieCache: {
@@ -105,8 +109,15 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 					maxAge: options.session?.expiresIn || 60 * 60 * 24 * 7, // match session expiresIn, default 7 days
 				},
 			},
+		}) as Options;
+	}
+
+	// secondaryStorage holds sessions and verification, not account records, so
+	// without a primary database the account (and its OAuth tokens) only has a
+	// durable home in a cookie. Keep it enabled whenever there is no database.
+	if (!options.database) {
+		options = defu(options, {
 			account: {
-				storeStateStrategy: "cookie" as const,
 				storeAccountCookie: true,
 			},
 		}) as Options;
@@ -263,7 +274,7 @@ Most of the features of Better Auth will not work correctly.`,
 		oauthConfig: {
 			storeStateStrategy:
 				options.account?.storeStateStrategy ||
-				(options.database || options.secondaryStorage ? "database" : "cookie"),
+				(isStateful ? "database" : "cookie"),
 			skipStateCookieCheck: !!options.account?.skipStateCookieCheck,
 		},
 		tables,
@@ -296,7 +307,6 @@ Most of the features of Better Auth will not work correctly.`,
 				// `refreshCache` is intended for fully stateless / DB-less setups.
 				// If a server-side store is configured, prefer fetching/refreshing from that source
 				// and disable stateless refresh behavior to avoid confusing/unsafe configurations.
-				const isStateful = !!options.database || !!options.secondaryStorage;
 				if (isStateful && refreshCache) {
 					logger.warn(
 						"[better-auth] `session.cookieCache.refreshCache` is enabled while `database` or `secondaryStorage` is configured. `refreshCache` is meant for stateless (DB-less) setups. Disabling `refreshCache` — remove it from your config to silence this warning.",

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -95,7 +95,7 @@ export async function createAuthContext<Options extends BetterAuthOptions>(
 	getDatabaseType: (database: Options["database"]) => string,
 ): Promise<AuthContext<Options>> {
 	//set default options for stateless mode
-	if (!options.database) {
+	if (!options.database && !options.secondaryStorage) {
 		options = defu(options, {
 			session: {
 				cookieCache: {
@@ -263,7 +263,7 @@ Most of the features of Better Auth will not work correctly.`,
 		oauthConfig: {
 			storeStateStrategy:
 				options.account?.storeStateStrategy ||
-				(options.database ? "database" : "cookie"),
+				(options.database || options.secondaryStorage ? "database" : "cookie"),
 			skipStateCookieCheck: !!options.account?.skipStateCookieCheck,
 		},
 		tables,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -321,7 +321,7 @@ export type AuthContext<Options extends BetterAuthOptions = BetterAuthOptions> =
 				 * - "cookie": Store state in an encrypted cookie (stateless)
 				 * - "database": Store state in the database
 				 *
-				 * @default "cookie"
+				 * @default "database" when `database` or `secondaryStorage` is configured, "cookie" otherwise
 				 */
 				storeStateStrategy: "database" | "cookie";
 			};

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1126,7 +1126,7 @@ export type BetterAuthOptions = {
 				 * - "cookie": Store state in an encrypted cookie (stateless)
 				 * - "database": Store state in the database
 				 *
-				 * @default "cookie"
+				 * @default "database" when `database` or `secondaryStorage` is configured, "cookie" otherwise
 				 */
 				storeStateStrategy?: "database" | "cookie";
 				/**


### PR DESCRIPTION
Closes #9581

A Better Auth setup that configures `secondaryStorage` without a primary `database` was storing OAuth sign-in state in a cookie. On platforms with request-size limits (such as AWS Lambda's 6MB cap), that cookie could grow large enough to break sign-in. `storeStateStrategy` now defaults to `"database"` whenever a `database` or `secondaryStorage` is configured, so OAuth state goes to the server-side store. Only a fully stateless setup, with neither configured, still defaults to `"cookie"`. The session cookie-cache defaults follow the same rule.

### Account tokens in secondaryStorage-only setups

`secondaryStorage` holds sessions and verification data, not account records. Without a primary `database`, the account cookie is the only durable home for the OAuth tokens that `getAccessToken` reads. This change keeps `storeAccountCookie` enabled whenever no `database` is configured, so a secondaryStorage-only deployment does not silently lose its tokens and later fail with `ACCOUNT_NOT_FOUND`.

### Migration

None required. Setups that explicitly set `account.storeStateStrategy` are unaffected. Setups relying on `secondaryStorage` now get the `"database"` default automatically and can drop any manual `storeStateStrategy: "database"` override.
