### PR TITLE
fix: support DPoP authorization scheme tokens

### DIFF
--- a/.changeset/oauth-dpop-authorization-scheme.md
+++ b/.changeset/oauth-dpop-authorization-scheme.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Accept DPoP authorization scheme values anywhere OAuth provider endpoints parse access tokens.

--- a/.cspell/auth-terms.txt
+++ b/.cspell/auth-terms.txt
@@ -1,6 +1,7 @@
 totp
 otps
 pkce
+dpop
 unban
 siwe
 scim

--- a/packages/oauth-provider/src/introspect.test.ts
+++ b/packages/oauth-provider/src/introspect.test.ts
@@ -205,6 +205,31 @@ describe("oauth introspect", async () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8656
+	 */
+	it("should accept DPoP authorization scheme for access token introspection", async () => {
+		const tokens = await getTokens();
+		const introspection = await client.oauth2.introspect(
+			{
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				token: `DPoP ${tokens.data?.access_token!}`,
+				token_type_hint: "access_token",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+		});
+	});
+
 	it("should pass with token_type_hint access_token and sent opaque access_token", async () => {
 		const tokens = await getTokens();
 		const introspection = await client.oauth2.introspect(

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -14,6 +14,7 @@ import type {
 } from "./types";
 import {
 	basicToClientCredentials,
+	getAuthorizationToken,
 	getClient,
 	getJwtPlugin,
 	getStoredToken,
@@ -424,9 +425,7 @@ export async function introspectEndpoint(
 	}
 
 	// Check token
-	if (token && typeof token === "string" && token.startsWith("Bearer ")) {
-		token = token.replace("Bearer ", "");
-	}
+	token = getAuthorizationToken(token) ?? "";
 	if (!token?.length) {
 		throw new APIError("BAD_REQUEST", {
 			error_description: "missing a required token for introspection",

--- a/packages/oauth-provider/src/mcp.ts
+++ b/packages/oauth-provider/src/mcp.ts
@@ -3,6 +3,7 @@ import { verifyAccessToken } from "better-auth/oauth2";
 import { APIError } from "better-call";
 import type { JWTPayload } from "jose";
 import type { Awaitable } from "./types/helpers";
+import { getAuthorizationToken } from "./utils";
 
 /**
  * A request middleware handler that checks and responds with
@@ -21,9 +22,7 @@ export const mcpHandler = (
 ) => {
 	return async (req: Request) => {
 		const authorization = req.headers?.get("authorization") ?? undefined;
-		const accessToken = authorization?.startsWith("Bearer ")
-			? authorization.replace("Bearer ", "")
-			: authorization;
+		const accessToken = getAuthorizationToken(authorization);
 		try {
 			if (!accessToken?.length) {
 				throw new APIError("UNAUTHORIZED", {

--- a/packages/oauth-provider/src/revoke.test.ts
+++ b/packages/oauth-provider/src/revoke.test.ts
@@ -190,6 +190,29 @@ describe("oauth revoke", async () => {
 		expect(revocation.error).toBe(null);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8656
+	 */
+	it("should accept DPoP authorization scheme for access token revocation", async () => {
+		const tokens = await getTokens();
+		const revocation = await client.oauth2.revoke(
+			{
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				token: `DPoP ${tokens.data?.access_token!}`,
+				token_type_hint: "access_token",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		expect(revocation.data).toBe(null);
+		expect(revocation.error).toBe(null);
+	});
+
 	it("should pass verification with token_type_hint access_token and sent opaque access_token", async () => {
 		const tokens = await getTokens();
 		const revocation = await client.oauth2.revoke(

--- a/packages/oauth-provider/src/revoke.ts
+++ b/packages/oauth-provider/src/revoke.ts
@@ -12,6 +12,7 @@ import type {
 } from "./types";
 import {
 	basicToClientCredentials,
+	getAuthorizationToken,
 	getJwtPlugin,
 	getStoredToken,
 	validateClientCredentials,
@@ -273,9 +274,7 @@ export async function revokeEndpoint(
 	}
 
 	// Check token
-	if (typeof token === "string" && token.startsWith("Bearer ")) {
-		token = token.replace("Bearer ", "");
-	}
+	token = getAuthorizationToken(token) ?? "";
 	if (!token?.length) {
 		throw new APIError("BAD_REQUEST", {
 			error_description: "missing a required token for introspection",

--- a/packages/oauth-provider/src/userinfo.test.ts
+++ b/packages/oauth-provider/src/userinfo.test.ts
@@ -204,6 +204,27 @@ describe("oauth userinfo", async () => {
 	 *
 	 * @see https://github.com/better-auth/better-auth/issues/8806
 	 */
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8656
+	 */
+	it("should accept DPoP authorization scheme for userinfo", async () => {
+		const tokens = await getTokens();
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: `DPoP ${tokens.data?.access_token ?? ""}`,
+				},
+			},
+		);
+
+		expect(userinfo.data).toMatchObject({
+			sub: user.id,
+			email: user.email,
+		});
+	});
+
 	it("should return userinfo via auth.api with headers only (no Request)", async () => {
 		const tokens = await getTokens();
 		expect(tokens.data?.access_token).toBeDefined();

--- a/packages/oauth-provider/src/userinfo.ts
+++ b/packages/oauth-provider/src/userinfo.ts
@@ -3,7 +3,11 @@ import { APIError } from "better-auth/api";
 import type { User } from "better-auth/types";
 import { validateAccessToken } from "./introspect";
 import type { OAuthOptions, Scope } from "./types";
-import { getClient, resolveSubjectIdentifier } from "./utils";
+import {
+	getAuthorizationToken,
+	getClient,
+	resolveSubjectIdentifier,
+} from "./utils";
 
 /**
  * Provides shared /userinfo and id_token claims functionality
@@ -38,10 +42,7 @@ export async function userInfoEndpoint(
 	opts: OAuthOptions<Scope[]>,
 ) {
 	const authorization = ctx.headers?.get("authorization");
-	const token =
-		typeof authorization === "string" && authorization?.startsWith("Bearer ")
-			? authorization?.replace("Bearer ", "")
-			: authorization;
+	const token = getAuthorizationToken(authorization);
 	if (!token?.length) {
 		throw new APIError("UNAUTHORIZED", {
 			error_description: "authorization header not found",

--- a/packages/oauth-provider/src/utils/authorization.test.ts
+++ b/packages/oauth-provider/src/utils/authorization.test.ts
@@ -8,6 +8,9 @@ describe("getAuthorizationToken", () => {
 		expect(getAuthorizationToken("dpop lowercase-token")).toBe(
 			"lowercase-token",
 		);
+		expect(getAuthorizationToken("  DPoP token-with-padding  ")).toBe(
+			"token-with-padding",
+		);
 	});
 
 	it("preserves raw token values for backwards compatibility", () => {

--- a/packages/oauth-provider/src/utils/authorization.test.ts
+++ b/packages/oauth-provider/src/utils/authorization.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getAuthorizationToken } from "./index";
+
+describe("getAuthorizationToken", () => {
+	it("extracts Bearer and DPoP scheme tokens", () => {
+		expect(getAuthorizationToken("Bearer bearer-token")).toBe("bearer-token");
+		expect(getAuthorizationToken("DPoP dpop-token")).toBe("dpop-token");
+		expect(getAuthorizationToken("dpop lowercase-token")).toBe(
+			"lowercase-token",
+		);
+	});
+
+	it("preserves raw token values for backwards compatibility", () => {
+		expect(getAuthorizationToken("raw-token")).toBe("raw-token");
+		expect(getAuthorizationToken(null)).toBeNull();
+		expect(getAuthorizationToken(undefined)).toBeUndefined();
+	});
+});

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -61,6 +61,23 @@ export const getJwtPlugin = (ctx: AuthContext) => {
 };
 
 /**
+ * Extracts an OAuth access token from Authorization header-style values.
+ *
+ * OAuth endpoints must accept both Bearer and DPoP authorization schemes.
+ * Unknown schemes are left unchanged for backward compatibility with callers
+ * that historically sent the raw token value without a scheme.
+ *
+ * @internal
+ */
+export function getAuthorizationToken(value: string | null | undefined) {
+	if (typeof value !== "string") {
+		return value;
+	}
+	const match = /^\s*(Bearer|DPoP)\s+(.+)\s*$/i.exec(value);
+	return match?.[2] ?? value;
+}
+
+/**
  * Normalizes timestamp-like values returned by adapters.
  *
  * Accepts Date instances, epoch milliseconds as numbers, and strings that are

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -74,7 +74,7 @@ export function getAuthorizationToken(value: string | null | undefined) {
 		return value;
 	}
 	const match = /^\s*(Bearer|DPoP)\s+(.+)\s*$/i.exec(value);
-	return match?.[2] ?? value;
+	return match?.[2]?.trim() ?? value;
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize Authorization header token extraction for Bearer and DPoP schemes
- apply DPoP token parsing to introspection, revocation, userinfo, and MCP resource flows
- add coverage for DPoP and backward-compatible raw token handling

Fixes #8656.

## Testing
- `pnpm --filter @better-auth/oauth-provider exec vitest run src/utils/authorization.test.ts src/introspect.test.ts src/revoke.test.ts src/userinfo.test.ts src/mcp.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept DPoP authorization scheme tokens across OAuth endpoints and trim Authorization header values by centralizing token parsing. Fixes #8656 and preserves raw token handling for backward compatibility.

- **Bug Fixes**
  - Extract tokens from Bearer or DPoP schemes (case-insensitive) and trim whitespace via `getAuthorizationToken`.
  - Apply to introspection, revocation, `userinfo`, and MCP middleware.
  - Add tests for DPoP, raw tokens, and trimmed/case-insensitive values; add `dpop` to spelling; publish patch for `@better-auth/oauth-provider`.
  - No API changes; existing Bearer and raw token calls still work.

<sup>Written for commit b2b7e096e3b6ac957029f49dde0a0a925b941f84. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9666?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

