### PR TITLE
feat(captcha): add Google reCAPTCHA Enterprise provider

### DIFF
--- a/.changeset/captcha-recaptcha-enterprise.md
+++ b/.changeset/captcha-recaptcha-enterprise.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+The captcha plugin now supports Google reCAPTCHA Enterprise as a new provider. Configure it with `provider: "google-recaptcha-enterprise"` and supply your Google Cloud `projectId`, `siteKey`, and an API key via `secretKey`. Clients may optionally send an `x-captcha-action` header, which the server forwards as `expectedAction` to the Assessments API to block token replay across actions.

--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -6,6 +6,7 @@ description: Captcha plugin
 The **Captcha Plugin** integrates bot protection into your Better Auth system by adding captcha verification for key endpoints. This plugin ensures that only human users can perform actions like signing up, signing in, or resetting passwords. The following providers are currently supported:
 
 * [Google reCAPTCHA](https://developers.google.com/recaptcha)
+* [Google reCAPTCHA Enterprise](https://cloud.google.com/recaptcha)
 * [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/)
 * [hCaptcha](https://www.hcaptcha.com/)
 * [CaptchaFox](https://captchafox.com/)
@@ -27,10 +28,21 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     export const auth = betterAuth({
         plugins: [
             captcha({ // [!code highlight]
-                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha, captchafox // [!code highlight]
+                provider: "cloudflare-turnstile", // or google-recaptcha, google-recaptcha-enterprise, hcaptcha, captchafox // [!code highlight]
                 secretKey: process.env.TURNSTILE_SECRET_KEY!, // [!code highlight]
             }), // [!code highlight]
         ],
+    });
+    ```
+
+    **Google reCAPTCHA Enterprise** uses the Google Cloud [Assessments API](https://cloud.google.com/recaptcha/docs/create-assessment-website) instead of the standard `siteverify` endpoint, so it also needs a `projectId` and `siteKey` (here `secretKey` is the Google Cloud API key):
+
+    ```ts title="auth.ts"
+    captcha({
+        provider: "google-recaptcha-enterprise",
+        secretKey: process.env.RECAPTCHA_API_KEY!,
+        projectId: "my-gcp-project",
+        siteKey: "6Lc...",
     });
     ```
   </Step>
@@ -62,6 +74,10 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     * To implement Google reCAPTCHA on the client side, follow the official [Google reCAPTCHA documentation](https://developers.google.com/recaptcha/intro) or use libraries like [react-google-recaptcha](https://www.npmjs.com/package/react-google-recaptcha) (v2) and [react-google-recaptcha-v3](https://www.npmjs.com/package/react-google-recaptcha-v3) (v3).
     * To implement hCaptcha on the client side, follow the official [hCaptcha documentation](https://docs.hcaptcha.com/#add-the-hcaptcha-widget-to-your-webpage) or use libraries like [@hcaptcha/react-hcaptcha](https://www.npmjs.com/package/@hcaptcha/react-hcaptcha)
     * To implement CaptchaFox on the client side, follow the official [CaptchaFox documentation](https://docs.captchafox.com/getting-started) or use libraries like [@captchafox/react](https://www.npmjs.com/package/@captchafox/react)
+
+    <Callout type="info">
+      For **Google reCAPTCHA Enterprise**, you can additionally send an `x-captcha-action` header (e.g. `"sign_in"`). When present, the server verifies it against the assessment's action, blocking tokens issued for a different action from being replayed.
+    </Callout>
   </Step>
 </Steps>
 
@@ -87,8 +103,9 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 ## Plugin Options
 
 * **`provider` (required)**: your captcha provider.
-* **`secretKey` (required)**: your provider's secret key used for the server-side validation.
+* **`secretKey` (required)**: your provider's secret key used for the server-side validation. For *Google reCAPTCHA Enterprise*, this is the Google Cloud API key.
 * `endpoints` (optional): replaces the default array of paths where captcha verification is enforced. If set, only the specified paths will be protected. Default is `["/sign-up/email", "/sign-in/email", "/request-password-reset"]`.
-* `minScore` (optional - only *Google ReCAPTCHA v3*): minimum score threshold. Default is `0.5`.
-* `siteKey` (optional - only *hCaptcha* and *CaptchaFox*): prevents tokens issued on one sitekey from being redeemed elsewhere.
-* `siteVerifyURLOverride` (optional): overrides endpoint URL for the captcha verification request.
+* `minScore` (optional - only *Google reCAPTCHA v3* and *Enterprise*): minimum score threshold (0.0 - 1.0). Default is `0.5`.
+* `projectId` (**required for *Google reCAPTCHA Enterprise***): the Google Cloud project ID that owns the reCAPTCHA key.
+* `siteKey` (required for *Google reCAPTCHA Enterprise*; optional for *hCaptcha* and *CaptchaFox*): prevents tokens issued on one sitekey from being redeemed elsewhere.
+* `siteVerifyURLOverride` (optional): overrides the endpoint URL for the captcha verification request.

--- a/packages/better-auth/src/plugins/captcha/captcha.test.ts
+++ b/packages/better-auth/src/plugins/captcha/captcha.test.ts
@@ -287,6 +287,208 @@ describe("captcha", async () => {
 			expect(res.error?.status).toBe(403);
 		});
 	});
+	describe("google-recaptcha-enterprise", async () => {
+		const { client } = await getTestInstance({
+			plugins: [
+				captcha({
+					provider: "google-recaptcha-enterprise",
+					secretKey: "xx-api-key",
+					projectId: "xx-project",
+					siteKey: "xx-site-key",
+				}),
+			],
+		});
+
+		it("Should successfully sign in users if they passed the CAPTCHA challenge", async () => {
+			mockBetterFetch.mockClear();
+			mockBetterFetch.mockResolvedValue({
+				data: {
+					tokenProperties: {
+						valid: true,
+						action: "sign_in",
+						hostname: "example.com",
+						invalidReason: "INVALID_REASON_UNSPECIFIED",
+					},
+					riskAnalysis: { score: 0.9, reasons: [] },
+				},
+			});
+
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "captcha-token",
+						"x-captcha-action": "sign_in",
+						"x-forwarded-for": "127.0.0.1",
+					},
+				},
+			});
+
+			expect(res.data?.user).toBeDefined();
+			expect(mockBetterFetch).toHaveBeenCalled();
+
+			const [calledUrl, fetchOptions] = mockBetterFetch.mock.calls[0]!;
+			expect(calledUrl).toBe(
+				"https://recaptchaenterprise.googleapis.com/v1/projects/xx-project/assessments?key=xx-api-key",
+			);
+			expect(fetchOptions.method).toBe("POST");
+			expect(fetchOptions.headers).toMatchObject({
+				"Content-Type": "application/json",
+			});
+			const body = JSON.parse(fetchOptions.body as string);
+			expect(body).toEqual({
+				event: {
+					token: "captcha-token",
+					siteKey: "xx-site-key",
+					userIpAddress: "127.0.0.1",
+					expectedAction: "sign_in",
+				},
+			});
+		});
+
+		it("Should return 403 when tokenProperties.valid is false", async () => {
+			mockBetterFetch.mockResolvedValue({
+				data: {
+					tokenProperties: {
+						valid: false,
+						invalidReason: "EXPIRED",
+					},
+					riskAnalysis: { score: 0.9, reasons: [] },
+				},
+			});
+
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "expired-token",
+					},
+				},
+			});
+
+			expect(res.error?.status).toBe(403);
+		});
+
+		it("Should return 403 when riskAnalysis.score is below minScore", async () => {
+			mockBetterFetch.mockResolvedValue({
+				data: {
+					tokenProperties: { valid: true, action: "" },
+					riskAnalysis: { score: 0.1, reasons: ["AUTOMATION"] },
+				},
+			});
+
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "low-score-token",
+					},
+				},
+			});
+
+			expect(res.error?.status).toBe(403);
+		});
+
+		it("Should return 403 when expectedAction is provided and does not match", async () => {
+			mockBetterFetch.mockResolvedValue({
+				data: {
+					tokenProperties: { valid: true, action: "homepage" },
+					riskAnalysis: { score: 0.9, reasons: [] },
+				},
+			});
+
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "captcha-token",
+						"x-captcha-action": "sign_in",
+					},
+				},
+			});
+
+			expect(res.error?.status).toBe(403);
+		});
+
+		it("Should pass when no expectedAction header is sent (action check skipped)", async () => {
+			mockBetterFetch.mockResolvedValue({
+				data: {
+					tokenProperties: { valid: true, action: "anything" },
+					riskAnalysis: { score: 0.9, reasons: [] },
+				},
+			});
+
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "captcha-token",
+					},
+				},
+			});
+
+			expect(res.data?.user).toBeDefined();
+		});
+
+		it("Should return 500 if the assessments call fails", async () => {
+			mockBetterFetch.mockResolvedValue({
+				error: "Failed to fetch",
+			});
+
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "captcha-token",
+					},
+				},
+			});
+
+			expect(res.error?.status).toBe(500);
+		});
+
+		it("Should honor siteVerifyURLOverride", async () => {
+			const { client: overrideClient } = await getTestInstance({
+				plugins: [
+					captcha({
+						provider: "google-recaptcha-enterprise",
+						secretKey: "xx-api-key",
+						projectId: "xx-project",
+						siteKey: "xx-site-key",
+						siteVerifyURLOverride:
+							"https://proxy.example.com/recaptcha-assessment",
+					}),
+				],
+			});
+
+			mockBetterFetch.mockClear();
+			mockBetterFetch.mockResolvedValue({
+				data: {
+					tokenProperties: { valid: true, action: "" },
+					riskAnalysis: { score: 0.9, reasons: [] },
+				},
+			});
+
+			await overrideClient.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+				fetchOptions: {
+					headers: {
+						"x-captcha-response": "captcha-token",
+					},
+				},
+			});
+
+			const [calledUrl] = mockBetterFetch.mock.calls[0]!;
+			expect(calledUrl).toBe("https://proxy.example.com/recaptcha-assessment");
+		});
+	});
 	describe("hcaptcha", async () => {
 		const { client } = await getTestInstance({
 			plugins: [

--- a/packages/better-auth/src/plugins/captcha/constants.ts
+++ b/packages/better-auth/src/plugins/captcha/constants.ts
@@ -9,11 +9,15 @@ export const defaultEndpoints = [
 export const Providers = {
 	CLOUDFLARE_TURNSTILE: "cloudflare-turnstile",
 	GOOGLE_RECAPTCHA: "google-recaptcha",
+	GOOGLE_RECAPTCHA_ENTERPRISE: "google-recaptcha-enterprise",
 	HCAPTCHA: "hcaptcha",
 	CAPTCHAFOX: "captchafox",
 } as const;
 
-export const siteVerifyMap: Record<Provider, string> = {
+export const siteVerifyMap: Record<
+	Exclude<Provider, typeof Providers.GOOGLE_RECAPTCHA_ENTERPRISE>,
+	string
+> = {
 	[Providers.CLOUDFLARE_TURNSTILE]:
 		"https://challenges.cloudflare.com/turnstile/v0/siteverify",
 	[Providers.GOOGLE_RECAPTCHA]:

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -64,6 +64,8 @@ export const captcha = (options: CaptchaOptions) =>
 				}
 
 				const captchaResponse = request.headers.get("x-captcha-response");
+				const expectedAction =
+					request.headers.get("x-captcha-action")?.trim() || undefined;
 				const remoteUserIP = getIp(request, ctx.options) ?? undefined;
 
 				if (!captchaResponse) {
@@ -74,23 +76,39 @@ export const captcha = (options: CaptchaOptions) =>
 					});
 				}
 
-				const siteVerifyURL =
-					options.siteVerifyURLOverride || siteVerifyMap[options.provider];
-
 				const handlerParams = {
-					siteVerifyURL,
 					captchaResponse,
 					secretKey: options.secretKey,
 					remoteIP: remoteUserIP,
 				};
 
+				// reCAPTCHA Enterprise uses the Assessments API rather than a
+				// static siteverify URL, so it's resolved before siteVerifyMap.
+				if (options.provider === Providers.GOOGLE_RECAPTCHA_ENTERPRISE) {
+					return await verifyHandlers.googleRecaptchaEnterprise({
+						...handlerParams,
+						siteVerifyURL: options.siteVerifyURLOverride,
+						projectId: options.projectId,
+						siteKey: options.siteKey,
+						expectedAction,
+						minScore: options.minScore,
+					});
+				}
+
+				const siteVerifyURL =
+					options.siteVerifyURLOverride || siteVerifyMap[options.provider];
+
 				if (options.provider === Providers.CLOUDFLARE_TURNSTILE) {
-					return await verifyHandlers.cloudflareTurnstile(handlerParams);
+					return await verifyHandlers.cloudflareTurnstile({
+						...handlerParams,
+						siteVerifyURL,
+					});
 				}
 
 				if (options.provider === Providers.GOOGLE_RECAPTCHA) {
 					return await verifyHandlers.googleRecaptcha({
 						...handlerParams,
+						siteVerifyURL,
 						minScore: options.minScore,
 					});
 				}
@@ -98,6 +116,7 @@ export const captcha = (options: CaptchaOptions) =>
 				if (options.provider === Providers.HCAPTCHA) {
 					return await verifyHandlers.hCaptcha({
 						...handlerParams,
+						siteVerifyURL,
 						siteKey: options.siteKey,
 					});
 				}
@@ -105,6 +124,7 @@ export const captcha = (options: CaptchaOptions) =>
 				if (options.provider === Providers.CAPTCHAFOX) {
 					return await verifyHandlers.captchaFox({
 						...handlerParams,
+						siteVerifyURL,
 						siteKey: options.siteKey,
 					});
 				}

--- a/packages/better-auth/src/plugins/captcha/types.ts
+++ b/packages/better-auth/src/plugins/captcha/types.ts
@@ -13,6 +13,13 @@ export interface GoogleRecaptchaOptions extends BaseCaptchaOptions {
 	minScore?: number | undefined;
 }
 
+export interface GoogleRecaptchaEnterpriseOptions extends BaseCaptchaOptions {
+	provider: typeof Providers.GOOGLE_RECAPTCHA_ENTERPRISE;
+	projectId: string;
+	siteKey: string;
+	minScore?: number | undefined;
+}
+
 export interface CloudflareTurnstileOptions extends BaseCaptchaOptions {
 	provider: typeof Providers.CLOUDFLARE_TURNSTILE;
 }
@@ -29,6 +36,7 @@ export interface CaptchaFoxOptions extends BaseCaptchaOptions {
 
 export type CaptchaOptions =
 	| GoogleRecaptchaOptions
+	| GoogleRecaptchaEnterpriseOptions
 	| CloudflareTurnstileOptions
 	| HCaptchaOptions
 	| CaptchaFoxOptions;

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/google-recaptcha-enterprise.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/google-recaptcha-enterprise.ts
@@ -1,0 +1,79 @@
+import { betterFetch } from "@better-fetch/fetch";
+import { middlewareResponse } from "../../../utils/middleware-response";
+import { EXTERNAL_ERROR_CODES, INTERNAL_ERROR_CODES } from "../error-codes";
+
+type Params = {
+	siteVerifyURL?: string | undefined;
+	secretKey: string;
+	projectId: string;
+	siteKey: string;
+	captchaResponse: string;
+	expectedAction?: string | undefined;
+	minScore?: number | undefined;
+	remoteIP?: string | undefined;
+};
+
+type AssessmentResponse = {
+	tokenProperties?: {
+		valid: boolean;
+		action?: string;
+		hostname?: string;
+		invalidReason?: string;
+		createTime?: string;
+	};
+	riskAnalysis?: {
+		score: number;
+		reasons?: string[];
+	};
+};
+
+export const googleRecaptchaEnterprise = async ({
+	siteVerifyURL,
+	secretKey,
+	projectId,
+	siteKey,
+	captchaResponse,
+	expectedAction,
+	minScore = 0.5,
+	remoteIP,
+}: Params) => {
+	const url =
+		siteVerifyURL ??
+		`https://recaptchaenterprise.googleapis.com/v1/projects/${encodeURIComponent(projectId)}/assessments?key=${encodeURIComponent(secretKey)}`;
+
+	const response = await betterFetch<AssessmentResponse>(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			event: {
+				token: captchaResponse,
+				siteKey,
+				...(remoteIP && { userIpAddress: remoteIP }),
+				...(expectedAction && { expectedAction }),
+			},
+		}),
+	});
+
+	if (!response.data || response.error) {
+		throw new Error(INTERNAL_ERROR_CODES.SERVICE_UNAVAILABLE.message);
+	}
+
+	const tokenProps = response.data.tokenProperties;
+	const score = response.data.riskAnalysis?.score;
+
+	const failed =
+		!tokenProps?.valid ||
+		(expectedAction !== undefined && tokenProps.action !== expectedAction) ||
+		typeof score !== "number" ||
+		score < minScore;
+
+	if (failed) {
+		return middlewareResponse({
+			message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.message,
+			code: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.code,
+			status: 403,
+		});
+	}
+
+	return undefined;
+};

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
@@ -1,4 +1,5 @@
 export { captchaFox } from "./captchafox";
 export { cloudflareTurnstile } from "./cloudflare-turnstile";
 export { googleRecaptcha } from "./google-recaptcha";
