### PR TITLE
feat(drizzle): allow overriding supportsJSON and supportsArrays per deployment

### DIFF
--- a/.changeset/drizzle-supports-json-arrays-override.md
+++ b/.changeset/drizzle-supports-json-arrays-override.md
@@ -1,0 +1,17 @@
+---
+"@better-auth/drizzle-adapter": patch
+---
+
+feat(drizzle): allow overriding `supportsJSON` / `supportsArrays` per deployment
+
+The adapter previously enabled JSON/array passthrough only when
+`provider === "pg"`, which is correct for MySQL but wrong for SQLite
+deployments (e.g. D1) whose Drizzle schema declares columns with
+`text("col", { mode: "json" })` — Drizzle's own column handling already
+stringifies on insert and parses on select, so the adapter's extra
+stringification produced a double-encoded value that round-tripped through
+better-auth but broke plain Drizzle queries.
+
+Two optional config fields, `supportsJSON` and `supportsArrays`, now let
+callers opt out of the adapter-side stringification. Existing
+`provider === "pg" | "mysql" | "sqlite"` defaults are unchanged.

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -204,4 +204,105 @@ describe("drizzle-adapter", () => {
 			).rejects.toThrow(/Schema not found/);
 		});
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8655
+	 */
+	describe("supportsJSON / supportsArrays override", () => {
+		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+
+		function createCaptureDb(schema: Record<string, Record<string, any>>) {
+			const captured: { values?: unknown } = {};
+			const db = {
+				_: { fullSchema: schema },
+				insert: vi.fn().mockReturnValue({
+					values: vi.fn().mockImplementation((value: unknown) => {
+						captured.values = value;
+						return {
+							returning: vi.fn().mockResolvedValue([{ id: "1" }]),
+						};
+					}),
+				}),
+			} as any;
+			return { db, captured };
+		}
+
+		const userTable = {
+			id: { name: "id" },
+			name: { name: "name" },
+			email: { name: "email" },
+			emailVerified: { name: "emailVerified" },
+			image: { name: "image" },
+			createdAt: { name: "createdAt" },
+			updatedAt: { name: "updatedAt" },
+			tags: { name: "tags" },
+		};
+
+		const userWithArrayField = {
+			user: {
+				additionalFields: {
+					tags: { type: "string[]" as const, required: false },
+				},
+			},
+		};
+
+		it("stringifies array fields on sqlite by default", async () => {
+			const { db, captured } = createCaptureDb({ user: userTable });
+			const factory = drizzleAdapter(db, { provider: "sqlite" });
+			const adapter = factory({ secret: defaultSecret, ...userWithArrayField });
+
+			await adapter.create({
+				model: "user",
+				data: {
+					name: "Test",
+					email: "test@example.com",
+					tags: ["a", "b"],
+				},
+			});
+
+			expect(typeof (captured.values as any)?.tags).toBe("string");
+			expect((captured.values as any)?.tags).toBe(JSON.stringify(["a", "b"]));
+		});
+
+		it("passes array fields through when supportsArrays override is true", async () => {
+			const { db, captured } = createCaptureDb({ user: userTable });
+			const factory = drizzleAdapter(db, {
+				provider: "sqlite",
+				supportsArrays: true,
+			});
+			const adapter = factory({ secret: defaultSecret, ...userWithArrayField });
+
+			await adapter.create({
+				model: "user",
+				data: {
+					name: "Test",
+					email: "test@example.com",
+					tags: ["a", "b"],
+				},
+			});
+
+			// With the override, Drizzle's own `mode: "json"` column handling
+			// stringifies the value on insert — the adapter must not double-encode.
+			expect(Array.isArray((captured.values as any)?.tags)).toBe(true);
+			expect((captured.values as any)?.tags).toEqual(["a", "b"]);
+		});
+
+		it("keeps default Postgres behavior when override is not provided", async () => {
+			const { db, captured } = createCaptureDb({ user: userTable });
+			const factory = drizzleAdapter(db, { provider: "pg" });
+			const adapter = factory({ secret: defaultSecret, ...userWithArrayField });
+
+			await adapter.create({
+				model: "user",
+				data: {
+					name: "Test",
+					email: "test@example.com",
+					tags: ["a", "b"],
+				},
+			});
+
+			// Postgres has native arrays — the adapter must not stringify.
+			expect(Array.isArray((captured.values as any)?.tags)).toBe(true);
+		});
+	});
 });

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -77,6 +77,33 @@ export interface DrizzleAdapterConfig {
 	 * @default false
 	 */
 	transaction?: boolean | undefined;
+	/**
+	 * Override whether the adapter pre-stringifies JSON fields before passing
+	 * them to Drizzle. By default only Postgres is treated as a JSON-capable
+	 * provider — MySQL and SQLite get a JSON.stringify on the way in.
+	 *
+	 * Set this to `true` for SQLite/D1 deployments whose Drizzle schema declares
+	 * JSON columns (e.g. `text("col", { mode: "json" })`). Drizzle's own JSON
+	 * column handling already stringifies on insert and parses on select, so
+	 * letting the adapter stringify on top produces a double-encoded value
+	 * that round-trips through better-auth but breaks plain Drizzle queries.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/8655
+	 * @default `provider === "pg"`
+	 */
+	supportsJSON?: boolean | undefined;
+	/**
+	 * Override whether the adapter passes array values to Drizzle as-is.
+	 * Defaults to `provider === "pg"` since only Postgres has native array
+	 * columns; MySQL and SQLite get arrays JSON-stringified.
+	 *
+	 * Set this to `true` for SQLite/D1 deployments using JSON-mode columns
+	 * to store array fields, for the same reason as `supportsJSON`.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/8655
+	 * @default `provider === "pg"`
+	 */
+	supportsArrays?: boolean | undefined;
 }
 
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
@@ -981,11 +1008,11 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 			usePlural: config.usePlural ?? false,
 			debugLogs: config.debugLogs ?? false,
 			supportsUUIDs: config.provider === "pg" ? true : false,
