### PR TITLE
feat(passkey): add `verifyPasskey` for step-up auth

### DIFF
--- a/.changeset/rare-pugs-train.md
+++ b/.changeset/rare-pugs-train.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/passkey": minor
+---
+
+Add `verifyPasskey` for step-up authentication — verify a passkey assertion without creating a session. New `POST /passkey/verify-assertion` endpoint and `authClient.passkey.verifyPasskey()` client method performing full WebAuthn verification (challenge, assertion, counter update) but return `{ verified, userId, credentialId }` instead of creating a session.

--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -206,6 +206,67 @@ await authClient.signIn.passkey({
 });
 ```
 
+### Step-up authentication (re-auth without session)
+
+Use `verifyPasskey` to verify a passkey assertion **without creating a session**. This is useful for step-up authentication on sensitive operations like money transfers, account changes, or resource deletion — where you need cryptographic proof of user presence but don't want orphaned sessions polluting your session table.
+
+Like `signIn.passkey`, it performs the full WebAuthn verification ceremony (challenge → browser assertion → server verification + counter update). The difference: it returns `{ verified, userId, credentialId }` instead of creating a session and setting cookies.
+
+<APIMethod path="/passkey/verify-assertion" method="POST" requireSession>
+  ```ts
+  type verifyPasskey = {
+      /**
+       * Browser autofill, a.k.a. Conditional UI.
+       */
+      autoFill?: boolean
+      /**
+       * Optional WebAuthn extensions
+       */
+      extensions?: AuthenticationExtensionsClientInputs
+      /**
+       * Client fetch options
+       */
+      fetchOptions?: ClientFetchOption
+  }
+  ```
+</APIMethod>
+
+#### Server-side
+
+```ts
+const result = await auth.api.verifyPasskeyAssertion({
+  headers,
+  body: { response: assertionResponse },
+});
+
+if (result.verified) {
+  // userId is confirmed via passkey. Proceed with sensitive action.
+  await performSensitiveAction(result.userId);
+}
+```
+
+#### Client-side
+
+```ts
+const { data } = await authClient.passkey.verifyPasskey({
+  autoFill: false,
+  fetchOptions: {
+    onError(context) {
+      console.error("Step-up verification failed:", context.error.message);
+    },
+  },
+});
+
+if (data?.verified) {
+  // Tell your backend the user has re-authenticated
+  await approveSensitiveAction({ credentialId: data.credentialId });
+}
+```
+
+<Callout>
+  `verifyPasskey` does **not** create a session or refresh the existing session. If you need both step-up and session refresh, use `signIn.passkey` instead.
+</Callout>
+
 ### Extensions
 
 You can use WebAuthn extensions through the client API by passing `extensions`. When `returnWebAuthnResponse` is true, the client returns `webauthn.clientExtensionResults`.

--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -206,7 +206,7 @@ await authClient.signIn.passkey({
 });
 ```
 
-### Step-up authentication (re-auth without session)
+### Step-up authentication (re-auth without creating a session)
 
 Use `verifyPasskey` to verify a passkey assertion **without creating a session**. This is useful for step-up authentication on sensitive operations like money transfers, account changes, or resource deletion — where you need cryptographic proof of user presence but don't want orphaned sessions polluting your session table.
 

--- a/packages/passkey/src/client.test.ts
+++ b/packages/passkey/src/client.test.ts
@@ -201,4 +201,47 @@ describe("passkey client", () => {
 			consoleError.mockRestore();
 		}
 	});
+
+	it("should verify passkey step-up without creating session", async () => {
+		const fetchMock = vi.fn(async (path: string, options?: any) => {
+			if (path === "/passkey/generate-authenticate-options") {
+				return {
+					data: {
+						challenge: "challenge",
+						rpId: "example.com",
+						allowCredentials: [],
+						userVerification: "preferred",
+					},
+				};
+			}
+			if (path === "/passkey/verify-assertion") {
+				expect(options?.body).toHaveProperty("response");
+				return {
+					data: {
+						verified: true,
+						userId: "user-id",
+						credentialId: "credential-id",
+					},
+				};
+			}
+			return { data: null };
+		});
+		const listPasskeys = { set: vi.fn() };
+		const store = { notify: vi.fn() };
+		const actions = getPasskeyActions(fetchMock as any, {
+			$listPasskeys: listPasskeys as any,
+			$store: store as any,
+		});
+
+		mocks.startAuthentication.mockResolvedValue({
+			clientExtensionResults: {},
+		});
+
+		const result = await actions.passkey.verifyPasskey();
+
+		expect(result.data?.verified).toBe(true);
+		expect(result.data?.userId).toBe("user-id");
+		expect(result.data?.credentialId).toBe("credential-id");
+		expect((result.data as any)?.session).toBeUndefined();
+	});
 });

