### PR TITLE
fix: tighten `changeEmail` config gate and encode callbackURL

### DIFF
--- a/.changeset/change-email-callback-url-and-gate.md
+++ b/.changeset/change-email-callback-url-and-gate.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`changeEmail` no longer silently returns `{ status: true }` when the flow cannot complete: if `emailVerification.sendVerificationEmail` is missing for a verified user, the request now fails with a 400 error. `callbackURL` values are also URL-encoded, so callbacks that carry their own query string survive the round trip through verify-email links.

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -765,3 +765,80 @@ describe("change-email without sendVerificationEmail", async () => {
 		});
 	});
 });
+
+describe("change-email callbackURL preservation", async () => {
+	const sendChangeEmail = vi.fn();
+	const { client, testUser, db, signInWithTestUser } = await getTestInstance({
+		emailVerification: {
+			async sendVerificationEmail() {},
+		},
+		user: {
+			changeEmail: {
+				enabled: true,
+				sendChangeEmailConfirmation: async ({ url }) => {
+					sendChangeEmail(url);
+				},
+			},
+		},
+	});
+
+	it("preserves a callbackURL that carries its own query string", async () => {
+		// Verified user routes through the sendChangeEmailConfirmation branch.
+		await db.update({
+			model: "user",
+			update: { emailVerified: true },
+			where: [{ field: "email", value: testUser.email }],
+		});
+
+		const { runWithUser } = await signInWithTestUser();
+		const callback = "/dashboard?tab=settings&from=email";
+
+		await runWithUser(async () => {
+			await client.changeEmail({
+				newEmail: "new-email@email.com",
+				callbackURL: callback,
+			});
+		});
+
+		expect(sendChangeEmail).toHaveBeenCalledOnce();
+		const sent = sendChangeEmail.mock.calls[0]?.[0] as string;
+		expect(sent).toBeTypeOf("string");
+
+		// Round-tripping through URLSearchParams recovers the callbackURL verbatim.
+		const parsed = new URL(sent);
+		expect(parsed.searchParams.get("callbackURL")).toBe(callback);
+		// The trailing `from=email` segment must not leak into the outer URL.
+		expect(parsed.searchParams.get("from")).toBeNull();
+	});
+});
+
+describe("change-email rejects confirmation-only config for verified users", async () => {
+	// Verified user with sendChangeEmailConfirmation but no sendVerificationEmail
+	// cannot complete the flow: the confirmation step generates a second token
+	// that requires sendVerificationEmail to deliver. The request must fail at
+	// the gate rather than return a misleading success.
+	const { client, testUser, db, signInWithTestUser } = await getTestInstance({
+		user: {
+			changeEmail: {
+				enabled: true,
+				sendChangeEmailConfirmation: async () => {},
+			},
+		},
+	});
+
+	it("returns 400 when sendVerificationEmail is not configured", async () => {
+		await db.update({
+			model: "user",
+			update: { emailVerified: true },
+			where: [{ field: "email", value: testUser.email }],
+		});
+
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
+			const res = await client.changeEmail({
+				newEmail: "unreachable@email.com",
+			});
+			expect(res.error?.status).toBe(400);
+		});
+	});
+});

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -741,11 +741,12 @@ export const changeEmail = createAuthEndpoint(
 		const canUpdateWithoutVerification =
 			ctx.context.session.user.emailVerified !== true &&
 			ctx.context.options.user.changeEmail.updateEmailWithoutVerification;
-		const canSendConfirmation =
-			ctx.context.session.user.emailVerified &&
-			ctx.context.options.user.changeEmail.sendChangeEmailConfirmation;
 		const canSendVerification =
 			ctx.context.options.emailVerification?.sendVerificationEmail;
+		const canSendConfirmation =
+			canSendVerification &&
+			ctx.context.session.user.emailVerified &&
+			ctx.context.options.user.changeEmail.sendChangeEmailConfirmation;
 
 		if (
 			!canUpdateWithoutVerification &&
@@ -800,9 +801,9 @@ export const changeEmail = createAuthEndpoint(
 				);
 				const url = `${
 					ctx.context.baseURL
-				}/verify-email?token=${token}&callbackURL=${
-					ctx.body.callbackURL || "/"
-				}`;
+				}/verify-email?token=${token}&callbackURL=${encodeURIComponent(
+					ctx.body.callbackURL || "/",
+				)}`;
 				await ctx.context.runInBackgroundOrAwait(
 					canSendVerification(
 						{
@@ -838,7 +839,9 @@ export const changeEmail = createAuthEndpoint(
 			);
 			const url = `${
 				ctx.context.baseURL
-			}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;
+			}/verify-email?token=${token}&callbackURL=${encodeURIComponent(
+				ctx.body.callbackURL || "/",
+			)}`;
 			await ctx.context.runInBackgroundOrAwait(
 				canSendConfirmation(
 					{
@@ -873,7 +876,9 @@ export const changeEmail = createAuthEndpoint(
 		);
 		const url = `${
 			ctx.context.baseURL
-		}/verify-email?token=${token}&callbackURL=${ctx.body.callbackURL || "/"}`;
+		}/verify-email?token=${token}&callbackURL=${encodeURIComponent(
+			ctx.body.callbackURL || "/",
+		)}`;
 		await ctx.context.runInBackgroundOrAwait(
 			canSendVerification(
 				{


### PR DESCRIPTION
- `changeEmail` now rejects verified-user requests with 400 when `emailVerification.sendVerificationEmail` is not configured. The confirmation flow generates a second token that needs that callback to deliver; without it, the endpoint previously returned `{ status: true }` while the email update never completed.

- The three `changeEmail` branches that build the verify-email URL now apply `encodeURIComponent` to `callbackURL`, matching `deleteUser`, `sendVerificationEmail`, and the `change-email-confirmation` redirect. A `callbackURL` that carries its own query string is preserved verbatim instead of splitting into sibling parameters of the outer auth URL.