### PR TITLE
feat(auth): add routeInputs option for custom request body fields

### DIFF
--- a/.changeset/custom-route-inputs.md
+++ b/.changeset/custom-route-inputs.md
@@ -1,0 +1,6 @@
+---
+"better-auth": minor
+"@better-auth/core": minor
+---
+
+Add routeInputs for validating custom request body fields on auth routes.

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -97,7 +97,7 @@ To sign a user in, you can use the `signIn.email` function provided by the clien
 </APIMethod>
 
 <Callout>
-  These are the default properties for the sign in email endpoint, however it's possible that with [additional fields](/docs/concepts/typescript#additional-fields) or special plugins you can pass different properties to the endpoint.
+  These are the default properties for the sign in email endpoint. You can add request-only fields with [`routeInputs`](/docs/reference/options#routeinputs), and plugins can also add route inputs that are available in hooks.
 </Callout>
 
 ### Sign Out

--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -236,6 +236,40 @@ This will add an `age` field to the `user` table and all `user` returning endpoi
   Don't store sensitive information in the `user` or `session` table. Create a new table if you need to store sensitive information.
 </Callout>
 
+### Route Inputs
+
+Plugins can add validated request body fields to existing auth routes with `routeInputs`. These fields are available on `ctx.body` in hooks and endpoint handlers, but they are not database fields unless you also add schema fields.
+
+```ts title="plugin.ts"
+import type { BetterAuthPlugin } from "better-auth";
+import { createAuthMiddleware } from "better-auth/api";
+
+export const tenantPlugin = () => {
+	return {
+		id: "tenant-plugin",
+		routeInputs: {
+			"/sign-in/email": {
+				tenantId: {
+					type: "string",
+					required: true,
+				},
+			},
+		},
+		hooks: {
+			before: [
+				{
+					matcher: (ctx) => ctx.path === "/sign-in/email",
+					handler: createAuthMiddleware(async (ctx) => {
+						const tenantId = ctx.body.tenantId;
+						// validate tenant access
+					}),
+				},
+			],
+		},
+	} satisfies BetterAuthPlugin;
+};
+```
+
 ### Hooks
 
 Hooks are used to run code before or after an action is performed, either from a client or directly on the server. You can add hooks to the server by passing a `hooks` object, which should contain `before` and `after` properties.

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -375,6 +375,36 @@ export const auth = betterAuth({
 })
 ```
 
+## `routeInputs`
+
+Add custom request body fields to auth routes. Route keys use Better Auth's internal path form, such as `/sign-in/email`, and are independent of `basePath`.
+
+```ts
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+	routeInputs: {
+		"/sign-in/email": {
+			tenantId: {
+				type: "string",
+				required: true,
+				description: "Tenant identifier",
+			},
+		},
+		"/sign-up/email": {
+			inviteCode: {
+				type: "string",
+				required: false,
+			},
+		},
+	},
+})
+```
+
+Custom route inputs are validated before hooks and endpoint handlers run, so they are available on `ctx.body` inside hooks. They are request-only fields and are not persisted to the user, session, account, or verification tables unless you also configure them as additional fields for that model.
+
+Plugins can also define `routeInputs` to extend built-in routes for their own hooks.
+
 ## `user`
 
 User configuration options.

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -20,6 +20,7 @@ import type { OverrideMerge, UnionToIntersection } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 import { originCheckMiddleware } from "./middlewares";
 import { onRequestRateLimit, onResponseRateLimit } from "./rate-limiter";
+import { applyRouteInputs } from "./route-inputs";
 import {
 	accountInfo,
 	callbackOAuth,
@@ -258,12 +259,15 @@ export function getEndpoints<Option extends BetterAuthOptions>(
 		getAccessToken,
 		accountInfo,
 	};
-	const endpoints = {
-		...baseEndpoints,
-		...pluginEndpoints,
-		ok,
-		error,
-	} as const;
+	const endpoints = applyRouteInputs(
+		{
+			...baseEndpoints,
+			...pluginEndpoints,
+			ok,
+			error,
+		} as const,
+		options,
+	);
 	const api = toAuthEndpoints(endpoints, ctx);
 	return {
 		api: api as unknown as OverrideMerge<typeof endpoints, PluginEndpoint>,

--- a/packages/better-auth/src/api/route-inputs.ts
+++ b/packages/better-auth/src/api/route-inputs.ts
@@ -99,11 +99,11 @@ function createFieldSchema(field: BetterAuthRouteInputField): z.ZodType {
 	if (field.description) {
 		schema = schema.meta({ description: field.description });
 	}
-	if (field.defaultValue !== undefined) {
-		schema = schema.default(field.defaultValue as never);
-	}
 	if (field.required === false) {
 		schema = schema.optional();
+	}
+	if (field.defaultValue !== undefined) {
+		schema = schema.default(field.defaultValue as never);
 	}
 	return schema;
 }

--- a/packages/better-auth/src/api/route-inputs.ts
+++ b/packages/better-auth/src/api/route-inputs.ts
@@ -1,0 +1,227 @@
+import type {
+	BetterAuthOptions,
+	BetterAuthRouteInputField,
+	BetterAuthRouteInputs,
+} from "@better-auth/core";
+import type { Endpoint } from "better-call";
+import * as z from "zod";
+
+type RouteInputSource = {
+	id: string;
+	routeInputs?: BetterAuthRouteInputs | undefined;
+};
+
+type RouteInputDefinition = {
+	field: BetterAuthRouteInputField;
+	source: string;
+};
+
+type MergedRouteInputs = Record<string, Record<string, RouteInputDefinition>>;
+
+function getRouteInputSources(options: BetterAuthOptions): RouteInputSource[] {
+	return [
+		...(options.plugins?.map((plugin) => ({
+			id: `plugin:${plugin.id}`,
+			routeInputs: plugin.routeInputs,
+		})) ?? []),
+		{
+			id: "options.routeInputs",
+			routeInputs: options.routeInputs,
+		},
+	];
+}
+
+function collectRouteInputs(options: BetterAuthOptions): MergedRouteInputs {
+	const merged: MergedRouteInputs = {};
+	for (const source of getRouteInputSources(options)) {
+		if (!source.routeInputs) continue;
+		for (const [path, fields] of Object.entries(source.routeInputs)) {
+			merged[path] ??= {};
+			for (const [name, field] of Object.entries(fields)) {
+				const existing = merged[path][name];
+				if (existing) {
+					throw new Error(
+						`Duplicate route input "${name}" for "${path}" from ${existing.source} and ${source.id}`,
+					);
+				}
+				merged[path][name] = { field, source: source.id };
+			}
+		}
+	}
+	return merged;
+}
+
+function unwrapZodDef(schema: z.ZodType) {
+	return (
+		(schema as unknown as { _def?: any; def?: any })._def ??
+		(schema as unknown as { def?: any }).def
+	);
+}
+
+function getBodyKeys(schema: unknown): Set<string> {
+	if (!schema || !(schema instanceof z.ZodType)) return new Set();
+	if (schema instanceof z.ZodObject) {
+		return new Set(Object.keys((schema as unknown as { shape: object }).shape));
+	}
+	if (schema instanceof z.ZodIntersection) {
+		const def = unwrapZodDef(schema);
+		return new Set([...getBodyKeys(def?.left), ...getBodyKeys(def?.right)]);
+	}
+	if (schema instanceof z.ZodOptional || schema instanceof z.ZodDefault) {
+		return getBodyKeys(schema.unwrap());
+	}
+	return new Set();
+}
+
+function createFieldSchema(field: BetterAuthRouteInputField): z.ZodType {
+	let schema: z.ZodType;
+	if (field.type === "json") {
+		schema = (z as unknown as { json?: () => z.ZodType }).json?.() ?? z.any();
+	} else if (field.type === "string[]") {
+		schema = z.array(z.string());
+	} else if (field.type === "number[]") {
+		schema = z.array(z.number());
+	} else if (Array.isArray(field.type)) {
+		schema = field.type.length
+			? z.enum(field.type as [string, ...string[]])
+			: z.any();
+	} else if (field.type === "date") {
+		schema = z.date();
+	} else if (field.type === "string") {
+		schema = z.string();
+	} else if (field.type === "number") {
+		schema = z.number();
+	} else if (field.type === "boolean") {
+		schema = z.boolean();
+	} else {
+		schema = z.any();
+	}
+	if (field.description) {
+		schema = schema.meta({ description: field.description });
+	}
+	if (field.defaultValue !== undefined) {
+		schema = schema.default(field.defaultValue as never);
+	}
+	if (field.required === false) {
+		schema = schema.optional();
+	}
+	return schema;
+}
+
+function createInputObject(fields: Record<string, RouteInputDefinition>) {
+	return z.object(
+		Object.fromEntries(
+			Object.entries(fields).map(([name, definition]) => [
+				name,
+				createFieldSchema(definition.field),
+			]),
+		),
+	);
+}
+
+function extendBodySchema(body: unknown, inputSchema: z.ZodObject<any>) {
+	if (!body) return inputSchema;
+	if (body instanceof z.ZodObject) {
+		return body.extend(inputSchema.shape);
+	}
+	if (body instanceof z.ZodType) {
+		return z.intersection(body, inputSchema);
+	}
+	throw new Error(
+		"Route inputs can only extend endpoints with Zod request bodies",
+	);
+}
+
+function getOpenAPIType(field: BetterAuthRouteInputField) {
+	if (field.type === "string[]")
+		return { type: "array", items: { type: "string" } };
+	if (field.type === "number[]")
+		return { type: "array", items: { type: "number" } };
+	if (field.type === "json") return {};
+	if (Array.isArray(field.type)) return { type: "string", enum: field.type };
+	if (field.type === "date") return { type: "string", format: "date-time" };
+	return { type: field.type };
+}
+
+function extendOpenAPIRequestBody(
+	requestBody: any,
+	fields: Record<string, RouteInputDefinition>,
+) {
+	if (!requestBody?.content?.["application/json"]?.schema) return requestBody;
+	const schema = requestBody.content["application/json"].schema;
+	schema.properties ??= {};
+	const required = new Set<string>(schema.required ?? []);
+	for (const [name, definition] of Object.entries(fields)) {
+		schema.properties[name] = {
+			...getOpenAPIType(definition.field),
+			...(definition.field.description
+				? { description: definition.field.description }
+				: {}),
+			...(definition.field.defaultValue !== undefined &&
+			typeof definition.field.defaultValue !== "function"
+				? { default: definition.field.defaultValue }
+				: {}),
+		};
+		if (
+			definition.field.required !== false &&
+			definition.field.defaultValue === undefined
+		) {
+			required.add(name);
+		}
+	}
+	schema.required = Array.from(required);
+	return requestBody;
+}
+
+function extendEndpoint(
+	endpoint: Endpoint,
+	fields: Record<string, RouteInputDefinition>,
+) {
+	const bodyKeys = getBodyKeys(endpoint.options?.body);
+	for (const name of Object.keys(fields)) {
+		if (bodyKeys.has(name)) {
+			throw new Error(
+				`Route input "${name}" for "${endpoint.path}" conflicts with an existing endpoint body field`,
+			);
+		}
+	}
+	const inputSchema = createInputObject(fields);
+	const extended = ((context: unknown) =>
+		(endpoint as unknown as (context: unknown) => unknown)(
+			context,
+		)) as Endpoint;
+	Object.assign(extended, endpoint);
+	const metadata = {
+		...(endpoint.options?.metadata ?? {}),
+		routeInputSchema: inputSchema,
+	};
+	if (metadata.openapi?.requestBody) {
+		metadata.openapi = {
+			...metadata.openapi,
+			requestBody: extendOpenAPIRequestBody(
+				structuredClone(metadata.openapi.requestBody),
+				fields,
+			),
+		};
+	}
+	(extended as any).options = {
+		...endpoint.options,
+		body: extendBodySchema(endpoint.options?.body, inputSchema),
+		metadata,
+	};
+	return extended;
+}
+
+export function applyRouteInputs<const E extends Record<string, Endpoint>>(
+	endpoints: E,
+	options: BetterAuthOptions,
+): E {
+	const routeInputs = collectRouteInputs(options);
+	if (!Object.keys(routeInputs).length) return endpoints;
+	const extended: Record<string, Endpoint> = {};
+	for (const [key, endpoint] of Object.entries(endpoints)) {
+		const fields = endpoint.path ? routeInputs[endpoint.path] : undefined;
+		extended[key] = fields ? extendEndpoint(endpoint, fields) : endpoint;
+	}
+	return extended as E;
+}

--- a/packages/better-auth/src/api/routes/sign-in.test.ts
+++ b/packages/better-auth/src/api/routes/sign-in.test.ts
@@ -1,5 +1,8 @@
+import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
+import { createAuthMiddleware } from "@better-auth/core/api";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { createAuthClient } from "../../client";
 import { parseSetCookieHeader } from "../../cookies";
 import { getTestInstance } from "../../test-utils/test-instance";
 
@@ -289,6 +292,195 @@ describe("sign-in with additionalFields", async () => {
 		expect(res.user).toBeDefined();
 		expect(res.user.newField).toBe("signin-value");
 		expect(res.user.isAdmin).toBe(true);
+	});
+});
+
+describe("custom route inputs", async () => {
+	it("should validate required sign-in route inputs and expose them to hooks", async () => {
+		let seenTenantId: string | undefined;
+		const plugin = {
+			id: "route-input-test",
+			routeInputs: {
+				"/sign-in/email": {
+					tenantId: {
+						type: "string",
+						required: true,
+					},
+				},
+			},
+			hooks: {
+				before: [
+					{
+						matcher: (ctx) => ctx.path === "/sign-in/email",
+						handler: createAuthMiddleware(async (ctx) => {
+							seenTenantId = ctx.body.tenantId;
+						}),
+					},
+				],
+			},
+		} satisfies BetterAuthPlugin;
+		const { auth, testUser } = await getTestInstance({
+			plugins: [plugin],
+		});
+
+		await expect(
+			auth.api.signInEmail({
+				body: {
+					email: testUser.email,
+					password: testUser.password,
+				} as any,
+			}),
+		).rejects.toThrow();
+
+		await auth.api.signInEmail({
+			body: {
+				email: testUser.email,
+				password: testUser.password,
+				tenantId: "tenant_123",
+			},
+		});
+		expect(seenTenantId).toBe("tenant_123");
+	});
+
+	it("should not persist sign-up route-only inputs as user fields", async () => {
+		let seenInviteCode: string | undefined;
+		const plugin = {
+			id: "route-input-sign-up-hook-test",
+			hooks: {
+				before: [
+					{
+						matcher: (ctx) => ctx.path === "/sign-up/email",
+						handler: createAuthMiddleware(async (ctx) => {
+							seenInviteCode = ctx.body.inviteCode;
+						}),
+					},
+				],
+			},
+		} satisfies BetterAuthPlugin;
+		const { auth } = await getTestInstance(
+			{
+				plugins: [plugin],
+				routeInputs: {
+					"/sign-up/email": {
+						inviteCode: {
+							type: "string",
+							required: true,
+						},
+					},
+				},
+			},
+			{
+				disableTestUser: true,
+			},
+		);
+
+		const res = await auth.api.signUpEmail({
+			body: {
+				email: "route-input-signup@test.com",
+				password: "password",
+				name: "Route Input",
+				inviteCode: "invite-123",
+			},
+		});
+
+		expect(seenInviteCode).toBe("invite-123");
+		expect((res.user as any).inviteCode).toBeUndefined();
+	});
+
+	it("should reject route inputs that collide with endpoint body fields", async () => {
+		await expect(
+			getTestInstance({
+				routeInputs: {
+					"/sign-in/email": {
+						email: {
+							type: "string",
+						},
+					},
+				},
+			}),
+		).rejects.toThrow(/conflicts with an existing endpoint body field/);
+	});
+
+	it("should reject duplicate route input fields", async () => {
+		const plugin = {
+			id: "duplicate-route-input-test",
+			routeInputs: {
+				"/sign-in/email": {
+					tenantId: {
+						type: "string",
+					},
+				},
+			},
+		} satisfies BetterAuthPlugin;
+		await expect(
+			getTestInstance({
+				plugins: [plugin],
+				routeInputs: {
+					"/sign-in/email": {
+						tenantId: {
+							type: "string",
+						},
+					},
+				},
+			}),
+		).rejects.toThrow(/Duplicate route input/);
+	});
+
+	it("should infer top-level and plugin route inputs on the client", async () => {
+		const plugin = {
+			id: "typed-route-input-test",
+			routeInputs: {
+				"/sign-in/email": {
+					pluginCode: {
+						type: "string",
+					},
+				},
+			},
+		} satisfies BetterAuthPlugin;
+		const authOptions = {
+			plugins: [plugin],
+			routeInputs: {
+				"/sign-in/email": {
+					tenantId: {
+						type: "string",
+					},
+					optionalCode: {
+						type: "string",
+						required: false,
+					},
+				},
+			},
+		} satisfies BetterAuthOptions;
+		const client = createAuthClient<{
+			$InferAuth: typeof authOptions;
+			plugins: [
+				{
+					id: "typed-route-input-client-test";
+					$InferServerPlugin: typeof plugin;
+				},
+			];
+		}>({
+			$InferAuth: {} as typeof authOptions,
+			plugins: [
+				{
+					id: "typed-route-input-client-test",
+					$InferServerPlugin: {} as typeof plugin,
+				},
+			],
+		});
+		type SignInInput = Parameters<typeof client.signIn.email>[0];
+		expectTypeOf<SignInInput>().toMatchTypeOf<{
+			tenantId: string;
+			pluginCode: string;
+			optionalCode?: string | null | undefined;
+		}>();
+		expectTypeOf<{
+			email: string;
+			password: string;
+			tenantId: string;
+			pluginCode: string;
+			optionalCode?: string | null | undefined;
+		}>().toMatchTypeOf<SignInInput>();
 	});
 });
 

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -1,4 +1,7 @@
-import type { BetterAuthOptions } from "@better-auth/core";
+import type {
+	BetterAuthOptions,
+	InferRouteInputsFromOptions,
+} from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import type { User } from "@better-auth/core/db";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
@@ -413,7 +416,7 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 						password: string;
 						callbackURL?: string | undefined;
 						rememberMe?: boolean | undefined;
-					},
+					} & InferRouteInputsFromOptions<O, "/sign-in/email">,
 					returned: {} as {
 						redirect: boolean;
 						token: string;

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -1,4 +1,7 @@
-import type { BetterAuthOptions } from "@better-auth/core";
+import type {
+	BetterAuthOptions,
+	InferRouteInputsFromOptions,
+} from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import { runWithTransaction } from "@better-auth/core/context";
 import { isDevelopment } from "@better-auth/core/env";
@@ -45,7 +48,8 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 						image?: string | undefined;
 						callbackURL?: string | undefined;
 						rememberMe?: boolean | undefined;
-					} & AdditionalUserFieldsInput<O>,
+					} & AdditionalUserFieldsInput<O> &
+						InferRouteInputsFromOptions<O, "/sign-up/email">,
 					returned: {} as {
 						token: string | null;
 						user: User<O["user"], O["plugins"]>;

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -114,6 +114,26 @@ async function resolveDynamicContext(
 	}
 }
 
+async function validateRouteInputs(
+	context: InternalContext,
+	endpoint: Endpoint,
+) {
+	const routeInputSchema = (endpoint.options?.metadata as any)
+		?.routeInputSchema;
+	if (!routeInputSchema?.safeParseAsync) return;
+	const result = await routeInputSchema.safeParseAsync(context.body ?? {});
+	if (!result.success) {
+		throw new APIError("BAD_REQUEST", {
+			code: "VALIDATION_ERROR",
+			message: result.error?.issues?.[0]?.message ?? "Validation Error",
+		});
+	}
+	context.body = {
+		...(context.body ?? {}),
+		...result.data,
+	};
+}
+
 export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 	endpoints: E,
 	ctx: AuthContext | Promise<AuthContext>,
@@ -167,6 +187,7 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 					},
 					async () =>
 						runWithEndpointContext(internalContext, async () => {
+							await validateRouteInputs(internalContext, endpoint);
 							const { beforeHooks, afterHooks } = getHooks(authContext);
 							const before = await runBeforeHooks(
 								internalContext,

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -1,6 +1,7 @@
 import type {
 	BetterAuthClientOptions,
 	ClientFetchOption,
+	InferRouteInputsFromOptions,
 } from "@better-auth/core";
 import type { SocialProviderList } from "@better-auth/core/social-providers";
 import type { BetterFetchResponse } from "@better-fetch/fetch";
@@ -41,6 +42,28 @@ type InferGenericOAuthProviderIds<O extends BetterAuthClientOptions> =
 				? ID & string
 				: never
 			: never);
+
+type InferRouteInputsFromClient<
+	ClientOpts extends BetterAuthClientOptions,
+	Path extends string,
+> = (NonNullable<ClientOpts["$InferAuth"]> extends {
+	routeInputs?: any;
+	plugins?: any;
+}
+	? InferRouteInputsFromOptions<NonNullable<ClientOpts["$InferAuth"]>, Path>
+	: {}) &
+	UnionToIntersection<
+		ClientOpts["plugins"] extends Array<infer Plugin>
+			? Plugin extends { $InferServerPlugin: infer ServerPlugin }
+				? NonNullable<ServerPlugin> extends {
+						routeInputs?: any;
+						plugins?: any;
+					}
+					? InferRouteInputsFromOptions<NonNullable<ServerPlugin>, Path>
+					: {}
+				: {}
+			: {}
+	>;
 
 type KeepNullishFromOriginal<Original, Replaced> =
 	| Replaced
@@ -122,7 +145,10 @@ export type InferSignUpEmailCtx<
 	image?: string | undefined;
 	callbackURL?: string | undefined;
 	fetchOptions?: FetchOptions | undefined;
-} & UnionToIntersection<InferAdditionalFromClient<ClientOpts, "user", "input">>;
+} & UnionToIntersection<
+	InferAdditionalFromClient<ClientOpts, "user", "input">
+> &
+	InferRouteInputsFromClient<ClientOpts, "/sign-up/email">;
 
 export type InferUserUpdateCtx<
 	ClientOpts extends BetterAuthClientOptions,
@@ -133,7 +159,8 @@ export type InferUserUpdateCtx<
 	fetchOptions?: FetchOptions | undefined;
 } & Partial<
 	UnionToIntersection<InferAdditionalFromClient<ClientOpts, "user", "input">>
->;
+> &
+	InferRouteInputsFromClient<ClientOpts, "/update-user">;
 
 type InferCtxQuery<
 	C extends InputContext<any, any>,
@@ -196,7 +223,8 @@ export type InferRoute<API, COpts extends BetterAuthClientOptions> =
 										>,
 									>(
 										...data: HasRequiredKeys<
-											InferCtx<C, FetchOptions>
+											InferCtx<C, FetchOptions> &
+												InferRouteInputsFromClient<COpts, T["path"]>
 										> extends true
 											? [
 													Prettify<
@@ -212,8 +240,12 @@ export type InferRoute<API, COpts extends BetterAuthClientOptions> =
 																			| InferGenericOAuthProviderIds<COpts>
 																			| (string & {});
 																		fetchOptions?: FetchOptions | undefined;
-																	}
-																: InferCtx<C, FetchOptions>
+																	} & InferRouteInputsFromClient<
+																			COpts,
+																			T["path"]
+																		>
+																: InferCtx<C, FetchOptions> &
+																		InferRouteInputsFromClient<COpts, T["path"]>
 													>,
 													FetchOptions?,
 												]
@@ -221,7 +253,8 @@ export type InferRoute<API, COpts extends BetterAuthClientOptions> =
 													Prettify<
 														T["path"] extends `/update-user`
 															? InferUserUpdateCtx<COpts, FetchOptions>
-															: InferCtx<C, FetchOptions>
+															: InferCtx<C, FetchOptions> &
+																	InferRouteInputsFromClient<COpts, T["path"]>
 													>?,
 													FetchOptions?,
 												]

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -371,7 +371,11 @@ function toOpenApiPath(path: string) {
 export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 	const baseEndpoints = getEndpoints(ctx, {
 		...options,
-		plugins: [],
+		plugins:
+			options.plugins?.map((plugin) => ({
+				id: plugin.id,
+				routeInputs: plugin.routeInputs,
+			})) ?? [],
 	});
 
 	const tables = getAuthTables({

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -1,3 +1,4 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
 import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { openAPI } from ".";
@@ -275,5 +276,65 @@ describe("open-api", async () => {
 		expect(signUpProps.rememberMe).toBeDefined();
 		const baseTypes = getBaseType(signUpProps.rememberMe.type);
 		expect(baseTypes).toContain("boolean");
+	});
+
+	it("should include custom route inputs in request body schemas", async () => {
+		const plugin = {
+			id: "open-api-route-input-test",
+			routeInputs: {
+				"/sign-up/email": {
+					referralSource: {
+						type: "string",
+						description: "Referral source",
+					},
+				},
+			},
+		} satisfies BetterAuthPlugin;
+		const { auth } = await getTestInstance(
+			{
+				plugins: [openAPI(), plugin],
+				routeInputs: {
+					"/sign-in/email": {
+						tenantId: {
+							type: "string",
+							description: "Tenant identifier",
+						},
+					},
+					"/sign-up/email": {
+						inviteCode: {
+							type: "string",
+							required: false,
+						},
+					},
+				},
+			},
+			{
+				disableTestUser: true,
+			},
+		);
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, any>;
+
+		const signInSchema =
+			paths["/sign-in/email"].post.requestBody.content["application/json"]
+				.schema;
+		expect(signInSchema.properties.tenantId).toEqual({
+			type: "string",
+			description: "Tenant identifier",
+		});
+		expect(signInSchema.required).toContain("tenantId");
+
+		const signUpSchema =
+			paths["/sign-up/email"].post.requestBody.content["application/json"]
+				.schema;
+		expect(signUpSchema.properties.inviteCode).toEqual({
+			type: "string",
+		});
+		expect(signUpSchema.required).not.toContain("inviteCode");
+		expect(signUpSchema.properties.referralSource).toEqual({
+			type: "string",
+			description: "Referral source",
+		});
+		expect(signUpSchema.required).toContain("referralSource");
 	});
 });

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -21,8 +21,11 @@ export type {
 	BetterAuthRateLimitOptions,
 	BetterAuthRateLimitRule,
 	BetterAuthRateLimitStorage,
+	BetterAuthRouteInputField,
+	BetterAuthRouteInputs,
 	DynamicBaseURLConfig,
 	GenerateIdFn,
+	InferRouteInputsFromOptions,
 	StoreIdentifierOption,
 } from "./init-options";
 export type {

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -189,7 +189,8 @@ type StaticRouteInputDefault =
 	| string[]
 	| number[]
 	| Record<string, unknown>
-	| unknown[];
+	| unknown[]
+	| (() => unknown);
 
 type InferRouteInputFields<Fields> =
 	Fields extends Record<infer Key, BetterAuthRouteInputField>

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -13,6 +13,8 @@ import type { AuthMiddleware } from "../api";
 import type {
 	Account,
 	DBFieldAttribute,
+	DBFieldType,
+	InferDBValueType,
 	ModelNames,
 	RateLimit,
 	SecondaryStorage,
@@ -29,7 +31,12 @@ import type { BaseVerification } from "../db/schema/verification";
 import type { Logger } from "../env";
 import type { SocialProviderList, SocialProviders } from "../social-providers";
 import type { AuthContext, GenericEndpointContext } from "./context";
-import type { Awaitable, LiteralString, LiteralUnion } from "./helper";
+import type {
+	Awaitable,
+	LiteralString,
+	LiteralUnion,
+	UnionToIntersection,
+} from "./helper";
 import type { BetterAuthPlugin } from "./plugin";
 
 type KyselyDatabaseType = "postgres" | "mysql" | "sqlite" | "mssql";
@@ -138,6 +145,87 @@ export type BetterAuthDBOptions<
 		[Key in Exclude<string, Keys | "id">]: DBFieldAttribute;
 	};
 };
+
+export type BetterAuthRouteInputField<Type extends DBFieldType = DBFieldType> =
+	Type extends DBFieldType
+		? {
+				/**
+				 * The primitive input type to validate for this route field.
+				 */
+				type: Type;
+				/**
+				 * Whether the field is required in the request body.
+				 *
+				 * @default true
+				 */
+				required?: boolean | undefined;
+				/**
+				 * Default value used when the request omits this field.
+				 */
+				defaultValue?:
+					| InferDBValueType<Type>
+					| (() => InferDBValueType<Type>)
+					| undefined;
+				/**
+				 * OpenAPI/metadata description for generated API references.
+				 */
+				description?: string | undefined;
+			}
+		: never;
+
+export type BetterAuthRouteInputs = Record<
+	string,
+	Record<string, BetterAuthRouteInputField>
+>;
+
+type InferRouteInputField<T extends BetterAuthRouteInputField> =
+	InferDBValueType<T["type"]>;
+
+type StaticRouteInputDefault =
+	| string
+	| number
+	| boolean
+	| Date
+	| string[]
+	| number[]
+	| Record<string, unknown>
+	| unknown[];
+
+type InferRouteInputFields<Fields> =
+	Fields extends Record<infer Key, BetterAuthRouteInputField>
+		? {
+				[key in Key as Fields[key]["required"] extends false
+					? never
+					: Fields[key]["defaultValue"] extends StaticRouteInputDefault
+						? never
+						: key]: InferRouteInputField<Fields[key]>;
+			} & {
+				[key in Key as Fields[key]["required"] extends false
+					? key
+					: Fields[key]["defaultValue"] extends StaticRouteInputDefault
+						? key
+						: never]?: InferRouteInputField<Fields[key]> | undefined | null;
+			}
+		: {};
+
+export type InferRouteInputsFromOptions<
+	Options extends {
+		routeInputs?: BetterAuthRouteInputs | undefined;
+		plugins?: BetterAuthPlugin[] | undefined;
+	},
+	Path extends string,
+> = (Options["routeInputs"] extends Record<Path, infer Fields>
+	? InferRouteInputFields<Fields>
+	: {}) &
+	UnionToIntersection<
+		Options["plugins"] extends Array<infer Plugin>
+			? Plugin extends {
+					routeInputs: Record<Path, infer Fields>;
+				}
+				? InferRouteInputFields<Fields>
+				: {}
+			: {}
+	>;
 
 export type BetterAuthRateLimitOptions = Optional<BetterAuthRateLimitRule> &
 	Omit<
@@ -771,6 +859,11 @@ export type BetterAuthOptions = {
 	 * List of Better Auth plugins
 	 */
 	plugins?: ([] | BetterAuthPlugin[]) | undefined;
+	/**
+	 * Additional request body inputs to validate for specific auth routes.
+	 * Route keys use Better Auth's internal path form, such as `/sign-in/email`.
+	 */
+	routeInputs?: BetterAuthRouteInputs | undefined;
 	/**
 	 * User configuration
 	 */

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -10,7 +10,7 @@ import type { BetterAuthPluginDBSchema } from "../db";
 import type { RawError } from "../utils/error-codes";
 import type { AuthContext } from "./context";
 import type { Awaitable, LiteralString } from "./helper";
-import type { BetterAuthOptions } from "./init-options";
+import type { BetterAuthOptions, BetterAuthRouteInputs } from "./init-options";
 
 type DeepPartial<T> = T extends Function
 	? T
@@ -64,6 +64,11 @@ export type BetterAuthPlugin = BetterAuthPluginErrorCodePart & {
 				middleware: Middleware;
 		  }[]
 		| undefined;
+	/**
+	 * Additional request body inputs to validate for specific auth routes.
+	 * Route keys use Better Auth's internal path form, such as `/sign-in/email`.
+	 */
+	routeInputs?: BetterAuthRouteInputs | undefined;
 	onRequest?:
 		| ((
 				request: Request,


### PR DESCRIPTION
## Summary

Adds `routeInputs` as a generic way to declare validated request body fields for auth routes from both top-level auth options and plugins.

- Supports custom request inputs on routes like `/sign-in/email` and `/sign-up/email`
- Validates route inputs before hooks and handlers so values are available on `ctx.body`
- Rejects duplicate route input fields and collisions with built-in endpoint body fields
- Adds client and server type inference for top-level and plugin-declared route inputs
- Reflects custom route inputs in OpenAPI request body schemas
- Documents the new option and plugin authoring flow

Closes #9612.

## Notes

Route inputs are request-only fields. They are not persisted to user/session/account records unless separately configured through schema additional fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `routeInputs` to declare and validate custom request body fields on auth routes like `/sign-in/email` and `/sign-up/email`. Inputs are validated before hooks/handlers, available on `ctx.body`, fully typed on server and client, and included in OpenAPI.

- New Features
  - Configure `routeInputs` in top-level options or plugins.
  - Validates inputs and rejects duplicates or collisions with existing fields.
  - Client/server infer custom input types (including plugin-provided inputs).
  - OpenAPI request bodies include custom inputs with required/optional and defaults.

- Bug Fixes
  - Apply .optional before .default and include function defaults in type inference.

<sup>Written for commit 948ab412e84390fcd5ee44134f0612c611eecb9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

