### PR TITLE
fix(organization): reject invitation team ids containing a comma

### DIFF
--- a/.changeset/organization-invite-reject-comma-team-id.md
+++ b/.changeset/organization-invite-reject-comma-team-id.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Organization invitations no longer silently route an invitee to the wrong team when `advanced.database.generateId` returns team ids containing a comma. The invitation API now rejects such ids with an `INVALID_TEAM_ID` error.

--- a/packages/better-auth/src/plugins/organization/error-codes.ts
+++ b/packages/better-auth/src/plugins/organization/error-codes.ts
@@ -92,4 +92,5 @@ export const ORGANIZATION_ERROR_CODES = defineErrorCodes({
 	CANNOT_DELETE_A_PRE_DEFINED_ROLE: "Cannot delete a pre-defined role",
 	ROLE_IS_ASSIGNED_TO_MEMBERS:
 		"Cannot delete a role that is assigned to members. Please reassign the members to a different role first",
+	INVALID_TEAM_ID: "Team id contains a reserved character",
 });

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -404,6 +404,23 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 			}
 
 			if (
+				ctx.context.orgOptions.teams?.enabled &&
+				"teamId" in ctx.body &&
+				ctx.body.teamId
+			) {
+				const requestedTeamIds =
+					typeof ctx.body.teamId === "string"
+						? [ctx.body.teamId]
+						: (ctx.body.teamId as string[]);
+				if (requestedTeamIds.some((id) => id.includes(","))) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.INVALID_TEAM_ID,
+					);
+				}
+			}
+
+			if (
 				ctx.context.orgOptions.teams &&
 				ctx.context.orgOptions.teams.enabled &&
 				typeof ctx.context.orgOptions.teams.maximumMembersPerTeam !==

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -1306,3 +1306,75 @@ describe("multi team support", async () => {
 		expect(stillTeam2Member).toBeUndefined();
 	});
 });
+
+describe("invitation with team id containing comma", async () => {
+	const { auth, signInWithTestUser } = await getTestInstance(
+		{
+			advanced: {
+				database: {
+					generateId: ({ model }) => {
+						if (model === "team") {
+							return `team,id,${crypto.randomUUID()}`;
+						}
+						return crypto.randomUUID();
+					},
+				},
+			},
+			plugins: [
+				organization({
+					async sendInvitationEmail() {},
+					teams: { enabled: true },
+				}),
+			],
+			logger: { level: "error" },
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => ({
+							data: { ...user, emailVerified: true },
+						}),
+					},
+				},
+			},
+		},
+		{ testWith: "sqlite" },
+	);
+
+	const admin = await signInWithTestUser();
+
+	const org = await auth.api.createOrganization({
+		headers: admin.headers,
+		body: { name: "Comma Org", slug: "comma-org" },
+	});
+	if (!org) throw new Error("failed to create organization");
+	const organizationId = org.id;
+
+	const team = await auth.api.createTeam({
+		headers: admin.headers,
+		body: { name: "Comma Team", organizationId },
+	});
+
+	it("seeds a team whose generated id contains the storage separator", () => {
+		expect(team.id).toContain(",");
+	});
+
+	it.each([
+		{ name: "string body", teamId: team.id },
+		{ name: "array body", teamId: [team.id] },
+	])("rejects createInvitation with $name", async ({ teamId }) => {
+		await expect(
+			auth.api.createInvitation({
+				headers: admin.headers,
+				body: {
+					email: "comma-invitee@email.com",
+					role: "member",
+					organizationId,
+					teamId,
+				},
+			}),
+		).rejects.toMatchObject({
+			status: "BAD_REQUEST",
+			body: { code: "INVALID_TEAM_ID" },
+		});
+	});
+});


### PR DESCRIPTION
The invitation row stores multiple teams as a comma-joined string in the single `teamId` column and accept splits on `,`. If a consumer's `advanced.database.generateId` yields ids that include a comma the invitee joins the wrong team (FK 500 or silent mis-routing). Validate the request payload before the join so the bad shape never reaches storage.