### PR TITLE
feat(scim): add group provisioning endpoints

### DIFF
--- a/.changeset/scim-groups.md
+++ b/.changeset/scim-groups.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": minor
+---
+
+Adds SCIM Group endpoints backed by organization roles, including group discovery metadata, virtual role group membership sync, and user group memberships in SCIM responses.

--- a/packages/scim/src/group-schemas.ts
+++ b/packages/scim/src/group-schemas.ts
@@ -1,0 +1,138 @@
+import * as z from "zod";
+
+const memberSchema = z.object({
+	value: z.string().optional(),
+	$ref: z.string().optional(),
+	display: z.string().optional(),
+	type: z.string().optional(),
+});
+
+export const APIGroupSchema = z.object({
+	externalId: z.string().optional(),
+	displayName: z.string(),
+	members: z.array(memberSchema).optional(),
+});
+
+export const OpenAPIGroupResourceSchema = {
+	type: "object",
+	properties: {
+		id: { type: "string" },
+		externalId: { type: "string" },
+		displayName: { type: "string" },
+		members: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					value: { type: "string" },
+					$ref: { type: "string" },
+					display: { type: "string" },
+				},
+			},
+		},
+		meta: {
+			type: "object",
+			properties: {
+				resourceType: { type: "string" },
+				location: { type: "string" },
+			},
+		},
+		schemas: {
+			type: "array",
+			items: { type: "string" },
+		},
+	},
+} as const;
+
+export const SCIMGroupResourceSchema = {
+	id: "urn:ietf:params:scim:schemas:core:2.0:Group",
+	schemas: ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
+	name: "Group",
+	description: "Group",
+	attributes: [
+		{
+			name: "id",
+			type: "string",
+			multiValued: false,
+			description: "Unique opaque identifier for the Group",
+			required: false,
+			caseExact: true,
+			mutability: "readOnly",
+			returned: "default",
+			uniqueness: "server",
+		},
+		{
+			name: "displayName",
+			type: "string",
+			multiValued: false,
+			description: "A human-readable name for the Group.",
+			required: true,
+			caseExact: false,
+			mutability: "readWrite",
+			returned: "default",
+			uniqueness: "none",
+		},
+		{
+			name: "members",
+			type: "complex",
+			multiValued: true,
+			description: "A list of members of the Group.",
+			required: false,
+			mutability: "readWrite",
+			returned: "default",
+			uniqueness: "none",
+			subAttributes: [
+				{
+					name: "value",
+					type: "string",
+					multiValued: false,
+					description: "Identifier of the member of this Group.",
+					required: false,
+					caseExact: true,
+					mutability: "immutable",
+					returned: "default",
+					uniqueness: "none",
+				},
+				{
+					name: "$ref",
+					type: "reference",
+					multiValued: false,
+					description: "The URI corresponding to a SCIM member resource.",
+					required: false,
+					caseExact: true,
+					mutability: "immutable",
+					returned: "default",
+					uniqueness: "none",
+				},
+				{
+					name: "display",
+					type: "string",
+					multiValued: false,
+					description: "A human-readable name for the member.",
+					required: false,
+					caseExact: false,
+					mutability: "immutable",
+					returned: "default",
+					uniqueness: "none",
+				},
+			],
+		},
+	],
+	meta: {
+		resourceType: "Schema",
+		location: "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group",
+	},
+};
+
+export const SCIMGroupResourceType = {
+	schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+	id: "Group",
+	name: "Group",
+	endpoint: "/Groups",
+	description: "Group",
+	schema: "urn:ietf:params:scim:schemas:core:2.0:Group",
+	meta: {
+		resourceType: "ResourceType",
+		location: "/scim/v2/ResourceTypes/Group",
+	},
+};

