### PR TITLE
fix: harden URL and Stripe escaping

### DIFF
--- a/.changeset/harden-url-stripe-escaping.md
+++ b/.changeset/harden-url-stripe-escaping.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/stripe": patch
+---
+
+Harden URL normalization and Stripe customer search escaping. URL helpers now trim trailing slashes without a regular expression, and Stripe search query values escape backslashes before quotes.

--- a/packages/better-auth/src/plugins/oauth-proxy/utils.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/utils.ts
@@ -1,6 +1,6 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { env } from "@better-auth/core/env";
-import { getOrigin } from "../../utils/url";
+import { getOrigin, trimTrailingSlashes } from "../../utils/url";
 import type { OAuthProxyOptions } from "./index";
 
 /**
@@ -8,7 +8,7 @@ import type { OAuthProxyOptions } from "./index";
  */
 export function stripTrailingSlash(url: string | undefined): string {
 	if (!url) return "";
-	return url.replace(/\/+$/, "");
+	return trimTrailingSlashes(url);
 }
 
 /**

--- a/packages/better-auth/src/utils/url.test.ts
+++ b/packages/better-auth/src/utils/url.test.ts
@@ -8,9 +8,31 @@ import {
 	matchesHostPattern,
 	resolveBaseURL,
 	resolveDynamicBaseURL,
+	trimTrailingSlashes,
 } from "./url";
 
+describe("trimTrailingSlashes", () => {
+	it("should remove trailing slashes", () => {
+		expect(trimTrailingSlashes("https://example.com///")).toBe(
+			"https://example.com",
+		);
+		expect(trimTrailingSlashes("///")).toBe("");
+	});
+
+	it("should leave non-trailing slashes unchanged", () => {
+		const value = `https://example.com/${"/".repeat(10_000)}a`;
+
+		expect(trimTrailingSlashes(value)).toBe(value);
+	});
+});
+
 describe("getBaseURL", () => {
+	it("should append the auth path after trailing slashes", () => {
+		expect(
+			getBaseURL("https://example.com////", "/auth", undefined, false),
+		).toBe("https://example.com/auth");
+	});
+
 	describe("trustedProxyHeaders validation", () => {
 		it("should reject malicious protocol in X-Forwarded-Proto", () => {
 			const request = new Request("http://localhost:3000/test", {

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -3,6 +3,8 @@ import { env } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
 import { wildcardMatch } from "./wildcard";
 
+const SLASH_CHAR_CODE = "/".charCodeAt(0);
+
 /**
  * Minimal loopback check for dev scheme inference only. Reachable from
  * `client/config.ts` via `getBaseURL`, so we MUST NOT import the full
@@ -27,10 +29,18 @@ function isLoopbackForDevScheme(host: string): boolean {
 	);
 }
 
+export function trimTrailingSlashes(value: string): string {
+	let end = value.length;
+	while (end > 0 && value.charCodeAt(end - 1) === SLASH_CHAR_CODE) {
+		end--;
+	}
+	return end === value.length ? value : value.slice(0, end);
+}
+
 function checkHasPath(url: string): boolean {
 	try {
 		const parsedUrl = new URL(url);
-		const pathname = parsedUrl.pathname.replace(/\/+$/, "") || "/";
+		const pathname = trimTrailingSlashes(parsedUrl.pathname) || "/";
 		return pathname !== "/";
 	} catch {
 		throw new BetterAuthError(
@@ -68,7 +78,7 @@ function withPath(url: string, path = "/api/auth") {
 		return url;
 	}
 
-	const trimmedUrl = url.replace(/\/+$/, "");
+	const trimmedUrl = trimTrailingSlashes(url);
 
 	if (!path || path === "/") {
 		return trimmedUrl;

--- a/packages/stripe/src/utils.ts
+++ b/packages/stripe/src/utils.ts
@@ -43,13 +43,13 @@ export function isStripePendingCancel(stripeSub: Stripe.Subscription): boolean {
 
 /**
  * Escapes a value for use in Stripe search queries.
- * Stripe search query uses double quotes for string values,
- * and double quotes within the value need to be escaped with backslash.
+ * Stripe search query uses backslash escaping inside double-quoted
+ * string values, so literal backslashes must be escaped before quotes.
  *
  * @see https://docs.stripe.com/search#search-query-language
  */
 export function escapeStripeSearchValue(value: string): string {
-	return value.replace(/"/g, '\\"');
+	return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
 /**

--- a/packages/stripe/test/utils.test.ts
+++ b/packages/stripe/test/utils.test.ts
@@ -15,6 +15,12 @@ describe("escapeStripeSearchValue", () => {
 	it("should escape multiple quotes", () => {
 		expect(escapeStripeSearchValue('"a" and "b"')).toBe('\\"a\\" and \\"b\\"');
 	});
+
+	it("should escape backslashes before escaping quotes", () => {
+		expect(escapeStripeSearchValue('customer\\segment"admin')).toBe(
+			'customer\\\\segment\\"admin',
+		);
+	});
 });
 
 describe("resolvePlanItem", () => {


### PR DESCRIPTION
## Summary

- replace trailing-slash regex trimming with a linear URL helper
- reuse the helper in the OAuth proxy URL utility
- escape backslashes before quotes in Stripe search query values
- add focused regression coverage for URL trimming and Stripe search escaping
- add a patch changeset for `better-auth` and `@better-auth/stripe`

## Validation

- `pnpm --filter better-auth exec vitest run src/utils/url.test.ts`
- `pnpm --filter @better-auth/stripe exec vitest run test/utils.test.ts`
- `pnpm exec biome check .changeset/harden-url-stripe-escaping.md packages/better-auth/src/utils/url.ts packages/better-auth/src/plugins/oauth-proxy/utils.ts packages/better-auth/src/utils/url.test.ts packages/stripe/src/utils.ts packages/stripe/test/utils.test.ts --error-on-warnings`
- `pnpm exec cspell .changeset/harden-url-stripe-escaping.md packages/better-auth/src/utils/url.ts packages/better-auth/src/plugins/oauth-proxy/utils.ts packages/better-auth/src/utils/url.test.ts packages/stripe/src/utils.ts packages/stripe/test/utils.test.ts --no-color`
- `git diff --check`

Notes:

- Package typechecks currently fail on pre-existing unrelated baseline errors.
- The OAuth proxy test file ran 17/18 tests; the database-mode test requires local Postgres on `localhost:5432` and failed with `ECONNREFUSED`.
