### PR TITLE
chore: bump `@better-auth/utils`

### DIFF
--- a/.changeset/workers-password-node-crypto.md
+++ b/.changeset/workers-password-node-crypto.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Email and password hashing on Cloudflare Workers (`nodejs_compat`) now uses the `node:crypto` implementation instead of the pure-JS fallback.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@better-auth/utils':
-      specifier: 0.4.0
-      version: 0.4.0
+      specifier: 0.4.1
+      version: 0.4.1
     '@better-fetch/fetch':
       specifier: 1.1.21
       version: 1.1.21
@@ -172,7 +172,7 @@ importers:
         version: 3.0.107(react@19.2.4)(zod@4.3.6)
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@better-fetch/fetch':
         specifier: 'catalog:'
         version: 1.1.21
@@ -835,7 +835,7 @@ importers:
     dependencies:
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       better-call:
         specifier: 'catalog:'
         version: 1.3.5(zod@4.3.6)
@@ -878,7 +878,7 @@ importers:
         version: link:../telemetry
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@better-fetch/fetch':
         specifier: 'catalog:'
         version: 1.1.21
@@ -1029,7 +1029,7 @@ importers:
         version: link:../telemetry
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
@@ -1121,7 +1121,7 @@ importers:
     devDependencies:
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@better-fetch/fetch':
         specifier: 'catalog:'
         version: 1.1.21
@@ -1160,7 +1160,7 @@ importers:
         version: link:../core
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260226.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@upstash/redis@1.36.4)(better-sqlite3@12.6.2)(bun-types@1.3.9)(kysely@0.28.17)(mysql2@3.18.2(@types/node@25.9.1))(pg@8.19.0)(postgres@3.4.8)(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
@@ -1175,7 +1175,7 @@ importers:
     dependencies:
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@better-fetch/fetch':
         specifier: 'catalog:'
         version: 1.1.21
@@ -1264,7 +1264,7 @@ importers:
         version: link:../core
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@cloudflare/workers-types':
         specifier: ^4.20250121.0
         version: 4.20260226.1
@@ -1285,7 +1285,7 @@ importers:
         version: link:../core
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       tsdown:
         specifier: 'catalog:'
         version: 0.21.1(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.19.0)(publint@0.3.17)(typescript@5.9.3)
@@ -1300,7 +1300,7 @@ importers:
         version: link:../core
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       mongodb:
         specifier: ^7.1.0
         version: 7.1.0
@@ -1315,7 +1315,7 @@ importers:
     dependencies:
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@better-fetch/fetch':
         specifier: 'catalog:'
         version: 1.1.21
@@ -1349,7 +1349,7 @@ importers:
     dependencies:
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@better-fetch/fetch':
         specifier: 'catalog:'
         version: 1.1.21
@@ -1393,7 +1393,7 @@ importers:
         version: link:../core
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       tsdown:
         specifier: 'catalog:'
         version: 0.21.1(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.19.0)(publint@0.3.17)(typescript@5.9.3)
@@ -1426,7 +1426,7 @@ importers:
     dependencies:
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       better-auth:
         specifier: workspace:^
         version: link:../better-auth
@@ -1451,7 +1451,7 @@ importers:
     dependencies:
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@better-fetch/fetch':
         specifier: 'catalog:'
         version: 1.1.21
@@ -1528,7 +1528,7 @@ importers:
     dependencies:
       '@better-auth/utils':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.4.1
       '@better-fetch/fetch':
         specifier: 'catalog:'
         version: 1.1.21
@@ -2297,6 +2297,9 @@ packages:
 
   '@better-auth/utils@0.4.0':
     resolution: {integrity: sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==}
+
+  '@better-auth/utils@0.4.1':
+    resolution: {integrity: sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==}
 
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
@@ -15412,6 +15415,10 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.0-rc.2
 
   '@better-auth/utils@0.4.0':
+    dependencies:
+      '@noble/hashes': 2.0.1
+
+  '@better-auth/utils@0.4.1':
     dependencies:
       '@noble/hashes': 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ overrides:
   effect@<3.20.0: '>=3.20.0 <4'
 
 catalog:
-  '@better-auth/utils': 0.4.0
+  '@better-auth/utils': 0.4.1
   '@better-fetch/fetch': 1.1.21
   better-call: 1.3.5
   kysely: ^0.28.17 || ^0.29.0


### PR DESCRIPTION
> [!NOTE]
> We're already requiring "nodejs_compat" because of AsyncLocalStorage, so there's no user-facing breaking change. Cloudflare Workers users will now use `node:crypto` scrypt instead of falling back to the pure-JS implementation. 

- Closes #9649