### PR TITLE
fix(client): decode escape sequences in parseJSON quoted strings

### DIFF
--- a/.changeset/client-parser-string-escapes.md
+++ b/.changeset/client-parser-string-escapes.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`parseJSON` now decodes escape sequences (`\n`, `\\`, `\uXXXX`, escaped quotes) in quoted strings. Values such as organization metadata that round-trip through `JSON.stringify` and back no longer come out with raw escape characters in place of the original characters.

--- a/.changeset/client-parser-string-escapes.md
+++ b/.changeset/client-parser-string-escapes.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-`parseJSON` now decodes escape sequences (`\n`, `\\`, `\uXXXX`, escaped quotes) in quoted strings. Values such as organization metadata that round-trip through `JSON.stringify` and back no longer come out with raw escape characters in place of the original characters.
+`parseJSON` now decodes escape sequences such as `\n`, `\\`, and `\uXXXX` in quoted strings. Values such as organization metadata that round-trip through `JSON.stringify` and back no longer come out with raw escape characters in place of the original characters.

--- a/packages/better-auth/src/client/parser.test.ts
+++ b/packages/better-auth/src/client/parser.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseJSON } from "./parser";
+
+describe("parseJSON", () => {
+	it.each([
+		{ name: "newline", input: '"hello\\nworld"', expected: "hello\nworld" },
+		{ name: "tab", input: '"with\\ttab"', expected: "with\ttab" },
+		{ name: "unicode escape", input: '"caf\\u00e9"', expected: "café" },
+		{ name: "backslash", input: '"back\\\\slash"', expected: "back\\slash" },
+		{
+			name: "escaped quote",
+			input: '"quote\\"inside"',
+			expected: 'quote"inside',
+		},
+	])("decodes $name inside quoted strings", ({ input, expected }) => {
+		expect(parseJSON(input)).toBe(expected);
+	});
+
+	it.each([
+		"plain",
+		"with\nnewline",
+		"with\ttab",
+		"with \\ backslash",
+		'with " quote',
+		"unicode: 안녕하세요",
+	])("round-trips %j through JSON.stringify", (value) => {
+		expect(parseJSON(JSON.stringify(value))).toBe(value);
+	});
+
+	it("still parses objects and arrays", () => {
+		expect(parseJSON('{"a":1,"b":"x"}')).toEqual({ a: 1, b: "x" });
+		expect(parseJSON("[1,2,3]")).toEqual([1, 2, 3]);
+	});
+
+	it.each([
+		{ input: "true", expected: true },
+		{ input: "false", expected: false },
+		{ input: "null", expected: null },
+		{ input: "42", expected: 42 },
+	])("parses primitive $input", ({ input, expected }) => {
+		expect(parseJSON(input)).toBe(expected);
+	});
+
+	it("preserves non-JSON strings as-is when not strict", () => {
+		expect(parseJSON("not json", { strict: false })).toBe("not json");
+	});
+});

--- a/packages/better-auth/src/client/parser.ts
+++ b/packages/better-auth/src/client/parser.ts
@@ -95,15 +95,6 @@ function betterJSONParse<T = unknown>(
 
 	const trimmed = value.trim();
 
-	if (
-		trimmed.length > 0 &&
-		trimmed[0] === '"' &&
-		trimmed.endsWith('"') &&
-		!trimmed.slice(1, -1).includes('"')
-	) {
-		return trimmed.slice(1, -1) as T;
-	}
-
 	const lowerValue = trimmed.toLowerCase();
 	if (lowerValue.length <= 9 && lowerValue in SPECIAL_VALUES) {
 		return SPECIAL_VALUES[lowerValue as keyof typeof SPECIAL_VALUES] as T;


### PR DESCRIPTION
The fast-path returned `trimmed.slice(1, -1)` whenever the input started and ended with `"` without an inner unescaped `"`, leaving `\n`, `\\`, `\uXXXX`, and similar escapes unprocessed. JSON-encoded strings round- tripping through `parseJSON(JSON.stringify(value))` ended up with the raw escape characters instead of the original value. Drop the short circuit and let `JSON.parse` handle every quoted form.