--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -1,10 +1,13 @@
 import type { BetterAuthPlugin } from "better-auth";
 import { authMiddlewareFactory } from "./middlewares";
 import {
+	createSCIMGroup,
 	createSCIMUser,
+	deleteSCIMGroup,
 	deleteSCIMProviderConnection,
 	deleteSCIMUser,
 	generateSCIMToken,
+	getSCIMGroup,
 	getSCIMProviderConnection,
 	getSCIMResourceType,
 	getSCIMResourceTypes,
@@ -12,9 +15,12 @@ import {
 	getSCIMSchemas,
 	getSCIMServiceProviderConfig,
 	getSCIMUser,
+	listSCIMGroups,
 	listSCIMProviderConnections,
 	listSCIMUsers,
+	patchSCIMGroup,
 	patchSCIMUser,
+	updateSCIMGroup,
 	updateSCIMUser,
 } from "./routes";
 import type { SCIMOptions } from "./types";
@@ -51,6 +57,12 @@ export const scim = (options?: SCIMOptions) => {
 			deleteSCIMUser: deleteSCIMUser(authMiddleware),
 			updateSCIMUser: updateSCIMUser(authMiddleware),
 			listSCIMUsers: listSCIMUsers(authMiddleware),
+			getSCIMGroup: getSCIMGroup(authMiddleware),
+			createSCIMGroup: createSCIMGroup(authMiddleware, opts),
+			patchSCIMGroup: patchSCIMGroup(authMiddleware),
+			deleteSCIMGroup: deleteSCIMGroup(authMiddleware),
+			updateSCIMGroup: updateSCIMGroup(authMiddleware),
+			listSCIMGroups: listSCIMGroups(authMiddleware),
 			getSCIMServiceProviderConfig,
 			getSCIMSchemas,
 			getSCIMSchema,

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -14,20 +14,36 @@ import {
 import { generateRandomString } from "better-auth/crypto";
 import type { Member } from "better-auth/plugins";
 import * as z from "zod";
+import {
+	APIGroupSchema,
+	OpenAPIGroupResourceSchema,
+	SCIMGroupResourceSchema,
+	SCIMGroupResourceType,
+} from "./group-schemas";
 import { getAccountId, getUserFullName, getUserPrimaryEmail } from "./mappings";
 import type { AuthMiddleware } from "./middlewares";
 import { buildUserPatch } from "./patch-operations";
 import { SCIMAPIError, SCIMErrorOpenAPISchemas } from "./scim-error";
 import type { DBFilter } from "./scim-filters";
-import { parseSCIMUserFilter, SCIMParseError } from "./scim-filters";
+import {
+	parseSCIMGroupFilter,
+	parseSCIMUserFilter,
+	SCIMParseError,
+} from "./scim-filters";
 import {
 	ResourceTypeOpenAPISchema,
 	SCIMSchemaOpenAPISchema,
 	ServiceProviderOpenAPISchema,
 } from "./scim-metadata";
-import { createUserResource } from "./scim-resources";
+import { createGroupResource, createUserResource } from "./scim-resources";
 import { storeSCIMToken } from "./scim-tokens";
-import type { SCIMOptions, SCIMProvider } from "./types";
+import type {
+	SCIMGroup,
+	SCIMGroupMember,
+	SCIMGroupMembership,
+	SCIMOptions,
+	SCIMProvider,
+} from "./types";
 import {
 	APIUserSchema,
 	OpenAPIUserResourceSchema,
@@ -36,8 +52,11 @@ import {
 } from "./user-schemas";
 import { getResourceURL } from "./utils";
 
-const supportedSCIMSchemas = [SCIMUserResourceSchema];
-const supportedSCIMResourceTypes = [SCIMUserResourceType];
+const supportedSCIMSchemas = [SCIMUserResourceSchema, SCIMGroupResourceSchema];
+const supportedSCIMResourceTypes = [
+	SCIMUserResourceType,
+	SCIMGroupResourceType,
+];
 const supportedMediaTypes = ["application/json", "application/scim+json"];
 
 const generateSCIMTokenBodySchema = z.object({
@@ -630,6 +649,7 @@ export const createSCIMUser = (authMiddleware: AuthMiddleware) =>
 				ctx.context.baseURL,
 				user,
 				account,
+				await getUserSCIMGroups(ctx, user.id),
 			);
 
 			ctx.setStatus(201);
@@ -713,6 +733,7 @@ export const updateSCIMUser = (authMiddleware: AuthMiddleware) =>
 				ctx.context.baseURL,
 				updatedUser!,
 				updatedAccount,
+				await getUserSCIMGroups(ctx, updatedUser!.id),
 			);
 
 			return ctx.json(userResource);
@@ -724,6 +745,408 @@ const listSCIMUsersQuerySchema = z
 		filter: z.string().optional(),
 	})
 	.optional();
+
+const listSCIMGroupsQuerySchema = z
+	.object({
+		filter: z.string().optional(),
+		startIndex: z.coerce.number().int().min(1).optional(),
+		count: z.coerce.number().int().min(0).optional(),
+	})
+	.optional();
+
+const patchSCIMGroupBodySchema = z.object({
+	schemas: z
+		.array(z.string())
+		.refine(
+			(s) => s.includes("urn:ietf:params:scim:api:messages:2.0:PatchOp"),
+			{
+				message: "Invalid schemas for PatchOp",
+			},
+		),
+	Operations: z.array(
+		z.object({
+			op: z
+				.string()
+				.toLowerCase()
+				.default("replace")
+				.pipe(z.enum(["replace", "add", "remove"])),
+			path: z.string().optional(),
+			value: z.any(),
+		}),
+	),
+});
+
+function getOrganizationId(ctx: GenericEndpointContext): string {
+	const organizationId = ctx.context.scimProvider.organizationId;
+	if (!organizationId) {
+		throw new SCIMAPIError("BAD_REQUEST", {
+			detail: "SCIM Groups require an organization-scoped token",
+			scimType: "invalidValue",
+		});
+	}
+	return organizationId;
+}
+
+function getGroupIdFromParam(groupId: string) {
+	return decodeURIComponent(groupId);
+}
+
+function normalizeRoleSet(roles: string | string[]): string[] {
+	const roleList = Array.isArray(roles) ? roles : [roles];
+	return Array.from(new Set(roleList.flatMap(parseMemberRoles)));
+}
+
+function serializeRoleSet(roles: string[]): string {
+	return roles.join(",");
+}
+
+function memberHasRoles(member: Member, roles: string[]): boolean {
+	const memberRoles = parseMemberRoles(member.role);
+	return roles.every((role) => memberRoles.includes(role));
+}
+
+function addRolesToMember(member: Member, roles: string[]): string {
+	return serializeRoleSet(
+		Array.from(new Set([...parseMemberRoles(member.role), ...roles])),
+	);
+}
+
+function removeRolesFromMember(member: Member, roles: string[]): string {
+	return serializeRoleSet(
+		parseMemberRoles(member.role).filter((role) => !roles.includes(role)),
+	);
+}
+
+function groupMembershipFromRoles(
+	baseURL: string,
+	roles: string[],
+): SCIMGroupMembership[] {
+	return roles.map((role) => ({
+		value: role,
+		$ref: getResourceURL(
+			`/scim/v2/Groups/${encodeURIComponent(role)}`,
+			baseURL,
+		),
+		display: role,
+	}));
+}
+
+async function resolveGroupRoles(
+	opts: SCIMOptions,
+	group: SCIMGroup,
+): Promise<string[]> {
+	const mappedRoles = opts.mapGroupToRole
+		? await opts.mapGroupToRole(group)
+		: group.displayName;
+	const roles = normalizeRoleSet(mappedRoles);
+	if (roles.length === 0) {
+		throw new SCIMAPIError("BAD_REQUEST", {
+			detail: "Group must map to at least one organization role",
+			scimType: "invalidValue",
+		});
+	}
+	return roles;
+}
+
+async function findSCIMProviderAccounts(ctx: GenericEndpointContext) {
+	return ctx.context.adapter.findMany<Account>({
+		model: "account",
+		where: [
+			{ field: "providerId", value: ctx.context.scimProvider.providerId },
+		],
+	});
+}
+
+async function findSCIMOrganizationMembers(ctx: GenericEndpointContext) {
+	const organizationId = getOrganizationId(ctx);
+	const accounts = await findSCIMProviderAccounts(ctx);
+	const accountUserIds = accounts.map((account) => account.userId);
+
+	if (accountUserIds.length === 0) {
+		return { members: [] as Member[], users: [] as User[] };
+	}
+
+	const [members, users] = await Promise.all([
+		ctx.context.adapter.findMany<Member>({
+			model: "member",
+			where: [
+				{ field: "organizationId", value: organizationId },
+				{ field: "userId", value: accountUserIds, operator: "in" },
+			],
+		}),
+		ctx.context.adapter.findMany<User>({
+			model: "user",
+			where: [{ field: "id", value: accountUserIds, operator: "in" }],
+		}),
+	]);
+
+	return { members, users };
+}
+
+function getUserDisplay(user: User): string {
+	return user.name || user.email || user.id;
+}
+
+function userToMemberRef(user: User, baseURL: string): SCIMGroupMembership {
+	return {
+		value: user.id,
+		$ref: getResourceURL(`/scim/v2/Users/${user.id}`, baseURL),
+		display: getUserDisplay(user),
+	};
+}
+
+async function replaceGroupMembers(
+	ctx: GenericEndpointContext,
+	roles: string[],
+	memberUserIds: Set<string>,
+) {
+	const { members } = await findSCIMOrganizationMembers(ctx);
+	await Promise.all(
+		members.map((member) =>
+			updateMemberRoles(ctx, member.userId, (currentMember) =>
+				memberUserIds.has(member.userId)
+					? addRolesToMember(currentMember, roles)
+					: removeRolesFromMember(currentMember, roles),
+			),
+		),
+	);
+}
+
+async function addGroupRoles(
+	ctx: GenericEndpointContext,
+	roles: string[],
+	users: User[],
+) {
+	await Promise.all(
+		users.map((user) =>
+			updateMemberRoles(ctx, user.id, (member) =>
+				addRolesToMember(member, roles),
+			),
+		),
+	);
+}
+
+async function removeGroupRoles(
+	ctx: GenericEndpointContext,
+	roles: string[],
+	users: User[],
+) {
+	await Promise.all(
+		users.map((user) =>
+			updateMemberRoles(ctx, user.id, (member) =>
+				removeRolesFromMember(member, roles),
+			),
+		),
+	);
+}
+
+function getPatchMemberFromPath(path?: string): SCIMGroupMember | null {
+	if (!path) {
+		return null;
+	}
+
+	const match = path.match(/^members\s*\[\s*value\s+eq\s+"([^"]+)"\s*\]$/i);
+	if (!match) {
+		return null;
+	}
+
+	return { value: match[1] };
+}
+
+function normalizePatchMembers(operation: {
+	op: "replace" | "add" | "remove";
+	path?: string;
+	value: unknown;
+}): { members: SCIMGroupMember[]; removeAll?: boolean } | null {
+	const path = operation.path?.trim();
+	const memberFromPath = getPatchMemberFromPath(path);
+
+	if (memberFromPath) {
+		return { members: [memberFromPath] };
+	}
+
+	if (path && path.toLowerCase() !== "members") {
+		return null;
+	}
+
+	if (operation.value === undefined) {
+		if (operation.op === "remove") {
+			return { members: [], removeAll: true };
+		}
+		throw new SCIMAPIError("BAD_REQUEST", {
+			detail: "Group member patch operation must include a value",
+			scimType: "invalidValue",
+		});
+	}
+
+	if (Array.isArray(operation.value)) {
+		return { members: operation.value as SCIMGroupMember[] };
+	}
+	const value = operation.value as Record<string, unknown> | undefined;
+	if (value?.members && Array.isArray(value.members)) {
+		return { members: value.members as SCIMGroupMember[] };
+	}
+	return { members: [operation.value as SCIMGroupMember] };
+}
+
+function getSCIMMemberValue(member: SCIMGroupMember): string {
+	if (member.type?.toLowerCase() === "group") {
+		throw new SCIMAPIError("BAD_REQUEST", {
+			detail: "Nested SCIM Groups are not supported",
+			scimType: "invalidValue",
+		});
+	}
+
+	if (member.value) {
+		return member.value;
+	}
+
+	if (member.$ref) {
+		if (member.$ref.includes("/Groups/")) {
+			throw new SCIMAPIError("BAD_REQUEST", {
+				detail: "Nested SCIM Groups are not supported",
+				scimType: "invalidValue",
+			});
+		}
+		const userId = member.$ref.match(/\/Users\/([^/?#]+)/)?.[1];
+		if (userId) {
+			return decodeURIComponent(userId);
+		}
+	}
+
+	throw new SCIMAPIError("BAD_REQUEST", {
+		detail: "Group member must reference a SCIM User",
+		scimType: "invalidValue",
+	});
+}
+
+async function resolveSCIMGroupUsers(
+	ctx: GenericEndpointContext,
+	members: SCIMGroupMember[] = [],
+): Promise<User[]> {
+	const users: User[] = [];
+	const seenUserIds = new Set<string>();
+	const organizationId = getOrganizationId(ctx);
+	const providerId = ctx.context.scimProvider.providerId;
+
+	for (const member of members) {
+		const userId = getSCIMMemberValue(member);
+		if (seenUserIds.has(userId)) {
+			continue;
+		}
+		const { user } = await findUserById(ctx.context.adapter, {
+			userId,
+			providerId,
+			organizationId,
+		});
+		if (!user) {
+			throw new SCIMAPIError("BAD_REQUEST", {
+				detail: "Group member target was not found",
+				scimType: "noTarget",
+			});
+		}
+		seenUserIds.add(userId);
+		users.push(user);
+	}
+
+	return users;
+}
+
+async function updateMemberRoles(
+	ctx: GenericEndpointContext,
+	userId: string,
+	updateRole: (member: Member) => string,
+) {
+	const organizationId = getOrganizationId(ctx);
+	const member = await ctx.context.adapter.findOne<Member>({
+		model: "member",
+		where: [
+			{ field: "organizationId", value: organizationId },
+			{ field: "userId", value: userId },
+		],
+	});
+
+	if (!member) {
+		throw new SCIMAPIError("BAD_REQUEST", {
+			detail: "Group member target was not found",
+			scimType: "noTarget",
+		});
+	}
+
+	return ctx.context.adapter.update<Member>({
+		model: "member",
+		where: [{ field: "id", value: member.id }],
+		update: { role: updateRole(member) },
+	});
+}
+
+function getGroupMembers(
+	roles: string[],
+	members: Member[],
+	usersById: Map<string, User>,
+	baseURL: string,
+): SCIMGroupMembership[] {
+	return members
+		.filter((member) => memberHasRoles(member, roles))
+		.map((member) => {
+			const user = usersById.get(member.userId);
+			if (!user) {
+				return null;
+			}
+			return userToMemberRef(user, baseURL);
+		})
+		.filter((member): member is SCIMGroupMembership => Boolean(member));
+}
+
+async function getGroupResource(
+	ctx: GenericEndpointContext,
+	groupId: string,
+	allowEmpty = false,
+) {
+	const roles = normalizeRoleSet(getGroupIdFromParam(groupId));
+	const { members, users } = await findSCIMOrganizationMembers(ctx);
+	const usersById = new Map(users.map((user) => [user.id, user]));
+	const groupMembers = getGroupMembers(
+		roles,
+		members,
+		usersById,
+		ctx.context.baseURL,
+	);
+
+	if (!allowEmpty && groupMembers.length === 0) {
+		throw new SCIMAPIError("NOT_FOUND", {
+			detail: "Group not found",
+		});
+	}
+
+	return createGroupResource(ctx.context.baseURL, {
+		id: serializeRoleSet(roles),
+		members: groupMembers,
+	});
+}
+
+async function getUserSCIMGroups(
+	ctx: GenericEndpointContext,
+	userId: string,
+): Promise<SCIMGroupMembership[] | undefined> {
+	const organizationId = ctx.context.scimProvider.organizationId;
+	if (!organizationId) {
+		return undefined;
+	}
+
+	const member = await ctx.context.adapter.findOne<Member>({
+		model: "member",
+		where: [
+			{ field: "organizationId", value: organizationId },
+			{ field: "userId", value: userId },
+		],
+	});
+
+	return groupMembershipFromRoles(
+		ctx.context.baseURL,
+		parseMemberRoles(member?.role ?? ""),
+	);
+}
 
 export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 	createAuthEndpoint(
@@ -821,6 +1244,24 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 				where: [...userFilters, ...apiFilters],
 			});
 
+			const membersByUserId = new Map<string, Member>();
+			if (organizationId) {
+				const members = await ctx.context.adapter.findMany<Member>({
+					model: "member",
+					where: [
+						{ field: "organizationId", value: organizationId },
+						{
+							field: "userId",
+							value: users.map((user) => user.id),
+							operator: "in",
+						},
+					],
+				});
+				for (const member of members) {
+					membersByUserId.set(member.userId, member);
+				}
+			}
+
 			return ctx.json({
 				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
 				totalResults: users.length,
@@ -828,9 +1269,341 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 				itemsPerPage: users.length,
 				Resources: users.map((user) => {
 					const account = accounts.find((a) => a.userId === user.id);
-					return createUserResource(ctx.context.baseURL, user, account);
+					const member = membersByUserId.get(user.id);
+					return createUserResource(
+						ctx.context.baseURL,
+						user,
+						account,
+						organizationId
+							? groupMembershipFromRoles(
+									ctx.context.baseURL,
+									parseMemberRoles(member?.role ?? ""),
+								)
+							: undefined,
+					);
 				}),
 			});
+		},
+	);
+
+export const listSCIMGroups = (authMiddleware: AuthMiddleware) =>
+	createAuthEndpoint(
+		"/scim/v2/Groups",
+		{
+			method: "GET",
+			query: listSCIMGroupsQuerySchema,
+			metadata: {
+				...HIDE_METADATA,
+				allowedMediaTypes: supportedMediaTypes,
+				openapi: {
+					summary: "List SCIM groups",
+					description:
+						"Returns virtual SCIM groups backed by organization roles.",
+					responses: {
+						"200": {
+							description: "SCIM group list",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											totalResults: { type: "number" },
+											itemsPerPage: { type: "number" },
+											startIndex: { type: "number" },
+											Resources: {
+												type: "array",
+												items: OpenAPIGroupResourceSchema,
+											},
+										},
+									},
+								},
+							},
+						},
+						...SCIMErrorOpenAPISchemas,
+					},
+				},
+			},
+			use: [authMiddleware],
+		},
+		async (ctx) => {
+			const { members, users } = await findSCIMOrganizationMembers(ctx);
+			const usersById = new Map(users.map((user) => [user.id, user]));
+			let roles = Array.from(
+				new Set(members.flatMap((member) => parseMemberRoles(member.role))),
+			).sort((a, b) => a.localeCompare(b));
+
+			if (ctx.query?.filter) {
+				const { value } = parseSCIMAPIGroupFilter(ctx.query.filter);
+				roles = roles.filter((role) => role.toLowerCase() === value);
+			}
+
+			const totalResults = roles.length;
+			const startIndex = ctx.query?.startIndex ?? 1;
+			const count = ctx.query?.count ?? totalResults;
+			const paginatedRoles = roles.slice(
+				startIndex - 1,
+				startIndex - 1 + count,
+			);
+
+			const baseURL = ctx.context.baseURL;
+			const Resources = paginatedRoles.map((role) => {
+				const resolvedRoles = normalizeRoleSet(getGroupIdFromParam(role));
+				const groupMembers = getGroupMembers(
+					resolvedRoles,
+					members,
+					usersById,
+					baseURL,
+				);
+				return createGroupResource(baseURL, {
+					id: serializeRoleSet(resolvedRoles),
+					members: groupMembers,
+				});
+			});
+
+			return ctx.json({
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+				totalResults,
+				startIndex,
+				itemsPerPage: Resources.length,
+				Resources,
+			});
+		},
+	);
+
+export const getSCIMGroup = (authMiddleware: AuthMiddleware) =>
+	createAuthEndpoint(
+		"/scim/v2/Groups/:groupId",
+		{
+			method: "GET",
+			metadata: {
+				...HIDE_METADATA,
+				allowedMediaTypes: supportedMediaTypes,
+				openapi: {
+					summary: "Get SCIM group details",
+					description:
+						"Returns a virtual SCIM group backed by an organization role.",
+					responses: {
+						"200": {
+							description: "SCIM group resource",
+							content: {
+								"application/json": {
+									schema: OpenAPIGroupResourceSchema,
+								},
+							},
+						},
+						...SCIMErrorOpenAPISchemas,
+					},
+				},
+			},
+			use: [authMiddleware],
+		},
+		async (ctx) => {
+			return ctx.json(await getGroupResource(ctx, ctx.params.groupId));
+		},
+	);
+
+export const createSCIMGroup = (
+	authMiddleware: AuthMiddleware,
+	opts: SCIMOptions,
+) =>
+	createAuthEndpoint(
+		"/scim/v2/Groups",
+		{
+			method: "POST",
+			body: APIGroupSchema,
+			metadata: {
+				...HIDE_METADATA,
+				allowedMediaTypes: supportedMediaTypes,
+				openapi: {
+					summary: "Create SCIM group",
+					description:
+						"Creates a virtual SCIM group by applying mapped organization role(s) to SCIM users.",
+					responses: {
+						"201": {
+							description: "SCIM group resource",
+							content: {
+								"application/json": {
+									schema: OpenAPIGroupResourceSchema,
+								},
+							},
+						},
+						...SCIMErrorOpenAPISchemas,
+					},
+				},
+			},
+			use: [authMiddleware],
+		},
+		async (ctx) => {
+			getOrganizationId(ctx);
+			const roles = await resolveGroupRoles(opts, ctx.body);
+			const groupId = serializeRoleSet(roles);
+
+			const { members } = await findSCIMOrganizationMembers(ctx);
+			if (members.some((member) => memberHasRoles(member, roles))) {
+				throw new SCIMAPIError("CONFLICT", {
+					detail: "Group already exists",
+					scimType: "uniqueness",
+				});
+			}
+
+			const users = await resolveSCIMGroupUsers(ctx, ctx.body.members);
+			await Promise.all(
+				users.map((user) =>
+					updateMemberRoles(ctx, user.id, (member) =>
+						addRolesToMember(member, roles),
+					),
+				),
+			);
+
+			const groupResource = createGroupResource(ctx.context.baseURL, {
+				id: groupId,
+				externalId: ctx.body.externalId,
+				displayName: ctx.body.displayName,
+				members: users.map((user) =>
+					userToMemberRef(user, ctx.context.baseURL),
+				),
+			});
+
+			ctx.setStatus(201);
+			ctx.setHeader("location", groupResource.meta.location);
+			return ctx.json(groupResource);
+		},
+	);
+
+export const updateSCIMGroup = (authMiddleware: AuthMiddleware) =>
+	createAuthEndpoint(
+		"/scim/v2/Groups/:groupId",
+		{
+			method: "PUT",
+			body: APIGroupSchema,
+			metadata: {
+				...HIDE_METADATA,
+				allowedMediaTypes: supportedMediaTypes,
+				openapi: {
+					summary: "Update SCIM group",
+					description:
+						"Replaces membership for a virtual SCIM group while preserving unrelated roles.",
+					responses: {
+						"200": {
+							description: "SCIM group resource",
+							content: {
+								"application/json": {
+									schema: OpenAPIGroupResourceSchema,
+								},
+							},
+						},
+						...SCIMErrorOpenAPISchemas,
+					},
+				},
+			},
+			use: [authMiddleware],
+		},
+		async (ctx) => {
+			const roles = normalizeRoleSet(getGroupIdFromParam(ctx.params.groupId));
+			const users = await resolveSCIMGroupUsers(ctx, ctx.body.members);
+			const nextUserIds = new Set(users.map((user) => user.id));
+
+			await replaceGroupMembers(ctx, roles, nextUserIds);
+
+			return ctx.json(await getGroupResource(ctx, ctx.params.groupId, true));
+		},
+	);
+
+export const patchSCIMGroup = (authMiddleware: AuthMiddleware) =>
+	createAuthEndpoint(
+		"/scim/v2/Groups/:groupId",
+		{
+			method: "PATCH",
+			body: patchSCIMGroupBodySchema,
+			metadata: {
+				...HIDE_METADATA,
+				allowedMediaTypes: supportedMediaTypes,
+				openapi: {
+					summary: "Patch SCIM group",
+					description:
+						"Adds, removes, or replaces members of a virtual SCIM group.",
+					responses: {
+						"200": {
+							description: "SCIM group resource",
+							content: {
+								"application/json": {
+									schema: OpenAPIGroupResourceSchema,
+								},
+							},
+						},
+						...SCIMErrorOpenAPISchemas,
+					},
+				},
+			},
+			use: [authMiddleware],
+		},
+		async (ctx) => {
+			const roles = normalizeRoleSet(getGroupIdFromParam(ctx.params.groupId));
+
+			for (const operation of ctx.body.Operations) {
+				const patchMembers = normalizePatchMembers(operation);
+				if (!patchMembers) {
+					continue;
+				}
+
+				const users = await resolveSCIMGroupUsers(ctx, patchMembers.members);
+				const userIds = new Set(users.map((user) => user.id));
+
+				if (operation.op === "replace") {
+					await replaceGroupMembers(ctx, roles, userIds);
+				} else if (operation.op === "add") {
+					await addGroupRoles(ctx, roles, users);
+				} else if (operation.op === "remove") {
+					if (patchMembers.removeAll) {
+						await replaceGroupMembers(ctx, roles, new Set());
+					} else {
+						await removeGroupRoles(ctx, roles, users);
+					}
+				}
+			}
+
+			return ctx.json(await getGroupResource(ctx, ctx.params.groupId, true));
+		},
+	);
+
+export const deleteSCIMGroup = (authMiddleware: AuthMiddleware) =>
+	createAuthEndpoint(
+		"/scim/v2/Groups/:groupId",
+		{
+			method: "DELETE",
+			metadata: {
+				...HIDE_METADATA,
+				allowedMediaTypes: [...supportedMediaTypes, ""],
+				openapi: {
+					summary: "Delete SCIM group",
+					description:
+						"Removes mapped organization role(s) from all members without deleting organization memberships.",
+					responses: {
+						"204": {
+							description: "Delete applied successfully",
+						},
+						...SCIMErrorOpenAPISchemas,
+					},
+				},
+			},
+			use: [authMiddleware],
+		},
+		async (ctx) => {
+			const roles = normalizeRoleSet(getGroupIdFromParam(ctx.params.groupId));
+			const { members } = await findSCIMOrganizationMembers(ctx);
+
+			await Promise.all(
+				members
+					.filter((member) => memberHasRoles(member, roles))
+					.map((member) =>
+						updateMemberRoles(ctx, member.userId, (currentMember) =>
+							removeRolesFromMember(currentMember, roles),
+						),
+					),
+			);
+
+			ctx.setStatus(204);
+			return;
 		},
 	);
 
