### PR TITLE
refactor(access): flatten role authorization logic

### DIFF
--- a/.changeset/flatten-role-authorize.md
+++ b/.changeset/flatten-role-authorize.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Refactor `role.authorize` control flow and reject malformed access action connector requests.
+Refactor `role.authorize` control flow while preserving existing authorization behavior.

--- a/.changeset/flatten-role-authorize.md
+++ b/.changeset/flatten-role-authorize.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Refactor `role.authorize` control flow and reject malformed access action connector requests.

--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -188,7 +188,7 @@ describe("access", () => {
 		}
 	});
 
-	it("should return the same unauthorized error format for unknown and denied resources", () => {
+	it("should preserve unauthorized error formats for unknown and denied resources", () => {
 		const unknownResource = looseRole.authorize({
 			audit: ["read"],
 		});
@@ -198,7 +198,7 @@ describe("access", () => {
 
 		expect(unknownResource).toEqual({
 			success: false,
-			error: 'unauthorized to access resource "audit"',
+			error: "You are not allowed to access resource: audit",
 		});
 		expect(deniedAction).toEqual({
 			success: false,
@@ -206,19 +206,22 @@ describe("access", () => {
 		});
 	});
 
-	it("should reject malformed action connector requests", () => {
-		expect(() =>
-			role1.authorize({
-				project: { actions: ["create"], connector: "XOR" },
-			} as never),
-		).toThrow("Invalid access control request");
+	it("should preserve AND behavior for unknown action connectors", () => {
+		const response = role1.authorize({
+			project: { actions: ["create", "delete-many"], connector: "XOR" },
+		} as never);
+
+		expect(response.success).toBe(false);
 	});
 
-	it("should reject non-string action values", () => {
-		expect(() =>
-			role1.authorize({
-				project: ["create", 1],
-			} as never),
-		).toThrow("Invalid access control request");
+	it("should return an unauthorized response for non-string action values", () => {
+		const response = role1.authorize({
+			project: ["create", 1],
+		} as never);
+
+		expect(response).toEqual({
+			success: false,
+			error: 'unauthorized to access resource "project"',
+		});
 	});
 });

--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -187,4 +187,38 @@ describe("access", () => {
 			expect(response.error).toContain("audit");
 		}
 	});
+
+	it("should return the same unauthorized error format for unknown and denied resources", () => {
+		const unknownResource = looseRole.authorize({
+			audit: ["read"],
+		});
+		const deniedAction = looseRole.authorize({
+			project: ["delete-many"],
+		});
+
+		expect(unknownResource).toEqual({
+			success: false,
+			error: 'unauthorized to access resource "audit"',
+		});
+		expect(deniedAction).toEqual({
+			success: false,
+			error: 'unauthorized to access resource "project"',
+		});
+	});
+
+	it("should reject malformed action connector requests", () => {
+		expect(() =>
+			role1.authorize({
+				project: { actions: ["create"], connector: "XOR" },
+			} as never),
+		).toThrow("Invalid access control request");
+	});
+
+	it("should reject non-string action values", () => {
+		expect(() =>
+			role1.authorize({
+				project: ["create", 1],
+			} as never),
+		).toThrow("Invalid access control request");
+	});
 });

--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -11,6 +11,79 @@ export type AuthorizeResponse =
 	| { success: false; error: string }
 	| { success: true; error?: never | undefined };
 
+type Connector = "OR" | "AND";
+
+type NormalizedActionRequest = {
+	actions: string[];
+	connector: Connector;
+};
+
+function unauthorizedResponse(requestedResource: string): AuthorizeResponse {
+	return {
+		success: false,
+		error: `unauthorized to access resource "${requestedResource}"`,
+	};
+}
+
+function isConnector(connector: unknown): connector is Connector {
+	return connector === "OR" || connector === "AND";
+}
+
+function isActionList(actions: unknown): actions is string[] {
+	return (
+		Array.isArray(actions) &&
+		actions.every((action) => typeof action === "string")
+	);
+}
+
+function normalizeActionRequest(
+	requestedActions: unknown,
+): NormalizedActionRequest {
+	if (isActionList(requestedActions)) {
+		return {
+			actions: requestedActions,
+			connector: "AND",
+		};
+	}
+
+	if (!requestedActions || typeof requestedActions !== "object") {
+		throw new BetterAuthError("Invalid access control request");
+	}
+
+	const { actions, connector } = requestedActions as {
+		actions?: unknown;
+		connector?: unknown;
+	};
+
+	if (!isActionList(actions) || !isConnector(connector)) {
+		throw new BetterAuthError("Invalid access control request");
+	}
+
+	return {
+		actions,
+		connector,
+	};
+}
+
+function isResourceAuthorized(
+	allowedActions: readonly string[],
+	{ actions, connector }: NormalizedActionRequest,
+) {
+	if (actions.length === 0) {
+		return false;
+	}
+
+	if (connector === "OR") {
+		return actions.some((requestedAction) =>
+			allowedActions.includes(requestedAction),
+		);
+	}
+
+	return actions.every((requestedAction) =>
+		allowedActions.includes(requestedAction),
+	);
+}
+
 export function role<
 	const TRoleStatements extends Statements,
 	TAuthorizeStatements extends Statements = TRoleStatements,
@@ -22,64 +95,36 @@ export function role<
 			request: RoleAuthorizeRequest<TAuthorizeStatements>,
 			connector: "OR" | "AND" = "AND",
 		): AuthorizeResponse {
-			let success = false;
+			let hasAuthorizedResource = false;
 			for (const [requestedResource, requestedActions] of Object.entries(
 				request,
 			)) {
 				const allowedActions = statements[requestedResource];
 				if (!allowedActions) {
 					if (connector === "AND") {
-						return {
-							success: false,
-							error: `You are not allowed to access resource: ${requestedResource}`,
-						};
+						return unauthorizedResponse(requestedResource);
 					}
-					success = false;
 					continue;
 				}
-				if (Array.isArray(requestedActions)) {
-					success =
-						requestedActions.length > 0 &&
-						(requestedActions as string[]).every((requestedAction) =>
-							allowedActions.includes(requestedAction),
-						);
-				} else {
-					if (typeof requestedActions === "object") {
-						const actions = requestedActions as {
-							actions: string[];
-							connector: "OR" | "AND";
-						};
-						if (
-							!Array.isArray(actions.actions) ||
-							actions.actions.length === 0
-						) {
-							success = false;
-						} else if (actions.connector === "OR") {
-							success = actions.actions.some((requestedAction) =>
-								allowedActions.includes(requestedAction),
-							);
-						} else {
-							success = actions.actions.every((requestedAction) =>
-								allowedActions.includes(requestedAction),
-							);
-						}
-					} else {
-						throw new BetterAuthError("Invalid access control request");
-					}
+
+				const isAuthorized = isResourceAuthorized(
+					allowedActions,
+					normalizeActionRequest(requestedActions),
+				);
+				if (isAuthorized) {
+					hasAuthorizedResource = true;
 				}
-				if (success && connector === "OR") {
-					return { success };
+
+				if (isAuthorized && connector === "OR") {
+					return { success: true };
 				}
-				if (!success && connector === "AND") {
-					return {
-						success: false,
-						error: `unauthorized to access resource "${requestedResource}"`,
-					};
+				if (!isAuthorized && connector === "AND") {
+					return unauthorizedResponse(requestedResource);
 				}
 			}
-			if (success) {
+			if (hasAuthorizedResource) {
 				return {
-					success,
+					success: true,
 				};
 			}
 			return {

--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -14,26 +14,32 @@ export type AuthorizeResponse =
 type Connector = "OR" | "AND";
 
 type NormalizedActionRequest = {
-	actions: string[];
+	actions: unknown[];
 	connector: Connector;
 };
 
-function unauthorizedResponse(requestedResource: string): AuthorizeResponse {
+function unknownResourceResponse(requestedResource: string): AuthorizeResponse {
+	return {
+		success: false,
+		error: `You are not allowed to access resource: ${requestedResource}`,
+	};
+}
+
+function unauthorizedResourceResponse(
+	requestedResource: string,
+): AuthorizeResponse {
 	return {
 		success: false,
 		error: `unauthorized to access resource "${requestedResource}"`,
 	};
 }
 
-function isConnector(connector: unknown): connector is Connector {
-	return connector === "OR" || connector === "AND";
+function normalizeConnector(connector: unknown): Connector {
+	return connector === "OR" ? "OR" : "AND";
 }
 
-function isActionList(actions: unknown): actions is string[] {
-	return (
-		Array.isArray(actions) &&
-		actions.every((action) => typeof action === "string")
-	);
+function isActionList(actions: unknown): actions is unknown[] {
+	return Array.isArray(actions);
 }
 
 function normalizeActionRequest(
@@ -55,14 +61,27 @@ function normalizeActionRequest(
 		connector?: unknown;
 	};
 
-	if (!isActionList(actions) || !isConnector(connector)) {
-		throw new BetterAuthError("Invalid access control request");
+	if (!isActionList(actions)) {
+		return {
+			actions: [],
+			connector: normalizeConnector(connector),
+		};
 	}
 
 	return {
 		actions,
-		connector,
+		connector: normalizeConnector(connector),
 	};
+}
+
+function hasAllowedAction(
+	allowedActions: readonly string[],
+	requestedAction: unknown,
+) {
+	return (
+		typeof requestedAction === "string" &&
+		allowedActions.includes(requestedAction)
+	);
 }
 
 function isResourceAuthorized(
@@ -75,12 +94,12 @@ function isResourceAuthorized(
 
 	if (connector === "OR") {
 		return actions.some((requestedAction) =>
-			allowedActions.includes(requestedAction),
+			hasAllowedAction(allowedActions, requestedAction),
 		);
 	}
 
 	return actions.every((requestedAction) =>
-		allowedActions.includes(requestedAction),
+		hasAllowedAction(allowedActions, requestedAction),
 	);
 }
 
@@ -102,7 +121,7 @@ export function role<
 				const allowedActions = statements[requestedResource];
 				if (!allowedActions) {
 					if (connector === "AND") {
-						return unauthorizedResponse(requestedResource);
+						return unknownResourceResponse(requestedResource);
 					}
 					continue;
 				}
@@ -119,7 +138,7 @@ export function role<
 					return { success: true };
 				}
 				if (!isAuthorized && connector === "AND") {
-					return unauthorizedResponse(requestedResource);
+					return unauthorizedResourceResponse(requestedResource);
 				}
 			}
 			if (hasAuthorizedResource) {


### PR DESCRIPTION
## Summary

- flatten `role.authorize` by separating request normalization, resource evaluation, and unauthorized response construction
- validate action connector requests at runtime so malformed connectors or non-string actions fail closed
- standardize resource-specific unauthorized errors and add focused tests for the new boundaries

## Why

`role.authorize` had accumulated nested validation, connector handling, and response construction in one loop. This keeps the outer loop focused on AND/OR authorization flow while moving the smaller responsibilities into local helpers.

Closes #9676.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattened `role.authorize` in `better-auth` with clear helpers for request normalization and resource checks. Preserves existing authorization behavior and error formats, with runtime validation and fail-closed defaults.

- **Refactors**
  - Extracted helpers for action normalization, resource evaluation (AND/OR), and unauthorized responses.
  - Outer loop now only handles AND/OR flow, removing nested validation branches.

- **Bug Fixes**
  - Reject malformed connector objects and non-string action values at runtime; unknown connectors default to AND (fail closed).
  - Preserve legacy unauthorized error messages for unknown vs. denied resources.

<sup>Written for commit 02fe1386c0b388b7ceb349a74fca52e6b2d1ea4a. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9677?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



