### PR TITLE
fix(core): handle Twitch token refreshing: Handle arrays of scopes during token refresh

### DIFF
--- a/.changeset/big-moles-thank.md
+++ b/.changeset/big-moles-thank.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Fixes token refreshing for providers sending scopes as an array. Fixes token refreshing for Twitch.

--- a/packages/core/src/oauth2/refresh-access-token.test.ts
+++ b/packages/core/src/oauth2/refresh-access-token.test.ts
@@ -87,4 +87,49 @@ describe("refreshAccessToken", () => {
 
 		expect(tokens.refreshTokenExpiresAt).toBeUndefined();
 	});
+
+	it("should handle scope as an array", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "new-access-token",
+				refresh_token: "new-refresh-token",
+				expires_in: 3600,
+				token_type: "Bearer",
+				scope: ["channel:read:subscriptions", "channel:manage:polls"],
+			},
+			error: null,
+		});
+
+		const tokens = await refreshAccessToken({
+			refreshToken: "old-refresh-token",
+			options: { clientId: "test-client", clientSecret: "test-secret" },
+			tokenEndpoint: "https://example.com/token",
+		});
+
+		expect(tokens.scopes).toEqual([
+			"channel:read:subscriptions",
+			"channel:manage:polls",
+		]);
+	});
+
+	it("should handle scope as a space-delimited string", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "new-access-token",
+				refresh_token: "new-refresh-token",
+				expires_in: 3600,
+				token_type: "Bearer",
+				scope: "read write profile",
+			},
+			error: null,
+		});
+
+		const tokens = await refreshAccessToken({
+			refreshToken: "old-refresh-token",
+			options: { clientId: "test-client", clientSecret: "test-secret" },
+			tokenEndpoint: "https://example.com/token",
+		});
+
+		expect(tokens.scopes).toEqual(["read", "write", "profile"]);
+	});
 });

--- a/packages/core/src/oauth2/refresh-access-token.ts
+++ b/packages/core/src/oauth2/refresh-access-token.ts
@@ -121,7 +121,7 @@ export async function refreshAccessToken({
 		expires_in?: number | undefined;
 		refresh_token_expires_in?: number | undefined;
 		token_type?: string | undefined;
-		scope?: string | undefined;
+		scope?: string | string[] | undefined;
 		id_token?: string | undefined;
 	}>(tokenEndpoint, {
 		method: "POST",
@@ -135,7 +135,7 @@ export async function refreshAccessToken({
 		accessToken: data.access_token,
 		refreshToken: data.refresh_token,
 		tokenType: data.token_type,
-		scopes: data.scope?.split(" "),
+		scopes: typeof data.scope === "string" ? data.scope.split(" ") : data.scope,
 		idToken: data.id_token,
 	};
 


### PR DESCRIPTION
Some providers, like Twitch, are sending oauth scopes as an array and not as a space-delimited string.

We handle this correctly in the initial token grant, but it looks like the refresh logic has drifted. It still expects only a string here, so refreshing tokens fails for these providers.

Resolves #9076.

I considered either fixing it inline or calling the same `getOAuth2Tokens` parser used for the initial grant.

As much as I'd like to prevent future drift, I inlined the fix for now: Using the initial parser does change the response slightly (I see it adds `raw` at the very least; not sure how sensitive downstream would be to that).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OAuth2 token refresh in `@better-auth/core` to handle scope arrays, not just space-delimited strings. Restores working refresh for Twitch and similar providers.

- **Bug Fixes**
  - Accept `scope` as `string | string[]` and parse it correctly during refresh.
  - Added tests for both array and space-delimited scope responses.

<sup>Written for commit dcad35fce24df206f0d992a3b7aad870a43b3b00. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9758?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

