### PR TITLE
fix(open-api): avoid circular session schema refs

### DIFF
--- a/.changeset/openapi-session-schema.md
+++ b/.changeset/openapi-session-schema.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix generated OpenAPI schema output for multi-method endpoints by avoiding shared response objects and duplicate operation IDs.

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -1720,7 +1720,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
       },
       "post": {
         "description": "Get the current session",
-        "operationId": "getSession",
+        "operationId": "getSessionPost",
         "parameters": [],
         "requestBody": {
           "content": {

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -1584,7 +1584,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
     "/get-session": {
       "get": {
         "description": "Get the current session",
-        "operationId": "getSession",
+        "operationId": "getSessionGet",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -257,7 +257,24 @@ function processZodType(zodType: z.ZodType<any>): any {
 	return baseSchema;
 }
 
+function deepClone(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(deepClone);
+	}
+	if (value && typeof value === "object" && value.constructor === Object) {
+		const result: Record<string, unknown> = {};
+		for (const key of Object.keys(value)) {
+			result[key] = deepClone((value as Record<string, unknown>)[key]);
+		}
+		return result;
+	}
+	return value;
+}
+
 function getResponse(responses?: Record<string, any> | undefined) {
+	const cloned = responses
+		? (deepClone(responses) as Record<string, any>)
+		: undefined;
 	return {
 		"400": {
 			content: {
@@ -355,8 +372,33 @@ function getResponse(responses?: Record<string, any> | undefined) {
 			description:
 				"Internal Server Error. This is a problem with the server that you cannot fix.",
 		},
-		...responses,
+		...cloned,
 	} as any;
+}
+
+function getUniqueOperationId(
+	operationId: string | undefined,
+	method: string,
+	usedOperationIds: Set<string>,
+) {
+	if (!operationId) {
+		return undefined;
+	}
+	if (!usedOperationIds.has(operationId)) {
+		usedOperationIds.add(operationId);
+		return operationId;
+	}
+	const methodSuffix =
+		method.charAt(0).toUpperCase() + method.slice(1).toLowerCase();
+	const baseOperationId = `${operationId}${methodSuffix}`;
+	let uniqueOperationId = baseOperationId;
+	let index = 2;
+	while (usedOperationIds.has(uniqueOperationId)) {
+		uniqueOperationId = `${baseOperationId}${index}`;
+		index++;
+	}
+	usedOperationIds.add(uniqueOperationId);
+	return uniqueOperationId;
 }
 
 function toOpenApiPath(path: string) {
@@ -419,6 +461,7 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 	};
 
 	const paths: Record<string, Path> = {};
+	const usedOperationIds = new Set<string>();
 
 	Object.entries(baseEndpoints.api).forEach(([_, value]) => {
 		if (!value.path || ctx.options.disabledPaths?.includes(value.path)) return;
@@ -434,7 +477,11 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 				[method.toLowerCase()]: {
 					tags: ["Default", ...(options.metadata?.openapi?.tags || [])],
 					description: options.metadata?.openapi?.description,
-					operationId: options.metadata?.openapi?.operationId,
+					operationId: getUniqueOperationId(
+						options.metadata?.openapi?.operationId,
+						method,
+						usedOperationIds,
+					),
 					security: [
 						{
 							bearerAuth: [],
@@ -454,7 +501,11 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 				[method.toLowerCase()]: {
 					tags: ["Default", ...(options.metadata?.openapi?.tags || [])],
 					description: options.metadata?.openapi?.description,
-					operationId: options.metadata?.openapi?.operationId,
+					operationId: getUniqueOperationId(
+						options.metadata?.openapi?.operationId,
+						method,
+						usedOperationIds,
+					),
 					security: [
 						{
 							bearerAuth: [],
@@ -519,7 +570,11 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 							plugin.id.charAt(0).toUpperCase() + plugin.id.slice(1),
 						],
 						description: options.metadata?.openapi?.description,
-						operationId: options.metadata?.openapi?.operationId,
+						operationId: getUniqueOperationId(
+							options.metadata?.openapi?.operationId,
+							method,
+							usedOperationIds,
+						),
 						security: [
 							{
 								bearerAuth: [],
@@ -540,7 +595,11 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 							plugin.id.charAt(0).toUpperCase() + plugin.id.slice(1),
 						],
 						description: options.metadata?.openapi?.description,
-						operationId: options.metadata?.openapi?.operationId,
+						operationId: getUniqueOperationId(
+							options.metadata?.openapi?.operationId,
+							method,
+							usedOperationIds,
+						),
 						security: [
 							{
 								bearerAuth: [],

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -379,26 +379,34 @@ function getResponse(responses?: Record<string, any> | undefined) {
 function getUniqueOperationId(
 	operationId: string | undefined,
 	method: string,
-	usedOperationIds: Set<string>,
+	path: string,
+	operationIdCounts: Map<string, number>,
+	operationIdMethodCounts: Map<string, number>,
 ) {
 	if (!operationId) {
 		return undefined;
 	}
-	if (!usedOperationIds.has(operationId)) {
-		usedOperationIds.add(operationId);
+	if ((operationIdCounts.get(operationId) || 0) <= 1) {
 		return operationId;
 	}
-	const methodSuffix =
-		method.charAt(0).toUpperCase() + method.slice(1).toLowerCase();
-	const baseOperationId = `${operationId}${methodSuffix}`;
-	let uniqueOperationId = baseOperationId;
-	let index = 2;
-	while (usedOperationIds.has(uniqueOperationId)) {
-		uniqueOperationId = `${baseOperationId}${index}`;
-		index++;
+	const methodSuffix = toPascalCase(method);
+	if ((operationIdMethodCounts.get(`${operationId}:${method}`) || 0) <= 1) {
+		return `${operationId}${methodSuffix}`;
 	}
-	usedOperationIds.add(uniqueOperationId);
-	return uniqueOperationId;
+	return `${operationId}${methodSuffix}${toPathOperationIdSuffix(path)}`;
+}
+
+function toPathOperationIdSuffix(path: string) {
+	return path
+		.split("/")
+		.flatMap((part) => part.replace(/[{}]/g, "").split(/[^a-zA-Z0-9]+/))
+		.filter(Boolean)
+		.map(toPascalCase)
+		.join("");
+}
+
+function toPascalCase(value: string) {
+	return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
 }
 
 function toOpenApiPath(path: string) {
@@ -461,7 +469,59 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 	};
 
 	const paths: Record<string, Path> = {};
-	const usedOperationIds = new Set<string>();
+	const operationIdCounts = new Map<string, number>();
+	const operationIdMethodCounts = new Map<string, number>();
+	const countOperationIds = (api: Endpoint[]) => {
+		for (const value of api) {
+			if (!value.path || ctx.options.disabledPaths?.includes(value.path)) {
+				continue;
+			}
+			const endpointOptions = value.options as EndpointOptions;
+			if (endpointOptions.metadata?.SERVER_ONLY) {
+				continue;
+			}
+			const operationId = endpointOptions.metadata?.openapi?.operationId;
+			if (!operationId) {
+				continue;
+			}
+			const methods = Array.isArray(endpointOptions.method)
+				? endpointOptions.method
+				: [endpointOptions.method];
+			operationIdCounts.set(
+				operationId,
+				(operationIdCounts.get(operationId) || 0) + methods.length,
+			);
+			for (const method of methods) {
+				const key = `${operationId}:${method}`;
+				operationIdMethodCounts.set(
+					key,
+					(operationIdMethodCounts.get(key) || 0) + 1,
+				);
+			}
+		}
+	};
+
+	countOperationIds(Object.values(baseEndpoints.api) as Endpoint[]);
+	for (const plugin of options.plugins || []) {
+		if (plugin.id === "open-api") {
+			continue;
+		}
+		const pluginEndpoints = getEndpoints(ctx, {
+			...options,
+			plugins: [plugin],
+		});
+		const api = Object.keys(pluginEndpoints.api)
+			.map((key) => {
+				if (
+					baseEndpoints.api[key as keyof typeof baseEndpoints.api] === undefined
+				) {
+					return pluginEndpoints.api[key as keyof typeof pluginEndpoints.api];
+				}
+				return null;
+			})
+			.filter((x) => x !== null) as Endpoint[];
+		countOperationIds(api);
+	}
 
 	Object.entries(baseEndpoints.api).forEach(([_, value]) => {
 		if (!value.path || ctx.options.disabledPaths?.includes(value.path)) return;
@@ -480,7 +540,9 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 					operationId: getUniqueOperationId(
 						options.metadata?.openapi?.operationId,
 						method,
-						usedOperationIds,
+						path,
+						operationIdCounts,
+						operationIdMethodCounts,
 					),
 					security: [
 						{
@@ -504,7 +566,9 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 					operationId: getUniqueOperationId(
 						options.metadata?.openapi?.operationId,
 						method,
-						usedOperationIds,
+						path,
+						operationIdCounts,
+						operationIdMethodCounts,
 					),
 					security: [
 						{
@@ -573,7 +637,9 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 						operationId: getUniqueOperationId(
 							options.metadata?.openapi?.operationId,
 							method,
-							usedOperationIds,
+							path,
+							operationIdCounts,
+							operationIdMethodCounts,
 						),
 						security: [
 							{
@@ -598,7 +664,9 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 						operationId: getUniqueOperationId(
 							options.metadata?.openapi?.operationId,
 							method,
-							usedOperationIds,
+							path,
+							operationIdCounts,
+							operationIdMethodCounts,
 						),
 						security: [
 							{

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -139,6 +139,47 @@ describe("open-api", async () => {
 		expect(getSessionSchema.nullable).toBe(undefined);
 	});
 
+	it("should generate unique operationIds", async () => {
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, any>;
+		const seen = new Map<string, string>();
+
+		for (const [path, pathItem] of Object.entries(paths)) {
+			for (const method of ["get", "post", "put", "patch", "delete"]) {
+				const operationId = pathItem[method]?.operationId;
+				if (!operationId) {
+					continue;
+				}
+				expect(seen.get(operationId)).toBeUndefined();
+				seen.set(operationId, `${method.toUpperCase()} ${path}`);
+			}
+		}
+
+		expect(paths["/get-session"].get.operationId).toBe("getSession");
+		expect(paths["/get-session"].post.operationId).toBe("getSessionPost");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9669
+	 */
+	it("should not share response objects between GET and POST methods", async () => {
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, any>;
+
+		const getResp = paths["/get-session"].get.responses;
+		const postResp = paths["/get-session"].post.responses;
+
+		expect(getResp).not.toBe(postResp);
+		expect(getResp["200"]).not.toBe(postResp["200"]);
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/open-api/generate-schema"),
+		);
+		const serialized = await response.text();
+		expect(response.status).toBe(200);
+		expect(serialized).not.toContain("[Circular ref");
+	});
+
 	it("should use anyOf format for optional object types in OpenAPI 3.1", async () => {
 		const schema = await auth.api.generateOpenAPISchema();
 		const paths = schema.paths as Record<string, any>;

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -155,7 +155,7 @@ describe("open-api", async () => {
 			}
 		}
 
-		expect(paths["/get-session"].get.operationId).toBe("getSession");
+		expect(paths["/get-session"].get.operationId).toBe("getSessionGet");
 		expect(paths["/get-session"].post.operationId).toBe("getSessionPost");
 	});
 


### PR DESCRIPTION
## Summary
- clone custom OpenAPI response metadata so multi-method endpoints do not share response object references
- generate unique operationIds when one endpoint exposes multiple HTTP methods
- add regression coverage for /get-session GET/POST schema output and the generated-schema HTTP response
- add a patch changeset for better-auth

Fixes #9669.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #9669 by removing circular refs in the OpenAPI session schema and making operationId generation stable and unique. Prevents shared response objects and duplicate IDs across base and plugin endpoints.

- **Bug Fixes**
  - Deep-clone response metadata so multi-method endpoints don’t share response objects. Generated schema now serializes without circular refs.
  - Generate stable, unique operationIds per method. Add method suffix, then path suffix if still duplicated, across base and plugin endpoints.
  - Add regression tests for /get-session GET/POST and the generated-schema endpoint; add a patch changeset for `better-auth`.

<sup>Written for commit f99603636b362eeec8d99482ed2dc1b73d1cc6bf. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9671?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



