### PR TITLE
fix(admin): route banned OAuth users to errorCallbackURL

### DIFF
--- a/.changeset/admin-banned-oauth-error-callback.md
+++ b/.changeset/admin-banned-oauth-error-callback.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Banned users signing in with an OAuth provider now redirect to the `errorCallbackURL` passed to `signIn.social`, with `?error=BANNED_USER&error_description=<message>` in the query string. Previously the redirect went to the auth server's default error page with `?error=banned`, which broke multi-domain deployments where the auth host and frontend host differ.

--- a/.changeset/admin-banned-oauth-error-callback.md
+++ b/.changeset/admin-banned-oauth-error-callback.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Banned users signing in with an OAuth provider now redirect to the `errorCallbackURL` passed to `signIn.social`, with `?error=BANNED_USER&error_description=<message>` in the query string. Previously the redirect went to the auth server's default error page with `?error=banned`, which broke multi-domain deployments where the auth host and frontend host differ.
+Banned users signing in with an OAuth provider now redirect to the `errorCallbackURL` passed to `signIn.social`, with `?error=BANNED_USER&error_description=<message>` in the query string. Previously the redirect went to the auth server's default error page with `?error=banned`, which broke multi-domain deployments where the auth host and frontend host differ. The `oauth-proxy` callback now also redirects banned users to the error URL (previously returned JSON 403).

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -268,6 +268,10 @@ export const callbackOAuth = createAuthEndpoint(
 			overrideUserInfo: provider.options?.overrideUserInfoOnSignIn,
 		});
 		if (result.error) {
+			if (result.errorCode) {
+				c.context.logger.error(result.errorCode);
+				return redirectOnError(result.errorCode, result.error);
+			}
 			c.context.logger.error(result.error.split(" ").join("_"));
 			return redirectOnError(result.error.split(" ").join("_"));
 		}

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -9,6 +9,7 @@ import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import { parseState } from "../../oauth2/state";
 import { setTokenUtil } from "../../oauth2/utils";
 import { HIDE_METADATA } from "../../utils/hide-metadata";
