### PR TITLE
fix(expo): persist large account cookies by chunking device storage

### DIFF
--- a/.changeset/expo-large-account-cookie.md
+++ b/.changeset/expo-large-account-cookie.md
@@ -1,0 +1,9 @@
+---
+"@better-auth/expo": patch
+---
+
+Fix sign-in being lost on Expo when a provider issues large tokens.
+
+After signing in with a provider whose tokens are large (such as Keycloak), the account cookie could silently fail to persist, leaving `useSession()` null and making `accountInfo` / `getAccessToken` return `ACCOUNT_NOT_FOUND`. The client stored the whole cookie jar as a single value, and native secure stores reject oversized writes, so the cookie never reached the next request.
+
+The Expo storage adapter now splits an oversized value across keys and reassembles it on read, keeping each write within the device limit. Values that already fit are stored unchanged, and a write the backend rejects is logged instead of being dropped silently.

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -254,16 +254,81 @@ export function normalizeCookieName(name: string) {
 	return name.replace(/:/g, "_");
 }
 
+/**
+ * Max characters written per `setItem`. Native secure stores silently reject
+ * oversized writes (iOS Keychain refuses values above ~2KB), losing the cookie,
+ * so a larger value is split across keys here. Mirrors the server's
+ * `chunkCookie`/`joinChunks` in `session-store.ts`; keep the two in sync.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/9151
+ */
+const STORAGE_VALUE_LIMIT = 1800;
+
+/**
+ * Marks a base key whose value is split across `<key>.0..N` chunks. The leading
+ * control char can't start a JSON value (so it never collides) and, unlike NUL,
+ * survives the native storage bridge without C-string truncation.
+ */
+const CHUNK_MARKER = "\u0001ba-chunks:";
+
 export function storageAdapter(storage: {
 	getItem: (name: string) => string | null;
-	setItem: (name: string, value: string) => void;
+	setItem: (name: string, value: string) => unknown;
 }) {
 	return {
-		getItem: (name: string) => {
-			return storage.getItem(normalizeCookieName(name));
+		/**
+		 * Reads a value, reassembling it if it was split across chunk keys. A value
+		 * that fit is returned as-is (values written before chunking still read
+		 * back); a missing chunk returns `null` so a torn write fails closed.
+		 */
+		getItem: (name: string): string | null => {
+			const key = normalizeCookieName(name);
+			const stored = storage.getItem(key);
+			if (stored == null || !stored.startsWith(CHUNK_MARKER)) {
+				return stored;
+			}
+			const count = Number(stored.slice(CHUNK_MARKER.length));
+			if (!Number.isInteger(count) || count < 1) {
+				return null;
+			}
+			let value = "";
+			for (let i = 0; i < count; i++) {
+				const chunk = storage.getItem(`${key}.${i}`);
+				if (chunk == null) {
+					return null;
+				}
+				value += chunk;
+			}
+			return value;
 		},
-		setItem: (name: string, value: string) => {
-			return storage.setItem(normalizeCookieName(name), value);
+		/**
+		 * Stores `value`, splitting it across chunk keys when it exceeds the
+		 * per-write limit. Data chunks are written before the base-key marker, so an
+		 * interrupted write leaves the previous value readable. Failures are logged,
+		 * not thrown: persistence is best-effort and must not break the request.
+		 */
+		setItem: async (name: string, value: string): Promise<void> => {
+			const key = normalizeCookieName(name);
+			try {
+				if (value.length <= STORAGE_VALUE_LIMIT) {
+					await storage.setItem(key, value);
+					return;
+				}
+				const count = Math.ceil(value.length / STORAGE_VALUE_LIMIT);
+				for (let i = 0; i < count; i++) {
+					const start = i * STORAGE_VALUE_LIMIT;
+					await storage.setItem(
+						`${key}.${i}`,
+						value.slice(start, start + STORAGE_VALUE_LIMIT),
+					);
+				}
+				await storage.setItem(key, `${CHUNK_MARKER}${count}`);
+			} catch (error) {
+				console.error(
+					`[better-auth/expo] failed to persist "${key}" to storage`,
+					error,
+				);
+			}
 		},
 	};
 }
@@ -352,11 +417,11 @@ export const expoClient = (opts: ExpoClientOptions) => {
 								// Only notify $sessionSignal if the session cookie values actually changed
 								// This prevents infinite refetching when the server sends the same cookie with updated expiry
 								if (hasSessionCookieChanged(prevCookie, toSetCookie)) {
-									storage.setItem(cookieName, toSetCookie);
+									await storage.setItem(cookieName, toSetCookie);
 									store?.notify("$sessionSignal");
 								} else {
 									// Still update the storage to refresh expiry times, but don't trigger refetch
-									storage.setItem(cookieName, toSetCookie);
+									await storage.setItem(cookieName, toSetCookie);
 								}
 							}
 						}
@@ -366,7 +431,7 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							!opts?.disableCache
 						) {
 							const data = context.data;
-							storage.setItem(localCacheName, JSON.stringify(data));
+							await storage.setItem(localCacheName, JSON.stringify(data));
 						}
 
 						if (
@@ -424,7 +489,7 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							if (!cookie) return;
 							const prevCookie = storage.getItem(cookieName);
 							const toSetCookie = getSetCookie(cookie, prevCookie ?? undefined);
-							storage.setItem(cookieName, toSetCookie);
+							await storage.setItem(cookieName, toSetCookie);
 							store?.notify("$sessionSignal");
 						}
 					},
