### PR TITLE
fix(two-factor): delete session cookie cache on 2fa response

### DIFF
--- a/.changeset/three-rabbits-wait.md
+++ b/.changeset/three-rabbits-wait.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix session cookie leak on 2FA-required sign-in. The credential handler wrote valid `session_token` / `session_data` cookies that the 2FA after-hook only appended expiring overrides to; raw-response readers could capture the valid values and replay them to bypass 2FA when `session.cookieCache.enabled`. `expireCookie` now scrubs prior matching `Set-Cookie` entries (including chunks) before re-setting. `/two-factor/disable` switched to `sensitiveSessionMiddleware` as defense in depth.

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1592,4 +1592,47 @@ describe("expireCookie", () => {
 			maxAge: 0,
 		});
 	});
+
+	it("scrubs collapsed Set-Cookie headers when getSetCookie is unavailable", () => {
+		const responseHeaders = new Headers();
+		responseHeaders.append("set-cookie", "keep=1; Path=/");
+		responseHeaders.append("set-cookie", "target=valid; Path=/");
+		responseHeaders.append("set-cookie", "target.0=chunk; Path=/");
+		Object.defineProperty(responseHeaders, "getSetCookie", {
+			value: undefined,
+		});
+
+		const setCookie = vi.fn(
+			(
+				name: string,
+				value: string,
+				options: { maxAge: number; path: string },
+			) => {
+				responseHeaders.append(
+					"set-cookie",
+					`${name}=${value}; Path=${options.path}; Max-Age=${options.maxAge}`,
+				);
+			},
+		);
+
+		expireCookie(
+			{
+				responseHeaders,
+				context: { responseHeaders },
+				setCookie,
+			} as any,
+			{
+				name: "target",
+				attributes: {
+					path: "/",
+				},
+			},
+		);
+
+		const setCookieHeader = responseHeaders.get("set-cookie") || "";
+		expect(setCookieHeader).toContain("keep=1");
+		expect(setCookieHeader).not.toContain("target=valid");
+		expect(setCookieHeader).not.toContain("target.0=chunk");
+		expect(setCookieHeader).toContain("target=; Path=/; Max-Age=0");
+	});
 });

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -24,7 +24,11 @@ import { getDate } from "../utils/date";
 import { isPromise } from "../utils/is-promise";
 import { sec } from "../utils/time";
 import { isDynamicBaseURLConfig } from "../utils/url";
