### PR TITLE
fix(open-api): emit unique operationIds for multi-method endpoints

### DIFF
--- a/.changeset/openapi-multi-method-dedupe.md
+++ b/.changeset/openapi-multi-method-dedupe.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Generated OpenAPI schema is now valid for endpoints that expose multiple HTTP methods, such as `/get-session`. Previously these endpoints emitted duplicate `operationId`s and shared response object references, producing schemas that some OpenAPI validators and client generators rejected.

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -1720,7 +1720,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
       },
       "post": {
         "description": "Get the current session",
-        "operationId": "getSession",
+        "operationId": "getSessionPost",
         "parameters": [],
         "requestBody": {
           "content": {

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -420,17 +420,20 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 	};
 
 	const paths: Record<string, Path> = {};
-	const seenOperationIds = new Map<string, number>();
+	const seenOperationIds = new Set<string>();
 	const uniqueOperationId = (
 		operationId: string | undefined,
 		method: string,
 	) => {
 		if (!operationId) return undefined;
-		const count = seenOperationIds.get(operationId) ?? 0;
-		seenOperationIds.set(operationId, count + 1);
-		return count === 0
-			? operationId
-			: `${operationId}${capitalizeFirstLetter(method.toLowerCase())}`;
+		const base = seenOperationIds.has(operationId)
+			? `${operationId}${capitalizeFirstLetter(method.toLowerCase())}`
+			: operationId;
+		let result = base;
+		let n = 2;
+		while (seenOperationIds.has(result)) result = `${base}${n++}`;
+		seenOperationIds.add(result);
+		return result;
 	};
 
 	Object.entries(baseEndpoints.api).forEach(([_, value]) => {

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -4,6 +4,7 @@ import type {
 	DBFieldAttributeConfig,
 	DBFieldType,
 } from "@better-auth/core/db";
+import { capitalizeFirstLetter } from "@better-auth/core/utils/string";
 import type {
 	Endpoint,
 	EndpointOptions,
@@ -355,7 +356,7 @@ function getResponse(responses?: Record<string, any> | undefined) {
 			description:
 				"Internal Server Error. This is a problem with the server that you cannot fix.",
 		},
-		...responses,
+		...(responses ? structuredClone(responses) : {}),
 	} as any;
 }
 
@@ -419,6 +420,18 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 	};
 
 	const paths: Record<string, Path> = {};
+	const seenOperationIds = new Map<string, number>();
+	const uniqueOperationId = (
+		operationId: string | undefined,
+		method: string,
+	) => {
+		if (!operationId) return undefined;
+		const count = seenOperationIds.get(operationId) ?? 0;
+		seenOperationIds.set(operationId, count + 1);
+		return count === 0
+			? operationId
+			: `${operationId}${capitalizeFirstLetter(method.toLowerCase())}`;
+	};
 
 	Object.entries(baseEndpoints.api).forEach(([_, value]) => {
 		if (!value.path || ctx.options.disabledPaths?.includes(value.path)) return;
@@ -434,7 +447,10 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 				[method.toLowerCase()]: {
 					tags: ["Default", ...(options.metadata?.openapi?.tags || [])],
 					description: options.metadata?.openapi?.description,
-					operationId: options.metadata?.openapi?.operationId,
+					operationId: uniqueOperationId(
+						options.metadata?.openapi?.operationId,
+						method,
+					),
 					security: [
 						{
 							bearerAuth: [],
@@ -454,7 +470,10 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 				[method.toLowerCase()]: {
 					tags: ["Default", ...(options.metadata?.openapi?.tags || [])],
 					description: options.metadata?.openapi?.description,
-					operationId: options.metadata?.openapi?.operationId,
+					operationId: uniqueOperationId(
+						options.metadata?.openapi?.operationId,
+						method,
+					),
 					security: [
 						{
 							bearerAuth: [],
@@ -519,7 +538,10 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 							plugin.id.charAt(0).toUpperCase() + plugin.id.slice(1),
 						],
 						description: options.metadata?.openapi?.description,
-						operationId: options.metadata?.openapi?.operationId,
+						operationId: uniqueOperationId(
+							options.metadata?.openapi?.operationId,
+							method,
+						),
 						security: [
 							{
 								bearerAuth: [],
@@ -540,7 +562,10 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 							plugin.id.charAt(0).toUpperCase() + plugin.id.slice(1),
 						],
 						description: options.metadata?.openapi?.description,
-						operationId: options.metadata?.openapi?.operationId,
+						operationId: uniqueOperationId(
+							options.metadata?.openapi?.operationId,
+							method,
+						),
 						security: [
 							{
 								bearerAuth: [],

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -139,6 +139,45 @@ describe("open-api", async () => {
 		expect(getSessionSchema.nullable).toBe(undefined);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9669
+	 */
+	it("should emit unique operationIds across multi-method endpoints", async () => {
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, any>;
+		const seen = new Set<string>();
+
+		for (const pathItem of Object.values(paths)) {
+			for (const method of ["get", "post", "put", "patch", "delete"]) {
+				const id = pathItem[method]?.operationId;
+				if (!id) continue;
+				expect(seen.has(id)).toBe(false);
+				seen.add(id);
+			}
+		}
+
+		expect(paths["/get-session"].get.operationId).toBe("getSession");
+		expect(paths["/get-session"].post.operationId).toBe("getSessionPost");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9669
+	 */
+	it("should serialize the generated schema without circular response refs", async () => {
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, any>;
+
+		expect(paths["/get-session"].get.responses["200"]).not.toBe(
+			paths["/get-session"].post.responses["200"],
+		);
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/open-api/generate-schema"),
+		);
+		expect(response.status).toBe(200);
+		expect(await response.text()).not.toContain("[Circular ref");
+	});
+
 	it("should use anyOf format for optional object types in OpenAPI 3.1", async () => {
 		const schema = await auth.api.generateOpenAPISchema();
 		const paths = schema.paths as Record<string, any>;


### PR DESCRIPTION
- Closes #9669
- Replaces #9671 by @GautamBytes 