### PR TITLE
feat(sso): add callback for validated SSO responses

### DIFF
--- a/.changeset/silver-sso-callbacks.md
+++ b/.changeset/silver-sso-callbacks.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+feat(sso): add callback for handling validated SSO responses

--- a/.changeset/silver-sso-callbacks.md
+++ b/.changeset/silver-sso-callbacks.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-feat(sso): add callback for handling validated SSO responses
+Add an SSO callback hook for handling validated provider responses before Better Auth creates a user session.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -691,6 +691,44 @@ The `provisionUser` function receives:
 * **token**: OAuth2 tokens (for OIDC providers) - may be undefined for SAML
 * **provider**: The SSO provider configuration
 
+### Custom SSO Callback Responses
+
+Use `onSSOAuthenticated` when you need to handle a validated SSO callback before Better Auth creates or links a user and sets a session cookie. Returning a `Response` takes over the callback response.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { sso } from "@better-auth/sso";
+
+const auth = betterAuth({
+    plugins: [
+        sso({
+            onSSOAuthenticated: async ({ userInfo, provider, callbackURL }) => {
+                await auditLog.create({
+                    action: "external_sso",
+                    providerId: provider.providerId,
+                    email: userInfo.email,
+                });
+
+                if (callbackURL.startsWith("/external/")) {
+                    return Response.redirect(
+                        new URL(callbackURL, "https://example.com").toString(),
+                    );
+                }
+            },
+        }),
+    ],
+});
+```
+
+The `onSSOAuthenticated` function receives:
+
+* **protocol**: The SSO protocol (`oidc` or `saml`)
+* **userInfo**: User information extracted from the SSO provider after protocol validation
+* **token**: OAuth2 tokens for OIDC providers
+* **provider**: The SSO provider configuration
+* **callbackURL**: The trusted callback URL Better Auth would redirect to after sign-in
+* **request**: The incoming callback request
+
 ### Organization Provisioning
 
 Organization provisioning automatically manages user memberships in organizations when SSO providers are linked to specific organizations. This is particularly useful for:
@@ -1535,6 +1573,8 @@ For a detailed guide on setting up SAML SSO with examples for Okta and testing w
 
 ### Server
 
+**onSSOAuthenticated**: A function called after an SSO response is validated and user info is extracted, but before Better Auth creates or links a user and sets a session cookie. Return a `Response` to take over the callback response.
+
 **provisionUser**: A custom function to provision a user when they sign in with an SSO provider.
 
 **provisionUserOnEveryLogin**: If `true`, the `provisionUser` callback runs on every login, not just on registration. Defaults to `false`.
@@ -1548,6 +1588,10 @@ For a detailed guide on setting up SAML SSO with examples for Okta and testing w
 If you want to allow account linking for specific trusted providers, enable the `accountLinking` option in your auth config and specify those providers in the `trustedProviders` list.
 
 export const ssoOptionsType = {
+	onSSOAuthenticated: {
+		description: "A function called after an SSO response is validated and user info is extracted, but before Better Auth creates or links a user and sets a session cookie. Return a Response to take over the callback response.",
+		type: "function",
+	},
 	provisionUser: {
 		description: "A custom function to provision a user when they sign in with an SSO provider.",
 		type: "function",

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -47,10 +47,24 @@ export {
 	SignatureAlgorithm,
 } from "./saml";
 
-import type { OIDCConfig, SAMLConfig, SSOOptions, SSOProvider } from "./types";
+import type {
+	OIDCConfig,
+	SAMLConfig,
+	SSOAuthenticatedContext,
+	SSOAuthenticatedUserInfo,
+	SSOOptions,
+	SSOProvider,
+} from "./types";
 import { PACKAGE_VERSION } from "./version";
 
-export type { SAMLConfig, OIDCConfig, SSOOptions, SSOProvider };
+export type {
+	SAMLConfig,
+	OIDCConfig,
+	SSOAuthenticatedContext,
+	SSOAuthenticatedUserInfo,
+	SSOOptions,
+	SSOProvider,
+};
 
 declare module "@better-auth/core" {
 	interface BetterAuthPluginRegistry<AuthOptions, Options> {

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -254,6 +254,76 @@ describe("SSO", async () => {
 		expect(callbackURL).toContain("/dashboard");
 	});
 
+	it("should allow handling an authenticated SSO callback before creating a session", async () => {
+		const onSSOAuthenticated = vi.fn(({ callbackURL, userInfo }) => {
+			const redirectURL = new URL(callbackURL, "http://localhost:3000");
+			redirectURL.searchParams.set("external", userInfo.id);
+			return Response.redirect(redirectURL.toString());
+		});
+		const { auth, signInWithTestUser, customFetchImpl, cookieSetter } =
+			await getTestInstance({
+				trustedOrigins: ["http://localhost:8080"],
+				plugins: [sso({ onSSOAuthenticated }), organization()],
+			});
+		const authClient = createAuthClient({
+			plugins: [ssoClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+		const { headers: adminHeaders } = await signInWithTestUser();
+		await auth.api.registerSSOProvider({
+			body: {
+				issuer: server.issuer.url!,
+				domain: "hook.com",
+				oidcConfig: {
+					clientId: "test",
+					clientSecret: "test",
+					authorizationEndpoint: `${server.issuer.url}/authorize`,
+					tokenEndpoint: `${server.issuer.url}/token`,
+					jwksEndpoint: `${server.issuer.url}/jwks`,
+					discoveryEndpoint: `${server.issuer.url}/.well-known/openid-configuration`,
+				},
+				providerId: "callback-hook",
+			},
+			headers: adminHeaders,
+		});
+		const headers = new Headers();
+		const res = await authClient.signIn.sso({
+			providerId: "callback-hook",
+			loginHint: "user@hook.com",
+			callbackURL: "/external-callback",
+			fetchOptions: {
+				throw: true,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const { callbackURL } = await simulateOAuthFlow(
+			res.url,
+			headers,
+			customFetchImpl,
+		);
+
+		expect(callbackURL).toBe(
+			"http://localhost:3000/external-callback?external=oauth2",
+		);
+		expect(onSSOAuthenticated).toHaveBeenCalledWith(
+			expect.objectContaining({
+				protocol: "oidc",
+				userInfo: expect.objectContaining({
+					id: "oauth2",
+					email: "oauth2@test.com",
+				}),
+				provider: expect.objectContaining({
+					providerId: "callback-hook",
+				}),
+				callbackURL: "/external-callback",
+			}),
+		);
+	});
+
 	it("should hydrate authorizationEndpoint via discovery when missing from stored config", async () => {
 		const { headers } = await signInWithTestUser();
 

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -314,7 +314,7 @@ describe("SSO", async () => {
 				protocol: "oidc",
 				userInfo: expect.objectContaining({
 					id: "oauth2",
-					email: "oauth2@test.com",
+					email: "test@localhost.com",
 				}),
 				provider: expect.objectContaining({
 					providerId: "callback-hook",

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -25,6 +25,10 @@ import { createIdP, createSP, findSAMLProvider } from "./helpers";
 
 type RelayState = Awaited<ReturnType<typeof parseRelayState>>;
 
+function cloneCallbackResponse(response: Response): Response {
+	return new Response(response.body, response);
+}
+
 /**
  * Validates and returns a safe redirect URL.
  * - Prevents open redirect attacks by validating against trusted origins
@@ -438,7 +442,7 @@ export async function processSAMLResponse(
 		request: ctx.request,
 	});
 	if (callbackResponse) {
-		return callbackResponse;
+		return cloneCallbackResponse(callbackResponse);
 	}
 
 	const result = await handleOAuthUserInfo(ctx, {

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -16,6 +16,7 @@ import type {
 	SAMLAssertionExtract,
 	SAMLConfig,
 	SAMLSessionRecord,
+	SSOAuthenticatedUserInfo,
 	SSOOptions,
 	SSOProvider,
 } from "../types";
@@ -125,7 +126,7 @@ export async function processSAMLResponse(
 	ctx: any,
 	params: SAMLResponseParams,
 	options?: SSOOptions,
-): Promise<string> {
+): Promise<Response | string> {
 	const { providerId, currentCallbackPath } = params;
 	const appOrigin = new URL(ctx.context.baseURL).origin;
 
@@ -411,13 +412,14 @@ export async function processSAMLResponse(
 			message: "Unable to extract user ID or email from SAML response",
 		});
 	}
+	const authenticatedUserInfo = userInfo as SSOAuthenticatedUserInfo;
 
 	// 15. Session creation
 	const isTrustedProvider: boolean =
 		ctx.context.trustedProviders.includes(providerId) ||
 		("domainVerified" in provider &&
 			!!(provider as { domainVerified?: boolean }).domainVerified &&
-			validateEmailDomain(userInfo.email as string, provider.domain));
+			validateEmailDomain(authenticatedUserInfo.email, provider.domain));
 
 	// TODO: split callbackUrl into separate ACS URL and post-auth redirect
 	// fields. Currently callbackUrl serves both purposes, which means
@@ -428,16 +430,27 @@ export async function processSAMLResponse(
 		parsedSamlConfig.callbackUrl ||
 		ctx.context.baseURL;
 
+	const callbackResponse = await options?.onSSOAuthenticated?.({
+		protocol: "saml",
+		userInfo: authenticatedUserInfo,
+		provider,
+		callbackURL: callbackUrl,
+		request: ctx.request,
+	});
+	if (callbackResponse) {
+		return callbackResponse;
+	}
+
 	const result = await handleOAuthUserInfo(ctx, {
 		userInfo: {
-			email: userInfo.email as string,
-			name: (userInfo.name || userInfo.email) as string,
-			id: userInfo.id as string,
+			email: authenticatedUserInfo.email,
+			name: authenticatedUserInfo.name || authenticatedUserInfo.email,
+			id: authenticatedUserInfo.id,
 			emailVerified: Boolean(userInfo.emailVerified),
 		},
 		account: {
 			providerId,
-			accountId: userInfo.id as string,
+			accountId: authenticatedUserInfo.id,
 			accessToken: "",
 			refreshToken: "",
 		},
@@ -461,7 +474,7 @@ export async function processSAMLResponse(
 	) {
 		await options.provisionUser({
 			user: user as User & Record<string, any>,
-			userInfo,
+			userInfo: authenticatedUserInfo,
 			provider,
 		});
 	}
@@ -472,8 +485,8 @@ export async function processSAMLResponse(
 		profile: {
 			providerType: "saml",
 			providerId,
-			accountId: userInfo.id as string,
-			email: userInfo.email as string,
+			accountId: authenticatedUserInfo.id,
+			email: authenticatedUserInfo.email,
 			emailVerified: Boolean(userInfo.emailVerified),
 			rawAttributes: attributes,
 		},

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -438,7 +438,7 @@ export async function processSAMLResponse(
 		protocol: "saml",
 		userInfo: authenticatedUserInfo,
 		provider,
-		callbackURL: callbackUrl,
+		callbackURL: samlRedirectUrl,
 		request: ctx.request,
 	});
 	if (callbackResponse) {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -41,6 +41,7 @@ import type {
 	SAMLAssertionExtract,
 	SAMLConfig,
 	SAMLSessionRecord,
+	SSOAuthenticatedUserInfo,
 	SSOOptions,
 	SSOProvider,
 } from "../types";
@@ -1541,14 +1542,7 @@ async function handleOIDCCallback(
 			}?error=invalid_provider&error_description=token_response_not_found`,
 		);
 	}
