### PR TITLE
fix: remove apostrophes from error codes in documentation URLs

### DIFF
--- a/.changeset/stale-clowns-look.md
+++ b/.changeset/stale-clowns-look.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix: remove apostrophes from error codes in documentation URLs

--- a/packages/better-auth/src/api/routes/error.test.ts
+++ b/packages/better-auth/src/api/routes/error.test.ts
@@ -30,4 +30,32 @@ describe("error page security", async () => {
 		// Invalid code defaults to UNKNOWN
 		expect(text).toContain("UNKNOWN");
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9681
+	 */
+	it("should generate valid documentation URLs for error codes with apostrophes", async () => {
+		// cspell:disable-next-line
+		const errorCode = "email_doesn't_match";
+		const res = await client.$fetch(
+			`/error?error=${encodeURIComponent(errorCode)}`,
+			{
+				method: "GET",
+			},
+		);
+
+		const text = typeof res === "string" ? res : JSON.stringify(res);
+		// cspell:disable
+		// The error code should be displayed with the apostrophe (as HTML entity)
+		expect(text).toContain("email_doesn&#39;t_match");
+		// The documentation URL should have apostrophe removed for valid routing
+		expect(text).toContain(
+			"https://better-auth.com/docs/reference/errors/email_doesnt_match",
+		);
+		// Should NOT contain the apostrophe in the URL path
+		expect(text).not.toContain(
+			"https://better-auth.com/docs/reference/errors/email_doesn%27t_match",
+		);
+		// cspell:enable
+	});
 });

--- a/packages/better-auth/src/api/routes/error.ts
+++ b/packages/better-auth/src/api/routes/error.ts
@@ -20,6 +20,7 @@ const html = (
 	description: string | null = null,
 ) => {
 	const custom = options.onAPIError?.customizeDefaultErrorPage;
+	const urlSafeCode = code.replace(/'/g, "");
 	return `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -306,7 +307,7 @@ ${
             ${
 							!description
 								? "We encountered an unexpected error. Please try again or return to the home page. If you're a developer, you can find " +
-									`<a href='https://better-auth.com/docs/reference/errors/${encodeURIComponent(code)}' target='_blank' rel="noopener noreferrer" style='color: var(--foreground); text-decoration: underline;'>more information about the error</a>.`
+									`<a href='https://better-auth.com/docs/reference/errors/${encodeURIComponent(urlSafeCode)}' target='_blank' rel="noopener noreferrer" style='color: var(--foreground); text-decoration: underline;'>more information about the error</a>.`
 								: description
 						}
           </p>
@@ -342,7 +343,7 @@ ${
             </div>
           </a>
           <a
-            href="https://better-auth.com/docs/reference/errors/${encodeURIComponent(code)}?askai=${encodeURIComponent(`What does the error code ${code} mean?`)}"
+            href="https://better-auth.com/docs/reference/errors/${encodeURIComponent(urlSafeCode)}?askai=${encodeURIComponent(`What does the error code ${code} mean?`)}"
             target="_blank"
             rel="noopener noreferrer"
             style="


### PR DESCRIPTION
This PR fixes issue #9681 where error codes containing apostrophes (like `email_doesn't_match`) were generating broken documentation URLs.

https://github.com/better-auth/better-auth/issues/9681