### PR TITLE
fix(client): infer session fields for updateSession

### DIFF
--- a/.changeset/update-session-additional-fields.md
+++ b/.changeset/update-session-additional-fields.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Client `updateSession` calls now accept inferred custom session fields from `inferAdditionalFields`.

--- a/packages/better-auth/src/client/path-to-object.ts
+++ b/packages/better-auth/src/client/path-to-object.ts
@@ -109,6 +109,15 @@ export type InferUserUpdateCtx<
 	UnionToIntersection<InferAdditionalFromClient<ClientOpts, "user", "input">>
 >;
 
+export type InferSessionUpdateCtx<
+	ClientOpts extends BetterAuthClientOptions,
+	FetchOptions extends ClientFetchOption,
+> = {
+	fetchOptions?: FetchOptions | undefined;
+} & Partial<
+	UnionToIntersection<InferAdditionalFromClient<ClientOpts, "session", "input">>
+>;
+
 type InferCtxQuery<
 	C extends InputContext<any, any>,
 	FetchOptions extends ClientFetchOption,
@@ -184,7 +193,9 @@ export type InferRoute<API, COpts extends BetterAuthClientOptions> =
 													Prettify<
 														T["path"] extends `/update-user`
 															? InferUserUpdateCtx<COpts, FetchOptions>
-															: InferCtx<C, FetchOptions>
+															: T["path"] extends `/update-session`
+																? InferSessionUpdateCtx<COpts, FetchOptions>
+																: InferCtx<C, FetchOptions>
 													>?,
 													FetchOptions?,
 												]

--- a/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
+++ b/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { betterAuth } from "../../auth/full";
 import { createAuthClient } from "../../client";
 import { createAuthClient as createReactAuthClient } from "../../client/react";
 import { getTestInstance } from "../../test-utils/test-instance";
@@ -191,6 +192,48 @@ describe("additionalFields", async () => {
 			};
 			session: Session;
 		} | null>;
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9770
+	 */
+	it("should infer session additional fields on updateSession", () => {
+		const auth = betterAuth({
+			session: {
+				additionalFields: {
+					color: {
+						type: "string",
+						required: false,
+					},
+					internalNote: {
+						type: "string",
+						input: false,
+						required: false,
+					},
+				},
+			},
+		});
+		const client = createAuthClient({
+			plugins: [inferAdditionalFields<typeof auth>()],
+		});
+
+		type UpdateSessionBody = NonNullable<
+			Parameters<typeof client.updateSession>[0]
+		>;
+
+		const body = {
+			color: "blue",
+		} satisfies UpdateSessionBody;
+		expect(body.color).toBe("blue");
+		expectTypeOf<UpdateSessionBody>().toMatchTypeOf<{
+			color?: string | null | undefined;
+		}>();
+
+		const blockedBody = {
+			// @ts-expect-error input: false fields must not be client-updateable.
+			internalNote: "hidden",
+		} satisfies UpdateSessionBody;
+		void blockedBody;
 	});
 
 	it("should infer it on the client without direct import", async () => {


### PR DESCRIPTION
## What changed

- Infer custom session additional fields for `authClient.updateSession(...)` when using `inferAdditionalFields`.
- Add regression coverage for issue #9770, including a guard that `input: false` session fields remain rejected on the client.
- Add a patch changeset for `better-auth`.

## Why

`updateSession` used the generic route body inference path, so inferred session additional fields were lost and valid calls like `authClient.updateSession({ color: "blue" })` failed to type-check.

Closes #9770.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes client-side type inference so `authClient.updateSession` accepts inferred custom session fields from `inferAdditionalFields`. Removes false type errors for valid fields and still blocks `input: false` fields.

- **Bug Fixes**
  - Infer session additional fields for `updateSession` via `InferSessionUpdateCtx` and `/update-session` handling so valid calls type-check.
  - Add regression tests for #9770 and keep `input: false` fields blocked; add a patch changeset for `better-auth`.

<sup>Written for commit fe78ebd7b31295b526d976b355c7440e5ebaca21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9777?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



