### PR TITLE
docs: clarify organization-owned api keys also require a user

### DIFF
--- a/docs/content/docs/plugins/api-key/advanced.mdx
+++ b/docs/content/docs/plugins/api-key/advanced.mdx
@@ -272,7 +272,7 @@ export const auth = betterAuth({
 
 ### Creating Organization-Owned Keys
 
-When creating an organization-owned API key, pass the `organizationId` instead of `userId`:
+When creating an organization-owned API key, pass the `organizationId` together with a user context. The user must be a member of the organization with permission to create API keys. That user is taken from the session (request `headers`); for a pure server call without headers, pass a `userId` in the body instead:
 
 ```ts title="create-org-api-key.ts"
 import { auth } from "@/lib/auth"
@@ -280,7 +280,8 @@ import { auth } from "@/lib/auth"
 const orgKey = await auth.api.createApiKey({
   body: {
     configId: "org-keys",
-    organizationId: "org_123", // Required for org-owned keys
+    organizationId: "org_123", // the organization that owns the key
+    userId: "user_123", // a member allowed to create keys; omit when passing session headers
   },
 });
 ```

--- a/docs/content/docs/plugins/api-key/index.mdx
+++ b/docs/content/docs/plugins/api-key/index.mdx
@@ -87,7 +87,7 @@ You can view the [API Key plugin options](/docs/plugins/api-key/reference#api-ke
 
 ### Create an API key
 
-<APIMethod path="/api-key/create" method="POST" serverOnlyNote="If you're creating an API key on the server, without access to headers, you must pass the `userId` property (for user-owned keys) or `organizationId` (for organization-owned keys)." clientOnlyNote="You can adjust more specific API key configurations by using the server method instead.">
+<APIMethod path="/api-key/create" method="POST" serverOnlyNote="If you're creating an API key on the server, without access to headers, you must pass the `userId` property (for user-owned keys). For organization-owned keys, pass the `organizationId` together with a `userId` that has permission to create keys in that organization." clientOnlyNote="You can adjust more specific API key configurations by using the server method instead.">
   ```ts
   type createApiKey = {
       /**


### PR DESCRIPTION
Closes #8778.

The api-key docs say to pass `organizationId` "instead of" `userId` for organization-owned keys, and the server-side example passes only `organizationId`. That doesn't match the code: in `packages/api-key/src/routes/create-api-key.ts`, for `references: "organization"` it resolves `const userId = session?.user.id || ctx.body.userId`, throws `UNAUTHORIZED_SESSION` if neither is present, then runs `checkOrgApiKeyPermission(ctx, userId, orgId, "create")`. So org-owned creation needs both the `organizationId` and a user (from session or body) that has create permission.

This is a docs-only change documenting current behavior:
- advanced guide: the "instead of `userId`" line and the server example now show passing `organizationId` together with a `userId` (or session headers).
- the create method's `serverOnlyNote` says the same.

Scoped to docs intentionally. #8778 also raises whether `organizationId` alone *should* be enough (a permission-check change); I left that design question to the maintainers since it's a security-labeled behavior change, not a docs fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarify that creating organization-owned API keys requires both `organizationId` and a user context with permission to create (from session headers or `userId`). Updated the advanced guide example and the `/api-key/create` server-only note to show this; closes #8778.

<sup>Written for commit 2a03531864f87d0fe84969d714e4508a528226ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9780?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

