### PR TITLE
fix(core): respect dynamic baseURL.protocol in getTrustedOrigins

### DIFF
--- a/packages/better-auth/src/auth/trusted-origins.test.ts
+++ b/packages/better-auth/src/auth/trusted-origins.test.ts
@@ -326,6 +326,69 @@ describe("trusted origins", () => {
 		});
 	});
 
+	describe("dynamic baseURL allowedHosts protocol", () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/9634
+		 */
+		it("should trust the http origin of an allowed host when protocol is 'http'", async () => {
+			const { isTrustedOrigin } = await createAuthTestInstance({
+				baseURL: {
+					allowedHosts: ["staging.example.com"],
+					protocol: "http",
+					fallback: "http://fallback.example.com",
+				},
+			});
+
+			await expect(isTrustedOrigin("http://staging.example.com")).resolves.toBe(
+				true,
+			);
+		});
+
+		it("should not trust the https origin of an allowed host when protocol is 'http'", async () => {
+			const { isTrustedOrigin } = await createAuthTestInstance({
+				baseURL: {
+					allowedHosts: ["staging.example.com"],
+					protocol: "http",
+					fallback: "http://staging.example.com",
+				},
+			});
+
+			await expect(
+				isTrustedOrigin("https://staging.example.com"),
+			).resolves.toBe(false);
+		});
+
+		it("should trust the https origin of an allowed host when protocol is 'https'", async () => {
+			const { isTrustedOrigin } = await createAuthTestInstance({
+				baseURL: {
+					allowedHosts: ["app.example.com"],
+					protocol: "https",
+					fallback: "https://app.example.com",
+				},
+			});
+
+			await expect(isTrustedOrigin("https://app.example.com")).resolves.toBe(
+				true,
+			);
+			await expect(isTrustedOrigin("http://app.example.com")).resolves.toBe(
+				false,
+			);
+		});
+
+		it("should still trust http for loopback hosts regardless of protocol default", async () => {
+			const { isTrustedOrigin } = await createAuthTestInstance({
+				baseURL: {
+					allowedHosts: ["localhost:3000"],
+					fallback: "https://app.example.com",
+				},
+			});
+
+			await expect(isTrustedOrigin("http://localhost:3000")).resolves.toBe(
+				true,
+			);
+		});
+	});
+
 	it("should merge trustedOrigins from plugins using init() with user config", async () => {
 		const { isTrustedOrigin } = await createAuthTestInstance({
 			trustedOrigins: async () => ["https://user-dynamic.com"],

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -113,11 +113,16 @@ export async function getTrustedOrigins(
 
 	if (isDynamicBaseURLConfig(options.baseURL)) {
 		const allowedHosts = options.baseURL.allowedHosts;
+		const protocol = options.baseURL.protocol;
 		for (const host of allowedHosts) {
 			if (!host.includes("://")) {
-				trustedOrigins.push(`https://${host}`);
-				if (isLoopbackHost(host)) {
+				if (protocol === "http") {
 					trustedOrigins.push(`http://${host}`);
+				} else {
+					trustedOrigins.push(`https://${host}`);
+					if (isLoopbackHost(host)) {
+						trustedOrigins.push(`http://${host}`);
+					}
 				}
 			} else {
 				trustedOrigins.push(host);


### PR DESCRIPTION
Fixes #9634.

`getTrustedOrigins` in `packages/better-auth/src/context/helpers.ts` always pushed `allowedHosts` entries as `https://` and only added an `http://` form for loopback hosts, ignoring the `protocol` option on the dynamic `baseURL` config. When a user sets `protocol: "http"` for a non-loopback host (staging, `.local`, etc.) the origin check rejects the request as `INVALID_ORIGIN` the moment any cookie is set for the domain — `resolveDynamicBaseURL` resolves `http://staging.example.com` but `trustedOrigins` only contains `https://staging.example.com`.

When `protocol === "http"` is explicitly set, push the `http://` form for the host. Other branches (`"https"`, `"auto"`, undefined) preserve the current HTTPS + loopback-HTTP behavior, so any setup that didn't set `protocol: "http"` is unaffected.

Regression tests added in `trusted-origins.test.ts` covering: HTTP origin trusted under `protocol: "http"`, HTTPS origin rejected under `protocol: "http"`, `protocol: "https"` behavior preserved, and the loopback HTTP exception preserved when no protocol is set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect `baseURL.protocol` in dynamic config so HTTP deployments are trusted correctly. Prevents INVALID_ORIGIN errors when using `protocol: "http"` with non-loopback hosts (e.g., staging or `.local`).

- **Bug Fixes**
  - Update `getTrustedOrigins` to add `http://` for allowed hosts when `baseURL.protocol === "http"`; keep existing HTTPS default and loopback HTTP exception for other values.
  - Add regression tests covering HTTP under `protocol: "http"`, rejecting HTTPS under `protocol: "http"`, `protocol: "https"` behavior, and loopback HTTP when no protocol is set.

<sup>Written for commit 5d93fcdb9d8b252742f4eadf0472b489c0823260. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9670?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

