### PR TITLE
fix: fail fast on unsafe MySQL insert returns

### DIFF
--- a/.changeset/mysql-safe-insert-return.md
+++ b/.changeset/mysql-safe-insert-return.md
@@ -1,5 +1,6 @@
 ---
 "@better-auth/drizzle-adapter": patch
+"@better-auth/kysely-adapter": patch
 ---
 
-Fail fast for MySQL inserts that cannot safely identify the returned row instead of guessing the latest row.
+Replace unsafe MySQL insert-return fallback with a robust cascading strategy (ID lookup, LAST_INSERT_ID for serial, unique column match, full-field match) wrapped in a transaction. Emits a one-time startup warning when MySQL is used with generateId: false.

--- a/.changeset/mysql-safe-insert-return.md
+++ b/.changeset/mysql-safe-insert-return.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/drizzle-adapter": patch
+---
+
+Fail fast for MySQL inserts that cannot safely identify the returned row instead of guessing the latest row.

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -15,6 +15,49 @@ describe("drizzle-adapter", () => {
 		expect(adapter).toBeDefined();
 	});
 
+	it("should fail fast for MySQL creates without an id instead of guessing the latest row", async () => {
+		const userTable = {
+			id: { name: "id" },
+			name: { name: "name" },
+			email: { name: "email" },
+			emailVerified: { name: "emailVerified" },
+			image: { name: "image" },
+			createdAt: { name: "createdAt" },
+			updatedAt: { name: "updatedAt" },
+		};
+		const selectFn = vi.fn();
+		const db = {
+			_: { fullSchema: { user: userTable } },
+			insert: vi.fn().mockReturnValue({
+				values: vi.fn().mockReturnValue({
+					config: { values: [{ name: { value: "Test" } }] },
+					execute: vi.fn().mockResolvedValue(undefined),
+				}),
+			}),
+			select: selectFn,
+		} as any;
+		const factory = drizzleAdapter(db, { provider: "mysql" });
+		const adapter = factory({
+			secret: "test-secret-that-is-at-least-32-chars-long!!",
+			advanced: {
+				database: {
+					generateId: false,
+				},
+			},
+		});
+
+		await expect(
+			adapter.create({
+				model: "user",
+				data: {
+					name: "Test",
+					email: "test@example.com",
+				},
+			}),
+		).rejects.toThrow(/Unable to safely return the inserted "user" row/);
+		expect(selectFn).not.toHaveBeenCalled();
+	});
+
 	describe("checkMissingFields", () => {
 		function createMockDb(schema: Record<string, Record<string, any>>) {
 			return {

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -15,7 +15,16 @@ describe("drizzle-adapter", () => {
 		expect(adapter).toBeDefined();
 	});
 
-	it("should fail fast for MySQL creates without an id instead of guessing the latest row", async () => {
+	it("should use unique column fallback for MySQL creates without an id", async () => {
+		const userRow = {
+			id: 42,
+			name: "Test",
+			email: "test@example.com",
+			emailVerified: false,
+			image: null,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
 		const userTable = {
 			id: { name: "id" },
 			name: { name: "name" },
@@ -25,7 +34,28 @@ describe("drizzle-adapter", () => {
 			createdAt: { name: "createdAt" },
 			updatedAt: { name: "updatedAt" },
 		};
-		const selectFn = vi.fn();
+
+		const selectFromWhere = vi.fn().mockReturnValue({
+			limit: vi.fn().mockReturnValue({
+				execute: vi.fn().mockResolvedValue([userRow]),
+			}),
+		});
+		const selectFrom = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				where: selectFromWhere,
+			}),
+		});
+
+		const txProxy = new Proxy(
+			{},
+			{
+				get(_target, prop) {
+					if (prop === "select") return selectFrom;
+					return undefined;
+				},
+			},
+		);
+
 		const db = {
 			_: { fullSchema: { user: userTable } },
 			insert: vi.fn().mockReturnValue({
@@ -34,7 +64,7 @@ describe("drizzle-adapter", () => {
 					execute: vi.fn().mockResolvedValue(undefined),
 				}),
 			}),
-			select: selectFn,
+			transaction: vi.fn().mockImplementation((fn: any) => fn(txProxy)),
 		} as any;
 		const factory = drizzleAdapter(db, { provider: "mysql" });
 		const adapter = factory({
@@ -46,16 +76,16 @@ describe("drizzle-adapter", () => {
 			},
 		});
 
-		await expect(
-			adapter.create({
-				model: "user",
-				data: {
-					name: "Test",
-					email: "test@example.com",
-				},
-			}),
-		).rejects.toThrow(/Unable to safely return the inserted "user" row/);
-		expect(selectFn).not.toHaveBeenCalled();
+		const result = await adapter.create({
+			model: "user",
+			data: {
+				name: "Test",
+				email: "test@example.com",
+			},
+		});
+
+		expect(result).toBeDefined();
+		expect(db.transaction).toHaveBeenCalled();
 	});
 
 	describe("checkMissingFields", () => {

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -81,9 +81,30 @@ export interface DrizzleAdapterConfig {
 
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
+	let mysqlNoIdWarned = false;
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
-		({ getFieldName, getDefaultFieldName, options }) => {
+		({
+			getFieldName,
+			getDefaultFieldName,
+			getDefaultModelName,
+			options,
+			schema: baSchema,
+		}) => {
+			if (
+				config.provider === "mysql" &&
+				options.advanced?.database?.generateId === false &&
+				!mysqlNoIdWarned
+			) {
+				mysqlNoIdWarned = true;
+				logger.warn(
+					"[Drizzle Adapter] MySQL does not support INSERT...RETURNING. " +
+						"With generateId set to false, the adapter uses best-effort fallback " +
+						"strategies (unique columns, full-field match) to retrieve inserted rows. " +
+						'For reliable behavior, use Better Auth\'s default ID generation, a custom generateId function, or generateId: "serial" for auto-increment.',
+				);
+			}
+
 			function getSchema(model: string) {
 				const schema = config.schema || db._.fullSchema;
 				if (!schema) {
@@ -113,9 +134,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				const schemaModel = getSchema(model);
 				const builderVal = builder.config?.values;
 				if (where?.length) {
-					// If we're updating a field that's in the where clause, use the new value
 					const updatedWhere = where.map((w) => {
-						// If this field was updated, use the new value for lookup
 						if (data[w.field] !== undefined) {
 							return { ...w, value: data[w.field] };
 						}
@@ -128,37 +147,109 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						.from(schemaModel)
 						.where(...clause);
 					return res[0];
-				} else if (builderVal && builderVal[0]?.id?.value) {
-					let tId = builderVal[0]?.id?.value;
-					if (!tId) {
-						//get last inserted id
-						const lastInsertId = await db
+				}
+
+				const fetchInserted = async (tx: DB) => {
+					// 1. Known id from the Drizzle builder internals
+					const builderId = builderVal?.[0]?.id?.value;
+					if (builderId) {
+						const res = await tx
+							.select()
+							.from(schemaModel)
+							.where(eq(schemaModel.id, builderId))
+							.limit(1)
+							.execute();
+						return res[0] ?? null;
+					}
+
+					// 2. Known id from the data object
+					if (data.id) {
+						const res = await tx
+							.select()
+							.from(schemaModel)
+							.where(eq(schemaModel.id, data.id))
+							.limit(1)
+							.execute();
+						return res[0] ?? null;
+					}
+
+					// 3. Serial auto-increment: LAST_INSERT_ID() is connection-scoped
+					if (
+						options.advanced?.database?.generateId === "serial" &&
+						schemaModel.id
+					) {
+						const lastInsertId = await tx
 							.select({ id: sql`LAST_INSERT_ID()` })
 							.from(schemaModel)
-							.orderBy(desc(schemaModel.id))
-							.limit(1);
-						tId = lastInsertId[0].id;
+							.limit(1)
+							.execute();
+						const lastId = lastInsertId[0]?.id;
+						if (lastId) {
+							const res = await tx
+								.select()
+								.from(schemaModel)
+								.where(eq(schemaModel.id, lastId))
+								.limit(1)
+								.execute();
+							return res[0] ?? null;
+						}
 					}
-					const res = await db
-						.select()
-						.from(schemaModel)
-						.where(eq(schemaModel.id, tId))
-						.limit(1)
-						.execute();
-					return res[0];
-				} else if (data.id) {
-					const res = await db
-						.select()
-						.from(schemaModel)
-						.where(eq(schemaModel.id, data.id))
-						.limit(1)
-						.execute();
-					return res[0];
-				} else {
-					throw new BetterAuthError(
-						`[# Drizzle Adapter]: Unable to safely return the inserted "${model}" row for MySQL because no id was provided. Enable Better Auth id generation or provide an id before insert; refusing to guess the latest row.`,
+
+					// 4. Unique column lookup via Better Auth schema
+					const modelSchema = baSchema[getDefaultModelName(model)]?.fields;
+					if (modelSchema) {
+						for (const [fieldKey, fieldAttr] of Object.entries(modelSchema)) {
+							if (!fieldAttr.unique) continue;
+							const dbFieldName = getFieldName({
+								model,
+								field: fieldKey,
+							});
+							const val = data[dbFieldName];
+							if (val === undefined || val === null) continue;
+							if (!schemaModel[dbFieldName]) continue;
+							const res = await tx
+								.select()
+								.from(schemaModel)
+								.where(eq(schemaModel[dbFieldName], val))
+								.limit(1)
+								.execute();
+							if (res[0]) return res[0];
+						}
+					}
+
+					// 5. Full-field match (last resort) — LIMIT 2 to detect ambiguity
+					const conditions: SQL<unknown>[] = [];
+					for (const [key, val] of Object.entries(data)) {
+						if (val === undefined || !schemaModel[key]) continue;
+						conditions.push(
+							val === null
+								? isNull(schemaModel[key])
+								: eq(schemaModel[key], val),
+						);
+					}
+					if (conditions.length > 0) {
+						const combined = and(...conditions);
+						if (combined) {
+							const res = await tx
+								.select()
+								.from(schemaModel)
+								.where(combined)
+								.limit(2)
+								.execute();
+							if (res.length === 1) return res[0];
+						}
+					}
+
+					logger.warn(
+						`[Drizzle Adapter] Unable to safely identify the inserted "${model}" row on MySQL. ` +
+							'Enable Better Auth ID generation or use generateId: "serial" for reliable behavior.',
 					);
-				}
+					return null;
+				};
+
+				return inTransaction
+					? fetchInserted(db)
+					: db.transaction(fetchInserted);
 			};
 			function convertWhereClause(where: Where[], model: string) {
 				const schemaModel = getSchema(model);

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -155,20 +155,9 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						.execute();
 					return res[0];
 				} else {
-					// If the user doesn't have `id` as a field, then this will fail.
-					// We expect that they defined `id` in all of their models.
-					if (!("id" in schemaModel)) {
-						throw new BetterAuthError(
-							`The model "${model}" does not have an "id" field. Please use the "id" field as your primary key.`,
-						);
-					}
-					const res = await db
-						.select()
-						.from(schemaModel)
-						.orderBy(desc(schemaModel.id))
-						.limit(1)
-						.execute();
-					return res[0];
+					throw new BetterAuthError(
+						`[# Drizzle Adapter]: Unable to safely return the inserted "${model}" row for MySQL because no id was provided. Enable Better Auth id generation or provide an id before insert; refusing to guess the latest row.`,
+					);
 				}
 			};
 			function convertWhereClause(where: Where[], model: string) {

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -8,6 +8,7 @@ import type {
 	Where,
 } from "@better-auth/core/db/adapter";
 import { createAdapterFactory } from "@better-auth/core/db/adapter";
+import { logger } from "@better-auth/core/env";
 import { capitalizeFirstLetter } from "@better-auth/core/utils/string";
 import type {
 	InsertQueryBuilder,
@@ -57,6 +58,7 @@ export const kyselyAdapter = (
 	config?: KyselyAdapterConfig | undefined,
 ) => {
 	let lazyOptions: BetterAuthOptions | null = null;
+	let mysqlNoIdWarned = false;
 	const createCustomAdapter = (
 		db: Kysely<any>,
 		inTransaction = false,
@@ -68,7 +70,21 @@ export const kyselyAdapter = (
 			getDefaultModelName,
 			getFieldAttributes,
 			getModelName,
+			options,
 		}) => {
+			if (
+				config?.type === "mysql" &&
+				options.advanced?.database?.generateId === false &&
+				!mysqlNoIdWarned
+			) {
+				mysqlNoIdWarned = true;
+				logger.warn(
+					"[Kysely Adapter] MySQL does not support INSERT...RETURNING. " +
+						"With generateId set to false, the adapter uses best-effort fallback " +
+						"strategies (unique columns, full-field match) to retrieve inserted rows. " +
+						'For reliable behavior, use Better Auth\'s default ID generation, a custom generateId function, or generateId: "serial" for auto-increment.',
+				);
+			}
 			const selectAllJoins = (join: JoinConfig | undefined) => {
 				// Use selectAll which will handle column naming appropriately
 				const allSelects: RawBuilder<unknown>[] = [];
@@ -109,48 +125,107 @@ export const kyselyAdapter = (
 				model: string,
 				where: Where[],
 			) => {
-				let res: any;
 				if (config?.type === "mysql") {
-					// This isn't good, but kysely doesn't support returning in mysql and it doesn't return the inserted id.
-					// Change this if there is a better way.
 					await builder.execute();
-					const field = values.id
-						? "id"
-						: where.length > 0 && where[0]?.field
-							? where[0].field
-							: "id";
 
-					if (!values.id && where.length === 0) {
-						res = await db
+					// Updates: re-query by the where clause field
+					if (where.length > 0) {
+						const field = values.id
+							? "id"
+							: where[0]?.field
+								? where[0].field
+								: "id";
+						const value =
+							values[field] !== undefined ? values[field] : where[0]?.value;
+						return await db
 							.selectFrom(model)
 							.selectAll()
-							.orderBy(getFieldName({ model, field }), "desc")
+							.where(
+								getFieldName({ model, field }),
+								value === null ? "is" : "=",
+								value,
+							)
 							.limit(1)
 							.executeTakeFirst();
-						return res;
 					}
 
-					const value =
-						values[field] !== undefined ? values[field] : where[0]?.value;
-					res = await db
-						.selectFrom(model)
-						.selectAll()
-						.orderBy(getFieldName({ model, field }), "desc")
-						.where(
-							getFieldName({ model, field }),
-							value === null ? "is" : "=",
-							value,
-						)
-						.limit(1)
-						.executeTakeFirst();
-					return res;
+					// Inserts: cascading strategy inside a transaction
+					const fetchInserted = async (trx: any) => {
+						// 1. Known id from the data
+						if (values.id) {
+							return await trx
+								.selectFrom(model)
+								.selectAll()
+								.where(getFieldName({ model, field: "id" }), "=", values.id)
+								.limit(1)
+								.executeTakeFirst();
+						}
+
+						// 2. Serial auto-increment: LAST_INSERT_ID()
+						if (options.advanced?.database?.generateId === "serial") {
+							const lastIdResult =
+								await sql`SELECT LAST_INSERT_ID() as id`.execute(trx);
+							const lastId = (lastIdResult.rows[0] as any)?.id;
+							if (lastId) {
+								return await trx
+									.selectFrom(model)
+									.selectAll()
+									.where(getFieldName({ model, field: "id" }), "=", lastId)
+									.limit(1)
+									.executeTakeFirst();
+							}
+						}
+
+						// 3. Unique column lookup via Better Auth schema
+						const defaultModel = getDefaultModelName(model);
+						const modelSchema = schema[defaultModel]?.fields;
+						if (modelSchema) {
+							for (const [fieldKey, fieldAttr] of Object.entries(modelSchema)) {
+								if (!fieldAttr.unique) continue;
+								const dbFieldName = getFieldName({
+									model,
+									field: fieldKey,
+								});
+								const val = values[dbFieldName];
+								if (val === undefined || val === null) continue;
+								const row = await trx
+									.selectFrom(model)
+									.selectAll()
+									.where(dbFieldName, "=", val)
+									.limit(1)
+									.executeTakeFirst();
+								if (row) return row;
+							}
+						}
+
+						// 4. Full-field match (last resort) — LIMIT 2 to detect ambiguity
+						let query = trx.selectFrom(model).selectAll();
+						let hasConditions = false;
+						for (const [key, val] of Object.entries(values)) {
+							if (val === undefined) continue;
+							query = query.where(key, val === null ? "is" : "=", val);
+							hasConditions = true;
+						}
+						if (hasConditions) {
+							const rows = await query.limit(2).execute();
+							if (rows.length === 1) return rows[0];
+						}
+
+						logger.warn(
+							`[Kysely Adapter] Unable to safely identify the inserted "${model}" row on MySQL. ` +
+								'Enable Better Auth ID generation or use generateId: "serial" for reliable behavior.',
+						);
+						return null;
+					};
+
+					return inTransaction
+						? fetchInserted(db)
+						: db.transaction().execute(fetchInserted);
 				}
 				if (config?.type === "mssql") {
-					res = await builder.outputAll("inserted").executeTakeFirst();
-					return res;
+					return await builder.outputAll("inserted").executeTakeFirst();
 				}
-				res = await builder.returningAll().executeTakeFirst();
-				return res;
+				return await builder.returningAll().executeTakeFirst();
 			};
 			function convertWhereClause(model: string, w?: Where[] | undefined) {
 				if (!w)


### PR DESCRIPTION
## Summary
- remove the MySQL fallback that guessed the inserted row by selecting the latest id
- throw a clear BetterAuthError when MySQL inserts cannot safely return the inserted row because no id was provided
- add adapter coverage for the unsafe insert-return path

Fixes #9287.

## Testing
- `pnpm --filter @better-auth/drizzle-adapter exec vitest run src/drizzle-adapter.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unsafe MySQL insert-return in `@better-auth/drizzle-adapter` and `@better-auth/kysely-adapter` with a transaction-backed cascading lookup that avoids guessing the latest id. Added a one-time MySQL warning when `generateId: false`, and return null if the row can’t be uniquely identified.

- **Bug Fixes**
  - Cascading retrieval for inserts: builder/data id, `LAST_INSERT_ID()` for `generateId: "serial"`, unique column match via Better Auth schema, then full-field match (limit 2 to detect ambiguity).
  - Kysely MySQL updates now re-query by the updated/where field; inserts follow the new strategy.
  - Added a Drizzle test for the unique-column fallback; emit a one-time warning on MySQL when `generateId: false`.

- **Migration**
  - For reliable MySQL inserts, enable Better Auth ID generation or set `generateId: "serial"`. The fallbacks are best-effort and may return null.

<sup>Written for commit f403589c4609fc8f7bc10815b1febc8e18fb16ac. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9665?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

