### PR TITLE
fix(generic-oauth): use absolute redirect_uri with allowedHosts dynamic baseURL

### DIFF
--- a/.changeset/generic-oauth-absolute-redirect-uri-allowedhosts.md
+++ b/.changeset/generic-oauth-absolute-redirect-uri-allowedhosts.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix `genericOAuth` plugin producing a relative `redirect_uri` when using `allowedHosts` dynamic baseURL config. The `init` closure captured `ctx.baseURL` (empty string at startup for dynamic config) instead of deriving the base from the per-request resolved URL available in `data.redirectURI`.

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2513,3 +2513,54 @@ describe("oauth2", async () => {
 		});
 	});
 });
+
+describe("generic-oauth with allowedHosts dynamic baseURL", async () => {
+	const dynamicServer = new OAuth2Server();
+	await dynamicServer.start();
+	const dynamicPort = Number(dynamicServer.issuer.url?.split(":")[2]!);
+
+	afterAll(async () => {
+		await dynamicServer.stop();
+	});
+
+	const { auth: dynamicAuth } = await getTestInstance({
+		baseURL: {
+			allowedHosts: ["localhost:3000"],
+		},
+		plugins: [
+			genericOAuth({
+				config: [
+					{
+						providerId: "dynamic-oauth-test",
+						discoveryUrl: `http://localhost:${dynamicPort}/.well-known/openid-configuration`,
+						clientId: "test-client-id",
+						clientSecret: "test-client-secret",
+					},
+				],
+			}),
+		],
+	});
+
+	beforeAll(async () => {
+		await dynamicServer.issuer.keys.generate("RS256");
+	});
+
+	it("should produce an absolute redirect_uri in the authorization URL", async () => {
+		const response = await dynamicAuth.handler(
+			new Request("http://localhost:3000/api/auth/sign-in/social", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					provider: "dynamic-oauth-test",
+					callbackURL: "/dashboard",
+					disableRedirect: true,
+				}),
+			}),
+		);
+		const json = (await response.json()) as { url?: string };
+		expect(json.url).toBeDefined();
+		const authUrl = new URL(json.url!);
+		const redirectUri = authUrl.searchParams.get("redirect_uri");
+		expect(redirectUri).toMatch(/^https?:\/\//);
+	});
+});

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -120,12 +120,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							state: data.state,
 							codeVerifier: c.pkce ? data.codeVerifier : undefined,
 							scopes: c.scopes || [],
-							redirectURI: (() => {
-								const idx = data.redirectURI.lastIndexOf("/callback/");
-								const base =
-									idx !== -1 ? data.redirectURI.slice(0, idx) : ctx.baseURL;
-								return `${base}/oauth2/callback/${c.providerId}`;
-							})(),
+							redirectURI: `${new URL(data.redirectURI).origin}${ctx.options.basePath}/oauth2/callback/${c.providerId}`,
 						});
 					},
 					async validateAuthorizationCode(data: {

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -120,7 +120,7 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							state: data.state,
 							codeVerifier: c.pkce ? data.codeVerifier : undefined,
 							scopes: c.scopes || [],
-							redirectURI: `${ctx.baseURL}/oauth2/callback/${c.providerId}`,
+							redirectURI: `${data.redirectURI.slice(0, data.redirectURI.lastIndexOf("/callback/"))}/oauth2/callback/${c.providerId}`,
 						});
 					},
 					async validateAuthorizationCode(data: {

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -120,7 +120,12 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							state: data.state,
 							codeVerifier: c.pkce ? data.codeVerifier : undefined,
 							scopes: c.scopes || [],
-							redirectURI: `${data.redirectURI.slice(0, data.redirectURI.lastIndexOf("/callback/"))}/oauth2/callback/${c.providerId}`,
+							redirectURI: (() => {
+								const idx = data.redirectURI.lastIndexOf("/callback/");
+								const base =
+									idx !== -1 ? data.redirectURI.slice(0, idx) : ctx.baseURL;
+								return `${base}/oauth2/callback/${c.providerId}`;
+							})(),
 						});
 					},
 					async validateAuthorizationCode(data: {


### PR DESCRIPTION
## Summary

- When `baseURL` is configured with `allowedHosts` (dynamic config), `genericOAuth`'s social sign-in path sent a **relative** `redirect_uri` (e.g. `/oauth2/callback/provider`) to OAuth providers like Auth0 — causing the flow to fail.
- Root cause: the `init` closure captures `ctx.baseURL` at startup. For dynamic `allowedHosts` config, `ctx.baseURL` is `""` because the URL is resolved per-request into a cloned context; the original `ctx` is never mutated.
- Fix: compose the `redirect_uri` the same way the working endpoint handlers do — `new URL(data.redirectURI).origin` (per-request origin from the social sign-in call) + `ctx.options.basePath` (normalised at startup by `createAuthContext`). This mirrors `ctx.context.baseURL` used in route handlers without needing string-matching on `/callback/`.

The bug only affected the **social sign-in path** (`/sign-in/social` → `createAuthorizationURL` in the `init` closure). The dedicated `signIn.oauth2` endpoint at `/sign-in/oauth2` was already correct as it uses `ctx.context.baseURL` (per-request).

## Test Plan

- [x] Added a regression test in `generic-oauth.test.ts`: creates a `getTestInstance` with `baseURL: { allowedHosts: ["localhost:3000"] }`, calls `/sign-in/social`, and asserts the `redirect_uri` in the returned authorization URL is absolute (`/^https?:\/\//`)
- [x] All 61 tests in `generic-oauth.test.ts` pass
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
