### PR TITLE
refactor(oauth): single-source Basic credentials + getHttpTestInstance

### DIFF
--- a/.changeset/private-key-jwt-followups.md
+++ b/.changeset/private-key-jwt-followups.md
@@ -1,13 +1,18 @@
 ---
-"better-auth": patch
-"@better-auth/core": patch
+"better-auth": minor
+"@better-auth/core": minor
 "@better-auth/oauth-provider": patch
 "@better-auth/sso": patch
 ---
 
-Harden `private_key_jwt` and token endpoint client authentication after the initial landing.
+Harden `private_key_jwt` and token endpoint client authentication, and add the helpers that make the fix structural.
 
-- `client_secret_basic` now percent-encodes `clientId` and `clientSecret` before base64-encoding the Basic credential, per RFC 6749 §2.3.1. Credentials containing reserved characters now authenticate against spec-compliant servers.
-- `signPrivateKeyJwtClientAssertion` rejects JWKs whose embedded `alg` is not an asymmetric algorithm supported for `private_key_jwt` (e.g. `HS256`, `none`), instead of silently signing with a disallowed algorithm.
-- OAuth Provider registration rejects `jwks` payloads with zero keys (both `jwks: []` and `jwks: { keys: [] }`). An empty JWKS previously registered and only failed later at authentication.
-- SSO `private_key_jwt` flow now redirects with `error_description=no_private_key_available` when `resolvePrivateKey` returns no `privateKeyJwk` or `privateKeyPem`, instead of falling through to an internal `private_key_jwt requires…` error during signing.
+`@better-auth/core/oauth2` now exposes `encodeBasicCredentials` and `decodeBasicCredentials`, a round-trip-tested pair that follows RFC 6749 §2.3.1 (percent-encode each value, split on the first `:` only). `client_secret_basic` on the client side and the Better Auth OAuth provider on the server side both go through these helpers, so credentials containing reserved characters now round-trip cleanly across the stack.
+
+`signPrivateKeyJwtClientAssertion` rejects a JWK whose embedded `alg` is not asymmetric (e.g. `HS256`, `none`), and throws on conflict when an explicit `algorithm` option disagrees with the JWK-embedded `alg`. The previous behavior silently let the explicit option win. **Breaking:** configurations that paired an HS-flavored JWK with an RS-flavored explicit option now fail at construction time.
+
+OAuth Provider DCR rejects empty `jwks` payloads at registration time (`jwks: []` and `jwks: { keys: [] }`). An empty JWKS used to register and only fail later at authentication.
+
+The SSO `private_key_jwt` flow redirects with `error_description=no_private_key_available` when a `resolvePrivateKey` callback returns no `privateKeyJwk` or `privateKeyPem`. The redirect path previously short-circuited only when the resolver was absent entirely; an empty resolver return fell through into an internal signing error.
+
+`better-auth/test` adds `getHttpTestInstance`, a counterpart to `getTestInstance` that binds a real HTTP listener on an OS-assigned port and constructs the auth instance against the discovered URL. It removes the temp-server-then-rebind race that test files have been individually copy-pasting.

--- a/.changeset/private-key-jwt-followups.md
+++ b/.changeset/private-key-jwt-followups.md
@@ -1,0 +1,13 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+"@better-auth/oauth-provider": patch
+"@better-auth/sso": patch
+---
+
+Harden `private_key_jwt` and token endpoint client authentication after the initial landing.
+
+- `client_secret_basic` now percent-encodes `clientId` and `clientSecret` before base64-encoding the Basic credential, per RFC 6749 §2.3.1. Credentials containing reserved characters now authenticate against spec-compliant servers.
+- `signPrivateKeyJwtClientAssertion` rejects JWKs whose embedded `alg` is not an asymmetric algorithm supported for `private_key_jwt` (e.g. `HS256`, `none`), instead of silently signing with a disallowed algorithm.
+- OAuth Provider registration rejects `jwks` payloads with zero keys (both `jwks: []` and `jwks: { keys: [] }`). An empty JWKS previously registered and only failed later at authentication.
+- SSO `private_key_jwt` flow now redirects with `error_description=no_private_key_available` when `resolvePrivateKey` returns no `privateKeyJwk` or `privateKeyPem`, instead of falling through to an internal `private_key_jwt requires…` error during signing.

--- a/.changeset/private-key-jwt-followups.md
+++ b/.changeset/private-key-jwt-followups.md
@@ -7,11 +7,11 @@
 
 Harden `private_key_jwt` and token endpoint client authentication, and add the helpers that make the fix structural.
 
-`@better-auth/core/oauth2` now exposes `encodeBasicCredentials` and `decodeBasicCredentials`, a round-trip-tested pair that follows RFC 6749 §2.3.1 (percent-encode each value, split on the first `:` only). `client_secret_basic` on the client side and the Better Auth OAuth provider on the server side both go through these helpers, so credentials containing reserved characters now round-trip cleanly across the stack.
+`@better-auth/core/oauth2` now exposes `encodeBasicCredentials` and `decodeBasicCredentials`, a round-trip-tested pair that follows RFC 6749 §2.3.1 (`application/x-www-form-urlencoded` each value, split on the first `:` only). The decoder accepts the scheme case-insensitively and tolerates one or more spaces before the credentials per RFC 7235 §2.1. `client_secret_basic` on the client side and the Better Auth OAuth provider on the server side both go through these helpers, so credentials containing reserved characters round-trip cleanly across the stack and headers like `basic xxx` or `Basic  xxx` are accepted.
 
-`signPrivateKeyJwtClientAssertion` rejects a JWK whose embedded `alg` is not asymmetric (e.g. `HS256`, `none`), and throws on conflict when an explicit `algorithm` option disagrees with the JWK-embedded `alg`. The previous behavior silently let the explicit option win. **Breaking:** configurations that paired an HS-flavored JWK with an RS-flavored explicit option now fail at construction time.
+`createPrivateKeyJwtClientAssertionGetter` validates options eagerly. Unsupported algorithms (`HS256`, `none`), a JWK with no key material, and disagreement between an explicit `algorithm` and the JWK-embedded `alg` all throw at construction rather than on the first token request. `signPrivateKeyJwtClientAssertion` enforces the same checks for direct callers. **Breaking:** configurations that paired an unsupported JWK `alg` with a different explicit `algorithm` used to silently sign with the explicit option; they now fail at construction.
 
-OAuth Provider DCR rejects empty `jwks` payloads at registration time (`jwks: []` and `jwks: { keys: [] }`). An empty JWKS used to register and only fail later at authentication.
+`@better-auth/oauth-provider` rejects empty `jwks` payloads at the schema layer (`jwks: []` and `jwks: { keys: [] }`) so the documented client metadata contract matches what `checkOAuthClient` already enforces at runtime. Schema consumers (TypeScript, OpenAPI, generated SDKs) now see the constraint.
 
 The SSO `private_key_jwt` flow redirects with `error_description=no_private_key_available` when a `resolvePrivateKey` callback returns no `privateKeyJwk` or `privateKeyPem`. The redirect path previously short-circuited only when the resolver was absent entirely; an empty resolver return fell through into an internal signing error.
 

