### PR TITLE
fix(api-key): verify non-default keys when configId is omitted

### DIFF
--- a/.changeset/curly-pillows-bow.md
+++ b/.changeset/curly-pillows-bow.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/api-key": patch
+---
+
+`verifyApiKey` rejected keys created under a non-default `configId` when the request omitted `configId`. It now validates the key against its own configuration.

--- a/docs/content/docs/plugins/api-key/advanced.mdx
+++ b/docs/content/docs/plugins/api-key/advanced.mdx
@@ -154,8 +154,9 @@ const secretKey = await auth.api.createApiKey({
 ```
 
 <Callout type="warn">
-  Note that when creating a key under a specific configId,
-  the `get`, `update`, `delete` and `verify` operations must also specify the `configId` parameter.
+  `get`, `update`, and `delete` must pass the same `configId` the key was created with.
+  `verify` resolves the key's own configuration, so it only needs `configId` when a
+  configuration differs from the default in storage or hashing.
 </Callout>
 
 ### Using configId for API Key Operations

--- a/docs/content/docs/plugins/api-key/index.mdx
+++ b/docs/content/docs/plugins/api-key/index.mdx
@@ -179,7 +179,7 @@ Otherwise if it throws, it will throw an `APIError`.
 
   type verifyApiKey = {
       /**
-       * The configuration ID to use for verification. If not provided, the default configuration is used.
+       * Configuration ID to scope verification to. When omitted, the key is validated against its own configuration.
        */
       configId?: string
       /**

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -1984,6 +1984,69 @@ describe("api-key", async () => {
 			expect(session?.session).toBeDefined();
 		});
 
+		it("should run customAPIKeyValidator once on the session path", async () => {
+			const validator = vi.fn(() => true);
+			const { auth, signInWithTestUser } = await getTestInstance(
+				{
+					plugins: [
+						apiKey({
+							enableSessionForAPIKeys: true,
+							customAPIKeyValidator: validator,
+						}),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [apiKeyClient()],
+					},
+				},
+			);
+
+			const { user } = await signInWithTestUser();
+			const apiKey2 = await auth.api.createApiKey({
+				body: { userId: user.id },
+			});
+
+			const headers = new Headers();
+			headers.set("x-api-key", apiKey2.key);
+			validator.mockClear();
+
+			await auth.api.getSession({ headers });
+
+			expect(validator).toHaveBeenCalledTimes(1);
+		});
+
+		it("should not grant a session for a key from a different config", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance(
+				{
+					plugins: [
+						apiKey([
+							{ configId: "primary", enableSessionForAPIKeys: true },
+							{ configId: "secondary", enableSessionForAPIKeys: true },
+						]),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [apiKeyClient()],
+					},
+				},
+			);
+
+			const { user } = await signInWithTestUser();
+
+			// Issued under "secondary" but presented via the shared default header,
+			// which matches the first config ("primary").
+			const secondaryKey = await auth.api.createApiKey({
+				body: { configId: "secondary", userId: user.id },
+			});
+
+			const headers = new Headers();
+			headers.set("x-api-key", secondaryKey.key);
+
+			await expect(auth.api.getSession({ headers })).rejects.toThrowError();
+		});
+
 		it("should not get session from an API key if enableSessionForAPIKeys is false", async () => {
 			const { client, auth, signInWithTestUser } = await getTestInstance(
 				{
@@ -4048,6 +4111,188 @@ describe("api-key", async () => {
 			expect(result.valid).toBe(true);
 			expect(result.key?.configId).toBe("public-api");
 			expect(result.key?.rateLimitMax).toBe(100);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/9779
+		 */
+		describe("verify scoping by configId", () => {
+			it("should verify a non-default key when configId is omitted", async () => {
+				const { user } = await signInWithTestUser();
+
+				const publicKey = await auth.api.createApiKey({
+					body: {
+						configId: "public-api",
+						userId: user.id,
+					},
+				});
+
+				const result = await auth.api.verifyApiKey({
+					body: { key: publicKey.key },
+				});
+
+				expect(result.valid).toBe(true);
+				expect(result.key?.configId).toBe("public-api");
+			});
+
+			it("should still verify a default key when configId is omitted", async () => {
+				const { user } = await signInWithTestUser();
+
+				const defaultKey = await auth.api.createApiKey({
+					body: { userId: user.id },
+				});
+
+				const result = await auth.api.verifyApiKey({
+					body: { key: defaultKey.key },
+				});
+
+				expect(result.valid).toBe(true);
+				expect(result.key?.configId).toBe("default");
+			});
+
+			// Preserves the #9393 check: scoping to the wrong config is rejected.
+			it("should reject a key when scoped to a different configId", async () => {
+				const { user } = await signInWithTestUser();
+
+				const publicKey = await auth.api.createApiKey({
+					body: {
+						configId: "public-api",
+						userId: user.id,
+					},
+				});
+
+				const result = await auth.api.verifyApiKey({
+					body: {
+						configId: "internal-api",
+						key: publicKey.key,
+					},
+				});
+
+				expect(result.valid).toBe(false);
+				expect(result.error?.code).toBe("INVALID_API_KEY");
+			});
+
+			// Default config disables rate limiting; the key's config enforces it,
+			// so the second unscoped verify must be rate limited.
+			it("should apply the key's own config when configId is omitted", async () => {
+				const { auth: scopedAuth, signInWithTestUser: scopedSignIn } =
+					await getTestInstance(
+						{
+							plugins: [
+								apiKey([
+									{
+										configId: "limited",
+										defaultPrefix: "lim_",
+										rateLimit: {
+											enabled: true,
+											maxRequests: 1,
+											timeWindow: 60000,
+										},
+									},
+									{
+										configId: "default",
+										defaultPrefix: "def_",
+										rateLimit: { enabled: false },
+									},
+								]),
+							],
+						},
+						{
+							clientOptions: {
+								plugins: [apiKeyClient()],
+							},
+						},
+					);
+
+				const { user } = await scopedSignIn();
+
+				const limitedKey = await scopedAuth.api.createApiKey({
+					body: { configId: "limited", userId: user.id },
+				});
+
+				const first = await scopedAuth.api.verifyApiKey({
+					body: { key: limitedKey.key },
+				});
+				expect(first.valid).toBe(true);
+
+				const second = await scopedAuth.api.verifyApiKey({
+					body: { key: limitedKey.key },
+				});
+				expect(second.valid).toBe(false);
+				expect(second.error?.code).toBe("RATE_LIMITED");
+			});
+
+			it("should run the key's own customAPIKeyValidator when configId is omitted", async () => {
+				const { auth: scopedAuth, signInWithTestUser: scopedSignIn } =
+					await getTestInstance(
+						{
+							plugins: [
+								apiKey([
+									{
+										configId: "guarded",
+										defaultPrefix: "grd_",
+										customAPIKeyValidator: () => false,
+									},
+									{ configId: "default", defaultPrefix: "def_" },
+								]),
+							],
+						},
+						{
+							clientOptions: {
+								plugins: [apiKeyClient()],
+							},
+						},
+					);
+
+				const { user } = await scopedSignIn();
+
+				const guardedKey = await scopedAuth.api.createApiKey({
+					body: { configId: "guarded", userId: user.id },
+				});
+
+				const result = await scopedAuth.api.verifyApiKey({
+					body: { key: guardedKey.key },
+				});
+
+				expect(result.valid).toBe(false);
+				expect(result.error?.code).toBe("KEY_NOT_FOUND");
+			});
+
+			it("should not apply the default config validator to a non-default key", async () => {
+				const { auth: scopedAuth, signInWithTestUser: scopedSignIn } =
+					await getTestInstance(
+						{
+							plugins: [
+								apiKey([
+									{
+										configId: "default",
+										defaultPrefix: "def_",
+										customAPIKeyValidator: () => false,
+									},
+									{ configId: "open", defaultPrefix: "opn_" },
+								]),
+							],
+						},
+						{
+							clientOptions: {
+								plugins: [apiKeyClient()],
+							},
+						},
+					);
+
+				const { user } = await scopedSignIn();
+
+				const openKey = await scopedAuth.api.createApiKey({
+					body: { configId: "open", userId: user.id },
+				});
+
+				const result = await scopedAuth.api.verifyApiKey({
+					body: { key: openKey.key },
+				});
+
+				expect(result.valid).toBe(true);
+				expect(result.key?.configId).toBe("open");
+			});
 		});
 
 		it("should get key and resolve correct config", async () => {

--- a/packages/api-key/src/index.ts
+++ b/packages/api-key/src/index.ts
@@ -200,15 +200,10 @@ export function apiKey(
 							}
 						}
 
-						const hashed = config.disableKeyHashing
-							? key
-							: await defaultKeyHasher(key);
-
-						const apiKey = await validateApiKey({
+						const { apiKey } = await validateApiKey({
 							key,
-							hashedKey: hashed,
 							ctx,
-							opts: config,
+							lookupOpts: config,
 							configurations,
 							schema,
 							expectedConfigId: config.configId,

--- a/packages/api-key/src/index.ts
+++ b/packages/api-key/src/index.ts
@@ -205,10 +205,13 @@ export function apiKey(
 							: await defaultKeyHasher(key);
 
 						const apiKey = await validateApiKey({
+							key,
 							hashedKey: hashed,
 							ctx,
 							opts: config,
+							configurations,
 							schema,
+							expectedConfigId: config.configId,
 						});
 
 						const cleanupTask = deleteAllExpiredApiKeys(ctx.context).catch(

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -17,20 +17,32 @@ import type { apiKeySchema } from "../schema";
 import type { ApiKey } from "../types";
 import { isAPIError } from "../utils";
 import type { PredefinedApiKeyOptions } from ".";
-import { resolveConfiguration } from ".";
+import { configIdMatches, resolveConfiguration } from ".";
 
 export async function validateApiKey({
+	key,
 	hashedKey,
 	ctx,
 	opts,
+	configurations,
 	schema,
 	permissions,
+	expectedConfigId,
+	runCustomValidator,
 }: {
+	key: string;
 	hashedKey: string;
 	opts: PredefinedApiKeyOptions;
+	configurations: PredefinedApiKeyOptions[];
 	schema: ReturnType<typeof apiKeySchema>;
 	permissions?: Record<string, string[]> | undefined;
 	ctx: GenericEndpointContext;
+	expectedConfigId?: string | undefined;
+	/**
+	 * Run the key's own `customAPIKeyValidator`. Callers that already ran it
+	 * against the correct config leave this off to avoid running it twice.
+	 */
+	runCustomValidator?: boolean | undefined;
 }) {
 	const apiKey = await getApiKey(ctx, hashedKey, opts);
 
@@ -38,8 +50,22 @@ export async function validateApiKey({
 		throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
 	}
 
-	if (apiKey.configId !== (opts.configId ?? "default")) {
+	if (
+		expectedConfigId !== undefined &&
+		!configIdMatches(apiKey.configId, expectedConfigId)
+	) {
 		throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
+	}
+
+	// Resolve the key's own config. The lookup used the caller's config, so an
+	// unscoped verify cannot find keys that use a different storage or hashing.
+	opts = resolveConfiguration(ctx.context, configurations, apiKey.configId);
+
+	if (runCustomValidator && opts.customAPIKeyValidator) {
+		const isValid = await opts.customAPIKeyValidator({ ctx, key });
+		if (!isValid) {
+			throw APIError.from("UNAUTHORIZED", ERROR_CODES.KEY_NOT_FOUND);
+		}
 	}
 
 	if (apiKey.enabled === false) {
@@ -227,7 +253,7 @@ const verifyApiKeyBodySchema = z.object({
 		.string()
 		.meta({
 			description:
-				"The configuration ID to use for verification. If not provided, the default configuration will be used.",
+				"Configuration ID to scope verification to. When omitted, the key is validated against its own configuration.",
 		})
 		.optional(),
 	key: z.string().meta({
@@ -268,7 +294,9 @@ export function verifyApiKey({
 				configId,
 			);
 
-			if (lookupOpts.customAPIKeyValidator) {
+			// Scoped: lookup config is the key's config, so run the validator now.
+			// Unscoped runs it inside validateApiKey once the key's config is known.
+			if (configId !== undefined && lookupOpts.customAPIKeyValidator) {
 				const isValid = await lookupOpts.customAPIKeyValidator({ ctx, key });
 				if (!isValid) {
 					return ctx.json({
@@ -290,11 +318,16 @@ export function verifyApiKey({
 
 			try {
 				apiKey = await validateApiKey({
+					key,
 					hashedKey: hashed,
 					permissions: ctx.body.permissions,
 					ctx,
 					opts: lookupOpts,
+					configurations,
 					schema,
+					expectedConfigId: configId,
+					// Scoped calls already ran the validator above with the right config.
+					runCustomValidator: configId === undefined,
 				});
 
 				// Resolve the correct config based on the API key's configId

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -21,9 +21,8 @@ import { configIdMatches, resolveConfiguration } from ".";
 
 export async function validateApiKey({
 	key,
-	hashedKey,
 	ctx,
-	opts,
+	lookupOpts,
 	configurations,
 	schema,
 	permissions,
@@ -31,8 +30,7 @@ export async function validateApiKey({
 	runCustomValidator,
 }: {
 	key: string;
-	hashedKey: string;
-	opts: PredefinedApiKeyOptions;
+	lookupOpts: PredefinedApiKeyOptions;
 	configurations: PredefinedApiKeyOptions[];
 	schema: ReturnType<typeof apiKeySchema>;
 	permissions?: Record<string, string[]> | undefined;
@@ -44,7 +42,10 @@ export async function validateApiKey({
 	 */
 	runCustomValidator?: boolean | undefined;
 }) {
-	const apiKey = await getApiKey(ctx, hashedKey, opts);
+	const hashedKey = lookupOpts.disableKeyHashing
+		? key
+		: await defaultKeyHasher(key);
+	const apiKey = await getApiKey(ctx, hashedKey, lookupOpts);
 
 	if (!apiKey) {
 		throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
@@ -57,9 +58,14 @@ export async function validateApiKey({
 		throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
 	}
 
-	// Resolve the key's own config. The lookup used the caller's config, so an
-	// unscoped verify cannot find keys that use a different storage or hashing.
-	opts = resolveConfiguration(ctx.context, configurations, apiKey.configId);
+	// Switch from the caller's lookup config to the key's own config for
+	// validation and updates. An unscoped verify cannot find keys that use a
+	// different storage or hashing than the lookup config.
+	const opts = resolveConfiguration(
+		ctx.context,
+		configurations,
+		apiKey.configId,
+	);
 
 	if (runCustomValidator && opts.customAPIKeyValidator) {
 		const isValid = await opts.customAPIKeyValidator({ ctx, key });
@@ -245,7 +251,7 @@ export async function validateApiKey({
 		}
 	}
 
-	return newApiKey;
+	return { apiKey: newApiKey, opts };
 }
 
 const verifyApiKeyBodySchema = z.object({
@@ -310,30 +316,23 @@ export function verifyApiKey({
 				}
 			}
 
-			const hashed = lookupOpts.disableKeyHashing
-				? key
-				: await defaultKeyHasher(key);
-
 			let apiKey: ApiKey | null = null;
+			let opts: PredefinedApiKeyOptions;
 
 			try {
-				apiKey = await validateApiKey({
+				const result = await validateApiKey({
 					key,
-					hashedKey: hashed,
 					permissions: ctx.body.permissions,
 					ctx,
-					opts: lookupOpts,
+					lookupOpts,
 					configurations,
 					schema,
 					expectedConfigId: configId,
 					// Scoped calls already ran the validator above with the right config.
 					runCustomValidator: configId === undefined,
 				});
-
-				// Resolve the correct config based on the API key's configId
-				const opts = apiKey
-					? resolveConfiguration(ctx.context, configurations, apiKey.configId)
-					: lookupOpts;
+				apiKey = result.apiKey;
+				opts = result.opts;
 
 				if (opts.deferUpdates) {
 					ctx.context.runInBackground(
@@ -373,11 +372,6 @@ export function verifyApiKey({
 				key: 1,
 				permissions: undefined,
 			};
-
-			// Resolve the correct config for metadata migration
-			const opts = apiKey
-				? resolveConfiguration(ctx.context, configurations, apiKey.configId)
-				: lookupOpts;
 
 			// Migrate legacy double-stringified metadata if needed
 			let migratedMetadata: Record<string, any> | null = null;


### PR DESCRIPTION
- Closes #9779 