### PR TITLE
fix: scope provider account lookups to current user

### DIFF
--- a/.changeset/provider-scoped-account-lookups.md
+++ b/.changeset/provider-scoped-account-lookups.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Avoid ambiguous provider account lookups in account info and Google One Tap flows when different providers issue the same account ID.

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -227,6 +227,74 @@ describe("account", async () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9502
+	 */
+	it("should resolve account info from the current user's accounts when provider account IDs collide", async () => {
+		const { auth, signInWithTestUser, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				accountLinking: {
+					allowDifferentEmails: true,
+				},
+				encryptOAuthTokens: true,
+			},
+		});
+		const ctx = await auth.$context;
+		const googleProvider = ctx.socialProviders.find((v) => v.id === "google")!;
+		const getUserInfoMock = vi.spyOn(googleProvider, "getUserInfo");
+		const sharedAccountId = "shared-provider-account-id";
+		const otherUser = await ctx.internalAdapter.createUser({
+			name: "Other User",
+			email: "other-account-info@example.com",
+		});
+		await ctx.internalAdapter.createAccount({
+			userId: otherUser.id,
+			providerId: "google",
+			accountId: sharedAccountId,
+			accessToken: "other-access-token",
+		});
+
+		const { runWithUser, user } = await signInWithTestUser();
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "google",
+			accountId: sharedAccountId,
+			accessToken: "current-access-token",
+		});
+
+		getUserInfoMock.mockResolvedValueOnce({
+			user: {
+				id: user.id,
+				name: user.name,
+				email: user.email,
+				emailVerified: user.emailVerified,
+			},
+			data: { source: "current-user" },
+		});
+
+		await runWithUser(async () => {
+			const info = await client.$fetch("/account-info", {
+				query: { accountId: sharedAccountId },
+				method: "GET",
+			});
+
+			expect(info.error).toBeNull();
+			expect(info.data).toMatchObject({
+				data: { source: "current-user" },
+			});
+			expect(getUserInfoMock).toHaveBeenCalledWith(
+				expect.objectContaining({ accessToken: "current-access-token" }),
+			);
+		});
+	});
+
 	it("should pass custom scopes to authorization URL", async () => {
 		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async () => {

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -295,6 +295,83 @@ describe("account", async () => {
 		});
 	});
 
+	it("should require providerId when a current user's provider account IDs collide", async () => {
+		const { auth, signInWithTestUser, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+				github: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				accountLinking: {
+					allowDifferentEmails: true,
+				},
+			},
+		});
+		const ctx = await auth.$context;
+		const googleProvider = ctx.socialProviders.find((v) => v.id === "google")!;
+		const githubProvider = ctx.socialProviders.find((v) => v.id === "github")!;
+		const googleGetUserInfoMock = vi.spyOn(googleProvider, "getUserInfo");
+		const githubGetUserInfoMock = vi.spyOn(githubProvider, "getUserInfo");
+		const sharedAccountId = "shared-provider-account-id";
+
+		const { runWithUser, user } = await signInWithTestUser();
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "google",
+			accountId: sharedAccountId,
+			accessToken: "google-access-token",
+		});
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "github",
+			accountId: sharedAccountId,
+			accessToken: "github-access-token",
+		});
+
+		await runWithUser(async () => {
+			const ambiguousInfo = await client.$fetch("/account-info", {
+				query: { accountId: sharedAccountId },
+				method: "GET",
+			});
+
+			expect(ambiguousInfo.error?.message).toBe(
+				BASE_ERROR_CODES.ACCOUNT_NOT_FOUND.message,
+			);
+			expect(googleGetUserInfoMock).not.toHaveBeenCalled();
+			expect(githubGetUserInfoMock).not.toHaveBeenCalled();
+
+			githubGetUserInfoMock.mockResolvedValueOnce({
+				user: {
+					id: user.id,
+					name: user.name,
+					email: user.email,
+					emailVerified: user.emailVerified,
+				},
+				data: { source: "github" },
+			});
+			const githubInfo = await client.$fetch("/account-info", {
+				query: { accountId: sharedAccountId, providerId: "github" },
+				method: "GET",
+			});
+
+			expect(githubInfo.error).toBeNull();
+			expect(githubInfo.data).toMatchObject({
+				data: { source: "github" },
+			});
+			expect(githubGetUserInfoMock).toHaveBeenCalledWith(
+				expect.objectContaining({ accessToken: "github-access-token" }),
+			);
+		});
+	});
+
 	it("should pass custom scopes to authorization URL", async () => {
 		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async () => {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -907,9 +907,12 @@ export const accountInfo = createAuthEndpoint(
 			const accounts = await ctx.context.internalAdapter.findAccounts(
 				ctx.context.session.user.id,
 			);
-			account = accounts.find(
+			const matchingAccounts = accounts.filter(
 				(account) => account.accountId === providedAccountId,
 			);
+			if (matchingAccounts.length === 1) {
+				account = matchingAccounts[0];
+			}
 		}
 
 		if (!account || account.userId !== ctx.context.session.user.id) {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -822,6 +822,13 @@ const accountInfoQuerySchema = z.optional(
 					"The provider given account id for which to get the account info",
 			})
 			.optional(),
+		providerId: z
+			.string()
+			.meta({
+				description:
+					"The provider ID to disambiguate provider-issued account IDs",
+			})
+			.optional(),
 	}),
 );
 
@@ -881,6 +888,7 @@ export const accountInfo = createAuthEndpoint(
 	},
 	async (ctx) => {
 		const providedAccountId = ctx.query?.accountId;
+		const providedProviderId = ctx.query?.providerId;
 		let account: Account | undefined = undefined;
 		if (!providedAccountId) {
 			if (ctx.context.options.account?.storeAccountCookie) {
@@ -889,12 +897,19 @@ export const accountInfo = createAuthEndpoint(
 					account = accountData;
 				}
 			}
+		} else if (providedProviderId) {
+			account =
+				(await ctx.context.internalAdapter.findAccountByProviderId(
+					providedAccountId,
+					providedProviderId,
+				)) ?? undefined;
 		} else {
-			const accountData =
-				await ctx.context.internalAdapter.findAccount(providedAccountId);
-			if (accountData) {
-				account = accountData;
-			}
+			const accounts = await ctx.context.internalAdapter.findAccounts(
+				ctx.context.session.user.id,
+			);
+			account = accounts.find(
+				(account) => account.accountId === providedAccountId,
+			);
 		}
 
 		if (!account || account.userId !== ctx.context.session.user.id) {

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -156,7 +156,11 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 							user: parseUserOutput(ctx.context.options, newUser.user),
 						});
 					}
