### PR TITLE
docs(redis-storage): fix documentation links

### DIFF
--- a/.changeset/redis-storage-doc-links.md
+++ b/.changeset/redis-storage-doc-links.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/redis-storage": patch
+---
+
+Fix the redis-storage package documentation links to point at the current Redis secondary storage docs.

--- a/.changeset/redis-storage-doc-links.md
+++ b/.changeset/redis-storage-doc-links.md
@@ -1,5 +1,0 @@
----
-"@better-auth/redis-storage": patch
----
-
-Fix the redis-storage package documentation links to point at the current Redis secondary storage docs.

--- a/packages/redis-storage/README.md
+++ b/packages/redis-storage/README.md
@@ -10,7 +10,9 @@ npm install @better-auth/redis-storage
 
 ## Documentation
 
-For full documentation, visit [better-auth.com/docs/storage](https://www.better-auth.com/docs/storage).
+For setup and usage documentation, see [Redis Storage](https://www.better-auth.com/docs/concepts/database#redis-storage).
+
+Redis secondary storage can be used for [session storage](https://www.better-auth.com/docs/concepts/session-management#sessions-in-secondary-storage) and [rate limiting](https://www.better-auth.com/docs/concepts/rate-limit#storage).
 
 ## License
 

--- a/packages/redis-storage/README.md
+++ b/packages/redis-storage/README.md
@@ -12,8 +12,6 @@ npm install @better-auth/redis-storage
 
 For setup and usage documentation, see [Redis Storage](https://www.better-auth.com/docs/concepts/database#redis-storage).
 
-Redis secondary storage can be used for [session storage](https://www.better-auth.com/docs/concepts/session-management#sessions-in-secondary-storage) and [rate limiting](https://www.better-auth.com/docs/concepts/rate-limit#storage).
-
 ## License
 
 MIT

--- a/packages/redis-storage/package.json
+++ b/packages/redis-storage/package.json
@@ -4,7 +4,7 @@
   "description": "Redis storage for Better Auth secondary storage",
   "type": "module",
   "license": "MIT",
-  "homepage": "https://www.better-auth.com/docs/storage",
+  "homepage": "https://www.better-auth.com/docs/concepts/database#redis-storage",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",


### PR DESCRIPTION
## Summary

Fixes #8752 by pointing the Redis storage package README and package homepage at the current Better Auth docs anchors.

## Tests

- pnpm --filter @better-auth/redis-storage build
- pnpm --filter @better-auth/redis-storage lint:package
- pnpm --filter @better-auth/redis-storage lint:types
- pnpm exec cspell packages/redis-storage/README.md .changeset/redis-storage-doc-links.md
- git diff --check

Reviewed by five independent review agents before opening.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `@better-auth/redis-storage` doc links to the Redis Storage anchor so readers land on the correct setup guide. Previously both the README and package homepage pointed to a generic storage page; now they link to `/docs/concepts/database#redis-storage`.

- Changes are limited to the README and `package.json` homepage; no runtime or API changes.
- Removes the changeset; no release will be published.

<sup>Written for commit 16646ee166e41958711713518bdedf5dec9f14bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

