### PR TITLE
feat(admin, organization): allow admins to list all organizations

### DIFF
--- a/.changeset/admin-list-organizations.md
+++ b/.changeset/admin-list-organizations.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Admins can opt in to a `listOrganizations` API that returns organizations across the application regardless of membership.

--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -207,6 +207,73 @@ const totalUsers = users.total;
 const totalPages = Math.ceil(totalUsers / pageSize)
 ```
 
+### List Organizations
+
+Allows an admin to list organizations across the application, regardless of
+membership. This endpoint requires both the Admin and Organization plugins and
+must be enabled explicitly.
+
+```ts title="auth.ts"
+import { admin, organization } from "better-auth/plugins"
+
+export const auth = betterAuth({
+    plugins: [
+        admin({
+            organizations: { enabled: true }, // [!code highlight]
+        }),
+        organization(), // [!code highlight]
+    ],
+})
+```
+
+```ts title="auth-client.ts"
+import { createAuthClient } from "better-auth/client"
+import { adminClient } from "better-auth/client/plugins"
+
+export const authClient = createAuthClient({
+    plugins: [
+        adminClient({
+            organizations: { enabled: true }, // [!code highlight]
+        }),
+    ],
+})
+```
+
+<APIMethod path="/admin/list-organizations" method="GET" requireSession resultVariable={"organizations"}>
+  ```ts
+  type adminListOrganizations = {
+    /**
+     * The value to search for.
+     */
+    searchValue?: string = "Acme"
+    /**
+     * The field to search in, defaults to name.
+     */
+    searchField?: "name" | "slug" = "name"
+    /**
+     * The operator to use for the search.
+     */
+    searchOperator?: "contains" | "starts_with" | "ends_with" = "contains"
+    /**
+     * Pagination and sorting options.
+     */
+    limit?: string | number
+    offset?: string | number
+    sortBy?: string
+    sortDirection?: "asc" | "desc"
+    /**
+     * Arbitrary organization field filter options.
+     */
+    filterField?: string = "slug"
+    filterValue?: string | number | boolean | string[] | number[]
+    filterOperator?: "eq" | "ne" | "lt" | "lte" | "gt" | "gte" | "in" | "not_in" | "contains" | "starts_with" | "ends_with" = "eq"
+  }
+  ```
+</APIMethod>
+
+The response is `{ organizations, total, limit, offset }`. With custom access
+control, callers need the `organization: ["admin-list"]` permission.
+
 ### Get User
 
 Fetches a user's information using an id.
@@ -456,6 +523,9 @@ By default, there are two resources with up to six permissions.
 
 **session**:
 `list` `revoke` `delete`
+
+**organization**:
+`admin-list`
 
 Users with the admin role have full control over all the resources and actions. Users with the user role have no control over any of those actions.
 
@@ -805,6 +875,19 @@ admin({
 ```
 
 If a user is in the `adminUserIds` list, they will be able to perform any admin operation.
+
+### Organizations
+
+Enable read-only system administrator access to list all organizations. The
+Organization plugin must also be enabled.
+
+```ts title="auth.ts"
+admin({
+    organizations: {
+        enabled: true,
+    },
+})
+```
 
 ### impersonationSessionDuration
 

--- a/packages/better-auth/src/plugins/admin/access/statement.ts
+++ b/packages/better-auth/src/plugins/admin/access/statement.ts
@@ -14,6 +14,7 @@ export const defaultStatements = {
 		"update",
 	],
 	session: ["list", "revoke", "delete"],
+	organization: ["admin-list"],
 } as const;
 
 export const defaultAc = createAccessControl(defaultStatements);
