### PR TITLE
fix(deps): widen Kysely peer dependency range for 0.29 support

### DIFF
--- a/.changeset/twelve-turtles-send.md
+++ b/.changeset/twelve-turtles-send.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+"@better-auth/kysely-adapter": patch
+---
+
+Widen Kysely peer dependency ranges to support both 0.28.x and 0.29.x.

--- a/demo/nextjs/package.json
+++ b/demo/nextjs/package.json
@@ -64,7 +64,7 @@
     "framer-motion": "^12.34.3",
     "geist": "^1.7.0",
     "input-otp": "^1.4.2",
-    "kysely": "^0.28.17",
+    "kysely": "^0.28.17 || ^0.29.0",
     "lucide-react": "^0.575.0",
     "mcp-handler": "^1.1.0",
     "mysql2": "^3.18.2",

--- a/demo/nextjs/package.json
+++ b/demo/nextjs/package.json
@@ -64,7 +64,7 @@
     "framer-motion": "^12.34.3",
     "geist": "^1.7.0",
     "input-otp": "^1.4.2",
-    "kysely": "^0.28.17 || ^0.29.0",
+    "kysely": "^0.28.17",
     "lucide-react": "^0.575.0",
     "mcp-handler": "^1.1.0",
     "mysql2": "^3.18.2",

--- a/demo/nextjs/pnpm-lock.yaml
+++ b/demo/nextjs/pnpm-lock.yaml
@@ -174,7 +174,7 @@ importers:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       kysely:
-        specifier: ^0.28.17
+        specifier: ^0.28.17 || ^0.29.0
         version: 0.28.17
       lucide-react:
         specifier: ^0.575.0
@@ -1327,24 +1327,28 @@ packages:
   '@react-email/button@0.2.1':
     resolution: {integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/code-block@0.2.1':
     resolution: {integrity: sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/code-inline@0.0.6':
     resolution: {integrity: sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/column@0.0.14':
     resolution: {integrity: sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -1358,60 +1362,70 @@ packages:
   '@react-email/container@0.0.16':
     resolution: {integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/font@0.0.10':
     resolution: {integrity: sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/head@0.0.13':
     resolution: {integrity: sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/heading@0.0.16':
     resolution: {integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/hr@0.0.12':
     resolution: {integrity: sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/html@0.0.12':
     resolution: {integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/img@0.0.12':
     resolution: {integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/link@0.0.13':
     resolution: {integrity: sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/markdown@0.0.18':
     resolution: {integrity: sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/preview@0.0.14':
     resolution: {integrity: sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -1425,12 +1439,14 @@ packages:
   '@react-email/row@0.0.13':
     resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/section@0.0.17':
     resolution: {integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -1476,6 +1492,7 @@ packages:
   '@react-email/text@0.1.6':
     resolution: {integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ catalogs:
       specifier: 1.3.5
       version: 1.3.5
     kysely:
-      specifier: ^0.28.17
+      specifier: ^0.28.17 || ^0.29.0
       version: 0.28.17
     tsdown:
       specifier: 0.21.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,13 +50,13 @@ catalog:
   '@better-auth/utils': 0.4.0
   '@better-fetch/fetch': 1.1.21
   better-call: 1.3.5
-  kysely: ^0.28.17
+  kysely: ^0.28.17 || ^0.29.0
   tsdown: 0.21.1
   typescript: ^5.9.3
 
 catalogs:
   peer:
-    kysely: ^0.28.5
+    kysely: ^0.28.5 || ^0.29.0
   react19:
     '@types/react': ^19.2.14
     '@types/react-dom': ^19.2.3


### PR DESCRIPTION
## Summary

Adds compatibility support for Kysely 0.29 by widening peer dependency ranges across Better Auth packages.

Closes #9678

## What changed

* Updated Kysely dependency/peer ranges to support both:

  * `^0.28.x`
  * `^0.29.x`
* Added a changeset for the affected packages.

## Why

ZenStack 3.7 depends on Kysely 0.29, while Better Auth currently restricts Kysely to the 0.28 line. This creates duplicate installs and invalid peer dependency graphs when using Better Auth together with `@zenstackhq/better-auth`.

## Validation

Tested locally with `kysely@0.29.2`:

* `pnpm typecheck --force` ✅
* `@better-auth/kysely-adapter` tests ✅
* Better Auth core test suite passed aside from unrelated PostgreSQL connection failures

I also reviewed the Kysely 0.29 breaking changes and did not find any incompatible APIs used in Better Auth adapters or query builder usage.

## Breaking changes

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `kysely` 0.29 across Better Auth by widening peer ranges. Fixes peer conflicts with ZenStack 3.7 and prevents duplicate installs when using `@zenstackhq/better-auth`.

- **Dependencies**
  - Widened `kysely` to `^0.28.x || ^0.29.x` in workspace catalogs (peer and main) and the Next.js demo.
  - Synced root and Next.js demo lockfiles; fixed the demo’s frozen lockfile for CI.
  - Added a changeset to publish patch updates for `better-auth`, `@better-auth/core`, and `@better-auth/kysely-adapter`.

<sup>Written for commit a4b4cca760282b56873ad2a183a28f4d6cf5d66d. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9683?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

