### PR TITLE
fix(device-authorization): stop throwing APIError for expected RFC 8628 polling states

### DIFF
--- a/.changeset/silly-trams-kneel.md
+++ b/.changeset/silly-trams-kneel.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+/device/token no longer throws exceptions for expected RFC 8628 polling states (authorization_pending, slow_down, expired_token, access_denied). These now return HTTP 400 responses without throwing, eliminating noise in platform error telemetry.

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -196,11 +196,9 @@ describe("device authorization flow", async () => {
 						client_id: "test-client",
 					},
 				}),
-			).rejects.toMatchObject({
-				body: {
-					error: "authorization_pending",
-					error_description: "Authorization pending",
-				},
+			).resolves.toMatchObject({
+				error: "authorization_pending",
+				error_description: "Authorization pending",
 			});
 		});
 
@@ -223,11 +221,9 @@ describe("device authorization flow", async () => {
 						client_id: "test-client",
 					},
 				}),
-			).rejects.toMatchObject({
-				body: {
-					error: "expired_token",
-					error_description: "Device code has expired",
-				},
+			).resolves.toMatchObject({
+				error: "expired_token",
+				error_description: "Device code has expired",
 			});
 
 			vi.useRealTimers();
@@ -357,11 +353,9 @@ describe("device authorization flow", async () => {
 						client_id: "test-client",
 					},
 				}),
-			).rejects.toMatchObject({
-				body: {
-					error: "access_denied",
-					error_description: "Access denied",
-				},
+			).resolves.toMatchObject({
+				error: "access_denied",
+				error_description: "Access denied",
 			});
 		});
 
@@ -392,18 +386,13 @@ describe("device authorization flow", async () => {
 				},
 			});
 
-			await auth.api
-				.deviceToken({
-					body: {
-						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-						device_code: device_code,
-						client_id: "test-client",
-					},
-				})
-				.catch(
-					// ignore the error
-					() => {},
-				);
+			await auth.api.deviceToken({
+				body: {
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code: device_code,
+					client_id: "test-client",
+				},
+			});
 
 			await expect(
 				auth.api.deviceToken({
@@ -413,11 +402,9 @@ describe("device authorization flow", async () => {
 						client_id: "test-client",
 					},
 				}),
-			).rejects.toMatchObject({
-				body: {
-					error: "slow_down",
-					error_description: "Polling too frequently",
-				},
+			).resolves.toMatchObject({
+				error: "slow_down",
+				error_description: "Polling too frequently",
 			});
 		});
 	});
@@ -637,8 +624,8 @@ describe("device authorization ownership gate", () => {
 					client_id: "test-client",
 				},
 			}),
-		).rejects.toMatchObject({
-			body: { error: "authorization_pending" },
+		).resolves.toMatchObject({
+			error: "authorization_pending",
 		});
 	});
 

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -331,11 +331,14 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 				const minInterval = deviceCodeRecord.pollingInterval;
 
 				if (timeSinceLastPoll < minInterval) {
-					throw new APIError("BAD_REQUEST", {
-						error: "slow_down",
-						error_description:
-							DEVICE_AUTHORIZATION_ERROR_CODES.POLLING_TOO_FREQUENTLY.message,
-					});
+					return ctx.json(
+						{
+							error: "slow_down",
+							error_description:
+								DEVICE_AUTHORIZATION_ERROR_CODES.POLLING_TOO_FREQUENTLY.message,
+						},
+						{ status: 400 },
+					);
 				}
 			}
 
@@ -363,19 +366,25 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 						},
 					],
 				});
-				throw new APIError("BAD_REQUEST", {
-					error: "expired_token",
-					error_description:
-						DEVICE_AUTHORIZATION_ERROR_CODES.EXPIRED_DEVICE_CODE.message,
-				});
+				return ctx.json(
+					{
+						error: "expired_token",
+						error_description:
+							DEVICE_AUTHORIZATION_ERROR_CODES.EXPIRED_DEVICE_CODE.message,
+					},
+					{ status: 400 },
+				);
 			}
 
 			if (deviceCodeRecord.status === "pending") {
-				throw new APIError("BAD_REQUEST", {
-					error: "authorization_pending",
-					error_description:
-						DEVICE_AUTHORIZATION_ERROR_CODES.AUTHORIZATION_PENDING.message,
-				});
+				return ctx.json(
+					{
+						error: "authorization_pending",
+						error_description:
+							DEVICE_AUTHORIZATION_ERROR_CODES.AUTHORIZATION_PENDING.message,
+					},
+					{ status: 400 },
+				);
 			}
 
 			if (deviceCodeRecord.status === "denied") {
@@ -388,11 +397,14 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 						},
 					],
 				});