--- a/packages/better-auth/src/test-utils/http-test-instance.ts
+++ b/packages/better-auth/src/test-utils/http-test-instance.ts
@@ -1,0 +1,89 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type {
+	BetterAuthClientOptions,
+	BetterAuthOptions,
+} from "@better-auth/core";
+import { listen } from "listhen";
+import { toNodeHandler } from "../integrations/node";
+import { getTestInstance } from "./test-instance";
+
+type NodeRequestHandler = (
+	req: IncomingMessage,
+	res: ServerResponse,
+) => unknown | Promise<unknown>;
+
+type GetTestInstanceConfig = NonNullable<Parameters<typeof getTestInstance>[1]>;
+
+export type HttpTestInstanceConfig<C extends BetterAuthClientOptions> = Omit<
+	GetTestInstanceConfig,
+	"port" | "clientOptions"
+> & {
+	clientOptions?: C;
+	/**
+	 * Customizes the HTTP request listener. Receives the bound auth instance
+	 * and returns a Node request handler. Defaults to
+	 * `toNodeHandler(auth.handler)`.
+	 *
+	 * Use this when the test needs to expose extra routes alongside the auth
+	 * handler (e.g. a `.well-known/openid-configuration` shim that calls
+	 * `auth.api.getOpenIdConfig()`).
+	 */
+	handler?: (
+		auth: Awaited<ReturnType<typeof getTestInstance>>["auth"],
+	) => NodeRequestHandler;
+};
+
+/**
+ * Like `getTestInstance`, but bound to an actual HTTP listener on an
+ * OS-assigned port (`port: 0`). The discovered URL is fed back into the auth
+ * instance so its `baseURL` matches the listener.
+ *
+ * This removes the race window that the temp-server-then-rebind pattern
+ * introduces. The listener is bound once, holds the port for its lifetime,
+ * and only swaps in the real request handler after the auth instance is
+ * fully constructed.
+ *
+ * The caller is responsible for calling `server.close()` in `afterAll`. Any
+ * `baseURL` passed in `options` is ignored — the URL must match the
+ * listener.
+ */
+export async function getHttpTestInstance<
+	O extends Partial<BetterAuthOptions>,
+	C extends BetterAuthClientOptions,
+>(options?: O, config?: HttpTestInstanceConfig<C>) {
+	let activeHandler: NodeRequestHandler = (_req, res) => {
+		res.statusCode = 503;
+		res.end("Test HTTP listener has no handler bound yet");
+	};
+
+	const server = await listen((req, res) => activeHandler(req, res), {
+		port: 0,
+	});
+	const boundPort = server.address?.port;
+	if (typeof boundPort !== "number") {
+		await server.close();
+		throw new Error(
+			"listhen did not report a bound port for the test listener",
+		);
+	}
+	const baseURL = `http://localhost:${boundPort}`;
+
+	try {
+		const instance = await getTestInstance(
+			{ ...(options as object), baseURL } as O,
+			{
+				clientOptions: config?.clientOptions as never,
+				disableTestUser: config?.disableTestUser,
+				testUser: config?.testUser,
+				testWith: config?.testWith,
+			},
+		);
+		activeHandler = config?.handler
+			? config.handler(instance.auth as never)
+			: toNodeHandler(instance.auth.handler);
+		return { ...instance, server, baseURL, port: boundPort };
+	} catch (error) {
+		await server.close();
+		throw error;
+	}
+}

--- a/packages/better-auth/src/test-utils/index.ts
+++ b/packages/better-auth/src/test-utils/index.ts
@@ -1,2 +1,6 @@
 export { convertSetCookieToCookie } from "./headers";
+export {
+	getHttpTestInstance,
+	type HttpTestInstanceConfig,
+} from "./http-test-instance";
 export { getTestInstance } from "./test-instance";

--- a/packages/core/src/oauth2/basic-credentials.test.ts
+++ b/packages/core/src/oauth2/basic-credentials.test.ts
@@ -21,6 +21,34 @@ describe("encode/decodeBasicCredentials", () => {
 		expect(decodeBasicCredentials(header)).toEqual({ clientId, clientSecret });
 	});
 
