### PR TITLE
fix(mongo-adapter): fallback to non-transactional on standalone mongo servers

### DIFF
--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -683,8 +683,21 @@ export const mongodbAdapter = (
 
 								await session.commitTransaction();
 								return result;
-							} catch (err) {
-								await session.abortTransaction();
+							} catch (err: any) {
+								await session.abortTransaction().catch(() => {});
+								if (
+									err.message?.includes("Transaction numbers are only allowed on a replica set member or mongos") ||
+									err.message?.includes("Transactions are not supported")
+								) {
+									const adapter = createAdapterFactory({
+										config: {
+											...adapterOptions!.config,
+											transaction: false,
+										},
+										adapter: createCustomAdapter(db),
+									})(lazyOptions!);
+									return await cb(adapter);
+								}
 								throw err;
 							} finally {
 								await session.endSession();


### PR DESCRIPTION
Fixes #9700

This PR automatically catches `MongoServerError: Transaction numbers are only allowed on a replica set member or mongos` (and similar transaction support errors). When caught, it aborts the current session and falls back to a non-transactional execution, rerunning the callback with a non-transactional adapter. 

This provides a better developer experience for standalone MongoDB environments (like local setups without replica sets) where `client` is provided but transactions are fundamentally unsupported, averting crashes without requiring users to explicitly dig through docs to set `transaction: false`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically fall back to non-transactional execution in `mongo-adapter` when MongoDB doesn’t support transactions (e.g., standalone servers), preventing crashes and letting operations continue.

- **Bug Fixes**
  - Catch transaction support errors and abort the session safely.
  - Re-run the callback with a non-transactional adapter (`transaction: false`).

<sup>Written for commit 30e8ce0ea6ad307b3b379b9a7121aa5d02856d0d. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9701?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