--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -280,6 +280,69 @@ export const getPasskeyActions = (
 		}
 	};
 
+	const verifyPasskey = async (
+		opts?: {
+			autoFill?: boolean;
+			extensions?: AuthenticationExtensionsClientInputs;
+			fetchOptions?: ClientFetchOption;
+		},
+		options?: ClientFetchOption | undefined,
+	) => {
+		const response = await $fetch<PublicKeyCredentialRequestOptionsJSON>(
+			"/passkey/generate-authenticate-options",
+			{
+				method: "GET",
+				throw: false,
+			},
+		);
+		if (!response.data) {
+			return response;
+		}
+		try {
+			const mergedExtensions =
+				response.data.extensions || opts?.extensions
+					? {
+							...(response.data.extensions || {}),
+							...(opts?.extensions || {}),
+						}
+					: undefined;
+			const res = await startAuthentication({
+				optionsJSON: {
+					...response.data,
+					extensions: mergedExtensions,
+				},
+				useBrowserAutofill: opts?.autoFill,
+			});
+			const { clientExtensionResults: _ce, ...responseBody } = res;
+			const verified = await $fetch<{
+				verified: boolean;
+				userId: string;
+				credentialId: string;
+			}>("/passkey/verify-assertion", {
+				body: {
+					response: responseBody,
+				},
+				...opts?.fetchOptions,
+				...options,
+				method: "POST",
+				throw: false,
+			});
+
+			return verified;
+		} catch (err) {
+			console.error(`[Better Auth] Error verifying passkey`, err);
+			return {
+				data: null,
+				error: {
+					code: "AUTH_CANCELLED",
+					message: PASSKEY_ERROR_CODES.AUTH_CANCELLED.message,
+					status: 400,
+					statusText: "BAD_REQUEST",
+				},
+			};
+		}
+	};
+
 	return {
 		signIn: {
 			/**
@@ -292,6 +355,11 @@ export const getPasskeyActions = (
 			 * Add a passkey to the user account
 			 */
 			addPasskey: registerPasskey,
+			/**
+			 * Verify a passkey assertion without creating a session.
+			 * Useful for step-up authentication on sensitive operations.
+			 */
+			verifyPasskey: verifyPasskey,
 		},
 		/**
 		 * Inferred Internal Types

--- a/packages/passkey/src/index.ts
+++ b/packages/passkey/src/index.ts
@@ -7,6 +7,7 @@ import {
 	generatePasskeyRegistrationOptions,
 	listPasskeys,
 	updatePasskey,
+	verifyPasskeyAssertion,
 	verifyPasskeyAuthentication,
 	verifyPasskeyRegistration,
 } from "./routes";
@@ -50,6 +51,7 @@ export const passkey = (options?: PasskeyOptions | undefined) => {
 				}),
 			verifyPasskeyRegistration: verifyPasskeyRegistration(opts),
 			verifyPasskeyAuthentication: verifyPasskeyAuthentication(opts),
+			verifyPasskeyAssertion: verifyPasskeyAssertion(opts),
 			listPasskeys,
 			deletePasskey,
 			updatePasskey,

--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -585,6 +585,115 @@ describe("passkey", async () => {
 		expect(response.user.id).toBe(user.id);
 		expect(response.user.email).toBe(user.email);
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8071
+	 */
+	it("should verify passkey assertion without creating a session (step-up auth)", async () => {
+		const { headers, user } = await signInWithTestUser();
+		const context = await auth.$context;
+
+		const passkeyRecord = await context.adapter.create<
+			Omit<Passkey, "id">,
+			Passkey
+		>({
+			model: "passkey",
+			data: {
+				userId: user.id,
+				publicKey: "mockPublicKey",
+				name: "mockNameStepUp",
+				counter: 0,
+				deviceType: "singleDevice",
+				credentialID: "mockCredentialIDStepUp",
+				createdAt: new Date(),
+				backedUp: false,
+				transports: "mockTransports",
+				aaguid: "mockAAGUID",
+			} satisfies Omit<Passkey, "id">,
+		});
+
+		const sessionsBefore = await context.adapter.findMany({
+			model: "session",
+		});
+		const sessionCountBefore = sessionsBefore.length;
+
+		const client = createAuthClient({
+			plugins: [passkeyClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				headers: headers,
+				customFetchImpl,
+			},
+		});
+
+		const sessionBefore = await client.getSession({
+			fetchOptions: { headers },
+		});
+
+		let passkeyCookie = "";
+		await client.passkey.generateAuthenticateOptions({
+			fetchOptions: {
+				onResponse(context) {
+					const setCookie = context.response.headers.get("Set-Cookie");
+					if (setCookie) {
+						passkeyCookie = setCookie.split(";")[0] ?? "";
+					}
+				},
+			},
+		});
+
+		serverMocks.verifyAuthenticationResponse.mockResolvedValueOnce({
+			verified: true,
+			authenticationInfo: { newCounter: 1 },
+		});
+
+		const existingCookie = headers.get("cookie") ?? "";
+		headers.set(
+			"cookie",
+			existingCookie ? `${existingCookie}; ${passkeyCookie}` : passkeyCookie,
+		);
+		headers.set("origin", "http://localhost:3000");
+
+		const response = await auth.api.verifyPasskeyAssertion({
+			headers,
+			body: {
+				response: {
+					id: "mockCredentialIDStepUp",
+					rawId: "mockRawId",
+					response: {
+						clientDataJSON: "mockClientDataJSON",
+						authenticatorData: "mockAuthenticatorData",
+						signature: "mockSignature",
+						userHandle: "mockUserHandle",
+					},
+					type: "public-key",
+					clientExtensionResults: {},
+				},
+			},
+		});
+
+		const sessionAfter = await client.getSession({
+			fetchOptions: { headers },
+		});
+
+		expect(response.verified).toBe(true);
+		expect(response.userId).toBe(user.id);
+		expect(response.credentialId).toBe("mockCredentialIDStepUp");
+		expect((response as Record<string, unknown>).session).toBeUndefined();
+
+		const sessionsAfter = await context.adapter.findMany({
+			model: "session",
+		});
+
+		expect(sessionsAfter.length).toBe(sessionCountBefore);
+		expect(sessionBefore.data?.session.id).toBe(sessionAfter.data?.session.id);
+
+		const updatedPasskey = await context.adapter.findOne<Passkey>({
+			model: "passkey",
+			where: [{ field: "id", value: passkeyRecord.id }],
+		});
+		expect(updatedPasskey?.counter).toBe(1);
+	});
 });
 
 describe("passkey expirationTime per-request", () => {

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -675,6 +675,104 @@ const verifyPasskeyAuthenticationBodySchema = z.object({
 	response: z.record(z.any(), z.any()),
 });
 
+interface PasskeyAssertionResult {
+	passkey: Passkey;
+	verificationToken: string;
+}
+
+async function handlePasskeyAssertion(
+	options: RequiredPassKeyOptions,
+	ctx: GenericEndpointContext,
+): Promise<PasskeyAssertionResult> {
+	const origin = options?.origin || ctx.headers?.get("origin") || "";
+	if (!origin) {
+		throw new APIError("BAD_REQUEST", {
+			message: "origin missing",
+		});
+	}
+	const resp = ctx.body.response;
+	const webAuthnCookie = ctx.context.createAuthCookie(
+		options.advanced.webAuthnChallengeCookie,
+	);
+	const verificationToken = await ctx.getSignedCookie(
+		webAuthnCookie.name,
+		ctx.context.secret,
+	);
+	if (!verificationToken) {
+		throw APIError.from("BAD_REQUEST", PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND);
+	}
+
+	const data =
+		await ctx.context.internalAdapter.findVerificationValue(verificationToken);
+	if (!data) {
+		throw APIError.from("BAD_REQUEST", PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND);
+	}
+	const { expectedChallenge } = JSON.parse(
+		data.value,
+	) as WebAuthnChallengeValue;
+	const passkey = await ctx.context.adapter.findOne<Passkey>({
+		model: "passkey",
+		where: [
+			{
+				field: "credentialID",
+				value: resp.id,
+			},
+		],
+	});
+	if (!passkey) {
+		throw APIError.from("UNAUTHORIZED", PASSKEY_ERROR_CODES.PASSKEY_NOT_FOUND);
+	}
+
+	const authBaseURL =
+		typeof ctx.context.options.baseURL === "string"
+			? ctx.context.options.baseURL
+			: undefined;
+	const verification = await verifyAuthenticationResponse({
+		response: resp as AuthenticationResponseJSON,
+		expectedChallenge,
+		expectedOrigin: origin,
+		expectedRPID: getRpID(options, authBaseURL),
+		credential: {
+			id: passkey.credentialID,
+			publicKey: base64.decode(passkey.publicKey),
+			counter: passkey.counter,
+			transports: passkey.transports?.split(
+				",",
+			) as AuthenticatorTransportFuture[],
+		},
+		requireUserVerification: false,
+	});
+	const { verified } = verification;
+	if (!verified)
+		throw APIError.from(
+			"UNAUTHORIZED",
+			PASSKEY_ERROR_CODES.AUTHENTICATION_FAILED,
+		);
+
+	if (options.authentication?.afterVerification) {
+		await options.authentication.afterVerification({
+			ctx,
+			verification,
+			clientData: resp as AuthenticationResponseJSON,
+		});
+	}
+
+	await ctx.context.adapter.update<Passkey>({
+		model: "passkey",
+		where: [
+			{
+				field: "id",
+				value: passkey.id,
+			},
+		],
+		update: {
+			counter: verification.authenticationInfo.newCounter,
+		},
+	});
+
+	return { passkey, verificationToken };
+}
+
 export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 	createAuthEndpoint(
 		"/passkey/verify-authentication",
@@ -714,102 +812,11 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 			},
 		},
 		async (ctx) => {
-			const origin = options?.origin || ctx.headers?.get("origin") || "";
-			if (!origin) {
-				throw new APIError("BAD_REQUEST", {
-					message: "origin missing",
-				});
-			}
-			const resp = ctx.body.response;
-			const webAuthnCookie = ctx.context.createAuthCookie(
-				options.advanced.webAuthnChallengeCookie,
-			);
-			const verificationToken = await ctx.getSignedCookie(
-				webAuthnCookie.name,
-				ctx.context.secret,
-			);
-			if (!verificationToken) {
-				throw APIError.from(
-					"BAD_REQUEST",
-					PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
-				);
-			}
-
-			const data =
-				await ctx.context.internalAdapter.findVerificationValue(
-					verificationToken,
-				);
-			if (!data) {
-				throw APIError.from(
-					"BAD_REQUEST",
-					PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
-				);
-			}
-			const { expectedChallenge } = JSON.parse(
-				data.value,
-			) as WebAuthnChallengeValue;
-			const passkey = await ctx.context.adapter.findOne<Passkey>({
-				model: "passkey",
-				where: [
-					{
-						field: "credentialID",
-						value: resp.id,
-					},
-				],
-			});
-			if (!passkey) {
-				throw APIError.from(
-					"UNAUTHORIZED",
-					PASSKEY_ERROR_CODES.PASSKEY_NOT_FOUND,
-				);
-			}
 			try {
-				const authBaseURL =
-					typeof ctx.context.options.baseURL === "string"
-						? ctx.context.options.baseURL
-						: undefined;
-				const verification = await verifyAuthenticationResponse({
-					response: resp as AuthenticationResponseJSON,
-					expectedChallenge,
-					expectedOrigin: origin,
-					expectedRPID: getRpID(options, authBaseURL),
-					credential: {
-						id: passkey.credentialID,
-						publicKey: base64.decode(passkey.publicKey),
-						counter: passkey.counter,
-						transports: passkey.transports?.split(
-							",",
-						) as AuthenticatorTransportFuture[],
-					},
-					requireUserVerification: false,
-				});
-				const { verified } = verification;
-				if (!verified)
-					throw APIError.from(
-						"UNAUTHORIZED",
-						PASSKEY_ERROR_CODES.AUTHENTICATION_FAILED,
-					);
-
-				if (options.authentication?.afterVerification) {
-					await options.authentication.afterVerification({
-						ctx,
-						verification,
-						clientData: resp as AuthenticationResponseJSON,
-					});
-				}
-
-				await ctx.context.adapter.update<Passkey>({
-					model: "passkey",
-					where: [
-						{
-							field: "id",
-							value: passkey.id,
-						},
-					],
-					update: {
-						counter: verification.authenticationInfo.newCounter,
-					},
-				});
+				const { passkey, verificationToken } = await handlePasskeyAssertion(
+					options,
+					ctx,
+				);
 				const s = await ctx.context.internalAdapter.createSession(
 					passkey.userId,
 				);
@@ -846,6 +853,76 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 				);
 			} catch (e) {
 				ctx.context.logger.error("Failed to verify authentication", e);
+				throw APIError.from(
+					"BAD_REQUEST",
+					PASSKEY_ERROR_CODES.AUTHENTICATION_FAILED,
+				);
+			}
+		},
+	);
+
+export const verifyPasskeyAssertion = (options: RequiredPassKeyOptions) =>
+	createAuthEndpoint(
+		"/passkey/verify-assertion",
+		{
+			method: "POST",
+			use: [sessionMiddleware],
+			body: verifyPasskeyAuthenticationBodySchema,
+			metadata: {
+				openapi: {
+					operationId: "passkeyVerifyAssertion",
+					description:
+						"Verify a passkey assertion for step-up authentication without creating a session",
+					responses: {
+						200: {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											verified: { type: "boolean" },
+											userId: { type: "string" },
+											credentialId: { type: "string" },
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				$Infer: {
+					body: {} as {
+						response: AuthenticationResponseJSON;
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			try {
+				const { passkey, verificationToken } = await handlePasskeyAssertion(
+					options,
+					ctx,
+				);
+				if (passkey.userId !== ctx.context.session.user.id) {
+					throw APIError.from(
+						"UNAUTHORIZED",
+						PASSKEY_ERROR_CODES.PASSKEY_NOT_FOUND,
+					);
+				}
+				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+					verificationToken,
+				);
+				return ctx.json(
+					{
+						verified: true,
+						userId: passkey.userId,
+						credentialId: passkey.credentialID,
+					},
+					{ status: 200 },
+				);
+			} catch (e) {
+				ctx.context.logger.error("Failed to verify passkey assertion", e);
 				throw APIError.from(
 					"BAD_REQUEST",
 					PASSKEY_ERROR_CODES.AUTHENTICATION_FAILED,


### PR DESCRIPTION
closes #8071

This implements passkey step-up as proposed in #8071 . `POST /passkey/verify-assertion` and `authClient.passkey.verifyPaskey()` use the same logic as `/passkey/verify-authentication` except it doesn't create/refresh a session

Feel free to close this PR if it doesn’t align with your vision for the project or if you’re planning to implement it differently. Otherwise, let me know what changes are needed to get it shipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds step-up passkey verification to re-authenticate a logged-in user without creating or refreshing a session. Useful for confirming identity before sensitive actions.

- New Features
  - Added `POST /passkey/verify-assertion` to verify a WebAuthn assertion and return `{ verified, userId, credentialId }`; requires an existing session.
  - Added `authClient.passkey.verifyPasskey({ autoFill?, extensions?, fetchOptions? })` to fetch options, perform browser assertion, and call `verify-assertion`.
  - Shared verification handler reused across endpoints; validates challenge and origin, ensures the passkey belongs to the current user, updates the counter, and clears the challenge token.
  - Exported `verifyPasskeyAssertion` from `@better-auth/passkey`; docs now include client/server examples, and tests cover step-up flows.

<sup>Written for commit 3a6007cf02a0951c371e4d8aea2946d7db1cae74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