-	let userInfo: {
-		id?: string;
-		email?: string;
-		name?: string;
-		image?: string;
-		emailVerified?: boolean;
-		[key: string]: any;
-	} | null = null;
+	let userInfo: Partial<SSOAuthenticatedUserInfo> | null = null;
 	const mapping = config.mapping || {};
 
 	if (config.userInfoEndpoint) {
@@ -1649,26 +1643,38 @@ async function handleOIDCCallback(
 			}?error=invalid_provider&error_description=missing_user_info`,
 		);
 	}
+	const authenticatedUserInfo = userInfo as SSOAuthenticatedUserInfo;
+	const callbackResponse = await options?.onSSOAuthenticated?.({
+		protocol: "oidc",
+		userInfo: authenticatedUserInfo,
+		token: tokenResponse,
+		provider,
+		callbackURL,
+		request: ctx.request,
+	});
+	if (callbackResponse) {
+		return callbackResponse;
+	}
 	const isTrustedProvider =
 		"domainVerified" in provider &&
 		(provider as { domainVerified?: boolean }).domainVerified === true &&
-		validateEmailDomain(userInfo.email, provider.domain);
+		validateEmailDomain(authenticatedUserInfo.email, provider.domain);
 
 	const linked = await handleOAuthUserInfo(ctx, {
 		userInfo: {
-			email: userInfo.email,
-			name: userInfo.name || "",
-			id: userInfo.id,
-			image: userInfo.image,
+			email: authenticatedUserInfo.email,
+			name: authenticatedUserInfo.name || "",
+			id: authenticatedUserInfo.id,
+			image: authenticatedUserInfo.image,
 			emailVerified: options?.trustEmailVerified
-				? userInfo.emailVerified || false
+				? authenticatedUserInfo.emailVerified || false
 				: false,
 		},
 		account: {
 			idToken: tokenResponse.idToken,
 			accessToken: tokenResponse.accessToken,
 			refreshToken: tokenResponse.refreshToken,
-			accountId: userInfo.id,
+			accountId: authenticatedUserInfo.id,
 			providerId: provider.providerId,
 			accessTokenExpiresAt: tokenResponse.accessTokenExpiresAt,
 			refreshTokenExpiresAt: tokenResponse.refreshTokenExpiresAt,
@@ -1690,7 +1696,7 @@ async function handleOIDCCallback(
 	) {
 		await options.provisionUser({
 			user,
-			userInfo,
+			userInfo: authenticatedUserInfo,
 			token: tokenResponse,
 			provider,
 		});
@@ -1701,10 +1707,10 @@ async function handleOIDCCallback(
 		profile: {
 			providerType: "oidc",
 			providerId: provider.providerId,
-			accountId: userInfo.id,
-			email: userInfo.email,
-			emailVerified: Boolean(userInfo.emailVerified),
-			rawAttributes: userInfo,
+			accountId: authenticatedUserInfo.id,
+			email: authenticatedUserInfo.email,
+			emailVerified: Boolean(authenticatedUserInfo.emailVerified),
+			rawAttributes: authenticatedUserInfo,
 		},
 		provider,
 		token: tokenResponse,
@@ -1877,7 +1883,7 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 				});
 			}
 
-			const safeRedirectUrl = await processSAMLResponse(
+			const callbackResult = await processSAMLResponse(
 				ctx,
 				{
 					SAMLResponse: ctx.body.SAMLResponse,
@@ -1887,7 +1893,10 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 				},
 				options,
 			);
-			throw ctx.redirect(safeRedirectUrl);
+			if (callbackResult instanceof Response) {
+				return callbackResult;
+			}
+			throw ctx.redirect(callbackResult);
 		},
 	);
 };
@@ -1929,7 +1938,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 			const appOrigin = new URL(ctx.context.baseURL).origin;
 
 			try {
-				const safeRedirectUrl = await processSAMLResponse(
+				const callbackResult = await processSAMLResponse(
 					ctx,
 					{
 						SAMLResponse: ctx.body.SAMLResponse,
@@ -1939,7 +1948,10 @@ export const acsEndpoint = (options?: SSOOptions) => {
 					},
 					options,
 				);
-				throw ctx.redirect(safeRedirectUrl);
+				if (callbackResult instanceof Response) {
+					return callbackResult;
+				}
+				throw ctx.redirect(callbackResult);
 			} catch (error) {
 				// Re-throw redirects (they use throw for control flow)
 				if (

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -81,6 +81,10 @@ function getOIDCRedirectURI(
 	return `${baseURL}/sso/callback/${providerId}`;
 }
 
+function cloneCallbackResponse(response: Response): Response {
+	return new Response(response.body, response);
+}
+
 export {
 	type SAMLConditions,
 	type TimestampValidationOptions,
@@ -1653,7 +1657,7 @@ async function handleOIDCCallback(
 		request: ctx.request,
 	});
 	if (callbackResponse) {
-		return callbackResponse;
+		return cloneCallbackResponse(callbackResponse);
 	}
 	const isTrustedProvider =
 		"domainVerified" in provider &&
@@ -1894,7 +1898,7 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 				options,
 			);
 			if (callbackResult instanceof Response) {
-				return callbackResult;
+				return cloneCallbackResponse(callbackResult);
 			}
 			throw ctx.redirect(callbackResult);
 		},
@@ -1949,7 +1953,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 					options,
 				);
 				if (callbackResult instanceof Response) {
-					return callbackResult;
+					return cloneCallbackResponse(callbackResult);
 				}
 				throw ctx.redirect(callbackResult);
 			} catch (error) {

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -131,7 +131,51 @@ export type SSOProvider<O extends SSOOptions> =
 			} & BaseSSOProvider
 		: BaseSSOProvider;
 
+export type SSOAuthenticatedUserInfo = {
+	id: string;
+	email: string;
+	name?: string | undefined;
+	image?: string | undefined;
+	emailVerified?: boolean | undefined;
+	[key: string]: any;
+};
+
+export type SSOAuthenticatedContext = {
+	/**
+	 * The protocol used for the SSO callback.
+	 */
+	protocol: "oidc" | "saml";
+	/**
+	 * The user info extracted from the provider after protocol validation.
+	 */
+	userInfo: SSOAuthenticatedUserInfo;
+	/**
+	 * The OAuth2 tokens from the provider. Only present for OIDC callbacks.
+	 */
+	token?: OAuth2Tokens;
+	/**
+	 * The SSO provider.
+	 */
+	provider: SSOProvider<SSOOptions>;
+	/**
+	 * The trusted callback URL Better Auth would redirect to after sign-in.
+	 */
+	callbackURL: string;
+	/**
+	 * The incoming callback request.
+	 */
+	request?: Request;
+};
+
 export interface SSOOptions {
+	/**
+	 * Called after an SSO response is validated and user info is extracted, but
+	 * before Better Auth creates or links a user and sets a session cookie. Return
+	 * a Response to take over the callback response.
+	 */
+	onSSOAuthenticated?:
+		| ((data: SSOAuthenticatedContext) => Awaitable<Response | void>)
+		| undefined;
 	/**
 	 * custom function to provision a user when they sign in with an SSO provider.
 	 */


### PR DESCRIPTION
## The problem

Some applications let their users create externally accessible applications or pages that should be protected by the user’s configured SSO provider. The people authenticating to those user-created apps are not necessarily users of the host application itself, so provisioning a better auth user and issuing a session is not desired.

Currently, the SSO plugin always continues from a validated provider response into better auth user provisioning/session creation. There is no hook to take over the callback after OIDC/SAML validation but before that finalization step, so applications that need this behavior have to reimplement the SSO flow from scratch.

## Proposed solution

- Add `onSSOAuthenticated` to the SSO plugin, called after OIDC or SAML provider responses are validated and user info is extracted
- Allow the hook to return a `Response` to take over the callback before Better Auth creates or links a user and sets a session cookie
- Keep existing SSO behavior unchanged when the hook returns nothing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `onSSOAuthenticated` to the SSO plugin so apps can handle validated OIDC/SAML callbacks before `better-auth` creates or links a user and sets a session. The hook receives a sanitized callback URL and can return a `Response` to take over; if nothing is returned, the existing flow runs as before.

- New Features
  - New `onSSOAuthenticated` hook in `@better-auth/sso` for OIDC and SAML flows. Receives: `protocol`, `userInfo`, `token` (OIDC only), `provider`, `callbackURL` (sanitized), `request`.
  - New types: `SSOAuthenticatedUserInfo` and `SSOAuthenticatedContext`, exported from `@better-auth/sso`.
  - Updated docs with a usage example and option description.
  - Tests added to verify redirect takeover and context payload.

<sup>Written for commit ceae329a2af89087c359cd3fb0dcd345a7a0cd0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