@@ -31,11 +32,13 @@ export const adminAc = defaultAc.newRole({
 		"update",
 	],
 	session: ["list", "revoke", "delete"],
+	organization: ["admin-list"],
 });
 
 export const userAc = defaultAc.newRole({
 	user: [],
 	session: [],
+	organization: [],
 });
 
 export const defaultRoles = {

--- a/packages/better-auth/src/plugins/admin/admin-organization.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin-organization.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+import { createAuthClient } from "../../client";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { createAccessControl } from "../access";
+import { organization } from "../organization";
+import { admin } from "./admin";
+import { adminClient } from "./client";
+
+describe("Admin organization listing", async () => {
+	const { auth, signInWithTestUser, signInWithUser, customFetchImpl } =
+		await getTestInstance(
+			{
+				plugins: [
+					admin({ organizations: { enabled: true } }),
+					organization({
+						schema: {
+							organization: {
+								additionalFields: {
+									internalNote: {
+										type: "string",
+										required: false,
+										returned: false,
+									},
+								},
+							},
+						},
+					}),
+				],
+				databaseHooks: {
+					user: {
+						create: {
+							before: async (user) => ({
+								data: {
+									...user,
+									...(user.name === "Admin" ? { role: "admin" } : {}),
+								},
+							}),
+						},
+					},
+				},
+			},
+			{ testUser: { name: "Admin" } },
+		);
+
+	const client = createAuthClient({
+		baseURL: "http://localhost:3000",
+		plugins: [adminClient({ organizations: { enabled: true } })],
+		fetchOptions: { customFetchImpl },
+	});
+	const { headers: adminHeaders } = await signInWithTestUser();
+
+	const memberUser = {
+		email: "organization-member@test.com",
+		password: "password",
+		name: "Organization Member",
+	};
+	await client.signUp.email(memberUser);
+	const { headers: memberHeaders } = await signInWithUser(
+		memberUser.email,
+		memberUser.password,
+	);
+
+	await auth.api.createOrganization({
+		headers: memberHeaders,
+		body: {
+			name: "Beta Org",
+			slug: "beta-org",
+			metadata: { plan: "pro" },
+			internalNote: "internal-beta",
+		},
+	});
+	await auth.api.createOrganization({
+		headers: memberHeaders,
+		body: {
+			name: "Alpha Org",
+			slug: "alpha-org",
+			internalNote: "internal-alpha",
+		},
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9735
+	 */
+	it("allows an admin to list organizations without being a member", async () => {
+		const result = await client.admin.listOrganizations({
+			query: {
+				sortBy: "name",
+				sortDirection: "asc",
+			},
+			fetchOptions: { headers: adminHeaders },
+		});
+
+		expect(result.data?.organizations.map((org) => org.name)).toEqual([
+			"Alpha Org",
+			"Beta Org",
+		]);
+		expect(result.data?.total).toBe(2);
+		expect(result.data?.organizations[1]?.metadata).toEqual({ plan: "pro" });
+		expect(
+			(result.data?.organizations[0] as { internalNote?: string } | undefined)
+				?.internalNote,
+		).toBeUndefined();
+
+		const memberScoped = await auth.api.listOrganizations({
+			headers: adminHeaders,
+		});
+		expect(memberScoped).toEqual([]);
+
+		const serverResult = await auth.api.adminListOrganizations({
+			headers: adminHeaders,
+			query: {
+				filterField: "slug",
+				filterValue: "beta-org",
+			},
+		});
+		expect(serverResult.organizations.map((org) => org.name)).toEqual([
+			"Beta Org",
+		]);
+	});
+
+	it("supports pagination and organization search filters", async () => {
+		const page = await client.admin.listOrganizations({
+			query: {
+				searchValue: "Beta",
+				searchField: "name",
+				limit: 1,
+				offset: 0,
+			},
+			fetchOptions: { headers: adminHeaders },
+		});
+
+		expect(page.data?.organizations.map((org) => org.slug)).toEqual([
+			"beta-org",
+		]);
+		expect(page.data?.total).toBe(1);
+		expect(page.data?.limit).toBe(1);
+		expect(page.data?.offset).toBeUndefined();
+
+		const filtered = await client.admin.listOrganizations({
+			query: {
+				filterField: "slug",
+				filterValue: "alpha-org",
+				filterOperator: "eq",
+			},
+			fetchOptions: { headers: adminHeaders },
+		});
+		expect(filtered.data?.organizations.map((org) => org.name)).toEqual([
+			"Alpha Org",
+		]);
+	});
+
+	it("does not allow a user without admin organization permission", async () => {
+		const result = await client.admin.listOrganizations({
+			query: {},
+			fetchOptions: { headers: memberHeaders },
+		});
+		expect(result.error?.status).toBe(403);
+	});
+});
+
+describe("Admin organization listing configuration", () => {
+	it("requires organization() when admin organization endpoints are enabled", async () => {
+		const { auth } = await getTestInstance(
+			{ plugins: [admin({ organizations: { enabled: true } })] },
+			{ disableTestUser: true },
+		);
+		await expect(auth.$context).rejects.toThrow(
+			"The admin organization endpoints require the organization plugin to be enabled.",
+		);
+	});
+
+	it("does not register the endpoint unless it is enabled", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [admin(), organization()],
+		});
+		expect(
+			(auth.api as unknown as Record<string, unknown>).adminListOrganizations,
+		).toBeUndefined();
+	});
+
+	it("honors custom admin organization permissions", async () => {
+		const ac = createAccessControl({
+			organization: ["admin-list"],
+		} as const);
+		const allowed = ac.newRole({ organization: ["admin-list"] });
+		const blocked = ac.newRole({ organization: [] });
+		const { customFetchImpl, signInWithUser } = await getTestInstance({
+			plugins: [
+				admin({
+					organizations: { enabled: true },
+					ac,
+					roles: { allowed, blocked },
+				}),
+				organization(),
+			],
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => ({
+							data: {
+								...user,
+								role: user.name === "Allowed" ? "allowed" : "blocked",
+							},
+						}),
+					},
+				},
+			},
+		});
+		const client = createAuthClient({
+			baseURL: "http://localhost:3000",
+			plugins: [adminClient({ organizations: { enabled: true } })],
+			fetchOptions: { customFetchImpl },
+		});
+
+		await client.signUp.email({
+			email: "allowed@test.com",
+			password: "password",
+			name: "Allowed",
+		});
+		await client.signUp.email({
+			email: "blocked@test.com",
+			password: "password",
+			name: "Blocked",
+		});
+		const { headers: allowedHeaders } = await signInWithUser(
+			"allowed@test.com",
+			"password",
+		);
+		const { headers: blockedHeaders } = await signInWithUser(
+			"blocked@test.com",
+			"password",
+		);
+
+		const success = await client.admin.listOrganizations({
+			query: {},
+			fetchOptions: { headers: allowedHeaders },
+		});
+		const forbidden = await client.admin.listOrganizations({
+			query: {},
+			fetchOptions: { headers: blockedHeaders },
+		});
+
+		expect(success.data?.organizations).toEqual([]);
+		expect(forbidden.error?.status).toBe(403);
+	});
+});

