### PR TITLE
fix(cookies): expire cookies when applying set-cookie

### DIFF
--- a/.changeset/apply-set-cookie-expiry.md
+++ b/.changeset/apply-set-cookie-expiry.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Ensure `applySetCookies` removes cookies expired by `Max-Age` or `Expires` when merging `Set-Cookie` headers.

--- a/packages/better-auth/src/cookies/cookie-utils.ts
+++ b/packages/better-auth/src/cookies/cookie-utils.ts
@@ -261,9 +261,9 @@ export function setRequestCookie(
  * Merge `Set-Cookie` header values into the target's `Cookie` header.
  * Mutates `target`.
  *
- * Name/value-level merge only. RFC 6265 §5 user-agent semantics
- * (expiration, domain/path scoping, ordering) are out of scope. Suitable
- * for single-request proxy, middleware, and test contexts.
+ * Name/value-level merge only. Expired cookies are removed by name; domain/path
+ * scoping and ordering are out of scope. Suitable for single-request proxy,
+ * middleware, and test contexts.
  */
 export function applySetCookies(
 	target: Headers,
@@ -272,13 +272,29 @@ export function applySetCookies(
 	const cookieMap = parseCookies(target.get("cookie") || "");
 	for (const setCookie of setCookieValues) {
 		for (const [name, attr] of parseSetCookieHeader(setCookie)) {
-			cookieMap.set(name, attr.value);
+			const maxAge = attr["max-age"];
+			const expiresAt = attr.expires?.getTime();
+			const hasValidMaxAge = maxAge !== undefined && !Number.isNaN(maxAge);
+			const isExpired = hasValidMaxAge
+				? maxAge <= 0
+				: expiresAt !== undefined &&
+					!Number.isNaN(expiresAt) &&
+					expiresAt <= Date.now();
+			if (isExpired) {
+				cookieMap.delete(name);
+			} else {
+				cookieMap.set(name, attr.value);
+			}
 		}
 	}
-	target.set(
-		"cookie",
-		Array.from(cookieMap, ([k, v]) => `${k}=${v}`).join("; "),
-	);
+	if (cookieMap.size === 0) {
+		target.delete("cookie");
+	} else {
+		target.set(
+			"cookie",
+			Array.from(cookieMap, ([k, v]) => `${k}=${v}`).join("; "),
+		);
+	}
 }
 
 export function setCookieToHeader(headers: Headers) {

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1574,6 +1574,34 @@ describe("applySetCookies", () => {
 		applySetCookies(headers, ["a=new; Path=/"]);
 		expect(headers.get("cookie")).toBe("a=new; b=keep");
 	});
+
+	it("removes cookies expired by Max-Age", () => {
+		const headers = new Headers({ cookie: "a=old; b=keep" });
+		applySetCookies(headers, ["a=; Path=/; Max-Age=0"]);
+		expect(headers.get("cookie")).toBe("b=keep");
+	});
+
+	it("removes cookies expired by Expires", () => {
+		const headers = new Headers({ cookie: "a=old; b=keep" });
+		applySetCookies(headers, [
+			"a=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+		]);
+		expect(headers.get("cookie")).toBe("b=keep");
+	});
+
+	it("keeps cookies with positive Max-Age and past Expires", () => {
+		const headers = new Headers({ cookie: "a=old; b=keep" });
+		applySetCookies(headers, [
+			"a=new; Path=/; Max-Age=3600; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+		]);
+		expect(headers.get("cookie")).toBe("a=new; b=keep");
+	});
+
+	it("clears Cookie header when all cookies expire", () => {
+		const headers = new Headers({ cookie: "a=old" });
+		applySetCookies(headers, ["a=; Path=/; Max-Age=0"]);
+		expect(headers.get("cookie")).toBeNull();
+	});
 });
 
 describe("expireCookie", () => {


### PR DESCRIPTION
## What changed
- Remove cookies from the merged Cookie header when Set-Cookie expires them with Max-Age=0 or a past Expires value.
- Delete the Cookie header when all merged cookies have expired.
- Add focused tests for Max-Age, Expires, and empty-header behavior.

## Validation
- pnpm --filter better-auth test src/cookies/cookies.test.ts --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cookie merging in `applySetCookies` to enforce expiration from `Set-Cookie`. Expired cookies are removed by name, and the `Cookie` header is deleted when none remain.

- **Bug Fixes**
  - Remove cookies when `Max-Age` <= 0 or `Expires` is in the past.
  - Prefer `Max-Age` over `Expires` when both are present.
  - Add tests for `Max-Age`, `Expires`, precedence, and empty-header behavior.

<sup>Written for commit bef5f17df361e194a3fc6fec36f5565e60e7a034. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9658?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