@@ -878,7 +1651,14 @@ export const getSCIMUser = (authMiddleware: AuthMiddleware) =>
 				});
 			}
 
-			return ctx.json(createUserResource(ctx.context.baseURL, user, account));
+			return ctx.json(
+				createUserResource(
+					ctx.context.baseURL,
+					user,
+					account,
+					await getUserSCIMGroups(ctx, user.id),
+				),
+			);
 		},
 	);
 
@@ -1338,4 +2118,16 @@ const parseSCIMAPIUserFilter = (filter?: string) => {
 	}
 
 	return filters;
+};
+
+const parseSCIMAPIGroupFilter = (filter: string) => {
+	try {
+		return parseSCIMGroupFilter(filter);
+	} catch (error) {
+		throw new SCIMAPIError("BAD_REQUEST", {
+			detail:
+				error instanceof SCIMParseError ? error.message : "Invalid SCIM filter",
+			scimType: "invalidFilter",
+		});
+	}
 };

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -771,7 +771,7 @@ const patchSCIMGroupBodySchema = z.object({
 				.default("replace")
 				.pipe(z.enum(["replace", "add", "remove"])),
 			path: z.string().optional(),
-			value: z.any(),
+			value: z.any().optional(),
 		}),
 	),
 });
@@ -791,9 +791,30 @@ function getGroupIdFromParam(groupId: string) {
 	return decodeURIComponent(groupId);
 }
 
