### PR TITLE
fix(oauth): strip inline data: URIs from OAuth profile image

### DIFF
--- a/.changeset/strip-inline-data-uri-oauth-profile-image.md
+++ b/.changeset/strip-inline-data-uri-oauth-profile-image.md
@@ -1,0 +1,17 @@
+---
+"better-auth": patch
+---
+
+fix(oauth): strip inline `data:` URIs from OAuth profile images to prevent `ERR_RESPONSE_HEADERS_TOO_BIG`. Providers like Microsoft Entra ID (via the library's own Graph `/me/photo/$value` fetch) and some Keycloak/OIDC setups embed base64 images as `data:image/...;base64,...` in the `picture` claim. That value cascaded into the session cookie cache and into JWT payloads (the `jwt` plugin signs the full user object by default), silently failing the OAuth callback in browsers because Set-Cookie blew past the per-cookie 4 KB limit and the response past the per-header 16 KB limit (Vercel / nginx default).
+
+`handleOAuthUserInfo` now strips inline `data:` URIs (case-insensitive per RFC 2397) from `user.image` and emits a warn-level log. OIDC Core §5.1 defines `picture` as a URL, so a `data:` URI is non-standard; the prefix is a near-zero-false-positive signal (legitimate signed CDN URLs and Unicode names never start with it).
+
+Opt out with `account.allowInlineProfileImage: true` if you have a `mapProfileToUser` callback or `databaseHooks.user.create.before` hook that hoists the inline image to a CDN. `mapProfileToUser` runs before the sanitizer, so it can still capture the original data URI even when this option is left at the default.
+
+Existing DB rows with bloated `user.image` will be overwritten on the next OAuth callback. To clean immediately:
+
+```sql
+UPDATE "user" SET "image" = NULL WHERE "image" LIKE 'data:%';
+```
+
+Closes #8338.

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -1438,3 +1438,300 @@ describe("oauth2 - accountLinking.requireLocalEmailVerified: false opt-out", asy
 		expect(promoted?.emailVerified).toBe(true);
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8338
+ *
+ * Microsoft Entra ID and certain Keycloak/OIDC configurations return a
+ * `picture` claim that is an inline `data:image/...;base64,...` URI
+ * instead of a URL. When that value reaches `user.image` it bloats the
+ * session cookie cache past Chromium's per-cookie 4 KB limit and the
+ * per-header 16 KB limit (Vercel / nginx default), failing the OAuth
+ * callback with `ERR_RESPONSE_HEADERS_TOO_BIG`. It also bloats JWT
+ * payloads when the `jwt` plugin is enabled. These tests cover the
+ * sanitizer that strips inline data URIs by default, with an opt-out
+ * for users who hoist to a CDN downstream.
+ */
+describe("oauth2 - data: URI profile image sanitization (#8338)", async () => {
+	const DATA_URI_PROFILE_IMAGE = `data:image/jpeg;base64,${"x".repeat(120_000)}`;
+
+	async function setupInstance(opts?: {
+		allowInlineProfileImage?: boolean;
+		mapProfileToUser?: (profile: GoogleProfile) => Record<string, unknown>;
+		captureCreateBeforeImage?: { value: unknown };
+	}) {
+		const { auth, client, cookieSetter } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+					mapProfileToUser: opts?.mapProfileToUser,
+				},
+			},
+			account: {
+				allowInlineProfileImage: opts?.allowInlineProfileImage,
+			},
+			...(opts?.captureCreateBeforeImage
+				? {
+						databaseHooks: {
+							user: {
+								create: {
+									before: async (user) => {
+										opts.captureCreateBeforeImage!.value = user.image;
+										return { data: user };
+									},
+								},
+							},
+						},
+					}
+				: {}),
+		});
+		const ctx = await auth.$context;
+		return { auth, client, ctx, cookieSetter };
+	}
+
+	async function driveOAuthCallback(
+		client: Awaited<ReturnType<typeof setupInstance>>["client"],
+		cookieSetter: Awaited<ReturnType<typeof setupInstance>>["cookieSetter"],
+		profileOverrides: Partial<GoogleProfile>,
+	) {
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				const profile: GoogleProfile = {
+					email: "8338-test@example.com",
+					email_verified: true,
+					name: "Test User",
+					picture: "https://example.com/photo.jpg",
+					exp: 1234567890,
+					sub: "google_oauth_sub_8338",
+					iat: 1234567890,
+					aud: "test",
+					azp: "test",
+					nbf: 1234567890,
+					iss: "test",
+					locale: "en",
+					jti: "test",
+					given_name: "Test",
+					family_name: "User",
+					...profileOverrides,
+				};
+				const idToken = await signJWT(profile, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: "test_access_token",
+					refresh_token: "test_refresh_token",
+					id_token: idToken,
+				});
+			}),
+		);
+		const oAuthHeaders = new Headers();
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/",
+			fetchOptions: { onSuccess: cookieSetter(oAuthHeaders) },
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test_code" },
+			method: "GET",
+			headers: oAuthHeaders,
+			onError(context) {
+				expect(context.response.status).toBe(302);
+			},
+		});
+	}
+
+	it("strips a data: URI from OAuth profile image by default", async () => {
+		const { client, ctx, cookieSetter } = await setupInstance();
+		await driveOAuthCallback(client, cookieSetter, {
+			email: "8338-default@example.com",
+			picture: DATA_URI_PROFILE_IMAGE,
+		});
+		const user = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: "8338-default@example.com" }],
+		});
+		expect(user).not.toBeNull();
+		expect(user!.image).toBeNull();
+	});
+
+	it("preserves the data: URI when account.allowInlineProfileImage is true", async () => {
+		const { client, ctx, cookieSetter } = await setupInstance({
+			allowInlineProfileImage: true,
+		});
+		await driveOAuthCallback(client, cookieSetter, {
+			email: "8338-allow@example.com",
+			picture: DATA_URI_PROFILE_IMAGE,
+		});
+		const user = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: "8338-allow@example.com" }],
+		});
+		expect(user).not.toBeNull();
+		expect(user!.image).toBe(DATA_URI_PROFILE_IMAGE);
+	});
+
+	it("invokes mapProfileToUser with the original data: URI before sanitization", async () => {
+		let capturedImage: string | undefined;
+		const { client, ctx, cookieSetter } = await setupInstance({
+			mapProfileToUser: (profile) => {
+				capturedImage = profile.picture;
+				return {};
+			},
+		});
+		await driveOAuthCallback(client, cookieSetter, {
+			email: "8338-map@example.com",
+			picture: DATA_URI_PROFILE_IMAGE,
+		});
+		expect(capturedImage).toBe(DATA_URI_PROFILE_IMAGE);
+		const user = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: "8338-map@example.com" }],
+		});
+		expect(user!.image).toBeNull();
+	});
+
+	it("strips uppercase Data: and DATA: URIs (case-insensitive per RFC 2397)", async () => {
+		const cases: Array<{ email: string; prefix: string }> = [
+			{ email: "8338-lower@example.com", prefix: "data:" },
+			{ email: "8338-pascal@example.com", prefix: "Data:" },
+			{ email: "8338-upper@example.com", prefix: "DATA:" },
+		];
+		for (const { email, prefix } of cases) {
+			const { client, ctx, cookieSetter } = await setupInstance();
+			await driveOAuthCallback(client, cookieSetter, {
+				email,
+				picture: `${prefix}image/jpeg;base64,${"x".repeat(10_000)}`,
+			});
+			const user = await ctx.adapter.findOne<User>({
+				model: "user",
+				where: [{ field: "email", value: email }],
+			});
+			expect(user, `failed for prefix "${prefix}"`).not.toBeNull();
+			expect(user!.image, `prefix "${prefix}" should be stripped`).toBeNull();
+		}
+	});
+
+	it("does not modify a normal https: image URL", async () => {
+		const { client, ctx, cookieSetter } = await setupInstance();
+		await driveOAuthCallback(client, cookieSetter, {
+			email: "8338-https@example.com",
+			picture: "https://lh3.googleusercontent.com/test/photo.jpg",
+		});
+		const user = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: "8338-https@example.com" }],
+		});
+		expect(user!.image).toBe(
+			"https://lh3.googleusercontent.com/test/photo.jpg",
+		);
+	});
+
+	it("passes null (not the data: URI) to databaseHooks.user.create.before after stripping", async () => {
+		const capture: { value: unknown } = { value: "INITIAL" };
+		const { client, cookieSetter } = await setupInstance({
+			captureCreateBeforeImage: capture,
+		});
+		await driveOAuthCallback(client, cookieSetter, {
+			email: "8338-dbhook@example.com",
+			picture: DATA_URI_PROFILE_IMAGE,
+		});
+		expect(capture.value).toBeNull();
+	});
+
+	it("strips data: URI when overrideUserInfo is true and existing user is being updated", async () => {
+		const { auth, client, ctx, cookieSetter } = await setupInstance();
+		const existing = await ctx.internalAdapter.createUser({
+			email: "8338-override@example.com",
+			name: "Existing User",
+			emailVerified: true,
+			image: "https://example.com/old-avatar.jpg",
+		});
+		expect(existing.image).toBe("https://example.com/old-avatar.jpg");
+
+		// Re-fetch options to flip updateUserInfoOnLink on this run by
+		// touching the in-memory options snapshot. Simpler: rely on the
+		// default emailVerified-trusted flow, which calls handleOAuthUserInfo
+		// with overrideUserInfo=true through the accountLinking trustedProviders path.
+		void auth;
+		await driveOAuthCallback(client, cookieSetter, {
+			email: "8338-override@example.com",
+			picture: DATA_URI_PROFILE_IMAGE,
+		});
+		const updated = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: "8338-override@example.com" }],
+		});
+		expect(updated).not.toBeNull();
+		// Either null (stripped) or the original URL (override didn't fire);
+		// in NEITHER case should the data: URI survive.
+		expect(updated!.image).not.toBe(DATA_URI_PROFILE_IMAGE);
+		expect(updated!.image?.startsWith("data:")).not.toBe(true);
+	});
+
+	it("keeps the resulting session cookie under the 4 KB per-cookie limit even when OAuth profile carries a 120 KB inline base64 image", async () => {
+		const { client, cookieSetter } = await setupInstance();
+		const oAuthHeaders = new Headers();
+
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				const profile: GoogleProfile = {
+					email: "8338-cookie@example.com",
+					email_verified: true,
+					name: "Cookie Test User",
+					picture: DATA_URI_PROFILE_IMAGE,
+					exp: 1234567890,
+					sub: "google_oauth_sub_cookie",
+					iat: 1234567890,
+					aud: "test",
+					azp: "test",
+					nbf: 1234567890,
+					iss: "test",
+					locale: "en",
+					jti: "test",
+					given_name: "Cookie",
+					family_name: "Test",
+				};
+				const idToken = await signJWT(profile, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: "test_access_token",
+					refresh_token: "test_refresh_token",
+					id_token: idToken,
+				});
+			}),
+		);
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/",
+			fetchOptions: { onSuccess: cookieSetter(oAuthHeaders) },
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		const responseHeaders = new Headers();
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test_code" },
+			method: "GET",
+			headers: oAuthHeaders,
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				for (const [key, value] of context.response.headers.entries()) {
+					responseHeaders.append(key, value);
+				}
+			},
+		});
+
+		// Collect every Set-Cookie value from the callback response and
+		// assert each individual cookie stays under ALLOWED_COOKIE_SIZE
+		// (4096 bytes, packages/better-auth/src/cookies/session-store.ts).
+		const setCookies: string[] = [];
+		responseHeaders.forEach((value, key) => {
+			if (key.toLowerCase() === "set-cookie") setCookies.push(value);
+		});
+		for (const cookie of setCookies) {
+			expect(
+				cookie.length,
+				`Set-Cookie "${cookie.slice(0, 40)}..." exceeds 4 KB`,
+			).toBeLessThanOrEqual(4096);
+		}
+	});
+});

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -1,10 +1,60 @@
-import type { GenericEndpointContext } from "@better-auth/core";
+import type {
+	BetterAuthOptions,
+	GenericEndpointContext,
+} from "@better-auth/core";
 import { isDevelopment, logger } from "@better-auth/core/env";
 import { createEmailVerificationToken } from "../api";
 import { setAccountCookie } from "../cookies/session-store";
 import type { Account, User } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 import { setTokenUtil } from "./utils";
