### PR TITLE
chore: use correct auth cli

### DIFF
--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: 'Package name (e.g., better-auth, @better-auth/cli)'
+        description: 'Package name (e.g., better-auth, @better-auth/core)'
         required: true
         type: string
       version:

--- a/docs/content/docs/plugins/scim.mdx
+++ b/docs/content/docs/plugins/scim.mdx
@@ -228,13 +228,13 @@ Once enabled, make sure you migrate the database schema (again).
 <Tabs items={["migrate", "generate"]}>
   <Tab value="migrate">
     ```bash
-    npx @better-auth/cli migrate
+    npx auth migrate
     ```
   </Tab>
 
   <Tab value="generate">
     ```bash
-    npx @better-auth/cli generate
+    npx auth generate
     ```
   </Tab>
 </Tabs>

--- a/docs/content/docs/reference/errors/state_mismatch.mdx
+++ b/docs/content/docs/reference/errors/state_mismatch.mdx
@@ -178,7 +178,7 @@ verification record could not be written to the database.
 
 ### How to fix
 
-* Run `npx @better-auth/cli migrate` to ensure all tables exist.
+* Run `npx auth migrate` to ensure all tables exist.
 * Check your database connection and credentials.
 * Review any `databaseHooks` on the `verification` model that might prevent writes.
 
@@ -200,7 +200,7 @@ triggers, and what to do about it.
 | **Medium**    | Signed cookie expired (5 min) while DB record is still valid (10 min) | `state_security_mismatch`                                       | The cookie has a shorter TTL than the DB record; users between 5–10 min will hit this |
 | **Low**       | Secret rotation mid-flow                                              | `state_invalid` (cookie) or `state_mismatch` (DB + hashed)      | Rotate secrets during low-traffic windows                                             |
 | **Low**       | OAuth provider altered the state parameter                            | `state_mismatch` (DB)                                           | Verify the provider preserves `state` exactly; check for URL encoding issues          |
-| **Low**       | Missing verification table / migration not run                        | `state_generation_error`                                        | Run `npx @better-auth/cli migrate`                                                    |
+| **Low**       | Missing verification table / migration not run                        | `state_generation_error`                                        | Run `npx auth migrate`                                                    |
 | **Very low**  | Clock skew between server instances                                   | request expired                                                 | Enable NTP on all servers                                                             |
 
 ***

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -4,7 +4,7 @@ import { spawnCommand } from "../utils/helper";
 
 async function loginAction() {
 	try {
-		await spawnCommand("npx @better-auth/cli@latest login");
+		await spawnCommand("npx auth@latest login");
 	} catch (error: any) {
 		log.error(error.message || "An unknown error occurred");
 		process.exit(1);
@@ -19,7 +19,7 @@ export const login = new Command("login")
 
 async function logoutAction() {
 	try {
-		await spawnCommand("npx @better-auth/cli@latest logout");
+		await spawnCommand("npx auth@latest logout");
 	} catch (error: any) {
 		log.error(error.message || "An unknown error occurred");
 		process.exit(1);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch all CLI usage to the new `auth` CLI and remove references to `@better-auth/cli`. Update docs and CI examples to use `auth` and `@better-auth/core`.

- **Bug Fixes**
  - CLI: `login`/`logout` now run `npx auth@latest` instead of `npx @better-auth/cli@latest`.
  - Docs: replace `npx @better-auth/cli migrate|generate` with `npx auth migrate|generate`, and update the error guide.
  - CI: update npm dist-tag input example to `@better-auth/core`.

<sup>Written for commit b497d3a1f9181acba8cd2b8eb457894cf1a08c87. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9638?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

