### PR TITLE
docs: clarify 2fa sign-in enforcement scope

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -109,7 +109,7 @@ When 2FA is enabled:
 Note: `twoFactorEnabled` won’t be set to `true` until the user verifies their TOTP code. Learn more about verifying TOTP in the [TOTP section](#totp). You can skip verification by setting `skipVerificationOnEnable` to true in your plugin config.
 
 <Callout type="warn">
-  By default, Two Factor requires a credential (password) account. To allow passwordless users (passkeys, magic links, email OTP, OAuth/social, or anonymous) to enable and manage 2FA, set `allowPasswordless: true`. This option does not change which sign-in methods are challenged for 2FA.
+  By default, the two-factor plugin requires a credential (password) account. To allow passwordless users (passkeys, magic links, email OTP, OAuth/social, or anonymous) to enable and manage 2FA, set `allowPasswordless: true`. This option does not change which sign-in methods are challenged for 2FA.
 </Callout>
 
 ### Sign In with 2FA

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -109,12 +109,14 @@ When 2FA is enabled:
 Note: `twoFactorEnabled` won’t be set to `true` until the user verifies their TOTP code. Learn more about verifying TOTP in the [TOTP section](#totp). You can skip verification by setting `skipVerificationOnEnable` to true in your plugin config.
 
 <Callout type="warn">
-  By default, Two Factor requires a credential (password) account. To allow passwordless users (passkeys, magic links, email OTP, OAuth/social, or anonymous), set `allowPasswordless: true`.
+  By default, Two Factor requires a credential (password) account. To allow passwordless users (passkeys, magic links, email OTP, OAuth/social, or anonymous) to enable and manage 2FA, set `allowPasswordless: true`. This option does not change which sign-in methods are challenged for 2FA.
 </Callout>
 
 ### Sign In with 2FA
 
-When a user with 2FA enabled tries to sign in via email, the response object will contain `twoFactorRedirect` set to `true` and `twoFactorMethods` — an array of the 2FA methods available for the user (e.g. `["totp"]`, `["totp", "otp"]`). Use `twoFactorMethods` to decide which verification UI to show.
+When a user with 2FA enabled tries to sign in via email, username, or phone number, the response object will contain `twoFactorRedirect` set to `true` and `twoFactorMethods` — an array of the 2FA methods available for the user (e.g. `["totp"]`, `["totp", "otp"]`). Use `twoFactorMethods` to decide which verification UI to show.
+
+By default, 2FA sign-in enforcement applies to the credential-based sign-in endpoints: `/sign-in/email`, `/sign-in/username`, and `/sign-in/phone-number`. Non-credential sign-in methods such as email OTP, magic link, OAuth/social, passkey, anonymous, and similar passwordless flows are not gated by 2FA by default.
 
 You can handle this in the `onSuccess` callback or by providing a `onTwoFactorRedirect` callback in the plugin config.
 

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -118,6 +118,8 @@ When a user with 2FA enabled tries to sign in via email, username, or phone numb
 
 By default, 2FA sign-in enforcement applies to the credential-based sign-in endpoints: `/sign-in/email`, `/sign-in/username`, and `/sign-in/phone-number`. Non-credential sign-in methods such as email OTP, magic link, OAuth/social, passkey, anonymous, and similar passwordless flows are not gated by 2FA by default.
 
+If your app needs to require 2FA for those sign-in methods, add custom hook handling for those endpoints and redirect users into your 2FA verification flow before treating the sign-in as complete.
+
 You can handle this in the `onSuccess` callback or by providing a `onTwoFactorRedirect` callback in the plugin config.
 
 ```tsx
@@ -509,7 +511,7 @@ export const twoFactorTableFields = [
 
 **skipVerificationOnEnable**: Skip the verification process before enabling two factor for a user.
 
-**allowPasswordless**: Allow enabling and managing 2FA without a password for users that do not have a credential account. Password is still required if a credential account exists.
+**allowPasswordless**: Allow enabling and managing 2FA without a password for users that do not have a credential account. Password is still required if a credential account exists. This option does not change which sign-in methods are challenged for 2FA.
 
 **Issuer**: The issuer is the name of your application. It's used to generate TOTP codes. It'll be displayed in the authenticator apps.
 


### PR DESCRIPTION
## Summary

- Clarifies that `allowPasswordless` only allows passwordless users to enable and manage 2FA.
- Documents that default 2FA sign-in enforcement applies only to `/sign-in/email`, `/sign-in/username`, and `/sign-in/phone-number`.
- Notes that email OTP, magic link, OAuth/social, passkey, anonymous, and similar passwordless flows are not gated by 2FA by default.
- Adds guidance that apps needing 2FA on non-credential sign-ins should add custom hook handling for those endpoints.

Refs #9552

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies 2FA enforcement scope and that `allowPasswordless` only lets passwordless users enable/manage 2FA; it does not change which sign-in methods are challenged. 2FA challenges run only on credential endpoints (`/sign-in/email`, `/sign-in/username`, `/sign-in/phone-number`); passwordless flows (email OTP, magic link, OAuth/social, passkey, anonymous) are not gated by default, and apps can add hooks to require 2FA and redirect before completing sign-in (refs #9552).

<sup>Written for commit 15b7aa08967de4b6858ebe6267cd07ba59944255. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

