### PR TITLE
fix(stripe): bail out of checkout.session.completed for non-subscription modes

### DIFF
--- a/packages/stripe/src/hooks.ts
+++ b/packages/stripe/src/hooks.ts
@@ -46,7 +46,14 @@ export async function onCheckoutSessionCompleted(
 	try {
 		const client = options.stripeClient;
 		const checkoutSession = event.data.object as Stripe.Checkout.Session;
-		if (checkoutSession.mode === "setup" || !options.subscription?.enabled) {
+		// Only `subscription` mode carries a subscription id we can retrieve.
+		// `setup` and `payment` (one-time purchase) modes do not, so bail out
+		// to avoid `subscriptions.retrieve(null)` throwing inside the try/catch.
+		// @see https://github.com/better-auth/better-auth/issues/4565
+		if (
+			checkoutSession.mode !== "subscription" ||
+			!options.subscription?.enabled
+		) {
 			return;
 		}
 		const subscription = await client.subscriptions.retrieve(

--- a/packages/stripe/test/webhook.test.ts
+++ b/packages/stripe/test/webhook.test.ts
@@ -2714,4 +2714,139 @@ describe("stripe webhook", () => {
 			expect(updatedSub!.endedAt!.getTime()).toBe(now * 1000);
 		});
 	});
+
+	describe("webhook: non-subscription checkout session modes", () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/4565
+		 *
+		 * checkout.session.completed with mode "payment" has no subscription
+		 * id. The handler must bail out before calling subscriptions.retrieve,
+		 * otherwise Stripe throws:
+		 * "Argument 'subscription_exposed_id' must be a string, but got: null".
+		 */
+		test("mode: payment does not call subscriptions.retrieve or onSubscriptionComplete", async ({
+			memory,
+			stripeOptions,
+		}) => {
+			const onSubscriptionComplete = vi.fn();
+			const subscriptionsRetrieve = vi.fn();
+
+			const webhookEvent = {
+				type: "checkout.session.completed",
+				data: {
+					object: {
+						id: "cs_4565_payment",
+						mode: "payment",
+						subscription: null,
+						customer: "cus_4565",
+						metadata: {},
+					},
+				},
+			};
+
+			const stripeForTest = {
+				...stripeOptions.stripeClient,
+				subscriptions: {
+					...stripeOptions.stripeClient.subscriptions,
+					retrieve: subscriptionsRetrieve,
+				},
+				webhooks: {
+					constructEventAsync: vi.fn().mockResolvedValue(webhookEvent),
+				},
+			};
+
+			const testOptions = {
+				...stripeOptions,
+				stripeClient: stripeForTest as unknown as Stripe,
+				stripeWebhookSecret: "test_secret",
+				subscription: {
+					...stripeOptions.subscription,
+					onSubscriptionComplete,
+				},
+			} satisfies StripeOptions;
+
+			const { auth: webhookAuth } = await getTestInstance(
+				{ database: memory, plugins: [stripe(testOptions)] },
+				{ disableTestUser: true },
+			);
+
+			const response = await webhookAuth.handler(
+				new Request("http://localhost:3000/api/auth/stripe/webhook", {
+					method: "POST",
+					headers: { "stripe-signature": "test_signature" },
+					body: JSON.stringify(webhookEvent),
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(subscriptionsRetrieve).not.toHaveBeenCalled();
+			expect(onSubscriptionComplete).not.toHaveBeenCalled();
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/4565
+		 *
+		 * setup mode also has no subscription id. This test guards the
+		 * existing early-return so that the fix for payment mode does not
+		 * regress the setup case.
+		 */
+		test("mode: setup does not call subscriptions.retrieve or onSubscriptionComplete", async ({
+			memory,
+			stripeOptions,
+		}) => {
+			const onSubscriptionComplete = vi.fn();
+			const subscriptionsRetrieve = vi.fn();
+
+			const webhookEvent = {
+				type: "checkout.session.completed",
+				data: {
+					object: {
+						id: "cs_4565_setup",
+						mode: "setup",
+						subscription: null,
+						customer: "cus_4565_setup",
+						metadata: {},
+					},
+				},
+			};
+
+			const stripeForTest = {
+				...stripeOptions.stripeClient,
+				subscriptions: {
+					...stripeOptions.stripeClient.subscriptions,
+					retrieve: subscriptionsRetrieve,
+				},
+				webhooks: {
+					constructEventAsync: vi.fn().mockResolvedValue(webhookEvent),
+				},
+			};
+
+			const testOptions = {
+				...stripeOptions,
+				stripeClient: stripeForTest as unknown as Stripe,
+				stripeWebhookSecret: "test_secret",
+				subscription: {
+					...stripeOptions.subscription,
+					onSubscriptionComplete,
+				},
+			} satisfies StripeOptions;
+
+			const { auth: webhookAuth } = await getTestInstance(
+				{ database: memory, plugins: [stripe(testOptions)] },
+				{ disableTestUser: true },
+			);
+
+			const response = await webhookAuth.handler(
+				new Request("http://localhost:3000/api/auth/stripe/webhook", {
+					method: "POST",
+					headers: { "stripe-signature": "test_signature" },
+					body: JSON.stringify(webhookEvent),
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect(subscriptionsRetrieve).not.toHaveBeenCalled();
+			expect(onSubscriptionComplete).not.toHaveBeenCalled();
+		});
+	});
 });


### PR DESCRIPTION
## Closes #4565

### The bug

`onCheckoutSessionCompleted` only early-returns when `mode === "setup"`. For one-time `mode: "payment"` checkouts the handler falls through and calls `client.subscriptions.retrieve(checkoutSession.subscription as string)` with a `null` subscription id, which crashes inside the `try/catch` and logs:

```
ERROR [Better Auth]: Stripe webhook failed.
  Error: Cannot read properties of undefined (reading 'items')
```

In production this manifests as the `subscription_exposed_id` error from the Stripe SDK that the issue reporter saw:

```
Stripe: Argument "subscription_exposed_id" must be a string, but got: null
  (on API request to `GET /v1/subscriptions/{subscription_exposed_id}`)
```

Side effect: every `mode: "payment"` checkout writes a noisy error to the logger, even when the user's `onEvent` callback handled it correctly. The event still 200s back to Stripe so there is no retry storm, but the noise hides real failures and the wrong `subscriptions.retrieve` call is wasted work on every one-time purchase.

### The fix

One condition flip in `packages/stripe/src/hooks.ts`:

```diff
- if (checkoutSession.mode === "setup" || !options.subscription?.enabled) {
+ // Only `subscription` mode carries a subscription id we can retrieve.
+ // `setup` and `payment` (one-time purchase) modes do not, so bail out
+ // to avoid `subscriptions.retrieve(null)` throwing inside the try/catch.
+ // @see https://github.com/better-auth/better-auth/issues/4565
+ if (
+   checkoutSession.mode !== "subscription" ||
+   !options.subscription?.enabled
+ ) {
    return;
  }
```

This intentionally does **not** add any payment-mode handling, callback, or schema. Per @bytaesu's note on the issue ("Stripe plugin is focused on subscriptions for now"), the goal is just to stop the silent error. Adding one-time payment support is a separate, larger scope; the previous attempt at that in #4892 was closed for going too broad.

### Test plan

Two regression tests added in `packages/stripe/test/webhook.test.ts` under a new `describe("webhook: non-subscription checkout session modes", ...)` block, each pinned with `@see https://github.com/better-auth/better-auth/issues/4565`.

Both assert:

1. `response.status === 200` (webhook ack unchanged)
2. `subscriptions.retrieve` was **not** called (proves we bail before the broken `retrieve(null)` path)
3. `onSubscriptionComplete` callback was **not** called (proves no spurious subscription notification for non-subscription events)

**Before fix** (`main`):

```
 RUN  v4.1.5 better-auth

stderr | test/webhook.test.ts > stripe webhook > webhook: non-subscription checkout session modes > mode: payment
ERROR [Better Auth]: Stripe webhook failed. Error: Cannot read properties of undefined (reading 'items')

 × mode: payment does not call subscriptions.retrieve or onSubscriptionComplete   31ms
 ✓ mode: setup does not call subscriptions.retrieve or onSubscriptionComplete     4ms

FAIL  test/webhook.test.ts > mode: payment does not call subscriptions.retrieve or onSubscriptionComplete
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:
  1st vi.fn() call:
    Array [ null ]
  Number of calls: 1

 ❯ test/webhook.test.ts:2782:38
    2781|    expect(response.status).toBe(200);
    2782|    expect(subscriptionsRetrieve).not.toHaveBeenCalled();
       |                                      ^

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed | 27 skipped (29)
```

The `mode: payment` test fails on `main` exactly the way users hit the bug: `subscriptions.retrieve` is invoked with `null`, the call throws inside the `try/catch`, and the error is swallowed.

**After fix** (this branch):

```
 RUN  v4.1.5 better-auth

 ✓ mode: payment does not call subscriptions.retrieve or onSubscriptionComplete   12ms
 ✓ mode: setup does not call subscriptions.retrieve or onSubscriptionComplete      4ms

 Test Files  1 passed (1)
      Tests  2 passed | 27 skipped (29)
```

**Full webhook suite:**

```
 Test Files  1 passed (1)
      Tests  29 passed (29)
```

**Full `packages/stripe` package:**

```
 Test Files  10 passed (10)
      Tests  165 passed (165)
```

**Typecheck:** `tsc --project tsconfig.json --noEmit` exits clean.

### Risk

- Behavior change is narrow: the condition that used to skip `setup` mode now also skips `payment` (and any future Stripe mode that is not `subscription`). For users on the current code path, this turns a silent-error-then-200 into a clean-200 with no log noise. No DB writes change, no callback signatures change, no public API changes.
- No risk to subscription flow: the full `webhook.test.ts` suite (including all subscription create/update/cancel/trial paths) still passes unchanged.
- Forward compatible: if Stripe adds another non-subscription mode in the future, this handler will continue to bail out cleanly instead of attempting an invalid `retrieve`.

### Out of scope

- Adding a payment-mode callback or schema (separate feature, gated on a maintainer-approved design).
- Refactoring the broader Stripe plugin towards a generic event router (that's the territory of #6075).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bail out of Stripe `checkout.session.completed` unless the session `mode` is `subscription`, preventing `subscriptions.retrieve(null)` for one‑time `payment` checkouts and eliminating noisy logs. Fixes #4565; subscription behavior is unchanged.

- **Bug Fixes**
  - Update `packages/stripe/src/hooks.ts` to early-return when `mode !== "subscription"` or subscription is disabled, so we never call `subscriptions.retrieve` without an id.
  - Add regression tests in `packages/stripe/test/webhook.test.ts` for `payment` and `setup` modes (200 response, no `subscriptions.retrieve`, no `onSubscriptionComplete`).

<sup>Written for commit 613e40c7d514be68aab080d40adcaccca07af53a. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9684?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