-			supportsJSON:
-				config.provider === "pg" // even though mysql also supports it, mysql requires to pass stringified json anyway.
-					? true
-					: false,
-			supportsArrays: config.provider === "pg" ? true : false,
+			// even though mysql also supports JSON, mysql requires to pass stringified json anyway.
+			// Allow callers to override (e.g. SQLite/D1 with `mode: "json"` columns where
+			// Drizzle already stringifies on insert) so we don't double-encode the value.
+			supportsJSON: config.supportsJSON ?? config.provider === "pg",
+			supportsArrays: config.supportsArrays ?? config.provider === "pg",
 			customTransformOutput: ({ data, fieldAttributes }) => {
 				// not all providers support dates
 				// one such example case is https://github.com/better-auth/better-auth/issues/7819


### PR DESCRIPTION
## Summary

Closes #8655.

SQLite deployments using Drizzle's \`text(\"col\", { mode: \"json\" })\` columns (notably Cloudflare D1) currently get double-encoded JSON values because the drizzle adapter forces a \`JSON.stringify\` on insert while Drizzle's own column handling stringifies again on the way out. better-auth's own queries round-trip cleanly so the bug is invisible to users who only read via better-auth's API, but plain Drizzle queries see escaped strings inside string columns (e.g. \`redirectUris: '[\"https://localhost\"]'\` instead of an array).

The reporter offered two paths and recommended the second:
> - put sqlite as a provider that supports JSON and array (some versions of sqlite might not??)
> - allow me to pass values for \`supports*\` (best for back compat)

This PR takes the back-compat-preserving option: add two optional fields to \`DrizzleAdapterConfig\`.

## Changes

`packages/drizzle-adapter/src/drizzle-adapter.ts`:

- New optional `supportsJSON?: boolean` and `supportsArrays?: boolean` on `DrizzleAdapterConfig`.
- The factory now uses `config.supportsJSON ?? (config.provider === "pg")` (same shape for `supportsArrays`), so existing users see no change.
- JSDoc on the new fields explains exactly when to flip them on (SQLite/D1 with `mode: "json"` columns) and links the issue.

## Test plan

- [x] New `describe("supportsJSON / supportsArrays override")` block in `drizzle-adapter.test.ts`:
  - `stringifies array fields on sqlite by default` — pins the current behaviour so future refactors can't silently change SQLite handling.
  - `passes array fields through when supportsArrays override is true` — the regression test for #8655. Fails on `main`.
  - `keeps default Postgres behaviour when override is not provided` — confirms PG users see no change.
- [x] Verified the new regression test fails on `main` without the source change and passes with it.
- [x] All existing drizzle-adapter unit tests still pass.

## Docs

The JSDoc on the new fields documents the use case in-place. No separate docs page change needed — the existing drizzle adapter doc doesn't enumerate adapter capabilities, and discovering the option via IDE tooltip / generated types is the canonical path for a per-deployment toggle.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-deployment overrides for JSON and array handling in `@better-auth/drizzle-adapter`. This prevents double-encoded values on SQLite/D1 when Drizzle columns use `mode: "json"`, while keeping existing defaults unchanged.

- **New Features**
  - Added `supportsJSON?` and `supportsArrays?` to `DrizzleAdapterConfig`.
  - Adapter uses overrides or defaults to `provider === "pg"` for passthrough.

- **Migration**
  - No action needed for most users.
  - For SQLite/D1 with Drizzle `text(..., { mode: "json" })`, set `supportsJSON: true` and `supportsArrays: true` to avoid double-encoding in plain Drizzle queries.

<sup>Written for commit 358bfd34b644af42352d6506f43d65388680fc1c. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9751?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