-				throw new APIError("BAD_REQUEST", {
-					error: "access_denied",
-					error_description:
-						DEVICE_AUTHORIZATION_ERROR_CODES.ACCESS_DENIED.message,
-				});
+				return ctx.json(
+					{
+						error: "access_denied",
+						error_description:
+							DEVICE_AUTHORIZATION_ERROR_CODES.ACCESS_DENIED.message,
+					},
+					{ status: 400 },
+				);
 			}
 
 			if (deviceCodeRecord.status === "approved" && deviceCodeRecord.userId) {


### PR DESCRIPTION
Closes #9784 

### What changed
The ```/device/token``` endpoint was using ```throw new APIError(...)``` to return the four expected RFC 8628 protocol states:

-  ```authorization_pending``` — user hasn't approved yet
- ```slow_down``` — client polling too fast
- ```expired_token``` — device code timed out
- ```access_denied``` — user denied
These are normal polling responses, not errors. Using ```throw``` caused platform runtimes (Cloudflare Workers, Sentry, Vercel) to capture them as real exceptions before the framework's error handler converted them to HTTP 400 responses. In a typical 5-minute auth session with 5-second polling intervals, this generates ~60 spurious exceptions — burying genuine errors in telemetry noise.

The fix replaces ```throw new APIError(...)``` with ```return ctx.json(body, { status: 400 })``` for these four states. Genuine errors ```(invalid_grant, INTERNAL_SERVER_ERROR)``` are left as throws.

### Wire format
Unchanged. HTTP clients still receive a 400 response with the same JSON body. This is purely an internal change in how the response is produced.

### Behavioral change for direct API callers
When calling ```auth.api.deviceToken(...)``` programmatically (not via HTTP), the promise now resolves with the error object instead of rejecting. Callers that previously used ```.catch()``` to handle polling states will need to check the resolved value instead:

```
// Before
await auth.api.deviceToken({ ... }).catch((e) => {
    if (e.body.error === "authorization_pending") { /* keep polling */ }
});
```
```
// After
const result = await auth.api.deviceToken({ ... });
if ("error" in result && result.error === "authorization_pending") { /* keep polling */ }
This is expected — RFC 8628 defines a polling protocol over HTTP. Clients should be polling the HTTP endpoint, not calling the internal API directly.
```
### Changes
```packages/better-auth/src/plugins/device-authorization/routes.ts``` — 4 ```throw new APIError(...)``` replaced with return ```ctx.json(..., { status: 400 })```
```packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts``` — updated 5 assertions from ```.rejects.toMatchObject({ body: { error } })``` to ```.resolves.toMatchObject({ error });``` removed unnecessary ```.catch(() => {})``` wrapper in the ```slow_down``` test
Breaking changes
None for HTTP clients. Direct internal API callers see a change in Promise resolution behavior (resolves instead of rejects for the four polling states).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop throwing `APIError` for expected RFC 8628 polling states in `/device/token`. These now return 400 JSON responses, reducing telemetry noise and keeping real errors visible.

- Bug Fixes
  - Treat `authorization_pending`, `slow_down`, `expired_token`, `access_denied` as normal polling responses.
  - Return `ctx.json(..., { status: 400 })` instead of throwing; HTTP wire format unchanged.
  - Still throw for real errors (`invalid_grant`, `INTERNAL_SERVER_ERROR`).

- Migration
  - Direct calls to `auth.api.deviceToken(...)` now resolve for these states; check `result.error` instead of using `.catch()`.

<sup>Written for commit 21dc0b1315fa4ba7bcfc74a2064763d6b743ac4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