+export { googleRecaptchaEnterprise } from "./google-recaptcha-enterprise";
 export { hCaptcha } from "./h-captcha";


### PR DESCRIPTION
## Summary

Adds **Google reCAPTCHA Enterprise** as a new provider for the captcha plugin.

The existing `google-recaptcha` provider (v2/v3) posts to the legacy `siteverify` endpoint. Enterprise instead uses the Google Cloud [Assessments API](https://cloud.google.com/recaptcha/docs/create-assessment-website), so it takes a `projectId` and `siteKey` alongside the API key (`secretKey`):

```ts
import { captcha } from "better-auth/plugins";

export const auth = betterAuth({
  plugins: [
    captcha({
      provider: "google-recaptcha-enterprise",
      secretKey: process.env.RECAPTCHA_API_KEY!, // Google Cloud API key
      projectId: "my-gcp-project",
      siteKey: "6Lc...",
      minScore: 0.5, // optional, defaults to 0.5
    }),
  ],
});
```

Verification runs through the existing `onRequest` middleware — no changes to other providers, this is purely additive. The handler validates `tokenProperties.valid` and checks `riskAnalysis.score` against `minScore`. Clients may optionally send an `x-captcha-action` header, which is forwarded to the assessment as `expectedAction` and matched against the returned action, so a token issued for one action can't be replayed on another.

## Changes

- New `google-recaptcha-enterprise` provider and verify handler
- `projectId` / `siteKey` / `minScore` wired through the discriminated `CaptchaOptions` union
- Docs updated (`docs/content/docs/plugins/captcha.mdx`)
- Changeset included (`minor`)

## Tests

All 24 captcha tests pass, including 7 new cases for the Enterprise provider: happy path, invalid token, low score, action mismatch, service error, and config validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google reCAPTCHA Enterprise to the `better-auth` captcha plugin using the Google Cloud Assessments API. Adds token verification with `projectId`, `siteKey`, API key, `minScore`, and optional action matching.

- **New Features**
  - New provider `google-recaptcha-enterprise`; configure with `secretKey` (GCP API key), `projectId`, `siteKey`, and optional `minScore` (default 0.5).
  - Supports `x-captcha-action` header mapped to `expectedAction`; forwards client IP when available; supports `siteVerifyURLOverride`.
  - Extends `CaptchaOptions`, adds verify handler, updates docs, and adds tests (7 new cases).

<sup>Written for commit 036593c6aab17a5cea3ab5f21e5c562825b13dcc. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9719?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

