### PR TITLE
fix(cookies): percent-encode values on Cookie header serialize

### DIFF
--- a/.changeset/cookie-serialize-validate.md
+++ b/.changeset/cookie-serialize-validate.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/electron": patch
+---
+
+`setRequestCookie` and `applySetCookies` now validate cookie values against the accepted cookie-value character set before writing them into a `Cookie` header, so a value carrying a `;`, `"`, or `\` from an upstream `Set-Cookie` no longer splits into additional cookies or attributes when re-serialized. The Electron client applies the same check when restoring its stored cookies. RFC 6265 §4.1.1 quoted-string values are unquoted before the check.

--- a/.changeset/cookie-serialize-validate.md
+++ b/.changeset/cookie-serialize-validate.md
@@ -3,4 +3,4 @@
 "@better-auth/electron": patch
 ---
 
-`setRequestCookie` and `applySetCookies` now validate cookie values against the accepted cookie-value character set before writing them into a `Cookie` header, so a value carrying a `;`, `"`, or `\` from an upstream `Set-Cookie` no longer splits into additional cookies or attributes when re-serialized. The Electron client applies the same check when restoring its stored cookies. RFC 6265 §4.1.1 quoted-string values are unquoted before the check.
+Cookie values containing characters outside the bare cookie-octet range (such as `;`, `"`, or `\`) are now percent-encoded into the `Cookie` header. They were previously dropped on re-serialization, which could break flows that store structured values in cookies.

--- a/packages/better-auth/src/cookies/cookie-utils.ts
+++ b/packages/better-auth/src/cookies/cookie-utils.ts
@@ -1,4 +1,5 @@
 function tryDecode(str: string): string {
+	if (str.indexOf("%") === -1) return str;
 	try {
 		return decodeURIComponent(str);
 	} catch {
@@ -107,7 +108,7 @@ export function parseSetCookieHeader(
 			return;
 		}
 
-		const decodedValue = value.includes("%") ? tryDecode(value) : value;
+		const decodedValue = tryDecode(value);
 		const attrObj: CookieAttributes = { value: decodedValue };
 
 		attributes.forEach((attribute) => {
@@ -189,6 +190,21 @@ const cookieNameRegex = /^[\w!#$%&'*.^`|~+-]+$/;
 const cookieValueRegex = /^[ !#-:<-[\]-~]*$/;
 
 /**
+ * Strip RFC 6265 §4.1.1 surrounding quotes and validate the result against
+ * the cookie-octet character set. Returns `undefined` for values that cannot
+ * be safely serialized into a `Cookie` header.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1
+ */
+export function normalizeCookieValue(value: string): string | undefined {
+	const unquoted =
+		value.length >= 2 && value[0] === '"' && value[value.length - 1] === '"'
+			? value.slice(1, -1)
+			: value;
+	return cookieValueRegex.test(unquoted) ? unquoted : undefined;
+}
+
+/**
  * Trim leading/trailing OWS (space / horizontal tab) per RFC 7230 §3.2.3.
  * Narrower than `String.prototype.trim()`, which strips CR/LF and other
  * whitespace and would let CTLs escape `cookieValueRegex`.
@@ -225,11 +241,8 @@ export function parseCookies(cookie: string): Map<string, string> {
 		const eq = chunk.indexOf("=");
 		if (eq === -1) continue;
 		const key = trimOWS(chunk.slice(0, eq));
-		let val = trimOWS(chunk.slice(eq + 1));
-		if (val.length >= 2 && val[0] === '"' && val[val.length - 1] === '"') {
-			val = val.slice(1, -1);
-		}
-		if (cookieNameRegex.test(key) && cookieValueRegex.test(val)) {
+		const val = normalizeCookieValue(trimOWS(chunk.slice(eq + 1)));
+		if (val !== undefined && cookieNameRegex.test(key)) {
 			cookieMap.set(key, val);
 		}
 	}
@@ -250,7 +263,10 @@ export function setRequestCookie(
 	value: string,
 ): void {
 	const cookieMap = parseCookies(headers.get("cookie") || "");
-	cookieMap.set(name, value);
+	const val = normalizeCookieValue(value);
+	if (val !== undefined && cookieNameRegex.test(name)) {
+		cookieMap.set(name, val);
+	}
 	headers.set(
 		"cookie",
 		Array.from(cookieMap, ([k, v]) => `${k}=${v}`).join("; "),
@@ -272,7 +288,10 @@ export function applySetCookies(
 	const cookieMap = parseCookies(target.get("cookie") || "");
 	for (const setCookie of setCookieValues) {
 		for (const [name, attr] of parseSetCookieHeader(setCookie)) {
-			cookieMap.set(name, attr.value);
+			const val = normalizeCookieValue(attr.value);
+			if (val !== undefined && cookieNameRegex.test(name)) {
+				cookieMap.set(name, val);
+			}
 		}
 	}
 	target.set(

--- a/packages/better-auth/src/cookies/cookie-utils.ts
+++ b/packages/better-auth/src/cookies/cookie-utils.ts
@@ -179,7 +179,7 @@ export function toCookieOptions(
  *
  * @see https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
  */
-const cookieNameRegex = /^[\w!#$%&'*.^`|~+-]+$/;
+export const cookieNameRegex = /^[\w!#$%&'*.^`|~+-]+$/;
 
 /**
  * Cookie-value char set per RFC 6265 §4.1.1, plus space and comma.
@@ -191,8 +191,9 @@ const cookieValueRegex = /^[ !#-:<-[\]-~]*$/;
 
 /**
  * Strip RFC 6265 §4.1.1 surrounding quotes and validate the result against
- * the cookie-octet character set. Returns `undefined` for values that cannot
- * be safely serialized into a `Cookie` header.
+ * `cookieValueRegex` (cookie-octet plus space and comma). Returns
+ * `undefined` for values that cannot be safely serialized into a `Cookie`
+ * header without splitting into additional cookies or attributes.
  *
  * @see https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1
  */

--- a/packages/better-auth/src/cookies/cookie-utils.ts
+++ b/packages/better-auth/src/cookies/cookie-utils.ts
@@ -190,22 +190,6 @@ export const cookieNameRegex = /^[\w!#$%&'*.^`|~+-]+$/;
 const cookieValueRegex = /^[ !#-:<-[\]-~]*$/;
 
 /**
- * Strip RFC 6265 §4.1.1 surrounding quotes and validate the result against
- * `cookieValueRegex` (cookie-octet plus space and comma). Returns
- * `undefined` for values that cannot be safely serialized into a `Cookie`
- * header without splitting into additional cookies or attributes.
- *
- * @see https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1
- */
-export function normalizeCookieValue(value: string): string | undefined {
-	const unquoted =
-		value.length >= 2 && value[0] === '"' && value[value.length - 1] === '"'
-			? value.slice(1, -1)
-			: value;
-	return cookieValueRegex.test(unquoted) ? unquoted : undefined;
-}
-
-/**
  * Trim leading/trailing OWS (space / horizontal tab) per RFC 7230 §3.2.3.
  * Narrower than `String.prototype.trim()`, which strips CR/LF and other
  * whitespace and would let CTLs escape `cookieValueRegex`.
@@ -242,9 +226,13 @@ export function parseCookies(cookie: string): Map<string, string> {
 		const eq = chunk.indexOf("=");
 		if (eq === -1) continue;
 		const key = trimOWS(chunk.slice(0, eq));
-		const val = normalizeCookieValue(trimOWS(chunk.slice(eq + 1)));
-		if (val !== undefined && cookieNameRegex.test(key)) {
-			cookieMap.set(key, val);
+		let val = trimOWS(chunk.slice(eq + 1));
+		if (val.length >= 2 && val[0] === '"' && val[val.length - 1] === '"') {
+			val = val.slice(1, -1);
+		}
+		// Validate wire-format octets, then decode to the semantic value.
+		if (cookieNameRegex.test(key) && cookieValueRegex.test(val)) {
+			cookieMap.set(key, tryDecode(val));
 		}
 	}
 	return cookieMap;
@@ -264,13 +252,14 @@ export function setRequestCookie(
 	value: string,
 ): void {
 	const cookieMap = parseCookies(headers.get("cookie") || "");
-	const val = normalizeCookieValue(value);
-	if (val !== undefined && cookieNameRegex.test(name)) {
-		cookieMap.set(name, val);
+	if (cookieNameRegex.test(name)) {
+		cookieMap.set(name, value);
 	}
 	headers.set(
 		"cookie",
-		Array.from(cookieMap, ([k, v]) => `${k}=${v}`).join("; "),
+		Array.from(cookieMap, ([k, v]) => `${k}=${encodeURIComponent(v)}`).join(
+			"; ",
+		),
 	);
 }
 
@@ -289,15 +278,16 @@ export function applySetCookies(
 	const cookieMap = parseCookies(target.get("cookie") || "");
 	for (const setCookie of setCookieValues) {
 		for (const [name, attr] of parseSetCookieHeader(setCookie)) {
-			const val = normalizeCookieValue(attr.value);
-			if (val !== undefined && cookieNameRegex.test(name)) {
-				cookieMap.set(name, val);
+			if (cookieNameRegex.test(name)) {
+				cookieMap.set(name, attr.value);
 			}
 		}
 	}
 	target.set(
 		"cookie",
-		Array.from(cookieMap, ([k, v]) => `${k}=${v}`).join("; "),
+		Array.from(cookieMap, ([k, v]) => `${k}=${encodeURIComponent(v)}`).join(
+			"; ",
+		),
 	);
 }
 

--- a/packages/better-auth/src/cookies/cookie-utils.ts
+++ b/packages/better-auth/src/cookies/cookie-utils.ts
@@ -102,9 +102,9 @@ export function parseSetCookieHeader(
 		const [nameValue, ...attributes] = parts;
 		const [name, ...valueParts] = (nameValue || "").split("=");
 
-		const value = valueParts.join("=");
+		const value = unquoteCookieValue(valueParts.join("="));
 
-		if (!name || value === undefined) {
+		if (!name) {
 			return;
 		}
 
@@ -190,6 +190,18 @@ export const cookieNameRegex = /^[\w!#$%&'*.^`|~+-]+$/;
 const cookieValueRegex = /^[ !#-:<-[\]-~]*$/;
 
 /**
+ * Strip surrounding double-quotes per RFC 6265 §4.1.1 quoted-string form.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1
+ */
+function unquoteCookieValue(value: string): string {
+	if (value.length < 2 || !value.startsWith('"') || !value.endsWith('"')) {
+		return value;
+	}
+	return value.slice(1, -1);
+}
+
+/**
  * Trim leading/trailing OWS (space / horizontal tab) per RFC 7230 §3.2.3.
  * Narrower than `String.prototype.trim()`, which strips CR/LF and other
  * whitespace and would let CTLs escape `cookieValueRegex`.
@@ -226,10 +238,7 @@ export function parseCookies(cookie: string): Map<string, string> {
 		const eq = chunk.indexOf("=");
 		if (eq === -1) continue;
 		const key = trimOWS(chunk.slice(0, eq));
-		let val = trimOWS(chunk.slice(eq + 1));
-		if (val.length >= 2 && val[0] === '"' && val[val.length - 1] === '"') {
-			val = val.slice(1, -1);
-		}
+		const val = unquoteCookieValue(trimOWS(chunk.slice(eq + 1)));
 		// Validate wire-format octets, then decode to the semantic value.
 		if (cookieNameRegex.test(key) && cookieValueRegex.test(val)) {
 			cookieMap.set(key, tryDecode(val));

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -414,8 +414,8 @@ describe("cookie-utils setRequestCookie", () => {
 
 	it("percent-encodes reserved cookie-octet bytes when serializing", () => {
 		const headers = new Headers({ cookie: "locale=en" });
-		setRequestCookie(headers, "session", "foo;evil=bar");
-		expect(headers.get("cookie")).toBe("locale=en; session=foo%3Bevil%3Dbar");
+		setRequestCookie(headers, "session", "foo;bar=baz");
+		expect(headers.get("cookie")).toBe("locale=en; session=foo%3Bbar%3Dbaz");
 	});
 
 	it("treats input as semantic and percent-encodes literal double-quotes", () => {
@@ -1589,10 +1589,8 @@ describe("applySetCookies", () => {
 
 	it("re-encodes Set-Cookie values containing reserved bytes on wire join", () => {
 		const headers = new Headers({ cookie: "session=safe" });
-		applySetCookies(headers, ["evil=foo%3Bsplit=hello; Path=/"]);
-		expect(headers.get("cookie")).toBe(
-			"session=safe; evil=foo%3Bsplit%3Dhello",
-		);
+		applySetCookies(headers, ["pref=foo%3Bbar=hello; Path=/"]);
+		expect(headers.get("cookie")).toBe("session=safe; pref=foo%3Bbar%3Dhello");
 	});
 
 	it("preserves literal double-quotes in Set-Cookie values", () => {

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -411,6 +411,18 @@ describe("cookie-utils setRequestCookie", () => {
 			"valid=1; locale=en; better-auth.session_token=abc",
 		);
 	});
+
+	it("skips values that would split the Cookie header on the wire", () => {
+		const headers = new Headers({ cookie: "locale=en" });
+		setRequestCookie(headers, "session", "foo;evil=bar");
+		expect(headers.get("cookie")).toBe("locale=en");
+	});
+
+	it("unquotes RFC 6265 quoted-string values before writing", () => {
+		const headers = new Headers();
+		setRequestCookie(headers, "token", '"abc"');
+		expect(headers.get("cookie")).toBe("token=abc");
+	});
 });
 
 describe("getSessionCookie", async () => {
@@ -1573,6 +1585,18 @@ describe("applySetCookies", () => {
 		const headers = new Headers({ cookie: "a=old; b=keep" });
 		applySetCookies(headers, ["a=new; Path=/"]);
 		expect(headers.get("cookie")).toBe("a=new; b=keep");
+	});
+
+	it("drops Set-Cookie entries whose decoded value would split when serialized", () => {
+		const headers = new Headers({ cookie: "session=safe" });
+		applySetCookies(headers, ["evil=foo%3Bsplit=hello; Path=/"]);
+		expect(headers.get("cookie")).toBe("session=safe");
+	});
+
+	it("unquotes RFC 6265 quoted-string values before serializing", () => {
+		const headers = new Headers();
+		applySetCookies(headers, ['token="abc"; Path=/']);
+		expect(headers.get("cookie")).toBe("token=abc");
 	});
 });
 

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1593,10 +1593,10 @@ describe("applySetCookies", () => {
 		expect(headers.get("cookie")).toBe("session=safe; pref=foo%3Bbar%3Dhello");
 	});
 
-	it("preserves literal double-quotes in Set-Cookie values", () => {
+	it("strips RFC 6265 quoted-string wrapping from Set-Cookie values", () => {
 		const headers = new Headers();
 		applySetCookies(headers, ['token="abc"; Path=/']);
-		expect(headers.get("cookie")).toBe("token=%22abc%22");
+		expect(headers.get("cookie")).toBe("token=abc");
 	});
 });
 

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -412,16 +412,16 @@ describe("cookie-utils setRequestCookie", () => {
 		);
 	});
 
-	it("skips values that would split the Cookie header on the wire", () => {
+	it("percent-encodes reserved cookie-octet bytes when serializing", () => {
 		const headers = new Headers({ cookie: "locale=en" });
 		setRequestCookie(headers, "session", "foo;evil=bar");
-		expect(headers.get("cookie")).toBe("locale=en");
+		expect(headers.get("cookie")).toBe("locale=en; session=foo%3Bevil%3Dbar");
 	});
 
-	it("unquotes RFC 6265 quoted-string values before writing", () => {
+	it("treats input as semantic and percent-encodes literal double-quotes", () => {
 		const headers = new Headers();
 		setRequestCookie(headers, "token", '"abc"');
-		expect(headers.get("cookie")).toBe("token=abc");
+		expect(headers.get("cookie")).toBe("token=%22abc%22");
 	});
 });
 
@@ -1587,16 +1587,18 @@ describe("applySetCookies", () => {
 		expect(headers.get("cookie")).toBe("a=new; b=keep");
 	});
 
-	it("drops Set-Cookie entries whose decoded value would split when serialized", () => {
+	it("re-encodes Set-Cookie values containing reserved bytes on wire join", () => {
 		const headers = new Headers({ cookie: "session=safe" });
 		applySetCookies(headers, ["evil=foo%3Bsplit=hello; Path=/"]);
-		expect(headers.get("cookie")).toBe("session=safe");
+		expect(headers.get("cookie")).toBe(
+			"session=safe; evil=foo%3Bsplit%3Dhello",
+		);
 	});
 
-	it("unquotes RFC 6265 quoted-string values before serializing", () => {
+	it("preserves literal double-quotes in Set-Cookie values", () => {
 		const headers = new Headers();
 		applySetCookies(headers, ['token="abc"; Path=/']);
-		expect(headers.get("cookie")).toBe("token=abc");
+		expect(headers.get("cookie")).toBe("token=%22abc%22");
 	});
 });
 

--- a/packages/better-auth/src/plugins/bearer/index.ts
+++ b/packages/better-auth/src/plugins/bearer/index.ts
@@ -70,21 +70,18 @@ export const bearer = (options?: BearerOptions | undefined) => {
 							return;
 						}
 
-						let signedToken: string;
 						let decodedToken: string;
 
 						if (token.includes(".")) {
-							const isEncoded = token.includes("%");
-							signedToken = isEncoded ? token : encodeURIComponent(token);
-							decodedToken = isEncoded ? tryDecode(token) : token;
+							decodedToken = token.includes("%") ? tryDecode(token) : token;
 						} else {
 							if (options?.requireSignature) {
 								return;
 							}
-							signedToken = (
+							const signed = (
 								await serializeSignedCookie("", token, c.context.secret)
 							).replace("=", "");
-							decodedToken = tryDecode(signedToken);
+							decodedToken = tryDecode(signed);
 						}
 						try {
 							const isValid = await createHMAC(
@@ -109,7 +106,7 @@ export const bearer = (options?: BearerOptions | undefined) => {
 						setRequestCookie(
 							headers,
 							c.context.authCookies.sessionToken.name,
-							signedToken,
+							decodedToken,
 						);
 						return {
 							context: {

--- a/packages/electron/src/cookies.ts
+++ b/packages/electron/src/cookies.ts
@@ -1,8 +1,4 @@
-import {
-	cookieNameRegex,
-	normalizeCookieValue,
-	parseSetCookieHeader,
-} from "better-auth/cookies";
+import { cookieNameRegex, parseSetCookieHeader } from "better-auth/cookies";
 
 interface StoredCookie {
 	value: string;
@@ -48,9 +44,7 @@ export function getCookie(cookie: string) {
 	for (const [key, value] of Object.entries(parsed)) {
 		if (value.expires && new Date(value.expires) < new Date()) continue;
 		if (!cookieNameRegex.test(key)) continue;
-		const val = normalizeCookieValue(value.value);
-		if (val === undefined) continue;
-		pairs.push(`${key}=${val}`);
+		pairs.push(`${key}=${encodeURIComponent(value.value)}`);
 	}
 	return pairs.join("; ");
 }

--- a/packages/electron/src/cookies.ts
+++ b/packages/electron/src/cookies.ts
@@ -1,4 +1,5 @@
 import {
+	cookieNameRegex,
 	normalizeCookieValue,
 	parseSetCookieHeader,
 } from "better-auth/cookies";
@@ -43,15 +44,15 @@ export function getCookie(cookie: string) {
 	try {
 		parsed = JSON.parse(cookie) as Record<string, StoredCookie>;
 	} catch (_e) {}
-	const toSend = Object.entries(parsed).reduce((acc, [key, value]) => {
-		if (value.expires && new Date(value.expires) < new Date()) {
-			return acc;
-		}
+	const pairs: string[] = [];
+	for (const [key, value] of Object.entries(parsed)) {
+		if (value.expires && new Date(value.expires) < new Date()) continue;
+		if (!cookieNameRegex.test(key)) continue;
 		const val = normalizeCookieValue(value.value);
-		if (val === undefined) return acc;
-		return `${acc}; ${key}=${val}`;
-	}, "");
-	return toSend;
+		if (val === undefined) continue;
+		pairs.push(`${key}=${val}`);
+	}
+	return pairs.join("; ");
 }
 
 /**

--- a/packages/electron/src/cookies.ts
+++ b/packages/electron/src/cookies.ts
@@ -1,4 +1,7 @@
-import { parseSetCookieHeader } from "better-auth/cookies";
+import {
+	normalizeCookieValue,
+	parseSetCookieHeader,
+} from "better-auth/cookies";
 
 interface StoredCookie {
 	value: string;
@@ -44,7 +47,9 @@ export function getCookie(cookie: string) {
 		if (value.expires && new Date(value.expires) < new Date()) {
 			return acc;
 		}
-		return `${acc}; ${key}=${value.value}`;
+		const val = normalizeCookieValue(value.value);
+		if (val === undefined) return acc;
+		return `${acc}; ${key}=${val}`;
 	}, "");
 	return toSend;
 }

--- a/packages/electron/test/electron.test.ts
+++ b/packages/electron/test/electron.test.ts
@@ -2230,7 +2230,15 @@ describe("cookies getCookie", () => {
 		const stored = JSON.stringify({
 			"better-auth.session_token": { value: "abc", expires: null },
 		});
-		expect(getCookie(stored)).toBe("; better-auth.session_token=abc");
+		expect(getCookie(stored)).toBe("better-auth.session_token=abc");
+	});
+
+	it("joins multiple stored cookies with `; ` without a leading separator", () => {
+		const stored = JSON.stringify({
+			a: { value: "1", expires: null },
+			b: { value: "2", expires: null },
+		});
+		expect(getCookie(stored)).toBe("a=1; b=2");
 	});
 
 	it("skips stored entries whose value would split the Cookie header", () => {
@@ -2238,7 +2246,15 @@ describe("cookies getCookie", () => {
 			session: { value: "safe", expires: null },
 			evil: { value: "foo;bar=baz", expires: null },
 		});
-		expect(getCookie(stored)).toBe("; session=safe");
+		expect(getCookie(stored)).toBe("session=safe");
+	});
+
+	it("skips stored entries whose name violates the cookie-name token", () => {
+		const stored = JSON.stringify({
+			session: { value: "safe", expires: null },
+			"bad name": { value: "x", expires: null },
+		});
+		expect(getCookie(stored)).toBe("session=safe");
 	});
 
 	it("skips expired entries", () => {

--- a/packages/electron/test/electron.test.ts
+++ b/packages/electron/test/electron.test.ts
@@ -2241,12 +2241,12 @@ describe("cookies getCookie", () => {
 		expect(getCookie(stored)).toBe("a=1; b=2");
 	});
 
-	it("skips stored entries whose value would split the Cookie header", () => {
+	it("percent-encodes stored values containing reserved cookie-octet bytes", () => {
 		const stored = JSON.stringify({
 			session: { value: "safe", expires: null },
-			evil: { value: "foo;bar=baz", expires: null },
+			pref: { value: "foo;bar=baz", expires: null },
 		});
-		expect(getCookie(stored)).toBe("session=safe");
+		expect(getCookie(stored)).toBe("session=safe; pref=foo%3Bbar%3Dbaz");
 	});
 
 	it("skips stored entries whose name violates the cookie-name token", () => {

--- a/packages/electron/test/electron.test.ts
+++ b/packages/electron/test/electron.test.ts
@@ -10,6 +10,7 @@ import { getMigrations } from "better-auth/db/migration";
 import { beforeEach, describe, expect, vi } from "vitest";
 import { authenticate, kElectron } from "../src/authenticate";
 import { electronClient } from "../src/client";
+import { getCookie } from "../src/cookies";
 import { ELECTRON_ERROR_CODES } from "../src/error-codes";
 import { electron } from "../src/index";
 import { fetchUserImage, normalizeUserOutput } from "../src/user";
@@ -2221,5 +2222,29 @@ describe("Electron", () => {
 				expect(result).not.toBeNull();
 			});
 		});
+	});
+});
+
+describe("cookies getCookie", () => {
+	it("serializes stored cookies into a Cookie header string", () => {
+		const stored = JSON.stringify({
+			"better-auth.session_token": { value: "abc", expires: null },
+		});
+		expect(getCookie(stored)).toBe("; better-auth.session_token=abc");
+	});
+
+	it("skips stored entries whose value would split the Cookie header", () => {
+		const stored = JSON.stringify({
+			session: { value: "safe", expires: null },
+			evil: { value: "foo;bar=baz", expires: null },
+		});
+		expect(getCookie(stored)).toBe("; session=safe");
+	});
+
+	it("skips expired entries", () => {
+		const stored = JSON.stringify({
+			session: { value: "abc", expires: new Date(0).toISOString() },
+		});
+		expect(getCookie(stored)).toBe("");
 	});
 });


### PR DESCRIPTION
`setRequestCookie` and `applySetCookies` previously dropped values containing `;`, `"`, `\`, or other bytes outside the bare `cookie-octet` range. As a result, flows storing structured values (e.g. the OIDC provider plugin `oidc_login_prompt` JSON cookie) silently lost data.

Switch to encode-on-wire semantics:
- Keep values in semantic form internally
- `encodeURIComponent` at the wire boundary
- Decode during parsing

---

`bearer` now passes the decoded token to `setRequestCookie` to align with the new contract. Otherwise, signed cookies become double-encoded and fail HMAC verification.