### PR TITLE
fix(organization): wrap delete cascades in a transaction

### DIFF
--- a/.changeset/organization-cascade-transaction.md
+++ b/.changeset/organization-cascade-transaction.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-`deleteOrganization` and `removeMember` cascades now run inside a transaction so a mid-cascade failure rolls back instead of leaving orphan rows.
+`deleteOrganization` and `removeMember` now roll back instead of leaving orphan rows when a step fails.

--- a/.changeset/organization-cascade-transaction.md
+++ b/.changeset/organization-cascade-transaction.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`deleteOrganization` and `removeMember` cascades now run inside a transaction so a mid-cascade failure rolls back instead of leaving orphan rows.

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1,5 +1,8 @@
 import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
-import { getCurrentAdapter } from "@better-auth/core/context";
+import {
+	getCurrentAdapter,
+	runWithTransaction,
+} from "@better-auth/core/context";
 import type { WhereOperator } from "@better-auth/core/db/adapter";
 import { BetterAuthError } from "@better-auth/core/error";
 import { filterOutputFields } from "@better-auth/core/utils/db";
@@ -328,48 +331,54 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			organizationId: string;
 			userId?: string;
 		}) => {
-			const adapter = await getCurrentAdapter(baseAdapter);
-			let userId: string;
-			if (!_userId) {
-				const member = await adapter.findOne<Member>({
-					model: "member",
-					where: [{ field: "id", value: memberId }],
-				});
-				if (!member) {
-					throw new BetterAuthError("Member not found");
+			return runWithTransaction(baseAdapter, async () => {
+				const adapter = await getCurrentAdapter(baseAdapter);
+				let userId: string;
+				if (!_userId) {
+					const member = await adapter.findOne<Member>({
+						model: "member",
+						where: [{ field: "id", value: memberId }],
+					});
+					if (!member) {
+						throw new BetterAuthError("Member not found");
+					}
+					userId = member.userId;
+				} else {
+					userId = _userId;
 				}
-				userId = member.userId;
-			} else {
-				userId = _userId;
-			}
-			const member = await adapter.delete<InferMember<O, false>>({
-				model: "member",
-				where: [
-					{
-						field: "id",
-						value: memberId,
-					},
-				],
-			});
-			// remove member from all teams they're part of
-			if (options?.teams?.enabled) {
-				const teams = await adapter.findMany<Team>({
-					model: "team",
-					where: [{ field: "organizationId", value: organizationId }],
+				const member = await adapter.delete<InferMember<O, false>>({
+					model: "member",
+					where: [
+						{
+							field: "id",
+							value: memberId,
+						},
+					],
 				});
-				await Promise.all(
-					teams.map((team) =>
-						adapter.deleteMany({
+				// remove member from all teams they're part of via a single `in`
+				// query so the cascade stays portable across transaction backends
+				// that reject parallel ops on the same session (notably MongoDB).
+				if (options?.teams?.enabled) {
+					const teams = await adapter.findMany<Team>({
+						model: "team",
+						where: [{ field: "organizationId", value: organizationId }],
+					});
+					if (teams.length > 0) {
+						await adapter.deleteMany({
 							model: "teamMember",
 							where: [
-								{ field: "teamId", value: team.id },
 								{ field: "userId", value: userId },
+								{
+									field: "teamId",
+									value: teams.map((team) => team.id),
+									operator: "in",
+								},
 							],
-						}),
-					),
-				);
-			}
-			return member;
+						});
+					}
+				}
+				return member;
+			});
 		},
 		updateOrganization: async (
 			organizationId: string,
@@ -407,35 +416,37 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			) as InferOrganization<O>;
 		},
 		deleteOrganization: async (organizationId: string) => {
-			const adapter = await getCurrentAdapter(baseAdapter);
-			await adapter.deleteMany({
-				model: "member",
-				where: [
-					{
-						field: "organizationId",
-						value: organizationId,
-					},
-				],
+			return runWithTransaction(baseAdapter, async () => {
+				const adapter = await getCurrentAdapter(baseAdapter);
+				await adapter.deleteMany({
+					model: "member",
+					where: [
+						{
+							field: "organizationId",
+							value: organizationId,
+						},
+					],
+				});
+				await adapter.deleteMany({
+					model: "invitation",
+					where: [
+						{
+							field: "organizationId",
+							value: organizationId,
+						},
+					],
+				});
+				await adapter.delete<InferOrganization<O, false>>({
+					model: "organization",
+					where: [
+						{
+							field: "id",
+							value: organizationId,
+						},
+					],
+				});
+				return organizationId;
 			});
-			await adapter.deleteMany({
-				model: "invitation",
-				where: [
-					{
-						field: "organizationId",
-						value: organizationId,
-					},
-				],
-			});
-			await adapter.delete<InferOrganization<O, false>>({
-				model: "organization",
-				where: [
-					{
-						field: "id",
-						value: organizationId,
-					},
-				],
-			});
-			return organizationId;
 		},
 		setActiveOrganization: async (
 			sessionToken: string,

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -355,9 +355,6 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 						},
 					],
 				});
-				// remove member from all teams they're part of via a single `in`
-				// query so the cascade stays portable across transaction backends
-				// that reject parallel ops on the same session (notably MongoDB).
 				if (options?.teams?.enabled) {
 					const teams = await adapter.findMany<Team>({
 						model: "team",

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -4011,7 +4011,7 @@ describe("delete cascade rollback", async () => {
 		expect(org).not.toBeNull();
 	});
 
-	it("rolls back deleteMember when an intermediate step throws", async () => {
+	it("rolls back removeMember when an intermediate step throws", async () => {
 		const db: Record<string, any[]> = {
 			users: [],
 			session: [],

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1,7 +1,7 @@
 import type { APIError } from "@better-auth/core/error";
 import { memoryAdapter } from "@better-auth/memory-adapter";
 import type { Prettify } from "better-call";
-import { describe, expect, expectTypeOf, it, onTestFinished } from "vitest";
+import { describe, expect, expectTypeOf, it, onTestFinished, vi } from "vitest";
 import type {
 	BetterFetchError,
 	PreinitializedWritableAtom,
@@ -3912,5 +3912,212 @@ describe("organization additionalFields with returned: false", async () => {
 
 		const dbOrg = db.organization.find((o) => o.id === org.data?.id);
 		expect(dbOrg?.secretField).toBe("updated-secret");
+	});
+});
+
+describe("delete cascade rollback", async () => {
+	it("rolls back deleteOrganization when an intermediate step throws", async () => {
+		const db: Record<string, any[]> = {
+			users: [],
+			session: [],
+			account: [],
+			verification: [],
+			organization: [],
+			member: [],
+			invitation: [],
+			team: [],
+			teamMember: [],
+		};
+		const { auth, signInWithTestUser, client } = await getTestInstance(
+			{
+				database: memoryAdapter(db, { debugLogs: false }),
+				user: { modelName: "users" },
+				plugins: [
+					organization({
+						async sendInvitationEmail() {},
+						teams: { enabled: true },
+					}),
+				],
+				logger: { level: "error" },
+			},
+			{
+				clientOptions: {
+					plugins: [organizationClient({ teams: { enabled: true } })],
+				},
+			},
+		);
+		const ctx = await auth.$context;
+		const { headers } = await signInWithTestUser();
+
+		const orgRes = await client.organization.create({
+			name: "Cascade Org",
+			slug: "cascade-org",
+			fetchOptions: { headers },
+		});
+		const organizationId = orgRes.data?.id as string;
+		expect(organizationId).toBeDefined();
+
+		const inviteRes = await client.organization.inviteMember(
+			{
+				email: "invitee@email.com",
+				role: "member",
+				organizationId,
+			},
+			{ headers },
+		);
+		expect(inviteRes.data).toBeDefined();
+
+		const originalTransaction = ctx.adapter.transaction.bind(ctx.adapter);
+		const spy = vi
+			.spyOn(ctx.adapter, "transaction")
+			.mockImplementation(async (cb: any) => {
+				return originalTransaction(async (trx: any) => {
+					const originalDeleteMany = trx.deleteMany.bind(trx);
+					trx.deleteMany = async (args: any) => {
+						if (args.model === "invitation") {
+							throw new Error("simulated mid-cascade failure");
+						}
+						return originalDeleteMany(args);
+					};
+					return cb(trx);
+				});
+			});
+
+		try {
+			await expect(
+				auth.api.deleteOrganization({
+					headers,
+					body: { organizationId },
+				}),
+			).rejects.toThrow();
+		} finally {
+			spy.mockRestore();
+		}
+
+		const memberCount = await ctx.adapter.count({
+			model: "member",
+			where: [{ field: "organizationId", value: organizationId }],
+		});
+		expect(memberCount).toBeGreaterThan(0);
+		const invitationCount = await ctx.adapter.count({
+			model: "invitation",
+			where: [{ field: "organizationId", value: organizationId }],
+		});
+		expect(invitationCount).toBeGreaterThan(0);
+		const org = await ctx.adapter.findOne({
+			model: "organization",
+			where: [{ field: "id", value: organizationId }],
+		});
+		expect(org).not.toBeNull();
+	});
+
+	it("rolls back deleteMember when an intermediate step throws", async () => {
+		const db: Record<string, any[]> = {
+			users: [],
+			session: [],
+			account: [],
+			verification: [],
+			organization: [],
+			member: [],
+			invitation: [],
+			team: [],
+			teamMember: [],
+		};
+		const { auth, signInWithTestUser, client, cookieSetter } =
+			await getTestInstance(
+				{
+					database: memoryAdapter(db, { debugLogs: false }),
+					user: { modelName: "users" },
+					plugins: [
+						organization({
+							async sendInvitationEmail() {},
+							teams: { enabled: true },
+						}),
+					],
+					logger: { level: "error" },
+				},
+				{
+					clientOptions: {
+						plugins: [organizationClient({ teams: { enabled: true } })],
+					},
+				},
+			);
+		const ctx = await auth.$context;
+		const { headers } = await signInWithTestUser();
+
+		const orgRes = await client.organization.create({
+			name: "Cascade Member Org",
+			slug: "cascade-member-org",
+			fetchOptions: { headers },
+		});
+		const organizationId = orgRes.data?.id as string;
+
+		const teamRes = await client.organization.createTeam(
+			{ name: "Cascade Team", organizationId },
+			{ headers },
+		);
+		const teamId = teamRes.data?.id as string;
+
+		const newUserHeaders = new Headers();
+		const signUpRes = await client.signUp.email(
+			{
+				email: "memberuser@email.com",
+				password: "password",
+				name: "Member User",
+			},
+			{ onSuccess: cookieSetter(newUserHeaders) },
+		);
+		const newUserId = signUpRes.data?.user.id as string;
+
+		const addedMember = await auth.api.addMember({
+			body: { organizationId, userId: newUserId, role: "member" },
+		});
+		const memberId = addedMember!.id;
+
+		await auth.api.addTeamMember({
+			headers,
+			body: { userId: newUserId, teamId, organizationId },
+		});
+
+		const originalTransaction = ctx.adapter.transaction.bind(ctx.adapter);
+		const spy = vi
+			.spyOn(ctx.adapter, "transaction")
+			.mockImplementation(async (cb: any) => {
+				return originalTransaction(async (trx: any) => {
+					const originalDeleteMany = trx.deleteMany.bind(trx);
+					trx.deleteMany = async (args: any) => {
+						if (args.model === "teamMember") {
+							throw new Error("simulated mid-cascade failure");
+						}
+						return originalDeleteMany(args);
+					};
+					return cb(trx);
+				});
+			});
+
+		try {
+			await expect(
+				auth.api.removeMember({
+					headers,
+					body: { organizationId, memberIdOrEmail: memberId },
+				}),
+			).rejects.toThrow();
+		} finally {
+			spy.mockRestore();
+		}
+
+		const memberStillThere = await ctx.adapter.findOne({
+			model: "member",
+			where: [{ field: "id", value: memberId }],
+		});
+		expect(memberStillThere).not.toBeNull();
+		const teamMemberCount = await ctx.adapter.count({
+			model: "teamMember",
+			where: [
+				{ field: "teamId", value: teamId },
+				{ field: "userId", value: newUserId },
+			],
+		});
+		expect(teamMemberCount).toBe(1);
 	});
 });


### PR DESCRIPTION
deleteOrganization and removeMember cascades now run inside runWithTransaction so a mid-cascade failure rolls back instead of leaving orphan rows. removeMember's per-team cleanup runs as a single deleteMany with an in clause to stay portable across transaction backends that reject parallel ops on the same session (MongoDB).