### PR TITLE
fix(oauth-provider): preserve colons in Basic Auth client secret

### DIFF
--- a/.changeset/oauth-provider-basic-auth-secret-colon.md
+++ b/.changeset/oauth-provider-basic-auth-secret-colon.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Basic Auth authentication now accepts `client_secret` values that contain `:`. Previously `/token`, `/revoke`, and `/introspect` rejected valid credentials for any confidential client whose secret contained a colon.

--- a/packages/oauth-provider/src/utils/basic-auth.test.ts
+++ b/packages/oauth-provider/src/utils/basic-auth.test.ts
@@ -1,0 +1,39 @@
+import { base64 } from "@better-auth/utils/base64";
+import { describe, expect, it } from "vitest";
+
+import { basicToClientCredentials } from "./index";
+
+function encodeBasic(clientId: string, clientSecret: string) {
+	const raw = `${clientId}:${clientSecret}`;
+	const encoded = base64.encode(new TextEncoder().encode(raw));
+	return `Basic ${encoded}`;
+}
+
+/**
+ * @see https://datatracker.ietf.org/doc/html/rfc7617#section-2
+ */
+describe("basicToClientCredentials", () => {
+	it("preserves colons inside client_secret per RFC 7617", () => {
+		const clientId = "cid";
+		const clientSecret = "pa:ss:word";
+
+		const result = basicToClientCredentials(
+			encodeBasic(clientId, clientSecret),
+		);
+
+		expect(result).toBeDefined();
+		expect(result?.client_id).toBe(clientId);
+		expect(result?.client_secret).toBe(clientSecret);
+	});
+
+	it("keeps a trailing colon as part of client_secret", () => {
+		const clientId = "cid";
+		const clientSecret = "secret:";
+
+		const result = basicToClientCredentials(
+			encodeBasic(clientId, clientSecret),
+		);
+
+		expect(result?.client_secret).toBe(clientSecret);
+	});
+});

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -379,13 +379,15 @@ export function basicToClientCredentials(authorization: string) {
 	if (authorization.startsWith("Basic ")) {
 		const encoded = authorization.replace("Basic ", "");
 		const decoded = new TextDecoder().decode(base64.decode(encoded));
-		if (!decoded.includes(":")) {
+		const separatorIndex = decoded.indexOf(":");
+		if (separatorIndex === -1) {
 			throw new APIError("BAD_REQUEST", {
 				error_description: "invalid authorization header format",
 				error: "invalid_client",
 			});
 		}
-		const [id, secret] = decoded.split(":", 2);
+		const id = decoded.slice(0, separatorIndex);
+		const secret = decoded.slice(separatorIndex + 1);
 		if (!id || !secret) {
 			throw new APIError("BAD_REQUEST", {
 				error_description: "invalid authorization header format",


### PR DESCRIPTION
> [!NOTE]
> Furthermore, a user-id containing a colon character is invalid, as
   the first colon in a user-pass string separates user-id and password
   from one another; text after the first colon is part of the password.
   User-ids containing colons cannot be encoded in user-pass strings.
> 
>https://datatracker.ietf.org/doc/html/rfc7617#section-2 

basicToClientCredentials previously used decoded.split(":", 2), which truncates the result array instead of capping the number of splits. Per RFC 7617 section 2, only the first colon separates user-id from password, so any further colons belong to the password. A client_secret containing : was silently shortened to the substring before the first colon, breaking /token, /revoke, and /introspect authentication for affected confidential clients.

Split on indexOf(":") so the full secret is preserved.