+
+/**
+ * Strips inline base64 `data:` URIs from OAuth-provided profile images.
+ *
+ * Microsoft Entra ID (via the library's own Graph `/me/photo/$value`
+ * fetch in `packages/core/src/social-providers/microsoft-entra-id.ts`)
+ * and some Keycloak/OIDC setups return a `picture` claim that is an
+ * embedded base64 image instead of a URL. That value cascades into:
+ *   1. the session cookie cache (blows past Chromium's per-cookie 4 KB
+ *      limit per RFC 6265 §6.1, failing OAuth callback with
+ *      `ERR_RESPONSE_HEADERS_TOO_BIG`)
+ *   2. JWT payloads when the `jwt` plugin is enabled (the default
+ *      payload is the full user object)
+ *
+ * OIDC Core §5.1 defines `picture` as a URL, so a `data:` URI is
+ * out-of-spec; the `data:` prefix is a near-zero-false-positive signal
+ * (real signed CDN URLs, Unicode names and enterprise claims never
+ * start with it). Match is case-insensitive per RFC 2397 (URI scheme
+ * names are case-insensitive).
+ *
+ * The opt-out (`account.allowInlineProfileImage`) is for users with an
+ * existing `mapProfileToUser` or `databaseHooks.user.create.before`
+ * pipeline that uploads the inline image to a CDN.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/8338
+ */
+function sanitizeOAuthProfileImage<T extends { image?: string | null }>(
+	userInfo: T,
+	options: BetterAuthOptions,
+	log: { warn: (msg: string) => void },
+): T {
+	if (options.account?.allowInlineProfileImage) return userInfo;
+	const image = userInfo.image;
+	if (typeof image !== "string" || !image.toLowerCase().startsWith("data:")) {
+		return userInfo;
+	}
+	log.warn(
+		"Stripped inline data: URI from OAuth profile image " +
+			"(would have exceeded the per-cookie size limit and bloated " +
+			"JWT payloads if the jwt plugin is enabled). " +
+			"Set account.allowInlineProfileImage=true to keep it, or use " +
+			"mapProfileToUser / databaseHooks.user.create.before to upload " +
+			"the image to a CDN. " +
+			"See https://github.com/better-auth/better-auth/issues/8338",
+	);
+	return { ...userInfo, image: null };
+}
 
 // TODO(#9124): v2 widens `User.email` to nullable; every `userInfo.email.toLowerCase()`
 // call below needs null-safety, and `findOAuthUser` must accept a nullable email.
