### PR TITLE
chore: add engines field to package.json

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -613,5 +613,8 @@
     "vitest": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -86,5 +86,8 @@
     "tsx": "^4.21.0",
     "type-fest": "^5.4.4",
     "typescript": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -190,5 +190,8 @@
     "@opentelemetry/api": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
Adds `engines` field to `package.json`

This makes it easier for consumers to know what to expect as far as compatibility goes. Both human consumers and static analysis tools.



---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare Node.js 22+ as the required runtime by adding the `engines.node` field to `packages/better-auth`, `packages/core`, and `packages/cli`. This standardizes our runtime and prevents installs on unsupported Node versions.

- **Migration**
  - Use Node 22+ locally and in CI; update `.nvmrc` and CI Node setup.
  - If your package manager enforces `engines`, installs on older Node will fail; adjust `engine-strict` as needed.

<sup>Written for commit eea36694670d76caa59beecd5afa6a70fc567944. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9643?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



