### PR TITLE
fix(email-verification): clone request before passing to sendVerificationEmail callback

### DIFF
--- a/.changeset/green-radios-pull.md
+++ b/.changeset/green-radios-pull.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix(email-verification): clone request before passing to sendVerificationEmail callback

--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -1,6 +1,124 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8969
+ */
+describe("Email Verification - Request body consumption bug", () => {
+	it("should not throw 'body already consumed' error when sendVerificationEmail callback reads the request", async () => {
+		const mockSendEmail = vi.fn();
+		let requestBodyReadError: Error | null = null;
+
+		const { auth, testUser } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				requireEmailVerification: true,
+			},
+			emailVerification: {
+				async sendVerificationEmail({ user, url, token }, request) {
+					mockSendEmail(user.email, url);
+					if (request) {
+						try {
+							await request.text();
+						} catch (error) {
+							requestBodyReadError = error as Error;
+						}
+					}
+				},
+			},
+		});
+
+		await auth.api.sendVerificationEmail({
+			body: {
+				email: testUser.email,
+			},
+		});
+
+		expect(mockSendEmail).toHaveBeenCalledWith(
+			testUser.email,
+			expect.any(String),
+		);
+		expect(requestBodyReadError).toBeNull();
+	});
+
+	it("should not throw 'body already consumed' error when sendVerificationEmail is called during sign-up", async () => {
+		const mockSendEmail = vi.fn();
+		let requestBodyReadError: Error | null = null;
+
+		const { client } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				requireEmailVerification: true,
+			},
+			emailVerification: {
+				sendOnSignUp: true,
+				async sendVerificationEmail({ user, url, token }, request) {
+					mockSendEmail(user.email, url);
+					if (request) {
+						try {
+							await request.text();
+						} catch (error) {
+							requestBodyReadError = error as Error;
+						}
+					}
+				},
+			},
+		});
+
+		await client.signUp.email({
+			name: "Test User",
+			email: "newuser@example.com",
+			password: "password123",
+		});
+
+		expect(mockSendEmail).toHaveBeenCalledWith(
+			"newuser@example.com",
+			expect.any(String),
+		);
+		expect(requestBodyReadError).toBeNull();
+	});
+
+	it("should not throw 'body already consumed' error when sendVerificationEmail is called during sign-in", async () => {
+		const mockSendEmail = vi.fn();
+		let requestBodyReadError: Error | null = null;
+
+		const { client, testUser } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				requireEmailVerification: true,
+			},
+			emailVerification: {
+				sendOnSignIn: true,
+				async sendVerificationEmail({ user, url, token }, request) {
+					mockSendEmail(user.email, url);
+					if (request) {
+						try {
+							await request.text();
+						} catch (error) {
+							requestBodyReadError = error as Error;
+						}
+					}
+				},
+			},
+		});
+
+		try {
+			await client.signIn.email({
+				email: testUser.email,
+				password: testUser.password,
+			});
+		} catch {
+			// Expected to throw EMAIL_NOT_VERIFIED, but we're testing the request body
+		}
+
+		expect(mockSendEmail).toHaveBeenCalledWith(
+			testUser.email,
+			expect.any(String),
+		);
+		expect(requestBodyReadError).toBeNull();
+	});
+});
+
 describe("Email Verification", async () => {
 	const mockSendEmail = vi.fn();
 	let token: string;

--- a/packages/better-auth/src/api/routes/email-verification.ts
+++ b/packages/better-auth/src/api/routes/email-verification.ts
@@ -71,7 +71,7 @@ export async function sendVerificationEmailFn(
 				url,
 				token,
 			},
-			ctx.request,
+			ctx.request?.clone(),
 		),
 	);
 }
@@ -80,6 +80,7 @@ export const sendVerificationEmail = createAuthEndpoint(
 	{
 		method: "POST",
 		operationId: "sendVerificationEmail",
+		cloneRequest: true,
 		body: z.object({
 			email: z.email().meta({
 				description: "The email to send the verification email to",
@@ -338,7 +339,7 @@ export const verifyEmail = createAuthEndpoint(
 									url,
 									token: newToken,
 								},
-								ctx.request,
+								ctx.request?.clone(),
 							),
 						);
 					}
@@ -437,7 +438,7 @@ export const verifyEmail = createAuthEndpoint(
 									url: `${ctx.context.baseURL}/verify-email?token=${newToken}&callbackURL=${updateCallbackURL}`,
 									token: newToken,
 								},
-								ctx.request,
+								ctx.request?.clone(),
 							),
 						);
 					}

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -365,6 +365,7 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 			method: "POST",
 			operationId: "signInEmail",
 			use: [formCsrfMiddleware],
+			cloneRequest: true,
 			body: z.object({
 				/**
 				 * Email of the user
@@ -556,7 +557,7 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 								url,
 								token,
 							},
-							ctx.request,
+							ctx.request?.clone(),
 						),
 					);
 				}

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -32,6 +32,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 			operationId: "signUpWithEmailAndPassword",
 			use: [formCsrfMiddleware],
 			body: signUpEmailBodySchema,
+			cloneRequest: true,
 			metadata: {
 				allowedMediaTypes: [
 					"application/x-www-form-urlencoded",
@@ -259,7 +260,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 							await ctx.context.runInBackgroundOrAwait(
 								ctx.context.options.emailAndPassword.onExistingUserSignUp(
 									{ user: dbUser.user },
-									ctx.request,
+									ctx.request?.clone(),
 								),
 							);
 						}
@@ -388,7 +389,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 									url,
 									token,
 								},
-								ctx.request,
+								ctx.request?.clone(),
 							),
 						);
 					}


### PR DESCRIPTION
## Problem

`ctx.request` was passed directly to `sendVerificationEmail` callbacks after the request body had already been consumed by better-call's body parser, causing:

```
TypeError: Body is unusable: Body has already been read
```


closes https://github.com/better-auth/better-auth/issues/8969