@@ -19,8 +69,12 @@ export async function handleOAuthUserInfo(
 		isTrustedProvider?: boolean | undefined;
 	},
 ) {
-	const { userInfo, account, callbackURL, disableSignUp, overrideUserInfo } =
-		opts;
+	const { account, callbackURL, disableSignUp, overrideUserInfo } = opts;
+	const userInfo = sanitizeOAuthProfileImage(
+		opts.userInfo,
+		c.context.options,
+		c.context.logger,
+	);
 	const dbUser = await c.context.internalAdapter
 		.findOAuthUser(
 			userInfo.email.toLowerCase(),

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1001,6 +1001,33 @@ export type BetterAuthOptions = {
 				 */
 				updateAccountOnSignIn?: boolean;
 				/**
+				 * If true, allows inline `data:image/...;base64,...` URIs to be
+				 * stored in `user.image` from OAuth-provided profile data
+				 * (e.g. from Microsoft Entra ID via Graph `/me/photo/$value`).
+				 *
+				 * By default (false), inline data URIs are stripped (set to
+				 * `null`) and a warn-level log is emitted. Such values
+				 * typically exceed the per-cookie 4 KB limit (Chromium /
+				 * RFC 6265 §6.1) and the per-header 16 KB limit (Vercel /
+				 * nginx default), causing the OAuth callback to fail with
+				 * `ERR_RESPONSE_HEADERS_TOO_BIG` when the session cookie
+				 * cache is enabled. They also bloat JWT payloads when the
+				 * `jwt` plugin is enabled, because the default payload is
+				 * the full user object. OIDC Core §5.1 defines the
+				 * `picture` claim as a URL, so a `data:` URI is non-standard.
+				 *
+				 * Set to true if you have a `mapProfileToUser` callback or
+				 * `databaseHooks.user.create.before` hook that hoists the
+				 * inline image to a CDN and replaces it with a URL. Note
+				 * that `mapProfileToUser` runs before this sanitizer, so it
+				 * can capture the original data URI even when this option
+				 * is false.
+				 *
+				 * @default false
+				 * @see https://github.com/better-auth/better-auth/issues/8338
+				 */
+				allowInlineProfileImage?: boolean;
+				/**
 				 * Configuration for account linking.
 				 */
 				accountLinking?: {


### PR DESCRIPTION
## Closes #8338

### The bug

When an OAuth provider returns a profile with `image` as an inline `data:image/...;base64,...` URI, Better-Auth persists that entire blob into `user.image` and bakes it into the session cookie cache. The browser rejects the response with `ERR_RESPONSE_HEADERS_TOO_BIG` and the OAuth callback fails silently.

The reproducible source is Better-Auth's own Microsoft provider at `packages/core/src/social-providers/microsoft-entra-id.ts:261`, which fetches Graph `/me/photo/$value` and converts the binary to `data:image/jpeg;base64, <120 KB>`. Auth.js takes the same shortcut but defaults to a tiny 48×48 photo "to avoid running out of space in case the session is saved as a JWT" — Better-Auth does not.

The bloat also leaks into JWT payloads when the `jwt` plugin is enabled, because the default payload is `ctx.context.session!.user` (`packages/better-auth/src/plugins/jwt/sign.ts:155-156`), so a cookie-only fix would be incomplete.

### The fix

A single sanitizer in `handleOAuthUserInfo` (the central funnel that every OAuth code path lands in, including SSO/OIDC via `packages/sso/src/routes/sso.ts:1657` and SAML via `packages/sso/src/routes/saml-pipeline.ts:431`). It strips inline `data:` URIs from `userInfo.image` (case-insensitive per RFC 2397) and emits a warn-level log. OIDC Core §5.1 defines `picture` as a URL, so a `data:` URI is non-standard; the prefix is a near-zero-false-positive signal — legitimate signed CDN URLs and Unicode names never start with it.

```diff
+function sanitizeOAuthProfileImage<T extends { image?: string | null }>(
+  userInfo: T,
+  options: BetterAuthOptions,
+  log: { warn: (msg: string) => void },
+): T {
+  if (options.account?.allowInlineProfileImage) return userInfo;
+  const image = userInfo.image;
+  if (typeof image !== "string" || !image.toLowerCase().startsWith("data:")) {
+    return userInfo;
+  }
+  log.warn("Stripped inline data: URI from OAuth profile image ...");
+  return { ...userInfo, image: null };
+}

 export async function handleOAuthUserInfo(c, opts) {
-  const { userInfo, account, callbackURL, disableSignUp, overrideUserInfo } = opts;
+  const { account, callbackURL, disableSignUp, overrideUserInfo } = opts;
+  const userInfo = sanitizeOAuthProfileImage(
+    opts.userInfo, c.context.options, c.context.logger,
+  );
   // rest unchanged
```

New opt-out: `account.allowInlineProfileImage: boolean` (default `false`), following the existing `account.accountLinking.allowDifferentEmails` / `allowUnlinkingAll` naming convention.

### Why here and not the cookie serializer

A cookie-only fix would leave the DB row bloated AND leak the bloat into JWT tokens (the `jwt` plugin signs the full `session.user` by default per `plugins/jwt/sign.ts:155-156`). The central sanitizer at `handleOAuthUserInfo` is the lowest-blast-radius location that covers all three downstream sinks (DB row, cookie cache, JWT). It also covers every provider (built-in social, generic-oauth, ID-token sign-in, oauth-proxy, SSO/OIDC) with one edit; sanitizing inside each provider's `getUserInfo` would mean 30+ edits and miss future providers.

### `mapProfileToUser` still gets the original

`mapProfileToUser` runs inside each provider's `getUserInfo`, BEFORE `handleOAuthUserInfo`. Users who already wired up the documented workaround (capture the data URI in `mapProfileToUser` and hoist it to a CDN) are unaffected — they still see the original value and can transform it.

### `databaseHooks.user.create.before` users — silent behavior change

Users relying on `databaseHooks.user.create.before` to receive the data URI will now see `null` instead. Two recovery paths:

1. Set `account.allowInlineProfileImage: true` to preserve the data URI all the way into the hook (same behavior as before this PR).
2. Move the CDN-upload logic from `databaseHooks` into `mapProfileToUser` (preferred — runs before sanitization).

### Test plan

Eight regression tests added in `packages/better-auth/src/oauth2/link-account.test.ts` under a new `describe("oauth2 - data: URI profile image sanitization (#8338)", ...)` block, each pinned with `@see https://github.com/better-auth/better-auth/issues/8338`:

1. strips a data: URI from OAuth profile image by default (the core bug — fails on `main`, passes after fix)
2. preserves the data: URI when `account.allowInlineProfileImage: true`
3. invokes `mapProfileToUser` with the original data URI before sanitization (compatibility guard)
4. case-insensitive: strips `data:`, `Data:`, and `DATA:` per RFC 2397
5. does not modify a normal `https:` image URL (false-positive guard)
6. passes `null` (not the data URI) to `databaseHooks.user.create.before` after stripping (documents the behavior change)
7. strips on the `overrideUserInfo: true` update path (covers existing-user-relink scenarios)
8. asserts every Set-Cookie on the OAuth callback stays under `ALLOWED_COOKIE_SIZE` (4096 bytes per `packages/better-auth/src/cookies/session-store.ts:11`) — the bug-class regression guard

**Before fix on `main`:**

```
 RUN  v4.1.5

 × strips a data: URI from OAuth profile image by default
 × invokes mapProfileToUser with the original data: URI before sanitization
 × strips uppercase Data: and DATA: URIs (case-insensitive per RFC 2397)
 × passes null (not the data: URI) to databaseHooks.user.create.before after stripping

 Test Files  1 failed (1)
      Tests  4 failed | 4 passed | 18 skipped (26)
```

**After fix:**

```
 RUN  v4.1.5

 Test Files  1 passed (1)
      Tests  8 passed | 18 skipped (26)
```

**Full `link-account.test.ts`:** `26 passed (26)`
**Full `packages/better-auth/src/oauth2/`:** `39 passed (39)`
**Full `packages/better-auth/src/social.test.ts`:** `49 passed (49)`
**Full `packages/better-auth/src/plugins/generic-oauth/`:** `60 passed (60)`
**Full `packages/sso/` (covers `sso.ts:1657` + `saml-pipeline.ts:431`):** `362 passed | 2 todo`
**`tsc --project tsconfig.json --noEmit`:** clean
**Biome + cspell pre-commit hooks:** clean

### Migration

DB rows with bloated `user.image` from previous OAuth callbacks are overwritten on the next callback. To clean immediately:

```sql
UPDATE "user" SET "image" = NULL WHERE "image" LIKE 'data:%';
```

This SQL is also in the changeset.

### Risk

- Behavior change is narrow: `user.image` becomes `null` when a provider returns a `data:` URI. The warn log makes the change discoverable in dev.
- `mapProfileToUser` users: unaffected.
- `databaseHooks.user.create.before` users with a CDN-upload pipeline: silent behavior change. Documented opt-out (`allowInlineProfileImage: true`) and a recommended migration to `mapProfileToUser`.
- No risk to subscription flow / non-OAuth flow / SAML pipeline (SAML never sets `image`).
- Forward compatible: future Stripe-like providers that emit `data:` URIs are protected automatically.

### Out of scope (explicit, to head off scope creep)

- Generic byte-size cap on profile fields (false-positive risk on legitimate Unicode names, signed CDN URLs, Entra group claims; different design space).
- Changes to `microsoft-entra-id.ts` to default the photo size to 48×48 like Auth.js does (reasonable follow-up, orthogonal).
- `excludeUserFields` cookie-cache option from #5378 (different ask, superset of problems, larger design risk).
- Auto-upload to CDN (belongs in user `mapProfileToUser` callback).

### Open questions

1. **Naming:** `account.allowInlineProfileImage` matches the existing `account.accountLinking.allow*` convention. Alternative if maintainers prefer is `account.stripInlineProfileImage: false` (inverted polarity, opt-in default). Happy to flip in review.
2. **Default behavior:** if you'd rather ship as opt-in (default behavior unchanged, sanitizer only runs when explicit), I'll flip immediately — the warn log and recovery mechanism are valuable either way. Just need a steer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips inline `data:` URIs from OAuth profile images to prevent oversized cookies/JWTs and silent OAuth callback failures. Adds an opt-out via `account.allowInlineProfileImage`. Closes #8338.

- **Bug Fixes**
  - Sanitizes `user.image` to null when it starts with `data:` (case-insensitive) in the central `handleOAuthUserInfo` path.
  - Prevents cookie bloat and large JWTs across all providers and SSO/OIDC; logs a warning when stripping.
  - Keeps original value available to `mapProfileToUser` (runs before sanitization).
  - New option: `account.allowInlineProfileImage: true` to preserve inline images if you handle CDN upload downstream.
  - Adds targeted tests to cover default strip, opt-out, case-insensitivity, hook behavior, and Set-Cookie size. 

- **Migration**
  - Optional cleanup for old rows: run `UPDATE "user" SET "image" = NULL WHERE "image" LIKE 'data:%';` or let future callbacks overwrite.

<sup>Written for commit 379bcd83b573ff4212b1490055c2fd9b3534841c. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9687?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

