### PR TITLE
fix(open-api): handle ZodIntersection and ZodRecord in schema generator

### DIFF
--- a/.changeset/lucky-cloths-switch.md
+++ b/.changeset/lucky-cloths-switch.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix OpenAPI generator silently dropping requestBody for endpoints

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -1876,10 +1876,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
               "schema": {
                 "properties": {
                   "additionalData": {
-                    "additionalProperties": {
-                      "description": undefined,
-                      "type": "string",
-                    },
+                    "additionalProperties": {},
                     "type": [
                       "object",
                       "null",
@@ -3941,10 +3938,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
               "schema": {
                 "properties": {
                   "additionalData": {
-                    "additionalProperties": {
-                      "description": undefined,
-                      "type": "string",
-                    },
+                    "additionalProperties": {},
                     "type": [
                       "object",
                       "null",
@@ -4768,11 +4762,12 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
           "content": {
             "application/json": {
               "schema": {
-                "properties": {},
+                "additionalProperties": {},
                 "type": "object",
               },
             },
           },
+          "required": true,
         },
         "responses": {
           "200": {

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -1876,9 +1876,12 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
               "schema": {
                 "properties": {
                   "additionalData": {
-                    "description": undefined,
+                    "additionalProperties": {
+                      "description": undefined,
+                      "type": "string",
+                    },
                     "type": [
-                      "string",
+                      "object",
                       "null",
                     ],
                   },
@@ -3938,9 +3941,12 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
               "schema": {
                 "properties": {
                   "additionalData": {
-                    "description": undefined,
+                    "additionalProperties": {
+                      "description": undefined,
+                      "type": "string",
+                    },
                     "type": [
-                      "string",
+                      "object",
                       "null",
                     ],
                   },

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -155,12 +155,10 @@ function getRequestBody(options: EndpointOptions): any {
 		return options.metadata.openapi.requestBody;
 	}
 	if (!options.body) return undefined;
-	if (
-		options.body instanceof z.ZodObject ||
-		options.body instanceof z.ZodOptional
-	) {
+	const body = options.body as z.ZodType<any>;
+	if (body instanceof z.ZodObject || body instanceof z.ZodOptional) {
 		// @ts-expect-error
-		const shape = options.body.shape;
+		const shape = body.shape;
 		if (!shape) return undefined;
 		const properties: Record<string, any> = {};
 		const required: string[] = [];
@@ -173,12 +171,7 @@ function getRequestBody(options: EndpointOptions): any {
 			}
 		});
 		return {
-			required:
-				options.body instanceof z.ZodOptional
-					? false
-					: options.body
-						? true
-						: false,
+			required: body instanceof z.ZodOptional ? false : body ? true : false,
 			content: {
 				"application/json": {
 					schema: {
@@ -190,20 +183,18 @@ function getRequestBody(options: EndpointOptions): any {
 			},
 		};
 	}
-	// Handle ZodIntersection body (e.g. z.object({...}).and(z.record(...)))
-	if (options.body instanceof z.ZodIntersection) {
-		const schema = processZodType(options.body);
-		if (!schema || !schema.properties) return undefined;
-		return {
-			required: true,
-			content: {
-				"application/json": {
-					schema,
-				},
+	// Generic fallback: handle ZodIntersection, ZodRecord, and any other
+	// Zod types processZodType supports (allOf, additionalProperties, etc.)
+	const schema = processZodType(body);
+	if (!schema) return undefined;
+	return {
+		required: !(body instanceof z.ZodOptional),
+		content: {
+			"application/json": {
+				schema,
 			},
-		};
-	}
-	return undefined;
+		},
+	};
 }
 
 function processZodType(zodType: z.ZodType<any>): any {
@@ -238,6 +229,10 @@ function processZodType(zodType: z.ZodType<any>): any {
 			default: defaultValue,
 		};
 	}
+	// ZodAny / ZodUnknown → unconstrained schema {}
+	if (zodType instanceof z.ZodAny || zodType instanceof z.ZodUnknown) {
+		return {};
+	}
 	// record unwrapping (z.record())
 	if (zodType instanceof z.ZodRecord) {
 		const valueType = processZodType((zodType as any)._def.valueType);
@@ -262,7 +257,9 @@ function processZodType(zodType: z.ZodType<any>): any {
 				properties: { ...left.properties, ...right.properties },
 				...(left.required || right.required
 					? {
-							required: [...(left.required ?? []), ...(right.required ?? [])],
+							required: Array.from(
+								new Set([...(left.required ?? []), ...(right.required ?? [])]),
+							),
 						}
 					: {}),
 				additionalProperties: true,

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -190,6 +190,19 @@ function getRequestBody(options: EndpointOptions): any {
 			},
 		};
 	}
+	// Handle ZodIntersection body (e.g. z.object({...}).and(z.record(...)))
+	if (options.body instanceof z.ZodIntersection) {
+		const schema = processZodType(options.body);
+		if (!schema || !schema.properties) return undefined;
+		return {
+			required: true,
+			content: {
+				"application/json": {
+					schema,
+				},
+			},
+		};
+	}
 	return undefined;
 }
 
@@ -224,6 +237,46 @@ function processZodType(zodType: z.ZodType<any>): any {
 			...innerSchema,
 			default: defaultValue,
 		};
+	}
+	// record unwrapping (z.record())
+	if (zodType instanceof z.ZodRecord) {
+		const valueType = processZodType((zodType as any)._def.valueType);
+		return {
+			type: "object",
+			additionalProperties: valueType,
+		};
+	}
+	// intersection unwrapping (.and())
+	if (zodType instanceof z.ZodIntersection) {
+		const left = processZodType((zodType as any)._def.left);
+		const right = processZodType((zodType as any)._def.right);
+		// If both sides are objects, merge their properties directly
+		if (
+			left.type === "object" &&
+			right.type === "object" &&
+			left.properties &&
+			right.properties
+		) {
+			return {
+				type: "object",
+				properties: { ...left.properties, ...right.properties },
+				...(left.required || right.required
+					? {
+							required: [...(left.required ?? []), ...(right.required ?? [])],
+						}
+					: {}),
+				additionalProperties: true,
+			};
+		}
+		// If one side is a record (additionalProperties), absorb it
+		if (left.type === "object" && right.additionalProperties !== undefined) {
+			return { ...left, additionalProperties: right.additionalProperties };
+		}
+		if (right.type === "object" && left.additionalProperties !== undefined) {
+			return { ...right, additionalProperties: left.additionalProperties };
+		}
+		// Fallback: use allOf
+		return { allOf: [left, right] };
 	}
 	// object unwrapping
 	if (zodType instanceof z.ZodObject) {

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -277,3 +277,43 @@ describe("open-api", async () => {
 		expect(baseTypes).toContain("boolean");
 	});
 });
+
+describe("open-api ZodIntersection and ZodRecord support", async () => {
+	const { auth: authWithEmailOTP } = await getTestInstance({
+		plugins: [
+			openAPI(),
+			(await import("../email-otp")).emailOTP({
+				async sendVerificationOTP() {},
+			}),
+		],
+	});
+
+	it("should include requestBody for signInEmailOTP endpoint", async () => {
+		const schema = await authWithEmailOTP.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, any>;
+		const endpoint = paths["/sign-in/email-otp"];
+
+		expect(endpoint).toBeDefined();
+		expect(endpoint.post).toBeDefined();
+		expect(endpoint.post.requestBody).toBeDefined();
+
+		const body = endpoint.post.requestBody.content["application/json"].schema;
+		expect(body).toBeDefined();
+		expect(body.properties).toBeDefined();
+		expect(body.properties.email).toBeDefined();
+		expect(body.properties.otp).toBeDefined();
+	});
+
+	it("should produce a valid object schema from ZodIntersection", async () => {
+		const schema = await authWithEmailOTP.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, any>;
+		const body =
+			paths["/sign-in/email-otp"].post.requestBody.content["application/json"]
+				.schema;
+
+		// The merged schema should be type object
+		expect(body.type).toBe("object");
+		// .and(z.record()) adds additionalProperties
+		expect(body.additionalProperties).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Problem

Closes #9679
Closes #9298

The OpenAPI schema generator silently dropped `requestBody` for any endpoint 
whose body schema used `.and()` (`ZodIntersection`) or `z.record()` (`ZodRecord`). 
The `signInEmailOTP` endpoint is the most visible case — its body is defined as:

z.object({ email, otp, ... }).and(z.record(z.string(), z.any()))

This caused the entire `requestBody` to be missing from the generated spec.

## Root Cause

Two gaps in `generator.ts`:

1. `processZodType` had no handler for `ZodIntersection` or `ZodRecord` — both 
fell through to the primitive type handler and returned `{ type: "string" }`.

2. `getRequestBody` had an explicit `instanceof` guard (`ZodObject || ZodOptional` 
only), so `ZodIntersection` bodies hit `return undefined` before `processZodType` 
was even called.

## Fix

Added handlers in `generator.ts`:

**`ZodRecord`** → `{ type: "object", additionalProperties: <valueType> }`

**`ZodIntersection`** in `processZodType`:
- Both sides are objects → merges properties directly, sets `additionalProperties: true`
- One side is a record → absorbs `additionalProperties` from the record into the object
- Fallback → `allOf: [left, right]`

**`ZodIntersection`** in `getRequestBody` → calls `processZodType` on the full 
body and wraps the result in the standard requestBody envelope.

## Changes

- `packages/better-auth/src/plugins/open-api/generator.ts` — added `ZodRecord` 
and `ZodIntersection` handlers in both `processZodType` and `getRequestBody`
- `packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap` 
— updated snapshot to reflect correct `ZodRecord` output for the `additionalData` field
- `packages/better-auth/src/plugins/open-api/open-api.test.ts` — added regression 
tests verifying `requestBody` is present and correctly structured for `signInEmailOTP`

## Testing

Two new regression tests under `open-api ZodIntersection and ZodRecord support`:

1. `signInEmailOTP` endpoint includes `requestBody` with `email` and `otp` properties
2. The merged schema is `type: object` with `additionalProperties` set

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OpenAPI generator in `better-auth` to keep `requestBody` when schemas use `.and()` (`ZodIntersection`) or `z.record()` (`ZodRecord`). Also adds safe fallbacks and sets `requestBody.required` unless the body is optional. Endpoints like `signInEmailOTP` now show an object schema with `additionalProperties`.

- **Bug Fixes**
  - Handle `ZodIntersection` and `ZodRecord`: merge object intersections, absorb records into `additionalProperties`, fallback to `allOf`.
  - Add `ZodAny`/`ZodUnknown` support (`{}`) and a generic `getRequestBody` path via `processZodType` for non-object bodies; respect `ZodOptional` when setting `required`.
  - Cast body to `z.ZodType` to fix a `StandardSchemaV1` type error; update snapshots and add regression tests for `signInEmailOTP`.

<sup>Written for commit 780a78d622d942294a0121b006c58c43436f3acb. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9680?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

