### PR TITLE
fix: `getMigration` field index order

### DIFF
--- a/.changeset/fiery-dots-cheat.md
+++ b/.changeset/fiery-dots-cheat.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix: getMigration field index order

--- a/packages/better-auth/src/db/get-migration-schema.test.ts
+++ b/packages/better-auth/src/db/get-migration-schema.test.ts
@@ -500,4 +500,190 @@ describe("index generation for columns added to existing tables", () => {
 		expect(sql).toContain("create index");
 		expect(sql).not.toContain("add index");
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9689
+	 */
+	it("should execute runMigrations without error when adding indexed columns to existing tables", async () => {
+		const config: BetterAuthOptions = {
+			database: new DatabaseSync(":memory:"),
+			emailAndPassword: {
+				enabled: true,
+			},
+		};
+
+		const initial = await getMigrations(config);
+		await initial.runMigrations();
+
+		config.plugins = [
+			{
+				id: "test-index",
+				schema: {
+					user: {
+						fields: {
+							externalId: {
+								type: "string",
+								index: true,
+								required: false,
+							},
+						},
+					},
+				},
+			},
+		];
+
+		const { runMigrations } = await getMigrations(config);
+		await expect(runMigrations()).resolves.not.toThrow();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9689
+	 */
+	it("should execute runMigrations when adding a new table with indexed columns to an existing database", async () => {
+		const config: BetterAuthOptions = {
+			database: new DatabaseSync(":memory:"),
+			emailAndPassword: {
+				enabled: true,
+			},
+		};
+
+		const initial = await getMigrations(config);
+		await initial.runMigrations();
+
+		config.plugins = [
+			{
+				id: "test-new-table",
+				schema: {
+					apikey: {
+						fields: {
+							configId: {
+								type: "string",
+								required: true,
+								index: true,
+							},
+							referenceId: {
+								type: "string",
+								required: true,
+								index: true,
+							},
+							key: {
+								type: "string",
+								required: true,
+								index: true,
+							},
+							createdAt: {
+								type: "date",
+								required: true,
+							},
+							updatedAt: {
+								type: "date",
+								required: true,
+							},
+						},
+					},
+				},
+			},
+		];
+
+		const { runMigrations } = await getMigrations(config);
+		await expect(runMigrations()).resolves.not.toThrow();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9689
+	 */
+	it("should execute runMigrations when upgrading an existing table with new indexed columns (simulates 1.4.x -> latest)", async () => {
+		const db = new DatabaseSync(":memory:");
+
+		const baseConfig: BetterAuthOptions = {
+			database: db,
+			emailAndPassword: {
+				enabled: true,
+			},
+			plugins: [
+				{
+					id: "old-apikey",
+					schema: {
+						apikey: {
+							fields: {
+								key: {
+									type: "string",
+									required: true,
+								},
+								userId: {
+									type: "string",
+									required: true,
+								},
+								createdAt: {
+									type: "date",
+									required: true,
+								},
+								updatedAt: {
+									type: "date",
+									required: true,
+								},
+							},
+						},
+					},
+				},
+			],
+		};
+
+		const initial = await getMigrations(baseConfig);
+		await initial.runMigrations();
+
+		const upgradedConfig: BetterAuthOptions = {
+			database: db,
+			emailAndPassword: {
+				enabled: true,
+			},
+			plugins: [
+				{
+					id: "new-apikey",
+					schema: {
+						apikey: {
+							fields: {
+								configId: {
+									type: "string",
+									required: true,
+									index: true,
+								},
+								referenceId: {
+									type: "string",
+									required: true,
+									index: true,
+								},
+								key: {
+									type: "string",
+									required: true,
+									index: true,
+								},
+								userId: {
+									type: "string",
+									required: true,
+								},
+								createdAt: {
+									type: "date",
+									required: true,
+								},
+								updatedAt: {
+									type: "date",
+									required: true,
+								},
+							},
+						},
+					},
+				},
+			],
+		};
+
+		const { runMigrations, toBeAdded } = await getMigrations(upgradedConfig);
+		expect(toBeAdded.length).toBeGreaterThan(0);
+		const apikeyAdded = toBeAdded.find((t) => t.table === "apikey");
+		expect(apikeyAdded).toBeDefined();
+		expect(apikeyAdded!.fields).toHaveProperty("configId");
+		expect(apikeyAdded!.fields).toHaveProperty("referenceId");
+
+		await expect(runMigrations()).resolves.not.toThrow();
+	});
 });

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -422,6 +422,10 @@ export async function getMigrations(config: BetterAuthOptions) {
 		}
 	}
 
+	// Indexes are collected separately and appended last to ensure all
+	// referenced columns/tables exist before any CREATE INDEX executes.
+	const deferredIndexes: CreateIndexBuilder[] = [];
+
 	if (toBeAdded.length) {
 		for (const table of toBeAdded) {
 			for (const [fieldName, field] of Object.entries(table.fields)) {
@@ -434,7 +438,9 @@ export async function getMigrations(config: BetterAuthOptions) {
 						.createIndex(indexName)
 						.on(table.table)
 						.columns([fieldName]);
-					migrations.push(field.unique ? indexBuilder.unique() : indexBuilder);
+					deferredIndexes.push(
+						field.unique ? indexBuilder.unique() : indexBuilder,
+					);
 				}
 
 				const built = builder.addColumn(fieldName, type, (col) => {
@@ -469,8 +475,6 @@ export async function getMigrations(config: BetterAuthOptions) {
 			}
 		}
 	}
-
-	const toBeIndexed: CreateIndexBuilder[] = [];
 
 	if (toBeCreated.length) {
 		for (const table of toBeCreated) {
@@ -540,19 +544,15 @@ export async function getMigrations(config: BetterAuthOptions) {
 						)
 						.on(table.table)
 						.columns([fieldName]);
-					toBeIndexed.push(field.unique ? builder.unique() : builder);
+					deferredIndexes.push(field.unique ? builder.unique() : builder);
 				}
 			}
 			migrations.push(dbT);
 		}
 	}
 
-	// instead of adding the index straight to `migrations`,
-	// we do this at the end so that indexes are created after the table is created
-	if (toBeIndexed.length) {
-		for (const index of toBeIndexed) {
-			migrations.push(index);
-		}
+	for (const index of deferredIndexes) {
+		migrations.push(index);
 	}
 
 	async function runMigrations() {


### PR DESCRIPTION
https://github.com/better-auth/better-auth/issues/9689

The order of indexing right now doesn't take into account of new fields which are yet to be created. 
This PR fixes this.