### PR TITLE
fix(cimd): tolerate unsupported grant_types/response_types in metadata documents

### DIFF
--- a/.changeset/cimd-tolerate-unsupported-grant-types.md
+++ b/.changeset/cimd-tolerate-unsupported-grant-types.md
@@ -1,0 +1,26 @@
+---
+"@better-auth/cimd": patch
+---
+
+fix(cimd): tolerate unsupported grant_types/response_types in metadata documents
+
+Client ID Metadata Document validation rejected the entire client when its
+`grant_types` or `response_types` contained any value the server does not
+support. VS Code's published metadata document
+(`https://vscode.dev/oauth/client-metadata.json`) declares
+`urn:ietf:params:oauth:grant-type:device_code` alongside `authorization_code`
+and `refresh_token`, so its MCP OAuth flow failed against any better-auth
+server with:
+
+```
+{"error":"invalid_client","error_description":"grant_types must be a subset of [\"authorization_code\", \"refresh_token\"]"}
+```
+
+Per [RFC 7591 §2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-2.1)
+and the [CIMD draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/),
+the authorization server should ignore grant/response types it does not support
+rather than rejecting the client. Validation now only requires that
+`authorization_code` (and `code` for `response_types`) is present, and the
+unsupported entries are filtered out before the client is persisted, so they
+never reach the database or grant any capability. The token endpoint already
+gates `grant_type` independently, so this grants no new capabilities.

--- a/packages/cimd/src/client-store.ts
+++ b/packages/cimd/src/client-store.ts
@@ -9,6 +9,8 @@ import { checkOAuthClient, oauthToSchema } from "@better-auth/oauth-provider";
 import { APIError } from "better-call";
 import type { CimdOptions } from "./types";
 import {
+	ALLOWED_GRANT_TYPES,
+	ALLOWED_RESPONSE_TYPES,
 	validateCimdMetadata,
 	validateClientIdUrl,
 } from "./validate-metadata-document";