--- a/packages/better-auth/src/plugins/admin/admin-organization.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin-organization.test.ts
@@ -147,6 +147,17 @@ describe("Admin organization listing", async () => {
 		expect(zeroLimit.data?.limit).toBe(0);
 		expect(zeroLimit.data?.offset).toBe(0);
 
+		const blankPagination = await client.admin.listOrganizations({
+			query: {
+				limit: "",
+				offset: " ",
+			},
+			fetchOptions: { headers: adminHeaders },
+		});
+		expect(blankPagination.data?.organizations).toHaveLength(2);
+		expect(blankPagination.data?.limit).toBeUndefined();
+		expect(blankPagination.data?.offset).toBeUndefined();
+
 		const filtered = await client.admin.listOrganizations({
 			query: {
 				filterField: "slug",

--- a/packages/better-auth/src/plugins/admin/admin-organization.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin-organization.test.ts
@@ -134,7 +134,18 @@ describe("Admin organization listing", async () => {
 		]);
 		expect(page.data?.total).toBe(1);
 		expect(page.data?.limit).toBe(1);
-		expect(page.data?.offset).toBeUndefined();
+		expect(page.data?.offset).toBe(0);
+
+		const zeroLimit = await client.admin.listOrganizations({
+			query: {
+				limit: 0,
+				offset: 0,
+			},
+			fetchOptions: { headers: adminHeaders },
+		});
+		expect(zeroLimit.data?.organizations).toEqual([]);
+		expect(zeroLimit.data?.limit).toBe(0);
+		expect(zeroLimit.data?.offset).toBe(0);
 
 		const filtered = await client.admin.listOrganizations({
 			query: {
@@ -176,6 +187,12 @@ describe("Admin organization listing configuration", () => {
 		expect(
 			(auth.api as unknown as Record<string, unknown>).adminListOrganizations,
 		).toBeUndefined();
+		expect(adminClient().pathMethods).not.toHaveProperty(
+			"/admin/list-organizations",
+		);
+		expect(
+			adminClient({ organizations: { enabled: true } }).pathMethods,
+		).toHaveProperty("/admin/list-organizations", "GET");
 	});
 
 	it("honors custom admin organization permissions", async () => {

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -7,6 +7,7 @@ import { PACKAGE_VERSION } from "../../version";
 import { defaultRoles } from "./access";
 import { ADMIN_ERROR_CODES } from "./error-codes";
 import {
+	adminListOrganizations,
 	adminUpdateUser,
 	banUser,
 	createUser,
@@ -38,7 +39,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-export const admin = <O extends AdminOptions>(options?: O | undefined) => {
+const createAdminPlugin = <O extends AdminOptions>(options?: O | undefined) => {
 	const opts = {
 		...(options || {}),
 		defaultRole: options?.defaultRole ?? "user",
@@ -71,7 +72,12 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 	return {
 		id: "admin",
 		version: PACKAGE_VERSION,
-		init() {
+		init(ctx) {
+			if (opts.organizations?.enabled && !ctx.hasPlugin("organization")) {
+				throw new BetterAuthError(
+					"The admin organization endpoints require the organization plugin to be enabled.",
+				);
+			}
 			return {
 				options: {
 					databaseHooks: {
@@ -162,6 +168,9 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 			createUser: createUser(opts),
 			adminUpdateUser: adminUpdateUser(opts),
 			listUsers: listUsers(opts),
+			...(opts.organizations?.enabled
+				? { adminListOrganizations: adminListOrganizations(opts) }
+				: {}),
 			listUserSessions: listUserSessions(opts),
 			unbanUser: unbanUser(opts),
 			banUser: banUser(opts),
@@ -178,3 +187,38 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 		options: options as NoInfer<O>,
 	} satisfies BetterAuthPlugin;
 };
+
+type DefaultAdminPlugin<O extends AdminOptions> = ReturnType<
+	typeof createAdminPlugin<O>
+>;
+
+export type AdminPluginWithoutOrganizations<O extends AdminOptions> = Omit<
+	DefaultAdminPlugin<O>,
+	"endpoints"
+> & {
+	endpoints: Omit<DefaultAdminPlugin<O>["endpoints"], "adminListOrganizations">;
+};
+
+export type AdminPluginWithOrganizations<O extends AdminOptions> = Omit<
+	DefaultAdminPlugin<O>,
+	"endpoints"
+> & {
+	endpoints: Omit<
+		DefaultAdminPlugin<O>["endpoints"],
+		"adminListOrganizations"
+	> & {
+		adminListOrganizations: ReturnType<typeof adminListOrganizations>;
+	};
+};
+
+export function admin<
+	O extends AdminOptions & { organizations: { enabled: true } },
+>(options: O): AdminPluginWithOrganizations<O>;
+export function admin<O extends AdminOptions>(
+	options?: O | undefined,
+): AdminPluginWithoutOrganizations<O>;
+export function admin<O extends AdminOptions>(options?: O | undefined) {
+	return createAdminPlugin(options) as
+		| AdminPluginWithoutOrganizations<O>
+		| AdminPluginWithOrganizations<O>;
+}

--- a/packages/better-auth/src/plugins/admin/client.ts
+++ b/packages/better-auth/src/plugins/admin/client.ts
@@ -3,7 +3,10 @@ import { PACKAGE_VERSION } from "../../version";
 import type { AccessControl, ArrayElement, Role } from "../access";
 import type { defaultStatements } from "./access";
 import { adminAc, userAc } from "./access";
-import type { admin } from "./admin";
+import type {
+	AdminPluginWithOrganizations,
+	AdminPluginWithoutOrganizations,
+} from "./admin";
 import { ADMIN_ERROR_CODES } from "./error-codes";
 import { hasPermission } from "./has-permission";
 
@@ -11,6 +14,11 @@ export * from "./error-codes";
 
 interface AdminClientOptions {
 	ac?: AccessControl | undefined;
+	organizations?:
+		| {
+				enabled: boolean;
+		  }
+		| undefined;
 	roles?:
 		| {
 				[key in string]: Role;
@@ -34,6 +42,17 @@ export const adminClient = <O extends AdminClientOptions>(
 	type PermissionExclusive = {
 		permissions: PermissionType;
 	};
+	type ServerAdminOptions = {
+		ac: O["ac"] extends AccessControl
+			? O["ac"]
+			: AccessControl<DefaultStatements>;
+		roles: O["roles"] extends Record<string, Role>
+			? O["roles"]
+			: {
+					admin: Role;
+					user: Role;
+				};
+	};
 
 	const roles = {
 		admin: adminAc,
@@ -44,19 +63,11 @@ export const adminClient = <O extends AdminClientOptions>(
 	return {
 		id: "admin-client",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<
-			typeof admin<{
-				ac: O["ac"] extends AccessControl
-					? O["ac"]
-					: AccessControl<DefaultStatements>;
-				roles: O["roles"] extends Record<string, Role>
-					? O["roles"]
-					: {
-							admin: Role;
-							user: Role;
-						};
-			}>
-		>,
+		$InferServerPlugin: {} as O["organizations"] extends { enabled: true }
+			? AdminPluginWithOrganizations<
+					ServerAdminOptions & { organizations: { enabled: true } }
+				>
+			: AdminPluginWithoutOrganizations<ServerAdminOptions>,
 		getActions: () => ({
 			admin: {
 				checkRolePermission: <
@@ -82,6 +93,7 @@ export const adminClient = <O extends AdminClientOptions>(
 		}),
 		pathMethods: {
 			"/admin/list-users": "GET",
+			"/admin/list-organizations": "GET",
 			"/admin/impersonate-user": "POST",
 			"/admin/stop-impersonating": "POST",
 		},

--- a/packages/better-auth/src/plugins/admin/client.ts
+++ b/packages/better-auth/src/plugins/admin/client.ts
@@ -93,7 +93,9 @@ export const adminClient = <O extends AdminClientOptions>(
 		}),
 		pathMethods: {
 			"/admin/list-users": "GET",
-			"/admin/list-organizations": "GET",
+			...(options?.organizations?.enabled
+				? { "/admin/list-organizations": "GET" as const }
+				: {}),
 			"/admin/impersonate-user": "POST",
 			"/admin/stop-impersonating": "POST",
 		},

--- a/packages/better-auth/src/plugins/admin/error-codes.ts
+++ b/packages/better-auth/src/plugins/admin/error-codes.ts
@@ -10,6 +10,8 @@ export const ADMIN_ERROR_CODES = defineErrorCodes({
 		"You are not allowed to change users role",
 	YOU_ARE_NOT_ALLOWED_TO_CREATE_USERS: "You are not allowed to create users",
 	YOU_ARE_NOT_ALLOWED_TO_LIST_USERS: "You are not allowed to list users",
+	YOU_ARE_NOT_ALLOWED_TO_LIST_ORGANIZATIONS:
+		"You are not allowed to list organizations",
 	YOU_ARE_NOT_ALLOWED_TO_LIST_USERS_SESSIONS:
 		"You are not allowed to list users sessions",
 	YOU_ARE_NOT_ALLOWED_TO_BAN_USERS: "You are not allowed to ban users",

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -720,6 +720,14 @@ const listOrganizationsQuerySchema = listUsersQuerySchema.extend({
 		.optional(),
 });
 
+const parsePaginationValue = (value: string | number | undefined) => {
+	if (value === undefined) {
+		return undefined;
+	}
+	const parsedValue = Number(value);
+	return Number.isNaN(parsedValue) ? undefined : parsedValue;
+};
+
 export const adminListOrganizations = (opts: AdminOptions) =>
 	createAuthEndpoint(
 		"/admin/list-organizations",
@@ -804,11 +812,13 @@ export const adminListOrganizations = (opts: AdminOptions) =>
 				});
 			}
 
+			const limit = parsePaginationValue(ctx.query?.limit);
+			const offset = parsePaginationValue(ctx.query?.offset);
 			const adapter = getOrgAdapter(ctx.context, organizationPlugin.options);
 			const [organizations, total] = await Promise.all([
 				adapter.listAllOrganizations({
-					limit: Number(ctx.query?.limit) || undefined,
-					offset: Number(ctx.query?.offset) || undefined,
+					limit,
+					offset,
 					sortBy: ctx.query?.sortBy,
 					sortDirection: ctx.query?.sortDirection,
 					where: where.length ? where : undefined,
@@ -818,8 +828,8 @@ export const adminListOrganizations = (opts: AdminOptions) =>
 			return ctx.json({
 				organizations,
 				total,
-				limit: Number(ctx.query?.limit) || undefined,
-				offset: Number(ctx.query?.offset) || undefined,
+				limit,
+				offset,
 			});
 		},
 	);

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -5,7 +5,11 @@ import {
 import type { Session } from "@better-auth/core/db";
 import type { Where } from "@better-auth/core/db/adapter";
 import { whereOperators } from "@better-auth/core/db/adapter";
-import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
+import {
+	APIError,
+	BASE_ERROR_CODES,
+	BetterAuthError,
+} from "@better-auth/core/error";
 import * as z from "zod";
 import { getSessionFromCtx } from "../../api";
 import {
@@ -16,6 +20,7 @@ import {
 import { parseSessionOutput, parseUserOutput } from "../../db/schema";
 import { getDate } from "../../utils/date";
 import type { AccessControl, ArrayElement } from "../access";
+import { getOrgAdapter } from "../organization/adapter";
 import type { defaultStatements } from "./access";
 import { ADMIN_ERROR_CODES } from "./error-codes";
 import { hasPermission } from "./has-permission";
@@ -695,6 +700,127 @@ export const listUsers = (opts: AdminOptions) =>
 					total: 0,
 				});
 			}
+		},
+	);
+
+const listOrganizationsQuerySchema = listUsersQuerySchema.extend({
+	searchField: z
+		.enum(["name", "slug"])
+		.meta({
+			description:
+				'The field to search in, defaults to name. Can be `name` or `slug`. Eg: "name"',
+		})
+		.optional(),
+	limit: z
+		.string()
+		.meta({
+			description: "The number of organizations to return",
+		})
+		.or(z.number())
+		.optional(),
+});
+
+export const adminListOrganizations = (opts: AdminOptions) =>
+	createAuthEndpoint(
+		"/admin/list-organizations",
+		{
+			method: "GET",
+			use: [adminMiddleware],
+			query: listOrganizationsQuerySchema,
+			metadata: {
+				openapi: {
+					operationId: "adminListOrganizations",
+					summary: "List organizations",
+					description: "List all organizations as a system administrator",
+					responses: {
+						200: {
+							description: "List of organizations",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											organizations: {
+												type: "array",
+												items: {
+													$ref: "#/components/schemas/Organization",
+												},
+											},
+											total: {
+												type: "number",
+											},
+											limit: {
+												type: "number",
+											},
+											offset: {
+												type: "number",
+											},
+										},
+										required: ["organizations", "total"],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const canListOrganizations = hasPermission({
+				userId: ctx.context.session.user.id,
+				role: ctx.context.session.user.role,
+				options: opts,
+				permissions: {
+					organization: ["admin-list"],
+				},
+			});
+			if (!canListOrganizations) {
+				throw APIError.from(
+					"FORBIDDEN",
+					ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_LIST_ORGANIZATIONS,
+				);
+			}
+
+			const organizationPlugin = ctx.context.getPlugin("organization");
+			if (!organizationPlugin) {
+				throw new BetterAuthError(
+					"The admin organization endpoints require the organization plugin to be enabled.",
+				);
+			}
+
+			const where: Where[] = [];
+			if (ctx.query?.searchValue) {
+				where.push({
+					field: ctx.query.searchField || "name",
+					operator: ctx.query.searchOperator || "contains",
+					value: ctx.query.searchValue,
+				});
+			}
+			if (ctx.query?.filterValue !== undefined) {
+				where.push({
+					field: ctx.query.filterField || "slug",
+					operator: ctx.query.filterOperator || "eq",
+					value: ctx.query.filterValue,
+				});
+			}
+
+			const adapter = getOrgAdapter(ctx.context, organizationPlugin.options);
+			const [organizations, total] = await Promise.all([
+				adapter.listAllOrganizations({
+					limit: Number(ctx.query?.limit) || undefined,
+					offset: Number(ctx.query?.offset) || undefined,
+					sortBy: ctx.query?.sortBy,
+					sortDirection: ctx.query?.sortDirection,
+					where: where.length ? where : undefined,
+				}),
+				adapter.countOrganizations(where.length ? where : undefined),
+			]);
+			return ctx.json({
+				organizations,
+				total,
+				limit: Number(ctx.query?.limit) || undefined,
+				offset: Number(ctx.query?.offset) || undefined,
+			});
 		},
 	);
 

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -721,7 +721,10 @@ const listOrganizationsQuerySchema = listUsersQuerySchema.extend({
 });
 
 const parsePaginationValue = (value: string | number | undefined) => {
-	if (value === undefined) {
+	if (
+		value === undefined ||
+		(typeof value === "string" && value.trim() === "")
+	) {
 		return undefined;
 	}
 	const parsedValue = Number(value);

--- a/packages/better-auth/src/plugins/admin/types.ts
+++ b/packages/better-auth/src/plugins/admin/types.ts
@@ -48,6 +48,16 @@ export interface AdminOptions {
 	 */
 	impersonationSessionDuration?: number | undefined;
 	/**
+	 * Enable organization administration endpoints.
+	 *
+	 * Requires the organization plugin to be configured.
+	 */
+	organizations?:
+		| {
+				enabled: boolean;
+		  }
+		| undefined;
+	/**
 	 * Custom schema for the admin plugin
 	 */
 	schema?: InferOptionSchema<AdminSchema> | undefined;

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1,6 +1,6 @@
 import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
 import { getCurrentAdapter } from "@better-auth/core/context";
-import type { WhereOperator } from "@better-auth/core/db/adapter";
+import type { Where, WhereOperator } from "@better-auth/core/db/adapter";
 import { BetterAuthError } from "@better-auth/core/error";
 import { filterOutputFields } from "@better-auth/core/utils/db";
 import { parseJSON } from "../../client/parser";
@@ -614,6 +614,51 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			);
 
 			return organizations;
+		},
+		listAllOrganizations: async (data: {
+			limit?: number | undefined;
+			offset?: number | undefined;
+			sortBy?: string | undefined;
+			sortDirection?: "asc" | "desc" | undefined;
+			where?: Where[] | undefined;
+		}): Promise<InferOrganization<O>[]> => {
+			const adapter = await getCurrentAdapter(baseAdapter);
+			const organizations = await adapter.findMany<InferOrganization<O, false>>(
+				{
+					model: "organization",
+					where: data.where,
+					limit: data.limit,
+					offset: data.offset,
+					sortBy: data.sortBy
+						? {
+								field: data.sortBy,
+								direction: data.sortDirection || "asc",
+							}
+						: undefined,
+				},
+			);
+
+			return organizations.map((organization) => {
+				const result = {
+					...organization,
+					metadata: organization.metadata
+						? parseJSON<Record<string, any>>(organization.metadata)
+						: undefined,
+				};
+				return filterOutputFields(
+					result,
+					orgAdditionalFields,
+				) as InferOrganization<O>;
+			});
+		},
+		countOrganizations: async (
+			where?: Where[] | undefined,
+		): Promise<number> => {
+			const adapter = await getCurrentAdapter(baseAdapter);
+			return adapter.count({
+				model: "organization",
+				where,
+			});
 		},
 		createTeam: async (data: TeamInput) => {
 			const adapter = await getCurrentAdapter(baseAdapter);


### PR DESCRIPTION
## Summary

- add opt-in `admin({ organizations: { enabled: true } })` support for `GET /admin/list-organizations`
- expose typed server and client methods for listing all organizations, independent of administrator membership
- add `organization: ["admin-list"]` admin access control, global organization adapter queries, documentation, tests, and a minor changeset

## Motivation

Closes #9735.

The existing organization list endpoint is intentionally scoped to the authenticated user's memberships. Admin dashboards need a supported read-only path to retrieve organizations across the application without querying the adapter directly.

## Scope And Security

- The new endpoint is read-only; this PR does not add organization create, update, delete, or cross-organization member management.
- The endpoint is only registered when `organizations.enabled` is `true` and initialization fails clearly if `organization()` is not installed.
- Requests pass through `adminMiddleware` and require `organization: ["admin-list"]`; default admins receive it, while custom roles must grant it explicitly.
- Results retain organization metadata parsing and respect `additionalFields.returned: false`.
- This targets `next`; the open organization rewrite in #7886 may require a later port if it lands first.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in admin endpoint and typed APIs to list all organizations across the app, regardless of membership. Improves admin dashboards with searchable, paginated org data while keeping access read-only and permission-gated.

- New Features
  - New GET `/admin/list-organizations` when `admin({ organizations: { enabled: true } })` and `organization()` are enabled in `better-auth`; init now fails fast if `organization()` is missing.
  - Access control via `organization: ["admin-list"]`; default admins have it, custom roles must grant it.
  - Supports search, filtering, sorting, and pagination; accepts numeric params as strings or numbers; blank `limit`/`offset` are ignored; search by `name` or `slug`. Response: `{ organizations, total, limit, offset }`, respects `additionalFields.returned: false`.
  - Typed methods: server `adminListOrganizations` and client `admin.listOrganizations` in `adminClient({ organizations: { enabled: true } })`.
  - Organization adapter adds `listAllOrganizations` and `countOrganizations`; new error code for forbidden access; docs updated.

- Migration
  - Enable on server: `admin({ organizations: { enabled: true } })` and ensure `organization()` is installed.
  - Enable on client: `adminClient({ organizations: { enabled: true } })`.
  - If using custom roles, grant `organization: ["admin-list"]` permission.

<sup>Written for commit 4a4ca982792d9695369b12ef74c025d74023d4be. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9741?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



