### PR TITLE
fix(next-js): forward multiple set-cookie headers in nextCookies

### DIFF
--- a/.changeset/next-cookies-set-cookie-list.md
+++ b/.changeset/next-cookies-set-cookie-list.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`nextCookies()` now forwards every `Set-Cookie` header from server-side auth API calls. Apps that refresh multiple cookies, such as session and account cache cookies, no longer drop those updates in Next.js server contexts.

--- a/packages/better-auth/src/integrations/next-js.test.ts
+++ b/packages/better-auth/src/integrations/next-js.test.ts
@@ -1,3 +1,5 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { createAuthEndpoint } from "@better-auth/core/api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("next-js integration", () => {
@@ -108,6 +110,90 @@ describe("next-js integration", () => {
 		expect(cookiesMock).not.toHaveBeenCalled();
 		expect(session).not.toBeNull();
 		expect(session?.needsRefresh).toBe(true);
+	});
+
+	it("should forward multiple set-cookie headers via getSetCookie", async () => {
+		const cookieSet = vi.fn();
+		vi.doMock("next/headers.js", () => ({
+			cookies: vi.fn(async () => ({
+				set: cookieSet,
+				delete: vi.fn(),
+				get: vi.fn(),
+			})),
+			headers: vi.fn(async () => new Headers({})),
+		}));
+
+		const [{ getTestInstance }, { nextCookies }] = await Promise.all([
+			import("../test-utils/test-instance"),
+			import("./next-js"),
+		]);
+
+		const multipleCookiesPlugin = {
+			id: "multiple-cookies",
+			endpoints: {
+				setMultipleCookies: createAuthEndpoint(
+					"/set-multiple-cookies",
+					{
+						method: "GET",
+					},
+					async (ctx) => {
+						ctx.setCookie("first", "one");
+						ctx.setCookie("second", "two");
+						return ctx.json({ ok: true });
+					},
+				),
+			},
+		} satisfies BetterAuthPlugin;
+
+		const { auth } = await getTestInstance(
+			{
+				plugins: [multipleCookiesPlugin, nextCookies()],
+			},
+			{
+				disableTestUser: true,
+			},
+		);
+
+		const originalGet = Headers.prototype.get;
+		const getSetCookie = vi.fn(() => ["first=one", "second=two"]);
+		const getSetCookieDescriptor = Object.getOwnPropertyDescriptor(
+			Headers.prototype,
+			"getSetCookie",
+		);
+		Object.defineProperty(Headers.prototype, "getSetCookie", {
+			configurable: true,
+			value: getSetCookie,
+		});
+		const getSpy = vi
+			.spyOn(Headers.prototype, "get")
+			.mockImplementation(function (name: string) {
+				if (name.toLowerCase() === "set-cookie") {
+					return null;
+				}
+				return originalGet.call(this, name);
+			});
+
+		try {
+			await auth.api.setMultipleCookies();
+		} finally {
+			getSpy.mockRestore();
+			if (getSetCookieDescriptor) {
+				Object.defineProperty(
+					Headers.prototype,
+					"getSetCookie",
+					getSetCookieDescriptor,
+				);
+			} else {
+				Reflect.deleteProperty(Headers.prototype, "getSetCookie");
+			}
+		}
+
+		expect(getSetCookie).toHaveBeenCalled();
+		expect(cookieSet).toHaveBeenCalledTimes(2);
+		expect(cookieSet.mock.calls.map(([name, value]) => [name, value])).toEqual([
+			["first", "one"],
+			["second", "two"],
+		]);
 	});
 
 	/**

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -1,7 +1,11 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
 import { setShouldSkipSessionRefresh } from "../api/state/should-session-refresh";
-import { parseSetCookieHeader, toCookieOptions } from "../cookies";
+import {
+	parseSetCookieHeader,
+	splitSetCookieHeader,
+	toCookieOptions,
+} from "../cookies";
 import { PACKAGE_VERSION } from "../version";
 import { warnIfCookiePluginNotLast } from "./cookie-plugin-guard";
 
@@ -85,9 +89,12 @@ export const nextCookies = () => {
 							return;
 						}
 						if (returned instanceof Headers) {
-							const setCookies = returned?.get("set-cookie");
-							if (!setCookies) return;
-							const parsed = parseSetCookieHeader(setCookies);
+							const setCookies = (
+								typeof returned.getSetCookie === "function"
+									? returned.getSetCookie()
+									: splitSetCookieHeader(returned.get("set-cookie") || "")
+							).filter((setCookie) => setCookie.trim().length > 0);
+							if (!setCookies.length) return;
 							let cookieHelper: Awaited<
 								ReturnType<typeof import("next/headers.js").cookies>
 							>;
@@ -108,14 +115,17 @@ export const nextCookies = () => {
 								}
 								throw error;
 							}
-							parsed.forEach((value, key) => {
-								if (!key) return;
-								try {
-									cookieHelper.set(key, value.value, toCookieOptions(value));
-								} catch {
-									// this will fail if the cookie is being set on server component
-								}
-							});
+							for (const setCookie of setCookies) {
+								const parsed = parseSetCookieHeader(setCookie);
+								parsed.forEach((value, key) => {
+									if (!key) return;
+									try {
+										cookieHelper.set(key, value.value, toCookieOptions(value));
+									} catch {
+										// this will fail if the cookie is being set on server component
+									}
+								});
+							}
 							return;
 						}
 					}),


### PR DESCRIPTION
## Summary

- fixes `nextCookies()` so server-side auth API calls forward every returned `Set-Cookie` header
- reads cookies with `Headers.getSetCookie()` when available, with the existing split-header helper as a fallback
- adds a regression test for the case where `Headers.get("set-cookie")` is unavailable while multiple cookies are present
- includes a patch changeset for `better-auth`

## Root cause

`nextCookies()` only read `responseHeaders.get("set-cookie")`. In runtimes where multiple `Set-Cookie` headers are exposed through `getSetCookie()` instead, the hook could see no cookies and silently skip forwarding them through Next.js `cookies().set()`.

Fixes #9705.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `nextCookies()` to forward all `Set-Cookie` headers from server-side auth responses in Next.js, preventing dropped multi-cookie updates (e.g., session + cache).

- **Bug Fixes**
  - Use `Headers.getSetCookie()` when available; fallback to `splitSetCookieHeader(returned.get('set-cookie') || '')`.
  - Forward each cookie to `cookies().set()` with parsed options.
  - Add a regression test for the `getSetCookie` path when `get('set-cookie')` is null, plus a patch changeset for `better-auth`.

<sup>Written for commit 2defccffd6935facee7aac3e671c0fed581a6ab3. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9709?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



