### PR TITLE
fix(session): preserve session.expiresAt across stateless refreshCache cycles

### DIFF
--- a/.changeset/fix-stateless-cache-expires-at-corruption.md
+++ b/.changeset/fix-stateless-cache-expires-at-corruption.md
@@ -1,0 +1,15 @@
+---
+"better-auth": patch
+---
+
+fix(session): preserve real `session.expiresAt` across stateless `refreshCache` cycles
+
+When `cookieCache.refreshCache` was enabled without a database, the stateless
+refresh path on `/get-session` overwrote `session.expiresAt` with
+`now + cookieCache.maxAge`. The corrupted value was both returned in the
+response and embedded in the next JWE cookie, so subsequent refreshes treated
+the session as expiring with the cache TTL (e.g. 5 minutes) instead of the
+real `session.expiresIn` (e.g. 7 days). `setCookieCache` already derives the
+cookie's own TTL from `authCookies.sessionData.attributes.maxAge`, so the
+override served no purpose other than to corrupt the public expiry — it is now
+removed.

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -1206,6 +1206,75 @@ describe("cookie cache refreshCache", async () => {
 	});
 
 	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8770
+	 */
+	it("should preserve session.expiresAt across stateless refreshCache cycles", async () => {
+		const sessionExpiresIn = 60 * 60 * 24 * 7; // 7 days
+		const cookieCacheMaxAge = 300; // 5 minutes
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			database: undefined as any,
+			session: {
+				expiresIn: sessionExpiresIn,
+				cookieCache: {
+					enabled: true,
+					strategy: "jwe",
+					maxAge: cookieCacheMaxAge,
+					refreshCache: {
+						updateAge: 60,
+					},
+				},
+			},
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(headers),
+			},
+		);
+
+		const firstSession = await client.getSession({
+			fetchOptions: {
+				headers,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		const originalExpiresAt = new Date(
+			firstSession.data!.session.expiresAt,
+		).getTime();
+		// The real session expiry should be roughly `now + sessionExpiresIn`,
+		// not capped at the much smaller `cookieCache.maxAge`.
+		expect(originalExpiresAt - Date.now()).toBeGreaterThan(
+			cookieCacheMaxAge * 1000 * 10,
+		);
+
+		vi.useFakeTimers();
+		// Cross the refresh threshold (300 - 60 = 240s) to force a stateless refresh.
+		await vi.advanceTimersByTimeAsync(1000 * 241);
+
+		const refreshedSession = await client.getSession({
+			fetchOptions: {
+				headers,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		// The refresh path must not overwrite `session.expiresAt` with
+		// `cookieCache.maxAge` — the public session expiry has to keep
+		// reflecting `sessionExpiresIn`, not the cache TTL.
+		const refreshedExpiresAt = new Date(
+			refreshedSession.data!.session.expiresAt,
+		).getTime();
+		expect(refreshedExpiresAt).toBe(originalExpiresAt);
+
+		vi.useRealTimers();
+	});
+
+	/**
 	 * @see https://github.com/better-auth/better-auth/issues/7994
 	 */
 	it("should extend session_token cookie expiry when refreshCache threshold is reached", async () => {

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -278,14 +278,13 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 								await getShouldSkipSessionRefresh();
 
 							if (timeUntilExpiry < updateAge && !shouldSkipSessionRefresh) {
-								const cookieMaxAge =
-									ctx.context.options.session?.cookieCache?.maxAge || 60 * 5;
-								const newExpiresAt = getDate(cookieMaxAge, "sec");
+								// Preserve the real session.expiresAt (e.g. 7 days from sign-in).
+								// `setCookieCache` derives its own JWE/cookie TTL from
+								// `authCookies.sessionData.attributes.maxAge`, so the cache
+								// lifetime is independent of `session.expiresAt`.
+								// @see https://github.com/better-auth/better-auth/issues/8770
 								const refreshedSession = {
-									session: {
-										...session.session,
-										expiresAt: newExpiresAt,
-									},
+									session: session.session,
 									user: session.user,
 									updatedAt: Date.now(),
 								};


### PR DESCRIPTION
## Summary

The `/get-session` stateless refresh path overwrote `session.session.expiresAt` with `now + cookieCache.maxAge` (the cache TTL, e.g. 5 minutes) instead of preserving the real session expiry from `session.expiresIn` (e.g. 7 days). The corrupted value was both returned in the JSON response and embedded in the next JWE cookie, so subsequent refreshes treated the session as expiring with the cache TTL.

`setCookieCache` already derives the cookie's own TTL from `authCookies.sessionData.attributes.maxAge`, so the override served no purpose other than corrupting the public expiry.

## Root cause

In `packages/better-auth/src/api/routes/session.ts`, the stateless refresh branch built `refreshedSession` with `expiresAt: newExpiresAt` where `newExpiresAt = getDate(cookieCache.maxAge, "sec")`. That value then flowed into:
- the JWE cookie payload (capping next refresh at the cache TTL)
- the JSON response (consumers seeing a 5-minute expiry instead of 7 days)

## Fix

Drop the `expiresAt` override. `...session.session` already carries the real expiry, and `setCookieCache` derives its own TTL from `sessionData.attributes.maxAge`.

## Test plan

- [x] New regression test: `should preserve session.expiresAt across stateless refreshCache cycles` (`session-api.test.ts`)
  - Configures `expiresIn: 7 days` + `cookieCache.maxAge: 5 min` + `refreshCache.updateAge: 60s`
  - Signs in, captures `firstSession.session.expiresAt`
  - Advances time past the refresh threshold
  - Asserts the refreshed `session.expiresAt` matches the original (not the cache TTL)
- [x] Test fails on `main` (confirmed) and passes after the fix
- [x] All 7 existing `refreshCache` tests still pass

Closes #8770

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stateless `/get-session` refresh in `better-auth` to preserve the real `session.expiresAt` (e.g., 7 days) instead of overwriting it with `cookieCache.maxAge`. Responses and JWE cookies now report the correct expiry, while the cache TTL remains managed by `setCookieCache`.

<sup>Written for commit c4f8fc25da1c9cdb7be3d0d8552e384819fc6a9b. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9646?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

