### PR TITLE
ci(workflows): harden GitHub workflow configuration

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -18,6 +18,9 @@ outputs:
   playwright-version:
     description: 'Detected Playwright version'
     value: ${{ steps.detect-version.outputs.version }}
+  validated-browsers:
+    description: 'Validated browser arguments for Playwright install commands'
+    value: ${{ steps.validate-browsers.outputs.browsers }}
 
 runs:
   using: composite
@@ -38,31 +41,63 @@ runs:
       id: detect-version
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        PLAYWRIGHT_WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
         PLAYWRIGHT_VERSION=$(pnpm --filter=. ls @playwright/test --json | jq --raw-output '.[0].devDependencies["@playwright/test"].version')
         if [ -z "$PLAYWRIGHT_VERSION" ] || [ "$PLAYWRIGHT_VERSION" = "null" ]; then
-          echo "::error::Could not detect @playwright/test version in ${{ inputs.working-directory }}. Ensure dependencies are installed before running this action."
+          echo "::error::Could not detect @playwright/test version in ${PLAYWRIGHT_WORKING_DIRECTORY}. Ensure dependencies are installed before running this action."
           exit 1
         fi
         echo "version=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Validate Playwright Browsers
+      id: validate-browsers
+      shell: bash
+      env:
+        PLAYWRIGHT_BROWSERS: ${{ inputs.browsers }}
+      run: |
+        browser_args=()
+        if [ -n "$PLAYWRIGHT_BROWSERS" ]; then
+          read -r -a browser_args <<< "$PLAYWRIGHT_BROWSERS"
+          for browser in "${browser_args[@]}"; do
+            if [[ ! "$browser" =~ ^[A-Za-z][A-Za-z0-9._-]*$ ]]; then
+              echo "::error::Invalid Playwright browser name: $browser"
+              exit 1
+            fi
+          done
+        fi
+        echo "browsers=${browser_args[*]}" >> "$GITHUB_OUTPUT"
 
     - name: Cache Playwright Browsers
       uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
       id: cache
       with:
         path: ${{ steps.cache-path.outputs.path }}
-        # Dynamically inject the requested browsers into the cache key ('all' is used as a fallback string if empty)
-        key: ${{ runner.os }}-playwright-${{ inputs.browsers || 'all' }}-${{ steps.detect-version.outputs.version }}
+        key: ${{ runner.os }}-playwright-${{ steps.validate-browsers.outputs.browsers || 'all' }}-${{ steps.detect-version.outputs.version }}
 
     - name: Install Playwright Browsers & OS Deps (Cache Miss)
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      # If inputs.browsers is empty, this safely resolves to 'pnpm exec playwright install --with-deps'
-      run: pnpm exec playwright install ${{ inputs.browsers }} --with-deps
+      env:
+        PLAYWRIGHT_BROWSERS: ${{ steps.validate-browsers.outputs.browsers }}
+      run: |
+        browser_args=()
+        if [ -n "$PLAYWRIGHT_BROWSERS" ]; then
+          read -r -a browser_args <<< "$PLAYWRIGHT_BROWSERS"
+        fi
+        pnpm exec playwright install "${browser_args[@]}" --with-deps
 
     - name: Install Playwright OS Dependencies (Cache Hit)
       if: steps.cache.outputs.cache-hit == 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: pnpm exec playwright install-deps ${{ inputs.browsers }}
+      env:
+        PLAYWRIGHT_BROWSERS: ${{ steps.validate-browsers.outputs.browsers }}
+      run: |
+        browser_args=()
+        if [ -n "$PLAYWRIGHT_BROWSERS" ]; then
+          read -r -a browser_args <<< "$PLAYWRIGHT_BROWSERS"
+        fi
+        pnpm exec playwright install-deps "${browser_args[@]}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       - dependencies
     commit-message:
       prefix: "chore(deps):"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -28,6 +30,7 @@ updates:
       prefix: "chore(deps):"
     versioning-strategy: increase
     cooldown:
+      default-days: 7
       semver-major-days: 5
     groups:
       workspace-minor-patch:
@@ -56,6 +59,7 @@ updates:
       prefix: "chore(deps):"
     versioning-strategy: increase
     cooldown:
+      default-days: 7
       semver-major-days: 5
     groups:
       demo-minor-patch:

--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -63,6 +63,7 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version-file: '.nvmrc'
+          package-manager-cache: false
 
       - name: Analyze PR
         id: analyze

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -45,6 +45,7 @@ jobs:
 
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          persist-credentials: false
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Check PR state and labels

--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Add dist-tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - run: pnpm install --frozen-lockfile
 
@@ -99,7 +100,7 @@ jobs:
       - name: Create Release Pull Request or Publish
         id: changesets
         if: steps.guard.outputs.skip != 'true'
-        uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308 # v1
+        uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308 # v1.4.9
         with:
           version: pnpm ci:version
           publish: pnpm ci:release
@@ -144,9 +145,11 @@ jobs:
             -e "s|__GITHUB_REPOSITORY__|${GITHUB_REPOSITORY}|g" \
             .github/prompts/release-notes-rewrite.md)
           EOF_DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
