### PR TITLE
fix(electron): forward each Set-Cookie from /electron/init-oauth-proxy individually

### DIFF
--- a/.changeset/fix-electron-init-oauth-proxy-set-cookie.md
+++ b/.changeset/fix-electron-init-oauth-proxy-set-cookie.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/electron": patch
+---
+
+`/electron/init-oauth-proxy` now forwards each Set-Cookie from the inner sign-in response separately. The previous `Headers.get("set-cookie")` returned them as one comma-joined string, so the browser silently dropped the transfer-token cookie that the desktop deep-link handoff needs.

--- a/packages/electron/src/routes.ts
+++ b/packages/electron/src/routes.ts
@@ -8,7 +8,11 @@ import { base64Url } from "@better-auth/utils/base64";
 import { createHash } from "@better-auth/utils/hash";
 import { betterFetch } from "@better-fetch/fetch";
 import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
-import { setSessionCookie } from "better-auth/cookies";
+import {
+	parseSetCookieHeader,
+	setSessionCookie,
+	toCookieOptions,
+} from "better-auth/cookies";
 import type { User } from "better-auth/db";
 import { parseUserOutput } from "better-auth/db";
 import * as z from "zod";
@@ -216,7 +220,7 @@ export const electronInitOAuthProxy = (opts: ElectronOptions) =>
 
 			const headers = new Headers(ctx.request?.headers);
 			headers.set("origin", new URL(ctx.context.baseURL).origin);
-			let setCookie: string | null = null;
+			let setCookies: string[] = [];
 			const searchParams = new URLSearchParams();
 			searchParams.set("client_id", opts.clientID || "electron");
 			searchParams.set("code_challenge", ctx.query.code_challenge);
@@ -235,9 +239,8 @@ export const electronInitOAuthProxy = (opts: ElectronOptions) =>
 					body: {
 						provider: ctx.query.provider,
 					},
-					onResponse: (ctx) => {
-						const headers = ctx.response.headers;
-						setCookie = headers.get("set-cookie") ?? null;
+					onResponse: (innerCtx) => {
+						setCookies = innerCtx.response.headers.getSetCookie();
 					},
 					headers,
 				},
@@ -249,9 +252,13 @@ export const electronInitOAuthProxy = (opts: ElectronOptions) =>
 				});
 			}
 
-			if (setCookie) {
-				ctx.setHeader("set-cookie", setCookie);
+			for (const cookieStr of setCookies) {
+				const parsed = parseSetCookieHeader(cookieStr);
+				parsed.forEach((attrs, name) => {
+					ctx.setCookie(name, attrs.value, toCookieOptions(attrs));
+				});
 			}
+
 			if (res.data.url && res.data.redirect) {
 				ctx.setHeader("Location", res.data.url);
 				ctx.setStatus(302);

--- a/packages/electron/test/electron.test.ts
+++ b/packages/electron/test/electron.test.ts
@@ -179,6 +179,36 @@ describe("Electron", () => {
 		expect(data!.electron_authorization_code).toBeTypeOf("string");
 	});
 
+	it("/electron/init-oauth-proxy should forward each Set-Cookie from the inner sign-in response as a separate header", async () => {
+		const innerHeaders = new Headers();
+		innerHeaders.append("set-cookie", "first.cookie=one; Path=/; HttpOnly");
+		innerHeaders.append("set-cookie", "second.cookie=two; Path=/; HttpOnly");
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					url: "https://provider.example/oauth/authorize",
+					redirect: true,
+				}),
+				{ status: 200, headers: innerHeaders },
+			),
+		);
+
+		const res = (await (auth.api as any).electronInitOAuthProxy({
+			query: {
+				provider: "google",
+				state: "x",
+				code_challenge: "y",
+				code_challenge_method: "plain",
+			},
+			asResponse: true,
+		})) as Response;
+
+		const setCookies = res.headers.getSetCookie();
+		expect(setCookies).toHaveLength(2);
+		expect(setCookies[0]).toMatch(/^first\.cookie=one/);
+		expect(setCookies[1]).toMatch(/^second\.cookie=two/);
+	});
+
 	it("should exchange token", async ({ setProcessType }) => {
 		setProcessType("browser");
 

--- a/packages/electron/test/electron.test.ts
+++ b/packages/electron/test/electron.test.ts
@@ -198,7 +198,7 @@ describe("Electron", () => {
 				provider: "google",
 				state: "x",
 				code_challenge: "y",
-				code_challenge_method: "plain",
+				code_challenge_method: "S256",
 			},
 			asResponse: true,
 		})) as Response;


### PR DESCRIPTION
Closes #10269

## Summary

`/electron/init-oauth-proxy` captures the Set-Cookie headers from its inner `/sign-in/social` call with `Headers.get("set-cookie")` and forwards them via `ctx.setHeader("set-cookie", value)`. For list-valued headers, `Headers.get` returns the comma-joined value, so the OAuth state cookie and the plugin's own transfer-token cookie arrive at the browser as one malformed Set-Cookie header. Then the browser drops the transfer-token, the subsequent `/callback/{provider}` after-hook finds no transfer payload, and the deep-link handoff back to the desktop app silently fails.

Switched to `Headers.getSetCookie()` and re-emit each cookie via `ctx.setCookie(name, value, toCookieOptions(attrs))`. Mirrors the fix landed in #7879 (`customSession`), #7133 (`lastLoginMethod`), and #6039 (`oauth-proxy`).

## Test plan

- New test in `packages/electron/test/electron.test.ts` stubs the inner sign-in response with two distinct Set-Cookie headers and asserts the endpoint forwards them as separate headers on the outer response. Verified it fails on the unfixed code.
- `pnpm -F @better-auth/electron test`: 76 / 76 passing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Set-Cookie forwarding in `/electron/init-oauth-proxy` in `@better-auth/electron`. Each cookie from the inner sign-in is forwarded separately so the browser keeps the transfer-token and the desktop deep-link handoff works.

- **Bug Fixes**
  - Use `Headers.getSetCookie()`, parse each with `parseSetCookieHeader`, and re-emit via `ctx.setCookie`/`toCookieOptions` to avoid a comma-joined `set-cookie`.
  - Add a test that stubs two inner `Set-Cookie` headers and asserts they’re forwarded individually; uses `code_challenge_method: "S256"`.

<sup>Written for commit c58e0918ff2c41fd0375b33ef11d1feb98397210. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



