### PR TITLE
feat(account): support server-side `accountInfo` calls without session headers

### DIFF
--- a/.changeset/account-info-server-side.md
+++ b/.changeset/account-info-server-side.md
@@ -1,0 +1,9 @@
+---
+"better-auth": patch
+---
+
+Support server-side `accountInfo` calls without session headers.
+
+`auth.api.accountInfo` now accepts an optional `userId`, so a trusted server-side caller can read a user's provider profile without constructing session headers. This mirrors `getAccessToken` and `refreshToken`. HTTP callers still require a valid session, and a session always takes precedence over a supplied `userId`.
+
+The shared "resolve the target user, then fetch a valid access token" logic behind these three endpoints now lives in one place. As part of that, a server-side call that supplies neither a session nor a `userId` reports `USER_ID_OR_SESSION_REQUIRED` (400) consistently, rather than `UNAUTHORIZED` on some endpoints.

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -108,7 +108,10 @@ server-side usage:
 
 ```ts
 await auth.api.accountInfo({
-  query: { accountId: "accountId" },
+  query: {
+    accountId: "accountId",
+    userId: "userId", // optional, if you don't provide headers with authenticated token
+  },
   headers: await headers() // headers containing the user's session token
 });
 ```

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -227,6 +227,68 @@ describe("account", async () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8350
+	 */
+	it("should get account info server-side using userId without session headers", async () => {
+		const { auth, client, cookieSetter } = await getTestInstance({
+			socialProviders: {
+				google: { clientId: "test", clientSecret: "test", enabled: true },
+			},
+		});
+
+		const headers = new Headers();
+		email = "account-info-server-side@test.com";
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: { onSuccess: cookieSetter(headers) },
+		});
+		const state =
+			signInRes.data && "url" in signInRes.data && signInRes.data.url
+				? new URL(signInRes.data.url).searchParams.get("state") || ""
+				: "";
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test" },
+			headers,
+			method: "GET",
+			onError(context) {
+				cookieSetter(headers)({ response: context.response });
+			},
+		});
+
+		const accounts = await auth.api.listUserAccounts({ headers });
+		const googleAccount = accounts.find((a) => a.providerId === "google");
+		expect(googleAccount).toBeTruthy();
+
+		// No headers: the server-side caller identifies the user via userId.
+		const info = await auth.api.accountInfo({
+			query: {
+				accountId: googleAccount!.accountId,
+				userId: googleAccount!.userId,
+			},
+		});
+
+		expect(info).toMatchObject({
+			user: expect.objectContaining({
+				id: expect.any(String),
+				email: expect.any(String),
+			}),
+			data: expect.any(Object),
+		});
+	});
+
+	it("should reject account info over HTTP without a session even when userId is passed", async () => {
+		const { user } = await signInWithTestUser();
+		// Top-level $fetch carries no session; a passed userId must not bypass auth.
+		const info = await client.$fetch("/account-info", {
+			query: { accountId: "any-account-id", userId: user.id },
+			method: "GET",
+		});
+		expect(info.data).toBeNull();
+		expect(info.error?.status).toBe(401);
+	});
+
 	it("should pass custom scopes to authorization URL", async () => {
 		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async () => {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -1,3 +1,4 @@
+import type { GenericEndpointContext } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import type { Account } from "@better-auth/core/db";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
@@ -445,6 +446,152 @@ export const unlinkAccount = createAuthEndpoint(
 	},
 );
 
+/**
+ * Resolves the user id an account-token operation should act on.
+ *
+ * A caller reaching the server over HTTP (a request or session headers are
+ * present) must have a valid session, and that session's user always wins.
+ * A trusted server-side `auth.api` caller with no session may instead name a
+ * `userId` directly. Throws `UNAUTHORIZED` when an HTTP caller is
+ * unauthenticated, and `USER_ID_OR_SESSION_REQUIRED` when neither a session
+ * nor a `userId` is available.
+ */
+async function resolveUserId(
+	ctx: GenericEndpointContext,
+	userId?: string,
+): Promise<string> {
+	const session = await getSessionFromCtx(ctx);
+	if (!session && (ctx.request || ctx.headers)) {
+		throw ctx.error("UNAUTHORIZED");
+	}
+	const resolvedUserId = session?.user?.id || userId;
+	if (!resolvedUserId) {
+		throw APIError.from("BAD_REQUEST", {
+			message: "Either userId or session is required",
+			code: "USER_ID_OR_SESSION_REQUIRED",
+		});
+	}
+	return resolvedUserId;
+}
+
+/**
+ * Fetches a currently-valid access token for a user's provider account,
+ * refreshing and persisting it when it is within five seconds of expiry.
+ * Shared by the `/get-access-token` endpoint and `/account-info` so both
+ * resolve and refresh tokens through one path.
+ */
+async function getValidAccessToken(
+	ctx: GenericEndpointContext,
+	{
+		resolvedUserId,
+		providerId,
+		accountId,
+	}: { resolvedUserId: string; providerId: string; accountId?: string },
+) {
+	const provider = await getAwaitableValue(ctx.context.socialProviders, {
+		value: providerId,
+	});
+	if (!provider) {
+		throw APIError.from("BAD_REQUEST", {
+			message: `Provider ${providerId} is not supported.`,
+			code: "PROVIDER_NOT_SUPPORTED",
+		});
+	}
+	const accountData = await getAccountCookie(ctx);
+	let account: Account | undefined = undefined;
+	if (
+		accountData &&
+		accountData.userId === resolvedUserId &&
+		providerId === accountData.providerId &&
+		(!accountId || accountData.accountId === accountId)
+	) {
+		account = accountData;
+	} else {
+		const accounts =
+			await ctx.context.internalAdapter.findAccounts(resolvedUserId);
+		account = accounts.find((acc) =>
+			accountId
+				? acc.accountId === accountId && acc.providerId === providerId
+				: acc.providerId === providerId,
+		);
+	}
+
+	if (!account) {
+		throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.ACCOUNT_NOT_FOUND);
+	}
+
+	try {
+		let newTokens: OAuth2Tokens | null = null;
+		const accessTokenExpired =
+			account.accessTokenExpiresAt &&
+			new Date(account.accessTokenExpiresAt).getTime() - Date.now() < 5_000;
+		if (
+			account.refreshToken &&
+			accessTokenExpired &&
+			provider.refreshAccessToken
+		) {
+			const refreshToken = await decryptOAuthToken(
+				account.refreshToken,
+				ctx.context,
+			);
+			newTokens = await provider.refreshAccessToken(refreshToken);
+			const updatedData = {
+				accessToken: await setTokenUtil(newTokens?.accessToken, ctx.context),
+				accessTokenExpiresAt: newTokens?.accessTokenExpiresAt,
+				refreshToken: newTokens?.refreshToken
+					? await setTokenUtil(newTokens.refreshToken, ctx.context)
+					: account.refreshToken,
+				refreshTokenExpiresAt:
+					newTokens?.refreshTokenExpiresAt ?? account.refreshTokenExpiresAt,
+				idToken: newTokens?.idToken || account.idToken,
+			};
+			let updatedAccount: Record<string, any> | null = null;
+			if (account.id) {
+				updatedAccount = await ctx.context.internalAdapter.updateAccount(
+					account.id,
+					updatedData,
+				);
+			}
+			if (ctx.context.options.account?.storeAccountCookie) {
+				await setAccountCookie(ctx, {
+					...account,
+					...(updatedAccount ?? updatedData),
+				});
+			}
+		}
+
+		const accessTokenExpiresAt = (() => {
+			if (newTokens?.accessTokenExpiresAt) {
+				if (typeof newTokens.accessTokenExpiresAt === "string") {
+					return new Date(newTokens.accessTokenExpiresAt);
+				}
+				return newTokens.accessTokenExpiresAt;
+			}
+			if (account.accessTokenExpiresAt) {
+				if (typeof account.accessTokenExpiresAt === "string") {
+					return new Date(account.accessTokenExpiresAt);
+				}
+				return account.accessTokenExpiresAt;
+			}
+			return undefined;
+		})();
+
+		return {
+			accessToken:
+				newTokens?.accessToken ??
+				(await decryptOAuthToken(account.accessToken ?? "", ctx.context)),
+			accessTokenExpiresAt,
+			scopes: account.scope?.split(",") ?? [],
+			idToken: newTokens?.idToken ?? account.idToken ?? undefined,
+		};
+	} catch (_error) {
+		throw APIError.from("BAD_REQUEST", {
+			message: "Failed to get a valid access token",
+			code: "FAILED_TO_GET_ACCESS_TOKEN",
+		});
+	}
+}
+
 export const getAccessToken = createAuthEndpoint(
 	"/get-access-token",
 	{
@@ -504,118 +651,13 @@ export const getAccessToken = createAuthEndpoint(
 	},
 	async (ctx) => {
 		const { providerId, accountId, userId } = ctx.body || {};
-		const req = ctx.request;
-		const session = await getSessionFromCtx(ctx);
-		if (req && !session) {
-			throw ctx.error("UNAUTHORIZED");
-		}
-		const resolvedUserId = session?.user?.id || userId;
-		if (!resolvedUserId) {
-			throw ctx.error("UNAUTHORIZED");
-		}
-		const provider = await getAwaitableValue(ctx.context.socialProviders, {
-			value: providerId,
+		const resolvedUserId = await resolveUserId(ctx, userId);
+		const tokens = await getValidAccessToken(ctx, {
+			resolvedUserId,
+			providerId,
+			accountId,
 		});
-		if (!provider) {
-			throw APIError.from("BAD_REQUEST", {
-				message: `Provider ${providerId} is not supported.`,
-				code: "PROVIDER_NOT_SUPPORTED",
-			});
-		}
-		const accountData = await getAccountCookie(ctx);
-		let account: Account | undefined = undefined;
-		if (
-			accountData &&
-			accountData.userId === resolvedUserId &&
-			providerId === accountData.providerId &&
-			(!accountId || accountData.accountId === accountId)
-		) {
-			account = accountData;
-		} else {
-			const accounts =
-				await ctx.context.internalAdapter.findAccounts(resolvedUserId);
-			account = accounts.find((acc) =>
-				accountId
-					? acc.accountId === accountId && acc.providerId === providerId
-					: acc.providerId === providerId,
-			);
-		}
-
-		if (!account) {
-			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.ACCOUNT_NOT_FOUND);
-		}
-
-		try {
-			let newTokens: OAuth2Tokens | null = null;
-			const accessTokenExpired =
-				account.accessTokenExpiresAt &&
-				new Date(account.accessTokenExpiresAt).getTime() - Date.now() < 5_000;
-			if (
-				account.refreshToken &&
-				accessTokenExpired &&
-				provider.refreshAccessToken
-			) {
-				const refreshToken = await decryptOAuthToken(
-					account.refreshToken,
-					ctx.context,
-				);
-				newTokens = await provider.refreshAccessToken(refreshToken);
-				const updatedData = {
-					accessToken: await setTokenUtil(newTokens?.accessToken, ctx.context),
-					accessTokenExpiresAt: newTokens?.accessTokenExpiresAt,
-					refreshToken: newTokens?.refreshToken
-						? await setTokenUtil(newTokens.refreshToken, ctx.context)
-						: account.refreshToken,
-					refreshTokenExpiresAt:
-						newTokens?.refreshTokenExpiresAt ?? account.refreshTokenExpiresAt,
-					idToken: newTokens?.idToken || account.idToken,
-				};
-				let updatedAccount: Record<string, any> | null = null;
-				if (account.id) {
-					updatedAccount = await ctx.context.internalAdapter.updateAccount(
-						account.id,
-						updatedData,
-					);
-				}
-				if (ctx.context.options.account?.storeAccountCookie) {
-					await setAccountCookie(ctx, {
-						...account,
-						...(updatedAccount ?? updatedData),
-					});
-				}
-			}
-
-			const accessTokenExpiresAt = (() => {
-				if (newTokens?.accessTokenExpiresAt) {
-					if (typeof newTokens.accessTokenExpiresAt === "string") {
-						return new Date(newTokens.accessTokenExpiresAt);
-					}
-					return newTokens.accessTokenExpiresAt;
-				}
-				if (account.accessTokenExpiresAt) {
-					if (typeof account.accessTokenExpiresAt === "string") {
-						return new Date(account.accessTokenExpiresAt);
-					}
-					return account.accessTokenExpiresAt;
-				}
-				return undefined;
-			})();
-
-			const tokens = {
-				accessToken:
-					newTokens?.accessToken ??
-					(await decryptOAuthToken(account.accessToken ?? "", ctx.context)),
-				accessTokenExpiresAt,
-				scopes: account.scope?.split(",") ?? [],
-				idToken: newTokens?.idToken ?? account.idToken ?? undefined,
-			};
-			return ctx.json(tokens);
-		} catch (_error) {
-			throw APIError.from("BAD_REQUEST", {
-				message: "Failed to get a valid access token",
-				code: "FAILED_TO_GET_ACCESS_TOKEN",
-			});
-		}
+		return ctx.json(tokens);
 	},
 );
 
@@ -685,18 +727,7 @@ export const refreshToken = createAuthEndpoint(
 	},
 	async (ctx) => {
 		const { providerId, accountId, userId } = ctx.body;
-		const req = ctx.request;
-		const session = await getSessionFromCtx(ctx);
-		if (req && !session) {
-			throw ctx.error("UNAUTHORIZED");
-		}
-		const resolvedUserId = session?.user?.id || userId;
-		if (!resolvedUserId) {
-			throw APIError.from("BAD_REQUEST", {
-				message: `Either userId or session is required`,
-				code: "USER_ID_OR_SESSION_REQUIRED",
-			});
-		}
+		const resolvedUserId = await resolveUserId(ctx, userId);
 		const provider = await getAwaitableValue(ctx.context.socialProviders, {
 			value: providerId,
 		});
@@ -822,6 +853,12 @@ const accountInfoQuerySchema = z.optional(
 					"The provider given account id for which to get the account info",
 			})
 			.optional(),
+		userId: z
+			.string()
+			.meta({
+				description: "The user ID associated with the account",
+			})
+			.optional(),
 	}),
 );
 
