### PR TITLE
fix(admin): guard unbanUser and setRole against missing users

### DIFF
--- a/.changeset/admin-routes-user-not-found-guards.md
+++ b/.changeset/admin-routes-user-not-found-guards.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The admin plugin's `unbanUser` and `setRole` endpoints used to call `internalAdapter.updateUser` without checking that the target user existed, so when the caller passed an unknown id the underlying database error (for example Prisma's `P2025`) bubbled up as a generic HTTP 500. Both endpoints now mirror the existing guard in `banUser`: look the user up via `findUserById`, and throw a clean `NOT_FOUND` (`USER_NOT_FOUND`) when no row is returned. Closes #9800.

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -707,6 +707,58 @@ describe("Admin plugin", async () => {
 		expect(res.error?.status).toBe(403);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9800
+	 */
+	it("should return 404 from unbanUser when the target user does not exist", async () => {
+		const res = await client.admin.unbanUser(
+			{
+				userId: "nonexistent-user-id",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.error?.status).toBe(404);
+		expect(res.error?.code).toBe("USER_NOT_FOUND");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9800
+	 */
+	it("should return 404 from setRole when the target user does not exist", async () => {
+		const res = await client.admin.setRole(
+			{
+				userId: "nonexistent-user-id",
+				role: "admin",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.error?.status).toBe(404);
+		expect(res.error?.code).toBe("USER_NOT_FOUND");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9800
+	 *
+	 * Regression coverage for the existing banUser guard so the three admin
+	 * endpoints (banUser, unbanUser, setRole) stay consistent.
+	 */
+	it("should return 404 from banUser when the target user does not exist", async () => {
+		const res = await client.admin.banUser(
+			{
+				userId: "nonexistent-user-id",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.error?.status).toBe(404);
+		expect(res.error?.code).toBe("USER_NOT_FOUND");
+	});
+
 	it("should allow admin to list user sessions", async () => {
 		const res = await client.admin.listUserSessions(
 			{

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -153,6 +153,15 @@ export const setRole = <O extends AdminOptions>(opts: O) =>
 					}
 				}
 			}
+
+			const foundUser = await ctx.context.internalAdapter.findUserById(
+				ctx.body.userId,
+			);
+
+			if (!foundUser) {
+				throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
+			}
+
 			const updatedUser = await ctx.context.internalAdapter.updateUser(
 				ctx.body.userId,
 				{
@@ -849,6 +858,14 @@ export const unbanUser = (opts: AdminOptions) =>
 					"FORBIDDEN",
 					ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_BAN_USERS,
 				);
+			}
+
+			const foundUser = await ctx.context.internalAdapter.findUserById(
+				ctx.body.userId,
+			);
+
+			if (!foundUser) {
+				throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
 			}
 
 			const user = await ctx.context.internalAdapter.updateUser(


### PR DESCRIPTION
Closes #9800.

## What was wrong

`unbanUser` and `setRole` in `packages/better-auth/src/plugins/admin/routes.ts` called `internalAdapter.updateUser` without checking that the target user existed. When the caller passed an unknown id the underlying database error (for example Prisma's `P2025`) bubbled all the way up to the HTTP layer as a generic 500 with a raw Prisma stack in the logs.

The sibling `banUser` endpoint already does this check (it was added in #4649), so the three admin user-update endpoints were inconsistent.

## The fix

Mirror the `banUser` guard in both endpoints: look the user up via `findUserById` first, and throw a clean `NOT_FOUND` with `BASE_ERROR_CODES.USER_NOT_FOUND` when no row is returned.

```ts
const foundUser = await ctx.context.internalAdapter.findUserById(
  ctx.body.userId,
);

if (!foundUser) {
  throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
}
```

For `setRole` the guard runs after the existing role-validation step so that invalid role inputs still surface as `BAD_REQUEST` rather than `NOT_FOUND`. For `unbanUser` the guard is the first thing after the permission check, matching `banUser` exactly.

## Tests

Added three regression tests under `packages/better-auth/src/plugins/admin/admin.test.ts`, each linked via `@see` to #9800:

- `unbanUser` returns 404 with `USER_NOT_FOUND` for a nonexistent user id (was 500 on `main`)
- `setRole` returns 404 with `USER_NOT_FOUND` for a nonexistent user id (was 500 on `main`)
- `banUser` returns 404 with `USER_NOT_FOUND` for a nonexistent user id (was already passing; included so the three endpoints stay in lockstep)

Verification:

- `pnpm vitest run src/plugins/admin/admin.test.ts`: 77 / 77 passing (74 existing + 3 new)
- RED baseline: reverting `routes.ts` to `main` makes the two new tests fail with 500 / Prisma `P2025`. Applying the fix turns them green; the `banUser` test stays green on both, which is the regression contract.
- Lefthook ran biome + spell on commit; both clean
- Changeset added at `.changeset/admin-routes-user-not-found-guards.md` (`better-auth`: patch)

## Out of scope

Other admin endpoints that read a single user (`getUser`, `listUserSessions`, `removeUser`, etc.) were not touched. `getUser` already has the same guard. The rest fall into either delete-style flows (which can be argued either way) or list-style flows (where 200 + empty is the right shape), so this PR is intentionally limited to the three endpoints that update a user record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `unbanUser` and `setRole` in `better-auth` to return a clean 404 (`USER_NOT_FOUND`) when the user id doesn’t exist, instead of a 500 from the DB. Aligns these endpoints with `banUser`. Closes #9800.

- **Bug Fixes**
  - Check existence with findUserById before update; throw NOT_FOUND (`USER_NOT_FOUND`) when missing.
  - In setRole, run the guard after role validation to keep invalid roles as BAD_REQUEST.
  - Added regression tests for `unbanUser`, `setRole`, and `banUser`.

<sup>Written for commit 145642fa6ff1977d6426455def1349f8cce42304. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