+import { isAPIError } from "../../utils/is-api-error";
 
 const schema = z.object({
 	code: z.string().optional(),
@@ -253,25 +254,29 @@ export const callbackOAuth = createAuthEndpoint(
 			...tokens,
 			scope: tokens.scopes?.join(","),
 		};
-		const result = await handleOAuthUserInfo(c, {
-			userInfo: {
-				...userInfo,
-				id: providerAccountId,
-				email: userInfo.email,
-				name: userInfo.name || "",
-			},
-			account: accountData,
-			callbackURL,
-			disableSignUp:
-				(provider.disableImplicitSignUp && !requestSignUp) ||
-				provider.options?.disableSignUp,
-			overrideUserInfo: provider.options?.overrideUserInfoOnSignIn,
-		});
-		if (result.error) {
-			if (result.errorCode) {
-				c.context.logger.error(result.errorCode);
-				return redirectOnError(result.errorCode, result.error);
+		let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;
+		try {
+			result = await handleOAuthUserInfo(c, {
+				userInfo: {
+					...userInfo,
+					id: providerAccountId,
+					email: userInfo.email,
+					name: userInfo.name || "",
+				},
+				account: accountData,
+				callbackURL,
+				disableSignUp:
+					(provider.disableImplicitSignUp && !requestSignUp) ||
+					provider.options?.disableSignUp,
+				overrideUserInfo: provider.options?.overrideUserInfoOnSignIn,
+			});
+		} catch (e) {
+			if (isAPIError(e) && e.body?.code) {
+				return redirectOnError(e.body.code, e.body.message);
 			}
+			throw e;
+		}
+		if (result.error) {
 			c.context.logger.error(result.error.split(" ").join("_"));
 			return redirectOnError(result.error.split(" ").join("_"));
 		}

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -257,15 +257,10 @@ export async function handleOAuthUserInfo(
 			isRegister,
 		};
 	} catch (e: any) {
-		logger.error(e);
-		if (isAPIError(e) && e.body?.code) {
-			return {
-				error: e.body.message || e.message,
-				errorCode: e.body.code,
-				data: null,
-				isRegister: false,
-			};
+		if (isAPIError(e)) {
+			throw e;
 		}
+		logger.error(e);
 		return {
 			error: "unable to create session",
 			data: null,

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -239,21 +239,37 @@ export async function handleOAuthUserInfo(
 		};
 	}
 
-	const session = await c.context.internalAdapter.createSession(user.id);
-	if (!session) {
+	try {
+		const session = await c.context.internalAdapter.createSession(user.id);
+		if (!session) {
+			return {
+				error: "unable to create session",
+				data: null,
+				isRegister: false,
+			};
+		}
+		return {
+			data: {
+				session,
+				user,
+			},
+			error: null,
+			isRegister,
+		};
+	} catch (e: any) {
+		logger.error(e);
+		if (isAPIError(e) && e.body?.code) {
+			return {
+				error: e.body.message || e.message,
+				errorCode: e.body.code,
+				data: null,
+				isRegister: false,
+			};
+		}
 		return {
 			error: "unable to create session",
 			data: null,
 			isRegister: false,
 		};
 	}
-
-	return {
-		data: {
-			session,
-			user,
-		},
-		error: null,
-		isRegister,
-	};
 }

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -75,6 +75,7 @@ describe("Admin plugin", async () => {
 		customFetchImpl,
 	} = await getTestInstance(
 		{
+			trustedOrigins: ["https://frontend.example.com"],
 			plugins: [
 				admin({
 					bannedUserMessage: "Custom banned user message",
@@ -620,7 +621,44 @@ describe("Admin plugin", async () => {
 			},
 		});
 		expect(errorLocation).toBeDefined();
-		expect(errorLocation).toContain("error=banned");
+		expect(errorLocation).toContain("error=BANNED_USER");
+	});
+
+	it("should redirect banned social sign-in to a cross-origin errorCallbackURL", async () => {
+		const errorCallbackURL = "https://frontend.example.com/auth-error";
+		const headers = new Headers();
+		const res = await client.signIn.social(
+			{
+				provider: "google",
+				errorCallbackURL,
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(headers),
+			},
+		);
+		const state = new URL(res.url!).searchParams.get("state");
+		let errorLocation: string | null = null;
+		await client.$fetch("/callback/google", {
+			query: {
+				state,
+				code: "test",
+			},
+			headers,
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				errorLocation = context.response.headers.get("location");
+			},
+		});
+		expect(errorLocation).toBeTruthy();
+		const url = new URL(errorLocation!);
+		expect(url.origin).toBe("https://frontend.example.com");
+		expect(`${url.origin}${url.pathname}`).toBe(errorCallbackURL);
+		expect(url.searchParams.get("error")).toBe("BANNED_USER");
+		expect(url.searchParams.get("error_description")).toBe(
+			"Custom banned user message",
+		);
 	});
 
 	it("should change banned user message", async () => {

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -1,5 +1,6 @@
 import { BetterAuthError } from "@better-auth/core/error";
 import type { GoogleProfile } from "@better-auth/core/social-providers";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import {
@@ -1971,5 +1972,69 @@ describe("edge cases: userId validation", async () => {
 				},
 			}),
 		).rejects.toThrow("user not found");
+	});
+});
+
+describe("Admin plugin id-token sign-in", async () => {
+	const googleKeyPair = await generateKeyPair("RS256");
+	const googleJwk = await exportJWK(googleKeyPair.publicKey);
+	const googleKid = "test-admin-google-kid";
+	googleJwk.kid = googleKid;
+	googleJwk.alg = "RS256";
+	googleJwk.use = "sig";
+
+	const clientId = "admin-idtoken-client.googleusercontent.com";
+
+	const signIdToken = (email: string) =>
+		new SignJWT({
+			email,
+			email_verified: true,
+			name: "Banned ID Token User",
+			sub: "banned-google-sub",
+		})
+			.setProtectedHeader({ alg: "RS256", kid: googleKid })
+			.setIssuedAt()
+			.setIssuer("https://accounts.google.com")
+			.setAudience(clientId)
+			.setExpirationTime("1h")
+			.sign(googleKeyPair.privateKey);
+
+	beforeAll(() => {
+		server.use(
+			http.get("https://www.googleapis.com/oauth2/v3/certs", () =>
+				HttpResponse.json({ keys: [googleJwk] }),
+			),
+		);
+	});
+
+	it("should return BANNED_USER 403 JSON for id-token sign-in by banned user", async () => {
+		const { client } = await getTestInstance(
+			{
+				plugins: [admin({ bannedUserMessage: "Custom banned user message" })],
+				socialProviders: {
+					google: { clientId, clientSecret: "test-secret" },
+				},
+				databaseHooks: {
+					user: {
+						create: {
+							before: async (user) => ({
+								data: { ...user, emailVerified: true, banned: true },
+							}),
+						},
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const idToken = await signIdToken("banned-idtoken@test.com");
+		const res = await client.signIn.social({
+			provider: "google",
+			idToken: { token: idToken },
+		});
+
+		expect(res.error?.status).toBe(403);
+		expect(res.error?.code).toBe("BANNED_USER");
+		expect(res.error?.message).toBe("Custom banned user message");
 	});
 });

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -113,19 +113,6 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 											return;
 										}
 
-										if (
-											ctx &&
-											(ctx.path.startsWith("/callback") ||
-												ctx.path.startsWith("/oauth2/callback"))
-										) {
-											const redirectURI =
-												ctx.context.options.onAPIError?.errorURL ||
-												`${ctx.context.baseURL}/error`;
-											throw ctx.redirect(
-												`${redirectURI}?error=banned&error_description=${opts.bannedUserMessage}`,
-											);
-										}
-
 										throw APIError.from("FORBIDDEN", {
 											message: opts.bannedUserMessage,
 											code: "BANNED_USER",

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -17,6 +17,7 @@ import { generateState, parseState } from "../../oauth2/state";
 import { setTokenUtil } from "../../oauth2/utils";
 import type { User } from "../../types";
 import { HIDE_METADATA } from "../../utils";
+import { isAPIError } from "../../utils/is-api-error";
 import { GENERIC_OAUTH_ERROR_CODES } from "./error-codes";
 import type { GenericOAuthOptions } from "./types";
 
@@ -514,25 +515,31 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 				throw ctx.redirect(toRedirectTo);
 			}
 
-			const result = await handleOAuthUserInfo(ctx, {
-				userInfo,
-				account: {
-					providerId: providerConfig.providerId,
-					accountId: userInfo.id,
-					...tokens,
-					scope: tokens.scopes?.join(","),
-				},
-				callbackURL: callbackURL,
-				disableSignUp:
-					(providerConfig.disableImplicitSignUp && !requestSignUp) ||
-					providerConfig.disableSignUp,
-				overrideUserInfo: providerConfig.overrideUserInfo,
-			});
+			let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;
+			try {
+				result = await handleOAuthUserInfo(ctx, {
+					userInfo,
+					account: {
+						providerId: providerConfig.providerId,
+						accountId: userInfo.id,
+						...tokens,
+						scope: tokens.scopes?.join(","),
+					},
+					callbackURL: callbackURL,
+					disableSignUp:
+						(providerConfig.disableImplicitSignUp && !requestSignUp) ||
+						providerConfig.disableSignUp,
+					overrideUserInfo: providerConfig.overrideUserInfo,
+				});
+			} catch (e) {
+				if (isAPIError(e) && e.body?.code) {
+					return redirectOnError(e.body.code);
+				}
+				throw e;
+			}
 
 			if (result.error) {
-				return redirectOnError(
-					result.errorCode || result.error.split(" ").join("_"),
-				);
+				return redirectOnError(result.error.split(" ").join("_"));
 			}
 			const { session, user } = result.data!;
 			await setSessionCookie(ctx, {

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -530,7 +530,9 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 			});
 
 			if (result.error) {
-				return redirectOnError(result.error.split(" ").join("_"));
+				return redirectOnError(
+					result.errorCode || result.error.split(" ").join("_"),
+				);
 			}
 			const { session, user } = result.data!;
 			await setSessionCookie(ctx, {

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -19,6 +19,7 @@ import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import type { StateData } from "../../state";
 import { parseGenericState } from "../../state";
 import type { Account, User } from "../../types";
+import { isAPIError } from "../../utils/is-api-error";
 import { getOrigin } from "../../utils/url";
 import { PACKAGE_VERSION } from "../../version";
 import {
@@ -242,22 +243,26 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 						ctx.context.logger.warn("Failed to clean up OAuth state", e);
 					}
 
-					const result = await handleOAuthUserInfo(ctx, {
-						userInfo: payload.userInfo,
-						account: payload.account,
-						callbackURL: payload.callbackURL,
-						disableSignUp: payload.disableSignUp,
-					});
+					let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;
+					try {
+						result = await handleOAuthUserInfo(ctx, {
+							userInfo: payload.userInfo,
+							account: payload.account,
+							callbackURL: payload.callbackURL,
+							disableSignUp: payload.disableSignUp,
+						});
+					} catch (e) {
+						if (isAPIError(e) && e.body?.code) {
+							throw redirectOnError(ctx, errorURL, e.body.code);
+						}
+						throw e;
+					}
 					if (result.error || !result.data) {
 						ctx.context.logger.error(
 							"Failed to create user or session",
 							result.error,
 						);
-						throw redirectOnError(
-							ctx,
-							errorURL,
-							result.errorCode || "user_creation_failed",
-						);
+						throw redirectOnError(ctx, errorURL, "user_creation_failed");
 					}
 
 					await setSessionCookie(ctx, result.data);

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -253,7 +253,11 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							"Failed to create user or session",
 							result.error,
 						);
-						throw redirectOnError(ctx, errorURL, "user_creation_failed");
+						throw redirectOnError(
+							ctx,
+							errorURL,
+							result.errorCode || "user_creation_failed",
+						);
 					}
 
 					await setSessionCookie(ctx, result.data);

--- a/packages/better-auth/src/plugins/oauth-proxy/utils.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/utils.ts
@@ -81,5 +81,5 @@ export function redirectOnError(
 	error: string,
 ): never {
 	const sep = errorURL.includes("?") ? "&" : "?";
-	throw ctx.redirect(`${errorURL}${sep}error=${error}`);
+	throw ctx.redirect(`${errorURL}${sep}error=${encodeURIComponent(error)}`);
 }


### PR DESCRIPTION
Related to https://discord.com/channels/1288403910284935179/1504897654587654224

The admin plugin `session.create.before` hook was sniffing OAuth callback paths and redirecting directly to the auth server's `baseURL`, bypassing the OAuth state's `errorCallbackURL` routing and breaking multi-domain deployments.

The query string changes from `?error=banned` to `?error=BANNED_USER`, matching `ADMIN_ERROR_CODES.BANNED_USER`. Kept as `patch` since the lowercase was an ad-hoc literal, not documented API.