### PR TITLE
fix(last-login-method): respect configured cookie prefix

### DIFF
--- a/packages/better-auth/src/plugins/last-login-method/client.ts
+++ b/packages/better-auth/src/plugins/last-login-method/client.ts
@@ -7,10 +7,17 @@ import { PACKAGE_VERSION } from "../../version";
  */
 export interface LastLoginMethodClientConfig {
 	/**
-	 * Name of the cookie to read the last login method from
+	 * Name of the cookie to read the last login method from. Defaults to
+	 * `${cookiePrefix}.last_used_login_method`.
 	 * @default "better-auth.last_used_login_method"
 	 */
 	cookieName?: string | undefined;
+	/**
+	 * Cookie prefix configured on the server via `advanced.cookiePrefix`.
+	 * Ignored when `cookieName` is provided.
+	 * @default "better-auth"
+	 */
+	cookiePrefix?: string | undefined;
 }
 
 function getCookieValue(name: string): string | null {
@@ -26,7 +33,8 @@ function getCookieValue(name: string): string | null {
 export const lastLoginMethodClient = (
 	config: LastLoginMethodClientConfig = {},
 ) => {
-	const cookieName = config.cookieName || "better-auth.last_used_login_method";
+	const cookieName = `${config.cookiePrefix || "better-auth"}.last_used_login_method`;
+	const resolvedCookieName = config.cookieName || cookieName;
 
 	return {
 		id: "last-login-method-client",
@@ -38,7 +46,7 @@ export const lastLoginMethodClient = (
 				 * @returns The last used login method or null if not found
 				 */
 				getLastUsedLoginMethod: (): string | null => {
-					return getCookieValue(cookieName);
+					return getCookieValue(resolvedCookieName);
 				},
 				/**
 				 * Clear the last used login method cookie
@@ -46,7 +54,7 @@ export const lastLoginMethodClient = (
 				 */
 				clearLastUsedLoginMethod: (): void => {
 					if (typeof document !== "undefined") {
-						document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+						document.cookie = `${resolvedCookieName}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
 					}
 				},
 				/**
@@ -55,7 +63,7 @@ export const lastLoginMethodClient = (
 				 * @returns True if the method was the last used, false otherwise
 				 */
 				isLastUsedLoginMethod: (method: string): boolean => {
-					const lastMethod = getCookieValue(cookieName);
+					const lastMethod = getCookieValue(resolvedCookieName);
 					return lastMethod === method;
 				},
 			};

--- a/packages/better-auth/src/plugins/last-login-method/custom-prefix.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/custom-prefix.test.ts
@@ -33,8 +33,8 @@ describe("lastLoginMethod custom cookie prefix", async () => {
 			},
 		);
 		const cookies = parseCookies(headers.get("cookie") || "");
-		// Uses exact cookie name from config, not affected by cookiePrefix
-		expect(cookies.get("better-auth.last_used_login_method")).toBe("email");
+		// Uses the configured Better Auth cookie prefix by default
+		expect(cookies.get("custom-auth.last_used_login_method")).toBe("email");
 	});
 
 	it("should work with custom cookie name and prefix", async () => {
@@ -130,9 +130,8 @@ describe("lastLoginMethod custom cookie prefix", async () => {
 					const setCookie = context.response.headers.get("set-cookie");
 					expect(setCookie).toContain("Domain=example.com");
 					expect(setCookie).toContain("SameSite=Lax");
-					// Uses exact cookie name from config, not affected by cookiePrefix
 					expect(setCookie).toContain(
-						"better-auth.last_used_login_method=email",
+						"custom-auth.last_used_login_method=email",
 					);
 				},
 			},

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -17,7 +17,8 @@ declare module "@better-auth/core" {
  */
 export interface LastLoginMethodOptions {
 	/**
-	 * Name of the cookie to store the last login method
+	 * Name of the cookie to store the last login method. Defaults to
+	 * `${advanced.cookiePrefix}.last_used_login_method`.
 	 * @default "better-auth.last_used_login_method"
 	 */
 	cookieName?: string | undefined;
@@ -89,10 +90,16 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 	};
 
 	const config = {
-		cookieName: "better-auth.last_used_login_method",
 		maxAge: 60 * 60 * 24 * 30,
 		...userConfig,
 	} satisfies LastLoginMethodOptions;
+
+	const getCookieName = (ctx: GenericEndpointContext) => {
+		return (
+			config.cookieName ||
+			`${ctx.context.options.advanced?.cookiePrefix || "better-auth"}.last_used_login_method`
+		);
+	};
 
 	return {
 		id: "last-login-method",
@@ -169,7 +176,7 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 								};
 
 								ctx.setCookie(
-									config.cookieName,
+									getCookieName(ctx),
 									lastUsedLoginMethod,
 									cookieAttributes,
 								);


### PR DESCRIPTION
## Summary
- derive the last-login-method cookie name from `advanced.cookiePrefix` when no explicit `cookieName` is provided
- add matching client-side `cookiePrefix` support for reading and clearing the cookie
- update custom-prefix coverage for default, explicit cookieName, and cross-subdomain cookies

Closes #9695.

## Validation
- `pnpm --filter better-auth... build`
- `pnpm vitest run packages/better-auth/src/plugins/last-login-method/custom-prefix.test.ts packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts`
- `pnpm biome check packages/better-auth/src/plugins/last-login-method/index.ts packages/better-auth/src/plugins/last-login-method/client.ts packages/better-auth/src/plugins/last-login-method/custom-prefix.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the configured cookie prefix for the last-login-method cookie across server and client. Adds client `cookiePrefix` support and aligns defaults with `advanced.cookiePrefix`.

- **Bug Fixes**
  - Server: derive cookie name from `advanced.cookiePrefix` (fallback `better-auth`) when `cookieName` is not set.
  - Client: add `cookiePrefix` option; resolve to `cookieName` or `${cookiePrefix}.last_used_login_method` for read/clear/check.
  - Tests updated for default, explicit `cookieName`, and cross-subdomain cookies.

- **Migration**
  - If you read the cookie manually, use `${cookiePrefix}.last_used_login_method` or set an explicit `cookieName`.

<sup>Written for commit e4a660d371a404cccd2ff79746e1b6d5e9e4a3a7. Summary will update on new commits. <a href="https://cubic.dev/pr/better-auth/better-auth/pull/9760?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

