### PR TITLE
fix(open-api): mark model ids as required

### DIFF
--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -22,6 +22,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
             "type": "string",
           },
           "id": {
+            "readOnly": true,
             "type": "string",
           },
           "idToken": {
@@ -52,6 +53,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
           },
         },
         "required": [
+          "id",
           "accountId",
           "providerId",
           "userId",
@@ -72,6 +74,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
             "type": "string",
           },
           "id": {
+            "readOnly": true,
             "type": "string",
           },
           "ipAddress": {
@@ -92,6 +95,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
           },
         },
         "required": [
+          "id",
           "expiresAt",
           "token",
           "createdAt",
@@ -116,6 +120,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
             "type": "boolean",
           },
           "id": {
+            "readOnly": true,
             "type": "string",
           },
           "image": {
@@ -138,6 +143,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
           },
         },
         "required": [
+          "id",
           "name",
           "email",
           "createdAt",
@@ -158,6 +164,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
             "type": "string",
           },
           "id": {
+            "readOnly": true,
             "type": "string",
           },
           "identifier": {
@@ -173,6 +180,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
           },
         },
         "required": [
+          "id",
           "identifier",
           "value",
           "expiresAt",

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -146,6 +146,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
           "id",
           "name",
           "email",
+          "emailVerified",
           "createdAt",
           "updatedAt",
           "role",

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -386,15 +386,15 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 	>((acc, [key, value]) => {
 		const modelName = key.charAt(0).toUpperCase() + key.slice(1);
 		const fields = value.fields;
-		const required: string[] = ["id"];
+		const required = new Set<string>(["id"]);
 		const properties: Record<string, FieldSchema> = {
 			id: { type: "string", readOnly: true },
 		};
 		Object.entries(fields).forEach(([fieldKey, fieldValue]) => {
 			if (!fieldValue) return;
 			properties[fieldKey] = getFieldSchema(fieldValue);
-			if (fieldValue.required && fieldValue.input !== false) {
-				required.push(fieldKey);
+			if (fieldValue.required && fieldValue.returned !== false) {
+				required.add(fieldKey);
 			}
 		});
 
@@ -407,7 +407,7 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 		acc[modelName] = {
 			type: "object",
 			properties,
-			required,
+			required: Array.from(required),
 		};
 		return acc;
 	}, {});

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -386,9 +386,9 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 	>((acc, [key, value]) => {
 		const modelName = key.charAt(0).toUpperCase() + key.slice(1);
 		const fields = value.fields;
-		const required: string[] = [];
+		const required: string[] = ["id"];
 		const properties: Record<string, FieldSchema> = {
-			id: { type: "string" },
+			id: { type: "string", readOnly: true },
 		};
 		Object.entries(fields).forEach(([fieldKey, fieldValue]) => {
 			if (!fieldValue) return;

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -37,6 +37,12 @@ describe("open-api", async () => {
 			type: "string",
 		});
 		expect(schemas["User"]!.required).toContain("id");
+		expect(schemas["User"]!.properties.emailVerified).toEqual({
+			default: false,
+			readOnly: true,
+			type: "boolean",
+		});
+		expect(schemas["User"]!.required).toContain("emailVerified");
 		expect(schemas["Session"]!.properties.id).toEqual({
 			readOnly: true,
 			type: "string",

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -26,15 +26,22 @@ describe("open-api", async () => {
 		expect(schema).toMatchSnapshot("openAPISchema");
 	});
 
-	it("should have an id field in the User schema", async () => {
+	it("should mark model id fields as required and read-only", async () => {
 		const schema = await auth.api.generateOpenAPISchema();
 		const schemas = schema.components.schemas as Record<
 			string,
 			Record<string, any>
 		>;
 		expect(schemas["User"]!.properties.id).toEqual({
+			readOnly: true,
 			type: "string",
 		});
+		expect(schemas["User"]!.required).toContain("id");
+		expect(schemas["Session"]!.properties.id).toEqual({
+			readOnly: true,
+			type: "string",
+		});
+		expect(schemas["Session"]!.required).toContain("id");
 	});
 
 	it("should include additionalFields in the User schema", async () => {


### PR DESCRIPTION
## Summary

- mark generated OpenAPI model `id` fields as required
- annotate generated model `id` fields as `readOnly`
- add regression coverage for `User` and `Session` model IDs

## Root Cause

The OpenAPI generator always adds a synthetic `id` property to model schemas, but it initialized the model `required` array empty and only populated it from database fields. Because the synthetic `id` is not part of `value.fields`, it was emitted as an optional property in generated specs.

Fixes #9686



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OpenAPI model `id` fields required and read-only, and also require read-only fields that are always returned (e.g., `emailVerified`), so specs match models and client types. Fixes #9686.

- **Bug Fixes**
  - Update generator to add `id` to `required`, set `properties.id.readOnly = true`, and derive `required` from returned fields so read-only required fields are included.
  - Add tests and update snapshots for `User` and `Session` (including `emailVerified`).

<sup>Written for commit bfecb074d894841ad52078a98f08ddf668e9afc9. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9704?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



