### PR TITLE
fix(organization): refetch active organization on session-changing client paths

### DIFF
--- a/packages/better-auth/src/plugins/organization/client.test.ts
+++ b/packages/better-auth/src/plugins/organization/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { betterAuth } from "../../auth/full";
 import { createAuthClient } from "../../client";
 import { inferOrgAdditionalFields, organizationClient } from "./client";
@@ -68,5 +68,62 @@ describe("organization", () => {
 			//@ts-expect-error - this field is not available
 			unavailableField: "123", //this should be not allowed
 		});
+	});
+});
+
+describe("organizationClient atomListeners", () => {
+	const getActiveOrgMatcher = () => {
+		const plugin = organizationClient();
+		const listener = plugin.atomListeners?.find(
+			(l) => l.signal === "$activeOrgSignal",
+		);
+		if (!listener) throw new Error("$activeOrgSignal listener not found");
+		return listener.matcher;
+	};
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9710
+	 */
+	it("$activeOrgSignal matcher flips on session-changing paths", () => {
+		const matcher = getActiveOrgMatcher();
+
+		// Session-changing paths — the new session may carry a different
+		// activeOrganizationId set server-side via the documented
+		// `databaseHooks.session.create.before` hook, so the active-org query
+		// must refetch to avoid returning a stale `null`.
+		expect(matcher("/sign-in/email")).toBe(true);
+		expect(matcher("/sign-up/email")).toBe(true);
+		expect(matcher("/verify-email")).toBe(true);
+		expect(matcher("/update-session")).toBe(true);
+		expect(matcher("/delete-user")).toBe(true);
+
+		// Existing behaviour — still flips on /sign-out and all /organization paths.
+		expect(matcher("/sign-out")).toBe(true);
+		expect(matcher("/organization/set-active")).toBe(true);
+		expect(matcher("/organization/create")).toBe(true);
+		expect(matcher("/organization/anything")).toBe(true);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9710
+	 *
+	 * Guard against over-triggering: non-session, non-organization paths must
+	 * not flip $activeOrgSignal — otherwise unrelated calls would force the
+	 * active-org query to refetch on every request.
+	 */
+	it("$activeOrgSignal matcher does not flip on unrelated paths", () => {
+		const matcher = getActiveOrgMatcher();
+
+		// Read-only session reads — must not trigger a refetch.
+		expect(matcher("/get-session")).toBe(false);
+		expect(matcher("/list-sessions")).toBe(false);
+
+		// User updates that don't change the active session/org — must not flip.
+		expect(matcher("/update-user")).toBe(false);
+		expect(matcher("/change-password")).toBe(false);
+		expect(matcher("/change-email")).toBe(false);
+
+		// Arbitrary unrelated path.
+		expect(matcher("/some/other/path")).toBe(false);
 	});
 });

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -248,7 +248,15 @@ export const organizationClient = <CO extends OrganizationClientOptions>(
 			},
 			{
 				matcher(path) {
-					return path === "/sign-out" || path.startsWith("/organization");
+					return (
+						path === "/sign-out" ||
+						path === "/sign-in/email" ||
+						path === "/sign-up/email" ||
+						path === "/verify-email" ||
+						path === "/update-session" ||
+						path === "/delete-user" ||
+						path.startsWith("/organization")
+					);
 				},
 				signal: "$activeOrgSignal",
 			},


### PR DESCRIPTION
Closes #9710.

## Problem

The org plugin's `\$activeOrgSignal` matcher in
[`packages/better-auth/src/plugins/organization/client.ts`](packages/better-auth/src/plugins/organization/client.ts)
only flips on `/sign-out` or paths starting with `/organization`. The
core `\$sessionSignal` matcher flips on every auth-state transition
(`/sign-in/email`, `/sign-up/email`, `/verify-email`, `/sign-out`,
`/update-session`, `/delete-user`, …).

So when a new session is established with `activeOrganizationId`
populated server-side via the [documented `databaseHooks.session.create.before` recipe](https://www.better-auth.com/docs/plugins/organization#set-the-active-organization),
the client never hits `/organization/set-active`. `useActiveOrganization()`
keeps its pre-session cached value (typically `null`) until a hard
refresh. Same shape of bug also fires on sign-in on a new device when
the server-side session already has `activeOrganizationId` set.

Issue body has a more detailed walk-through of the symptom and the
root-cause analysis.

## Fix

Expand `\$activeOrgSignal`'s matcher to also flip on the session-changing
paths the core `\$sessionSignal` matcher already lists:

\`\`\`diff
 {
   matcher(path) {
-    return path === "/sign-out" || path.startsWith("/organization");
+    return (
+      path === "/sign-out" ||
+      path === "/sign-in/email" ||
+      path === "/sign-up/email" ||
+      path === "/verify-email" ||
+      path === "/update-session" ||
+      path === "/delete-user" ||
+      path.startsWith("/organization")
+    );
   },
   signal: "\$activeOrgSignal"
 }
\`\`\`

`/update-user`, `/change-email`, `/change-password`, and `/revoke-*` are
intentionally not added, since they don't open a new session with a
potentially different `activeOrganizationId`.

## Tests

[`packages/better-auth/src/plugins/organization/client.test.ts`](packages/better-auth/src/plugins/organization/client.test.ts):
two new unit tests inspired by [`packages/better-auth/src/client/proxy.test.ts`](packages/better-auth/src/client/proxy.test.ts).

- **positive** — `\$activeOrgSignal` matcher returns `true` for every
  session-change path, `/sign-out`, and existing `/organization/*`
  coverage.
- **negative** — matcher returns `false` for read-only paths
  (`/get-session`, `/list-sessions`), user-attribute updates
  (`/update-user`, `/change-password`, `/change-email`), and arbitrary
  unrelated paths, so it doesn't over-trigger refetches.

### Verification

\`\`\`
$ pnpm vitest run src/plugins/organization/client.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ pnpm vitest run src/plugins/organization/
 Test Files  9 passed (9)
      Tests  208 passed | 1 skipped | 1 todo (210)

$ pnpm typecheck
$ tsc --build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the `\$activeOrgSignal` matcher to refetch the active organization on all session-changing client paths. Fixes stale `useActiveOrganization()` values after sign-in or new-session events.

- **Bug Fixes**
  - Mirror core `\$sessionSignal` paths: `/sign-in/email`, `/sign-up/email`, `/verify-email`, `/update-session`, `/delete-user`, and `/sign-out`, plus existing `/organization/*`, so the active-org query updates without a hard refresh.
  - Exclude non-session paths (`/update-user`, `/change-email`, `/change-password`, `revoke-*`) to avoid extra refetches; added unit tests for positive and negative cases.

<sup>Written for commit e3c44a14a093fecd154f45363d947a8ae1ce4f10. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9736?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

