### PR TITLE
feat(social-providers): add 42 school

### DIFF
--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -33,3 +33,4 @@ C-W-D-Harshit
 efiz
 Braem
 mhbdev
+jdoe

--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -65,3 +65,4 @@ Oligo
 febf
 fdff
 fffe
+vogsphere

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -137,6 +137,7 @@ Better Auth provides pre-configured helper functions for popular OAuth providers
 * **Okta** - `okta(options)`
 * **Slack** - `slack(options)`
 * **Patreon** - `patreon(options)`
+* **42** - `fortytwo(options)`
 
 ### Example: Using Pre-configured Providers
 
@@ -155,6 +156,7 @@ import {
 	okta,
 	slack,
 	patreon,
+  fortytwo
 } from 'better-auth/plugins';
 
 export const auth = betterAuth({
@@ -209,6 +211,10 @@ export const auth = betterAuth({
 					clientId: process.env.PATREON_CLIENT_ID,
 					clientSecret: process.env.PATREON_CLIENT_SECRET,
 				}),
+        fortytwo({
+          clientId: process.env.FT_CLIENT_UID,
+          clientSecret: process.env.FT_CLIENT_SECRET,
+        })
 			],
 		}),
 	],
@@ -225,15 +231,19 @@ Each provider helper accepts common OAuth options (extending `BaseOAuthProviderO
 * **Okta**: Requires `issuer` (e.g., `https://dev-xxxxx.okta.com/oauth2/default`)
 * **Slack**: No additional required fields
 * **Patreon**: No additional required fields
+* **42**: No additional required fields
 
 All providers support the same optional fields:
 
 * `scopes?: string[]` - Array of OAuth scopes to request
 * `redirectURI?: string` - Custom redirect URI
-* `pkce?: boolean` - Enable PKCE (defaults to `false`)
 * `disableImplicitSignUp?: boolean` - Disable automatic sign-up for new users
 * `disableSignUp?: boolean` - Disable sign-up entirely
 * `overrideUserInfo?: boolean` - Override user info on sign in
+
+Almost all providers support PKCE, through an optional field:
+
+* `pkce?: boolean` - Enable PKCE (defaults to `false`, overridden to false in fortytwo)
 
 ## Configuration
 

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -156,7 +156,7 @@ import {
 	okta,
 	slack,
 	patreon,
-  fortytwo
+	fortytwo
 } from 'better-auth/plugins';
 
 export const auth = betterAuth({
@@ -241,9 +241,9 @@ All providers support the same optional fields:
 * `disableSignUp?: boolean` - Disable sign-up entirely
 * `overrideUserInfo?: boolean` - Override user info on sign in
 
-Almost all providers support PKCE, through an optional field:
+Almost all providers support PKCE through an optional field, except for 42 (fortytwo):
 
-* `pkce?: boolean` - Enable PKCE (defaults to `false`, overridden to false in fortytwo)
+* `pkce?: boolean` - Enable PKCE (defaults to `false`)
 
 ## Configuration
 

--- a/packages/better-auth/src/plugins/generic-oauth/providers/fortytwo.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/fortytwo.ts
@@ -1,0 +1,152 @@
+import type { OAuth2Tokens, OAuth2UserInfo } from "@better-auth/core/oauth2";
+import { betterFetch } from "@better-fetch/fetch";
+import type { BaseOAuthProviderOptions, GenericOAuthConfig } from "../index";
+
+export interface FortyTwoOptions extends BaseOAuthProviderOptions {}
+
+export interface FortyTwoProfile extends Record<string, unknown> {
+	/** the user's id */
+	id: number;
+	/** the user's email */
+	email: string;
+	/**
+	 * the user's login/username based on their first and last name
+	 * i.e. John Doe's login could be jdoe, but it could follow a different pattern
+	 */
+	login: string;
+	/** the user's first name */
+	first_name: string;
+	/** the user's last name */
+	last_name: string;
+	/** the user's full usual name */
+	usual_full_name: string;
+	/** the user's usual first name */
+	usual_first_name: string;
+	/** 42's api url to the user's full information */
+	url: string;
+	/** the user's phone number */
+	phone: string | null;
+	/** the user's full name */
+	displayname: string;
+	/** user type/role, some possible values are 'student' or 'admin' */
+	kind: "student" | "admin" | string;
+	/** the user's profile picture */
+	image?: {
+		/** the user's profile picture url */
+		link: string;
+		/** the user's profile picture url in different versions */
+		versions: {
+			large: string;
+			medium: string;
+			small: string;
+			micro: string;
+		};
+	};
+	/** if the user is part of 42's staff */
+	"staff?": boolean;
+	/** how many evaluation points the user has */
+	correction_point: number;
+	/** the month of the "piscine" the user did */
+	pool_month: string;
+	/** the year of the "piscine" the user did */
+	pool_year: string;
+	/** which computer the user is logged in */
+	location: string | null;
+	/** how much internal currency the user has */
+	wallet: number;
+	/** the date at which the user will have their data anonymized */
+	anonymize_date: string;
+	/** the date at which the user will have their data erased */
+	data_erasure_date: string | null;
+	/** if the user is an alumni (past student) */
+	"alumni?": boolean;
+	/** if the user is currently active */
+	"active?": boolean;
+	/** which campuses the user is in */
+	campus: Array<{
+		id: number;
+		name: string;
+		time_zone: string;
+		language: {
+			id: number;
+			name: string;
+			identifier: string;
+			created_at: string;
+			updated_at: string;
+		};
+		users_count: number;
+		vogsphere_id: number;
+	}>;
+	/** the user's internal user for the campuses */
+	campus_users: Array<{
+		id: number;
+		user_id: number;
+		campus_id: number;
+		is_primary: boolean;
+	}>;
+}
+
+/**
+ * 42 OAuth provider helper
+ *
+ * @example
+ * ```ts
+ * import { genericOAuth, fortytwo } from "better-auth/plugins/generic-oauth";
+ *
+ * export const auth = betterAuth({
+ *   plugins: [
+ *     genericOAuth({
+ *       config: [
+ *         fortytwo({
+ *           clientId: process.env.FT_CLIENT_UID,
+ *           clientSecret: process.env.FT_CLIENT_SECRET,
+ *         }),
+ *       ],
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function fortytwo(options: FortyTwoOptions): GenericOAuthConfig {
+	const defaultScopes = ["public"];
+
+	const getUserInfo = async (
+		tokens: OAuth2Tokens,
+	): Promise<OAuth2UserInfo | null> => {
+		const { data: profile, error } = await betterFetch<FortyTwoProfile>(
+			"https://api.intra.42.fr/v2/me",
+			{
+				method: "GET",
+				headers: {
+					Authorization: `Bearer ${tokens.accessToken}`,
+				},
+			},
+		);
+
+		if (error || !profile) {
+			return null;
+		}
+
+		return {
+			...profile,
+			emailVerified: true,
+			image: profile.image?.link,
+		};
+	};
+
+	return {
+		providerId: "fortytwo",
+		authorizationUrl: "https://api.intra.42.fr/oauth/authorize",
+		tokenUrl: "https://api.intra.42.fr/oauth/token",
+		clientId: options.clientId,
+		clientSecret: options.clientSecret,
+		scopes: options.scopes ?? defaultScopes,
+		redirectURI: options.redirectURI,
+		/** unsure if PKCE is possible */
+		pkce: false,
+		disableImplicitSignUp: options.disableImplicitSignUp,
+		disableSignUp: options.disableSignUp,
+		overrideUserInfo: options.overrideUserInfo,
+		getUserInfo,
+	};
+}

--- a/packages/better-auth/src/plugins/generic-oauth/providers/fortytwo.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/fortytwo.ts
@@ -2,7 +2,8 @@ import type { OAuth2Tokens, OAuth2UserInfo } from "@better-auth/core/oauth2";
 import { betterFetch } from "@better-fetch/fetch";
 import type { BaseOAuthProviderOptions, GenericOAuthConfig } from "../index";
 
-export interface FortyTwoOptions extends BaseOAuthProviderOptions {}
+export interface FortyTwoOptions
+	extends Omit<BaseOAuthProviderOptions, "pkce"> {}
 
 export interface FortyTwoProfile extends Record<string, unknown> {
 	/** the user's id */
@@ -142,7 +143,7 @@ export function fortytwo(options: FortyTwoOptions): GenericOAuthConfig {
 		clientSecret: options.clientSecret,
 		scopes: options.scopes ?? defaultScopes,
 		redirectURI: options.redirectURI,
-		/** unsure if PKCE is possible */
+		/** unsure if PKCE is possible, disabling */
 		pkce: false,
 		disableImplicitSignUp: options.disableImplicitSignUp,
 		disableSignUp: options.disableSignUp,

--- a/packages/better-auth/src/plugins/generic-oauth/providers/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/index.ts
@@ -37,6 +37,7 @@
  */
 
 export { type Auth0Options, auth0 } from "./auth0";
+export { type FortyTwoOptions, fortytwo } from "./fortytwo";
 export { type GumroadOptions, gumroad } from "./gumroad";
 export { type HubSpotOptions, hubspot } from "./hubspot";
 export { type KeycloakOptions, keycloak } from "./keycloak";


### PR DESCRIPTION
Closes #8077 

Replaces #8078 

I added the "jdoe" username example to the CSpell file, which fixes the CI issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 42 School OAuth provider (`fortytwo`) to `generic-oauth` so users can sign in with 42 accounts. Exported the provider, updated docs, and added cspell terms.

- New Features
  - `fortytwo` provider with authorize/token URLs, default `public` scope, and PKCE disabled; fetches user info from https://api.intra.42.fr/v2/me via `@better-fetch/fetch`.
  - Exposed in `providers/index.ts` and documented with usage.

- Bug Fixes
  - Types: `FortyTwoOptions` now omits `pkce`; docs clarify PKCE isn’t supported for 42.
  - cspell: added `jdoe` and `vogsphere`.

<sup>Written for commit fac654f888ee074a824cfcbd8e9fa35df2bfda24. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9738?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

