### PR TITLE
fix(kysely-adapter): report SQLite tables as non-views in introspector

### DIFF
--- a/.changeset/kysely-sqlite-introspector-is-view.md
+++ b/.changeset/kysely-sqlite-introspector-is-view.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/kysely-adapter": patch
+---
+
+Fix the bundled SQLite introspectors (`BunSqliteDialect`, `NodeSqliteDialect`) so that tables are no longer reported as views. The introspector queries only rows where `type = 'table'`, but each `TableMetadata` was returned with `isView: true`. Consumers that branch on `isView` (CLI codegen, schema diffing) now see the correct value.

--- a/packages/kysely-adapter/src/bun-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/bun-sqlite-dialect.ts
@@ -252,7 +252,7 @@ class BunSqliteIntrospector implements DatabaseIntrospector {
 				isAutoIncrementing: col.name === autoIncrementCol,
 				hasDefaultValue: col.dflt_value != null,
 			})),
-			isView: true,
+			isView: false,
 		};
 	}
 }

--- a/packages/kysely-adapter/src/node-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/node-sqlite-dialect.ts
@@ -254,7 +254,7 @@ class NodeSqliteIntrospector implements DatabaseIntrospector {
 				isAutoIncrementing: col.name === autoIncrementCol,
 				hasDefaultValue: col.dflt_value != null,
 			})),
-			isView: true,
+			isView: false,
 		};
 	}
 }

--- a/packages/kysely-adapter/src/sqlite-introspector.test.ts
+++ b/packages/kysely-adapter/src/sqlite-introspector.test.ts
@@ -1,0 +1,66 @@
+import type { SQLInputValue } from "node:sqlite";
+import { DatabaseSync } from "node:sqlite";
+import { Kysely } from "kysely";
+import { describe, expect, it } from "vitest";
+import { BunSqliteDialect } from "./bun-sqlite-dialect";
+import { NodeSqliteDialect } from "./node-sqlite-dialect";
+
+function createSchema(db: DatabaseSync) {
+	for (const sql of [
+		"CREATE TABLE accounts (id INTEGER PRIMARY KEY, name TEXT)",
+		"CREATE TABLE sessions (id INTEGER PRIMARY KEY, token TEXT)",
+		"CREATE VIEW active_accounts AS SELECT * FROM accounts",
+	]) {
+		db.prepare(sql).run();
+	}
+}
+
+function asBunLikeDatabase(db: DatabaseSync) {
+	return {
+		prepare(sql: string) {
+			const stmt = db.prepare(sql);
+			return {
+				all(params: SQLInputValue[]) {
+					return stmt.all(...(params ?? []));
+				},
+			};
+		},
+		close() {
+			db.close();
+		},
+	} as unknown as ConstructorParameters<typeof BunSqliteDialect>[0]["database"];
+}
+
+describe("sqlite introspector", () => {
+	it("NodeSqliteDialect reports tables as non-views", async () => {
+		const sqlite = new DatabaseSync(":memory:");
+		createSchema(sqlite);
+		const db = new Kysely({
+			dialect: new NodeSqliteDialect({ database: sqlite }),
+		});
+
+		const tables = await db.introspection.getTables();
+		await db.destroy();
+
+		expect(tables.length).toBeGreaterThan(0);
+		for (const table of tables) {
+			expect(table.isView).toBe(false);
+		}
+	});
+
+	it("BunSqliteDialect reports tables as non-views", async () => {
+		const sqlite = new DatabaseSync(":memory:");
+		createSchema(sqlite);
+		const db = new Kysely({
+			dialect: new BunSqliteDialect({ database: asBunLikeDatabase(sqlite) }),
+		});
+
+		const tables = await db.introspection.getTables();
+		await db.destroy();
+
+		expect(tables.length).toBeGreaterThan(0);
+		for (const table of tables) {
+			expect(table.isView).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
> [!NOTE]
> Reference:
> - https://www.sqlite.org/schematab.html#interpretation_of_the_schema_table
> - https://github.com/kysely-org/kysely/blob/ce247b248efa6221ddb772618283604909ecb571/src/dialect/sqlite/sqlite-introspector.ts#L61-L66

The bundled SQLite introspectors for BunSqliteDialect and NodeSqliteDialect filter the catalog with `WHERE type = 'table'` but built each TableMetadata with `isView: true`. Consumers that branch on `isView` (CLI codegen, schema diffing) saw every table marked as a view. Set `isView: false` to match the underlying query, mirroring the D1 dialect which derives the flag from the `type` column.