### PR TITLE
fix(sso): normalize OIDC signup_disabled error in callback redirect

### DIFF
--- a/.changeset/sso-oidc-signup-disabled-underscore.md
+++ b/.changeset/sso-oidc-signup-disabled-underscore.md
@@ -2,4 +2,4 @@
 "@better-auth/sso": patch
 ---
 
-Normalize the SSO OIDC `signup disabled` error to `signup_disabled` when redirecting after `disableImplicitSignUp` blocks an unknown user, matching the convention used by SAML, the core OAuth callback, and the generic OAuth plugin.
+OIDC sign-in blocked by `disableImplicitSignUp` now redirects with `?error=signup_disabled` instead of `?error=signup%20disabled`, so the error code is consistent with the rest of Better Auth.

--- a/.changeset/sso-oidc-signup-disabled-underscore.md
+++ b/.changeset/sso-oidc-signup-disabled-underscore.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+Normalize the SSO OIDC `signup disabled` error to `signup_disabled` when redirecting after `disableImplicitSignUp` blocks an unknown user, matching the convention used by SAML, the core OAuth callback, and the generic OAuth plugin.

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -572,6 +572,9 @@ describe("SSO disable implicit sign in", async () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9412
+	 */
 	it("should not create user with SSO provider when sign ups are disabled", async () => {
 		const headers = new Headers();
 		const res = await authClient.signIn.sso({
@@ -587,7 +590,7 @@ describe("SSO disable implicit sign in", async () => {
 			"redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fauth%2Fsso%2Fcallback%2Ftest",
 		);
 		const { callbackURL } = await simulateOAuthFlow(res.url, headers);
-		expect(callbackURL).toContain("/api/auth/error?error=signup disabled");
+		expect(callbackURL).toContain("/api/auth/error?error=signup_disabled");
 	});
 
 	it("should create user with SSO provider when sign ups are disabled but sign up is requested", async () => {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1680,7 +1680,9 @@ async function handleOIDCCallback(
 		isTrustedProvider,
 	});
 	if (linked.error) {
-		throw ctx.redirect(`${errorURL || callbackURL}?error=${linked.error}`);
+		throw ctx.redirect(
+			`${errorURL || callbackURL}?error=${linked.error.split(" ").join("_")}`,
+		);
 	}
 	const { session, user } = linked.data!;
 


### PR DESCRIPTION
## Summary

- The `@better-auth/sso` OIDC callback was redirecting with `?error=signup%20disabled` (space-encoded) when `disableImplicitSignUp` blocked an unknown user, while every other path that uses `handleOAuthUserInfo` — SAML in this same package, the core OAuth callback, and the generic OAuth plugin — normalizes that error to `signup_disabled` before putting it in the redirect URL.
- This PR applies the same `split(" ").join("_")` normalization to the OIDC callback in `packages/sso/src/routes/sso.ts` so the emitted error code is consistent across SSO transports and matches what consumers parse against everywhere else in better-auth.

## Fixes

Closes #9412

## Changes

- `packages/sso/src/routes/sso.ts` — normalize `linked.error` to underscored form before appending it to the redirect URL in `handleOIDCCallback`.
- `packages/sso/src/oidc.test.ts` — update the assertion for the "should not create user with SSO provider when sign ups are disabled" test to expect `error=signup_disabled` (was previously asserting the buggy `error=signup disabled`); add an `@see` link to issue #9412 so this stays tagged as a regression test.
- `.changeset/sso-oidc-signup-disabled-underscore.md` — patch changeset for `@better-auth/sso`.

## Test plan

- [x] `pnpm vitest run packages/sso/src/oidc.test.ts packages/sso/src/saml.test.ts` — 141 passed, 2 todo, 0 failures.
- [x] `pnpm --filter @better-auth/sso typecheck` passes.
- [x] Verified `handleOAuthUserInfo` only returns the unnormalized `"signup disabled"` error from `packages/better-auth/src/oauth2/link-account.ts`, so this is a SSO-callsite fix rather than a change to the shared helper. All other callers (`callback.ts`, `generic-oauth/routes.ts`, `saml-pipeline.ts`) already normalize identically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the OIDC callback in `@better-auth/sso` to redirect with `error=signup_disabled` when `disableImplicitSignUp` blocks a new user. Aligns OIDC with SAML and other OAuth paths so clients can parse a consistent error code.

- **Bug Fixes**
  - Normalize `linked.error` in `handleOIDCCallback` before adding it to the redirect URL.
  - Update the OIDC test to expect `error=signup_disabled`; add a patch changeset for `@better-auth/sso` with end-user changelog wording.

<sup>Written for commit acf0c46ed37b681e7b1c29f003907cc16c0c1338. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