@@ -482,14 +547,14 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							}
 						}
 						if (url.includes("/sign-out")) {
-							storage.setItem(cookieName, "{}");
+							await storage.setItem(cookieName, "{}");
 							store?.atoms.session?.set({
 								...store.atoms.session.get(),
 								data: null,
 								error: null,
 								isPending: false,
 							});
-							storage.setItem(localCacheName, "{}");
+							await storage.setItem(localCacheName, "{}");
 						}
 					}
 					return {

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -303,9 +303,11 @@ export function storageAdapter(storage: {
 		},
 		/**
 		 * Stores `value`, splitting it across chunk keys when it exceeds the
-		 * per-write limit. Data chunks are written before the base-key marker, so an
-		 * interrupted write leaves the previous value readable. Failures are logged,
-		 * not thrown: persistence is best-effort and must not break the request.
+		 * per-write limit. The base key is cleared before the chunks are rewritten
+		 * and set to the marker last, as the commit point, so a write interrupted
+		 * partway through reads as absent rather than a mix of old and new chunks.
+		 * Failures are logged, not thrown: persistence is best-effort and must not
+		 * break the request.
 		 */
 		setItem: async (name: string, value: string): Promise<void> => {
 			const key = normalizeCookieName(name);
@@ -314,6 +316,10 @@ export function storageAdapter(storage: {
 					await storage.setItem(key, value);
 					return;
 				}
+				// Drop the marker first: chunks are overwritten in place below, so
+				// without this an interrupted rewrite would leave the old marker
+				// pointing at a mix of new and stale chunks.
+				await storage.setItem(key, "");
 				const count = Math.ceil(value.length / STORAGE_VALUE_LIMIT);
 				for (let i = 0; i < count; i++) {
 					const start = i * STORAGE_VALUE_LIMIT;

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -906,6 +906,37 @@ describe("expo with cookieCache", async () => {
 		expect(storage.getItem("better-auth_cookie")).toBeNull();
 	});
 
+	it("should not return mixed old/new data when a chunked overwrite is interrupted", async () => {
+		const map = new Map<string, string>();
+		let failAfter = Number.POSITIVE_INFINITY;
+		let writes = 0;
+		const storage = storageAdapter({
+			getItem: (name) => map.get(name) ?? null,
+			setItem: (name, value) => {
+				if (writes++ >= failAfter) {
+					throw new Error("interrupted");
+				}
+				map.set(name, value);
+			},
+		});
+
+		const oldValue = "a".repeat(5_000);
+		await storage.setItem("better-auth_cookie", oldValue);
+		expect(storage.getItem("better-auth_cookie")).toBe(oldValue);
+
+		// Overwrite with another large value, failing after the marker clear and
+		// the first chunk so the remaining chunks keep their old data.
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		writes = 0;
+		failAfter = 2;
+		await storage.setItem("better-auth_cookie", "b".repeat(5_000));
+		error.mockRestore();
+
+		// The reassembled value must never splice old "a" chunks into the new write.
+		const result = storage.getItem("better-auth_cookie");
+		expect(result ?? "").not.toContain("a");
+	});
+
 	it("should shrink from chunked to a single value without bleeding stale chunks", async () => {
 		const map = new Map<string, string>();
 		const storage = storageAdapter({

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -825,9 +825,114 @@ describe("expo with cookieCache", async () => {
 				map.set(name, value);
 			},
 		});
-		storage.setItem("better-auth:session_token", "123");
+		await storage.setItem("better-auth:session_token", "123");
 		expect(map.has("better-auth_session_token")).toBe(true);
 		expect(map.has("better-auth:session_token")).toBe(false);
+	});
+
+	/**
+	 * Large provider tokens (e.g. Keycloak) overflow the device storage ceiling,
+	 * so the adapter must split and reassemble the value instead of dropping it.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/9151
+	 * @see https://github.com/better-auth/better-auth/issues/9814
+	 */
+	it("should round-trip a value larger than the per-write storage limit", async () => {
+		const WRITE_LIMIT = 2048;
+		const map = new Map<string, string>();
+		const storage = storageAdapter({
+			getItem: (name) => map.get(name) ?? null,
+			setItem: (name, value) => {
+				if (value.length > WRITE_LIMIT) {
+					throw new Error("value exceeds storage limit");
+				}
+				map.set(name, value);
+			},
+		});
+
+		const large = "x".repeat(10_000);
+		await storage.setItem("better-auth_cookie", large);
+
+		// No single physical write may exceed the backend limit.
+		for (const value of map.values()) {
+			expect(value.length).toBeLessThanOrEqual(WRITE_LIMIT);
+		}
+		// The value is split across several keys, not stored under the base key.
+		expect(map.size).toBeGreaterThan(1);
+		expect(storage.getItem("better-auth_cookie")).toBe(large);
+	});
+
+	it("should store a value within the limit under the base key unchanged", async () => {
+		const map = new Map<string, string>();
+		const storage = storageAdapter({
+			getItem: (name) => map.get(name) ?? null,
+			setItem: (name, value) => map.set(name, value),
+		});
+
+		const small = JSON.stringify({ token: "abc" });
+		await storage.setItem("better-auth_cookie", small);
+
+		expect(map.get("better-auth_cookie")).toBe(small);
+		expect(map.size).toBe(1);
+		expect(storage.getItem("better-auth_cookie")).toBe(small);
+	});
+
+	it("should read back a value written before chunking existed", () => {
+		// Pre-fix installs stored the whole jar under the base key.
+		const map = new Map<string, string>([
+			["better-auth_cookie", JSON.stringify({ legacy: true })],
+		]);
+		const storage = storageAdapter({
+			getItem: (name) => map.get(name) ?? null,
+			setItem: (name, value) => map.set(name, value),
+		});
+
+		expect(storage.getItem("better-auth_cookie")).toBe(
+			JSON.stringify({ legacy: true }),
+		);
+	});
+
+	it("should fail closed when a chunk is missing", async () => {
+		const map = new Map<string, string>();
+		const storage = storageAdapter({
+			getItem: (name) => map.get(name) ?? null,
+			setItem: (name, value) => map.set(name, value),
+		});
+
+		await storage.setItem("better-auth_cookie", "y".repeat(5_000));
+		// Simulate a torn write: drop one data chunk.
+		map.delete("better-auth_cookie.1");
+
+		expect(storage.getItem("better-auth_cookie")).toBeNull();
+	});
+
+	it("should shrink from chunked to a single value without bleeding stale chunks", async () => {
+		const map = new Map<string, string>();
+		const storage = storageAdapter({
+			getItem: (name) => map.get(name) ?? null,
+			setItem: (name, value) => map.set(name, value),
+		});
+
+		await storage.setItem("better-auth_cookie", "z".repeat(5_000));
+		await storage.setItem("better-auth_cookie", "small");
+
+		expect(storage.getItem("better-auth_cookie")).toBe("small");
+	});
+
+	it("should log instead of throw when the backend rejects a write", async () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const storage = storageAdapter({
+			getItem: () => null,
+			setItem: () => {
+				throw new Error("keychain rejected write");
+			},
+		});
+
+		await expect(
+			storage.setItem("better-auth_cookie", "value"),
+		).resolves.toBeUndefined();
+		expect(error).toHaveBeenCalledOnce();
+		error.mockRestore();
 	});
 });
 


### PR DESCRIPTION
Signing in on Expo with a provider that issues large tokens (such as Keycloak) could leave the user logged out: `useSession()` stayed null and server-side `accountInfo` / `getAccessToken` returned `ACCOUNT_NOT_FOUND`. The client stored the whole cookie jar as a single value, and native secure stores reject oversized writes (iOS Keychain refuses values above roughly 2KB) silently, so the account cookie was dropped and never reached the next request. With no database configured there was no fallback, so the account could not be found.

The Expo storage adapter now splits an oversized value across keys and reassembles it on read, keeping every physical write within the device limit. Values that already fit stay under the base key unchanged, so existing installs read back seamlessly. A write the backend rejects is now logged instead of being lost silently.

Closes #9814. Closes #9151.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost sign-in on Expo when providers issue large tokens (e.g., Keycloak). The `@better-auth/expo` storage adapter now chunks and restores the account cookie so sessions persist and `useSession()` and server helpers work reliably.

- **Bug Fixes**
  - Chunk oversized cookie values across keys; reassemble on read.
  - Keep small values under the base key for seamless upgrades.
  - Clear the chunk marker before rewriting and set it last so torn writes fail closed instead of mixing old/new data; return null if any chunk is missing.
  - Await storage writes for session, cache, and sign-out paths; log rejected writes instead of dropping them.

<sup>Written for commit 12f55d399de00642514480542ce766fb6b5082e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