@@ -829,7 +866,6 @@ export const accountInfo = createAuthEndpoint(
 	"/account-info",
 	{
 		method: "GET",
-		use: [sessionMiddleware],
 		metadata: {
 			openapi: {
 				description: "Get the account info provided by the provider",
@@ -880,7 +916,9 @@ export const accountInfo = createAuthEndpoint(
 		query: accountInfoQuerySchema,
 	},
 	async (ctx) => {
-		const providedAccountId = ctx.query?.accountId;
+		const { accountId: providedAccountId, userId } = ctx.query || {};
+		const resolvedUserId = await resolveUserId(ctx, userId);
+
 		let account: Account | undefined = undefined;
 		if (!providedAccountId) {
 			if (ctx.context.options.account?.storeAccountCookie) {
@@ -897,7 +935,7 @@ export const accountInfo = createAuthEndpoint(
 			}
 		}
 
-		if (!account || account.userId !== ctx.context.session.user.id) {
+		if (!account || account.userId !== resolvedUserId) {
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.ACCOUNT_NOT_FOUND);
 		}
 
@@ -911,15 +949,10 @@ export const accountInfo = createAuthEndpoint(
 				code: "PROVIDER_NOT_CONFIGURED",
 			});
 		}
-		const tokens = await getAccessToken({
-			...ctx,
-			method: "POST",
-			body: {
-				accountId: account.accountId,
-				providerId: account.providerId,
-			},
-			returnHeaders: false,
-			returnStatus: false,
+		const tokens = await getValidAccessToken(ctx, {
+			resolvedUserId,
+			providerId: account.providerId,
+			accountId: account.accountId,
 		});
 		if (!tokens.accessToken) {
 			throw APIError.from("BAD_REQUEST", {
@@ -929,7 +962,7 @@ export const accountInfo = createAuthEndpoint(
 		}
 		const info = await provider.getUserInfo({
 			...tokens,
-			accessToken: tokens.accessToken as string,
+			accessToken: tokens.accessToken,
 		});
 		return ctx.json(info);
 	},


### PR DESCRIPTION
`auth.api.accountInfo` could not be called from server-side code without forging session headers: it ran behind the session middleware and had no way to name a user directly. This adds an optional `userId` query parameter so a trusted server-side caller can read a user's provider profile, the same way `getAccessToken` and `refreshToken` already allow. HTTP callers still require a valid session, and a session always takes precedence over a supplied `userId`, so the parameter cannot read another user's data over the network.

Behind these three endpoints, the "resolve the target user, then fetch a valid access token" logic now lives in two small helpers. `accountInfo` fetches its token through the shared helper instead of re-entering the `getAccessToken` endpoint, which on the server-side path dropped the resolved user and returned `UNAUTHORIZED`. A call that supplies neither a session nor a `userId` now reports `USER_ID_OR_SESSION_REQUIRED` (400) consistently across all three endpoints.

Supersedes #8351, which had drifted roughly 300 commits behind `main`, and keeps @NathanColosimo's original `userId` approach. Closes #8350. Closes #8351.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable server-side `auth.api.accountInfo` calls without session headers by accepting an optional `userId`, matching `getAccessToken` and `refreshToken`. HTTP requests still require a valid session; sessions override a supplied `userId`.

- **New Features**
  - `auth.api.accountInfo` accepts `userId` for trusted server-side use.
  - Session is required over HTTP, and always takes precedence over `userId`.
  - Calls without a session or `userId` now return `USER_ID_OR_SESSION_REQUIRED` (400).
  
- **Refactors**
  - Centralized user resolution and token refresh into shared helpers; `accountInfo` now uses them directly.
  - Added tests for the server-side path and HTTP rejection; updated OAuth docs with the optional `userId`.

<sup>Written for commit ed6ee93ae0e6a02af33d355f75ec2441324be7f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