-          echo "prompt<<${EOF_DELIM}" >> "$GITHUB_OUTPUT"
-          echo "$PROMPT" >> "$GITHUB_OUTPUT"
-          echo "${EOF_DELIM}" >> "$GITHUB_OUTPUT"
+          {
+            echo "prompt<<${EOF_DELIM}"
+            echo "$PROMPT"
+            echo "${EOF_DELIM}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Rewrite release notes with AI
         id: ai-notes
@@ -173,9 +176,9 @@ jobs:
           fi
 
           # Count PR links in both files
-          RAW_COUNT=$(grep -coP '\[#\d+\]' "$RAW_PATH" 2>/dev/null || true)
+          RAW_COUNT=$(grep -coP "\\[#\\d+\\]" "$RAW_PATH" 2>/dev/null || true)
           RAW_COUNT=${RAW_COUNT:-0}
-          FINAL_COUNT=$(grep -coP '\[#\d+\]' "$FINAL" 2>/dev/null || true)
+          FINAL_COUNT=$(grep -coP "\\[#\\d+\\]" "$FINAL" 2>/dev/null || true)
           FINAL_COUNT=${FINAL_COUNT:-0}
 
           if [ "$FINAL_COUNT" -lt "$RAW_COUNT" ]; then
@@ -191,7 +194,7 @@ jobs:
               echo "::warning::Missing package heading: $heading"
               MISSING=$((MISSING + 1))
             fi
-          done < <(grep -oP '## `[^`]+`' "$RAW_PATH")
+          done < <(grep -oP "## \`[^\`]+\`" "$RAW_PATH")
 
           if [ "$MISSING" -gt 0 ]; then
             echo "::warning::AI output is missing $MISSING package heading(s). Falling back to raw notes."
@@ -323,6 +326,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - run: pnpm install --frozen-lockfile
 
@@ -378,6 +382,7 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version-file: '.nvmrc'
+          package-manager-cache: false
 
       - name: Validate inputs
         env:
@@ -417,9 +422,11 @@ jobs:
             -e "s|__GITHUB_REPOSITORY__|${GITHUB_REPOSITORY}|g" \
             .github/prompts/release-notes-rewrite.md)
           EOF_DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
-          echo "prompt<<${EOF_DELIM}" >> "$GITHUB_OUTPUT"
-          echo "$PROMPT" >> "$GITHUB_OUTPUT"
-          echo "${EOF_DELIM}" >> "$GITHUB_OUTPUT"
+          {
+            echo "prompt<<${EOF_DELIM}"
+            echo "$PROMPT"
+            echo "${EOF_DELIM}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Rewrite release notes with AI
         id: ai-notes

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Check PR title
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         id: lint_pr_title
         with:
           subjectPattern: ^(?![A-Z]).+$ # Ensure the subject doesn't start with an uppercase character
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Comment on invalid PR title
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3
+        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2
         # NOTE: null comparison is intentional per official README
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
@@ -71,7 +71,7 @@ jobs:
             ```
 
       - name: Remove comment on valid PR title
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3
+        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2
         # NOTE: null comparison is intentional per official README
         if: ${{ steps.lint_pr_title.outputs.error_message == null }}
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,3 +1,6 @@
+# Policy: fix shell-injection, cache, and credential-persistence findings.
+# Suppress only intentional metadata-only workflows, and state the trust
+# boundary so future workflow changes do not mix privilege with PR code.
 rules:
   dangerous-triggers:
     ignore:
@@ -8,3 +11,19 @@ rules:
       # Intentional: reads .changeset/*.md content via GitHub API only.
       # No checkout of fork code. No code execution.
       - auto-retarget.yml
+      # Intentional: applies labels from repository-owned config only. It does
+      # not check out or execute PR code; pull_request_target is required so
+      # labels can be applied to fork PRs.
+      - auto-label.yml
+      # Intentional: creates backports for already-merged PRs or maintainer
+      # slash commands. Checkout persists no credentials; the action receives
+      # an explicit token and does not execute fork PR code.
+      - backport.yml
+  use-trusted-publishing:
+    ignore:
+      # Intentional: pkg.pr.new publishes ephemeral PR preview packages, not npm
+      # release artifacts. Do not add id-token: write to this pull_request
+      # workflow without redesigning the preview-publish trust boundary. If a
+      # future maintainer enables trusted publishing here, also re-evaluate
+      # the pull_request trigger.
+      - preview.yml


### PR DESCRIPTION
## Summary

- tighten workflow credential and package-manager cache configuration
- consolidate Playwright browser input validation in the shared setup action
- document intentional workflow-audit suppressions and Dependabot cooldown policy

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/backport.yml .github/workflows/auto-label.yml .github/workflows/semantic-pull-request.yml .github/workflows/preview.yml .github/workflows/npm-dist-tag.yml .github/workflows/auto-changeset.yml`
- `zizmor .github --format plain`
- `git diff --check`
- commit hooks: `spell`, `biome`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub workflows to reduce credential risk and cache misuse, and made Playwright setup safer by validating browser inputs. Also documented audit suppressions with clear trust boundaries and added a 7‑day Dependabot cooldown.

- **Refactors**
  - `setup-playwright`: validate browser args, expose `validated-browsers`, and use it in cache keys and `install`/`install-deps`; clearer `@playwright/test` version error messages.
  - Credentials/caching: set `persist-credentials: false` in backport checkout; disable `actions/setup-node` `package-manager-cache` in `release`, `npm-dist-tag`, and `auto-changeset`.
  - Release flow: safer `$GITHUB_OUTPUT` heredoc writes and escaped grep patterns; pinned action comments to exact versions across workflows (e.g., `changesets/action@v1.4.9`, `amannn/action-semantic-pull-request@v6.1.1`, `marocchino/sticky-pull-request-comment@v3.0.2`).
  - `.github/zizmor.yml`: expanded, explicit suppressions with trust boundaries for `auto-label`, `backport`, and `preview`.

- **Dependencies**
  - Dependabot: add `cooldown.default-days: 7` across ecosystems.

<sup>Written for commit ad27694da704884edeed3268d7f0c97451ad4bcf. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9659?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