@@ -113,6 +115,20 @@ function toOAuthClientBody(metadata: Record<string, unknown>): OAuthClient {
 		if (key in metadata) {
 			filtered[key] = metadata[key];
 		}
+	}
+	// The metadata document may declare grant/response types the server does not
+	// support (validation tolerates them per RFC 7591 §2.1). Drop the
+	// unsupported entries so they never reach the DB or the client's stored
+	// capabilities.
+	if (Array.isArray(filtered.grant_types)) {
+		filtered.grant_types = filtered.grant_types.filter(
+			(g) => typeof g === "string" && ALLOWED_GRANT_TYPES.has(g),
+		);
+	}
+	if (Array.isArray(filtered.response_types)) {
+		filtered.response_types = filtered.response_types.filter(
+			(r) => typeof r === "string" && ALLOWED_RESPONSE_TYPES.has(r),
+		);
 	}
 	return {
 		...(filtered as OAuthClient),

--- a/packages/cimd/src/validate-metadata-document.test.ts
+++ b/packages/cimd/src/validate-metadata-document.test.ts
@@ -317,7 +317,7 @@ describe("validateCimdMetadata", () => {
 		expect(result.error).toContain("redirect_uris");
 	});
 
-	it("rejects disallowed grant_types", () => {
+	it("rejects grant_types without authorization_code", () => {
 		const result = validateCimdMetadata(
 			fetchUrl,
 			validMetadata(fetchUrl, {
@@ -348,7 +348,24 @@ describe("validateCimdMetadata", () => {
 		expect(result.valid).toBe(true);
 	});
 
-	it("rejects disallowed response_types", () => {
+	// Regression: clients (e.g. VS Code's published CIMD document) may declare
+	// grant types the server does not support. Per RFC 7591 §2.1 the server
+	// ignores them rather than rejecting the whole client.
+	it("accepts grant_types with unsupported entries alongside authorization_code", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				grant_types: [
+					"authorization_code",
+					"refresh_token",
+					"urn:ietf:params:oauth:grant-type:device_code",
+				],
+			}),
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	it("rejects response_types without code", () => {
 		const result = validateCimdMetadata(
 			fetchUrl,
 			validMetadata(fetchUrl, {
@@ -364,6 +381,18 @@ describe("validateCimdMetadata", () => {
 			fetchUrl,
 			validMetadata(fetchUrl, {
 				response_types: ["code"],
+			}),
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	// Regression: unsupported response types are ignored as long as "code" is
+	// present (mirrors the grant_types liberal-acceptance policy).
+	it("accepts response_types with unsupported entries alongside code", () => {
+		const result = validateCimdMetadata(
+			fetchUrl,
+			validMetadata(fetchUrl, {
+				response_types: ["code", "token"],
 			}),
 		);
 		expect(result.valid).toBe(true);

--- a/packages/cimd/src/validate-metadata-document.ts
+++ b/packages/cimd/src/validate-metadata-document.ts
@@ -15,9 +15,14 @@ const SYMMETRIC_AUTH_METHODS = new Set([
 	"client_secret_jwt",
 ]);
 
-const ALLOWED_GRANT_TYPES = new Set(["authorization_code", "refresh_token"]);
+/** Grant types the authorization server supports for CIMD clients. */
+export const ALLOWED_GRANT_TYPES = new Set([
+	"authorization_code",
+	"refresh_token",
+]);
 
-const ALLOWED_RESPONSE_TYPES = new Set(["code"]);
+/** Response types the authorization server supports for CIMD clients. */
+export const ALLOWED_RESPONSE_TYPES = new Set(["code"]);
 
 export interface ClientIdMetadataDocumentResult {
 	valid: boolean;
@@ -319,36 +324,49 @@ export function validateCimdMetadata(
 		};
 	}
 
-	// grant_types: must be a subset of allowed types
-	if (
-		doc.grant_types !== undefined &&
-		!(
-			Array.isArray(doc.grant_types) &&
-			doc.grant_types.every(
-				(g: unknown) => typeof g === "string" && ALLOWED_GRANT_TYPES.has(g),
-			)
-		)
-	) {
-		return {
-			valid: false,
-			error: `grant_types must be a subset of [${[...ALLOWED_GRANT_TYPES].map((g) => `"${g}"`).join(", ")}]`,
-		};
+	// grant_types: per RFC 7591 §2.1 and the CIMD draft, the authorization
+	// server ignores grant types it does not support rather than rejecting the
+	// whole client. We therefore tolerate unsupported entries (e.g. VS Code
+	// declares "urn:ietf:params:oauth:grant-type:device_code") and only require
+	// that the authorization_code grant the code flow relies on is present.
+	// Unsupported values are dropped before persistence (see client-store.ts).
+	if (doc.grant_types !== undefined) {
+		if (
+			!Array.isArray(doc.grant_types) ||
+			!doc.grant_types.every((g: unknown) => typeof g === "string")
+		) {
+			return {
+				valid: false,
+				error: "grant_types must be an array of strings",
+			};
+		}
+		if (!doc.grant_types.includes("authorization_code")) {
+			return {
+				valid: false,
+				error: 'grant_types must include "authorization_code"',
+			};
+		}
 	}
 
-	// response_types: must be a subset of allowed types
-	if (
-		doc.response_types !== undefined &&
-		!(
-			Array.isArray(doc.response_types) &&
-			doc.response_types.every(
-				(r: unknown) => typeof r === "string" && ALLOWED_RESPONSE_TYPES.has(r),
-			)
-		)
-	) {
-		return {
-			valid: false,
-			error: 'response_types must be a subset of ["code"]',
-		};
+	// response_types: same liberal-acceptance policy as grant_types. Unsupported
+	// response types are ignored; we only require the "code" response type that
+	// the authorization-code flow uses.
+	if (doc.response_types !== undefined) {
+		if (
+			!Array.isArray(doc.response_types) ||
+			!doc.response_types.every((r: unknown) => typeof r === "string")
+		) {
+			return {
+				valid: false,
+				error: "response_types must be an array of strings",
+			};
+		}
+		if (!doc.response_types.includes("code")) {
+			return {
+				valid: false,
+				error: 'response_types must include "code"',
+			};
+		}
 	}
 
 	// Validate client_uri and logo_uri for SSRF if present


### PR DESCRIPTION
### Summary

CIMD (Client ID Metadata Document) validation rejects the **entire** client when its `grant_types` or `response_types` contains any value the server doesn't support. This breaks VS Code's MCP OAuth flow against any Better Auth server.

VS Code sends `client_id=https://vscode.dev/oauth/client-metadata.json`, whose document declares:

```json
"grant_types": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"]
```

`packages/cimd/src/validate-metadata-document.ts` validates with a strict subset check, so the `device_code` entry makes the whole client fail with:

```
{"error":"invalid_client","error_description":"grant_types must be a subset of [\"authorization_code\", \"refresh_token\"]"}
```

### Why this is the right fix

[RFC 7591 §2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-2.1) and the [CIMD draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) say the authorization server should **ignore** grant/response types it doesn't support, not reject the client. A client only needs to be able to use *some* of its declared grants.

### Changes

- **`validate-metadata-document.ts`**: require only that `authorization_code` (and `code` for `response_types`) is present; tolerate unsupported entries. `ALLOWED_GRANT_TYPES`/`ALLOWED_RESPONSE_TYPES` are now exported.
- **`client-store.ts`** (`toOAuthClientBody`): filter `grant_types`/`response_types` down to the supported sets before persistence, so unsupported values (e.g. `device_code`) never reach the DB. The token endpoint already gates `grant_type` independently, so this grants **no** new capability.
- Regression tests: VS Code's metadata (with `device_code`) is accepted; `["code","token"]` accepted; existing rejection cases (`client_credentials`, `token`) still reject because the required type is absent.

### Testing

`pnpm --filter @better-auth/cimd test` → **71 passed**. `@better-auth/cimd` builds clean.

### AI disclosure

Drafted with Claude per the project's AI policy; I've reviewed each diff, the spec citations, and the test output.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerate unsupported `grant_types` and `response_types` in CIMD so clients like VS Code are accepted. Require `authorization_code` and `code`, and strip unsupported values before persisting.

- **Bug Fixes**
  - Relaxed `@better-auth/cimd` validation to ignore unknown types per RFC 7591/CIMD; only require `authorization_code` and `code`.
  - Exported `ALLOWED_GRANT_TYPES`/`ALLOWED_RESPONSE_TYPES` and filter in `client-store.ts` so unsupported entries never hit the DB.
  - Added regression tests for VS Code’s metadata and mixed response types.

<sup>Written for commit f168f01e7aae113f079a95d798796521cb17ec90. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9734?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

