### PR TITLE
fix(core): convert jose verification failures to UNAUTHORIZED APIError

### DIFF
--- a/packages/core/src/oauth2/verify.ts
+++ b/packages/core/src/oauth2/verify.ts
@@ -7,6 +7,7 @@ import type {
 	ProtectedHeaderParameters,
 } from "jose";
 import {
+	errors as joseErrors,
 	createLocalJWKSet,
 	decodeProtectedHeader,
 	jwtVerify,
@@ -15,6 +16,13 @@ import {
 import { logger } from "../env";
 
 /** Last fetched jwks used locally in getJwks @internal */
+// Small, stable set: jose errors that mean "server problem," not "bad token."
+const JOSE_INFRA_CODES = new Set<string>([
+	joseErrors.JWKSTimeout?.code || "ERR_JWKS_TIMEOUT",
+	joseErrors.JWKSInvalid?.code || "ERR_JWKS_INVALID",
+	joseErrors.JWKSMultipleMatchingKeys?.code || "ERR_JWKS_MULTIPLE_MATCHING_KEYS",
+]);
+
 let jwks: JSONWebKeySet | undefined;
 
 export interface VerifyAccessTokenRemote {
@@ -82,7 +90,9 @@ export async function getJwks(
 		throw new Error(error as unknown as string);
 	}
 
-	if (!jwtHeaders.kid) throw new Error("Missing jwt kid");
+	if (!jwtHeaders.kid) {
+		throw new APIError("UNAUTHORIZED", { message: "invalid access token" });
+	}
 
 	// Fetch jwks if not set or has a different kid than the one stored
 	if (!jwks || !jwks.keys.find((jwk) => jwk.kid === jwtHeaders.kid)) {
@@ -134,20 +144,20 @@ export async function verifyAccessToken(
 				verifyOptions: opts.verifyOptions,
 			});
 		} catch (error) {
-			if (error instanceof Error) {
-				if (error.name === "TypeError" || error.name === "JWSInvalid") {
-					// likely an opaque token (continue)
-				} else if (error.name === "JWTExpired") {
-					throw new APIError("UNAUTHORIZED", {
-						message: "token expired",
-					});
-				} else if (error.name === "JWTInvalid") {
-					throw new APIError("UNAUTHORIZED", {
-						message: "token invalid",
-					});
-				} else {
+			if (
+				error instanceof Error &&
+				(error.name === "TypeError" || error.name === "JWSInvalid")
+			) {
+				// likely an opaque token (continue)
+			} else if (error instanceof joseErrors.JOSEError) {
+				if (JOSE_INFRA_CODES.has(error.code)) {
 					throw error;
 				}
+				throw new APIError("UNAUTHORIZED", {
+					message: "invalid access token",
+				});
+			} else if (error instanceof Error) {
+				throw error;
 			} else {
 				throw new Error(error as unknown as string);
 			}


### PR DESCRIPTION
Fixes #9654.

This PR ensures that `verifyAccessToken` translates all jose client-token-shape verification failures (such as a wrong audience or missing `kid`) into an `APIError("UNAUTHORIZED")` rather than letting them fall through as unhandled raw `Error`s. 

- Known server-side infrastructure failures (`JWKSTimeout`, `JWKSInvalid`, `JWKSMultipleMatchingKeys`) are intentionally kept as raw exceptions to correctly surface as 500s.
- Existing opaque-token fallback logic remains intact.

Testing:
- Checked error logic structure against `#9654` suggested fixes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes access token verification errors by converting `jose` verification failures in `verifyAccessToken` into `APIError("UNAUTHORIZED")`, returning consistent 401s. JWKS infrastructure failures still bubble up as 500s.

- **Bug Fixes**
  - Map all non-infra `jose` `JOSEError`s to `APIError("UNAUTHORIZED", { message: "invalid access token" })`.
  - Keep JWKS infra errors (`JWKSTimeout`, `JWKSInvalid`, `JWKSMultipleMatchingKeys`) as raw to surface 500s.
  - Treat missing `kid` as unauthorized instead of a generic error.
  - Preserve opaque-token fallback for `TypeError`/`JWSInvalid`.

<sup>Written for commit 6106f4dc792c2073393e5320064b73cfb012f659. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9703?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

