### PR TITLE
docs: add ton-better-auth plugin information

### DIFF
--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -32,3 +32,4 @@ qamarq
 C-W-D-Harshit
 efiz
 Braem
+mhbdev

--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -285,7 +285,7 @@ export const communityPlugins: CommunityPlugin[] = [
 		name: "ton-better-auth",
 		url: "https://github.com/mhbdev/ton-better-auth",
 		description:
-			"Sign in with TonConnect",
+			"Sign in with Ton Connect",
 		author: {
 			name: "mhbdev",
 			github: "mhbdev",

--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -281,4 +281,15 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/elliotBraem.png",
 		},
 	},
+	{
+		name: "ton-better-auth",
+		url: "https://github.com/mhbdev/ton-better-auth",
+		description:
+			"Sign in with TonConnect",
+		author: {
+			name: "mhbdev",
+			github: "mhbdev",
+			avatar: "https://github.com/mhbdev.png",
+		},
+	},
 ];

--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -284,8 +284,7 @@ export const communityPlugins: CommunityPlugin[] = [
 	{
 		name: "ton-better-auth",
 		url: "https://github.com/mhbdev/ton-better-auth",
-		description:
-			"Sign in with Ton Connect",
+		description: "Sign in with Ton Connect",
 		author: {
 			name: "mhbdev",
 			github: "mhbdev",


### PR DESCRIPTION
Sign in with TON Connect for [Better Auth](https://better-auth.com/). TON Connect enables communication between wallets and apps in the TON ecosystem. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `ton-better-auth` to the Community Plugins list, linking to a TON Connect sign-in plugin for `better-auth` by `mhbdev`. Updated `.cspell` names to include `mhbdev`.

<sup>Written for commit e212b968643394eac4945d866bc0e686cd9ada8c. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9637?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