-import { parseCookies, SECURE_COOKIE_PREFIX } from "./cookie-utils";
+import {
+	parseCookies,
+	SECURE_COOKIE_PREFIX,
+	splitSetCookieHeader,
+} from "./cookie-utils";
 import {
 	createAccountStore,
 	createSessionStore,
@@ -345,12 +349,14 @@ function removeSetCookieEntries(
 
 	for (const headers of targets) {
 		// `Headers.getSetCookie()` is standard on Node ≥18.14, Bun, Deno, and
-		// Cloudflare Workers, but older Node and some polyfilled Headers
-		// shims don't expose it. Degrade gracefully on those rather than
-		// throwing — the leak goes un-scrubbed, but every other expireCookie
-		// caller in the codebase keeps working.
-		if (typeof headers.getSetCookie !== "function") continue;
-		const existing = headers.getSetCookie();
+		// Cloudflare Workers, but older Node and some polyfilled Headers shims
+		// expose Set-Cookie as a collapsed string. Parse that fallback before
+		// rewriting the header so stale session cookies don't survive there.
+		const existing =
+			typeof headers.getSetCookie === "function"
+				? headers.getSetCookie()
+				: splitSetCookieHeader(headers.get("set-cookie") || "");
+		if (!existing.length) continue;
 		const survivors = existing.filter(
 			(entry) => !entry.startsWith(exact) && !entry.startsWith(chunk),
 		);

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -305,6 +305,63 @@ export async function setSessionCookie(
 	ctx.context.setNewSession(session);
 }
 
+type CookieScrubView = GenericEndpointContext & {
+	responseHeaders?: Headers;
+	context: GenericEndpointContext["context"] & { responseHeaders?: Headers };
+};
+
+/**
+ * Remove any prior `Set-Cookie` entries on the current response whose cookie
+ * name matches `cookieName` or any chunked variant (`${cookieName}.0`, etc.).
+ *
+ * Prevents a valid cookie value from leaking on the wire when the same cookie
+ * is set and then expired within a single request (e.g. `/sign-in/email`
+ * writes credential session cookies and the 2FA after-hook expires them).
+ * Browsers honor the expiring entry, but anything reading the raw response
+ * headers — proxy/LB logs, server-side SDK consumers, observability tools —
+ * sees the earlier valid value and could replay it (bypassing the 2FA gate
+ * when the cookie cache is enabled).
+ *
+ * Scrubs both the local middleware scope's `responseHeaders` and the outer
+ * endpoint scope's `ctx.context.responseHeaders`, because plugin after-hooks
+ * run in a fresh local scope while accumulated response headers live on the
+ * outer one. `scoped.context` is required by {@link GenericEndpointContext}
+ * but unit-test mocks pass a minimal object via `as any`, so we use optional
+ * chaining defensively. The `Set` collapses the case where both scopes
+ * reference the same `Headers`.
+ */
+function removeSetCookieEntries(
+	ctx: GenericEndpointContext,
+	cookieName: string,
+) {
+	const scoped = ctx as CookieScrubView;
+	const targets = new Set<Headers>();
+	if (scoped.responseHeaders) targets.add(scoped.responseHeaders);
+	if (scoped.context?.responseHeaders)
+		targets.add(scoped.context.responseHeaders);
+
+	const exact = `${cookieName}=`;
+	const chunk = `${cookieName}.`;
+
+	for (const headers of targets) {
+		// `Headers.getSetCookie()` is standard on Node ≥18.14, Bun, Deno, and
+		// Cloudflare Workers, but older Node and some polyfilled Headers
+		// shims don't expose it. Degrade gracefully on those rather than
+		// throwing — the leak goes un-scrubbed, but every other expireCookie
+		// caller in the codebase keeps working.
+		if (typeof headers.getSetCookie !== "function") continue;
+		const existing = headers.getSetCookie();
+		const survivors = existing.filter(
+			(entry) => !entry.startsWith(exact) && !entry.startsWith(chunk),
+		);
+		if (survivors.length === existing.length) continue;
+		headers.delete("set-cookie");
+		for (const entry of survivors) {
+			headers.append("set-cookie", entry);
+		}
+	}
+}
+
 /**
  * Expires a cookie by setting `maxAge: 0` while preserving its attributes
  */
@@ -312,6 +369,7 @@ export function expireCookie(
 	ctx: GenericEndpointContext,
 	cookie: BetterAuthCookie,
 ) {
+	removeSetCookieEntries(ctx, cookie.name);
 	ctx.setCookie(cookie.name, "", {
 		...cookie.attributes,
 		maxAge: 0,

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -7,7 +7,7 @@ import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import { createHMAC } from "@better-auth/utils/hmac";
 import { createOTP } from "@better-auth/utils/otp";
 import * as z from "zod";
-import { sessionMiddleware } from "../../api";
+import { sensitiveSessionMiddleware, sessionMiddleware } from "../../api";
 import {
 	deleteSessionCookie,
 	expireCookie,
@@ -266,7 +266,11 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 				{
 					method: "POST",
 					body: disableTwoFactorBodySchema,
-					use: [sessionMiddleware],
+					// Disabling 2FA is a sensitive operation; require a DB-backed
+					// session so a stale or replayed cookie-cache payload cannot
+					// authorize it (defense in depth against the duplicate
+					// Set-Cookie leak fixed in cookies/expireCookie).
+					use: [sensitiveSessionMiddleware],
 					metadata: {
 						openapi: {
 							summary: "Disable two factor authentication",

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -473,6 +473,7 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 						 */
 						deleteSessionCookie(ctx, true);
 						await ctx.context.internalAdapter.deleteSession(data.session.token);
+						ctx.context.setNewSession(null);
 						const maxAge = options?.twoFactorCookieMaxAge ?? 10 * 60; // 10 minutes
 						const twoFactorCookie = ctx.context.createAuthCookie(
 							TWO_FACTOR_COOKIE_NAME,

--- a/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
@@ -285,10 +285,11 @@ describe("two-factor security: sign-in does not leak session cookies (cookieCach
 
 describe("two-factor security: chunked session_data is fully scrubbed on 2FA-required sign-in", async () => {
 	// Forces session_data to be chunked by inflating the user payload past 4KB,
-	// then asserts every chunk (`session_data.0`, `session_data.1`, ...) is
-	// emptied. This pins the chunk-prefix branch of removeSetCookieEntries —
-	// without it, a future tightening of the match (e.g. exact-only) could
-	// silently leak `session_data.N` chunks while passing the non-chunked tests.
+	// verifies that the credential sign-in path actually emits chunks, then
+	// asserts the 2FA-required sign-in response exposes no valid chunk value.
+	// This pins the chunk-prefix branch of removeSetCookieEntries — without it,
+	// a future tightening of the match (e.g. exact-only) could silently leak
+	// `session_data.N` chunks while passing the non-chunked tests.
 	const filler = "x".repeat(2200);
 	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
 		secret: DEFAULT_SECRET,
@@ -314,6 +315,14 @@ describe("two-factor security: chunked session_data is fully scrubbed on 2FA-req
 		update: { blob1: filler, blob2: filler },
 	});
 
+	const chunkProbeRes = await auth.api.signInEmail({
+		body: { email: testUser.email, password: testUser.password },
+		asResponse: true,
+	});
+	const chunkProbeEntries = extractSetCookies(chunkProbeRes).filter((entry) =>
+		entry.startsWith("better-auth.session_data."),
+	);
+
 	const enrollment = await auth.api.enableTwoFactor({
 		body: { password: testUser.password },
 		headers,
@@ -331,6 +340,11 @@ describe("two-factor security: chunked session_data is fully scrubbed on 2FA-req
 	});
 	const totpCode = await createOTP(secret).totp();
 	await auth.api.verifyTOTP({ body: { code: totpCode }, headers });
+
+	it("test setup exercises chunked session_data cookies", () => {
+		expect(chunkProbeRes.status).toBe(200);
+		expect(chunkProbeEntries.length).toBeGreaterThan(0);
+	});
 
 	it("no session_data.N chunk leaks a non-empty value and replay cannot authenticate", async () => {
 		const res = await auth.api.signInEmail({

--- a/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
@@ -1,0 +1,370 @@
+import { createOTP } from "@better-auth/utils/otp";
+import { describe, expect, it } from "vitest";
+import { symmetricDecrypt } from "../../crypto";
+import { getTestInstance } from "../../test-utils/test-instance";
+import type { User } from "../../types";
+import { DEFAULT_SECRET } from "../../utils/constants";
+import { phoneNumber } from "../phone-number";
+import { username } from "../username";
+import { twoFactor } from ".";
+import type { TwoFactorTable, UserWithTwoFactor } from "./types";
+
+/**
+ * Regression coverage for the duplicate `Set-Cookie` leak on a 2FA-required
+ * credential sign-in.
+ *
+ * Prior to the fix in `cookies/expireCookie`, the credential handler wrote
+ * valid `session_token` / `session_data` cookies into the response and the
+ * two-factor after-hook only appended expiring overrides on top. A browser
+ * would honor the expiring entries, but an attacker reading the raw response
+ * could capture the valid signed values and (with `session.cookieCache.enabled`)
+ * replay them to bypass the 2FA gate entirely — including calling
+ * `/two-factor/disable` to permanently remove 2FA.
+ *
+ * These tests deliberately use `headers.getSetCookie()` instead of the
+ * `parseSetCookieHeader` helper, because that helper's `Map.set(name, ...)`
+ * silently drops duplicates and hides the leak.
+ *
+ * The 2FA after-hook matcher covers `/sign-in/email`, `/sign-in/username` and
+ * `/sign-in/phone-number`; we parameterize over all three to pin the fix
+ * against every entry point that triggers it.
+ *
+ * @see https://github.com/better-auth/better-auth/security/advisories
+ */
+
+function extractSetCookies(res: Response): string[] {
+	return res.headers.getSetCookie();
+}
+
+function buildCookieHeader(entries: string[], names: string[]): Headers {
+	const headers = new Headers();
+	const parts = entries
+		.filter((entry) => names.some((n) => entry.startsWith(`${n}=`)))
+		.filter((entry) => {
+			const firstSegment = entry.split(";")[0] ?? "";
+			const eq = firstSegment.indexOf("=");
+			return eq > 0 && firstSegment.slice(eq + 1).length > 0;
+		})
+		.map((entry) => entry.split(";")[0]!);
+	headers.set("cookie", parts.join("; "));
+	return headers;
+}
+
+function getCookieValue(entry: string): string {
+	const firstSegment = entry.split(";")[0] ?? "";
+	const eq = firstSegment.indexOf("=");
+	return eq > 0 ? firstSegment.slice(eq + 1) : "";
+}
+
+describe("two-factor security: sign-in does not leak session cookies (cookieCache enabled)", async () => {
+	const TEST_USERNAME = "security_user";
+	const TEST_PHONE = "+15551230000";
+
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		session: { cookieCache: { enabled: true } },
+		plugins: [
+			twoFactor(),
+			username(),
+			phoneNumber({
+				sendOTP: async () => {
+					/* not exercised */
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const dbUser = await db.findOne<User>({
+		model: "user",
+		where: [{ field: "email", value: testUser.email }],
+	});
+	const userId = dbUser?.id as string;
+	await db.update({
+		model: "user",
+		where: [{ field: "id", value: userId }],
+		update: {
+			username: TEST_USERNAME,
+			displayUsername: TEST_USERNAME,
+			phoneNumber: TEST_PHONE,
+			phoneNumberVerified: true,
+		},
+	});
+
+	const enrollment = await auth.api.enableTwoFactor({
+		body: { password: testUser.password },
+		headers,
+	});
+	if (enrollment.method !== "totp") {
+		throw new Error("expected totp enrollment");
+	}
+	const row = await db.findOne<TwoFactorTable>({
+		model: "twoFactor",
+		where: [{ field: "userId", value: userId }],
+	});
+	const secret = await symmetricDecrypt({
+		key: DEFAULT_SECRET,
+		data: row!.secret,
+	});
+	const totpCode = await createOTP(secret).totp();
+	await auth.api.verifyTOTP({ body: { code: totpCode }, headers });
+	const verified = await db.findOne<UserWithTwoFactor>({
+		model: "user",
+		where: [{ field: "id", value: userId }],
+	});
+	if (!verified?.twoFactorEnabled) {
+		throw new Error("failed to enable 2FA for test user");
+	}
+
+	const cases = [
+		{
+			path: "/sign-in/email",
+			call: () =>
+				auth.api.signInEmail({
+					body: { email: testUser.email, password: testUser.password },
+					asResponse: true,
+				}),
+		},
+		{
+			path: "/sign-in/username",
+			call: () =>
+				auth.api.signInUsername({
+					body: { username: TEST_USERNAME, password: testUser.password },
+					asResponse: true,
+				}),
+		},
+		{
+			path: "/sign-in/phone-number",
+			call: () =>
+				auth.api.signInPhoneNumber({
+					body: { phoneNumber: TEST_PHONE, password: testUser.password },
+					asResponse: true,
+				}),
+		},
+	];
+
+	it.each(
+		cases,
+	)("$path: response carries no valid signed session_token or session_data", async ({
+		call,
+	}) => {
+		const res = await call();
+		expect(res.status).toBe(200);
+
+		const setCookies = extractSetCookies(res);
+		expect(setCookies.length).toBeGreaterThan(0);
+
+		const sessionEntries = setCookies.filter(
+			(entry) =>
+				entry.startsWith("better-auth.session_token=") ||
+				entry.startsWith("better-auth.session_data=") ||
+				entry.startsWith("better-auth.session_data."),
+		);
+
+		for (const entry of sessionEntries) {
+			expect(getCookieValue(entry)).toBe("");
+		}
+
+		const twoFactorEntry = setCookies.find((entry) =>
+			entry.startsWith("better-auth.two_factor="),
+		);
+		expect(twoFactorEntry).toBeDefined();
+	});
+
+	it.each(
+		cases,
+	)("$path: replaying captured cookies cannot authenticate or disable 2FA", async ({
+		call,
+	}) => {
+		const res = await call();
+		const setCookies = extractSetCookies(res);
+		const replay = buildCookieHeader(setCookies, [
+			"better-auth.session_token",
+			"better-auth.session_data",
+		]);
+
+		const session = await auth.api.getSession({ headers: replay });
+		expect(session).toBeNull();
+
+		const disableRes = await auth.api.disableTwoFactor({
+			body: { password: testUser.password },
+			headers: replay,
+			asResponse: true,
+		});
+		expect(disableRes.status).toBe(401);
+	});
+});
+
+describe("two-factor security: sign-in does not leak session cookies (cookieCache disabled)", async () => {
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [twoFactor()],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const enrollment = await auth.api.enableTwoFactor({
+		body: { password: testUser.password },
+		headers,
+	});
+	if (enrollment.method !== "totp") {
+		throw new Error("expected totp enrollment");
+	}
+	const dbUser = await db.findOne<User>({
+		model: "user",
+		where: [{ field: "email", value: testUser.email }],
+	});
+	const userId = dbUser?.id as string;
+	const row = await db.findOne<TwoFactorTable>({
+		model: "twoFactor",
+		where: [{ field: "userId", value: userId }],
+	});
+	const secret = await symmetricDecrypt({
+		key: DEFAULT_SECRET,
+		data: row!.secret,
+	});
+	const totpCode = await createOTP(secret).totp();
+	await auth.api.verifyTOTP({ body: { code: totpCode }, headers });
+	const verified = await db.findOne<UserWithTwoFactor>({
+		model: "user",
+		where: [{ field: "id", value: userId }],
+	});
+	if (!verified?.twoFactorEnabled) {
+		throw new Error("failed to enable 2FA for test user");
+	}
+
+	it("response carries no valid signed session_token on 2FA-required sign-in", async () => {
+		const res = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		expect(res.status).toBe(200);
+
+		const setCookies = extractSetCookies(res);
+		const tokenEntries = setCookies.filter((entry) =>
+			entry.startsWith("better-auth.session_token="),
+		);
+		for (const entry of tokenEntries) {
+			expect(getCookieValue(entry)).toBe("");
+		}
+	});
+
+	it("replaying any cookies captured from the response cannot authenticate", async () => {
+		const res = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		const setCookies = extractSetCookies(res);
+		const replay = buildCookieHeader(setCookies, [
+			"better-auth.session_token",
+			"better-auth.session_data",
+		]);
+
+		const session = await auth.api.getSession({ headers: replay });
+		expect(session).toBeNull();
+	});
+});
+
+describe("two-factor security: chunked session_data is fully scrubbed on 2FA-required sign-in", async () => {
+	// Forces session_data to be chunked by inflating the user payload past 4KB,
+	// then asserts every chunk (`session_data.0`, `session_data.1`, ...) is
+	// emptied. This pins the chunk-prefix branch of removeSetCookieEntries —
+	// without it, a future tightening of the match (e.g. exact-only) could
+	// silently leak `session_data.N` chunks while passing the non-chunked tests.
+	const filler = "x".repeat(2200);
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		user: {
+			additionalFields: {
+				blob1: { type: "string", defaultValue: "" },
+				blob2: { type: "string", defaultValue: "" },
+			},
+		},
+		session: { cookieCache: { enabled: true } },
+		plugins: [twoFactor()],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const dbUser = await db.findOne<User>({
+		model: "user",
+		where: [{ field: "email", value: testUser.email }],
+	});
+	const userId = dbUser?.id as string;
+	await db.update({
+		model: "user",
+		where: [{ field: "id", value: userId }],
+		update: { blob1: filler, blob2: filler },
+	});
+
+	const enrollment = await auth.api.enableTwoFactor({
+		body: { password: testUser.password },
+		headers,
+	});
+	if (enrollment.method !== "totp") {
+		throw new Error("expected totp enrollment");
+	}
+	const row = await db.findOne<TwoFactorTable>({
+		model: "twoFactor",
+		where: [{ field: "userId", value: userId }],
+	});
+	const secret = await symmetricDecrypt({
+		key: DEFAULT_SECRET,
+		data: row!.secret,
+	});
+	const totpCode = await createOTP(secret).totp();
+	await auth.api.verifyTOTP({ body: { code: totpCode }, headers });
+
+	it("no session_data.N chunk leaks a non-empty value and replay cannot authenticate", async () => {
+		const res = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		expect(res.status).toBe(200);
+
+		const setCookies = extractSetCookies(res);
+
+		// Pre-fix, the credential handler emits `session_data.0=<valid>` and
+		// `session_data.1=<valid>` (the chunking debug log fires above) and the
+		// after-hook only appends an expiring single `session_data=`. The scrub
+		// in `removeSetCookieEntries` (chunk-prefix branch) deletes every
+		// `session_data.*` entry, so either none survive OR any that do must
+		// carry an empty value.
+		const chunkEntries = setCookies.filter((entry) =>
+			entry.startsWith("better-auth.session_data."),
+		);
+		for (const entry of chunkEntries) {
+			expect(getCookieValue(entry)).toBe("");
+		}
+
+		const tokenEntries = setCookies.filter((entry) =>
+			entry.startsWith("better-auth.session_token="),
+		);
+		for (const entry of tokenEntries) {
+			expect(getCookieValue(entry)).toBe("");
+		}
+
+		// Replay covers the regression case too: even if the chunk-prefix scrub
+		// silently regresses and `session_data.N=<valid>` leaks back, the cookie
+		// cache would reconstruct a valid session here and this assertion fails.
+		const replay = new Headers();
+		const parts: string[] = [];
+		for (const entry of setCookies) {
+			if (
+				!entry.startsWith("better-auth.session_token=") &&
+				!entry.startsWith("better-auth.session_data=") &&
+				!entry.startsWith("better-auth.session_data.")
+			) {
+				continue;
+			}
+			const firstSegment = entry.split(";")[0] ?? "";
+			const eq = firstSegment.indexOf("=");
+			if (eq <= 0) continue;
+			const value = firstSegment.slice(eq + 1);
+			if (value.length === 0) continue;
+			parts.push(firstSegment);
+		}
+		replay.set("cookie", parts.join("; "));
+
+		const session = await auth.api.getSession({ headers: replay });
+		expect(session).toBeNull();
+	});
+});

--- a/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
@@ -1,3 +1,5 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { createAuthMiddleware } from "@better-auth/core/api";
 import { createOTP } from "@better-auth/utils/otp";
 import { describe, expect, it } from "vitest";
 import { symmetricDecrypt } from "../../crypto";
@@ -59,6 +61,21 @@ function getCookieValue(entry: string): string {
 describe("two-factor security: sign-in does not leak session cookies (cookieCache enabled)", async () => {
 	const TEST_USERNAME = "security_user";
 	const TEST_PHONE = "+15551230000";
+	const newSessionProbe = {
+		id: "new-session-probe",
+		hooks: {
+			after: [
+				{
+					matcher: (ctx) => ctx.path?.startsWith("/sign-in/") === true,
+					handler: createAuthMiddleware(async (ctx) => {
+						if (ctx.context.newSession) {
+							ctx.setHeader("x-new-session-visible", "true");
+						}
+					}),
+				},
+			],
+		},
+	} satisfies BetterAuthPlugin;
 
 	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
 		secret: DEFAULT_SECRET,
@@ -71,6 +88,7 @@ describe("two-factor security: sign-in does not leak session cookies (cookieCach
 					/* not exercised */
 				},
 			}),
+			newSessionProbe,
 		],
 	});
 
@@ -150,6 +168,7 @@ describe("two-factor security: sign-in does not leak session cookies (cookieCach
 	}) => {
 		const res = await call();
 		expect(res.status).toBe(200);
+		expect(res.headers.get("x-new-session-visible")).toBeNull();
 
 		const setCookies = extractSetCookies(res);
 		expect(setCookies.length).toBeGreaterThan(0);

--- a/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
@@ -113,7 +113,7 @@ describe("two-factor security: sign-in does not leak session cookies (cookieCach
 		body: { password: testUser.password },
 		headers,
 	});
-	if (enrollment.method !== "totp") {
+	if (!enrollment.totpURI) {
 		throw new Error("expected totp enrollment");
 	}
 	const row = await db.findOne<TwoFactorTable>({
@@ -225,7 +225,7 @@ describe("two-factor security: sign-in does not leak session cookies (cookieCach
 		body: { password: testUser.password },
 		headers,
 	});
-	if (enrollment.method !== "totp") {
+	if (!enrollment.totpURI) {
 		throw new Error("expected totp enrollment");
 	}
 	const dbUser = await db.findOne<User>({
@@ -327,7 +327,7 @@ describe("two-factor security: chunked session_data is fully scrubbed on 2FA-req
 		body: { password: testUser.password },
 		headers,
 	});
-	if (enrollment.method !== "totp") {
+	if (!enrollment.totpURI) {
 		throw new Error("expected totp enrollment");
 	}
 	const row = await db.findOne<TwoFactorTable>({


### PR DESCRIPTION
## Summary

When a user with 2FA enabled signs in via `/sign-in/{email,username,phone-number}`, the credential handler writes valid `session_token` / `session_data` cookies and the 2FA after-hook only appends expiring overrides. Browsers honor the last entry, but anything reading the raw response (logs, SDK consumers, proxies) sees the first valid value and can replay it. With `session.cookieCache.enabled`, that replay bypasses the 2FA gate — including calling `/two-factor/disable`.

## Fix

- `expireCookie` now scrubs prior matching `Set-Cookie` entries (exact name + chunk prefix) before appending the expiring entry. Targets both the local middleware scope and the outer endpoint scope where after-hook merges land.
- `/two-factor/disable` switched to `sensitiveSessionMiddleware` (DB-backed) — defense in depth, same pattern as `/change-password`, `/delete-user`, `/update-user`.
