### PR TITLE
fix(client): prevent duplicate session refetch on focus

### DIFF
--- a/.changeset/happy-apes-hug.md
+++ b/.changeset/happy-apes-hug.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Prevent duplicate session refetches triggered by focus events in the client.

--- a/packages/better-auth/src/client/query.ts
+++ b/packages/better-auth/src/client/query.ts
@@ -17,6 +17,10 @@ export type AuthQueryAtom<T> = PreinitializedWritableAtom<{
 	) => Promise<void>;
 }>;
 
+export interface UseAuthQueryConfig {
+	refreshMarkerAtom?: PreinitializedWritableAtom<any> | null;
+}
+
 export const useAuthQuery = <T>(
 	initializedAtom:
 		| PreinitializedWritableAtom<any>
@@ -33,6 +37,7 @@ export const useAuthQuery = <T>(
 				| ClientFetchOption
 		  )
 		| undefined,
+	config?: UseAuthQueryConfig,
 ) => {
 	const value: AuthQueryAtom<T> = atom({
 		data: null,
@@ -121,6 +126,10 @@ export const useAuthQuery = <T>(
 		? initializedAtom
 		: [initializedAtom];
 	let isInitialized = false;
+	let skipNextRefetch = false;
+	// Optional marker atom used by session management to deduplicate
+	// self-triggered signal bounces after a direct refresh fetch.
+	const refreshMarkerAtom = config?.refreshMarkerAtom ?? null;
 
 	for (const initAtom of initializedAtom) {
 		initAtom.subscribe(async () => {
@@ -128,7 +137,18 @@ export const useAuthQuery = <T>(
 				// On server, don't trigger fetch
 				return;
 			}
+			if (initAtom === refreshMarkerAtom) {
+				if (isInitialized) {
+					skipNextRefetch = true;
+				}
+				return;
+			}
 			if (isInitialized) {
+				if (skipNextRefetch) {
+					// Consume the marker so only the signal bounce is skipped.
+					skipNextRefetch = false;
+					return;
+				}
 				await fn();
 			} else {
 				onMount(value, () => {

--- a/packages/better-auth/src/client/session-atom.ts
+++ b/packages/better-auth/src/client/session-atom.ts
@@ -16,12 +16,23 @@ export function getSessionAtom(
 	options?: BetterAuthClientOptions | undefined,
 ) {
 	const $signal = atom<boolean>(false);
+	// Marker atom incremented after direct session fetch to signal the query layer
+	// that the next signal toggle is self-originated and should skip one refetch.
+	const $sessionRefreshMarker = atom(0);
 	const session: SessionAtom = useAuthQuery<{
 		user: User;
 		session: Session;
-	}>($signal, "/get-session", $fetch, {
-		method: "GET",
-	});
+	}>(
+		[$signal, $sessionRefreshMarker],
+		"/get-session",
+		$fetch,
+		{
+			method: "GET",
+		},
+		{
+			refreshMarkerAtom: $sessionRefreshMarker,
+		},
+	);
 
 	let broadcastSessionUpdate: (
 		trigger: "signout" | "getSession" | "updateUser",
@@ -31,10 +42,10 @@ export function getSessionAtom(
 		const refreshManager = createSessionRefreshManager({
 			sessionAtom: session,
 			sessionSignal: $signal,
+			sessionRefreshMarker: $sessionRefreshMarker,
 			$fetch,
 			options,
 		});
-
 		refreshManager.init();
 		broadcastSessionUpdate = refreshManager.broadcastSessionUpdate;
 

--- a/packages/better-auth/src/client/session-refresh.test.ts
+++ b/packages/better-auth/src/client/session-refresh.test.ts
@@ -965,11 +965,13 @@ describe("session-refresh", () => {
 		// Wait for all async operations to complete
 		await vi.runAllTimersAsync();
 
-		// BUG: Currently this results in 2 requests when it should be 1:
-		// - First request from fetchSessionWithRefresh in session-refresh.ts
-		// - Second request from useAuthQuery subscription triggered by sessionSignal toggle
+		// Regression test: visibility changes previously caused 2 /get-session requests:
+		// 1. Direct fetch from fetchSessionWithRefresh in session-refresh.ts
+		// 2. Secondary fetch from useAuthQuery subscription triggered by sessionSignal toggle
 		//
-		// Expected: exactly 1 /get-session request per visibility event
+		// The $sessionRefreshMarker mechanism prevents the duplicate by setting skipNextRefetch
+		// when the marker changes, ensuring the signal-triggered fetch is skipped exactly once.
+		// This verifies that each visibility event now results in only 1 /get-session request.
 		expect(fetchCallCount).toBe(1);
 
 		unsubscribe();

--- a/packages/better-auth/src/client/session-refresh.test.ts
+++ b/packages/better-auth/src/client/session-refresh.test.ts
@@ -2,8 +2,11 @@
 
 import { atom } from "nanostores";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Session, User } from "../types";
 import { getGlobalBroadcastChannel } from "./broadcast-channel";
+import { getGlobalFocusManager, kFocusManager } from "./focus-manager";
 import { getGlobalOnlineManager } from "./online-manager";
+import { useAuthQuery } from "./query";
 import type { SessionAtom } from "./session-atom";
 import { createSessionRefreshManager } from "./session-refresh";
 
@@ -884,5 +887,94 @@ describe("session-refresh", () => {
 		);
 
 		manager.cleanup();
+	});
+	it("should not cause duplicate /get-session requests on visibility change when useAuthQuery subscribes to sessionSignal", async () => {
+		vi.useFakeTimers();
+
+		// Reset focus manager to ensure clean state
+		delete (globalThis as any)[kFocusManager];
+
+		const sessionData = {
+			user: { id: "1", email: "test@test.com" },
+			session: { id: "session-1" },
+		};
+
+		let fetchCallCount = 0;
+		const mockFetch = vi.fn(async (url: string) => {
+			if (url === "/get-session") {
+				fetchCallCount++;
+			}
+			return {
+				data: sessionData,
+				error: null,
+			};
+		}) as any;
+
+		// Set up the signal (shared between useAuthQuery and session-refresh)
+		const $signal = atom<boolean>(false);
+		const $sessionRefreshMarker = atom(0);
+
+		// Create the session atom using useAuthQuery (simulating session-atom.ts getSessionAtom)
+		const session: SessionAtom = useAuthQuery<{
+			user: User;
+			session: Session;
+		}>(
+			[$signal, $sessionRefreshMarker],
+			"/get-session",
+			mockFetch,
+			{
+				method: "GET",
+			},
+			{
+				refreshMarkerAtom: $sessionRefreshMarker,
+			},
+		);
+
+		// Set up refresh manager (simulating onMount in session-atom.ts)
+		const refreshManager = createSessionRefreshManager({
+			sessionAtom: session,
+			sessionSignal: $signal,
+			sessionRefreshMarker: $sessionRefreshMarker,
+			$fetch: mockFetch,
+			options: {
+				sessionOptions: {
+					refetchOnWindowFocus: true,
+				},
+			},
+		});
+
+		refreshManager.init();
+
+		// Subscribe to session atom to activate it (simulating component mount)
+		const unsubscribe = session.listen(() => {});
+
+		// Wait for initial fetch
+		await vi.runAllTimersAsync();
+		const _initialFetchCount = fetchCallCount;
+
+		// Wait past the rate limit window (5 seconds)
+		await vi.advanceTimersByTimeAsync(6000);
+
+		// Reset fetch count to isolate the visibility change test
+		fetchCallCount = 0;
+
+		// Simulate visibility change (user switches back to tab)
+		const focusManager = getGlobalFocusManager();
+		focusManager.setFocused(true);
+
+		// Wait for all async operations to complete
+		await vi.runAllTimersAsync();
+
+		// BUG: Currently this results in 2 requests when it should be 1:
+		// - First request from fetchSessionWithRefresh in session-refresh.ts
+		// - Second request from useAuthQuery subscription triggered by sessionSignal toggle
+		//
+		// Expected: exactly 1 /get-session request per visibility event
+		expect(fetchCallCount).toBe(1);
+
+		unsubscribe();
+		refreshManager.cleanup();
+		delete (globalThis as any)[kFocusManager];
+		vi.useRealTimers();
 	});
 });

--- a/packages/better-auth/src/client/session-refresh.ts
+++ b/packages/better-auth/src/client/session-refresh.ts
@@ -40,6 +40,7 @@ export interface SessionRefreshOptions {
 		} & Record<string, any>
 	>;
 	sessionSignal: WritableAtom<boolean>;
+	sessionRefreshMarker?: WritableAtom<number> | undefined;
 	$fetch: BetterFetch;
 	options?: BetterAuthClientOptions | undefined;
 }
@@ -69,7 +70,13 @@ export type SessionResponse = (
 	Record<string, any>;
 
 export function createSessionRefreshManager(opts: SessionRefreshOptions) {
-	const { sessionAtom, sessionSignal, $fetch, options = {} } = opts;
+	const {
+		sessionAtom,
+		sessionSignal,
+		sessionRefreshMarker,
+		$fetch,
+		options = {},
+	} = opts;
 
 	const refetchInterval = options.sessionOptions?.refetchInterval ?? 0;
 	const refetchOnWindowFocus =
@@ -126,6 +133,9 @@ export function createSessionRefreshManager(opts: SessionRefreshOptions) {
 						data: sessionData,
 						error: error as Parameters<typeof sessionAtom.set>[0]["error"],
 					});
+					if (sessionRefreshMarker) {
+						sessionRefreshMarker.set(sessionRefreshMarker.get() + 1);
+					}
 					state.lastSync = now();
 					sessionSignal.set(!sessionSignal.get());
 				})


### PR DESCRIPTION
## Summary

Adds an explicit refresh marker flow for session refresh deduplication.

The refresh manager now emits a dedicated refresh marker before triggering the normal session signal. `useAuthQuery` consumes that marker to skip the immediate self-triggered refetch exactly once, while preserving existing invalidation and synchronization behavior.

The implementation keeps the behavior explicitly scoped to session refresh wiring instead of relying on implicit multi-atom ordering.

Closes #9613

## Changes

* added `$sessionRefreshMarker` for explicit refresh context
* added one-shot skip handling in `useAuthQuery`
* scoped deduplication through explicit `refreshMarkerAtom` config
* added regression coverage for duplicate focus refetches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate get-session requests when the tab regains focus by adding a refresh marker and a one-shot skip in the client. This removes the extra refetch while keeping session sync behavior unchanged.

- **Bug Fixes**
  - Added `$sessionRefreshMarker` and `refreshMarkerAtom` config to `useAuthQuery` to skip the next self-triggered refetch.
  - `createSessionRefreshManager` now emits the marker before toggling `sessionSignal` to dedupe the focus-triggered bounce.
  - Wired the marker into `getSessionAtom`, added a regression test to ensure one request per focus event, and included a changeset for a patch release.

<sup>Written for commit 012cef97172caab2630ea61696ddcf013cb2394f. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9651?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