-function normalizeRoleSet(roles: string | string[]): string[] {
+function validateRoleName(role: string): string {
+	const trimmedRole = role.trim();
+	if (!trimmedRole) {
+		return "";
+	}
+	if (trimmedRole.includes(",")) {
+		throw new SCIMAPIError("BAD_REQUEST", {
+			detail:
+				'SCIM Group role names cannot contain ",". Return multiple roles as an array from mapGroupToRole.',
+			scimType: "invalidValue",
+		});
+	}
+	return trimmedRole;
+}
+
+function normalizeRoleSet(
+	roles: string | string[],
+	options: { splitComma?: boolean } = {},
+): string[] {
 	const roleList = Array.isArray(roles) ? roles : [roles];
-	return Array.from(new Set(roleList.flatMap(parseMemberRoles)));
+	const normalizedRoles = roleList.flatMap((role) =>
+		options.splitComma ? parseMemberRoles(role) : [validateRoleName(role)],
+	);
+	return Array.from(new Set(normalizedRoles.filter(Boolean)));
 }
 
 function serializeRoleSet(roles: string[]): string {
@@ -903,7 +924,7 @@ async function replaceGroupMembers(
 	const { members } = await findSCIMOrganizationMembers(ctx);
 	await Promise.all(
 		members.map((member) =>
-			updateMemberRoles(ctx, member.userId, (currentMember) =>
+			updateExistingMemberRoles(ctx, member, (currentMember) =>
 				memberUserIds.has(member.userId)
 					? addRolesToMember(currentMember, roles)
 					: removeRolesFromMember(currentMember, roles),
@@ -917,12 +938,20 @@ async function addGroupRoles(
 	roles: string[],
 	users: User[],
 ) {
+	const membersByUserId = await findOrganizationMembersByUserIds(
+		ctx,
+		users.map((user) => user.id),
+	);
 	await Promise.all(
-		users.map((user) =>
-			updateMemberRoles(ctx, user.id, (member) =>
-				addRolesToMember(member, roles),
-			),
-		),
+		users.map((user) => {
+			const member = membersByUserId.get(user.id);
+			if (!member) {
+				throwGroupMemberNotFound();
+			}
+			return updateExistingMemberRoles(ctx, member, (currentMember) =>
+				addRolesToMember(currentMember, roles),
+			);
+		}),
 	);
 }
 
@@ -931,12 +960,20 @@ async function removeGroupRoles(
 	roles: string[],
 	users: User[],
 ) {
+	const membersByUserId = await findOrganizationMembersByUserIds(
+		ctx,
+		users.map((user) => user.id),
+	);
 	await Promise.all(
-		users.map((user) =>
-			updateMemberRoles(ctx, user.id, (member) =>
-				removeRolesFromMember(member, roles),
-			),
-		),
+		users.map((user) => {
+			const member = membersByUserId.get(user.id);
+			if (!member) {
+				throwGroupMemberNotFound();
+			}
+			return updateExistingMemberRoles(ctx, member, (currentMember) =>
+				removeRolesFromMember(currentMember, roles),
+			);
+		}),
 	);
 }
 
@@ -956,7 +993,7 @@ function getPatchMemberFromPath(path?: string): SCIMGroupMember | null {
 function normalizePatchMembers(operation: {
 	op: "replace" | "add" | "remove";
 	path?: string;
-	value: unknown;
+	value?: unknown;
 }): { members: SCIMGroupMember[]; removeAll?: boolean } | null {
 	const path = operation.path?.trim();
 	const memberFromPath = getPatchMemberFromPath(path);
@@ -1024,59 +1061,93 @@ async function resolveSCIMGroupUsers(
 	ctx: GenericEndpointContext,
 	members: SCIMGroupMember[] = [],
 ): Promise<User[]> {
-	const users: User[] = [];
-	const seenUserIds = new Set<string>();
 	const organizationId = getOrganizationId(ctx);
 	const providerId = ctx.context.scimProvider.providerId;
+	const userIds = Array.from(
+		new Set(members.map((member) => getSCIMMemberValue(member))),
+	);
 
-	for (const member of members) {
-		const userId = getSCIMMemberValue(member);
-		if (seenUserIds.has(userId)) {
-			continue;
-		}
-		const { user } = await findUserById(ctx.context.adapter, {
-			userId,
-			providerId,
-			organizationId,
-		});
-		if (!user) {
-			throw new SCIMAPIError("BAD_REQUEST", {
-				detail: "Group member target was not found",
-				scimType: "noTarget",
-			});
-		}
-		seenUserIds.add(userId);
-		users.push(user);
+	if (userIds.length === 0) {
+		return [];
 	}
 
-	return users;
+	const [accounts, organizationMembers, users] = await Promise.all([
+		ctx.context.adapter.findMany<Account>({
+			model: "account",
+			where: [
+				{ field: "providerId", value: providerId },
+				{ field: "userId", value: userIds, operator: "in" },
+			],
+		}),
+		ctx.context.adapter.findMany<Member>({
+			model: "member",
+			where: [
+				{ field: "organizationId", value: organizationId },
+				{ field: "userId", value: userIds, operator: "in" },
+			],
+		}),
+		ctx.context.adapter.findMany<User>({
+			model: "user",
+			where: [{ field: "id", value: userIds, operator: "in" }],
+		}),
+	]);
+
+	const accountUserIds = new Set(accounts.map((account) => account.userId));
+	const memberUserIds = new Set(
+		organizationMembers.map((member) => member.userId),
+	);
+	const usersById = new Map(users.map((user) => [user.id, user]));
+
+	return userIds.map((userId) => {
+		const user = usersById.get(userId);
+		if (!accountUserIds.has(userId) || !memberUserIds.has(userId) || !user) {
+			throwGroupMemberNotFound();
+		}
+		return user;
+	});
 }
 
-async function updateMemberRoles(
+function throwGroupMemberNotFound(): never {
+	throw new SCIMAPIError("BAD_REQUEST", {
+		detail: "Group member target was not found",
+		scimType: "noTarget",
+	});
+}
+
+async function findOrganizationMembersByUserIds(
 	ctx: GenericEndpointContext,
-	userId: string,
-	updateRole: (member: Member) => string,
-) {
+	userIds: string[],
+): Promise<Map<string, Member>> {
+	if (userIds.length === 0) {
+		return new Map();
+	}
+
 	const organizationId = getOrganizationId(ctx);
-	const member = await ctx.context.adapter.findOne<Member>({
+	const members = await ctx.context.adapter.findMany<Member>({
 		model: "member",
 		where: [
 			{ field: "organizationId", value: organizationId },
-			{ field: "userId", value: userId },
+			{ field: "userId", value: userIds, operator: "in" },
 		],
 	});
 
-	if (!member) {
-		throw new SCIMAPIError("BAD_REQUEST", {
-			detail: "Group member target was not found",
-			scimType: "noTarget",
-		});
+	return new Map(members.map((member) => [member.userId, member]));
+}
+
+async function updateExistingMemberRoles(
+	ctx: GenericEndpointContext,
+	member: Member,
+	updateRole: (member: Member) => string,
+) {
+	const role = updateRole(member);
+	if (role === member.role) {
+		return member;
 	}
 
 	return ctx.context.adapter.update<Member>({
 		model: "member",
 		where: [{ field: "id", value: member.id }],
-		update: { role: updateRole(member) },
+		update: { role },
 	});
 }
 
@@ -1101,9 +1172,11 @@ function getGroupMembers(
 async function getGroupResource(
 	ctx: GenericEndpointContext,
 	groupId: string,
-	allowEmpty = false,
+	allowEmpty = true,
 ) {
-	const roles = normalizeRoleSet(getGroupIdFromParam(groupId));
+	const roles = normalizeRoleSet(getGroupIdFromParam(groupId), {
+		splitComma: true,
+	});
 	const { members, users } = await findSCIMOrganizationMembers(ctx);
 	const usersById = new Map(users.map((user) => [user.id, user]));
 	const groupMembers = getGroupMembers(
@@ -1347,7 +1420,9 @@ export const listSCIMGroups = (authMiddleware: AuthMiddleware) =>
 
 			const baseURL = ctx.context.baseURL;
 			const Resources = paginatedRoles.map((role) => {
-				const resolvedRoles = normalizeRoleSet(getGroupIdFromParam(role));
+				const resolvedRoles = normalizeRoleSet(getGroupIdFromParam(role), {
+					splitComma: true,
+				});
 				const groupMembers = getGroupMembers(
 					resolvedRoles,
 					members,
@@ -1447,13 +1522,7 @@ export const createSCIMGroup = (
 			}
 
 			const users = await resolveSCIMGroupUsers(ctx, ctx.body.members);
-			await Promise.all(
-				users.map((user) =>
-					updateMemberRoles(ctx, user.id, (member) =>
-						addRolesToMember(member, roles),
-					),
-				),
-			);
+			await addGroupRoles(ctx, roles, users);
 
 			const groupResource = createGroupResource(ctx.context.baseURL, {
 				id: groupId,
@@ -1499,7 +1568,9 @@ export const updateSCIMGroup = (authMiddleware: AuthMiddleware) =>
 			use: [authMiddleware],
 		},
 		async (ctx) => {
-			const roles = normalizeRoleSet(getGroupIdFromParam(ctx.params.groupId));
+			const roles = normalizeRoleSet(getGroupIdFromParam(ctx.params.groupId), {
+				splitComma: true,
+			});
 			const users = await resolveSCIMGroupUsers(ctx, ctx.body.members);
 			const nextUserIds = new Set(users.map((user) => user.id));
 
@@ -1538,7 +1609,9 @@ export const patchSCIMGroup = (authMiddleware: AuthMiddleware) =>
 			use: [authMiddleware],
 		},
 		async (ctx) => {
-			const roles = normalizeRoleSet(getGroupIdFromParam(ctx.params.groupId));
+			const roles = normalizeRoleSet(getGroupIdFromParam(ctx.params.groupId), {
+				splitComma: true,
+			});
 
 			for (const operation of ctx.body.Operations) {
 				const patchMembers = normalizePatchMembers(operation);
@@ -1589,14 +1662,16 @@ export const deleteSCIMGroup = (authMiddleware: AuthMiddleware) =>
 			use: [authMiddleware],
 		},
 		async (ctx) => {
-			const roles = normalizeRoleSet(getGroupIdFromParam(ctx.params.groupId));
+			const roles = normalizeRoleSet(getGroupIdFromParam(ctx.params.groupId), {
+				splitComma: true,
+			});
 			const { members } = await findSCIMOrganizationMembers(ctx);
 
 			await Promise.all(
 				members
 					.filter((member) => memberHasRoles(member, roles))
 					.map((member) =>
-						updateMemberRoles(ctx, member.userId, (currentMember) =>
+						updateExistingMemberRoles(ctx, member, (currentMember) =>
 							removeRolesFromMember(currentMember, roles),
 						),
 					),
@@ -2122,7 +2197,13 @@ const parseSCIMAPIUserFilter = (filter?: string) => {
 
 const parseSCIMAPIGroupFilter = (filter: string) => {
 	try {
-		return parseSCIMGroupFilter(filter);
+		const parsedFilter = parseSCIMGroupFilter(filter);
+		if (parsedFilter.operator !== "eq") {
+			throw new SCIMParseError(
+				`The operator "${parsedFilter.operator}" is not supported`,
+			);
+		}
+		return parsedFilter;
 	} catch (error) {
 		throw new SCIMAPIError("BAD_REQUEST", {
 			detail:

--- a/packages/scim/src/scim-error.ts
+++ b/packages/scim/src/scim-error.ts
@@ -78,6 +78,15 @@ export const SCIMErrorOpenAPISchemas = {
 			},
 		},
 	},
+	"409": {
+		description:
+			"Conflict. The requested resource conflicts with an existing resource.",
+		content: {
+			"application/json": {
+				schema: SCIMErrorOpenAPISchema,
+			},
+		},
+	},
 	"429": {
 		description:
 			"Too Many Requests. You have exceeded the rate limit. Try again later.",

--- a/packages/scim/src/scim-filters.ts
+++ b/packages/scim/src/scim-filters.ts
@@ -46,6 +46,13 @@ const parseSCIMFilter = (filter: string) => {
 	return { attribute, operator, value };
 };
 
+const unquoteFilterValue = (value: string) => {
+	if (value.startsWith('"') && value.endsWith('"')) {
+		return value.slice(1, -1);
+	}
+	return value;
+};
+
 export const parseSCIMUserFilter = (filter: string) => {
 	const { attribute, operator, value } = parseSCIMFilter(filter);
 
@@ -59,7 +66,7 @@ export const parseSCIMUserFilter = (filter: string) => {
 		throw new SCIMParseError(`The attribute "${attribute}" is not supported`);
 	}
 
-	let finalValue = value.replaceAll('"', "");
+	let finalValue = unquoteFilterValue(value);
 	if (!resourceAttribute.caseExact) {
 		finalValue = finalValue.toLowerCase();
 	}
@@ -85,7 +92,7 @@ export const parseSCIMGroupFilter = (filter: string) => {
 		throw new SCIMParseError(`The attribute "${attribute}" is not supported`);
 	}
 
-	let finalValue = value.replaceAll('"', "");
+	let finalValue = unquoteFilterValue(value);
 	if (!resourceAttribute.caseExact) {
 		finalValue = finalValue.toLowerCase();
 	}

--- a/packages/scim/src/scim-filters.ts
+++ b/packages/scim/src/scim-filters.ts
@@ -1,3 +1,4 @@
+import { SCIMGroupResourceSchema } from "./group-schemas";
 import { SCIMUserResourceSchema } from "./user-schemas";
 
 export type DBFilter = {
@@ -12,6 +13,10 @@ const SCIMOperators: Record<string, string | undefined> = {
 
 const SCIMUserAttributes: Record<string, string | undefined> = {
 	userName: "email",
+};
+
+const SCIMGroupAttributes: Record<string, string | undefined> = {
+	displayName: "displayName",
 };
 
 export class SCIMParseError extends Error {}
@@ -66,4 +71,28 @@ export const parseSCIMUserFilter = (filter: string) => {
 	});
 
 	return filters;
+};
+
+export const parseSCIMGroupFilter = (filter: string) => {
+	const { attribute, operator, value } = parseSCIMFilter(filter);
+
+	const targetAttribute = SCIMGroupAttributes[attribute];
+	const resourceAttribute = SCIMGroupResourceSchema.attributes.find(
+		(attr) => attr.name === attribute,
+	);
+
+	if (!targetAttribute || !resourceAttribute) {
+		throw new SCIMParseError(`The attribute "${attribute}" is not supported`);
+	}
+
+	let finalValue = value.replaceAll('"', "");
+	if (!resourceAttribute.caseExact) {
+		finalValue = finalValue.toLowerCase();
+	}
+
+	return {
+		field: targetAttribute,
+		value: finalValue,
+		operator,
+	};
 };

--- a/packages/scim/src/scim-groups.test.ts
+++ b/packages/scim/src/scim-groups.test.ts
@@ -219,6 +219,14 @@ describe("SCIM Groups", () => {
 			itemsPerPage: 1,
 			Resources: [expect.objectContaining({ id: "member" })],
 		});
+		await expect(
+			auth.api.listSCIMGroups({
+				query: { filter: 'displayName ne "member"' },
+				headers: headers(scimToken),
+			}),
+		).rejects.toMatchObject({
+			body: { status: "400", scimType: "invalidFilter" },
+		});
 	});
 
 	it("should include role groups on user resources", async () => {
@@ -359,7 +367,6 @@ describe("SCIM Groups", () => {
 					{
 						op: "remove",
 						path: `members[value eq "${userA.id}"]`,
-						value: undefined,
 					},
 				],
 			},
@@ -369,8 +376,12 @@ describe("SCIM Groups", () => {
 			params: { groupId: "admin" },
 			body: {
 				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-				Operations: [{ op: "remove", path: "members", value: undefined }],
+				Operations: [{ op: "remove", path: "members" }],
 			},
+			headers: headers(scimToken),
+		});
+		const emptyGroup = await auth.api.getSCIMGroup({
+			params: { groupId: "admin" },
 			headers: headers(scimToken),
 		});
 
@@ -378,6 +389,7 @@ describe("SCIM Groups", () => {
 			expect.objectContaining({ value: userB.id }),
 		]);
 		expect(removeAll.members).toEqual([]);
+		expect(emptyGroup.members).toEqual([]);
 	});
 
 	it("should delete only the mapped role and keep org membership", async () => {
@@ -455,6 +467,11 @@ describe("SCIM Groups", () => {
 
 		await expect(createGroup(orgAToken, "admin", [])).rejects.toMatchObject({
 			body: { status: "409", scimType: "uniqueness" },
+		});
+		await expect(
+			createGroup(orgAToken, "admin,editor", [{ value: userA.id }]),
+		).rejects.toMatchObject({
+			body: { status: "400", scimType: "invalidValue" },
 		});
 		await expect(
 			createGroup(orgAToken, "nested", [{ value: "admin", type: "Group" }]),

--- a/packages/scim/src/scim-groups.test.ts
+++ b/packages/scim/src/scim-groups.test.ts
@@ -1,0 +1,484 @@
+import { sso } from "@better-auth/sso";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { createAuthClient } from "better-auth/client";
+import { setCookieToHeader } from "better-auth/cookies";
+import { bearer, organization } from "better-auth/plugins";
+import { describe, expect, it } from "vitest";
+import { scim } from ".";
+import { scimClient } from "./client";
+import type { SCIMOptions } from "./types";
+
+const createTestInstance = (scimOptions?: SCIMOptions) => {
+	const testUser = {
+		email: "test@email.com",
+		password: "password",
+		name: "Test User",
+	};
+	let orgCount = 0;
+
+	const data = {
+		user: [] as any[],
+		session: [] as any[],
+		verification: [] as any[],
+		account: [] as any[],
+		ssoProvider: [] as any[],
+		scimProvider: [] as any[],
+		organization: [] as any[],
+		member: [] as any[],
+	};
+	const memory = memoryAdapter(data);
+
+	const auth = betterAuth({
+		database: memory,
+		baseURL: "http://localhost:3000",
+		emailAndPassword: {
+			enabled: true,
+		},
+		plugins: [sso(), scim(scimOptions), organization()],
+	});
+
+	const authClient = createAuthClient({
+		baseURL: "http://localhost:3000",
+		plugins: [bearer(), scimClient()],
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+
+	async function getAuthCookieHeaders() {
+		const headers = new Headers();
+
+		await authClient.signUp.email(testUser);
+		await authClient.signIn.email(testUser, {
+			throw: true,
+			onSuccess: setCookieToHeader(headers),
+		});
+
+		return headers;
+	}
+
+	async function registerOrganization() {
+		const headers = await getAuthCookieHeaders();
+		orgCount += 1;
+		return auth.api.createOrganization({
+			body: {
+				slug: `the-org-${orgCount}`,
+				name: `The Organization ${orgCount}`,
+			},
+			headers,
+		});
+	}
+
+	async function getSCIMToken(
+		providerId: string = "the-saml-provider-1",
+		organizationId?: string,
+	) {
+		const headers = await getAuthCookieHeaders();
+		const { scimToken } = await auth.api.generateSCIMToken({
+			body: {
+				providerId,
+				organizationId,
+			},
+			headers,
+		});
+
+		return scimToken;
+	}
+
+	async function getOrganizationSCIMToken(providerId = "the-saml-provider-1") {
+		const organization = await registerOrganization();
+		const scimToken = await getSCIMToken(providerId, organization?.id);
+		return { organization, scimToken };
+	}
+
+	const headers = (scimToken: string) => ({
+		authorization: `Bearer ${scimToken}`,
+	});
+
+	const createUser = (scimToken: string, userName: string) =>
+		auth.api.createSCIMUser({
+			body: { userName },
+			headers: headers(scimToken),
+		});
+
+	const createGroup = (
+		scimToken: string,
+		displayName: string,
+		members: { value: string; type?: string }[] = [],
+	) =>
+		auth.api.createSCIMGroup({
+			body: { displayName, members },
+			headers: headers(scimToken),
+		});
+
+	return {
+		auth,
+		data,
+		headers,
+		createUser,
+		createGroup,
+		getSCIMToken,
+		getOrganizationSCIMToken,
+	};
+};
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9708
+ */
+describe("SCIM Groups", () => {
+	it("should expose Group schema and resource type metadata", async () => {
+		const { auth } = createTestInstance();
+
+		const [schemas, resourceTypes] = await Promise.all([
+			auth.api.getSCIMSchemas(),
+			auth.api.getSCIMResourceTypes(),
+		]);
+
+		expect(schemas.Resources.map((schema) => schema.id)).toContain(
+			"urn:ietf:params:scim:schemas:core:2.0:Group",
+		);
+		expect(resourceTypes.Resources).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "Group",
+					endpoint: "/Groups",
+					schema: "urn:ietf:params:scim:schemas:core:2.0:Group",
+				}),
+			]),
+		);
+	});
+
+	it("should create, list, and get virtual role groups", async () => {
+		const { auth, headers, createUser, createGroup, getOrganizationSCIMToken } =
+			createTestInstance();
+		const { scimToken } = await getOrganizationSCIMToken();
+		const [userA, userB] = await Promise.all([
+			createUser(scimToken, "user-a"),
+			createUser(scimToken, "user-b"),
+		]);
+
+		const group = await createGroup(scimToken, "admin", [
+			{ value: userA.id },
+			{ value: userB.id },
+		]);
+		const listedGroups = await auth.api.listSCIMGroups({
+			headers: headers(scimToken),
+		});
+		const retrievedGroup = await auth.api.getSCIMGroup({
+			params: { groupId: "admin" },
+			headers: headers(scimToken),
+		});
+
+		expect(group).toMatchObject({
+			id: "admin",
+			displayName: "admin",
+			members: [
+				expect.objectContaining({ value: userA.id }),
+				expect.objectContaining({ value: userB.id }),
+			],
+		});
+		expect(listedGroups).toMatchObject({
+			totalResults: 2,
+			itemsPerPage: 2,
+			startIndex: 1,
+		});
+		expect(listedGroups.Resources).toEqual(
+			expect.arrayContaining([
+				retrievedGroup,
+				expect.objectContaining({ id: "member" }),
+			]),
+		);
+	});
+
+	it("should filter and paginate virtual groups", async () => {
+		const { auth, headers, createUser, createGroup, getOrganizationSCIMToken } =
+			createTestInstance();
+		const { scimToken } = await getOrganizationSCIMToken();
+		const user = await createUser(scimToken, "user-a");
+		await createGroup(scimToken, "admin", [{ value: user.id }]);
+
+		const filtered = await auth.api.listSCIMGroups({
+			query: { filter: 'displayName eq "member"' },
+			headers: headers(scimToken),
+		});
+		const paginated = await auth.api.listSCIMGroups({
+			query: { startIndex: 2, count: 1 },
+			headers: headers(scimToken),
+		});
+
+		expect(filtered).toMatchObject({
+			totalResults: 1,
+			Resources: [expect.objectContaining({ id: "member" })],
+		});
+		expect(paginated).toMatchObject({
+			totalResults: 2,
+			startIndex: 2,
+			itemsPerPage: 1,
+			Resources: [expect.objectContaining({ id: "member" })],
+		});
+	});
+
+	it("should include role groups on user resources", async () => {
+		const { auth, headers, createUser, createGroup, getOrganizationSCIMToken } =
+			createTestInstance();
+		const { scimToken } = await getOrganizationSCIMToken();
+		const user = await createUser(scimToken, "user-a");
+		await createGroup(scimToken, "admin", [{ value: user.id }]);
+
+		const [retrievedUser, listedUsers] = await Promise.all([
+			auth.api.getSCIMUser({
+				params: { userId: user.id },
+				headers: headers(scimToken),
+			}),
+			auth.api.listSCIMUsers({
+				headers: headers(scimToken),
+			}),
+		]);
+
+		expect(retrievedUser.groups).toEqual([
+			expect.objectContaining({ value: "member" }),
+			expect.objectContaining({ value: "admin" }),
+		]);
+		expect(listedUsers.Resources[0]?.groups).toEqual(retrievedUser.groups);
+	});
+
+	it("should replace group membership while preserving unrelated roles", async () => {
+		const { auth, headers, createUser, createGroup, getOrganizationSCIMToken } =
+			createTestInstance();
+		const { scimToken } = await getOrganizationSCIMToken();
+		const [userA, userB] = await Promise.all([
+			createUser(scimToken, "user-a"),
+			createUser(scimToken, "user-b"),
+		]);
+		await createGroup(scimToken, "admin", [{ value: userA.id }]);
+
+		const updatedGroup = await auth.api.updateSCIMGroup({
+			params: { groupId: "admin" },
+			body: {
+				displayName: "admin",
+				members: [{ value: userB.id }],
+			},
+			headers: headers(scimToken),
+		});
+		const [userAfterReplace, promotedUser] = await Promise.all([
+			auth.api.getSCIMUser({
+				params: { userId: userA.id },
+				headers: headers(scimToken),
+			}),
+			auth.api.getSCIMUser({
+				params: { userId: userB.id },
+				headers: headers(scimToken),
+			}),
+		]);
+
+		expect(updatedGroup.members).toEqual([
+			expect.objectContaining({ value: userB.id }),
+		]);
+		expect(userAfterReplace.groups).toEqual([
+			expect.objectContaining({ value: "member" }),
+		]);
+		expect(promotedUser.groups).toEqual([
+			expect.objectContaining({ value: "member" }),
+			expect.objectContaining({ value: "admin" }),
+		]);
+	});
+
+	it("should patch group membership", async () => {
+		const { auth, headers, createUser, createGroup, getOrganizationSCIMToken } =
+			createTestInstance();
+		const { scimToken } = await getOrganizationSCIMToken();
+		const [userA, userB] = await Promise.all([
+			createUser(scimToken, "user-a"),
+			createUser(scimToken, "user-b"),
+		]);
+		await createGroup(scimToken, "admin", [{ value: userA.id }]);
+
+		const addedGroup = await auth.api.patchSCIMGroup({
+			params: { groupId: "admin" },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [
+					{ op: "add", path: "members", value: [{ value: userB.id }] },
+				],
+			},
+			headers: headers(scimToken),
+		});
+		const removedGroup = await auth.api.patchSCIMGroup({
+			params: { groupId: "admin" },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [
+					{ op: "remove", path: "members", value: [{ value: userA.id }] },
+				],
+			},
+			headers: headers(scimToken),
+		});
+		const replacedGroup = await auth.api.patchSCIMGroup({
+			params: { groupId: "admin" },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [
+					{ op: "replace", path: "members", value: [{ value: userA.id }] },
+				],
+			},
+			headers: headers(scimToken),
+		});
+
+		expect(addedGroup.members.map((member) => member.value).sort()).toEqual([
+			...[userA.id, userB.id].sort(),
+		]);
+		expect(removedGroup.members).toEqual([
+			expect.objectContaining({ value: userB.id }),
+		]);
+		expect(replacedGroup.members).toEqual([
+			expect.objectContaining({ value: userA.id }),
+		]);
+	});
+
+	it("should patch remove members using SCIM path filters and bare members paths", async () => {
+		const { auth, headers, createUser, createGroup, getOrganizationSCIMToken } =
+			createTestInstance();
+		const { scimToken } = await getOrganizationSCIMToken();
+		const [userA, userB] = await Promise.all([
+			createUser(scimToken, "user-a"),
+			createUser(scimToken, "user-b"),
+		]);
+		await createGroup(scimToken, "admin", [
+			{ value: userA.id },
+			{ value: userB.id },
+		]);
+
+		const filteredRemove = await auth.api.patchSCIMGroup({
+			params: { groupId: "admin" },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [
+					{
+						op: "remove",
+						path: `members[value eq "${userA.id}"]`,
+						value: undefined,
+					},
+				],
+			},
+			headers: headers(scimToken),
+		});
+		const removeAll = await auth.api.patchSCIMGroup({
+			params: { groupId: "admin" },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [{ op: "remove", path: "members", value: undefined }],
+			},
+			headers: headers(scimToken),
+		});
+
+		expect(filteredRemove.members).toEqual([
+			expect.objectContaining({ value: userB.id }),
+		]);
+		expect(removeAll.members).toEqual([]);
+	});
+
+	it("should delete only the mapped role and keep org membership", async () => {
+		const {
+			auth,
+			data,
+			headers,
+			createUser,
+			createGroup,
+			getOrganizationSCIMToken,
+		} = createTestInstance();
+		const { scimToken } = await getOrganizationSCIMToken();
+		const user = await createUser(scimToken, "user-a");
+		await createGroup(scimToken, "admin", [{ value: user.id }]);
+
+		await auth.api.deleteSCIMGroup({
+			params: { groupId: "admin" },
+			headers: headers(scimToken),
+		});
+		const retrievedUser = await auth.api.getSCIMUser({
+			params: { userId: user.id },
+			headers: headers(scimToken),
+		});
+
+		expect(retrievedUser.groups).toEqual([
+			expect.objectContaining({ value: "member" }),
+		]);
+		const scimUserMember = data.member.find(
+			(member) => member.userId === user.id,
+		);
+		expect(scimUserMember?.role).toBe("member");
+	});
+
+	it("should support mapping a group to multiple roles", async () => {
+		const { auth, headers, createUser, createGroup, getOrganizationSCIMToken } =
+			createTestInstance({
+				mapGroupToRole: (group) =>
+					group.displayName === "Admins" ? ["admin", "editor"] : "member",
+			});
+		const { scimToken } = await getOrganizationSCIMToken();
+		const user = await createUser(scimToken, "user-a");
+
+		await createGroup(scimToken, "Admins", [{ value: user.id }]);
+		const retrievedUser = await auth.api.getSCIMUser({
+			params: { userId: user.id },
+			headers: headers(scimToken),
+		});
+
+		expect(retrievedUser.groups).toEqual([
+			expect.objectContaining({ value: "member" }),
+			expect.objectContaining({ value: "admin" }),
+			expect.objectContaining({ value: "editor" }),
+		]);
+	});
+
+	it("should return SCIM errors for unsupported or invalid group targets", async () => {
+		const { createGroup, getSCIMToken } = createTestInstance();
+		const nonOrgToken = await getSCIMToken("non-org-provider");
+
+		await expect(createGroup(nonOrgToken, "admin", [])).rejects.toMatchObject({
+			body: { status: "400", scimType: "invalidValue" },
+		});
+	});
+
+	it("should reject duplicate, nested, unknown, and cross-org group members", async () => {
+		const { auth, headers, createUser, createGroup, getOrganizationSCIMToken } =
+			createTestInstance();
+		const { scimToken: orgAToken } =
+			await getOrganizationSCIMToken("provider-a");
+		const { scimToken: orgBToken } =
+			await getOrganizationSCIMToken("provider-b");
+		const userA = await createUser(orgAToken, "user-a");
+		const userB = await createUser(orgBToken, "user-b");
+		await createGroup(orgAToken, "admin", [{ value: userA.id }]);
+
+		await expect(createGroup(orgAToken, "admin", [])).rejects.toMatchObject({
+			body: { status: "409", scimType: "uniqueness" },
+		});
+		await expect(
+			createGroup(orgAToken, "nested", [{ value: "admin", type: "Group" }]),
+		).rejects.toMatchObject({
+			body: { status: "400", scimType: "invalidValue" },
+		});
+		await expect(
+			createGroup(orgAToken, "unknown", [{ value: "missing-user-id" }]),
+		).rejects.toMatchObject({
+			body: { status: "400", scimType: "noTarget" },
+		});
+		await expect(
+			createGroup(orgAToken, "cross-org", [{ value: userB.id }]),
+		).rejects.toMatchObject({
+			body: { status: "400", scimType: "noTarget" },
+		});
+		expect(
+			await auth.api.getSCIMGroup({
+				params: { groupId: "admin" },
+				headers: headers(orgAToken),
+			}),
+		).toMatchObject({
+			id: "admin",
+			members: [expect.objectContaining({ value: userA.id })],
+		});
+	});
+});

--- a/packages/scim/src/scim-resources.ts
+++ b/packages/scim/src/scim-resources.ts
@@ -1,4 +1,6 @@
 import type { Account, User } from "better-auth";
+import { SCIMGroupResourceSchema } from "./group-schemas";
+import type { SCIMGroupMembership } from "./types";
 import { SCIMUserResourceSchema } from "./user-schemas";
 import { getResourceURL } from "./utils";
 
@@ -6,6 +8,7 @@ export const createUserResource = (
 	baseURL: string,
 	user: User,
 	account?: Account | null,
+	groups?: SCIMGroupMembership[],
 ) => {
 	return {
 		// Common attributes
@@ -30,6 +33,32 @@ export const createUserResource = (
 		displayName: user.name,
 		active: true,
 		emails: [{ primary: true, value: user.email }],
+		...(groups ? { groups } : {}),
 		schemas: [SCIMUserResourceSchema.id],
+	};
+};
+
+export const createGroupResource = (
+	baseURL: string,
+	group: {
+		id: string;
+		displayName?: string;
+		externalId?: string | undefined;
+		members?: SCIMGroupMembership[];
+	},
+) => {
+	return {
+		id: group.id,
+		...(group.externalId ? { externalId: group.externalId } : {}),
+		displayName: group.displayName ?? group.id,
+		members: group.members ?? [],
+		meta: {
+			resourceType: "Group",
+			location: getResourceURL(
+				`/scim/v2/Groups/${encodeURIComponent(group.id)}`,
+				baseURL,
+			),
+		},
+		schemas: [SCIMGroupResourceSchema.id],
 	};
 };

--- a/packages/scim/src/scim.test.ts
+++ b/packages/scim/src/scim.test.ts
@@ -205,148 +205,16 @@ describe("SCIM", () => {
 			const { auth } = createTestInstance();
 			const schemas = await auth.api.getSCIMSchemas();
 
-			expect(schemas).toMatchInlineSnapshot(`
-				{
-				  "Resources": [
-				    {
-				      "attributes": [
-				        {
-				          "caseExact": true,
-				          "description": "Unique opaque identifier for the User",
-				          "multiValued": false,
-				          "mutability": "readOnly",
-				          "name": "id",
-				          "required": false,
-				          "returned": "default",
-				          "type": "string",
-				          "uniqueness": "server",
-				        },
-				        {
-				          "caseExact": false,
-				          "description": "Unique identifier for the User, typically used by the user to directly authenticate to the service provider",
-				          "multiValued": false,
-				          "mutability": "readWrite",
-				          "name": "userName",
-				          "required": true,
-				          "returned": "default",
-				          "type": "string",
-				          "uniqueness": "server",
-				        },
-				        {
-				          "caseExact": true,
-				          "description": "The name of the User, suitable for display to end-users.  The name SHOULD be the full name of the User being described, if known.",
-				          "multiValued": false,
-				          "mutability": "readOnly",
-				          "name": "displayName",
-				          "required": false,
-				          "returned": "default",
-				          "type": "string",
-				          "uniqueness": "none",
-				        },
-				        {
-				          "description": "A Boolean value indicating the User's administrative status.",
-				          "multiValued": false,
-				          "mutability": "readOnly",
-				          "name": "active",
-				          "required": false,
-				          "returned": "default",
-				          "type": "boolean",
-				        },
-				        {
-				          "description": "The components of the user's real name.",
-				          "multiValued": false,
-				          "name": "name",
-				          "required": false,
-				          "subAttributes": [
-				            {
-				              "caseExact": false,
-				              "description": "The full name, including all middlenames, titles, and suffixes as appropriate, formatted for display(e.g., 'Ms. Barbara J Jensen, III').",
-				              "multiValued": false,
-				              "mutability": "readWrite",
-				              "name": "formatted",
-				              "required": false,
-				              "returned": "default",
-				              "type": "string",
-				              "uniqueness": "none",
-				            },
-				            {
-				              "caseExact": false,
-				              "description": "The family name of the User, or last name in most Western languages (e.g., 'Jensen' given the fullname 'Ms. Barbara J Jensen, III').",
-				              "multiValued": false,
-				              "mutability": "readWrite",
-				              "name": "familyName",
-				              "required": false,
-				              "returned": "default",
-				              "type": "string",
-				              "uniqueness": "none",
-				            },
-				            {
-				              "caseExact": false,
-				              "description": "The given name of the User, or first name in most Western languages (e.g., 'Barbara' given the full name 'Ms. Barbara J Jensen, III').",
-				              "multiValued": false,
-				              "mutability": "readWrite",
-				              "name": "givenName",
-				              "required": false,
-				              "returned": "default",
-				              "type": "string",
-				              "uniqueness": "none",
-				            },
-				          ],
-				          "type": "complex",
-				        },
-				        {
-				          "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. Canonical type values of 'work', 'home', and 'other'.",
-				          "multiValued": true,
-				          "mutability": "readWrite",
-				          "name": "emails",
-				          "required": false,
-				          "returned": "default",
-				          "subAttributes": [
-				            {
-				              "caseExact": false,
-				              "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. Canonical type values of 'work', 'home', and 'other'.",
-				              "multiValued": false,
-				              "mutability": "readWrite",
-				              "name": "value",
-				              "required": false,
-				              "returned": "default",
-				              "type": "string",
-				              "uniqueness": "server",
-				            },
-				            {
-				              "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred mailing address or primary email address.  The primary attribute value 'true' MUST appear no more than once.",
-				              "multiValued": false,
-				              "mutability": "readWrite",
-				              "name": "primary",
-				              "required": false,
-				              "returned": "default",
-				              "type": "boolean",
-				            },
-				          ],
-				          "type": "complex",
-				          "uniqueness": "none",
-				        },
-				      ],
-				      "description": "User Account",
-				      "id": "urn:ietf:params:scim:schemas:core:2.0:User",
-				      "meta": {
-				        "location": "http://localhost:3000/api/auth/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
-				        "resourceType": "Schema",
-				      },
-				      "name": "User",
-				      "schemas": [
-				        "urn:ietf:params:scim:schemas:core:2.0:Schema",
-				      ],
-				    },
-				  ],
-				  "itemsPerPage": 1,
-				  "schemas": [
-				    "urn:ietf:params:scim:api:messages:2.0:ListResponse",
-				  ],
-				  "startIndex": 1,
-				  "totalResults": 1,
-				}
-			`);
+			expect(schemas).toMatchObject({
+				itemsPerPage: 2,
+				startIndex: 1,
+				totalResults: 2,
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+			});
+			expect(schemas.Resources.map((schema) => schema.id)).toEqual([
+				"urn:ietf:params:scim:schemas:core:2.0:User",
+				"urn:ietf:params:scim:schemas:core:2.0:Group",
+			]);
 		});
 
 		it("should fetch a single resource schema", async () => {
@@ -519,32 +387,26 @@ describe("SCIM", () => {
 			const { auth } = createTestInstance();
 			const resourceTypes = await auth.api.getSCIMResourceTypes();
 
-			expect(resourceTypes).toMatchInlineSnapshot(`
-				{
-				  "Resources": [
-				    {
-				      "description": "User Account",
-				      "endpoint": "/Users",
-				      "id": "User",
-				      "meta": {
-				        "location": "http://localhost:3000/api/auth/scim/v2/ResourceTypes/User",
-				        "resourceType": "ResourceType",
-				      },
-				      "name": "User",
-				      "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
-				      "schemas": [
-				        "urn:ietf:params:scim:schemas:core:2.0:ResourceType",
-				      ],
-				    },
-				  ],
-				  "itemsPerPage": 1,
-				  "schemas": [
-				    "urn:ietf:params:scim:api:messages:2.0:ListResponse",
-				  ],
-				  "startIndex": 1,
-				  "totalResults": 1,
-				}
-			`);
+			expect(resourceTypes).toMatchObject({
+				itemsPerPage: 2,
+				startIndex: 1,
+				totalResults: 2,
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+			});
+			expect(resourceTypes.Resources).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						id: "User",
+						endpoint: "/Users",
+						schema: "urn:ietf:params:scim:schemas:core:2.0:User",
+					}),
+					expect.objectContaining({
+						id: "Group",
+						endpoint: "/Groups",
+						schema: "urn:ietf:params:scim:schemas:core:2.0:Group",
+					}),
+				]),
+			);
 		});
 
 		it("should fetch a single resource type", async () => {

--- a/packages/scim/src/types.ts
+++ b/packages/scim/src/types.ts
@@ -17,6 +17,26 @@ export type SCIMName = {
 
 export type SCIMEmail = { value?: string; primary?: boolean };
 
+export type SCIMGroupMember = {
+	value?: string;
+	$ref?: string;
+	display?: string;
+	type?: string;
+};
+
+export type SCIMGroup = {
+	id?: string;
+	externalId?: string;
+	displayName: string;
+	members?: SCIMGroupMember[];
+};
+
+export type SCIMGroupMembership = {
+	value: string;
+	$ref: string;
+	display: string;
+};
+
 export type SCIMOptions = {
 	/**
 	 * SCIM provider ownership configuration. When enabled, each provider
@@ -37,6 +57,14 @@ export type SCIMOptions = {
 	 * These will take precedence over the database when present.
 	 */
 	defaultSCIM?: Omit<SCIMProvider, "id">[];
+	/**
+	 * Maps an incoming SCIM Group resource to Better Auth organization role(s).
+	 *
+	 * Defaults to using the group's displayName as the role name.
+	 */
+	mapGroupToRole?: (
+		group: SCIMGroup,
+	) => string | string[] | Promise<string | string[]>;
 	/**
 	 * A callback that runs before a new SCIM token is generated.
 	 * Runs after the built-in role check, so it can add additional


### PR DESCRIPTION
## Summary

- add SCIM Group schema/resource type metadata and `/scim/v2/Groups` endpoints
- back v1 groups with Better Auth organization roles without database schema changes
- include SCIM `groups` memberships on org-scoped User resources
- address review feedback around PatchOp validation, filter handling, comma-safe role mapping, empty virtual groups, and group-member query batching

## Why

SCIM group provisioning is a core SCIM resource flow. Without `/Groups`, identity providers cannot sync group membership changes or use Better Auth organization roles as SCIM-managed groups.

Closes #9708