+	it("uses application/x-www-form-urlencoded for each value (escapes `!'()*`, space → `+`)", () => {
+		// Computed independently via URLSearchParams to avoid mirroring the
+		// implementation's encoding choice. This is the contract RFC 6749 §2.3.1
+		// requires; encodeURIComponent leaves `!'()*` unescaped and would fail.
+		const clientId = "alice!*'";
+		const clientSecret = "p@ss word (1)";
+		const header = encodeBasicCredentials(clientId, clientSecret);
+
+		const expectedClientId = "alice%21*%27";
+		const expectedClientSecret = "p%40ss+word+%281%29";
+		const payload = `${expectedClientId}:${expectedClientSecret}`;
+		const expectedHeader = `Basic ${Buffer.from(payload).toString("base64")}`;
+
+		expect(header).toBe(expectedHeader);
+		expect(decodeBasicCredentials(header)).toEqual({ clientId, clientSecret });
+	});
+
+	it("decodes `+` and `%20` symmetrically as space", () => {
+		const plusEncoded = `Basic ${Buffer.from("user:hello+world").toString("base64")}`;
+		const percentEncoded = `Basic ${Buffer.from("user:hello%20world").toString("base64")}`;
+		expect(decodeBasicCredentials(plusEncoded).clientSecret).toBe(
+			"hello world",
+		);
+		expect(decodeBasicCredentials(percentEncoded).clientSecret).toBe(
+			"hello world",
+		);
+	});
+
 	it("round-trips a client secret that contains a colon", () => {
 		const clientId = "id";
 		const clientSecret = "abc:def:ghi";
@@ -62,10 +90,14 @@ describe("encode/decodeBasicCredentials", () => {
 		);
 	});
 
-	it("rejects a Basic payload with malformed percent-encoding", () => {
+	it("passes invalid percent-encoding through untouched (URL Standard form-url-decoding is lenient)", () => {
+		// A malformed credential won't match any stored client and the server
+		// will fail at lookup time with `invalid_client`. The decoder itself
+		// does not need to reject — that matches the URL Living Standard.
 		const payload = Buffer.from("id:%ZZ").toString("base64");
-		expect(() => decodeBasicCredentials(`Basic ${payload}`)).toThrow(
-			/percent-encoded/,
-		);
+		expect(decodeBasicCredentials(`Basic ${payload}`)).toEqual({
+			clientId: "id",
+			clientSecret: "%ZZ",
+		});
 	});
 });

--- a/packages/core/src/oauth2/basic-credentials.test.ts
+++ b/packages/core/src/oauth2/basic-credentials.test.ts
@@ -6,11 +6,11 @@ import {
 
 describe("encode/decodeBasicCredentials", () => {
 	it("round-trips simple ASCII credentials", () => {
-		const header = encodeBasicCredentials("alice", "s3cret");
+		const header = encodeBasicCredentials("alice", "secret");
 		expect(header.startsWith("Basic ")).toBe(true);
 		expect(decodeBasicCredentials(header)).toEqual({
 			clientId: "alice",
-			clientSecret: "s3cret",
+			clientSecret: "secret",
 		});
 	});
 
@@ -70,7 +70,7 @@ describe("encode/decodeBasicCredentials", () => {
 	});
 
 	it("rejects a Basic payload without a separator", () => {
-		const payload = Buffer.from("idonly").toString("base64");
+		const payload = Buffer.from("missing-colon").toString("base64");
 		expect(() => decodeBasicCredentials(`Basic ${payload}`)).toThrow(
 			/separator/,
 		);

--- a/packages/core/src/oauth2/basic-credentials.test.ts
+++ b/packages/core/src/oauth2/basic-credentials.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+	decodeBasicCredentials,
+	encodeBasicCredentials,
+} from "./basic-credentials";
+
+describe("encode/decodeBasicCredentials", () => {
+	it("round-trips simple ASCII credentials", () => {
+		const header = encodeBasicCredentials("alice", "s3cret");
+		expect(header.startsWith("Basic ")).toBe(true);
+		expect(decodeBasicCredentials(header)).toEqual({
+			clientId: "alice",
+			clientSecret: "s3cret",
+		});
+	});
+
+	it("round-trips credentials containing reserved characters", () => {
+		const clientId = "id:with/special@chars";
+		const clientSecret = "secret with spaces & symbols+";
+		const header = encodeBasicCredentials(clientId, clientSecret);
+		expect(decodeBasicCredentials(header)).toEqual({ clientId, clientSecret });
+	});
+
+	it("round-trips a client secret that contains a colon", () => {
+		const clientId = "id";
+		const clientSecret = "abc:def:ghi";
+		const header = encodeBasicCredentials(clientId, clientSecret);
+		expect(decodeBasicCredentials(header)).toEqual({ clientId, clientSecret });
+	});
+
+	it("round-trips credentials containing non-ASCII text", () => {
+		const clientId = "クライアント";
+		const clientSecret = "🔑secret";
+		const header = encodeBasicCredentials(clientId, clientSecret);
+		expect(decodeBasicCredentials(header)).toEqual({ clientId, clientSecret });
+	});
+
+	it("rejects an authorization header without the Basic prefix", () => {
+		expect(() => decodeBasicCredentials("Bearer abc")).toThrow(
+			/not a Basic credential/,
+		);
+	});
+
+	it("rejects a Basic payload without a separator", () => {
+		const payload = Buffer.from("idonly").toString("base64");
+		expect(() => decodeBasicCredentials(`Basic ${payload}`)).toThrow(
+			/separator/,
+		);
+	});
+
+	it("rejects a Basic payload with an empty client id", () => {
+		const payload = Buffer.from(":secret").toString("base64");
+		expect(() => decodeBasicCredentials(`Basic ${payload}`)).toThrow(
+			/non-empty/,
+		);
+	});
+
+	it("rejects a Basic payload with an empty client secret", () => {
+		const payload = Buffer.from("id:").toString("base64");
+		expect(() => decodeBasicCredentials(`Basic ${payload}`)).toThrow(
+			/non-empty/,
+		);
+	});
+
+	it("rejects a Basic payload with malformed percent-encoding", () => {
+		const payload = Buffer.from("id:%ZZ").toString("base64");
+		expect(() => decodeBasicCredentials(`Basic ${payload}`)).toThrow(
+			/percent-encoded/,
+		);
+	});
+});

--- a/packages/core/src/oauth2/basic-credentials.test.ts
+++ b/packages/core/src/oauth2/basic-credentials.test.ts
@@ -21,10 +21,11 @@ describe("encode/decodeBasicCredentials", () => {
 		expect(decodeBasicCredentials(header)).toEqual({ clientId, clientSecret });
 	});
 
-	it("uses application/x-www-form-urlencoded for each value (escapes `!'()*`, space → `+`)", () => {
+	it("uses application/x-www-form-urlencoded for each value (escapes `!'()`, space → `+`)", () => {
 		// Computed independently via URLSearchParams to avoid mirroring the
 		// implementation's encoding choice. This is the contract RFC 6749 §2.3.1
-		// requires; encodeURIComponent leaves `!'()*` unescaped and would fail.
+		// requires; encodeURIComponent leaves `!'()` unescaped and would fail.
+		// Note: the URL Standard percent-encode set leaves `*` unescaped.
 		const clientId = "alice!*'";
 		const clientSecret = "p@ss word (1)";
 		const header = encodeBasicCredentials(clientId, clientSecret);
@@ -67,6 +68,24 @@ describe("encode/decodeBasicCredentials", () => {
 		expect(() => decodeBasicCredentials("Bearer abc")).toThrow(
 			/not a Basic credential/,
 		);
+	});
+
+	it("accepts the Basic scheme case-insensitively (RFC 7235 §2.1)", () => {
+		const payload = Buffer.from("alice:secret").toString("base64");
+		for (const scheme of ["Basic", "basic", "BASIC", "BaSiC"] as const) {
+			expect(decodeBasicCredentials(`${scheme} ${payload}`)).toEqual({
+				clientId: "alice",
+				clientSecret: "secret",
+			});
+		}
+	});
+
+	it("accepts one or more spaces between the scheme and credentials", () => {
+		const payload = Buffer.from("alice:secret").toString("base64");
+		expect(decodeBasicCredentials(`Basic   ${payload}`)).toEqual({
+			clientId: "alice",
+			clientSecret: "secret",
+		});
 	});
 
 	it("rejects a Basic payload without a separator", () => {

--- a/packages/core/src/oauth2/basic-credentials.ts
+++ b/packages/core/src/oauth2/basic-credentials.ts
@@ -3,18 +3,39 @@ import { base64 } from "@better-auth/utils/base64";
 const BASIC_PREFIX = "Basic ";
 
 /**
+ * Encodes a value using `application/x-www-form-urlencoded` per the URL
+ * Living Standard. Differs from `encodeURIComponent` in two ways: it escapes
+ * `!`, `'`, `(`, `)`, and `*`, and it represents space as `+` rather than
+ * `%20`.
+ */
+function formUrlEncode(value: string): string {
+	return new URLSearchParams({ v: value }).toString().slice("v=".length);
+}
+
+/**
+ * Inverse of `formUrlEncode`: decodes a single `application/x-www-form-urlencoded`
+ * value, handling both `+` and `%20` as space.
+ */
+function formUrlDecode(value: string): string {
+	const decoded = new URLSearchParams(`v=${value}`).get("v");
+	if (decoded === null) {
+		throw new Error("form-url-encoded value could not be decoded");
+	}
+	return decoded;
+}
+
+/**
  * Encodes an OAuth client id and secret as an HTTP Basic credential string.
  *
- * Follows RFC 6749 §2.3.1: both values are percent-encoded
- * (`application/x-www-form-urlencoded`) prior to base64 encoding. The returned
- * string is the value of the `Authorization` header, including the `Basic `
- * prefix.
+ * Follows RFC 6749 §2.3.1: both values are `application/x-www-form-urlencoded`
+ * prior to base64 encoding. The returned string is the full value of the
+ * `Authorization` header, including the `Basic ` prefix.
  */
 export function encodeBasicCredentials(
 	clientId: string,
 	clientSecret: string,
 ): string {
-	const payload = `${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`;
+	const payload = `${formUrlEncode(clientId)}:${formUrlEncode(clientSecret)}`;
 	return `${BASIC_PREFIX}${base64.encode(payload)}`;
 }
 
@@ -23,12 +44,13 @@ export function encodeBasicCredentials(
  * and secret.
  *
  * The base64 payload is split on the first `:` only, so secrets containing
- * colons round-trip correctly. Both values are percent-decoded per RFC 6749
- * §2.3.1.
+ * colons round-trip correctly. Each half is form-url-decoded per RFC 6749
+ * §2.3.1, accepting both `+` and `%20` as space. Per the URL Living Standard,
+ * invalid percent-escapes pass through as-is; downstream client lookup will
+ * fail with `invalid_client` for malformed credentials.
  *
  * Throws when the header is not a Basic credential, when the base64 payload
- * contains no `:`, when either half is empty, or when either half is not
- * valid percent-encoded text.
+ * contains no `:`, or when either half is empty.
  */
 export function decodeBasicCredentials(authorization: string): {
 	clientId: string;
@@ -52,15 +74,8 @@ export function decodeBasicCredentials(authorization: string): {
 			"Basic credential client id and secret must both be non-empty",
 		);
 	}
-	let clientId: string;
-	let clientSecret: string;
-	try {
-		clientId = decodeURIComponent(rawClientId);
-		clientSecret = decodeURIComponent(rawClientSecret);
-	} catch {
-		throw new Error(
-			"Basic credential contains invalid percent-encoded characters",
-		);
-	}
-	return { clientId, clientSecret };
+	return {
+		clientId: formUrlDecode(rawClientId),
+		clientSecret: formUrlDecode(rawClientSecret),
+	};
 }

--- a/packages/core/src/oauth2/basic-credentials.ts
+++ b/packages/core/src/oauth2/basic-credentials.ts
@@ -1,0 +1,66 @@
+import { base64 } from "@better-auth/utils/base64";
+
+const BASIC_PREFIX = "Basic ";
+
+/**
+ * Encodes an OAuth client id and secret as an HTTP Basic credential string.
+ *
+ * Follows RFC 6749 §2.3.1: both values are percent-encoded
+ * (`application/x-www-form-urlencoded`) prior to base64 encoding. The returned
+ * string is the value of the `Authorization` header, including the `Basic `
+ * prefix.
+ */
+export function encodeBasicCredentials(
+	clientId: string,
+	clientSecret: string,
+): string {
+	const payload = `${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`;
+	return `${BASIC_PREFIX}${base64.encode(payload)}`;
+}
+
+/**
+ * Decodes an `Authorization: Basic …` header value into its OAuth client id
+ * and secret.
+ *
+ * The base64 payload is split on the first `:` only, so secrets containing
+ * colons round-trip correctly. Both values are percent-decoded per RFC 6749
+ * §2.3.1.
+ *
+ * Throws when the header is not a Basic credential, when the base64 payload
+ * contains no `:`, when either half is empty, or when either half is not
+ * valid percent-encoded text.
+ */
+export function decodeBasicCredentials(authorization: string): {
+	clientId: string;
+	clientSecret: string;
+} {
+	if (!authorization.startsWith(BASIC_PREFIX)) {
+		throw new Error("Authorization header is not a Basic credential");
+	}
+	const encoded = authorization.slice(BASIC_PREFIX.length);
+	const decoded = new TextDecoder().decode(base64.decode(encoded));
+	const separatorIndex = decoded.indexOf(":");
+	if (separatorIndex === -1) {
+		throw new Error(
+			"Basic credential is missing the client id/secret separator",
+		);
+	}
+	const rawClientId = decoded.slice(0, separatorIndex);
+	const rawClientSecret = decoded.slice(separatorIndex + 1);
+	if (!rawClientId || !rawClientSecret) {
+		throw new Error(
+			"Basic credential client id and secret must both be non-empty",
+		);
+	}
+	let clientId: string;
+	let clientSecret: string;
+	try {
+		clientId = decodeURIComponent(rawClientId);
+		clientSecret = decodeURIComponent(rawClientSecret);
+	} catch {
+		throw new Error(
+			"Basic credential contains invalid percent-encoded characters",
+		);
+	}
+	return { clientId, clientSecret };
+}

--- a/packages/core/src/oauth2/basic-credentials.ts
+++ b/packages/core/src/oauth2/basic-credentials.ts
@@ -1,12 +1,15 @@
 import { base64 } from "@better-auth/utils/base64";
 
-const BASIC_PREFIX = "Basic ";
+// RFC 7235 §2.1: auth scheme is case-insensitive and is followed by one or
+// more SP before the credentials. The trailing capture is everything after
+// the whitespace (may be empty, which downstream checks reject).
+const BASIC_AUTHORIZATION_PATTERN = /^Basic +(.*)$/i;
 
 /**
  * Encodes a value using `application/x-www-form-urlencoded` per the URL
  * Living Standard. Differs from `encodeURIComponent` in two ways: it escapes
- * `!`, `'`, `(`, `)`, and `*`, and it represents space as `+` rather than
- * `%20`.
+ * `!`, `'`, `(`, and `)`, and it represents space as `+` rather than `%20`.
+ * `*` is left unescaped, matching the URL Standard's percent-encode set.
  */
 function formUrlEncode(value: string): string {
 	return new URLSearchParams({ v: value }).toString().slice("v=".length);
@@ -36,18 +39,20 @@ export function encodeBasicCredentials(
 	clientSecret: string,
 ): string {
 	const payload = `${formUrlEncode(clientId)}:${formUrlEncode(clientSecret)}`;
-	return `${BASIC_PREFIX}${base64.encode(payload)}`;
+	return `Basic ${base64.encode(payload)}`;
 }
 
 /**
  * Decodes an `Authorization: Basic …` header value into its OAuth client id
  * and secret.
  *
- * The base64 payload is split on the first `:` only, so secrets containing
- * colons round-trip correctly. Each half is form-url-decoded per RFC 6749
- * §2.3.1, accepting both `+` and `%20` as space. Per the URL Living Standard,
- * invalid percent-escapes pass through as-is; downstream client lookup will
- * fail with `invalid_client` for malformed credentials.
+ * Scheme matching is case-insensitive and tolerates one or more spaces
+ * between the scheme and credentials per RFC 7235 §2.1. The base64 payload
+ * is split on the first `:` only, so secrets containing colons round-trip
+ * correctly. Each half is form-url-decoded per RFC 6749 §2.3.1, accepting
+ * both `+` and `%20` as space. Per the URL Living Standard, invalid
+ * percent-escapes pass through as-is; downstream client lookup will fail
+ * with `invalid_client` for malformed credentials.
  *
  * Throws when the header is not a Basic credential, when the base64 payload
  * contains no `:`, or when either half is empty.
@@ -56,10 +61,11 @@ export function decodeBasicCredentials(authorization: string): {
 	clientId: string;
 	clientSecret: string;
 } {
-	if (!authorization.startsWith(BASIC_PREFIX)) {
+	const match = authorization.match(BASIC_AUTHORIZATION_PATTERN);
+	if (!match) {
 		throw new Error("Authorization header is not a Basic credential");
 	}
-	const encoded = authorization.slice(BASIC_PREFIX.length);
+	const encoded = match[1] ?? "";
 	const decoded = new TextDecoder().decode(base64.decode(encoded));
 	const separatorIndex = decoded.indexOf(":");
 	if (separatorIndex === -1) {

--- a/packages/core/src/oauth2/client-assertion.test.ts
+++ b/packages/core/src/oauth2/client-assertion.test.ts
@@ -213,6 +213,40 @@ describe("signPrivateKeyJwtClientAssertion", () => {
 		).rejects.toThrow(/Unsupported private_key_jwt signing algorithm: HS256/);
 	});
 
+	it("rejects a disallowed explicit algorithm passed by JavaScript callers", async () => {
+		const { privateKey } = await generateKeyPair("RS256", {
+			extractable: true,
+		});
+		const privateJwk = await exportJWK(privateKey);
+
+		await expect(
+			signPrivateKeyJwtClientAssertion({
+				clientId,
+				tokenEndpoint,
+				privateKeyJwk: privateJwk,
+				// @ts-expect-error — JS callers can pass an unsupported alg string.
+				algorithm: "HS256",
+			}),
+		).rejects.toThrow(/Unsupported private_key_jwt signing algorithm: HS256/);
+	});
+
+	it("createPrivateKeyJwtClientAssertionGetter throws eagerly on misconfiguration", async () => {
+		const { privateKey } = await generateKeyPair("RS256", {
+			extractable: true,
+		});
+		const privateJwk = { ...(await exportJWK(privateKey)), alg: "HS256" };
+
+		expect(() =>
+			createPrivateKeyJwtClientAssertionGetter({
+				privateKeyJwk: privateJwk,
+			}),
+		).toThrow(/Unsupported private_key_jwt signing algorithm: HS256/);
+
+		expect(() =>
+			createPrivateKeyJwtClientAssertionGetter({ algorithm: "RS256" }),
+		).toThrow(/private_key_jwt requires either privateKeyJwk or privateKeyPem/);
+	});
+
 	it("throws when neither JWK nor PEM is provided", async () => {
 		await expect(
 			signPrivateKeyJwtClientAssertion({ clientId, tokenEndpoint }),

--- a/packages/core/src/oauth2/client-assertion.test.ts
+++ b/packages/core/src/oauth2/client-assertion.test.ts
@@ -179,6 +179,40 @@ describe("signPrivateKeyJwtClientAssertion", () => {
 		).rejects.toThrow(/Unsupported private_key_jwt signing algorithm: HS256/);
 	});
 
+	it("rejects a JWK whose embedded alg conflicts with the explicit algorithm", async () => {
+		const { privateKey } = await generateKeyPair("RS256", {
+			extractable: true,
+		});
+		const privateJwk = { ...(await exportJWK(privateKey)), alg: "RS256" };
+
+		await expect(
+			signPrivateKeyJwtClientAssertion({
+				clientId,
+				tokenEndpoint,
+				privateKeyJwk: privateJwk,
+				algorithm: "PS256",
+			}),
+		).rejects.toThrow(
+			/JWK alg "RS256" does not match configured algorithm "PS256"/,
+		);
+	});
+
+	it("rejects a disallowed embedded alg even when an explicit algorithm is set", async () => {
+		const { privateKey } = await generateKeyPair("RS256", {
+			extractable: true,
+		});
+		const privateJwk = { ...(await exportJWK(privateKey)), alg: "HS256" };
+
+		await expect(
+			signPrivateKeyJwtClientAssertion({
+				clientId,
+				tokenEndpoint,
+				privateKeyJwk: privateJwk,
+				algorithm: "RS256",
+			}),
+		).rejects.toThrow(/Unsupported private_key_jwt signing algorithm: HS256/);
+	});
+
 	it("throws when neither JWK nor PEM is provided", async () => {
 		await expect(
 			signPrivateKeyJwtClientAssertion({ clientId, tokenEndpoint }),

--- a/packages/core/src/oauth2/client-assertion.test.ts
+++ b/packages/core/src/oauth2/client-assertion.test.ts
@@ -164,6 +164,21 @@ describe("signPrivateKeyJwtClientAssertion", () => {
 		expect(payload.iss).toBe(clientId);
 	});
 
+	it("rejects a JWK whose embedded alg is not allowed for private_key_jwt", async () => {
+		const { privateKey } = await generateKeyPair("RS256", {
+			extractable: true,
+		});
+		const privateJwk = { ...(await exportJWK(privateKey)), alg: "HS256" };
+
+		await expect(
+			signPrivateKeyJwtClientAssertion({
+				clientId,
+				tokenEndpoint,
+				privateKeyJwk: privateJwk,
+			}),
+		).rejects.toThrow(/Unsupported private_key_jwt signing algorithm: HS256/);
+	});
+
 	it("throws when neither JWK nor PEM is provided", async () => {
 		await expect(
 			signPrivateKeyJwtClientAssertion({ clientId, tokenEndpoint }),

--- a/packages/core/src/oauth2/client-assertion.ts
+++ b/packages/core/src/oauth2/client-assertion.ts
@@ -98,15 +98,16 @@ export async function signPrivateKeyJwtClientAssertion({
 	const jwk = privateKeyJwk as Record<string, unknown> | undefined;
 	const resolvedKid = kid ?? (jwk?.kid as string | undefined);
 	const jwkAlg = privateKeyJwk?.alg;
-	let resolvedAlg: PrivateKeyJwtSigningAlgorithm;
-	if (algorithm) {
-		resolvedAlg = algorithm;
-	} else if (typeof jwkAlg === "string") {
+	if (typeof jwkAlg === "string") {
 		assertSupportedPrivateKeyJwtAlgorithm(jwkAlg);
-		resolvedAlg = jwkAlg;
-	} else {
-		resolvedAlg = "RS256";
 	}
+	if (algorithm && typeof jwkAlg === "string" && algorithm !== jwkAlg) {
+		throw new Error(
+			`JWK alg "${jwkAlg}" does not match configured algorithm "${algorithm}". Remove the JWK alg field, or pass an algorithm that matches the JWK.`,
+		);
+	}
+	const resolvedAlg: PrivateKeyJwtSigningAlgorithm =
+		algorithm ?? (typeof jwkAlg === "string" ? jwkAlg : "RS256");
 
 	let key: Awaited<ReturnType<typeof importJWK>>;
 	if (privateKeyJwk) {

--- a/packages/core/src/oauth2/client-assertion.ts
+++ b/packages/core/src/oauth2/client-assertion.ts
@@ -33,6 +33,43 @@ function assertSupportedPrivateKeyJwtAlgorithm(
 	}
 }
 
+/**
+ * Validates `private_key_jwt` options eagerly and returns the algorithm to
+ * use for signing.
+ *
+ * Asserts that key material is configured, that any explicit `algorithm` is
+ * supported, that any JWK-embedded `alg` is supported, and that the two
+ * agree when both are set.
+ */
+function resolveValidPrivateKeyJwtOptions(options: {
+	privateKeyJwk?: JsonWebKey;
+	privateKeyPem?: string;
+	algorithm?: PrivateKeyJwtSigningAlgorithm;
+}): PrivateKeyJwtSigningAlgorithm {
+	if (!options.privateKeyJwk && !options.privateKeyPem) {
+		throw new Error(
+			"private_key_jwt requires either privateKeyJwk or privateKeyPem",
+		);
+	}
+	if (options.algorithm) {
+		assertSupportedPrivateKeyJwtAlgorithm(options.algorithm);
+	}
+	const jwkAlg = options.privateKeyJwk?.alg;
+	if (typeof jwkAlg === "string") {
+		assertSupportedPrivateKeyJwtAlgorithm(jwkAlg);
+	}
+	if (
+		options.algorithm &&
+		typeof jwkAlg === "string" &&
+		options.algorithm !== jwkAlg
+	) {
+		throw new Error(
+			`JWK alg "${jwkAlg}" does not match configured algorithm "${options.algorithm}". Remove the JWK alg field, or pass an algorithm that matches the JWK.`,
+		);
+	}
+	return options.algorithm ?? (typeof jwkAlg === "string" ? jwkAlg : "RS256");
+}
+
 export const CLIENT_ASSERTION_TYPE =
 	"urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
@@ -93,32 +130,19 @@ export async function signPrivateKeyJwtClientAssertion({
 	algorithm?: PrivateKeyJwtSigningAlgorithm;
 	expiresIn?: number;
 }): Promise<string> {
-	// Fall back to JWK-embedded kid/alg when not explicitly provided (RFC 7517).
-	// JsonWebKey includes alg but not kid; access kid via index.
+	const resolvedAlg = resolveValidPrivateKeyJwtOptions({
+		privateKeyJwk,
+		privateKeyPem,
+		algorithm,
+	});
+	// Fall back to the JWK-embedded kid when not explicitly provided (RFC 7517).
+	// JsonWebKey types include alg but not kid; access kid via index.
 	const jwk = privateKeyJwk as Record<string, unknown> | undefined;
 	const resolvedKid = kid ?? (jwk?.kid as string | undefined);
-	const jwkAlg = privateKeyJwk?.alg;
-	if (typeof jwkAlg === "string") {
-		assertSupportedPrivateKeyJwtAlgorithm(jwkAlg);
-	}
-	if (algorithm && typeof jwkAlg === "string" && algorithm !== jwkAlg) {
-		throw new Error(
-			`JWK alg "${jwkAlg}" does not match configured algorithm "${algorithm}". Remove the JWK alg field, or pass an algorithm that matches the JWK.`,
-		);
-	}
-	const resolvedAlg: PrivateKeyJwtSigningAlgorithm =
-		algorithm ?? (typeof jwkAlg === "string" ? jwkAlg : "RS256");
 
-	let key: Awaited<ReturnType<typeof importJWK>>;
-	if (privateKeyJwk) {
-		key = await importJWK(privateKeyJwk, resolvedAlg);
-	} else if (privateKeyPem) {
-		key = await importPKCS8(privateKeyPem, resolvedAlg);
-	} else {
-		throw new Error(
-			"private_key_jwt requires either privateKeyJwk or privateKeyPem",
-		);
-	}
+	const key: Awaited<ReturnType<typeof importJWK>> = privateKeyJwk
+		? await importJWK(privateKeyJwk, resolvedAlg)
+		: await importPKCS8(privateKeyPem as string, resolvedAlg);
 
 	const now = Math.floor(Date.now() / 1000);
 	const jti = crypto.randomUUID();
@@ -142,11 +166,19 @@ export async function signPrivateKeyJwtClientAssertion({
 /**
  * Creates a client assertion getter for `private_key_jwt` authentication.
  *
- * The returned function signs a fresh RFC 7523 JWT assertion for every token endpoint request.
+ * Validates options eagerly (key material, supported algorithm, JWK alg
+ * agreement) so misconfiguration surfaces at construction rather than on the
+ * first token request. The returned function signs a fresh RFC 7523 JWT
+ * assertion for every token endpoint request.
  */
 export function createPrivateKeyJwtClientAssertionGetter(
 	options: PrivateKeyJwtClientAssertionGetterOptions,
 ): ClientAssertionGetter {
+	resolveValidPrivateKeyJwtOptions({
+		privateKeyJwk: options.privateKeyJwk,
+		privateKeyPem: options.privateKeyPem,
+		algorithm: options.algorithm,
+	});
 	return ({ clientId, tokenEndpoint }) =>
 		signPrivateKeyJwtClientAssertion({
 			clientId,

--- a/packages/core/src/oauth2/client-assertion.ts
+++ b/packages/core/src/oauth2/client-assertion.ts
@@ -19,6 +19,20 @@ export const PRIVATE_KEY_JWT_SIGNING_ALGORITHMS = [
 export type PrivateKeyJwtSigningAlgorithm =
 	(typeof PRIVATE_KEY_JWT_SIGNING_ALGORITHMS)[number];
 
+function assertSupportedPrivateKeyJwtAlgorithm(
+	candidate: string,
+): asserts candidate is PrivateKeyJwtSigningAlgorithm {
+	if (
+		!(PRIVATE_KEY_JWT_SIGNING_ALGORITHMS as readonly string[]).includes(
+			candidate,
+		)
+	) {
+		throw new Error(
+			`Unsupported private_key_jwt signing algorithm: ${candidate}. Use one of ${PRIVATE_KEY_JWT_SIGNING_ALGORITHMS.join(", ")}.`,
+		);
+	}
+}
+
 export const CLIENT_ASSERTION_TYPE =
 	"urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
@@ -83,10 +97,16 @@ export async function signPrivateKeyJwtClientAssertion({
 	// JsonWebKey includes alg but not kid; access kid via index.
 	const jwk = privateKeyJwk as Record<string, unknown> | undefined;
 	const resolvedKid = kid ?? (jwk?.kid as string | undefined);
-	const resolvedAlg =
-		algorithm ??
-		(privateKeyJwk?.alg as PrivateKeyJwtSigningAlgorithm | undefined) ??
-		"RS256";
+	const jwkAlg = privateKeyJwk?.alg;
+	let resolvedAlg: PrivateKeyJwtSigningAlgorithm;
+	if (algorithm) {
+		resolvedAlg = algorithm;
+	} else if (typeof jwkAlg === "string") {
+		assertSupportedPrivateKeyJwtAlgorithm(jwkAlg);
+		resolvedAlg = jwkAlg;
+	} else {
+		resolvedAlg = "RS256";
+	}
 
 	let key: Awaited<ReturnType<typeof importJWK>>;
 	if (privateKeyJwk) {

--- a/packages/core/src/oauth2/index.ts
+++ b/packages/core/src/oauth2/index.ts
@@ -1,3 +1,7 @@
+export {
+	decodeBasicCredentials,
+	encodeBasicCredentials,
+} from "./basic-credentials";
 export type {
 	ClientAssertionContext,
 	ClientAssertionGetter,

--- a/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
+++ b/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
@@ -317,9 +317,13 @@ describe("private_key_jwt OAuth2 helpers", () => {
 		expect(body.get("client_secret")).toBeNull();
 	});
 
-	it("percent-encodes clientId and clientSecret for client_secret_basic per RFC 6749 §2.3.1", async () => {
-		const specialClientId = "id:with/special@chars";
-		const specialClientSecret = "secret with spaces & symbols";
+	it("form-url-encodes clientId and clientSecret for client_secret_basic per RFC 6749 §2.3.1", async () => {
+		// Use characters whose form-urlencoded encoding differs from
+		// encodeURIComponent: space becomes `+` and `!'()*` are escaped. The
+		// expected value is computed through URLSearchParams independently of
+		// the implementation so the test catches the wrong encoding choice.
+		const specialClientId = "alice!*'";
+		const specialClientSecret = "p@ss word (1)";
 
 		const { headers } = await authorizationCodeRequest({
 			code: "auth-code",
@@ -332,8 +336,10 @@ describe("private_key_jwt OAuth2 helpers", () => {
 			tokenEndpointAuth: { method: "client_secret_basic" },
 		});
 
+		const formEncode = (value: string) =>
+			new URLSearchParams({ v: value }).toString().slice("v=".length);
 		const expected = `Basic ${base64.encode(
-			`${encodeURIComponent(specialClientId)}:${encodeURIComponent(specialClientSecret)}`,
+			`${formEncode(specialClientId)}:${formEncode(specialClientSecret)}`,
 		)}`;
 		expect(headers.authorization).toBe(expected);
 	});

--- a/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
+++ b/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
@@ -319,9 +319,10 @@ describe("private_key_jwt OAuth2 helpers", () => {
 
 	it("form-url-encodes clientId and clientSecret for client_secret_basic per RFC 6749 §2.3.1", async () => {
 		// Use characters whose form-urlencoded encoding differs from
-		// encodeURIComponent: space becomes `+` and `!'()*` are escaped. The
+		// encodeURIComponent: space becomes `+` and `!'()` are escaped. The
 		// expected value is computed through URLSearchParams independently of
 		// the implementation so the test catches the wrong encoding choice.
+		// Note: `*` is in the URL Standard's unreserved set and is left as-is.
 		const specialClientId = "alice!*'";
 		const specialClientSecret = "p@ss word (1)";
 

--- a/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
+++ b/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
@@ -317,6 +317,27 @@ describe("private_key_jwt OAuth2 helpers", () => {
 		expect(body.get("client_secret")).toBeNull();
 	});
 
+	it("percent-encodes clientId and clientSecret for client_secret_basic per RFC 6749 §2.3.1", async () => {
+		const specialClientId = "id:with/special@chars";
+		const specialClientSecret = "secret with spaces & symbols";
+
+		const { headers } = await authorizationCodeRequest({
+			code: "auth-code",
+			redirectURI: "https://rp.example.com/callback",
+			options: {
+				clientId: specialClientId,
+				clientSecret: specialClientSecret,
+			},
+			tokenEndpoint,
+			tokenEndpointAuth: { method: "client_secret_basic" },
+		});
+
+		const expected = `Basic ${base64.encode(
+			`${encodeURIComponent(specialClientId)}:${encodeURIComponent(specialClientSecret)}`,
+		)}`;
+		expect(headers.authorization).toBe(expected);
+	});
+
 	it.each([
 		"client_secret_basic",
 		"client_secret_post",

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -1,4 +1,4 @@
-import { base64 } from "@better-auth/utils/base64";
+import { encodeBasicCredentials } from "./basic-credentials";
 import type {
 	ClientAssertionGetter,
 	ClientAssertionGrantType,
@@ -132,11 +132,10 @@ function setClientSecretBasicAuth({
 	}
 	assertClientSecretConfigured("client_secret_basic", options);
 	assertClientIdConfigured("client_secret_basic", clientId);
-	// RFC 6749 §2.3.1: clientId and clientSecret are
-	// application/x-www-form-urlencoded prior to base64 encoding.
-	headers.authorization = `Basic ${base64.encode(
-		`${encodeURIComponent(clientId)}:${encodeURIComponent(options.clientSecret)}`,
-	)}`;
+	headers.authorization = encodeBasicCredentials(
+		clientId,
+		options.clientSecret,
+	);
 }
 
 function assertCompleteManualClientAssertion(body: URLSearchParams) {

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -74,7 +74,7 @@ function setClientId(body: URLSearchParams, clientId: string | undefined) {
 function assertClientSecretConfigured(
 	method: "client_secret_basic" | "client_secret_post",
 	options: TokenEndpointClientOptions,
-) {
+): asserts options is TokenEndpointClientOptions & { clientSecret: string } {
 	if (!options.clientSecret) {
 		throw new Error(
 			`${method} token endpoint authentication requires clientSecret`,
@@ -132,8 +132,10 @@ function setClientSecretBasicAuth({
 	}
 	assertClientSecretConfigured("client_secret_basic", options);
 	assertClientIdConfigured("client_secret_basic", clientId);
+	// RFC 6749 §2.3.1: clientId and clientSecret are
+	// application/x-www-form-urlencoded prior to base64 encoding.
 	headers.authorization = `Basic ${base64.encode(
-		`${clientId}:${options.clientSecret}`,
+		`${encodeURIComponent(clientId)}:${encodeURIComponent(options.clientSecret)}`,
 	)}`;
 }
 

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1216,9 +1216,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							.optional(),
 						jwks: z
 							.union([
-								z.array(z.record(z.string(), z.unknown())),
+								z.array(z.record(z.string(), z.unknown())).min(1),
 								z.object({
-									keys: z.array(z.record(z.string(), z.unknown())),
+									keys: z.array(z.record(z.string(), z.unknown())).min(1),
 								}),
 							])
 							.optional(),

--- a/packages/oauth-provider/src/oauthClient/index.ts
+++ b/packages/oauth-provider/src/oauthClient/index.ts
@@ -47,8 +47,10 @@ export const adminCreateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 					.optional(),
 				jwks: z
 					.union([
-						z.array(z.record(z.string(), z.unknown())),
-						z.object({ keys: z.array(z.record(z.string(), z.unknown())) }),
+						z.array(z.record(z.string(), z.unknown())).min(1),
+						z.object({
+							keys: z.array(z.record(z.string(), z.unknown())).min(1),
+						}),
 					])
 					.optional(),
 				jwks_uri: z.string().optional(),
@@ -274,8 +276,10 @@ export const createOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 					.optional(),
 				jwks: z
 					.union([
-						z.array(z.record(z.string(), z.unknown())),
-						z.object({ keys: z.array(z.record(z.string(), z.unknown())) }),
+						z.array(z.record(z.string(), z.unknown())).min(1),
+						z.object({
+							keys: z.array(z.record(z.string(), z.unknown())).min(1),
+						}),
 					])
 					.optional(),
 				jwks_uri: z.string().optional(),

--- a/packages/oauth-provider/src/private-key-jwt-e2e.test.ts
+++ b/packages/oauth-provider/src/private-key-jwt-e2e.test.ts
@@ -3,10 +3,8 @@ import { toNodeHandler } from "better-auth/node";
 import { createPrivateKeyJwtClientAssertionGetter } from "better-auth/oauth2";
 import { genericOAuth } from "better-auth/plugins/generic-oauth";
 import { jwt } from "better-auth/plugins/jwt";
-import { getTestInstance } from "better-auth/test";
+import { getHttpTestInstance, getTestInstance } from "better-auth/test";
 import { exportJWK, generateKeyPair } from "jose";
-import type { Listener } from "listhen";
-import { listen } from "listhen";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
@@ -21,19 +19,8 @@ import type { OAuthClient } from "./types/oauth";
  * - Flow: RP → authorize → login → callback → token exchange (with JWT assertion) → session
  */
 describe("private_key_jwt e2e", async () => {
-	// Discover a free OS-assigned port so concurrent test files don't collide.
-	const tempServer = await listen(
-		(_req, res) => {
-			res.end();
-		},
-		{ port: 0 },
-	);
-	const port = tempServer.address?.port ?? 3002;
-	await tempServer.close();
-	const authServerBaseUrl = `http://localhost:${port}`;
 	const rpBaseUrl = "http://localhost:5002";
 	const providerId = "jwt-assertion-provider";
-	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
 
 	// Generate RSA key pair
 	const keyPair = await generateKeyPair("RS256", { extractable: true });
@@ -46,22 +33,40 @@ describe("private_key_jwt e2e", async () => {
 		customFetchImpl,
 		cookieSetter,
 		testUser,
-	} = await getTestInstance({
+		server,
 		baseURL: authServerBaseUrl,
-		trustedOrigins: ["https://trusted.example.com"],
-		plugins: [
-			jwt(),
-			oauthProvider({
-				loginPage: "/login",
-				consentPage: "/consent",
-				assertionMaxLifetime: 300,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
-			}),
-		],
-	});
+	} = await getHttpTestInstance(
+		{
+			trustedOrigins: ["https://trusted.example.com"],
+			plugins: [
+				jwt(),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					assertionMaxLifetime: 300,
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		},
+		{
+			handler: (auth) => {
+				const nodeHandler = toNodeHandler(auth.handler);
+				return async (req, res) => {
+					if (req.url === "/.well-known/openid-configuration") {
+						const config = await auth.api.getOpenIdConfig();
+						res.setHeader("Content-Type", "application/json");
+						res.end(JSON.stringify(config));
+						return;
+					}
+					await nodeHandler(req, res);
+				};
+			},
+		},
+	);
+	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
 
 	const authClient = createAuthClient({
 		plugins: [oauthProviderClient()],
@@ -69,25 +74,10 @@ describe("private_key_jwt e2e", async () => {
 		fetchOptions: { customFetchImpl },
 	});
 
-	let server: Listener;
 	let oauthClient: OAuthClient;
 	let oauthJwksUriClient: OAuthClient;
 
 	beforeAll(async () => {
-		// Start actual HTTP server for the authorization server
-		server = await listen(
-			async (req, res) => {
-				if (req.url === "/.well-known/openid-configuration") {
-					const config = await authorizationServer.api.getOpenIdConfig();
-					res.setHeader("Content-Type", "application/json");
-					res.end(JSON.stringify(config));
-				} else {
-					await toNodeHandler(authorizationServer.handler)(req, res);
-				}
-			},
-			{ port },
-		);
-
 		// Register a private_key_jwt client on the authorization server
 		const { headers } = await signInWithTestUser();
 		oauthClient = (await authorizationServer.api.adminCreateOAuthClient({

--- a/packages/oauth-provider/src/private-key-jwt-e2e.test.ts
+++ b/packages/oauth-provider/src/private-key-jwt-e2e.test.ts
@@ -21,7 +21,15 @@ import type { OAuthClient } from "./types/oauth";
  * - Flow: RP → authorize → login → callback → token exchange (with JWT assertion) → session
  */
 describe("private_key_jwt e2e", async () => {
-	const port = 3002;
+	// Discover a free OS-assigned port so concurrent test files don't collide.
+	const tempServer = await listen(
+		(_req, res) => {
+			res.end();
+		},
+		{ port: 0 },
+	);
+	const port = tempServer.address?.port ?? 3002;
+	await tempServer.close();
 	const authServerBaseUrl = `http://localhost:${port}`;
 	const rpBaseUrl = "http://localhost:5002";
 	const providerId = "jwt-assertion-provider";

--- a/packages/oauth-provider/src/private-key-jwt.test.ts
+++ b/packages/oauth-provider/src/private-key-jwt.test.ts
@@ -678,6 +678,7 @@ describe("private_key_jwt registration validation", async () => {
 			jwt({ jwt: { issuer: authServerBaseUrl } }),
 			oauthProvider({
 				loginPage: "/login",
+				consentPage: "/consent",
 				silenceWarnings: {
 					oauthAuthServerConfig: true,
 					openidConfig: true,

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -258,7 +258,7 @@ describe("oauth register", async () => {
 		expect(response.error?.status).toBe(400);
 	});
 
-	it("should reject registration with an empty jwks.keys object", async () => {
+	it("should reject registration with an empty jwks.keys array", async () => {
 		const response = await serverClient.oauth2.register({
 			redirect_uris: [redirectUri],
 			token_endpoint_auth_method: "private_key_jwt",

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -249,6 +249,37 @@ describe("oauth register", async () => {
 		expect(response?.nested).toEqual({ key: "value" });
 	});
 
+	it("should reject registration with an empty jwks array", async () => {
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			token_endpoint_auth_method: "private_key_jwt",
+			jwks: [] as Record<string, unknown>[],
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("should reject registration with an empty jwks.keys object", async () => {
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			token_endpoint_auth_method: "private_key_jwt",
+			jwks: { keys: [] } as { keys: Record<string, unknown>[] },
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("should reject admin registration with an empty jwks array", async () => {
+		await expect(
+			auth.api.adminCreateOAuthClient({
+				headers,
+				body: {
+					redirect_uris: [redirectUri],
+					token_endpoint_auth_method: "private_key_jwt",
+					jwks: [] as Record<string, unknown>[],
+				},
+			}),
+		).rejects.toThrow();
+	});
+
 	it("should register client with metadata and strip extra fields not in schema", async () => {
 		const response = await auth.api.adminCreateOAuthClient({
 			headers,

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -417,8 +417,13 @@ export async function getStoredToken(
  *
  * @internal
  */
+// RFC 7235 §2.1: the auth scheme is case-insensitive and is followed by
+// one or more SP. Match liberally so requests using `basic` or extra
+// spaces aren't rejected before reaching the spec-correct decoder.
+const BASIC_SCHEME_PREFIX = /^Basic +/i;
+
 function basicToClientCredentials(authorization: string) {
-	if (!authorization.startsWith("Basic ")) {
+	if (!BASIC_SCHEME_PREFIX.test(authorization)) {
 		return undefined;
 	}
 	try {

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -1,6 +1,7 @@
 import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
 import { BetterAuthError } from "@better-auth/core/error";
-import { base64, base64Url } from "@better-auth/utils/base64";
+import { decodeBasicCredentials } from "@better-auth/core/oauth2";
+import { base64Url } from "@better-auth/utils/base64";
 import { createHash } from "@better-auth/utils/hash";
 import {
 	constantTimeEqual,
@@ -417,26 +418,17 @@ export async function getStoredToken(
  * @internal
  */
 function basicToClientCredentials(authorization: string) {
-	if (authorization.startsWith("Basic ")) {
-		const encoded = authorization.replace("Basic ", "");
-		const decoded = new TextDecoder().decode(base64.decode(encoded));
-		if (!decoded.includes(":")) {
-			throw new APIError("BAD_REQUEST", {
-				error_description: "invalid authorization header format",
-				error: "invalid_client",
-			});
-		}
-		const [id, secret] = decoded.split(":", 2);
-		if (!id || !secret) {
-			throw new APIError("BAD_REQUEST", {
-				error_description: "invalid authorization header format",
-				error: "invalid_client",
-			});
-		}
-		return {
-			client_id: id,
-			client_secret: secret,
-		};
+	if (!authorization.startsWith("Basic ")) {
+		return undefined;
+	}
+	try {
+		const { clientId, clientSecret } = decodeBasicCredentials(authorization);
+		return { client_id: clientId, client_secret: clientSecret };
+	} catch {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "invalid authorization header format",
+			error: "invalid_client",
+		});
 	}
 }
 

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1593,6 +1593,25 @@ describe("OIDC SSO with private_key_jwt", async () => {
 		});
 		expect(session.data?.user.email).toBe("jwt-auth-user@private-key-jwt.com");
 	});
+
+	it("should redirect with no_private_key_available when resolvePrivateKey returns no key material", async () => {
+		resolvePrivateKey.mockResolvedValueOnce(
+			{} as Awaited<ReturnType<typeof resolvePrivateKey>>,
+		);
+
+		const signInHeaders = new Headers();
+		const res = await authClient.signIn.sso({
+			providerId: "private-key-jwt-provider",
+			callbackURL: "/dashboard",
+			fetchOptions: {
+				throw: true,
+				onSuccess: cookieSetter(signInHeaders),
+			},
+		});
+
+		const { callbackURL } = await simulateOAuthFlow(res.url, signInHeaders);
+		expect(callbackURL).toContain("error_description=no_private_key_available");
+	});
 });
 
 /**

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1466,6 +1466,33 @@ describe("OIDC SSO with private_key_jwt", async () => {
 		server.service.on("beforeResponse", responseHandler);
 		await server.issuer.keys.generate("RS256");
 		await server.start(8080, "localhost");
+
+		const { headers } = await signInWithTestUser();
+		await auth.api.registerSSOProvider({
+			headers,
+			body: {
+				issuer: server.issuer.url!,
+				domain: "private-key-jwt.com",
+				providerId: "private-key-jwt-provider",
+				oidcConfig: {
+					clientId: "private-key-jwt-client",
+					authorizationEndpoint: `${server.issuer.url}/authorize`,
+					tokenEndpoint: `${server.issuer.url}/token`,
+					jwksEndpoint: `${server.issuer.url}/jwks`,
+					discoveryEndpoint: `${server.issuer.url}/.well-known/openid-configuration`,
+					tokenEndpointAuthentication: "private_key_jwt",
+					privateKeyId: "private-key-jwt-key",
+					privateKeyAlgorithm: "RS256",
+					mapping: {
+						id: "sub",
+						email: "email",
+						emailVerified: "email_verified",
+						name: "name",
+						image: "picture",
+					},
+				},
+			},
+		});
 	});
 
 	afterAll(async () => {
@@ -1504,33 +1531,6 @@ describe("OIDC SSO with private_key_jwt", async () => {
 	it("should sign in using private_key_jwt and resolvePrivateKey", async () => {
 		capturedTokenRequest = undefined;
 		resolvePrivateKey.mockClear();
-		const { headers } = await signInWithTestUser();
-
-		await auth.api.registerSSOProvider({
-			headers,
-			body: {
-				issuer: server.issuer.url!,
-				domain: "private-key-jwt.com",
-				providerId: "private-key-jwt-provider",
-				oidcConfig: {
-					clientId: "private-key-jwt-client",
-					authorizationEndpoint: `${server.issuer.url}/authorize`,
-					tokenEndpoint: `${server.issuer.url}/token`,
-					jwksEndpoint: `${server.issuer.url}/jwks`,
-					discoveryEndpoint: `${server.issuer.url}/.well-known/openid-configuration`,
-					tokenEndpointAuthentication: "private_key_jwt",
-					privateKeyId: "private-key-jwt-key",
-					privateKeyAlgorithm: "RS256",
-					mapping: {
-						id: "sub",
-						email: "email",
-						emailVerified: "email_verified",
-						name: "name",
-						image: "picture",
-					},
-				},
-			},
-		});
 
 		const signInHeaders = new Headers();
 		const res = await authClient.signIn.sso({

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1465,7 +1465,7 @@ async function handleOIDCCallback(
 			});
 		}
 
-		if (!resolved) {
+		if (!resolved || (!resolved.privateKeyJwk && !resolved.privateKeyPem)) {
 			throw ctx.redirect(
 				`${
 					errorURL || callbackURL


### PR DESCRIPTION
OAuth clients with reserved characters in their id or secret now authenticate against spec-compliant servers, and Better Auth same-stack round-trips work correctly. Misconfigured `private_key_jwt` setups fail loudly at construction instead of signing with the wrong algorithm. Test suites get a race-free helper for real HTTP listeners.

The behavior changes:

- `@better-auth/core/oauth2` exposes new helpers `encodeBasicCredentials` and `decodeBasicCredentials`. Both follow RFC 6749 §2.3.1 and are round-trip tested. `client_secret_basic` on the client and the OAuth provider's Basic header parser both delegate to them. Three previously-divergent inline implementations are gone.
- `signPrivateKeyJwtClientAssertion` validates the JWK-embedded `alg` whenever present. It throws when an explicit `algorithm` option disagrees with the JWK. The earlier code silently let the explicit option win.
- OAuth Provider DCR rejects empty `jwks` payloads at registration time. Empty registrations used to fail later at authentication.
- The SSO `private_key_jwt` flow redirects with `error_description=no_private_key_available` when a `resolvePrivateKey` callback returns no key material. Previously this fell through into an internal signing error.

For tests:

- `better-auth/test` adds `getHttpTestInstance`, a counterpart to `getTestInstance` that binds a real HTTP listener on an OS-assigned port. The auth instance is constructed against the discovered URL. The temp-server-then-rebind race that test files were copy-pasting is gone for any test that adopts the helper.
- The `private_key_jwt` e2e test migrates to the new helper.
- The SSO `private_key_jwt` suite moves provider registration into `beforeAll`, so its tests no longer depend on order.

**Breaking change**

Configurations that paired a JWK whose embedded `alg` was symmetric or `none` with a different explicit `algorithm` option now fail at construction. The old behavior was a footgun: it signed with the explicit option, leaving the JWK's stated algorithm a lie.