### PR TITLE
fix: forward session cookie refresh headers

### DIFF
--- a/.changeset/forward-session-refresh-headers.md
+++ b/.changeset/forward-session-refresh-headers.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Forward cookie refresh headers emitted while resolving sessions through getSessionFromCtx.

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -1,6 +1,9 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
-import { runWithEndpointContext } from "@better-auth/core/context";
+import {
+	runWithEndpointContext,
+	runWithRequestState,
+} from "@better-auth/core/context";
 import type { MemoryDB } from "@better-auth/memory-adapter";
 import { memoryAdapter } from "@better-auth/memory-adapter";
 import {
@@ -16,7 +19,7 @@ import { parseCookies, parseSetCookieHeader } from "../../cookies";
 import { signJWT, verifyJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { getDate } from "../../utils/date";
-import { freshSessionMiddleware } from "./session";
+import { freshSessionMiddleware, getSessionFromCtx } from "./session";
 
 describe("session", async () => {
 	const { client, testUser, sessionSetter, cookieSetter, auth } =
@@ -1205,6 +1208,70 @@ describe("cookie cache refreshCache", async () => {
 		vi.useRealTimers();
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8763
+	 */
+	it("should forward cookie cache headers from getSessionFromCtx", async () => {
+		const { client, testUser, cookieSetter, auth } = await getTestInstance({
+			session: {
+				cookieCache: {
+					enabled: true,
+					strategy: "jwe",
+				},
+			},
+		});
+		const ctx = await auth.$context;
+		const headers = new Headers();
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				onSuccess: cookieSetter(headers),
+			},
+		);
+
+		const requestCookies = parseCookies(headers.get("cookie") || "");
+		for (const name of requestCookies.keys()) {
+			if (
+				name === ctx.authCookies.sessionData.name ||
+				name.startsWith(`${ctx.authCookies.sessionData.name}.`)
+			) {
+				requestCookies.delete(name);
+			}
+		}
+		headers.set(
+			"cookie",
+			Array.from(requestCookies, ([name, value]) => `${name}=${value}`).join(
+				"; ",
+			),
+		);
+
+		const endpointCtx = {
+			context: ctx,
+			headers,
+			query: {},
+		} as unknown as GenericEndpointContext;
+
+		await runWithRequestState(new WeakMap(), async () => {
+			await runWithEndpointContext(endpointCtx, async () => {
+				const session = await getSessionFromCtx(endpointCtx);
+				expect(session?.user.email).toBe(testUser.email);
+
+				const parsed = parseSetCookieHeader(
+					endpointCtx.context.responseHeaders?.get("set-cookie") || "",
+				);
+				const forwardedSessionDataCookie = Array.from(parsed.keys()).some(
+					(name) =>
+						name === ctx.authCookies.sessionData.name ||
+						name.startsWith(`${ctx.authCookies.sessionData.name}.`),
+				);
+				expect(forwardedSessionDataCookie).toBe(true);
+			});
+		});
+	});
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/7994
 	 */

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -546,17 +546,32 @@ export const getSessionFromCtx = async <
 		method: "GET",
 		asResponse: false,
 		headers: ctx.headers!,
-		returnHeaders: false,
+		returnHeaders: true,
 		returnStatus: false,
 		query: {
 			...config,
 			...ctx.query,
 		},
-	}).catch((e) => {
+	}).catch(() => {
 		return null;
 	});
-	ctx.context.session = session;
-	return session as {
+	if (!session) {
+		ctx.context.session = null;
+		return null;
+	}
+	if (session.headers) {
+		session.headers.forEach((value, key) => {
+			if (!ctx.context.responseHeaders) {
+				ctx.context.responseHeaders = new Headers({ [key]: value });
+			} else if (key.toLowerCase() === "set-cookie") {
+				ctx.context.responseHeaders.append(key, value);
+			} else {
+				ctx.context.responseHeaders.set(key, value);
+			}
+		});
+	}
+	ctx.context.session = session.response;
+	return session.response as {
 		session: S & Session;
 		user: U & User;
 	} | null;


### PR DESCRIPTION
## Summary
- request headers from `getSession` inside `getSessionFromCtx` so cookie-cache refresh cookies are not dropped
- forward returned headers onto the endpoint response headers, preserving multiple Set-Cookie values
- add regression coverage for direct `getSessionFromCtx` cookie-cache refresh header forwarding

Fixes #8763.

## Testing
- `pnpm --filter better-auth exec vitest run src/api/routes/session-api.test.ts`
- `pnpm --filter better-auth typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward session cookie refresh headers from `getSessionFromCtx`, preserving multiple `Set-Cookie` values so cookie-cache refresh works reliably. Fixes #8763.

- **Bug Fixes**
  - Call `getSession` with `returnHeaders: true` in `getSessionFromCtx` and store `session.response`.
  - Forward returned headers to `context.responseHeaders`; append for `set-cookie`, set for others.
  - Add regression test verifying header forwarding via `getSessionFromCtx`.

<sup>Written for commit e2616556ef248820a377ad3648967951f6b4b760. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9667?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

