### PR TITLE
fix(captcha): exempt `/sign-in/email-otp` from captcha enforcement

### DIFF
--- a/.changeset/captcha-exempt-email-otp.md
+++ b/.changeset/captcha-exempt-email-otp.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Email OTP sign-in no longer fails with a missing-captcha-token error under the default captcha settings. If you intentionally want captcha on email OTP sign-in, add `/sign-in/email-otp` to `captcha({ endpoints })`.

--- a/packages/better-auth/src/plugins/captcha/captcha.test.ts
+++ b/packages/better-auth/src/plugins/captcha/captcha.test.ts
@@ -1,6 +1,8 @@
 import * as betterFetchModule from "@better-fetch/fetch";
 import { describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
+import { emailOTP } from "../email-otp";
+import { emailOTPClient } from "../email-otp/client";
 import { captcha } from ".";
 
 vi.mock("@better-fetch/fetch", async (importOriginal) => {
@@ -437,6 +439,83 @@ describe("captcha", async () => {
 			});
 
 			expect(res.error?.status).toBe(403);
+		});
+	});
+
+	describe("exempt paths", () => {
+		it("should not apply captcha to /sign-in/email-otp with default endpoints", async () => {
+			let capturedOtp = "";
+
+			const { client } = await getTestInstance(
+				{
+					plugins: [
+						captcha({
+							provider: "cloudflare-turnstile",
+							secretKey: "xx-secret-key",
+						}),
+						emailOTP({
+							async sendVerificationOTP({ otp }) {
+								capturedOtp = otp;
+							},
+						}),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [emailOTPClient()],
+					},
+				},
+			);
+
+			const send = await client.emailOtp.sendVerificationOtp({
+				email: "test@test.com",
+				type: "sign-in",
+			});
+			expect(send.data?.success).toBe(true);
+			expect(capturedOtp).toHaveLength(6);
+
+			const res = await client.signIn.emailOtp({
+				email: "test@test.com",
+				otp: capturedOtp,
+			});
+
+			// Captcha must be bypassed; the sign-in flow completes and yields a session.
+			expect(res.error).toBeNull();
+			expect(res.data?.token).toEqual(expect.any(String));
+			expect(res.data?.user?.email).toBe("test@test.com");
+		});
+
+		it("should still apply captcha when /sign-in/email-otp is explicitly opted in", async () => {
+			const { client } = await getTestInstance(
+				{
+					plugins: [
+						captcha({
+							provider: "cloudflare-turnstile",
+							secretKey: "xx-secret-key",
+							endpoints: ["/sign-in/email-otp"],
+						}),
+						emailOTP({
+							sendVerificationOTP: async () => {},
+						}),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [emailOTPClient()],
+					},
+				},
+			);
+
+			const res = await client.signIn.emailOtp({
+				email: "test@test.com",
+				otp: "000000",
+			});
+
+			// Captcha middleware must short-circuit before the OTP is consulted.
+			expect(res.error).toMatchObject({
+				status: 400,
+				code: "MISSING_RESPONSE",
+			});
 		});
 	});
 });

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -39,9 +39,9 @@ export const captcha = (options: CaptchaOptions) =>
 				if (!pathname.startsWith("/")) pathname = "/" + pathname;
 
 				// we don't want to accidentally block email-otp endpoint.
-				const blockedPaths = ["/sign-in/email-otp"].reduce<string[]>(
+				const exemptPaths = ["/sign-in/email-otp"].reduce<string[]>(
 					(acc, curr) => {
-						// if custom endpoints includes a blocked path, we dont include the blocked path in the blocked paths array
+						// if custom endpoints include an exempt path, we don't include the exempt path in the exempt paths array
 						if (options.endpoints?.length && options.endpoints.includes(curr)) {
 							return acc;
 						}
@@ -51,7 +51,8 @@ export const captcha = (options: CaptchaOptions) =>
 				);
 				const match = endpoints.some((endpoint) => {
 					return (
-						pathname.includes(endpoint) && !blockedPaths.includes(endpoint)
+						pathname.includes(endpoint) &&
+						!exemptPaths.some((p) => pathname.includes(p))
 					);
 				});
 


### PR DESCRIPTION
Related PR #8339

The existing guard was not performing the comparison properly.