-					const account = await ctx.context.internalAdapter.findAccount(sub);
+					const account =
+						await ctx.context.internalAdapter.findAccountByProviderId(
+							sub,
+							"google",
+						);
 					if (!account) {
 						const accountLinking = ctx.context.options.account?.accountLinking;
 						const providerEmailVerified =

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -2,13 +2,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { oneTap } from "./index";
 
-const verifiedPayload = {
+const defaultVerifiedPayload = {
 	email: "one-tap-user@example.com",
 	email_verified: true,
 	name: "One Tap User",
 	picture: "https://example.com/photo.jpg",
 	sub: "google_oauth_sub_one_tap",
 };
+
+const verifiedPayload = { ...defaultVerifiedPayload };
 
 vi.mock("jose", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("jose")>();
@@ -24,7 +26,7 @@ vi.mock("jose", async (importOriginal) => {
 
 describe("one-tap implicit linking gate", async () => {
 	afterEach(() => {
-		verifiedPayload.email_verified = true;
+		Object.assign(verifiedPayload, defaultVerifiedPayload);
 	});
 
 	/**
@@ -157,6 +159,65 @@ describe("one-tap implicit linking gate", async () => {
 			],
 		});
 		expect(accounts.length).toBeGreaterThanOrEqual(1);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9502
+	 */
+	it("links Google One Tap when another provider has the same account ID", async () => {
+		verifiedPayload.email = "one-tap-provider-collision@example.com";
+		verifiedPayload.sub = "shared-one-tap-provider-account-id";
+
+		const { auth, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+				},
+			},
+			account: {
+				accountLinking: {
+					requireLocalEmailVerified: false,
+				},
+			},
+			plugins: [oneTap()],
+		});
+
+		const ctx = await auth.$context;
+		const otherUser = await ctx.internalAdapter.createUser({
+			name: "Other Provider User",
+			email: "one-tap-other-provider@example.com",
+		});
+		await ctx.internalAdapter.createAccount({
+			userId: otherUser.id,
+			providerId: "github",
+			accountId: verifiedPayload.sub,
+		});
+
+		await client.signUp.email({
+			email: verifiedPayload.email,
+			password: "password123",
+			name: "Pre-existing Local User",
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error).toBeFalsy();
+		const googleAccounts = await ctx.adapter.findMany<{ providerId: string }>({
+			model: "account",
+			where: [
+				{ field: "providerId", value: "google" },
+				{ field: "accountId", value: verifiedPayload.sub },
+			],
+		});
+		expect(googleAccounts).toHaveLength(1);
 	});
 
 	it("honors accountLinking.disableImplicitLinking even when the local user is verified", async () => {


### PR DESCRIPTION
## Summary
- scope `/account-info` accountId lookups to the authenticated user's accounts unless a providerId is explicitly supplied
- use provider-scoped account lookup for Google One Tap so provider account IDs from other providers cannot block linking
- add regressions for colliding provider account IDs in account-info and One Tap flows

Fixes #9502.

## Testing
- `pnpm --filter better-auth exec vitest run src/api/routes/account.test.ts src/plugins/one-tap/one-tap.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope provider account lookups to the current user and provider to prevent collisions and ambiguous matches. Fixes Google One Tap linking when another provider shares the same account ID and adds `providerId` support to `/account-info`.

- **Bug Fixes**
  - `/account-info`: If only `accountId` is provided, search the authenticated user's accounts; if multiple matches exist, return not found and require `providerId`. Support provider-scoped lookup via `providerId` (`findAccountByProviderId`).
  - Google One Tap: Use provider-scoped lookup (`findAccountByProviderId` with `"google"`) so other providers with the same ID don't block linking.
  - Tests: Added regressions for cross-user and same-user provider ID collisions in `/account-info`, and for One Tap collisions.

<sup>Written for commit 3bbe38d894d3b81087bad66e41b12adbdd3b5f94. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9664?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

