### PR TITLE
fix(oauth): honor per-flow errorCallbackURL when state validation fails

### DIFF
--- a/.changeset/oauth-error-callback-url-on-state-failure.md
+++ b/.changeset/oauth-error-callback-url-on-state-failure.md
@@ -1,0 +1,9 @@
+---
+"better-auth": patch
+---
+
+Honor the per-flow `errorCallbackURL` when OAuth state validation fails.
+
+A social sign-in that passed `errorCallbackURL` was still redirected to the default error page (`onAPIError.errorURL` or `/api/auth/error`) when the callback's state check failed, instead of the URL the caller specified. This broke native flows (such as Expo) that need to land on their own error route rather than a backend page.
+
+The callback now recovers the `errorCallbackURL` from the parsed state and redirects there on a state mismatch. Recovery only applies when the state was parsed before the failure (a nonce or state-cookie mismatch, or an expired request); failures where nothing could be parsed still fall back to the default. The recovered URL needs no new allowlist because `errorCallbackURL` is already validated against `trustedOrigins` at sign-in.

--- a/packages/better-auth/src/oauth2/state.test.ts
+++ b/packages/better-auth/src/oauth2/state.test.ts
@@ -93,4 +93,27 @@ describe("parseState error mapping", () => {
 			"https://example.com/error?foo=bar&error=state_invalid",
 		);
 	});
+
+	/**
+	 * The per-flow `errorCallbackURL` recovered from the state takes precedence
+	 * over the default error page, and the error parameter is appended with the
+	 * correct separator when that URL already carries a query string.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/5467
+	 */
+	it("prefers the recovered per-flow errorURL and appends with & when it has a query", async () => {
+		const { StateError } = await import("../state");
+		errorToThrow = new StateError("State mismatch", {
+			code: "state_security_mismatch",
+			errorURL: "/oauth-error?source=expo",
+		});
+
+		const { parseState } = await import("./state");
+		const { ctx, redirectCalls } = createMockContext();
+		await parseState(ctx as unknown as GenericEndpointContext).catch(() => {});
+
+		expect(redirectCalls[0]).toBe(
+			"/oauth-error?source=expo&error=state_mismatch",
+		);
+	});
 });

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -60,13 +60,15 @@ export async function parseState(c: GenericEndpointContext) {
 		c.context.logger.error("Failed to parse state", error);
 
 		let code = "internal_server_error";
+		let redirectErrorURL = errorURL;
 		if (error instanceof StateError) {
 			code =
 				error.code === "state_security_mismatch"
 					? "state_mismatch"
 					: error.code;
+			redirectErrorURL = error.errorURL ?? errorURL;
 		}
-		redirectOnError(c, errorURL, code);
+		redirectOnError(c, redirectErrorURL, code);
 	}
 
 	if (!parsedData.errorURL) {

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -282,6 +282,44 @@ describe("Social Providers", async (c) => {
 		});
 	});
 
+	/**
+	 * When OAuth state validation fails, the redirect must honor the per-flow
+	 * `errorCallbackURL` the caller passed at sign-in, not the default error
+	 * page. The error URL is recoverable from the parsed state even when the
+	 * state-cookie check fails, and it was already origin-validated at sign-in.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/5467
+	 */
+	it("redirects to the per-flow errorCallbackURL when state validation fails", async () => {
+		const headers = new Headers();
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			errorCallbackURL: "/oauth-error",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+
+		// Omit the state cookie so the signed-cookie check fails
+		// (state_security_mismatch) while the verification record still parses.
+		await client.$fetch("/callback/google", {
+			query: {
+				state,
+				code: "test",
+			},
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				const location = context.response.headers.get("location") ?? "";
+				expect(location).toContain("/oauth-error");
+				expect(location).toContain("error=state_mismatch");
+				expect(location).not.toContain("/api/auth/error");
+			},
+		});
+	});
+
 	it("should be able to sign in with async social provider", async () => {
 		const headers = new Headers();
 		const signInRes = await client.signIn.social({

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -40,17 +40,27 @@ export type StateErrorCode =
 export class StateError extends BetterAuthError {
 	code: string;
 	details?: Record<string, any>;
+	/**
+	 * The per-flow `errorCallbackURL` recovered from the parsed state, when the
+	 * failure happened after the state was successfully parsed (for example a
+	 * nonce or state-cookie mismatch). It was origin-validated at sign-in, so
+	 * the callback can safely redirect there instead of the default error page.
+	 * Absent when the state could not be parsed at all.
+	 */
+	errorURL?: string;
 
 	constructor(
 		message: string,
 		options: ErrorOptions & {
 			code: StateErrorCode;
 			details?: Record<string, any>;
+			errorURL?: string;
 		},
 	) {
 		super(message, options);
 		this.code = options.code;
 		this.details = options.details;
+		this.errorURL = options.errorURL;
 	}
 }
 
@@ -188,6 +198,7 @@ export async function parseGenericState(
 				{
 					code: "state_security_mismatch",
 					details: { state },
+					errorURL: parsedData.errorURL,
 				},
 			);
 		}
@@ -215,6 +226,7 @@ export async function parseGenericState(
 				{
 					code: "state_security_mismatch",
 					details: { state },
+					errorURL: parsedData.errorURL,
 				},
 			);
 		}
@@ -247,6 +259,7 @@ export async function parseGenericState(
 			throw new StateError("State mismatch: State not persisted correctly", {
 				code: "state_security_mismatch",
 				details: { state },
+				errorURL: parsedData.errorURL,
 			});
 		}
 
@@ -263,6 +276,7 @@ export async function parseGenericState(
 			details: {
 				expiresAt: parsedData.expiresAt,
 			},
+			errorURL: parsedData.errorURL,
 		});
 	}
 


### PR DESCRIPTION
A social sign-in that passed `errorCallbackURL` was redirected to the default error page when the callback's state check failed, instead of the URL the caller specified. Native flows such as Expo, which need to land on their own error route rather than a backend page, were the main casualty.

The error URL is stored inside the state, so it can only be recovered when the state was actually parsed before the failure: a nonce mismatch, a state-cookie mismatch, or an expired request. In those cases the callback now redirects to the caller's `errorCallbackURL`. Failures where nothing could be parsed (missing cookie, decryption failure, missing verification record) still fall back to the default error page.

No new configuration is required. `errorCallbackURL` is already validated against `trustedOrigins` at sign-in, so a value that reached the parsed state was provably trusted when it was stored; re-validating at redirect time would only duplicate that check.

Closes #5467.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth callbacks to honor the per-flow `errorCallbackURL` when state validation fails, so native flows (e.g., Expo) land on their own error route instead of the default error page.

- **Bug Fixes**
  - Redirect to the caller’s `errorCallbackURL` when the state was parsed but validation failed (nonce/state-cookie mismatch or expired request), and append `error=state_mismatch` with the correct separator when the URL already has a query.
  - Fall back to the default error page (`onAPIError.errorURL` or `/api/auth/error`) only when the state can’t be parsed.
  - `StateError` now carries the recovered URL and `parseState` uses it on redirect; no new config needed as the URL is already validated against `trustedOrigins`.

<sup>Written for commit d251471649680eae33cadee603a09308c439781f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9789?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

